### PR TITLE
fix: allow updating of CSS properties when they are already defined

### DIFF
--- a/change/@fluentui-web-components-55475f34-e514-43d2-9e62-b2f8ce5d3cb3.json
+++ b/change/@fluentui-web-components-55475f34-e514-43d2-9e62-b2f8ce5d3cb3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "add try-catch block to ensure that registered properties can be updated dynamically",
+  "packageName": "@fluentui/web-components",
+  "email": "13071055+chrisdholt@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/theme/set-theme.ts
+++ b/packages/web-components/src/theme/set-theme.ts
@@ -11,11 +11,15 @@ const tokenNames = Object.keys(tokens) as (keyof Theme)[];
 export const setTheme = (theme: Theme) => {
   for (const t of tokenNames) {
     if ('registerProperty' in CSS) {
-      CSS.registerProperty({
-        name: `--${t}`,
-        inherits: true,
-        initialValue: theme[t] as string,
-      });
+      try {
+        CSS.registerProperty({
+          name: `--${t}`,
+          inherits: true,
+          initialValue: theme[t] as string,
+        });
+      } catch {
+        document.body.style.setProperty(`--${t}`, theme[t] as string);
+      }
     } else {
       document.body.style.setProperty(`--${t}`, theme[t] as string);
     }


### PR DESCRIPTION
## Previous Behavior
Dynamically updating CSS properties is not working because once a property is registered you cannot register it again.
## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
This PR adds a try/catch block to mitigate the issue and ensure that if a property has already been registered the value is updated in the DOM. In the case where something is not registered, it will use the registerProperty method. In the case it has already been registered, this will ensure the property gets updated.

- Fixes #
