### PR TITLE
fix: Drawer story accessibility fixes and docs update

### DIFF
--- a/packages/react-components/react-drawer/stories/src/Drawer/DrawerBestPractices.md
+++ b/packages/react-components/react-drawer/stories/src/Drawer/DrawerBestPractices.md
@@ -14,6 +14,8 @@
 ### Accessibility
 
 - `OverlayDrawer`: <br>Please refer to the Dialog component to understand the accessibility recommendations and implications.
-- `InlineDrawer`: <br>Renders a plain div and do not imply any A11y tags or attributes by default. It accepts all aria attributes and it should be customized depending on its context within a page
+- `InlineDrawer`: <br>
+  **Semantics**: Renders a plain div and do not imply any accessibility semantics by default. It accepts all aria attributes and it should be customized depending on its context within a page. Consider using `role="region"` for large page-level drawers. <br><br>
+  **Focus**: If the `InlineDrawer` has a trigger and can be closed, use the `useRestoreFocusTarget` and `useRestoreFocusSource` hooks to handle focus restoration as shown in our Default and Inline examples.
 
 </details>

--- a/packages/react-components/react-drawer/stories/src/Drawer/DrawerDefault.stories.tsx
+++ b/packages/react-components/react-drawer/stories/src/Drawer/DrawerDefault.stories.tsx
@@ -12,6 +12,8 @@ import {
   makeStyles,
   tokens,
   useId,
+  useRestoreFocusSource,
+  useRestoreFocusTarget,
 } from '@fluentui/react-components';
 import { Dismiss24Regular } from '@fluentui/react-icons';
 
@@ -51,9 +53,19 @@ export const Default = () => {
   const [isOpen, setIsOpen] = React.useState(false);
   const [type, setType] = React.useState<DrawerType>('overlay');
 
+  // Overlay Drawer will handle focus by default, but inline Drawers need manual focus restoration attributes, if applicable
+  const restoreFocusTargetAttributes = useRestoreFocusTarget();
+  const restoreFocusSourceAttributes = useRestoreFocusSource();
+
   return (
     <div className={styles.root}>
-      <Drawer type={type} separator open={isOpen} onOpenChange={(_, { open }) => setIsOpen(open)}>
+      <Drawer
+        {...restoreFocusSourceAttributes}
+        type={type}
+        separator
+        open={isOpen}
+        onOpenChange={(_, { open }) => setIsOpen(open)}
+      >
         <DrawerHeader>
           <DrawerHeaderTitle
             action={
@@ -75,7 +87,7 @@ export const Default = () => {
       </Drawer>
 
       <div className={styles.content}>
-        <Button appearance="primary" onClick={() => setIsOpen(!isOpen)}>
+        <Button {...restoreFocusTargetAttributes} appearance="primary" onClick={() => setIsOpen(!isOpen)}>
           {type === 'inline' ? 'Toggle' : 'Open'}
         </Button>
 

--- a/packages/react-components/react-drawer/stories/src/Drawer/DrawerWithNavigation.stories.tsx
+++ b/packages/react-components/react-drawer/stories/src/Drawer/DrawerWithNavigation.stories.tsx
@@ -19,7 +19,8 @@ import {
 } from '@fluentui/react-icons';
 
 const useStyles = makeStyles({
-  toolbar: {
+  header: {
+    display: 'flex',
     justifyContent: 'space-between',
   },
 });
@@ -33,10 +34,9 @@ export const WithNavigation = () => {
     <div>
       <OverlayDrawer position="start" open={isOpen} onOpenChange={(_, { open }) => setIsOpen(open)}>
         <DrawerHeader>
-          <DrawerHeaderNavigation>
-            <Toolbar className={styles.toolbar}>
-              <ToolbarButton aria-label="Back" appearance="subtle" icon={<ArrowLeft24Regular />} />
-
+          <DrawerHeaderNavigation className={styles.header}>
+            <Button aria-label="Back" appearance="subtle" icon={<ArrowLeft24Regular />} />
+            <Toolbar>
               <ToolbarGroup>
                 <ToolbarButton aria-label="Reload content" appearance="subtle" icon={<ArrowClockwise24Regular />} />
                 <ToolbarButton aria-label="Settings" appearance="subtle" icon={<Settings24Regular />} />

--- a/packages/react-components/react-drawer/stories/src/Drawer/InlineDrawer.stories.tsx
+++ b/packages/react-components/react-drawer/stories/src/Drawer/InlineDrawer.stories.tsx
@@ -9,6 +9,8 @@ import {
   tokens,
   DrawerProps,
   mergeClasses,
+  useRestoreFocusSource,
+  useRestoreFocusTarget,
 } from '@fluentui/react-components';
 import { Dismiss24Regular } from '@fluentui/react-icons';
 
@@ -43,6 +45,7 @@ const useStyles = makeStyles({
     right: '-16px',
     left: '-16px',
     display: 'flex',
+    flexWrap: 'wrap',
     justifyContent: 'center',
     alignItems: 'flex-start',
     columnGap: tokens.spacingHorizontalXS,
@@ -92,8 +95,9 @@ const setButtonText = (open: boolean, position: DrawerProps['position']) => {
 };
 
 const DrawerInlineExample: React.FC<DrawerInlineExampleProps> = ({ setOpen, ...props }) => {
+  const restoreFocusSourceAttributes = useRestoreFocusSource();
   return (
-    <InlineDrawer {...props}>
+    <InlineDrawer {...restoreFocusSourceAttributes} {...props}>
       <DrawerHeader>
         <DrawerHeaderTitle
           action={
@@ -118,6 +122,8 @@ export const Inline = () => {
   const [rightOpen, setRightOpen] = React.useState(false);
   const [bottomOpen, setBottomOpen] = React.useState(false);
 
+  const restoreFocusTargetAttributes = useRestoreFocusTarget();
+
   return (
     <div className={mergeClasses(styles.root, styles.flexColumn)}>
       <div className={styles.root}>
@@ -125,15 +131,15 @@ export const Inline = () => {
 
         <div className={styles.content}>
           <div className={styles.buttons}>
-            <Button appearance="primary" onClick={() => setLeftOpen(!leftOpen)}>
+            <Button {...restoreFocusTargetAttributes} appearance="primary" onClick={() => setLeftOpen(!leftOpen)}>
               {setButtonText(leftOpen, 'start')}
             </Button>
 
-            <Button appearance="primary" onClick={() => setRightOpen(!rightOpen)}>
+            <Button {...restoreFocusTargetAttributes} appearance="primary" onClick={() => setRightOpen(!rightOpen)}>
               {setButtonText(rightOpen, 'end')}
             </Button>
 
-            <Button appearance="primary" onClick={() => setBottomOpen(!bottomOpen)}>
+            <Button {...restoreFocusTargetAttributes} appearance="primary" onClick={() => setBottomOpen(!bottomOpen)}>
               {setButtonText(bottomOpen, 'bottom')}
             </Button>
           </div>


### PR DESCRIPTION
## Previous Behavior

No package changes, fixes several bugs in the storybook examples:
- InlineDrawer stories & best practices docs show how to handle focus restoration
- Inline story doesn't clip left/right/bottom buttons at high zoom %
- Navigation story's drawer splits the back button out from the toolbar (not technically a compliance bug, but I agree that visually it's unexpected to need to arrow from the back button to the actions)

(Fixes several ADO a11y bugs)
