### PR TITLE
fix(web-components): Use internal anchor element for all keydown-driven navigation actions in Anchor Button

### DIFF
--- a/change/@fluentui-web-components-29061b0f-f3e0-4bf2-a30f-07f5af8e0709.json
+++ b/change/@fluentui-web-components-29061b0f-f3e0-4bf2-a30f-07f5af8e0709.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: use internal anchor for all keydown-driven navigation actions in AnchorButton",
+  "packageName": "@fluentui/web-components",
+  "email": "863023+radium-v@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/anchor-button/anchor-button.spec.ts
+++ b/packages/web-components/src/anchor-button/anchor-button.spec.ts
@@ -80,66 +80,144 @@ test.describe('Anchor Button', () => {
 
   test('should navigate to the provided url when clicked', async ({ page }) => {
     const element = page.locator('fluent-anchor-button');
-    const expectedUrl = '#foo';
 
     await page.setContent(/* html */ `
-          <fluent-anchor-button href="${expectedUrl}"></fluent-anchor-button>
-        `);
+      <fluent-anchor-button href="#foo"></fluent-anchor-button>
+    `);
 
     await element.click();
 
-    expect(page.url()).toContain(expectedUrl);
+    await expect(page).toHaveURL(/#foo$/);
   });
 
-  test('should navigate to the provided url when clicked while pressing the `Control` key on Windows or Meta on Mac', async ({
+  test('should open a new tab when middle clicked', async ({ page, context }) => {
+    // currently in Playwright there's no way to know if the new page is a new window or a new tab
+    const element = page.locator('fluent-anchor-button');
+
+    await page.setContent(/* html */ `
+      <fluent-anchor-button href="#foo"></fluent-anchor-button>
+    `);
+
+    const pagePromise = context.waitForEvent('page');
+
+    await element.click({ button: 'middle' });
+
+    const newPage = await pagePromise;
+
+    await expect(newPage).toHaveURL(/#foo$/);
+  });
+
+  // TODO: currently in Playwright there's no way to know if the new page is a new window or a new tab,
+  // and all pages are treated as focused. See https://playwright.dev/docs/pages#multiple-pages
+  test('should open the link in a new unfocused tab when `CtrlOrMeta` is pressed while clicked', async ({
     page,
     context,
   }) => {
     const element = page.locator('fluent-anchor-button');
-    const expectedUrl = '#foo';
 
     await page.setContent(/* html */ `
-      <fluent-anchor-button href="${expectedUrl}"></fluent-anchor-button>
+      <fluent-anchor-button href="#foo"></fluent-anchor-button>
     `);
 
-    const [newPage] = await Promise.all([
-      context.waitForEvent('page'),
-      element.click({ modifiers: ['ControlOrMeta'] }),
-    ]);
+    const pagePromise = context.waitForEvent('page');
 
-    expect(newPage.url()).toContain(expectedUrl);
+    await element.click({ modifiers: ['ControlOrMeta'] });
+
+    const newPage = await pagePromise;
+
+    await expect(newPage).toHaveURL(/#foo$/);
   });
 
-  test('should navigate to the provided url when `Enter` is pressed via keyboard', async ({ page }) => {
+  // TODO: currently in Playwright there's no way to know if the new page is a new window or a new tab,
+  // and all pages are treated as focused. See https://playwright.dev/docs/pages#multiple-pages
+  test('should open the link in a new window when `Shift` is pressed while clicked', async ({ page, context }) => {
     const element = page.locator('fluent-anchor-button');
-    const expectedUrl = '#foo';
 
     await page.setContent(/* html */ `
-        <fluent-anchor-button href="${expectedUrl}"></fluent-anchor-button>
-      `);
+      <fluent-anchor-button href="#foo"></fluent-anchor-button>
+    `);
+
+    const pagePromise = context.waitForEvent('page');
+
+    await element.click({ modifiers: ['Shift'] });
+
+    const newPage = await pagePromise;
+
+    await expect(newPage).toHaveURL(/#foo$/);
+  });
+
+  test('should open the link in the same tab when `Enter` is pressed', async ({ page }) => {
+    const element = page.locator('fluent-anchor-button');
+
+    await page.setContent(/* html */ `
+      <fluent-anchor-button href="#foo"></fluent-anchor-button>
+    `);
 
     await element.focus();
 
     await element.press('Enter');
 
-    expect(page.url()).toContain(expectedUrl);
+    await expect(page).toHaveURL(/#foo$/);
   });
 
-  test('should navigate to the provided url when `ctrl` and `Enter` are pressed via keyboard', async ({
+  // TODO: currently in Playwright there's no way to know if the new page is a new window or a new tab,
+  // and all pages are treated as focused. See https://playwright.dev/docs/pages#multiple-pages
+  test('should open the link in a new unfocused tab when `CtrlOrMeta+Enter` is pressed', async ({ page, context }) => {
+    const element = page.locator('fluent-anchor-button');
+
+    await page.setContent(/* html */ `
+      <fluent-anchor-button href="#foo"></fluent-anchor-button>
+    `);
+
+    const pagePromise = context.waitForEvent('page');
+
+    await element.press('ControlOrMeta+Enter');
+
+    const newPage = await pagePromise;
+
+    await expect(newPage).toHaveURL(/#foo$/);
+  });
+
+  // TODO: currently in Playwright there's no way to know if the new page is a new window or a new tab,
+  // and all pages are treated as focused. See https://playwright.dev/docs/pages#multiple-pages
+  test('should open the link in a new focused tab when `CtrlOrMeta+Shift+Enter` is pressed', async ({
     page,
     context,
   }) => {
     const element = page.locator('fluent-anchor-button');
-    const expectedUrl = '#foo';
 
     await page.setContent(/* html */ `
-      <fluent-anchor-button href="${expectedUrl}"></fluent-anchor-button>
+      <fluent-anchor-button href="#foo"></fluent-anchor-button>
     `);
 
-    await element.focus();
+    const pagePromise = context.waitForEvent('page');
 
-    const [newPage] = await Promise.all([context.waitForEvent('page'), element.press('ControlOrMeta+Enter')]);
+    await element.press('ControlOrMeta+Shift+Enter');
 
-    expect(newPage.url()).toContain(expectedUrl);
+    const newPage = await pagePromise;
+
+    await expect(newPage).toHaveURL(/#foo$/);
+  });
+
+  test('should NOT open the link when no `href` is provided', async ({ page }) => {
+    const element = page.locator('fluent-anchor-button');
+
+    await page.setContent(/* html */ `
+      <fluent-anchor-button></fluent-anchor-button>
+    `);
+
+    await test.step('when clicked', async () => {
+      await element.click();
+
+      await expect(page).not.toHaveURL(/#/);
+    });
+
+    await test.step('when `Enter` is pressed', async () => {
+      await element.focus();
+
+      await element.press('Enter');
+
+      await expect(page).not.toHaveURL(/#/);
+    });
   });
 });

--- a/packages/web-components/src/anchor-button/anchor-button.template.ts
+++ b/packages/web-components/src/anchor-button/anchor-button.template.ts
@@ -8,11 +8,7 @@ import type { AnchorButton, AnchorOptions } from './anchor-button.js';
  */
 export function anchorTemplate<T extends AnchorButton>(options: AnchorOptions = {}): ViewTemplate<T> {
   return html<T>`
-    <template
-      tabindex="0"
-      @click="${(x, c) => x.clickHandler(c.event as PointerEvent)}"
-      @keydown="${(x, c) => x.keydownHandler(c.event as KeyboardEvent)}"
-    >
+    <template tabindex="0" @keydown="${(x, c) => x.keydownHandler(c.event as KeyboardEvent)}">
       ${startSlotTemplate(options)}
       <span class="content" part="content">
         <slot></slot>

--- a/packages/web-components/src/anchor-button/anchor-button.ts
+++ b/packages/web-components/src/anchor-button/anchor-button.ts
@@ -178,21 +178,6 @@ export class BaseAnchor extends FASTElement {
   }
 
   /**
-   * Handles the anchor click event.
-   *
-   * @param e - The event object
-   * @internal
-   */
-  public clickHandler(e: PointerEvent): boolean {
-    if (this.href) {
-      const newTab = !this.isMac ? e.ctrlKey : e.metaKey;
-      this.handleNavigation(newTab);
-    }
-
-    return true;
-  }
-
-  /**
    * Handles keydown events for the anchor.
    *
    * @param e - the keyboard event


### PR DESCRIPTION
## Previous Behavior

Calls to navigate the page were performed with `window.open` and had didn't cover most keyboard shortcut options.

## New Behavior

It turns out setting the target of the internal anchor to `_blank` allows synthetic click events to be dispatched. This PR proxies modifier key flags to the internal anchor during keydown events.

## Additional Notes

Playwright doesn't yet have a way to determine if any new pages are in a new window or tab, or if they're focused (all pages are treated as active and focused).

## Related Issue(s)

- Closes #31722 
