### PR TITLE
chore(react-components): use performant type-check target

### DIFF
--- a/change/@fluentui-react-components-27f92d7e-90df-4cb6-9e56-d4d1a72d1edd.json
+++ b/change/@fluentui-react-components-27f92d7e-90df-4cb6-9e56-d4d1a72d1edd.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(react-components): use performant type-check target",
+  "packageName": "@fluentui/react-components",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-components/package.json
+++ b/packages/react-components/react-components/package.json
@@ -20,7 +20,7 @@
     "lint": "just-scripts lint",
     "start": "echo 'This doesn't do anything. Run `yarn workspace @fluentui/public-docsite-v9 storybook` instead.'",
     "test": "jest --passWithNoTests",
-    "type-check": "tsc -b tsconfig.json",
+    "type-check": "just-scripts type-check",
     "generate-api": "just-scripts generate-api",
     "verify-packaging": "just-scripts verify-packaging"
   },


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

see PR title

`@fluentui/react-components type-check` comparison speed:

| before | after |
|--------|--------|
| 57.92s | 9.59s / **𝚫 83% 🚅** | 

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Partially implements https://github.com/microsoft/fluentui/issues/30516
