### PR TITLE
feat:(react-nav-preview) Selection indicator and icon animation

### DIFF
--- a/change/@fluentui-react-nav-preview-527c5ff5-5fa1-4d9b-a84c-90d725ddc550.json
+++ b/change/@fluentui-react-nav-preview-527c5ff5-5fa1-4d9b-a84c-90d725ddc550.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "(feat): Adds animation to selection indicator and icon.",
+  "packageName": "@fluentui/react-nav-preview",
+  "email": "matejera@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-nav-preview-527c5ff5-5fa1-4d9b-a84c-90d725ddc550.json
+++ b/change/@fluentui-react-nav-preview-527c5ff5-5fa1-4d9b-a84c-90d725ddc550.json
@@ -1,7 +1,7 @@
 {
-  "type": "patch",
+  "type": "minor",
   "comment": "(feat): Adds animation to selection indicator and icon.",
   "packageName": "@fluentui/react-nav-preview",
   "email": "matejera@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "minor"
 }

--- a/change/@fluentui-react-nav-preview-527c5ff5-5fa1-4d9b-a84c-90d725ddc550.json
+++ b/change/@fluentui-react-nav-preview-527c5ff5-5fa1-4d9b-a84c-90d725ddc550.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "(feat): Adds animation to selection indicator and icon.",
+  "comment": "feat: Adds animation to selection indicator and icon.",
   "packageName": "@fluentui/react-nav-preview",
   "email": "matejera@microsoft.com",
   "dependentChangeType": "minor"

--- a/packages/react-components/react-nav-preview/library/src/components/sharedNavStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/library/src/components/sharedNavStyles.styles.ts
@@ -32,6 +32,11 @@ export const useRootDefaultClassName = makeResetStyles({
   // this element can change between a button and an anchor
   // so we need to reset box sizing to prevent horizontal overflow
   boxSizing: 'border-box',
+
+  transitionDuration: tokens.durationFast,
+  transitionTimingFunction: tokens.curveAccelerateMid,
+  transitionProperty: 'background',
+
   width: '100%',
   ...typographyStyles.body1,
   ':hover': {
@@ -64,6 +69,13 @@ export const useIndicatorStyles = makeStyles({
   base: {
     '::after': {
       position: 'absolute',
+      animationDuration: tokens.durationFast,
+      animationFillMode: 'both',
+      animationTimingFunction: tokens.curveAccelerateMid,
+      animationName: {
+        '0%': { background: 'transparent' },
+        '100%': { background: tokens.colorCompoundBrandForeground1 },
+      },
       marginInlineStart: `-${navItemTokens.indicatorOffset}px`,
       backgroundColor: tokens.colorCompoundBrandForeground1,
       height: `${navItemTokens.indicatorHeight}px`,

--- a/packages/react-components/react-nav-preview/library/src/components/sharedNavStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/library/src/components/sharedNavStyles.styles.ts
@@ -38,8 +38,8 @@ export const useRootDefaultClassName = makeResetStyles({
   // so we need to reset box sizing to prevent horizontal overflow
   boxSizing: 'border-box',
 
-  transitionDuration: tokens.durationFast,
-  transitionTimingFunction: tokens.curveAccelerateMid,
+  transitionDuration: navItemTokens.animationTokens.animationDuration,
+  transitionTimingFunction: navItemTokens.animationTokens.animationTimingFunction,
   transitionProperty: 'background',
 
   width: '100%',

--- a/packages/react-components/react-nav-preview/library/src/components/sharedNavStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/library/src/components/sharedNavStyles.styles.ts
@@ -11,6 +11,11 @@ export const navItemTokens = {
   backgroundColor: tokens.colorNeutralBackground4,
   backgroundColorHover: tokens.colorNeutralBackground4Hover,
   backgroundColorPressed: tokens.colorNeutralBackground4Pressed,
+  animationTokens: {
+    animationDuration: tokens.durationFast,
+    animationFillMode: 'both',
+    animationTimingFunction: tokens.curveAccelerateMid,
+  },
 };
 
 /**
@@ -69,13 +74,12 @@ export const useIndicatorStyles = makeStyles({
   base: {
     '::after': {
       position: 'absolute',
-      animationDuration: tokens.durationFast,
-      animationFillMode: 'both',
-      animationTimingFunction: tokens.curveAccelerateMid,
+      ...navItemTokens.animationTokens,
       animationName: {
         '0%': { background: 'transparent' },
         '100%': { background: tokens.colorCompoundBrandForeground1 },
       },
+
       marginInlineStart: `-${navItemTokens.indicatorOffset}px`,
       backgroundColor: tokens.colorCompoundBrandForeground1,
       height: `${navItemTokens.indicatorHeight}px`,
@@ -97,26 +101,52 @@ export const useIndicatorStyles = makeStyles({
  */
 export const useIconStyles = makeStyles({
   base: {
+    display: 'grid',
+    gridTemplateAreas: 'overlay-area',
     minHeight: '20px',
     minWidth: '20px',
     alignItems: 'top',
-    display: 'inline-flex',
     justifyContent: 'center',
     overflow: 'hidden',
     [`& .${iconFilledClassName}`]: {
+      gridArea: 'overlay-area',
+      color: 'transparent',
       display: 'none',
     },
     [`& .${iconRegularClassName}`]: {
+      gridArea: 'overlay-area',
       display: 'inline',
     },
   },
   selected: {
     [`& .${iconFilledClassName}`]: {
+      ...navItemTokens.animationTokens,
       display: 'inline',
       color: tokens.colorCompoundBrandForeground1,
+      animationName: {
+        '0%': {
+          display: 'none',
+          color: 'transparent',
+        },
+        '100%': {
+          display: 'inline',
+          color: tokens.colorNeutralForeground2BrandSelected,
+        },
+      },
     },
     [`& .${iconRegularClassName}`]: {
-      display: 'none',
+      color: tokens.colorNeutralForeground2BrandSelected,
+      ...navItemTokens.animationTokens,
+      animationName: {
+        '0%': {
+          display: 'inline',
+          color: tokens.colorNeutralForeground2,
+        },
+        '100%': {
+          display: 'none',
+          color: 'transparent',
+        },
+      },
     },
   },
 });

--- a/packages/react-components/react-nav-preview/library/src/components/sharedNavStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/library/src/components/sharedNavStyles.styles.ts
@@ -122,7 +122,6 @@ export const useIconStyles = makeStyles({
     [`& .${iconFilledClassName}`]: {
       ...navItemTokens.animationTokens,
       display: 'inline',
-      color: tokens.colorCompoundBrandForeground1,
       animationName: {
         '0%': {
           display: 'none',
@@ -135,7 +134,6 @@ export const useIconStyles = makeStyles({
       },
     },
     [`& .${iconRegularClassName}`]: {
-      color: tokens.colorNeutralForeground2BrandSelected,
       ...navItemTokens.animationTokens,
       animationName: {
         '0%': {

--- a/packages/react-components/react-nav-preview/stories/src/NavDrawer/NavDrawerDefault.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/src/NavDrawer/NavDrawerDefault.stories.tsx
@@ -13,7 +13,7 @@ import {
   NavSubItemGroup,
 } from '@fluentui/react-nav-preview';
 import { DrawerProps } from '@fluentui/react-drawer';
-import { Label, Radio, RadioGroup, makeStyles, tokens, useId } from '@fluentui/react-components';
+import { Label, Radio, RadioGroup, Switch, makeStyles, tokens, useId } from '@fluentui/react-components';
 import {
   Board20Filled,
   Board20Regular,
@@ -85,10 +85,14 @@ type DrawerType = Required<DrawerProps>['type'];
 export const NavDrawerDefault = (props: Partial<NavDrawerProps>) => {
   const styles = useStyles();
 
-  const labelId = useId('type-label');
+  const typeLableId = useId('type-label');
+  const linkLabelId = useId('link-label');
 
   const [isOpen, setIsOpen] = React.useState(true);
+  const [enabledLinks, setEnabledLinks] = React.useState(false); // todo change this back to true before checkin
   const [type, setType] = React.useState<DrawerType>('inline');
+
+  const linkDestination = enabledLinks ? 'https://www.bing.com' : '';
 
   return (
     <div className={styles.root}>
@@ -98,19 +102,19 @@ export const NavDrawerDefault = (props: Partial<NavDrawerProps>) => {
         </NavDrawerHeader>
         <NavDrawerBody>
           <NavSectionHeader>Home</NavSectionHeader>
-          <NavItem href="https://www.bing.com" icon={<Dashboard />} value="1">
+          <NavItem href={linkDestination} icon={<Dashboard />} value="1">
             Dashboard
           </NavItem>
-          <NavItem icon={<Announcements />} value="2">
+          <NavItem href={linkDestination} icon={<Announcements />} value="2">
             Announcements
           </NavItem>
-          <NavItem icon={<EmployeeSpotlight />} value="3">
+          <NavItem href={linkDestination} icon={<EmployeeSpotlight />} value="3">
             Employee Spotlight
           </NavItem>
-          <NavItem icon={<Search />} href="https://www.bing.com" value="4">
+          <NavItem icon={<Search />} href={linkDestination} value="4">
             Profile Search
           </NavItem>
-          <NavItem icon={<PerformanceReviews />} href="https://www.bing.com" value="5">
+          <NavItem icon={<PerformanceReviews />} href={linkDestination} value="5">
             Performance Reviews
           </NavItem>
 
@@ -118,10 +122,10 @@ export const NavDrawerDefault = (props: Partial<NavDrawerProps>) => {
           <NavCategory value="6">
             <NavCategoryItem icon={<JobPostings />}>Job Postings</NavCategoryItem>
             <NavSubItemGroup>
-              <NavSubItem href="https://www.bing.com" value="7">
+              <NavSubItem href={linkDestination} value="7">
                 Openings
               </NavSubItem>
-              <NavSubItem href="https://www.bing.com" value="8">
+              <NavSubItem href={linkDestination} value="8">
                 Submissions
               </NavSubItem>
             </NavSubItemGroup>
@@ -139,10 +143,10 @@ export const NavDrawerDefault = (props: Partial<NavDrawerProps>) => {
               Retirement
             </NavCategoryItem>
             <NavSubItemGroup>
-              <NavSubItem href="https://www.bing.com" value="13">
+              <NavSubItem href={linkDestination} value="13">
                 Plan Information
               </NavSubItem>
-              <NavSubItem href="https://www.bing.com" value="14">
+              <NavSubItem href={linkDestination} value="14">
                 Fund Performance
               </NavSubItem>
             </NavSubItemGroup>
@@ -155,10 +159,10 @@ export const NavDrawerDefault = (props: Partial<NavDrawerProps>) => {
           <NavCategory value="16">
             <NavCategoryItem icon={<CareerDevelopment />}>Career Development</NavCategoryItem>
             <NavSubItemGroup>
-              <NavSubItem href="https://www.bing.com" value="17">
+              <NavSubItem href={linkDestination} value="17">
                 Career Paths
               </NavSubItem>
-              <NavSubItem href="https://www.bing.com" value="18">
+              <NavSubItem href={linkDestination} value="18">
                 Planning
               </NavSubItem>
             </NavSubItemGroup>
@@ -168,7 +172,7 @@ export const NavDrawerDefault = (props: Partial<NavDrawerProps>) => {
           <NavItem target="_blank" icon={<Analytics />} value="19">
             Workforce Data
           </NavItem>
-          <NavItem href="https://www.bing.com" icon={<Reports />} value="20">
+          <NavItem href={linkDestination} icon={<Reports />} value="20">
             Reports
           </NavItem>
         </NavDrawerBody>
@@ -176,11 +180,22 @@ export const NavDrawerDefault = (props: Partial<NavDrawerProps>) => {
       <div className={styles.content}>
         {!isOpen && <Hamburger onClick={() => setIsOpen(true)} />}
         <div className={styles.field}>
-          <Label id={labelId}>Type</Label>
-          <RadioGroup value={type} onChange={(_, data) => setType(data.value as DrawerType)} aria-labelledby={labelId}>
+          <Label id={typeLableId}>Type</Label>
+          <RadioGroup
+            value={type}
+            onChange={(_, data) => setType(data.value as DrawerType)}
+            aria-labelledby={typeLableId}
+          >
             <Radio value="overlay" label="Overlay (Default)" />
             <Radio value="inline" label="Inline" />
           </RadioGroup>
+          <Label id={linkLabelId}>Links</Label>
+          <Switch
+            checked={enabledLinks}
+            onChange={(_, data) => setEnabledLinks(data.checked as boolean)}
+            label={enabledLinks ? 'Enabled' : 'Disabled'}
+            aria-labelledby={linkLabelId}
+          />
         </div>
       </div>
     </div>

--- a/packages/react-components/react-nav-preview/stories/src/NavDrawer/NavDrawerDefault.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/src/NavDrawer/NavDrawerDefault.stories.tsx
@@ -101,10 +101,10 @@ export const NavDrawerDefault = (props: Partial<NavDrawerProps>) => {
           <NavItem href="https://www.bing.com" icon={<Dashboard />} value="1">
             Dashboard
           </NavItem>
-          <NavItem href="https://www.bing.com" icon={<Announcements />} value="2">
+          <NavItem icon={<Announcements />} value="2">
             Announcements
           </NavItem>
-          <NavItem href="https://www.bing.com" icon={<EmployeeSpotlight />} value="3">
+          <NavItem icon={<EmployeeSpotlight />} value="3">
             Employee Spotlight
           </NavItem>
           <NavItem icon={<Search />} href="https://www.bing.com" value="4">

--- a/packages/react-components/react-nav-preview/stories/src/NavDrawer/NavDrawerDefault.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/src/NavDrawer/NavDrawerDefault.stories.tsx
@@ -89,7 +89,7 @@ export const NavDrawerDefault = (props: Partial<NavDrawerProps>) => {
   const linkLabelId = useId('link-label');
 
   const [isOpen, setIsOpen] = React.useState(true);
-  const [enabledLinks, setEnabledLinks] = React.useState(false); // todo change this back to true before checkin
+  const [enabledLinks, setEnabledLinks] = React.useState(true);
   const [type, setType] = React.useState<DrawerType>('inline');
 
   const linkDestination = enabledLinks ? 'https://www.bing.com' : '';


### PR DESCRIPTION
Adding graceful animations to the selection behavior.

I'd like to pull this out into it's own component some day for cases where the extra DOM bloat necessary (wrapper w/ css overlapping grid) is appropriate.

Updates examples to toggle link behavior to enable testing.

https://github.com/microsoft/fluentui/assets/17346018/98cb0396-0679-46ce-b40c-3e1cf4ea95cc

ladders to #26649 

