### PR TITLE
ci: remove codesandbox ci

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,6 +1,0 @@
-{
-  "buildCommand": "build:codesandbox",
-  "packages": ["packages/react", "packages/react-components/react-components"],
-  "sandboxes": ["x5u3t", "spnyu"],
-  "node": "20"
-}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "scripts": {
     "dedupe": "npx yarn-deduplicate --strategy fewer",
     "build": "lage build --verbose",
-    "build:codesandbox": "yarn build --to @fluentui/react --to @fluentui/react-components",
     "buildci": "lage build test lint type-check test-ssr verify-packaging --verbose",
     "builddemo": "yarn build --to public-docsite-resources",
     "buildto": "lage build --verbose --to",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

Recently codesandbox pipelines started failing on every PR

_Example:_

https://github.com/microsoft/fluentui/pull/31586
![image](https://github.com/microsoft/fluentui/assets/1223799/d2ad9a61-1738-40c0-a5c6-7e758b2d084a)

Why?

I dunno 🕵️‍♂️ but it is clearly broken on their side as those pipeline Pass but show as failed within our PRs

![image](https://github.com/microsoft/fluentui/assets/1223799/44136e03-a806-46a8-b68b-a410ad7d115d)

**Action:**

- CS app was removed from repo
- this PR removes ci config

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/27531
