### PR TITLE
feat: add imperative cancel to motion handle

### DIFF
--- a/packages/react-components/react-motions-preview/src/hooks/useMotionImperativeRef.ts
+++ b/packages/react-components/react-motions-preview/src/hooks/useMotionImperativeRef.ts
@@ -5,6 +5,10 @@ export function useMotionImperativeRef(imperativeRef: React.Ref<MotionImperative
   const animationRef = React.useRef<AnimationHandle | undefined>();
 
   React.useImperativeHandle(imperativeRef, () => ({
+    cancel: () => {
+      animationRef.current?.cancel();
+    },
+
     setPlayState: state => {
       if (state === 'running') {
         animationRef.current?.play();

--- a/packages/react-components/react-motions-preview/src/types.ts
+++ b/packages/react-components/react-motions-preview/src/types.ts
@@ -20,4 +20,10 @@ export type MotionImperativeRef = {
 
   /** Sets the state of the animation to running or paused. */
   setPlayState: (state: 'running' | 'paused') => void;
+
+  /**
+   * Cancels the animation and keyframe effects, jumping to the end of the animation if it's currently playing.
+   * https://developer.mozilla.org/en-US/docs/Web/API/Animation/cancel
+   */
+  cancel: () => void;
 };


### PR DESCRIPTION
Forwards the imperative `cancel` from the underlying animation to userland.

This can be useful for expand/collapse scenarios where the size of the content within an expanded element changes. Due to the limitations of animations, it's only possible to expand to a concrete pixel value.

```ts
const Expand = createMotionComponent(element => {
  console.log(element.offsetHeight);
  const expandHeight = `${element.scrollHeight}px`;

  return {
    keyframes: [
      { maxHeight: '0px' },
      { maxHeight: expandHeight },
    ],
    duration: 200,
  };
});
```

Once the above enter animation has been completed the keyframe effect persists, which results in the container not adapting to content changes.

By leveraging `cancel` it's possible to clear keyframe effects so that `maxHeight` returns to defaults.

