### PR TITLE
fix(pr-deploy-site): explicitly set types to not include whole @types/* globals which are causing issues with addition of @types/web

### DIFF
--- a/apps/pr-deploy-site/package.json
+++ b/apps/pr-deploy-site/package.json
@@ -8,7 +8,7 @@
     "clean": "just-scripts clean",
     "generate:site": "just-scripts generate:site",
     "lint": "eslint --ext .js,.ts --cache .",
-    "type-check": "tsc -p ."
+    "type-check": "tsc -p . --noEmit"
   },
   "license": "MIT",
   "devDependencies": {

--- a/apps/pr-deploy-site/tsconfig.json
+++ b/apps/pr-deploy-site/tsconfig.json
@@ -5,6 +5,7 @@
     "allowJs": true,
     "lib": ["ES2020", "DOM"]
   },
+  "types": [],
   "include": ["pr-deploy-site.js", "just.config.ts"],
   "files": ["../../typings/find-free-port/index.d.ts"]
 }


### PR DESCRIPTION


<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

one more explicit `types` set, see follows PR at the bottom

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows https://github.com/microsoft/fluentui/pull/31463
