### PR TITLE
docs: remove "preview" label from motion stories

### DIFF
--- a/packages/react-components/react-motion/stories/CreateMotionComponent/index.stories.ts
+++ b/packages/react-components/react-motion/stories/CreateMotionComponent/index.stories.ts
@@ -11,7 +11,7 @@ export { MotionArrays as arrays } from './MotionArrays.stories';
 export { MotionFunctions as functions } from './MotionFunctions.stories';
 
 export default {
-  title: 'Utilities/Web Motions (Preview)/createMotionComponent',
+  title: 'Utilities/Web Motions/createMotionComponent',
   component: null,
   parameters: {
     docs: {

--- a/packages/react-components/react-motion/stories/PresenceGroup/index.stories.ts
+++ b/packages/react-components/react-motion/stories/PresenceGroup/index.stories.ts
@@ -3,7 +3,7 @@ import PresenceGroupDescription from './PresenceGroupDescription.md';
 export { PresenceGroupDefault as Default } from './PresenceGroupDefault.stories';
 
 export default {
-  title: 'Utilities/Web Motions (Preview)/PresenceGroup',
+  title: 'Utilities/Web Motions/PresenceGroup',
   component: null,
   parameters: {
     docs: {


### PR DESCRIPTION
See title. Missed in #31574.