### PR TITLE
fix(public-docsite-v9): disable storybook keyboard shortcuts

### DIFF
--- a/apps/public-docsite-v9/.storybook/manager.js
+++ b/apps/public-docsite-v9/.storybook/manager.js
@@ -4,6 +4,7 @@ import { ApplicationInsights } from '@microsoft/applicationinsights-web';
 import { STORY_CHANGED, STORY_ERRORED, STORY_MISSING } from '@storybook/core-events';
 
 addons.setConfig({
+  enableShortcuts: false,
   theme: fluentStorybookTheme,
   showPanel: false,
 });


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

The Storybook platform uses `alt+down` and `alt+up` to navigate between components. And that conflicts with the dropdown list keyboard shortcuts. 

## New Behavior

The suggested solution is to disable Storybook's keyboard shortcuts to avoid conflicts with the existing components keyboard shortcuts.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #31363 
