### PR TITLE
(web-components) Resolve output warnings for storybook and api-extractor

### DIFF
--- a/change/@fluentui-web-components-777f3360-25b3-4060-9042-001475420001.json
+++ b/change/@fluentui-web-components-777f3360-25b3-4060-9042-001475420001.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: Resolve output warnings for Storybook and api-extractor",
+  "packageName": "@fluentui/web-components",
+  "email": "863023+radium-v@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/api-extractor.json
+++ b/packages/web-components/api-extractor.json
@@ -21,35 +21,14 @@
     "tsconfigFilePath": "./tsconfig.api-extractor.json"
   },
   "messages": {
-    "tsdocMessageReporting": {
-      "tsdoc-undefined-tag": {
-        "logLevel": "none"
-      },
-      "tsdoc-unsupported-tag": {
-        "logLevel": "none"
-      },
-      "tsdoc-param-tag-with-invalid-type": {
-        "logLevel": "none"
-      },
-      "tsdoc-param-tag-missing-hyphen": {
-        "logLevel": "none"
-      }
-    },
     "extractorMessageReporting": {
-      "ae-forgotten-export": {
-        "logLevel": "none"
-      },
       "ae-missing-release-tag": {
-        "logLevel": "none"
-      },
-      "ae-unresolved-link": {
-        "logLevel": "none"
-      },
-      "ae-internal-missing-underscore": {
-        "logLevel": "none"
+        "logLevel": "none",
+        "addToApiReportFile": true
       },
       "ae-different-release-tags": {
-        "logLevel": "none"
+        "logLevel": "none",
+        "addToApiReportFile": true
       }
     }
   }

--- a/packages/web-components/docs/api-report.md
+++ b/packages/web-components/docs/api-report.md
@@ -50,9 +50,10 @@ export const AccordionExpandMode: {
 // @public
 export type AccordionExpandMode = ValuesOf<typeof AccordionExpandMode>;
 
+// Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
 // Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "AccordionItem" because one of its declarations is marked as @internal
 //
-// @public
+// @public (undocumented)
 export class AccordionItem extends FASTElement {
     block: boolean;
     // @internal (undocumented)
@@ -76,6 +77,8 @@ export interface AccordionItem extends StartEnd {
 // @public (undocumented)
 export const accordionItemDefinition: FASTElementDefinition<typeof AccordionItem>;
 
+// Warning: (ae-missing-release-tag) "AccordionItemExpandIconPosition" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public
 export const AccordionItemExpandIconPosition: {
     readonly start: "start";
@@ -93,6 +96,8 @@ export type AccordionItemOptions = StartEndOptions<AccordionItem> & {
     collapsedIcon?: StaticallyComposableHTML<AccordionItem>;
 };
 
+// Warning: (ae-missing-release-tag) "AccordionItemSize" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public
 export const AccordionItemSize: {
     readonly small: "small";
@@ -104,18 +109,25 @@ export const AccordionItemSize: {
 // @public
 export type AccordionItemSize = ValuesOf<typeof AccordionItemSize>;
 
+// Warning: (ae-missing-release-tag) "styles" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export const accordionItemStyles: ElementStyles;
 
 // @public
 export const accordionItemTemplate: ElementViewTemplate<AccordionItem>;
 
+// Warning: (ae-missing-release-tag) "styles" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export const accordionStyles: ElementStyles;
 
+// Warning: (ae-missing-release-tag) "template" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export const accordionTemplate: ElementViewTemplate<Accordion>;
 
+// Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
 // Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "AnchorButton" because one of its declarations is marked as @internal
 //
 // @public
@@ -222,6 +234,9 @@ export class Avatar extends FASTElement {
     size?: AvatarSize | undefined;
 }
 
+// Warning: (ae-missing-release-tag) "AvatarActive" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "AvatarActive" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public
 export const AvatarActive: {
     readonly active: "active";
@@ -231,6 +246,9 @@ export const AvatarActive: {
 // @public
 export type AvatarActive = ValuesOf<typeof AvatarActive>;
 
+// Warning: (ae-missing-release-tag) "AvatarAppearance" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "AvatarAppearance" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public
 export const AvatarAppearance: {
     readonly ring: "ring";
@@ -241,6 +259,9 @@ export const AvatarAppearance: {
 // @public
 export type AvatarAppearance = ValuesOf<typeof AvatarAppearance>;
 
+// Warning: (ae-missing-release-tag) "AvatarColor" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "AvatarColor" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public
 export const AvatarColor: {
     readonly darkRed: "dark-red";
@@ -284,6 +305,8 @@ export type AvatarColor = ValuesOf<typeof AvatarColor>;
 // @public
 export const AvatarDefinition: FASTElementDefinition<typeof Avatar>;
 
+// Warning: (ae-missing-release-tag) "AvatarNamedColor" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public
 export const AvatarNamedColor: {
     readonly darkRed: "dark-red";
@@ -321,6 +344,9 @@ export const AvatarNamedColor: {
 // @public
 export type AvatarNamedColor = ValuesOf<typeof AvatarNamedColor>;
 
+// Warning: (ae-missing-release-tag) "AvatarShape" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "AvatarShape" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public
 export const AvatarShape: {
     readonly circular: "circular";
@@ -354,9 +380,12 @@ export type AvatarSize = ValuesOf<typeof AvatarSize>;
 // @public
 export const AvatarStyles: ElementStyles;
 
+// Warning: (ae-missing-release-tag) "template" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export const AvatarTemplate: ElementViewTemplate<Avatar>;
 
+// Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
 // Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "Badge" because one of its declarations is marked as @internal
 //
 // @public
@@ -426,27 +455,30 @@ export type BadgeSize = ValuesOf<typeof BadgeSize>;
 // @public
 export const BadgeStyles: ElementStyles;
 
+// Warning: (ae-missing-release-tag) "template" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export const BadgeTemplate: ElementViewTemplate<Badge>;
 
-// @public (undocumented)
+// @public
 export const borderRadiusCircular = "var(--borderRadiusCircular)";
 
-// @public (undocumented)
+// @public
 export const borderRadiusLarge = "var(--borderRadiusLarge)";
 
-// @public (undocumented)
+// @public
 export const borderRadiusMedium = "var(--borderRadiusMedium)";
 
-// @public (undocumented)
+// @public
 export const borderRadiusNone = "var(--borderRadiusNone)";
 
-// @public (undocumented)
+// @public
 export const borderRadiusSmall = "var(--borderRadiusSmall)";
 
-// @public (undocumented)
+// @public
 export const borderRadiusXLarge = "var(--borderRadiusXLarge)";
 
+// Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
 // Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "Button" because one of its declarations is marked as @internal
 //
 // @public
@@ -572,6 +604,7 @@ export class Checkbox extends FormAssociatedCheckbox {
     initialValue: string;
     // @internal (undocumented)
     keypressHandler: (e: KeyboardEvent) => void;
+    // Warning: (ae-forgotten-export) The symbol "CheckboxLabelPosition" needs to be exported by the entry point index.d.ts
     labelPosition?: CheckboxLabelPosition;
     shape?: CheckboxShape;
     size?: CheckboxSize;
@@ -581,20 +614,13 @@ export class Checkbox extends FormAssociatedCheckbox {
 export const CheckboxDefinition: FASTElementDefinition<typeof Checkbox>;
 
 // @public
-export const CheckboxLabelPosition: {
-    readonly before: "before";
-    readonly after: "after";
-};
-
-// @public (undocumented)
-export type CheckboxLabelPosition = ValuesOf<typeof CheckboxLabelPosition>;
-
-// @public
 export type CheckboxOptions = {
     checkedIndicator?: StaticallyComposableHTML<Checkbox>;
     indeterminateIndicator?: StaticallyComposableHTML<Checkbox>;
 };
 
+// Warning: (ae-missing-release-tag) "CheckboxShape" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public
 export const CheckboxShape: {
     readonly circular: "circular";
@@ -604,6 +630,8 @@ export const CheckboxShape: {
 // @public (undocumented)
 export type CheckboxShape = ValuesOf<typeof CheckboxShape>;
 
+// Warning: (ae-missing-release-tag) "CheckboxSize" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public
 export const CheckboxSize: {
     readonly medium: "medium";
@@ -619,1048 +647,1048 @@ export const CheckboxStyles: ElementStyles;
 // @public
 export const CheckboxTemplate: ElementViewTemplate<Checkbox>;
 
-// @public (undocumented)
+// @public
 export const colorBackgroundOverlay = "var(--colorBackgroundOverlay)";
 
-// @public (undocumented)
+// @public
 export const colorBrandBackground = "var(--colorBrandBackground)";
 
-// @public (undocumented)
+// @public
 export const colorBrandBackground2 = "var(--colorBrandBackground2)";
 
-// @public (undocumented)
+// @public
 export const colorBrandBackground2Hover = "var(--colorBrandBackground2Hover)";
 
-// @public (undocumented)
+// @public
 export const colorBrandBackground2Pressed = "var(--colorBrandBackground2Pressed)";
 
-// @public (undocumented)
+// @public
 export const colorBrandBackground3Static = "var(--colorBrandBackground3Static)";
 
-// @public (undocumented)
+// @public
 export const colorBrandBackground4Static = "var(--colorBrandBackground4Static)";
 
-// @public (undocumented)
+// @public
 export const colorBrandBackgroundHover = "var(--colorBrandBackgroundHover)";
 
-// @public (undocumented)
+// @public
 export const colorBrandBackgroundInverted = "var(--colorBrandBackgroundInverted)";
 
-// @public (undocumented)
+// @public
 export const colorBrandBackgroundInvertedHover = "var(--colorBrandBackgroundInvertedHover)";
 
-// @public (undocumented)
+// @public
 export const colorBrandBackgroundInvertedPressed = "var(--colorBrandBackgroundInvertedPressed)";
 
-// @public (undocumented)
+// @public
 export const colorBrandBackgroundInvertedSelected = "var(--colorBrandBackgroundInvertedSelected)";
 
-// @public (undocumented)
+// @public
 export const colorBrandBackgroundPressed = "var(--colorBrandBackgroundPressed)";
 
-// @public (undocumented)
+// @public
 export const colorBrandBackgroundSelected = "var(--colorBrandBackgroundSelected)";
 
-// @public (undocumented)
+// @public
 export const colorBrandBackgroundStatic = "var(--colorBrandBackgroundStatic)";
 
-// @public (undocumented)
+// @public
 export const colorBrandForeground1 = "var(--colorBrandForeground1)";
 
-// @public (undocumented)
+// @public
 export const colorBrandForeground2 = "var(--colorBrandForeground2)";
 
-// @public (undocumented)
+// @public
 export const colorBrandForeground2Hover = "var(--colorBrandForeground2Hover)";
 
-// @public (undocumented)
+// @public
 export const colorBrandForeground2Pressed = "var(--colorBrandForeground2Pressed)";
 
-// @public (undocumented)
+// @public
 export const colorBrandForegroundInverted = "var(--colorBrandForegroundInverted)";
 
-// @public (undocumented)
+// @public
 export const colorBrandForegroundInvertedHover = "var(--colorBrandForegroundInvertedHover)";
 
-// @public (undocumented)
+// @public
 export const colorBrandForegroundInvertedPressed = "var(--colorBrandForegroundInvertedPressed)";
 
-// @public (undocumented)
+// @public
 export const colorBrandForegroundLink = "var(--colorBrandForegroundLink)";
 
-// @public (undocumented)
+// @public
 export const colorBrandForegroundLinkHover = "var(--colorBrandForegroundLinkHover)";
 
-// @public (undocumented)
+// @public
 export const colorBrandForegroundLinkPressed = "var(--colorBrandForegroundLinkPressed)";
 
-// @public (undocumented)
+// @public
 export const colorBrandForegroundLinkSelected = "var(--colorBrandForegroundLinkSelected)";
 
-// @public (undocumented)
+// @public
 export const colorBrandForegroundOnLight = "var(--colorBrandForegroundOnLight)";
 
-// @public (undocumented)
+// @public
 export const colorBrandForegroundOnLightHover = "var(--colorBrandForegroundOnLightHover)";
 
-// @public (undocumented)
+// @public
 export const colorBrandForegroundOnLightPressed = "var(--colorBrandForegroundOnLightPressed)";
 
-// @public (undocumented)
+// @public
 export const colorBrandForegroundOnLightSelected = "var(--colorBrandForegroundOnLightSelected)";
 
-// @public (undocumented)
+// @public
 export const colorBrandShadowAmbient = "var(--colorBrandShadowAmbient)";
 
-// @public (undocumented)
+// @public
 export const colorBrandShadowKey = "var(--colorBrandShadowKey)";
 
-// @public (undocumented)
+// @public
 export const colorBrandStroke1 = "var(--colorBrandStroke1)";
 
-// @public (undocumented)
+// @public
 export const colorBrandStroke2 = "var(--colorBrandStroke2)";
 
-// @public (undocumented)
+// @public
 export const colorBrandStroke2Contrast = "var(--colorBrandStroke2Contrast)";
 
-// @public (undocumented)
+// @public
 export const colorBrandStroke2Hover = "var(--colorBrandStroke2Hover)";
 
-// @public (undocumented)
+// @public
 export const colorBrandStroke2Pressed = "var(--colorBrandStroke2Pressed)";
 
-// @public (undocumented)
+// @public
 export const colorCompoundBrandBackground = "var(--colorCompoundBrandBackground)";
 
-// @public (undocumented)
+// @public
 export const colorCompoundBrandBackgroundHover = "var(--colorCompoundBrandBackgroundHover)";
 
-// @public (undocumented)
+// @public
 export const colorCompoundBrandBackgroundPressed = "var(--colorCompoundBrandBackgroundPressed)";
 
-// @public (undocumented)
+// @public
 export const colorCompoundBrandForeground1 = "var(--colorCompoundBrandForeground1)";
 
-// @public (undocumented)
+// @public
 export const colorCompoundBrandForeground1Hover = "var(--colorCompoundBrandForeground1Hover)";
 
-// @public (undocumented)
+// @public
 export const colorCompoundBrandForeground1Pressed = "var(--colorCompoundBrandForeground1Pressed)";
 
-// @public (undocumented)
+// @public
 export const colorCompoundBrandStroke = "var(--colorCompoundBrandStroke)";
 
-// @public (undocumented)
+// @public
 export const colorCompoundBrandStrokeHover = "var(--colorCompoundBrandStrokeHover)";
 
-// @public (undocumented)
+// @public
 export const colorCompoundBrandStrokePressed = "var(--colorCompoundBrandStrokePressed)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralBackground1 = "var(--colorNeutralBackground1)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralBackground1Hover = "var(--colorNeutralBackground1Hover)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralBackground1Pressed = "var(--colorNeutralBackground1Pressed)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralBackground1Selected = "var(--colorNeutralBackground1Selected)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralBackground2 = "var(--colorNeutralBackground2)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralBackground2Hover = "var(--colorNeutralBackground2Hover)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralBackground2Pressed = "var(--colorNeutralBackground2Pressed)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralBackground2Selected = "var(--colorNeutralBackground2Selected)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralBackground3 = "var(--colorNeutralBackground3)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralBackground3Hover = "var(--colorNeutralBackground3Hover)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralBackground3Pressed = "var(--colorNeutralBackground3Pressed)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralBackground3Selected = "var(--colorNeutralBackground3Selected)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralBackground4 = "var(--colorNeutralBackground4)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralBackground4Hover = "var(--colorNeutralBackground4Hover)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralBackground4Pressed = "var(--colorNeutralBackground4Pressed)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralBackground4Selected = "var(--colorNeutralBackground4Selected)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralBackground5 = "var(--colorNeutralBackground5)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralBackground5Hover = "var(--colorNeutralBackground5Hover)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralBackground5Pressed = "var(--colorNeutralBackground5Pressed)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralBackground5Selected = "var(--colorNeutralBackground5Selected)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralBackground6 = "var(--colorNeutralBackground6)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralBackgroundAlpha = "var(--colorNeutralBackgroundAlpha)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralBackgroundAlpha2 = "var(--colorNeutralBackgroundAlpha2)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralBackgroundDisabled = "var(--colorNeutralBackgroundDisabled)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralBackgroundInverted = "var(--colorNeutralBackgroundInverted)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralBackgroundInvertedDisabled = "var(--colorNeutralBackgroundInvertedDisabled)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralBackgroundStatic = "var(--colorNeutralBackgroundStatic)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralCardBackground = "var(--colorNeutralCardBackground)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralCardBackgroundDisabled = "var(--colorNeutralCardBackgroundDisabled)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralCardBackgroundHover = "var(--colorNeutralCardBackgroundHover)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralCardBackgroundPressed = "var(--colorNeutralCardBackgroundPressed)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralCardBackgroundSelected = "var(--colorNeutralCardBackgroundSelected)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralForeground1 = "var(--colorNeutralForeground1)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralForeground1Hover = "var(--colorNeutralForeground1Hover)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralForeground1Pressed = "var(--colorNeutralForeground1Pressed)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralForeground1Selected = "var(--colorNeutralForeground1Selected)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralForeground1Static = "var(--colorNeutralForeground1Static)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralForeground2 = "var(--colorNeutralForeground2)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralForeground2BrandHover = "var(--colorNeutralForeground2BrandHover)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralForeground2BrandPressed = "var(--colorNeutralForeground2BrandPressed)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralForeground2BrandSelected = "var(--colorNeutralForeground2BrandSelected)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralForeground2Hover = "var(--colorNeutralForeground2Hover)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralForeground2Link = "var(--colorNeutralForeground2Link)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralForeground2LinkHover = "var(--colorNeutralForeground2LinkHover)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralForeground2LinkPressed = "var(--colorNeutralForeground2LinkPressed)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralForeground2LinkSelected = "var(--colorNeutralForeground2LinkSelected)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralForeground2Pressed = "var(--colorNeutralForeground2Pressed)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralForeground2Selected = "var(--colorNeutralForeground2Selected)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralForeground3 = "var(--colorNeutralForeground3)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralForeground3BrandHover = "var(--colorNeutralForeground3BrandHover)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralForeground3BrandPressed = "var(--colorNeutralForeground3BrandPressed)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralForeground3BrandSelected = "var(--colorNeutralForeground3BrandSelected)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralForeground3Hover = "var(--colorNeutralForeground3Hover)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralForeground3Pressed = "var(--colorNeutralForeground3Pressed)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralForeground3Selected = "var(--colorNeutralForeground3Selected)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralForeground4 = "var(--colorNeutralForeground4)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralForegroundDisabled = "var(--colorNeutralForegroundDisabled)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralForegroundInverted = "var(--colorNeutralForegroundInverted)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralForegroundInverted2 = "var(--colorNeutralForegroundInverted2)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralForegroundInvertedDisabled = "var(--colorNeutralForegroundInvertedDisabled)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralForegroundInvertedHover = "var(--colorNeutralForegroundInvertedHover)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralForegroundInvertedLink = "var(--colorNeutralForegroundInvertedLink)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralForegroundInvertedLinkHover = "var(--colorNeutralForegroundInvertedLinkHover)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralForegroundInvertedLinkPressed = "var(--colorNeutralForegroundInvertedLinkPressed)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralForegroundInvertedLinkSelected = "var(--colorNeutralForegroundInvertedLinkSelected)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralForegroundInvertedPressed = "var(--colorNeutralForegroundInvertedPressed)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralForegroundInvertedSelected = "var(--colorNeutralForegroundInvertedSelected)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralForegroundOnBrand = "var(--colorNeutralForegroundOnBrand)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralForegroundStaticInverted = "var(--colorNeutralForegroundStaticInverted)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralShadowAmbient = "var(--colorNeutralShadowAmbient)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralShadowAmbientDarker = "var(--colorNeutralShadowAmbientDarker)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralShadowAmbientLighter = "var(--colorNeutralShadowAmbientLighter)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralShadowKey = "var(--colorNeutralShadowKey)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralShadowKeyDarker = "var(--colorNeutralShadowKeyDarker)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralShadowKeyLighter = "var(--colorNeutralShadowKeyLighter)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralStencil1 = "var(--colorNeutralStencil1)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralStencil1Alpha = "var(--colorNeutralStencil1Alpha)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralStencil2 = "var(--colorNeutralStencil2)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralStencil2Alpha = "var(--colorNeutralStencil2Alpha)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralStroke1 = "var(--colorNeutralStroke1)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralStroke1Hover = "var(--colorNeutralStroke1Hover)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralStroke1Pressed = "var(--colorNeutralStroke1Pressed)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralStroke1Selected = "var(--colorNeutralStroke1Selected)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralStroke2 = "var(--colorNeutralStroke2)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralStroke3 = "var(--colorNeutralStroke3)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralStrokeAccessible = "var(--colorNeutralStrokeAccessible)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralStrokeAccessibleHover = "var(--colorNeutralStrokeAccessibleHover)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralStrokeAccessiblePressed = "var(--colorNeutralStrokeAccessiblePressed)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralStrokeAccessibleSelected = "var(--colorNeutralStrokeAccessibleSelected)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralStrokeAlpha = "var(--colorNeutralStrokeAlpha)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralStrokeAlpha2 = "var(--colorNeutralStrokeAlpha2)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralStrokeDisabled = "var(--colorNeutralStrokeDisabled)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralStrokeInvertedDisabled = "var(--colorNeutralStrokeInvertedDisabled)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralStrokeOnBrand = "var(--colorNeutralStrokeOnBrand)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralStrokeOnBrand2 = "var(--colorNeutralStrokeOnBrand2)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralStrokeOnBrand2Hover = "var(--colorNeutralStrokeOnBrand2Hover)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralStrokeOnBrand2Pressed = "var(--colorNeutralStrokeOnBrand2Pressed)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralStrokeOnBrand2Selected = "var(--colorNeutralStrokeOnBrand2Selected)";
 
-// @public (undocumented)
+// @public
 export const colorNeutralStrokeSubtle = "var(--colorNeutralStrokeSubtle)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteAnchorBackground2 = "var(--colorPaletteAnchorBackground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteAnchorBorderActive = "var(--colorPaletteAnchorBorderActive)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteAnchorForeground2 = "var(--colorPaletteAnchorForeground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteBeigeBackground2 = "var(--colorPaletteBeigeBackground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteBeigeBorderActive = "var(--colorPaletteBeigeBorderActive)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteBeigeForeground2 = "var(--colorPaletteBeigeForeground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteBerryBackground1 = "var(--colorPaletteBerryBackground1)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteBerryBackground2 = "var(--colorPaletteBerryBackground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteBerryBackground3 = "var(--colorPaletteBerryBackground3)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteBerryBorder1 = "var(--colorPaletteBerryBorder1)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteBerryBorder2 = "var(--colorPaletteBerryBorder2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteBerryBorderActive = "var(--colorPaletteBerryBorderActive)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteBerryForeground1 = "var(--colorPaletteBerryForeground1)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteBerryForeground2 = "var(--colorPaletteBerryForeground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteBerryForeground3 = "var(--colorPaletteBerryForeground3)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteBlueBackground2 = "var(--colorPaletteBlueBackground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteBlueBorderActive = "var(--colorPaletteBlueBorderActive)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteBlueForeground2 = "var(--colorPaletteBlueForeground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteBrassBackground2 = "var(--colorPaletteBrassBackground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteBrassBorderActive = "var(--colorPaletteBrassBorderActive)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteBrassForeground2 = "var(--colorPaletteBrassForeground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteBrownBackground2 = "var(--colorPaletteBrownBackground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteBrownBorderActive = "var(--colorPaletteBrownBorderActive)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteBrownForeground2 = "var(--colorPaletteBrownForeground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteCornflowerBackground2 = "var(--colorPaletteCornflowerBackground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteCornflowerBorderActive = "var(--colorPaletteCornflowerBorderActive)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteCornflowerForeground2 = "var(--colorPaletteCornflowerForeground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteCranberryBackground2 = "var(--colorPaletteCranberryBackground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteCranberryBorderActive = "var(--colorPaletteCranberryBorderActive)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteCranberryForeground2 = "var(--colorPaletteCranberryForeground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteDarkGreenBackground2 = "var(--colorPaletteDarkGreenBackground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteDarkGreenBorderActive = "var(--colorPaletteDarkGreenBorderActive)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteDarkGreenForeground2 = "var(--colorPaletteDarkGreenForeground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteDarkOrangeBackground1 = "var(--colorPaletteDarkOrangeBackground1)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteDarkOrangeBackground2 = "var(--colorPaletteDarkOrangeBackground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteDarkOrangeBackground3 = "var(--colorPaletteDarkOrangeBackground3)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteDarkOrangeBorder1 = "var(--colorPaletteDarkOrangeBorder1)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteDarkOrangeBorder2 = "var(--colorPaletteDarkOrangeBorder2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteDarkOrangeBorderActive = "var(--colorPaletteDarkOrangeBorderActive)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteDarkOrangeForeground1 = "var(--colorPaletteDarkOrangeForeground1)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteDarkOrangeForeground2 = "var(--colorPaletteDarkOrangeForeground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteDarkOrangeForeground3 = "var(--colorPaletteDarkOrangeForeground3)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteDarkRedBackground2 = "var(--colorPaletteDarkRedBackground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteDarkRedBorderActive = "var(--colorPaletteDarkRedBorderActive)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteDarkRedForeground2 = "var(--colorPaletteDarkRedForeground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteForestBackground2 = "var(--colorPaletteForestBackground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteForestBorderActive = "var(--colorPaletteForestBorderActive)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteForestForeground2 = "var(--colorPaletteForestForeground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteGoldBackground2 = "var(--colorPaletteGoldBackground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteGoldBorderActive = "var(--colorPaletteGoldBorderActive)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteGoldForeground2 = "var(--colorPaletteGoldForeground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteGrapeBackground2 = "var(--colorPaletteGrapeBackground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteGrapeBorderActive = "var(--colorPaletteGrapeBorderActive)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteGrapeForeground2 = "var(--colorPaletteGrapeForeground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteGreenBackground1 = "var(--colorPaletteGreenBackground1)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteGreenBackground2 = "var(--colorPaletteGreenBackground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteGreenBackground3 = "var(--colorPaletteGreenBackground3)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteGreenBorder1 = "var(--colorPaletteGreenBorder1)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteGreenBorder2 = "var(--colorPaletteGreenBorder2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteGreenBorderActive = "var(--colorPaletteGreenBorderActive)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteGreenForeground1 = "var(--colorPaletteGreenForeground1)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteGreenForeground2 = "var(--colorPaletteGreenForeground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteGreenForeground3 = "var(--colorPaletteGreenForeground3)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteGreenForegroundInverted = "var(--colorPaletteGreenForegroundInverted)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteLavenderBackground2 = "var(--colorPaletteLavenderBackground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteLavenderBorderActive = "var(--colorPaletteLavenderBorderActive)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteLavenderForeground2 = "var(--colorPaletteLavenderForeground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteLightGreenBackground1 = "var(--colorPaletteLightGreenBackground1)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteLightGreenBackground2 = "var(--colorPaletteLightGreenBackground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteLightGreenBackground3 = "var(--colorPaletteLightGreenBackground3)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteLightGreenBorder1 = "var(--colorPaletteLightGreenBorder1)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteLightGreenBorder2 = "var(--colorPaletteLightGreenBorder2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteLightGreenBorderActive = "var(--colorPaletteLightGreenBorderActive)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteLightGreenForeground1 = "var(--colorPaletteLightGreenForeground1)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteLightGreenForeground2 = "var(--colorPaletteLightGreenForeground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteLightGreenForeground3 = "var(--colorPaletteLightGreenForeground3)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteLightTealBackground2 = "var(--colorPaletteLightTealBackground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteLightTealBorderActive = "var(--colorPaletteLightTealBorderActive)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteLightTealForeground2 = "var(--colorPaletteLightTealForeground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteLilacBackground2 = "var(--colorPaletteLilacBackground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteLilacBorderActive = "var(--colorPaletteLilacBorderActive)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteLilacForeground2 = "var(--colorPaletteLilacForeground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteMagentaBackground2 = "var(--colorPaletteMagentaBackground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteMagentaBorderActive = "var(--colorPaletteMagentaBorderActive)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteMagentaForeground2 = "var(--colorPaletteMagentaForeground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteMarigoldBackground1 = "var(--colorPaletteMarigoldBackground1)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteMarigoldBackground2 = "var(--colorPaletteMarigoldBackground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteMarigoldBackground3 = "var(--colorPaletteMarigoldBackground3)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteMarigoldBorder1 = "var(--colorPaletteMarigoldBorder1)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteMarigoldBorder2 = "var(--colorPaletteMarigoldBorder2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteMarigoldBorderActive = "var(--colorPaletteMarigoldBorderActive)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteMarigoldForeground1 = "var(--colorPaletteMarigoldForeground1)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteMarigoldForeground2 = "var(--colorPaletteMarigoldForeground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteMarigoldForeground3 = "var(--colorPaletteMarigoldForeground3)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteMinkBackground2 = "var(--colorPaletteMinkBackground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteMinkBorderActive = "var(--colorPaletteMinkBorderActive)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteMinkForeground2 = "var(--colorPaletteMinkForeground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteNavyBackground2 = "var(--colorPaletteNavyBackground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteNavyBorderActive = "var(--colorPaletteNavyBorderActive)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteNavyForeground2 = "var(--colorPaletteNavyForeground2)";
 
-// @public (undocumented)
+// @public
 export const colorPalettePeachBackground2 = "var(--colorPalettePeachBackground2)";
 
-// @public (undocumented)
+// @public
 export const colorPalettePeachBorderActive = "var(--colorPalettePeachBorderActive)";
 
-// @public (undocumented)
+// @public
 export const colorPalettePeachForeground2 = "var(--colorPalettePeachForeground2)";
 
-// @public (undocumented)
+// @public
 export const colorPalettePinkBackground2 = "var(--colorPalettePinkBackground2)";
 
-// @public (undocumented)
+// @public
 export const colorPalettePinkBorderActive = "var(--colorPalettePinkBorderActive)";
 
-// @public (undocumented)
+// @public
 export const colorPalettePinkForeground2 = "var(--colorPalettePinkForeground2)";
 
-// @public (undocumented)
+// @public
 export const colorPalettePlatinumBackground2 = "var(--colorPalettePlatinumBackground2)";
 
-// @public (undocumented)
+// @public
 export const colorPalettePlatinumBorderActive = "var(--colorPalettePlatinumBorderActive)";
 
-// @public (undocumented)
+// @public
 export const colorPalettePlatinumForeground2 = "var(--colorPalettePlatinumForeground2)";
 
-// @public (undocumented)
+// @public
 export const colorPalettePlumBackground2 = "var(--colorPalettePlumBackground2)";
 
-// @public (undocumented)
+// @public
 export const colorPalettePlumBorderActive = "var(--colorPalettePlumBorderActive)";
 
-// @public (undocumented)
+// @public
 export const colorPalettePlumForeground2 = "var(--colorPalettePlumForeground2)";
 
-// @public (undocumented)
+// @public
 export const colorPalettePumpkinBackground2 = "var(--colorPalettePumpkinBackground2)";
 
-// @public (undocumented)
+// @public
 export const colorPalettePumpkinBorderActive = "var(--colorPalettePumpkinBorderActive)";
 
-// @public (undocumented)
+// @public
 export const colorPalettePumpkinForeground2 = "var(--colorPalettePumpkinForeground2)";
 
-// @public (undocumented)
+// @public
 export const colorPalettePurpleBackground2 = "var(--colorPalettePurpleBackground2)";
 
-// @public (undocumented)
+// @public
 export const colorPalettePurpleBorderActive = "var(--colorPalettePurpleBorderActive)";
 
-// @public (undocumented)
+// @public
 export const colorPalettePurpleForeground2 = "var(--colorPalettePurpleForeground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteRedBackground1 = "var(--colorPaletteRedBackground1)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteRedBackground2 = "var(--colorPaletteRedBackground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteRedBackground3 = "var(--colorPaletteRedBackground3)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteRedBorder1 = "var(--colorPaletteRedBorder1)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteRedBorder2 = "var(--colorPaletteRedBorder2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteRedBorderActive = "var(--colorPaletteRedBorderActive)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteRedForeground1 = "var(--colorPaletteRedForeground1)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteRedForeground2 = "var(--colorPaletteRedForeground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteRedForeground3 = "var(--colorPaletteRedForeground3)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteRedForegroundInverted = "var(--colorPaletteRedForegroundInverted)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteRoyalBlueBackground2 = "var(--colorPaletteRoyalBlueBackground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteRoyalBlueBorderActive = "var(--colorPaletteRoyalBlueBorderActive)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteRoyalBlueForeground2 = "var(--colorPaletteRoyalBlueForeground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteSeafoamBackground2 = "var(--colorPaletteSeafoamBackground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteSeafoamBorderActive = "var(--colorPaletteSeafoamBorderActive)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteSeafoamForeground2 = "var(--colorPaletteSeafoamForeground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteSteelBackground2 = "var(--colorPaletteSteelBackground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteSteelBorderActive = "var(--colorPaletteSteelBorderActive)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteSteelForeground2 = "var(--colorPaletteSteelForeground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteTealBackground2 = "var(--colorPaletteTealBackground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteTealBorderActive = "var(--colorPaletteTealBorderActive)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteTealForeground2 = "var(--colorPaletteTealForeground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteYellowBackground1 = "var(--colorPaletteYellowBackground1)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteYellowBackground2 = "var(--colorPaletteYellowBackground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteYellowBackground3 = "var(--colorPaletteYellowBackground3)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteYellowBorder1 = "var(--colorPaletteYellowBorder1)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteYellowBorder2 = "var(--colorPaletteYellowBorder2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteYellowBorderActive = "var(--colorPaletteYellowBorderActive)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteYellowForeground1 = "var(--colorPaletteYellowForeground1)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteYellowForeground2 = "var(--colorPaletteYellowForeground2)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteYellowForeground3 = "var(--colorPaletteYellowForeground3)";
 
-// @public (undocumented)
+// @public
 export const colorPaletteYellowForegroundInverted = "var(--colorPaletteYellowForegroundInverted)";
 
-// @public (undocumented)
+// @public
 export const colorScrollbarOverlay = "var(--colorScrollbarOverlay)";
 
-// @public (undocumented)
+// @public
 export const colorStatusDangerBackground1 = "var(--colorStatusDangerBackground1)";
 
-// @public (undocumented)
+// @public
 export const colorStatusDangerBackground2 = "var(--colorStatusDangerBackground2)";
 
-// @public (undocumented)
+// @public
 export const colorStatusDangerBackground3 = "var(--colorStatusDangerBackground3)";
 
-// @public (undocumented)
+// @public
 export const colorStatusDangerBackground3Hover = "var(--colorStatusDangerBackground3Hover)";
 
-// @public (undocumented)
+// @public
 export const colorStatusDangerBackground3Pressed = "var(--colorStatusDangerBackground3Pressed)";
 
-// @public (undocumented)
+// @public
 export const colorStatusDangerBorder1 = "var(--colorStatusDangerBorder1)";
 
-// @public (undocumented)
+// @public
 export const colorStatusDangerBorder2 = "var(--colorStatusDangerBorder2)";
 
-// @public (undocumented)
+// @public
 export const colorStatusDangerBorderActive = "var(--colorStatusDangerBorderActive)";
 
-// @public (undocumented)
+// @public
 export const colorStatusDangerForeground1 = "var(--colorStatusDangerForeground1)";
 
-// @public (undocumented)
+// @public
 export const colorStatusDangerForeground2 = "var(--colorStatusDangerForeground2)";
 
-// @public (undocumented)
+// @public
 export const colorStatusDangerForeground3 = "var(--colorStatusDangerForeground3)";
 
-// @public (undocumented)
+// @public
 export const colorStatusDangerForegroundInverted = "var(--colorStatusDangerForegroundInverted)";
 
-// @public (undocumented)
+// @public
 export const colorStatusSuccessBackground1 = "var(--colorStatusSuccessBackground1)";
 
-// @public (undocumented)
+// @public
 export const colorStatusSuccessBackground2 = "var(--colorStatusSuccessBackground2)";
 
-// @public (undocumented)
+// @public
 export const colorStatusSuccessBackground3 = "var(--colorStatusSuccessBackground3)";
 
-// @public (undocumented)
+// @public
 export const colorStatusSuccessBorder1 = "var(--colorStatusSuccessBorder1)";
 
-// @public (undocumented)
+// @public
 export const colorStatusSuccessBorder2 = "var(--colorStatusSuccessBorder2)";
 
-// @public (undocumented)
+// @public
 export const colorStatusSuccessBorderActive = "var(--colorStatusSuccessBorderActive)";
 
-// @public (undocumented)
+// @public
 export const colorStatusSuccessForeground1 = "var(--colorStatusSuccessForeground1)";
 
-// @public (undocumented)
+// @public
 export const colorStatusSuccessForeground2 = "var(--colorStatusSuccessForeground2)";
 
-// @public (undocumented)
+// @public
 export const colorStatusSuccessForeground3 = "var(--colorStatusSuccessForeground3)";
 
-// @public (undocumented)
+// @public
 export const colorStatusSuccessForegroundInverted = "var(--colorStatusSuccessForegroundInverted)";
 
-// @public (undocumented)
+// @public
 export const colorStatusWarningBackground1 = "var(--colorStatusWarningBackground1)";
 
-// @public (undocumented)
+// @public
 export const colorStatusWarningBackground2 = "var(--colorStatusWarningBackground2)";
 
-// @public (undocumented)
+// @public
 export const colorStatusWarningBackground3 = "var(--colorStatusWarningBackground3)";
 
-// @public (undocumented)
+// @public
 export const colorStatusWarningBorder1 = "var(--colorStatusWarningBorder1)";
 
-// @public (undocumented)
+// @public
 export const colorStatusWarningBorder2 = "var(--colorStatusWarningBorder2)";
 
-// @public (undocumented)
+// @public
 export const colorStatusWarningBorderActive = "var(--colorStatusWarningBorderActive)";
 
-// @public (undocumented)
+// @public
 export const colorStatusWarningForeground1 = "var(--colorStatusWarningForeground1)";
 
-// @public (undocumented)
+// @public
 export const colorStatusWarningForeground2 = "var(--colorStatusWarningForeground2)";
 
-// @public (undocumented)
+// @public
 export const colorStatusWarningForeground3 = "var(--colorStatusWarningForeground3)";
 
-// @public (undocumented)
+// @public
 export const colorStatusWarningForegroundInverted = "var(--colorStatusWarningForegroundInverted)";
 
-// @public (undocumented)
+// @public
 export const colorStrokeFocus1 = "var(--colorStrokeFocus1)";
 
-// @public (undocumented)
+// @public
 export const colorStrokeFocus2 = "var(--colorStrokeFocus2)";
 
-// @public (undocumented)
+// @public
 export const colorSubtleBackground = "var(--colorSubtleBackground)";
 
-// @public (undocumented)
+// @public
 export const colorSubtleBackgroundHover = "var(--colorSubtleBackgroundHover)";
 
-// @public (undocumented)
+// @public
 export const colorSubtleBackgroundInverted = "var(--colorSubtleBackgroundInverted)";
 
-// @public (undocumented)
+// @public
 export const colorSubtleBackgroundInvertedHover = "var(--colorSubtleBackgroundInvertedHover)";
 
-// @public (undocumented)
+// @public
 export const colorSubtleBackgroundInvertedPressed = "var(--colorSubtleBackgroundInvertedPressed)";
 
-// @public (undocumented)
+// @public
 export const colorSubtleBackgroundInvertedSelected = "var(--colorSubtleBackgroundInvertedSelected)";
 
-// @public (undocumented)
+// @public
 export const colorSubtleBackgroundLightAlphaHover = "var(--colorSubtleBackgroundLightAlphaHover)";
 
-// @public (undocumented)
+// @public
 export const colorSubtleBackgroundLightAlphaPressed = "var(--colorSubtleBackgroundLightAlphaPressed)";
 
-// @public (undocumented)
+// @public
 export const colorSubtleBackgroundLightAlphaSelected = "var(--colorSubtleBackgroundLightAlphaSelected)";
 
-// @public (undocumented)
+// @public
 export const colorSubtleBackgroundPressed = "var(--colorSubtleBackgroundPressed)";
 
-// @public (undocumented)
+// @public
 export const colorSubtleBackgroundSelected = "var(--colorSubtleBackgroundSelected)";
 
-// @public (undocumented)
+// @public
 export const colorTransparentBackground = "var(--colorTransparentBackground)";
 
-// @public (undocumented)
+// @public
 export const colorTransparentBackgroundHover = "var(--colorTransparentBackgroundHover)";
 
-// @public (undocumented)
+// @public
 export const colorTransparentBackgroundPressed = "var(--colorTransparentBackgroundPressed)";
 
-// @public (undocumented)
+// @public
 export const colorTransparentBackgroundSelected = "var(--colorTransparentBackgroundSelected)";
 
-// @public (undocumented)
+// @public
 export const colorTransparentStroke = "var(--colorTransparentStroke)";
 
-// @public (undocumented)
+// @public
 export const colorTransparentStrokeDisabled = "var(--colorTransparentStrokeDisabled)";
 
-// @public (undocumented)
+// @public
 export const colorTransparentStrokeInteractive = "var(--colorTransparentStrokeInteractive)";
 
 // @public
@@ -1702,12 +1730,15 @@ export const CompoundButtonSize: {
 // @public
 export type CompoundButtonSize = ValuesOf<typeof CompoundButtonSize>;
 
+// Warning: (ae-missing-release-tag) "styles" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export const CompoundButtonStyles: ElementStyles;
 
 // @public
 export const CompoundButtonTemplate: ElementViewTemplate<CompoundButton>;
 
+// Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
 // Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "CounterBadge" because one of its declarations is marked as @internal
 //
 // @public
@@ -1787,31 +1818,31 @@ export const CounterBadgeStyles: ElementStyles;
 // @public
 export const CounterBadgeTemplate: ElementViewTemplate<CounterBadge>;
 
-// @public (undocumented)
+// @public
 export const curveAccelerateMax = "var(--curveAccelerateMax)";
 
-// @public (undocumented)
+// @public
 export const curveAccelerateMid = "var(--curveAccelerateMid)";
 
-// @public (undocumented)
+// @public
 export const curveAccelerateMin = "var(--curveAccelerateMin)";
 
-// @public (undocumented)
+// @public
 export const curveDecelerateMax = "var(--curveDecelerateMax)";
 
-// @public (undocumented)
+// @public
 export const curveDecelerateMid = "var(--curveDecelerateMid)";
 
-// @public (undocumented)
+// @public
 export const curveDecelerateMin = "var(--curveDecelerateMin)";
 
-// @public (undocumented)
+// @public
 export const curveEasyEase = "var(--curveEasyEase)";
 
-// @public (undocumented)
+// @public
 export const curveEasyEaseMax = "var(--curveEasyEaseMax)";
 
-// @public (undocumented)
+// @public
 export const curveLinear = "var(--curveLinear)";
 
 // @public
@@ -1843,6 +1874,8 @@ export class Dialog extends FASTElement {
 // @public
 export const DialogDefinition: FASTElementDefinition<typeof Dialog>;
 
+// Warning: (ae-missing-release-tag) "DialogModalType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public
 export const DialogModalType: {
     readonly modal: "modal";
@@ -1864,10 +1897,15 @@ export const DialogTemplate: ElementViewTemplate<Dialog>;
 // @public
 export function display(displayValue: CSSDisplayPropertyValue): string;
 
+// Warning: (ae-missing-release-tag) "Divider" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public
 export class Divider extends FASTElement {
+    // (undocumented)
     alignContent?: DividerAlignContent;
+    // (undocumented)
     appearance?: DividerAppearance;
+    // (undocumented)
     inset?: boolean;
     orientation: DividerOrientation;
     role: DividerRole;
@@ -1924,30 +1962,32 @@ export const DividerStyles: ElementStyles;
 // @public
 export const DividerTemplate: ElementViewTemplate<Divider>;
 
-// @public (undocumented)
+// @public
 export const durationFast = "var(--durationFast)";
 
-// @public (undocumented)
+// @public
 export const durationFaster = "var(--durationFaster)";
 
-// @public (undocumented)
+// @public
 export const durationGentle = "var(--durationGentle)";
 
-// @public (undocumented)
+// @public
 export const durationNormal = "var(--durationNormal)";
 
-// @public (undocumented)
+// @public
 export const durationSlow = "var(--durationSlow)";
 
-// @public (undocumented)
+// @public
 export const durationSlower = "var(--durationSlower)";
 
-// @public (undocumented)
+// @public
 export const durationUltraFast = "var(--durationUltraFast)";
 
-// @public (undocumented)
+// @public
 export const durationUltraSlow = "var(--durationUltraSlow)";
 
+// Warning: (ae-missing-release-tag) "FluentDesignSystem" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export const FluentDesignSystem: Readonly<{
     prefix: "fluent";
@@ -1955,55 +1995,55 @@ export const FluentDesignSystem: Readonly<{
     registry: CustomElementRegistry;
 }>;
 
-// @public (undocumented)
+// @public
 export const fontFamilyBase = "var(--fontFamilyBase)";
 
-// @public (undocumented)
+// @public
 export const fontFamilyMonospace = "var(--fontFamilyMonospace)";
 
-// @public (undocumented)
+// @public
 export const fontFamilyNumeric = "var(--fontFamilyNumeric)";
 
-// @public (undocumented)
+// @public
 export const fontSizeBase100 = "var(--fontSizeBase100)";
 
-// @public (undocumented)
+// @public
 export const fontSizeBase200 = "var(--fontSizeBase200)";
 
-// @public (undocumented)
+// @public
 export const fontSizeBase300 = "var(--fontSizeBase300)";
 
-// @public (undocumented)
+// @public
 export const fontSizeBase400 = "var(--fontSizeBase400)";
 
-// @public (undocumented)
+// @public
 export const fontSizeBase500 = "var(--fontSizeBase500)";
 
-// @public (undocumented)
+// @public
 export const fontSizeBase600 = "var(--fontSizeBase600)";
 
-// @public (undocumented)
+// @public
 export const fontSizeHero1000 = "var(--fontSizeHero1000)";
 
-// @public (undocumented)
+// @public
 export const fontSizeHero700 = "var(--fontSizeHero700)";
 
-// @public (undocumented)
+// @public
 export const fontSizeHero800 = "var(--fontSizeHero800)";
 
-// @public (undocumented)
+// @public
 export const fontSizeHero900 = "var(--fontSizeHero900)";
 
-// @public (undocumented)
+// @public
 export const fontWeightBold = "var(--fontWeightBold)";
 
-// @public (undocumented)
+// @public
 export const fontWeightMedium = "var(--fontWeightMedium)";
 
-// @public (undocumented)
+// @public
 export const fontWeightRegular = "var(--fontWeightRegular)";
 
-// @public (undocumented)
+// @public
 export const fontWeightSemibold = "var(--fontWeightSemibold)";
 
 // @public
@@ -2037,6 +2077,8 @@ export const ImageFit: {
 // @public
 export type ImageFit = ValuesOf<typeof ImageFit>;
 
+// Warning: (ae-missing-release-tag) "ImageShape" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public
 export const ImageShape: {
     readonly circular: "circular";
@@ -2064,6 +2106,8 @@ export class Label extends FASTElement {
 // @public
 export const LabelDefinition: FASTElementDefinition<typeof Label>;
 
+// Warning: (ae-missing-release-tag) "LabelSize" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public
 export const LabelSize: {
     readonly small: "small";
@@ -2077,9 +2121,13 @@ export type LabelSize = ValuesOf<typeof LabelSize>;
 // @public
 export const LabelStyles: ElementStyles;
 
+// Warning: (ae-missing-release-tag) "template" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export const LabelTemplate: ElementViewTemplate<Label>;
 
+// Warning: (ae-missing-release-tag) "LabelWeight" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public
 export const LabelWeight: {
     readonly regular: "regular";
@@ -2092,34 +2140,34 @@ export type LabelWeight = ValuesOf<typeof LabelWeight>;
 // @public
 export const lightModeStylesheetBehavior: (styles: ElementStyles) => MatchMediaStyleSheetBehavior;
 
-// @public (undocumented)
+// @public
 export const lineHeightBase100 = "var(--lineHeightBase100)";
 
-// @public (undocumented)
+// @public
 export const lineHeightBase200 = "var(--lineHeightBase200)";
 
-// @public (undocumented)
+// @public
 export const lineHeightBase300 = "var(--lineHeightBase300)";
 
-// @public (undocumented)
+// @public
 export const lineHeightBase400 = "var(--lineHeightBase400)";
 
-// @public (undocumented)
+// @public
 export const lineHeightBase500 = "var(--lineHeightBase500)";
 
-// @public (undocumented)
+// @public
 export const lineHeightBase600 = "var(--lineHeightBase600)";
 
-// @public (undocumented)
+// @public
 export const lineHeightHero1000 = "var(--lineHeightHero1000)";
 
-// @public (undocumented)
+// @public
 export const lineHeightHero700 = "var(--lineHeightHero700)";
 
-// @public (undocumented)
+// @public
 export const lineHeightHero800 = "var(--lineHeightHero800)";
 
-// @public (undocumented)
+// @public
 export const lineHeightHero900 = "var(--lineHeightHero900)";
 
 // @public
@@ -2169,7 +2217,9 @@ export class Menu extends FASTElement {
     // @internal
     positioningContainer?: HTMLElement;
     setComponent(): void;
+    // @internal
     protected setPositioning(): void;
+    // @internal
     protected setPositioningTask: () => void;
     slottedMenuList: MenuList[];
     slottedTriggers: HTMLElement[];
@@ -2221,6 +2271,7 @@ export const MenuButtonTemplate: ElementViewTemplate<MenuButton>;
 // @public
 export const MenuDefinition: FASTElementDefinition<typeof Menu>;
 
+// Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
 // Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "MenuItem" because one of its declarations is marked as @internal
 //
 // @public
@@ -2264,6 +2315,8 @@ export class MenuItem extends FASTElement {
 export interface MenuItem extends StartEnd {
 }
 
+// Warning: (ae-missing-release-tag) "MenuItemColumnCount" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export type MenuItemColumnCount = 0 | 1 | 2;
 
@@ -2290,6 +2343,8 @@ export type MenuItemRole = ValuesOf<typeof MenuItemRole>;
 // @public
 export const MenuItemStyles: ElementStyles;
 
+// Warning: (ae-missing-release-tag) "template" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export const MenuItemTemplate: ElementViewTemplate<MenuItem>;
 
@@ -2326,12 +2381,16 @@ export const MenuListDefinition: FASTElementDefinition<typeof MenuList>;
 // @public
 export const MenuListStyles: ElementStyles;
 
+// Warning: (ae-missing-release-tag) "template" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export const MenuListTemplate: ElementViewTemplate<MenuList>;
 
 // @public
 export const MenuStyles: ElementStyles;
 
+// Warning: (ae-missing-release-tag) "template" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export const MenuTemplate: ElementViewTemplate<Menu>;
 
@@ -2359,6 +2418,8 @@ export type ProgressBarShape = ValuesOf<typeof ProgressBarShape>;
 // @public
 export const ProgressBarStyles: ElementStyles;
 
+// Warning: (ae-missing-release-tag) "template" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export const ProgressBarTemplate: ElementViewTemplate<ProgressBar>;
 
@@ -2461,6 +2522,8 @@ export type RadioGroupOrientation = ValuesOf<typeof RadioGroupOrientation>;
 // @public
 export const RadioGroupStyles: ElementStyles;
 
+// Warning: (ae-missing-release-tag) "template" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export const RadioGroupTemplate: ElementViewTemplate<RadioGroup>;
 
@@ -2472,6 +2535,8 @@ export type RadioOptions = {
 // @public
 export const RadioStyles: ElementStyles;
 
+// Warning: (ae-missing-release-tag) "template" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export const RadioTemplate: ElementViewTemplate<Radio>;
 
@@ -2482,46 +2547,50 @@ export const roleForMenuItem: {
     [value in keyof typeof MenuItemRole]: (typeof MenuItemRole)[value];
 };
 
-// @public
+// Warning: (ae-internal-missing-underscore) The name "setTheme" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal
 export const setTheme: (theme: Theme) => void;
 
-// @public (undocumented)
+// Warning: (ae-internal-missing-underscore) The name "setThemeFor" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal (undocumented)
 export const setThemeFor: (element: HTMLElement, theme: Theme) => void;
 
-// @public (undocumented)
+// @public
 export const shadow16 = "var(--shadow16)";
 
-// @public (undocumented)
+// @public
 export const shadow16Brand = "var(--shadow16Brand)";
 
-// @public (undocumented)
+// @public
 export const shadow2 = "var(--shadow2)";
 
-// @public (undocumented)
+// @public
 export const shadow28 = "var(--shadow28)";
 
-// @public (undocumented)
+// @public
 export const shadow28Brand = "var(--shadow28Brand)";
 
-// @public (undocumented)
+// @public
 export const shadow2Brand = "var(--shadow2Brand)";
 
-// @public (undocumented)
+// @public
 export const shadow4 = "var(--shadow4)";
 
-// @public (undocumented)
+// @public
 export const shadow4Brand = "var(--shadow4Brand)";
 
-// @public (undocumented)
+// @public
 export const shadow64 = "var(--shadow64)";
 
-// @public (undocumented)
+// @public
 export const shadow64Brand = "var(--shadow64Brand)";
 
-// @public (undocumented)
+// @public
 export const shadow8 = "var(--shadow8)";
 
-// @public (undocumented)
+// @public
 export const shadow8Brand = "var(--shadow8Brand)";
 
 // Warning: (ae-forgotten-export) The symbol "FormAssociatedSlider" needs to be exported by the entry point index.d.ts
@@ -2642,73 +2711,75 @@ export type SliderSize = ValuesOf<typeof SliderSize>;
 // @public
 export const SliderStyles: ElementStyles;
 
+// Warning: (ae-missing-release-tag) "template" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export const SliderTemplate: ElementViewTemplate<Slider>;
 
-// @public (undocumented)
+// @public
 export const spacingHorizontalL = "var(--spacingHorizontalL)";
 
-// @public (undocumented)
+// @public
 export const spacingHorizontalM = "var(--spacingHorizontalM)";
 
-// @public (undocumented)
+// @public
 export const spacingHorizontalMNudge = "var(--spacingHorizontalMNudge)";
 
-// @public (undocumented)
+// @public
 export const spacingHorizontalNone = "var(--spacingHorizontalNone)";
 
-// @public (undocumented)
+// @public
 export const spacingHorizontalS = "var(--spacingHorizontalS)";
 
-// @public (undocumented)
+// @public
 export const spacingHorizontalSNudge = "var(--spacingHorizontalSNudge)";
 
-// @public (undocumented)
+// @public
 export const spacingHorizontalXL = "var(--spacingHorizontalXL)";
 
-// @public (undocumented)
+// @public
 export const spacingHorizontalXS = "var(--spacingHorizontalXS)";
 
-// @public (undocumented)
+// @public
 export const spacingHorizontalXXL = "var(--spacingHorizontalXXL)";
 
-// @public (undocumented)
+// @public
 export const spacingHorizontalXXS = "var(--spacingHorizontalXXS)";
 
-// @public (undocumented)
+// @public
 export const spacingHorizontalXXXL = "var(--spacingHorizontalXXXL)";
 
-// @public (undocumented)
+// @public
 export const spacingVerticalL = "var(--spacingVerticalL)";
 
-// @public (undocumented)
+// @public
 export const spacingVerticalM = "var(--spacingVerticalM)";
 
-// @public (undocumented)
+// @public
 export const spacingVerticalMNudge = "var(--spacingVerticalMNudge)";
 
-// @public (undocumented)
+// @public
 export const spacingVerticalNone = "var(--spacingVerticalNone)";
 
-// @public (undocumented)
+// @public
 export const spacingVerticalS = "var(--spacingVerticalS)";
 
-// @public (undocumented)
+// @public
 export const spacingVerticalSNudge = "var(--spacingVerticalSNudge)";
 
-// @public (undocumented)
+// @public
 export const spacingVerticalXL = "var(--spacingVerticalXL)";
 
-// @public (undocumented)
+// @public
 export const spacingVerticalXS = "var(--spacingVerticalXS)";
 
-// @public (undocumented)
+// @public
 export const spacingVerticalXXL = "var(--spacingVerticalXXL)";
 
-// @public (undocumented)
+// @public
 export const spacingVerticalXXS = "var(--spacingVerticalXXS)";
 
-// @public (undocumented)
+// @public
 export const spacingVerticalXXXL = "var(--spacingVerticalXXXL)";
 
 // @public
@@ -2746,22 +2817,26 @@ export const SpinnerSize: {
 // @public
 export type SpinnerSize = ValuesOf<typeof SpinnerSize>;
 
+// Warning: (ae-missing-release-tag) "styles" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export const SpinnerStyles: ElementStyles;
 
+// Warning: (ae-missing-release-tag) "template" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export const SpinnerTemplate: ViewTemplate<Spinner, any>;
 
-// @public (undocumented)
+// @public
 export const strokeWidthThick = "var(--strokeWidthThick)";
 
-// @public (undocumented)
+// @public
 export const strokeWidthThicker = "var(--strokeWidthThicker)";
 
-// @public (undocumented)
+// @public
 export const strokeWidthThickest = "var(--strokeWidthThickest)";
 
-// @public (undocumented)
+// @public
 export const strokeWidthThin = "var(--strokeWidthThin)";
 
 // @public
@@ -2770,6 +2845,7 @@ export { styles as ButtonStyles }
 export { styles as MenuButtonStyles }
 
 // Warning: (ae-forgotten-export) The symbol "FormAssociatedSwitch" needs to be exported by the entry point index.d.ts
+// Warning: (ae-missing-release-tag) "Switch" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class Switch extends FormAssociatedSwitch {
@@ -2801,17 +2877,26 @@ export const SwitchLabelPosition: {
 // @public
 export type SwitchLabelPosition = ValuesOf<typeof SwitchLabelPosition>;
 
+// Warning: (ae-missing-release-tag) "SwitchOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export type SwitchOptions = {
     switch?: StaticallyComposableHTML<Switch>;
 };
 
+// Warning: (ae-missing-release-tag) "styles" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export const SwitchStyles: ElementStyles;
 
+// Warning: (ae-missing-release-tag) "template" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export const SwitchTemplate: ElementViewTemplate<Switch>;
 
+// Warning: (ae-missing-release-tag) "Tab" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "Tab" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public
 export class Tab extends FASTElement {
     // (undocumented)
@@ -2823,26 +2908,38 @@ export class Tab extends FASTElement {
 export interface Tab extends StartEnd {
 }
 
+// Warning: (ae-missing-release-tag) "definition" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export const TabDefinition: FASTElementDefinition<typeof Tab>;
 
 // @public
 export type TabOptions = StartEndOptions<Tab>;
 
+// Warning: (ae-missing-release-tag) "TabPanel" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export class TabPanel extends FASTElement {
 }
 
+// Warning: (ae-missing-release-tag) "definition" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export const TabPanelDefinition: FASTElementDefinition<typeof TabPanel>;
 
+// Warning: (ae-missing-release-tag) "styles" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export const TabPanelStyles: ElementStyles;
 
+// Warning: (ae-missing-release-tag) "template" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export const TabPanelTemplate: ElementViewTemplate<TabPanel, any>;
 
 // Warning: (ae-forgotten-export) The symbol "BaseTabs" needs to be exported by the entry point index.d.ts
+// Warning: (ae-missing-release-tag) "Tabs" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "Tabs" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class Tabs extends BaseTabs {
@@ -2859,6 +2956,9 @@ export class Tabs extends BaseTabs {
 export interface Tabs extends StartEnd {
 }
 
+// Warning: (ae-missing-release-tag) "TabsAppearance" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "TabsAppearance" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export const TabsAppearance: {
     readonly subtle: "subtle";
@@ -2868,6 +2968,8 @@ export const TabsAppearance: {
 // @public (undocumented)
 export type TabsAppearance = ValuesOf<typeof TabsAppearance>;
 
+// Warning: (ae-missing-release-tag) "definition" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export const TabsDefinition: FASTElementDefinition<typeof Tabs>;
 
@@ -2883,6 +2985,9 @@ export const TabsOrientation: {
 // @public
 export type TabsOrientation = ValuesOf<typeof TabsOrientation>;
 
+// Warning: (ae-missing-release-tag) "TabsSize" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "TabsSize" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export const TabsSize: {
     readonly small: "small";
@@ -2893,15 +2998,23 @@ export const TabsSize: {
 // @public (undocumented)
 export type TabsSize = ValuesOf<typeof TabsSize>;
 
+// Warning: (ae-missing-release-tag) "styles" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export const TabsStyles: ElementStyles;
 
+// Warning: (ae-missing-release-tag) "template" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export const TabsTemplate: ElementViewTemplate<Tabs, any>;
 
+// Warning: (ae-missing-release-tag) "styles" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export const TabStyles: ElementStyles;
 
+// Warning: (ae-missing-release-tag) "template" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export const TabTemplate: ElementViewTemplate<Tab, any>;
 
@@ -2944,11 +3057,11 @@ export const TextFont: {
 // @public
 export type TextFont = ValuesOf<typeof TextFont>;
 
+// Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
 // Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "TextInput" because one of its declarations is marked as @internal
 //
 // @public
 export class TextInput extends FASTElement {
-    constructor();
     appearance?: TextInputAppearance;
     autocomplete?: string;
     autofocus: boolean;
@@ -3015,6 +3128,8 @@ export class TextInput extends FASTElement {
 export interface TextInput extends StartEnd {
 }
 
+// Warning: (ae-missing-release-tag) "TextInputAppearance" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public
 export const TextInputAppearance: {
     readonly outline: "outline";
@@ -3026,6 +3141,8 @@ export const TextInputAppearance: {
 // @public (undocumented)
 export type TextInputAppearance = ValuesOf<typeof TextInputAppearance>;
 
+// Warning: (ae-missing-release-tag) "TextInputControlSize" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public
 export const TextInputControlSize: {
     readonly small: "small";
@@ -3050,6 +3167,8 @@ export const TextInputStyles: ElementStyles;
 // @internal (undocumented)
 export const TextInputTemplate: ElementViewTemplate<TextInput>;
 
+// Warning: (ae-missing-release-tag) "TextInputType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public
 export const TextInputType: {
     readonly email: "email";
@@ -3153,54 +3272,88 @@ export const ToggleButtonStyles: ElementStyles;
 // @public
 export const ToggleButtonTemplate: ElementViewTemplate<ToggleButton>;
 
+// Warning: (ae-missing-release-tag) "typographyBody1StrongerStyles" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export const typographyBody1StrongerStyles: CSSDirective;
 
+// Warning: (ae-missing-release-tag) "typographyBody1StrongStyles" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export const typographyBody1StrongStyles: CSSDirective;
 
+// Warning: (ae-missing-release-tag) "typographyBody1Styles" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export const typographyBody1Styles: CSSDirective;
 
+// Warning: (ae-missing-release-tag) "typographyBody2Styles" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export const typographyBody2Styles: CSSDirective;
 
+// Warning: (ae-missing-release-tag) "typographyCaption1StrongerStyles" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export const typographyCaption1StrongerStyles: CSSDirective;
 
+// Warning: (ae-missing-release-tag) "typographyCaption1StrongStyles" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export const typographyCaption1StrongStyles: CSSDirective;
 
+// Warning: (ae-missing-release-tag) "typographyCaption1Styles" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export const typographyCaption1Styles: CSSDirective;
 
+// Warning: (ae-missing-release-tag) "typographyCaption2StrongStyles" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export const typographyCaption2StrongStyles: CSSDirective;
 
+// Warning: (ae-missing-release-tag) "typographyCaption2Styles" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export const typographyCaption2Styles: CSSDirective;
 
+// Warning: (ae-missing-release-tag) "typographyDisplayStyles" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export const typographyDisplayStyles: CSSDirective;
 
+// Warning: (ae-missing-release-tag) "typographyLargeTitleStyles" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export const typographyLargeTitleStyles: CSSDirective;
 
+// Warning: (ae-missing-release-tag) "typographySubtitle1Styles" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export const typographySubtitle1Styles: CSSDirective;
 
+// Warning: (ae-missing-release-tag) "typographySubtitle2StrongerStyles" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export const typographySubtitle2StrongerStyles: CSSDirective;
 
+// Warning: (ae-missing-release-tag) "typographySubtitle2Styles" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export const typographySubtitle2Styles: CSSDirective;
 
+// Warning: (ae-missing-release-tag) "typographyTitle1Styles" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export const typographyTitle1Styles: CSSDirective;
 
+// Warning: (ae-missing-release-tag) "typographyTitle2Styles" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export const typographyTitle2Styles: CSSDirective;
 
+// Warning: (ae-missing-release-tag) "typographyTitle3Styles" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export const typographyTitle3Styles: CSSDirective;
 

--- a/packages/web-components/scripts/generate-tokens.js
+++ b/packages/web-components/scripts/generate-tokens.js
@@ -17,7 +17,13 @@ function main() {
   const comment = '// THIS FILE IS GENERATED AS PART OF THE BUILD PROCESS. DO NOT MANUALLY MODIFY THIS FILE\n';
 
   const generatedTokens = fluentTokens.reduce((acc, t) => {
-    const token = `export const ${t} = 'var(--${t})';\n`;
+    const token = `
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#${t} | \`${t}\`} design token.
+ * @public
+ */
+export const ${t} = 'var(--${t})';
+`;
     return acc + token;
   }, '');
 

--- a/packages/web-components/src/accordion-item/accordion-item.template.ts
+++ b/packages/web-components/src/accordion-item/accordion-item.template.ts
@@ -1,7 +1,7 @@
 import { ElementViewTemplate, html, ref } from '@microsoft/fast-element';
 import { endSlotTemplate, startSlotTemplate } from '../patterns/index.js';
 import { staticallyCompose } from '../utils/index.js';
-import { AccordionItem, AccordionItemOptions } from './accordion-item.js';
+import type { AccordionItem, AccordionItemOptions } from './accordion-item.js';
 
 const chevronRight20Filled = html.partial(`<svg
   width="20"

--- a/packages/web-components/src/accordion-item/accordion-item.ts
+++ b/packages/web-components/src/accordion-item/accordion-item.ts
@@ -37,7 +37,6 @@ export class AccordionItem extends FASTElement {
    * Configures the {@link https://www.w3.org/TR/wai-aria-1.1/#aria-level | level} of the
    * heading element.
    *
-   * @defaultValue 2
    * @public
    * @remarks
    * HTML attribute: heading-level
@@ -83,7 +82,6 @@ export class AccordionItem extends FASTElement {
    * Defines accordion header font size.
    *
    * @public
-   * @default 'medium'
    * @remarks
    * HTML Attribute: size
    */
@@ -104,9 +102,8 @@ export class AccordionItem extends FASTElement {
    * Sets expand and collapsed icon position.
    *
    * @public
-   * @default 'start'
    * @remarks
-   * HTML Attribute: expandIconPosition
+   * HTML Attribute: expand-icon-position
    */
   @attr({ attribute: 'expand-icon-position' })
   public expandIconPosition?: AccordionItemExpandIconPosition;

--- a/packages/web-components/src/accordion-item/index.ts
+++ b/packages/web-components/src/accordion-item/index.ts
@@ -1,4 +1,5 @@
-export { AccordionItem, AccordionItemOptions } from './accordion-item.js';
+export { AccordionItem } from './accordion-item.js';
+export type { AccordionItemOptions } from './accordion-item.js';
 export { AccordionItemSize, AccordionItemExpandIconPosition } from './accordion-item.options.js';
 export { styles as accordionItemStyles } from './accordion-item.styles.js';
 export { definition as accordionItemDefinition } from './accordion-item.definition.js';

--- a/packages/web-components/src/accordion/accordion.options.ts
+++ b/packages/web-components/src/accordion/accordion.options.ts
@@ -1,7 +1,7 @@
 import type { ValuesOf } from '../utils/index.js';
 
 /**
- * Expand mode for {@link FASTAccordion}
+ * Expand mode for {@link Accordion}
  * @public
  */
 export const AccordionExpandMode = {
@@ -10,7 +10,7 @@ export const AccordionExpandMode = {
 } as const;
 
 /**
- * Type for the {@link FASTAccordion} Expand Mode
+ * Type for the {@link Accordion} Expand Mode
  * @public
  */
 export type AccordionExpandMode = ValuesOf<typeof AccordionExpandMode>;

--- a/packages/web-components/src/anchor-button/index.ts
+++ b/packages/web-components/src/anchor-button/index.ts
@@ -1,10 +1,5 @@
-export { AnchorButton } from './anchor-button.js';
-export {
-  AnchorButtonOptions,
-  AnchorButtonAppearance,
-  AnchorButtonShape,
-  AnchorButtonSize,
-  AnchorTarget,
-} from './anchor-button.options.js';
-export { template as AnchorButtonTemplate } from './anchor-button.template.js';
 export { definition as AnchorButtonDefinition } from './anchor-button.definition.js';
+export { AnchorButton } from './anchor-button.js';
+export { AnchorButtonAppearance, AnchorButtonShape, AnchorButtonSize, AnchorTarget } from './anchor-button.options.js';
+export type { AnchorButtonOptions } from './anchor-button.options.js';
+export { template as AnchorButtonTemplate } from './anchor-button.template.js';

--- a/packages/web-components/src/button/index.ts
+++ b/packages/web-components/src/button/index.ts
@@ -1,12 +1,6 @@
-export { Button } from './button.js';
-export {
-  ButtonAppearance,
-  ButtonFormTarget,
-  ButtonShape,
-  ButtonSize,
-  ButtonType,
-  ButtonOptions,
-} from './button.options.js';
-export { template as ButtonTemplate } from './button.template.js';
-export { styles as ButtonStyles } from './button.styles.js';
 export { definition as ButtonDefinition } from './button.definition.js';
+export { Button } from './button.js';
+export { ButtonAppearance, ButtonFormTarget, ButtonShape, ButtonSize, ButtonType } from './button.options.js';
+export type { ButtonOptions } from './button.options.js';
+export { styles as ButtonStyles } from './button.styles.js';
+export { template as ButtonTemplate } from './button.template.js';

--- a/packages/web-components/src/checkbox/checkbox.ts
+++ b/packages/web-components/src/checkbox/checkbox.ts
@@ -31,7 +31,6 @@ export class Checkbox extends FormAssociatedCheckbox {
    * Sets shape of the checkbox.
    *
    * @public
-   * @default 'square'
    * @remarks
    * HTML Attribute: shape
    */
@@ -42,7 +41,6 @@ export class Checkbox extends FormAssociatedCheckbox {
    * Sets size of the checkbox.
    *
    * @public
-   * @default 'medium'
    * @remarks
    * HTML Attribute: size
    */
@@ -53,7 +51,6 @@ export class Checkbox extends FormAssociatedCheckbox {
    * Sets position of the label relative to the input
    *
    * @public
-   * @default 'after'
    * @remarks
    * HTML Attribute: label-position
    */

--- a/packages/web-components/src/checkbox/index.ts
+++ b/packages/web-components/src/checkbox/index.ts
@@ -1,5 +1,6 @@
-export { Checkbox, CheckboxOptions } from './checkbox.js';
-export { CheckboxLabelPosition, CheckboxShape, CheckboxSize } from './checkbox.options.js';
 export { definition as CheckboxDefinition } from './checkbox.definition.js';
-export { template as CheckboxTemplate } from './checkbox.template.js';
+export { Checkbox } from './checkbox.js';
+export type { CheckboxOptions } from './checkbox.js';
+export { CheckboxLabelPosition, CheckboxShape, CheckboxSize } from './checkbox.options.js';
 export { styles as CheckboxStyles } from './checkbox.styles.js';
+export { template as CheckboxTemplate } from './checkbox.template.js';

--- a/packages/web-components/src/dialog/dialog.ts
+++ b/packages/web-components/src/dialog/dialog.ts
@@ -5,14 +5,13 @@ import { Button as FluentButton } from '../button/button.js';
 import { DialogModalType } from './dialog.options.js';
 
 /**
- * Dialog component that extends the FASTElement class.
+ * A Dialog Custom HTML Element.
  *
  * @public
- * @extends FASTElement
  */
 export class Dialog extends FASTElement {
   /**
-   * @private
+   * @internal
    * Indicates whether focus is being trapped within the dialog
    */
   private isTrappingFocus: boolean = false;
@@ -97,7 +96,7 @@ export class Dialog extends FASTElement {
   public noTitleAction: boolean = false;
 
   /**
-   * @private
+   * @internal
    * Indicates whether focus should be trapped within the dialog
    */
   private trapFocus: boolean = false;
@@ -228,7 +227,7 @@ export class Dialog extends FASTElement {
   };
 
   /**
-   * @private
+   * @internal
    * Handles keydown events on the document
    * @param e - The keydown event
    */
@@ -243,7 +242,7 @@ export class Dialog extends FASTElement {
   };
 
   /**
-   * @private
+   * @internal
    * Handles tab keydown events
    * @param e - The keydown event
    */
@@ -272,7 +271,7 @@ export class Dialog extends FASTElement {
   };
 
   /**
-   * @private
+   * @internal
    * Gets the bounds of the tab queue
    * @returns (HTMLElement | SVGElement)[]
    */
@@ -283,7 +282,7 @@ export class Dialog extends FASTElement {
   };
 
   /**
-   * @private
+   * @internal
    * Focuses the first element in the tab queue
    */
   private focusFirstElement = (): void => {
@@ -299,7 +298,7 @@ export class Dialog extends FASTElement {
   };
 
   /**
-   * @private
+   * @internal
    * Determines if focus should be forced
    * @param currentFocusElement - The currently focused element
    * @returns boolean
@@ -309,7 +308,7 @@ export class Dialog extends FASTElement {
   };
 
   /**
-   * @private
+   * @internal
    * Determines if focus should be trapped
    * @returns boolean
    */
@@ -318,7 +317,7 @@ export class Dialog extends FASTElement {
   };
 
   /**
-   * @private
+   * @internal
    * Handles focus events on the document
    * @param e - The focus event
    */
@@ -330,7 +329,7 @@ export class Dialog extends FASTElement {
   };
 
   /**
-   * @private
+   * @internal
    * Updates the state of focus trapping
    * @param shouldTrapFocusOverride - Optional override for whether focus should be trapped
    */
@@ -354,7 +353,7 @@ export class Dialog extends FASTElement {
   };
 
   /**
-   * @private
+   * @internal
    * Reduces the list of tabbable items
    * @param elements - The current list of elements
    * @param element - The element to consider adding to the list
@@ -377,7 +376,7 @@ export class Dialog extends FASTElement {
   }
 
   /**
-   * @private
+   * @internal
    * Determines if an element is a focusable FASTElement
    * @param element - The element to check
    * @returns boolean
@@ -387,7 +386,7 @@ export class Dialog extends FASTElement {
   }
 
   /**
-   * @private
+   * @internal
    * Determines if an element has a tabbable shadow
    * @param element - The element to check
    * @returns boolean

--- a/packages/web-components/src/divider/divider.ts
+++ b/packages/web-components/src/divider/divider.ts
@@ -2,7 +2,7 @@ import { attr, FASTElement } from '@microsoft/fast-element';
 import { DividerAlignContent, DividerAppearance, DividerOrientation, DividerRole } from './divider.options.js';
 
 /**
- * @class Divider component
+ * A Divider Custom HTML Element.
  *
  * @remarks
  * A divider groups sections of content to create visual rhythm and hierarchy. Use dividers along with spacing and headers to organize content in your layout.
@@ -29,8 +29,7 @@ export class Divider extends FASTElement {
   public orientation: DividerOrientation = DividerOrientation.horizontal;
 
   /**
-   * @property alignContent
-   * @default center
+   * @public
    * @remarks
    * Determines the alignment of the content within the divider. Select from start or end. When not specified, the content will be aligned to the center.
    */
@@ -38,8 +37,7 @@ export class Divider extends FASTElement {
   public alignContent?: DividerAlignContent;
 
   /**
-   * @property appearance
-   * @default default
+   * @public
    * @remarks
    * A divider can have one of the preset appearances. Select from strong, brand, subtle. When not specified, the divider has its default appearance.
    */
@@ -47,8 +45,7 @@ export class Divider extends FASTElement {
   public appearance?: DividerAppearance;
 
   /**
-   * @property inset
-   * @default false
+   * @public
    * @remarks
    * Adds padding to the beginning and end of the divider.
    */

--- a/packages/web-components/src/index.ts
+++ b/packages/web-components/src/index.ts
@@ -1,222 +1,170 @@
 export {
+  AccordionItem,
+  accordionItemDefinition,
+  AccordionItemExpandIconPosition,
+  AccordionItemSize,
+  accordionItemStyles,
+  accordionItemTemplate,
+} from './accordion-item/index.js';
+export type { AccordionItemOptions } from './accordion-item/index.js';
+export {
   Accordion,
-  AccordionExpandMode,
-  accordionTemplate,
-  accordionStyles,
   accordionDefinition,
+  AccordionExpandMode,
+  accordionStyles,
+  accordionTemplate,
 } from './accordion/index.js';
 export {
-  AccordionItem,
-  AccordionItemOptions,
-  AccordionItemSize,
-  AccordionItemExpandIconPosition,
-  accordionItemTemplate,
-  accordionItemStyles,
-  accordionItemDefinition,
-} from './accordion-item/index.js';
-export {
   AnchorButton,
-  AnchorButtonOptions,
   AnchorButtonAppearance,
+  AnchorButtonDefinition,
   AnchorButtonShape,
   AnchorButtonSize,
-  AnchorTarget,
   AnchorButtonTemplate,
-  AnchorButtonDefinition,
+  AnchorTarget,
 } from './anchor-button/index.js';
+export type { AnchorButtonOptions } from './anchor-button/index.js';
 export {
   Avatar,
   AvatarActive,
   AvatarAppearance,
   AvatarColor,
+  AvatarDefinition,
   AvatarNamedColor,
   AvatarShape,
   AvatarSize,
-  AvatarTemplate,
   AvatarStyles,
-  AvatarDefinition,
+  AvatarTemplate,
 } from './avatar/index.js';
 export {
   Badge,
   BadgeAppearance,
   BadgeColor,
+  BadgeDefinition,
   BadgeShape,
   BadgeSize,
-  BadgeTemplate,
   BadgeStyles,
-  BadgeDefinition,
+  BadgeTemplate,
 } from './badge/index.js';
 export {
   Button,
   ButtonAppearance,
+  ButtonDefinition,
   ButtonFormTarget,
   ButtonShape,
   ButtonSize,
-  ButtonType,
-  ButtonOptions,
-  ButtonTemplate,
   ButtonStyles,
-  ButtonDefinition,
+  ButtonTemplate,
+  ButtonType,
 } from './button/index.js';
+export type { ButtonOptions } from './button/index.js';
 export {
   Checkbox,
-  CheckboxOptions,
-  CheckboxLabelPosition,
+  CheckboxDefinition,
   CheckboxShape,
   CheckboxSize,
-  CheckboxDefinition,
-  CheckboxTemplate,
   CheckboxStyles,
+  CheckboxTemplate,
 } from './checkbox/index.js';
+export type { CheckboxOptions } from './checkbox/index.js';
 export {
   CompoundButton,
   CompoundButtonAppearance,
+  CompoundButtonDefinition,
   CompoundButtonShape,
   CompoundButtonSize,
-  CompoundButtonTemplate,
   CompoundButtonStyles,
-  CompoundButtonDefinition,
+  CompoundButtonTemplate,
 } from './compound-button/index.js';
 export {
   CounterBadge,
   CounterBadgeAppearance,
   CounterBadgeColor,
+  CounterBadgeDefinition,
   CounterBadgeShape,
   CounterBadgeSize,
-  CounterBadgeTemplate,
   CounterBadgeStyles,
-  CounterBadgeDefinition,
+  CounterBadgeTemplate,
 } from './counter-badge/index.js';
-export { Dialog, DialogModalType, DialogDefinition, DialogTemplate, DialogStyles } from './dialog/index.js';
+export { Dialog, DialogDefinition, DialogModalType, DialogStyles, DialogTemplate } from './dialog/index.js';
 export {
   Divider,
   DividerAlignContent,
   DividerAppearance,
+  DividerDefinition,
   DividerOrientation,
   DividerRole,
-  DividerDefinition,
-  DividerTemplate,
   DividerStyles,
+  DividerTemplate,
 } from './divider/index.js';
-export { Image, ImageFit, ImageShape, ImageDefinition, ImageTemplate, ImageStyles } from './image/index.js';
-export { Label, LabelSize, LabelWeight, LabelDefinition, LabelStyles, LabelTemplate } from './label/index.js';
-export { Menu, MenuTemplate, MenuStyles, MenuDefinition } from './menu/index.js';
+export { FluentDesignSystem } from './fluent-design-system.js';
+export { Image, ImageDefinition, ImageFit, ImageShape, ImageStyles, ImageTemplate } from './image/index.js';
+export { Label, LabelDefinition, LabelSize, LabelStyles, LabelTemplate, LabelWeight } from './label/index.js';
 export {
   MenuButton,
   MenuButtonAppearance,
+  MenuButtonDefinition,
   MenuButtonShape,
   MenuButtonSize,
-  MenuButtonOptions,
-  MenuButtonTemplate,
   MenuButtonStyles,
-  MenuButtonDefinition,
+  MenuButtonTemplate,
 } from './menu-button/index.js';
+export type { MenuButtonOptions } from './menu-button/index.js';
 export {
   MenuItem,
-  MenuItemColumnCount,
-  MenuItemOptions,
-  MenuItemRole,
-  roleForMenuItem,
-  MenuItemTemplate,
-  MenuItemStyles,
   MenuItemDefinition,
+  MenuItemRole,
+  MenuItemStyles,
+  MenuItemTemplate,
+  roleForMenuItem,
 } from './menu-item/index.js';
-export { MenuList, MenuListTemplate, MenuListStyles, MenuListDefinition } from './menu-list/index.js';
+export type { MenuItemColumnCount, MenuItemOptions } from './menu-item/index.js';
+export { MenuList, MenuListDefinition, MenuListStyles, MenuListTemplate } from './menu-list/index.js';
+export { Menu, MenuDefinition, MenuStyles, MenuTemplate } from './menu/index.js';
 export {
   ProgressBar,
-  ProgressOptions,
-  ProgressBarShape,
-  ProgressBarThickness,
-  ProgressBarValidationState,
   ProgressBarDefinition,
+  ProgressBarShape,
   ProgressBarStyles,
   ProgressBarTemplate,
+  ProgressBarThickness,
+  ProgressBarValidationState,
 } from './progress-bar/index.js';
-export { Radio, RadioControl, RadioOptions, RadioDefinition, RadioStyles, RadioTemplate } from './radio/index.js';
+export type { ProgressOptions } from './progress-bar/index.js';
 export {
   RadioGroup,
-  RadioGroupOrientation,
   RadioGroupDefinition,
+  RadioGroupOrientation,
   RadioGroupStyles,
   RadioGroupTemplate,
 } from './radio-group/index.js';
+export { Radio, RadioDefinition, RadioStyles, RadioTemplate } from './radio/index.js';
+export type { RadioControl, RadioOptions } from './radio/index.js';
 export {
   Slider,
-  SliderConfiguration,
+  SliderDefinition,
   SliderMode,
-  SliderOptions,
   SliderOrientation,
   SliderSize,
-  SliderDefinition,
   SliderStyles,
   SliderTemplate,
 } from './slider/index.js';
+export type { SliderConfiguration, SliderOptions } from './slider/index.js';
 export {
   Spinner,
   SpinnerAppearance,
-  SpinnerSize,
-  SpinnerTemplate,
-  SpinnerStyles,
   SpinnerDefinition,
+  SpinnerSize,
+  SpinnerStyles,
+  SpinnerTemplate,
 } from './spinner/index.js';
 export {
-  Switch,
-  SwitchOptions,
-  SwitchLabelPosition,
-  SwitchDefinition,
-  SwitchStyles,
-  SwitchTemplate,
-} from './switch/index.js';
-export { Tab, TabOptions, TabTemplate, TabStyles, TabDefinition } from './tab/index.js';
-export { TabPanel, TabPanelTemplate, TabPanelStyles, TabPanelDefinition } from './tab-panel/index.js';
-export {
-  Tabs,
-  TabsAppearance,
-  TabsOptions,
-  TabsOrientation,
-  TabsSize,
-  TabsTemplate,
-  TabsStyles,
-  TabsDefinition,
-} from './tabs/index.js';
-export {
-  Text,
-  TextAlign,
-  TextFont,
-  TextSize,
-  TextWeight,
-  TextTemplate,
-  TextStyles,
-  TextDefinition,
-} from './text/index.js';
-export {
-  TextInputOptions,
-  TextInput,
-  TextInputType,
-  TextInputAppearance,
-  TextInputControlSize,
-  TextInputTemplate,
-  TextInputStyles,
-  TextInputDefinition,
-} from './text-input/index.js';
-export {
-  ToggleButton,
-  ToggleButtonAppearance,
-  ToggleButtonOptions,
-  ToggleButtonShape,
-  ToggleButtonSize,
-  ToggleButtonTemplate,
-  ToggleButtonStyles,
-  ToggleButtonDefinition,
-} from './toggle-button/index.js';
-
-export {
-  typographyBody1Styles,
-  typographyBody1StrongStyles,
   typographyBody1StrongerStyles,
+  typographyBody1StrongStyles,
+  typographyBody1Styles,
   typographyBody2Styles,
-  typographyCaption1StrongStyles,
   typographyCaption1StrongerStyles,
+  typographyCaption1StrongStyles,
   typographyCaption1Styles,
   typographyCaption2StrongStyles,
   typographyCaption2Styles,
@@ -229,19 +177,60 @@ export {
   typographyTitle2Styles,
   typographyTitle3Styles,
 } from './styles/partials/typography.partials.js';
-
-export { getDirection } from './utils/direction.js';
-export { display } from './utils/display.js';
+export { Switch, SwitchDefinition, SwitchLabelPosition, SwitchStyles, SwitchTemplate } from './switch/index.js';
+export type { SwitchOptions } from './switch/index.js';
+export { TabPanel, TabPanelDefinition, TabPanelStyles, TabPanelTemplate } from './tab-panel/index.js';
+export { Tab, TabDefinition, TabStyles, TabTemplate } from './tab/index.js';
+export type { TabOptions } from './tab/index.js';
 export {
+  Tabs,
+  TabsAppearance,
+  TabsDefinition,
+  TabsOrientation,
+  TabsSize,
+  TabsStyles,
+  TabsTemplate,
+} from './tabs/index.js';
+export type { TabsOptions } from './tabs/index.js';
+export {
+  TextInput,
+  TextInputAppearance,
+  TextInputControlSize,
+  TextInputDefinition,
+  TextInputStyles,
+  TextInputTemplate,
+  TextInputType,
+} from './text-input/index.js';
+export type { TextInputOptions } from './text-input/index.js';
+export {
+  Text,
+  TextAlign,
+  TextDefinition,
+  TextFont,
+  TextSize,
+  TextStyles,
+  TextTemplate,
+  TextWeight,
+} from './text/index.js';
+export * from './theme/design-tokens.js';
+export { setTheme, setThemeFor } from './theme/index.js';
+export {
+  ToggleButton,
+  ToggleButtonAppearance,
+  ToggleButtonDefinition,
+  ToggleButtonShape,
+  ToggleButtonSize,
+  ToggleButtonStyles,
+  ToggleButtonTemplate,
+} from './toggle-button/index.js';
+export type { ToggleButtonOptions } from './toggle-button/index.js';
+export {
+  darkModeStylesheetBehavior,
   forcedColorsStylesheetBehavior,
+  lightModeStylesheetBehavior,
   MatchMediaBehavior,
   MatchMediaStyleSheetBehavior,
-  MediaQueryListListener,
-  darkModeStylesheetBehavior,
-  lightModeStylesheetBehavior,
 } from './utils/behaviors/match-media-stylesheet-behavior.js';
-
-export { FluentDesignSystem } from './fluent-design-system.js';
-export { setTheme, setThemeFor } from './theme/index.js';
-
-export * from './theme/design-tokens.js';
+export type { MediaQueryListListener } from './utils/behaviors/match-media-stylesheet-behavior.js';
+export { getDirection } from './utils/direction.js';
+export { display } from './utils/display.js';

--- a/packages/web-components/src/label/label.ts
+++ b/packages/web-components/src/label/label.ts
@@ -10,7 +10,6 @@ export class Label extends FASTElement {
    * 	Specifies font size of a label
    *
    * @public
-   * @default 'medium'
    * @remarks
    * HTML Attribute: size
    */
@@ -21,7 +20,6 @@ export class Label extends FASTElement {
    * 	Specifies font weight of a label
    *
    * @public
-   * @default 'regular'
    * @remarks
    * HTML Attribute: weight
    */

--- a/packages/web-components/src/menu-button/index.ts
+++ b/packages/web-components/src/menu-button/index.ts
@@ -1,5 +1,6 @@
-export { MenuButton } from './menu-button.js';
-export { MenuButtonAppearance, MenuButtonShape, MenuButtonSize, MenuButtonOptions } from './menu-button.options.js';
-export { template as MenuButtonTemplate } from './menu-button.template.js';
 export { styles as MenuButtonStyles } from '../button/button.styles.js';
 export { definition as MenuButtonDefinition } from './menu-button.definition.js';
+export { MenuButton } from './menu-button.js';
+export { MenuButtonAppearance, MenuButtonShape, MenuButtonSize } from './menu-button.options.js';
+export type { MenuButtonOptions } from './menu-button.options.js';
+export { template as MenuButtonTemplate } from './menu-button.template.js';

--- a/packages/web-components/src/menu-button/menu-button.options.ts
+++ b/packages/web-components/src/menu-button/menu-button.options.ts
@@ -38,4 +38,4 @@ export const MenuButtonSize = ButtonSize;
  */
 export type MenuButtonSize = ValuesOf<typeof MenuButtonSize>;
 
-export { ButtonOptions as MenuButtonOptions };
+export type { ButtonOptions as MenuButtonOptions };

--- a/packages/web-components/src/menu-item/index.ts
+++ b/packages/web-components/src/menu-item/index.ts
@@ -1,5 +1,6 @@
-export { MenuItem, MenuItemColumnCount, MenuItemOptions } from './menu-item.js';
-export { MenuItemRole, roleForMenuItem } from './menu-item.options.js';
-export { template as MenuItemTemplate } from './menu-item.template.js';
-export { styles as MenuItemStyles } from './menu-item.styles.js';
 export { definition as MenuItemDefinition } from './menu-item.definition.js';
+export { MenuItem } from './menu-item.js';
+export type { MenuItemColumnCount, MenuItemOptions } from './menu-item.js';
+export { MenuItemRole, roleForMenuItem } from './menu-item.options.js';
+export { styles as MenuItemStyles } from './menu-item.styles.js';
+export { template as MenuItemTemplate } from './menu-item.template.js';

--- a/packages/web-components/src/menu-list/menu-list.ts
+++ b/packages/web-components/src/menu-list/menu-list.ts
@@ -1,6 +1,8 @@
 import { FASTElement, Observable, observable, Updates } from '@microsoft/fast-element';
 import { isHTMLElement, keyArrowDown, keyArrowUp, keyEnd, keyHome } from '@microsoft/fast-web-utilities';
-import { MenuItem, MenuItemColumnCount, MenuItemRole } from '../menu-item/index.js';
+import type { MenuItemColumnCount } from '../menu-item/menu-item.js';
+import { MenuItem } from '../menu-item/menu-item.js';
+import { MenuItemRole } from '../menu-item/menu-item.options.js';
 
 /**
  * A Menu Custom HTML Element.

--- a/packages/web-components/src/menu/menu.ts
+++ b/packages/web-components/src/menu/menu.ts
@@ -70,13 +70,13 @@ export class Menu extends FASTElement {
 
   /**
    * The trigger element of the menu.
-   * @private
+   * @internal
    */
   private _trigger?: HTMLElement;
 
   /**
    * The menu list element of the menu.
-   * @private
+   * @internal
    */
   private _menuList?: HTMLElement;
 
@@ -188,9 +188,10 @@ export class Menu extends FASTElement {
    * Updates the 'aria-expanded' attribute and sets the positioning of the menu.
    * Sets menu list position
    * emits openChanged event
+   *
+   * @param oldValue - The previous value of 'open'.
+   * @param newValue - The new value of 'open'.
    * @public
-   * @param {boolean} oldValue - The previous value of 'open'.
-   * @param {boolean} newValue - The new value of 'open'.
    */
   public openChanged(oldValue: boolean, newValue: boolean): void {
     if (this.$fastController.isConnected && this._trigger instanceof HTMLElement) {
@@ -206,9 +207,10 @@ export class Menu extends FASTElement {
   /**
    * Called whenever the 'openOnHover' property changes.
    * Adds or removes a 'mouseover' event listener to the trigger based on the new value.
+   *
+   * @param oldValue - The previous value of 'openOnHover'.
+   * @param newValue - The new value of 'openOnHover'.
    * @public
-   * @param {boolean} oldValue - The previous value of 'openOnHover'.
-   * @param {boolean} newValue - The new value of 'openOnHover'.
    */
   public openOnHoverChanged(oldValue: boolean, newValue: boolean): void {
     if (newValue) {
@@ -222,8 +224,8 @@ export class Menu extends FASTElement {
    * Called whenever the 'persistOnItemClick' property changes.
    * Adds or removes a 'click' event listener to the menu list based on the new value.
    * @public
-   * @param {boolean} oldValue - The previous value of 'persistOnItemClick'.
-   * @param {boolean} newValue - The new value of 'persistOnItemClick'.
+   * @param oldValue - The previous value of 'persistOnItemClick'.
+   * @param newValue - The new value of 'persistOnItemClick'.
    */
   public persistOnItemClickChanged(oldValue: boolean, newValue: boolean): void {
     if (!newValue) {
@@ -237,8 +239,8 @@ export class Menu extends FASTElement {
    * Called whenever the 'openOnContext' property changes.
    * Adds or removes a 'contextmenu' event listener to the trigger based on the new value.
    * @public
-   * @param {boolean} oldValue - The previous value of 'openOnContext'.
-   * @param {boolean} newValue - The new value of 'openOnContext'.
+   * @param oldValue - The previous value of 'openOnContext'.
+   * @param newValue - The new value of 'openOnContext'.
    */
   public openOnContextChanged(oldValue: boolean, newValue: boolean): void {
     if (newValue) {
@@ -252,8 +254,8 @@ export class Menu extends FASTElement {
    * Called whenever the 'closeOnScroll' property changes.
    * Adds or removes a 'closeOnScroll' event listener to the trigger based on the new value.
    * @public
-   * @param {boolean} oldValue - The previous value of 'closeOnScroll'.
-   * @param {boolean} newValue - The new value of 'closeOnScroll'.
+   * @param oldValue - The previous value of 'closeOnScroll'.
+   * @param newValue - The new value of 'closeOnScroll'.
    */
   public closeOnScrollChanged(oldValue: boolean, newValue: boolean): void {
     if (newValue) {
@@ -265,7 +267,7 @@ export class Menu extends FASTElement {
 
   /**
    * The task to set the positioning of the menu.
-   * @protected
+   * @internal
    */
   protected setPositioningTask = () => {
     this.setPositioning();
@@ -273,7 +275,7 @@ export class Menu extends FASTElement {
 
   /**
    * Sets the positioning of the menu.
-   * @protected
+   * @internal
    */
   protected setPositioning(): void {
     if (this.$fastController.isConnected && this._menuList && this.open && this._trigger) {
@@ -336,7 +338,7 @@ export class Menu extends FASTElement {
    * Removes event listeners.
    * Removes click and keydown event listeners from the trigger and a click event listener from the document.
    * Also removes 'mouseover' event listeners from the trigger.
-   * @private
+   * @internal
    */
   private removeListeners(): void {
     document.removeEventListener('click', this.handleDocumentClick);
@@ -355,11 +357,11 @@ export class Menu extends FASTElement {
   }
 
   /**
-   * Handles keyboard interaction for the menu.
-   * Closes the menu and focuses on the trigger when the Escape key is pressed.
-   * Closes the menu when the Tab key is pressed.
+   * Handles keyboard interaction for the menu. Closes the menu and focuses on the trigger when the Escape key is
+   * pressed. Closes the menu when the Tab key is pressed.
+   *
+   * @param e - the keyboard event
    * @public
-   * @param {KeyboardEvent} e - the keyboard event
    */
   public handleMenuKeydown(e: KeyboardEvent): boolean | void {
     if (e.defaultPrevented) {
@@ -388,11 +390,11 @@ export class Menu extends FASTElement {
   }
 
   /**
-   * Handles keyboard interaction for the trigger.
-   * Toggles the menu when the Space or Enter key is pressed.
-   * If the menu is open, focuses on the menu list.
+   * Handles keyboard interaction for the trigger. Toggles the menu when the Space or Enter key is pressed. If the menu
+   * is open, focuses on the menu list.
+   *
+   * @param e - the keyboard event
    * @public
-   * @param {KeyboardEvent} e - the keyboard event
    */
   public handleTriggerKeydown = (e: KeyboardEvent): boolean | void => {
     if (e.defaultPrevented) {
@@ -415,8 +417,8 @@ export class Menu extends FASTElement {
 
   /**
    * Handles document click events to close the menu when a click occurs outside of the menu or the trigger.
-   * @private
-   * @param {Event} e - The event triggered on document click.
+   * @internal
+   * @param e - The event triggered on document click.
    */
   private handleDocumentClick = (e: any) => {
     if (e && !e.composedPath().includes(this._menuList) && !e.composedPath().includes(this._trigger)) {

--- a/packages/web-components/src/progress-bar/index.ts
+++ b/packages/web-components/src/progress-bar/index.ts
@@ -1,10 +1,6 @@
-export { ProgressBar } from './progress-bar.js';
-export {
-  ProgressOptions,
-  ProgressBarShape,
-  ProgressBarThickness,
-  ProgressBarValidationState,
-} from './progress-bar.options.js';
 export { definition as ProgressBarDefinition } from './progress-bar.definition.js';
+export { ProgressBar } from './progress-bar.js';
+export { ProgressBarShape, ProgressBarThickness, ProgressBarValidationState } from './progress-bar.options.js';
+export type { ProgressOptions } from './progress-bar.options.js';
 export { styles as ProgressBarStyles } from './progress-bar.styles.js';
 export { template as ProgressBarTemplate } from './progress-bar.template.js';

--- a/packages/web-components/src/radio/index.ts
+++ b/packages/web-components/src/radio/index.ts
@@ -1,4 +1,5 @@
-export { Radio, RadioControl, RadioOptions } from './radio.js';
 export { definition as RadioDefinition } from './radio.definition.js';
+export { Radio } from './radio.js';
+export type { RadioControl, RadioOptions } from './radio.js';
 export { styles as RadioStyles } from './radio.styles.js';
 export { template as RadioTemplate } from './radio.template.js';

--- a/packages/web-components/src/slider/index.ts
+++ b/packages/web-components/src/slider/index.ts
@@ -1,5 +1,6 @@
-export { Slider } from './slider.js';
-export { SliderConfiguration, SliderMode, SliderOptions, SliderOrientation, SliderSize } from './slider.options.js';
 export { definition as SliderDefinition } from './slider.definition.js';
+export { Slider } from './slider.js';
+export { SliderMode, SliderOrientation, SliderSize } from './slider.options.js';
+export type { SliderConfiguration, SliderOptions } from './slider.options.js';
 export { styles as SliderStyles } from './slider.styles.js';
 export { template as SliderTemplate } from './slider.template.js';

--- a/packages/web-components/src/spinner/spinner.ts
+++ b/packages/web-components/src/spinner/spinner.ts
@@ -17,7 +17,6 @@ export class Spinner extends FASTElement {
    * The size of the spinner
    *
    * @public
-   * @default 'medium'
    * @remarks
    * HTML Attribute: size
    */
@@ -27,7 +26,6 @@ export class Spinner extends FASTElement {
   /**
    * The appearance of the spinner
    * @public
-   * @default 'primary'
    * @remarks
    * HTML Attribute: appearance
    */

--- a/packages/web-components/src/switch/index.ts
+++ b/packages/web-components/src/switch/index.ts
@@ -1,5 +1,6 @@
-export { Switch, SwitchOptions } from './switch.js';
-export { SwitchLabelPosition } from './switch.options.js';
 export { definition as SwitchDefinition } from './switch.definition.js';
+export { Switch } from './switch.js';
+export type { SwitchOptions } from './switch.js';
+export { SwitchLabelPosition } from './switch.options.js';
 export { styles as SwitchStyles } from './switch.styles.js';
 export { template as SwitchTemplate } from './switch.template.js';

--- a/packages/web-components/src/switch/switch.ts
+++ b/packages/web-components/src/switch/switch.ts
@@ -13,7 +13,6 @@ export class Switch extends FormAssociatedSwitch {
    * The label position of the switch
    *
    * @public
-   * @default 'after'
    * @remarks
    * HTML Attribute: labelposition
    */

--- a/packages/web-components/src/tab/index.ts
+++ b/packages/web-components/src/tab/index.ts
@@ -1,4 +1,5 @@
-export { Tab, TabOptions } from './tab.js';
-export { template as TabTemplate } from './tab.template.js';
-export { styles as TabStyles } from './tab.styles.js';
 export { definition as TabDefinition } from './tab.definition.js';
+export { Tab } from './tab.js';
+export type { TabOptions } from './tab.js';
+export { styles as TabStyles } from './tab.styles.js';
+export { template as TabTemplate } from './tab.template.js';

--- a/packages/web-components/src/tab/tab.template.ts
+++ b/packages/web-components/src/tab/tab.template.ts
@@ -1,6 +1,6 @@
 import { ElementViewTemplate, html } from '@microsoft/fast-element';
 import { endSlotTemplate, startSlotTemplate } from '../patterns/index.js';
-import { Tab, TabOptions } from './tab.js';
+import type { Tab, TabOptions } from './tab.js';
 
 export function tabTemplate<T extends Tab>(options: TabOptions = {}): ElementViewTemplate<T> {
   return html<T>`

--- a/packages/web-components/src/tabs/index.ts
+++ b/packages/web-components/src/tabs/index.ts
@@ -1,5 +1,6 @@
-export { Tabs } from './tabs.js';
-export { TabsAppearance, TabsOptions, TabsOrientation, TabsSize } from './tabs.options.js';
-export { template as TabsTemplate } from './tabs.template.js';
-export { styles as TabsStyles } from './tabs.styles.js';
 export { definition as TabsDefinition } from './tabs.definition.js';
+export { Tabs } from './tabs.js';
+export { TabsAppearance, TabsOrientation, TabsSize } from './tabs.options.js';
+export type { TabsOptions } from './tabs.options.js';
+export { styles as TabsStyles } from './tabs.styles.js';
+export { template as TabsTemplate } from './tabs.template.js';

--- a/packages/web-components/src/tabs/tabs.ts
+++ b/packages/web-components/src/tabs/tabs.ts
@@ -17,8 +17,8 @@ import { TabsAppearance, TabsOrientation, TabsSize } from './tabs.options.js';
 type TabData = Omit<DOMRect, 'top' | 'bottom' | 'left' | 'right' | 'toJSON'>;
 
 /**
+ * A Tabs component that wraps a collection of tab and tab panel elements.
  *
- * @class TabList component
  * @public
  */
 export class BaseTabs extends FASTElement {
@@ -413,10 +413,10 @@ export class Tabs extends BaseTabs {
   }
 
   /**
-   * applyUpdatedCSSValues
+   * Calculates and applies updated values to CSS variables.
    *
-   * calculates and applies updated values to CSS variables
-   * @param tab
+   * @param tab - the tab element to apply the updated values to
+   * @internal
    */
   private applyUpdatedCSSValues(tab: Tab) {
     this.calculateAnimationProperties(tab);
@@ -425,9 +425,11 @@ export class Tabs extends BaseTabs {
   }
 
   /**
-   * animationLoop
-   * runs through all the operations required for setting the tab active indicator to its starting location, ending location, and applying the animated css class to the tab.
-   * @param tab
+   * Runs through all the operations required for setting the tab active indicator to its starting location, ending
+   * location, and applying the animated css class to the tab.
+   *
+   * @param tab - the tab element to apply the updated values to
+   * @internal
    */
   private animationLoop(tab: Tab) {
     // remove the animated class so nothing animates yet
@@ -443,8 +445,10 @@ export class Tabs extends BaseTabs {
   }
 
   /**
-   * setTabData
-   * sets the data from the active tab onto the class. used for making all the animation calculations for the active tab indicator.
+   * Sets the data from the active tab onto the class. used for making all the animation calculations for the active
+   * tab indicator.
+   *
+   * @internal
    */
   private setTabData(): void {
     if (this.tabs && this.tabs.length > 0) {

--- a/packages/web-components/src/text-input/text-input.ts
+++ b/packages/web-components/src/text-input/text-input.ts
@@ -22,7 +22,6 @@ export class TextInput extends FASTElement {
    * Indicates the styled appearance of the element.
    *
    * @public
-   * @default 'outline'
    * @remarks
    * HTML Attribute: `appearance`
    */
@@ -55,7 +54,6 @@ export class TextInput extends FASTElement {
    * Sets the size of the control.
    *
    * @public
-   * @default 'medium'
    * @remarks
    * HTML Attribute: `control-size`
    */

--- a/packages/web-components/src/theme/design-tokens.ts
+++ b/packages/web-components/src/theme/design-tokens.ts
@@ -1,437 +1,2617 @@
 // THIS FILE IS GENERATED AS PART OF THE BUILD PROCESS. DO NOT MANUALLY MODIFY THIS FILE
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralForeground1 | `colorNeutralForeground1`} design token.
+ * @public
+ */
 export const colorNeutralForeground1 = 'var(--colorNeutralForeground1)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralForeground1Hover | `colorNeutralForeground1Hover`} design token.
+ * @public
+ */
 export const colorNeutralForeground1Hover = 'var(--colorNeutralForeground1Hover)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralForeground1Pressed | `colorNeutralForeground1Pressed`} design token.
+ * @public
+ */
 export const colorNeutralForeground1Pressed = 'var(--colorNeutralForeground1Pressed)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralForeground1Selected | `colorNeutralForeground1Selected`} design token.
+ * @public
+ */
 export const colorNeutralForeground1Selected = 'var(--colorNeutralForeground1Selected)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralForeground2 | `colorNeutralForeground2`} design token.
+ * @public
+ */
 export const colorNeutralForeground2 = 'var(--colorNeutralForeground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralForeground2Hover | `colorNeutralForeground2Hover`} design token.
+ * @public
+ */
 export const colorNeutralForeground2Hover = 'var(--colorNeutralForeground2Hover)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralForeground2Pressed | `colorNeutralForeground2Pressed`} design token.
+ * @public
+ */
 export const colorNeutralForeground2Pressed = 'var(--colorNeutralForeground2Pressed)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralForeground2Selected | `colorNeutralForeground2Selected`} design token.
+ * @public
+ */
 export const colorNeutralForeground2Selected = 'var(--colorNeutralForeground2Selected)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralForeground2BrandHover | `colorNeutralForeground2BrandHover`} design token.
+ * @public
+ */
 export const colorNeutralForeground2BrandHover = 'var(--colorNeutralForeground2BrandHover)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralForeground2BrandPressed | `colorNeutralForeground2BrandPressed`} design token.
+ * @public
+ */
 export const colorNeutralForeground2BrandPressed = 'var(--colorNeutralForeground2BrandPressed)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralForeground2BrandSelected | `colorNeutralForeground2BrandSelected`} design token.
+ * @public
+ */
 export const colorNeutralForeground2BrandSelected = 'var(--colorNeutralForeground2BrandSelected)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralForeground3 | `colorNeutralForeground3`} design token.
+ * @public
+ */
 export const colorNeutralForeground3 = 'var(--colorNeutralForeground3)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralForeground3Hover | `colorNeutralForeground3Hover`} design token.
+ * @public
+ */
 export const colorNeutralForeground3Hover = 'var(--colorNeutralForeground3Hover)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralForeground3Pressed | `colorNeutralForeground3Pressed`} design token.
+ * @public
+ */
 export const colorNeutralForeground3Pressed = 'var(--colorNeutralForeground3Pressed)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralForeground3Selected | `colorNeutralForeground3Selected`} design token.
+ * @public
+ */
 export const colorNeutralForeground3Selected = 'var(--colorNeutralForeground3Selected)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralForeground3BrandHover | `colorNeutralForeground3BrandHover`} design token.
+ * @public
+ */
 export const colorNeutralForeground3BrandHover = 'var(--colorNeutralForeground3BrandHover)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralForeground3BrandPressed | `colorNeutralForeground3BrandPressed`} design token.
+ * @public
+ */
 export const colorNeutralForeground3BrandPressed = 'var(--colorNeutralForeground3BrandPressed)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralForeground3BrandSelected | `colorNeutralForeground3BrandSelected`} design token.
+ * @public
+ */
 export const colorNeutralForeground3BrandSelected = 'var(--colorNeutralForeground3BrandSelected)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralForeground4 | `colorNeutralForeground4`} design token.
+ * @public
+ */
 export const colorNeutralForeground4 = 'var(--colorNeutralForeground4)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralForegroundDisabled | `colorNeutralForegroundDisabled`} design token.
+ * @public
+ */
 export const colorNeutralForegroundDisabled = 'var(--colorNeutralForegroundDisabled)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorBrandForegroundLink | `colorBrandForegroundLink`} design token.
+ * @public
+ */
 export const colorBrandForegroundLink = 'var(--colorBrandForegroundLink)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorBrandForegroundLinkHover | `colorBrandForegroundLinkHover`} design token.
+ * @public
+ */
 export const colorBrandForegroundLinkHover = 'var(--colorBrandForegroundLinkHover)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorBrandForegroundLinkPressed | `colorBrandForegroundLinkPressed`} design token.
+ * @public
+ */
 export const colorBrandForegroundLinkPressed = 'var(--colorBrandForegroundLinkPressed)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorBrandForegroundLinkSelected | `colorBrandForegroundLinkSelected`} design token.
+ * @public
+ */
 export const colorBrandForegroundLinkSelected = 'var(--colorBrandForegroundLinkSelected)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralForeground2Link | `colorNeutralForeground2Link`} design token.
+ * @public
+ */
 export const colorNeutralForeground2Link = 'var(--colorNeutralForeground2Link)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralForeground2LinkHover | `colorNeutralForeground2LinkHover`} design token.
+ * @public
+ */
 export const colorNeutralForeground2LinkHover = 'var(--colorNeutralForeground2LinkHover)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralForeground2LinkPressed | `colorNeutralForeground2LinkPressed`} design token.
+ * @public
+ */
 export const colorNeutralForeground2LinkPressed = 'var(--colorNeutralForeground2LinkPressed)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralForeground2LinkSelected | `colorNeutralForeground2LinkSelected`} design token.
+ * @public
+ */
 export const colorNeutralForeground2LinkSelected = 'var(--colorNeutralForeground2LinkSelected)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorCompoundBrandForeground1 | `colorCompoundBrandForeground1`} design token.
+ * @public
+ */
 export const colorCompoundBrandForeground1 = 'var(--colorCompoundBrandForeground1)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorCompoundBrandForeground1Hover | `colorCompoundBrandForeground1Hover`} design token.
+ * @public
+ */
 export const colorCompoundBrandForeground1Hover = 'var(--colorCompoundBrandForeground1Hover)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorCompoundBrandForeground1Pressed | `colorCompoundBrandForeground1Pressed`} design token.
+ * @public
+ */
 export const colorCompoundBrandForeground1Pressed = 'var(--colorCompoundBrandForeground1Pressed)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralForegroundOnBrand | `colorNeutralForegroundOnBrand`} design token.
+ * @public
+ */
 export const colorNeutralForegroundOnBrand = 'var(--colorNeutralForegroundOnBrand)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralForegroundInverted | `colorNeutralForegroundInverted`} design token.
+ * @public
+ */
 export const colorNeutralForegroundInverted = 'var(--colorNeutralForegroundInverted)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralForegroundInvertedHover | `colorNeutralForegroundInvertedHover`} design token.
+ * @public
+ */
 export const colorNeutralForegroundInvertedHover = 'var(--colorNeutralForegroundInvertedHover)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralForegroundInvertedPressed | `colorNeutralForegroundInvertedPressed`} design token.
+ * @public
+ */
 export const colorNeutralForegroundInvertedPressed = 'var(--colorNeutralForegroundInvertedPressed)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralForegroundInvertedSelected | `colorNeutralForegroundInvertedSelected`} design token.
+ * @public
+ */
 export const colorNeutralForegroundInvertedSelected = 'var(--colorNeutralForegroundInvertedSelected)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralForegroundInverted2 | `colorNeutralForegroundInverted2`} design token.
+ * @public
+ */
 export const colorNeutralForegroundInverted2 = 'var(--colorNeutralForegroundInverted2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralForegroundStaticInverted | `colorNeutralForegroundStaticInverted`} design token.
+ * @public
+ */
 export const colorNeutralForegroundStaticInverted = 'var(--colorNeutralForegroundStaticInverted)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralForegroundInvertedLink | `colorNeutralForegroundInvertedLink`} design token.
+ * @public
+ */
 export const colorNeutralForegroundInvertedLink = 'var(--colorNeutralForegroundInvertedLink)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralForegroundInvertedLinkHover | `colorNeutralForegroundInvertedLinkHover`} design token.
+ * @public
+ */
 export const colorNeutralForegroundInvertedLinkHover = 'var(--colorNeutralForegroundInvertedLinkHover)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralForegroundInvertedLinkPressed | `colorNeutralForegroundInvertedLinkPressed`} design token.
+ * @public
+ */
 export const colorNeutralForegroundInvertedLinkPressed = 'var(--colorNeutralForegroundInvertedLinkPressed)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralForegroundInvertedLinkSelected | `colorNeutralForegroundInvertedLinkSelected`} design token.
+ * @public
+ */
 export const colorNeutralForegroundInvertedLinkSelected = 'var(--colorNeutralForegroundInvertedLinkSelected)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralForegroundInvertedDisabled | `colorNeutralForegroundInvertedDisabled`} design token.
+ * @public
+ */
 export const colorNeutralForegroundInvertedDisabled = 'var(--colorNeutralForegroundInvertedDisabled)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorBrandForeground1 | `colorBrandForeground1`} design token.
+ * @public
+ */
 export const colorBrandForeground1 = 'var(--colorBrandForeground1)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorBrandForeground2 | `colorBrandForeground2`} design token.
+ * @public
+ */
 export const colorBrandForeground2 = 'var(--colorBrandForeground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorBrandForeground2Hover | `colorBrandForeground2Hover`} design token.
+ * @public
+ */
 export const colorBrandForeground2Hover = 'var(--colorBrandForeground2Hover)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorBrandForeground2Pressed | `colorBrandForeground2Pressed`} design token.
+ * @public
+ */
 export const colorBrandForeground2Pressed = 'var(--colorBrandForeground2Pressed)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralForeground1Static | `colorNeutralForeground1Static`} design token.
+ * @public
+ */
 export const colorNeutralForeground1Static = 'var(--colorNeutralForeground1Static)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorBrandForegroundInverted | `colorBrandForegroundInverted`} design token.
+ * @public
+ */
 export const colorBrandForegroundInverted = 'var(--colorBrandForegroundInverted)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorBrandForegroundInvertedHover | `colorBrandForegroundInvertedHover`} design token.
+ * @public
+ */
 export const colorBrandForegroundInvertedHover = 'var(--colorBrandForegroundInvertedHover)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorBrandForegroundInvertedPressed | `colorBrandForegroundInvertedPressed`} design token.
+ * @public
+ */
 export const colorBrandForegroundInvertedPressed = 'var(--colorBrandForegroundInvertedPressed)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorBrandForegroundOnLight | `colorBrandForegroundOnLight`} design token.
+ * @public
+ */
 export const colorBrandForegroundOnLight = 'var(--colorBrandForegroundOnLight)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorBrandForegroundOnLightHover | `colorBrandForegroundOnLightHover`} design token.
+ * @public
+ */
 export const colorBrandForegroundOnLightHover = 'var(--colorBrandForegroundOnLightHover)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorBrandForegroundOnLightPressed | `colorBrandForegroundOnLightPressed`} design token.
+ * @public
+ */
 export const colorBrandForegroundOnLightPressed = 'var(--colorBrandForegroundOnLightPressed)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorBrandForegroundOnLightSelected | `colorBrandForegroundOnLightSelected`} design token.
+ * @public
+ */
 export const colorBrandForegroundOnLightSelected = 'var(--colorBrandForegroundOnLightSelected)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralBackground1 | `colorNeutralBackground1`} design token.
+ * @public
+ */
 export const colorNeutralBackground1 = 'var(--colorNeutralBackground1)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralBackground1Hover | `colorNeutralBackground1Hover`} design token.
+ * @public
+ */
 export const colorNeutralBackground1Hover = 'var(--colorNeutralBackground1Hover)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralBackground1Pressed | `colorNeutralBackground1Pressed`} design token.
+ * @public
+ */
 export const colorNeutralBackground1Pressed = 'var(--colorNeutralBackground1Pressed)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralBackground1Selected | `colorNeutralBackground1Selected`} design token.
+ * @public
+ */
 export const colorNeutralBackground1Selected = 'var(--colorNeutralBackground1Selected)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralBackground2 | `colorNeutralBackground2`} design token.
+ * @public
+ */
 export const colorNeutralBackground2 = 'var(--colorNeutralBackground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralBackground2Hover | `colorNeutralBackground2Hover`} design token.
+ * @public
+ */
 export const colorNeutralBackground2Hover = 'var(--colorNeutralBackground2Hover)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralBackground2Pressed | `colorNeutralBackground2Pressed`} design token.
+ * @public
+ */
 export const colorNeutralBackground2Pressed = 'var(--colorNeutralBackground2Pressed)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralBackground2Selected | `colorNeutralBackground2Selected`} design token.
+ * @public
+ */
 export const colorNeutralBackground2Selected = 'var(--colorNeutralBackground2Selected)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralBackground3 | `colorNeutralBackground3`} design token.
+ * @public
+ */
 export const colorNeutralBackground3 = 'var(--colorNeutralBackground3)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralBackground3Hover | `colorNeutralBackground3Hover`} design token.
+ * @public
+ */
 export const colorNeutralBackground3Hover = 'var(--colorNeutralBackground3Hover)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralBackground3Pressed | `colorNeutralBackground3Pressed`} design token.
+ * @public
+ */
 export const colorNeutralBackground3Pressed = 'var(--colorNeutralBackground3Pressed)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralBackground3Selected | `colorNeutralBackground3Selected`} design token.
+ * @public
+ */
 export const colorNeutralBackground3Selected = 'var(--colorNeutralBackground3Selected)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralBackground4 | `colorNeutralBackground4`} design token.
+ * @public
+ */
 export const colorNeutralBackground4 = 'var(--colorNeutralBackground4)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralBackground4Hover | `colorNeutralBackground4Hover`} design token.
+ * @public
+ */
 export const colorNeutralBackground4Hover = 'var(--colorNeutralBackground4Hover)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralBackground4Pressed | `colorNeutralBackground4Pressed`} design token.
+ * @public
+ */
 export const colorNeutralBackground4Pressed = 'var(--colorNeutralBackground4Pressed)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralBackground4Selected | `colorNeutralBackground4Selected`} design token.
+ * @public
+ */
 export const colorNeutralBackground4Selected = 'var(--colorNeutralBackground4Selected)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralBackground5 | `colorNeutralBackground5`} design token.
+ * @public
+ */
 export const colorNeutralBackground5 = 'var(--colorNeutralBackground5)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralBackground5Hover | `colorNeutralBackground5Hover`} design token.
+ * @public
+ */
 export const colorNeutralBackground5Hover = 'var(--colorNeutralBackground5Hover)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralBackground5Pressed | `colorNeutralBackground5Pressed`} design token.
+ * @public
+ */
 export const colorNeutralBackground5Pressed = 'var(--colorNeutralBackground5Pressed)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralBackground5Selected | `colorNeutralBackground5Selected`} design token.
+ * @public
+ */
 export const colorNeutralBackground5Selected = 'var(--colorNeutralBackground5Selected)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralBackground6 | `colorNeutralBackground6`} design token.
+ * @public
+ */
 export const colorNeutralBackground6 = 'var(--colorNeutralBackground6)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralBackgroundInverted | `colorNeutralBackgroundInverted`} design token.
+ * @public
+ */
 export const colorNeutralBackgroundInverted = 'var(--colorNeutralBackgroundInverted)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralBackgroundStatic | `colorNeutralBackgroundStatic`} design token.
+ * @public
+ */
 export const colorNeutralBackgroundStatic = 'var(--colorNeutralBackgroundStatic)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralBackgroundAlpha | `colorNeutralBackgroundAlpha`} design token.
+ * @public
+ */
 export const colorNeutralBackgroundAlpha = 'var(--colorNeutralBackgroundAlpha)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralBackgroundAlpha2 | `colorNeutralBackgroundAlpha2`} design token.
+ * @public
+ */
 export const colorNeutralBackgroundAlpha2 = 'var(--colorNeutralBackgroundAlpha2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorSubtleBackground | `colorSubtleBackground`} design token.
+ * @public
+ */
 export const colorSubtleBackground = 'var(--colorSubtleBackground)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorSubtleBackgroundHover | `colorSubtleBackgroundHover`} design token.
+ * @public
+ */
 export const colorSubtleBackgroundHover = 'var(--colorSubtleBackgroundHover)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorSubtleBackgroundPressed | `colorSubtleBackgroundPressed`} design token.
+ * @public
+ */
 export const colorSubtleBackgroundPressed = 'var(--colorSubtleBackgroundPressed)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorSubtleBackgroundSelected | `colorSubtleBackgroundSelected`} design token.
+ * @public
+ */
 export const colorSubtleBackgroundSelected = 'var(--colorSubtleBackgroundSelected)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorSubtleBackgroundLightAlphaHover | `colorSubtleBackgroundLightAlphaHover`} design token.
+ * @public
+ */
 export const colorSubtleBackgroundLightAlphaHover = 'var(--colorSubtleBackgroundLightAlphaHover)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorSubtleBackgroundLightAlphaPressed | `colorSubtleBackgroundLightAlphaPressed`} design token.
+ * @public
+ */
 export const colorSubtleBackgroundLightAlphaPressed = 'var(--colorSubtleBackgroundLightAlphaPressed)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorSubtleBackgroundLightAlphaSelected | `colorSubtleBackgroundLightAlphaSelected`} design token.
+ * @public
+ */
 export const colorSubtleBackgroundLightAlphaSelected = 'var(--colorSubtleBackgroundLightAlphaSelected)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorSubtleBackgroundInverted | `colorSubtleBackgroundInverted`} design token.
+ * @public
+ */
 export const colorSubtleBackgroundInverted = 'var(--colorSubtleBackgroundInverted)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorSubtleBackgroundInvertedHover | `colorSubtleBackgroundInvertedHover`} design token.
+ * @public
+ */
 export const colorSubtleBackgroundInvertedHover = 'var(--colorSubtleBackgroundInvertedHover)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorSubtleBackgroundInvertedPressed | `colorSubtleBackgroundInvertedPressed`} design token.
+ * @public
+ */
 export const colorSubtleBackgroundInvertedPressed = 'var(--colorSubtleBackgroundInvertedPressed)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorSubtleBackgroundInvertedSelected | `colorSubtleBackgroundInvertedSelected`} design token.
+ * @public
+ */
 export const colorSubtleBackgroundInvertedSelected = 'var(--colorSubtleBackgroundInvertedSelected)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorTransparentBackground | `colorTransparentBackground`} design token.
+ * @public
+ */
 export const colorTransparentBackground = 'var(--colorTransparentBackground)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorTransparentBackgroundHover | `colorTransparentBackgroundHover`} design token.
+ * @public
+ */
 export const colorTransparentBackgroundHover = 'var(--colorTransparentBackgroundHover)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorTransparentBackgroundPressed | `colorTransparentBackgroundPressed`} design token.
+ * @public
+ */
 export const colorTransparentBackgroundPressed = 'var(--colorTransparentBackgroundPressed)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorTransparentBackgroundSelected | `colorTransparentBackgroundSelected`} design token.
+ * @public
+ */
 export const colorTransparentBackgroundSelected = 'var(--colorTransparentBackgroundSelected)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralBackgroundDisabled | `colorNeutralBackgroundDisabled`} design token.
+ * @public
+ */
 export const colorNeutralBackgroundDisabled = 'var(--colorNeutralBackgroundDisabled)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralBackgroundInvertedDisabled | `colorNeutralBackgroundInvertedDisabled`} design token.
+ * @public
+ */
 export const colorNeutralBackgroundInvertedDisabled = 'var(--colorNeutralBackgroundInvertedDisabled)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralStencil1 | `colorNeutralStencil1`} design token.
+ * @public
+ */
 export const colorNeutralStencil1 = 'var(--colorNeutralStencil1)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralStencil2 | `colorNeutralStencil2`} design token.
+ * @public
+ */
 export const colorNeutralStencil2 = 'var(--colorNeutralStencil2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralStencil1Alpha | `colorNeutralStencil1Alpha`} design token.
+ * @public
+ */
 export const colorNeutralStencil1Alpha = 'var(--colorNeutralStencil1Alpha)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralStencil2Alpha | `colorNeutralStencil2Alpha`} design token.
+ * @public
+ */
 export const colorNeutralStencil2Alpha = 'var(--colorNeutralStencil2Alpha)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorBackgroundOverlay | `colorBackgroundOverlay`} design token.
+ * @public
+ */
 export const colorBackgroundOverlay = 'var(--colorBackgroundOverlay)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorScrollbarOverlay | `colorScrollbarOverlay`} design token.
+ * @public
+ */
 export const colorScrollbarOverlay = 'var(--colorScrollbarOverlay)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorBrandBackground | `colorBrandBackground`} design token.
+ * @public
+ */
 export const colorBrandBackground = 'var(--colorBrandBackground)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorBrandBackgroundHover | `colorBrandBackgroundHover`} design token.
+ * @public
+ */
 export const colorBrandBackgroundHover = 'var(--colorBrandBackgroundHover)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorBrandBackgroundPressed | `colorBrandBackgroundPressed`} design token.
+ * @public
+ */
 export const colorBrandBackgroundPressed = 'var(--colorBrandBackgroundPressed)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorBrandBackgroundSelected | `colorBrandBackgroundSelected`} design token.
+ * @public
+ */
 export const colorBrandBackgroundSelected = 'var(--colorBrandBackgroundSelected)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorCompoundBrandBackground | `colorCompoundBrandBackground`} design token.
+ * @public
+ */
 export const colorCompoundBrandBackground = 'var(--colorCompoundBrandBackground)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorCompoundBrandBackgroundHover | `colorCompoundBrandBackgroundHover`} design token.
+ * @public
+ */
 export const colorCompoundBrandBackgroundHover = 'var(--colorCompoundBrandBackgroundHover)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorCompoundBrandBackgroundPressed | `colorCompoundBrandBackgroundPressed`} design token.
+ * @public
+ */
 export const colorCompoundBrandBackgroundPressed = 'var(--colorCompoundBrandBackgroundPressed)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorBrandBackgroundStatic | `colorBrandBackgroundStatic`} design token.
+ * @public
+ */
 export const colorBrandBackgroundStatic = 'var(--colorBrandBackgroundStatic)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorBrandBackground2 | `colorBrandBackground2`} design token.
+ * @public
+ */
 export const colorBrandBackground2 = 'var(--colorBrandBackground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorBrandBackground2Hover | `colorBrandBackground2Hover`} design token.
+ * @public
+ */
 export const colorBrandBackground2Hover = 'var(--colorBrandBackground2Hover)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorBrandBackground2Pressed | `colorBrandBackground2Pressed`} design token.
+ * @public
+ */
 export const colorBrandBackground2Pressed = 'var(--colorBrandBackground2Pressed)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorBrandBackground3Static | `colorBrandBackground3Static`} design token.
+ * @public
+ */
 export const colorBrandBackground3Static = 'var(--colorBrandBackground3Static)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorBrandBackground4Static | `colorBrandBackground4Static`} design token.
+ * @public
+ */
 export const colorBrandBackground4Static = 'var(--colorBrandBackground4Static)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorBrandBackgroundInverted | `colorBrandBackgroundInverted`} design token.
+ * @public
+ */
 export const colorBrandBackgroundInverted = 'var(--colorBrandBackgroundInverted)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorBrandBackgroundInvertedHover | `colorBrandBackgroundInvertedHover`} design token.
+ * @public
+ */
 export const colorBrandBackgroundInvertedHover = 'var(--colorBrandBackgroundInvertedHover)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorBrandBackgroundInvertedPressed | `colorBrandBackgroundInvertedPressed`} design token.
+ * @public
+ */
 export const colorBrandBackgroundInvertedPressed = 'var(--colorBrandBackgroundInvertedPressed)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorBrandBackgroundInvertedSelected | `colorBrandBackgroundInvertedSelected`} design token.
+ * @public
+ */
 export const colorBrandBackgroundInvertedSelected = 'var(--colorBrandBackgroundInvertedSelected)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralCardBackground | `colorNeutralCardBackground`} design token.
+ * @public
+ */
 export const colorNeutralCardBackground = 'var(--colorNeutralCardBackground)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralCardBackgroundHover | `colorNeutralCardBackgroundHover`} design token.
+ * @public
+ */
 export const colorNeutralCardBackgroundHover = 'var(--colorNeutralCardBackgroundHover)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralCardBackgroundPressed | `colorNeutralCardBackgroundPressed`} design token.
+ * @public
+ */
 export const colorNeutralCardBackgroundPressed = 'var(--colorNeutralCardBackgroundPressed)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralCardBackgroundSelected | `colorNeutralCardBackgroundSelected`} design token.
+ * @public
+ */
 export const colorNeutralCardBackgroundSelected = 'var(--colorNeutralCardBackgroundSelected)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralCardBackgroundDisabled | `colorNeutralCardBackgroundDisabled`} design token.
+ * @public
+ */
 export const colorNeutralCardBackgroundDisabled = 'var(--colorNeutralCardBackgroundDisabled)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralStrokeAccessible | `colorNeutralStrokeAccessible`} design token.
+ * @public
+ */
 export const colorNeutralStrokeAccessible = 'var(--colorNeutralStrokeAccessible)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralStrokeAccessibleHover | `colorNeutralStrokeAccessibleHover`} design token.
+ * @public
+ */
 export const colorNeutralStrokeAccessibleHover = 'var(--colorNeutralStrokeAccessibleHover)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralStrokeAccessiblePressed | `colorNeutralStrokeAccessiblePressed`} design token.
+ * @public
+ */
 export const colorNeutralStrokeAccessiblePressed = 'var(--colorNeutralStrokeAccessiblePressed)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralStrokeAccessibleSelected | `colorNeutralStrokeAccessibleSelected`} design token.
+ * @public
+ */
 export const colorNeutralStrokeAccessibleSelected = 'var(--colorNeutralStrokeAccessibleSelected)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralStroke1 | `colorNeutralStroke1`} design token.
+ * @public
+ */
 export const colorNeutralStroke1 = 'var(--colorNeutralStroke1)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralStroke1Hover | `colorNeutralStroke1Hover`} design token.
+ * @public
+ */
 export const colorNeutralStroke1Hover = 'var(--colorNeutralStroke1Hover)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralStroke1Pressed | `colorNeutralStroke1Pressed`} design token.
+ * @public
+ */
 export const colorNeutralStroke1Pressed = 'var(--colorNeutralStroke1Pressed)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralStroke1Selected | `colorNeutralStroke1Selected`} design token.
+ * @public
+ */
 export const colorNeutralStroke1Selected = 'var(--colorNeutralStroke1Selected)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralStroke2 | `colorNeutralStroke2`} design token.
+ * @public
+ */
 export const colorNeutralStroke2 = 'var(--colorNeutralStroke2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralStroke3 | `colorNeutralStroke3`} design token.
+ * @public
+ */
 export const colorNeutralStroke3 = 'var(--colorNeutralStroke3)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralStrokeSubtle | `colorNeutralStrokeSubtle`} design token.
+ * @public
+ */
 export const colorNeutralStrokeSubtle = 'var(--colorNeutralStrokeSubtle)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralStrokeOnBrand | `colorNeutralStrokeOnBrand`} design token.
+ * @public
+ */
 export const colorNeutralStrokeOnBrand = 'var(--colorNeutralStrokeOnBrand)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralStrokeOnBrand2 | `colorNeutralStrokeOnBrand2`} design token.
+ * @public
+ */
 export const colorNeutralStrokeOnBrand2 = 'var(--colorNeutralStrokeOnBrand2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralStrokeOnBrand2Hover | `colorNeutralStrokeOnBrand2Hover`} design token.
+ * @public
+ */
 export const colorNeutralStrokeOnBrand2Hover = 'var(--colorNeutralStrokeOnBrand2Hover)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralStrokeOnBrand2Pressed | `colorNeutralStrokeOnBrand2Pressed`} design token.
+ * @public
+ */
 export const colorNeutralStrokeOnBrand2Pressed = 'var(--colorNeutralStrokeOnBrand2Pressed)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralStrokeOnBrand2Selected | `colorNeutralStrokeOnBrand2Selected`} design token.
+ * @public
+ */
 export const colorNeutralStrokeOnBrand2Selected = 'var(--colorNeutralStrokeOnBrand2Selected)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorBrandStroke1 | `colorBrandStroke1`} design token.
+ * @public
+ */
 export const colorBrandStroke1 = 'var(--colorBrandStroke1)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorBrandStroke2 | `colorBrandStroke2`} design token.
+ * @public
+ */
 export const colorBrandStroke2 = 'var(--colorBrandStroke2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorBrandStroke2Hover | `colorBrandStroke2Hover`} design token.
+ * @public
+ */
 export const colorBrandStroke2Hover = 'var(--colorBrandStroke2Hover)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorBrandStroke2Pressed | `colorBrandStroke2Pressed`} design token.
+ * @public
+ */
 export const colorBrandStroke2Pressed = 'var(--colorBrandStroke2Pressed)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorBrandStroke2Contrast | `colorBrandStroke2Contrast`} design token.
+ * @public
+ */
 export const colorBrandStroke2Contrast = 'var(--colorBrandStroke2Contrast)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorCompoundBrandStroke | `colorCompoundBrandStroke`} design token.
+ * @public
+ */
 export const colorCompoundBrandStroke = 'var(--colorCompoundBrandStroke)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorCompoundBrandStrokeHover | `colorCompoundBrandStrokeHover`} design token.
+ * @public
+ */
 export const colorCompoundBrandStrokeHover = 'var(--colorCompoundBrandStrokeHover)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorCompoundBrandStrokePressed | `colorCompoundBrandStrokePressed`} design token.
+ * @public
+ */
 export const colorCompoundBrandStrokePressed = 'var(--colorCompoundBrandStrokePressed)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralStrokeDisabled | `colorNeutralStrokeDisabled`} design token.
+ * @public
+ */
 export const colorNeutralStrokeDisabled = 'var(--colorNeutralStrokeDisabled)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralStrokeInvertedDisabled | `colorNeutralStrokeInvertedDisabled`} design token.
+ * @public
+ */
 export const colorNeutralStrokeInvertedDisabled = 'var(--colorNeutralStrokeInvertedDisabled)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorTransparentStroke | `colorTransparentStroke`} design token.
+ * @public
+ */
 export const colorTransparentStroke = 'var(--colorTransparentStroke)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorTransparentStrokeInteractive | `colorTransparentStrokeInteractive`} design token.
+ * @public
+ */
 export const colorTransparentStrokeInteractive = 'var(--colorTransparentStrokeInteractive)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorTransparentStrokeDisabled | `colorTransparentStrokeDisabled`} design token.
+ * @public
+ */
 export const colorTransparentStrokeDisabled = 'var(--colorTransparentStrokeDisabled)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralStrokeAlpha | `colorNeutralStrokeAlpha`} design token.
+ * @public
+ */
 export const colorNeutralStrokeAlpha = 'var(--colorNeutralStrokeAlpha)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralStrokeAlpha2 | `colorNeutralStrokeAlpha2`} design token.
+ * @public
+ */
 export const colorNeutralStrokeAlpha2 = 'var(--colorNeutralStrokeAlpha2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorStrokeFocus1 | `colorStrokeFocus1`} design token.
+ * @public
+ */
 export const colorStrokeFocus1 = 'var(--colorStrokeFocus1)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorStrokeFocus2 | `colorStrokeFocus2`} design token.
+ * @public
+ */
 export const colorStrokeFocus2 = 'var(--colorStrokeFocus2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralShadowAmbient | `colorNeutralShadowAmbient`} design token.
+ * @public
+ */
 export const colorNeutralShadowAmbient = 'var(--colorNeutralShadowAmbient)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralShadowKey | `colorNeutralShadowKey`} design token.
+ * @public
+ */
 export const colorNeutralShadowKey = 'var(--colorNeutralShadowKey)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralShadowAmbientLighter | `colorNeutralShadowAmbientLighter`} design token.
+ * @public
+ */
 export const colorNeutralShadowAmbientLighter = 'var(--colorNeutralShadowAmbientLighter)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralShadowKeyLighter | `colorNeutralShadowKeyLighter`} design token.
+ * @public
+ */
 export const colorNeutralShadowKeyLighter = 'var(--colorNeutralShadowKeyLighter)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralShadowAmbientDarker | `colorNeutralShadowAmbientDarker`} design token.
+ * @public
+ */
 export const colorNeutralShadowAmbientDarker = 'var(--colorNeutralShadowAmbientDarker)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorNeutralShadowKeyDarker | `colorNeutralShadowKeyDarker`} design token.
+ * @public
+ */
 export const colorNeutralShadowKeyDarker = 'var(--colorNeutralShadowKeyDarker)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorBrandShadowAmbient | `colorBrandShadowAmbient`} design token.
+ * @public
+ */
 export const colorBrandShadowAmbient = 'var(--colorBrandShadowAmbient)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorBrandShadowKey | `colorBrandShadowKey`} design token.
+ * @public
+ */
 export const colorBrandShadowKey = 'var(--colorBrandShadowKey)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteRedBackground1 | `colorPaletteRedBackground1`} design token.
+ * @public
+ */
 export const colorPaletteRedBackground1 = 'var(--colorPaletteRedBackground1)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteRedBackground2 | `colorPaletteRedBackground2`} design token.
+ * @public
+ */
 export const colorPaletteRedBackground2 = 'var(--colorPaletteRedBackground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteRedBackground3 | `colorPaletteRedBackground3`} design token.
+ * @public
+ */
 export const colorPaletteRedBackground3 = 'var(--colorPaletteRedBackground3)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteRedBorderActive | `colorPaletteRedBorderActive`} design token.
+ * @public
+ */
 export const colorPaletteRedBorderActive = 'var(--colorPaletteRedBorderActive)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteRedBorder1 | `colorPaletteRedBorder1`} design token.
+ * @public
+ */
 export const colorPaletteRedBorder1 = 'var(--colorPaletteRedBorder1)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteRedBorder2 | `colorPaletteRedBorder2`} design token.
+ * @public
+ */
 export const colorPaletteRedBorder2 = 'var(--colorPaletteRedBorder2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteRedForeground1 | `colorPaletteRedForeground1`} design token.
+ * @public
+ */
 export const colorPaletteRedForeground1 = 'var(--colorPaletteRedForeground1)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteRedForeground2 | `colorPaletteRedForeground2`} design token.
+ * @public
+ */
 export const colorPaletteRedForeground2 = 'var(--colorPaletteRedForeground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteRedForeground3 | `colorPaletteRedForeground3`} design token.
+ * @public
+ */
 export const colorPaletteRedForeground3 = 'var(--colorPaletteRedForeground3)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteRedForegroundInverted | `colorPaletteRedForegroundInverted`} design token.
+ * @public
+ */
 export const colorPaletteRedForegroundInverted = 'var(--colorPaletteRedForegroundInverted)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteGreenBackground1 | `colorPaletteGreenBackground1`} design token.
+ * @public
+ */
 export const colorPaletteGreenBackground1 = 'var(--colorPaletteGreenBackground1)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteGreenBackground2 | `colorPaletteGreenBackground2`} design token.
+ * @public
+ */
 export const colorPaletteGreenBackground2 = 'var(--colorPaletteGreenBackground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteGreenBackground3 | `colorPaletteGreenBackground3`} design token.
+ * @public
+ */
 export const colorPaletteGreenBackground3 = 'var(--colorPaletteGreenBackground3)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteGreenBorderActive | `colorPaletteGreenBorderActive`} design token.
+ * @public
+ */
 export const colorPaletteGreenBorderActive = 'var(--colorPaletteGreenBorderActive)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteGreenBorder1 | `colorPaletteGreenBorder1`} design token.
+ * @public
+ */
 export const colorPaletteGreenBorder1 = 'var(--colorPaletteGreenBorder1)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteGreenBorder2 | `colorPaletteGreenBorder2`} design token.
+ * @public
+ */
 export const colorPaletteGreenBorder2 = 'var(--colorPaletteGreenBorder2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteGreenForeground1 | `colorPaletteGreenForeground1`} design token.
+ * @public
+ */
 export const colorPaletteGreenForeground1 = 'var(--colorPaletteGreenForeground1)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteGreenForeground2 | `colorPaletteGreenForeground2`} design token.
+ * @public
+ */
 export const colorPaletteGreenForeground2 = 'var(--colorPaletteGreenForeground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteGreenForeground3 | `colorPaletteGreenForeground3`} design token.
+ * @public
+ */
 export const colorPaletteGreenForeground3 = 'var(--colorPaletteGreenForeground3)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteGreenForegroundInverted | `colorPaletteGreenForegroundInverted`} design token.
+ * @public
+ */
 export const colorPaletteGreenForegroundInverted = 'var(--colorPaletteGreenForegroundInverted)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteDarkOrangeBackground1 | `colorPaletteDarkOrangeBackground1`} design token.
+ * @public
+ */
 export const colorPaletteDarkOrangeBackground1 = 'var(--colorPaletteDarkOrangeBackground1)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteDarkOrangeBackground2 | `colorPaletteDarkOrangeBackground2`} design token.
+ * @public
+ */
 export const colorPaletteDarkOrangeBackground2 = 'var(--colorPaletteDarkOrangeBackground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteDarkOrangeBackground3 | `colorPaletteDarkOrangeBackground3`} design token.
+ * @public
+ */
 export const colorPaletteDarkOrangeBackground3 = 'var(--colorPaletteDarkOrangeBackground3)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteDarkOrangeBorderActive | `colorPaletteDarkOrangeBorderActive`} design token.
+ * @public
+ */
 export const colorPaletteDarkOrangeBorderActive = 'var(--colorPaletteDarkOrangeBorderActive)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteDarkOrangeBorder1 | `colorPaletteDarkOrangeBorder1`} design token.
+ * @public
+ */
 export const colorPaletteDarkOrangeBorder1 = 'var(--colorPaletteDarkOrangeBorder1)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteDarkOrangeBorder2 | `colorPaletteDarkOrangeBorder2`} design token.
+ * @public
+ */
 export const colorPaletteDarkOrangeBorder2 = 'var(--colorPaletteDarkOrangeBorder2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteDarkOrangeForeground1 | `colorPaletteDarkOrangeForeground1`} design token.
+ * @public
+ */
 export const colorPaletteDarkOrangeForeground1 = 'var(--colorPaletteDarkOrangeForeground1)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteDarkOrangeForeground2 | `colorPaletteDarkOrangeForeground2`} design token.
+ * @public
+ */
 export const colorPaletteDarkOrangeForeground2 = 'var(--colorPaletteDarkOrangeForeground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteDarkOrangeForeground3 | `colorPaletteDarkOrangeForeground3`} design token.
+ * @public
+ */
 export const colorPaletteDarkOrangeForeground3 = 'var(--colorPaletteDarkOrangeForeground3)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteYellowBackground1 | `colorPaletteYellowBackground1`} design token.
+ * @public
+ */
 export const colorPaletteYellowBackground1 = 'var(--colorPaletteYellowBackground1)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteYellowBackground2 | `colorPaletteYellowBackground2`} design token.
+ * @public
+ */
 export const colorPaletteYellowBackground2 = 'var(--colorPaletteYellowBackground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteYellowBackground3 | `colorPaletteYellowBackground3`} design token.
+ * @public
+ */
 export const colorPaletteYellowBackground3 = 'var(--colorPaletteYellowBackground3)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteYellowBorderActive | `colorPaletteYellowBorderActive`} design token.
+ * @public
+ */
 export const colorPaletteYellowBorderActive = 'var(--colorPaletteYellowBorderActive)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteYellowBorder1 | `colorPaletteYellowBorder1`} design token.
+ * @public
+ */
 export const colorPaletteYellowBorder1 = 'var(--colorPaletteYellowBorder1)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteYellowBorder2 | `colorPaletteYellowBorder2`} design token.
+ * @public
+ */
 export const colorPaletteYellowBorder2 = 'var(--colorPaletteYellowBorder2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteYellowForeground1 | `colorPaletteYellowForeground1`} design token.
+ * @public
+ */
 export const colorPaletteYellowForeground1 = 'var(--colorPaletteYellowForeground1)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteYellowForeground2 | `colorPaletteYellowForeground2`} design token.
+ * @public
+ */
 export const colorPaletteYellowForeground2 = 'var(--colorPaletteYellowForeground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteYellowForeground3 | `colorPaletteYellowForeground3`} design token.
+ * @public
+ */
 export const colorPaletteYellowForeground3 = 'var(--colorPaletteYellowForeground3)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteYellowForegroundInverted | `colorPaletteYellowForegroundInverted`} design token.
+ * @public
+ */
 export const colorPaletteYellowForegroundInverted = 'var(--colorPaletteYellowForegroundInverted)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteBerryBackground1 | `colorPaletteBerryBackground1`} design token.
+ * @public
+ */
 export const colorPaletteBerryBackground1 = 'var(--colorPaletteBerryBackground1)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteBerryBackground2 | `colorPaletteBerryBackground2`} design token.
+ * @public
+ */
 export const colorPaletteBerryBackground2 = 'var(--colorPaletteBerryBackground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteBerryBackground3 | `colorPaletteBerryBackground3`} design token.
+ * @public
+ */
 export const colorPaletteBerryBackground3 = 'var(--colorPaletteBerryBackground3)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteBerryBorderActive | `colorPaletteBerryBorderActive`} design token.
+ * @public
+ */
 export const colorPaletteBerryBorderActive = 'var(--colorPaletteBerryBorderActive)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteBerryBorder1 | `colorPaletteBerryBorder1`} design token.
+ * @public
+ */
 export const colorPaletteBerryBorder1 = 'var(--colorPaletteBerryBorder1)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteBerryBorder2 | `colorPaletteBerryBorder2`} design token.
+ * @public
+ */
 export const colorPaletteBerryBorder2 = 'var(--colorPaletteBerryBorder2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteBerryForeground1 | `colorPaletteBerryForeground1`} design token.
+ * @public
+ */
 export const colorPaletteBerryForeground1 = 'var(--colorPaletteBerryForeground1)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteBerryForeground2 | `colorPaletteBerryForeground2`} design token.
+ * @public
+ */
 export const colorPaletteBerryForeground2 = 'var(--colorPaletteBerryForeground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteBerryForeground3 | `colorPaletteBerryForeground3`} design token.
+ * @public
+ */
 export const colorPaletteBerryForeground3 = 'var(--colorPaletteBerryForeground3)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteMarigoldBackground1 | `colorPaletteMarigoldBackground1`} design token.
+ * @public
+ */
 export const colorPaletteMarigoldBackground1 = 'var(--colorPaletteMarigoldBackground1)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteMarigoldBackground2 | `colorPaletteMarigoldBackground2`} design token.
+ * @public
+ */
 export const colorPaletteMarigoldBackground2 = 'var(--colorPaletteMarigoldBackground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteMarigoldBackground3 | `colorPaletteMarigoldBackground3`} design token.
+ * @public
+ */
 export const colorPaletteMarigoldBackground3 = 'var(--colorPaletteMarigoldBackground3)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteMarigoldBorderActive | `colorPaletteMarigoldBorderActive`} design token.
+ * @public
+ */
 export const colorPaletteMarigoldBorderActive = 'var(--colorPaletteMarigoldBorderActive)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteMarigoldBorder1 | `colorPaletteMarigoldBorder1`} design token.
+ * @public
+ */
 export const colorPaletteMarigoldBorder1 = 'var(--colorPaletteMarigoldBorder1)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteMarigoldBorder2 | `colorPaletteMarigoldBorder2`} design token.
+ * @public
+ */
 export const colorPaletteMarigoldBorder2 = 'var(--colorPaletteMarigoldBorder2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteMarigoldForeground1 | `colorPaletteMarigoldForeground1`} design token.
+ * @public
+ */
 export const colorPaletteMarigoldForeground1 = 'var(--colorPaletteMarigoldForeground1)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteMarigoldForeground2 | `colorPaletteMarigoldForeground2`} design token.
+ * @public
+ */
 export const colorPaletteMarigoldForeground2 = 'var(--colorPaletteMarigoldForeground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteMarigoldForeground3 | `colorPaletteMarigoldForeground3`} design token.
+ * @public
+ */
 export const colorPaletteMarigoldForeground3 = 'var(--colorPaletteMarigoldForeground3)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteLightGreenBackground1 | `colorPaletteLightGreenBackground1`} design token.
+ * @public
+ */
 export const colorPaletteLightGreenBackground1 = 'var(--colorPaletteLightGreenBackground1)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteLightGreenBackground2 | `colorPaletteLightGreenBackground2`} design token.
+ * @public
+ */
 export const colorPaletteLightGreenBackground2 = 'var(--colorPaletteLightGreenBackground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteLightGreenBackground3 | `colorPaletteLightGreenBackground3`} design token.
+ * @public
+ */
 export const colorPaletteLightGreenBackground3 = 'var(--colorPaletteLightGreenBackground3)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteLightGreenBorderActive | `colorPaletteLightGreenBorderActive`} design token.
+ * @public
+ */
 export const colorPaletteLightGreenBorderActive = 'var(--colorPaletteLightGreenBorderActive)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteLightGreenBorder1 | `colorPaletteLightGreenBorder1`} design token.
+ * @public
+ */
 export const colorPaletteLightGreenBorder1 = 'var(--colorPaletteLightGreenBorder1)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteLightGreenBorder2 | `colorPaletteLightGreenBorder2`} design token.
+ * @public
+ */
 export const colorPaletteLightGreenBorder2 = 'var(--colorPaletteLightGreenBorder2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteLightGreenForeground1 | `colorPaletteLightGreenForeground1`} design token.
+ * @public
+ */
 export const colorPaletteLightGreenForeground1 = 'var(--colorPaletteLightGreenForeground1)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteLightGreenForeground2 | `colorPaletteLightGreenForeground2`} design token.
+ * @public
+ */
 export const colorPaletteLightGreenForeground2 = 'var(--colorPaletteLightGreenForeground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteLightGreenForeground3 | `colorPaletteLightGreenForeground3`} design token.
+ * @public
+ */
 export const colorPaletteLightGreenForeground3 = 'var(--colorPaletteLightGreenForeground3)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteAnchorBackground2 | `colorPaletteAnchorBackground2`} design token.
+ * @public
+ */
 export const colorPaletteAnchorBackground2 = 'var(--colorPaletteAnchorBackground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteAnchorBorderActive | `colorPaletteAnchorBorderActive`} design token.
+ * @public
+ */
 export const colorPaletteAnchorBorderActive = 'var(--colorPaletteAnchorBorderActive)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteAnchorForeground2 | `colorPaletteAnchorForeground2`} design token.
+ * @public
+ */
 export const colorPaletteAnchorForeground2 = 'var(--colorPaletteAnchorForeground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteBeigeBackground2 | `colorPaletteBeigeBackground2`} design token.
+ * @public
+ */
 export const colorPaletteBeigeBackground2 = 'var(--colorPaletteBeigeBackground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteBeigeBorderActive | `colorPaletteBeigeBorderActive`} design token.
+ * @public
+ */
 export const colorPaletteBeigeBorderActive = 'var(--colorPaletteBeigeBorderActive)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteBeigeForeground2 | `colorPaletteBeigeForeground2`} design token.
+ * @public
+ */
 export const colorPaletteBeigeForeground2 = 'var(--colorPaletteBeigeForeground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteBlueBackground2 | `colorPaletteBlueBackground2`} design token.
+ * @public
+ */
 export const colorPaletteBlueBackground2 = 'var(--colorPaletteBlueBackground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteBlueBorderActive | `colorPaletteBlueBorderActive`} design token.
+ * @public
+ */
 export const colorPaletteBlueBorderActive = 'var(--colorPaletteBlueBorderActive)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteBlueForeground2 | `colorPaletteBlueForeground2`} design token.
+ * @public
+ */
 export const colorPaletteBlueForeground2 = 'var(--colorPaletteBlueForeground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteBrassBackground2 | `colorPaletteBrassBackground2`} design token.
+ * @public
+ */
 export const colorPaletteBrassBackground2 = 'var(--colorPaletteBrassBackground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteBrassBorderActive | `colorPaletteBrassBorderActive`} design token.
+ * @public
+ */
 export const colorPaletteBrassBorderActive = 'var(--colorPaletteBrassBorderActive)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteBrassForeground2 | `colorPaletteBrassForeground2`} design token.
+ * @public
+ */
 export const colorPaletteBrassForeground2 = 'var(--colorPaletteBrassForeground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteBrownBackground2 | `colorPaletteBrownBackground2`} design token.
+ * @public
+ */
 export const colorPaletteBrownBackground2 = 'var(--colorPaletteBrownBackground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteBrownBorderActive | `colorPaletteBrownBorderActive`} design token.
+ * @public
+ */
 export const colorPaletteBrownBorderActive = 'var(--colorPaletteBrownBorderActive)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteBrownForeground2 | `colorPaletteBrownForeground2`} design token.
+ * @public
+ */
 export const colorPaletteBrownForeground2 = 'var(--colorPaletteBrownForeground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteCornflowerBackground2 | `colorPaletteCornflowerBackground2`} design token.
+ * @public
+ */
 export const colorPaletteCornflowerBackground2 = 'var(--colorPaletteCornflowerBackground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteCornflowerBorderActive | `colorPaletteCornflowerBorderActive`} design token.
+ * @public
+ */
 export const colorPaletteCornflowerBorderActive = 'var(--colorPaletteCornflowerBorderActive)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteCornflowerForeground2 | `colorPaletteCornflowerForeground2`} design token.
+ * @public
+ */
 export const colorPaletteCornflowerForeground2 = 'var(--colorPaletteCornflowerForeground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteCranberryBackground2 | `colorPaletteCranberryBackground2`} design token.
+ * @public
+ */
 export const colorPaletteCranberryBackground2 = 'var(--colorPaletteCranberryBackground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteCranberryBorderActive | `colorPaletteCranberryBorderActive`} design token.
+ * @public
+ */
 export const colorPaletteCranberryBorderActive = 'var(--colorPaletteCranberryBorderActive)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteCranberryForeground2 | `colorPaletteCranberryForeground2`} design token.
+ * @public
+ */
 export const colorPaletteCranberryForeground2 = 'var(--colorPaletteCranberryForeground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteDarkGreenBackground2 | `colorPaletteDarkGreenBackground2`} design token.
+ * @public
+ */
 export const colorPaletteDarkGreenBackground2 = 'var(--colorPaletteDarkGreenBackground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteDarkGreenBorderActive | `colorPaletteDarkGreenBorderActive`} design token.
+ * @public
+ */
 export const colorPaletteDarkGreenBorderActive = 'var(--colorPaletteDarkGreenBorderActive)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteDarkGreenForeground2 | `colorPaletteDarkGreenForeground2`} design token.
+ * @public
+ */
 export const colorPaletteDarkGreenForeground2 = 'var(--colorPaletteDarkGreenForeground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteDarkRedBackground2 | `colorPaletteDarkRedBackground2`} design token.
+ * @public
+ */
 export const colorPaletteDarkRedBackground2 = 'var(--colorPaletteDarkRedBackground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteDarkRedBorderActive | `colorPaletteDarkRedBorderActive`} design token.
+ * @public
+ */
 export const colorPaletteDarkRedBorderActive = 'var(--colorPaletteDarkRedBorderActive)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteDarkRedForeground2 | `colorPaletteDarkRedForeground2`} design token.
+ * @public
+ */
 export const colorPaletteDarkRedForeground2 = 'var(--colorPaletteDarkRedForeground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteForestBackground2 | `colorPaletteForestBackground2`} design token.
+ * @public
+ */
 export const colorPaletteForestBackground2 = 'var(--colorPaletteForestBackground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteForestBorderActive | `colorPaletteForestBorderActive`} design token.
+ * @public
+ */
 export const colorPaletteForestBorderActive = 'var(--colorPaletteForestBorderActive)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteForestForeground2 | `colorPaletteForestForeground2`} design token.
+ * @public
+ */
 export const colorPaletteForestForeground2 = 'var(--colorPaletteForestForeground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteGoldBackground2 | `colorPaletteGoldBackground2`} design token.
+ * @public
+ */
 export const colorPaletteGoldBackground2 = 'var(--colorPaletteGoldBackground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteGoldBorderActive | `colorPaletteGoldBorderActive`} design token.
+ * @public
+ */
 export const colorPaletteGoldBorderActive = 'var(--colorPaletteGoldBorderActive)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteGoldForeground2 | `colorPaletteGoldForeground2`} design token.
+ * @public
+ */
 export const colorPaletteGoldForeground2 = 'var(--colorPaletteGoldForeground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteGrapeBackground2 | `colorPaletteGrapeBackground2`} design token.
+ * @public
+ */
 export const colorPaletteGrapeBackground2 = 'var(--colorPaletteGrapeBackground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteGrapeBorderActive | `colorPaletteGrapeBorderActive`} design token.
+ * @public
+ */
 export const colorPaletteGrapeBorderActive = 'var(--colorPaletteGrapeBorderActive)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteGrapeForeground2 | `colorPaletteGrapeForeground2`} design token.
+ * @public
+ */
 export const colorPaletteGrapeForeground2 = 'var(--colorPaletteGrapeForeground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteLavenderBackground2 | `colorPaletteLavenderBackground2`} design token.
+ * @public
+ */
 export const colorPaletteLavenderBackground2 = 'var(--colorPaletteLavenderBackground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteLavenderBorderActive | `colorPaletteLavenderBorderActive`} design token.
+ * @public
+ */
 export const colorPaletteLavenderBorderActive = 'var(--colorPaletteLavenderBorderActive)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteLavenderForeground2 | `colorPaletteLavenderForeground2`} design token.
+ * @public
+ */
 export const colorPaletteLavenderForeground2 = 'var(--colorPaletteLavenderForeground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteLightTealBackground2 | `colorPaletteLightTealBackground2`} design token.
+ * @public
+ */
 export const colorPaletteLightTealBackground2 = 'var(--colorPaletteLightTealBackground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteLightTealBorderActive | `colorPaletteLightTealBorderActive`} design token.
+ * @public
+ */
 export const colorPaletteLightTealBorderActive = 'var(--colorPaletteLightTealBorderActive)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteLightTealForeground2 | `colorPaletteLightTealForeground2`} design token.
+ * @public
+ */
 export const colorPaletteLightTealForeground2 = 'var(--colorPaletteLightTealForeground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteLilacBackground2 | `colorPaletteLilacBackground2`} design token.
+ * @public
+ */
 export const colorPaletteLilacBackground2 = 'var(--colorPaletteLilacBackground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteLilacBorderActive | `colorPaletteLilacBorderActive`} design token.
+ * @public
+ */
 export const colorPaletteLilacBorderActive = 'var(--colorPaletteLilacBorderActive)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteLilacForeground2 | `colorPaletteLilacForeground2`} design token.
+ * @public
+ */
 export const colorPaletteLilacForeground2 = 'var(--colorPaletteLilacForeground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteMagentaBackground2 | `colorPaletteMagentaBackground2`} design token.
+ * @public
+ */
 export const colorPaletteMagentaBackground2 = 'var(--colorPaletteMagentaBackground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteMagentaBorderActive | `colorPaletteMagentaBorderActive`} design token.
+ * @public
+ */
 export const colorPaletteMagentaBorderActive = 'var(--colorPaletteMagentaBorderActive)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteMagentaForeground2 | `colorPaletteMagentaForeground2`} design token.
+ * @public
+ */
 export const colorPaletteMagentaForeground2 = 'var(--colorPaletteMagentaForeground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteMinkBackground2 | `colorPaletteMinkBackground2`} design token.
+ * @public
+ */
 export const colorPaletteMinkBackground2 = 'var(--colorPaletteMinkBackground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteMinkBorderActive | `colorPaletteMinkBorderActive`} design token.
+ * @public
+ */
 export const colorPaletteMinkBorderActive = 'var(--colorPaletteMinkBorderActive)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteMinkForeground2 | `colorPaletteMinkForeground2`} design token.
+ * @public
+ */
 export const colorPaletteMinkForeground2 = 'var(--colorPaletteMinkForeground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteNavyBackground2 | `colorPaletteNavyBackground2`} design token.
+ * @public
+ */
 export const colorPaletteNavyBackground2 = 'var(--colorPaletteNavyBackground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteNavyBorderActive | `colorPaletteNavyBorderActive`} design token.
+ * @public
+ */
 export const colorPaletteNavyBorderActive = 'var(--colorPaletteNavyBorderActive)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteNavyForeground2 | `colorPaletteNavyForeground2`} design token.
+ * @public
+ */
 export const colorPaletteNavyForeground2 = 'var(--colorPaletteNavyForeground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPalettePeachBackground2 | `colorPalettePeachBackground2`} design token.
+ * @public
+ */
 export const colorPalettePeachBackground2 = 'var(--colorPalettePeachBackground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPalettePeachBorderActive | `colorPalettePeachBorderActive`} design token.
+ * @public
+ */
 export const colorPalettePeachBorderActive = 'var(--colorPalettePeachBorderActive)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPalettePeachForeground2 | `colorPalettePeachForeground2`} design token.
+ * @public
+ */
 export const colorPalettePeachForeground2 = 'var(--colorPalettePeachForeground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPalettePinkBackground2 | `colorPalettePinkBackground2`} design token.
+ * @public
+ */
 export const colorPalettePinkBackground2 = 'var(--colorPalettePinkBackground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPalettePinkBorderActive | `colorPalettePinkBorderActive`} design token.
+ * @public
+ */
 export const colorPalettePinkBorderActive = 'var(--colorPalettePinkBorderActive)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPalettePinkForeground2 | `colorPalettePinkForeground2`} design token.
+ * @public
+ */
 export const colorPalettePinkForeground2 = 'var(--colorPalettePinkForeground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPalettePlatinumBackground2 | `colorPalettePlatinumBackground2`} design token.
+ * @public
+ */
 export const colorPalettePlatinumBackground2 = 'var(--colorPalettePlatinumBackground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPalettePlatinumBorderActive | `colorPalettePlatinumBorderActive`} design token.
+ * @public
+ */
 export const colorPalettePlatinumBorderActive = 'var(--colorPalettePlatinumBorderActive)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPalettePlatinumForeground2 | `colorPalettePlatinumForeground2`} design token.
+ * @public
+ */
 export const colorPalettePlatinumForeground2 = 'var(--colorPalettePlatinumForeground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPalettePlumBackground2 | `colorPalettePlumBackground2`} design token.
+ * @public
+ */
 export const colorPalettePlumBackground2 = 'var(--colorPalettePlumBackground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPalettePlumBorderActive | `colorPalettePlumBorderActive`} design token.
+ * @public
+ */
 export const colorPalettePlumBorderActive = 'var(--colorPalettePlumBorderActive)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPalettePlumForeground2 | `colorPalettePlumForeground2`} design token.
+ * @public
+ */
 export const colorPalettePlumForeground2 = 'var(--colorPalettePlumForeground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPalettePumpkinBackground2 | `colorPalettePumpkinBackground2`} design token.
+ * @public
+ */
 export const colorPalettePumpkinBackground2 = 'var(--colorPalettePumpkinBackground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPalettePumpkinBorderActive | `colorPalettePumpkinBorderActive`} design token.
+ * @public
+ */
 export const colorPalettePumpkinBorderActive = 'var(--colorPalettePumpkinBorderActive)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPalettePumpkinForeground2 | `colorPalettePumpkinForeground2`} design token.
+ * @public
+ */
 export const colorPalettePumpkinForeground2 = 'var(--colorPalettePumpkinForeground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPalettePurpleBackground2 | `colorPalettePurpleBackground2`} design token.
+ * @public
+ */
 export const colorPalettePurpleBackground2 = 'var(--colorPalettePurpleBackground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPalettePurpleBorderActive | `colorPalettePurpleBorderActive`} design token.
+ * @public
+ */
 export const colorPalettePurpleBorderActive = 'var(--colorPalettePurpleBorderActive)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPalettePurpleForeground2 | `colorPalettePurpleForeground2`} design token.
+ * @public
+ */
 export const colorPalettePurpleForeground2 = 'var(--colorPalettePurpleForeground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteRoyalBlueBackground2 | `colorPaletteRoyalBlueBackground2`} design token.
+ * @public
+ */
 export const colorPaletteRoyalBlueBackground2 = 'var(--colorPaletteRoyalBlueBackground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteRoyalBlueBorderActive | `colorPaletteRoyalBlueBorderActive`} design token.
+ * @public
+ */
 export const colorPaletteRoyalBlueBorderActive = 'var(--colorPaletteRoyalBlueBorderActive)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteRoyalBlueForeground2 | `colorPaletteRoyalBlueForeground2`} design token.
+ * @public
+ */
 export const colorPaletteRoyalBlueForeground2 = 'var(--colorPaletteRoyalBlueForeground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteSeafoamBackground2 | `colorPaletteSeafoamBackground2`} design token.
+ * @public
+ */
 export const colorPaletteSeafoamBackground2 = 'var(--colorPaletteSeafoamBackground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteSeafoamBorderActive | `colorPaletteSeafoamBorderActive`} design token.
+ * @public
+ */
 export const colorPaletteSeafoamBorderActive = 'var(--colorPaletteSeafoamBorderActive)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteSeafoamForeground2 | `colorPaletteSeafoamForeground2`} design token.
+ * @public
+ */
 export const colorPaletteSeafoamForeground2 = 'var(--colorPaletteSeafoamForeground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteSteelBackground2 | `colorPaletteSteelBackground2`} design token.
+ * @public
+ */
 export const colorPaletteSteelBackground2 = 'var(--colorPaletteSteelBackground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteSteelBorderActive | `colorPaletteSteelBorderActive`} design token.
+ * @public
+ */
 export const colorPaletteSteelBorderActive = 'var(--colorPaletteSteelBorderActive)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteSteelForeground2 | `colorPaletteSteelForeground2`} design token.
+ * @public
+ */
 export const colorPaletteSteelForeground2 = 'var(--colorPaletteSteelForeground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteTealBackground2 | `colorPaletteTealBackground2`} design token.
+ * @public
+ */
 export const colorPaletteTealBackground2 = 'var(--colorPaletteTealBackground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteTealBorderActive | `colorPaletteTealBorderActive`} design token.
+ * @public
+ */
 export const colorPaletteTealBorderActive = 'var(--colorPaletteTealBorderActive)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorPaletteTealForeground2 | `colorPaletteTealForeground2`} design token.
+ * @public
+ */
 export const colorPaletteTealForeground2 = 'var(--colorPaletteTealForeground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorStatusSuccessBackground1 | `colorStatusSuccessBackground1`} design token.
+ * @public
+ */
 export const colorStatusSuccessBackground1 = 'var(--colorStatusSuccessBackground1)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorStatusSuccessBackground2 | `colorStatusSuccessBackground2`} design token.
+ * @public
+ */
 export const colorStatusSuccessBackground2 = 'var(--colorStatusSuccessBackground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorStatusSuccessBackground3 | `colorStatusSuccessBackground3`} design token.
+ * @public
+ */
 export const colorStatusSuccessBackground3 = 'var(--colorStatusSuccessBackground3)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorStatusSuccessForeground1 | `colorStatusSuccessForeground1`} design token.
+ * @public
+ */
 export const colorStatusSuccessForeground1 = 'var(--colorStatusSuccessForeground1)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorStatusSuccessForeground2 | `colorStatusSuccessForeground2`} design token.
+ * @public
+ */
 export const colorStatusSuccessForeground2 = 'var(--colorStatusSuccessForeground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorStatusSuccessForeground3 | `colorStatusSuccessForeground3`} design token.
+ * @public
+ */
 export const colorStatusSuccessForeground3 = 'var(--colorStatusSuccessForeground3)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorStatusSuccessForegroundInverted | `colorStatusSuccessForegroundInverted`} design token.
+ * @public
+ */
 export const colorStatusSuccessForegroundInverted = 'var(--colorStatusSuccessForegroundInverted)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorStatusSuccessBorderActive | `colorStatusSuccessBorderActive`} design token.
+ * @public
+ */
 export const colorStatusSuccessBorderActive = 'var(--colorStatusSuccessBorderActive)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorStatusSuccessBorder1 | `colorStatusSuccessBorder1`} design token.
+ * @public
+ */
 export const colorStatusSuccessBorder1 = 'var(--colorStatusSuccessBorder1)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorStatusSuccessBorder2 | `colorStatusSuccessBorder2`} design token.
+ * @public
+ */
 export const colorStatusSuccessBorder2 = 'var(--colorStatusSuccessBorder2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorStatusWarningBackground1 | `colorStatusWarningBackground1`} design token.
+ * @public
+ */
 export const colorStatusWarningBackground1 = 'var(--colorStatusWarningBackground1)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorStatusWarningBackground2 | `colorStatusWarningBackground2`} design token.
+ * @public
+ */
 export const colorStatusWarningBackground2 = 'var(--colorStatusWarningBackground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorStatusWarningBackground3 | `colorStatusWarningBackground3`} design token.
+ * @public
+ */
 export const colorStatusWarningBackground3 = 'var(--colorStatusWarningBackground3)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorStatusWarningForeground1 | `colorStatusWarningForeground1`} design token.
+ * @public
+ */
 export const colorStatusWarningForeground1 = 'var(--colorStatusWarningForeground1)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorStatusWarningForeground2 | `colorStatusWarningForeground2`} design token.
+ * @public
+ */
 export const colorStatusWarningForeground2 = 'var(--colorStatusWarningForeground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorStatusWarningForeground3 | `colorStatusWarningForeground3`} design token.
+ * @public
+ */
 export const colorStatusWarningForeground3 = 'var(--colorStatusWarningForeground3)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorStatusWarningForegroundInverted | `colorStatusWarningForegroundInverted`} design token.
+ * @public
+ */
 export const colorStatusWarningForegroundInverted = 'var(--colorStatusWarningForegroundInverted)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorStatusWarningBorderActive | `colorStatusWarningBorderActive`} design token.
+ * @public
+ */
 export const colorStatusWarningBorderActive = 'var(--colorStatusWarningBorderActive)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorStatusWarningBorder1 | `colorStatusWarningBorder1`} design token.
+ * @public
+ */
 export const colorStatusWarningBorder1 = 'var(--colorStatusWarningBorder1)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorStatusWarningBorder2 | `colorStatusWarningBorder2`} design token.
+ * @public
+ */
 export const colorStatusWarningBorder2 = 'var(--colorStatusWarningBorder2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorStatusDangerBackground1 | `colorStatusDangerBackground1`} design token.
+ * @public
+ */
 export const colorStatusDangerBackground1 = 'var(--colorStatusDangerBackground1)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorStatusDangerBackground2 | `colorStatusDangerBackground2`} design token.
+ * @public
+ */
 export const colorStatusDangerBackground2 = 'var(--colorStatusDangerBackground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorStatusDangerBackground3 | `colorStatusDangerBackground3`} design token.
+ * @public
+ */
 export const colorStatusDangerBackground3 = 'var(--colorStatusDangerBackground3)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorStatusDangerBackground3Hover | `colorStatusDangerBackground3Hover`} design token.
+ * @public
+ */
 export const colorStatusDangerBackground3Hover = 'var(--colorStatusDangerBackground3Hover)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorStatusDangerBackground3Pressed | `colorStatusDangerBackground3Pressed`} design token.
+ * @public
+ */
 export const colorStatusDangerBackground3Pressed = 'var(--colorStatusDangerBackground3Pressed)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorStatusDangerForeground1 | `colorStatusDangerForeground1`} design token.
+ * @public
+ */
 export const colorStatusDangerForeground1 = 'var(--colorStatusDangerForeground1)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorStatusDangerForeground2 | `colorStatusDangerForeground2`} design token.
+ * @public
+ */
 export const colorStatusDangerForeground2 = 'var(--colorStatusDangerForeground2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorStatusDangerForeground3 | `colorStatusDangerForeground3`} design token.
+ * @public
+ */
 export const colorStatusDangerForeground3 = 'var(--colorStatusDangerForeground3)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorStatusDangerForegroundInverted | `colorStatusDangerForegroundInverted`} design token.
+ * @public
+ */
 export const colorStatusDangerForegroundInverted = 'var(--colorStatusDangerForegroundInverted)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorStatusDangerBorderActive | `colorStatusDangerBorderActive`} design token.
+ * @public
+ */
 export const colorStatusDangerBorderActive = 'var(--colorStatusDangerBorderActive)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorStatusDangerBorder1 | `colorStatusDangerBorder1`} design token.
+ * @public
+ */
 export const colorStatusDangerBorder1 = 'var(--colorStatusDangerBorder1)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#colorStatusDangerBorder2 | `colorStatusDangerBorder2`} design token.
+ * @public
+ */
 export const colorStatusDangerBorder2 = 'var(--colorStatusDangerBorder2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#borderRadiusNone | `borderRadiusNone`} design token.
+ * @public
+ */
 export const borderRadiusNone = 'var(--borderRadiusNone)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#borderRadiusSmall | `borderRadiusSmall`} design token.
+ * @public
+ */
 export const borderRadiusSmall = 'var(--borderRadiusSmall)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#borderRadiusMedium | `borderRadiusMedium`} design token.
+ * @public
+ */
 export const borderRadiusMedium = 'var(--borderRadiusMedium)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#borderRadiusLarge | `borderRadiusLarge`} design token.
+ * @public
+ */
 export const borderRadiusLarge = 'var(--borderRadiusLarge)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#borderRadiusXLarge | `borderRadiusXLarge`} design token.
+ * @public
+ */
 export const borderRadiusXLarge = 'var(--borderRadiusXLarge)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#borderRadiusCircular | `borderRadiusCircular`} design token.
+ * @public
+ */
 export const borderRadiusCircular = 'var(--borderRadiusCircular)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#fontFamilyBase | `fontFamilyBase`} design token.
+ * @public
+ */
 export const fontFamilyBase = 'var(--fontFamilyBase)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#fontFamilyMonospace | `fontFamilyMonospace`} design token.
+ * @public
+ */
 export const fontFamilyMonospace = 'var(--fontFamilyMonospace)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#fontFamilyNumeric | `fontFamilyNumeric`} design token.
+ * @public
+ */
 export const fontFamilyNumeric = 'var(--fontFamilyNumeric)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#fontSizeBase100 | `fontSizeBase100`} design token.
+ * @public
+ */
 export const fontSizeBase100 = 'var(--fontSizeBase100)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#fontSizeBase200 | `fontSizeBase200`} design token.
+ * @public
+ */
 export const fontSizeBase200 = 'var(--fontSizeBase200)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#fontSizeBase300 | `fontSizeBase300`} design token.
+ * @public
+ */
 export const fontSizeBase300 = 'var(--fontSizeBase300)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#fontSizeBase400 | `fontSizeBase400`} design token.
+ * @public
+ */
 export const fontSizeBase400 = 'var(--fontSizeBase400)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#fontSizeBase500 | `fontSizeBase500`} design token.
+ * @public
+ */
 export const fontSizeBase500 = 'var(--fontSizeBase500)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#fontSizeBase600 | `fontSizeBase600`} design token.
+ * @public
+ */
 export const fontSizeBase600 = 'var(--fontSizeBase600)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#fontSizeHero700 | `fontSizeHero700`} design token.
+ * @public
+ */
 export const fontSizeHero700 = 'var(--fontSizeHero700)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#fontSizeHero800 | `fontSizeHero800`} design token.
+ * @public
+ */
 export const fontSizeHero800 = 'var(--fontSizeHero800)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#fontSizeHero900 | `fontSizeHero900`} design token.
+ * @public
+ */
 export const fontSizeHero900 = 'var(--fontSizeHero900)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#fontSizeHero1000 | `fontSizeHero1000`} design token.
+ * @public
+ */
 export const fontSizeHero1000 = 'var(--fontSizeHero1000)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#fontWeightRegular | `fontWeightRegular`} design token.
+ * @public
+ */
 export const fontWeightRegular = 'var(--fontWeightRegular)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#fontWeightMedium | `fontWeightMedium`} design token.
+ * @public
+ */
 export const fontWeightMedium = 'var(--fontWeightMedium)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#fontWeightSemibold | `fontWeightSemibold`} design token.
+ * @public
+ */
 export const fontWeightSemibold = 'var(--fontWeightSemibold)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#fontWeightBold | `fontWeightBold`} design token.
+ * @public
+ */
 export const fontWeightBold = 'var(--fontWeightBold)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#lineHeightBase100 | `lineHeightBase100`} design token.
+ * @public
+ */
 export const lineHeightBase100 = 'var(--lineHeightBase100)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#lineHeightBase200 | `lineHeightBase200`} design token.
+ * @public
+ */
 export const lineHeightBase200 = 'var(--lineHeightBase200)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#lineHeightBase300 | `lineHeightBase300`} design token.
+ * @public
+ */
 export const lineHeightBase300 = 'var(--lineHeightBase300)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#lineHeightBase400 | `lineHeightBase400`} design token.
+ * @public
+ */
 export const lineHeightBase400 = 'var(--lineHeightBase400)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#lineHeightBase500 | `lineHeightBase500`} design token.
+ * @public
+ */
 export const lineHeightBase500 = 'var(--lineHeightBase500)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#lineHeightBase600 | `lineHeightBase600`} design token.
+ * @public
+ */
 export const lineHeightBase600 = 'var(--lineHeightBase600)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#lineHeightHero700 | `lineHeightHero700`} design token.
+ * @public
+ */
 export const lineHeightHero700 = 'var(--lineHeightHero700)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#lineHeightHero800 | `lineHeightHero800`} design token.
+ * @public
+ */
 export const lineHeightHero800 = 'var(--lineHeightHero800)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#lineHeightHero900 | `lineHeightHero900`} design token.
+ * @public
+ */
 export const lineHeightHero900 = 'var(--lineHeightHero900)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#lineHeightHero1000 | `lineHeightHero1000`} design token.
+ * @public
+ */
 export const lineHeightHero1000 = 'var(--lineHeightHero1000)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#shadow2 | `shadow2`} design token.
+ * @public
+ */
 export const shadow2 = 'var(--shadow2)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#shadow4 | `shadow4`} design token.
+ * @public
+ */
 export const shadow4 = 'var(--shadow4)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#shadow8 | `shadow8`} design token.
+ * @public
+ */
 export const shadow8 = 'var(--shadow8)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#shadow16 | `shadow16`} design token.
+ * @public
+ */
 export const shadow16 = 'var(--shadow16)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#shadow28 | `shadow28`} design token.
+ * @public
+ */
 export const shadow28 = 'var(--shadow28)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#shadow64 | `shadow64`} design token.
+ * @public
+ */
 export const shadow64 = 'var(--shadow64)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#shadow2Brand | `shadow2Brand`} design token.
+ * @public
+ */
 export const shadow2Brand = 'var(--shadow2Brand)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#shadow4Brand | `shadow4Brand`} design token.
+ * @public
+ */
 export const shadow4Brand = 'var(--shadow4Brand)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#shadow8Brand | `shadow8Brand`} design token.
+ * @public
+ */
 export const shadow8Brand = 'var(--shadow8Brand)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#shadow16Brand | `shadow16Brand`} design token.
+ * @public
+ */
 export const shadow16Brand = 'var(--shadow16Brand)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#shadow28Brand | `shadow28Brand`} design token.
+ * @public
+ */
 export const shadow28Brand = 'var(--shadow28Brand)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#shadow64Brand | `shadow64Brand`} design token.
+ * @public
+ */
 export const shadow64Brand = 'var(--shadow64Brand)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#strokeWidthThin | `strokeWidthThin`} design token.
+ * @public
+ */
 export const strokeWidthThin = 'var(--strokeWidthThin)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#strokeWidthThick | `strokeWidthThick`} design token.
+ * @public
+ */
 export const strokeWidthThick = 'var(--strokeWidthThick)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#strokeWidthThicker | `strokeWidthThicker`} design token.
+ * @public
+ */
 export const strokeWidthThicker = 'var(--strokeWidthThicker)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#strokeWidthThickest | `strokeWidthThickest`} design token.
+ * @public
+ */
 export const strokeWidthThickest = 'var(--strokeWidthThickest)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#spacingHorizontalNone | `spacingHorizontalNone`} design token.
+ * @public
+ */
 export const spacingHorizontalNone = 'var(--spacingHorizontalNone)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#spacingHorizontalXXS | `spacingHorizontalXXS`} design token.
+ * @public
+ */
 export const spacingHorizontalXXS = 'var(--spacingHorizontalXXS)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#spacingHorizontalXS | `spacingHorizontalXS`} design token.
+ * @public
+ */
 export const spacingHorizontalXS = 'var(--spacingHorizontalXS)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#spacingHorizontalSNudge | `spacingHorizontalSNudge`} design token.
+ * @public
+ */
 export const spacingHorizontalSNudge = 'var(--spacingHorizontalSNudge)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#spacingHorizontalS | `spacingHorizontalS`} design token.
+ * @public
+ */
 export const spacingHorizontalS = 'var(--spacingHorizontalS)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#spacingHorizontalMNudge | `spacingHorizontalMNudge`} design token.
+ * @public
+ */
 export const spacingHorizontalMNudge = 'var(--spacingHorizontalMNudge)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#spacingHorizontalM | `spacingHorizontalM`} design token.
+ * @public
+ */
 export const spacingHorizontalM = 'var(--spacingHorizontalM)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#spacingHorizontalL | `spacingHorizontalL`} design token.
+ * @public
+ */
 export const spacingHorizontalL = 'var(--spacingHorizontalL)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#spacingHorizontalXL | `spacingHorizontalXL`} design token.
+ * @public
+ */
 export const spacingHorizontalXL = 'var(--spacingHorizontalXL)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#spacingHorizontalXXL | `spacingHorizontalXXL`} design token.
+ * @public
+ */
 export const spacingHorizontalXXL = 'var(--spacingHorizontalXXL)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#spacingHorizontalXXXL | `spacingHorizontalXXXL`} design token.
+ * @public
+ */
 export const spacingHorizontalXXXL = 'var(--spacingHorizontalXXXL)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#spacingVerticalNone | `spacingVerticalNone`} design token.
+ * @public
+ */
 export const spacingVerticalNone = 'var(--spacingVerticalNone)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#spacingVerticalXXS | `spacingVerticalXXS`} design token.
+ * @public
+ */
 export const spacingVerticalXXS = 'var(--spacingVerticalXXS)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#spacingVerticalXS | `spacingVerticalXS`} design token.
+ * @public
+ */
 export const spacingVerticalXS = 'var(--spacingVerticalXS)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#spacingVerticalSNudge | `spacingVerticalSNudge`} design token.
+ * @public
+ */
 export const spacingVerticalSNudge = 'var(--spacingVerticalSNudge)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#spacingVerticalS | `spacingVerticalS`} design token.
+ * @public
+ */
 export const spacingVerticalS = 'var(--spacingVerticalS)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#spacingVerticalMNudge | `spacingVerticalMNudge`} design token.
+ * @public
+ */
 export const spacingVerticalMNudge = 'var(--spacingVerticalMNudge)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#spacingVerticalM | `spacingVerticalM`} design token.
+ * @public
+ */
 export const spacingVerticalM = 'var(--spacingVerticalM)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#spacingVerticalL | `spacingVerticalL`} design token.
+ * @public
+ */
 export const spacingVerticalL = 'var(--spacingVerticalL)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#spacingVerticalXL | `spacingVerticalXL`} design token.
+ * @public
+ */
 export const spacingVerticalXL = 'var(--spacingVerticalXL)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#spacingVerticalXXL | `spacingVerticalXXL`} design token.
+ * @public
+ */
 export const spacingVerticalXXL = 'var(--spacingVerticalXXL)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#spacingVerticalXXXL | `spacingVerticalXXXL`} design token.
+ * @public
+ */
 export const spacingVerticalXXXL = 'var(--spacingVerticalXXXL)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#durationUltraFast | `durationUltraFast`} design token.
+ * @public
+ */
 export const durationUltraFast = 'var(--durationUltraFast)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#durationFaster | `durationFaster`} design token.
+ * @public
+ */
 export const durationFaster = 'var(--durationFaster)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#durationFast | `durationFast`} design token.
+ * @public
+ */
 export const durationFast = 'var(--durationFast)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#durationNormal | `durationNormal`} design token.
+ * @public
+ */
 export const durationNormal = 'var(--durationNormal)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#durationGentle | `durationGentle`} design token.
+ * @public
+ */
 export const durationGentle = 'var(--durationGentle)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#durationSlow | `durationSlow`} design token.
+ * @public
+ */
 export const durationSlow = 'var(--durationSlow)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#durationSlower | `durationSlower`} design token.
+ * @public
+ */
 export const durationSlower = 'var(--durationSlower)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#durationUltraSlow | `durationUltraSlow`} design token.
+ * @public
+ */
 export const durationUltraSlow = 'var(--durationUltraSlow)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#curveAccelerateMax | `curveAccelerateMax`} design token.
+ * @public
+ */
 export const curveAccelerateMax = 'var(--curveAccelerateMax)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#curveAccelerateMid | `curveAccelerateMid`} design token.
+ * @public
+ */
 export const curveAccelerateMid = 'var(--curveAccelerateMid)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#curveAccelerateMin | `curveAccelerateMin`} design token.
+ * @public
+ */
 export const curveAccelerateMin = 'var(--curveAccelerateMin)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#curveDecelerateMax | `curveDecelerateMax`} design token.
+ * @public
+ */
 export const curveDecelerateMax = 'var(--curveDecelerateMax)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#curveDecelerateMid | `curveDecelerateMid`} design token.
+ * @public
+ */
 export const curveDecelerateMid = 'var(--curveDecelerateMid)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#curveDecelerateMin | `curveDecelerateMin`} design token.
+ * @public
+ */
 export const curveDecelerateMin = 'var(--curveDecelerateMin)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#curveEasyEaseMax | `curveEasyEaseMax`} design token.
+ * @public
+ */
 export const curveEasyEaseMax = 'var(--curveEasyEaseMax)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#curveEasyEase | `curveEasyEase`} design token.
+ * @public
+ */
 export const curveEasyEase = 'var(--curveEasyEase)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#curveLinear | `curveLinear`} design token.
+ * @public
+ */
 export const curveLinear = 'var(--curveLinear)';

--- a/packages/web-components/src/theme/set-theme.ts
+++ b/packages/web-components/src/theme/set-theme.ts
@@ -5,7 +5,8 @@ const tokenNames = Object.keys(tokens) as (keyof Theme)[];
 
 /**
  * Sets the theme tokens on defaultNode.
- * @param theme Flat object of theme token values.
+ * @param theme - Flat object of theme token values.
+ * @internal
  */
 export const setTheme = (theme: Theme) => {
   for (const t of tokenNames) {
@@ -13,6 +14,9 @@ export const setTheme = (theme: Theme) => {
   }
 };
 
+/**
+ * @internal
+ */
 export const setThemeFor = (element: HTMLElement, theme: Theme) => {
   for (const t of tokenNames) {
     element.style.setProperty(`--${t}`, theme[t] as string);

--- a/packages/web-components/src/toggle-button/index.ts
+++ b/packages/web-components/src/toggle-button/index.ts
@@ -1,10 +1,6 @@
-export { ToggleButton } from './toggle-button.js';
-export {
-  ToggleButtonAppearance,
-  ToggleButtonOptions,
-  ToggleButtonShape,
-  ToggleButtonSize,
-} from './toggle-button.options.js';
-export { template as ToggleButtonTemplate } from './toggle-button.template.js';
-export { styles as ToggleButtonStyles } from './toggle-button.styles.js';
 export { definition as ToggleButtonDefinition } from './toggle-button.definition.js';
+export { ToggleButton } from './toggle-button.js';
+export { ToggleButtonAppearance, ToggleButtonShape, ToggleButtonSize } from './toggle-button.options.js';
+export type { ToggleButtonOptions } from './toggle-button.options.js';
+export { styles as ToggleButtonStyles } from './toggle-button.styles.js';
+export { template as ToggleButtonTemplate } from './toggle-button.template.js';

--- a/packages/web-components/src/toggle-button/toggle-button.options.ts
+++ b/packages/web-components/src/toggle-button/toggle-button.options.ts
@@ -37,4 +37,4 @@ export const ToggleButtonSize = ButtonSize;
  */
 export type ToggleButtonSize = ValuesOf<typeof ToggleButtonSize>;
 
-export { ButtonOptions as ToggleButtonOptions };
+export type { ButtonOptions as ToggleButtonOptions };

--- a/packages/web-components/tsdoc.json
+++ b/packages/web-components/tsdoc.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+  "extends": ["@microsoft/api-extractor/extends/tsdoc-base.json"],
+  "tagDefinitions": [
+    {
+      "tagName": "@slot",
+      "syntaxKind": "block",
+      "allowMultiple": true
+    },
+    {
+      "tagName": "@csspart",
+      "syntaxKind": "block",
+      "allowMultiple": true
+    },
+    {
+      "tagName": "@cssprop",
+      "syntaxKind": "block",
+      "allowMultiple": true
+    },
+    {
+      "tagName": "@cssproperty",
+      "syntaxKind": "block",
+      "allowMultiple": true
+    },
+    {
+      "tagName": "@event",
+      "syntaxKind": "block",
+      "allowMultiple": true
+    },
+    {
+      "tagName": "@fires",
+      "syntaxKind": "block",
+      "allowMultiple": true
+    }
+  ],
+  "supportForTags": {
+    "@slot": true,
+    "@csspart": true,
+    "@cssprop": true,
+    "@cssproperty": true,
+    "@event": true,
+    "@fires": true
+  }
+}


### PR DESCRIPTION
## Previous Behavior

The `api-extractor` step outputs a long list of warnings due to problems with documentation blocks in the component modules.

Additionally, Storybook outputs a long list of warnings for all exported types as values (`import`/`export` vs `import type`/`export type`).

## New Behavior

This PR resolves the warnings and modifies the `api-extractor` and `tsdoc` configurations to reduce the number of warnings. Any warnings generated during the `compile`/`build` steps should be more relevant and actionable going forward.

## Related Issue(s)

- Related to https://github.com/microsoft/fluentui/pull/31422#discussion_r1608658686
