### PR TITLE
feat(Carousel): implement peeking

### DIFF
--- a/packages/react-components/react-carousel-preview/etc/react-carousel-preview.api.md
+++ b/packages/react-components/react-carousel-preview/etc/react-carousel-preview.api.md
@@ -78,6 +78,7 @@ export type CarouselCardSlots = {
 // @public
 export type CarouselCardState = ComponentState<CarouselCardSlots> & {
     visible: boolean;
+    peekDir?: 'prev' | 'next' | null;
 } & Pick<CarouselCardProps, 'value'>;
 
 // @public (undocumented)
@@ -167,6 +168,7 @@ export type CarouselProps = ComponentProps<CarouselSlots> & {
     value?: string;
     onValueChange?: EventHandler<CarouselValueChangeData>;
     circular?: Boolean;
+    peeking?: Boolean;
 };
 
 // @public (undocumented)

--- a/packages/react-components/react-carousel-preview/src/components/Carousel/Carousel.tsx
+++ b/packages/react-components/react-carousel-preview/src/components/Carousel/Carousel.tsx
@@ -4,7 +4,7 @@ import { useCarousel_unstable } from './useCarousel';
 import { renderCarousel_unstable } from './renderCarousel';
 import { useCarouselStyles_unstable } from './useCarouselStyles.styles';
 import type { CarouselProps } from './Carousel.types';
-import { useCarouselContextValues_unstable } from '../CarouselContext';
+import { useCarouselContextValues_unstable } from './useCarouselContextValues';
 
 /**
  * Carousel is the context wrapper and container for all carousel content/controls,

--- a/packages/react-components/react-carousel-preview/src/components/Carousel/Carousel.types.ts
+++ b/packages/react-components/react-carousel-preview/src/components/Carousel/Carousel.types.ts
@@ -28,6 +28,11 @@ export type CarouselProps = ComponentProps<CarouselSlots> & {
    * Circular enables the carousel to loop back around on navigation past trailing index
    */
   circular?: Boolean;
+
+  /**
+   * Peeking enables the next/prev carousel pages to 'peek' into the current view
+   */
+  peeking?: Boolean;
 };
 
 /**

--- a/packages/react-components/react-carousel-preview/src/components/Carousel/useCarousel.ts
+++ b/packages/react-components/react-carousel-preview/src/components/Carousel/useCarousel.ts
@@ -5,6 +5,7 @@ import {
   slot,
   useControllableState,
   useEventCallback,
+  useIsomorphicLayoutEffect,
   useMergedRefs,
 } from '@fluentui/react-utilities';
 import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
@@ -25,18 +26,19 @@ import type { CarouselContextValue } from '../CarouselContext.types';
  * @param ref - reference to root HTMLDivElement of Carousel
  */
 export function useCarousel_unstable(props: CarouselProps, ref: React.Ref<HTMLDivElement>): CarouselState {
-  const { onValueChange, circular } = props;
+  const { onValueChange, circular, peeking } = props;
 
   const { targetDocument } = useFluent();
   const win = targetDocument?.defaultView;
   const { ref: carouselRef, walker: carouselWalker } = useCarouselWalker_unstable();
-  const [store] = React.useState(() => createCarouselStore());
 
   const [value, setValue] = useControllableState({
     defaultState: props.defaultValue,
     state: props.value,
     initialState: null,
   });
+  const [store] = React.useState(() => createCarouselStore(value));
+
   const rootRef = React.useRef<HTMLDivElement>(null);
 
   if (process.env.NODE_ENV !== 'production') {
@@ -51,6 +53,10 @@ export function useCarousel_unstable(props: CarouselProps, ref: React.Ref<HTMLDi
     }, [value]);
   }
 
+  useIsomorphicLayoutEffect(() => {
+    store.setActiveValue(value);
+  }, [value]);
+
   React.useEffect(() => {
     const allItems = rootRef.current?.querySelectorAll(`[${CAROUSEL_ITEM}]`)!;
 
@@ -59,7 +65,7 @@ export function useCarousel_unstable(props: CarouselProps, ref: React.Ref<HTMLDi
     }
 
     return () => {
-      store.clear();
+      store.clearValues();
     };
   }, [store]);
 
@@ -149,9 +155,9 @@ export function useCarousel_unstable(props: CarouselProps, ref: React.Ref<HTMLDi
       { elementType: 'div' },
     ),
     store,
-    value,
     selectPageByDirection,
     selectPageByValue,
     circular,
+    peeking,
   };
 }

--- a/packages/react-components/react-carousel-preview/src/components/Carousel/useCarousel.ts
+++ b/packages/react-components/react-carousel-preview/src/components/Carousel/useCarousel.ts
@@ -55,6 +55,7 @@ export function useCarousel_unstable(props: CarouselProps, ref: React.Ref<HTMLDi
 
   useIsomorphicLayoutEffect(() => {
     store.setActiveValue(value);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value]);
 
   React.useEffect(() => {

--- a/packages/react-components/react-carousel-preview/src/components/Carousel/useCarousel.ts
+++ b/packages/react-components/react-carousel-preview/src/components/Carousel/useCarousel.ts
@@ -55,8 +55,7 @@ export function useCarousel_unstable(props: CarouselProps, ref: React.Ref<HTMLDi
 
   useIsomorphicLayoutEffect(() => {
     store.setActiveValue(value);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [value]);
+  }, [store, value]);
 
   React.useEffect(() => {
     const allItems = rootRef.current?.querySelectorAll(`[${CAROUSEL_ITEM}]`)!;

--- a/packages/react-components/react-carousel-preview/src/components/Carousel/useCarouselContextValues.ts
+++ b/packages/react-components/react-carousel-preview/src/components/Carousel/useCarouselContextValues.ts
@@ -1,0 +1,21 @@
+import * as React from 'react';
+
+import type { CarouselContextValues } from '../CarouselContext.types';
+import type { CarouselState } from './Carousel.types';
+
+export function useCarouselContextValues_unstable(state: CarouselState): CarouselContextValues {
+  const { store, selectPageByDirection, selectPageByValue, circular, peeking } = state;
+
+  const carousel = React.useMemo(
+    () => ({
+      store,
+      selectPageByDirection,
+      selectPageByValue,
+      circular,
+      peeking,
+    }),
+    [store, selectPageByDirection, selectPageByValue, circular, peeking],
+  );
+
+  return { carousel };
+}

--- a/packages/react-components/react-carousel-preview/src/components/Carousel/useCarouselStyles.styles.ts
+++ b/packages/react-components/react-carousel-preview/src/components/Carousel/useCarouselStyles.styles.ts
@@ -4,16 +4,20 @@ import type { CarouselSlots, CarouselState } from './Carousel.types';
 
 export const carouselClassNames: SlotClassNames<CarouselSlots> = {
   root: 'fui-Carousel',
-  // TODO: add class names for all slots on CarouselSlots.
-  // Should be of the form `<slotName>: 'fui-Carousel__<slotName>`
 };
+
+// TODO: Enable varying sizes w/ tokens
+const PeekSize = '100px';
 
 /**
  * Styles for the root slot
  */
 const useStyles = makeStyles({
-  root: {
-    // TODO Add default styles for the root element
+  root: {},
+  rootPeek: {
+    position: 'relative',
+    marginRight: PeekSize,
+    marginLeft: PeekSize,
   },
 
   // TODO add additional classes for different states and/or slots
@@ -23,11 +27,15 @@ const useStyles = makeStyles({
  * Apply styling to the Carousel slots based on the state
  */
 export const useCarouselStyles_unstable = (state: CarouselState): CarouselState => {
+  const { peeking } = state;
   const styles = useStyles();
-  state.root.className = mergeClasses(carouselClassNames.root, styles.root, state.root.className);
 
-  // TODO Add class names to slots, for example:
-  // state.mySlot.className = mergeClasses(styles.mySlot, state.mySlot.className);
+  state.root.className = mergeClasses(
+    carouselClassNames.root,
+    styles.root,
+    peeking && styles.rootPeek,
+    state.root.className,
+  );
 
   return state;
 };

--- a/packages/react-components/react-carousel-preview/src/components/CarouselButton/useCarouselButton.tsx
+++ b/packages/react-components/react-carousel-preview/src/components/CarouselButton/useCarouselButton.tsx
@@ -3,7 +3,7 @@ import { mergeCallbacks, useEventCallback } from '@fluentui/react-utilities';
 import type { CarouselButtonProps, CarouselButtonState } from './CarouselButton.types';
 import { useButton_unstable } from '@fluentui/react-button';
 import { useCarouselContext_unstable } from '../CarouselContext';
-import { useCarouselValues_unstable } from '../useCarouselValues';
+import { useCarouselStore_unstable } from '../useCarouselStore';
 import { slot } from '@fluentui/react-utilities';
 import { ChevronLeftRegular, ChevronRightRegular } from '@fluentui/react-icons';
 import { ARIAButtonElement } from '@fluentui/react-aria';
@@ -23,10 +23,18 @@ export const useCarouselButton_unstable = (
 ): CarouselButtonState => {
   const { navType } = props;
 
-  const selectPageByDirection = useCarouselContext_unstable(c => c.selectPageByDirection);
-  const values = useCarouselValues_unstable(snapshot => snapshot);
-  const activeValue = useCarouselContext_unstable(c => c.value);
-  const circular = useCarouselContext_unstable(c => c.circular);
+  const { circular, selectPageByDirection } = useCarouselContext_unstable();
+  const isTrailing = useCarouselStore_unstable(snapshot => {
+    if (!snapshot.activeValue || circular) {
+      return false;
+    }
+
+    if (navType === 'prev') {
+      return snapshot.values.indexOf(snapshot.activeValue) === 0;
+    }
+
+    return snapshot.values.indexOf(snapshot.activeValue) === snapshot.values.length - 1;
+  });
 
   const handleClick = (event: React.MouseEvent<HTMLButtonElement & HTMLAnchorElement>) => {
     if (event.isDefaultPrevented()) {
@@ -37,18 +45,6 @@ export const useCarouselButton_unstable = (
   };
 
   const handleButtonClick = useEventCallback(mergeCallbacks(handleClick, props.onClick));
-
-  const isTrailing = React.useMemo(() => {
-    if (!activeValue || circular) {
-      return false;
-    }
-
-    if (navType === 'prev') {
-      return values.indexOf(activeValue) === 0;
-    }
-
-    return values.indexOf(activeValue) === values.length - 1;
-  }, [navType, activeValue, values, circular]);
 
   return {
     navType,

--- a/packages/react-components/react-carousel-preview/src/components/CarouselCard/CarouselCard.types.ts
+++ b/packages/react-components/react-carousel-preview/src/components/CarouselCard/CarouselCard.types.ts
@@ -20,4 +20,8 @@ export type CarouselCardProps = ComponentProps<CarouselCardSlots> & {
  */
 export type CarouselCardState = ComponentState<CarouselCardSlots> & {
   visible: boolean;
+  /**
+   * Declares if card should be peeking as previous/next card
+   */
+  peekDir?: 'prev' | 'next' | null;
 } & Pick<CarouselCardProps, 'value'>;

--- a/packages/react-components/react-carousel-preview/src/components/CarouselCard/__snapshots__/CarouselCard.test.tsx.snap
+++ b/packages/react-components/react-carousel-preview/src/components/CarouselCard/__snapshots__/CarouselCard.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`CarouselCard renders a default state 1`] = `
 <div>
   <div
+    aria-hidden="true"
     class="fui-CarouselCard"
     data-carousel-active-item="false"
     data-carousel-item="test-0"

--- a/packages/react-components/react-carousel-preview/src/components/CarouselCard/useCarouselCard.ts
+++ b/packages/react-components/react-carousel-preview/src/components/CarouselCard/useCarouselCard.ts
@@ -3,6 +3,7 @@ import { getIntrinsicElementProps, slot } from '@fluentui/react-utilities';
 import type { CarouselCardProps, CarouselCardState } from './CarouselCard.types';
 import { CAROUSEL_ACTIVE_ITEM, CAROUSEL_ITEM } from '../constants';
 import { useCarouselContext_unstable } from '../CarouselContext';
+import { useCarouselStore_unstable } from '../useCarouselStore';
 
 /**
  * Create the state required to render CarouselCard.
@@ -18,11 +19,38 @@ export const useCarouselCard_unstable = (
   ref: React.Ref<HTMLDivElement>,
 ): CarouselCardState => {
   const { value } = props;
+  const { circular, peeking } = useCarouselContext_unstable();
 
-  const visible = useCarouselContext_unstable(c => c.value === value);
+  const visible = useCarouselStore_unstable(snapshot => snapshot.activeValue === value);
+  const peekDir: 'prev' | 'next' | undefined = useCarouselStore_unstable(snapshot => {
+    if (!peeking) {
+      return;
+    }
+
+    const currentIndex = snapshot.activeValue ? snapshot.values.indexOf(snapshot.activeValue) : null;
+
+    if (currentIndex !== null && currentIndex >= 0) {
+      let nextValue = currentIndex + 1 < snapshot.values.length ? snapshot.values[currentIndex + 1] : null;
+      let prevValue = currentIndex - 1 >= 0 ? snapshot.values[currentIndex - 1] : null;
+
+      if (!nextValue && circular) {
+        nextValue = snapshot.values[0];
+      }
+
+      if (!prevValue && circular) {
+        prevValue = snapshot.values[snapshot.values.length - 1];
+      }
+
+      if (nextValue === value || prevValue === value) {
+        return nextValue === value ? 'next' : 'prev';
+      }
+    }
+  });
+
   const state: CarouselCardState = {
     value,
     visible,
+    peekDir,
     components: {
       root: 'div',
     },
@@ -31,7 +59,9 @@ export const useCarouselCard_unstable = (
         ref,
         [CAROUSEL_ITEM]: value,
         [CAROUSEL_ACTIVE_ITEM]: visible,
-        hidden: !visible,
+        hidden: !visible && !peekDir,
+        'aria-hidden': !visible,
+        inert: !visible,
         role: 'presentation',
         ...props,
       }),
@@ -39,7 +69,7 @@ export const useCarouselCard_unstable = (
     ),
   };
 
-  if (!visible) {
+  if (!visible && !peekDir) {
     state.root.children = null;
   }
 

--- a/packages/react-components/react-carousel-preview/src/components/CarouselCard/useCarouselCardStyles.styles.ts
+++ b/packages/react-components/react-carousel-preview/src/components/CarouselCard/useCarouselCardStyles.styles.ts
@@ -4,27 +4,48 @@ import type { CarouselCardSlots, CarouselCardState } from './CarouselCard.types'
 
 export const carouselCardClassNames: SlotClassNames<CarouselCardSlots> = {
   root: 'fui-CarouselCard',
-  // TODO: add class names for all slots on CarouselCardSlots.
-  // Should be of the form `<slotName>: 'fui-CarouselCard__<slotName>`
 };
+
+// TODO: Enable varying sizes w/ tokens
+const GapSize = 10;
 
 /**
  * Styles for the root slot
  */
 const useStyles = makeStyles({
   root: {
-    // TODO Add default styles for the root element
+    marginLeft: GapSize / 2 + 'px',
+    marginRight: GapSize / 2 + 'px',
   },
-
-  // TODO add additional classes for different states and/or slots
+  peekLeft: {
+    position: 'absolute',
+    float: 'left',
+    right: '100%',
+    top: 0,
+    width: '100%',
+  },
+  peekRight: {
+    position: 'absolute',
+    float: 'right',
+    left: '100%',
+    top: 0,
+    width: '100%',
+  },
 });
 
 /**
  * Apply styling to the CarouselCard slots based on the state
  */
 export const useCarouselCardStyles_unstable = (state: CarouselCardState): CarouselCardState => {
+  const { peekDir } = state;
   const styles = useStyles();
-  state.root.className = mergeClasses(carouselCardClassNames.root, styles.root, state.root.className);
+  state.root.className = mergeClasses(
+    carouselCardClassNames.root,
+    styles.root,
+    peekDir === 'next' && styles.peekRight,
+    peekDir === 'prev' && styles.peekLeft,
+    state.root.className,
+  );
 
   // TODO Add class names to slots, for example:
   // state.mySlot.className = mergeClasses(styles.mySlot, state.mySlot.className);

--- a/packages/react-components/react-carousel-preview/src/components/CarouselContext.ts
+++ b/packages/react-components/react-carousel-preview/src/components/CarouselContext.ts
@@ -1,12 +1,10 @@
-import { type Context, ContextSelector, createContext, useContextSelector } from '@fluentui/react-context-selector';
+import * as React from 'react';
 
 import { createCarouselStore } from './createCarouselStore';
-import { CarouselState } from '../Carousel';
-import { CarouselContextValue, CarouselContextValues } from './CarouselContext.types';
+import { CarouselContextValue } from './CarouselContext.types';
 
 export const carouselContextDefaultValue: CarouselContextValue = {
-  store: createCarouselStore(),
-  value: null,
+  store: createCarouselStore(null),
   selectPageByDirection: () => {
     /** noop */
   },
@@ -14,27 +12,11 @@ export const carouselContextDefaultValue: CarouselContextValue = {
     /** noop */
   },
   circular: false,
+  peeking: false,
 };
 
-const CarouselContext: Context<CarouselContextValue> = createContext<CarouselContextValue | undefined>(
-  undefined,
-) as Context<CarouselContextValue>;
+const CarouselContext = React.createContext<CarouselContextValue | undefined>(undefined);
 
 export const CarouselProvider = CarouselContext.Provider;
 
-export const useCarouselContext_unstable = <T>(selector: ContextSelector<CarouselContextValue, T>): T =>
-  useContextSelector(CarouselContext, (ctx = carouselContextDefaultValue) => selector(ctx));
-
-export function useCarouselContextValues_unstable(state: CarouselState): CarouselContextValues {
-  const { store, value, selectPageByDirection, selectPageByValue, circular } = state;
-
-  const carousel = {
-    store,
-    value,
-    selectPageByDirection,
-    selectPageByValue,
-    circular,
-  };
-
-  return { carousel };
-}
+export const useCarouselContext_unstable = () => React.useContext(CarouselContext) ?? carouselContextDefaultValue;

--- a/packages/react-components/react-carousel-preview/src/components/CarouselContext.types.ts
+++ b/packages/react-components/react-carousel-preview/src/components/CarouselContext.types.ts
@@ -2,12 +2,18 @@ import * as React from 'react';
 import { EventData } from '@fluentui/react-utilities';
 
 export type CarouselStore = {
-  clear: () => void;
+  setActiveValue: (newValue: string | null) => void;
+
+  clearValues: () => void;
   addValue: (value: string) => void;
   insertValue: (value: string, prev: string | null) => void;
   removeValue: (value: string) => void;
   subscribe: (listener: () => void) => () => void;
-  getSnapshot: () => string[];
+
+  getSnapshot: () => {
+    activeValue: string | null;
+    values: string[];
+  };
 };
 
 export type CarouselItem = {
@@ -24,13 +30,13 @@ export type CarouselValueChangeData = EventData<'click', React.MouseEvent<HTMLBu
 
 export type CarouselContextValue = {
   store: CarouselStore;
-  value: string | null;
   selectPageByDirection: (
     event: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>,
     direction: 'next' | 'prev',
   ) => void;
   selectPageByValue: (event: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>, value: string) => void;
   circular?: Boolean;
+  peeking?: Boolean;
 };
 
 /**

--- a/packages/react-components/react-carousel-preview/src/components/CarouselNav/useCarouselNav.ts
+++ b/packages/react-components/react-carousel-preview/src/components/CarouselNav/useCarouselNav.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { getIntrinsicElementProps, slot } from '@fluentui/react-utilities';
 import type { CarouselNavProps, CarouselNavState } from './CarouselNav.types';
 import { useArrowNavigationGroup } from '@fluentui/react-tabster';
-import { useCarouselValues_unstable } from '../useCarouselValues';
+import { useCarouselStore_unstable } from '../useCarouselStore';
 
 /**
  * Create the state required to render CarouselNav.
@@ -22,7 +22,7 @@ export const useCarouselNav_unstable = (props: CarouselNavProps, ref: React.Ref<
     unstable_hasDefault: true,
   });
 
-  const values = useCarouselValues_unstable(snapshot => snapshot);
+  const values = useCarouselStore_unstable(snapshot => snapshot.values);
 
   return {
     values,

--- a/packages/react-components/react-carousel-preview/src/components/CarouselNavButton/useCarouselNavButton.ts
+++ b/packages/react-components/react-carousel-preview/src/components/CarouselNavButton/useCarouselNavButton.ts
@@ -5,6 +5,7 @@ import { useCarouselNavContext } from '../CarouselNav/CarouselNavContext';
 import { useCarouselContext_unstable } from '../CarouselContext';
 import { ARIAButtonElement, ARIAButtonSlotProps, useARIAButtonProps } from '@fluentui/react-aria';
 import { useTabsterAttributes } from '@fluentui/react-tabster';
+import { useCarouselStore_unstable } from '../useCarouselStore';
 
 /**
  * Create the state required to render CarouselNavButton.
@@ -23,8 +24,8 @@ export const useCarouselNavButton_unstable = (
 
   const value = useCarouselNavContext();
 
-  const selectPageByValue = useCarouselContext_unstable(c => c.selectPageByValue);
-  const selected = useCarouselContext_unstable(c => c.value === value);
+  const { selectPageByValue } = useCarouselContext_unstable();
+  const selected = useCarouselStore_unstable(snapshot => snapshot.activeValue === value);
 
   const handleClick: ARIAButtonSlotProps['onClick'] = useEventCallback(event => {
     onClick?.(event);

--- a/packages/react-components/react-carousel-preview/src/components/CarouselNavImageButton/useCarouselNavImageButton.ts
+++ b/packages/react-components/react-carousel-preview/src/components/CarouselNavImageButton/useCarouselNavImageButton.ts
@@ -5,6 +5,7 @@ import { ARIAButtonElement, ARIAButtonSlotProps, useARIAButtonProps } from '@flu
 import { useTabsterAttributes } from '@fluentui/react-tabster';
 import { useCarouselContext_unstable } from '../CarouselContext';
 import { useCarouselNavContext } from '../CarouselNav/CarouselNavContext';
+import { useCarouselStore_unstable } from '../useCarouselStore';
 
 /**
  * Create the state required to render CarouselNavImageButton.
@@ -23,8 +24,8 @@ export const useCarouselNavImageButton_unstable = (
 
   const value = useCarouselNavContext();
 
-  const selectPageByValue = useCarouselContext_unstable(c => c.selectPageByValue);
-  const selected = useCarouselContext_unstable(c => c.value === value);
+  const { selectPageByValue } = useCarouselContext_unstable();
+  const selected = useCarouselStore_unstable(snapshot => snapshot.activeValue === value);
 
   const handleClick: ARIAButtonSlotProps['onClick'] = useEventCallback(event => {
     onClick?.(event);

--- a/packages/react-components/react-carousel-preview/src/components/createCarouselStore.test.ts
+++ b/packages/react-components/react-carousel-preview/src/components/createCarouselStore.test.ts
@@ -6,7 +6,7 @@ describe('createCarouselStore', () => {
       const store = createCarouselStore(null);
       store.addValue('foo');
 
-      expect(store.getSnapshot()).toEqual(['foo']);
+      expect(store.getSnapshot()).toEqual({ activeValue: null, values: ['foo'] });
     });
   });
 
@@ -18,7 +18,7 @@ describe('createCarouselStore', () => {
       store.addValue('bar');
       store.insertValue('baz', 'foo');
 
-      expect(store.getSnapshot()).toEqual(['foo', 'baz', 'bar']);
+      expect(store.getSnapshot()).toEqual({ activeValue: null, values: ['foo', 'baz', 'bar'] });
     });
   });
 
@@ -31,7 +31,7 @@ describe('createCarouselStore', () => {
       store.addValue('baz');
       store.removeValue('bar');
 
-      expect(store.getSnapshot()).toEqual(['foo', 'baz']);
+      expect(store.getSnapshot()).toEqual({ activeValue: null, values: ['foo', 'baz'] });
     });
   });
 
@@ -43,7 +43,7 @@ describe('createCarouselStore', () => {
       store.addValue('bar');
       store.clearValues();
 
-      expect(store.getSnapshot()).toEqual([]);
+      expect(store.getSnapshot()).toEqual({ activeValue: null, values: [] });
     });
   });
 

--- a/packages/react-components/react-carousel-preview/src/components/createCarouselStore.test.ts
+++ b/packages/react-components/react-carousel-preview/src/components/createCarouselStore.test.ts
@@ -3,7 +3,7 @@ import { createCarouselStore } from './createCarouselStore';
 describe('createCarouselStore', () => {
   describe('addValue', () => {
     it('adds a value', () => {
-      const store = createCarouselStore();
+      const store = createCarouselStore(null);
       store.addValue('foo');
 
       expect(store.getSnapshot()).toEqual(['foo']);
@@ -12,7 +12,7 @@ describe('createCarouselStore', () => {
 
   describe('insertValue', () => {
     it('inserts a value', () => {
-      const store = createCarouselStore();
+      const store = createCarouselStore(null);
 
       store.addValue('foo');
       store.addValue('bar');
@@ -24,7 +24,7 @@ describe('createCarouselStore', () => {
 
   describe('removeValue', () => {
     it('removes a value', () => {
-      const store = createCarouselStore();
+      const store = createCarouselStore(null);
 
       store.addValue('foo');
       store.addValue('bar');
@@ -37,11 +37,11 @@ describe('createCarouselStore', () => {
 
   describe('clear', () => {
     it('clears all values', () => {
-      const store = createCarouselStore();
+      const store = createCarouselStore(null);
 
       store.addValue('foo');
       store.addValue('bar');
-      store.clear();
+      store.clearValues();
 
       expect(store.getSnapshot()).toEqual([]);
     });
@@ -49,7 +49,7 @@ describe('createCarouselStore', () => {
 
   describe('subscribe', () => {
     it('subscribes to changes', () => {
-      const store = createCarouselStore();
+      const store = createCarouselStore(null);
       const listener = jest.fn();
 
       store.subscribe(listener);
@@ -59,7 +59,7 @@ describe('createCarouselStore', () => {
     });
 
     it('unsubscribes from changes', () => {
-      const store = createCarouselStore();
+      const store = createCarouselStore(null);
       const listener = jest.fn();
 
       const unsubscribe = store.subscribe(listener);

--- a/packages/react-components/react-carousel-preview/src/components/createCarouselStore.ts
+++ b/packages/react-components/react-carousel-preview/src/components/createCarouselStore.ts
@@ -1,11 +1,18 @@
 import { type CarouselStore } from './CarouselContext.types';
 
-export const createCarouselStore = (): CarouselStore => {
+export const createCarouselStore = (initialValue: string | null): CarouselStore => {
   let values: string[] = [];
+  let activeValue: string | null = initialValue;
+
   let listeners: Array<() => void> = [];
 
   const carouselStore = {
-    clear() {
+    setActiveValue(newValue: string | null) {
+      activeValue = newValue;
+      emitChange();
+    },
+
+    clearValues() {
       values = [];
       emitChange();
     },
@@ -39,8 +46,9 @@ export const createCarouselStore = (): CarouselStore => {
         listeners = listeners.filter(l => l !== listener);
       };
     },
+
     getSnapshot() {
-      return values;
+      return { activeValue, values };
     },
   };
 

--- a/packages/react-components/react-carousel-preview/src/components/useCarouselStore.ts
+++ b/packages/react-components/react-carousel-preview/src/components/useCarouselStore.ts
@@ -1,0 +1,12 @@
+import { useSyncExternalStore } from 'use-sync-external-store/shim';
+
+import { useCarouselContext_unstable } from './CarouselContext';
+import type { CarouselStore } from './CarouselContext.types';
+
+export function useCarouselStore_unstable<T>(
+  getSnapshot: (snapshot: ReturnType<CarouselStore['getSnapshot']>) => T,
+): T {
+  const { store } = useCarouselContext_unstable();
+
+  return useSyncExternalStore(store.subscribe, () => getSnapshot(store.getSnapshot()));
+}

--- a/packages/react-components/react-carousel-preview/src/components/useCarouselValues.ts
+++ b/packages/react-components/react-carousel-preview/src/components/useCarouselValues.ts
@@ -1,9 +1,0 @@
-import { useSyncExternalStore } from 'use-sync-external-store/shim';
-
-import { useCarouselContext_unstable } from './CarouselContext';
-
-export function useCarouselValues_unstable<T>(getSnapshot: (values: string[]) => T): T {
-  const store = useCarouselContext_unstable(c => c.store);
-
-  return useSyncExternalStore(store.subscribe, () => getSnapshot(store.getSnapshot()));
-}

--- a/packages/react-components/react-carousel-preview/stories/Carousel/CarouselDefault.stories.tsx
+++ b/packages/react-components/react-carousel-preview/stories/Carousel/CarouselDefault.stories.tsx
@@ -10,16 +10,40 @@ import {
 
 const swapImage = 'https://fabricweb.azureedge.net/fabric-website/assets/images/wireframe/image-square.png';
 
-export const Default = (props: Partial<CarouselProps>) => (
-  <Carousel circular={true} defaultValue={'test-1'} {...props}>
-    <CarouselCard value="test-1">{'test-1'}</CarouselCard>
-    <CarouselCard value="test-2">{'test-2'}</CarouselCard>
-    <CarouselCard value="test-3">{'test-3'}</CarouselCard>
-    <CarouselCard value="test-4">{'test-4'}</CarouselCard>
-    <div style={{ display: 'flex', flexDirection: 'row' }}>
-      <CarouselButton navType="prev" />
-      <CarouselNav>{() => <CarouselNavImageButton image={{ src: swapImage }} />}</CarouselNav>
-      <CarouselButton navType="next" />
+const TestDiv = (text: string, bgColor: string) => {
+  return (
+    <div
+      style={{
+        height: '100px',
+        borderRadius: '12px',
+        backgroundColor: bgColor,
+        alignContent: 'center',
+        textAlign: 'center',
+      }}
+    >
+      {text}
     </div>
-  </Carousel>
+  );
+};
+
+export const Default = (props: Partial<CarouselProps>) => (
+  <div style={{ overflow: 'hidden' }}>
+    <Carousel circular={true} peeking={true} defaultValue={'test-1'} {...props}>
+      <CarouselCard value="test-1">{TestDiv('test-1', 'lightgrey')}</CarouselCard>
+      <CarouselCard value="test-2">{TestDiv('test-2', 'lightblue')}</CarouselCard>
+      <CarouselCard value="test-3">{TestDiv('test-3', 'BlanchedAlmond')}</CarouselCard>
+      <CarouselCard value="test-4">{TestDiv('test-4', 'DarkKhaki')}</CarouselCard>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'row',
+          justifyContent: 'center',
+        }}
+      >
+        <CarouselButton navType="prev" />
+        <CarouselNav>{() => <CarouselNavImageButton image={{ src: swapImage }} />}</CarouselNav>
+        <CarouselButton navType="next" />
+      </div>
+    </Carousel>
+  </div>
 );


### PR DESCRIPTION
## New Behavior

`Carousel` supports `peeking` prop that allows to have "previous" & "next" cards in a view:

![image](https://github.com/microsoft/fluentui/assets/14183168/7249fef6-7c36-438d-80bc-fc6006c79bf9)

Also moves `value` (i.e. `activeValue`) to a state store, so we can build selectors based both on `value` & `values`.