### PR TITLE
fix(`react-button`): Adding checked condition for icon styles when `ToggleButton` is checked + its appearance is subtle or transparent

### DIFF
--- a/change/@fluentui-react-button-e2ba90aa-0fcc-468f-87bf-a3b63395b846.json
+++ b/change/@fluentui-react-button-e2ba90aa-0fcc-468f-87bf-a3b63395b846.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": " fix: Adding checked condition for icon styles when `ToggleButton` is checked + its appearance is subtle or transparent.",
+  "packageName": "@fluentui/react-button",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-button/library/src/components/ToggleButton/useToggleButtonStyles.styles.ts
+++ b/packages/react-components/react-button/library/src/components/ToggleButton/useToggleButtonStyles.styles.ts
@@ -280,7 +280,7 @@ export const useToggleButtonStyles_unstable = (state: ToggleButtonState): Toggle
   if (state.icon) {
     state.icon.className = mergeClasses(
       toggleButtonClassNames.icon,
-      (appearance === 'subtle' || appearance === 'transparent') && iconCheckedStyles.subtleOrTransparent,
+      checked && (appearance === 'subtle' || appearance === 'transparent') && iconCheckedStyles.subtleOrTransparent,
       iconCheckedStyles.highContrast,
       state.icon.className,
     );


### PR DESCRIPTION
## Previous Behavior

The checked styles for the icon when the `ToggleButton` was `subtle` or `transparent` were being applied even when the button was not checked.

## New Behavior

The checked styles for the icon when the `ToggleButton` is `subtle` or `transparent` are only applied when the button is checked.

## Related Issue(s)

- Fixes #31763
