### PR TITLE
chore: fix Toast cypress test

### DIFF
--- a/packages/react-components/react-toast/src/components/Toast/Toast.cy.tsx
+++ b/packages/react-components/react-toast/src/components/Toast/Toast.cy.tsx
@@ -742,6 +742,8 @@ describe('Toast', () => {
           <Toast>
             <ToastTitle>This is a toast</ToastTitle>
           </Toast>,
+          // giant timeout to prevent auto-dismissal
+          { timeout: 100000 },
         );
       };
 
@@ -760,7 +762,7 @@ describe('Toast', () => {
       .click()
       .get(`#container .${toastClassNames.root}`)
       .should('exist')
-      .get(`body .${toastClassNames.root}`)
+      .get(`[data-portal-node] .${toastClassNames.root}`)
       .should('not.exist');
   });
 });


### PR DESCRIPTION
## Previous Behavior

Test had invalid selector and passed only because a toast will close.

## New Behavior

Test has valid selector.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
