### PR TITLE
chore: add React Compiler eslint rule

### DIFF
--- a/change/@fluentui-eslint-plugin-1fd8f4c6-4d8c-41fb-a53a-063e999ed9df.json
+++ b/change/@fluentui-eslint-plugin-1fd8f4c6-4d8c-41fb-a53a-063e999ed9df.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add eslint react-compiler",
+  "packageName": "@fluentui/eslint-plugin",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-accordion-fb735b51-0d39-4ec7-9891-0440b40eeb9b.json
+++ b/change/@fluentui-react-accordion-fb735b51-0d39-4ec7-9891-0440b40eeb9b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-accordion",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-avatar-d76e8c97-3dc3-489e-a013-5de35f97c4cf.json
+++ b/change/@fluentui-react-avatar-d76e8c97-3dc3-489e-a013-5de35f97c4cf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-avatar",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-badge-7ce4a0e6-22a1-401b-b604-6f60ec841788.json
+++ b/change/@fluentui-react-badge-7ce4a0e6-22a1-401b-b604-6f60ec841788.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-badge",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-breadcrumb-6c052518-e793-4e2c-8a6b-b553e38cbb93.json
+++ b/change/@fluentui-react-breadcrumb-6c052518-e793-4e2c-8a6b-b553e38cbb93.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-breadcrumb",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-button-9648ea8d-ce0d-41fb-825b-7218c29ae95f.json
+++ b/change/@fluentui-react-button-9648ea8d-ce0d-41fb-825b-7218c29ae95f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-button",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-calendar-compat-ace22a26-2b6f-4dc3-bdb7-67f9191ad2a8.json
+++ b/change/@fluentui-react-calendar-compat-ace22a26-2b6f-4dc3-bdb7-67f9191ad2a8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-calendar-compat",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-card-f94f3f36-7d12-4a00-a352-c080be80d96d.json
+++ b/change/@fluentui-react-card-f94f3f36-7d12-4a00-a352-c080be80d96d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-card",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-checkbox-ef5648c0-1696-4008-a8a5-d6fcde3338de.json
+++ b/change/@fluentui-react-checkbox-ef5648c0-1696-4008-a8a5-d6fcde3338de.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-combobox-2fe46f46-6903-46f6-8381-02fc1aec1b65.json
+++ b/change/@fluentui-react-combobox-2fe46f46-6903-46f6-8381-02fc1aec1b65.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-combobox",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-datepicker-compat-a643ced4-ca9d-4c6d-8e8f-f33cd2d68f7a.json
+++ b/change/@fluentui-react-datepicker-compat-a643ced4-ca9d-4c6d-8e8f-f33cd2d68f7a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-datepicker-compat",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-dialog-dbeaed22-660e-4f93-9300-519897b2a47d.json
+++ b/change/@fluentui-react-dialog-dbeaed22-660e-4f93-9300-519897b2a47d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-dialog",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-divider-14500f1e-b1b6-4aed-82cf-f426361146ec.json
+++ b/change/@fluentui-react-divider-14500f1e-b1b6-4aed-82cf-f426361146ec.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-divider",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-drawer-04dfa473-e038-4bc0-a514-cc5a21a61b43.json
+++ b/change/@fluentui-react-drawer-04dfa473-e038-4bc0-a514-cc5a21a61b43.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-drawer",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-field-1f83f1e8-31f8-4588-a547-15e5ba611f01.json
+++ b/change/@fluentui-react-field-1f83f1e8-31f8-4588-a547-15e5ba611f01.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-field",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-image-218cd54c-5ecd-4578-9740-5570281edd23.json
+++ b/change/@fluentui-react-image-218cd54c-5ecd-4578-9740-5570281edd23.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-image",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-infolabel-fb5adb88-bba4-48f0-a13d-c7033f068d97.json
+++ b/change/@fluentui-react-infolabel-fb5adb88-bba4-48f0-a13d-c7033f068d97.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-infolabel",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-input-1162f0d5-9cc6-4b0d-8a12-7b334eed3742.json
+++ b/change/@fluentui-react-input-1162f0d5-9cc6-4b0d-8a12-7b334eed3742.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-input",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-label-3f1949c6-7d5a-47cd-8727-0b7a4449a82d.json
+++ b/change/@fluentui-react-label-3f1949c6-7d5a-47cd-8727-0b7a4449a82d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-label",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-link-aff12c4d-e738-430c-bcee-ad59f3917dc9.json
+++ b/change/@fluentui-react-link-aff12c4d-e738-430c-bcee-ad59f3917dc9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-link",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-list-preview-5eda5a2a-3846-4864-9448-f00d4d6b4be9.json
+++ b/change/@fluentui-react-list-preview-5eda5a2a-3846-4864-9448-f00d4d6b4be9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-list-preview",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-menu-8d09ca2b-220e-4b33-9819-86d290b5db5b.json
+++ b/change/@fluentui-react-menu-8d09ca2b-220e-4b33-9819-86d290b5db5b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-menu",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-message-bar-a73a5c2b-e855-405e-a480-dcb135df4ca5.json
+++ b/change/@fluentui-react-message-bar-a73a5c2b-e855-405e-a480-dcb135df4ca5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-message-bar",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-migration-v0-v9-bc8b3fd9-9596-4a3c-aac8-e3e2a9818a29.json
+++ b/change/@fluentui-react-migration-v0-v9-bc8b3fd9-9596-4a3c-aac8-e3e2a9818a29.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-migration-v0-v9",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-migration-v8-v9-91f7b279-389d-441b-8744-e926a5721f63.json
+++ b/change/@fluentui-react-migration-v8-v9-91f7b279-389d-441b-8744-e926a5721f63.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-migration-v8-v9",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-motion-05f5e53c-65b7-4d64-9a23-5a329499b0b9.json
+++ b/change/@fluentui-react-motion-05f5e53c-65b7-4d64-9a23-5a329499b0b9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-motion",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-motion-preview-28326b79-c56e-4540-882a-7d8973d2ab7c.json
+++ b/change/@fluentui-react-motion-preview-28326b79-c56e-4540-882a-7d8973d2ab7c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-motion-preview",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-nav-preview-8634e599-31af-4c55-a76f-22c75adacdfa.json
+++ b/change/@fluentui-react-nav-preview-8634e599-31af-4c55-a76f-22c75adacdfa.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-nav-preview",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-persona-9a5b93a3-74e1-4c79-b7ae-f7dfc07ba0b9.json
+++ b/change/@fluentui-react-persona-9a5b93a3-74e1-4c79-b7ae-f7dfc07ba0b9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-persona",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-popover-33994fa7-f959-445a-acb5-dcaf1c0ebfc5.json
+++ b/change/@fluentui-react-popover-33994fa7-f959-445a-acb5-dcaf1c0ebfc5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-popover",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-portal-885f7815-60d5-461f-9a23-279f1e87c08d.json
+++ b/change/@fluentui-react-portal-885f7815-60d5-461f-9a23-279f1e87c08d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-portal",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-portal-compat-74c309a7-0e9a-4c82-aba0-bfe3f4150c2b.json
+++ b/change/@fluentui-react-portal-compat-74c309a7-0e9a-4c82-aba0-bfe3f4150c2b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-portal-compat",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-positioning-e665dc09-acea-4196-ab15-d56d8d23b3d4.json
+++ b/change/@fluentui-react-positioning-e665dc09-acea-4196-ab15-d56d8d23b3d4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-positioning",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-progress-1a7e9078-9727-4b2e-a195-bf702f83841e.json
+++ b/change/@fluentui-react-progress-1a7e9078-9727-4b2e-a195-bf702f83841e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-progress",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-provider-fd9aca22-805a-4fde-a5f4-a906a9279731.json
+++ b/change/@fluentui-react-provider-fd9aca22-805a-4fde-a5f4-a906a9279731.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-provider",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-radio-aa2c5453-d363-47ff-b651-9686a75c7af5.json
+++ b/change/@fluentui-react-radio-aa2c5453-d363-47ff-b651-9686a75c7af5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-radio",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-rating-b7e9ce8f-2740-415c-b0d9-09908ffd56fb.json
+++ b/change/@fluentui-react-rating-b7e9ce8f-2740-415c-b0d9-09908ffd56fb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-rating",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-search-93c30ac7-5b41-47cf-a279-8f94a4f77739.json
+++ b/change/@fluentui-react-search-93c30ac7-5b41-47cf-a279-8f94a4f77739.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-search",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-select-a643efde-6864-46fb-888c-930c8b031cec.json
+++ b/change/@fluentui-react-select-a643efde-6864-46fb-888c-930c8b031cec.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-select",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-skeleton-164d8009-6a64-4e19-a00d-531eedf7f7cb.json
+++ b/change/@fluentui-react-skeleton-164d8009-6a64-4e19-a00d-531eedf7f7cb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-skeleton",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-slider-5a384171-9aaf-41aa-bbbb-022344852aa7.json
+++ b/change/@fluentui-react-slider-5a384171-9aaf-41aa-bbbb-022344852aa7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-slider",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-spinbutton-c152781b-8c26-4c43-a325-bac6ddd16b2b.json
+++ b/change/@fluentui-react-spinbutton-c152781b-8c26-4c43-a325-bac6ddd16b2b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-spinbutton",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-spinner-c7bf1dcd-2a60-4dea-81c3-0aa056bc686f.json
+++ b/change/@fluentui-react-spinner-c7bf1dcd-2a60-4dea-81c3-0aa056bc686f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-spinner",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-swatch-picker-8f9aaf5b-80d2-4283-9003-24f429ffc2d4.json
+++ b/change/@fluentui-react-swatch-picker-8f9aaf5b-80d2-4283-9003-24f429ffc2d4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-swatch-picker",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-switch-504067b4-a75a-42a6-8460-4be8798ea211.json
+++ b/change/@fluentui-react-switch-504067b4-a75a-42a6-8460-4be8798ea211.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-switch",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-table-e5442d8e-baab-494a-8e59-8137770e1a26.json
+++ b/change/@fluentui-react-table-e5442d8e-baab-494a-8e59-8137770e1a26.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-table",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tabs-08a7eb9a-6f96-4f1f-b100-899c77877ca7.json
+++ b/change/@fluentui-react-tabs-08a7eb9a-6f96-4f1f-b100-899c77877ca7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-tabs",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tabster-8e6c9b6c-f0df-4f43-9e07-015dc7af7056.json
+++ b/change/@fluentui-react-tabster-8e6c9b6c-f0df-4f43-9e07-015dc7af7056.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-tabster",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tag-picker-41aa745e-58b3-4986-9dd8-3bee74ddfd7f.json
+++ b/change/@fluentui-react-tag-picker-41aa745e-58b3-4986-9dd8-3bee74ddfd7f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-tag-picker",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tags-640d8c74-3773-4235-98c1-64a9de1ed66e.json
+++ b/change/@fluentui-react-tags-640d8c74-3773-4235-98c1-64a9de1ed66e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-tags",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-teaching-popover-383a5401-80f5-4f8a-84ec-55d446dc4696.json
+++ b/change/@fluentui-react-teaching-popover-383a5401-80f5-4f8a-84ec-55d446dc4696.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-teaching-popover",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-text-124cc0e6-a14e-4b8d-a84c-1f911f4ff803.json
+++ b/change/@fluentui-react-text-124cc0e6-a14e-4b8d-a84c-1f911f4ff803.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-text",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-textarea-f93d0a3f-51b8-45a2-8ad6-1e36534219bf.json
+++ b/change/@fluentui-react-textarea-f93d0a3f-51b8-45a2-8ad6-1e36534219bf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-textarea",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-timepicker-compat-59d30c23-38a0-4c2a-b043-d6aea861a293.json
+++ b/change/@fluentui-react-timepicker-compat-59d30c23-38a0-4c2a-b043-d6aea861a293.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-timepicker-compat",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-toast-5b6bef23-f753-4f69-97cf-f66e25f3d536.json
+++ b/change/@fluentui-react-toast-5b6bef23-f753-4f69-97cf-f66e25f3d536.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-toast",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-toolbar-0bc0774f-cb3d-4ea1-acf3-16b44545d153.json
+++ b/change/@fluentui-react-toolbar-0bc0774f-cb3d-4ea1-acf3-16b44545d153.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-toolbar",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tooltip-0534be82-ee1d-4b36-98db-61b4f6ed3cc7.json
+++ b/change/@fluentui-react-tooltip-0534be82-ee1d-4b36-98db-61b4f6ed3cc7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tree-5166f10a-a4f4-4e9a-83f6-789c09cd2dda.json
+++ b/change/@fluentui-react-tree-5166f10a-a4f4-4e9a-83f6-789c09cd2dda.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-tree",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-utilities-62eab790-0247-46aa-b27f-835f5c67d566.json
+++ b/change/@fluentui-react-utilities-62eab790-0247-46aa-b27f-835f5c67d566.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-utilities",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-virtualizer-f5d2d565-d553-45d2-a78a-bf067ada0738.json
+++ b/change/@fluentui-react-virtualizer-f5d2d565-d553-45d2-a78a-bf067ada0738.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: add eslint react-compiler",
+  "packageName": "@fluentui/react-virtualizer",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/eslint-plugin/src/configs/react.js
+++ b/packages/eslint-plugin/src/configs/react.js
@@ -18,6 +18,7 @@ const v9PackageDeps = Object.keys(
 /** @type {import("eslint").Linter.Config} */
 module.exports = {
   extends: [path.join(__dirname, 'base'), path.join(__dirname, 'react-config')],
+  plugins: ['react-compiler'],
   rules: {
     'jsdoc/check-tag-names': [
       'error',
@@ -32,6 +33,7 @@ module.exports = {
         imports: ['react', '@fluentui/react-context-selector', '@fluentui/global-context'],
       },
     ],
+    'react-compiler/react-compiler': ['error'],
   },
   overrides: [
     // Enable rules requiring type info only for appropriate files/circumstances
@@ -50,6 +52,7 @@ module.exports = {
             ],
           },
         ],
+        'react-compiler/react-compiler': 'off',
       },
     },
     {
@@ -57,6 +60,13 @@ module.exports = {
       rules: {
         'import/no-extraneous-dependencies': 'off',
         'react/jsx-no-bind': 'off',
+        'react-compiler/react-compiler': 'off',
+      },
+    },
+    {
+      files: '**/*.test.{ts,tsx}',
+      rules: {
+        'react-compiler/react-compiler': 'off',
       },
     },
     __internal.overrides.react,

--- a/packages/react-components/react-accordion/library/src/components/Accordion/useAccordionStyles.styles.ts
+++ b/packages/react-components/react-accordion/library/src/components/Accordion/useAccordionStyles.styles.ts
@@ -7,6 +7,8 @@ export const accordionClassNames: SlotClassNames<AccordionSlots> = {
 };
 
 export const useAccordionStyles_unstable = (state: AccordionState) => {
+  'use no memo';
+
   state.root.className = mergeClasses(accordionClassNames.root, state.root.className);
 
   return state;

--- a/packages/react-components/react-accordion/library/src/components/AccordionHeader/useAccordionHeaderStyles.styles.ts
+++ b/packages/react-components/react-accordion/library/src/components/AccordionHeader/useAccordionHeaderStyles.styles.ts
@@ -105,6 +105,8 @@ const useStyles = makeStyles({
 
 /** Applies style classnames to slots */
 export const useAccordionHeaderStyles_unstable = (state: AccordionHeaderState) => {
+  'use no memo';
+
   const styles = useStyles();
   state.root.className = mergeClasses(
     accordionHeaderClassNames.root,

--- a/packages/react-components/react-accordion/library/src/components/AccordionItem/useAccordionItemStyles.styles.ts
+++ b/packages/react-components/react-accordion/library/src/components/AccordionItem/useAccordionItemStyles.styles.ts
@@ -7,6 +7,8 @@ export const accordionItemClassNames: SlotClassNames<AccordionItemSlots> = {
 };
 
 export const useAccordionItemStyles_unstable = (state: AccordionItemState) => {
+  'use no memo';
+
   state.root.className = mergeClasses(accordionItemClassNames.root, state.root.className);
 
   return state;

--- a/packages/react-components/react-accordion/library/src/components/AccordionPanel/useAccordionPanelStyles.styles.ts
+++ b/packages/react-components/react-accordion/library/src/components/AccordionPanel/useAccordionPanelStyles.styles.ts
@@ -19,6 +19,8 @@ const useStyles = makeStyles({
 
 /** Applies style classnames to slots */
 export const useAccordionPanelStyles_unstable = (state: AccordionPanelState) => {
+  'use no memo';
+
   const styles = useStyles();
   state.root.className = mergeClasses(accordionPanelClassNames.root, styles.root, state.root.className);
 

--- a/packages/react-components/react-avatar/library/src/components/Avatar/useAvatarStyles.styles.ts
+++ b/packages/react-components/react-avatar/library/src/components/Avatar/useAvatarStyles.styles.ts
@@ -478,6 +478,8 @@ const useRingColorStyles = makeStyles({
 });
 
 export const useAvatarStyles_unstable = (state: AvatarState): AvatarState => {
+  'use no memo';
+
   const { size, shape, active, activeAppearance, color } = state;
 
   const rootClassName = useRootClassName();

--- a/packages/react-components/react-avatar/library/src/components/AvatarGroup/useAvatarGroupStyles.styles.ts
+++ b/packages/react-components/react-avatar/library/src/components/AvatarGroup/useAvatarGroupStyles.styles.ts
@@ -29,6 +29,8 @@ const useStyles = makeStyles({
  * Apply styling to the AvatarGroup slots based on the state
  */
 export const useAvatarGroupStyles_unstable = (state: AvatarGroupState): AvatarGroupState => {
+  'use no memo';
+
   const { layout, size } = state;
   const styles = useStyles();
   const sizeStyles = useSizeStyles();

--- a/packages/react-components/react-avatar/library/src/components/AvatarGroupItem/useAvatarGroupItemStyles.styles.ts
+++ b/packages/react-components/react-avatar/library/src/components/AvatarGroupItem/useAvatarGroupItemStyles.styles.ts
@@ -159,6 +159,8 @@ const usePieStyles = makeStyles({
  * Apply styling to the AvatarGroupItem slots based on the state
  */
 export const useAvatarGroupItemStyles_unstable = (state: AvatarGroupItemState): AvatarGroupItemState => {
+  'use no memo';
+
   const { isOverflowItem, layout, size } = state;
   const { dir } = useFluent();
 

--- a/packages/react-components/react-avatar/library/src/components/AvatarGroupPopover/useAvatarGroupPopoverStyles.styles.ts
+++ b/packages/react-components/react-avatar/library/src/components/AvatarGroupPopover/useAvatarGroupPopoverStyles.styles.ts
@@ -116,6 +116,8 @@ const useTriggerButtonStyles = makeStyles({
  * Apply styling to the AvatarGroupPopover slots based on the state
  */
 export const useAvatarGroupPopoverStyles_unstable = (state: AvatarGroupPopoverState): AvatarGroupPopoverState => {
+  'use no memo';
+
   const { indicator, size, layout, popoverOpen } = state;
   const sizeStyles = useSizeStyles();
   const triggerButtonStyles = useTriggerButtonStyles();

--- a/packages/react-components/react-badge/library/src/components/Badge/useBadgeStyles.styles.ts
+++ b/packages/react-components/react-badge/library/src/components/Badge/useBadgeStyles.styles.ts
@@ -298,6 +298,8 @@ const useIconStyles = makeStyles({
  * Applies style classnames to slots
  */
 export const useBadgeStyles_unstable = (state: BadgeState): BadgeState => {
+  'use no memo';
+
   const rootClassName = useRootClassName();
   const rootStyles = useRootStyles();
 

--- a/packages/react-components/react-badge/library/src/components/CounterBadge/useCounterBadgeStyles.styles.ts
+++ b/packages/react-components/react-badge/library/src/components/CounterBadge/useCounterBadgeStyles.styles.ts
@@ -25,6 +25,8 @@ const useStyles = makeStyles({
  * Applies style classnames to slots
  */
 export const useCounterBadgeStyles_unstable = (state: CounterBadgeState): CounterBadgeState => {
+  'use no memo';
+
   const styles = useStyles();
   state.root.className = mergeClasses(
     counterBadgeClassNames.root,

--- a/packages/react-components/react-badge/library/src/components/PresenceBadge/usePresenceBadgeStyles.styles.ts
+++ b/packages/react-components/react-badge/library/src/components/PresenceBadge/usePresenceBadgeStyles.styles.ts
@@ -105,6 +105,8 @@ const useStyles = makeStyles({
  * Applies style classnames to slots
  */
 export const usePresenceBadgeStyles_unstable = (state: PresenceBadgeState): PresenceBadgeState => {
+  'use no memo';
+
   const rootClassName = useRootClassName();
   const iconClassName = useIconClassName();
   const styles = useStyles();

--- a/packages/react-components/react-breadcrumb/library/src/components/Breadcrumb/useBreadcrumbStyles.styles.ts
+++ b/packages/react-components/react-breadcrumb/library/src/components/Breadcrumb/useBreadcrumbStyles.styles.ts
@@ -19,6 +19,8 @@ const useListClassName = makeResetStyles({
  * Apply styling to the Breadcrumb slots based on the state
  */
 export const useBreadcrumbStyles_unstable = (state: BreadcrumbState): BreadcrumbState => {
+  'use no memo';
+
   const listBaseClassName = useListClassName();
   state.root.className = mergeClasses(breadcrumbClassNames.root, state.root.className);
   if (state.list) {

--- a/packages/react-components/react-breadcrumb/library/src/components/BreadcrumbButton/useBreadcrumbButtonStyles.styles.ts
+++ b/packages/react-components/react-breadcrumb/library/src/components/BreadcrumbButton/useBreadcrumbButtonStyles.styles.ts
@@ -108,6 +108,8 @@ const useStyles = makeStyles({
  * Apply styling to the BreadcrumbButton slots based on the state
  */
 export const useBreadcrumbButtonStyles_unstable = (state: BreadcrumbButtonState): BreadcrumbButtonState => {
+  'use no memo';
+
   const styles = useStyles();
   const iconStyles = useIconStyles();
 

--- a/packages/react-components/react-breadcrumb/library/src/components/BreadcrumbDivider/useBreadcrumbDividerStyles.styles.ts
+++ b/packages/react-components/react-breadcrumb/library/src/components/BreadcrumbDivider/useBreadcrumbDividerStyles.styles.ts
@@ -29,6 +29,8 @@ const useIconStyles = makeStyles({
  * Apply styling to the BreadcrumbDivider slots based on the state
  */
 export const useBreadcrumbDividerStyles_unstable = (state: BreadcrumbDividerState): BreadcrumbDividerState => {
+  'use no memo';
+
   const styles = useStyles();
   const iconStyles = useIconStyles();
   const { size = 'medium' } = state;

--- a/packages/react-components/react-breadcrumb/library/src/components/BreadcrumbItem/useBreadcrumbItemStyles.styles.ts
+++ b/packages/react-components/react-breadcrumb/library/src/components/BreadcrumbItem/useBreadcrumbItemStyles.styles.ts
@@ -19,6 +19,8 @@ const useBreadcrumbItemResetStyles = makeResetStyles({
  * Apply styling to the BreadcrumbItem slots based on the state
  */
 export const useBreadcrumbItemStyles_unstable = (state: BreadcrumbItemState): BreadcrumbItemState => {
+  'use no memo';
+
   const resetStyles = useBreadcrumbItemResetStyles();
 
   state.root.className = mergeClasses(breadcrumbItemClassNames.root, resetStyles, state.root.className);

--- a/packages/react-components/react-button/library/src/components/Button/useButtonStyles.styles.ts
+++ b/packages/react-components/react-button/library/src/components/Button/useButtonStyles.styles.ts
@@ -537,6 +537,8 @@ const useIconStyles = makeStyles({
 });
 
 export const useButtonStyles_unstable = (state: ButtonState): ButtonState => {
+  'use no memo';
+
   const rootBaseClassName = useRootBaseClassName();
   const iconBaseClassName = useIconBaseClassName();
 

--- a/packages/react-components/react-button/library/src/components/CompoundButton/useCompoundButtonStyles.styles.ts
+++ b/packages/react-components/react-button/library/src/components/CompoundButton/useCompoundButtonStyles.styles.ts
@@ -257,6 +257,8 @@ const useSecondaryContentStyles = makeStyles({
 });
 
 export const useCompoundButtonStyles_unstable = (state: CompoundButtonState): CompoundButtonState => {
+  'use no memo';
+
   const rootStyles = useRootStyles();
   const rootIconOnlyStyles = useRootIconOnlyStyles();
   const iconStyles = useIconStyles();

--- a/packages/react-components/react-button/library/src/components/MenuButton/useMenuButton.tsx
+++ b/packages/react-components/react-button/library/src/components/MenuButton/useMenuButton.tsx
@@ -11,6 +11,8 @@ export const useMenuButton_unstable = (
   { menuIcon, ...props }: MenuButtonProps,
   ref: React.Ref<HTMLButtonElement | HTMLAnchorElement>,
 ): MenuButtonState => {
+  'use no memo';
+
   const buttonState = useButton_unstable(props, ref);
   buttonState.root['aria-expanded'] = props['aria-expanded'] ?? false;
 

--- a/packages/react-components/react-button/library/src/components/MenuButton/useMenuButtonStyles.styles.ts
+++ b/packages/react-components/react-button/library/src/components/MenuButton/useMenuButtonStyles.styles.ts
@@ -104,6 +104,8 @@ const useMenuIconStyles = makeStyles({
 });
 
 export const useMenuButtonStyles_unstable = (state: MenuButtonState): MenuButtonState => {
+  'use no memo';
+
   const rootExpandedStyles = useRootExpandedStyles();
   const iconExpandedStyles = useIconExpandedStyles();
   const menuIconStyles = useMenuIconStyles();

--- a/packages/react-components/react-button/library/src/components/SplitButton/useSplitButtonStyles.styles.ts
+++ b/packages/react-components/react-button/library/src/components/SplitButton/useSplitButtonStyles.styles.ts
@@ -168,6 +168,8 @@ const useRootStyles = makeStyles({
 });
 
 export const useSplitButtonStyles_unstable = (state: SplitButtonState): SplitButtonState => {
+  'use no memo';
+
   const rootStyles = useRootStyles();
   const focusStyles = useFocusStyles();
 

--- a/packages/react-components/react-button/library/src/components/ToggleButton/useToggleButtonStyles.styles.ts
+++ b/packages/react-components/react-button/library/src/components/ToggleButton/useToggleButtonStyles.styles.ts
@@ -248,6 +248,8 @@ const usePrimaryHighContrastStyles = makeStyles({
 });
 
 export const useToggleButtonStyles_unstable = (state: ToggleButtonState): ToggleButtonState => {
+  'use no memo';
+
   const rootCheckedStyles = useRootCheckedStyles();
   const rootDisabledStyles = useRootDisabledStyles();
   const iconCheckedStyles = useIconCheckedStyles();

--- a/packages/react-components/react-calendar-compat/library/src/components/Calendar/useCalendarStyles.styles.ts
+++ b/packages/react-components/react-calendar-compat/library/src/components/Calendar/useCalendarStyles.styles.ts
@@ -111,6 +111,8 @@ const useLiveRegionStyles = makeStyles({
  * Apply styling to the Calendar slots based on the state
  */
 export const useCalendarStyles_unstable = (props: CalendarStyleProps): CalendarStyles => {
+  'use no memo';
+
   const rootStyles = useRootStyles();
   const dividerStyles = useDividerStyles();
   const monthPickerWrapperStyles = useMonthPickerWrapperStyles();

--- a/packages/react-components/react-calendar-compat/library/src/components/CalendarDay/useCalendarDayStyles.styles.ts
+++ b/packages/react-components/react-calendar-compat/library/src/components/CalendarDay/useCalendarDayStyles.styles.ts
@@ -136,6 +136,8 @@ const useDisabledStyleStyles = makeStyles({
  * Apply styling to the CalendarDay slots based on the state
  */
 export const useCalendarDayStyles_unstable = (props: CalendarDayStyleProps): CalendarDayStyles => {
+  'use no memo';
+
   const rootStyles = useRootStyles();
   const headerStyles = useHeaderStyles();
   const monthAndYearStyles = useMonthAndYearStyles();

--- a/packages/react-components/react-calendar-compat/library/src/components/CalendarDayGrid/CalendarGridDayCell.tsx
+++ b/packages/react-components/react-calendar-compat/library/src/components/CalendarDayGrid/CalendarGridDayCell.tsx
@@ -22,6 +22,8 @@ export interface CalendarGridDayCellProps extends CalendarGridRowProps {
  * @internal
  */
 export const CalendarGridDayCell: React.FunctionComponent<CalendarGridDayCellProps> = props => {
+  'use no memo';
+
   const {
     navigatedDate,
     dateTimeFormatter,

--- a/packages/react-components/react-calendar-compat/library/src/components/CalendarDayGrid/useCalendarDayGridStyles.styles.ts
+++ b/packages/react-components/react-calendar-compat/library/src/components/CalendarDayGrid/useCalendarDayGridStyles.styles.ts
@@ -382,6 +382,8 @@ const useCornerBorderAndRadiusStyles = makeStyles({
  * Apply styling to the CalendarDayGrid slots based on the state
  */
 export const useCalendarDayGridStyles_unstable = (props: CalendarDayGridStyleProps): CalendarDayGridStyles => {
+  'use no memo';
+
   const wrapperStyles = useWrapperStyles();
   const tableStyles = useTableStyles();
   const dayCellStyles = useDayCellStyles();

--- a/packages/react-components/react-calendar-compat/library/src/components/CalendarDayGrid/useWeeks.ts
+++ b/packages/react-components/react-calendar-compat/library/src/components/CalendarDayGrid/useWeeks.ts
@@ -11,6 +11,8 @@ export function useWeeks(
   onSelectDate: (date: Date) => void,
   getSetRefCallback: (dayKey: string) => (element: HTMLElement | null) => void,
 ): DayInfo[][] {
+  'use no memo';
+
   /**
    * Initial parsing of the given props to generate IDayInfo two dimensional array, which contains a representation
    * of every day in the grid. Convenient for helping with conversions between day refs and Date objects in callbacks.

--- a/packages/react-components/react-calendar-compat/library/src/components/CalendarMonth/useCalendarMonthStyles.styles.ts
+++ b/packages/react-components/react-calendar-compat/library/src/components/CalendarMonth/useCalendarMonthStyles.styles.ts
@@ -7,5 +7,7 @@ import type { CalendarMonthStyleProps, CalendarMonthStyles } from './CalendarMon
  * Apply styling to the CalendarMonth slots based on the state
  */
 export const useCalendarMonthStyles_unstable = (props: CalendarMonthStyleProps): CalendarMonthStyles => {
+  'use no memo';
+
   return useCalendarPickerStyles_unstable(props);
 };

--- a/packages/react-components/react-calendar-compat/library/src/components/CalendarPicker/useCalendarPickerStyles.styles.ts
+++ b/packages/react-components/react-calendar-compat/library/src/components/CalendarPicker/useCalendarPickerStyles.styles.ts
@@ -286,6 +286,8 @@ const useDisabledStyles = makeStyles({
  * Apply styling to the CalendarPicker slots based on the state
  */
 export const useCalendarPickerStyles_unstable = (props: CalendarPickerStyleProps): CalendarPickerStyles => {
+  'use no memo';
+
   const rootStyles = useRootStyles();
   const headerContainerStyles = useHeaderContainerStyles();
   const currentItemButtonStyles = useCurrentItemButtonStyles();

--- a/packages/react-components/react-calendar-compat/library/src/components/CalendarYear/useCalendarYearStyles.styles.ts
+++ b/packages/react-components/react-calendar-compat/library/src/components/CalendarYear/useCalendarYearStyles.styles.ts
@@ -7,5 +7,7 @@ import type { CalendarYearStyleProps, CalendarYearStyles } from './CalendarYear.
  * Apply styling to the CalendarYear slots based on the state
  */
 export const useCalendarYearStyles_unstable = (props: CalendarYearStyleProps): CalendarYearStyles => {
+  'use no memo';
+
   return useCalendarPickerStyles_unstable(props);
 };

--- a/packages/react-components/react-card/library/src/components/Card/useCardStyles.styles.ts
+++ b/packages/react-components/react-card/library/src/components/Card/useCardStyles.styles.ts
@@ -354,6 +354,8 @@ const useStyles = makeStyles({
  * Apply styling to the Card slots based on the state.
  */
 export const useCardStyles_unstable = (state: CardState): CardState => {
+  'use no memo';
+
   const styles = useStyles();
 
   const orientationMap = {

--- a/packages/react-components/react-card/library/src/components/CardFooter/useCardFooterStyles.styles.ts
+++ b/packages/react-components/react-card/library/src/components/CardFooter/useCardFooterStyles.styles.ts
@@ -35,6 +35,8 @@ const useStyles = makeStyles({
  * Apply styling to the CardFooter slots based on the state.
  */
 export const useCardFooterStyles_unstable = (state: CardFooterState): CardFooterState => {
+  'use no memo';
+
   const styles = useStyles();
   state.root.className = mergeClasses(cardFooterClassNames.root, styles.root, state.root.className);
 

--- a/packages/react-components/react-card/library/src/components/CardHeader/useCardHeaderStyles.styles.ts
+++ b/packages/react-components/react-card/library/src/components/CardHeader/useCardHeaderStyles.styles.ts
@@ -95,6 +95,8 @@ const useStylesFlex = makeStyles<keyof CardHeaderSlots>({
  * Apply styling to the CardHeader slots based on the state.
  */
 export const useCardHeaderStyles_unstable = (state: CardHeaderState): CardHeaderState => {
+  'use no memo';
+
   const styles = useStyles();
   const stylesGrid = useStylesGrid();
   const stylesFlex = useStylesFlex();

--- a/packages/react-components/react-card/library/src/components/CardPreview/useCardPreviewStyles.styles.ts
+++ b/packages/react-components/react-card/library/src/components/CardPreview/useCardPreviewStyles.styles.ts
@@ -34,6 +34,8 @@ const useStyles = makeStyles({
  * Apply styling to the CardPreview slots based on the state.
  */
 export const useCardPreviewStyles_unstable = (state: CardPreviewState): CardPreviewState => {
+  'use no memo';
+
   const styles = useStyles();
   state.root.className = mergeClasses(cardPreviewClassNames.root, styles.root, state.root.className);
 

--- a/packages/react-components/react-carousel-preview/library/src/components/Carousel/useCarousel.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/Carousel/useCarousel.ts
@@ -26,6 +26,8 @@ import type { CarouselContextValue } from '../CarouselContext.types';
  * @param ref - reference to root HTMLDivElement of Carousel
  */
 export function useCarousel_unstable(props: CarouselProps, ref: React.Ref<HTMLDivElement>): CarouselState {
+  'use no memo';
+
   const { onValueChange, circular, peeking } = props;
 
   const { targetDocument } = useFluent();

--- a/packages/react-components/react-carousel-preview/library/src/components/Carousel/useCarouselStyles.styles.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/Carousel/useCarouselStyles.styles.ts
@@ -27,6 +27,8 @@ const useStyles = makeStyles({
  * Apply styling to the Carousel slots based on the state
  */
 export const useCarouselStyles_unstable = (state: CarouselState): CarouselState => {
+  'use no memo';
+
   const { peeking } = state;
   const styles = useStyles();
 

--- a/packages/react-components/react-carousel-preview/library/src/components/CarouselAutoplayButton/useCarouselAutoplayButtonStyles.styles.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/CarouselAutoplayButton/useCarouselAutoplayButtonStyles.styles.ts
@@ -25,6 +25,8 @@ const useStyles = makeStyles({
 export const useCarouselAutoplayButtonStyles_unstable = (
   state: CarouselAutoplayButtonState,
 ): CarouselAutoplayButtonState => {
+  'use no memo';
+
   const styles = useStyles();
   state.root.className = mergeClasses(carouselAutoplayButtonClassNames.root, styles.root, state.root.className);
 

--- a/packages/react-components/react-carousel-preview/library/src/components/CarouselButton/useCarouselButtonStyles.styles.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/CarouselButton/useCarouselButtonStyles.styles.ts
@@ -29,6 +29,8 @@ const useStyles = makeStyles({
  * Apply styling to the CarouselButton slots based on the state
  */
 export const useCarouselButtonStyles_unstable = (state: CarouselButtonState): CarouselButtonState => {
+  'use no memo';
+
   const styles = useStyles();
 
   state = {

--- a/packages/react-components/react-carousel-preview/library/src/components/CarouselCard/useCarouselCardStyles.styles.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/CarouselCard/useCarouselCardStyles.styles.ts
@@ -37,6 +37,8 @@ const useStyles = makeStyles({
  * Apply styling to the CarouselCard slots based on the state
  */
 export const useCarouselCardStyles_unstable = (state: CarouselCardState): CarouselCardState => {
+  'use no memo';
+
   const { peekDir } = state;
   const styles = useStyles();
   state.root.className = mergeClasses(

--- a/packages/react-components/react-carousel-preview/library/src/components/CarouselFooter/useCarouselFooterStyles.styles.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/CarouselFooter/useCarouselFooterStyles.styles.ts
@@ -23,6 +23,8 @@ const useStyles = makeStyles({
  * Apply styling to the CarouselFooter slots based on the state
  */
 export const useCarouselFooterStyles_unstable = (state: CarouselFooterState): CarouselFooterState => {
+  'use no memo';
+
   const styles = useStyles();
   state.root.className = mergeClasses(carouselFooterClassNames.root, styles.root, state.root.className);
 

--- a/packages/react-components/react-carousel-preview/library/src/components/CarouselNav/useCarouselNavStyles.styles.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/CarouselNav/useCarouselNavStyles.styles.ts
@@ -34,6 +34,8 @@ const useStyles = makeStyles({
  * Apply styling to the CarouselNav slots based on the state
  */
 export const useCarouselNavStyles_unstable = (state: CarouselNavState): CarouselNavState => {
+  'use no memo';
+
   const styles = useStyles();
   state.root.className = mergeClasses(carouselNavClassNames.root, styles.root, state.root.className);
 

--- a/packages/react-components/react-carousel-preview/library/src/components/CarouselNavButton/useCarouselNavButtonStyles.styles.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/CarouselNavButton/useCarouselNavButtonStyles.styles.ts
@@ -58,6 +58,8 @@ const useStyles = makeStyles({
  * Apply styling to the CarouselNavButton slots based on the state
  */
 export const useCarouselNavButtonStyles_unstable = (state: CarouselNavButtonState): CarouselNavButtonState => {
+  'use no memo';
+
   const styles = useStyles();
 
   const { selected } = state;

--- a/packages/react-components/react-carousel-preview/library/src/components/CarouselNavImageButton/useCarouselNavImageButtonStyles.styles.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/CarouselNavImageButton/useCarouselNavImageButtonStyles.styles.ts
@@ -44,6 +44,8 @@ const useStyles = makeStyles({
 export const useCarouselNavImageButtonStyles_unstable = (
   state: CarouselNavImageButtonState,
 ): CarouselNavImageButtonState => {
+  'use no memo';
+
   const { selected } = state;
   const styles = useStyles();
   state.root.className = mergeClasses(

--- a/packages/react-components/react-checkbox/library/src/components/Checkbox/useCheckbox.tsx
+++ b/packages/react-components/react-checkbox/library/src/components/Checkbox/useCheckbox.tsx
@@ -30,6 +30,8 @@ import { useFocusWithin } from '@fluentui/react-tabster';
  * @param ref - reference to `<input>` element of Checkbox
  */
 export const useCheckbox_unstable = (props: CheckboxProps, ref: React.Ref<HTMLInputElement>): CheckboxState => {
+  'use no memo';
+
   // Merge props from surrounding <Field>, if any
   props = useFieldControlProps_unstable(props, { supportsLabelFor: true, supportsRequired: true });
 

--- a/packages/react-components/react-checkbox/library/src/components/Checkbox/useCheckboxStyles.styles.ts
+++ b/packages/react-components/react-checkbox/library/src/components/Checkbox/useCheckboxStyles.styles.ts
@@ -184,6 +184,8 @@ const useLabelStyles = makeStyles({
  * Apply styling to the Checkbox slots based on the state
  */
 export const useCheckboxStyles_unstable = (state: CheckboxState): CheckboxState => {
+  'use no memo';
+
   const { checked, disabled, labelPosition, shape, size } = state;
 
   const rootBaseClassName = useRootBaseClassName();

--- a/packages/react-components/react-combobox/library/src/components/Combobox/useCombobox.tsx
+++ b/packages/react-components/react-combobox/library/src/components/Combobox/useCombobox.tsx
@@ -28,6 +28,8 @@ import { optionClassNames } from '../Option/useOptionStyles.styles';
  * @param ref - reference to root HTMLElement of Combobox
  */
 export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLInputElement>): ComboboxState => {
+  'use no memo';
+
   // Merge props from surrounding <Field>, if any
   props = useFieldControlProps_unstable(props, { supportsLabelFor: true, supportsRequired: true, supportsSize: true });
   const {

--- a/packages/react-components/react-combobox/library/src/components/Combobox/useComboboxStyles.styles.ts
+++ b/packages/react-components/react-combobox/library/src/components/Combobox/useComboboxStyles.styles.ts
@@ -255,6 +255,8 @@ const useIconStyles = makeStyles({
  * Apply styling to the Combobox slots based on the state
  */
 export const useComboboxStyles_unstable = (state: ComboboxState): ComboboxState => {
+  'use no memo';
+
   const { appearance, open, size, showClearIcon } = state;
   const invalid = `${state.input['aria-invalid']}` === 'true';
   const disabled = state.input.disabled;

--- a/packages/react-components/react-combobox/library/src/components/Combobox/useInputTriggerSlot.ts
+++ b/packages/react-components/react-combobox/library/src/components/Combobox/useInputTriggerSlot.ts
@@ -30,6 +30,8 @@ export function useInputTriggerSlot(
   ref: React.Ref<HTMLInputElement>,
   options: UseInputTriggerSlotOptions,
 ): SlotComponentType<ExtractSlotProps<Slot<'input'>>> {
+  'use no memo';
+
   const {
     state: {
       open,

--- a/packages/react-components/react-combobox/library/src/components/Dropdown/useButtonTriggerSlot.ts
+++ b/packages/react-components/react-combobox/library/src/components/Dropdown/useButtonTriggerSlot.ts
@@ -22,6 +22,8 @@ export function useButtonTriggerSlot(
   ref: React.Ref<HTMLButtonElement>,
   options: UseButtonTriggerSlotOptions,
 ): SlotComponentType<ExtractSlotProps<Slot<'button'>>> {
+  'use no memo';
+
   const {
     state: { open, setOpen, getOptionById },
     defaultProps,

--- a/packages/react-components/react-combobox/library/src/components/Dropdown/useDropdown.tsx
+++ b/packages/react-components/react-combobox/library/src/components/Dropdown/useDropdown.tsx
@@ -27,6 +27,8 @@ import { optionClassNames } from '../Option/useOptionStyles.styles';
  * @param ref - reference to root HTMLElement of Dropdown
  */
 export const useDropdown_unstable = (props: DropdownProps, ref: React.Ref<HTMLButtonElement>): DropdownState => {
+  'use no memo';
+
   // Merge props from surrounding <Field>, if any
   props = useFieldControlProps_unstable(props, { supportsLabelFor: true, supportsSize: true });
   const {

--- a/packages/react-components/react-combobox/library/src/components/Dropdown/useDropdownStyles.styles.ts
+++ b/packages/react-components/react-combobox/library/src/components/Dropdown/useDropdownStyles.styles.ts
@@ -251,6 +251,8 @@ const useBaseClearButtonStyle = makeResetStyles({
  * Apply styling to the Dropdown slots based on the state
  */
 export const useDropdownStyles_unstable = (state: DropdownState): DropdownState => {
+  'use no memo';
+
   const { appearance, open, placeholderVisible, showClearButton, size } = state;
   const invalid = `${state.button['aria-invalid']}` === 'true';
   const disabled = state.button.disabled;

--- a/packages/react-components/react-combobox/library/src/components/Listbox/useListboxStyles.styles.ts
+++ b/packages/react-components/react-combobox/library/src/components/Listbox/useListboxStyles.styles.ts
@@ -28,6 +28,8 @@ const useStyles = makeStyles({
  * Apply styling to the Listbox slots based on the state
  */
 export const useListboxStyles_unstable = (state: ListboxState): ListboxState => {
+  'use no memo';
+
   const styles = useStyles();
   state.root.className = mergeClasses(listboxClassNames.root, styles.root, state.root.className);
 

--- a/packages/react-components/react-combobox/library/src/components/Option/useOptionStyles.styles.ts
+++ b/packages/react-components/react-combobox/library/src/components/Option/useOptionStyles.styles.ts
@@ -131,6 +131,8 @@ const useStyles = makeStyles({
  * Apply styling to the Option slots based on the state
  */
 export const useOptionStyles_unstable = (state: OptionState): OptionState => {
+  'use no memo';
+
   const { disabled, multiselect, selected } = state;
   const styles = useStyles();
   state.root.className = mergeClasses(

--- a/packages/react-components/react-combobox/library/src/components/OptionGroup/useOptionGroupStyles.styles.ts
+++ b/packages/react-components/react-combobox/library/src/components/OptionGroup/useOptionGroupStyles.styles.ts
@@ -41,6 +41,8 @@ const useStyles = makeStyles({
  * Apply styling to the OptionGroup slots based on the state
  */
 export const useOptionGroupStyles_unstable = (state: OptionGroupState): OptionGroupState => {
+  'use no memo';
+
   const styles = useStyles();
   state.root.className = mergeClasses(optionGroupClassNames.root, styles.root, state.root.className);
 

--- a/packages/react-components/react-combobox/library/src/utils/useComboboxBaseState.ts
+++ b/packages/react-components/react-combobox/library/src/utils/useComboboxBaseState.ts
@@ -21,6 +21,8 @@ export const useComboboxBaseState = (
     activeDescendantController: ActiveDescendantImperativeRef;
   },
 ): ComboboxBaseState => {
+  'use no memo';
+
   const {
     appearance = 'outline',
     children,

--- a/packages/react-components/react-datepicker-compat/library/src/components/DatePicker/useDatePicker.tsx
+++ b/packages/react-components/react-datepicker-compat/library/src/components/DatePicker/useDatePicker.tsx
@@ -42,6 +42,8 @@ function useFocusLogic() {
 }
 
 function usePopupVisibility(props: DatePickerProps) {
+  'use no memo';
+
   const [open, setOpen] = useControllableState({
     initialState: false,
     defaultState: props.defaultOpen,
@@ -101,6 +103,8 @@ const defaultParseDateFromString = (dateStr: string) => {
  * @param ref - reference to root Input slot
  */
 export const useDatePicker_unstable = (props: DatePickerProps, ref: React.Ref<HTMLInputElement>): DatePickerState => {
+  'use no memo';
+
   const {
     allowTextInput = false,
     allFocusable = false,

--- a/packages/react-components/react-datepicker-compat/library/src/components/DatePicker/useDatePickerStyles.styles.ts
+++ b/packages/react-components/react-datepicker-compat/library/src/components/DatePicker/useDatePickerStyles.styles.ts
@@ -46,6 +46,8 @@ const usePopupSurfaceClassName = makeResetStyles({
  * Apply styling to the DatePicker slots based on the state
  */
 export const useDatePickerStyles_unstable = (state: DatePickerState): DatePickerState => {
+  'use no memo';
+
   const styles = useStyles();
   const popupSurfaceClassName = usePopupSurfaceClassName();
   const { disabled, inlinePopup } = state;

--- a/packages/react-components/react-dialog/library/src/components/DialogActions/useDialogActionsStyles.styles.ts
+++ b/packages/react-components/react-dialog/library/src/components/DialogActions/useDialogActionsStyles.styles.ts
@@ -56,6 +56,8 @@ const useStyles = makeStyles({
  * Apply styling to the DialogActions slots based on the state
  */
 export const useDialogActionsStyles_unstable = (state: DialogActionsState): DialogActionsState => {
+  'use no memo';
+
   const resetStyles = useResetStyles();
   const styles = useStyles();
   state.root.className = mergeClasses(

--- a/packages/react-components/react-dialog/library/src/components/DialogBody/useDialogBodyStyles.styles.ts
+++ b/packages/react-components/react-dialog/library/src/components/DialogBody/useDialogBodyStyles.styles.ts
@@ -33,6 +33,8 @@ const useResetStyles = makeResetStyles({
  * Apply styling to the DialogBody slots based on the state
  */
 export const useDialogBodyStyles_unstable = (state: DialogBodyState): DialogBodyState => {
+  'use no memo';
+
   const resetStyles = useResetStyles();
 
   state.root.className = mergeClasses(dialogBodyClassNames.root, resetStyles, state.root.className);

--- a/packages/react-components/react-dialog/library/src/components/DialogContent/useDialogContentStyles.styles.ts
+++ b/packages/react-components/react-dialog/library/src/components/DialogContent/useDialogContentStyles.styles.ts
@@ -32,6 +32,8 @@ const useStyles = makeResetStyles({
  * Apply styling to the DialogContent slots based on the state
  */
 export const useDialogContentStyles_unstable = (state: DialogContentState): DialogContentState => {
+  'use no memo';
+
   const styles = useStyles();
   state.root.className = mergeClasses(dialogContentClassNames.root, styles, state.root.className);
   return state;

--- a/packages/react-components/react-dialog/library/src/components/DialogSurface/useDialogSurfaceStyles.styles.ts
+++ b/packages/react-components/react-dialog/library/src/components/DialogSurface/useDialogSurfaceStyles.styles.ts
@@ -71,6 +71,8 @@ const useBackdropStyles = makeStyles({
  * Apply styling to the DialogSurface slots based on the state
  */
 export const useDialogSurfaceStyles_unstable = (state: DialogSurfaceState): DialogSurfaceState => {
+  'use no memo';
+
   const { isNestedDialog, root, backdrop } = state;
 
   const rootBaseStyle = useRootBaseStyle();

--- a/packages/react-components/react-dialog/library/src/components/DialogTitle/useDialogTitleStyles.styles.ts
+++ b/packages/react-components/react-dialog/library/src/components/DialogTitle/useDialogTitleStyles.styles.ts
@@ -63,6 +63,8 @@ export const useDialogTitleInternalStyles = makeResetStyles({
  * Apply styling to the DialogTitle slots based on the state
  */
 export const useDialogTitleStyles_unstable = (state: DialogTitleState): DialogTitleState => {
+  'use no memo';
+
   const rootResetStyles = useRootResetStyles();
   const actionResetStyles = useActionResetStyles();
   const styles = useStyles();

--- a/packages/react-components/react-divider/library/src/components/Divider/useDividerStyles.styles.ts
+++ b/packages/react-components/react-divider/library/src/components/Divider/useDividerStyles.styles.ts
@@ -241,6 +241,8 @@ const useVerticalStyles = makeStyles({
 });
 
 export const useDividerStyles_unstable = (state: DividerState): DividerState => {
+  'use no memo';
+
   const baseStyles = useBaseStyles();
   const horizontalStyles = useHorizontalStyles();
   const verticalStyles = useVerticalStyles();

--- a/packages/react-components/react-drawer/library/src/components/Drawer/useDrawerStyles.styles.ts
+++ b/packages/react-components/react-drawer/library/src/components/Drawer/useDrawerStyles.styles.ts
@@ -11,6 +11,8 @@ export const drawerClassNames: SlotClassNames<DrawerSlots> = {
  * Apply styling to the Drawer slots based on the state
  */
 export const useDrawerStyles_unstable = (state: DrawerState): DrawerState => {
+  'use no memo';
+
   state.root.className = mergeClasses(drawerClassNames.root, state.root.className);
 
   return state;

--- a/packages/react-components/react-drawer/library/src/components/DrawerBody/useDrawerBodyStyles.styles.ts
+++ b/packages/react-components/react-drawer/library/src/components/DrawerBody/useDrawerBodyStyles.styles.ts
@@ -32,6 +32,8 @@ const useStyles = makeResetStyles({
  * Apply styling to the DrawerBody slots based on the state
  */
 export const useDrawerBodyStyles_unstable = (state: DrawerBodyState): DrawerBodyState => {
+  'use no memo';
+
   const styles = useStyles();
 
   state.root.className = mergeClasses(drawerBodyClassNames.root, styles, state.root.className);

--- a/packages/react-components/react-drawer/library/src/components/DrawerFooter/useDrawerFooterStyles.styles.ts
+++ b/packages/react-components/react-drawer/library/src/components/DrawerFooter/useDrawerFooterStyles.styles.ts
@@ -45,6 +45,8 @@ const useDrawerFooterStyles = makeStyles({
  * Apply styling to the DrawerFooter slots based on the state
  */
 export const useDrawerFooterStyles_unstable = (state: DrawerFooterState): DrawerFooterState => {
+  'use no memo';
+
   const styles = useStyles();
   const rootStyles = useDrawerFooterStyles();
 

--- a/packages/react-components/react-drawer/library/src/components/DrawerHeader/useDrawerHeaderStyles.styles.ts
+++ b/packages/react-components/react-drawer/library/src/components/DrawerHeader/useDrawerHeaderStyles.styles.ts
@@ -45,6 +45,8 @@ const useDrawerHeaderStyles = makeStyles({
  * Apply styling to the DrawerHeader slots based on the state
  */
 export const useDrawerHeaderStyles_unstable = (state: DrawerHeaderState): DrawerHeaderState => {
+  'use no memo';
+
   const styles = useStyles();
   const rootStyles = useDrawerHeaderStyles();
 

--- a/packages/react-components/react-drawer/library/src/components/DrawerHeaderNavigation/useDrawerHeaderNavigationStyles.styles.ts
+++ b/packages/react-components/react-drawer/library/src/components/DrawerHeaderNavigation/useDrawerHeaderNavigationStyles.styles.ts
@@ -21,6 +21,8 @@ const useStyles = makeResetStyles({
 export const useDrawerHeaderNavigationStyles_unstable = (
   state: DrawerHeaderNavigationState,
 ): DrawerHeaderNavigationState => {
+  'use no memo';
+
   const styles = useStyles();
 
   state.root.className = mergeClasses(drawerHeaderNavigationClassNames.root, styles, state.root.className);

--- a/packages/react-components/react-drawer/library/src/components/DrawerHeaderTitle/useDrawerHeaderTitleStyles.styles.ts
+++ b/packages/react-components/react-drawer/library/src/components/DrawerHeaderTitle/useDrawerHeaderTitleStyles.styles.ts
@@ -31,6 +31,8 @@ const useStyles = makeStyles({
  * Apply styling to the DrawerHeaderTitle slots based on the state
  */
 export const useDrawerHeaderTitleStyles_unstable = (state: DrawerHeaderTitleState): DrawerHeaderTitleState => {
+  'use no memo';
+
   const styles = useStyles();
 
   const { heading: root = {}, action, components } = state;

--- a/packages/react-components/react-drawer/library/src/components/InlineDrawer/useInlineDrawerStyles.styles.ts
+++ b/packages/react-components/react-drawer/library/src/components/InlineDrawer/useInlineDrawerStyles.styles.ts
@@ -76,6 +76,8 @@ function getSeparatorClass(state: InlineDrawerState, classNames: ReturnType<type
  * Apply styling to the InlineDrawer slots based on the state
  */
 export const useInlineDrawerStyles_unstable = (state: InlineDrawerState): InlineDrawerState => {
+  'use no memo';
+
   const resetStyles = useDrawerResetStyles();
   const baseClassNames = useDrawerBaseClassNames(state);
   const rootStyles = useDrawerRootStyles();

--- a/packages/react-components/react-drawer/library/src/components/OverlayDrawer/OverlayDrawerSurface/useOverlayDrawerSurfaceStyles.styles.ts
+++ b/packages/react-components/react-drawer/library/src/components/OverlayDrawer/OverlayDrawerSurface/useOverlayDrawerSurfaceStyles.styles.ts
@@ -29,6 +29,8 @@ const useBackdropStyles = makeStyles({
  * Apply styling to the OverlayDrawerSurface slots based on the state
  */
 export const useOverlayDrawerSurfaceStyles_unstable = (state: DialogSurfaceState): DialogSurfaceState => {
+  'use no memo';
+
   const backdropResetStyles = useBackdropResetStyles();
   const backdropStyles = useBackdropStyles();
 

--- a/packages/react-components/react-drawer/library/src/components/OverlayDrawer/useOverlayDrawerStyles.styles.ts
+++ b/packages/react-components/react-drawer/library/src/components/OverlayDrawer/useOverlayDrawerStyles.styles.ts
@@ -80,6 +80,8 @@ const useBackdropMotionStyles = makeStyles({
  * Apply styling to the OverlayDrawer slots based on the state
  */
 export const useOverlayDrawerStyles_unstable = (state: OverlayDrawerState): OverlayDrawerState => {
+  'use no memo';
+
   const baseClassNames = useDrawerBaseClassNames(state);
   const resetStyles = useDrawerResetStyles();
   const rootStyles = useDrawerRootStyles();

--- a/packages/react-components/react-field/library/src/components/Field/useFieldStyles.styles.ts
+++ b/packages/react-components/react-field/library/src/components/Field/useFieldStyles.styles.ts
@@ -116,6 +116,8 @@ const useValidationMessageIconStyles = makeStyles({
  * Apply styling to the Field slots based on the state
  */
 export const useFieldStyles_unstable = (state: FieldState): FieldState => {
+  'use no memo';
+
   const { validationState, size } = state;
   const horizontal = state.orientation === 'horizontal';
 

--- a/packages/react-components/react-image/library/src/components/Image/useImageStyles.styles.ts
+++ b/packages/react-components/react-image/library/src/components/Image/useImageStyles.styles.ts
@@ -71,6 +71,8 @@ const useStyles = makeStyles({
 });
 
 export const useImageStyles_unstable = (state: ImageState): ImageState => {
+  'use no memo';
+
   const styles = useStyles();
 
   state.root.className = mergeClasses(

--- a/packages/react-components/react-infolabel/library/src/components/InfoButton/useInfoButtonStyles.styles.ts
+++ b/packages/react-components/react-infolabel/library/src/components/InfoButton/useInfoButtonStyles.styles.ts
@@ -103,6 +103,8 @@ const usePopoverSurfaceStyles = makeStyles({
  * Apply styling to the InfoButton slots based on the state
  */
 export const useInfoButtonStyles_unstable = (state: InfoButtonState): InfoButtonState => {
+  'use no memo';
+
   const { size } = state;
   const { open } = state.popover;
   const buttonStyles = useButtonStyles();

--- a/packages/react-components/react-infolabel/library/src/components/InfoLabel/useInfoLabelStyles.styles.ts
+++ b/packages/react-components/react-infolabel/library/src/components/InfoLabel/useInfoLabelStyles.styles.ts
@@ -37,6 +37,8 @@ const useInfoButtonStyles = makeStyles({
  * Apply styling to the InfoLabel slots based on the state
  */
 export const useInfoLabelStyles_unstable = (state: InfoLabelState): InfoLabelState => {
+  'use no memo';
+
   state.root.className = mergeClasses(infoLabelClassNames.root, state.root.className);
 
   const labelStyles = useLabelStyles();

--- a/packages/react-components/react-input/library/src/components/Input/useInputStyles.styles.ts
+++ b/packages/react-components/react-input/library/src/components/Input/useInputStyles.styles.ts
@@ -324,6 +324,8 @@ const useContentStyles = makeStyles({
  * Apply styling to the Input slots based on the state
  */
 export const useInputStyles_unstable = (state: InputState): InputState => {
+  'use no memo';
+
   const { size, appearance } = state;
   const disabled = state.input.disabled;
   const invalid = `${state.input['aria-invalid']}` === 'true';

--- a/packages/react-components/react-label/library/src/components/Label/useLabelStyles.styles.ts
+++ b/packages/react-components/react-label/library/src/components/Label/useLabelStyles.styles.ts
@@ -54,6 +54,8 @@ const useStyles = makeStyles({
  * Apply styling to the Label slots based on the state
  */
 export const useLabelStyles_unstable = (state: LabelState): LabelState => {
+  'use no memo';
+
   const styles = useStyles();
   state.root.className = mergeClasses(
     labelClassNames.root,

--- a/packages/react-components/react-link/library/src/components/Link/useLinkStyles.styles.ts
+++ b/packages/react-components/react-link/library/src/components/Link/useLinkStyles.styles.ts
@@ -102,6 +102,8 @@ const useStyles = makeStyles({
 });
 
 export const useLinkStyles_unstable = (state: LinkState): LinkState => {
+  'use no memo';
+
   const styles = useStyles();
   const { appearance, disabled, inline, root, backgroundAppearance } = state;
 

--- a/packages/react-components/react-list-preview/library/src/components/List/useListStyles.styles.ts
+++ b/packages/react-components/react-list-preview/library/src/components/List/useListStyles.styles.ts
@@ -17,6 +17,8 @@ const useRootBaseStyles = makeResetStyles({
  * Apply styling to the List slots based on the state
  */
 export const useListStyles_unstable = (state: ListState): ListState => {
+  'use no memo';
+
   const rootStyles = useRootBaseStyles();
 
   state.root.className = mergeClasses(listClassNames.root, rootStyles, state.root.className);

--- a/packages/react-components/react-list-preview/library/src/components/ListItem/useListItemStyles.styles.ts
+++ b/packages/react-components/react-list-preview/library/src/components/ListItem/useListItemStyles.styles.ts
@@ -44,6 +44,8 @@ const useStyles = makeStyles({
  * Apply styling to the ListItem slots based on the state
  */
 export const useListItemStyles_unstable = (state: ListItemState): ListItemState => {
+  'use no memo';
+
   const rootBaseStyles = useRootBaseStyles();
   const checkmarkBaseStyles = useCheckmarkBaseStyles();
   const styles = useStyles();

--- a/packages/react-components/react-menu/library/src/components/MenuDivider/useMenuDividerStyles.styles.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuDivider/useMenuDividerStyles.styles.ts
@@ -16,6 +16,8 @@ const useStyles = makeStyles({
 });
 
 export const useMenuDividerStyles_unstable = (state: MenuDividerState) => {
+  'use no memo';
+
   const styles = useStyles();
   state.root.className = mergeClasses(menuDividerClassNames.root, styles.root, state.root.className);
 

--- a/packages/react-components/react-menu/library/src/components/MenuGroup/useMenuGroupStyles.styles.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuGroup/useMenuGroupStyles.styles.ts
@@ -7,6 +7,8 @@ export const menuGroupClassNames: SlotClassNames<MenuGroupSlots> = {
 };
 
 export const useMenuGroupStyles_unstable = (state: MenuGroupState): MenuGroupState => {
+  'use no memo';
+
   state.root.className = mergeClasses(menuGroupClassNames.root, state.root.className);
 
   return state;

--- a/packages/react-components/react-menu/library/src/components/MenuGroupHeader/useMenuGroupHeaderStyles.styles.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuGroupHeader/useMenuGroupHeaderStyles.styles.ts
@@ -21,6 +21,8 @@ const useStyles = makeStyles({
 });
 
 export const useMenuGroupHeaderStyles_unstable = (state: MenuGroupHeaderState) => {
+  'use no memo';
+
   const styles = useStyles();
   state.root.className = mergeClasses(menuGroupHeaderClassNames.root, styles.root, state.root.className);
 

--- a/packages/react-components/react-menu/library/src/components/MenuItem/useCharacterSearch.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuItem/useCharacterSearch.ts
@@ -4,6 +4,8 @@ import type { MenuItemState } from '../../components/index';
 import type { ARIAButtonElementIntersection } from '@fluentui/react-aria';
 
 export const useCharacterSearch = (state: MenuItemState, ref: React.RefObject<HTMLElement>) => {
+  'use no memo';
+
   const setFocusByFirstCharacter = useMenuListContext_unstable(context => context.setFocusByFirstCharacter);
 
   const { onKeyDown: originalOnKeyDown } = state.root;

--- a/packages/react-components/react-menu/library/src/components/MenuItem/useMenuItemStyles.styles.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuItem/useMenuItemStyles.styles.ts
@@ -176,6 +176,8 @@ const useStyles = makeStyles({
 
 /** Applies style classnames to slots */
 export const useMenuItemStyles_unstable = (state: MenuItemState): MenuItemState => {
+  'use no memo';
+
   const styles = useStyles();
   const rootBaseStyles = useRootBaseStyles();
   const contentBaseStyles = useContentBaseStyles();

--- a/packages/react-components/react-menu/library/src/components/MenuItemCheckbox/useMenuItemCheckboxStyles.styles.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuItemCheckbox/useMenuItemCheckboxStyles.styles.ts
@@ -14,6 +14,8 @@ export const menuItemCheckboxClassNames: SlotClassNames<Omit<MenuItemSlots, 'sub
 };
 
 export const useMenuItemCheckboxStyles_unstable = (state: MenuItemCheckboxState): MenuItemCheckboxState => {
+  'use no memo';
+
   state.root.className = mergeClasses(menuItemCheckboxClassNames.root, state.root.className);
 
   if (state.content) {

--- a/packages/react-components/react-menu/library/src/components/MenuItemLink/useMenuItemLinkStyles.styles.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuItemLink/useMenuItemLinkStyles.styles.ts
@@ -28,6 +28,8 @@ const useStyles = makeStyles({
  * Apply styling to the MenuItemLink slots based on the state
  */
 export const useMenuItemLinkStyles_unstable = (state: MenuItemLinkState): MenuItemLinkState => {
+  'use no memo';
+
   useMenuItemStyles_unstable(state as MenuItemState);
   const styles = useStyles();
   state.root.className = mergeClasses(menuItemLinkClassNames.root, styles.resetLink, state.root.className);

--- a/packages/react-components/react-menu/library/src/components/MenuItemRadio/useMenuItemRadioStyles.styles.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuItemRadio/useMenuItemRadioStyles.styles.ts
@@ -14,6 +14,8 @@ export const menuItemRadioClassNames: SlotClassNames<Omit<MenuItemSlots, 'submen
 };
 
 export const useMenuItemRadioStyles_unstable = (state: MenuItemRadioState) => {
+  'use no memo';
+
   state.root.className = mergeClasses(menuItemRadioClassNames.root, state.root.className);
 
   if (state.content) {

--- a/packages/react-components/react-menu/library/src/components/MenuItemSwitch/useMenuItemSwitchStyles.styles.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuItemSwitch/useMenuItemSwitchStyles.styles.ts
@@ -88,6 +88,8 @@ const useSwitchIndicatorStyles = makeStyles({
  * Apply styling to the MenuItemSwitch slots based on the state
  */
 export const useMenuItemSwitchStyles_unstable = (state: MenuItemSwitchState): MenuItemSwitchState => {
+  'use no memo';
+
   const { checked } = state;
   const switchIndicatorStyles = useSwitchIndicatorStyles();
   const switchIndicatorBaseStyles = useSwitchIndicatorBaseClassName();

--- a/packages/react-components/react-menu/library/src/components/MenuList/useMenuListStyles.styles.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuList/useMenuListStyles.styles.ts
@@ -21,6 +21,8 @@ const useStyles = makeStyles({
  * Apply styling to the Menu slots based on the state
  */
 export const useMenuListStyles_unstable = (state: MenuListState): MenuListState => {
+  'use no memo';
+
   const styles = useStyles();
   state.root.className = mergeClasses(
     menuListClassNames.root,

--- a/packages/react-components/react-menu/library/src/components/MenuPopover/useMenuPopover.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuPopover/useMenuPopover.ts
@@ -18,6 +18,8 @@ import { useRestoreFocusSource } from '@fluentui/react-tabster';
  * @param ref - reference to root HTMLElement of MenuPopover
  */
 export const useMenuPopover_unstable = (props: MenuPopoverProps, ref: React.Ref<HTMLElement>): MenuPopoverState => {
+  'use no memo';
+
   const popoverRef = useMenuContext_unstable(context => context.menuPopoverRef);
   const setOpen = useMenuContext_unstable(context => context.setOpen);
   const open = useMenuContext_unstable(context => context.open);

--- a/packages/react-components/react-menu/library/src/components/MenuPopover/useMenuPopoverStyles.styles.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuPopover/useMenuPopoverStyles.styles.ts
@@ -30,6 +30,8 @@ const useStyles = makeStyles({
  * Apply styling to the Menu slots based on the state
  */
 export const useMenuPopoverStyles_unstable = (state: MenuPopoverState): MenuPopoverState => {
+  'use no memo';
+
   const styles = useStyles();
   state.root.className = mergeClasses(menuPopoverClassNames.root, styles.root, state.root.className);
   return state;

--- a/packages/react-components/react-menu/library/src/components/MenuSplitGroup/useMenuSplitGroupStyles.styles.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuSplitGroup/useMenuSplitGroupStyles.styles.ts
@@ -34,6 +34,8 @@ const useStyles = makeStyles({
  * Apply styling to the MenuSplitGroup slots based on the state
  */
 export const useMenuSplitGroupStyles_unstable = (state: MenuSplitGroupState): MenuSplitGroupState => {
+  'use no memo';
+
   const styles = useStyles();
   state.root.className = mergeClasses(menuSplitGroupClassNames.root, styles.root, state.root.className);
   return state;

--- a/packages/react-components/react-menu/library/src/selectable/useCheckmarkStyles.styles.ts
+++ b/packages/react-components/react-menu/library/src/selectable/useCheckmarkStyles.styles.ts
@@ -19,6 +19,8 @@ const useStyles = makeStyles({
  * @param state - should contain a `checkmark` slot
  */
 export const useCheckmarkStyles_unstable = (state: MenuItemSelectableState & Pick<MenuItemState, 'checkmark'>) => {
+  'use no memo';
+
   const styles = useStyles();
   if (state.checkmark) {
     state.checkmark.className = mergeClasses(

--- a/packages/react-components/react-message-bar/library/src/components/MessageBar/useMessageBarStyles.styles.ts
+++ b/packages/react-components/react-message-bar/library/src/components/MessageBar/useMessageBarStyles.styles.ts
@@ -99,6 +99,8 @@ const useRootIntentStyles = makeStyles({
  * Apply styling to the MessageBar slots based on the state
  */
 export const useMessageBarStyles_unstable = (state: MessageBarState): MessageBarState => {
+  'use no memo';
+
   const rootBaseStyles = useRootBaseStyles();
   const iconBaseStyles = useIconBaseStyles();
   const iconIntentStyles = useIconIntentStyles();

--- a/packages/react-components/react-message-bar/library/src/components/MessageBarActions/useMessageBarActionsStyles.styles.ts
+++ b/packages/react-components/react-message-bar/library/src/components/MessageBarActions/useMessageBarActionsStyles.styles.ts
@@ -41,6 +41,8 @@ const useMultilineStyles = makeStyles({
  * Apply styling to the MessageBarActions slots based on the state
  */
 export const useMessageBarActionsStyles_unstable = (state: MessageBarActionsState): MessageBarActionsState => {
+  'use no memo';
+
   const rootBaseStyles = useRootBaseStyles();
   const containerActionBaseStyles = useContainerActionBaseStyles();
   const multilineStyles = useMultilineStyles();

--- a/packages/react-components/react-message-bar/library/src/components/MessageBarBody/useMessageBarBodyStyles.styles.ts
+++ b/packages/react-components/react-message-bar/library/src/components/MessageBarBody/useMessageBarBodyStyles.styles.ts
@@ -17,6 +17,8 @@ const useRootBaseStyles = makeResetStyles({
  * Apply styling to the MessageBarBody slots based on the state
  */
 export const useMessageBarBodyStyles_unstable = (state: MessageBarBodyState): MessageBarBodyState => {
+  'use no memo';
+
   const rootBaseStyles = useRootBaseStyles();
   state.root.className = mergeClasses(messageBarBodyClassNames.root, rootBaseStyles, state.root.className);
 

--- a/packages/react-components/react-message-bar/library/src/components/MessageBarGroup/useMessageBarGroupStyles.styles.ts
+++ b/packages/react-components/react-message-bar/library/src/components/MessageBarGroup/useMessageBarGroupStyles.styles.ts
@@ -45,6 +45,8 @@ const useStyles = makeStyles({
  * Apply styling to the MessageBarGroup slots based on the state
  */
 export const useMessageBarGroupStyles_unstable = (state: MessageBarGroupState): MessageBarGroupState => {
+  'use no memo';
+
   const styles = useStyles();
   state.root.className = mergeClasses(messageBarGroupClassNames.root, state.root.className);
   state.enterStyles = mergeClasses(styles.base, styles.enter);

--- a/packages/react-components/react-message-bar/library/src/components/MessageBarTitle/useMessageBarTitleStyles.styles.ts
+++ b/packages/react-components/react-message-bar/library/src/components/MessageBarTitle/useMessageBarTitleStyles.styles.ts
@@ -21,6 +21,8 @@ const useRootBaseStyles = makeResetStyles({
  * Apply styling to the MessageBarTitle slots based on the state
  */
 export const useMessageBarTitleStyles_unstable = (state: MessageBarTitleState): MessageBarTitleState => {
+  'use no memo';
+
   const rootBaseStyles = useRootBaseStyles();
   state.root.className = mergeClasses(messageBarTitleClassNames.root, rootBaseStyles, state.root.className);
 

--- a/packages/react-components/react-migration-v0-v9/src/components/List/List/useListStyles.styles.ts
+++ b/packages/react-components/react-migration-v0-v9/src/components/List/List/useListStyles.styles.ts
@@ -30,6 +30,8 @@ const useStyles = makeStyles({
  * Apply styling to the List slots based on the state
  */
 export const useListStyles_unstable = (state: ListState): ListState => {
+  'use no memo';
+
   const rootStyles = useRootBaseStyles();
   const styles = useStyles();
 

--- a/packages/react-components/react-migration-v0-v9/src/components/List/ListItem/useListItemStyles.styles.ts
+++ b/packages/react-components/react-migration-v0-v9/src/components/List/ListItem/useListItemStyles.styles.ts
@@ -61,6 +61,8 @@ const useStyles = makeStyles({
  * Apply styling to the ListItem slots based on the state
  */
 export const useListItemStyles_unstable = (state: ListItemState): ListItemState => {
+  'use no memo';
+
   const rootBaseStyles = useRootBaseStyles();
   const styles = useStyles();
 

--- a/packages/react-components/react-migration-v8-v9/src/components/Checkbox/CheckboxShim.tsx
+++ b/packages/react-components/react-migration-v8-v9/src/components/Checkbox/CheckboxShim.tsx
@@ -10,6 +10,8 @@ const getClassNames = classNamesFunction<ICheckboxStyleProps, ICheckboxStyles>({
 });
 
 export const CheckboxShim = React.forwardRef((props: ICheckboxProps, _ref: React.ForwardedRef<HTMLInputElement>) => {
+  'use no memo';
+
   const { className, styles: stylesV8, onRenderLabel, label, componentRef } = props;
   const shimProps = useCheckboxProps(props);
   const styles = getClassNames(stylesV8);

--- a/packages/react-components/react-motion-preview/library/src/hooks/useMotion.ts
+++ b/packages/react-components/react-motion-preview/library/src/hooks/useMotion.ts
@@ -88,6 +88,8 @@ function useMotionPresence<Element extends HTMLElement>(
   presence: boolean,
   options: MotionOptions = {},
 ): MotionState<Element> {
+  'use no memo';
+
   const { animateOnFirstMount, duration } = { animateOnFirstMount: false, ...options };
 
   const [type, setType] = React.useState<MotionType>(

--- a/packages/react-components/react-motion/library/src/factories/createMotionComponent.ts
+++ b/packages/react-components/react-motion/library/src/factories/createMotionComponent.ts
@@ -42,6 +42,8 @@ export function createMotionComponent<MotionParams extends Record<string, Motion
   value: AtomMotion | AtomMotion[] | AtomMotionFn<MotionParams>,
 ) {
   const Atom: React.FC<MotionComponentProps & MotionParams> = props => {
+    'use no memo';
+
     const {
       children,
       imperativeRef,

--- a/packages/react-components/react-motion/library/src/factories/createPresenceComponent.ts
+++ b/packages/react-components/react-motion/library/src/factories/createPresenceComponent.ts
@@ -59,6 +59,8 @@ export function createPresenceComponent<MotionParams extends Record<string, Moti
   value: PresenceMotion | PresenceMotionFn<MotionParams>,
 ) {
   const Presence: React.FC<PresenceComponentProps & MotionParams> = props => {
+    'use no memo';
+
     const itemContext = React.useContext(PresenceGroupChildContext);
     const merged = { ...itemContext, ...props };
 

--- a/packages/react-components/react-nav-preview/library/src/components/Hamburger/useHamburgerStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/library/src/components/Hamburger/useHamburgerStyles.styles.ts
@@ -30,6 +30,8 @@ const useStyles = makeStyles({
  * Apply styling to the Hamburger slots based on the state
  */
 export const useHamburgerStyles_unstable = (state: HamburgerState): HamburgerState => {
+  'use no memo';
+
   useButtonStyles_unstable(state);
   const styles = useStyles();
 

--- a/packages/react-components/react-nav-preview/library/src/components/Nav/useNavStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/library/src/components/Nav/useNavStyles.styles.ts
@@ -24,6 +24,8 @@ const useStyles = makeStyles({
  * Apply styling to the Nav slots based on the state
  */
 export const useNavStyles_unstable = (state: NavState): NavState => {
+  'use no memo';
+
   const styles = useStyles();
   state.root.className = mergeClasses(navClassNames.root, styles.root, state.root.className);
 

--- a/packages/react-components/react-nav-preview/library/src/components/NavCategoryItem/useNavCategoryItem.styles.ts
+++ b/packages/react-components/react-nav-preview/library/src/components/NavCategoryItem/useNavCategoryItem.styles.ts
@@ -41,6 +41,8 @@ export const useRootStyles = makeStyles({
  * Apply styling to the NavCategoryItem slots based on the state
  */
 export const useNavCategoryItemStyles_unstable = (state: NavCategoryItemState): NavCategoryItemState => {
+  'use no memo';
+
   const rootStyles = useRootStyles();
   const smallStyles = useSmallStyles();
   const defaultRootClassName = useRootDefaultClassName();

--- a/packages/react-components/react-nav-preview/library/src/components/NavDrawer/useNavDrawerStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/library/src/components/NavDrawer/useNavDrawerStyles.styles.ts
@@ -23,6 +23,8 @@ const useStyles = makeStyles({
  * Apply styling to the NavDrawer slots based on the state
  */
 export const useNavDrawerStyles_unstable = (state: NavDrawerState): NavDrawerState => {
+  'use no memo';
+
   const styles = useStyles();
   state.root.className = mergeClasses(navDrawerClassNames.root, styles.root, state.root.className);
 

--- a/packages/react-components/react-nav-preview/library/src/components/NavDrawerBody/useNavDrawerBodyStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/library/src/components/NavDrawerBody/useNavDrawerBodyStyles.styles.ts
@@ -25,6 +25,8 @@ const useStyles = makeStyles({
  * Apply styling to the NavDrawerBody slots based on the state
  */
 export const useNavDrawerBodyStyles_unstable = (state: NavDrawerBodyState): NavDrawerBodyState => {
+  'use no memo';
+
   useDrawerBodyStyles_unstable(state);
   const styles = useStyles();
   state.root.className = mergeClasses(navDrawerBodyClassNames.root, styles.root, state.root.className);

--- a/packages/react-components/react-nav-preview/library/src/components/NavDrawerFooter/useNavDrawerFooterStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/library/src/components/NavDrawerFooter/useNavDrawerFooterStyles.styles.ts
@@ -24,6 +24,8 @@ const useStyles = makeStyles({
  * Apply styling to the NavDrawerFooter slots based on the state
  */
 export const useNavDrawerFooterStyles_unstable = (state: NavDrawerFooterState): NavDrawerFooterState => {
+  'use no memo';
+
   useDrawerFooterStyles_unstable(state);
   const styles = useStyles();
   state.root.className = mergeClasses(navDrawerFooterClassNames.root, styles.root, state.root.className);

--- a/packages/react-components/react-nav-preview/library/src/components/NavDrawerHeader/useNavDrawerHeaderStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/library/src/components/NavDrawerHeader/useNavDrawerHeaderStyles.styles.ts
@@ -23,6 +23,8 @@ const useStyles = makeStyles({
  * Apply styling to the NavDrawerHeader slots based on the state
  */
 export const useNavDrawerHeaderStyles_unstable = (state: NavDrawerHeaderState): NavDrawerHeaderState => {
+  'use no memo';
+
   useDrawerHeaderStyles_unstable(state);
   const styles = useStyles();
   state.root.className = mergeClasses(navDrawerHeaderClassNames.root, styles.root, state.root.className);

--- a/packages/react-components/react-nav-preview/library/src/components/NavItem/useNavItemStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/library/src/components/NavItem/useNavItemStyles.styles.ts
@@ -18,6 +18,8 @@ export const navItemClassNames: SlotClassNames<NavItemSlots> = {
  * Apply styling to the NavItem slots based on the state
  */
 export const useNavItemStyles_unstable = (state: NavItemState): NavItemState => {
+  'use no memo';
+
   const rootDefaultClassName = useRootDefaultClassName();
   const smallStyles = useSmallStyles();
   const contentStyles = useContentStyles();

--- a/packages/react-components/react-nav-preview/library/src/components/NavSectionHeader/useNavSectionHeaderStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/library/src/components/NavSectionHeader/useNavSectionHeaderStyles.styles.ts
@@ -22,6 +22,8 @@ const useStyles = makeStyles({
  * Apply styling to the NavSectionHeader slots based on the state
  */
 export const useNavSectionHeaderStyles_unstable = (state: NavSectionHeaderState): NavSectionHeaderState => {
+  'use no memo';
+
   const styles = useStyles();
   state.root.className = mergeClasses(navSectionHeaderClassNames.root, styles.root, state.root.className);
 

--- a/packages/react-components/react-nav-preview/library/src/components/NavSubItem/useNavSubItemStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/library/src/components/NavSubItem/useNavSubItemStyles.styles.ts
@@ -34,6 +34,8 @@ const useNavSubItemSpecificStyles = makeStyles({
  * Apply styling to the NavSubItem slots based on the state
  */
 export const useNavSubItemStyles_unstable = (state: NavSubItemState): NavSubItemState => {
+  'use no memo';
+
   const rootDefaultClassName = useRootDefaultClassName();
   const smallStyles = useSmallStyles();
   const contentStyles = useContentStyles();

--- a/packages/react-components/react-nav-preview/library/src/components/NavSubItemGroup/useNavSubItemGroupStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/library/src/components/NavSubItemGroup/useNavSubItemGroupStyles.styles.ts
@@ -23,6 +23,8 @@ const useStyles = makeStyles({
  * Apply styling to the NavSubItemGroup slots based on the state
  */
 export const useNavSubItemGroupStyles_unstable = (state: NavSubItemGroupState): NavSubItemGroupState => {
+  'use no memo';
+
   const styles = useStyles();
   state.root.className = mergeClasses(navSubItemGroupClassNames.root, styles.root, state.root.className);
 

--- a/packages/react-components/react-persona/library/src/components/Persona/usePersonaStyles.styles.ts
+++ b/packages/react-components/react-persona/library/src/components/Persona/usePersonaStyles.styles.ts
@@ -122,6 +122,8 @@ const usePresenceSpacingStyles = makeStyles({
  * Apply styling to the Persona slots based on the state
  */
 export const usePersonaStyles_unstable = (state: PersonaState): PersonaState => {
+  'use no memo';
+
   const { presenceOnly, size, textAlignment, textPosition } = state;
 
   const alignToPrimary = presenceOnly && textAlignment === 'start' && size !== 'extra-large' && size !== 'huge';

--- a/packages/react-components/react-popover/library/src/components/Popover/usePopover.ts
+++ b/packages/react-components/react-popover/library/src/components/Popover/usePopover.ts
@@ -148,6 +148,8 @@ export const usePopover_unstable = (props: PopoverProps): PopoverState => {
 function useOpenState(
   state: Pick<PopoverState, 'setContextTarget' | 'onOpenChange'> & Pick<PopoverProps, 'open' | 'defaultOpen'>,
 ) {
+  'use no memo';
+
   const onOpenChange: PopoverState['onOpenChange'] = useEventCallback((e, data) => state.onOpenChange?.(e, data));
 
   const [open, setOpenState] = useControllableState({
@@ -184,6 +186,8 @@ function usePopoverRefs(
   state: Pick<PopoverState, 'size' | 'contextTarget'> &
     Pick<PopoverProps, 'positioning' | 'openOnContext' | 'withArrow'>,
 ) {
+  'use no memo';
+
   const positioningOptions = {
     position: 'above' as const,
     align: 'center' as const,

--- a/packages/react-components/react-popover/library/src/components/PopoverSurface/usePopoverSurfaceStyles.styles.ts
+++ b/packages/react-components/react-popover/library/src/components/PopoverSurface/usePopoverSurfaceStyles.styles.ts
@@ -60,6 +60,8 @@ const useStyles = makeStyles({
  * Apply styling to the PopoverSurface slots based on the state
  */
 export const usePopoverSurfaceStyles_unstable = (state: PopoverSurfaceState): PopoverSurfaceState => {
+  'use no memo';
+
   const styles = useStyles();
   state.root.className = mergeClasses(
     popoverSurfaceClassNames.root,

--- a/packages/react-components/react-portal-compat/src/PortalCompatProvider.tsx
+++ b/packages/react-components/react-portal-compat/src/PortalCompatProvider.tsx
@@ -8,6 +8,8 @@ import type { RegisterPortalFn } from '@fluentui/react-portal-compat-context';
 const CLASS_NAME_REGEX = new RegExp(`([^\\s]*${fluentProviderClassNames.root}\\w+)`, 'g');
 
 export function useProviderThemeClasses(): string[] {
+  'use no memo';
+
   const themeClassName = useThemeClassName();
   const cssVariablesClasses = React.useMemo<string[]>(
     // "themeClassName" may contain multiple classes while we want to add only classes that host CSS variables

--- a/packages/react-components/react-portal/library/src/components/Portal/usePortalMountNode.ts
+++ b/packages/react-components/react-portal/library/src/components/Portal/usePortalMountNode.ts
@@ -25,6 +25,8 @@ export type UsePortalMountNodeOptions = {
  * Creates a new element on a "document.body" to mount portals.
  */
 export const usePortalMountNode = (options: UsePortalMountNodeOptions): HTMLElement | null => {
+  'use no memo';
+
   const { targetDocument, dir } = useFluent();
   const mountNode = usePortalMountNodeContext();
 

--- a/packages/react-components/react-positioning/src/usePositioning.ts
+++ b/packages/react-components/react-positioning/src/usePositioning.ts
@@ -30,6 +30,8 @@ import { POSITIONING_END_EVENT } from './constants';
  * @internal
  */
 export function usePositioning(options: PositioningProps & PositioningOptions): UsePositioningReturn {
+  'use no memo';
+
   const managerRef = React.useRef<PositionManager | null>(null);
   const targetRef = React.useRef<TargetElement | null>(null);
   const overrideTargetRef = React.useRef<TargetElement | null>(null);
@@ -158,6 +160,8 @@ export function usePositioning(options: PositioningProps & PositioningOptions): 
 }
 
 function usePositioningOptions(options: PositioningOptions) {
+  'use no memo';
+
   const {
     align,
     arrowPadding,

--- a/packages/react-components/react-progress/library/src/components/ProgressBar/useProgressBarStyles.styles.ts
+++ b/packages/react-components/react-progress/library/src/components/ProgressBar/useProgressBarStyles.styles.ts
@@ -108,6 +108,8 @@ const useBarStyles = makeStyles({
  * Apply styling to the ProgressBar slots based on the state
  */
 export const useProgressBarStyles_unstable = (state: ProgressBarState): ProgressBarState => {
+  'use no memo';
+
   const { color, max, shape, thickness, value } = state;
   const rootStyles = useRootStyles();
   const barStyles = useBarStyles();

--- a/packages/react-components/react-provider/library/src/components/FluentProvider/useFluentProvider.ts
+++ b/packages/react-components/react-provider/library/src/components/FluentProvider/useFluentProvider.ts
@@ -33,6 +33,8 @@ export const useFluentProvider_unstable = (
   props: FluentProviderProps,
   ref: React.Ref<HTMLElement>,
 ): FluentProviderState => {
+  'use no memo';
+
   const parentContext = useFluent();
   const parentTheme = useTheme();
   const parentOverrides = useOverrides();

--- a/packages/react-components/react-provider/library/src/components/FluentProvider/useFluentProviderStyles.styles.ts
+++ b/packages/react-components/react-provider/library/src/components/FluentProvider/useFluentProviderStyles.styles.ts
@@ -19,6 +19,8 @@ const useStyles = makeStyles({
 
 /** Applies style classnames to slots */
 export const useFluentProviderStyles_unstable = (state: FluentProviderState) => {
+  'use no memo';
+
   const renderer = useRenderer_unstable();
   const styles = useStyles({ dir: state.dir, renderer });
 

--- a/packages/react-components/react-provider/library/src/components/FluentProvider/useFluentProviderThemeStyleTag.ts
+++ b/packages/react-components/react-provider/library/src/components/FluentProvider/useFluentProviderThemeStyleTag.ts
@@ -47,6 +47,8 @@ const insertSheet = (tag: HTMLStyleElement, rule: string) => {
 export const useFluentProviderThemeStyleTag = (
   options: Pick<FluentProviderState, 'theme' | 'targetDocument'> & { rendererAttributes: Record<string, string> },
 ) => {
+  'use no memo';
+
   const { targetDocument, theme, rendererAttributes } = options;
 
   const styleTag = React.useRef<HTMLStyleElement | undefined | null>();

--- a/packages/react-components/react-radio/library/src/components/Radio/useRadioStyles.styles.ts
+++ b/packages/react-components/react-radio/library/src/components/Radio/useRadioStyles.styles.ts
@@ -208,6 +208,8 @@ const useLabelStyles = makeStyles({
  * Apply styling to the Radio slots based on the state
  */
 export const useRadioStyles_unstable = (state: RadioState): RadioState => {
+  'use no memo';
+
   const { labelPosition } = state;
 
   const rootBaseClassName = useRootBaseClassName();

--- a/packages/react-components/react-radio/library/src/components/RadioGroup/useRadioGroupStyles.styles.ts
+++ b/packages/react-components/react-radio/library/src/components/RadioGroup/useRadioGroupStyles.styles.ts
@@ -21,6 +21,8 @@ const useStyles = makeStyles({
  * Apply styling to the RadioGroup slots based on the state
  */
 export const useRadioGroupStyles_unstable = (state: RadioGroupState): RadioGroupState => {
+  'use no memo';
+
   const styles = useStyles();
 
   state.root.className = mergeClasses(

--- a/packages/react-components/react-rating/library/src/components/Rating/useRatingStyles.styles.ts
+++ b/packages/react-components/react-rating/library/src/components/Rating/useRatingStyles.styles.ts
@@ -19,6 +19,8 @@ const useRootClassName = makeResetStyles({
  * Apply styling to the Rating slots based on the state
  */
 export const useRatingStyles_unstable = (state: RatingState): RatingState => {
+  'use no memo';
+
   const rootClassName = useRootClassName();
   state.root.className = mergeClasses(ratingClassNames.root, rootClassName, state.root.className);
   return state;

--- a/packages/react-components/react-rating/library/src/components/RatingDisplay/useRatingDisplayStyles.styles.ts
+++ b/packages/react-components/react-rating/library/src/components/RatingDisplay/useRatingDisplayStyles.styles.ts
@@ -50,6 +50,8 @@ const useLabelStyles = makeStyles({
  * Apply styling to the RatingDisplay slots based on the state
  */
 export const useRatingDisplayStyles_unstable = (state: RatingDisplayState): RatingDisplayState => {
+  'use no memo';
+
   const { size } = state;
   const rootClassName = useRootClassName();
   state.root.className = mergeClasses(ratingDisplayClassNames.root, rootClassName, state.root.className);

--- a/packages/react-components/react-rating/library/src/components/RatingItem/useRatingItemStyles.styles.ts
+++ b/packages/react-components/react-rating/library/src/components/RatingItem/useRatingItemStyles.styles.ts
@@ -117,6 +117,8 @@ const useIndicatorStyles = makeStyles({
  * Apply styling to the RatingItem slots based on the state
  */
 export const useRatingItemStyles_unstable = (state: RatingItemState): RatingItemState => {
+  'use no memo';
+
   const { color, size, iconFillWidth, appearance } = state;
   const styles = useStyles();
   const inputBaseClassName = useInputBaseClassName();

--- a/packages/react-components/react-search/library/src/components/SearchBox/useSearchBoxStyles.styles.ts
+++ b/packages/react-components/react-search/library/src/components/SearchBox/useSearchBoxStyles.styles.ts
@@ -94,6 +94,8 @@ const useDismissStyles = makeStyles({
  * Apply styling to the SearchBox slots based on the state
  */
 export const useSearchBoxStyles_unstable = (state: SearchBoxState): SearchBoxState => {
+  'use no memo';
+
   const { disabled, focused, size } = state;
 
   const rootStyles = useRootStyles();

--- a/packages/react-components/react-select/library/src/components/Select/useSelectStyles.styles.ts
+++ b/packages/react-components/react-select/library/src/components/Select/useSelectStyles.styles.ts
@@ -242,6 +242,8 @@ const useIconStyles = makeStyles({
  * Apply styling to the Select slots based on the state
  */
 export const useSelectStyles_unstable = (state: SelectState): SelectState => {
+  'use no memo';
+
   const { size, appearance } = state;
   const disabled = state.select.disabled;
   const invalid = `${state.select['aria-invalid']}` === 'true';

--- a/packages/react-components/react-skeleton/library/src/components/Skeleton/useSkeletonStyles.styles.ts
+++ b/packages/react-components/react-skeleton/library/src/components/Skeleton/useSkeletonStyles.styles.ts
@@ -9,6 +9,8 @@ export const skeletonClassNames: SlotClassNames<SkeletonSlots> = {
  * Apply styling to the Skeleton slots based on the state
  */
 export const useSkeletonStyles_unstable = (state: SkeletonState): SkeletonState => {
+  'use no memo';
+
   state.root.className = mergeClasses(skeletonClassNames.root, state.root.className);
 
   return state;

--- a/packages/react-components/react-skeleton/library/src/components/SkeletonItem/useSkeletonItemStyles.styles.ts
+++ b/packages/react-components/react-skeleton/library/src/components/SkeletonItem/useSkeletonItemStyles.styles.ts
@@ -148,6 +148,8 @@ const useCircleSizeStyles = makeStyles({
  * Apply styling to the SkeletonItem slots based on the state
  */
 export const useSkeletonItemStyles_unstable = (state: SkeletonItemState): SkeletonItemState => {
+  'use no memo';
+
   const { animation, appearance, size, shape } = state;
   const { dir } = useFluent();
 

--- a/packages/react-components/react-slider/library/src/components/Slider/useSliderState.tsx
+++ b/packages/react-components/react-slider/library/src/components/Slider/useSliderState.tsx
@@ -11,6 +11,8 @@ const getPercent = (value: number, min: number, max: number) => {
 };
 
 export const useSliderState_unstable = (state: SliderState, props: SliderProps) => {
+  'use no memo';
+
   const { min = 0, max = 100, step } = props;
   const { dir } = useFluent();
   const [currentValue, setCurrentValue] = useControllableState({

--- a/packages/react-components/react-slider/library/src/components/Slider/useSliderStyles.styles.ts
+++ b/packages/react-components/react-slider/library/src/components/Slider/useSliderStyles.styles.ts
@@ -254,6 +254,8 @@ const useInputStyles = makeStyles({
  * Apply styling to the Slider slots based on the state
  */
 export const useSliderStyles_unstable = (state: SliderState): SliderState => {
+  'use no memo';
+
   const rootStyles = useRootStyles();
   const railStyles = useRailStyles();
   const thumbStyles = useThumbStyles();

--- a/packages/react-components/react-spinbutton/library/src/components/SpinButton/useSpinButtonStyles.styles.ts
+++ b/packages/react-components/react-spinbutton/library/src/components/SpinButton/useSpinButtonStyles.styles.ts
@@ -474,6 +474,8 @@ const useButtonDisabledStyles = makeStyles({
  * Apply styling to the SpinButton slots based on the state
  */
 export const useSpinButtonStyles_unstable = (state: SpinButtonState): SpinButtonState => {
+  'use no memo';
+
   const { appearance, atBound, spinState, size } = state;
   const disabled = state.input.disabled;
   const invalid = `${state.input['aria-invalid']}` === 'true';

--- a/packages/react-components/react-spinner/library/src/components/Spinner/useSpinnerStyles.styles.ts
+++ b/packages/react-components/react-spinner/library/src/components/Spinner/useSpinnerStyles.styles.ts
@@ -224,6 +224,8 @@ const useLabelStyles = makeStyles({
  * Apply styling to the Spinner slots based on the state
  */
 export const useSpinnerStyles_unstable = (state: SpinnerState): SpinnerState => {
+  'use no memo';
+
   const { labelPosition, size, appearance } = state;
   const { dir } = useFluent();
 

--- a/packages/react-components/react-swatch-picker/library/src/components/ColorSwatch/useColorSwatchStyles.styles.ts
+++ b/packages/react-components/react-swatch-picker/library/src/components/ColorSwatch/useColorSwatchStyles.styles.ts
@@ -151,6 +151,8 @@ const useIconStyles = makeStyles({
  * Apply styling to the ColorSwatch slots based on the state
  */
 export const useColorSwatchStyles_unstable = (state: ColorSwatchState): ColorSwatchState => {
+  'use no memo';
+
   const resetStyles = useResetStyles();
   const styles = useStyles();
   const sizeStyles = useSizeStyles();

--- a/packages/react-components/react-swatch-picker/library/src/components/EmptySwatch/useEmptySwatchStyles.styles.ts
+++ b/packages/react-components/react-swatch-picker/library/src/components/EmptySwatch/useEmptySwatchStyles.styles.ts
@@ -54,6 +54,8 @@ const useShapeStyles = makeStyles({
  * Apply styling to the EmptySwatch slots based on the state
  */
 export const useEmptySwatchStyles_unstable = (state: EmptySwatchState): EmptySwatchState => {
+  'use no memo';
+
   const styles = useStyles();
   const sizeStyles = useSizeStyles();
   const shapeStyles = useShapeStyles();

--- a/packages/react-components/react-swatch-picker/library/src/components/ImageSwatch/useImageSwatchStyles.styles.ts
+++ b/packages/react-components/react-swatch-picker/library/src/components/ImageSwatch/useImageSwatchStyles.styles.ts
@@ -109,6 +109,8 @@ const useShapeStyles = makeStyles({
  * Apply styling to the ImageSwatch slots based on the state
  */
 export const useImageSwatchStyles_unstable = (state: ImageSwatchState): ImageSwatchState => {
+  'use no memo';
+
   const styles = useStyles();
   const selectedStyles = useStylesSelected();
   const sizeStyles = useSizeStyles();

--- a/packages/react-components/react-swatch-picker/library/src/components/SwatchPicker/useSwatchPickerStyles.styles.ts
+++ b/packages/react-components/react-swatch-picker/library/src/components/SwatchPicker/useSwatchPickerStyles.styles.ts
@@ -28,6 +28,8 @@ const useStyles = makeStyles({
  * Apply styling to the SwatchPicker slots based on the state
  */
 export const useSwatchPickerStyles_unstable = (state: SwatchPickerState): SwatchPickerState => {
+  'use no memo';
+
   const styles = useStyles();
   const layoutStyle = state.isGrid ? styles.grid : styles.row;
 

--- a/packages/react-components/react-swatch-picker/library/src/components/SwatchPickerRow/useSwatchPickerRowStyles.styles.ts
+++ b/packages/react-components/react-swatch-picker/library/src/components/SwatchPickerRow/useSwatchPickerRowStyles.styles.ts
@@ -27,6 +27,8 @@ const useStyles = makeStyles({
  * Apply styling to the SwatchPickerRow slots based on the state
  */
 export const useSwatchPickerRowStyles_unstable = (state: SwatchPickerRowState): SwatchPickerRowState => {
+  'use no memo';
+
   const resetStyles = useResetStyles();
   const styles = useStyles();
   const spacingStyle = state.spacing === 'small' ? styles.spacingSmall : styles.spacingMedium;

--- a/packages/react-components/react-switch/library/src/components/Switch/useSwitchStyles.styles.ts
+++ b/packages/react-components/react-switch/library/src/components/Switch/useSwitchStyles.styles.ts
@@ -262,6 +262,8 @@ const useLabelStyles = makeStyles({
  * Apply styling to the Switch slots based on the state
  */
 export const useSwitchStyles_unstable = (state: SwitchState): SwitchState => {
+  'use no memo';
+
   const rootBaseClassName = useRootBaseClassName();
   const rootStyles = useRootStyles();
   const indicatorBaseClassName = useIndicatorBaseClassName();

--- a/packages/react-components/react-table/library/src/components/DataGrid/useDataGridStyles.styles.ts
+++ b/packages/react-components/react-table/library/src/components/DataGrid/useDataGridStyles.styles.ts
@@ -11,6 +11,8 @@ export const dataGridClassNames: SlotClassNames<DataGridSlots> = {
  * Apply styling to the DataGrid slots based on the state
  */
 export const useDataGridStyles_unstable = (state: DataGridState): DataGridState => {
+  'use no memo';
+
   useTableStyles_unstable(state);
   state.root.className = mergeClasses(dataGridClassNames.root, state.root.className);
 

--- a/packages/react-components/react-table/library/src/components/DataGridBody/useDataGridBodyStyles.styles.ts
+++ b/packages/react-components/react-table/library/src/components/DataGridBody/useDataGridBodyStyles.styles.ts
@@ -11,6 +11,8 @@ export const dataGridBodyClassNames: SlotClassNames<DataGridBodySlots> = {
  * Apply styling to the DataGridBody slots based on the state
  */
 export const useDataGridBodyStyles_unstable = (state: DataGridBodyState): DataGridBodyState => {
+  'use no memo';
+
   useTableBodyStyles_unstable(state);
   state.root.className = mergeClasses(dataGridBodyClassNames.root, state.root.className);
 

--- a/packages/react-components/react-table/library/src/components/DataGridCell/useDataGridCellStyles.styles.ts
+++ b/packages/react-components/react-table/library/src/components/DataGridCell/useDataGridCellStyles.styles.ts
@@ -11,6 +11,8 @@ export const dataGridCellClassNames: SlotClassNames<DataGridCellSlots> = {
  * Apply styling to the DataGridCell slots based on the state
  */
 export const useDataGridCellStyles_unstable = (state: DataGridCellState): DataGridCellState => {
+  'use no memo';
+
   useTableCellStyles_unstable(state);
   state.root.className = mergeClasses(dataGridCellClassNames.root, state.root.className);
 

--- a/packages/react-components/react-table/library/src/components/DataGridHeader/useDataGridHeaderStyles.styles.ts
+++ b/packages/react-components/react-table/library/src/components/DataGridHeader/useDataGridHeaderStyles.styles.ts
@@ -11,6 +11,8 @@ export const dataGridHeaderClassNames: SlotClassNames<DataGridHeaderSlots> = {
  * Apply styling to the DataGridHeader slots based on the state
  */
 export const useDataGridHeaderStyles_unstable = (state: DataGridHeaderState): DataGridHeaderState => {
+  'use no memo';
+
   useTableHeaderStyles_unstable(state);
   state.root.className = mergeClasses(dataGridHeaderClassNames.root, state.root.className);
 

--- a/packages/react-components/react-table/library/src/components/DataGridHeaderCell/useDataGridHeaderCellStyles.styles.ts
+++ b/packages/react-components/react-table/library/src/components/DataGridHeaderCell/useDataGridHeaderCellStyles.styles.ts
@@ -14,6 +14,8 @@ export const dataGridHeaderCellClassNames: SlotClassNames<DataGridHeaderCellSlot
  * Apply styling to the DataGridHeaderCell slots based on the state
  */
 export const useDataGridHeaderCellStyles_unstable = (state: DataGridHeaderCellState): DataGridHeaderCellState => {
+  'use no memo';
+
   useTableHeaderCellStyles_unstable(state);
   state.root.className = mergeClasses(dataGridHeaderCellClassNames.root, state.root.className);
 

--- a/packages/react-components/react-table/library/src/components/DataGridRow/useDataGridRowStyles.styles.ts
+++ b/packages/react-components/react-table/library/src/components/DataGridRow/useDataGridRowStyles.styles.ts
@@ -12,6 +12,8 @@ export const dataGridRowClassNames: SlotClassNames<DataGridRowSlots> = {
  * Apply styling to the DataGridRow slots based on the state
  */
 export const useDataGridRowStyles_unstable = (state: DataGridRowState): DataGridRowState => {
+  'use no memo';
+
   useTableRowStyles_unstable(state);
   state.root.className = mergeClasses(dataGridRowClassNames.root, state.root.className);
   if (state.selectionCell) {

--- a/packages/react-components/react-table/library/src/components/DataGridSelectionCell/useDataGridSelectionCellStyles.styles.ts
+++ b/packages/react-components/react-table/library/src/components/DataGridSelectionCell/useDataGridSelectionCellStyles.styles.ts
@@ -15,6 +15,8 @@ export const dataGridSelectionCellClassNames: SlotClassNames<DataGridSelectionCe
 export const useDataGridSelectionCellStyles_unstable = (
   state: DataGridSelectionCellState,
 ): DataGridSelectionCellState => {
+  'use no memo';
+
   useTableSelectionCellStyles_unstable(state);
   state.root.className = mergeClasses(dataGridSelectionCellClassNames.root, state.root.className);
 

--- a/packages/react-components/react-table/library/src/components/Table/useTableStyles.styles.ts
+++ b/packages/react-components/react-table/library/src/components/Table/useTableStyles.styles.ts
@@ -37,6 +37,8 @@ const useStyles = makeStyles({
  * Apply styling to the Table slots based on the state
  */
 export const useTableStyles_unstable = (state: TableState): TableState => {
+  'use no memo';
+
   const styles = useStyles();
   const layoutStyles = {
     table: useTableLayoutStyles(),

--- a/packages/react-components/react-table/library/src/components/TableBody/useTableBodyStyles.styles.ts
+++ b/packages/react-components/react-table/library/src/components/TableBody/useTableBodyStyles.styles.ts
@@ -23,6 +23,8 @@ export const tableBodyClassNames: SlotClassNames<TableBodySlots> = {
  * Apply styling to the TableBody slots based on the state
  */
 export const useTableBodyStyles_unstable = (state: TableBodyState): TableBodyState => {
+  'use no memo';
+
   const layoutStyles = {
     table: useTableLayoutStyles(),
     flex: useFlexLayoutStyles(),

--- a/packages/react-components/react-table/library/src/components/TableCell/useTableCellStyles.styles.ts
+++ b/packages/react-components/react-table/library/src/components/TableCell/useTableCellStyles.styles.ts
@@ -68,6 +68,8 @@ const useStyles = makeStyles({
  * Apply styling to the TableCell slots based on the state
  */
 export const useTableCellStyles_unstable = (state: TableCellState): TableCellState => {
+  'use no memo';
+
   const styles = useStyles();
   const layoutStyles = {
     table: useTableLayoutStyles(),

--- a/packages/react-components/react-table/library/src/components/TableCellActions/useTableCellActionsStyles.styles.ts
+++ b/packages/react-components/react-table/library/src/components/TableCellActions/useTableCellActionsStyles.styles.ts
@@ -29,6 +29,8 @@ const useStyles = makeStyles({
  * Apply styling to the TableCellActions slots based on the state
  */
 export const useTableCellActionsStyles_unstable = (state: TableCellActionsState): TableCellActionsState => {
+  'use no memo';
+
   const styles = useStyles();
   state.root.className = mergeClasses(
     tableCellActionsClassNames.root,

--- a/packages/react-components/react-table/library/src/components/TableCellLayout/useTableCellLayoutStyles.styles.ts
+++ b/packages/react-components/react-table/library/src/components/TableCellLayout/useTableCellLayoutStyles.styles.ts
@@ -73,6 +73,8 @@ const useStyles = makeStyles({
  * Apply styling to the TableCellLayout slots based on the state
  */
 export const useTableCellLayoutStyles_unstable = (state: TableCellLayoutState): TableCellLayoutState => {
+  'use no memo';
+
   const styles = useStyles();
   const { truncate } = state;
 

--- a/packages/react-components/react-table/library/src/components/TableHeader/useTableHeaderStyles.styles.ts
+++ b/packages/react-components/react-table/library/src/components/TableHeader/useTableHeaderStyles.styles.ts
@@ -23,6 +23,8 @@ const useTableLayoutStyles = makeStyles({
  * Apply styling to the TableHeader slots based on the state
  */
 export const useTableHeaderStyles_unstable = (state: TableHeaderState): TableHeaderState => {
+  'use no memo';
+
   const layoutStyles = {
     table: useTableLayoutStyles(),
     flex: useFlexLayoutStyles(),

--- a/packages/react-components/react-table/library/src/components/TableHeaderCell/useTableHeaderCellStyles.styles.ts
+++ b/packages/react-components/react-table/library/src/components/TableHeaderCell/useTableHeaderCellStyles.styles.ts
@@ -94,6 +94,8 @@ const useStyles = makeStyles({
  * Apply styling to the TableHeaderCell slots based on the state
  */
 export const useTableHeaderCellStyles_unstable = (state: TableHeaderCellState): TableHeaderCellState => {
+  'use no memo';
+
   const styles = useStyles();
   const layoutStyles = {
     table: useTableLayoutStyles(),

--- a/packages/react-components/react-table/library/src/components/TableResizeHandle/useTableResizeHandleStyles.styles.ts
+++ b/packages/react-components/react-table/library/src/components/TableResizeHandle/useTableResizeHandleStyles.styles.ts
@@ -54,6 +54,8 @@ const useStyles = makeStyles({
  * Apply styling to the TableResizeHandle slots based on the state
  */
 export const useTableResizeHandleStyles_unstable = (state: TableResizeHandleState): TableResizeHandleState => {
+  'use no memo';
+
   const styles = useStyles();
   state.root.className = mergeClasses(tableResizeHandleClassNames.root, styles.root, state.root.className);
   return state;

--- a/packages/react-components/react-table/library/src/components/TableRow/useTableRowStyles.styles.ts
+++ b/packages/react-components/react-table/library/src/components/TableRow/useTableRowStyles.styles.ts
@@ -132,6 +132,8 @@ const useStyles = makeStyles({
  * Apply styling to the TableRow slots based on the state
  */
 export const useTableRowStyles_unstable = (state: TableRowState): TableRowState => {
+  'use no memo';
+
   const styles = useStyles();
   const layoutStyles = {
     table: useTableLayoutStyles(),

--- a/packages/react-components/react-table/library/src/components/TableSelectionCell/useTableSelectionCellStyles.styles.ts
+++ b/packages/react-components/react-table/library/src/components/TableSelectionCell/useTableSelectionCellStyles.styles.ts
@@ -69,6 +69,8 @@ const useStyles = makeStyles({
  * Apply styling to the TableSelectionCell slots based on the state
  */
 export const useTableSelectionCellStyles_unstable = (state: TableSelectionCellState): TableSelectionCellState => {
+  'use no memo';
+
   const styles = useStyles();
   const layoutStyles = {
     table: useTableLayoutStyles(),

--- a/packages/react-components/react-table/library/src/hooks/useTableColumnSizing.tsx
+++ b/packages/react-components/react-table/library/src/hooks/useTableColumnSizing.tsx
@@ -25,6 +25,8 @@ export const defaultColumnSizingState: TableColumnSizingState = {
 };
 
 export function useTableColumnSizing_unstable<TItem>(params?: UseTableColumnSizingParams) {
+  'use no memo';
+
   // False positive, these plugin hooks are intended to be run on every render
 
   return (tableState: TableFeaturesState<TItem>) =>

--- a/packages/react-components/react-table/library/src/hooks/useTableSelection.ts
+++ b/packages/react-components/react-table/library/src/hooks/useTableSelection.ts
@@ -18,6 +18,8 @@ export const defaultTableSelectionState: TableSelectionState = {
 };
 
 export function useTableSelection<TItem>(options: SelectionHookParams) {
+  'use no memo';
+
   // False positive, these plugin hooks are intended to be run on every render
   // eslint-disable-next-line react-hooks/rules-of-hooks
   return (tableState: TableFeaturesState<TItem>) => useTableSelectionState(tableState, options);

--- a/packages/react-components/react-table/library/src/hooks/useTableSort.ts
+++ b/packages/react-components/react-table/library/src/hooks/useTableSort.ts
@@ -21,6 +21,8 @@ export const defaultTableSortState: TableSortState<unknown> = {
 };
 
 export function useTableSort<TItem>(options: UseTableSortOptions) {
+  'use no memo';
+
   // False positive, these plugin hooks are intended to be run on every render
   // eslint-disable-next-line react-hooks/rules-of-hooks
   return (tableState: TableFeaturesState<TItem>) => useTableSortState(tableState, options);

--- a/packages/react-components/react-tabs/library/src/components/Tab/useTabStyles.styles.ts
+++ b/packages/react-components/react-tabs/library/src/components/Tab/useTabStyles.styles.ts
@@ -438,6 +438,8 @@ const useContentStyles = makeStyles({
  * Apply styling to the Tab slots based on the state
  */
 export const useTabStyles_unstable = (state: TabState): TabState => {
+  'use no memo';
+
   const rootStyles = useRootStyles();
   const focusStyles = useFocusStyles();
   const pendingIndicatorStyles = usePendingIndicatorStyles();

--- a/packages/react-components/react-tabs/library/src/components/TabList/useTabListStyles.styles.ts
+++ b/packages/react-components/react-tabs/library/src/components/TabList/useTabListStyles.styles.ts
@@ -31,6 +31,8 @@ const useStyles = makeStyles({
  * Apply styling to the TabList slots based on the state
  */
 export const useTabListStyles_unstable = (state: TabListState): TabListState => {
+  'use no memo';
+
   const { vertical } = state;
 
   const styles = useStyles();

--- a/packages/react-components/react-tabster/src/hooks/useMergeTabsterAttributes.ts
+++ b/packages/react-components/react-tabster/src/hooks/useMergeTabsterAttributes.ts
@@ -12,6 +12,8 @@ import { Types, TABSTER_ATTRIBUTE_NAME } from 'tabster';
 export const useMergedTabsterAttributes_unstable: (
   ...attributes: Types.TabsterDOMAttribute[]
 ) => Types.TabsterDOMAttribute = (...attributes) => {
+  'use no memo';
+
   const stringAttributes = attributes.map(attribute => attribute[TABSTER_ATTRIBUTE_NAME]).filter(Boolean) as string[];
 
   return React.useMemo(() => {

--- a/packages/react-components/react-tag-picker/library/etc/react-tag-picker.api.md
+++ b/packages/react-components/react-tag-picker/library/etc/react-tag-picker.api.md
@@ -261,7 +261,7 @@ export const useTagPickerGroup_unstable: (props: TagPickerGroupProps, ref: React
 export const useTagPickerGroupStyles_unstable: (state: TagPickerGroupState) => TagPickerGroupState;
 
 // @public
-export const useTagPickerInput_unstable: (props: TagPickerInputProps, ref: React_2.Ref<HTMLInputElement>) => TagPickerInputState;
+export const useTagPickerInput_unstable: (propsArg: TagPickerInputProps, ref: React_2.Ref<HTMLInputElement>) => TagPickerInputState;
 
 // @public
 export const useTagPickerInputStyles_unstable: (state: TagPickerInputState) => TagPickerInputState;

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerButton/useTagPickerButtonStyles.styles.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerButton/useTagPickerButtonStyles.styles.ts
@@ -126,6 +126,8 @@ const useStyles = makeStyles({
  * Apply styling to the PickerButton slots based on the state
  */
 export const useTagPickerButtonStyles_unstable = (state: TagPickerButtonState): TagPickerButtonState => {
+  'use no memo';
+
   const styles = useStyles();
   state.root.className = mergeClasses(
     tagPickerButtonClassNames.root,

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerControl/useTagPickerControlStyles.styles.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerControl/useTagPickerControlStyles.styles.ts
@@ -218,6 +218,8 @@ const useIconStyles = makeStyles({
  * Apply styling to the PickerControl slots based on the state
  */
 export const useTagPickerControlStyles_unstable = (state: TagPickerControlState): TagPickerControlState => {
+  'use no memo';
+
   const styles = useStyles();
   const iconStyles = useIconStyles();
   const asideStyles = useAsideStyles();

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerGroup/useTagPickerGroupStyles.styles.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerGroup/useTagPickerGroupStyles.styles.ts
@@ -37,6 +37,8 @@ const useStyles = makeStyles({
  * Apply styling to the TagPickerGroup slots based on the state
  */
 export const useTagPickerGroupStyles_unstable = (state: TagPickerGroupState): TagPickerGroupState => {
+  'use no memo';
+
   useTagGroupStyles_unstable(state);
   const styles = useStyles();
   state.root.className = mergeClasses(

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerInput/useTagPickerInput.tsx
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerInput/useTagPickerInput.tsx
@@ -25,10 +25,14 @@ import { useFocusFinders } from '@fluentui/react-tabster';
  * @param ref - reference to root HTMLDivElement of TagPickerInput
  */
 export const useTagPickerInput_unstable = (
-  props: TagPickerInputProps,
+  propsArg: TagPickerInputProps,
   ref: React.Ref<HTMLInputElement>,
 ): TagPickerInputState => {
-  props = useFieldControlProps_unstable(props, { supportsLabelFor: true, supportsRequired: true, supportsSize: true });
+  const props = useFieldControlProps_unstable(propsArg, {
+    supportsLabelFor: true,
+    supportsRequired: true,
+    supportsSize: true,
+  });
   const { controller: activeDescendantController } = useActiveDescendantContext();
   const size = useTagPickerContext_unstable(ctx => ctx.size);
   const contextDisabled = useTagPickerContext_unstable(ctx => ctx.disabled);

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerInput/useTagPickerInputStyles.styles.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerInput/useTagPickerInputStyles.styles.ts
@@ -66,6 +66,8 @@ const useStyles = makeStyles({
  * Apply styling to the TagPickerInput slots based on the state
  */
 export const useTagPickerInputStyles_unstable = (state: TagPickerInputState): TagPickerInputState => {
+  'use no memo';
+
   const baseStyle = useBaseStyle();
   const styles = useStyles();
   state.root.className = mergeClasses(

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerList/useTagPickerListStyles.styles.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerList/useTagPickerListStyles.styles.ts
@@ -27,6 +27,8 @@ const useStyles = makeStyles({
  * Apply styling to the TagPickerList slots based on the state
  */
 export const useTagPickerListStyles_unstable = (state: TagPickerListState): TagPickerListState => {
+  'use no memo';
+
   const styles = useStyles();
   state.root.className = mergeClasses(
     tagPickerListClassNames.root,

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerOption/useTagPickerOptionStyles.styles.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerOption/useTagPickerOptionStyles.styles.ts
@@ -33,6 +33,8 @@ const useStyles = makeStyles({
  * Apply styling to the TagPickerOption slots based on the state
  */
 export const useTagPickerOptionStyles_unstable = (state: TagPickerOptionState): TagPickerOptionState => {
+  'use no memo';
+
   useOptionStyles_unstable({
     ...state,
     active: false,

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerOptionGroup/useTagPickerOptionGroupStyles.styles.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerOptionGroup/useTagPickerOptionGroupStyles.styles.ts
@@ -12,6 +12,8 @@ export const tagPickerOptionGroupClassNames: SlotClassNames<TagPickerOptionGroup
  * Apply styling to the TagPickerOptionGroup slots based on the state
  */
 export const useTagPickerOptionGroupStyles = (state: TagPickerOptionGroupState): TagPickerOptionGroupState => {
+  'use no memo';
+
   useOptionGroupStyles_unstable(state);
   state.root.className = mergeClasses(tagPickerOptionGroupClassNames.root, state.root.className);
 

--- a/packages/react-components/react-tags/library/src/components/InteractionTag/useInteractionTagStyles.styles.ts
+++ b/packages/react-components/react-tags/library/src/components/InteractionTag/useInteractionTagStyles.styles.ts
@@ -33,6 +33,8 @@ const useRootStyles = makeStyles({
  * Apply styling to the InteractionTag slots based on the state
  */
 export const useInteractionTagStyles_unstable = (state: InteractionTagState): InteractionTagState => {
+  'use no memo';
+
   const rootBaseClassName = useRootBaseClassName();
   const rootStyles = useRootStyles();
 

--- a/packages/react-components/react-tags/library/src/components/InteractionTagPrimary/useInteractionTagPrimaryStyles.styles.ts
+++ b/packages/react-components/react-tags/library/src/components/InteractionTagPrimary/useInteractionTagPrimaryStyles.styles.ts
@@ -263,6 +263,8 @@ const useRootWithSecondaryActionStyles = makeStyles({
 export const useInteractionTagPrimaryStyles_unstable = (
   state: InteractionTagPrimaryState,
 ): InteractionTagPrimaryState => {
+  'use no memo';
+
   const rootRoundedBaseClassName = useRootRoundedBaseClassName();
   const rootCircularBaseClassName = useRootCircularBaseClassName();
   const rootStyles = useRootStyles();

--- a/packages/react-components/react-tags/library/src/components/InteractionTagSecondary/useInteractionTagSecondaryStyles.styles.ts
+++ b/packages/react-components/react-tags/library/src/components/InteractionTagSecondary/useInteractionTagSecondaryStyles.styles.ts
@@ -156,6 +156,8 @@ const useRootDisabledStyles = makeStyles({
 export const useInteractionTagSecondaryStyles_unstable = (
   state: InteractionTagSecondaryState,
 ): InteractionTagSecondaryState => {
+  'use no memo';
+
   const rootBaseClassName = useRootBaseClassName();
   const rootStyles = useRootStyles();
   const rootDisabledStyles = useRootDisabledStyles();

--- a/packages/react-components/react-tags/library/src/components/Tag/useTagStyles.styles.ts
+++ b/packages/react-components/react-tags/library/src/components/Tag/useTagStyles.styles.ts
@@ -325,6 +325,8 @@ export const useSecondaryTextBaseClassName = makeResetStyles({
  * Apply styling to the Tag slots based on the state
  */
 export const useTagStyles_unstable = (state: TagState): TagState => {
+  'use no memo';
+
   const rootRoundedBaseClassName = useRootRoundedBaseClassName();
   const rootCircularBaseClassName = useRootCircularBaseClassName();
 

--- a/packages/react-components/react-tags/library/src/components/TagGroup/useTagGroupStyles.styles.ts
+++ b/packages/react-components/react-tags/library/src/components/TagGroup/useTagGroupStyles.styles.ts
@@ -29,6 +29,8 @@ const useRootStyles = makeStyles({
  * Apply styling to the TagGroup slots based on the state
  */
 export const useTagGroupStyles_unstable = (state: TagGroupState): TagGroupState => {
+  'use no memo';
+
   const styles = useRootStyles();
   const { size } = state;
   state.root.className = mergeClasses(tagGroupClassNames.root, styles.base, styles[size], state.root.className);

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverBody/useTeachingPopoverBodyStyles.styles.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverBody/useTeachingPopoverBodyStyles.styles.ts
@@ -49,6 +49,8 @@ const useStyles = makeStyles({
 
 /** Applies style classnames to slots */
 export const useTeachingPopoverBodyStyles_unstable = (state: TeachingPopoverBodyState) => {
+  'use no memo';
+
   const { mediaLength } = state;
   const styles = useStyles();
   const mediaStyles = useMediaStyles();

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarousel/Carousel/Carousel.tsx
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarousel/Carousel/Carousel.tsx
@@ -25,6 +25,8 @@ export type UseCarouselOptions = {
 // TODO: Migrate this into an external @fluentui/carousel component
 // For now, we won't export this publicly, is only for internal TeachingPopover use until stabilized.
 export function useCarousel_unstable(options: UseCarouselOptions) {
+  'use no memo';
+
   const { onValueChange, onFinish } = options;
 
   const { targetDocument } = useFluent();

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarousel/useTeachingPopoverCarouselStyles.styles.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarousel/useTeachingPopoverCarouselStyles.styles.ts
@@ -13,6 +13,8 @@ const useStyles = makeStyles({
 
 /** Applies style classnames to slots */
 export const useTeachingPopoverCarouselStyles_unstable = (state: TeachingPopoverCarouselState) => {
+  'use no memo';
+
   const styles = useStyles();
 
   state.root.className = mergeClasses(teachingPopoverCarouselClassNames.root, styles.root, state.root.className);

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselCard/useTeachingPopoverCarouselCardStyles.styles.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselCard/useTeachingPopoverCarouselCardStyles.styles.ts
@@ -15,6 +15,8 @@ const useStyles = makeStyles({
 
 /** Applies style classnames to slots */
 export const useTeachingPopoverCarouselCardStyles_unstable = (state: TeachingPopoverCarouselCardState) => {
+  'use no memo';
+
   const styles = useStyles();
 
   state.root.className = mergeClasses(teachingPopoverCarouselCardClassNames.root, styles.root, state.root.className);

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselFooter/useTeachingPopoverCarouselFooterStyles.styles.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselFooter/useTeachingPopoverCarouselFooterStyles.styles.ts
@@ -31,6 +31,8 @@ const useStyles = makeStyles({
 
 /** Applies style classnames to slots */
 export const useTeachingPopoverCarouselFooterStyles_unstable = (state: TeachingPopoverCarouselFooterState) => {
+  'use no memo';
+
   const styles = useStyles();
   const { layout } = state;
 

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselFooterButton/useTeachingPopoverCarouselFooterButtonStyles.styles.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselFooterButton/useTeachingPopoverCarouselFooterButtonStyles.styles.ts
@@ -52,6 +52,8 @@ const useStyles = makeStyles({
 export const useTeachingPopoverCarouselFooterButtonStyles_unstable = (
   state: TeachingPopoverCarouselFooterButtonState,
 ): TeachingPopoverCarouselFooterButtonState => {
+  'use no memo';
+
   const styles = useStyles();
   const { navType, popoverAppearance } = state;
 

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselNav/useTeachingPopoverCarouselNavStyles.styles.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselNav/useTeachingPopoverCarouselNavStyles.styles.ts
@@ -28,6 +28,8 @@ const useStyles = makeStyles({
 
 /** Applies style classnames to slots */
 export const useTeachingPopoverCarouselNavStyles_unstable = (state: TeachingPopoverCarouselNavState) => {
+  'use no memo';
+
   const styles = useStyles();
 
   state.root.className = mergeClasses(teachingPopoverCarouselNavClassNames.root, styles.root, state.root.className);

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselNavButton/useTeachingPopoverCarouselNavButtonStyles.styles.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselNavButton/useTeachingPopoverCarouselNavButtonStyles.styles.ts
@@ -71,6 +71,8 @@ const useStyles = makeStyles({
 export const useTeachingPopoverCarouselNavButtonStyles_unstable = (
   state: TeachingPopoverCarouselNavButtonState,
 ): TeachingPopoverCarouselNavButtonState => {
+  'use no memo';
+
   const styles = useStyles();
   const { appearance, isSelected } = state;
 

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselPageCount/useTeachingPopoverCarouselPageCountStyles.styles.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselPageCount/useTeachingPopoverCarouselPageCountStyles.styles.ts
@@ -26,6 +26,8 @@ const useStyles = makeStyles({
 export const useTeachingPopoverCarouselPageCountStyles_unstable = (
   state: TeachingPopoverCarouselPageCountState,
 ): TeachingPopoverCarouselPageCountState => {
+  'use no memo';
+
   const styles = useStyles();
   state.root.className = mergeClasses(
     teachingPopoverCarouselPageCountClassNames.root,

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverFooter/useTeachingPopoverFooterStyles.styles.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverFooter/useTeachingPopoverFooterStyles.styles.ts
@@ -49,6 +49,8 @@ const useStyles = makeStyles({
 
 /** Applies style classnames to slots */
 export const useTeachingPopoverFooterStyles_unstable = (state: TeachingPopoverFooterState) => {
+  'use no memo';
+
   const styles = useStyles();
   const { appearance, footerLayout } = state;
 

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverHeader/useTeachingPopoverHeaderStyles.styles.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverHeader/useTeachingPopoverHeaderStyles.styles.ts
@@ -73,6 +73,8 @@ const useStyles = makeStyles({
 
 /** Applies style classnames to slots */
 export const useTeachingPopoverHeaderStyles_unstable = (state: TeachingPopoverHeaderState) => {
+  'use no memo';
+
   const styles = useStyles();
   const { appearance } = state;
 

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverSurface/useTeachingPopoverSurfaceStyles.styles.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverSurface/useTeachingPopoverSurfaceStyles.styles.ts
@@ -23,6 +23,8 @@ const useStyles = makeStyles({
 export const useTeachingPopoverSurfaceStyles_unstable = (
   state: TeachingPopoverSurfaceState,
 ): TeachingPopoverSurfaceState => {
+  'use no memo';
+
   const styles = useStyles();
 
   // Make sure to merge teaching bubble surface prior to popover styles

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverTitle/useTeachingPopoverTitleStyles.styles.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverTitle/useTeachingPopoverTitleStyles.styles.ts
@@ -51,6 +51,8 @@ const useStyles = makeStyles({
 
 /** Applies style classnames to slots */
 export const useTeachingPopoverTitleStyles_unstable = (state: TeachingPopoverTitleState) => {
+  'use no memo';
+
   const styles = useStyles();
   const { appearance } = state;
 

--- a/packages/react-components/react-text/library/src/components/Text/useTextStyles.styles.ts
+++ b/packages/react-components/react-text/library/src/components/Text/useTextStyles.styles.ts
@@ -110,6 +110,8 @@ const useStyles = makeStyles({
  * Apply styling to the Text slots based on the state
  */
 export const useTextStyles_unstable = (state: TextState): TextState => {
+  'use no memo';
+
   const styles = useStyles();
 
   state.root.className = mergeClasses(

--- a/packages/react-components/react-text/library/src/components/presets/createPreset.ts
+++ b/packages/react-components/react-text/library/src/components/presets/createPreset.ts
@@ -11,6 +11,8 @@ export function createPreset(options: {
 }): React.FunctionComponent<TextPresetProps> {
   const { useStyles, className, displayName } = options;
   const Wrapper: ForwardRefComponent<TextPresetProps> = React.forwardRef((props, ref) => {
+    'use no memo';
+
     const styles = useStyles();
     const state = useText_unstable(props as TextProps, ref);
 

--- a/packages/react-components/react-textarea/library/src/components/Textarea/useTextareaStyles.styles.ts
+++ b/packages/react-components/react-textarea/library/src/components/Textarea/useTextareaStyles.styles.ts
@@ -222,6 +222,8 @@ const useTextareaResizeStyles = makeStyles({
  * Apply styling to the Textarea slots based on the state
  */
 export const useTextareaStyles_unstable = (state: TextareaState): TextareaState => {
+  'use no memo';
+
   const { size, appearance, resize } = state;
   const disabled = state.textarea.disabled;
   const invalid = `${state.textarea['aria-invalid']}` === 'true';

--- a/packages/react-components/react-timepicker-compat/library/src/components/TimePicker/useTimePickerStyles.styles.ts
+++ b/packages/react-components/react-timepicker-compat/library/src/components/TimePicker/useTimePickerStyles.styles.ts
@@ -21,6 +21,8 @@ const useStyles = makeStyles({
  * Apply styling to the TimePicker slots based on the state
  */
 export const useTimePickerStyles_unstable = (state: TimePickerState): TimePickerState => {
+  'use no memo';
+
   const styles = useStyles();
 
   state.root.className = mergeClasses(timePickerClassNames.root, state.root.className);

--- a/packages/react-components/react-toast/library/src/components/AriaLive/useAriaLiveStyles.styles.ts
+++ b/packages/react-components/react-toast/library/src/components/AriaLive/useAriaLiveStyles.styles.ts
@@ -24,6 +24,8 @@ const useResetStyles = makeResetStyles({
  * Apply styling to the AriaLive slots based on the state
  */
 export const useAriaLiveStyles_unstable = (state: AriaLiveState): AriaLiveState => {
+  'use no memo';
+
   const visuallyHidden = useResetStyles();
   state.assertive.className = mergeClasses(visuallyHidden, ariaLiveClassNames.assertive, state.assertive.className);
   state.polite.className = mergeClasses(visuallyHidden, ariaLiveClassNames.polite, state.polite.className);

--- a/packages/react-components/react-toast/library/src/components/Toast/useToastStyles.styles.ts
+++ b/packages/react-components/react-toast/library/src/components/Toast/useToastStyles.styles.ts
@@ -32,6 +32,8 @@ const useStyles = makeStyles({
  * Apply styling to the Toast slots based on the state
  */
 export const useToastStyles_unstable = (state: ToastState): ToastState => {
+  'use no memo';
+
   const rootBaseClassName = useRootBaseClassName();
   const styles = useStyles();
   state.root.className = mergeClasses(

--- a/packages/react-components/react-toast/library/src/components/ToastBody/useToastBodyStyles.styles.ts
+++ b/packages/react-components/react-toast/library/src/components/ToastBody/useToastBodyStyles.styles.ts
@@ -42,6 +42,8 @@ const useInvertedStyles = makeStyles({
  * Apply styling to the ToastBody slots based on the state
  */
 export const useToastBodyStyles_unstable = (state: ToastBodyState): ToastBodyState => {
+  'use no memo';
+
   const rootBaseClassName = useRootBaseClassName();
   const subtitleBaseClassName = useSubtitleBaseClassName();
   const invertedStyles = useInvertedStyles();

--- a/packages/react-components/react-toast/library/src/components/ToastContainer/useToastContainerStyles.styles.ts
+++ b/packages/react-components/react-toast/library/src/components/ToastContainer/useToastContainerStyles.styles.ts
@@ -23,6 +23,8 @@ const useRootBaseClassName = makeResetStyles({
  * Apply styling to the ToastContainer slots based on the state
  */
 export const useToastContainerStyles_unstable = (state: ToastContainerState): ToastContainerState => {
+  'use no memo';
+
   const rootBaseClassName = useRootBaseClassName();
   state.root.className = mergeClasses(toastContainerClassNames.root, rootBaseClassName, state.root.className);
 

--- a/packages/react-components/react-toast/library/src/components/ToastFooter/useToastFooterStyles.styles.ts
+++ b/packages/react-components/react-toast/library/src/components/ToastFooter/useToastFooterStyles.styles.ts
@@ -22,6 +22,8 @@ const useRootBaseClassName = makeResetStyles({
  * Apply styling to the ToastFooter slots based on the state
  */
 export const useToastFooterStyles_unstable = (state: ToastFooterState): ToastFooterState => {
+  'use no memo';
+
   const rootBaseClassName = useRootBaseClassName();
   state.root.className = mergeClasses(toastFooterClassNames.root, rootBaseClassName, state.root.className);
 

--- a/packages/react-components/react-toast/library/src/components/ToastTitle/useToastTitleStyles.styles.ts
+++ b/packages/react-components/react-toast/library/src/components/ToastTitle/useToastTitleStyles.styles.ts
@@ -81,6 +81,8 @@ const useIntentIconStylesInverted = makeStyles({
  * Apply styling to the ToastTitle slots based on the state
  */
 export const useToastTitleStyles_unstable = (state: ToastTitleState): ToastTitleState => {
+  'use no memo';
+
   const rootBaseClassName = useRootBaseClassName();
   const actionBaseClassName = useActionBaseClassName();
   const mediaBaseClassName = useMediaBaseClassName();

--- a/packages/react-components/react-toast/library/src/components/Toaster/useToaster.tsx
+++ b/packages/react-components/react-toast/library/src/components/Toaster/useToaster.tsx
@@ -23,6 +23,8 @@ import { useToastAnnounce } from './useToastAnnounce';
  * @param props - props from this instance of Toaster
  */
 export const useToaster_unstable = (props: ToasterProps): ToasterState => {
+  'use no memo';
+
   const { offset, announce: announceProp, mountNode, inline = false, ...rest } = props;
   const announceRef = React.useRef<Announce>(() => null);
   const { toastsToRender, isToastVisible, pauseAllToasts, playAllToasts, tryRestoreFocus, closeAllToasts } =

--- a/packages/react-components/react-toast/library/src/components/Toaster/useToasterStyles.styles.ts
+++ b/packages/react-components/react-toast/library/src/components/Toaster/useToasterStyles.styles.ts
@@ -26,6 +26,8 @@ const useToasterStyles = makeStyles({
  * Apply styling to the Toaster slots based on the state
  */
 export const useToasterStyles_unstable = (state: ToasterState): ToasterState => {
+  'use no memo';
+
   const rootBaseClassName = useRootBaseClassName();
   const styles = useToasterStyles();
   const className = mergeClasses(

--- a/packages/react-components/react-toolbar/library/src/components/Toolbar/useToolbarStyles.styles.ts
+++ b/packages/react-components/react-toolbar/library/src/components/Toolbar/useToolbarStyles.styles.ts
@@ -28,6 +28,8 @@ const useStyles = makeStyles({
  * Apply styling to the Toolbar slots based on the state
  */
 export const useToolbarStyles_unstable = (state: ToolbarState): ToolbarState => {
+  'use no memo';
+
   const styles = useStyles();
   const { vertical, size } = state;
   state.root.className = mergeClasses(

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarButton/useToolbarButtonStyles.styles.ts
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarButton/useToolbarButtonStyles.styles.ts
@@ -16,6 +16,8 @@ const useBaseStyles = makeStyles({
  * Apply styling to the ToolbarButton slots based on the state
  */
 export const useToolbarButtonStyles_unstable = (state: ToolbarButtonState) => {
+  'use no memo';
+
   useButtonStyles_unstable(state);
   const buttonStyles = useBaseStyles();
 

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarDivider/useToolbarDividerStyles.styles.ts
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarDivider/useToolbarDividerStyles.styles.ts
@@ -18,6 +18,8 @@ const useBaseStyles = makeStyles({
  * Apply styling to the ToolbarDivider slots based on the state
  */
 export const useToolbarDividerStyles_unstable = (state: ToolbarDividerState): ToolbarDividerState => {
+  'use no memo';
+
   useDividerStyles_unstable(state);
   const { vertical } = state;
   const toolbarDividerStyles = useBaseStyles();

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarGroup/useToolbarGroupStyles.styles.ts
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarGroup/useToolbarGroupStyles.styles.ts
@@ -10,6 +10,8 @@ export const toolbarGroupClassNames: SlotClassNames<ToolbarGroupSlots> = {
  * Apply styling to the Toolbar slots based on the state
  */
 export const useToolbarGroupStyles_unstable = (state: ToolbarGroupState): ToolbarGroupState => {
+  'use no memo';
+
   state.root.className = mergeClasses(toolbarGroupClassNames.root, state.root.className);
 
   return state;

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarRadioButton/useToolbarRadioButtonStyles.styles.ts
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarRadioButton/useToolbarRadioButtonStyles.styles.ts
@@ -13,6 +13,8 @@ const useBaseStyles = makeStyles({
  * Apply styling to the ToolbarRadioButton slots based on the state
  */
 export const useToolbarRadioButtonStyles_unstable = (state: ToolbarRadioButtonState): ToolbarRadioButtonState => {
+  'use no memo';
+
   useToggleButtonStyles_unstable(state);
   const toggleButtonStyles = useBaseStyles();
 

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarToggleButton/useToolbarToggleButtonStyles.styles.ts
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarToggleButton/useToolbarToggleButtonStyles.styles.ts
@@ -13,6 +13,8 @@ const useBaseStyles = makeStyles({
  * Apply styling to the ToolbarToggleButton slots based on the state
  */
 export const useToolbarToggleButtonStyles_unstable = (state: ToolbarToggleButtonState): ToolbarToggleButtonState => {
+  'use no memo';
+
   useToggleButtonStyles_unstable(state);
   const toggleButtonStyles = useBaseStyles();
 

--- a/packages/react-components/react-tooltip/library/src/components/Tooltip/useTooltip.tsx
+++ b/packages/react-components/react-tooltip/library/src/components/Tooltip/useTooltip.tsx
@@ -32,6 +32,8 @@ import { Escape } from '@fluentui/keyboard-keys';
  * @param props - props from this instance of Tooltip
  */
 export const useTooltip_unstable = (props: TooltipProps): TooltipState => {
+  'use no memo';
+
   const context = useTooltipVisibility();
   const isServerSideRender = useIsSSR();
   const { targetDocument } = useFluent();
@@ -151,7 +153,7 @@ export const useTooltip_unstable = (props: TooltipProps): TooltipState => {
     }
   }, [context, targetDocument, visible, setVisible]);
 
-  // Used to skip showing the tooltip  in certain situations when the trigger is focued.
+  // Used to skip showing the tooltip  in certain situations when the trigger is focused.
   // See comments where this is set for more info.
   const ignoreNextFocusEventRef = React.useRef(false);
 

--- a/packages/react-components/react-tooltip/library/src/components/Tooltip/useTooltipStyles.styles.ts
+++ b/packages/react-components/react-tooltip/library/src/components/Tooltip/useTooltipStyles.styles.ts
@@ -50,6 +50,8 @@ const useStyles = makeStyles({
  * Apply styling to the Tooltip slots based on the state
  */
 export const useTooltipStyles_unstable = (state: TooltipState): TooltipState => {
+  'use no memo';
+
   const styles = useStyles();
 
   state.content.className = mergeClasses(

--- a/packages/react-components/react-tree/library/src/components/FlatTree/useFlatTree.ts
+++ b/packages/react-components/react-tree/library/src/components/FlatTree/useFlatTree.ts
@@ -12,6 +12,8 @@ export const useFlatTree_unstable: (props: FlatTreeProps, ref: React.Ref<HTMLEle
   props,
   ref,
 ) => {
+  'use no memo';
+
   const isRoot = React.useContext(SubtreeContext) === undefined;
   // as level is static, this doesn't break rule of hooks
   // and if this becomes an issue later on, this can be easily converted

--- a/packages/react-components/react-tree/library/src/components/FlatTree/useFlatTreeStyles.styles.ts
+++ b/packages/react-components/react-tree/library/src/components/FlatTree/useFlatTreeStyles.styles.ts
@@ -14,6 +14,8 @@ const useBaseStyles = makeResetStyles({
 });
 
 export const useFlatTreeStyles_unstable = (state: FlatTreeState): FlatTreeState => {
+  'use no memo';
+
   const baseStyles = useBaseStyles();
   state.root.className = mergeClasses(flatTreeClassNames.root, baseStyles, state.root.className);
   return state;

--- a/packages/react-components/react-tree/library/src/components/FlatTree/useHeadlessFlatTree.ts
+++ b/packages/react-components/react-tree/library/src/components/FlatTree/useHeadlessFlatTree.ts
@@ -119,6 +119,8 @@ export function useHeadlessFlatTree_unstable<Props extends HeadlessTreeItemProps
   props: Props[],
   options: HeadlessFlatTreeOptions = {},
 ): HeadlessFlatTreeReturn<Props> {
+  'use no memo';
+
   const headlessTree = React.useMemo(() => createHeadlessTree(props), [props]);
   const [openItems, setOpenItems] = useControllableOpenItems(options);
   const [checkedItems, setCheckedItems] = useFlatControllableCheckedItems(options, headlessTree);

--- a/packages/react-components/react-tree/library/src/components/Tree/useTree.ts
+++ b/packages/react-components/react-tree/library/src/components/Tree/useTree.ts
@@ -10,6 +10,8 @@ import { useTreeNavigation } from '../../hooks/useTreeNavigation';
 import { useTreeContext_unstable } from '../../contexts/treeContext';
 
 export const useTree_unstable = (props: TreeProps, ref: React.Ref<HTMLElement>): TreeState => {
+  'use no memo';
+
   const isRoot = React.useContext(SubtreeContext) === undefined;
   // as level is static, this doesn't break rule of hooks
   // and if this becomes an issue later on, this can be easily converted
@@ -18,6 +20,8 @@ export const useTree_unstable = (props: TreeProps, ref: React.Ref<HTMLElement>):
 };
 
 function useNestedRootTree(props: TreeProps, ref: React.Ref<HTMLElement>): TreeState {
+  'use no memo';
+
   const [openItems, setOpenItems] = useControllableOpenItems(props);
   const checkedItems = useNestedCheckedItems(props);
   const navigation = useTreeNavigation();
@@ -59,6 +63,8 @@ function useNestedRootTree(props: TreeProps, ref: React.Ref<HTMLElement>): TreeS
 }
 
 function useNestedSubtree(props: TreeProps, ref: React.Ref<HTMLElement>): TreeState {
+  'use no memo';
+
   if (process.env.NODE_ENV === 'development') {
     // this doesn't break rule of hooks, as environment is a static value
     // eslint-disable-next-line react-hooks/rules-of-hooks

--- a/packages/react-components/react-tree/library/src/components/Tree/useTreeContextValues.ts
+++ b/packages/react-components/react-tree/library/src/components/Tree/useTreeContextValues.ts
@@ -3,6 +3,8 @@ import { TreeContextValue } from '../../contexts';
 import { TreeContextValues, TreeState } from './Tree.types';
 
 export function useTreeContextValues_unstable(state: TreeState): TreeContextValues {
+  'use no memo';
+
   if (state.contextType === 'root') {
     const {
       openItems,

--- a/packages/react-components/react-tree/library/src/components/Tree/useTreeStyles.styles.ts
+++ b/packages/react-components/react-tree/library/src/components/Tree/useTreeStyles.styles.ts
@@ -20,6 +20,8 @@ const useStyles = makeStyles({
 });
 
 export const useTreeStyles_unstable = (state: TreeState): TreeState => {
+  'use no memo';
+
   const baseStyles = useBaseStyles();
   const styles = useStyles();
   const isSubTree = state.level > 1;

--- a/packages/react-components/react-tree/library/src/components/TreeItem/useTreeItemStyles.styles.ts
+++ b/packages/react-components/react-tree/library/src/components/TreeItem/useTreeItemStyles.styles.ts
@@ -60,6 +60,8 @@ const useStyles = makeStyles({
  * Apply styling to the TreeItem slots based on the state
  */
 export const useTreeItemStyles_unstable = (state: TreeItemState): TreeItemState => {
+  'use no memo';
+
   const baseStyles = useBaseStyles();
   const styles = useStyles();
 

--- a/packages/react-components/react-tree/library/src/components/TreeItemLayout/useTreeItemLayout.tsx
+++ b/packages/react-components/react-tree/library/src/components/TreeItemLayout/useTreeItemLayout.tsx
@@ -33,6 +33,8 @@ export const useTreeItemLayout_unstable = (
   props: TreeItemLayoutProps,
   ref: React.Ref<HTMLElement>,
 ): TreeItemLayoutState => {
+  'use no memo';
+
   const { main, iconAfter, iconBefore } = props;
 
   const layoutRef = useTreeItemContext_unstable(ctx => ctx.layoutRef);

--- a/packages/react-components/react-tree/library/src/components/TreeItemLayout/useTreeItemLayoutStyles.styles.ts
+++ b/packages/react-components/react-tree/library/src/components/TreeItemLayout/useTreeItemLayoutStyles.styles.ts
@@ -157,6 +157,8 @@ const useIconAfterStyles = makeStyles({
  * Apply styling to the TreeItemLayout slots based on the state
  */
 export const useTreeItemLayoutStyles_unstable = (state: TreeItemLayoutState): TreeItemLayoutState => {
+  'use no memo';
+
   const { main, iconAfter, iconBefore, expandIcon, root, aside, actions, selector } = state;
   const rootStyles = useRootStyles();
   const rootBaseStyles = useRootBaseStyles();

--- a/packages/react-components/react-tree/library/src/components/TreeItemPersonaLayout/useTreeItemPersonaLayoutStyles.styles.ts
+++ b/packages/react-components/react-tree/library/src/components/TreeItemPersonaLayout/useTreeItemPersonaLayoutStyles.styles.ts
@@ -130,6 +130,8 @@ const useExpandIconBaseStyles = makeResetStyles({
 export const useTreeItemPersonaLayoutStyles_unstable = (
   state: TreeItemPersonaLayoutState,
 ): TreeItemPersonaLayoutState => {
+  'use no memo';
+
   const rootBaseStyles = useRootBaseStyles();
   const rootStyles = useRootStyles();
   const mediaBaseStyles = useMediaBaseStyles();

--- a/packages/react-components/react-tree/library/src/hooks/useFlatTreeNavigation.ts
+++ b/packages/react-components/react-tree/library/src/hooks/useFlatTreeNavigation.ts
@@ -10,6 +10,8 @@ import * as React from 'react';
 import { useHTMLElementWalkerRef } from './useHTMLElementWalkerRef';
 
 export function useFlatTreeNavigation() {
+  'use no memo';
+
   const { walkerRef, rootRef: walkerRootRef } = useHTMLElementWalkerRef();
   const { rove, initialize: initializeRovingTabIndex } = useRovingTabIndex();
 

--- a/packages/react-components/react-tree/library/src/hooks/useTreeNavigation.ts
+++ b/packages/react-components/react-tree/library/src/hooks/useTreeNavigation.ts
@@ -11,6 +11,8 @@ import { useMergedRefs } from '@fluentui/react-utilities';
  * @internal
  */
 export function useTreeNavigation() {
+  'use no memo';
+
   const { rove, initialize: initializeRovingTabIndex } = useRovingTabIndex();
   const { walkerRef, rootRef: walkerRootRef } = useHTMLElementWalkerRef();
 

--- a/packages/react-components/react-utilities/src/hooks/useControllableState.ts
+++ b/packages/react-components/react-utilities/src/hooks/useControllableState.ts
@@ -43,6 +43,8 @@ function isFactoryDispatch<State>(newState: React.SetStateAction<State>): newSta
 export const useControllableState = <State>(
   options: UseControllableStateOptions<State>,
 ): [State, React.Dispatch<React.SetStateAction<State>>] => {
+  'use no memo';
+
   if (process.env.NODE_ENV !== 'production') {
     if (options.state !== undefined && options.defaultState !== undefined) {
       // eslint-disable-next-line no-console
@@ -90,6 +92,8 @@ function isInitializer<State>(value: State | (() => State)): value is () => Stat
  * @returns - whether the value is controlled
  */
 const useIsControlled = <V>(controlledValue: V | undefined): controlledValue is V => {
+  'use no memo';
+
   const [isControlled] = React.useState<boolean>(() => controlledValue !== undefined);
 
   if (process.env.NODE_ENV !== 'production') {

--- a/packages/react-components/react-utilities/src/hooks/useId.ts
+++ b/packages/react-components/react-utilities/src/hooks/useId.ts
@@ -29,6 +29,8 @@ export function resetIdsForTests(): void {
  * @returns The ID
  */
 export function useId(prefix: string = 'fui-', providedId?: string): string {
+  'use no memo';
+
   const contextValue = useSSRContext();
   const idPrefix = useIdPrefix();
 

--- a/packages/react-components/react-utilities/src/hooks/useMergedRefs.ts
+++ b/packages/react-components/react-utilities/src/hooks/useMergedRefs.ts
@@ -13,6 +13,8 @@ export type RefObjectFunction<T> = React.RefObject<T> & ((value: T) => void);
  * @returns A function with an attached "current" prop, so that it can be treated like a RefObject.
  */
 export function useMergedRefs<T>(...refs: (React.Ref<T> | undefined)[]): RefObjectFunction<T> {
+  'use no memo';
+
   const mergedCallback: RefObjectFunction<T> = React.useCallback(
     (value: T) => {
       // Update the "current" prop hanging on the function.

--- a/packages/react-components/react-utilities/src/selection/useSelection.ts
+++ b/packages/react-components/react-utilities/src/selection/useSelection.ts
@@ -80,6 +80,8 @@ function useMultipleSelection(params: Omit<SelectionHookParams, 'selectionMode'>
 }
 
 export function useSelection(params: SelectionHookParams) {
+  'use no memo';
+
   if (params.selectionMode === 'multiselect') {
     // selectionMode is a static value, so we can safely ignore rules-of-hooks
     // eslint-disable-next-line react-hooks/rules-of-hooks

--- a/packages/react-components/react-utilities/src/ssr/canUseDOM.ts
+++ b/packages/react-components/react-utilities/src/ssr/canUseDOM.ts
@@ -4,6 +4,6 @@
 export function canUseDOM(): boolean {
   return (
     // eslint-disable-next-line deprecation/deprecation, no-restricted-globals
-    typeof window !== 'undefined' && !!(window.document && window.document.createElement)
+    (typeof window !== 'undefined' && !!(window.document && window.document.createElement))
   );
 }

--- a/packages/react-components/react-utilities/src/ssr/canUseDOM.ts
+++ b/packages/react-components/react-utilities/src/ssr/canUseDOM.ts
@@ -4,6 +4,6 @@
 export function canUseDOM(): boolean {
   return (
     // eslint-disable-next-line deprecation/deprecation, no-restricted-globals
-    (typeof window !== 'undefined' && !!(window.document && window.document.createElement))
+    typeof window !== 'undefined' && !!(window.document && window.document.createElement)
   );
 }

--- a/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
@@ -8,6 +8,8 @@ import { useVirtualizerContextState_unstable } from '../../Utilities';
 import { slot, useTimeout } from '@fluentui/react-utilities';
 
 export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerState {
+  'use no memo';
+
   const {
     itemSize,
     numItems,

--- a/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizerStyles.styles.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizerStyles.styles.ts
@@ -30,6 +30,8 @@ const useStyles = makeStyles({
  * Apply styling to the Virtualizer states
  */
 export const useVirtualizerStyles_unstable = (state: VirtualizerState): VirtualizerState => {
+  'use no memo';
+
   const styles = useStyles();
   const { reversed, axis, beforeBufferHeight, afterBufferHeight, bufferSize } = state;
   const horizontal = axis === 'horizontal';

--- a/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollView/useVirtualizerScrollViewStyles.styles.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollView/useVirtualizerScrollViewStyles.styles.ts
@@ -41,6 +41,8 @@ const useStyles = makeStyles({
 export const useVirtualizerScrollViewStyles_unstable = (
   state: VirtualizerScrollViewState,
 ): VirtualizerScrollViewState => {
+  'use no memo';
+
   const styles = useStyles();
 
   // Default virtualizer styles base

--- a/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollViewDynamic/useVirtualizerScrollViewDynamic.tsx
+++ b/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollViewDynamic/useVirtualizerScrollViewDynamic.tsx
@@ -16,6 +16,8 @@ import { useDynamicVirtualizerPagination } from '../../hooks/useDynamicPaginatio
 export function useVirtualizerScrollViewDynamic_unstable(
   props: VirtualizerScrollViewDynamicProps,
 ): VirtualizerScrollViewDynamicState {
+  'use no memo';
+
   const contextState = useVirtualizerContextState_unstable(props.virtualizerContext);
   const { imperativeRef, axis = 'vertical', reversed, imperativeVirtualizerRef, enablePagination = false } = props;
 

--- a/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollViewDynamic/useVirtualizerScrollViewDynamicStyles.styles.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollViewDynamic/useVirtualizerScrollViewDynamicStyles.styles.ts
@@ -43,6 +43,8 @@ const useStyles = makeStyles({
 export const useVirtualizerScrollViewDynamicStyles_unstable = (
   state: VirtualizerScrollViewDynamicState,
 ): VirtualizerScrollViewDynamicState => {
+  'use no memo';
+
   const styles = useStyles();
 
   // Default virtualizer styles base

--- a/packages/react-components/react-virtualizer/library/src/hooks/useDynamicPagination.ts
+++ b/packages/react-components/react-virtualizer/library/src/hooks/useDynamicPagination.ts
@@ -13,6 +13,8 @@ export const useDynamicVirtualizerPagination = (
   virtualizerProps: VirtualizerDynamicPaginationProps,
   paginationEnabled: Boolean = true,
 ) => {
+  'use no memo';
+
   const { axis = 'vertical', currentIndex, progressiveItemSizes, virtualizerLength } = virtualizerProps;
 
   const [setScrollTimer, clearScrollTimer] = useTimeout();

--- a/packages/react-components/react-virtualizer/library/src/hooks/useIntersectionObserver.ts
+++ b/packages/react-components/react-virtualizer/library/src/hooks/useIntersectionObserver.ts
@@ -60,6 +60,8 @@ export const useIntersectionObserver = (
   // eslint-disable-next-line no-restricted-globals
   observer: MutableRefObject<IntersectionObserver | undefined>;
 } => {
+  'use no memo';
+
   // TODO: exclude types from this lint rule: https://github.com/microsoft/fluentui/issues/31286
   // eslint-disable-next-line no-restricted-globals
   const observer = useRef<IntersectionObserver>();

--- a/packages/react-components/react-virtualizer/library/src/hooks/useMutationObserver.ts
+++ b/packages/react-components/react-virtualizer/library/src/hooks/useMutationObserver.ts
@@ -11,6 +11,8 @@ export const useMutationObserver = (
 ): {
   observer: MutableRefObject<MutationObserver | undefined>; // eslint-disable-line no-restricted-globals
 } => {
+  'use no memo';
+
   // TODO: exclude types from this lint rule: https://github.com/microsoft/fluentui/issues/31286
   // eslint-disable-next-line no-restricted-globals
   const observer = useRef<MutationObserver>();

--- a/packages/react-components/react-virtualizer/library/src/hooks/useResizeObserverRef.ts
+++ b/packages/react-components/react-virtualizer/library/src/hooks/useResizeObserverRef.ts
@@ -8,6 +8,8 @@ import { ResizeCallbackWithRef } from './hooks.types';
  * useResizeObserverRef_unstable simplifies resize observer connection and ensures debounce/cleanup
  */
 export const useResizeObserverRef_unstable = (resizeCallback: ResizeCallbackWithRef) => {
+  'use no memo';
+
   const { targetDocument } = useFluent();
   const container = React.useRef<HTMLElement | null>(null);
   // the handler for resize observer

--- a/packages/react-components/react-virtualizer/library/src/hooks/useStaticPagination.ts
+++ b/packages/react-components/react-virtualizer/library/src/hooks/useStaticPagination.ts
@@ -13,6 +13,8 @@ export const useStaticVirtualizerPagination = (
   virtualizerProps: VirtualizerStaticPaginationProps,
   paginationEnabled: Boolean = true,
 ) => {
+  'use no memo';
+
   const { itemSize, axis = 'vertical' } = virtualizerProps;
 
   const [setScrollTimer, clearScrollTimer] = useTimeout();

--- a/tools/workspace-plugin/src/generators/react-component/files/component/use__componentName__Styles.styles.ts__tmpl__
+++ b/tools/workspace-plugin/src/generators/react-component/files/component/use__componentName__Styles.styles.ts__tmpl__
@@ -24,6 +24,8 @@ const useStyles = makeStyles({
  * Apply styling to the <%= componentName %> slots based on the state
  */
 export const use<%= componentName %>Styles_unstable = (state: <%= componentName %>State): <%= componentName %>State => {
+  'use no memo';
+
   const styles = useStyles();
   state.root.className = mergeClasses(<%= propertyName %>ClassNames.root, styles.root, state.root.className);
 

--- a/tools/workspace-plugin/src/generators/react-component/index.spec.ts
+++ b/tools/workspace-plugin/src/generators/react-component/index.spec.ts
@@ -130,6 +130,8 @@ describe('react-component generator', () => {
        * Apply styling to the MyOne slots based on the state
        */
       export const useMyOneStyles_unstable = (state: MyOneState): MyOneState => {
+        'use no memo';
+
         const styles = useStyles();
         state.root.className = mergeClasses(
           myOneClassNames.root,


### PR DESCRIPTION
## Previous Behavior

No linting for the Rules of React.

## New Behavior

Apologies for the massive PR but this change touches all or nearly all Fluent v9 components!

Adds `eslint-plugin-react-compiler`. For background information on React Compiler (previously "React Forget") see: https://react.dev/learn/react-compiler

While React Compiler require React 19, [the eslint plugin does not](https://react.dev/learn/react-compiler#installing-eslint-plugin-react-compiler).

This lint rule will help us adhere to the [Rules of React](https://react.dev/reference/rules) much like the lint rule that enforces the Rules of Hooks.

The `"use no memo"` directive is used to disable the linter rather than an `eslint-disable-*` comment as the directive will also instruct the actual React Forget compiler.

### Summary of changes

1. I've disabled this linter for all the styles hooks. After looking at this the conclusion about the reported error is that this is a false positive as the state being mutated is not React state but "Fluent state". Further experimentation showed that the Compiler does not change this code when it has been modified to be immutable (i.e. there are no real upsides to change it).
2. The template for style hooks has been updated to disable this lint rule for all future components.
