### PR TITLE
breaking(react-motions): AtomMotionFn & PresenceMotionFn have an object as param

### DIFF
--- a/change/@fluentui-react-motions-preview-f7e0f94c-24bd-4fa0-bae2-886019aac40f.json
+++ b/change/@fluentui-react-motions-preview-f7e0f94c-24bd-4fa0-bae2-886019aac40f.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "breaking: AtomMotionFn & PresenceMotionFn have an object as param",
+  "packageName": "@fluentui/react-motions-preview",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-toast-f2e79a5a-f5e1-4b7d-b12f-470610a0840b.json
+++ b/change/@fluentui-react-toast-f2e79a5a-f5e1-4b7d-b12f-470610a0840b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: adopt changes in motion APIs",
+  "packageName": "@fluentui/react-toast",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-motions-preview/etc/react-motions-preview.api.md
+++ b/packages/react-components/react-motions-preview/etc/react-motions-preview.api.md
@@ -12,7 +12,9 @@ export type AtomMotion = {
 } & KeyframeEffectOptions;
 
 // @public (undocumented)
-export type AtomMotionFn = (element: HTMLElement) => AtomMotion | AtomMotion[];
+export type AtomMotionFn = (params: {
+    element: HTMLElement;
+}) => AtomMotion | AtomMotion[];
 
 // @public
 export function createMotionComponent(value: AtomMotion | AtomMotion[] | AtomMotionFn): React_2.FC<MotionComponentProps>;
@@ -113,7 +115,9 @@ export type PresenceMotion = {
 };
 
 // @public (undocumented)
-export type PresenceMotionFn = (element: HTMLElement) => PresenceMotion;
+export type PresenceMotionFn = (params: {
+    element: HTMLElement;
+}) => PresenceMotion;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react-components/react-motions-preview/src/factories/createMotionComponent.test.tsx
+++ b/packages/react-components/react-motions-preview/src/factories/createMotionComponent.test.tsx
@@ -59,7 +59,7 @@ describe('createMotionComponent', () => {
     );
 
     expect(fnMotion).toHaveBeenCalledTimes(1);
-    expect(fnMotion).toHaveBeenCalledWith({ animate: animateMock } /* mock of html element */);
+    expect(fnMotion).toHaveBeenCalledWith({ element: { animate: animateMock } /* mock of html element */ });
 
     expect(animateMock).toHaveBeenCalledTimes(1);
   });

--- a/packages/react-components/react-motions-preview/src/factories/createMotionComponent.ts
+++ b/packages/react-components/react-motions-preview/src/factories/createMotionComponent.ts
@@ -33,7 +33,7 @@ export function createMotionComponent(value: AtomMotion | AtomMotion[] | AtomMot
       const element = elementRef.current;
 
       if (element) {
-        const atoms = typeof value === 'function' ? value(element) : value;
+        const atoms = typeof value === 'function' ? value({ element }) : value;
         const handle = animateAtoms(element, atoms, { isReducedMotion: isReducedMotion() });
 
         handleRef.current = handle;

--- a/packages/react-components/react-motions-preview/src/factories/createPresenceComponent.test.tsx
+++ b/packages/react-components/react-motions-preview/src/factories/createPresenceComponent.test.tsx
@@ -240,7 +240,7 @@ describe('createPresenceComponent', () => {
       );
 
       expect(fnMotion).toHaveBeenCalledTimes(1);
-      expect(fnMotion).toHaveBeenCalledWith({ animate: animateMock } /* mock of html element */);
+      expect(fnMotion).toHaveBeenCalledWith({ element: { animate: animateMock } /* mock of html element */ });
 
       expect(animateMock).toHaveBeenCalledWith(exitKeyframes, options);
     });

--- a/packages/react-components/react-motions-preview/src/factories/createPresenceComponent.ts
+++ b/packages/react-components/react-motions-preview/src/factories/createPresenceComponent.ts
@@ -85,7 +85,7 @@ export function createPresenceComponent(value: PresenceMotion | PresenceMotionFn
           return;
         }
 
-        const presenceMotion = typeof value === 'function' ? value(element) : value;
+        const presenceMotion = typeof value === 'function' ? value({ element }) : value;
         const atoms = visible ? presenceMotion.enter : presenceMotion.exit;
 
         const handle = animateAtoms(element, atoms, { isReducedMotion: isReducedMotion() });

--- a/packages/react-components/react-motions-preview/src/types.ts
+++ b/packages/react-components/react-motions-preview/src/types.ts
@@ -5,8 +5,8 @@ export type PresenceMotion = {
   exit: AtomMotion | AtomMotion[];
 };
 
-export type AtomMotionFn = (element: HTMLElement) => AtomMotion | AtomMotion[];
-export type PresenceMotionFn = (element: HTMLElement) => PresenceMotion;
+export type AtomMotionFn = (params: { element: HTMLElement }) => AtomMotion | AtomMotion[];
+export type PresenceMotionFn = (params: { element: HTMLElement }) => PresenceMotion;
 
 // ---
 

--- a/packages/react-components/react-motions-preview/stories/CreateMotionComponent/MotionFunctions.stories.md
+++ b/packages/react-components/react-motions-preview/stories/CreateMotionComponent/MotionFunctions.stories.md
@@ -1,7 +1,7 @@
 Atoms definitions can be also defined as functions that accept an animated element as an argument. This allows to define more complex animations that depend on the animated element's properties, for example:
 
 ```ts
-const Grow = createMotionComponent(element => ({
+const Grow = createMotionComponent(({ element }) => ({
   duration: 300,
   keyframes: [
     { opacity: 0, maxHeight: `${element.scrollHeight / 2}px` },

--- a/packages/react-components/react-motions-preview/stories/CreateMotionComponent/MotionFunctions.stories.tsx
+++ b/packages/react-components/react-motions-preview/stories/CreateMotionComponent/MotionFunctions.stories.tsx
@@ -41,7 +41,7 @@ const useClasses = makeStyles({
   description: { margin: '5px' },
 });
 
-const Grow = createMotionComponent(element => ({
+const Grow = createMotionComponent(({ element }) => ({
   duration: motionTokens.durationUltraSlow,
   keyframes: [
     { opacity: 0, maxHeight: `${element.scrollHeight / 2}px` },

--- a/packages/react-components/react-motions-preview/stories/CreatePresenceComponent/PresenceMotionFunctions.stories.md
+++ b/packages/react-components/react-motions-preview/stories/CreatePresenceComponent/PresenceMotionFunctions.stories.md
@@ -1,7 +1,7 @@
 Presence definitions can be also defined as functions that accept an animated element as an argument. This allows to define more complex animations that depend on the animated element's properties, for example:
 
 ```ts
-const Collapse = createPresenceComponent(element => {
+const Collapse = createPresenceComponent(({ element }) => {
   const duration = 500;
   const keyframes = [
     { opacity: 0, maxHeight: '0px', overflow: 'hidden' },

--- a/packages/react-components/react-motions-preview/stories/CreatePresenceComponent/PresenceMotionFunctions.stories.tsx
+++ b/packages/react-components/react-motions-preview/stories/CreatePresenceComponent/PresenceMotionFunctions.stories.tsx
@@ -41,7 +41,7 @@ const useClasses = makeStyles({
   description: { margin: '5px' },
 });
 
-const collapseMotion: PresenceMotionFn = element => {
+const collapseMotion: PresenceMotionFn = ({ element }) => {
   const duration = 500;
   const keyframes = [
     { opacity: 0, maxHeight: '0px', overflow: 'hidden' },

--- a/packages/react-components/react-toast/src/components/ToastContainer/ToastContainerMotion.tsx
+++ b/packages/react-components/react-toast/src/components/ToastContainer/ToastContainerMotion.tsx
@@ -1,6 +1,6 @@
 import { createPresenceComponent } from '@fluentui/react-motions-preview';
 
-export const ToastContainerMotion = createPresenceComponent(element => ({
+export const ToastContainerMotion = createPresenceComponent(({ element }) => ({
   enter: [
     {
       keyframes: [


### PR DESCRIPTION
## BREAKING CHANGES

This PR changes `AtomMotionFn` & `PresenceMotionFn`:

```diff
-type AtomMotionFn = (element: HTMLElement) => AtomMotion;
-type PresenceMotionFn = (element: HTMLElement) => PresenceMotion;
+type AtomMotionFn = (params: { element: HTMLElement }) => AtomMotion;
+type PresenceMotionFn = (params: { element: HTMLElement }) => PresenceMotion;
```

The motivation is to have an opportunity to extend it with additional params while `element` may not be used i.e.:

```ts
const Motion = createMotionComponent(({ someNonImplementedParam }) => {
  /* --- */
});
```

## Previous Behavior

```ts
const Motion = createMotionComponent(element => {
  /* --- */
});
const PresenceMotion = createPresenceComponent(element => {
  /* --- */
});
```

## New Behavior

```ts
const Motion = createMotionComponent(({ element }) => {
  /* --- */
});
const PresenceMotion = createPresenceComponent(({ element }) => {
  /* --- */
});
```
