### PR TITLE
fix(web-components): fix disabled button styles

### DIFF
--- a/change/@fluentui-web-components-3a27963c-2795-4898-8b1e-adeb72be5c72.json
+++ b/change/@fluentui-web-components-3a27963c-2795-4898-8b1e-adeb72be5c72.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix disabled button styles",
+  "packageName": "@fluentui/web-components",
+  "email": "rupertdavid@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/button/button.spec.ts
+++ b/packages/web-components/src/button/button.spec.ts
@@ -104,14 +104,35 @@ test.describe('Button', () => {
     await expect(element).not.toBeFocused();
   });
 
-  test('should have transparent border when the `disabled` attribute is present', async ({ page }) => {
+  test('should apply transparency correctly when the `disabled` attribute is present', async ({ page }) => {
     const element = page.locator('fluent-button');
-
+    const transparent = 'rgba(0, 0, 0, 0)';
     await page.setContent(/* html */ `
-      <fluent-button appearance='primary' disabled>Button</fluent-button>
+      <fluent-button disabled>Button</fluent-button>
     `);
 
-    await expect(element).toHaveCSS('border-color', 'rgb(0, 0, 0)');
+    await expect(element).not.toHaveCSS('border-color', transparent);
+    await expect(element).not.toHaveCSS('background-color', transparent);
+
+    await element.evaluate(node => node.setAttribute('appearance', 'primary'));
+    await expect(element).toHaveCSS('border-color', transparent);
+    await expect(element).not.toHaveCSS('background-color', transparent);
+
+    await element.evaluate(node => node.setAttribute('appearance', 'secondary'));
+    await expect(element).not.toHaveCSS('border-color', transparent);
+    await expect(element).not.toHaveCSS('background-color', transparent);
+
+    await element.evaluate(node => node.setAttribute('appearance', 'outline'));
+    await expect(element).not.toHaveCSS('border-color', transparent);
+    await expect(element).toHaveCSS('background-color', transparent);
+
+    await element.evaluate(node => node.setAttribute('appearance', 'subtle'));
+    await expect(element).toHaveCSS('border-color', transparent);
+    await expect(element).toHaveCSS('background-color', transparent);
+
+    await element.evaluate(node => node.setAttribute('appearance', 'transparent'));
+    await expect(element).toHaveCSS('border-color', transparent);
+    await expect(element).toHaveCSS('background-color', transparent);
   });
 
   test('should be focusable when the `disabled-focusable` attribute is present', async ({ page }) => {
@@ -126,14 +147,35 @@ test.describe('Button', () => {
     await expect(element).toBeFocused();
   });
 
-  test('should have transparent border when the `disabled-focusable` attribute is present', async ({ page }) => {
+  test('should apply transparency correctly when the `disabled-focusable` attribute is present', async ({ page }) => {
     const element = page.locator('fluent-button');
-
+    const transparent = 'rgba(0, 0, 0, 0)';
     await page.setContent(/* html */ `
-      <fluent-button appearance='primary' disabled-focusable>Button</fluent-button>
+      <fluent-button disabled-focusable>Button</fluent-button>
     `);
 
-    await expect(element).toHaveCSS('border-color', 'rgb(0, 0, 0)');
+    await expect(element).not.toHaveCSS('border-color', transparent);
+    await expect(element).not.toHaveCSS('background-color', transparent);
+
+    await element.evaluate(node => node.setAttribute('appearance', 'primary'));
+    await expect(element).toHaveCSS('border-color', transparent);
+    await expect(element).not.toHaveCSS('background-color', transparent);
+
+    await element.evaluate(node => node.setAttribute('appearance', 'secondary'));
+    await expect(element).not.toHaveCSS('border-color', transparent);
+    await expect(element).not.toHaveCSS('background-color', transparent);
+
+    await element.evaluate(node => node.setAttribute('appearance', 'outline'));
+    await expect(element).not.toHaveCSS('border-color', transparent);
+    await expect(element).toHaveCSS('background-color', transparent);
+
+    await element.evaluate(node => node.setAttribute('appearance', 'subtle'));
+    await expect(element).toHaveCSS('border-color', transparent);
+    await expect(element).toHaveCSS('background-color', transparent);
+
+    await element.evaluate(node => node.setAttribute('appearance', 'transparent'));
+    await expect(element).toHaveCSS('border-color', transparent);
+    await expect(element).toHaveCSS('background-color', transparent);
   });
 
   test('should NOT be clickable when the `disabled` attribute is present', async ({ page }) => {

--- a/packages/web-components/src/button/button.styles.ts
+++ b/packages/web-components/src/button/button.styles.ts
@@ -113,7 +113,7 @@ export const styles = css`
 
   :host(:focus-visible) {
     border-color: ${colorTransparentStroke};
-    outline: ${strokeWidthThick}) solid ${colorTransparentStroke};
+    outline: ${strokeWidthThick} solid ${colorTransparentStroke};
     box-shadow: ${shadow4}, 0 0 0 2px ${colorStrokeFocus2};
   }
 
@@ -213,12 +213,6 @@ export const styles = css`
     box-shadow: ${shadow2}, 0 0 0 2px ${colorStrokeFocus2};
   }
 
-  :host(:is([disabled][appearance='primary'], [disabled-focusabale][appearance='primary'])),
-  :host(:is([disabled][appearance='primary'], [disabled-focusabale][appearance='primary']):hover),
-  :host(:is([disabled][appearance='primary'], [disabled-focusabale][appearance='primary']):hover:active) {
-    border-color: transparent;
-  }
-
   :host([appearance='outline']) {
     background-color: ${colorTransparentBackground};
   }
@@ -229,12 +223,6 @@ export const styles = css`
 
   :host([appearance='outline']:hover:active) {
     background-color: ${colorTransparentBackgroundPressed};
-  }
-
-  :host(:is([disabled][appearance='outline'], [disabled-focusabale][appearance='outline'])),
-  :host(:is([disabled][appearance='outline'], [disabled-focusabale][appearance='outline']):hover),
-  :host(:is([disabled][appearance='outline'], [disabled-focusabale][appearance='outline']):hover:active) {
-    background-color: ${colorTransparentBackground};
   }
 
   :host([appearance='subtle']) {
@@ -252,13 +240,6 @@ export const styles = css`
   :host([appearance='subtle']:hover:active) {
     background-color: ${colorSubtleBackgroundPressed};
     color: ${colorNeutralForeground2Pressed};
-    border-color: transparent;
-  }
-
-  :host(:is([disabled][appearance='subtle'], [disabled-focusabale][appearance='subtle'])),
-  :host(:is([disabled][appearance='subtle'], [disabled-focusabale][appearance='subtle']):hover),
-  :host(:is([disabled][appearance='subtle'], [disabled-focusabale][appearance='subtle']):hover:active) {
-    background-color: ${colorTransparentBackground};
     border-color: transparent;
   }
 
@@ -291,13 +272,6 @@ export const styles = css`
     border-color: transparent;
   }
 
-  :host(:is([disabled][appearance='transparent'], [disabled-focusabale][appearance='transparent'])),
-  :host(:is([disabled][appearance='transparent'], [disabled-focusabale][appearance='transparent']):hover),
-  :host(:is([disabled][appearance='transparent'], [disabled-focusabale][appearance='transparent']):hover:active) {
-    border-color: transparent;
-    background-color: ${colorTransparentBackground};
-  }
-
   :host(:is([disabled], [disabled-focusable], [appearance][disabled], [appearance][disabled-focusable])),
   :host(:is([disabled], [disabled-focusable], [appearance][disabled], [appearance][disabled-focusable]):hover),
   :host(:is([disabled], [disabled-focusable], [appearance][disabled], [appearance][disabled-focusable]):hover:active) {
@@ -305,6 +279,32 @@ export const styles = css`
     border-color: ${colorNeutralStrokeDisabled};
     color: ${colorNeutralForegroundDisabled};
     cursor: not-allowed;
+  }
+
+  :host(:is([disabled][appearance='primary'], [disabled-focusable][appearance='primary'])),
+  :host(:is([disabled][appearance='primary'], [disabled-focusable][appearance='primary']):hover),
+  :host(:is([disabled][appearance='primary'], [disabled-focusable][appearance='primary']):hover:active) {
+    border-color: transparent;
+  }
+
+  :host(:is([disabled][appearance='outline'], [disabled-focusable][appearance='outline'])),
+  :host(:is([disabled][appearance='outline'], [disabled-focusable][appearance='outline']):hover),
+  :host(:is([disabled][appearance='outline'], [disabled-focusable][appearance='outline']):hover:active) {
+    background-color: ${colorTransparentBackground};
+  }
+
+  :host(:is([disabled][appearance='subtle'], [disabled-focusable][appearance='subtle'])),
+  :host(:is([disabled][appearance='subtle'], [disabled-focusable][appearance='subtle']):hover),
+  :host(:is([disabled][appearance='subtle'], [disabled-focusable][appearance='subtle']):hover:active) {
+    background-color: ${colorTransparentBackground};
+    border-color: transparent;
+  }
+
+  :host(:is([disabled][appearance='transparent'], [disabled-focusable][appearance='transparent'])),
+  :host(:is([disabled][appearance='transparent'], [disabled-focusable][appearance='transparent']):hover),
+  :host(:is([disabled][appearance='transparent'], [disabled-focusable][appearance='transparent']):hover:active) {
+    border-color: transparent;
+    background-color: ${colorTransparentBackground};
   }
 `.withBehaviors(
   forcedColorsStylesheetBehavior(css`

--- a/packages/web-components/src/theme/set-theme.ts
+++ b/packages/web-components/src/theme/set-theme.ts
@@ -10,7 +10,15 @@ const tokenNames = Object.keys(tokens) as (keyof Theme)[];
  */
 export const setTheme = (theme: Theme) => {
   for (const t of tokenNames) {
-    document.body.style.setProperty(`--${t}`, theme[t] as string);
+    if ('registerProperty' in CSS) {
+      CSS.registerProperty({
+        name: `--${t}`,
+        inherits: true,
+        initialValue: theme[t] as string,
+      });
+    } else {
+      document.body.style.setProperty(`--${t}`, theme[t] as string);
+    }
   }
 };
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

- Bug filed for `[disabled][appearance="subtle"]` fluent-buttons where they are expected to not have a background or outline when disabled, but actually were showing a background and outline.
  - Confirmed that a "fix" in https://github.com/microsoft/fluentui/commit/fa9416a9f3fefc36b2e2ee3b32ea8c038bb4d91e caused a regression where "fixed" styles were now overriding existing behavior due to cascade order.
  - This exposed a false positive in our Playwright tests where CSS variables were being wiped out by the use of `setContent`.
- Discovered a "`focusabale`" typo in button styles
- Discovered a bug with `:focus-visible` not working in High Contrast Mode

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

- Reorganized CSS so that `[disabled]` styles cascade correctly.
- Fixed `focusabale` typo
- Removed errant `)` char from `:focus-visible` styles to fix high-contrast mode focus states.
- Thanks to help from @radium-v and prior investigation by @janechu, changed how we register CSS properties in `setTheme` to prevent them being wiped out by `page.setContent`
  - Now using `CSS.registerProperty` with a fallback to current method for current versions of Firefox and older browsers.
- Fixed and improved tests to help preserve behavior.

The `CSS.registerProperty` change is probably significant enough to heavily scrutinize this PR. It's pretty naive at the moment, just applying an `initialValue`. In the future I think we'd want to set actual CSSOM types (integer, pixel values, etc). 

Look forward to feedback.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #31552 

## Screenshots 

![Screenshot 2024-06-05 at 11 34 42 AM](https://github.com/microsoft/fluentui/assets/42218/a8d49815-53a0-40a0-83e7-16ad7f1d1bd7)

![Screenshot 2024-06-05 at 11 36 00 AM](https://github.com/microsoft/fluentui/assets/42218/b4c5891f-d2f9-4046-9086-6fba7c9b6fd2)
