### PR TITLE
Fix storybook favicon

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -94,7 +94,7 @@ module.exports = /** @type {Omit<StorybookConfig,'typescript'|'babel'>} */ ({
   },
   /**
    * Programmatically enhance previewHead as inheriting just static file `preview-head.html` doesn't work in monorepo
-   * @see https://storybook.js.org/docs/react/addons/writing-presets#previewmanager-templates
+   * @see https://storybook.js.org/docs/addons/writing-presets#ui-configuration
    */
   previewHead: head => head + previewHeadTemplate,
 });

--- a/apps/public-docsite-v9/.storybook/manager-head.html
+++ b/apps/public-docsite-v9/.storybook/manager-head.html
@@ -1,13 +1,7 @@
 <!--
   Override the default favicon used in the Storybook in the browser tab.
  -->
-<link rel="shortcut icon" href="https://www.microsoft.com/design/fluent/assets/favicons/favicon-192.png" />
-<link
-  rel="icon"
-  type="image/png"
-  href="https://www.microsoft.com/design/fluent/assets/favicons/favicon-192.png"
-  sizes="192x192"
-/>
+<link rel="shortcut icon" type="image/x-icon" href="https://react.fluentui.dev/favicon-192.ico" />
 <link href="/shell.css" rel="stylesheet" />
 
 <!-- Primary meta tags -->


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
Favicon was removed or server-side routing was broken
```html
<link rel="shortcut icon" href="https://www.microsoft.com/design/fluent/assets/favicons/favicon-192.png" />
```
This url redirects with 301 to the main page
```bash
curl -Ls -o /dev/null -w %{url_effective} https://www.microsoft.com/design/fluent/assets/favicons/favicon-192.png
https://fluent2.microsoft.design/
```

<!-- This is the behavior we have today -->

## New Behavior
fluent2.microsoft.design uses this configuration, so I made similar changes but with own Fluent UI icon
```html
<link rel="shortcut icon" type="image/x-icon" href="/favicons/favicon.ico">
```

Also I fixed url in JSDoc in storybook config

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #31606
