### PR TITLE
fix: show default title action in dialog body for modal dialogs

### DIFF
--- a/change/@fluentui-web-components-24db3759-9402-48da-b37b-d829a7c7902a.json
+++ b/change/@fluentui-web-components-24db3759-9402-48da-b37b-d829a7c7902a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: show default title action in dialog-body for modal dialogs",
+  "packageName": "@fluentui/web-components",
+  "email": "13071055+chrisdholt@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/dialog-body/dialog-body.spec.ts
+++ b/packages/web-components/src/dialog-body/dialog-body.spec.ts
@@ -27,7 +27,7 @@ test.describe('Dialog Body', () => {
     `);
 
     await expect(element).toBeVisible();
-    await expect(closeButton).toBeHidden();
+    await expect(closeButton).toBeVisible();
   });
 
   test('should add default close button for non-modal dialogs', async ({ page }) => {

--- a/packages/web-components/src/dialog-body/dialog-body.template.ts
+++ b/packages/web-components/src/dialog-body/dialog-body.template.ts
@@ -25,7 +25,7 @@ export const template: ElementViewTemplate = html`
     <slot name="title"></slot>
     <slot name="title-action">
       <fluent-button
-        ?hidden=${x => x.noTitleAction || x.parentNode?.type !== DialogType.nonModal}
+        ?hidden=${x => x.noTitleAction || x.parentNode?.type === DialogType.alert}
         tabindex="0"
         part="title-action"
         class="title-action"


### PR DESCRIPTION
## Previous Behavior
Title action would only show by default for non-modal dialogs.

## New Behavior
Title action will show by default for both non-modal and modal dialogs. It is hidden by default for alert dialogs.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
