### PR TITLE
fix:react-nav-preview: High contrast issues

### DIFF
--- a/change/@fluentui-react-nav-preview-71eeaf96-dc68-4684-9b39-e17f06cdd4c1.json
+++ b/change/@fluentui-react-nav-preview-71eeaf96-dc68-4684-9b39-e17f06cdd4c1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "(fix): Addresses icon and indicator Windows and Teams Theme high constrast issues.",
+  "packageName": "@fluentui/react-nav-preview",
+  "email": "17346018+mltejera@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-nav-preview-71eeaf96-dc68-4684-9b39-e17f06cdd4c1.json
+++ b/change/@fluentui-react-nav-preview-71eeaf96-dc68-4684-9b39-e17f06cdd4c1.json
@@ -2,6 +2,6 @@
   "type": "patch",
   "comment": "(fix): Addresses icon and indicator Windows and Teams Theme high constrast issues.",
   "packageName": "@fluentui/react-nav-preview",
-  "email": "17346018+mltejera@users.noreply.github.com",
+  "email": "matejera@microsoft.com",
   "dependentChangeType": "patch"
 }

--- a/change/@fluentui-react-nav-preview-71eeaf96-dc68-4684-9b39-e17f06cdd4c1.json
+++ b/change/@fluentui-react-nav-preview-71eeaf96-dc68-4684-9b39-e17f06cdd4c1.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "(fix): Addresses icon and indicator Windows and Teams Theme high constrast issues.",
+  "comment": "fix: Addresses icon and indicator Windows and Teams Theme high contrast issues.",
   "packageName": "@fluentui/react-nav-preview",
   "email": "matejera@microsoft.com",
   "dependentChangeType": "patch"

--- a/docs/react-v9/contributing/dev-workflow.md
+++ b/docs/react-v9/contributing/dev-workflow.md
@@ -61,7 +61,7 @@ It is strongly recommended that you rebase your branch onto (rather than merging
 ```
 git checkout master // Switches to master
 git pull upstream master // Syncs your local master with the latest version of master at the origin
-yarn // refreshes the code incase things have changed.
+yarn // Installs and updates dependencies in case there have been changes in the project's dependencies.
 git push // syncs your forks definition of master with the upstream repo
 git checkout your-fancy-branch // Switches back to your branch
 git rebase -i master // Tacks your commits onto the end of master. Force is necessary since rebase changes history.

--- a/docs/react-v9/contributing/dev-workflow.md
+++ b/docs/react-v9/contributing/dev-workflow.md
@@ -21,20 +21,22 @@ We don't have an official branch naming policy. Since every contribution happens
 
 The inner development loop usually involves these steps:
 
-First, `cd` to the root folder of the repo (usually `fluentui`) and run `yarn` to install dependencies and link packages. This can take some time.
+First, `cd` to the root folder of the repo (usually `fluentui`) and run `yarn` to install dependencies and link packages. This can take some time if it's the first time you've run it.
 
 ```
 cd fluentui
 yarn
 ```
 
-Windows users not working in WSL should run `yarn clean` and then `yarn build` on first use to ensure correct linking in non-\*nix systems.
+It's generally a good idea to `yarn` each time you sync with master.
+
+Windows users not working in WSL should run `yarn clean` and then `yarn build` first use to ensure correct linking in non-\*nix systems.
 
 Run `yarn start` and select your start up project.
 
 ```
 @fluentui/public-docsite // starts the public v8 documentation site.
-@fluentui/public-docsite-v9 // starts the internal v9 documentation storybook site.
+@fluentui/public-docsite-v9 // starts the v9 documentation storybook site.
 ```
 
 Pick a specific component package if you intend to work on a v9 component directly.
@@ -59,6 +61,7 @@ It is strongly recommended that you rebase your branch onto (rather than merging
 ```
 git checkout master // Switches to master
 git pull upstream master // Syncs your local master with the latest version of master at the origin
+yarn // refreshes the code incase things have changed.
 git push // syncs your forks definition of master with the upstream repo
 git checkout your-fancy-branch // Switches back to your branch
 git rebase -i master // Tacks your commits onto the end of master. Force is necessary since rebase changes history.

--- a/packages/react-components/react-nav-preview/library/src/components/sharedNavStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/library/src/components/sharedNavStyles.styles.ts
@@ -65,7 +65,7 @@ export const useIndicatorStyles = makeStyles({
     '::after': {
       position: 'absolute',
       marginInlineStart: `-${navItemTokens.indicatorOffset}px`,
-      backgroundColor: tokens.colorCompoundBrandStroke,
+      backgroundColor: tokens.colorCompoundBrandForeground1,
       height: `${navItemTokens.indicatorHeight}px`,
       width: `${navItemTokens.indicatorWidth}px`,
       borderRadius: tokens.borderRadiusCircular,
@@ -101,7 +101,7 @@ export const useIconStyles = makeStyles({
   selected: {
     [`& .${iconFilledClassName}`]: {
       display: 'inline',
-      color: tokens.colorCompoundBrandStroke,
+      color: tokens.colorCompoundBrandForeground1,
     },
     [`& .${iconRegularClassName}`]: {
       display: 'none',

--- a/packages/react-components/react-nav-preview/library/src/components/sharedNavStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/library/src/components/sharedNavStyles.styles.ts
@@ -65,11 +65,16 @@ export const useIndicatorStyles = makeStyles({
     '::after': {
       position: 'absolute',
       marginInlineStart: `-${navItemTokens.indicatorOffset}px`,
-      backgroundColor: tokens.colorNeutralForeground2BrandSelected,
+      backgroundColor: tokens.colorCompoundBrandStroke,
       height: `${navItemTokens.indicatorHeight}px`,
       width: `${navItemTokens.indicatorWidth}px`,
       borderRadius: tokens.borderRadiusCircular,
       content: '""',
+    },
+    '@media (forced-colors: active)': {
+      '::after': {
+        backgroundColor: 'ButtonText',
+      },
     },
   },
 });
@@ -96,7 +101,7 @@ export const useIconStyles = makeStyles({
   selected: {
     [`& .${iconFilledClassName}`]: {
       display: 'inline',
-      color: tokens.colorNeutralForeground2BrandSelected,
+      color: tokens.colorCompoundBrandStroke,
     },
     [`& .${iconRegularClassName}`]: {
       display: 'none',


### PR DESCRIPTION
Addresses icon and indicator issues in Teams HC theme and Windows High Contrast when items are selected.

Teams HC before:
![image](https://github.com/microsoft/fluentui/assets/17346018/e0ebe35b-aa1e-48ae-92c0-77187f92c1a1)

Windows HC before:
![image](https://github.com/microsoft/fluentui/assets/17346018/8db563f6-51a1-406d-a6e8-8d5aef37c0f3)

Teams HC after:
![image](https://github.com/microsoft/fluentui/assets/17346018/a00163bd-6dbe-4c08-b98d-4de5589b5bd9)

Windows HC after:
![image](https://github.com/microsoft/fluentui/assets/17346018/7cd446dc-b713-44f7-9ac0-72f50ee09cf3)

Ladders to #26649 
