### PR TITLE
breaking(react-motions): remove `iterations` prop from createMotionComponent()

### DIFF
--- a/change/@fluentui-react-motions-preview-dffb90ce-ff7d-44d5-8d92-31d75815ea2d.json
+++ b/change/@fluentui-react-motions-preview-dffb90ce-ff7d-44d5-8d92-31d75815ea2d.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "breaking(react-motions): remove `iterations` prop from createMotionComponent()",
+  "packageName": "@fluentui/react-motions-preview",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-motions-preview-dffb90ce-ff7d-44d5-8d92-31d75815ea2d.json
+++ b/change/@fluentui-react-motions-preview-dffb90ce-ff7d-44d5-8d92-31d75815ea2d.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "breaking(react-motions): remove `iterations` prop from createMotionComponent()",
+  "comment": "BREAKING: remove `iterations` prop from createMotionComponent()",
   "packageName": "@fluentui/react-motions-preview",
   "email": "olfedias@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/react-components/react-motions-preview/src/factories/createMotionComponent.test.tsx
+++ b/packages/react-components/react-motions-preview/src/factories/createMotionComponent.test.tsx
@@ -43,7 +43,6 @@ describe('createMotionComponent', () => {
     expect(animateMock).toHaveBeenCalledWith(motion.keyframes, {
       duration: motion.duration,
       fill: 'forwards',
-      iterations: 1,
     });
   });
 

--- a/packages/react-components/react-motions-preview/src/factories/createMotionComponent.ts
+++ b/packages/react-components/react-motions-preview/src/factories/createMotionComponent.ts
@@ -12,8 +12,6 @@ type MotionComponentProps = {
 
   /** Provides imperative controls for the animation. */
   imperativeRef?: React.Ref<MotionImperativeRef | undefined>;
-
-  iterations?: number;
 };
 
 /**
@@ -23,7 +21,7 @@ type MotionComponentProps = {
  */
 export function createMotionComponent(motion: AtomMotion | AtomMotionFn) {
   const Atom: React.FC<MotionComponentProps> = props => {
-    const { children, iterations = 1, imperativeRef } = props;
+    const { children, imperativeRef } = props;
 
     const child = getChildElement(children);
 
@@ -43,8 +41,6 @@ export function createMotionComponent(motion: AtomMotion | AtomMotionFn) {
           fill: 'forwards',
 
           ...options,
-          iterations,
-
           ...(isReducedMotion() && { duration: 1 }),
         });
 
@@ -58,7 +54,7 @@ export function createMotionComponent(motion: AtomMotion | AtomMotionFn) {
           animation.cancel();
         };
       }
-    }, [animationRef, iterations, isReducedMotion]);
+    }, [animationRef, isReducedMotion]);
 
     return React.cloneElement(children, { ref: useMergedRefs(elementRef, child.ref) });
   };

--- a/packages/react-components/react-motions-preview/stories/CreateMotionComponent/CreateMotionComponent.stories.tsx
+++ b/packages/react-components/react-motions-preview/stories/CreateMotionComponent/CreateMotionComponent.stories.tsx
@@ -35,6 +35,7 @@ const DropIn = createMotionComponent({
     { transform: 'rotate(0deg) translateY(0%)', opacity: 1 },
   ],
   duration: 4000,
+  iterations: Infinity,
 });
 
 export const CreateMotionComponent = () => {
@@ -43,7 +44,7 @@ export const CreateMotionComponent = () => {
   return (
     <div className={classes.container}>
       <div className={classes.card}>
-        <DropIn iterations={Infinity}>
+        <DropIn>
           <div className={classes.item} />
         </DropIn>
 

--- a/packages/react-components/react-motions-preview/stories/CreateMotionComponent/CreateMotionComponentDefault.stories.tsx
+++ b/packages/react-components/react-motions-preview/stories/CreateMotionComponent/CreateMotionComponentDefault.stories.tsx
@@ -26,6 +26,7 @@ const useClasses = makeStyles({
 const FadeEnter = createMotionComponent({
   keyframes: [{ opacity: 0 }, { opacity: 1 }],
   duration: motionTokens.durationSlow,
+  iterations: Infinity,
 });
 
 export const CreateMotionComponentDefault = () => {
@@ -41,7 +42,7 @@ export const CreateMotionComponentDefault = () => {
   return (
     <div className={classes.container}>
       <div className={classes.card}>
-        <FadeEnter iterations={Infinity} imperativeRef={motionRef}>
+        <FadeEnter imperativeRef={motionRef}>
           <div className={classes.item} />
         </FadeEnter>
       </div>

--- a/packages/react-components/react-motions-preview/stories/CreateMotionComponent/ImperativeRefPlayState.stories.tsx
+++ b/packages/react-components/react-motions-preview/stories/CreateMotionComponent/ImperativeRefPlayState.stories.tsx
@@ -43,6 +43,7 @@ const useClasses = makeStyles({
 const FadeEnter = createMotionComponent({
   keyframes: [{ opacity: 0 }, { opacity: 1 }],
   duration: motionTokens.durationSlow,
+  iterations: Infinity,
 });
 
 export const ImperativeRefPlayState = () => {
@@ -67,7 +68,7 @@ export const ImperativeRefPlayState = () => {
     <>
       <div className={classes.container}>
         <div className={classes.card}>
-          <FadeEnter iterations={Infinity} imperativeRef={motionRef}>
+          <FadeEnter imperativeRef={motionRef}>
             <div className={classes.item} />
           </FadeEnter>
 

--- a/packages/react-components/react-motions-preview/stories/CreateMotionComponent/TokensUsage.stories.tsx
+++ b/packages/react-components/react-motions-preview/stories/CreateMotionComponent/TokensUsage.stories.tsx
@@ -35,6 +35,7 @@ const BackgroundChange = createMotionComponent({
     { backgroundColor: tokens.colorStatusSuccessBackground3 },
   ],
   duration: 3000,
+  iterations: Infinity,
 });
 
 export const TokensUsage = () => {
@@ -43,7 +44,7 @@ export const TokensUsage = () => {
   return (
     <div className={classes.container}>
       <div className={classes.card}>
-        <BackgroundChange iterations={Infinity}>
+        <BackgroundChange>
           <div className={classes.item} />
         </BackgroundChange>
 


### PR DESCRIPTION
## BREAKING CHANGES 🚨

This PR removes `iterations` prop from a component created by `createMotionComponent()`. Before `iterations` could be passed both to a `AtomMotion` and a component's props that created confusion.

## Previous Behavior

```tsx
import { createMotionComponent, motionTokens } from '@fluentui/react-motions-preview';

const FadeEnter = createMotionComponent({
  keyframes: [{ opacity: 0 }, { opacity: 1 }],
  duration: motionTokens.durationSlow,
});

function App() {
  return <FadeEnter iterations={Infinity} />
}
```

## New Behavior

```tsx
import { createMotionComponent, motionTokens } from '@fluentui/react-motions-preview';

const FadeEnter = createMotionComponent({
  keyframes: [{ opacity: 0 }, { opacity: 1 }],
  duration: motionTokens.durationSlow,
  iterations: Infinity,
});

function App() {
  return <FadeEnter />
}
```