### PR TITLE
fix(storybook): replace env var destructuring with const

### DIFF
--- a/apps/public-docsite-v9/.storybook/manager.js
+++ b/apps/public-docsite-v9/.storybook/manager.js
@@ -10,7 +10,7 @@ addons.setConfig({
 
 addons.register('application-insights', api => {
   if (process.env.NODE_ENV === 'production') {
-    const { STORYBOOK_APPINSIGHTS_INSTRUMENTATION_KEY } = process.env;
+    const STORYBOOK_APPINSIGHTS_INSTRUMENTATION_KEY = process.env.STORYBOOK_APPINSIGHTS_INSTRUMENTATION_KEY;
 
     if (STORYBOOK_APPINSIGHTS_INSTRUMENTATION_KEY) {
       const appInsights = new ApplicationInsights({


### PR DESCRIPTION
## Previous Behavior

Storybook App Insights were not being tracked.

## New Behavior

Storybook App insights work as they should be. The problem was caused by env var being replaced verbatim at build time, so destructuring didn't work.