### PR TITLE
chore(react-tree): ensures history navigation keys are respected

### DIFF
--- a/change/@fluentui-react-tree-0bbd4942-7582-456a-9fdd-9027eaa0af91.json
+++ b/change/@fluentui-react-tree-0bbd4942-7582-456a-9fdd-9027eaa0af91.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: ensures history navigation keys are respected",
+  "packageName": "@fluentui/react-tree",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tree/library/src/components/FlatTree/FlatTree.cy.tsx
+++ b/packages/react-components/react-tree/library/src/components/FlatTree/FlatTree.cy.tsx
@@ -163,6 +163,13 @@ describe('FlatTree', () => {
       cy.get(`[data-testid="item1"] .${treeItemLayoutClassNames.root}`).realPress('{rightarrow}');
       cy.get('[data-testid="item1__item1"]').should('exist');
     });
+    it('should not expand item on Alt + Right key', () => {
+      mount(<TreeTest />);
+      cy.get('[data-testid="item1"]').focus();
+      cy.get('[data-testid="item1__item1"]').should('not.exist');
+      cy.get(`[data-testid="item1"] .${treeItemLayoutClassNames.root}`).realPress(['Alt', '{rightarrow}']);
+      cy.get('[data-testid="item1__item1"]').should('not.exist');
+    });
     it('should collapse item on Left key', () => {
       mount(<TreeTest />);
       cy.get('[data-testid="item1"]').focus();
@@ -171,6 +178,15 @@ describe('FlatTree', () => {
       cy.get('[data-testid="item1__item1"]').should('exist');
       cy.get(`[data-testid="item1"] .${treeItemLayoutClassNames.root}`).realPress('{leftarrow}');
       cy.get('[data-testid="item1__item1"]').should('not.exist');
+    });
+    it('should not collapse item on Alt + Left key', () => {
+      mount(<TreeTest />);
+      cy.get('[data-testid="item1"]').focus();
+      cy.get('[data-testid="item1__item1"]').should('not.exist');
+      cy.get(`[data-testid="item1"] .${treeItemLayoutClassNames.root}`).realPress('{rightarrow}');
+      cy.get('[data-testid="item1__item1"]').should('exist');
+      cy.get(`[data-testid="item1"] .${treeItemLayoutClassNames.root}`).realPress(['Alt', '{leftarrow}']);
+      cy.get('[data-testid="item1__item1"]').should('exist');
     });
     it('should focus on actions when pressing tab key', () => {
       mount(
@@ -239,6 +255,17 @@ describe('FlatTree', () => {
         cy.get('[data-testid="item1"]').focus().realPress('{downarrow}');
         cy.get('[data-testid="item2"]').should('be.focused').realPress('{rightarrow}');
         cy.get('[data-testid="item2__item1"]').should('be.focused').realPress('{rightarrow}');
+        cy.get('[data-testid="item2__item1__item1"]').should('be.focused').realPress('{leftarrow}');
+        cy.get('[data-testid="item2__item1"]').should('be.focused').realPress('{leftarrow}').realPress('{leftarrow}');
+        cy.get('[data-testid="item2"]').should('be.focused');
+      });
+      it('should not move with Alt + Left/Right keys', () => {
+        mount(<TreeTest defaultOpenItems={['item2', 'item2__item1']} />);
+        cy.get('[data-testid="item1"]').focus().realPress('{downarrow}');
+        cy.get('[data-testid="item2"]').should('be.focused').realPress(['Alt', '{rightarrow}']);
+        cy.get('[data-testid="item2"]').should('be.focused').realPress('{rightarrow}');
+        cy.get('[data-testid="item2__item1"]').should('be.focused').realPress('{rightarrow}');
+        cy.get('[data-testid="item2__item1__item1"]').should('be.focused').realPress(['Alt', '{leftarrow}']);
         cy.get('[data-testid="item2__item1__item1"]').should('be.focused').realPress('{leftarrow}');
         cy.get('[data-testid="item2__item1"]').should('be.focused').realPress('{leftarrow}').realPress('{leftarrow}');
         cy.get('[data-testid="item2"]').should('be.focused');

--- a/packages/react-components/react-tree/library/src/components/Tree/Tree.cy.tsx
+++ b/packages/react-components/react-tree/library/src/components/Tree/Tree.cy.tsx
@@ -137,14 +137,21 @@ describe('Tree', () => {
       cy.get(`[data-testid="item1"] .${treeItemLayoutClassNames.root}`).realPress('{enter}');
       cy.get('[data-testid="item1__item1"]').should('exist');
     });
-    it('should expand item on Right key', () => {
+    it('should expand item on right key', () => {
       mount(<TreeTest />);
       cy.get('[data-testid="item1"]').focus();
       cy.get('[data-testid="item1__item1"]').should('not.exist');
       cy.get(`[data-testid="item1"] .${treeItemLayoutClassNames.root}`).realPress('{rightarrow}');
       cy.get('[data-testid="item1__item1"]').should('exist');
     });
-    it('should collapse item on Left key', () => {
+    it('should not expand item on alt + right key', () => {
+      mount(<TreeTest />);
+      cy.get('[data-testid="item1"]').focus();
+      cy.get('[data-testid="item1__item1"]').should('not.exist');
+      cy.get(`[data-testid="item1"] .${treeItemLayoutClassNames.root}`).realPress(['Alt', 'ArrowRight']);
+      cy.get('[data-testid="item1__item1"]').should('not.exist');
+    });
+    it('should collapse item on left key', () => {
       mount(<TreeTest />);
       cy.get('[data-testid="item1"]').focus();
       cy.get('[data-testid="item1__item1"]').should('not.exist');
@@ -152,6 +159,15 @@ describe('Tree', () => {
       cy.get('[data-testid="item1__item1"]').should('exist');
       cy.get(`[data-testid="item1"] .${treeItemLayoutClassNames.root}`).realPress('{leftarrow}');
       cy.get('[data-testid="item1__item1"]').should('not.exist');
+    });
+    it('should not collapse item on alt + left key', () => {
+      mount(<TreeTest />);
+      cy.get('[data-testid="item1"]').focus();
+      cy.get('[data-testid="item1__item1"]').should('not.exist');
+      cy.get(`[data-testid="item1"] .${treeItemLayoutClassNames.root}`).realPress('ArrowRight');
+      cy.get('[data-testid="item1__item1"]').should('exist');
+      cy.get(`[data-testid="item1"] .${treeItemLayoutClassNames.root}`).realPress(['Alt', 'ArrowLeft']);
+      cy.get('[data-testid="item1__item1"]').should('exist');
     });
     it('should focus on actions when pressing tab key', () => {
       mount(
@@ -220,6 +236,17 @@ describe('Tree', () => {
         cy.get('[data-testid="item1"]').focus().realPress('{downarrow}');
         cy.get('[data-testid="item2"]').should('be.focused').realPress('{rightarrow}');
         cy.get('[data-testid="item2__item1"]').should('be.focused').realPress('{rightarrow}');
+        cy.get('[data-testid="item2__item1__item1"]').should('be.focused').realPress('{leftarrow}');
+        cy.get('[data-testid="item2__item1"]').should('be.focused').realPress('{leftarrow}').realPress('{leftarrow}');
+        cy.get('[data-testid="item2"]').should('be.focused');
+      });
+      it('should not move with Alt + Left/Right keys', () => {
+        mount(<TreeTest defaultOpenItems={['item2', 'item2__item1']} />);
+        cy.get('[data-testid="item1"]').focus().realPress('{downarrow}');
+        cy.get('[data-testid="item2"]').should('be.focused').realPress(['Alt', '{rightarrow}']);
+        cy.get('[data-testid="item2"]').should('be.focused').realPress('{rightarrow}');
+        cy.get('[data-testid="item2__item1"]').should('be.focused').realPress('{rightarrow}');
+        cy.get('[data-testid="item2__item1__item1"]').should('be.focused').realPress(['Alt', '{leftarrow}']);
         cy.get('[data-testid="item2__item1__item1"]').should('be.focused').realPress('{leftarrow}');
         cy.get('[data-testid="item2__item1"]').should('be.focused').realPress('{leftarrow}').realPress('{leftarrow}');
         cy.get('[data-testid="item2"]').should('be.focused');

--- a/packages/react-components/react-tree/library/src/components/TreeItem/useTreeItem.tsx
+++ b/packages/react-components/react-tree/library/src/components/TreeItem/useTreeItem.tsx
@@ -152,6 +152,10 @@ export function useTreeItem_unstable(props: TreeItemProps, ref: React.Ref<HTMLDi
           target: event.currentTarget,
         });
       case treeDataTypes.ArrowLeft: {
+        // arrow left with alt key is reserved for history navigation
+        if (event.altKey) {
+          return;
+        }
         // do not navigate to parent if the item is on the top level
         if (level === 1 && !open) {
           return;
@@ -174,7 +178,11 @@ export function useTreeItem_unstable(props: TreeItemProps, ref: React.Ref<HTMLDi
         });
         return;
       }
-      case treeDataTypes.ArrowRight:
+      case treeDataTypes.ArrowRight: {
+        // arrow right with alt key is reserved for history navigation
+        if (event.altKey) {
+          return;
+        }
         // do not navigate or open if the item is a leaf
         if (itemType === 'leaf') {
           return;
@@ -196,6 +204,7 @@ export function useTreeItem_unstable(props: TreeItemProps, ref: React.Ref<HTMLDi
           requestType: open ? 'navigate' : 'open',
         });
         return;
+      }
     }
     const isTypeAheadCharacter =
       event.key.length === 1 && event.key.match(/\w/) && !event.altKey && !event.ctrlKey && !event.metaKey;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

`left/right arrow + alt` is a native browser key command for navigating through tab history. At the moment the `TreeItem` is changing its open state and navigating when `left/right arrow + alt` is pressed.

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

1. `TreeItem` checks if `alt` key is pressed together with `left/right` arrow and short circuits internal logic if so.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
