### PR TITLE
feat: re-export `useTimeout` and `useAnimationFrame`

### DIFF
--- a/change/@fluentui-react-components-19684b24-7a15-4208-b630-adf5c6aedabc.json
+++ b/change/@fluentui-react-components-19684b24-7a15-4208-b630-adf5c6aedabc.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: re-export `useTimeout()` and `useAnimationFrame()`.",
+  "packageName": "@fluentui/react-components",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-components/etc/react-components.api.md
+++ b/packages/react-components/react-components/etc/react-components.api.md
@@ -1298,6 +1298,7 @@ import { useAccordionItemStyles_unstable } from '@fluentui/react-accordion';
 import { useAccordionPanel_unstable } from '@fluentui/react-accordion';
 import { useAccordionPanelStyles_unstable } from '@fluentui/react-accordion';
 import { useAccordionStyles_unstable } from '@fluentui/react-accordion';
+import { useAnimationFrame } from '@fluentui/react-utilities';
 import { useAnnounce } from '@fluentui/react-shared-contexts';
 import { useAriaLiveAnnouncer_unstable } from '@fluentui/react-aria';
 import { useAriaLiveAnnouncerContextValues_unstable } from '@fluentui/react-aria';
@@ -1657,6 +1658,7 @@ import { useTextarea_unstable } from '@fluentui/react-textarea';
 import { useTextareaStyles_unstable } from '@fluentui/react-textarea';
 import { useTextStyles_unstable } from '@fluentui/react-text';
 import { useThemeClassName_unstable as useThemeClassName } from '@fluentui/react-shared-contexts';
+import { useTimeout } from '@fluentui/react-utilities';
 import { useToast_unstable } from '@fluentui/react-toast';
 import { useToastBody_unstable } from '@fluentui/react-toast';
 import { useToastBodyStyles_unstable } from '@fluentui/react-toast';
@@ -4292,6 +4294,8 @@ export { useAccordionPanelStyles_unstable }
 
 export { useAccordionStyles_unstable }
 
+export { useAnimationFrame }
+
 export { useAnnounce }
 
 export { useAriaLiveAnnouncer_unstable }
@@ -5009,6 +5013,8 @@ export { useTextareaStyles_unstable }
 export { useTextStyles_unstable }
 
 export { useThemeClassName }
+
+export { useTimeout }
 
 export { useToast_unstable }
 

--- a/packages/react-components/react-components/src/index.ts
+++ b/packages/react-components/react-components/src/index.ts
@@ -118,6 +118,7 @@ export {
   // eslint-disable-next-line deprecation/deprecation
   resolveShorthand,
   SSRProvider,
+  useAnimationFrame,
   useId,
   useIsomorphicLayoutEffect,
   useEventCallback,
@@ -126,6 +127,7 @@ export {
   useMergedRefs,
   useScrollbarWidth,
   useSelection,
+  useTimeout,
 } from '@fluentui/react-utilities';
 export type {
   ComponentProps,


### PR DESCRIPTION
## Previous Behavior

`useTimeout()` and `useAnimationFrame()` are not exported from `@fluentui/react-components`.

## New Behavior

`useTimeout()` and `useAnimationFrame()` are exported from `@fluentui/react-components`.
