### PR TITLE
chore: entirely remove stress-test app

### DIFF
--- a/apps/stress-test/README.md
+++ b/apps/stress-test/README.md
@@ -1,1 +1,0 @@
-`stress-test` has been removed from this repo as it's functionality has moved to [`tensile-perf`](https://github.com/microsoft/tensile-perf).


### PR DESCRIPTION
## Previous Behavior

App was previously removed but I kept a README to link elsewhere.

## New Behavior

After chatting with @Hotell I learned this is an invalid entry in our monorepo and since we no longer keep it here we should just get rid of it.