### PR TITLE
chore:docs Adding back references to yarn build

### DIFF
--- a/docs/react-v9/contributing/command-cheat-sheet.md
+++ b/docs/react-v9/contributing/command-cheat-sheet.md
@@ -8,7 +8,7 @@ yarn create-package # scaffolds a new package
 yarn create-component # scaffolds a new component
 yarn change # creates a new change file, if needed
 yarn clean # tidies any cached dependencies
-yarn build # Windows users not using WSL may likely have to run this after cleaning, or if they need to generate an api change file. Note that this command can take up to an hour depending on the speed of your hard drive.
+yarn build # generates and relinks all packages and temporary files, this can be a good option if you see errors unrelated to the packages you are working on
 yarn start # runs a package. You can select the package of choice.
 yarn update-snapshots # updates snapshot tests
 yarn run dedupe # dedupes dependencies - necessary to run after any kind of package bump/changes

--- a/docs/react-v9/contributing/command-cheat-sheet.md
+++ b/docs/react-v9/contributing/command-cheat-sheet.md
@@ -8,6 +8,7 @@ yarn create-package # scaffolds a new package
 yarn create-component # scaffolds a new component
 yarn change # creates a new change file, if needed
 yarn clean # tidies any cached dependencies
+yarn build # Windows users not using WSL may likely have to run this after cleaning, or if they need to generate an api change file. Note that this command can take up to an hour depending on the speed of your hard drive.
 yarn start # runs a package. You can select the package of choice.
 yarn update-snapshots # updates snapshot tests
 yarn run dedupe # dedupes dependencies - necessary to run after any kind of package bump/changes

--- a/docs/react-v9/contributing/common-dev-snags.md
+++ b/docs/react-v9/contributing/common-dev-snags.md
@@ -6,11 +6,11 @@ First, file an issue [here](https://github.com/microsoft/fluentui/issues/new/cho
 
 Make sure all your desired changes are stashed or otherwise saved somewhere you can pull them back in.
 
-First try running:
+Then try running:
 
 `yarn`
 
 If the issues still persist, clean your repo:
 
 `yarn cache clean`
-`yarn`
+`yarn` // Vanilla Windows users may have better luck with yarn build.

--- a/docs/react-v9/contributing/common-dev-snags.md
+++ b/docs/react-v9/contributing/common-dev-snags.md
@@ -13,4 +13,8 @@ Then try running:
 If the issues still persist, clean your repo:
 
 `yarn cache clean`
-`yarn` // Vanilla Windows users may have better luck with yarn build.
+`yarn`
+
+If unrelated errors are still persistent, a clean build may resolve:
+
+`yarn build`

--- a/docs/react-v9/contributing/dev-env.md
+++ b/docs/react-v9/contributing/dev-env.md
@@ -34,7 +34,7 @@ Open a command line and run:
 
 If you do not wish to contribute changes, for `@fluentui/react` version 8 please follow the instructions on the [`@fluentui/react` README](https://github.com/microsoft/fluentui/blob/master/packages/react/README.md#building-the-repo) page for how to clone and build the main repo. Else, keep reading.
 
-Run `yarn`. This may take a while initially, especially on vanilla Windows systems.
+Run `yarn`. This may take a while initially.
 
 Run `yarn start` and select your start up project.
 

--- a/docs/react-v9/contributing/dev-env.md
+++ b/docs/react-v9/contributing/dev-env.md
@@ -33,7 +33,7 @@ Open a command line and run:
 
 If you do not wish to contribute changes, for `@fluentui/react` version 8 please follow the instructions on the [`@fluentui/react` README](https://github.com/microsoft/fluentui/blob/master/packages/react/README.md#building-the-repo) page for how to clone and build the main repo. Else, keep reading.
 
-Run `yarn`. This may take a while initially.
+Run `yarn`. This may take a while initially, especially on vanilla Windows systems.
 
 Run `yarn start` and select your start up project.
 

--- a/docs/react-v9/contributing/dev-env.md
+++ b/docs/react-v9/contributing/dev-env.md
@@ -18,6 +18,7 @@ This document describes how to set up your development environment and contribut
 - Optional: **[Accessibility insight for web](https://accessibilityinsights.io/)**
 - Optional: **[Node Version Manager](https://github.com/nvm-sh/nvm)**
 - Optional: **[CSpell VS Code Extension](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker)**
+- Optional: **[Improve build times: WSL for Windows](https://learn.microsoft.com/en-us/windows/dev-environment/javascript/nodejs-on-wsl)**
 
 ### Verify your environment
 

--- a/docs/react-v9/contributing/dev-workflow.md
+++ b/docs/react-v9/contributing/dev-workflow.md
@@ -79,8 +79,7 @@ In other cases, such as before checking in or running tests, you may need to run
 ### Making a pull request
 
 Make sure all your changes are committed, and run `yarn nx run @fluentui/react-components:build` or `yarn buildto @fluentui/react-components` for changes to the v9 components. This will compare your changes and detect if the publicly facing API has changed, and update our API docs accordingly. Commit this file change.
-
-Windows users not using WSL may have to run `yarn build` to generate the APU change file.
+Note: If you encounter build errors here (especially on non-\*nix systems) a 'yarn build' to ensure packages are correctly updated and linked may be nessecary.
 
 Some of our tests make use of DOM snapshot tests. If your branch makes any changes or additions to the DOM, you may need to run `yarn nx run @fluentui/<package>:test -u` or `yarn workspace @fluentui/<package> test --updateSnapshot`. This will update any necessary files used by our snapshot tests.
 

--- a/docs/react-v9/contributing/dev-workflow.md
+++ b/docs/react-v9/contributing/dev-workflow.md
@@ -96,7 +96,7 @@ When your change is ready, [create a pull request](https://github.com/microsoft/
 
 Common checklist for PR's
 
-- Descriptive title: "feat:package-name Adding 'multiple' prop to Nav"
+- Descriptive title: "feat(package-name): Adding 'multiple' prop to Nav"
 - Brief description of the improvement you're making. You should summarize the issue you are addressing. Assume the PR is the reviewer's starting point and they should only have to dive into the issue for very specific details.
 - Link to the relevant issue.
 - Visual aid for changes to give more context. Before and After clips help a lot.

--- a/docs/react-v9/contributing/dev-workflow.md
+++ b/docs/react-v9/contributing/dev-workflow.md
@@ -28,7 +28,7 @@ cd fluentui
 yarn
 ```
 
-Vanilla Windows users not working in WSL should run `yarn clean` and then `yarn build` weekly or when pulling from master breaks the environment.
+Windows users not working in WSL should run `yarn clean` and then `yarn build` on first use to ensure correct linking in non-\*nix systems.
 
 Run `yarn start` and select your start up project.
 

--- a/docs/react-v9/contributing/dev-workflow.md
+++ b/docs/react-v9/contributing/dev-workflow.md
@@ -28,6 +28,8 @@ cd fluentui
 yarn
 ```
 
+Vanilla Windows users not working in WSL should run `yarn clean` and then `yarn build` weekly or when pulling from master breaks the environment.
+
 Run `yarn start` and select your start up project.
 
 ```
@@ -57,6 +59,7 @@ It is strongly recommended that you rebase your branch onto (rather than merging
 ```
 git checkout master // Switches to master
 git pull upstream master // Syncs your local master with the latest version of master at the origin
+git push // syncs your forks definition of master with the upstream repo
 git checkout your-fancy-branch // Switches back to your branch
 git rebase -i master // Tacks your commits onto the end of master. Force is necessary since rebase changes history.
 ```
@@ -77,6 +80,8 @@ In other cases, such as before checking in or running tests, you may need to run
 
 Make sure all your changes are committed, and run `yarn nx run @fluentui/react-components:build` or `yarn buildto @fluentui/react-components` for changes to the v9 components. This will compare your changes and detect if the publicly facing API has changed, and update our API docs accordingly. Commit this file change.
 
+Windows users not using WSL may have to run `yarn build` to generate the APU change file.
+
 Some of our tests make use of DOM snapshot tests. If your branch makes any changes or additions to the DOM, you may need to run `yarn nx run @fluentui/<package>:test -u` or `yarn workspace @fluentui/<package> test --updateSnapshot`. This will update any necessary files used by our snapshot tests.
 
 Before creating a pull request, be sure to run `yarn change` and provide a high-level description of your change, which will be used in the release notes. You will need to run this at least once for every PR made to a published package. We follow [semantic versioning](https://semver.org/), so use the guide when selecting a change type:
@@ -91,7 +96,7 @@ When your change is ready, [create a pull request](https://github.com/microsoft/
 
 Common checklist for PR's
 
-- Descriptive title: "feat(package-name): Adding 'multiple' prop to Nav"
+- Descriptive title: "feat:package-name Adding 'multiple' prop to Nav"
 - Brief description of the improvement you're making. You should summarize the issue you are addressing. Assume the PR is the reviewer's starting point and they should only have to dive into the issue for very specific details.
 - Link to the relevant issue.
 - Visual aid for changes to give more context. Before and After clips help a lot.


### PR DESCRIPTION
There is a large contingent of contributors at MSFT using vanilla windows, rather than a unix based system.

Sometimes running a `yarn build` is the right thing for them to do. 

Many developers are accustomed to yarn building regularly.

This adds it back to the docs.