### PR TITLE
feat: update spinner to use Element Internals for presentational styling

### DIFF
--- a/change/@fluentui-web-components-d43a8b52-e22f-4523-af8b-a42fd90a4765.json
+++ b/change/@fluentui-web-components-d43a8b52-e22f-4523-af8b-a42fd90a4765.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: update spinner to use Element Internals for presentational styling",
+  "packageName": "@fluentui/web-components",
+  "email": "13071055+chrisdholt@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/spinner/spinner.spec.ts
+++ b/packages/web-components/src/spinner/spinner.spec.ts
@@ -39,6 +39,21 @@ test.describe('Spinner', () => {
     await expect(element).toHaveJSProperty('appearance', 'inverted');
   });
 
+  test('should add a custom state matching the `appearance` attribute when provided', async () => {
+    await element.evaluate((node: Spinner) => {
+      node.appearance = 'primary';
+    });
+
+    expect(await element.evaluate((node: Spinner) => node.elementInternals.states.has('primary'))).toBe(true);
+
+    await element.evaluate((node: Spinner) => {
+      node.appearance = 'inverted';
+    });
+
+    expect(await element.evaluate((node: Spinner) => node.elementInternals.states.has('primary'))).toBe(false);
+    expect(await element.evaluate((node: Spinner) => node.elementInternals.states.has('inverted'))).toBe(true);
+  });
+
   test('should set and retrieve the `size` property correctly to tiny', async () => {
     await element.evaluate((node: Spinner) => {
       node.size = 'tiny';
@@ -85,5 +100,27 @@ test.describe('Spinner', () => {
     });
 
     await expect(element).toHaveJSProperty('size', 'huge');
+  });
+
+  test('should add a custom state matching the `size` attribute when provided', async () => {
+    await element.evaluate((node: Spinner) => {
+      node.size = 'tiny';
+    });
+
+    expect(await element.evaluate((node: Spinner) => node.elementInternals.states.has('tiny'))).toBe(true);
+
+    await element.evaluate((node: Spinner) => {
+      node.size = 'small';
+    });
+
+    expect(await element.evaluate((node: Spinner) => node.elementInternals.states.has('tiny'))).toBe(false);
+    expect(await element.evaluate((node: Spinner) => node.elementInternals.states.has('small'))).toBe(true);
+
+    await element.evaluate((node: Spinner) => {
+      node.size = 'huge';
+    });
+
+    expect(await element.evaluate((node: Spinner) => node.elementInternals.states.has('small'))).toBe(false);
+    expect(await element.evaluate((node: Spinner) => node.elementInternals.states.has('huge'))).toBe(true);
   });
 });

--- a/packages/web-components/src/spinner/spinner.styles.ts
+++ b/packages/web-components/src/spinner/spinner.styles.ts
@@ -1,6 +1,15 @@
 import { css } from '@microsoft/fast-element';
 import { display } from '../utils/index.js';
 import { colorBrandStroke1, colorBrandStroke2, colorNeutralStrokeOnBrand2 } from '../theme/design-tokens.js';
+import {
+  extraLargeState,
+  extraSmallState,
+  hugeState,
+  invertedState,
+  largeState,
+  smallState,
+  tinyState,
+} from '../styles/states/index.js';
 
 export const styles = css`
   ${display('flex')}
@@ -12,27 +21,27 @@ export const styles = css`
     width: 32px;
     contain: content;
   }
-  :host([size='tiny']) {
+  :host(${tinyState}) {
     height: 20px;
     width: 20px;
   }
-  :host([size='extra-small']) {
+  :host(${extraSmallState}) {
     height: 24px;
     width: 24px;
   }
-  :host([size='small']) {
+  :host(${smallState}) {
     height: 28px;
     width: 28px;
   }
-  :host([size='large']) {
+  :host(${largeState}) {
     height: 36px;
     width: 36px;
   }
-  :host([size='extra-large']) {
+  :host(${extraLargeState}) {
     height: 40px;
     width: 40px;
   }
-  :host([size='huge']) {
+  :host(${hugeState}) {
     height: 44px;
     width: 44px;
   }
@@ -47,7 +56,7 @@ export const styles = css`
     stroke-width: 1.5px;
   }
 
-  :host([appearance='inverted']) .background {
+  :host(${invertedState}) .background {
     stroke: rgba(255, 255, 255, 0.2);
   }
 
@@ -62,7 +71,7 @@ export const styles = css`
     animation: spin-infinite 3s cubic-bezier(0.53, 0.21, 0.29, 0.67) infinite;
   }
 
-  :host([appearance='inverted']) .indicator {
+  :host(${invertedState}) .indicator {
     stroke: ${colorNeutralStrokeOnBrand2};
   }
 

--- a/packages/web-components/src/spinner/spinner.ts
+++ b/packages/web-components/src/spinner/spinner.ts
@@ -12,7 +12,7 @@ export class Spinner extends FASTElement {
    *
    * @internal
    */
-  protected elementInternals: ElementInternals = this.attachInternals();
+  public elementInternals: ElementInternals = this.attachInternals();
 
   /**
    * The size of the spinner

--- a/packages/web-components/src/spinner/spinner.ts
+++ b/packages/web-components/src/spinner/spinner.ts
@@ -1,4 +1,5 @@
 import { attr, FASTElement } from '@microsoft/fast-element';
+import { toggleState } from '../utils/element-internals.js';
 import type { SpinnerAppearance, SpinnerSize } from './spinner.options.js';
 
 /**
@@ -24,6 +25,20 @@ export class Spinner extends FASTElement {
   public size?: SpinnerSize;
 
   /**
+   * Handles changes to size attribute custom states
+   * @param prev - the previous state
+   * @param next - the next state
+   */
+  public sizeChanged(prev: SpinnerSize | undefined, next: SpinnerSize | undefined) {
+    if (prev) {
+      toggleState(this.elementInternals, `${prev}`, false);
+    }
+    if (next) {
+      toggleState(this.elementInternals, `${next}`, true);
+    }
+  }
+
+  /**
    * The appearance of the spinner
    * @public
    * @remarks
@@ -31,6 +46,20 @@ export class Spinner extends FASTElement {
    */
   @attr
   public appearance?: SpinnerAppearance;
+
+  /**
+   * Handles changes to appearance attribute custom states
+   * @param prev - the previous state
+   * @param next - the next state
+   */
+  public appearanceChanged(prev: SpinnerAppearance | undefined, next: SpinnerAppearance | undefined) {
+    if (prev) {
+      toggleState(this.elementInternals, `${prev}`, false);
+    }
+    if (next) {
+      toggleState(this.elementInternals, `${next}`, true);
+    }
+  }
 
   constructor() {
     super();

--- a/packages/web-components/src/styles/states/index.ts
+++ b/packages/web-components/src/styles/states/index.ts
@@ -7,6 +7,12 @@ import { css } from '@microsoft/fast-element';
 export const ghostState = css.partial`:is([state--ghost], :state(ghost))`;
 
 /**
+ * Selector for the `inverted` state.
+ * @public
+ */
+export const invertedState = css.partial`:is([state--inverted], :state(inverted))`;
+
+/**
  * Selector for the `primary` state.
  * @public
  */
@@ -89,6 +95,12 @@ export const largeState = css.partial`:is([state--large], :state(large))`;
  * @public
  */
 export const extraLargeState = css.partial`:is([state--extra-large], :state(extra-large))`;
+
+/**
+ * Selector for the `huge` state.
+ * @public
+ */
+export const hugeState = css.partial`:is([state--huge], :state(huge))`;
 
 /**
  * Selector for the `alignment` start state.


### PR DESCRIPTION
## New Behavior
This PR updates the spinner to use Element Internals custom states for presentational styling with an attribute fallback where not available.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
