### PR TITLE
feat: update Avatar to leverage ElementInternals for role and color states

### DIFF
--- a/change/@fluentui-web-components-a05b784c-1559-4ccd-b8f2-0c5e7818fdfb.json
+++ b/change/@fluentui-web-components-a05b784c-1559-4ccd-b8f2-0c5e7818fdfb.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "update avatar to use ElementInternals for role and states for color",
+  "packageName": "@fluentui/web-components",
+  "email": "13071055+chrisdholt@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/docs/api-report.md
+++ b/packages/web-components/docs/api-report.md
@@ -193,13 +193,20 @@ export type AnchorTarget = ValuesOf<typeof AnchorTarget>;
 
 // @public
 export class Avatar extends FASTElement {
+    constructor();
     active?: AvatarActive | undefined;
     appearance?: AvatarAppearance | undefined;
     color?: AvatarColor;
+    // @internal
+    colorChanged(): void;
     colorId?: AvatarNamedColor | undefined;
+    // @internal
+    colorIdChanged(): void;
     static colors: ("anchor" | "dark-red" | "cranberry" | "red" | "pumpkin" | "peach" | "marigold" | "gold" | "brass" | "brown" | "forest" | "seafoam" | "dark-green" | "light-teal" | "teal" | "steel" | "blue" | "royal-blue" | "cornflower" | "navy" | "lavender" | "purple" | "grape" | "lilac" | "pink" | "magenta" | "plum" | "beige" | "mink" | "platinum")[];
     // @internal
-    generateColor(): AvatarColor | void;
+    elementInternals: ElementInternals;
+    // @internal
+    generateColor(): void;
     // @internal
     generateInitials(): string | void;
     initials?: string | undefined;

--- a/packages/web-components/docs/api-report.md
+++ b/packages/web-components/docs/api-report.md
@@ -196,19 +196,21 @@ export class Avatar extends FASTElement {
     constructor();
     active?: AvatarActive | undefined;
     appearance?: AvatarAppearance | undefined;
-    color?: AvatarColor;
-    // @internal
-    colorChanged(): void;
+    color?: AvatarColor | undefined;
     colorId?: AvatarNamedColor | undefined;
-    // @internal
-    colorIdChanged(): void;
     static colors: ("anchor" | "dark-red" | "cranberry" | "red" | "pumpkin" | "peach" | "marigold" | "gold" | "brass" | "brown" | "forest" | "seafoam" | "dark-green" | "light-teal" | "teal" | "steel" | "blue" | "royal-blue" | "cornflower" | "navy" | "lavender" | "purple" | "grape" | "lilac" | "pink" | "magenta" | "plum" | "beige" | "mink" | "platinum")[];
+    // (undocumented)
+    connectedCallback(): void;
+    // (undocumented)
+    disconnectedCallback(): void;
     // @internal
     elementInternals: ElementInternals;
     // @internal
     generateColor(): void;
     // @internal
     generateInitials(): string | void;
+    // @internal
+    handleChange(source: any, propertyName: string): void;
     initials?: string | undefined;
     name?: string | undefined;
     shape?: AvatarShape | undefined;

--- a/packages/web-components/src/avatar/avatar.spec.ts
+++ b/packages/web-components/src/avatar/avatar.spec.ts
@@ -155,7 +155,7 @@ test.describe('Avatar Component', () => {
   test('should prioritize color derivation from colorId over name when set to "colorful"', async () => {
     await root.evaluate(node => {
       node.innerHTML = /* html */ `
-        <fluent-avatar color-id="pumpkin" name="John Doe" color="colorful"></fluent-avatar>
+        <fluent-avatar color-id="pumpkin" name="Steve Smith" color="colorful"></fluent-avatar>
       `;
     });
 

--- a/packages/web-components/src/avatar/avatar.spec.ts
+++ b/packages/web-components/src/avatar/avatar.spec.ts
@@ -139,31 +139,17 @@ test.describe('Avatar Component', () => {
   });
 
   test('default color should be neutral', async () => {
-    expect(await element.evaluate((node: Avatar) => node.elementInternals.states.has(`neutral`))).toBe(true);
+    expect(await element.evaluate((node: Avatar) => node.elementInternals.states.has('neutral'))).toBe(true);
   });
 
-  test('should default to a specific color when "colorful" is set without name or colorId', async () => {
-    await element.evaluate((node: Avatar) => {
-      node.color = 'colorful';
-    });
-    const generatedColor = await element.evaluate((node: Avatar) => {
-      return node.generateColor();
-    });
-    expect(await element.evaluate((node: Avatar) => node.elementInternals.states.has(`${generatedColor}`))).toBe(true);
-  });
-
-  test('should derive the color from the name attribute when set to "colorful"', async () => {
+  test('should add a custom state of `brand` when `brand is provided as the color', async () => {
     await root.evaluate(node => {
       node.innerHTML = /* html */ `
-        <fluent-avatar name="John Doe" color="colorful"></fluent-avatar>
+        <fluent-avatar color-id="pumpkin" name="John Doe" color="brand"></fluent-avatar>
       `;
     });
 
-    const generatedColor = await element.evaluate((node: Avatar) => {
-      return node.generateColor();
-    });
-
-    expect(await element.evaluate((node: Avatar) => node.elementInternals.states.has(`${generatedColor}`))).toBe(true);
+    expect(await element.evaluate((node: Avatar) => node.elementInternals.states.has('brand'))).toBe(true);
   });
 
   test('should prioritize color derivation from colorId over name when set to "colorful"', async () => {
@@ -173,10 +159,7 @@ test.describe('Avatar Component', () => {
       `;
     });
 
-    const generatedColor = await element.evaluate((node: Avatar) => {
-      return node.generateColor();
-    });
-    expect(await element.evaluate((node: Avatar) => node.elementInternals.states.has(`${generatedColor}`))).toBe(true);
+    expect(await element.evaluate((node: Avatar) => node.elementInternals.states.has('pumpkin'))).toBe(true);
   });
 
   for (const [, value] of Object.entries(colorAttributes)) {

--- a/packages/web-components/src/avatar/avatar.spec.ts
+++ b/packages/web-components/src/avatar/avatar.spec.ts
@@ -87,6 +87,11 @@ test.describe('Avatar Component', () => {
     await expect(element).toBeVisible();
   });
 
+  test('should have a role of img', async () => {
+    await page.waitForSelector('fluent-avatar');
+    await expect(element).toHaveJSProperty('elementInternals.role', 'img');
+  });
+
   test('When no name value is set, should render with custom initials based on the provided initials value', async () => {
     await root.evaluate(node => {
       node.innerHTML = /* html */ `
@@ -134,7 +139,7 @@ test.describe('Avatar Component', () => {
   });
 
   test('default color should be neutral', async () => {
-    await expect(element).toHaveAttribute('data-color', `neutral`);
+    expect(await element.evaluate((node: Avatar) => node.elementInternals.states.has(`neutral`))).toBe(true);
   });
 
   test('should default to a specific color when "colorful" is set without name or colorId', async () => {
@@ -144,7 +149,7 @@ test.describe('Avatar Component', () => {
     const generatedColor = await element.evaluate((node: Avatar) => {
       return node.generateColor();
     });
-    await expect(element).toHaveAttribute('data-color', `${generatedColor}`);
+    expect(await element.evaluate((node: Avatar) => node.elementInternals.states.has(`${generatedColor}`))).toBe(true);
   });
 
   test('should derive the color from the name attribute when set to "colorful"', async () => {
@@ -158,7 +163,7 @@ test.describe('Avatar Component', () => {
       return node.generateColor();
     });
 
-    await expect(element).toHaveAttribute('data-color', `${generatedColor}`);
+    expect(await element.evaluate((node: Avatar) => node.elementInternals.states.has(`${generatedColor}`))).toBe(true);
   });
 
   test('should prioritize color derivation from colorId over name when set to "colorful"', async () => {
@@ -171,7 +176,7 @@ test.describe('Avatar Component', () => {
     const generatedColor = await element.evaluate((node: Avatar) => {
       return node.generateColor();
     });
-    await expect(element).toHaveAttribute('data-color', `${generatedColor}`);
+    expect(await element.evaluate((node: Avatar) => node.elementInternals.states.has(`${generatedColor}`))).toBe(true);
   });
 
   for (const [, value] of Object.entries(colorAttributes)) {

--- a/packages/web-components/src/avatar/avatar.styles.ts
+++ b/packages/web-components/src/avatar/avatar.styles.ts
@@ -322,157 +322,157 @@ export const styles = css`
     border-radius: ${borderRadiusXLarge};
   }
 
-  :host([data-color='brand']) {
+  :host(:is([state--brand], :state(brand))) {
     color: ${colorNeutralForegroundStaticInverted};
     background-color: ${colorBrandBackgroundStatic};
   }
 
-  :host([data-color='dark-red']) {
+  :host(:is([state--dark-red], :state(dark-red))) {
     color: ${colorPaletteDarkRedForeground2};
     background-color: ${colorPaletteDarkRedBackground2};
   }
 
-  :host([data-color='cranberry']) {
+  :host(:is([state--cranberry], :state(cranberry))) {
     color: ${colorPaletteCranberryForeground2};
     background-color: ${colorPaletteCranberryBackground2};
   }
 
-  :host([data-color='red']) {
+  :host(:is([state--red], :state(red))) {
     color: ${colorPaletteRedForeground2};
     background-color: ${colorPaletteRedBackground2};
   }
 
-  :host([data-color='pumpkin']) {
+  :host(:is([state--pumpkin], :state(pumpkin))) {
     color: ${colorPalettePumpkinForeground2};
     background-color: ${colorPalettePumpkinBackground2};
   }
 
-  :host([data-color='peach']) {
+  :host(:is([state--peach], :state(peach))) {
     color: ${colorPalettePeachForeground2};
     background-color: ${colorPalettePeachBackground2};
   }
 
-  :host([data-color='marigold']) {
+  :host(:is([state--marigold], :state(marigold))) {
     color: ${colorPaletteMarigoldForeground2};
     background-color: ${colorPaletteMarigoldBackground2};
   }
 
-  :host([data-color='gold']) {
+  :host(:is([state--gold], :state(gold))) {
     color: ${colorPaletteGoldForeground2};
     background-color: ${colorPaletteGoldBackground2};
   }
 
-  :host([data-color='brass']) {
+  :host(:is([state--brass], :state(brass))) {
     color: ${colorPaletteBrassForeground2};
     background-color: ${colorPaletteBrassBackground2};
   }
 
-  :host([data-color='brown']) {
+  :host(:is([state--brown], :state(brown))) {
     color: ${colorPaletteBrownForeground2};
     background-color: ${colorPaletteBrownBackground2};
   }
 
-  :host([data-color='forest']) {
+  :host(:is([state--forest], :state(forest))) {
     color: ${colorPaletteForestForeground2};
     background-color: ${colorPaletteForestBackground2};
   }
 
-  :host([data-color='seafoam']) {
+  :host(:is([state--seafoam], :state(seafoam))) {
     color: ${colorPaletteSeafoamForeground2};
     background-color: ${colorPaletteSeafoamBackground2};
   }
 
-  :host([data-color='dark-green']) {
+  :host(:is([state--dark-green], :state(dark-green))) {
     color: ${colorPaletteDarkGreenForeground2};
     background-color: ${colorPaletteDarkGreenBackground2};
   }
 
-  :host([data-color='light-teal']) {
+  :host(:is([state--light-teal], :state(light-teal))) {
     color: ${colorPaletteLightTealForeground2};
     background-color: ${colorPaletteLightTealBackground2};
   }
 
-  :host([data-color='teal']) {
+  :host(:is([state--teal], :state(teal))) {
     color: ${colorPaletteTealForeground2};
     background-color: ${colorPaletteTealBackground2};
   }
 
-  :host([data-color='steel']) {
+  :host(:is([state--steel], :state(steel))) {
     color: ${colorPaletteSteelForeground2};
     background-color: ${colorPaletteSteelBackground2};
   }
 
-  :host([data-color='blue']) {
+  :host(:is([state--blue], :state(blue))) {
     color: ${colorPaletteBlueForeground2};
     background-color: ${colorPaletteBlueBackground2};
   }
 
-  :host([data-color='royal-blue']) {
+  :host(:is([state--royal-blue], :state(royal-blue))) {
     color: ${colorPaletteRoyalBlueForeground2};
     background-color: ${colorPaletteRoyalBlueBackground2};
   }
 
-  :host([data-color='cornflower']) {
+  :host(:is([state--cornflower], :state(cornflower))) {
     color: ${colorPaletteCornflowerForeground2};
     background-color: ${colorPaletteCornflowerBackground2};
   }
 
-  :host([data-color='navy']) {
+  :host(:is([state--navy], :state(navy))) {
     color: ${colorPaletteNavyForeground2};
     background-color: ${colorPaletteNavyBackground2};
   }
 
-  :host([data-color='lavender']) {
+  :host(:is([state--lavender], :state(lavender))) {
     color: ${colorPaletteLavenderForeground2};
     background-color: ${colorPaletteLavenderBackground2};
   }
 
-  :host([data-color='purple']) {
+  :host(:is([state--purple], :state(purple))) {
     color: ${colorPalettePurpleForeground2};
     background-color: ${colorPalettePurpleBackground2};
   }
 
-  :host([data-color='grape']) {
+  :host(:is([state--grape], :state(grape))) {
     color: ${colorPaletteGrapeForeground2};
     background-color: ${colorPaletteGrapeBackground2};
   }
 
-  :host([data-color='lilac']) {
+  :host(:is([state--lilac], :state(lilac))) {
     color: ${colorPaletteLilacForeground2};
     background-color: ${colorPaletteLilacBackground2};
   }
 
-  :host([data-color='pink']) {
+  :host(:is([state--pink], :state(pink))) {
     color: ${colorPalettePinkForeground2};
     background-color: ${colorPalettePinkBackground2};
   }
 
-  :host([data-color='magenta']) {
+  :host(:is([state--magenta], :state(magenta))) {
     color: ${colorPaletteMagentaForeground2};
     background-color: ${colorPaletteMagentaBackground2};
   }
 
-  :host([data-color='plum']) {
+  :host(:is([state--plum], :state(plum))) {
     color: ${colorPalettePlumForeground2};
     background-color: ${colorPalettePlumBackground2};
   }
 
-  :host([data-color='beige']) {
+  :host(:is([state--beige], :state(beige))) {
     color: ${colorPaletteBeigeForeground2};
     background-color: ${colorPaletteBeigeBackground2};
   }
 
-  :host([data-color='mink']) {
+  :host(:is([state--mink], :state(mink))) {
     color: ${colorPaletteMinkForeground2};
     background-color: ${colorPaletteMinkBackground2};
   }
 
-  :host([data-color='platinum']) {
+  :host(:is([state--platinum], :state(platinum))) {
     color: ${colorPalettePlatinumForeground2};
     background-color: ${colorPalettePlatinumBackground2};
   }
 
-  :host([data-color='anchor']) {
+  :host(:is([state--anchor], :state(anchor))) {
     color: ${colorPaletteAnchorForeground2};
     background-color: ${colorPaletteAnchorBackground2};
   }

--- a/packages/web-components/src/avatar/avatar.template.ts
+++ b/packages/web-components/src/avatar/avatar.template.ts
@@ -21,10 +21,8 @@ const defaultIconTemplate = html`<svg
  */
 export function avatarTemplate<T extends Avatar>(): ElementViewTemplate<T> {
   return html<T>`
-    <template role="img" data-color=${x => x.generateColor()}>
-      <slot>${x => (x.name || x.initials ? x.generateInitials() : defaultIconTemplate)}</slot>
-      <slot name="badge"></slot>
-    </template>
+    <slot>${x => (x.name || x.initials ? x.generateInitials() : defaultIconTemplate)}</slot>
+    <slot name="badge"></slot>
   `;
 }
 

--- a/packages/web-components/src/avatar/avatar.ts
+++ b/packages/web-components/src/avatar/avatar.ts
@@ -124,7 +124,9 @@ export class Avatar extends FASTElement {
 
     Observable.getNotifier(this).subscribe(this);
 
-    this.generateColor();
+    Object.keys(this.$fastController.definition.attributeLookup).forEach(key => {
+      this.handleChange(this, key);
+    });
   }
 
   public disconnectedCallback(): void {
@@ -140,7 +142,7 @@ export class Avatar extends FASTElement {
    * @param propertyName - the property name being changed
    */
   public handleChange(source: any, propertyName: string) {
-    if (propertyName === ('color' || 'color-id')) {
+    if (propertyName === ('color' || 'colorId')) {
       this.generateColor();
     }
   }
@@ -159,7 +161,7 @@ export class Avatar extends FASTElement {
         ? (Avatar.colors[getHashCode(this.colorId ?? this.name ?? '') % Avatar.colors.length] as AvatarColor)
         : this.color;
 
-    toggleState(this.elementInternals, color);
+    toggleState(this.elementInternals, color, !!this.color);
   }
 
   /**

--- a/packages/web-components/src/avatar/avatar.ts
+++ b/packages/web-components/src/avatar/avatar.ts
@@ -1,5 +1,6 @@
 import { attr, FASTElement, nullableNumberConverter } from '@microsoft/fast-element';
 import { getInitials } from '../utils/get-initials.js';
+import { toggleState } from '../utils/element-internals.js';
 import {
   AvatarActive,
   AvatarAppearance,
@@ -14,6 +15,13 @@ import {
  * @public
  */
 export class Avatar extends FASTElement {
+  /**
+   * The internal {@link https://developer.mozilla.org/docs/Web/API/ElementInternals | `ElementInternals`} instance for the component.
+   *
+   * @internal
+   */
+  public elementInternals: ElementInternals = this.attachInternals();
+
   /**
    * The name of the person or entity represented by this Avatar. This should always be provided if it is available.
    *
@@ -99,6 +107,14 @@ export class Avatar extends FASTElement {
   public color?: AvatarColor = 'neutral';
 
   /**
+   * Synchronizes the color with the element internals state
+   * @internal
+   */
+  public colorChanged(): void {
+    this.generateColor();
+  }
+
+  /**
    * Specify a string to be used instead of the name, to determine which color to use when color="colorful".
    * Use this when a name is not available, but there is another unique identifier that can be used instead.
    */
@@ -106,17 +122,34 @@ export class Avatar extends FASTElement {
   public colorId?: AvatarNamedColor | undefined;
 
   /**
+   * Synchronizes the color with the element internals state when the colorId is changed
+   * @internal
+   */
+  public colorIdChanged(): void {
+    this.generateColor();
+  }
+
+  constructor() {
+    super();
+
+    this.elementInternals.role = 'img';
+  }
+
+  /**
    * Sets the data-color attribute used for the visual presentation
    * @internal
    */
-  public generateColor(): AvatarColor | void {
+  public generateColor(): void {
     if (!this.color) {
       return;
     }
 
-    return this.color === AvatarColor.colorful
-      ? (Avatar.colors[getHashCode(this.colorId ?? this.name ?? '') % Avatar.colors.length] as AvatarColor)
-      : this.color;
+    const color =
+      this.color === AvatarColor.colorful
+        ? (Avatar.colors[getHashCode(this.colorId ?? this.name ?? '') % Avatar.colors.length] as AvatarColor)
+        : this.color;
+
+    toggleState(this.elementInternals, color);
   }
 
   /**

--- a/packages/web-components/src/avatar/avatar.ts
+++ b/packages/web-components/src/avatar/avatar.ts
@@ -1,4 +1,4 @@
-import { attr, FASTElement, nullableNumberConverter } from '@microsoft/fast-element';
+import { attr, FASTElement, nullableNumberConverter, Observable } from '@microsoft/fast-element';
 import { getInitials } from '../utils/get-initials.js';
 import { toggleState } from '../utils/element-internals.js';
 import {
@@ -107,32 +107,42 @@ export class Avatar extends FASTElement {
   public color?: AvatarColor = 'neutral';
 
   /**
-   * Synchronizes the color with the element internals state
-   * @internal
-   */
-  public colorChanged(): void {
-    this.generateColor();
-  }
-
-  /**
    * Specify a string to be used instead of the name, to determine which color to use when color="colorful".
    * Use this when a name is not available, but there is another unique identifier that can be used instead.
    */
   @attr({ attribute: 'color-id' })
   public colorId?: AvatarNamedColor | undefined;
 
-  /**
-   * Synchronizes the color with the element internals state when the colorId is changed
-   * @internal
-   */
-  public colorIdChanged(): void {
-    this.generateColor();
-  }
-
   constructor() {
     super();
 
     this.elementInternals.role = 'img';
+  }
+
+  public connectedCallback(): void {
+    super.connectedCallback();
+
+    Observable.getNotifier(this).subscribe(this);
+
+    this.generateColor();
+  }
+
+  public disconnectedCallback(): void {
+    super.disconnectedCallback();
+
+    Observable.getNotifier(this).unsubscribe(this);
+  }
+
+  /**
+   * Handles changes to observable properties
+   * @internal
+   * @param source - the source of the change
+   * @param propertyName - the property name being changed
+   */
+  public handleChange(source: any, propertyName: string) {
+    if (propertyName === ('color' || 'color-id')) {
+      this.generateColor();
+    }
   }
 
   /**


### PR DESCRIPTION
## Previous Behavior
Avatar applies the role and color in the DOM.

## New Behavior
Avatar uses ElementInternals for the role and setting a custom state (with attribute fallback) for colors, to avoid sprouting unnecessary attributes.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
