### PR TITLE
docs: Add AriaLiveAnnouncer to all examples

### DIFF
--- a/packages/react-components/react-storybook-addon/package.json
+++ b/packages/react-components/react-storybook-addon/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@fluentui/react-theme": "^9.1.19",
     "@fluentui/react-provider": "^9.16.3",
+    "@fluentui/react-aria": "^9.12.1",
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {

--- a/packages/react-components/react-storybook-addon/src/decorators/withAriaLive.tsx
+++ b/packages/react-components/react-storybook-addon/src/decorators/withAriaLive.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+
+import { AriaLiveAnnouncer } from '@fluentui/react-aria';
+
+export const withAriaLive = (StoryFn: () => JSX.Element) => {
+  return <AriaLiveWrapper>{StoryFn()}</AriaLiveWrapper>;
+};
+
+const AriaLiveWrapper: React.FC<{ children: React.ReactNode }> = props => {
+  const [mounted, setMounted] = React.useState(false);
+  React.useEffect(() => {
+    // The AriaLiveAnnouncer appends an element to DOM in an effect
+    // Trigger an extra renderer to make sure that doc examples that need to announce on mount can do so
+    setMounted(true);
+  }, []);
+  return <AriaLiveAnnouncer>{mounted && props.children}</AriaLiveAnnouncer>;
+};

--- a/packages/react-components/react-storybook-addon/src/preset/preview.ts
+++ b/packages/react-components/react-storybook-addon/src/preset/preview.ts
@@ -11,7 +11,8 @@
 
 import { withFluentProvider } from '../decorators/withFluentProvider';
 import { withReactStrictMode } from '../decorators/withReactStrictMode';
+import { withAriaLive } from '../decorators/withAriaLive';
 import { THEME_ID } from '../constants';
 
-export const decorators = [withFluentProvider, withReactStrictMode];
+export const decorators = [withFluentProvider, withAriaLive, withReactStrictMode];
 export const globals = { [THEME_ID]: undefined }; // allow theme to be set by URL query param


### PR DESCRIPTION
Creates a new decorator around stories so that an aria live announcer is included with an example.

Fixes #31504

