### PR TITLE
fix(web-components): update dialog border

### DIFF
--- a/change/@fluentui-web-components-cb78e90b-9ba3-4165-8ed1-8aa132f8403e.json
+++ b/change/@fluentui-web-components-cb78e90b-9ba3-4165-8ed1-8aa132f8403e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Move dialog border styles to forcedColors mode",
+  "packageName": "@fluentui/web-components",
+  "email": "rupertdavid@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/dialog/dialog.styles.ts
+++ b/packages/web-components/src/dialog/dialog.styles.ts
@@ -12,6 +12,7 @@ import {
   shadow64,
   strokeWidthThin,
 } from '../theme/design-tokens.js';
+import { forcedColorsStylesheetBehavior } from '../utils/behaviors/match-media-stylesheet-behavior.js';
 
 /** Dialog styles
  * @public
@@ -28,9 +29,10 @@ export const styles = css`
     }
 
     dialog {
+      box-sizing: border-box;
       background: ${colorNeutralBackground1};
       border-radius: ${borderRadiusXLarge};
-      border: ${strokeWidthThin} solid ${colorTransparentStroke};
+      border: none;
       box-shadow: ${shadow64};
       color: ${colorNeutralForeground1};
       max-height: calc(-48px + 100vh);
@@ -88,4 +90,12 @@ export const styles = css`
       }
     }
   }
-`;
+`.withBehaviors(
+  forcedColorsStylesheetBehavior(css`
+    @layer base {
+      dialog {
+        border: ${strokeWidthThin} solid ${colorTransparentStroke};
+      }
+    }
+  `),
+);

--- a/packages/web-components/src/dialog/dialog.styles.ts
+++ b/packages/web-components/src/dialog/dialog.styles.ts
@@ -29,7 +29,6 @@ export const styles = css`
     }
 
     dialog {
-      box-sizing: border-box;
       background: ${colorNeutralBackground1};
       border-radius: ${borderRadiusXLarge};
       border: none;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x ] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

![Screenshot 2024-06-06 at 2 14 06 PM](https://github.com/microsoft/fluentui/assets/42218/2d4342d1-0883-4fde-ab15-e332098ff36d)

Unnecessary/unwanted visible border around dialogs

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
![Screenshot 2024-06-06 at 2 14 59 PM](https://github.com/microsoft/fluentui/assets/42218/df233810-8701-463c-83ed-f6ca429555a3)
![Screenshot 2024-06-06 at 2 15 48 PM](https://github.com/microsoft/fluentui/assets/42218/52518307-c527-47b4-9990-6dc220bc8310)

Moved border per Figma design spec into Forced Colors mode. 

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
