### PR TITLE
bugfix(react-tree): defaultCheckedItems conflicts with checkedItems

### DIFF
--- a/change/@fluentui-react-tree-12dac24a-04f5-472b-b3b6-d1fd3d82c7b4.json
+++ b/change/@fluentui-react-tree-12dac24a-04f5-472b-b3b6-d1fd3d82c7b4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: defaultCheckedItems conflicts with checkedItems",
+  "packageName": "@fluentui/react-tree",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tree/library/src/components/FlatTree/FlatTree.cy.tsx
+++ b/packages/react-components/react-tree/library/src/components/FlatTree/FlatTree.cy.tsx
@@ -350,6 +350,22 @@ describe('FlatTree', () => {
       cy.get('[data-testid="item1__item1"]').should('exist');
       cy.get('[data-testid="item1__item1"]').should('have.attr', 'aria-checked', 'true');
     });
+    it('should warn if checkedItems and defaultCheckedItems are provided at the same time', () => {
+      cy.window().then(win => {
+        cy.spy(win.console, 'error');
+      });
+      mount(
+        <TreeTest
+          selectionMode="multiselect"
+          defaultOpenItems={['item1']}
+          checkedItems={['item1__item1']}
+          defaultCheckedItems={['item1__item1']}
+        />,
+      );
+      cy.window().then(win => {
+        expect(win.console.error).to.be.callCount(1);
+      });
+    });
     it('should change selection when selecting a closed branch', () => {
       mount(<TreeTest selectionMode="multiselect" />);
       cy.get('[data-testid="item1"]').should('have.attr', 'aria-checked', 'false');

--- a/packages/react-components/react-tree/library/src/components/FlatTree/useFlatControllableCheckedItems.ts
+++ b/packages/react-components/react-tree/library/src/components/FlatTree/useFlatControllableCheckedItems.ts
@@ -17,7 +17,7 @@ export function useFlatControllableCheckedItems<Props extends HeadlessTreeItemPr
       () => (props.selectionMode ? props.checkedItems && createCheckedItems(props.checkedItems) : undefined),
       [props.checkedItems, props.selectionMode],
     ),
-    defaultState: () => initializeCheckedItems(props, headlessTree),
+    defaultState: props.defaultCheckedItems ? () => initializeCheckedItems(props, headlessTree) : undefined,
   });
 }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
1. ensures that `defaultState` is not provided at the same time as `state` on `useControllableState` invocation, as it'll console error https://github.com/microsoft/fluentui/pull/31461

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
