### PR TITLE
ci: tweak release commit message in order to easily determine what release did happen from git history

### DIFF
--- a/azure-pipelines.release-vnext.yml
+++ b/azure-pipelines.release-vnext.yml
@@ -84,7 +84,7 @@ extends:
                 displayName: yarn build
 
               - script: |
-                  yarn publish:beachball -n $(npmToken) --config scripts/beachball/src/release-vNext.config.js
+                  yarn publish:beachball -n $(npmToken) --config scripts/beachball/src/release-vNext.config.js --message 'release: applying package updates - react-components'
                   git reset --hard origin/master
                 env:
                   GITHUB_PAT: $(githubPAT)

--- a/azure-pipelines.release.web-components.yml
+++ b/azure-pipelines.release.web-components.yml
@@ -75,7 +75,7 @@ extends:
                 displayName: Build, [test], Lint
 
               - script: |
-                  yarn publish:beachball -n $(npmToken) --config scripts/beachball/src/release-web-components.config.js
+                  yarn publish:beachball -n $(npmToken) --config scripts/beachball/src/release-web-components.config.js 'release: applying package updates - web-components'
                   git reset --hard origin/master
                 env:
                   GITHUB_PAT: $(githubPAT)

--- a/azure-pipelines.release.web-components.yml
+++ b/azure-pipelines.release.web-components.yml
@@ -75,7 +75,7 @@ extends:
                 displayName: Build, [test], Lint
 
               - script: |
-                  yarn publish:beachball -n $(npmToken) --config scripts/beachball/src/release-web-components.config.js 'release: applying package updates - web-components'
+                  yarn publish:beachball -n $(npmToken) --config scripts/beachball/src/release-web-components.config.js --message 'release: applying package updates - web-components'
                   git reset --hard origin/master
                 env:
                   GITHUB_PAT: $(githubPAT)

--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -120,7 +120,7 @@ extends:
                 displayName: yarn bundle
 
               - script: |
-                  yarn publish:beachball -n $(npmToken) --config scripts/beachball/src/release-v8.config.js
+                  yarn publish:beachball -n $(npmToken) --config scripts/beachball/src/release-v8.config.js --message 'release: applying package updates - react v8'
                   git reset --hard origin/master
                 env:
                   GITHUB_PAT: $(githubPAT)


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

when release is triggered it creates commit with generic message `applying package updates`, which is not obvious for what library/framework did the release happen.

## New Behavior

when release is triggered it creates commit with proper context about library/framework:

`release: applying package updates - <framework-name>`

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
