### PR TITLE
docs(react-skeleton): extend Skeleton story with SkeletonItem examples

### DIFF
--- a/packages/react-components/react-skeleton/stories/Skeleton/SkeletonItemShape.stories.tsx
+++ b/packages/react-components/react-skeleton/stories/Skeleton/SkeletonItemShape.stories.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import { Skeleton, SkeletonItem, makeStyles, tokens } from '@fluentui/react-components';
+
+const useStyles = makeStyles({
+  invertedWrapper: {
+    background: tokens.colorNeutralBackground1,
+    display: 'flex',
+    padding: tokens.spacingHorizontalXL,
+  },
+  row: {
+    display: 'grid',
+    gap: tokens.spacingHorizontalL,
+    gridTemplateColumns: '1fr 150px 1fr',
+  },
+});
+
+export const Shape = () => {
+  const styles = useStyles();
+  return (
+    <div className={styles.invertedWrapper}>
+      <Skeleton className={styles.row}>
+        <SkeletonItem size={64} shape="circle" />
+        <SkeletonItem size={64} shape="rectangle" />
+        <SkeletonItem size={64} shape="square" />
+      </Skeleton>
+    </div>
+  );
+};
+
+Shape.parameters = {
+  docs: {
+    description: {
+      story: `The shape of the \`SkeletonItem\` can be set to circle, rectangle, or square.`,
+    },
+  },
+};

--- a/packages/react-components/react-skeleton/stories/Skeleton/SkeletonItemSize.stories.tsx
+++ b/packages/react-components/react-skeleton/stories/Skeleton/SkeletonItemSize.stories.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import { Skeleton, SkeletonItem, makeStyles, Text, tokens } from '@fluentui/react-components';
+
+const useStyles = makeStyles({
+  wrapper: {
+    display: 'flex',
+    background: tokens.colorNeutralBackground1,
+    flexDirection: 'column',
+    padding: tokens.spacingHorizontalXL,
+    gap: tokens.spacingVerticalL,
+  },
+  innerWrapper: {
+    display: 'grid',
+    alignItems: 'center',
+    gridTemplateColumns: '25px 1fr',
+    gridGap: tokens.spacingHorizontalS,
+  },
+});
+
+const SIZES = [8, 12, 16, 20, 24, 28, 32, 36, 40, 48, 56, 64, 72, 96, 120, 128] as const;
+
+export const Size = () => {
+  const styles = useStyles();
+  return (
+    <div className={styles.wrapper}>
+      {SIZES.map(size => (
+        <div key={size} className={styles.innerWrapper}>
+          <Text align="center">{size}</Text>
+          <Skeleton>
+            <SkeletonItem size={size} />
+          </Skeleton>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+Size.parameters = {
+  docs: {
+    description: {
+      story: `You can specify the size of the \`SkeletonItem\` by using the \`size\` prop.
+      The size is a number that represents the height of the \`SkeletonItem\` in pixels`,
+    },
+  },
+};

--- a/packages/react-components/react-skeleton/stories/Skeleton/index.stories.tsx
+++ b/packages/react-components/react-skeleton/stories/Skeleton/index.stories.tsx
@@ -7,6 +7,8 @@ export { Default } from './SkeletonDefault.stories';
 export { Appearance } from './SkeletonAppearance.stories';
 export { Animation } from './SkeletonAnimation.stories';
 export { Row } from './SkeletonRow.stories';
+export { Size } from './SkeletonItemSize.stories';
+export { Shape } from './SkeletonItemShape.stories';
 
 export default {
   title: 'Components/Skeleton',


### PR DESCRIPTION
Resolves #31222. Extended `Skeleton` story to have `SkeletonItem` examples for `size` and `shape` props. Tbh, not sure if it deserves completely separated tab, as `SkeletonItem` isn't standalone and supposed to be used as a child component of `Skeleton`.

## Related Issue(s)
#31222