### PR TITLE
fix(react-message-bar): set correct icon for error state

### DIFF
--- a/change/@fluentui-react-message-bar-0408d1da-e3d1-4d30-955d-7fa6120e573d.json
+++ b/change/@fluentui-react-message-bar-0408d1da-e3d1-4d30-955d-7fa6120e573d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fixing incorrect error state icon",
+  "packageName": "@fluentui/react-message-bar",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-message-bar/library/src/components/MessageBar/getIntentIcon.tsx
+++ b/packages/react-components/react-message-bar/library/src/components/MessageBar/getIntentIcon.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { MessageBarProps } from './MessageBar.types';
-import { CheckmarkCircleFilled, InfoFilled, WarningFilled, ErrorCircleFilled } from '@fluentui/react-icons';
+import { CheckmarkCircleFilled, InfoFilled, WarningFilled, DismissCircleFilled } from '@fluentui/react-icons';
 
 export function getIntentIcon(intent: MessageBarProps['intent']) {
   switch (intent) {
@@ -9,7 +9,7 @@ export function getIntentIcon(intent: MessageBarProps['intent']) {
     case 'warning':
       return <WarningFilled />;
     case 'error':
-      return <ErrorCircleFilled />;
+      return <DismissCircleFilled />;
     case 'success':
       return <CheckmarkCircleFilled />;
 


### PR DESCRIPTION
Fixes #31604. Icon was incorrect, I wonder why was not caught on visual regression. Maybe happened after update in the icon package 🤷🏻 , maybe because of the slightly confusing naming, as I first looked on other error icons, only later found dismiss ones. 
 

Previous behavior 
![image](https://github.com/microsoft/fluentui/assets/14054752/7a3a14db-4580-47a0-ac1d-45f8f05a1c0b)

Current behavior 
<img width="592" alt="Screenshot 2024-06-18 at 14 07 33" src="https://github.com/microsoft/fluentui/assets/14054752/599440d0-f980-4da3-943f-cb1b094aa6a2">
