### PR TITLE
fix: Teaching bubble carousel tabs are visible in windows high contrast

### DIFF
--- a/change/@fluentui-react-teaching-popover-cdaeeec1-2b74-432f-a6ec-694d78207d7c.json
+++ b/change/@fluentui-react-teaching-popover-cdaeeec1-2b74-432f-a6ec-694d78207d7c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: carousel tabs are visible in windows high contrast",
+  "packageName": "@fluentui/react-teaching-popover",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselNavButton/useTeachingPopoverCarouselNavButtonStyles.styles.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselNavButton/useTeachingPopoverCarouselNavButtonStyles.styles.ts
@@ -27,7 +27,7 @@ const useStyles = makeStyles({
     border: 'none',
     borderRadius: '50%',
     padding: '0px',
-    outline: tokens.strokeWidthThin, // For high contrast
+    outline: `${tokens.strokeWidthThin} solid transparent`, // For high contrast
     ...createCustomFocusIndicatorStyle({
       outline: `${tokens.strokeWidthThick} solid ${tokens.colorStrokeFocus2}`,
       borderRadius: tokens.borderRadiusMedium,
@@ -41,7 +41,7 @@ const useStyles = makeStyles({
     },
   },
   rootSelected: {
-    outline: tokens.strokeWidthThin, // For high contrast
+    outline: `${tokens.strokeWidthThin} solid transparent`, // For high contrast
     width: '16px',
     border: 'none',
     borderRadius: '4px',
@@ -51,6 +51,9 @@ const useStyles = makeStyles({
       borderRadius: tokens.borderRadiusMedium,
       ...shorthands.borderColor('transparent'),
     }),
+    '@media (forced-colors: active)': {
+      backgroundColor: 'CanvasText',
+    },
   },
   rootBrand: {
     backgroundColor: tokens.colorNeutralForegroundOnBrand,


### PR DESCRIPTION
## Previous Behavior

The tabs/dots were not visible in WHCM:
![screenshot of the teaching popover in dark and light high contrast themes, showing no visible dots between the previous and next buttons](https://github.com/microsoft/fluentui/assets/3819570/f25aa7f6-c49f-4796-a05a-625ae168af1a)


## New Behavior

![screenshot of the teaching popover in dark high contrast, showing visible dots](https://github.com/microsoft/fluentui/assets/3819570/5b43b06b-e8bc-4b11-9ec7-3ff737b2ed1c)


## Related Issue(s)

- Fixes an ADO a11y issue
