### PR TITLE
fix(react-swatch-picker): added aria-labels and fixed popup example

### DIFF
--- a/packages/react-components/react-swatch-picker/stories/src/SwatchPicker/EmptySwatch.stories.tsx
+++ b/packages/react-components/react-swatch-picker/stories/src/SwatchPicker/EmptySwatch.stories.tsx
@@ -49,7 +49,7 @@ export const EmptySwatchExample = () => {
     // "value" should be unique as it's used as a key and for selection
     const newValue = `custom-${newColor} [${items.length - ITEMS_LIMIT}]`;
 
-    setItems([...items, { color: newColor, value: newValue, 'aria-label': newColor }]);
+    setItems([...items, { color: newColor, value: newValue, 'aria-label': `swatch-${newColor}` }]);
   };
 
   return (
@@ -60,10 +60,16 @@ export const EmptySwatchExample = () => {
         onSelectionChange={handleSelect}
       >
         {items.map(item => (
-          <ColorSwatch key={item.value} {...item} />
+          <ColorSwatch key={item.value} aria-live="polite" aria-controls="add-new-color" {...item} />
         ))}
         {emptyItems.map((_, index) => (
-          <EmptySwatch disabled key={index} aria-label={`empty-swatch-${index}`} />
+          <EmptySwatch
+            disabled
+            key={index}
+            aria-label={`empty-swatch-${index}`}
+            aria-live="polite"
+            aria-controls="reset-example"
+          />
         ))}
       </SwatchPicker>
 
@@ -78,6 +84,8 @@ export const EmptySwatchExample = () => {
         name="color-select"
       />
       <Button
+        id="add-new-color"
+        aria-label="Add new color"
         className={styles.button}
         appearance="primary"
         disabled={items.length >= ITEMS_LIMIT}
@@ -85,7 +93,12 @@ export const EmptySwatchExample = () => {
       >
         Add new color
       </Button>
-      <Button className={styles.button} onClick={() => setItems(defaultItems)}>
+      <Button
+        id="reset-example"
+        aria-label="Reset example"
+        className={styles.button}
+        onClick={() => setItems(defaultItems)}
+      >
         Reset example
       </Button>
     </>

--- a/packages/react-components/react-swatch-picker/stories/src/SwatchPicker/SwatchPickerPopup.stories.tsx
+++ b/packages/react-components/react-swatch-picker/stories/src/SwatchPicker/SwatchPickerPopup.stories.tsx
@@ -7,6 +7,7 @@ import {
   PopoverTrigger,
   SwatchPicker,
   ColorSwatch,
+  renderSwatchPickerGrid,
 } from '@fluentui/react-components';
 import type { SwatchPickerOnSelectEventHandler } from '@fluentui/react-components';
 
@@ -22,22 +23,44 @@ const useStyles = makeStyles({
   },
 });
 
-const colors = [
+const colorSet1 = [
   { color: '#FF1921', value: 'FF1921', 'aria-label': 'red' },
-  { color: '#FF7A00', value: 'FF7A00', 'aria-label': 'dark orange' },
-  { color: '#FFC12E', value: 'FFC12E', 'aria-label': 'orange' },
-  { color: '#90D057', value: '90D057', 'aria-label': 'light green' },
   { color: '#00B053', value: '00B053', 'aria-label': 'green' },
   { color: '#00AFED', value: '00AFED', 'aria-label': 'light blue' },
   { color: '#006EBD', value: '006EBD', 'aria-label': 'blue' },
   { color: '#712F9E', value: '712F9E', 'aria-label': 'purple' },
 ];
 
-const gradientColors = [
+const colorSet2 = [
+  { color: '#FF7A00', value: 'FF7A00', 'aria-label': 'dark orange' },
+  { color: '#90D057', value: '90D057', 'aria-label': 'light green' },
+  { color: '#3BC4F5', value: '3BC4F5', 'aria-label': 'light blue 10' },
+  { color: '#1F93E6', value: '1F93E6', 'aria-label': 'blue 10' },
+  { color: '#A01CFa', value: 'A01CFa', 'aria-label': 'bright purple' },
   {
     color: 'linear-gradient(0deg, #FF1921, #FFB92E)',
     value: 'orange-red',
     'aria-label': 'gradient orange-red',
+  },
+  {
+    color: 'linear-gradient(0deg, #00B053, #90D057)',
+    value: 'light-green-gradient',
+    'aria-label': 'gradient light green',
+  },
+  {
+    color: 'linear-gradient(0deg, #006EBD, #00AFED)',
+    value: 'blue gradient',
+    'aria-label': 'gradient blue',
+  },
+  {
+    color: 'linear-gradient(0deg, #712F9E, #00AFED)',
+    value: 'blue-purple',
+    'aria-label': 'gradient blue-purple',
+  },
+  {
+    color: 'linear-gradient(0deg, #fA1CBC, #A01CFa)',
+    value: 'blue-purple',
+    'aria-label': 'gradient pink-purple',
   },
   {
     color: 'linear-gradient(0deg, #FFC12E, #FEFF37)',
@@ -50,24 +73,14 @@ const gradientColors = [
     'aria-label': 'gradient yellow-green',
   },
   {
-    color: 'linear-gradient(0deg, #00B053, #90D057)',
-    value: 'light-green-gradient',
-    'aria-label': 'gradient light green',
-  },
-  {
     color: 'linear-gradient(0deg, #00B053, #00AFED)',
     value: 'green-blue',
     'aria-label': 'gradient green-blue',
   },
   {
-    color: 'linear-gradient(0deg, #006EBD, #00AFED)',
-    value: 'blue gradient',
+    color: 'linear-gradient(0deg, #A01CFA, #00AFED)',
+    value: 'blue-purple gradient',
     'aria-label': 'gradient blue',
-  },
-  {
-    color: 'linear-gradient(0deg, #712F9E, #00AFED)',
-    value: 'blue-purple',
-    'aria-label': 'gradient blue-purple',
   },
   {
     color:
@@ -96,20 +109,26 @@ export const SwatchPickerPopup = () => {
     <>
       <Popover open={popoverOpen} trapFocus onOpenChange={(_, data) => setPopoverOpen(data.open)}>
         <PopoverTrigger disableButtonEnhancement>
-          <Button>Choose color</Button>
+          <Button aria-label="Choose color">Choose color</Button>
         </PopoverTrigger>
 
         <PopoverSurface>
           <h3>Color set 1</h3>
           <SwatchPicker aria-label="SwatchPicker set 1" selectedValue={selectedValue} onSelectionChange={handleSelect}>
-            {colors.map((color, index) => {
+            {colorSet1.map((color, index) => {
               return <ColorSwatch key={`${color.value}-${index}`} {...color} />;
             })}
           </SwatchPicker>
           <h3>Color set 2</h3>
-          <SwatchPicker aria-label="SwatchPicker set 2" selectedValue={selectedValue} onSelectionChange={handleSelect}>
-            {gradientColors.map((color, index) => {
-              return <ColorSwatch key={`${color.value}-${index}`} {...color} />;
+          <SwatchPicker
+            layout="grid"
+            aria-label="SwatchPicker set 2"
+            selectedValue={selectedValue}
+            onSelectionChange={handleSelect}
+          >
+            {renderSwatchPickerGrid({
+              items: colorSet2,
+              columnCount: 5,
             })}
           </SwatchPicker>
         </PopoverSurface>


### PR DESCRIPTION
## Previous Behavior
- aria-labels were missing buttons in EmptySwatch examples
- there were no feedback for user after button clicks

## New Behavior
- Added aria-labels for EmptySwatch examples
- Added live regions for feedback when clicks on buttons occur
- Added grid layout for an example with popup