### PR TITLE
feature(react-tree): preventScroll on navigation

### DIFF
--- a/change/@fluentui-react-tree-82531355-9d67-474e-b007-7fb1e6a64060.json
+++ b/change/@fluentui-react-tree-82531355-9d67-474e-b007-7fb1e6a64060.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feature: preventScroll on navigation",
+  "packageName": "@fluentui/react-tree",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tree/etc/react-tree.api.md
+++ b/packages/react-components/react-tree/etc/react-tree.api.md
@@ -300,7 +300,7 @@ export type TreeNavigationData_unstable = {
     target: HTMLElement;
     value: TreeItemValue;
     parentValue: TreeItemValue | undefined;
-} & ({
+} & FocusOptions & ({
     event: React_2.MouseEvent<HTMLElement>;
     type: 'Click';
 } | {

--- a/packages/react-components/react-tree/etc/react-tree.api.md
+++ b/packages/react-components/react-tree/etc/react-tree.api.md
@@ -300,7 +300,7 @@ export type TreeNavigationData_unstable = {
     target: HTMLElement;
     value: TreeItemValue;
     parentValue: TreeItemValue | undefined;
-} & FocusOptions & ({
+} & ({
     event: React_2.MouseEvent<HTMLElement>;
     type: 'Click';
 } | {
@@ -369,7 +369,7 @@ export type TreeProps = ComponentProps<TreeSlots> & {
     openItems?: Iterable<TreeItemValue>;
     defaultOpenItems?: Iterable<TreeItemValue>;
     onOpenChange?(event: TreeOpenChangeEvent, data: TreeOpenChangeData): void;
-    onNavigation?(event: TreeNavigationEvent_unstable, data: TreeNavigationData_unstable): void;
+    onNavigation?(event: TreeNavigationEvent_unstable, data: TreeNavigationDataParam): void;
     selectionMode?: SelectionMode_2;
     checkedItems?: Iterable<TreeItemValue | [TreeItemValue, TreeSelectionValue]>;
     onCheckedChange?(event: TreeCheckedChangeEvent, data: TreeCheckedChangeData): void;

--- a/packages/react-components/react-tree/src/components/Tree/Tree.types.ts
+++ b/packages/react-components/react-tree/src/components/Tree/Tree.types.ts
@@ -19,17 +19,16 @@ export type TreeNavigationData_unstable = {
   target: HTMLElement;
   value: TreeItemValue;
   parentValue: TreeItemValue | undefined;
-} & FocusOptions &
-  (
-    | { event: React.MouseEvent<HTMLElement>; type: 'Click' }
-    | { event: React.KeyboardEvent<HTMLElement>; type: 'TypeAhead' }
-    | { event: React.KeyboardEvent<HTMLElement>; type: typeof ArrowRight }
-    | { event: React.KeyboardEvent<HTMLElement>; type: typeof ArrowLeft }
-    | { event: React.KeyboardEvent<HTMLElement>; type: typeof ArrowUp }
-    | { event: React.KeyboardEvent<HTMLElement>; type: typeof ArrowDown }
-    | { event: React.KeyboardEvent<HTMLElement>; type: typeof Home }
-    | { event: React.KeyboardEvent<HTMLElement>; type: typeof End }
-  );
+} & (
+  | { event: React.MouseEvent<HTMLElement>; type: 'Click' }
+  | { event: React.KeyboardEvent<HTMLElement>; type: 'TypeAhead' }
+  | { event: React.KeyboardEvent<HTMLElement>; type: typeof ArrowRight }
+  | { event: React.KeyboardEvent<HTMLElement>; type: typeof ArrowLeft }
+  | { event: React.KeyboardEvent<HTMLElement>; type: typeof ArrowUp }
+  | { event: React.KeyboardEvent<HTMLElement>; type: typeof ArrowDown }
+  | { event: React.KeyboardEvent<HTMLElement>; type: typeof Home }
+  | { event: React.KeyboardEvent<HTMLElement>; type: typeof End }
+);
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export type TreeNavigationEvent_unstable = TreeNavigationData_unstable['event'];
@@ -52,6 +51,18 @@ export type TreeOpenChangeData = {
   | { event: React.KeyboardEvent<HTMLElement>; type: typeof ArrowRight }
   | { event: React.KeyboardEvent<HTMLElement>; type: typeof ArrowLeft }
 );
+
+/**
+ * @internal
+ *
+ * To avoid breaking changes on TreeNavigationData
+ * we are creating a new type that extends the old one
+ * and adds the new methods, and this type will not be exported
+ */
+type TreeNavigationDataParam = TreeNavigationData_unstable & {
+  preventScroll(): void;
+  isScrollPrevented(): boolean;
+};
 
 export type TreeOpenChangeEvent = TreeOpenChangeData['event'];
 
@@ -122,7 +133,7 @@ export type TreeProps = ComponentProps<TreeSlots> & {
    * @param event - a React's Synthetic event
    * @param data - A data object with relevant information,
    */
-  onNavigation?(event: TreeNavigationEvent_unstable, data: TreeNavigationData_unstable): void;
+  onNavigation?(event: TreeNavigationEvent_unstable, data: TreeNavigationDataParam): void;
 
   /**
    * This refers to the selection mode of the tree.

--- a/packages/react-components/react-tree/src/components/Tree/Tree.types.ts
+++ b/packages/react-components/react-tree/src/components/Tree/Tree.types.ts
@@ -19,16 +19,17 @@ export type TreeNavigationData_unstable = {
   target: HTMLElement;
   value: TreeItemValue;
   parentValue: TreeItemValue | undefined;
-} & (
-  | { event: React.MouseEvent<HTMLElement>; type: 'Click' }
-  | { event: React.KeyboardEvent<HTMLElement>; type: 'TypeAhead' }
-  | { event: React.KeyboardEvent<HTMLElement>; type: typeof ArrowRight }
-  | { event: React.KeyboardEvent<HTMLElement>; type: typeof ArrowLeft }
-  | { event: React.KeyboardEvent<HTMLElement>; type: typeof ArrowUp }
-  | { event: React.KeyboardEvent<HTMLElement>; type: typeof ArrowDown }
-  | { event: React.KeyboardEvent<HTMLElement>; type: typeof Home }
-  | { event: React.KeyboardEvent<HTMLElement>; type: typeof End }
-);
+} & FocusOptions &
+  (
+    | { event: React.MouseEvent<HTMLElement>; type: 'Click' }
+    | { event: React.KeyboardEvent<HTMLElement>; type: 'TypeAhead' }
+    | { event: React.KeyboardEvent<HTMLElement>; type: typeof ArrowRight }
+    | { event: React.KeyboardEvent<HTMLElement>; type: typeof ArrowLeft }
+    | { event: React.KeyboardEvent<HTMLElement>; type: typeof ArrowUp }
+    | { event: React.KeyboardEvent<HTMLElement>; type: typeof ArrowDown }
+    | { event: React.KeyboardEvent<HTMLElement>; type: typeof Home }
+    | { event: React.KeyboardEvent<HTMLElement>; type: typeof End }
+  );
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export type TreeNavigationEvent_unstable = TreeNavigationData_unstable['event'];

--- a/packages/react-components/react-tree/src/components/Tree/useTree.ts
+++ b/packages/react-components/react-tree/src/components/Tree/useTree.ts
@@ -39,7 +39,9 @@ function useNestedRootTree(props: TreeProps, ref: React.Ref<HTMLElement>): TreeS
         onNavigation: useEventCallback((event, data) => {
           props.onNavigation?.(event, data);
           if (!event.isDefaultPrevented()) {
-            navigation.navigate(data);
+            navigation.navigate(data, {
+              preventScroll: data.isScrollPrevented(),
+            });
           }
         }),
         onCheckedChange: useEventCallback((event, data) => {

--- a/packages/react-components/react-tree/src/components/Tree/useTree.ts
+++ b/packages/react-components/react-tree/src/components/Tree/useTree.ts
@@ -50,7 +50,7 @@ function useNestedRootTree(props: TreeProps, ref: React.Ref<HTMLElement>): TreeS
           });
         }),
       },
-      useMergedRefs(ref, navigation.rootRef),
+      useMergedRefs(ref, navigation.treeRef),
     ),
     { treeType: 'nested' } as const,
   );

--- a/packages/react-components/react-tree/src/hooks/useRootTree.ts
+++ b/packages/react-components/react-tree/src/hooks/useRootTree.ts
@@ -44,7 +44,14 @@ export function useRootTree(
   };
 
   const requestNavigation = (request: Extract<TreeItemRequest, { requestType: 'navigate' }>) => {
-    props.onNavigation?.(request.event, request);
+    let isScrollPrevented = false;
+    props.onNavigation?.(request.event, {
+      ...request,
+      preventScroll: () => {
+        isScrollPrevented = true;
+      },
+      isScrollPrevented: () => isScrollPrevented,
+    });
     switch (request.type) {
       case treeDataTypes.ArrowDown:
       case treeDataTypes.ArrowUp:

--- a/packages/react-components/react-tree/src/hooks/useRovingTabIndexes.ts
+++ b/packages/react-components/react-tree/src/hooks/useRovingTabIndexes.ts
@@ -4,6 +4,7 @@ import { useFocusedElementChange } from '@fluentui/react-tabster';
 import { elementContains } from '@fluentui/react-utilities';
 
 /**
+ * @internal
  * https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex
  */
 export function useRovingTabIndex() {
@@ -37,13 +38,13 @@ export function useRovingTabIndex() {
       nextElement.tabIndex = -1;
     }
   }, []);
-  const rove = React.useCallback((nextElement: HTMLElement) => {
+  const rove = React.useCallback((nextElement: HTMLElement, focusOptions?: FocusOptions) => {
     if (!currentElementRef.current) {
       return;
     }
     currentElementRef.current.tabIndex = -1;
     nextElement.tabIndex = 0;
-    nextElement.focus();
+    nextElement.focus(focusOptions);
     currentElementRef.current = nextElement;
   }, []);
 

--- a/packages/react-components/react-tree/src/hooks/useTreeNavigation.ts
+++ b/packages/react-components/react-tree/src/hooks/useTreeNavigation.ts
@@ -7,6 +7,9 @@ import * as React from 'react';
 import { useHTMLElementWalkerRef } from './useHTMLElementWalkerRef';
 import { useMergedRefs } from '@fluentui/react-utilities';
 
+/**
+ * @internal
+ */
 export function useTreeNavigation() {
   const { rove, initialize: initializeRovingTabIndex } = useRovingTabIndex();
   const { walkerRef, rootRef: walkerRootRef } = useHTMLElementWalkerRef();
@@ -53,10 +56,13 @@ export function useTreeNavigation() {
   function navigate(data: TreeNavigationData_unstable) {
     const nextElement = getNextElement(data);
     if (nextElement) {
-      rove(nextElement);
+      rove(nextElement, data);
     }
   }
-  return { navigate, rootRef: useMergedRefs(walkerRootRef, rootRefCallback) } as const;
+  return {
+    navigate,
+    treeRef: useMergedRefs(walkerRootRef, rootRefCallback) as React.RefCallback<HTMLElement>,
+  } as const;
 }
 
 function lastChildRecursive(walker: HTMLElementWalker) {

--- a/packages/react-components/react-tree/src/hooks/useTreeNavigation.ts
+++ b/packages/react-components/react-tree/src/hooks/useTreeNavigation.ts
@@ -53,10 +53,10 @@ export function useTreeNavigation() {
         return walkerRef.current.previousElement();
     }
   };
-  function navigate(data: TreeNavigationData_unstable) {
+  function navigate(data: TreeNavigationData_unstable, focusOptions?: FocusOptions) {
     const nextElement = getNextElement(data);
     if (nextElement) {
-      rove(nextElement, data);
+      rove(nextElement, focusOptions);
     }
   }
   return {


### PR DESCRIPTION
## Previous Behavior

<!-- This is the behavior we have today -->
In the nested tree when navigating, we focus on the `TreeItem` itself and since that item includes all its children nested inside of it the browser will automatically scroll that whole item into view (see https://github.com/microsoft/fluentui/issues/31557).

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

1. adds `preventScroll` and `isScrollPrevented` methods to `onNavigation` data parameter. When `preventScroll` is invoked then the navigation focus will not scroll to the element while focusing (see [preventScroll](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus#preventscroll))

With this feature now it's possible to maintain navigation as is while opting out of the scroll mechanism, allowing the user to create its own (in the case of https://github.com/microsoft/fluentui/issues/31557 we could just scroll into the `TreeItemLayout` instead of the `TreeItem` when navigating)

```ts
const handleNavigation: TreeProps['onNavigation'] = (_event, data) => {
  data.preventScroll();
  // request animation frame to wait for the active element to be updated
  targetDocument?.defaultView?.requestAnimationFrame(() => {
    const layoutElement = targetDocument?.activeElement?.querySelector<HTMLElement>(
      `.${treeItemLayoutClassNames.root}`,
    );
    if (layoutElement && !isElementInViewport(layoutElement)) {
      layoutElement.scrollIntoView({ block: 'nearest', behavior: 'auto' });
    }
  });
};
```

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/31557
