### PR TITLE
feat(react-motion): add support for params

### DIFF
--- a/change/@fluentui-react-motion-74754f46-cdfd-42ee-8838-8389f353b5c6.json
+++ b/change/@fluentui-react-motion-74754f46-cdfd-42ee-8838-8389f353b5c6.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add support for params",
+  "packageName": "@fluentui/react-motion",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-motion/library/etc/react-motion.api.md
+++ b/packages/react-components/react-motion/library/etc/react-motion.api.md
@@ -12,15 +12,15 @@ export type AtomMotion = {
 } & KeyframeEffectOptions;
 
 // @public (undocumented)
-export type AtomMotionFn = (params: {
+export type AtomMotionFn<MotionParams extends Record<string, MotionParam> = {}> = (params: {
     element: HTMLElement;
-}) => AtomMotion | AtomMotion[];
+} & MotionParams) => AtomMotion | AtomMotion[];
 
 // @public
-export function createMotionComponent(value: AtomMotion | AtomMotion[] | AtomMotionFn): React_2.FC<MotionComponentProps>;
+export function createMotionComponent<MotionParams extends Record<string, MotionParam> = {}>(value: AtomMotion | AtomMotion[] | AtomMotionFn<MotionParams>): React_2.FC<MotionComponentProps & MotionParams>;
 
 // @public (undocumented)
-export function createPresenceComponent(value: PresenceMotion | PresenceMotionFn): React_2.FC<PresenceComponentProps>;
+export function createPresenceComponent<MotionParams extends Record<string, MotionParam> = {}>(value: PresenceMotion | PresenceMotionFn<MotionParams>): React_2.FC<PresenceComponentProps & MotionParams>;
 
 // @public (undocumented)
 export const curves: {
@@ -115,9 +115,9 @@ export type PresenceMotion = {
 };
 
 // @public (undocumented)
-export type PresenceMotionFn = (params: {
+export type PresenceMotionFn<MotionParams extends Record<string, MotionParam> = {}> = (params: {
     element: HTMLElement;
-}) => PresenceMotion;
+} & MotionParams) => PresenceMotion;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react-components/react-motion/library/src/factories/createMotionComponent.ts
+++ b/packages/react-components/react-motion/library/src/factories/createMotionComponent.ts
@@ -5,7 +5,7 @@ import { useIsReducedMotion } from '../hooks/useIsReducedMotion';
 import { useMotionImperativeRef } from '../hooks/useMotionImperativeRef';
 import { animateAtoms } from '../utils/animateAtoms';
 import { getChildElement } from '../utils/getChildElement';
-import type { AtomMotion, AtomMotionFn, MotionImperativeRef } from '../types';
+import type { AtomMotion, AtomMotionFn, MotionParam, MotionImperativeRef } from '../types';
 
 export type MotionComponentProps = {
   children: React.ReactElement;
@@ -19,21 +19,29 @@ export type MotionComponentProps = {
  *
  * @param value - A motion definition.
  */
-export function createMotionComponent(value: AtomMotion | AtomMotion[] | AtomMotionFn) {
-  const Atom: React.FC<MotionComponentProps> = props => {
-    const { children, imperativeRef } = props;
+export function createMotionComponent<MotionParams extends Record<string, MotionParam> = {}>(
+  value: AtomMotion | AtomMotion[] | AtomMotionFn<MotionParams>,
+) {
+  const Atom: React.FC<MotionComponentProps & MotionParams> = props => {
+    const { children, imperativeRef, ..._rest } = props;
+    const params = _rest as unknown as MotionParams;
     const child = getChildElement(children);
 
     const handleRef = useMotionImperativeRef(imperativeRef);
     const elementRef = React.useRef<HTMLElement>();
+    const paramsRef = React.useRef<MotionParams>(params);
 
     const isReducedMotion = useIsReducedMotion();
+
+    useIsomorphicLayoutEffect(() => {
+      paramsRef.current = params;
+    });
 
     useIsomorphicLayoutEffect(() => {
       const element = elementRef.current;
 
       if (element) {
-        const atoms = typeof value === 'function' ? value({ element }) : value;
+        const atoms = typeof value === 'function' ? value({ element, ...paramsRef.current }) : value;
         const handle = animateAtoms(element, atoms, { isReducedMotion: isReducedMotion() });
 
         handleRef.current = handle;

--- a/packages/react-components/react-motion/library/src/factories/createMotionComponent.ts
+++ b/packages/react-components/react-motion/library/src/factories/createMotionComponent.ts
@@ -24,7 +24,7 @@ export function createMotionComponent<MotionParams extends Record<string, Motion
 ) {
   const Atom: React.FC<MotionComponentProps & MotionParams> = props => {
     const { children, imperativeRef, ..._rest } = props;
-    const params = _rest as unknown as MotionParams;
+    const params = _rest as Exclude<typeof props, MotionComponentProps>;
     const child = getChildElement(children);
 
     const handleRef = useMotionImperativeRef(imperativeRef);
@@ -34,6 +34,8 @@ export function createMotionComponent<MotionParams extends Record<string, Motion
     const isReducedMotion = useIsReducedMotion();
 
     useIsomorphicLayoutEffect(() => {
+      // Heads up!
+      // We store the params in a ref to avoid re-rendering the component when the params change.
       paramsRef.current = params;
     });
 

--- a/packages/react-components/react-motion/library/src/factories/createPresenceComponent.ts
+++ b/packages/react-components/react-motion/library/src/factories/createPresenceComponent.ts
@@ -7,7 +7,7 @@ import { useMotionImperativeRef } from '../hooks/useMotionImperativeRef';
 import { useMountedState } from '../hooks/useMountedState';
 import { animateAtoms } from '../utils/animateAtoms';
 import { getChildElement } from '../utils/getChildElement';
-import type { PresenceMotion, MotionImperativeRef, PresenceMotionFn } from '../types';
+import type { MotionParam, PresenceMotion, MotionImperativeRef, PresenceMotionFn } from '../types';
 
 export type PresenceComponentProps = {
   /**
@@ -45,10 +45,16 @@ function shouldSkipAnimation(appear: boolean | undefined, isFirstMount: boolean,
   return !appear && isFirstMount && visible;
 }
 
-export function createPresenceComponent(value: PresenceMotion | PresenceMotionFn) {
-  const Presence: React.FC<PresenceComponentProps> = props => {
+export function createPresenceComponent<MotionParams extends Record<string, MotionParam> = {}>(
+  value: PresenceMotion | PresenceMotionFn<MotionParams>,
+) {
+  const Presence: React.FC<PresenceComponentProps & MotionParams> = props => {
     const itemContext = React.useContext(PresenceGroupChildContext);
-    const { appear, children, imperativeRef, onMotionFinish, visible, unmountOnExit } = { ...itemContext, ...props };
+    const { appear, children, imperativeRef, onExit, onMotionFinish, visible, unmountOnExit, ..._rest } = {
+      ...itemContext,
+      ...props,
+    };
+    const params = _rest as unknown as MotionParams;
 
     const [mounted, setMounted] = useMountedState(visible, unmountOnExit);
     const child = getChildElement(children);
@@ -56,7 +62,7 @@ export function createPresenceComponent(value: PresenceMotion | PresenceMotionFn
     const handleRef = useMotionImperativeRef(imperativeRef);
     const elementRef = React.useRef<HTMLElement>();
     const ref = useMergedRefs(elementRef, child.ref);
-    const optionsRef = React.useRef<{ appear?: boolean }>({});
+    const optionsRef = React.useRef<{ appear?: boolean; params: MotionParams }>({ appear, params });
 
     const isFirstMount = useFirstMount();
     const isReducedMotion = useIsReducedMotion();
@@ -69,12 +75,12 @@ export function createPresenceComponent(value: PresenceMotion | PresenceMotionFn
 
       if (unmountOnExit) {
         setMounted(false);
-        itemContext?.onExit();
+        onExit?.();
       }
     });
 
     useIsomorphicLayoutEffect(() => {
-      optionsRef.current = { appear };
+      optionsRef.current = { appear, params };
     });
 
     useIsomorphicLayoutEffect(
@@ -85,7 +91,7 @@ export function createPresenceComponent(value: PresenceMotion | PresenceMotionFn
           return;
         }
 
-        const presenceMotion = typeof value === 'function' ? value({ element }) : value;
+        const presenceMotion = typeof value === 'function' ? value({ element, ...optionsRef.current.params }) : value;
         const atoms = visible ? presenceMotion.enter : presenceMotion.exit;
 
         const handle = animateAtoms(element, atoms, { isReducedMotion: isReducedMotion() });

--- a/packages/react-components/react-motion/library/src/factories/createPresenceComponent.ts
+++ b/packages/react-components/react-motion/library/src/factories/createPresenceComponent.ts
@@ -50,11 +50,10 @@ export function createPresenceComponent<MotionParams extends Record<string, Moti
 ) {
   const Presence: React.FC<PresenceComponentProps & MotionParams> = props => {
     const itemContext = React.useContext(PresenceGroupChildContext);
-    const { appear, children, imperativeRef, onExit, onMotionFinish, visible, unmountOnExit, ..._rest } = {
-      ...itemContext,
-      ...props,
-    };
-    const params = _rest as unknown as MotionParams;
+    const merged = { ...itemContext, ...props };
+
+    const { appear, children, imperativeRef, onExit, onMotionFinish, visible, unmountOnExit, ..._rest } = merged;
+    const params = _rest as Exclude<typeof merged, PresenceComponentProps | typeof itemContext>;
 
     const [mounted, setMounted] = useMountedState(visible, unmountOnExit);
     const child = getChildElement(children);
@@ -80,6 +79,8 @@ export function createPresenceComponent<MotionParams extends Record<string, Moti
     });
 
     useIsomorphicLayoutEffect(() => {
+      // Heads up!
+      // We store the params in a ref to avoid re-rendering the component when the params change.
       optionsRef.current = { appear, params };
     });
 

--- a/packages/react-components/react-motion/library/src/types.ts
+++ b/packages/react-components/react-motion/library/src/types.ts
@@ -5,8 +5,14 @@ export type PresenceMotion = {
   exit: AtomMotion | AtomMotion[];
 };
 
-export type AtomMotionFn = (params: { element: HTMLElement }) => AtomMotion | AtomMotion[];
-export type PresenceMotionFn = (params: { element: HTMLElement }) => PresenceMotion;
+export type MotionParam = boolean | number | string;
+
+export type AtomMotionFn<MotionParams extends Record<string, MotionParam> = {}> = (
+  params: { element: HTMLElement } & MotionParams,
+) => AtomMotion | AtomMotion[];
+export type PresenceMotionFn<MotionParams extends Record<string, MotionParam> = {}> = (
+  params: { element: HTMLElement } & MotionParams,
+) => PresenceMotion;
 
 // ---
 

--- a/packages/react-components/react-motion/library/src/types.ts
+++ b/packages/react-components/react-motion/library/src/types.ts
@@ -5,6 +5,12 @@ export type PresenceMotion = {
   exit: AtomMotion | AtomMotion[];
 };
 
+/**
+ * @internal
+ *
+ * A motion param should be a primitive value that can be serialized to JSON and could be potentially used a plain
+ * dependency for React hooks.
+ */
 export type MotionParam = boolean | number | string;
 
 export type AtomMotionFn<MotionParams extends Record<string, MotionParam> = {}> = (

--- a/packages/react-components/react-motion/stories/src/CreateMotionComponent/MotionFunctionParams.stories.md
+++ b/packages/react-components/react-motion/stories/src/CreateMotionComponent/MotionFunctionParams.stories.md
@@ -1,0 +1,13 @@
+Atoms definitions can be also defined as functions that accept an animated element as an argument. This allows to define more complex animations that depend on the animated element's properties, for example:
+
+```ts
+const Grow = createMotionComponent(({ element }) => ({
+  duration: 300,
+  keyframes: [
+    { opacity: 0, maxHeight: `${element.scrollHeight / 2}px` },
+    { opacity: 1, maxHeight: `${element.scrollHeight}px` },
+    { opacity: 0, maxHeight: `${element.scrollHeight / 2}px` },
+  ],
+  iterations: Infinity,
+}));
+```

--- a/packages/react-components/react-motion/stories/src/CreateMotionComponent/MotionFunctionParams.stories.tsx
+++ b/packages/react-components/react-motion/stories/src/CreateMotionComponent/MotionFunctionParams.stories.tsx
@@ -1,0 +1,151 @@
+import {
+  createMotionComponent,
+  Field,
+  makeStyles,
+  mergeClasses,
+  type MotionImperativeRef,
+  motionTokens,
+  Slider,
+  tokens,
+} from '@fluentui/react-components';
+import * as React from 'react';
+
+import description from './MotionFunctionParams.stories.md';
+
+const useClasses = makeStyles({
+  container: {
+    display: 'grid',
+    gridTemplate: `"cardA cardB" "controls ." / 1fr 1fr`,
+    gap: '20px 10px',
+  },
+  card: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'end',
+
+    border: `${tokens.strokeWidthThicker} solid ${tokens.colorNeutralForeground3}`,
+    borderRadius: tokens.borderRadiusMedium,
+    boxShadow: tokens.shadow16,
+    padding: '10px',
+  },
+  controls: {
+    display: 'flex',
+    flexDirection: 'column',
+    gridArea: 'controls',
+
+    border: `${tokens.strokeWidthThicker} solid ${tokens.colorNeutralForeground3}`,
+    borderRadius: tokens.borderRadiusMedium,
+    boxShadow: tokens.shadow16,
+    padding: '10px',
+  },
+  field: {
+    flex: 1,
+  },
+  sliderField: {
+    gridTemplateColumns: 'min-content 1fr',
+  },
+  sliderLabel: {
+    textWrap: 'nowrap',
+  },
+
+  cardA: {
+    gridArea: 'cardA',
+  },
+  cardB: {
+    gridArea: 'cardB',
+  },
+  item: {
+    backgroundColor: tokens.colorBrandBackground,
+    border: `${tokens.strokeWidthThicker} solid ${tokens.colorTransparentStroke}`,
+    borderRadius: '50%',
+
+    width: '100px',
+    height: '100px',
+  },
+  description: {
+    fontFamily: tokens.fontFamilyMonospace,
+    borderRadius: tokens.borderRadiusMedium,
+    marginTop: '10px',
+    padding: '5px 10px',
+    backgroundColor: tokens.colorNeutralBackground1Pressed,
+  },
+});
+
+const Scale = createMotionComponent<{ startFrom?: number }>(({ startFrom = 0.5 }) => {
+  return {
+    keyframes: [
+      { opacity: 0, transform: `scale(${startFrom})` },
+      { opacity: 1, transform: 'scale(1)' },
+      { opacity: 0, transform: `scale(${startFrom})` },
+    ],
+    duration: motionTokens.durationUltraSlow,
+    iterations: Infinity,
+  };
+});
+
+export const MotionFunctionParams = () => {
+  const classes = useClasses();
+
+  const motionBRef = React.useRef<MotionImperativeRef>();
+  const motionARef = React.useRef<MotionImperativeRef>();
+
+  const [playbackRate, setPlaybackRate] = React.useState<number>(20);
+
+  // Heads up!
+  // This is optional and is intended solely to slow down the animations, making motions more visible in the examples.
+  React.useEffect(() => {
+    motionARef.current?.setPlaybackRate(playbackRate / 100);
+    motionBRef.current?.setPlaybackRate(playbackRate / 100);
+  }, [playbackRate]);
+
+  return (
+    <div className={classes.container}>
+      <div className={mergeClasses(classes.card, classes.cardA)}>
+        <Scale imperativeRef={motionARef} startFrom={0.1}>
+          <div className={classes.item} />
+        </Scale>
+        <div className={classes.description}>startFrom=0.1</div>
+      </div>
+      <div className={mergeClasses(classes.card, classes.cardB)}>
+        <Scale imperativeRef={motionBRef} startFrom={0.8}>
+          <div className={classes.item} />
+        </Scale>
+        <div className={classes.description}>startFrom=0.8</div>
+      </div>
+
+      <div className={classes.controls}>
+        <Field
+          className={mergeClasses(classes.field, classes.sliderField)}
+          label={{
+            children: (
+              <>
+                <code>playbackRate</code>: {playbackRate}%
+              </>
+            ),
+            className: classes.sliderLabel,
+          }}
+          orientation="horizontal"
+        >
+          <Slider
+            aria-valuetext={`Value is ${playbackRate}%`}
+            className={mergeClasses(classes.field, classes.sliderField)}
+            value={playbackRate}
+            onChange={(ev, data) => setPlaybackRate(data.value)}
+            min={0}
+            max={100}
+            step={5}
+          />
+        </Field>
+      </div>
+    </div>
+  );
+};
+
+MotionFunctionParams.parameters = {
+  docs: {
+    description: {
+      story: description,
+    },
+  },
+};

--- a/packages/react-components/react-motion/stories/src/CreateMotionComponent/index.stories.ts
+++ b/packages/react-components/react-motion/stories/src/CreateMotionComponent/index.stories.ts
@@ -9,6 +9,7 @@ export { TokensUsage as tokens } from './TokensUsage.stories';
 
 export { MotionArrays as arrays } from './MotionArrays.stories';
 export { MotionFunctions as functions } from './MotionFunctions.stories';
+export { MotionFunctionParams as functionParams } from './MotionFunctionParams.stories';
 
 export default {
   title: 'Utilities/Web Motions/createMotionComponent',

--- a/packages/react-components/react-motion/stories/src/CreatePresenceComponent/PresenceMotionFunctionParams.stories.md
+++ b/packages/react-components/react-motion/stories/src/CreatePresenceComponent/PresenceMotionFunctionParams.stories.md
@@ -1,0 +1,21 @@
+Functions in presence definitions also can be used to define motion parameters, this is useful when motion has different variations.
+
+```tsx
+const Scale = createPresenceComponent<{ startFrom?: number }>(({ startFrom = 0.5 }) => {
+  const keyframes = [
+    { opacity: 0, transform: `scale(${startFrom})` },
+    { opacity: 1, transform: 'scale(1)' },
+  ];
+
+  return {
+    enter: {
+      keyframes,
+      duration: motionTokens.durationUltraSlow,
+    },
+    exit: {
+      keyframes: [...keyframes].reverse(),
+      duration: motionTokens.durationSlow,
+    },
+  };
+});
+```

--- a/packages/react-components/react-motion/stories/src/CreatePresenceComponent/PresenceMotionFunctionParams.stories.tsx
+++ b/packages/react-components/react-motion/stories/src/CreatePresenceComponent/PresenceMotionFunctionParams.stories.tsx
@@ -1,0 +1,161 @@
+import {
+  createPresenceComponent,
+  Field,
+  makeStyles,
+  mergeClasses,
+  type MotionImperativeRef,
+  motionTokens,
+  Slider,
+  Switch,
+  tokens,
+} from '@fluentui/react-components';
+import * as React from 'react';
+
+import description from './PresenceMotionFunctionParams.stories.md';
+
+const useClasses = makeStyles({
+  container: {
+    display: 'grid',
+    gridTemplate: `"cardA cardB" "controls ." / 1fr 1fr`,
+    gap: '20px 10px',
+  },
+  card: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'end',
+
+    border: `${tokens.strokeWidthThicker} solid ${tokens.colorNeutralForeground3}`,
+    borderRadius: tokens.borderRadiusMedium,
+    boxShadow: tokens.shadow16,
+    padding: '10px',
+  },
+  controls: {
+    display: 'flex',
+    flexDirection: 'column',
+    gridArea: 'controls',
+
+    border: `${tokens.strokeWidthThicker} solid ${tokens.colorNeutralForeground3}`,
+    borderRadius: tokens.borderRadiusMedium,
+    boxShadow: tokens.shadow16,
+    padding: '10px',
+  },
+  field: {
+    flex: 1,
+  },
+  sliderField: {
+    gridTemplateColumns: 'min-content 1fr',
+  },
+  sliderLabel: {
+    textWrap: 'nowrap',
+  },
+
+  cardA: {
+    gridArea: 'cardA',
+  },
+  cardB: {
+    gridArea: 'cardB',
+  },
+  item: {
+    backgroundColor: tokens.colorBrandBackground,
+    border: `${tokens.strokeWidthThicker} solid ${tokens.colorTransparentStroke}`,
+    borderRadius: '50%',
+
+    width: '100px',
+    height: '100px',
+  },
+  description: {
+    fontFamily: tokens.fontFamilyMonospace,
+    borderRadius: tokens.borderRadiusMedium,
+    marginTop: '10px',
+    padding: '5px 10px',
+    backgroundColor: tokens.colorNeutralBackground1Pressed,
+  },
+});
+
+const Scale = createPresenceComponent<{ startFrom?: number }>(({ startFrom = 0.5 }) => {
+  const keyframes = [
+    { opacity: 0, transform: `scale(${startFrom})` },
+    { opacity: 1, transform: 'scale(1)' },
+  ];
+
+  return {
+    enter: {
+      keyframes,
+      duration: motionTokens.durationUltraSlow,
+    },
+    exit: {
+      keyframes: [...keyframes].reverse(),
+      duration: motionTokens.durationSlow,
+    },
+  };
+});
+
+export const PresenceMotionFunctionParams = () => {
+  const classes = useClasses();
+
+  const motionBRef = React.useRef<MotionImperativeRef>();
+  const motionARef = React.useRef<MotionImperativeRef>();
+
+  const [playbackRate, setPlaybackRate] = React.useState<number>(30);
+  const [visible, setVisible] = React.useState<boolean>(true);
+
+  // Heads up!
+  // This is optional and is intended solely to slow down the animations, making motions more visible in the examples.
+  React.useEffect(() => {
+    motionARef.current?.setPlaybackRate(playbackRate / 100);
+    motionBRef.current?.setPlaybackRate(playbackRate / 100);
+  }, [playbackRate, visible]);
+
+  return (
+    <div className={classes.container}>
+      <div className={mergeClasses(classes.card, classes.cardA)}>
+        <Scale imperativeRef={motionARef} startFrom={0.1} visible={visible}>
+          <div className={classes.item} />
+        </Scale>
+        <div className={classes.description}>startFrom=0.1</div>
+      </div>
+      <div className={mergeClasses(classes.card, classes.cardB)}>
+        <Scale imperativeRef={motionBRef} startFrom={0.8} visible={visible}>
+          <div className={classes.item} />
+        </Scale>
+        <div className={classes.description}>startFrom=0.8</div>
+      </div>
+
+      <div className={classes.controls}>
+        <Field className={classes.field}>
+          <Switch label="Visible" checked={visible} onChange={() => setVisible(v => !v)} />
+        </Field>
+        <Field
+          className={mergeClasses(classes.field, classes.sliderField)}
+          label={{
+            children: (
+              <>
+                <code>playbackRate</code>: {playbackRate}%
+              </>
+            ),
+            className: classes.sliderLabel,
+          }}
+          orientation="horizontal"
+        >
+          <Slider
+            aria-valuetext={`Value is ${playbackRate}%`}
+            value={playbackRate}
+            onChange={(ev, data) => setPlaybackRate(data.value)}
+            min={0}
+            max={100}
+            step={5}
+          />
+        </Field>
+      </div>
+    </div>
+  );
+};
+
+PresenceMotionFunctionParams.parameters = {
+  docs: {
+    description: {
+      story: description,
+    },
+  },
+};

--- a/packages/react-components/react-motion/stories/src/CreatePresenceComponent/index.stories.ts
+++ b/packages/react-components/react-motion/stories/src/CreatePresenceComponent/index.stories.ts
@@ -10,6 +10,7 @@ export { PresenceOnMotionFinish as onMotionFinish } from './PresenceOnMotionFini
 
 export { PresenceMotionArrays as arrays } from './PresenceMotionArrays.stories';
 export { PresenceMotionFunctions as functions } from './PresenceMotionFunctions.stories';
+export { PresenceMotionFunctionParams as functionParams } from './PresenceMotionFunctionParams.stories';
 
 export default {
   title: 'Utilities/Web Motions/createPresenceComponent',


### PR DESCRIPTION
## New Behavior

Adds support for custom props (params) in motions to to `createMotionComponent()` & `createPresenceComponent()`.

```tsx
const Scale = createPresenceComponent<{ startFrom?: number }>(({ startFrom = 0.5 }) => {
  const keyframes = [
    { opacity: 0, transform: `scale(${startFrom})` },
    { opacity: 1, transform: 'scale(1)' },
  ];

  return {
    enter: {
      keyframes,
      duration: motionTokens.durationUltraSlow,
    },
    exit: {
      keyframes: [...keyframes].reverse(),
      duration: motionTokens.durationSlow,
    },
  };
});
```

## Related Issue(s)

Fixes [#31576](https://github.com/microsoft/fluentui/issues/31576).
