### PR TITLE
fix(react-calendar-compat): fixed focus indicator cut off

### DIFF
--- a/change/@fluentui-react-calendar-compat-f38fe669-e50e-4648-9f66-ec82e13beee3.json
+++ b/change/@fluentui-react-calendar-compat-f38fe669-e50e-4648-9f66-ec82e13beee3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(react-calendar-compat): fixed focus indicator cut off",
+  "packageName": "@fluentui/react-calendar-compat",
+  "email": "vkozlova@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-calendar-compat/library/src/components/CalendarDayGrid/useCalendarDayGridStyles.styles.ts
+++ b/packages/react-components/react-calendar-compat/library/src/components/CalendarDayGrid/useCalendarDayGridStyles.styles.ts
@@ -173,6 +173,12 @@ const useDaySingleSelectedStyles = makeStyles({
 
 const useWeekRowStyles = makeStyles({
   base: {
+    position: 'relative',
+    ':focus-within': {
+      zIndex: 1,
+    },
+  },
+  animation: {
     animationDuration: DURATION_3,
     animationFillMode: 'both',
     animationTimingFunction: EASING_FUNCTION_1,
@@ -419,7 +425,8 @@ export const useCalendarDayGridStyles_unstable = (props: CalendarDayGridStylePro
     daySingleSelected: mergeClasses(calendarDayGridClassNames.daySingleSelected, daySingleSelectedStyles.base),
     weekRow: mergeClasses(
       calendarDayGridClassNames.weekRow,
-      animateBackwards !== undefined && weekRowStyles.base,
+      weekRowStyles.base,
+      animateBackwards !== undefined && weekRowStyles.animation,
       animateBackwards !== undefined &&
         (animationDirection === AnimationDirection.Horizontal
           ? animateBackwards


### PR DESCRIPTION
## Previous Behavior
- Focus indicator get cut off in Calendar Month selection
![focus-bug](https://github.com/microsoft/fluentui/assets/11574680/57080020-a2e5-468a-9d87-f34fecac8cd0)

## New Behavior
- Focus should be fully visible
- Removed TRANSITION_ROW_DISAPPEARANCE animation to improve performance
![focus-fix-](https://github.com/microsoft/fluentui/assets/11574680/8443ab1d-344e-4d19-b76c-b6c8686fb7be)
