### PR TITLE
fix(merge-styles): introduce `DeepPartialV2` type to avoid infinite type instantiation and make unions declaration more performant

### DIFF
--- a/change/@fluentui-merge-styles-3328f941-f74b-4a07-8fc0-aca13cacd01f.json
+++ b/change/@fluentui-merge-styles-3328f941-f74b-4a07-8fc0-aca13cacd01f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(merge-styles): improve DeepPartial type infinite recursion triggerpoint",
+  "packageName": "@fluentui/merge-styles",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/merge-styles/etc/merge-styles.api.md
+++ b/packages/merge-styles/etc/merge-styles.api.md
@@ -13,33 +13,37 @@ export type AddSheetCallback = ({ key, sheet }: {
 // @public (undocumented)
 export const cloneCSSStyleSheet: (srcSheet: CSSStyleSheet, targetSheet: CSSStyleSheet) => CSSStyleSheet;
 
+// Warning: (ae-forgotten-export) The symbol "Missing_2" needs to be exported by the entry point index.d.ts
+//
 // @public
-export function concatStyleSets<TStyleSet>(styleSet: TStyleSet | false | null | undefined): IConcatenatedStyleSet<ObjectOnly<TStyleSet>>;
+export function concatStyleSets<TStyleSet>(styleSet: TStyleSet | Missing_2): IConcatenatedStyleSet<ObjectOnly<TStyleSet>>;
 
 // @public
-export function concatStyleSets<TStyleSet1, TStyleSet2>(styleSet1: TStyleSet1 | false | null | undefined | ShadowConfig, styleSet2: TStyleSet2 | false | null | undefined): IConcatenatedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2>>;
+export function concatStyleSets<TStyleSet1, TStyleSet2>(styleSet1: TStyleSet1 | Missing_2 | ShadowConfig, styleSet2: TStyleSet2 | Missing_2): IConcatenatedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2>>;
 
 // @public
-export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3>(styleSet1: TStyleSet1 | false | null | undefined | ShadowConfig, styleSet2: TStyleSet2 | false | null | undefined, styleSet3: TStyleSet3 | false | null | undefined): IConcatenatedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3>>;
+export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3>(styleSet1: TStyleSet1 | Missing_2 | ShadowConfig, styleSet2: TStyleSet2 | Missing_2, styleSet3: TStyleSet3 | Missing_2): IConcatenatedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3>>;
 
 // @public
-export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4>(styleSet1: TStyleSet1 | false | null | undefined | ShadowConfig, styleSet2: TStyleSet2 | false | null | undefined, styleSet3: TStyleSet3 | false | null | undefined, styleSet4: TStyleSet4 | false | null | undefined): IConcatenatedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3> & ObjectOnly<TStyleSet4>>;
+export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4>(styleSet1: TStyleSet1 | Missing_2 | ShadowConfig, styleSet2: TStyleSet2 | Missing_2, styleSet3: TStyleSet3 | Missing_2, styleSet4: TStyleSet4 | Missing_2): IConcatenatedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3> & ObjectOnly<TStyleSet4>>;
 
 // @public
-export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4, TStyleSet5>(styleSet1: TStyleSet1 | false | null | undefined | ShadowConfig, styleSet2: TStyleSet2 | false | null | undefined, styleSet3: TStyleSet3 | false | null | undefined, styleSet4: TStyleSet4 | false | null | undefined, styleSet5: TStyleSet5 | false | null | undefined): IConcatenatedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3> & ObjectOnly<TStyleSet4> & ObjectOnly<TStyleSet5>>;
+export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4, TStyleSet5>(styleSet1: TStyleSet1 | Missing_2 | ShadowConfig, styleSet2: TStyleSet2 | Missing_2, styleSet3: TStyleSet3 | Missing_2, styleSet4: TStyleSet4 | Missing_2, styleSet5: TStyleSet5 | Missing_2): IConcatenatedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3> & ObjectOnly<TStyleSet4> & ObjectOnly<TStyleSet5>>;
 
 // @public
-export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4, TStyleSet5, TStyleSet6>(styleSet1: TStyleSet1 | false | null | undefined | ShadowConfig, styleSet2: TStyleSet2 | false | null | undefined, styleSet3: TStyleSet3 | false | null | undefined, styleSet4: TStyleSet4 | false | null | undefined, styleSet5: TStyleSet5 | false | null | undefined, styleSet6: TStyleSet6 | false | null | undefined): IConcatenatedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3> & ObjectOnly<TStyleSet4> & ObjectOnly<TStyleSet5> & ObjectOnly<TStyleSet6>>;
+export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4, TStyleSet5, TStyleSet6>(styleSet1: TStyleSet1 | Missing_2 | ShadowConfig, styleSet2: TStyleSet2 | Missing_2, styleSet3: TStyleSet3 | Missing_2, styleSet4: TStyleSet4 | Missing_2, styleSet5: TStyleSet5 | Missing_2, styleSet6: TStyleSet6 | Missing_2): IConcatenatedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3> & ObjectOnly<TStyleSet4> & ObjectOnly<TStyleSet5> & ObjectOnly<TStyleSet6>>;
 
 // @public
-export function concatStyleSets(...styleSets: (IStyleSet | false | null | undefined | ShadowConfig)[]): IConcatenatedStyleSet<any>;
+export function concatStyleSets(...styleSets: (IStyleSet | Missing_2 | ShadowConfig)[]): IConcatenatedStyleSet<any>;
 
+// Warning: (ae-forgotten-export) The symbol "DeepPartialV2" needs to be exported by the entry point index.d.ts
+//
 // @public
-export function concatStyleSetsWithProps<TStyleProps, TStyleSet extends IStyleSetBase>(styleProps: TStyleProps, ...allStyles: (IStyleFunctionOrObject<TStyleProps, TStyleSet> | undefined)[]): DeepPartial<TStyleSet>;
+export function concatStyleSetsWithProps<TStyleProps, TStyleSet extends IStyleSetBase>(styleProps: TStyleProps, ...allStyles: (IStyleFunctionOrObject<TStyleProps, TStyleSet> | undefined)[]): DeepPartialV2<TStyleSet>;
 
-// @public
+// @public @deprecated
 export type DeepPartial<T> = {
-    [P in keyof T]?: T[P] extends (infer U)[] ? DeepPartial<U>[] : T[P] extends object ? DeepPartial<T[P]> : T[P];
+    [P in keyof T]?: T[P] extends Array<infer U> ? Array<DeepPartial<U>> : T[P] extends object ? DeepPartial<T[P]> : T[P];
 };
 
 // @public (undocumented)
@@ -139,7 +143,7 @@ export interface IRawStyle extends IRawStyleBase {
     displayName?: string;
     // @deprecated (undocumented)
     selectors?: {
-        [key: string]: IStyle;
+        [key: string]: IStyle_2;
     };
 }
 
@@ -449,14 +453,14 @@ export type IStyle = IStyleBase | IStyleBaseArray;
 export type IStyleBase = IRawStyle | string | false | null | undefined;
 
 // @public (undocumented)
-export interface IStyleBaseArray extends Array<IStyle> {
+export interface IStyleBaseArray extends Array<IStyleBase | IStyleBaseArray> {
 }
 
 // @public
-export type IStyleFunction<TStylesProps, TStyleSet extends IStyleSetBase> = (props: TStylesProps) => DeepPartial<TStyleSet>;
+export type IStyleFunction<TStylesProps, TStyleSet extends IStyleSetBase> = (props: TStylesProps) => DeepPartialV2<TStyleSet>;
 
 // @public
-export type IStyleFunctionOrObject<TStylesProps, TStyleSet extends IStyleSetBase> = IStyleFunction<TStylesProps, TStyleSet> | DeepPartial<TStyleSet>;
+export type IStyleFunctionOrObject<TStylesProps, TStyleSet extends IStyleSetBase> = IStyleFunction<TStylesProps, TStyleSet> | DeepPartialV2<TStyleSet>;
 
 // @public
 export type IStyleSet<TStyleSet extends IStyleSetBase = {
@@ -503,58 +507,54 @@ export function keyframes(timeline: IKeyframes): string;
 // @public (undocumented)
 export const makeShadowConfig: (stylesheetKey: string, inShadow: boolean, window?: Window) => ShadowConfig;
 
+// Warning: (ae-forgotten-export) The symbol "StyleArgWithShadow" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "IStyleOptions" needs to be exported by the entry point index.d.ts
 //
 // @public
-export function mergeCss(args: (IStyle | IStyleBaseArray | false | null | undefined | ShadowConfig) | (IStyle | IStyleBaseArray | false | null | undefined | ShadowConfig)[], options?: IStyleOptions): string;
+export function mergeCss(args: StyleArgWithShadow | StyleArgWithShadow[], options?: IStyleOptions): string;
+
+// Warning: (ae-forgotten-export) The symbol "Missing" needs to be exported by the entry point index.d.ts
+//
+// @public
+export function mergeCssSets<TStyleSet>(styleSets: [TStyleSet | Missing], options?: IStyleOptions): IProcessedStyleSet<ObjectOnly<TStyleSet>>;
 
 // @public
-export function mergeCssSets<TStyleSet>(styleSets: [TStyleSet | false | null | undefined], options?: IStyleOptions): IProcessedStyleSet<ObjectOnly<TStyleSet>>;
+export function mergeCssSets<TStyleSet1, TStyleSet2>(styleSets: [TStyleSet1 | Missing | ShadowConfig, TStyleSet2 | Missing], options?: IStyleOptions): IProcessedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2>>;
 
 // @public
-export function mergeCssSets<TStyleSet1, TStyleSet2>(styleSets: [TStyleSet1 | false | null | undefined | ShadowConfig, TStyleSet2 | false | null | undefined], options?: IStyleOptions): IProcessedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2>>;
+export function mergeCssSets<TStyleSet1, TStyleSet2, TStyleSet3>(styleSets: [TStyleSet1 | Missing | ShadowConfig, TStyleSet2 | Missing, TStyleSet3 | Missing], options?: IStyleOptions): IProcessedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3>>;
 
 // @public
-export function mergeCssSets<TStyleSet1, TStyleSet2, TStyleSet3>(styleSets: [
-TStyleSet1 | false | null | undefined | ShadowConfig,
-TStyleSet2 | false | null | undefined,
-TStyleSet3 | false | null | undefined
-], options?: IStyleOptions): IProcessedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3>>;
+export function mergeCssSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4>(styleSets: [TStyleSet1 | Missing | ShadowConfig, TStyleSet2 | Missing, TStyleSet3 | Missing, TStyleSet4 | Missing], options?: IStyleOptions): IProcessedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3> & ObjectOnly<TStyleSet4>>;
 
 // @public
-export function mergeCssSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4>(styleSets: [
-TStyleSet1 | false | null | undefined | ShadowConfig,
-TStyleSet2 | false | null | undefined,
-TStyleSet3 | false | null | undefined,
-TStyleSet4 | false | null | undefined
-], options?: IStyleOptions): IProcessedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3> & ObjectOnly<TStyleSet4>>;
+export function mergeCssSets<TStyleSet>(styleSet: [TStyleSet | Missing], options?: IStyleOptions): IProcessedStyleSet<ObjectOnly<TStyleSet>>;
 
-// @public
-export function mergeCssSets<TStyleSet>(styleSet: [TStyleSet | false | null | undefined], options?: IStyleOptions): IProcessedStyleSet<ObjectOnly<TStyleSet>>;
+// Warning: (ae-forgotten-export) The symbol "StyleArg" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export function mergeStyles(...args: StyleArg[]): string;
 
 // @public (undocumented)
-export function mergeStyles(...args: (IStyle | IStyleBaseArray | false | null | undefined)[]): string;
+export function mergeStyles(shadowConfig: ShadowConfig, ...args: StyleArg[]): string;
+
+// @public
+export function mergeStyleSets<TStyleSet>(styleSet: TStyleSet | Missing): IProcessedStyleSet<ObjectOnly<TStyleSet>>;
+
+// @public
+export function mergeStyleSets<TStyleSet1, TStyleSet2>(styleSet1: TStyleSet1 | Missing, styleSet2: TStyleSet2 | Missing): IProcessedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2>>;
+
+// @public
+export function mergeStyleSets<TStyleSet1, TStyleSet2, TStyleSet3>(styleSet1: TStyleSet1 | Missing, styleSet2: TStyleSet2 | Missing, styleSet3: TStyleSet3 | Missing): IProcessedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3>>;
+
+// @public
+export function mergeStyleSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4>(styleSet1: TStyleSet1 | Missing, styleSet2: TStyleSet2 | Missing, styleSet3: TStyleSet3 | Missing, styleSet4: TStyleSet4 | Missing): IProcessedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3> & ObjectOnly<TStyleSet4>>;
+
+// @public
+export function mergeStyleSets(...styleSets: Array<IStyleSet | Missing | ShadowConfig>): IProcessedStyleSet<any>;
 
 // @public (undocumented)
-export function mergeStyles(shadowConfig: ShadowConfig, ...args: (IStyle | IStyleBaseArray | false | null | undefined)[]): string;
-
-// @public
-export function mergeStyleSets<TStyleSet>(styleSet: TStyleSet | false | null | undefined): IProcessedStyleSet<ObjectOnly<TStyleSet>>;
-
-// @public
-export function mergeStyleSets<TStyleSet1, TStyleSet2>(styleSet1: TStyleSet1 | false | null | undefined, styleSet2: TStyleSet2 | false | null | undefined): IProcessedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2>>;
-
-// @public
-export function mergeStyleSets<TStyleSet1, TStyleSet2, TStyleSet3>(styleSet1: TStyleSet1 | false | null | undefined, styleSet2: TStyleSet2 | false | null | undefined, styleSet3: TStyleSet3 | false | null | undefined): IProcessedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3>>;
-
-// @public
-export function mergeStyleSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4>(styleSet1: TStyleSet1 | false | null | undefined, styleSet2: TStyleSet2 | false | null | undefined, styleSet3: TStyleSet3 | false | null | undefined, styleSet4: TStyleSet4 | false | null | undefined): IProcessedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3> & ObjectOnly<TStyleSet4>>;
-
-// @public
-export function mergeStyleSets(...styleSets: Array<IStyleSet | undefined | false | null | ShadowConfig>): IProcessedStyleSet<any>;
-
-// @public (undocumented)
-export function mergeStyleSets(shadowConfig: ShadowConfig, ...styleSets: Array<IStyleSet | undefined | false | null>): IProcessedStyleSet<any>;
+export function mergeStyleSets(shadowConfig: ShadowConfig, ...styleSets: Array<IStyleSet | Missing>): IProcessedStyleSet<any>;
 
 // @public (undocumented)
 export type ObjectOnly<TArg> = TArg extends {} ? TArg : {};
@@ -634,6 +634,7 @@ export const SUPPORTS_MODIFYING_ADOPTED_STYLESHEETS: boolean;
 
 // Warnings were encountered during analysis:
 //
+// lib/IRawStyle.d.ts:24:9 - (ae-forgotten-export) The symbol "IStyle_2" needs to be exported by the entry point index.d.ts
 // lib/IStyleSet.d.ts:61:5 - (ae-forgotten-export) The symbol "__MapToFunctionType" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/packages/merge-styles/etc/merge-styles.api.md
+++ b/packages/merge-styles/etc/merge-styles.api.md
@@ -13,28 +13,30 @@ export type AddSheetCallback = ({ key, sheet }: {
 // @public (undocumented)
 export const cloneCSSStyleSheet: (srcSheet: CSSStyleSheet, targetSheet: CSSStyleSheet) => CSSStyleSheet;
 
-// Warning: (ae-forgotten-export) The symbol "Missing_2" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "Missing_3" needs to be exported by the entry point index.d.ts
 //
 // @public
-export function concatStyleSets<TStyleSet>(styleSet: TStyleSet | Missing_2): IConcatenatedStyleSet<ObjectOnly<TStyleSet>>;
+export function concatStyleSets<TStyleSet>(styleSet: TStyleSet | Missing_3): IConcatenatedStyleSet<ObjectOnly<TStyleSet>>;
+
+// Warning: (ae-forgotten-export) The symbol "MissingOrShadowConfig_2" needs to be exported by the entry point index.d.ts
+//
+// @public
+export function concatStyleSets<TStyleSet1, TStyleSet2>(styleSet1: TStyleSet1 | MissingOrShadowConfig_2, styleSet2: TStyleSet2 | Missing_3): IConcatenatedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2>>;
 
 // @public
-export function concatStyleSets<TStyleSet1, TStyleSet2>(styleSet1: TStyleSet1 | Missing_2 | ShadowConfig, styleSet2: TStyleSet2 | Missing_2): IConcatenatedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2>>;
+export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3>(styleSet1: TStyleSet1 | MissingOrShadowConfig_2, styleSet2: TStyleSet2 | Missing_3, styleSet3: TStyleSet3 | Missing_3): IConcatenatedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3>>;
 
 // @public
-export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3>(styleSet1: TStyleSet1 | Missing_2 | ShadowConfig, styleSet2: TStyleSet2 | Missing_2, styleSet3: TStyleSet3 | Missing_2): IConcatenatedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3>>;
+export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4>(styleSet1: TStyleSet1 | MissingOrShadowConfig_2, styleSet2: TStyleSet2 | Missing_3, styleSet3: TStyleSet3 | Missing_3, styleSet4: TStyleSet4 | Missing_3): IConcatenatedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3> & ObjectOnly<TStyleSet4>>;
 
 // @public
-export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4>(styleSet1: TStyleSet1 | Missing_2 | ShadowConfig, styleSet2: TStyleSet2 | Missing_2, styleSet3: TStyleSet3 | Missing_2, styleSet4: TStyleSet4 | Missing_2): IConcatenatedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3> & ObjectOnly<TStyleSet4>>;
+export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4, TStyleSet5>(styleSet1: TStyleSet1 | MissingOrShadowConfig_2, styleSet2: TStyleSet2 | Missing_3, styleSet3: TStyleSet3 | Missing_3, styleSet4: TStyleSet4 | Missing_3, styleSet5: TStyleSet5 | Missing_3): IConcatenatedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3> & ObjectOnly<TStyleSet4> & ObjectOnly<TStyleSet5>>;
 
 // @public
-export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4, TStyleSet5>(styleSet1: TStyleSet1 | Missing_2 | ShadowConfig, styleSet2: TStyleSet2 | Missing_2, styleSet3: TStyleSet3 | Missing_2, styleSet4: TStyleSet4 | Missing_2, styleSet5: TStyleSet5 | Missing_2): IConcatenatedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3> & ObjectOnly<TStyleSet4> & ObjectOnly<TStyleSet5>>;
+export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4, TStyleSet5, TStyleSet6>(styleSet1: TStyleSet1 | MissingOrShadowConfig_2, styleSet2: TStyleSet2 | Missing_3, styleSet3: TStyleSet3 | Missing_3, styleSet4: TStyleSet4 | Missing_3, styleSet5: TStyleSet5 | Missing_3, styleSet6: TStyleSet6 | Missing_3): IConcatenatedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3> & ObjectOnly<TStyleSet4> & ObjectOnly<TStyleSet5> & ObjectOnly<TStyleSet6>>;
 
 // @public
-export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4, TStyleSet5, TStyleSet6>(styleSet1: TStyleSet1 | Missing_2 | ShadowConfig, styleSet2: TStyleSet2 | Missing_2, styleSet3: TStyleSet3 | Missing_2, styleSet4: TStyleSet4 | Missing_2, styleSet5: TStyleSet5 | Missing_2, styleSet6: TStyleSet6 | Missing_2): IConcatenatedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3> & ObjectOnly<TStyleSet4> & ObjectOnly<TStyleSet5> & ObjectOnly<TStyleSet6>>;
-
-// @public
-export function concatStyleSets(...styleSets: (IStyleSet | Missing_2 | ShadowConfig)[]): IConcatenatedStyleSet<any>;
+export function concatStyleSets(...styleSets: (IStyleSet | MissingOrShadowConfig_2)[]): IConcatenatedStyleSet<any>;
 
 // Warning: (ae-forgotten-export) The symbol "DeepPartialV2" needs to be exported by the entry point index.d.ts
 //
@@ -65,7 +67,7 @@ export const GLOBAL_STYLESHEET_KEY = "__global__";
 //
 // @public
 export type IConcatenatedStyleSet<TStyleSet extends IStyleSetBase> = {
-    [P in keyof Omit<TStyleSet, 'subComponentStyles'>]: IStyle;
+    [P in keyof Omit_2<TStyleSet, 'subComponentStyles'>]: IStyle;
 } & {
     subComponentStyles?: {
         [P in keyof TStyleSet['subComponentStyles']]: IStyleFunction<any, any>;
@@ -114,7 +116,7 @@ export type InsertRuleCallback = ({ key, sheet, rule }: InsertRuleArgs) => void;
 
 // @public
 export type IProcessedStyleSet<TStyleSet extends IStyleSetBase> = {
-    [P in keyof Omit<TStyleSet, 'subComponentStyles'>]: string;
+    [P in keyof Omit_2<TStyleSet, 'subComponentStyles'>]: string;
 } & {
     subComponentStyles: {
         [P in keyof TStyleSet['subComponentStyles']]: __MapToFunctionType<TStyleSet['subComponentStyles'] extends infer J ? (P extends keyof J ? J[P] : never) : never>;
@@ -143,7 +145,7 @@ export interface IRawStyle extends IRawStyleBase {
     displayName?: string;
     // @deprecated (undocumented)
     selectors?: {
-        [key: string]: IStyle_2;
+        [key: string]: IStyle;
     };
 }
 
@@ -453,7 +455,7 @@ export type IStyle = IStyleBase | IStyleBaseArray;
 export type IStyleBase = IRawStyle | string | false | null | undefined;
 
 // @public (undocumented)
-export interface IStyleBaseArray extends Array<IStyleBase | IStyleBaseArray> {
+export interface IStyleBaseArray extends Array<IStyle> {
 }
 
 // @public
@@ -466,7 +468,7 @@ export type IStyleFunctionOrObject<TStylesProps, TStyleSet extends IStyleSetBase
 export type IStyleSet<TStyleSet extends IStyleSetBase = {
     [key: string]: any;
 }> = {
-    [P in keyof Omit<TStyleSet, 'subComponentStyles'>]: IStyle;
+    [P in keyof Omit_2<TStyleSet, 'subComponentStyles'>]: IStyle;
 } & {
     subComponentStyles?: {
         [P in keyof TStyleSet['subComponentStyles']]: IStyleFunctionOrObject<any, any>;
@@ -513,22 +515,24 @@ export const makeShadowConfig: (stylesheetKey: string, inShadow: boolean, window
 // @public
 export function mergeCss(args: StyleArgWithShadow | StyleArgWithShadow[], options?: IStyleOptions): string;
 
-// Warning: (ae-forgotten-export) The symbol "Missing" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "Missing_2" needs to be exported by the entry point index.d.ts
 //
 // @public
-export function mergeCssSets<TStyleSet>(styleSets: [TStyleSet | Missing], options?: IStyleOptions): IProcessedStyleSet<ObjectOnly<TStyleSet>>;
+export function mergeCssSets<TStyleSet>(styleSets: [TStyleSet | Missing_2], options?: IStyleOptions): IProcessedStyleSet<ObjectOnly<TStyleSet>>;
+
+// Warning: (ae-forgotten-export) The symbol "MissingOrShadowConfig" needs to be exported by the entry point index.d.ts
+//
+// @public
+export function mergeCssSets<TStyleSet1, TStyleSet2>(styleSets: [TStyleSet1 | MissingOrShadowConfig, TStyleSet2 | Missing_2], options?: IStyleOptions): IProcessedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2>>;
 
 // @public
-export function mergeCssSets<TStyleSet1, TStyleSet2>(styleSets: [TStyleSet1 | Missing | ShadowConfig, TStyleSet2 | Missing], options?: IStyleOptions): IProcessedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2>>;
+export function mergeCssSets<TStyleSet1, TStyleSet2, TStyleSet3>(styleSets: [TStyleSet1 | MissingOrShadowConfig, TStyleSet2 | Missing_2, TStyleSet3 | Missing_2], options?: IStyleOptions): IProcessedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3>>;
 
 // @public
-export function mergeCssSets<TStyleSet1, TStyleSet2, TStyleSet3>(styleSets: [TStyleSet1 | Missing | ShadowConfig, TStyleSet2 | Missing, TStyleSet3 | Missing], options?: IStyleOptions): IProcessedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3>>;
+export function mergeCssSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4>(styleSets: [TStyleSet1 | MissingOrShadowConfig, TStyleSet2 | Missing_2, TStyleSet3 | Missing_2, TStyleSet4 | Missing_2], options?: IStyleOptions): IProcessedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3> & ObjectOnly<TStyleSet4>>;
 
 // @public
-export function mergeCssSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4>(styleSets: [TStyleSet1 | Missing | ShadowConfig, TStyleSet2 | Missing, TStyleSet3 | Missing, TStyleSet4 | Missing], options?: IStyleOptions): IProcessedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3> & ObjectOnly<TStyleSet4>>;
-
-// @public
-export function mergeCssSets<TStyleSet>(styleSet: [TStyleSet | Missing], options?: IStyleOptions): IProcessedStyleSet<ObjectOnly<TStyleSet>>;
+export function mergeCssSets<TStyleSet>(styleSet: [TStyleSet | Missing_2], options?: IStyleOptions): IProcessedStyleSet<ObjectOnly<TStyleSet>>;
 
 // Warning: (ae-forgotten-export) The symbol "StyleArg" needs to be exported by the entry point index.d.ts
 //
@@ -539,22 +543,22 @@ export function mergeStyles(...args: StyleArg[]): string;
 export function mergeStyles(shadowConfig: ShadowConfig, ...args: StyleArg[]): string;
 
 // @public
-export function mergeStyleSets<TStyleSet>(styleSet: TStyleSet | Missing): IProcessedStyleSet<ObjectOnly<TStyleSet>>;
+export function mergeStyleSets<TStyleSet>(styleSet: TStyleSet | Missing_2): IProcessedStyleSet<ObjectOnly<TStyleSet>>;
 
 // @public
-export function mergeStyleSets<TStyleSet1, TStyleSet2>(styleSet1: TStyleSet1 | Missing, styleSet2: TStyleSet2 | Missing): IProcessedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2>>;
+export function mergeStyleSets<TStyleSet1, TStyleSet2>(styleSet1: TStyleSet1 | Missing_2, styleSet2: TStyleSet2 | Missing_2): IProcessedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2>>;
 
 // @public
-export function mergeStyleSets<TStyleSet1, TStyleSet2, TStyleSet3>(styleSet1: TStyleSet1 | Missing, styleSet2: TStyleSet2 | Missing, styleSet3: TStyleSet3 | Missing): IProcessedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3>>;
+export function mergeStyleSets<TStyleSet1, TStyleSet2, TStyleSet3>(styleSet1: TStyleSet1 | Missing_2, styleSet2: TStyleSet2 | Missing_2, styleSet3: TStyleSet3 | Missing_2): IProcessedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3>>;
 
 // @public
-export function mergeStyleSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4>(styleSet1: TStyleSet1 | Missing, styleSet2: TStyleSet2 | Missing, styleSet3: TStyleSet3 | Missing, styleSet4: TStyleSet4 | Missing): IProcessedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3> & ObjectOnly<TStyleSet4>>;
+export function mergeStyleSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4>(styleSet1: TStyleSet1 | Missing_2, styleSet2: TStyleSet2 | Missing_2, styleSet3: TStyleSet3 | Missing_2, styleSet4: TStyleSet4 | Missing_2): IProcessedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3> & ObjectOnly<TStyleSet4>>;
 
 // @public
-export function mergeStyleSets(...styleSets: Array<IStyleSet | Missing | ShadowConfig>): IProcessedStyleSet<any>;
+export function mergeStyleSets(...styleSets: Array<IStyleSet | MissingOrShadowConfig>): IProcessedStyleSet<any>;
 
 // @public (undocumented)
-export function mergeStyleSets(shadowConfig: ShadowConfig, ...styleSets: Array<IStyleSet | Missing>): IProcessedStyleSet<any>;
+export function mergeStyleSets(shadowConfig: ShadowConfig, ...styleSets: Array<IStyleSet | Missing_2>): IProcessedStyleSet<any>;
 
 // @public (undocumented)
 export type ObjectOnly<TArg> = TArg extends {} ? TArg : {};
@@ -638,7 +642,6 @@ export const SUPPORTS_MODIFYING_ADOPTED_STYLESHEETS: boolean;
 
 // Warnings were encountered during analysis:
 //
-// lib/IRawStyle.d.ts:24:9 - (ae-forgotten-export) The symbol "IStyle_2" needs to be exported by the entry point index.d.ts
 // lib/IStyleSet.d.ts:62:5 - (ae-forgotten-export) The symbol "__MapToFunctionType" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/packages/merge-styles/etc/merge-styles.api.md
+++ b/packages/merge-styles/etc/merge-styles.api.md
@@ -65,7 +65,7 @@ export const GLOBAL_STYLESHEET_KEY = "__global__";
 //
 // @public
 export type IConcatenatedStyleSet<TStyleSet extends IStyleSetBase> = {
-    [P in keyof Omit_2<TStyleSet, 'subComponentStyles'>]: IStyle;
+    [P in keyof Omit<TStyleSet, 'subComponentStyles'>]: IStyle;
 } & {
     subComponentStyles?: {
         [P in keyof TStyleSet['subComponentStyles']]: IStyleFunction<any, any>;
@@ -114,7 +114,7 @@ export type InsertRuleCallback = ({ key, sheet, rule }: InsertRuleArgs) => void;
 
 // @public
 export type IProcessedStyleSet<TStyleSet extends IStyleSetBase> = {
-    [P in keyof Omit_2<TStyleSet, 'subComponentStyles'>]: string;
+    [P in keyof Omit<TStyleSet, 'subComponentStyles'>]: string;
 } & {
     subComponentStyles: {
         [P in keyof TStyleSet['subComponentStyles']]: __MapToFunctionType<TStyleSet['subComponentStyles'] extends infer J ? (P extends keyof J ? J[P] : never) : never>;
@@ -466,7 +466,7 @@ export type IStyleFunctionOrObject<TStylesProps, TStyleSet extends IStyleSetBase
 export type IStyleSet<TStyleSet extends IStyleSetBase = {
     [key: string]: any;
 }> = {
-    [P in keyof Omit_2<TStyleSet, 'subComponentStyles'>]: IStyle;
+    [P in keyof Omit<TStyleSet, 'subComponentStyles'>]: IStyle;
 } & {
     subComponentStyles?: {
         [P in keyof TStyleSet['subComponentStyles']]: IStyleFunctionOrObject<any, any>;
@@ -569,12 +569,16 @@ export { Omit_2 as Omit }
 export function setRTL(isRTL: boolean): void;
 
 // @public (undocumented)
-export type ShadowConfig = {
-    stylesheetKey: string;
-    inShadow: boolean;
-    window?: Window;
+export interface ShadowConfig {
+    // (undocumented)
     __isShadowConfig__: true;
-};
+    // (undocumented)
+    inShadow: boolean;
+    // (undocumented)
+    stylesheetKey: string;
+    // (undocumented)
+    window?: Window;
+}
 
 // @public (undocumented)
 export class ShadowDomStylesheet extends Stylesheet {
@@ -635,7 +639,7 @@ export const SUPPORTS_MODIFYING_ADOPTED_STYLESHEETS: boolean;
 // Warnings were encountered during analysis:
 //
 // lib/IRawStyle.d.ts:24:9 - (ae-forgotten-export) The symbol "IStyle_2" needs to be exported by the entry point index.d.ts
-// lib/IStyleSet.d.ts:61:5 - (ae-forgotten-export) The symbol "__MapToFunctionType" needs to be exported by the entry point index.d.ts
+// lib/IStyleSet.d.ts:62:5 - (ae-forgotten-export) The symbol "__MapToFunctionType" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/merge-styles/src/DeepPartial.ts
+++ b/packages/merge-styles/src/DeepPartial.ts
@@ -1,6 +1,22 @@
 /**
  * TypeScript type to return a deep partial object (each property can be undefined, recursively.)
+ * @deprecated - This type will hit infinite type instantiation recursion. Please use {@link DeepPartialV2}
  */
 export type DeepPartial<T> = {
-  [P in keyof T]?: T[P] extends (infer U)[] ? DeepPartial<U>[] : T[P] extends object ? DeepPartial<T[P]> : T[P];
+  // eslint-disable-next-line deprecation/deprecation
+  [P in keyof T]?: T[P] extends Array<infer U> ? Array<DeepPartial<U>> : T[P] extends object ? DeepPartial<T[P]> : T[P];
 };
+
+interface IDeepPartialArray<T> extends Array<DeepPartialV2<T>> {}
+
+type DeepPartialObject<T> = {
+  [Key in keyof T]?: DeepPartialV2<T[Key]>;
+};
+
+export type DeepPartialV2<T> = T extends Function
+  ? T
+  : T extends Array<infer U>
+  ? IDeepPartialArray<U>
+  : T extends object
+  ? DeepPartialObject<T>
+  : T;

--- a/packages/merge-styles/src/IRawStyle.ts
+++ b/packages/merge-styles/src/IRawStyle.ts
@@ -1,5 +1,4 @@
-import { IRawStyleBase } from './IRawStyleBase';
-import { IStyle } from './IStyle';
+import type { IRawStyleBase } from './IRawStyleBase';
 
 /**
  * IRawStyle extends a raw style object, but allows selectors to be defined
@@ -29,3 +28,7 @@ export interface IRawStyle extends IRawStyleBase {
     [key: string]: IStyle;
   };
 }
+
+type IStyleBase = IRawStyle | string | false | null | undefined;
+interface IStyleBaseArray extends Array<IStyleBase | IStyleBaseArray> {}
+type IStyle = IStyleBase | IStyleBaseArray;

--- a/packages/merge-styles/src/IRawStyle.ts
+++ b/packages/merge-styles/src/IRawStyle.ts
@@ -1,4 +1,5 @@
 import type { IRawStyleBase } from './IRawStyleBase';
+import type { IStyle } from './IStyle';
 
 /**
  * IRawStyle extends a raw style object, but allows selectors to be defined
@@ -28,7 +29,3 @@ export interface IRawStyle extends IRawStyleBase {
     [key: string]: IStyle;
   };
 }
-
-type IStyleBase = IRawStyle | string | false | null | undefined;
-interface IStyleBaseArray extends Array<IStyleBase | IStyleBaseArray> {}
-type IStyle = IStyleBase | IStyleBaseArray;

--- a/packages/merge-styles/src/IStyle.ts
+++ b/packages/merge-styles/src/IStyle.ts
@@ -8,7 +8,7 @@ export type IStyleBase = IRawStyle | string | false | null | undefined;
 /**
  * {@docCategory IStyleBaseArray}
  */
-export interface IStyleBaseArray extends Array<IStyleBase | IStyleBaseArray> {}
+export interface IStyleBaseArray extends Array<IStyle> {}
 
 /**
  * IStyleObject extends a raw style objects, but allows selectors to be defined

--- a/packages/merge-styles/src/IStyle.ts
+++ b/packages/merge-styles/src/IStyle.ts
@@ -1,4 +1,4 @@
-import { IRawStyle } from './IRawStyle';
+import type { IRawStyle } from './IRawStyle';
 
 /**
  * {@docCategory IStyleBase}
@@ -8,7 +8,7 @@ export type IStyleBase = IRawStyle | string | false | null | undefined;
 /**
  * {@docCategory IStyleBaseArray}
  */
-export interface IStyleBaseArray extends Array<IStyle> {}
+export interface IStyleBaseArray extends Array<IStyleBase | IStyleBaseArray> {}
 
 /**
  * IStyleObject extends a raw style objects, but allows selectors to be defined

--- a/packages/merge-styles/src/IStyleFunction.ts
+++ b/packages/merge-styles/src/IStyleFunction.ts
@@ -1,5 +1,5 @@
 import { IStyleSetBase } from './IStyleSet';
-import { DeepPartial } from './DeepPartial';
+import type { DeepPartialV2 } from './DeepPartial';
 
 /**
  * A style function takes in styleprops and returns a partial styleset.
@@ -7,7 +7,7 @@ import { DeepPartial } from './DeepPartial';
  */
 export type IStyleFunction<TStylesProps, TStyleSet extends IStyleSetBase> = (
   props: TStylesProps,
-) => DeepPartial<TStyleSet>;
+) => DeepPartialV2<TStyleSet>;
 
 /**
  * Represents either a style function that takes in style props and returns a partial styleset,
@@ -16,4 +16,4 @@ export type IStyleFunction<TStylesProps, TStyleSet extends IStyleSetBase> = (
  */
 export type IStyleFunctionOrObject<TStylesProps, TStyleSet extends IStyleSetBase> =
   | IStyleFunction<TStylesProps, TStyleSet>
-  | DeepPartial<TStyleSet>;
+  | DeepPartialV2<TStyleSet>;

--- a/packages/merge-styles/src/IStyleFunction.ts
+++ b/packages/merge-styles/src/IStyleFunction.ts
@@ -1,5 +1,5 @@
 import { IStyleSetBase } from './IStyleSet';
-import type { DeepPartialV2 } from './DeepPartial';
+import type { DeepPartialV2 as DeepPartial } from './DeepPartial';
 
 /**
  * A style function takes in styleprops and returns a partial styleset.
@@ -7,7 +7,7 @@ import type { DeepPartialV2 } from './DeepPartial';
  */
 export type IStyleFunction<TStylesProps, TStyleSet extends IStyleSetBase> = (
   props: TStylesProps,
-) => DeepPartialV2<TStyleSet>;
+) => DeepPartial<TStyleSet>;
 
 /**
  * Represents either a style function that takes in style props and returns a partial styleset,
@@ -16,4 +16,4 @@ export type IStyleFunction<TStylesProps, TStyleSet extends IStyleSetBase> = (
  */
 export type IStyleFunctionOrObject<TStylesProps, TStyleSet extends IStyleSetBase> =
   | IStyleFunction<TStylesProps, TStyleSet>
-  | DeepPartialV2<TStyleSet>;
+  | DeepPartial<TStyleSet>;

--- a/packages/merge-styles/src/IStyleOptions.ts
+++ b/packages/merge-styles/src/IStyleOptions.ts
@@ -1,4 +1,4 @@
-import { ShadowConfig } from './shadowConfig';
+import type { ShadowConfig } from './shadowConfig';
 import type { Stylesheet } from './Stylesheet';
 
 export interface IStyleOptions {

--- a/packages/merge-styles/src/IStyleSet.ts
+++ b/packages/merge-styles/src/IStyleSet.ts
@@ -1,6 +1,6 @@
 import { IStyle } from './IStyle';
 import { IStyleFunctionOrObject, IStyleFunction } from './IStyleFunction';
-import { ShadowConfig } from './shadowConfig';
+import type { ShadowConfig } from './shadowConfig';
 
 /**
  * @deprecated Use `Exclude` provided by TypeScript instead.
@@ -69,6 +69,6 @@ export type IProcessedStyleSet<TStyleSet extends IStyleSetBase> = {
   };
 } & IShadowConfig;
 
-type IShadowConfig = {
+interface IShadowConfig {
   __shadowConfig__?: ShadowConfig;
-};
+}

--- a/packages/merge-styles/src/IStyleSet.ts
+++ b/packages/merge-styles/src/IStyleSet.ts
@@ -12,8 +12,10 @@ export type Diff<T extends keyof any, U extends keyof any> = ({ [P in T]: P } & 
 /**
  * @deprecated Use the version provided by TypeScript instead.
  */
+// eslint-disable-next-line deprecation/deprecation, @typescript-eslint/naming-convention
+type _Omit<U, K extends keyof U> = Pick<U, Diff<keyof U, K>>;
 // eslint-disable-next-line deprecation/deprecation
-export type Omit<U, K extends keyof U> = Pick<U, Diff<keyof U, K>>;
+export type { _Omit as Omit };
 
 /**
  * Helper function whose role is supposed to express that regardless if T is a style object or style function,
@@ -38,7 +40,6 @@ export interface IStyleSetBase {
  * property.
  */
 export type IStyleSet<TStyleSet extends IStyleSetBase = { [key: string]: any }> = {
-  // eslint-disable-next-line deprecation/deprecation
   [P in keyof Omit<TStyleSet, 'subComponentStyles'>]: IStyle;
 } & {
   subComponentStyles?: { [P in keyof TStyleSet['subComponentStyles']]: IStyleFunctionOrObject<any, any> };
@@ -48,7 +49,6 @@ export type IStyleSet<TStyleSet extends IStyleSetBase = { [key: string]: any }> 
  * A concatenated style set differs from `IStyleSet` in that subComponentStyles will always be a style function.
  */
 export type IConcatenatedStyleSet<TStyleSet extends IStyleSetBase> = {
-  // eslint-disable-next-line deprecation/deprecation
   [P in keyof Omit<TStyleSet, 'subComponentStyles'>]: IStyle;
 } & {
   subComponentStyles?: { [P in keyof TStyleSet['subComponentStyles']]: IStyleFunction<any, any> };
@@ -59,7 +59,6 @@ export type IConcatenatedStyleSet<TStyleSet extends IStyleSetBase> = {
  * into a class name. Additionally, all subComponentStyles are style functions.
  */
 export type IProcessedStyleSet<TStyleSet extends IStyleSetBase> = {
-  // eslint-disable-next-line deprecation/deprecation
   [P in keyof Omit<TStyleSet, 'subComponentStyles'>]: string;
 } & {
   subComponentStyles: {

--- a/packages/merge-styles/src/IStyleSet.ts
+++ b/packages/merge-styles/src/IStyleSet.ts
@@ -40,7 +40,8 @@ export interface IStyleSetBase {
  * property.
  */
 export type IStyleSet<TStyleSet extends IStyleSetBase = { [key: string]: any }> = {
-  [P in keyof Omit<TStyleSet, 'subComponentStyles'>]: IStyle;
+  // eslint-disable-next-line deprecation/deprecation
+  [P in keyof _Omit<TStyleSet, 'subComponentStyles'>]: IStyle;
 } & {
   subComponentStyles?: { [P in keyof TStyleSet['subComponentStyles']]: IStyleFunctionOrObject<any, any> };
 } & IShadowConfig;
@@ -49,7 +50,8 @@ export type IStyleSet<TStyleSet extends IStyleSetBase = { [key: string]: any }> 
  * A concatenated style set differs from `IStyleSet` in that subComponentStyles will always be a style function.
  */
 export type IConcatenatedStyleSet<TStyleSet extends IStyleSetBase> = {
-  [P in keyof Omit<TStyleSet, 'subComponentStyles'>]: IStyle;
+  // eslint-disable-next-line deprecation/deprecation
+  [P in keyof _Omit<TStyleSet, 'subComponentStyles'>]: IStyle;
 } & {
   subComponentStyles?: { [P in keyof TStyleSet['subComponentStyles']]: IStyleFunction<any, any> };
 } & IShadowConfig;
@@ -59,7 +61,8 @@ export type IConcatenatedStyleSet<TStyleSet extends IStyleSetBase> = {
  * into a class name. Additionally, all subComponentStyles are style functions.
  */
 export type IProcessedStyleSet<TStyleSet extends IStyleSetBase> = {
-  [P in keyof Omit<TStyleSet, 'subComponentStyles'>]: string;
+  // eslint-disable-next-line deprecation/deprecation
+  [P in keyof _Omit<TStyleSet, 'subComponentStyles'>]: string;
 } & {
   subComponentStyles: {
     [P in keyof TStyleSet['subComponentStyles']]: __MapToFunctionType<
@@ -68,6 +71,6 @@ export type IProcessedStyleSet<TStyleSet extends IStyleSetBase> = {
   };
 } & IShadowConfig;
 
-interface IShadowConfig {
+type IShadowConfig = {
   __shadowConfig__?: ShadowConfig;
-}
+};

--- a/packages/merge-styles/src/concatStyleSets.ts
+++ b/packages/merge-styles/src/concatStyleSets.ts
@@ -4,13 +4,12 @@ import { IStyleFunctionOrObject } from './IStyleFunction';
 import { ObjectOnly } from './ObjectOnly';
 import { ShadowConfig, isShadowConfig } from './shadowConfig';
 
+type Missing = false | null | undefined;
 /**
  * Combine a set of styles together (but does not register css classes).
  * @param styleSet - The first style set to be concatenated.
  */
-export function concatStyleSets<TStyleSet>(
-  styleSet: TStyleSet | false | null | undefined,
-): IConcatenatedStyleSet<ObjectOnly<TStyleSet>>;
+export function concatStyleSets<TStyleSet>(styleSet: TStyleSet | Missing): IConcatenatedStyleSet<ObjectOnly<TStyleSet>>;
 
 /**
  * Combine a set of styles together (but does not register css classes).
@@ -18,8 +17,8 @@ export function concatStyleSets<TStyleSet>(
  * @param styleSet2 - The second style set to be concatenated.
  */
 export function concatStyleSets<TStyleSet1, TStyleSet2>(
-  styleSet1: TStyleSet1 | false | null | undefined | ShadowConfig,
-  styleSet2: TStyleSet2 | false | null | undefined,
+  styleSet1: TStyleSet1 | Missing | ShadowConfig,
+  styleSet2: TStyleSet2 | Missing,
 ): IConcatenatedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2>>;
 
 /**
@@ -29,9 +28,9 @@ export function concatStyleSets<TStyleSet1, TStyleSet2>(
  * @param styleSet3 - The third style set to be concatenated.
  */
 export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3>(
-  styleSet1: TStyleSet1 | false | null | undefined | ShadowConfig,
-  styleSet2: TStyleSet2 | false | null | undefined,
-  styleSet3: TStyleSet3 | false | null | undefined,
+  styleSet1: TStyleSet1 | Missing | ShadowConfig,
+  styleSet2: TStyleSet2 | Missing,
+  styleSet3: TStyleSet3 | Missing,
 ): IConcatenatedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3>>;
 
 /**
@@ -42,10 +41,10 @@ export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3>(
  * @param styleSet4 - The fourth style set to be concatenated.
  */
 export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4>(
-  styleSet1: TStyleSet1 | false | null | undefined | ShadowConfig,
-  styleSet2: TStyleSet2 | false | null | undefined,
-  styleSet3: TStyleSet3 | false | null | undefined,
-  styleSet4: TStyleSet4 | false | null | undefined,
+  styleSet1: TStyleSet1 | Missing | ShadowConfig,
+  styleSet2: TStyleSet2 | Missing,
+  styleSet3: TStyleSet3 | Missing,
+  styleSet4: TStyleSet4 | Missing,
 ): IConcatenatedStyleSet<
   ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3> & ObjectOnly<TStyleSet4>
 >;
@@ -59,11 +58,11 @@ export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4>(
  * @param styleSet5 - The fifth set to be concatenated.
  */
 export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4, TStyleSet5>(
-  styleSet1: TStyleSet1 | false | null | undefined | ShadowConfig,
-  styleSet2: TStyleSet2 | false | null | undefined,
-  styleSet3: TStyleSet3 | false | null | undefined,
-  styleSet4: TStyleSet4 | false | null | undefined,
-  styleSet5: TStyleSet5 | false | null | undefined,
+  styleSet1: TStyleSet1 | Missing | ShadowConfig,
+  styleSet2: TStyleSet2 | Missing,
+  styleSet3: TStyleSet3 | Missing,
+  styleSet4: TStyleSet4 | Missing,
+  styleSet5: TStyleSet5 | Missing,
 ): IConcatenatedStyleSet<
   ObjectOnly<TStyleSet1> &
     ObjectOnly<TStyleSet2> &
@@ -82,12 +81,12 @@ export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4, 
  * @param styleSet6 - The sixth set to be concatenated.
  */
 export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4, TStyleSet5, TStyleSet6>(
-  styleSet1: TStyleSet1 | false | null | undefined | ShadowConfig,
-  styleSet2: TStyleSet2 | false | null | undefined,
-  styleSet3: TStyleSet3 | false | null | undefined,
-  styleSet4: TStyleSet4 | false | null | undefined,
-  styleSet5: TStyleSet5 | false | null | undefined,
-  styleSet6: TStyleSet6 | false | null | undefined,
+  styleSet1: TStyleSet1 | Missing | ShadowConfig,
+  styleSet2: TStyleSet2 | Missing,
+  styleSet3: TStyleSet3 | Missing,
+  styleSet4: TStyleSet4 | Missing,
+  styleSet5: TStyleSet5 | Missing,
+  styleSet6: TStyleSet6 | Missing,
 ): IConcatenatedStyleSet<
   ObjectOnly<TStyleSet1> &
     ObjectOnly<TStyleSet2> &
@@ -101,17 +100,13 @@ export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4, 
  * Combine a set of styles together (but does not register css classes).
  * @param styleSets - One or more stylesets to be merged (each param can also be falsy).
  */
-export function concatStyleSets(
-  ...styleSets: (IStyleSet | false | null | undefined | ShadowConfig)[]
-): IConcatenatedStyleSet<any>;
+export function concatStyleSets(...styleSets: (IStyleSet | Missing | ShadowConfig)[]): IConcatenatedStyleSet<any>;
 
 /**
  * Combine a set of styles together (but does not register css classes).
  * @param styleSets - One or more stylesets to be merged (each param can also be falsy).
  */
-export function concatStyleSets(
-  ...styleSets: (IStyleSet | false | null | undefined | ShadowConfig)[]
-): IConcatenatedStyleSet<any> {
+export function concatStyleSets(...styleSets: any[]): IConcatenatedStyleSet<any> {
   if (
     styleSets &&
     styleSets.length === 1 &&

--- a/packages/merge-styles/src/concatStyleSets.ts
+++ b/packages/merge-styles/src/concatStyleSets.ts
@@ -5,6 +5,8 @@ import { ObjectOnly } from './ObjectOnly';
 import { ShadowConfig, isShadowConfig } from './shadowConfig';
 
 type Missing = false | null | undefined;
+type MissingOrShadowConfig = Missing | ShadowConfig;
+
 /**
  * Combine a set of styles together (but does not register css classes).
  * @param styleSet - The first style set to be concatenated.
@@ -17,7 +19,7 @@ export function concatStyleSets<TStyleSet>(styleSet: TStyleSet | Missing): IConc
  * @param styleSet2 - The second style set to be concatenated.
  */
 export function concatStyleSets<TStyleSet1, TStyleSet2>(
-  styleSet1: TStyleSet1 | Missing | ShadowConfig,
+  styleSet1: TStyleSet1 | MissingOrShadowConfig,
   styleSet2: TStyleSet2 | Missing,
 ): IConcatenatedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2>>;
 
@@ -28,7 +30,7 @@ export function concatStyleSets<TStyleSet1, TStyleSet2>(
  * @param styleSet3 - The third style set to be concatenated.
  */
 export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3>(
-  styleSet1: TStyleSet1 | Missing | ShadowConfig,
+  styleSet1: TStyleSet1 | MissingOrShadowConfig,
   styleSet2: TStyleSet2 | Missing,
   styleSet3: TStyleSet3 | Missing,
 ): IConcatenatedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3>>;
@@ -41,7 +43,7 @@ export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3>(
  * @param styleSet4 - The fourth style set to be concatenated.
  */
 export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4>(
-  styleSet1: TStyleSet1 | Missing | ShadowConfig,
+  styleSet1: TStyleSet1 | MissingOrShadowConfig,
   styleSet2: TStyleSet2 | Missing,
   styleSet3: TStyleSet3 | Missing,
   styleSet4: TStyleSet4 | Missing,
@@ -58,7 +60,7 @@ export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4>(
  * @param styleSet5 - The fifth set to be concatenated.
  */
 export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4, TStyleSet5>(
-  styleSet1: TStyleSet1 | Missing | ShadowConfig,
+  styleSet1: TStyleSet1 | MissingOrShadowConfig,
   styleSet2: TStyleSet2 | Missing,
   styleSet3: TStyleSet3 | Missing,
   styleSet4: TStyleSet4 | Missing,
@@ -81,7 +83,7 @@ export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4, 
  * @param styleSet6 - The sixth set to be concatenated.
  */
 export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4, TStyleSet5, TStyleSet6>(
-  styleSet1: TStyleSet1 | Missing | ShadowConfig,
+  styleSet1: TStyleSet1 | MissingOrShadowConfig,
   styleSet2: TStyleSet2 | Missing,
   styleSet3: TStyleSet3 | Missing,
   styleSet4: TStyleSet4 | Missing,
@@ -100,7 +102,7 @@ export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4, 
  * Combine a set of styles together (but does not register css classes).
  * @param styleSets - One or more stylesets to be merged (each param can also be falsy).
  */
-export function concatStyleSets(...styleSets: (IStyleSet | Missing | ShadowConfig)[]): IConcatenatedStyleSet<any>;
+export function concatStyleSets(...styleSets: (IStyleSet | MissingOrShadowConfig)[]): IConcatenatedStyleSet<any>;
 
 /**
  * Combine a set of styles together (but does not register css classes).

--- a/packages/merge-styles/src/concatStyleSetsWithProps.ts
+++ b/packages/merge-styles/src/concatStyleSetsWithProps.ts
@@ -1,7 +1,7 @@
 import { concatStyleSets } from './concatStyleSets';
 import { IStyleSetBase } from './IStyleSet';
 import { IStyleFunctionOrObject } from './IStyleFunction';
-import { DeepPartial } from './DeepPartial';
+import { DeepPartialV2 } from './DeepPartial';
 
 /**
  * Concatenates style sets into one, but resolves functional sets using the given props.
@@ -11,22 +11,22 @@ import { DeepPartial } from './DeepPartial';
 export function concatStyleSetsWithProps<TStyleProps, TStyleSet extends IStyleSetBase>(
   styleProps: TStyleProps,
   ...allStyles: (IStyleFunctionOrObject<TStyleProps, TStyleSet> | undefined)[]
-): DeepPartial<TStyleSet> {
-  const result: DeepPartial<TStyleSet>[] = [];
+): DeepPartialV2<TStyleSet> {
+  const result: DeepPartialV2<TStyleSet>[] = [];
   for (const styles of allStyles) {
     if (styles) {
       result.push(typeof styles === 'function' ? styles(styleProps) : styles);
     }
   }
   if (result.length === 1) {
-    return result[0] as DeepPartial<TStyleSet>;
+    return result[0] as DeepPartialV2<TStyleSet>;
   } else if (result.length) {
     // cliffkoh: I cannot figure out how to avoid the cast to any here.
     // It is something to do with the use of Omit in IStyleSet.
     // It might not be necessary once  Omit becomes part of lib.d.ts (when we remove our own Omit and rely on
     // the official version).
-    return concatStyleSets(...(result as any)) as any;
+    return concatStyleSets(...result) as any;
   }
 
-  return {};
+  return {} as any;
 }

--- a/packages/merge-styles/src/concatStyleSetsWithProps.ts
+++ b/packages/merge-styles/src/concatStyleSetsWithProps.ts
@@ -12,21 +12,21 @@ export function concatStyleSetsWithProps<TStyleProps, TStyleSet extends IStyleSe
   styleProps: TStyleProps,
   ...allStyles: (IStyleFunctionOrObject<TStyleProps, TStyleSet> | undefined)[]
 ): DeepPartialV2<TStyleSet> {
-  const result: DeepPartialV2<TStyleSet>[] = [];
+  const result: Array<DeepPartialV2<TStyleSet>> = [];
   for (const styles of allStyles) {
     if (styles) {
       result.push(typeof styles === 'function' ? styles(styleProps) : styles);
     }
   }
   if (result.length === 1) {
-    return result[0] as DeepPartialV2<TStyleSet>;
+    return result[0];
   } else if (result.length) {
     // cliffkoh: I cannot figure out how to avoid the cast to any here.
     // It is something to do with the use of Omit in IStyleSet.
     // It might not be necessary once  Omit becomes part of lib.d.ts (when we remove our own Omit and rely on
     // the official version).
-    return concatStyleSets(...result) as any;
+    return concatStyleSets(...result) as DeepPartialV2<TStyleSet>;
   }
 
-  return {} as any;
+  return {} as DeepPartialV2<TStyleSet>;
 }

--- a/packages/merge-styles/src/concatStyleSetsWithProps.ts
+++ b/packages/merge-styles/src/concatStyleSetsWithProps.ts
@@ -1,7 +1,7 @@
 import { concatStyleSets } from './concatStyleSets';
 import { IStyleSetBase } from './IStyleSet';
 import { IStyleFunctionOrObject } from './IStyleFunction';
-import { DeepPartialV2 } from './DeepPartial';
+import { DeepPartialV2 as DeepPartial } from './DeepPartial';
 
 /**
  * Concatenates style sets into one, but resolves functional sets using the given props.
@@ -11,8 +11,8 @@ import { DeepPartialV2 } from './DeepPartial';
 export function concatStyleSetsWithProps<TStyleProps, TStyleSet extends IStyleSetBase>(
   styleProps: TStyleProps,
   ...allStyles: (IStyleFunctionOrObject<TStyleProps, TStyleSet> | undefined)[]
-): DeepPartialV2<TStyleSet> {
-  const result: Array<DeepPartialV2<TStyleSet>> = [];
+): DeepPartial<TStyleSet> {
+  const result: Array<DeepPartial<TStyleSet>> = [];
   for (const styles of allStyles) {
     if (styles) {
       result.push(typeof styles === 'function' ? styles(styleProps) : styles);
@@ -25,8 +25,8 @@ export function concatStyleSetsWithProps<TStyleProps, TStyleSet extends IStyleSe
     // It is something to do with the use of Omit in IStyleSet.
     // It might not be necessary once  Omit becomes part of lib.d.ts (when we remove our own Omit and rely on
     // the official version).
-    return concatStyleSets(...result) as DeepPartialV2<TStyleSet>;
+    return concatStyleSets(...result) as DeepPartial<TStyleSet>;
   }
 
-  return {} as DeepPartialV2<TStyleSet>;
+  return {} as DeepPartial<TStyleSet>;
 }

--- a/packages/merge-styles/src/index.ts
+++ b/packages/merge-styles/src/index.ts
@@ -6,6 +6,7 @@ export type { IKeyframes } from './IKeyframes';
 
 export type { IStyleFunction, IStyleFunctionOrObject } from './IStyleFunction';
 
+// eslint-disable-next-line deprecation/deprecation
 export type { DeepPartial } from './DeepPartial';
 
 // eslint-disable-next-line deprecation/deprecation

--- a/packages/merge-styles/src/mergeStyleSets.ts
+++ b/packages/merge-styles/src/mergeStyleSets.ts
@@ -179,12 +179,12 @@ export function mergeCssSets<TStyleSet>(
  * @param options - (optional) Options to use when creating rules.
  */
 export function mergeCssSets(styleSets: any[], options?: IStyleOptions): IProcessedStyleSet<any> {
-  const classNameSet: IProcessedStyleSet<any> = { subComponentStyles: {} };
+  const classNameSet = { subComponentStyles: {} } as IProcessedStyleSet<any>;
 
   let shadowConfig: ShadowConfig | undefined = undefined;
   let styleSet;
   if (isShadowConfig(styleSets[0])) {
-    shadowConfig = styleSets[0] as ShadowConfig;
+    shadowConfig = styleSets[0];
     styleSet = styleSets[1];
   } else {
     styleSet = styleSets[0];
@@ -207,7 +207,7 @@ export function mergeCssSets(styleSets: any[], options?: IStyleOptions): IProces
   for (const styleSetArea in concatenatedStyleSet) {
     if (concatenatedStyleSet.hasOwnProperty(styleSetArea)) {
       if (styleSetArea === 'subComponentStyles') {
-        classNameSet.subComponentStyles = (concatenatedStyleSet as IConcatenatedStyleSet<any>).subComponentStyles || {};
+        classNameSet.subComponentStyles = concatenatedStyleSet.subComponentStyles || {};
         continue;
       } else if (styleSetArea === '__shadowConfig__') {
         continue;
@@ -222,12 +222,10 @@ export function mergeCssSets(styleSets: any[], options?: IStyleOptions): IProces
 
         if (registration) {
           registrations.push(registration);
-          // FIXME: classNameSet invalid types - exposed in TS 4.5 - cast needed
-          (classNameSet as Record<string, any>)[styleSetArea] = classes.concat([registration.className]).join(' ');
+          classNameSet[styleSetArea] = classes.concat([registration.className]).join(' ');
         }
       } else {
-        // FIXME: classNameSet invalid types - exposed in TS 4.5 - cast needed
-        (classNameSet as Record<string, any>)[styleSetArea] = classes.join(' ');
+        classNameSet[styleSetArea] = classes.join(' ');
       }
     }
   }

--- a/packages/merge-styles/src/mergeStyleSets.ts
+++ b/packages/merge-styles/src/mergeStyleSets.ts
@@ -9,6 +9,7 @@ import { ObjectOnly } from './ObjectOnly';
 import { isShadowConfig, ShadowConfig } from './shadowConfig';
 import { Stylesheet } from './Stylesheet';
 
+type Missing = false | null | undefined;
 /**
  * Takes in one or more style set objects, each consisting of a set of areas,
  * each which will produce a class name. Using this is analogous to calling
@@ -17,9 +18,7 @@ import { Stylesheet } from './Stylesheet';
  *
  * @param styleSet - The first style set to be merged and reigstered.
  */
-export function mergeStyleSets<TStyleSet>(
-  styleSet: TStyleSet | false | null | undefined,
-): IProcessedStyleSet<ObjectOnly<TStyleSet>>;
+export function mergeStyleSets<TStyleSet>(styleSet: TStyleSet | Missing): IProcessedStyleSet<ObjectOnly<TStyleSet>>;
 
 /**
  * Takes in one or more style set objects, each consisting of a set of areas,
@@ -31,8 +30,8 @@ export function mergeStyleSets<TStyleSet>(
  * @param styleSet2 - The second style set to be merged.
  */
 export function mergeStyleSets<TStyleSet1, TStyleSet2>(
-  styleSet1: TStyleSet1 | false | null | undefined,
-  styleSet2: TStyleSet2 | false | null | undefined,
+  styleSet1: TStyleSet1 | Missing,
+  styleSet2: TStyleSet2 | Missing,
 ): IProcessedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2>>;
 
 /**
@@ -46,9 +45,9 @@ export function mergeStyleSets<TStyleSet1, TStyleSet2>(
  * @param styleSet3 - The third style set to be merged.
  */
 export function mergeStyleSets<TStyleSet1, TStyleSet2, TStyleSet3>(
-  styleSet1: TStyleSet1 | false | null | undefined,
-  styleSet2: TStyleSet2 | false | null | undefined,
-  styleSet3: TStyleSet3 | false | null | undefined,
+  styleSet1: TStyleSet1 | Missing,
+  styleSet2: TStyleSet2 | Missing,
+  styleSet3: TStyleSet3 | Missing,
 ): IProcessedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3>>;
 
 /**
@@ -63,10 +62,10 @@ export function mergeStyleSets<TStyleSet1, TStyleSet2, TStyleSet3>(
  * @param styleSet4 - The fourth style set to be merged.
  */
 export function mergeStyleSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4>(
-  styleSet1: TStyleSet1 | false | null | undefined,
-  styleSet2: TStyleSet2 | false | null | undefined,
-  styleSet3: TStyleSet3 | false | null | undefined,
-  styleSet4: TStyleSet4 | false | null | undefined,
+  styleSet1: TStyleSet1 | Missing,
+  styleSet2: TStyleSet2 | Missing,
+  styleSet3: TStyleSet3 | Missing,
+  styleSet4: TStyleSet4 | Missing,
 ): IProcessedStyleSet<
   ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3> & ObjectOnly<TStyleSet4>
 >;
@@ -79,13 +78,11 @@ export function mergeStyleSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4>(
  *
  * @param styleSets - One or more style sets to be merged.
  */
-export function mergeStyleSets(
-  ...styleSets: Array<IStyleSet | undefined | false | null | ShadowConfig>
-): IProcessedStyleSet<any>;
+export function mergeStyleSets(...styleSets: Array<IStyleSet | Missing | ShadowConfig>): IProcessedStyleSet<any>;
 
 export function mergeStyleSets(
   shadowConfig: ShadowConfig,
-  ...styleSets: Array<IStyleSet | undefined | false | null>
+  ...styleSets: Array<IStyleSet | Missing>
 ): IProcessedStyleSet<any>;
 
 /**
@@ -96,9 +93,7 @@ export function mergeStyleSets(
  *
  * @param styleSets - One or more style sets to be merged.
  */
-export function mergeStyleSets(
-  ...styleSets: Array<IStyleSet | undefined | false | null | ShadowConfig>
-): IProcessedStyleSet<any> {
+export function mergeStyleSets(...styleSets: any[]): IProcessedStyleSet<any> {
   return mergeCssSets(styleSets as any, getStyleOptions());
 }
 
@@ -112,7 +107,7 @@ export function mergeStyleSets(
  * @param options - (optional) Options to use when creating rules.
  */
 export function mergeCssSets<TStyleSet>(
-  styleSets: [TStyleSet | false | null | undefined],
+  styleSets: [TStyleSet | Missing],
   options?: IStyleOptions,
 ): IProcessedStyleSet<ObjectOnly<TStyleSet>>;
 
@@ -126,7 +121,7 @@ export function mergeCssSets<TStyleSet>(
  * @param options - (optional) Options to use when creating rules.
  */
 export function mergeCssSets<TStyleSet1, TStyleSet2>(
-  styleSets: [TStyleSet1 | false | null | undefined | ShadowConfig, TStyleSet2 | false | null | undefined],
+  styleSets: [TStyleSet1 | Missing | ShadowConfig, TStyleSet2 | Missing],
   options?: IStyleOptions,
 ): IProcessedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2>>;
 
@@ -140,11 +135,7 @@ export function mergeCssSets<TStyleSet1, TStyleSet2>(
  * @param options - (optional) Options to use when creating rules.
  */
 export function mergeCssSets<TStyleSet1, TStyleSet2, TStyleSet3>(
-  styleSets: [
-    TStyleSet1 | false | null | undefined | ShadowConfig,
-    TStyleSet2 | false | null | undefined,
-    TStyleSet3 | false | null | undefined,
-  ],
+  styleSets: [TStyleSet1 | Missing | ShadowConfig, TStyleSet2 | Missing, TStyleSet3 | Missing],
   options?: IStyleOptions,
 ): IProcessedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3>>;
 
@@ -158,12 +149,7 @@ export function mergeCssSets<TStyleSet1, TStyleSet2, TStyleSet3>(
  * @param options - (optional) Options to use when creating rules.
  */
 export function mergeCssSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4>(
-  styleSets: [
-    TStyleSet1 | false | null | undefined | ShadowConfig,
-    TStyleSet2 | false | null | undefined,
-    TStyleSet3 | false | null | undefined,
-    TStyleSet4 | false | null | undefined,
-  ],
+  styleSets: [TStyleSet1 | Missing | ShadowConfig, TStyleSet2 | Missing, TStyleSet3 | Missing, TStyleSet4 | Missing],
   options?: IStyleOptions,
 ): IProcessedStyleSet<
   ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3> & ObjectOnly<TStyleSet4>
@@ -179,7 +165,7 @@ export function mergeCssSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4>(
  * @param options - (optional) Options to use when creating rules.
  */
 export function mergeCssSets<TStyleSet>(
-  styleSet: [TStyleSet | false | null | undefined],
+  styleSet: [TStyleSet | Missing],
   options?: IStyleOptions,
 ): IProcessedStyleSet<ObjectOnly<TStyleSet>>;
 
@@ -192,10 +178,7 @@ export function mergeCssSets<TStyleSet>(
  * @param styleSets - One or more style sets to be merged.
  * @param options - (optional) Options to use when creating rules.
  */
-export function mergeCssSets(
-  styleSets: Array<IStyleSet | undefined | false | null | ShadowConfig>,
-  options?: IStyleOptions,
-): IProcessedStyleSet<any> {
+export function mergeCssSets(styleSets: any[], options?: IStyleOptions): IProcessedStyleSet<any> {
   const classNameSet: IProcessedStyleSet<any> = { subComponentStyles: {} };
 
   let shadowConfig: ShadowConfig | undefined = undefined;
@@ -255,5 +238,5 @@ export function mergeCssSets(
     }
   }
 
-  return classNameSet as any;
+  return classNameSet;
 }

--- a/packages/merge-styles/src/mergeStyleSets.ts
+++ b/packages/merge-styles/src/mergeStyleSets.ts
@@ -10,6 +10,8 @@ import { isShadowConfig, ShadowConfig } from './shadowConfig';
 import { Stylesheet } from './Stylesheet';
 
 type Missing = false | null | undefined;
+type MissingOrShadowConfig = Missing | ShadowConfig;
+
 /**
  * Takes in one or more style set objects, each consisting of a set of areas,
  * each which will produce a class name. Using this is analogous to calling
@@ -78,7 +80,7 @@ export function mergeStyleSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4>(
  *
  * @param styleSets - One or more style sets to be merged.
  */
-export function mergeStyleSets(...styleSets: Array<IStyleSet | Missing | ShadowConfig>): IProcessedStyleSet<any>;
+export function mergeStyleSets(...styleSets: Array<IStyleSet | MissingOrShadowConfig>): IProcessedStyleSet<any>;
 
 export function mergeStyleSets(
   shadowConfig: ShadowConfig,
@@ -121,7 +123,7 @@ export function mergeCssSets<TStyleSet>(
  * @param options - (optional) Options to use when creating rules.
  */
 export function mergeCssSets<TStyleSet1, TStyleSet2>(
-  styleSets: [TStyleSet1 | Missing | ShadowConfig, TStyleSet2 | Missing],
+  styleSets: [TStyleSet1 | MissingOrShadowConfig, TStyleSet2 | Missing],
   options?: IStyleOptions,
 ): IProcessedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2>>;
 
@@ -135,7 +137,7 @@ export function mergeCssSets<TStyleSet1, TStyleSet2>(
  * @param options - (optional) Options to use when creating rules.
  */
 export function mergeCssSets<TStyleSet1, TStyleSet2, TStyleSet3>(
-  styleSets: [TStyleSet1 | Missing | ShadowConfig, TStyleSet2 | Missing, TStyleSet3 | Missing],
+  styleSets: [TStyleSet1 | MissingOrShadowConfig, TStyleSet2 | Missing, TStyleSet3 | Missing],
   options?: IStyleOptions,
 ): IProcessedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3>>;
 
@@ -149,7 +151,7 @@ export function mergeCssSets<TStyleSet1, TStyleSet2, TStyleSet3>(
  * @param options - (optional) Options to use when creating rules.
  */
 export function mergeCssSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4>(
-  styleSets: [TStyleSet1 | Missing | ShadowConfig, TStyleSet2 | Missing, TStyleSet3 | Missing, TStyleSet4 | Missing],
+  styleSets: [TStyleSet1 | MissingOrShadowConfig, TStyleSet2 | Missing, TStyleSet3 | Missing, TStyleSet4 | Missing],
   options?: IStyleOptions,
 ): IProcessedStyleSet<
   ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3> & ObjectOnly<TStyleSet4>
@@ -179,7 +181,7 @@ export function mergeCssSets<TStyleSet>(
  * @param options - (optional) Options to use when creating rules.
  */
 export function mergeCssSets(styleSets: any[], options?: IStyleOptions): IProcessedStyleSet<any> {
-  const classNameSet = { subComponentStyles: {} } as IProcessedStyleSet<any>;
+  const classNameSet: IProcessedStyleSet<any> & Record<string, unknown> = { subComponentStyles: {} };
 
   let shadowConfig: ShadowConfig | undefined = undefined;
   let styleSet;

--- a/packages/merge-styles/src/mergeStyles.ts
+++ b/packages/merge-styles/src/mergeStyles.ts
@@ -6,7 +6,8 @@ import { getStyleOptions } from './StyleOptionsState';
 import { Stylesheet } from './Stylesheet';
 import { styleToClassName } from './styleToClassName';
 
-type StyleArg = IStyle | IStyleBaseArray | false | null | undefined;
+type Missing = false | null | undefined;
+type StyleArg = IStyle | IStyleBaseArray | Missing;
 type StyleArgWithShadow = StyleArg | ShadowConfig;
 
 export function mergeStyles(...args: StyleArg[]): string;

--- a/packages/merge-styles/src/mergeStyles.ts
+++ b/packages/merge-styles/src/mergeStyles.ts
@@ -6,18 +6,17 @@ import { getStyleOptions } from './StyleOptionsState';
 import { Stylesheet } from './Stylesheet';
 import { styleToClassName } from './styleToClassName';
 
-export function mergeStyles(...args: (IStyle | IStyleBaseArray | false | null | undefined)[]): string;
-export function mergeStyles(
-  shadowConfig: ShadowConfig,
-  ...args: (IStyle | IStyleBaseArray | false | null | undefined)[]
-): string;
+type StyleArg = IStyle | IStyleBaseArray | false | null | undefined;
+type StyleArgWithShadow = StyleArg | ShadowConfig;
 
+export function mergeStyles(...args: StyleArg[]): string;
+export function mergeStyles(shadowConfig: ShadowConfig, ...args: StyleArg[]): string;
 /**
  * Concatenation helper, which can merge class names together. Skips over falsey values.
  *
  * @public
  */
-export function mergeStyles(...args: (IStyle | IStyleBaseArray | false | null | undefined)[]): string {
+export function mergeStyles(...args: any[]): string {
   return mergeCss(args, getStyleOptions());
 }
 
@@ -27,12 +26,7 @@ export function mergeStyles(...args: (IStyle | IStyleBaseArray | false | null | 
  *
  * @public
  */
-export function mergeCss(
-  args:
-    | (IStyle | IStyleBaseArray | false | null | undefined | ShadowConfig)
-    | (IStyle | IStyleBaseArray | false | null | undefined | ShadowConfig)[],
-  options?: IStyleOptions,
-): string {
+export function mergeCss(args: StyleArgWithShadow | StyleArgWithShadow[], options?: IStyleOptions): string {
   const styleArgs = args instanceof Array ? args : [args];
   const opts = options || {};
   const hasShadowConfig = isShadowConfig(styleArgs[0]);

--- a/packages/merge-styles/src/shadowConfig.ts
+++ b/packages/merge-styles/src/shadowConfig.ts
@@ -1,9 +1,10 @@
-export type ShadowConfig = {
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export interface ShadowConfig {
   stylesheetKey: string;
   inShadow: boolean;
   window?: Window;
   __isShadowConfig__: true;
-};
+}
 
 export const GLOBAL_STYLESHEET_KEY = '__global__';
 export const SHADOW_DOM_STYLESHEET_SETTING = '__shadow_dom_stylesheet__';
@@ -13,7 +14,7 @@ export const DEFAULT_SHADOW_CONFIG: ShadowConfig = {
   inShadow: false,
   window: undefined,
   __isShadowConfig__: true,
-} as const;
+};
 
 export const makeShadowConfig = (stylesheetKey: string, inShadow: boolean, window?: Window): ShadowConfig => {
   return {
@@ -24,10 +25,14 @@ export const makeShadowConfig = (stylesheetKey: string, inShadow: boolean, windo
   };
 };
 
-export const isShadowConfig = (obj: unknown): obj is ShadowConfig => {
-  if (!obj) {
+export const isShadowConfig = (value: unknown): value is ShadowConfig => {
+  if (!(value && isRecord(value))) {
     return false;
   }
 
-  return (obj as ShadowConfig).__isShadowConfig__ === true;
+  return value.__isShadowConfig__ === true;
 };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

This PR mitigates `TS2589: Type instantiation is excessively deep and possibly infinite.` Error that our users started to run into after adding opt in ShadowDom functionality into v8 styling system (https://github.com/microsoft/fluentui/pull/30689)

- new `DeepPartialV2` is used within codebase instead of problematic `DeepPartial`
  - `DeepPartial` is marked `@deprecated` as we cannot remove it because it's  exposed as part of  public API
- complex repetitive union types across function overloads are aggregated to shared type for reuse and performance (https://github.com/microsoft/TypeScript/pull/42149)
- renames internally custom `Omit` to `_Omit` to be explicit about it's not from ts.lib
- some internal logic types have been fixed as well
- `isShadowConfig` type predicate internals have been improved for more robust runtime check (that's causing tiny bundle size bump )

**Summary:**

- tested against users large codebase that was facing this TS issue
  - TS issue mitigated
  - TS type-check performance is 6% FASTER 🚅

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows https://github.com/microsoft/fluentui/pull/30689
