### PR TITLE
feature(react-tree): onVisibilityChange method to TreeItemLayout action slot

### DIFF
--- a/change/@fluentui-react-tree-c13347b6-7d03-4e17-9814-38c22c21bacd.json
+++ b/change/@fluentui-react-tree-c13347b6-7d03-4e17-9814-38c22c21bacd.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feature: onVisibilityChange method to TreeItemLayout action slot",
+  "packageName": "@fluentui/react-tree",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tree/etc/react-tree.api.md
+++ b/packages/react-components/react-tree/etc/react-tree.api.md
@@ -21,6 +21,8 @@ import { ContextSelector } from '@fluentui/react-context-selector';
 import type { DistributiveOmit } from '@fluentui/react-utilities';
 import type { End } from '@fluentui/keyboard-keys';
 import type { Enter } from '@fluentui/keyboard-keys';
+import type { EventData } from '@fluentui/react-utilities';
+import type { EventHandler } from '@fluentui/react-utilities';
 import type { ExtractSlotProps } from '@fluentui/react-utilities';
 import { ForwardRefComponent } from '@fluentui/react-utilities';
 import type { Home } from '@fluentui/keyboard-keys';
@@ -202,9 +204,7 @@ export type TreeItemLayoutSlots = {
     iconAfter?: Slot<'div'>;
     expandIcon?: Slot<'div'>;
     aside?: Slot<'div'>;
-    actions?: Slot<ExtractSlotProps<Slot<'div'> & {
-        visible?: boolean;
-    }>>;
+    actions?: Slot<TreeItemLayoutActionSlotProps>;
     selector?: Slot<typeof Checkbox> | Slot<typeof Radio>;
 };
 

--- a/packages/react-components/react-tree/src/components/TreeItemLayout/TreeItemLayout.types.ts
+++ b/packages/react-components/react-tree/src/components/TreeItemLayout/TreeItemLayout.types.ts
@@ -1,7 +1,31 @@
-import type { ComponentProps, ComponentState, ExtractSlotProps, Slot } from '@fluentui/react-utilities';
+import type * as React from 'react';
+import type {
+  Slot,
+  ComponentProps,
+  ComponentState,
+  ExtractSlotProps,
+  EventData,
+  EventHandler,
+} from '@fluentui/react-utilities';
 import { ButtonContextValue } from '@fluentui/react-button';
 import { Checkbox } from '@fluentui/react-checkbox';
 import { Radio } from '@fluentui/react-radio';
+
+export type TreeItemLayoutActionVisibilityChangeData = (
+  | EventData<'mouseover' | 'mouseout', MouseEvent>
+  | EventData<'focus' | 'blur', FocusEvent>
+  | EventData<'blur', React.FocusEvent>
+) & { visible: boolean };
+
+export type TreeItemLayoutActionSlotProps = ExtractSlotProps<
+  Slot<'div'> & {
+    /**
+     * Forces visibility of the aside/action content
+     */
+    visible?: boolean;
+    onVisibilityChange?: EventHandler<TreeItemLayoutActionVisibilityChangeData>;
+  }
+>;
 
 export type TreeItemLayoutSlots = {
   root: Slot<'div'>;
@@ -37,16 +61,7 @@ export type TreeItemLayoutSlots = {
    *
    * `actions` slot supports a `visible` prop to force visibility of the actions.
    */
-  actions?: Slot<
-    ExtractSlotProps<
-      Slot<'div'> & {
-        /**
-         * Forces visibility of the aside/action content
-         */
-        visible?: boolean;
-      }
-    >
-  >;
+  actions?: Slot<TreeItemLayoutActionSlotProps>;
   selector?: Slot<typeof Checkbox> | Slot<typeof Radio>;
 };
 


### PR DESCRIPTION


<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

1. adds `onVisibilityChange` method to `TreeItemLayout` `action` slot signature

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/31584
