### PR TITLE
chore(react-utilities): useControllableState warns if controlled and uncontrolled at the same time

### DIFF
--- a/change/@fluentui-react-accordion-f9c02eb6-6762-46e7-8b0b-70e84ec5c265.json
+++ b/change/@fluentui-react-accordion-f9c02eb6-6762-46e7-8b0b-70e84ec5c265.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: ensure only state or defaultState is provided on useControllableState hook invocation",
+  "packageName": "@fluentui/react-accordion",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-calendar-compat-b69a9f42-7bdf-4389-bae1-53017bc02397.json
+++ b/change/@fluentui-react-calendar-compat-b69a9f42-7bdf-4389-bae1-53017bc02397.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: ensure only state or defaultState is provided on useControllableState hook invocation",
+  "packageName": "@fluentui/react-calendar-compat",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-list-preview-dc4d6a47-7870-4690-a5e8-81b1a25c2f92.json
+++ b/change/@fluentui-react-list-preview-dc4d6a47-7870-4690-a5e8-81b1a25c2f92.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: ensure only state or defaultState is provided on useControllableState hook invocation",
+  "packageName": "@fluentui/react-list-preview",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-search-45a3f7ae-3db8-4b8d-856f-efbbb0766910.json
+++ b/change/@fluentui-react-search-45a3f7ae-3db8-4b8d-856f-efbbb0766910.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: ensure only state or defaultState is provided on useControllableState hook invocation",
+  "packageName": "@fluentui/react-search",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-slider-ebfac3f4-e325-47b7-850c-b3dbd9dfc127.json
+++ b/change/@fluentui-react-slider-ebfac3f4-e325-47b7-850c-b3dbd9dfc127.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: ensure only state or defaultState is provided on useControllableState hook invocation",
+  "packageName": "@fluentui/react-slider",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tree-d5c80dfa-0994-4082-9500-e9acdc7023f6.json
+++ b/change/@fluentui-react-tree-d5c80dfa-0994-4082-9500-e9acdc7023f6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: ensure only state or defaultState is provided on useControllableState hook invocation",
+  "packageName": "@fluentui/react-tree",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-utilities-7d570c9e-82bf-48fd-84c2-7e660f079e19.json
+++ b/change/@fluentui-react-utilities-7d570c9e-82bf-48fd-84c2-7e660f079e19.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: useControllableState warns if controlled and uncontrolled at the same time",
+  "packageName": "@fluentui/react-utilities",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-accordion/src/components/Accordion/useAccordion.ts
+++ b/packages/react-components/react-accordion/src/components/Accordion/useAccordion.ts
@@ -24,7 +24,7 @@ export const useAccordion_unstable = <Value = AccordionItemValue>(
   } = props;
   const [openItems, setOpenItems] = useControllableState({
     state: React.useMemo(() => normalizeValues(controlledOpenItems), [controlledOpenItems]),
-    defaultState: () => initializeUncontrolledOpenItems({ defaultOpenItems, multiple }),
+    defaultState: defaultOpenItems && (() => initializeUncontrolledOpenItems({ defaultOpenItems, multiple })),
     initialState: [],
   });
 

--- a/packages/react-components/react-calendar-compat/src/components/Calendar/Calendar.tsx
+++ b/packages/react-components/react-calendar-compat/src/components/Calendar/Calendar.tsx
@@ -33,18 +33,13 @@ const defaultWorkWeekDays: DayOfWeek[] = [
 function useDateState(props: CalendarProps) {
   const { value, today: todayProp, onSelectDate } = props;
 
-  const today = React.useMemo(() => {
-    if (todayProp === undefined) {
-      return new Date();
-    }
-    return todayProp;
-  }, [todayProp]);
+  const today = React.useMemo(() => todayProp ?? new Date(), [todayProp]);
 
   /** The currently selected date in the calendar */
   const [selectedDate, setSelectedDate] = useControllableState({
-    defaultState: today,
-    initialState: today,
     state: value,
+    defaultState: value ? undefined : today,
+    initialState: today,
   });
 
   /** The currently focused date in the day picker, but not necessarily selected */
@@ -91,17 +86,13 @@ function useVisibilityState({
     showMonthPickerAsOverlay,
   });
 
-  const [isMonthPickerVisible, setIsMonthPickerVisible] = useControllableState({
-    defaultState: false,
-    initialState: true,
-    state: showMonthPickerAsOverlayState ? undefined : isMonthPickerVisibleProp,
-  });
+  const [isMonthPickerVisible, setIsMonthPickerVisible] = React.useState(() =>
+    showMonthPickerAsOverlayState ? false : isMonthPickerVisibleProp ?? false,
+  );
   /** State used to show/hide day picker */
-  const [isDayPickerVisible, setIsDayPickerVisible] = useControllableState({
-    defaultState: true,
-    initialState: true,
-    state: showMonthPickerAsOverlayState ? undefined : isDayPickerVisibleProp,
-  });
+  const [isDayPickerVisible, setIsDayPickerVisible] = React.useState(() =>
+    showMonthPickerAsOverlayState ? true : isDayPickerVisibleProp ?? true,
+  );
 
   const toggleDayMonthPickerVisibility = () => {
     setIsMonthPickerVisible(!isMonthPickerVisible);

--- a/packages/react-components/react-list-preview/src/components/List/useList.ts
+++ b/packages/react-components/react-list-preview/src/components/List/useList.ts
@@ -62,7 +62,6 @@ export const useList_unstable = (
     onSelectionChange: onChange,
     selectionMode: selectionMode || 'multiselect',
     selectedItems: selectionState,
-    defaultSelectedItems,
   });
 
   const listRole = props.role || calculateListRole(navigationMode, !!selectionMode);

--- a/packages/react-components/react-search/src/components/SearchBox/useSearchBox.tsx
+++ b/packages/react-components/react-search/src/components/SearchBox/useSearchBox.tsx
@@ -22,14 +22,24 @@ import type { SearchBoxSlots, SearchBoxProps, SearchBoxState } from './SearchBox
  * @param ref - reference to root HTMLElement of SearchBox
  */
 export const useSearchBox_unstable = (props: SearchBoxProps, ref: React.Ref<HTMLInputElement>): SearchBoxState => {
-  const { size = 'medium', disabled = false, root, contentBefore, dismiss, contentAfter, ...inputProps } = props;
+  const {
+    size = 'medium',
+    disabled = false,
+    root,
+    contentBefore,
+    dismiss,
+    contentAfter,
+    value,
+    defaultValue,
+    ...inputProps
+  } = props;
 
   const searchBoxRootRef = React.useRef<HTMLDivElement>(null);
   const searchBoxRef = React.useRef<HTMLInputElement>(null);
 
-  const [value, setValue] = useControllableState({
-    state: props.value,
-    defaultState: props.defaultValue,
+  const [internalValue, setInternalValue] = useControllableState({
+    state: value,
+    defaultState: defaultValue,
     initialState: '',
   });
 
@@ -51,7 +61,7 @@ export const useSearchBox_unstable = (props: SearchBoxProps, ref: React.Ref<HTML
       dismiss.onClick?.(event);
     }
     const newValue = '';
-    setValue(newValue);
+    setInternalValue(newValue);
     props.onChange?.(event, { value: newValue });
   });
 
@@ -60,7 +70,7 @@ export const useSearchBox_unstable = (props: SearchBoxProps, ref: React.Ref<HTML
       type: 'search',
       disabled,
       size,
-      value,
+      value: internalValue,
       root: slot.always<ExtractSlotProps<SearchBoxSlots['root']>>(
         {
           ...rootProps,
@@ -87,7 +97,7 @@ export const useSearchBox_unstable = (props: SearchBoxProps, ref: React.Ref<HTML
       onChange: useEventCallback(ev => {
         const newValue = ev.target.value;
         props.onChange?.(ev, { value: newValue });
-        setValue(newValue);
+        setInternalValue(newValue);
       }),
     },
     useMergedRefs(searchBoxRef, ref),

--- a/packages/react-components/react-slider/src/components/Slider/useSliderState.tsx
+++ b/packages/react-components/react-slider/src/components/Slider/useSliderState.tsx
@@ -11,14 +11,15 @@ const getPercent = (value: number, min: number, max: number) => {
 };
 
 export const useSliderState_unstable = (state: SliderState, props: SliderProps) => {
-  const { defaultValue = 0, min = 0, max = 100, step, value } = props;
+  const { min = 0, max = 100, step } = props;
   const { dir } = useFluent();
   const [currentValue, setCurrentValue] = useControllableState({
-    state: value !== undefined ? clamp(value, min, max) : undefined,
-    defaultState: clamp(defaultValue, min, max),
+    state: props.value,
+    defaultState: props.defaultValue,
     initialState: 0,
   });
-  const valuePercent = getPercent(currentValue, min, max);
+  const clampedValue = clamp(currentValue, min, max);
+  const valuePercent = getPercent(clampedValue, min, max);
 
   const inputOnChange = state.input.onChange;
   const propsOnChange = props.onChange;
@@ -47,7 +48,7 @@ export const useSliderState_unstable = (state: SliderState, props: SliderProps) 
   };
 
   // Input Props
-  state.input.value = currentValue;
+  state.input.value = clampedValue;
   state.input.onChange = onChange;
 
   return state;

--- a/packages/react-components/react-tree/src/hooks/useControllableOpenItems.ts
+++ b/packages/react-components/react-tree/src/hooks/useControllableOpenItems.ts
@@ -11,7 +11,7 @@ import { TreeOpenChangeData, TreeProps } from '../Tree';
 export function useControllableOpenItems(props: Pick<TreeProps, 'openItems' | 'defaultOpenItems'>) {
   return useControllableState({
     state: React.useMemo(() => props.openItems && createOpenItems(props.openItems), [props.openItems]),
-    defaultState: () => createOpenItems(props.defaultOpenItems),
+    defaultState: props.defaultOpenItems && (() => createOpenItems(props.defaultOpenItems)),
     initialState: ImmutableSet.empty,
   });
 }

--- a/packages/react-components/react-utilities/src/hooks/useControllableState.ts
+++ b/packages/react-components/react-utilities/src/hooks/useControllableState.ts
@@ -43,6 +43,18 @@ function isFactoryDispatch<State>(newState: React.SetStateAction<State>): newSta
 export const useControllableState = <State>(
   options: UseControllableStateOptions<State>,
 ): [State, React.Dispatch<React.SetStateAction<State>>] => {
+  if (process.env.NODE_ENV !== 'production') {
+    if (options.state !== undefined && options.defaultState !== undefined) {
+      // eslint-disable-next-line no-console
+      console.error(/** #__DE-INDENT__ */ `
+      @fluentui/react-utilities [useControllableState]:
+      A component must be either controlled or uncontrolled (specify either the state or the defaultState, but not both).
+      Decide between using a controlled or uncontrolled component and remove one of this props.
+      More info: https://reactjs.org/link/controlled-components
+      ${new Error().stack}
+    `);
+    }
+  }
   const [internalState, setInternalState] = React.useState<State>(() => {
     if (options.defaultState === undefined) {
       return options.initialState;
@@ -95,7 +107,7 @@ const useIsControlled = <V>(controlledValue: V | undefined): controlledValue is 
 
         // eslint-disable-next-line no-console
         console.error(/** #__DE-INDENT__ */ `
-          @fluentui/react-utilities [${useControllableState.name}]:
+          @fluentui/react-utilities [useControllableState]:
           A component is changing ${controlWarning}. This is likely caused by the value changing from ${undefinedWarning} value, which should not happen.
           Decide between using a controlled or uncontrolled input element for the lifetime of the component.
           More info: https://reactjs.org/link/controlled-components


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Using both controlled and uncontrolled state on `useControllableState` hook would default to the state value, which is expected.

In native react elements (such as `input`) if the user provides both controlled `value` and uncontrolled `defaultValue` an error will be displayed in the console:

![image](https://github.com/microsoft/fluentui/assets/5483269/e809bbbb-7878-440b-b97d-877542e05ba6)

The element works as expected, the controlled value takes precedence, but the warning is emitted as extra information to avoid confusion from the user side (as something might be going wrong if the user is providing both)

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

1. consoles a warning whenever the user provide both controlled and uncontrolled state value, similar to what react does on native elements.
2. refactors `react-utilities` tests to count for the console.error
3. updates v9 packages to properly use the hook
   * `react-accordion`
   * `react-calendar-compat`
   * `react-list-preview`
   * `react-search`
   * `react-slider`
   * `react-tree`

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/31445
