### PR TITLE
fix(scripts-beachball): ignore web-components packages from v8 release scope

### DIFF
--- a/change/@fluentui-react-infobutton-bf89c268-c7d9-4643-a950-446a32a51e7e.json
+++ b/change/@fluentui-react-infobutton-bf89c268-c7d9-4643-a950-446a32a51e7e.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "chore: bump @griffel/react",
-  "packageName": "@fluentui/react-infobutton",
-  "email": "olfedias@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@fluentui-react-motions-preview-2a7ccd1a-4e03-4c37-812f-a8abe7a8fde4.json
+++ b/change/@fluentui-react-motions-preview-2a7ccd1a-4e03-4c37-812f-a8abe7a8fde4.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "feat(react-motions): add grouped motions",
-  "packageName": "@fluentui/react-motions-preview",
-  "email": "olfedias@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@fluentui-react-motions-preview-8fed56ea-bf79-45b6-966d-c8e1b83efc50.json
+++ b/change/@fluentui-react-motions-preview-8fed56ea-bf79-45b6-966d-c8e1b83efc50.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "BREAKING: remove event argument from \"onMotionFinish\" prop",
-  "packageName": "@fluentui/react-motions-preview",
-  "email": "olfedias@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@fluentui-react-motions-preview-dffb90ce-ff7d-44d5-8d92-31d75815ea2d.json
+++ b/change/@fluentui-react-motions-preview-dffb90ce-ff7d-44d5-8d92-31d75815ea2d.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "BREAKING: remove `iterations` prop from createMotionComponent()",
-  "packageName": "@fluentui/react-motions-preview",
-  "email": "olfedias@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@fluentui-react-motions-preview-e1a364d2-4a00-430c-b330-736eaf432fd7.json
+++ b/change/@fluentui-react-motions-preview-e1a364d2-4a00-430c-b330-736eaf432fd7.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "chore: export types for component props",
-  "packageName": "@fluentui/react-motions-preview",
-  "email": "olfedias@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@fluentui-react-motions-preview-f7e0f94c-24bd-4fa0-bae2-886019aac40f.json
+++ b/change/@fluentui-react-motions-preview-f7e0f94c-24bd-4fa0-bae2-886019aac40f.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "breaking: AtomMotionFn & PresenceMotionFn have an object as param",
-  "packageName": "@fluentui/react-motions-preview",
-  "email": "olfedias@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@fluentui-react-search-preview-799fdb3b-d35b-4f1d-a246-2e4f524927ca.json
+++ b/change/@fluentui-react-search-preview-799fdb3b-d35b-4f1d-a246-2e4f524927ca.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "chore: Update react-icons to 2.0.235",
-  "packageName": "@fluentui/react-search-preview",
-  "email": "ololubek@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@fluentui-react-swatch-picker-preview-827150f2-7642-4787-ad58-1bfe3bbd31ec.json
+++ b/change/@fluentui-react-swatch-picker-preview-827150f2-7642-4787-ad58-1bfe3bbd31ec.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "chore: bump @griffel/react",
-  "packageName": "@fluentui/react-swatch-picker-preview",
-  "email": "olfedias@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@fluentui-react-tag-picker-preview-35e06389-b8ac-46fa-a9a9-c186c3c2941e.json
+++ b/change/@fluentui-react-tag-picker-preview-35e06389-b8ac-46fa-a9a9-c186c3c2941e.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "fix: move focus on backspace press; fix space key closing dropdown",
-  "packageName": "@fluentui/react-tag-picker-preview",
-  "email": "bernardo.sunderhus@gmail.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@fluentui-react-tag-picker-preview-4dc187e5-80b6-49e0-9937-0ab7ada11736.json
+++ b/change/@fluentui-react-tag-picker-preview-4dc187e5-80b6-49e0-9937-0ab7ada11736.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "bugfix: fixes padding error introduced by PR 31272",
-  "packageName": "@fluentui/react-tag-picker-preview",
-  "email": "bernardo.sunderhus@gmail.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@fluentui-react-tag-picker-preview-7bcdff38-0f92-440f-a2e7-b36bad408a21.json
+++ b/change/@fluentui-react-tag-picker-preview-7bcdff38-0f92-440f-a2e7-b36bad408a21.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "chore: bump @griffel/react",
-  "packageName": "@fluentui/react-tag-picker-preview",
-  "email": "olfedias@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@fluentui-react-tag-picker-preview-f8f44d4f-94d1-47ff-818c-80bce94db23c.json
+++ b/change/@fluentui-react-tag-picker-preview-f8f44d4f-94d1-47ff-818c-80bce94db23c.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": " chore: Upgrade react-icons version to 2.0.239 to pick up provider export map fix.",
-  "packageName": "@fluentui/react-tag-picker-preview",
-  "email": "ololubek@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/scripts/beachball/src/config.test.ts
+++ b/scripts/beachball/src/config.test.ts
@@ -4,6 +4,8 @@ import webComponentsConfig from './release-web-components.config';
 import { config as sharedConfig } from './shared.config';
 
 describe(`beachball configs`, () => {
+  const excludedPackagesFromReleaseProcess = ['!packages/fluentui/*'];
+
   it(`should generate shared config`, () => {
     expect(sharedConfig).toEqual({
       changehint: "Run 'yarn change' to generate a change file",
@@ -45,9 +47,10 @@ describe(`beachball configs`, () => {
   it(`should generate v8 release config`, () => {
     expect(v8Config.scope).toEqual(
       expect.arrayContaining([
-        '!packages/fluentui/*',
+        ...excludedPackagesFromReleaseProcess,
         '!apps/perf-test-react-components',
         '!apps/vr-tests-react-components',
+        '!packages/web-components',
       ]),
     );
     expect(v8Config.scope.some(scope => scope.startsWith('!packages/react-'))).toBe(true);
@@ -55,11 +58,9 @@ describe(`beachball configs`, () => {
   });
 
   it(`should generate vNext release config`, () => {
-    const excludedPackages = ['!packages/fluentui/*'];
-
     expect(vNextConfig.scope).toEqual(
       expect.arrayContaining([
-        ...excludedPackages,
+        ...excludedPackagesFromReleaseProcess,
         'apps/perf-test-react-components',
         'apps/vr-tests-react-components',
       ]),
@@ -67,7 +68,7 @@ describe(`beachball configs`, () => {
 
     expect(vNextConfig.scope.some(scope => scope.startsWith('packages/react-'))).toBe(true);
 
-    const includeScopes = vNextConfig.scope.filter(scope => !excludedPackages.includes(scope));
+    const includeScopes = vNextConfig.scope.filter(scope => !excludedPackagesFromReleaseProcess.includes(scope));
 
     expect(vNextConfig.changelog.customRenderers).toEqual(sharedConfig.changelog.customRenderers);
     expect(vNextConfig.changelog.groups).toEqual([
@@ -82,15 +83,12 @@ describe(`beachball configs`, () => {
   it(`should generate web-components release config`, () => {
     expect(webComponentsConfig.scope).toEqual(
       expect.arrayContaining([
+        ...excludedPackagesFromReleaseProcess,
+        'apps/vr-tests-web-components',
         'packages/web-components',
-        '!packages/fluentui/*',
-        '!apps/*',
-        '!apps/perf-test-react-components',
-        '!apps/vr-tests-react-components',
-        '!packages/react-components/react-components',
       ]),
     );
-    expect(webComponentsConfig.scope.some(scope => scope.startsWith('!packages/react-'))).toBe(true);
+
     expect(webComponentsConfig.changelog).toEqual(sharedConfig.changelog);
   });
 });


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

`web-components` were not ignored within v8 release scope, thus invalid releases have been triggered every-time web-components added a change file. 

Even more confusion was added to changelog.md v8 files which  refers to web-component changes with date of web-component release.

Example:

https://github.com/microsoft/fluentui/blob/master/packages/react/CHANGELOG.md#81176 points to https://github.com/microsoft/fluentui/pull/31585/files which was released https://github.com/microsoft/fluentui/blob/master/packages/web-components/CHANGELOG.md#300-beta24

## New Behavior

- `web-components` tagged packages are excluded from v8 `scope` 
- `web-components` tagged packages are explicitly provided to web-components release-scope without ignoring all v9 tagged packages ( which is not needed )

**Extra:**

- invalid changefiles are removed

<img width="1503" alt="image" src="https://github.com/microsoft/fluentui/assets/1223799/0d645748-66c7-48f2-a354-9aec2e74721b">


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/31476
