### PR TITLE
breaking(react-motions): remove event argument from "onMotionFinish" prop

### DIFF
--- a/change/@fluentui-react-motions-preview-8fed56ea-bf79-45b6-966d-c8e1b83efc50.json
+++ b/change/@fluentui-react-motions-preview-8fed56ea-bf79-45b6-966d-c8e1b83efc50.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "BREAKING: remove event argument from \"onMotionFinish\" prop",
+  "packageName": "@fluentui/react-motions-preview",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-motions-preview/etc/react-motions-preview.api.md
+++ b/packages/react-components/react-motions-preview/etc/react-motions-preview.api.md
@@ -4,8 +4,6 @@
 
 ```ts
 
-import type { EventData } from '@fluentui/react-utilities';
-import type { EventHandler } from '@fluentui/react-utilities';
 import * as React_2 from 'react';
 
 // @public (undocumented)

--- a/packages/react-components/react-motions-preview/src/factories/createPresenceComponent.test.tsx
+++ b/packages/react-components/react-motions-preview/src/factories/createPresenceComponent.test.tsx
@@ -70,6 +70,42 @@ describe('createPresenceComponent', () => {
     });
   });
 
+  describe('onMotionFinish', () => {
+    it('is not called on first render', () => {
+      const onMotionFinish = jest.fn();
+      const TestAtom = createPresenceComponent(motion);
+      const { ElementMock } = createElementMock();
+
+      render(
+        <TestAtom onMotionFinish={onMotionFinish}>
+          <ElementMock />
+        </TestAtom>,
+      );
+
+      expect(onMotionFinish).toHaveBeenCalledTimes(0);
+    });
+
+    it('calls "onMotionFinish" when animation finishes', () => {
+      const onMotionFinish = jest.fn();
+      const TestAtom = createPresenceComponent(motion);
+      const { ElementMock } = createElementMock();
+
+      const { rerender } = render(
+        <TestAtom onMotionFinish={onMotionFinish} visible>
+          <ElementMock />
+        </TestAtom>,
+      );
+      rerender(
+        <TestAtom onMotionFinish={onMotionFinish} visible={false}>
+          <ElementMock />
+        </TestAtom>,
+      );
+
+      expect(onMotionFinish).toHaveBeenCalledTimes(1);
+      expect(onMotionFinish).toHaveBeenCalledWith(null, { direction: 'exit' });
+    });
+  });
+
   describe('visible', () => {
     it('animates when state changes', () => {
       const TestAtom = createPresenceComponent(motion);

--- a/packages/react-components/react-motions-preview/src/factories/createPresenceComponent.ts
+++ b/packages/react-components/react-motions-preview/src/factories/createPresenceComponent.ts
@@ -22,7 +22,12 @@ export type PresenceComponentProps = {
   /** Provides imperative controls for the animation. */
   imperativeRef?: React.Ref<MotionImperativeRef | undefined>;
 
-  /** Callback that is called when the motion finishes. */
+  /**
+   * Callback that is called when the whole motion finishes.
+   *
+   * A motion definition can contain multiple animations and therefore multiple "finish" events. The callback is
+   * triggered once all animations have finished with "null" instead of an event object to avoid ambiguity.
+   */
   // eslint-disable-next-line @nx/workspace-consistent-callback-type -- EventHandler<T> does not support "null"
   onMotionFinish?: (ev: null, data: { direction: 'enter' | 'exit' }) => void;
 

--- a/packages/react-components/react-motions-preview/src/factories/createPresenceComponent.ts
+++ b/packages/react-components/react-motions-preview/src/factories/createPresenceComponent.ts
@@ -1,5 +1,4 @@
 import { useEventCallback, useFirstMount, useIsomorphicLayoutEffect, useMergedRefs } from '@fluentui/react-utilities';
-import type { EventData, EventHandler } from '@fluentui/react-utilities';
 import * as React from 'react';
 
 import { PresenceGroupChildContext } from '../contexts/PresenceGroupChildContext';
@@ -9,10 +8,6 @@ import { useMountedState } from '../hooks/useMountedState';
 import { animate } from '../utils/animate';
 import { getChildElement } from '../utils/getChildElement';
 import type { PresenceMotion, MotionImperativeRef, PresenceMotionFn } from '../types';
-
-type PresenceMotionEventData = EventData<'animation', AnimationPlaybackEvent> & {
-  direction: 'enter' | 'exit';
-};
 
 export type PresenceComponentProps = {
   /**
@@ -27,7 +22,9 @@ export type PresenceComponentProps = {
   /** Provides imperative controls for the animation. */
   imperativeRef?: React.Ref<MotionImperativeRef | undefined>;
 
-  onMotionFinish?: EventHandler<PresenceMotionEventData>;
+  /** Callback that is called when the motion finishes. */
+  // eslint-disable-next-line @nx/workspace-consistent-callback-type -- EventHandler<T> does not support "null"
+  onMotionFinish?: (ev: null, data: { direction: 'enter' | 'exit' }) => void;
 
   /** Defines whether a component is visible; triggers the "enter" or "exit" motions. */
   visible?: boolean;
@@ -59,11 +56,11 @@ export function createPresenceComponent(motion: PresenceMotion | PresenceMotionF
     const isFirstMount = useFirstMount();
     const isReducedMotion = useIsReducedMotion();
 
-    const onEnterFinish = useEventCallback((event: AnimationPlaybackEvent) => {
-      onMotionFinish?.(event, { event, type: 'animation', direction: 'enter' });
+    const onEnterFinish = useEventCallback(() => {
+      onMotionFinish?.(null, { direction: 'enter' });
     });
-    const onExitFinish = useEventCallback((event: AnimationPlaybackEvent) => {
-      onMotionFinish?.(event, { event, type: 'animation', direction: 'exit' });
+    const onExitFinish = useEventCallback(() => {
+      onMotionFinish?.(null, { direction: 'exit' });
 
       if (unmountOnExit) {
         setMounted(false);


### PR DESCRIPTION
## BREAKING CHANGES 🚨

This PR updates `onMotionFinish` callback to pass `null` as a first param instead of `AnimationPlaybackEvent`. The motivation is to support more complex scenarios (like grouping #31487) when there is no a single event.

## Previous Behavior

```tsx
const Fade = createPresenceComponent({ /* --- */ });

<Fade
  onMotionFinish={(ev: AnimationPlaybackEvent, data) => {
  }}
/>
```

## New Behavior

```tsx
const Fade = createPresenceComponent({ /* --- */ });

<Fade
  onMotionFinish={(ev: null, data) => {
    /* ev is "null" now */  
  }}
/>
```