### PR TITLE
Update Accordion Size story to allow collapsing

### DIFF
--- a/packages/react-components/react-accordion/stories/Accordion/AccordionSizes.stories.tsx
+++ b/packages/react-components/react-accordion/stories/Accordion/AccordionSizes.stories.tsx
@@ -7,7 +7,7 @@ export const Sizes = () => (
       <AccordionItem value="1">
         <AccordionHeader size="small">Small Header</AccordionHeader>
         <AccordionPanel>
-          <div>Accordion Panel 1</div>
+          <div>Accordion Panel</div>
         </AccordionPanel>
       </AccordionItem>
     </Accordion>
@@ -15,7 +15,7 @@ export const Sizes = () => (
       <AccordionItem value="1">
         <AccordionHeader size="medium">Medium Header</AccordionHeader>
         <AccordionPanel>
-          <div>Accordion Panel 1</div>
+          <div>Accordion Panel</div>
         </AccordionPanel>
       </AccordionItem>
     </Accordion>
@@ -23,7 +23,7 @@ export const Sizes = () => (
       <AccordionItem value="1">
         <AccordionHeader size="large">Large Header</AccordionHeader>
         <AccordionPanel>
-          <div>Accordion Panel 1</div>
+          <div>Accordion Panel</div>
         </AccordionPanel>
       </AccordionItem>
     </Accordion>
@@ -31,7 +31,7 @@ export const Sizes = () => (
       <AccordionItem value="1">
         <AccordionHeader size="extra-large">Extra-Large Header</AccordionHeader>
         <AccordionPanel>
-          <div>Accordion Panel 1</div>
+          <div>Accordion Panel</div>
         </AccordionPanel>
       </AccordionItem>
     </Accordion>
@@ -41,7 +41,7 @@ export const Sizes = () => (
 Sizes.parameters = {
   docs: {
     description: {
-      story: 'An accordion supports `small`, `medium`, `large` and `extra-large` header sizes.',
+      story: 'AccordionHeader supports `small`, `medium`, `large` and `extra-large` sizes.',
     },
   },
 };

--- a/packages/react-components/react-accordion/stories/Accordion/AccordionSizes.stories.tsx
+++ b/packages/react-components/react-accordion/stories/Accordion/AccordionSizes.stories.tsx
@@ -5,7 +5,7 @@ export const Sizes = () => (
   <>
     <Accordion collapsible>
       <AccordionItem value="1">
-        <AccordionHeader size="small">Accordion Header 1</AccordionHeader>
+        <AccordionHeader size="small">Small Header</AccordionHeader>
         <AccordionPanel>
           <div>Accordion Panel 1</div>
         </AccordionPanel>

--- a/packages/react-components/react-accordion/stories/Accordion/AccordionSizes.stories.tsx
+++ b/packages/react-components/react-accordion/stories/Accordion/AccordionSizes.stories.tsx
@@ -3,7 +3,7 @@ import { Accordion, AccordionHeader, AccordionItem, AccordionPanel } from '@flue
 
 export const Sizes = () => (
   <>
-    <Accordion>
+    <Accordion collapsible>
       <AccordionItem value="1">
         <AccordionHeader size="small">Accordion Header 1</AccordionHeader>
         <AccordionPanel>
@@ -11,25 +11,25 @@ export const Sizes = () => (
         </AccordionPanel>
       </AccordionItem>
     </Accordion>
-    <Accordion>
+    <Accordion collapsible>
       <AccordionItem value="1">
-        <AccordionHeader size="medium">Accordion Header 1</AccordionHeader>
+        <AccordionHeader size="medium">Medium Header</AccordionHeader>
         <AccordionPanel>
           <div>Accordion Panel 1</div>
         </AccordionPanel>
       </AccordionItem>
     </Accordion>
-    <Accordion>
+    <Accordion collapsible>
       <AccordionItem value="1">
-        <AccordionHeader size="large">Accordion Header 1</AccordionHeader>
+        <AccordionHeader size="large">Large Header</AccordionHeader>
         <AccordionPanel>
           <div>Accordion Panel 1</div>
         </AccordionPanel>
       </AccordionItem>
     </Accordion>
-    <Accordion>
+    <Accordion collapsible>
       <AccordionItem value="1">
-        <AccordionHeader size="extra-large">Accordion Header 1</AccordionHeader>
+        <AccordionHeader size="extra-large">Extra-Large Header</AccordionHeader>
         <AccordionPanel>
           <div>Accordion Panel 1</div>
         </AccordionPanel>
@@ -41,7 +41,7 @@ export const Sizes = () => (
 Sizes.parameters = {
   docs: {
     description: {
-      story: 'An accordion supports `small`, `medium`, `large` and `extra-large` sizes.',
+      story: 'An accordion supports `small`, `medium`, `large` and `extra-large` header sizes.',
     },
   },
 };


### PR DESCRIPTION
## Previous Behavior

The Accordion Size story has multiple different accordions to show the different sizes, but appears broken because they can't be collapsed when another is opened.

## New Behavior

Add `collapsible` to the accordions in this story, and update the header text to be more descriptive. 

Note: an alternative would be to combine the sizes into a single accordion panel, but mixing sizes in a single accordion isn't recommended, and we prefer to avoid non-recommended usages in story examples.

## Related Issue(s)

- Fixes #31610
