### PR TITLE
fix(recipes-react-components): explicitly set types to not include whole @types/* globals which are cauising issues with addition of @types/web

### DIFF
--- a/apps/recipes-react-components/tsconfig.app.json
+++ b/apps/recipes-react-components/tsconfig.app.json
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "noEmit": true,
     "lib": ["ES2019", "dom"],
-    "declaration": true,
-    "inlineSources": true
+    "types": []
   },
   "include": ["./src/**/*.ts", "./src/**/*.tsx"]
 }

--- a/apps/recipes-react-components/tsconfig.json
+++ b/apps/recipes-react-components/tsconfig.json
@@ -5,11 +5,9 @@
     "target": "ES2019",
     "noEmit": true,
     "isolatedModules": true,
-    "importHelpers": true,
     "jsx": "react",
     "noUnusedLocals": true,
-    "preserveConstEnums": true,
-    "skipLibCheck": true
+    "preserveConstEnums": true
   },
   "include": [],
   "files": [],


### PR DESCRIPTION

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

- see PR title
- it turns out the culprit is that recipes app didn't set `types` config property. if that's not present typescript loads all `@type/*` globals which is a antipattern and started to be problematic since `@types/web` landed to master with web-components v3 ( which is hoisted thus getting those `node_modules` issues on CI )

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/pull/31456
