### PR TITLE
fix(scripts-lint-staged): correctly resolve package groupping based on provided git staged files

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -13,12 +13,14 @@ const commands = {
   lint: 'node ./scripts/lint-staged/src/eslint',
 };
 
+const nonJsExtensions = [
+  prettierSupportedFileExtensionsByContext.stylesheets,
+  prettierSupportedFileExtensionsByContext.markdown,
+  prettierSupportedFileExtensionsByContext.others,
+].flat();
+
 // https://www.npmjs.com/package/lint-staged
 module.exports = {
-  [`**/*.{${[].concat(
-    prettierSupportedFileExtensionsByContext.stylesheets,
-    prettierSupportedFileExtensionsByContext.markdown,
-    prettierSupportedFileExtensionsByContext.others,
-  )}}`]: [commands.format],
-  [`**/*.{${prettierSupportedFileExtensionsByContext.js}}`]: [commands.format, commands.lint],
+  [`**/*.{${nonJsExtensions}}`]: [commands.format],
+  [`**/*.{${prettierSupportedFileExtensionsByContext.js}}`]: [/* commands.format, */ commands.lint],
 };

--- a/scripts/lint-staged/package.json
+++ b/scripts/lint-staged/package.json
@@ -11,7 +11,8 @@
     "type-check": "just-scripts type-check"
   },
   "dependencies": {
-    "@fluentui/scripts-monorepo": "*"
+    "@fluentui/scripts-monorepo": "*",
+    "@fluentui/scripts-utils": "*"
   },
   "devDependencies": {}
 }

--- a/scripts/lint-staged/src/eslint-for-package.js
+++ b/scripts/lint-staged/src/eslint-for-package.js
@@ -1,10 +1,10 @@
 // @ts-check
 
+const fs = require('fs');
 const path = require('path');
 
 const { eslintConstants } = require('@fluentui/scripts-monorepo');
 const { ESLint } = require('eslint');
-const fs = require('fs-extra');
 const micromatch = require('micromatch');
 
 /**
@@ -21,8 +21,9 @@ const micromatch = require('micromatch');
 async function run() {
   // Get information needed to determine whether files in this package should be linted
   const packagePath = process.cwd();
-  const packageJson = fs.readJSONSync(path.join(packagePath, 'package.json'));
-  const lintScript = packageJson.scripts.lint || '';
+  /** @type {{scripts?:Record<string,string>}} */
+  const packageJson = JSON.parse(fs.readFileSync(path.join(packagePath, 'package.json'), 'utf-8'));
+  const lintScript = packageJson.scripts?.lint ?? '';
   /** @type {import('eslint').ESLint} */
   let eslint;
   /** @type {string} */
@@ -43,7 +44,7 @@ async function run() {
     eslint = new ESLint({ fix: true, cache: lintScript.includes('--cache') });
   }
 
-  // files are provided by @see `./eslint.js` via cli
+  // files are provided by @see `file://./eslint.js` via cli
   const cliFiles = process.argv.slice(2);
   // Filter out files with non-linted extensions
   const files = cliFiles.filter(file => micromatch.isMatch(file, includePattern));


### PR DESCRIPTION
depends on:
- [x] https://github.com/microsoft/fluentui/pull/31475

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

`lint-staged` is broken for `/scripts` packages as it incorectly resolves file groupping to root package

## New Behavior

- `lint-staged` works across all scenarios 
- perf is improved as well as we no longer need to fetch all projects Map from nx Daemon on every commit


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
