### PR TITLE
bugfix(react-tree): ensure roving tab index when children changes

### DIFF
--- a/change/@fluentui-react-tree-886c9d74-378a-47cd-8541-ed8067e40e4f.json
+++ b/change/@fluentui-react-tree-886c9d74-378a-47cd-8541-ed8067e40e4f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: ensure roving tab index when children content changes",
+  "packageName": "@fluentui/react-tree",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tree/src/components/Tree/Tree.cy.tsx
+++ b/packages/react-components/react-tree/src/components/Tree/Tree.cy.tsx
@@ -1,3 +1,4 @@
+import 'cypress-real-events';
 import * as React from 'react';
 import { mount as mountBase } from '@cypress/react';
 import { FluentProvider } from '@fluentui/react-provider';
@@ -394,6 +395,35 @@ describe('Tree', () => {
     cy.get('[data-testid="item2__item1"]').focus().realPress('Tab');
     cy.get('#btn-after-tree').should('be.focused').realPress(['Shift', 'Tab']);
     cy.get('[data-testid="item2__item1"]').should('be.focused');
+  });
+  it('should ensure roving tab indexes when children change', () => {
+    const RovingTreeTest = () => {
+      const [show, setShow] = React.useState(false);
+      return (
+        <>
+          <button onClick={() => setShow(true)} id="btn-before-tree">
+            show tree
+          </button>
+          <TreeTest>
+            {show && (
+              <>
+                <TreeItem itemType="leaf" value="item1" data-testid="item1">
+                  <TreeItemLayout>level 1, item 1</TreeItemLayout>
+                </TreeItem>
+                <TreeItem itemType="leaf" value="item2" data-testid="item2">
+                  <TreeItemLayout>level 1, item 2</TreeItemLayout>
+                </TreeItem>
+              </>
+            )}
+          </TreeTest>
+        </>
+      );
+    };
+
+    mount(<RovingTreeTest />);
+    cy.get('#btn-before-tree').focus().realClick();
+    cy.get('[data-testid="item1"]').should('have.attr', 'tabindex', '0').focus().realPress('ArrowDown');
+    cy.get('[data-testid="item2"]').should('be.focused');
   });
 });
 

--- a/packages/react-components/react-tree/src/hooks/useRovingTabIndexes.ts
+++ b/packages/react-components/react-tree/src/hooks/useRovingTabIndexes.ts
@@ -8,8 +8,15 @@ import { elementContains } from '@fluentui/react-utilities';
  * https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex
  */
 export function useRovingTabIndex() {
-  const currentElementRef = React.useRef<HTMLElement>();
+  const currentElementRef = React.useRef<HTMLElement | null>(null);
   const walkerRef = React.useRef<HTMLElementWalker | null>(null);
+
+  React.useEffect(() => {
+    if (currentElementRef.current === null && walkerRef.current) {
+      initialize(walkerRef.current);
+    }
+  });
+
   useFocusedElementChange(element => {
     if (
       element?.getAttribute('role') === 'treeitem' &&


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

1. adds `useEffect` to ensure that if no element is currently with `tabindex=0` then the roved element should be recalculated.
2. adds test to ensure behavior

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/31583
