### PR TITLE
Fix dropdown header styles

### DIFF
--- a/change/@fluentui-react-combobox-aa960a4f-c395-4dac-a6cb-45903b66d649.json
+++ b/change/@fluentui-react-combobox-aa960a4f-c395-4dac-a6cb-45903b66d649.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add header font family",
+  "packageName": "@fluentui/react-combobox",
+  "email": "mingyuanyu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/library/src/components/OptionGroup/useOptionGroupStyles.styles.ts
+++ b/packages/react-components/react-combobox/library/src/components/OptionGroup/useOptionGroupStyles.styles.ts
@@ -16,6 +16,7 @@ const useStyles = makeStyles({
     display: 'flex',
     flexDirection: 'column',
     rowGap: tokens.spacingHorizontalXXS,
+    fontFamily: tokens.fontFamilyBase,
 
     '&:not(:last-child)::after': {
       content: '""',


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
There is no font family in the option header.
<!-- This is the behavior we have today -->

## New Behavior
There is font family in the option header style.
![image](https://github.com/microsoft/fluentui/assets/11665103/b558b89a-59b3-4425-8585-8830de9dc1df)

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
