### PR TITLE
ci: migrate to node 20

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -2,5 +2,5 @@
   "buildCommand": "build:codesandbox",
   "packages": ["packages/react", "packages/react-components/react-components"],
   "sandboxes": ["x5u3t", "spnyu"],
-  "node": "18"
+  "node": "20"
 }

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-ARG VARIANT=18-bookworm
+ARG VARIANT=20-bookworm
 # https://github.com/devcontainers/images/tree/main/src/typescript-node
 FROM mcr.microsoft.com/devcontainers/typescript-node:1-${VARIANT}
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
   "build": {
     "dockerfile": "Dockerfile",
     "args": {
-      "VARIANT": "18-bookworm"
+      "VARIANT": "20-bookworm"
     }
   },
   "features": {

--- a/.devops/templates/tools.yml
+++ b/.devops/templates/tools.yml
@@ -6,7 +6,7 @@ steps:
       # - we can use only versions that ship with container, otherwise we will run into nodejs installation issues.
       # - as 1es bumps those versions within container automatically we need to use `<major>.x` to not run into issues once they bump the versions.
       # https://github.com/actions/runner-images/blob/ubuntu20/20230924.1/images/linux/Ubuntu2004-Readme.md#nodejs
-      version: '18.x'
+      version: '20.x'
       checkLatest: false
     displayName: 'Install Node.js'
     retryCountOnTaskFailure: 1

--- a/.github/workflows/check-packages.yml
+++ b/.github/workflows/check-packages.yml
@@ -12,7 +12,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 20.x
           cache: 'yarn'
 
       - uses: tj-actions/changed-files@v41
@@ -44,7 +44,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 20.x
 
       - uses: actions/github-script@v6
         with:
@@ -70,7 +70,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 20.x
 
       - uses: actions/github-script@v6
         with:

--- a/.github/workflows/docsite-publish-chromatic.yml
+++ b/.github/workflows/docsite-publish-chromatic.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 20.x
           cache: 'yarn'
 
       - name: Install packages

--- a/.github/workflows/docsite-publish-ghpages.yml
+++ b/.github/workflows/docsite-publish-ghpages.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 20.x
           cache: 'yarn'
 
       - name: Install packages

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "engines": {
-    "node": "^18.0.0 || ^20.0.0"
+    "node": "^20.0.0 || ^22.0.0"
   },
   "scripts": {
     "dedupe": "npx yarn-deduplicate --strategy fewer",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

- Migrates repo to Node LTS which is v20.
- release announcement https://nodejs.org/en/blog/announcements/v20-release-announce

> [!IMPORTANT]
> - once this PR is merged you won't be able to install packages etc if you use older node that v20.
> - you can temporarily mitigate this by running `yarn install --ignore-engines`, but you should migrate to node v20

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
