### PR TITLE
add data support to option

### DIFF
--- a/change/@fluentui-react-combobox-f82862de-39d9-42be-a5f6-0d9ba31eb83b.json
+++ b/change/@fluentui-react-combobox-f82862de-39d9-42be-a5f6-0d9ba31eb83b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add data support for option",
+  "packageName": "@fluentui/react-combobox",
+  "email": "mingyuanyu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/library/src/components/Option/Option.test.tsx
+++ b/packages/react-components/react-combobox/library/src/components/Option/Option.test.tsx
@@ -184,6 +184,7 @@ describe('Option', () => {
 
     expect(typeof registerProps?.id).toEqual('string');
     expect(registerProps?.disabled).toBeFalsy();
+    expect(registerProps?.data).toBeFalsy();
     expect(registerProps?.value).toEqual('Option 1');
     expect(registerProps?.text).toEqual('Option 1');
     expect(registerRef).toEqual(getByRole('option'));
@@ -193,7 +194,7 @@ describe('Option', () => {
     const registerOption = jest.fn();
     render(
       <ListboxContext.Provider value={{ ...defaultContextValues, registerOption }}>
-        <Option id="op1" disabled value="foo" text="Option 1">
+        <Option id="op1" disabled value="foo" text="Option 1" data={{ property: 'This is option 1' }}>
           text content
         </Option>
       </ListboxContext.Provider>,
@@ -204,6 +205,7 @@ describe('Option', () => {
     expect(registerProps?.id).toEqual('op1');
     expect(registerProps?.disabled).toBeTruthy();
     expect(registerProps?.value).toEqual('foo');
+    expect(registerProps?.data).toEqual({ property: 'This is option 1' });
     expect(registerProps?.text).toEqual('Option 1');
   });
 
@@ -229,7 +231,7 @@ describe('Option', () => {
     const { getByRole } = render(
       <ActiveDescendantContextProvider value={{ controller: { focus } as unknown as ActiveDescendantImperativeRef }}>
         <ListboxContext.Provider value={{ ...defaultContextValues, selectOption }}>
-          <Option id="optionId" value="foo">
+          <Option id="optionId" value="foo" data={{ property: 'This is option 1' }}>
             Option 1
           </Option>
         </ListboxContext.Provider>
@@ -237,7 +239,13 @@ describe('Option', () => {
     );
 
     fireEvent.click(getByRole('option'));
-    const optionData = { id: 'optionId', disabled: undefined, text: 'Option 1', value: 'foo' };
+    const optionData = {
+      id: 'optionId',
+      disabled: undefined,
+      text: 'Option 1',
+      value: 'foo',
+      data: { property: 'This is option 1' },
+    };
 
     expect(selectOption).toHaveBeenCalledTimes(1);
     expect(selectOption).toHaveBeenCalledWith(expect.anything(), optionData);

--- a/packages/react-components/react-combobox/library/src/components/Option/Option.types.ts
+++ b/packages/react-components/react-combobox/library/src/components/Option/Option.types.ts
@@ -12,7 +12,8 @@ export type OptionSlots = {
 /**
  * Option Props
  */
-export type OptionProps = ComponentProps<Partial<OptionSlots>> & {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type OptionProps<T = any> = ComponentProps<Partial<OptionSlots>> & {
   /**
    * Sets an option to the `disabled` state.
    * Disabled options cannot be selected, but are still keyboard navigable
@@ -25,6 +26,11 @@ export type OptionProps = ComponentProps<Partial<OptionSlots>> & {
    * Defaults to `text` if not provided.
    */
   value?: string;
+
+  /**
+   * Data available to custom onRender functions.
+   */
+  data?: T;
 } & (
     | {
         /**

--- a/packages/react-components/react-combobox/library/src/components/Option/useOption.tsx
+++ b/packages/react-components/react-combobox/library/src/components/Option/useOption.tsx
@@ -40,7 +40,7 @@ function getTextString(text: string | undefined, children: React.ReactNode) {
  * @param ref - reference to root HTMLElement of Option
  */
 export const useOption_unstable = (props: OptionProps, ref: React.Ref<HTMLElement>): OptionState => {
-  const { children, disabled, text, value } = props;
+  const { children, disabled, text, value, data } = props;
   const optionRef = React.useRef<HTMLElement>(null);
   const optionText = getTextString(text, children);
   const optionValue = value ?? optionText;
@@ -50,8 +50,8 @@ export const useOption_unstable = (props: OptionProps, ref: React.Ref<HTMLElemen
 
   // data used for context registration & events
   const optionData = React.useMemo<OptionValue>(
-    () => ({ id, disabled, text: optionText, value: optionValue }),
-    [id, disabled, optionText, optionValue],
+    () => ({ id, disabled, text: optionText, value: optionValue, data }),
+    [id, disabled, optionText, optionValue, data],
   );
 
   // context values

--- a/packages/react-components/react-combobox/library/src/utils/OptionCollection.types.ts
+++ b/packages/react-components/react-combobox/library/src/utils/OptionCollection.types.ts
@@ -1,4 +1,5 @@
-export type OptionValue = {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type OptionValue<T = any> = {
   /** The disabled state of the option. */
   disabled?: boolean;
 
@@ -10,6 +11,9 @@ export type OptionValue = {
 
   /** The value string of the option. */
   value: string;
+
+  /** The additional data of the option */
+  data?: T;
 };
 
 export type OptionCollectionState = {

--- a/packages/react-components/react-combobox/library/src/utils/Selection.types.ts
+++ b/packages/react-components/react-combobox/library/src/utils/Selection.types.ts
@@ -39,10 +39,12 @@ export type SelectionState = {
  * Data for the onOptionSelect callback.
  * `optionValue` and `optionText` will be undefined if multiple options are modified at once.
  */
-export type OptionOnSelectData = {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type OptionOnSelectData<T = any> = {
   optionValue: string | undefined;
   optionText: string | undefined;
   selectedOptions: string[];
+  data?: T;
 };
 
 /** Possible event types for onOptionSelect */

--- a/packages/react-components/react-combobox/library/src/utils/useSelection.ts
+++ b/packages/react-components/react-combobox/library/src/utils/useSelection.ts
@@ -35,7 +35,12 @@ export const useSelection = (props: SelectionProps): SelectionState => {
       }
 
       setSelectedOptions(newSelection);
-      onOptionSelect?.(event, { optionValue: option.value, optionText: option.text, selectedOptions: newSelection });
+      onOptionSelect?.(event, {
+        optionValue: option.value,
+        optionText: option.text,
+        selectedOptions: newSelection,
+        data: option.data,
+      });
     },
     [onOptionSelect, multiselect, selectedOptions, setSelectedOptions],
   );


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->
While v8 dropdown supports passing data to the click event, v9 does not support this.

## Previous Behavior
No data is passed when option is clicked.

<!-- This is the behavior we have today -->

## New Behavior
Data is passed to then OnOptionSelect event.


<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
