### PR TITLE
feat: Implement `onMotionCancel` callback handler

### DIFF
--- a/change/@fluentui-react-motion-f8cc73b4-883a-4c0a-a9df-8df610c222ff.json
+++ b/change/@fluentui-react-motion-f8cc73b4-883a-4c0a-a9df-8df610c222ff.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: Implement `onMotionCancel` callback handler",
+  "packageName": "@fluentui/react-motion",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-motion/library/cypress.config.ts
+++ b/packages/react-components/react-motion/library/cypress.config.ts
@@ -1,0 +1,3 @@
+import { baseConfig } from '@fluentui/scripts-cypress';
+
+export default baseConfig;

--- a/packages/react-components/react-motion/library/etc/react-motion.api.md
+++ b/packages/react-components/react-motion/library/etc/react-motion.api.md
@@ -52,6 +52,7 @@ export type MotionComponentProps = {
     children: React_2.ReactElement;
     imperativeRef?: React_2.Ref<MotionImperativeRef | undefined>;
     onMotionFinish?: (ev: null) => void;
+    onMotionCancel?: (ev: null) => void;
     onMotionStart?: (ev: null) => void;
 };
 
@@ -88,6 +89,9 @@ export type PresenceComponentProps = {
     children: React_2.ReactElement;
     imperativeRef?: React_2.Ref<MotionImperativeRef | undefined>;
     onMotionFinish?: (ev: null, data: {
+        direction: 'enter' | 'exit';
+    }) => void;
+    onMotionCancel?: (ev: null, data: {
         direction: 'enter' | 'exit';
     }) => void;
     onMotionStart?: (ev: null, data: {

--- a/packages/react-components/react-motion/library/package.json
+++ b/packages/react-components/react-motion/library/package.json
@@ -25,14 +25,17 @@
     "start": "yarn storybook",
     "storybook": "yarn --cwd ../stories storybook",
     "test": "jest --passWithNoTests",
-    "type-check": "just-scripts type-check"
+    "type-check": "just-scripts type-check",
+    "e2e": "cypress run --component",
+    "e2e:local": "cypress open --component"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
     "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-tasks": "*",
+    "@fluentui/scripts-cypress": "*"
   },
   "dependencies": {
     "@fluentui/react-shared-contexts": "^9.19.0",

--- a/packages/react-components/react-motion/library/src/factories/createMotionComponent.ts
+++ b/packages/react-components/react-motion/library/src/factories/createMotionComponent.ts
@@ -95,8 +95,7 @@ export function createMotionComponent<MotionParams extends Record<string, Motion
 
         const handle = animateAtoms(element, atoms, { isReducedMotion: isReducedMotion() });
 
-        handle.onfinish = onMotionFinish;
-        handle.oncancel = onMotionCancel;
+        handle.setMotionEndCallbacks(onMotionFinish, onMotionCancel);
         handleRef.current = handle;
 
         return () => {

--- a/packages/react-components/react-motion/library/src/factories/createPresenceComponent.cy.tsx
+++ b/packages/react-components/react-motion/library/src/factories/createPresenceComponent.cy.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import { mount } from '@cypress/react';
+import { createPresenceComponent } from './createPresenceComponent';
+
+describe('createPresenceComponent', () => {
+  it('should call onMotionCancel', () => {
+    const TestMotion = createPresenceComponent({
+      enter: { keyframes: [{ opacity: 0 }, { opacity: 1 }], duration: 1000 },
+      exit: { keyframes: [{ opacity: 1 }, { opacity: 0 }], duration: 1000 },
+    });
+
+    const TestComponent = () => {
+      const [visible, setVisible] = React.useState(true);
+      const [cancel, setCancel] = React.useState(0);
+
+      return (
+        <>
+          <button id="toggle" onClick={() => setVisible(!visible)}>
+            Toggle
+          </button>
+          <TestMotion
+            visible={visible}
+            onMotionCancel={(ev, data) => {
+              console.log('onMotionCancel', data.direction);
+              setCancel(s => s + 1);
+            }}
+          >
+            <div />
+          </TestMotion>
+
+          <div id="cancel">{cancel}</div>
+        </>
+      );
+    };
+
+    mount(<TestComponent />);
+
+    cy.get('#toggle').click().wait(100).click().get('#cancel').should('have.text', '1');
+  });
+});

--- a/packages/react-components/react-motion/library/src/factories/createPresenceComponent.ts
+++ b/packages/react-components/react-motion/library/src/factories/createPresenceComponent.ts
@@ -147,12 +147,10 @@ export function createPresenceComponent<MotionParams extends Record<string, Moti
         }
 
         handleRef.current = handle;
-        handle.onfinish = () => {
-          handleMotionFinish(direction);
-        };
-        handle.oncancel = () => {
-          handleMotionCancel(direction);
-        };
+        handle.setMotionEndCallbacks(
+          () => handleMotionFinish(direction),
+          () => handleMotionCancel(direction),
+        );
 
         return () => {
           handle.cancel();

--- a/packages/react-components/react-motion/library/src/factories/createPresenceComponent.ts
+++ b/packages/react-components/react-motion/library/src/factories/createPresenceComponent.ts
@@ -32,6 +32,16 @@ export type PresenceComponentProps = {
   onMotionFinish?: (ev: null, data: { direction: 'enter' | 'exit' }) => void;
 
   /**
+   * Callback that is called when the whole motion is cancelled. When a motion is cancelled it does not
+   * emit a finish event but a specific cancel event
+   *
+   * A motion definition can contain multiple animations and therefore multiple "finish" events. The callback is
+   * triggered once all animations have finished with "null" instead of an event object to avoid ambiguity.
+   */
+  // eslint-disable-next-line @nx/workspace-consistent-callback-type -- EventHandler<T> does not support "null"
+  onMotionCancel?: (ev: null, data: { direction: 'enter' | 'exit' }) => void;
+
+  /**
    * Callback that is called when the whole motion starts.
    *
    * A motion definition can contain multiple animations and therefore multiple "start" events. The callback is
@@ -62,8 +72,18 @@ export function createPresenceComponent<MotionParams extends Record<string, Moti
     const itemContext = React.useContext(PresenceGroupChildContext);
     const merged = { ...itemContext, ...props };
 
-    const { appear, children, imperativeRef, onExit, onMotionFinish, onMotionStart, visible, unmountOnExit, ..._rest } =
-      merged;
+    const {
+      appear,
+      children,
+      imperativeRef,
+      onExit,
+      onMotionFinish,
+      onMotionStart,
+      onMotionCancel,
+      visible,
+      unmountOnExit,
+      ..._rest
+    } = merged;
     const params = _rest as Exclude<typeof merged, PresenceComponentProps | typeof itemContext>;
 
     const [mounted, setMounted] = useMountedState(visible, unmountOnExit);
@@ -87,6 +107,10 @@ export function createPresenceComponent<MotionParams extends Record<string, Moti
         setMounted(false);
         onExit?.();
       }
+    });
+
+    const handleMotionCancel = useEventCallback((direction: 'enter' | 'exit') => {
+      onMotionCancel?.(null, { direction });
     });
 
     useIsomorphicLayoutEffect(() => {
@@ -126,6 +150,9 @@ export function createPresenceComponent<MotionParams extends Record<string, Moti
         handle.onfinish = () => {
           handleMotionFinish(direction);
         };
+        handle.oncancel = () => {
+          handleMotionCancel(direction);
+        };
 
         return () => {
           handle.cancel();
@@ -133,7 +160,7 @@ export function createPresenceComponent<MotionParams extends Record<string, Moti
       },
       // Excluding `isFirstMount` from deps to prevent re-triggering the animation on subsequent renders
       // eslint-disable-next-line react-hooks/exhaustive-deps
-      [handleRef, isReducedMotion, handleMotionFinish, handleMotionStart, visible],
+      [handleRef, isReducedMotion, handleMotionFinish, handleMotionStart, handleMotionCancel, visible],
     );
 
     if (mounted) {

--- a/packages/react-components/react-motion/library/src/types.ts
+++ b/packages/react-components/react-motion/library/src/types.ts
@@ -24,6 +24,7 @@ export type PresenceMotionFn<MotionParams extends Record<string, MotionParam> = 
 
 export type AnimationHandle = Pick<Animation, 'cancel' | 'finish' | 'pause' | 'play' | 'playbackRate'> & {
   onfinish: () => void;
+  oncancel: () => void;
 };
 
 export type MotionImperativeRef = {

--- a/packages/react-components/react-motion/library/src/types.ts
+++ b/packages/react-components/react-motion/library/src/types.ts
@@ -23,8 +23,7 @@ export type PresenceMotionFn<MotionParams extends Record<string, MotionParam> = 
 // ---
 
 export type AnimationHandle = Pick<Animation, 'cancel' | 'finish' | 'pause' | 'play' | 'playbackRate'> & {
-  onfinish: () => void;
-  oncancel: () => void;
+  setMotionEndCallbacks: (onfinish: () => void, oncancel: () => void) => void;
 };
 
 export type MotionImperativeRef = {

--- a/packages/react-components/react-motion/library/src/utils/animateAtoms.ts
+++ b/packages/react-components/react-motion/library/src/utils/animateAtoms.ts
@@ -37,6 +37,45 @@ export function animateAtoms(
         animation.playbackRate = rate;
       });
     },
+    set oncancel(callback: () => void) {
+      // Heads up!
+      // Jest uses jsdom as the default environment, which doesn't support the Web Animations API. This no-op is
+      // necessary to avoid errors in tests.
+      //
+      // See https://github.com/microsoft/fluentui/issues/31593
+      // See https://github.com/jsdom/jsdom/issues/3429
+      if (process.env.NODE_ENV === 'test') {
+        if (animations.length === 0) {
+          callback();
+          return;
+        }
+      }
+
+      Promise.allSettled(animations.map(animation => animation.finished)).then(res => {
+        const DOMException = element.ownerDocument.defaultView?.DOMException;
+        const rejected = res.filter(result => result.status === 'rejected');
+        if (!rejected.length) {
+          return;
+        }
+
+        const unexpectedError = rejected.find(result => {
+          if (result.status === 'fulfilled') {
+            return false;
+          }
+
+          return DOMException && result.reason instanceof DOMException && result.reason.name !== 'AbortError';
+        });
+
+        if (!unexpectedError) {
+          callback();
+          return;
+        }
+
+        // This error is not a result of an animation being cancelled - rethrow
+        throw unexpectedError;
+      });
+    },
+
     set onfinish(callback: () => void) {
       // Heads up!
       // Jest uses jsdom as the default environment, which doesn't support the Web Animations API. This no-op is
@@ -59,7 +98,7 @@ export function animateAtoms(
           const DOMException = element.ownerDocument.defaultView?.DOMException;
 
           // Ignores "DOMException: The user aborted a request" that appears if animations are cancelled
-          if (DOMException && err instanceof DOMException) {
+          if (DOMException && err instanceof DOMException && err.name === 'AbortError') {
             return;
           }
 

--- a/packages/react-components/react-motion/library/src/utils/animateAtoms.ts
+++ b/packages/react-components/react-motion/library/src/utils/animateAtoms.ts
@@ -52,7 +52,7 @@ export function animateAtoms(
       }
 
       Promise.allSettled(animations.map(animation => animation.finished)).then(res => {
-        const DOMException = element.ownerDocument.defaultView?.DOMException;
+        const DOMException = element.ownerDocument?.defaultView?.DOMException;
         const rejected = res.filter(result => result.status === 'rejected');
         if (!rejected.length) {
           return;

--- a/packages/react-components/react-motion/library/tsconfig.cy.json
+++ b/packages/react-components/react-motion/library/tsconfig.cy.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "isolatedModules": false,
+    "types": ["node", "cypress", "cypress-storybook/cypress", "cypress-real-events"],
+    "lib": ["ES2019", "dom"]
+  },
+  "include": ["**/*.cy.ts", "**/*.cy.tsx"]
+}

--- a/packages/react-components/react-motion/library/tsconfig.json
+++ b/packages/react-components/react-motion/library/tsconfig.json
@@ -17,6 +17,9 @@
     },
     {
       "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./tsconfig.cy.json"
     }
   ]
 }

--- a/packages/react-components/react-motion/library/tsconfig.lib.json
+++ b/packages/react-components/react-motion/library/tsconfig.lib.json
@@ -16,7 +16,9 @@
     "**/*.test.ts",
     "**/*.test.tsx",
     "**/*.stories.ts",
-    "**/*.stories.tsx"
+    "**/*.stories.tsx",
+    "**/*.cy.ts",
+    "**/*.cy.tsx"
   ],
   "include": ["./src/**/*.ts", "./src/**/*.tsx"]
 }

--- a/packages/react-components/react-motion/library/tsconfig.lib.json
+++ b/packages/react-components/react-motion/library/tsconfig.lib.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "noEmit": false,
-    "lib": ["ES2019", "dom", "ES2020.Promise"],
+    "lib": ["ES2019", "dom"],
     "declaration": true,
     "declarationDir": "../../../../dist/out-tsc/types",
     "outDir": "../../../../dist/out-tsc",

--- a/packages/react-components/react-motion/library/tsconfig.lib.json
+++ b/packages/react-components/react-motion/library/tsconfig.lib.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "noEmit": false,
-    "lib": ["ES2019", "dom"],
+    "lib": ["ES2019", "dom", "ES2020.Promise"],
     "declaration": true,
     "declarationDir": "../../../../dist/out-tsc/types",
     "outDir": "../../../../dist/out-tsc",

--- a/packages/react-components/react-motion/stories/src/CreateMotionComponent/MotionLifecycleCallbacks.stories.md
+++ b/packages/react-components/react-motion/stories/src/CreateMotionComponent/MotionLifecycleCallbacks.stories.md
@@ -2,5 +2,6 @@ A React component created with `createMotionComponent` has the following lifecyc
 
 - `onMotionStart` \- This is called when any motion has started
 - `onMotionFinish` \- This is called when all motions have finished
+- `onMotionCancel` \- This is called when the motion is cancelled, this called instead of `onMotionFinish`. This can happen when the motion component is unmounted before the full motion is finished.
 
 These callbacks can be useful when orchestrating motions or running side effects resulting from a motion.

--- a/packages/react-components/react-motion/stories/src/CreateMotionComponent/MotionLifecycleCallbacks.stories.tsx
+++ b/packages/react-components/react-motion/stories/src/CreateMotionComponent/MotionLifecycleCallbacks.stories.tsx
@@ -124,6 +124,9 @@ export const MotionLifecycleCallbacks = () => {
             setPlaying(false);
             setStatusLog(entries => [[Date.now(), 'onMotionFinish'], ...entries]);
           }}
+          onMotionCancel={() => {
+            setStatusLog(entries => [[Date.now(), 'onMotionCancel'], ...entries]);
+          }}
         >
           <div className={classes.item} />
         </FadeEnter>
@@ -144,7 +147,7 @@ export const MotionLifecycleCallbacks = () => {
 
       <div className={classes.controls}>
         <div>
-          <Button appearance="subtle" disabled={playing} icon={<ReplayFilled />} onClick={() => setCount(s => s + 1)}>
+          <Button appearance="subtle" icon={<ReplayFilled />} onClick={() => setCount(s => s + 1)}>
             Restart
           </Button>
         </div>

--- a/packages/react-components/react-motion/stories/src/CreateMotionComponent/MotionLifecycleCallbacks.stories.tsx
+++ b/packages/react-components/react-motion/stories/src/CreateMotionComponent/MotionLifecycleCallbacks.stories.tsx
@@ -102,7 +102,6 @@ export const MotionLifecycleCallbacks = () => {
 
   const [playbackRate, setPlaybackRate] = React.useState<number>(30);
   const [count, setCount] = React.useState(0);
-  const [playing, setPlaying] = React.useState(false);
 
   // Heads up!
   // This is optional and is intended solely to slow down the animations, making motions more visible in the examples.
@@ -117,11 +116,9 @@ export const MotionLifecycleCallbacks = () => {
           key={count}
           imperativeRef={motionRef}
           onMotionStart={() => {
-            setPlaying(true);
             setStatusLog(entries => [[Date.now(), 'onMotionStart'], ...entries]);
           }}
           onMotionFinish={() => {
-            setPlaying(false);
             setStatusLog(entries => [[Date.now(), 'onMotionFinish'], ...entries]);
           }}
           onMotionCancel={() => {

--- a/packages/react-components/react-motion/stories/src/CreatePresenceComponent/PresenceLifecycleCallbacks.stories.md
+++ b/packages/react-components/react-motion/stories/src/CreatePresenceComponent/PresenceLifecycleCallbacks.stories.md
@@ -2,6 +2,7 @@ A React component created with `createPresenceComponent` has the following lifec
 
 - `onMotionStart` \- This is called when any motion has started
 - `onMotionFinish` \- This is called when all motions have finished
+- `onMotionCancel` \- This is called when the motino is cancelled and is called instead of `onMotionFinish`
 
 These callbacks can be useful when orchestrating motions or running side effects resulting from a motion.
 The lifecycle callbacks apply to both `enter` and `exit` motion definitions.

--- a/packages/react-components/react-motion/stories/src/CreatePresenceComponent/PresenceLifecycleCallbacks.stories.tsx
+++ b/packages/react-components/react-motion/stories/src/CreatePresenceComponent/PresenceLifecycleCallbacks.stories.tsx
@@ -125,6 +125,9 @@ export const PresenceLifecycleCallbacks = () => {
           onMotionFinish={(ev, data) => {
             setStatusLog(entries => [[Date.now(), 'onMotionFinish', data.direction], ...entries]);
           }}
+          onMotionCancel={(ev, data) => {
+            setStatusLog(entries => [[Date.now(), 'onMotionCancel', data.direction], ...entries]);
+          }}
           visible={visible}
         >
           <div className={classes.item} />


### PR DESCRIPTION
 When a motion or presence changes state or is unmounted before it finishes, the internals calls `.cancel` which does not emit a `finish` event.

Adds `onMotionCancel` to presence and motion components so that users can hook into all possible lifecycle events.

Also adds cypress test for this new callback
