### PR TITLE
fix(react-checkbox): adjust indicator type to include span

### DIFF
--- a/change/@fluentui-react-checkbox-0bd07ac3-68d9-4702-a438-ddb46d25af4e.json
+++ b/change/@fluentui-react-checkbox-0bd07ac3-68d9-4702-a438-ddb46d25af4e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "adjust indicator type to include span",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-checkbox/library/docs/Spec.md
+++ b/packages/react-components/react-checkbox/library/docs/Spec.md
@@ -136,7 +136,7 @@ See [Checkbox.types.ts](../src/components/Checkbox/Checkbox.types.ts)
 - `root`: Outermost `<span>` that contains the rest of the slots
 - `input`: The HTML `<input type="checkbox">`. This is the **primary** slot: it receives all of the native props passed to the
   Checkbox component. It has opacity 0 and overlaps the entire `root` slot, for hit testing.
-- `indicator`: A `<div>` that is the visual representation of the check "box". Its child is the checkmark icon.
+- `indicator`: A `<span>` that is the visual representation of the check "box". Its child is the checkmark icon.
 - `label`: (optional) The `<label>` describing this checkbox.
 
 ### **Public**
@@ -161,9 +161,9 @@ See [Checkbox.types.ts](../src/components/Checkbox/Checkbox.types.ts)
 ```html
 <span class="fui-Checkbox">
   <input type="checkbox" id="checkbox-1" class="fui-Checkbox__input" />
-  <div aria-hidden="true" class="fui-Checkbox__indicator">
+  <span aria-hidden="true" class="fui-Checkbox__indicator">
     <CheckmarkRegular />
-  </div>
+  </span>
   <label for="checkbox-1" className="fui-Checkbox__label">Example Checkbox</label>
 </span>
 ```

--- a/packages/react-components/react-checkbox/library/etc/react-checkbox.api.md
+++ b/packages/react-components/react-checkbox/library/etc/react-checkbox.api.md
@@ -42,7 +42,7 @@ export type CheckboxSlots = {
     root: NonNullable<Slot<'span'>>;
     label?: Slot<typeof Label>;
     input: NonNullable<Slot<'input'>>;
-    indicator: Slot<'div'>;
+    indicator: Slot<'div', 'span'>;
 };
 
 // @public

--- a/packages/react-components/react-checkbox/library/src/components/Checkbox/Checkbox.types.ts
+++ b/packages/react-components/react-checkbox/library/src/components/Checkbox/Checkbox.types.ts
@@ -27,7 +27,10 @@ export type CheckboxSlots = {
   /**
    * The checkbox, with the checkmark icon as its child when checked.
    */
-  indicator: Slot<'div'>;
+  // FIXME: this should be 'span' by default, because you cannot have a 'div' inside of a 'span'
+  // but changing the signature would be a breaking change
+  // TODO: change the default value to 'span' in the next major
+  indicator: Slot<'div', 'span'>;
 };
 
 /**


### PR DESCRIPTION
Indicator type is extended to accept `span`. Added warning comments about current incorrect semantics and updated the doc file to have correct semantics. 
Have to be removed in the next major. 

Partially fixes #29969 