### PR TITLE
fix: corrects the border-color for switch when in the checked state on rest

### DIFF
--- a/change/@fluentui-web-components-1fa74631-ff88-48ec-a0c6-15691f79e0a1.json
+++ b/change/@fluentui-web-components-1fa74631-ff88-48ec-a0c6-15691f79e0a1.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fixes the border-color for switch when in the checked state on rest",
+  "packageName": "@fluentui/web-components",
+  "email": "13071055+chrisdholt@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/switch/switch.styles.ts
+++ b/packages/web-components/src/switch/switch.styles.ts
@@ -67,6 +67,7 @@ export const styles = css`
   }
   :host(${checkedState}) {
     background: ${colorCompoundBrandBackground};
+    border-color: ${colorCompoundBrandBackground};
   }
   :host(${checkedState}:hover) {
     background: ${colorCompoundBrandBackgroundHover};


### PR DESCRIPTION
## Previous Behavior
The border color maintains the unchecked rest state color, which is incorrect. The color should match the fill in a checked state.

## New Behavior
The border color matches the fill state as per the design file.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
