### PR TITLE
fix: v9 Select options in underline appearance are readable in dark themes

### DIFF
--- a/change/@fluentui-react-select-1166c4a9-ab11-4b39-be63-4dd68664630d.json
+++ b/change/@fluentui-react-select-1166c4a9-ab11-4b39-be63-4dd68664630d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: underline appearance is readable in dark themes",
+  "packageName": "@fluentui/react-select",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-select/library/src/components/Select/useSelectStyles.styles.ts
+++ b/packages/react-components/react-select/library/src/components/Select/useSelectStyles.styles.ts
@@ -179,6 +179,10 @@ const useSelectStyles = makeStyles({
     backgroundColor: tokens.colorTransparentBackground,
     borderBottom: `1px solid ${tokens.colorNeutralStrokeAccessible}`,
     borderRadius: '0',
+    '& option': {
+      // The transparent select bg means the option background must be set so the text is visible in dark themes
+      backgroundColor: tokens.colorNeutralBackground1,
+    },
   },
   'filled-lighter': {
     backgroundColor: tokens.colorNeutralBackground1,


### PR DESCRIPTION
## Previous Behavior

On Windows browsers, Select options in the underline appearance variant picked up the parent `<select>` text color style, but always have the default background color since underline has a transparent background. In dark themes, this causes them to have a light color over a light background:

![screenshot of a native select in a dark theme. Only the selected option is visible, the other options show as blank white space](https://github.com/microsoft/fluentui/assets/3819570/20d3194d-6717-4f5a-9137-6ef287a4daf9)

## New Behavior

Options in the underline appearance have an explicit background color set:
![same select, but options have a dark background with white text](https://github.com/microsoft/fluentui/assets/3819570/ddea887d-2c7e-4d4e-b20d-b8f699efab34)

## Related Issue(s)

- Fixes an ADO issue
