### PR TITLE
feat: update image styles to use custom states

### DIFF
--- a/change/@fluentui-web-components-89765cbd-e940-4368-8e9c-2e6a6aea5943.json
+++ b/change/@fluentui-web-components-89765cbd-e940-4368-8e9c-2e6a6aea5943.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "update image to use element internals custom states for visual states",
+  "packageName": "@fluentui/web-components",
+  "email": "13071055+chrisdholt@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/docs/api-report.md
+++ b/packages/web-components/docs/api-report.md
@@ -2103,10 +2103,17 @@ export const getDirection: (rootNode: HTMLElement) => Direction;
 // @public
 class Image_2 extends FASTElement {
     block?: boolean;
+    blockChanged(prev: boolean, next: boolean): void;
     bordered?: boolean;
+    borderedChanged(prev: boolean, next: boolean): void;
+    // @internal
+    elementInternals: ElementInternals;
     fit?: ImageFit;
+    fitChanged(prev: ImageFit | undefined, next: ImageFit | undefined): void;
     shadow?: boolean;
+    shadowChanged(prev: boolean, next: boolean): void;
     shape?: ImageShape;
+    shapeChanged(prev: ImageShape | undefined, next: ImageShape | undefined): void;
 }
 export { Image_2 as Image }
 

--- a/packages/web-components/src/image/image.spec.ts
+++ b/packages/web-components/src/image/image.spec.ts
@@ -19,7 +19,7 @@ test.describe('Image', () => {
     await page.close();
   });
 
-  test('should initialize to the `block` attribute', async () => {
+  test('should initialize to the `block` attribute when provided', async () => {
     await root.evaluate(node => {
       node.innerHTML = /* html */ `
         <fluent-image block>
@@ -34,6 +34,20 @@ test.describe('Image', () => {
       node.block = false;
     });
     await expect(element).not.toHaveJSProperty('block', true);
+  });
+
+  test('should add a custom state of `block` when a value of true is provided', async () => {
+    await element.evaluate((node: Image) => {
+      node.block = true;
+    });
+
+    expect(await element.evaluate((node: Image) => node.elementInternals.states.has('block'))).toBe(true);
+
+    await element.evaluate((node: Image) => {
+      node.block = false;
+    });
+
+    expect(await element.evaluate((node: Image) => node.elementInternals.states.has('block'))).toBe(false);
   });
 
   test('should initialize to the `bordered` attribute', async () => {
@@ -53,6 +67,20 @@ test.describe('Image', () => {
     await expect(element).not.toHaveJSProperty('bordered', true);
   });
 
+  test('should add a custom state of `bordered` when a value of true is provided', async () => {
+    await element.evaluate((node: Image) => {
+      node.bordered = true;
+    });
+
+    expect(await element.evaluate((node: Image) => node.elementInternals.states.has('bordered'))).toBe(true);
+
+    await element.evaluate((node: Image) => {
+      node.bordered = false;
+    });
+
+    expect(await element.evaluate((node: Image) => node.elementInternals.states.has('bordered'))).toBe(false);
+  });
+
   test('should initialize to the `shadow` attribute', async () => {
     await root.evaluate(node => {
       node.innerHTML = /* html */ `
@@ -68,6 +96,20 @@ test.describe('Image', () => {
       node.shadow = undefined;
     });
     await expect(element).not.toHaveJSProperty('shadow', true);
+  });
+
+  test('should add a custom state of `shadow` when a value of true is provided', async () => {
+    await element.evaluate((node: Image) => {
+      node.shadow = true;
+    });
+
+    expect(await element.evaluate((node: Image) => node.elementInternals.states.has('shadow'))).toBe(true);
+
+    await element.evaluate((node: Image) => {
+      node.shadow = false;
+    });
+
+    expect(await element.evaluate((node: Image) => node.elementInternals.states.has('shadow'))).toBe(false);
   });
 
   test('should initialize to the `fit` attribute', async () => {
@@ -102,6 +144,28 @@ test.describe('Image', () => {
     await expect(element).toHaveJSProperty('fit', 'cover');
   });
 
+  test('should add a custom state matching the `fit` attribute when provided', async () => {
+    await element.evaluate((node: Image) => {
+      node.fit = 'contain';
+    });
+
+    expect(await element.evaluate((node: Image) => node.elementInternals.states.has('fit-contain'))).toBe(true);
+
+    await element.evaluate((node: Image) => {
+      node.fit = 'none';
+    });
+
+    expect(await element.evaluate((node: Image) => node.elementInternals.states.has('fit-contain'))).toBe(false);
+    expect(await element.evaluate((node: Image) => node.elementInternals.states.has('fit-none'))).toBe(true);
+
+    await element.evaluate((node: Image) => {
+      node.fit = 'cover';
+    });
+
+    expect(await element.evaluate((node: Image) => node.elementInternals.states.has('fit-none'))).toBe(false);
+    expect(await element.evaluate((node: Image) => node.elementInternals.states.has('fit-cover'))).toBe(true);
+  });
+
   test('should initialize to the `shape` attribute', async () => {
     await root.evaluate(node => {
       node.innerHTML = /* html */ `
@@ -122,5 +186,35 @@ test.describe('Image', () => {
       node.shape = 'square';
     });
     await expect(element).toHaveJSProperty('shape', 'square');
+  });
+
+  test('should add a custom state matching the `shape` attribute when provided', async () => {
+    await element.evaluate((node: Image) => {
+      node.shape = 'circular';
+    });
+
+    expect(await element.evaluate((node: Image) => node.elementInternals.states.has('circular'))).toBe(true);
+
+    await element.evaluate((node: Image) => {
+      node.shape = 'rounded';
+    });
+
+    expect(await element.evaluate((node: Image) => node.elementInternals.states.has('circular'))).toBe(false);
+    expect(await element.evaluate((node: Image) => node.elementInternals.states.has('rounded'))).toBe(true);
+
+    await element.evaluate((node: Image) => {
+      node.shape = 'square';
+    });
+
+    expect(await element.evaluate((node: Image) => node.elementInternals.states.has('rounded'))).toBe(false);
+    expect(await element.evaluate((node: Image) => node.elementInternals.states.has('square'))).toBe(true);
+
+    await element.evaluate((node: Image) => {
+      node.shape = undefined;
+    });
+
+    expect(await element.evaluate((node: Image) => node.elementInternals.states.has('rounded'))).toBe(false);
+    expect(await element.evaluate((node: Image) => node.elementInternals.states.has('square'))).toBe(false);
+    expect(await element.evaluate((node: Image) => node.elementInternals.states.has('circular'))).toBe(false);
   });
 });

--- a/packages/web-components/src/image/image.styles.ts
+++ b/packages/web-components/src/image/image.styles.ts
@@ -6,6 +6,7 @@ import {
   shadow4,
   strokeWidthThin,
 } from '../theme/design-tokens.js';
+import { circularState, roundedState } from '../styles/states/index.js';
 
 /** Image styles
  *
@@ -22,44 +23,44 @@ export const styles = css`
     min-width: 8px;
     display: inline-block;
   }
-  :host([block]) ::slotted(img) {
+  :host(:is([state--block], :state(block))) ::slotted(img) {
     width: 100%;
     height: auto;
   }
-  :host([bordered]) ::slotted(img) {
+  :host(:is([state--bordered], :state(bordered))) ::slotted(img) {
     border: ${strokeWidthThin} solid ${colorNeutralStroke2};
   }
-  :host([fit='none']) ::slotted(img) {
+  :host(:is([state--fit-none], :state(fit-none))) ::slotted(img) {
     object-fit: none;
     object-position: top left;
     height: 100%;
     width: 100%;
   }
-  :host([fit='center']) ::slotted(img) {
+  :host(:is([state--fit-center], :state(fit-center))) ::slotted(img) {
     object-fit: none;
     object-position: center;
     height: 100%;
     width: 100%;
   }
-  :host([fit='contain']) ::slotted(img) {
+  :host(:is([state--fit-contain], :state(fit-contain))) ::slotted(img) {
     object-fit: contain;
     object-position: center;
     height: 100%;
     width: 100%;
   }
-  :host([fit='cover']) ::slotted(img) {
+  :host(:is([state--fit-cover], :state(fit-cover))) ::slotted(img) {
     object-fit: cover;
     object-position: center;
     height: 100%;
     width: 100%;
   }
-  :host([shadow]) ::slotted(img) {
+  :host(:is([state--shadowed], :state(shadowed))) ::slotted(img) {
     box-shadow: ${shadow4};
   }
-  :host([shape='circular']) ::slotted(img) {
+  :host(${circularState}) ::slotted(img) {
     border-radius: ${borderRadiusCircular};
   }
-  :host([shape='rounded']) ::slotted(img) {
+  :host(${roundedState}) ::slotted(img) {
     border-radius: ${borderRadiusMedium};
   }
 `;

--- a/packages/web-components/src/image/image.ts
+++ b/packages/web-components/src/image/image.ts
@@ -1,4 +1,5 @@
 import { attr, FASTElement } from '@microsoft/fast-element';
+import { toggleState } from '../utils/element-internals.js';
 import { ImageFit, ImageShape } from './image.options.js';
 
 /**
@@ -7,6 +8,13 @@ import { ImageFit, ImageShape } from './image.options.js';
  */
 export class Image extends FASTElement {
   /**
+   * The internal {@link https://developer.mozilla.org/docs/Web/API/ElementInternals | `ElementInternals`} instance for the component.
+   *
+   * @internal
+   */
+  public elementInternals: ElementInternals = this.attachInternals();
+
+  /**
    * Image layout
    *
    * @public
@@ -14,7 +22,17 @@ export class Image extends FASTElement {
    * HTML attribute: block.
    */
   @attr({ mode: 'boolean' })
-  public block?: boolean;
+  public block?: boolean = false;
+
+  /**
+   * Handles changes to block custom states
+   * @param prev - the previous state
+   * @param next - the next state
+   */
+  public blockChanged(prev: boolean, next: boolean) {
+    toggleState(this.elementInternals, 'block', next);
+  }
+
   /**
    * Image border
    *
@@ -24,6 +42,16 @@ export class Image extends FASTElement {
    */
   @attr({ mode: 'boolean' })
   public bordered?: boolean;
+
+  /**
+   * Handles changes to bordered custom states
+   * @param prev - the previous state
+   * @param next - the next state
+   */
+  public borderedChanged(prev: boolean, next: boolean) {
+    toggleState(this.elementInternals, 'bordered', next);
+  }
+
   /**
    * Image shadow
    *
@@ -33,6 +61,16 @@ export class Image extends FASTElement {
    */
   @attr({ mode: 'boolean' })
   public shadow?: boolean;
+
+  /**
+   * Handles changes to shadow custom states
+   * @param prev - the previous state
+   * @param next - the next state
+   */
+  public shadowChanged(prev: boolean, next: boolean) {
+    toggleState(this.elementInternals, 'shadow', next);
+  }
+
   /**
    * Image fit
    *
@@ -42,6 +80,21 @@ export class Image extends FASTElement {
    */
   @attr
   public fit?: ImageFit;
+
+  /**
+   * Handles changes to fit attribute custom states
+   * @param prev - the previous state
+   * @param next - the next state
+   */
+  public fitChanged(prev: ImageFit | undefined, next: ImageFit | undefined) {
+    if (prev) {
+      toggleState(this.elementInternals, `fit-${prev}`, false);
+    }
+    if (next) {
+      toggleState(this.elementInternals, `fit-${next}`, true);
+    }
+  }
+
   /**
    * Image shape
    *
@@ -51,4 +104,18 @@ export class Image extends FASTElement {
    */
   @attr
   public shape?: ImageShape;
+
+  /**
+   * Handles changes to shape attribute custom states
+   * @param prev - the previous state
+   * @param next - the next state
+   */
+  public shapeChanged(prev: ImageShape | undefined, next: ImageShape | undefined) {
+    if (prev) {
+      toggleState(this.elementInternals, `${prev}`, false);
+    }
+    if (next) {
+      toggleState(this.elementInternals, `${next}`, true);
+    }
+  }
 }


### PR DESCRIPTION
## New Behavior
Moves styling from attributes to Element Internals custom states with an attribute fallback where not supported.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
