### PR TITLE
bugfix(react-tree): console error if `TreeItem` has no parent `Tree`

### DIFF
--- a/change/@fluentui-react-tree-bd13a9b3-9413-43ea-91f2-9b58288a77d8.json
+++ b/change/@fluentui-react-tree-bd13a9b3-9413-43ea-91f2-9b58288a77d8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: console error if TreeItem has no parent Tree",
+  "packageName": "@fluentui/react-tree",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tree/library/src/components/TreeItem/TreeItem.test.tsx
+++ b/packages/react-components/react-tree/library/src/components/TreeItem/TreeItem.test.tsx
@@ -10,6 +10,7 @@ describe('TreeItem', () => {
   isConformant<TreeItemProps>({
     Component: TreeItem,
     displayName: 'TreeItem',
+    renderOptions: { wrapper: ({ children }) => <Tree>{children}</Tree> },
     getTargetElement(renderResult, attr) {
       return renderResult.container.querySelector(`.${treeItemClassNames.root}`) ?? renderResult.container;
     },
@@ -29,8 +30,14 @@ describe('TreeItem', () => {
   // TODO add more tests here, and create visual regression tests in /apps/vr-tests
 
   it('renders a default state', () => {
-    const result = render(<TreeItem itemType="leaf">Default TreeItem</TreeItem>);
-    expect(result.container).toMatchSnapshot();
+    const result = render(
+      <Tree>
+        <TreeItem value="1" itemType="leaf">
+          Default TreeItem
+        </TreeItem>
+      </Tree>,
+    );
+    expect(result.container.firstChild).toMatchSnapshot();
   });
   it('should not update open state when the TreeItem is a leaf', () => {
     const handleOpenChange = jest.fn();
@@ -42,7 +49,6 @@ describe('TreeItem', () => {
       </Tree>,
     );
     fireEvent.click(result.getByText('Default TreeItem'));
-    expect(handleOpenChange).toHaveBeenNthCalledWith(1, expect.anything(), expect.objectContaining({ open: false }));
-    expect(handleOpenChange).toHaveBeenNthCalledWith(2, expect.anything(), expect.objectContaining({ open: false }));
+    expect(handleOpenChange).not.toHaveBeenCalled();
   });
 });

--- a/packages/react-components/react-tree/library/src/components/TreeItem/__snapshots__/TreeItem.test.tsx.snap
+++ b/packages/react-components/react-tree/library/src/components/TreeItem/__snapshots__/TreeItem.test.tsx.snap
@@ -1,13 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TreeItem renders a default state 1`] = `
-<div>
+<div
+  class="fui-Tree"
+  role="tree"
+>
   <div
-    aria-level="0"
+    aria-level="1"
     class="fui-TreeItem"
-    data-fui-tree-item-value="fuiTreeItemValue-7"
+    data-fui-tree-item-value="1"
     role="treeitem"
-    tabindex="-1"
+    tabindex="0"
   >
     Default TreeItem
   </div>


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

1. A `TreeItem` will not function properly if outside of a `Tree` component, as it requires the context provided by `Tree` to work properly.
2. `openChange` is being called even if a `TreeItem` is a leaf (this might cause false negatives)

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

1. consoles error if no `TreeContext` has been found
2. short circuit to ensure `onOpenChange` won't be called on a `TreeItem`

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/31765
