### PR TITLE
chore:docs Ports CLA from wiki

### DIFF
--- a/docs/react-v9/contributing/cla.md
+++ b/docs/react-v9/contributing/cla.md
@@ -1,0 +1,5 @@
+### Contribution license agreement
+
+For pull requests, you will need to sign a [Contribution License Agreement (CLA)](https://cla.microsoft.com/) before your contribution can be incorporated. To complete the CLA, you will need to submit the request via the form and then electronically sign the CLA when you receive the email containing the link to the document.
+
+This needs to only be done once for any Microsoft open source project.


### PR DESCRIPTION
Ports the CLA (unchanged) from the wiki.

https://github.com/microsoft/fluentui/wiki/CLA