### PR TITLE
build: add @floating-ui/dom as a dependency

### DIFF
--- a/change/@fluentui-web-components-11e8a2bd-9b9b-4ffd-91ed-6e4984f9eccf.json
+++ b/change/@fluentui-web-components-11e8a2bd-9b9b-4ffd-91ed-6e4984f9eccf.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "add @floating-ui/dom as a dependency",
+  "packageName": "@fluentui/web-components",
+  "email": "zacky.ma@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -218,6 +218,7 @@
   "dependencies": {
     "@microsoft/fast-element": "2.0.0-beta.26",
     "@microsoft/fast-web-utilities": "^6.0.0",
+    "@floating-ui/dom": "^1.2.0",
     "@fluentui/tokens": "1.0.0-alpha.16",
     "tabbable": "^6.2.0",
     "tslib": "^2.1.0"


### PR DESCRIPTION
## Previous Behavior

The Menu component depends on `@floating-ui/dom` but the package is not in `web-components/package.json`, which can cause issues in build when another package depends on `@fluentui/web-components`.

## New Behavior

Added `@floating-ui/dom` as a dependency.
