### PR TITLE
chore: migrate Toast to new motion library

### DIFF
--- a/change/@fluentui-react-motions-preview-e1a364d2-4a00-430c-b330-736eaf432fd7.json
+++ b/change/@fluentui-react-motions-preview-e1a364d2-4a00-430c-b330-736eaf432fd7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: export types for component props",
+  "packageName": "@fluentui/react-motions-preview",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-toast-2054e639-6e4f-4fcc-a62c-e0b0da7d9e4d.json
+++ b/change/@fluentui-react-toast-2054e639-6e4f-4fcc-a62c-e0b0da7d9e4d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: migrate Toast to new motion library",
+  "packageName": "@fluentui/react-toast",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-motions-preview/etc/react-motions-preview.api.md
+++ b/packages/react-components/react-motions-preview/etc/react-motions-preview.api.md
@@ -46,6 +46,12 @@ export const durations: {
 };
 
 // @public (undocumented)
+export type MotionComponentProps = {
+    children: React_2.ReactElement;
+    imperativeRef?: React_2.Ref<MotionImperativeRef | undefined>;
+};
+
+// @public (undocumented)
 export type MotionImperativeRef = {
     setPlaybackRate: (rate: number) => void;
     setPlayState: (state: 'running' | 'paused') => void;
@@ -70,6 +76,18 @@ export const motionTokens: {
     durationSlow: 300;
     durationSlower: 400;
     durationUltraSlow: 500;
+};
+
+// @public (undocumented)
+export type PresenceComponentProps = {
+    appear?: boolean;
+    children: React_2.ReactElement;
+    imperativeRef?: React_2.Ref<MotionImperativeRef | undefined>;
+    onMotionFinish?: (ev: null, data: {
+        direction: 'enter' | 'exit';
+    }) => void;
+    visible?: boolean;
+    unmountOnExit?: boolean;
 };
 
 // @public (undocumented)

--- a/packages/react-components/react-motions-preview/src/factories/createMotionComponent.ts
+++ b/packages/react-components/react-motions-preview/src/factories/createMotionComponent.ts
@@ -7,7 +7,7 @@ import { animateAtoms } from '../utils/animateAtoms';
 import { getChildElement } from '../utils/getChildElement';
 import type { AtomMotion, AtomMotionFn, MotionImperativeRef } from '../types';
 
-type MotionComponentProps = {
+export type MotionComponentProps = {
   children: React.ReactElement;
 
   /** Provides imperative controls for the animation. */

--- a/packages/react-components/react-motions-preview/src/index.ts
+++ b/packages/react-components/react-motions-preview/src/index.ts
@@ -1,7 +1,7 @@
 export { motionTokens, durations, curves } from './motions/motionTokens';
 
-export { createMotionComponent } from './factories/createMotionComponent';
-export { createPresenceComponent } from './factories/createPresenceComponent';
+export { createMotionComponent, type MotionComponentProps } from './factories/createMotionComponent';
+export { createPresenceComponent, type PresenceComponentProps } from './factories/createPresenceComponent';
 
 export { PresenceGroup } from './components/PresenceGroup';
 

--- a/packages/react-components/react-toast/package.json
+++ b/packages/react-components/react-toast/package.json
@@ -35,7 +35,7 @@
     "@fluentui/scripts-tasks": "*"
   },
   "dependencies": {
-    "react-transition-group": "^4.4.1",
+    "@fluentui/react-motions-preview": "^0.3.2",
     "@fluentui/keyboard-keys": "^9.0.7",
     "@fluentui/react-aria": "^9.11.4",
     "@fluentui/react-icons": "^2.0.239",

--- a/packages/react-components/react-toast/src/components/ToastContainer/ToastContainer.types.ts
+++ b/packages/react-components/react-toast/src/components/ToastContainer/ToastContainer.types.ts
@@ -31,9 +31,20 @@ export type ToastContainerProps = Omit<ComponentProps<Partial<ToastContainerSlot
 export type ToastContainerState = ComponentState<ToastContainerSlots> &
   Pick<ToastContainerProps, 'remove' | 'close' | 'updateId' | 'visible' | 'intent'> &
   Pick<ToastContainerContextValue, 'titleId' | 'bodyId'> & {
+    /**
+     * @deprecated Will be always "0".
+     */
     transitionTimeout: number;
     timerTimeout: number;
     running: boolean;
+    /**
+     * @deprecated Will be always no-op.
+     */
     onTransitionEntering: () => void;
+    /**
+     * @deprecated
+     */
     nodeRef: React.Ref<HTMLDivElement>;
+
+    onMotionFinish?: (event: null, data: { direction: 'enter' | 'exit' }) => void;
   };

--- a/packages/react-components/react-toast/src/components/ToastContainer/ToastContainerMotion.tsx
+++ b/packages/react-components/react-toast/src/components/ToastContainer/ToastContainerMotion.tsx
@@ -1,0 +1,33 @@
+import { createPresenceComponent } from '@fluentui/react-motions-preview';
+
+export const ToastContainerMotion = createPresenceComponent(element => ({
+  enter: [
+    {
+      keyframes: [
+        { marginTop: 0, minHeight: 0, maxHeight: 0, opacity: 0 },
+        { marginTop: '16px', minHeight: 44, maxHeight: `${element.scrollHeight}px`, opacity: 0 },
+      ],
+      duration: 200,
+    },
+    {
+      keyframes: [{ opacity: 0 }, { opacity: 1 }],
+      delay: 200,
+      duration: 400,
+    },
+  ],
+
+  exit: [
+    {
+      keyframes: [
+        { marginTop: '16px', minHeight: 44, maxHeight: `${element.scrollHeight}px` },
+        { marginTop: 0, minHeight: 0, maxHeight: 0 },
+      ],
+      delay: 400,
+      duration: 200,
+    },
+    {
+      keyframes: [{ opacity: 1 }, { opacity: 0 }],
+      duration: 400,
+    },
+  ],
+}));

--- a/packages/react-components/react-toast/src/components/ToastContainer/__snapshots__/ToastContainer.test.tsx.snap
+++ b/packages/react-components/react-toast/src/components/ToastContainer/__snapshots__/ToastContainer.test.tsx.snap
@@ -8,7 +8,6 @@ exports[`ToastContainer renders a default state 1`] = `
     class="fui-ToastContainer"
     data-tabster="{\\"groupper\\":{\\"tabbability\\":2},\\"focusable\\":{\\"ignoreKeydown\\":{\\"Tab\\":true,\\"Escape\\":true,\\"Enter\\":true}}}"
     role="listitem"
-    style="--fui-toast-height: 0px;"
     tabindex="0"
   >
     Default ToastContainer

--- a/packages/react-components/react-toast/src/components/ToastContainer/renderToastContainer.tsx
+++ b/packages/react-components/react-toast/src/components/ToastContainer/renderToastContainer.tsx
@@ -1,9 +1,9 @@
 /** @jsxRuntime automatic */
 /** @jsxImportSource @fluentui/react-jsx-runtime */
 import { assertSlots } from '@fluentui/react-utilities';
-import { Transition } from 'react-transition-group';
 import type { ToastContainerState, ToastContainerSlots, ToastContainerContextValues } from './ToastContainer.types';
 import { ToastContainerContextProvider } from '../../contexts/toastContainerContext';
+import { ToastContainerMotion } from './ToastContainerMotion';
 
 /**
  * Render the final JSX of ToastContainer
@@ -12,23 +12,17 @@ export const renderToastContainer_unstable = (
   state: ToastContainerState,
   contextValues: ToastContainerContextValues,
 ) => {
-  const { onTransitionEntering, visible, transitionTimeout, remove, nodeRef, updateId } = state;
+  const { onMotionFinish, visible, updateId } = state;
   assertSlots<ToastContainerSlots>(state);
 
   return (
-    <Transition
-      in={visible}
-      appear
-      unmountOnExit
-      timeout={transitionTimeout}
-      onExited={remove}
-      onEntering={onTransitionEntering}
-      nodeRef={nodeRef}
-    >
-      <ToastContainerContextProvider value={contextValues.toast}>
-        <state.root />
-        <state.timer key={updateId} />
-      </ToastContainerContextProvider>
-    </Transition>
+    <ToastContainerContextProvider value={contextValues.toast}>
+      <ToastContainerMotion appear onMotionFinish={onMotionFinish} visible={visible} unmountOnExit>
+        <state.root>
+          {state.root.children}
+          <state.timer key={updateId} />
+        </state.root>
+      </ToastContainerMotion>
+    </ToastContainerContextProvider>
   );
 };

--- a/packages/react-components/react-toast/src/components/ToastContainer/useToastContainerStyles.styles.ts
+++ b/packages/react-components/react-toast/src/components/ToastContainer/useToastContainerStyles.styles.ts
@@ -1,4 +1,4 @@
-import { makeResetStyles, makeStyles, mergeClasses } from '@griffel/react';
+import { makeResetStyles, mergeClasses } from '@griffel/react';
 import { tokens } from '@fluentui/react-theme';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import { createCustomFocusIndicatorStyle } from '@fluentui/react-tabster';
@@ -12,70 +12,11 @@ export const toastContainerClassNames: SlotClassNames<ToastContainerSlots> = {
 const useRootBaseClassName = makeResetStyles({
   boxSizing: 'border-box',
   marginTop: '16px',
-  minHeight: '44px',
   pointerEvents: 'all',
   borderRadius: tokens.borderRadiusMedium,
-  '--fui-toast-height': '44px',
   ...createCustomFocusIndicatorStyle({
     outline: `${tokens.strokeWidthThick} solid ${tokens.colorStrokeFocus2}`,
   }),
-});
-
-/**
- * Styles for the root slot
- */
-const useStyles = makeStyles({
-  enter: {
-    animationDuration: '200ms, 400ms',
-    animationDelay: '0ms, 200ms',
-    animationName: [
-      {
-        from: {
-          maxHeight: 0,
-          opacity: 0,
-          marginTop: 0,
-        },
-        to: {
-          marginTop: '16px',
-          opacity: 0,
-          maxHeight: 'var(--fui-toast-height)',
-        },
-      },
-      {
-        from: {
-          opacity: 0,
-        },
-        to: {
-          opacity: 1,
-        },
-      },
-    ],
-  },
-
-  exit: {
-    animationDuration: '400ms, 200ms',
-    animationDelay: '0ms, 400ms',
-    animationName: [
-      {
-        from: {
-          opacity: 1,
-        },
-        to: {
-          opacity: 0,
-        },
-      },
-      {
-        from: {
-          opacity: 0,
-        },
-        to: {
-          opacity: 0,
-          marginTop: 0,
-          maxHeight: 0,
-        },
-      },
-    ],
-  },
 });
 
 /**
@@ -83,13 +24,7 @@ const useStyles = makeStyles({
  */
 export const useToastContainerStyles_unstable = (state: ToastContainerState): ToastContainerState => {
   const rootBaseClassName = useRootBaseClassName();
-  const styles = useStyles();
-  state.root.className = mergeClasses(
-    toastContainerClassNames.root,
-    rootBaseClassName,
-    state.visible ? styles.enter : styles.exit,
-    state.root.className,
-  );
+  state.root.className = mergeClasses(toastContainerClassNames.root, rootBaseClassName, state.root.className);
 
   return state;
 };


### PR DESCRIPTION
## Previous Behavior

`@fluentui/react-toast` uses `react-transition-group`.

## New Behavior

`@fluentui/react-toast` uses `@fluentui/react-motions-preview` 💪 

## Related Issue(s)

Fixes #30697.
