### PR TITLE
chore:react-nav-preview Removing unnecessary size prop

### DIFF
--- a/packages/react-components/react-nav-preview/stories/NavDrawer/NavDrawerDefault.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/NavDrawer/NavDrawerDefault.stories.tsx
@@ -97,7 +97,7 @@ export const NavDrawerDefault = (props: Partial<NavDrawerProps>) => {
 
   return (
     <div className={styles.root}>
-      <NavDrawer defaultSelectedValue="2" defaultSelectedCategoryValue="1" open={isOpen} type={type} size="small">
+      <NavDrawer defaultSelectedValue="2" defaultSelectedCategoryValue="1" open={isOpen} type={type}>
         <NavDrawerHeader>
           <NavDrawerHeaderNav>
             <Hamburger onClick={() => setIsOpen(false)} />


### PR DESCRIPTION
Size==small is the default prop on drawer, and also the one we want for the nav.

This pr removes the unneeded assignment from the example.

Visuals are unchanged.

Ladders to #26649 