### PR TITLE
Fix: Ensure createV9Theme uses appropriate base theme for dark theme

### DIFF
--- a/packages/react-components/react-migration-v8-v9/src/components/Theme/v9ThemeShim.ts
+++ b/packages/react-components/react-migration-v8-v9/src/components/Theme/v9ThemeShim.ts
@@ -1,6 +1,6 @@
 import { Theme as ThemeV8 } from '@fluentui/react';
 import type { IEffects, IPalette } from '@fluentui/react';
-import { Theme as ThemeV9, webLightTheme } from '@fluentui/react-components';
+import { Theme as ThemeV9, webLightTheme, webDarkTheme } from '@fluentui/react-components';
 import type { BorderRadiusTokens, ColorTokens, ShadowTokens } from '@fluentui/react-components';
 import { blackAlpha, whiteAlpha, grey, grey10Alpha, grey12Alpha } from './themeDuplicates';
 
@@ -206,8 +206,7 @@ const mapBorderRadiusTokens = (effects: IEffects): Partial<BorderRadiusTokens> =
  * You can optional pass a base v9 theme; otherwise webLightTheme is used.
  */
 export const createV9Theme = (themeV8: ThemeV8, baseThemeV9?: ThemeV9): ThemeV9 => {
-  const baseTheme = baseThemeV9 ?? webLightTheme;
-
+  const baseTheme = baseThemeV9 ?? (themeV8.isInverted ? webDarkTheme : webLightTheme);
   return {
     ...baseTheme,
     ...mapAliasColors(themeV8.palette, themeV8.isInverted),


### PR DESCRIPTION
## Previous Behavior

The `createV9Theme` function did not fully support some tokens in the dark theme. Specifically, there was no mapping for status tokens between V8 and V9. As a result, even in the dark theme, the token values were derived from `webLightTheme`, leading to incorrect colors in the dark theme.

## New Behavior

The `createV9Theme` function now correctly detects if the provided V8 theme is a dark theme and uses `webDarkTheme` as the base theme instead of `webLightTheme`. This ensures that the tokens are correctly mapped and rendered for the dark theme.

🚨 **With the fix, `createV9Theme` now depends on both `webLightTheme` and `webDarkTheme` and adds both to a bundle. We need to decide whether that is worth it.**

## Related Issue(s)

- Fixes #31728