### PR TITLE
Add `PartialShadowConfig` type

### DIFF
--- a/change/@fluentui-merge-styles-52357a5f-e1d6-43dd-81b0-f79074751672.json
+++ b/change/@fluentui-merge-styles-52357a5f-e1d6-43dd-81b0-f79074751672.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "fix: add PartialShadowConfig type.",
+  "packageName": "@fluentui/merge-styles",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-a25e2f5c-4b4d-4dec-a512-eec5218b9a90.json
+++ b/change/@fluentui-react-a25e2f5c-4b4d-4dec-a512-eec5218b9a90.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "fix: add PartialShadowConfig type.",
+  "packageName": "@fluentui/react",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-style-utilities-67dfcc6e-f161-458a-9c00-72fba29b3f6b.json
+++ b/change/@fluentui-style-utilities-67dfcc6e-f161-458a-9c00-72fba29b3f6b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "fix: add PartialShadowConfig type.",
+  "packageName": "@fluentui/style-utilities",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-utilities-1829e3a7-837d-40eb-ab92-6b479b8d124c.json
+++ b/change/@fluentui-utilities-1829e3a7-837d-40eb-ab92-6b479b8d124c.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "fix: add PartialShadowConfig type.",
+  "packageName": "@fluentui/utilities",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/merge-styles/etc/merge-styles.api.md
+++ b/packages/merge-styles/etc/merge-styles.api.md
@@ -17,22 +17,22 @@ export const cloneCSSStyleSheet: (srcSheet: CSSStyleSheet, targetSheet: CSSStyle
 export function concatStyleSets<TStyleSet>(styleSet: TStyleSet | false | null | undefined): IConcatenatedStyleSet<ObjectOnly<TStyleSet>>;
 
 // @public
-export function concatStyleSets<TStyleSet1, TStyleSet2>(styleSet1: TStyleSet1 | false | null | undefined | ShadowConfig, styleSet2: TStyleSet2 | false | null | undefined): IConcatenatedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2>>;
+export function concatStyleSets<TStyleSet1, TStyleSet2>(styleSet1: TStyleSet1 | false | null | undefined | PartialShadowConfig, styleSet2: TStyleSet2 | false | null | undefined): IConcatenatedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2>>;
 
 // @public
-export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3>(styleSet1: TStyleSet1 | false | null | undefined | ShadowConfig, styleSet2: TStyleSet2 | false | null | undefined, styleSet3: TStyleSet3 | false | null | undefined): IConcatenatedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3>>;
+export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3>(styleSet1: TStyleSet1 | false | null | undefined | PartialShadowConfig, styleSet2: TStyleSet2 | false | null | undefined, styleSet3: TStyleSet3 | false | null | undefined): IConcatenatedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3>>;
 
 // @public
-export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4>(styleSet1: TStyleSet1 | false | null | undefined | ShadowConfig, styleSet2: TStyleSet2 | false | null | undefined, styleSet3: TStyleSet3 | false | null | undefined, styleSet4: TStyleSet4 | false | null | undefined): IConcatenatedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3> & ObjectOnly<TStyleSet4>>;
+export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4>(styleSet1: TStyleSet1 | false | null | undefined | PartialShadowConfig, styleSet2: TStyleSet2 | false | null | undefined, styleSet3: TStyleSet3 | false | null | undefined, styleSet4: TStyleSet4 | false | null | undefined): IConcatenatedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3> & ObjectOnly<TStyleSet4>>;
 
 // @public
-export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4, TStyleSet5>(styleSet1: TStyleSet1 | false | null | undefined | ShadowConfig, styleSet2: TStyleSet2 | false | null | undefined, styleSet3: TStyleSet3 | false | null | undefined, styleSet4: TStyleSet4 | false | null | undefined, styleSet5: TStyleSet5 | false | null | undefined): IConcatenatedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3> & ObjectOnly<TStyleSet4> & ObjectOnly<TStyleSet5>>;
+export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4, TStyleSet5>(styleSet1: TStyleSet1 | false | null | undefined | PartialShadowConfig, styleSet2: TStyleSet2 | false | null | undefined, styleSet3: TStyleSet3 | false | null | undefined, styleSet4: TStyleSet4 | false | null | undefined, styleSet5: TStyleSet5 | false | null | undefined): IConcatenatedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3> & ObjectOnly<TStyleSet4> & ObjectOnly<TStyleSet5>>;
 
 // @public
-export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4, TStyleSet5, TStyleSet6>(styleSet1: TStyleSet1 | false | null | undefined | ShadowConfig, styleSet2: TStyleSet2 | false | null | undefined, styleSet3: TStyleSet3 | false | null | undefined, styleSet4: TStyleSet4 | false | null | undefined, styleSet5: TStyleSet5 | false | null | undefined, styleSet6: TStyleSet6 | false | null | undefined): IConcatenatedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3> & ObjectOnly<TStyleSet4> & ObjectOnly<TStyleSet5> & ObjectOnly<TStyleSet6>>;
+export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4, TStyleSet5, TStyleSet6>(styleSet1: TStyleSet1 | false | null | undefined | PartialShadowConfig, styleSet2: TStyleSet2 | false | null | undefined, styleSet3: TStyleSet3 | false | null | undefined, styleSet4: TStyleSet4 | false | null | undefined, styleSet5: TStyleSet5 | false | null | undefined, styleSet6: TStyleSet6 | false | null | undefined): IConcatenatedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3> & ObjectOnly<TStyleSet4> & ObjectOnly<TStyleSet5> & ObjectOnly<TStyleSet6>>;
 
 // @public
-export function concatStyleSets(...styleSets: (IStyleSet | false | null | undefined | ShadowConfig)[]): IConcatenatedStyleSet<any>;
+export function concatStyleSets(...styleSets: (IStyleSet | false | null | undefined | PartialShadowConfig)[]): IConcatenatedStyleSet<any>;
 
 // @public
 export function concatStyleSetsWithProps<TStyleProps, TStyleSet extends IStyleSetBase>(styleProps: TStyleProps, ...allStyles: (IStyleFunctionOrObject<TStyleProps, TStyleSet> | undefined)[]): DeepPartial<TStyleSet>;
@@ -506,24 +506,24 @@ export const makeShadowConfig: (stylesheetKey: string, inShadow: boolean, window
 // Warning: (ae-forgotten-export) The symbol "IStyleOptions" needs to be exported by the entry point index.d.ts
 //
 // @public
-export function mergeCss(args: (IStyle | IStyleBaseArray | false | null | undefined | ShadowConfig) | (IStyle | IStyleBaseArray | false | null | undefined | ShadowConfig)[], options?: IStyleOptions): string;
+export function mergeCss(args: (IStyle | IStyleBaseArray | false | null | undefined | PartialShadowConfig) | (IStyle | IStyleBaseArray | false | null | undefined | PartialShadowConfig)[], options?: IStyleOptions): string;
 
 // @public
 export function mergeCssSets<TStyleSet>(styleSets: [TStyleSet | false | null | undefined], options?: IStyleOptions): IProcessedStyleSet<ObjectOnly<TStyleSet>>;
 
 // @public
-export function mergeCssSets<TStyleSet1, TStyleSet2>(styleSets: [TStyleSet1 | false | null | undefined | ShadowConfig, TStyleSet2 | false | null | undefined], options?: IStyleOptions): IProcessedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2>>;
+export function mergeCssSets<TStyleSet1, TStyleSet2>(styleSets: [TStyleSet1 | false | null | undefined | PartialShadowConfig, TStyleSet2 | false | null | undefined], options?: IStyleOptions): IProcessedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2>>;
 
 // @public
 export function mergeCssSets<TStyleSet1, TStyleSet2, TStyleSet3>(styleSets: [
-TStyleSet1 | false | null | undefined | ShadowConfig,
+TStyleSet1 | false | null | undefined | PartialShadowConfig,
 TStyleSet2 | false | null | undefined,
 TStyleSet3 | false | null | undefined
 ], options?: IStyleOptions): IProcessedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3>>;
 
 // @public
 export function mergeCssSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4>(styleSets: [
-TStyleSet1 | false | null | undefined | ShadowConfig,
+TStyleSet1 | false | null | undefined | PartialShadowConfig,
 TStyleSet2 | false | null | undefined,
 TStyleSet3 | false | null | undefined,
 TStyleSet4 | false | null | undefined
@@ -536,7 +536,7 @@ export function mergeCssSets<TStyleSet>(styleSet: [TStyleSet | false | null | un
 export function mergeStyles(...args: (IStyle | IStyleBaseArray | false | null | undefined)[]): string;
 
 // @public (undocumented)
-export function mergeStyles(shadowConfig: ShadowConfig, ...args: (IStyle | IStyleBaseArray | false | null | undefined)[]): string;
+export function mergeStyles(shadowConfig: PartialShadowConfig, ...args: (IStyle | IStyleBaseArray | false | null | undefined)[]): string;
 
 // @public
 export function mergeStyleSets<TStyleSet>(styleSet: TStyleSet | false | null | undefined): IProcessedStyleSet<ObjectOnly<TStyleSet>>;
@@ -551,10 +551,10 @@ export function mergeStyleSets<TStyleSet1, TStyleSet2, TStyleSet3>(styleSet1: TS
 export function mergeStyleSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4>(styleSet1: TStyleSet1 | false | null | undefined, styleSet2: TStyleSet2 | false | null | undefined, styleSet3: TStyleSet3 | false | null | undefined, styleSet4: TStyleSet4 | false | null | undefined): IProcessedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3> & ObjectOnly<TStyleSet4>>;
 
 // @public
-export function mergeStyleSets(...styleSets: Array<IStyleSet | undefined | false | null | ShadowConfig>): IProcessedStyleSet<any>;
+export function mergeStyleSets(...styleSets: Array<IStyleSet | undefined | false | null | PartialShadowConfig>): IProcessedStyleSet<any>;
 
 // @public (undocumented)
-export function mergeStyleSets(shadowConfig: ShadowConfig, ...styleSets: Array<IStyleSet | undefined | false | null>): IProcessedStyleSet<any>;
+export function mergeStyleSets(shadowConfig: PartialShadowConfig, ...styleSets: Array<IStyleSet | undefined | false | null>): IProcessedStyleSet<any>;
 
 // @public (undocumented)
 export type ObjectOnly<TArg> = TArg extends {} ? TArg : {};
@@ -564,6 +564,9 @@ export type ObjectOnly<TArg> = TArg extends {} ? TArg : {};
 // @public @deprecated (undocumented)
 type Omit_2<U, K extends keyof U> = Pick<U, Diff<keyof U, K>>;
 export { Omit_2 as Omit }
+
+// @public (undocumented)
+export type PartialShadowConfig = Partial<ShadowConfig>;
 
 // @public
 export function setRTL(isRTL: boolean): void;
@@ -586,7 +589,7 @@ export class ShadowDomStylesheet extends Stylesheet {
     // (undocumented)
     protected _getCacheKey(key: string): string;
     // (undocumented)
-    static getInstance(shadowConfig?: ShadowConfig): ShadowDomStylesheet;
+    static getInstance(shadowConfig?: PartialShadowConfig): ShadowDomStylesheet;
     // (undocumented)
     insertRule(rule: string, preserve?: boolean): void;
     // (undocumented)
@@ -609,7 +612,7 @@ export class Stylesheet {
     getClassNameCache(): {
         [key: string]: string;
     };
-    static getInstance(shadowConfig?: ShadowConfig): Stylesheet;
+    static getInstance(shadowConfig?: PartialShadowConfig): Stylesheet;
     getRules(includePreservedRules?: boolean): string;
     insertedRulesFromClassName(className: string): string[] | undefined;
     insertRule(rule: string, preserve?: boolean, stylesheetKey?: string): void;

--- a/packages/merge-styles/src/IStyleOptions.ts
+++ b/packages/merge-styles/src/IStyleOptions.ts
@@ -1,9 +1,9 @@
-import { ShadowConfig } from './shadowConfig';
+import { PartialShadowConfig } from './shadowConfig';
 import type { Stylesheet } from './Stylesheet';
 
 export interface IStyleOptions {
   rtl?: boolean;
   specificityMultiplier?: number;
-  shadowConfig?: ShadowConfig;
+  shadowConfig?: PartialShadowConfig;
   stylesheet?: Stylesheet;
 }

--- a/packages/merge-styles/src/IStyleSet.ts
+++ b/packages/merge-styles/src/IStyleSet.ts
@@ -1,6 +1,6 @@
 import { IStyle } from './IStyle';
 import { IStyleFunctionOrObject, IStyleFunction } from './IStyleFunction';
-import { ShadowConfig } from './shadowConfig';
+import { PartialShadowConfig } from './shadowConfig';
 
 /**
  * @deprecated Use `Exclude` provided by TypeScript instead.
@@ -70,5 +70,5 @@ export type IProcessedStyleSet<TStyleSet extends IStyleSetBase> = {
 } & IShadowConfig;
 
 type IShadowConfig = {
-  __shadowConfig__?: ShadowConfig;
+  __shadowConfig__?: PartialShadowConfig;
 };

--- a/packages/merge-styles/src/ShadowDomStylesheet.ts
+++ b/packages/merge-styles/src/ShadowDomStylesheet.ts
@@ -8,7 +8,7 @@ import type {
   IStyleSheetConfig,
   WindowWithMergeStyles,
 } from './Stylesheet';
-import type { ShadowConfig } from './shadowConfig';
+import type { PartialShadowConfig } from './shadowConfig';
 
 export const SUPPORTS_CONSTRUCTABLE_STYLESHEETS =
   typeof document !== 'undefined' && Array.isArray(document.adoptedStyleSheets) && 'replace' in CSSStyleSheet.prototype;
@@ -79,8 +79,11 @@ export class ShadowDomStylesheet extends Stylesheet {
   private _adoptableSheets: Map<string, ExtendedCSSStyleSheet>;
   private _sheetCounter = 0;
 
-  public static getInstance(shadowConfig?: ShadowConfig): ShadowDomStylesheet {
+  public static getInstance(shadowConfig?: PartialShadowConfig): ShadowDomStylesheet {
     const sConfig = shadowConfig || DEFAULT_SHADOW_CONFIG;
+    sConfig.stylesheetKey = sConfig.stylesheetKey || GLOBAL_STYLESHEET_KEY;
+    sConfig.inShadow = sConfig.inShadow || false;
+    sConfig.__isShadowConfig__ = true;
     const stylesheetKey = sConfig.stylesheetKey || GLOBAL_STYLESHEET_KEY;
     const inShadow = sConfig.inShadow;
     const win = sConfig.window || (typeof window !== 'undefined' ? window : undefined);

--- a/packages/merge-styles/src/Stylesheet.ts
+++ b/packages/merge-styles/src/Stylesheet.ts
@@ -3,7 +3,7 @@
 // See: https://github.com/microsoft/fluentui/issues/28058
 import { IStyle } from './IStyle';
 import { GLOBAL_STYLESHEET_KEY, SHADOW_DOM_STYLESHEET_SETTING } from './shadowConfig';
-import type { ShadowConfig } from './shadowConfig';
+import type { PartialShadowConfig } from './shadowConfig';
 
 export const InjectionMode = {
   /**
@@ -173,7 +173,7 @@ export class Stylesheet {
   /**
    * Gets the singleton instance.
    */
-  public static getInstance(shadowConfig?: ShadowConfig): Stylesheet {
+  public static getInstance(shadowConfig?: PartialShadowConfig): Stylesheet {
     _stylesheet = _global[STYLESHEET_SETTING] as Stylesheet;
 
     if (_global[SHADOW_DOM_STYLESHEET_SETTING]) {

--- a/packages/merge-styles/src/concatStyleSets.ts
+++ b/packages/merge-styles/src/concatStyleSets.ts
@@ -2,7 +2,7 @@ import { IStyleSet, IConcatenatedStyleSet } from './IStyleSet';
 import { IStyleBase, IStyle } from './IStyle';
 import { IStyleFunctionOrObject } from './IStyleFunction';
 import { ObjectOnly } from './ObjectOnly';
-import { ShadowConfig, isShadowConfig } from './shadowConfig';
+import { PartialShadowConfig, isShadowConfig } from './shadowConfig';
 
 /**
  * Combine a set of styles together (but does not register css classes).
@@ -18,7 +18,7 @@ export function concatStyleSets<TStyleSet>(
  * @param styleSet2 - The second style set to be concatenated.
  */
 export function concatStyleSets<TStyleSet1, TStyleSet2>(
-  styleSet1: TStyleSet1 | false | null | undefined | ShadowConfig,
+  styleSet1: TStyleSet1 | false | null | undefined | PartialShadowConfig,
   styleSet2: TStyleSet2 | false | null | undefined,
 ): IConcatenatedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2>>;
 
@@ -29,7 +29,7 @@ export function concatStyleSets<TStyleSet1, TStyleSet2>(
  * @param styleSet3 - The third style set to be concatenated.
  */
 export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3>(
-  styleSet1: TStyleSet1 | false | null | undefined | ShadowConfig,
+  styleSet1: TStyleSet1 | false | null | undefined | PartialShadowConfig,
   styleSet2: TStyleSet2 | false | null | undefined,
   styleSet3: TStyleSet3 | false | null | undefined,
 ): IConcatenatedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2> & ObjectOnly<TStyleSet3>>;
@@ -42,7 +42,7 @@ export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3>(
  * @param styleSet4 - The fourth style set to be concatenated.
  */
 export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4>(
-  styleSet1: TStyleSet1 | false | null | undefined | ShadowConfig,
+  styleSet1: TStyleSet1 | false | null | undefined | PartialShadowConfig,
   styleSet2: TStyleSet2 | false | null | undefined,
   styleSet3: TStyleSet3 | false | null | undefined,
   styleSet4: TStyleSet4 | false | null | undefined,
@@ -59,7 +59,7 @@ export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4>(
  * @param styleSet5 - The fifth set to be concatenated.
  */
 export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4, TStyleSet5>(
-  styleSet1: TStyleSet1 | false | null | undefined | ShadowConfig,
+  styleSet1: TStyleSet1 | false | null | undefined | PartialShadowConfig,
   styleSet2: TStyleSet2 | false | null | undefined,
   styleSet3: TStyleSet3 | false | null | undefined,
   styleSet4: TStyleSet4 | false | null | undefined,
@@ -82,7 +82,7 @@ export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4, 
  * @param styleSet6 - The sixth set to be concatenated.
  */
 export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4, TStyleSet5, TStyleSet6>(
-  styleSet1: TStyleSet1 | false | null | undefined | ShadowConfig,
+  styleSet1: TStyleSet1 | false | null | undefined | PartialShadowConfig,
   styleSet2: TStyleSet2 | false | null | undefined,
   styleSet3: TStyleSet3 | false | null | undefined,
   styleSet4: TStyleSet4 | false | null | undefined,
@@ -102,7 +102,7 @@ export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4, 
  * @param styleSets - One or more stylesets to be merged (each param can also be falsy).
  */
 export function concatStyleSets(
-  ...styleSets: (IStyleSet | false | null | undefined | ShadowConfig)[]
+  ...styleSets: (IStyleSet | false | null | undefined | PartialShadowConfig)[]
 ): IConcatenatedStyleSet<any>;
 
 /**
@@ -110,7 +110,7 @@ export function concatStyleSets(
  * @param styleSets - One or more stylesets to be merged (each param can also be falsy).
  */
 export function concatStyleSets(
-  ...styleSets: (IStyleSet | false | null | undefined | ShadowConfig)[]
+  ...styleSets: (IStyleSet | false | null | undefined | PartialShadowConfig)[]
 ): IConcatenatedStyleSet<any> {
   if (
     styleSets &&

--- a/packages/merge-styles/src/index.ts
+++ b/packages/merge-styles/src/index.ts
@@ -54,7 +54,7 @@ export { setRTL } from './StyleOptionsState';
 export type { ObjectOnly } from './ObjectOnly';
 
 export { DEFAULT_SHADOW_CONFIG, GLOBAL_STYLESHEET_KEY, makeShadowConfig } from './shadowConfig';
-export type { ShadowConfig } from './shadowConfig';
+export type { ShadowConfig, PartialShadowConfig } from './shadowConfig';
 
 export { cloneCSSStyleSheet } from './cloneCSSStyleSheet';
 

--- a/packages/merge-styles/src/mergeStyleSets.ts
+++ b/packages/merge-styles/src/mergeStyleSets.ts
@@ -6,7 +6,8 @@ import { IConcatenatedStyleSet, IProcessedStyleSet, IStyleSet } from './IStyleSe
 import { getStyleOptions } from './StyleOptionsState';
 import { applyRegistration, styleToRegistration } from './styleToClassName';
 import { ObjectOnly } from './ObjectOnly';
-import { isShadowConfig, ShadowConfig } from './shadowConfig';
+import { isShadowConfig } from './shadowConfig';
+import type { PartialShadowConfig } from './shadowConfig';
 import { Stylesheet } from './Stylesheet';
 
 /**
@@ -80,11 +81,11 @@ export function mergeStyleSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4>(
  * @param styleSets - One or more style sets to be merged.
  */
 export function mergeStyleSets(
-  ...styleSets: Array<IStyleSet | undefined | false | null | ShadowConfig>
+  ...styleSets: Array<IStyleSet | undefined | false | null | PartialShadowConfig>
 ): IProcessedStyleSet<any>;
 
 export function mergeStyleSets(
-  shadowConfig: ShadowConfig,
+  shadowConfig: PartialShadowConfig,
   ...styleSets: Array<IStyleSet | undefined | false | null>
 ): IProcessedStyleSet<any>;
 
@@ -97,7 +98,7 @@ export function mergeStyleSets(
  * @param styleSets - One or more style sets to be merged.
  */
 export function mergeStyleSets(
-  ...styleSets: Array<IStyleSet | undefined | false | null | ShadowConfig>
+  ...styleSets: Array<IStyleSet | undefined | false | null | PartialShadowConfig>
 ): IProcessedStyleSet<any> {
   return mergeCssSets(styleSets as any, getStyleOptions());
 }
@@ -126,7 +127,7 @@ export function mergeCssSets<TStyleSet>(
  * @param options - (optional) Options to use when creating rules.
  */
 export function mergeCssSets<TStyleSet1, TStyleSet2>(
-  styleSets: [TStyleSet1 | false | null | undefined | ShadowConfig, TStyleSet2 | false | null | undefined],
+  styleSets: [TStyleSet1 | false | null | undefined | PartialShadowConfig, TStyleSet2 | false | null | undefined],
   options?: IStyleOptions,
 ): IProcessedStyleSet<ObjectOnly<TStyleSet1> & ObjectOnly<TStyleSet2>>;
 
@@ -141,7 +142,7 @@ export function mergeCssSets<TStyleSet1, TStyleSet2>(
  */
 export function mergeCssSets<TStyleSet1, TStyleSet2, TStyleSet3>(
   styleSets: [
-    TStyleSet1 | false | null | undefined | ShadowConfig,
+    TStyleSet1 | false | null | undefined | PartialShadowConfig,
     TStyleSet2 | false | null | undefined,
     TStyleSet3 | false | null | undefined,
   ],
@@ -159,7 +160,7 @@ export function mergeCssSets<TStyleSet1, TStyleSet2, TStyleSet3>(
  */
 export function mergeCssSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4>(
   styleSets: [
-    TStyleSet1 | false | null | undefined | ShadowConfig,
+    TStyleSet1 | false | null | undefined | PartialShadowConfig,
     TStyleSet2 | false | null | undefined,
     TStyleSet3 | false | null | undefined,
     TStyleSet4 | false | null | undefined,
@@ -193,15 +194,15 @@ export function mergeCssSets<TStyleSet>(
  * @param options - (optional) Options to use when creating rules.
  */
 export function mergeCssSets(
-  styleSets: Array<IStyleSet | undefined | false | null | ShadowConfig>,
+  styleSets: Array<IStyleSet | undefined | false | null | PartialShadowConfig>,
   options?: IStyleOptions,
 ): IProcessedStyleSet<any> {
   const classNameSet: IProcessedStyleSet<any> = { subComponentStyles: {} };
 
-  let shadowConfig: ShadowConfig | undefined = undefined;
+  let shadowConfig: PartialShadowConfig | undefined = undefined;
   let styleSet;
   if (isShadowConfig(styleSets[0])) {
-    shadowConfig = styleSets[0] as ShadowConfig;
+    shadowConfig = styleSets[0] as PartialShadowConfig;
     styleSet = styleSets[1];
   } else {
     styleSet = styleSets[0];

--- a/packages/merge-styles/src/mergeStyles.ts
+++ b/packages/merge-styles/src/mergeStyles.ts
@@ -1,14 +1,15 @@
 import { extractStyleParts } from './extractStyleParts';
 import { IStyle, IStyleBaseArray } from './IStyle';
 import { IStyleOptions } from './IStyleOptions';
-import { isShadowConfig, ShadowConfig } from './shadowConfig';
+import { isShadowConfig } from './shadowConfig';
+import type { PartialShadowConfig } from './shadowConfig';
 import { getStyleOptions } from './StyleOptionsState';
 import { Stylesheet } from './Stylesheet';
 import { styleToClassName } from './styleToClassName';
 
 export function mergeStyles(...args: (IStyle | IStyleBaseArray | false | null | undefined)[]): string;
 export function mergeStyles(
-  shadowConfig: ShadowConfig,
+  shadowConfig: PartialShadowConfig,
   ...args: (IStyle | IStyleBaseArray | false | null | undefined)[]
 ): string;
 
@@ -29,15 +30,15 @@ export function mergeStyles(...args: (IStyle | IStyleBaseArray | false | null | 
  */
 export function mergeCss(
   args:
-    | (IStyle | IStyleBaseArray | false | null | undefined | ShadowConfig)
-    | (IStyle | IStyleBaseArray | false | null | undefined | ShadowConfig)[],
+    | (IStyle | IStyleBaseArray | false | null | undefined | PartialShadowConfig)
+    | (IStyle | IStyleBaseArray | false | null | undefined | PartialShadowConfig)[],
   options?: IStyleOptions,
 ): string {
   const styleArgs = args instanceof Array ? args : [args];
   const opts = options || {};
   const hasShadowConfig = isShadowConfig(styleArgs[0]);
   if (hasShadowConfig) {
-    opts.shadowConfig = styleArgs[0] as ShadowConfig;
+    opts.shadowConfig = styleArgs[0] as PartialShadowConfig;
   }
   opts.stylesheet = Stylesheet.getInstance(opts.shadowConfig);
   const { classes, objects } = extractStyleParts(opts.stylesheet, styleArgs);

--- a/packages/merge-styles/src/shadowConfig.ts
+++ b/packages/merge-styles/src/shadowConfig.ts
@@ -5,6 +5,8 @@ export type ShadowConfig = {
   __isShadowConfig__: true;
 };
 
+export type PartialShadowConfig = Partial<ShadowConfig>;
+
 export const GLOBAL_STYLESHEET_KEY = '__global__';
 export const SHADOW_DOM_STYLESHEET_SETTING = '__shadow_dom_stylesheet__';
 
@@ -24,10 +26,14 @@ export const makeShadowConfig = (stylesheetKey: string, inShadow: boolean, windo
   };
 };
 
-export const isShadowConfig = (obj: unknown): obj is ShadowConfig => {
+export const isShadowConfig = <T extends ShadowConfig | PartialShadowConfig>(obj: unknown): obj is T => {
   if (!obj) {
     return false;
   }
 
-  return (obj as ShadowConfig).__isShadowConfig__ === true;
+  return (
+    (obj as ShadowConfig).__isShadowConfig__ === true &&
+    typeof (obj as ShadowConfig).stylesheetKey === 'string' &&
+    typeof (obj as ShadowConfig).inShadow === 'boolean'
+  );
 };

--- a/packages/merge-styles/src/styleToClassName.ts
+++ b/packages/merge-styles/src/styleToClassName.ts
@@ -8,7 +8,7 @@ import { provideUnits } from './transforms/provideUnits';
 import { rtlifyRules } from './transforms/rtlifyRules';
 import { IStyleOptions } from './IStyleOptions';
 import { tokenizeWithParentheses } from './tokenizeWithParentheses';
-import { ShadowConfig } from './shadowConfig';
+import type { PartialShadowConfig } from './shadowConfig';
 
 const DISPLAY_NAME = 'displayName';
 
@@ -293,7 +293,7 @@ export function styleToRegistration(options: IStyleOptions, ...args: IStyle[]): 
 export function applyRegistration(
   registration: IRegistration,
   specificityMultiplier: number = 1,
-  shadowConfig?: ShadowConfig,
+  shadowConfig?: PartialShadowConfig,
   sheet?: Stylesheet,
 ): void {
   const stylesheet = sheet ?? Stylesheet.getInstance(shadowConfig);

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -303,6 +303,7 @@ import { omit } from '@fluentui/utilities';
 import { Omit as Omit_2 } from '@fluentui/utilities';
 import { on } from '@fluentui/utilities';
 import { optionProperties } from '@fluentui/utilities';
+import type { PartialShadowConfig } from '@fluentui/style-utilities';
 import { PartialTheme } from '@fluentui/theme';
 import { Point } from '@fluentui/utilities';
 import { portalContainsElement } from '@fluentui/utilities';
@@ -356,7 +357,6 @@ import { Settings } from '@fluentui/utilities';
 import { SettingsFunction } from '@fluentui/utilities';
 import { setVirtualParent } from '@fluentui/utilities';
 import { setWarningCallback } from '@fluentui/utilities';
-import type { ShadowConfig } from '@fluentui/style-utilities';
 import { shallowCompare } from '@fluentui/utilities';
 import { SharedColors } from '@fluentui/theme';
 import { shouldWrapFocus } from '@fluentui/utilities';
@@ -8423,7 +8423,7 @@ export { IsFocusVisibleClassName }
 
 // @public (undocumented)
 export interface IShadowDomStyle {
-    __shadowConfig__?: ShadowConfig;
+    __shadowConfig__?: PartialShadowConfig;
 }
 
 // @public (undocumented)

--- a/packages/react/src/Styling.ts
+++ b/packages/react/src/Styling.ts
@@ -97,12 +97,13 @@ export type {
   IStyleSheetConfig,
   ITheme,
   ShadowConfig,
+  PartialShadowConfig,
 } from '@fluentui/style-utilities';
 
-import type { ShadowConfig } from '@fluentui/style-utilities';
+import type { PartialShadowConfig } from '@fluentui/style-utilities';
 export interface IShadowDomStyle {
   /**
    * Optional configuration object when using shadow DOM.
    */
-  __shadowConfig__?: ShadowConfig;
+  __shadowConfig__?: PartialShadowConfig;
 }

--- a/packages/style-utilities/etc/style-utilities.api.md
+++ b/packages/style-utilities/etc/style-utilities.api.md
@@ -43,6 +43,7 @@ import { ITheme } from '@fluentui/theme';
 import { keyframes } from '@fluentui/merge-styles';
 import { mergeStyles } from '@fluentui/merge-styles';
 import { mergeStyleSets } from '@fluentui/merge-styles';
+import { PartialShadowConfig } from '@fluentui/merge-styles';
 import { registerDefaultFontFaces } from '@fluentui/theme';
 import { ShadowConfig } from '@fluentui/merge-styles';
 import { Stylesheet } from '@fluentui/merge-styles';
@@ -270,6 +271,8 @@ export const normalize: IRawStyle;
 
 // @public (undocumented)
 export const noWrap: IRawStyle;
+
+export { PartialShadowConfig }
 
 // @public (undocumented)
 export const PulsingBeaconAnimationStyles: {

--- a/packages/style-utilities/src/MergeStyles.ts
+++ b/packages/style-utilities/src/MergeStyles.ts
@@ -19,4 +19,5 @@ export type {
   IStyleSheetConfig,
   ICSPSettings,
   ShadowConfig,
+  PartialShadowConfig,
 } from '@fluentui/merge-styles';

--- a/packages/style-utilities/src/index.ts
+++ b/packages/style-utilities/src/index.ts
@@ -103,6 +103,7 @@ export type {
   IStyleSheetConfig,
   ICSPSettings,
   ShadowConfig,
+  PartialShadowConfig,
 } from './MergeStyles';
 
 export { FLUENT_CDN_BASE_URL } from './cdn';

--- a/packages/utilities/etc/utilities.api.md
+++ b/packages/utilities/etc/utilities.api.md
@@ -21,11 +21,12 @@ import type { IStyleSetBase } from '@fluentui/merge-styles';
 import { isVirtualElement } from '@fluentui/dom-utilities';
 import { IVirtualElement } from '@fluentui/dom-utilities';
 import { Omit as Omit_2 } from '@fluentui/merge-styles';
+import type { PartialShadowConfig } from '@fluentui/merge-styles';
 import { portalContainsElement } from '@fluentui/dom-utilities';
 import * as React_2 from 'react';
 import { setPortalAttribute } from '@fluentui/dom-utilities';
 import { setVirtualParent } from '@fluentui/dom-utilities';
-import { ShadowConfig } from '@fluentui/merge-styles';
+import type { ShadowConfig } from '@fluentui/merge-styles';
 
 // @public
 export function addDirectionalKeyCode(which: number): void;
@@ -1313,7 +1314,7 @@ export function styled<TComponentProps extends IPropsWithStyles<TStyleProps, TSt
 export type StyleFunction<TStyleProps, TStyleSet extends IStyleSetBase> = IStyleFunctionOrObject<TStyleProps, TStyleSet> & {
     __cachedInputs__: (IStyleFunctionOrObject<TStyleProps, TStyleSet> | undefined)[];
     __noStyleOverride__: boolean;
-    __shadowConfig__?: ShadowConfig;
+    __shadowConfig__?: PartialShadowConfig;
 };
 
 // @public

--- a/packages/utilities/etc/utilities.api.md
+++ b/packages/utilities/etc/utilities.api.md
@@ -21,7 +21,6 @@ import type { IStyleSetBase } from '@fluentui/merge-styles';
 import { isVirtualElement } from '@fluentui/dom-utilities';
 import { IVirtualElement } from '@fluentui/dom-utilities';
 import { Omit as Omit_2 } from '@fluentui/merge-styles';
-import type { PartialShadowConfig } from '@fluentui/merge-styles';
 import { portalContainsElement } from '@fluentui/dom-utilities';
 import * as React_2 from 'react';
 import { setPortalAttribute } from '@fluentui/dom-utilities';
@@ -1314,7 +1313,7 @@ export function styled<TComponentProps extends IPropsWithStyles<TStyleProps, TSt
 export type StyleFunction<TStyleProps, TStyleSet extends IStyleSetBase> = IStyleFunctionOrObject<TStyleProps, TStyleSet> & {
     __cachedInputs__: (IStyleFunctionOrObject<TStyleProps, TStyleSet> | undefined)[];
     __noStyleOverride__: boolean;
-    __shadowConfig__?: PartialShadowConfig;
+    __shadowConfig__?: ShadowConfig;
 };
 
 // @public

--- a/packages/utilities/src/customizations/customizable.tsx
+++ b/packages/utilities/src/customizations/customizable.tsx
@@ -7,14 +7,14 @@ import { MergeStylesShadowRootConsumer } from '../shadowDom/contexts/MergeStyles
 import { getWindow } from '../dom/getWindow';
 import { WindowContext } from '@fluentui/react-window-provider';
 import type { ICustomizerContext } from './CustomizerContext';
-import type { ShadowConfig } from '@fluentui/merge-styles';
+import type { PartialShadowConfig } from '@fluentui/merge-styles';
 
 import { memoizeFunction } from '../memoize';
 
 const memoizedMakeShadowConfig = memoizeFunction(makeShadowConfig);
 const mergeComponentStyles = memoizeFunction(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (defaultStyles: any, componentStyles: any, shadowConfig: ShadowConfig): any => {
+  (defaultStyles: any, componentStyles: any, shadowConfig: PartialShadowConfig): any => {
     return {
       ...defaultStyles,
       ...componentStyles,

--- a/packages/utilities/src/customizations/customizable.tsx
+++ b/packages/utilities/src/customizations/customizable.tsx
@@ -7,14 +7,14 @@ import { MergeStylesShadowRootConsumer } from '../shadowDom/contexts/MergeStyles
 import { getWindow } from '../dom/getWindow';
 import { WindowContext } from '@fluentui/react-window-provider';
 import type { ICustomizerContext } from './CustomizerContext';
-import type { PartialShadowConfig } from '@fluentui/merge-styles';
+import type { ShadowConfig } from '@fluentui/merge-styles';
 
 import { memoizeFunction } from '../memoize';
 
 const memoizedMakeShadowConfig = memoizeFunction(makeShadowConfig);
 const mergeComponentStyles = memoizeFunction(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (defaultStyles: any, componentStyles: any, shadowConfig: PartialShadowConfig): any => {
+  (defaultStyles: any, componentStyles: any, shadowConfig: ShadowConfig): any => {
     return {
       ...defaultStyles,
       ...componentStyles,

--- a/packages/utilities/src/shadowDom/hooks/useStyled.ts
+++ b/packages/utilities/src/shadowDom/hooks/useStyled.ts
@@ -1,4 +1,4 @@
-import { ShadowConfig } from '@fluentui/merge-styles';
+import type { ShadowConfig } from '@fluentui/merge-styles';
 import { getWindow } from '../../dom';
 import { useMergeStylesHooks } from './useMergeStylesHooks';
 

--- a/packages/utilities/src/styled.tsx
+++ b/packages/utilities/src/styled.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { concatStyleSetsWithProps } from '@fluentui/merge-styles';
 import { useMergeStylesHooks } from './shadowDom/index';
 import { useCustomizationSettings } from './customizations/useCustomizationSettings';
-import type { IStyleSetBase, IStyleFunctionOrObject, PartialShadowConfig } from '@fluentui/merge-styles';
+import type { IStyleSetBase, IStyleFunctionOrObject, ShadowConfig } from '@fluentui/merge-styles';
 
 export interface IPropsWithStyles<TStyleProps, TStyleSet extends IStyleSetBase> {
   styles?: IStyleFunctionOrObject<TStyleProps, TStyleSet>;
@@ -34,7 +34,7 @@ export type StyleFunction<TStyleProps, TStyleSet extends IStyleSetBase> = IStyle
   __noStyleOverride__: boolean;
 
   /** Shadow DOM configuration object */
-  __shadowConfig__?: PartialShadowConfig;
+  __shadowConfig__?: ShadowConfig;
 };
 
 /**

--- a/packages/utilities/src/styled.tsx
+++ b/packages/utilities/src/styled.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { concatStyleSetsWithProps } from '@fluentui/merge-styles';
 import { useMergeStylesHooks } from './shadowDom/index';
 import { useCustomizationSettings } from './customizations/useCustomizationSettings';
-import type { IStyleSetBase, IStyleFunctionOrObject, ShadowConfig } from '@fluentui/merge-styles';
+import type { IStyleSetBase, IStyleFunctionOrObject, PartialShadowConfig } from '@fluentui/merge-styles';
 
 export interface IPropsWithStyles<TStyleProps, TStyleSet extends IStyleSetBase> {
   styles?: IStyleFunctionOrObject<TStyleProps, TStyleSet>;
@@ -34,7 +34,7 @@ export type StyleFunction<TStyleProps, TStyleSet extends IStyleSetBase> = IStyle
   __noStyleOverride__: boolean;
 
   /** Shadow DOM configuration object */
-  __shadowConfig__?: ShadowConfig;
+  __shadowConfig__?: PartialShadowConfig;
 };
 
 /**


### PR DESCRIPTION
## Previous Behavior

The `ShadowConfig` type has required properties which complicates type checking in some cases.

## New Behavior

`ShadowConfig` remains the same but we've added `PartialShadowConfig` which is `Partial<ShadowConfig>`, making all properties optional. All APIs that previously accepted `ShadowConfig` now take `PartialShadowConfig`, a [backward compatible change](https://www.typescriptlang.org/play/?#code/C4TwDgpgBAygFgQwCYHsDuBhFA7AZgSwHMoBeKAbwFgAoKKAZ1ABsJ64IJgBpCEALgbAATvmyEA3DTqj4ydAIBGKFCwTZJtKGlGo0AfgEB1Heg10A+ufz1ZurHiKWBwgK4QNAXw01QkKAAUEIWB8BCZbdHsCYjJA4NCmAB4IzBxogD5vahZgKDAgkLCBOMLwxDs0olIKLxocqABjSsIBFKiqsnJBEBY2Dm5eAQByAGteIYAaKBly+ShXCCnLazbmp3mhNyha6hoAej2oQFByGnz4sOqmhwkafcPAGXIaK+jqs9KNIA) (I think).

## Related Issue(s)

- Follows https://github.com/microsoft/fluentui/pull/30689
