### PR TITLE
chore: Fixing typo in `CheckboxShim` migration

### DIFF
--- a/change/@fluentui-react-migration-v8-v9-4e7ddd14-c033-416b-a5e7-f2a57c3ccada.json
+++ b/change/@fluentui-react-migration-v8-v9-4e7ddd14-c033-416b-a5e7-f2a57c3ccada.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Fixing typo in CheckboxShim migration.",
+  "packageName": "@fluentui/react-migration-v8-v9",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-migration-v8-v9/src/components/Checkbox/CheckboxShim.tsx
+++ b/packages/react-components/react-migration-v8-v9/src/components/Checkbox/CheckboxShim.tsx
@@ -26,10 +26,10 @@ export const CheckboxShim = React.forwardRef((props: ICheckboxProps, _ref: React
     if (!checkboxProps) {
       return null;
     }
-    const { label: defualtLabel, title } = checkboxProps;
-    return defualtLabel ? (
+    const { label: defaultLabel, title } = checkboxProps;
+    return defaultLabel ? (
       <span title={title} className={styles.text}>
-        {defualtLabel}
+        {defaultLabel}
       </span>
     ) : null;
   };


### PR DESCRIPTION
## Changes

This PR fixes a typo in the `CheckboxShim` migration example from `defualt` to `default`.
