### PR TITLE
fix(`merge-styles`): Correctly processing selectors when value is a class name and they are not wrapped in `selectors` wrapper

### DIFF
--- a/change/@fluentui-merge-styles-80cf5b64-7950-4db5-9b45-b92cc006f2db.json
+++ b/change/@fluentui-merge-styles-80cf5b64-7950-4db5-9b45-b92cc006f2db.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Correctly processing selectors when value is a class name and they are not wrapped in 'selectors' wrapper.",
+  "packageName": "@fluentui/merge-styles",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/merge-styles/src/styleToClassName.ts
+++ b/packages/merge-styles/src/styleToClassName.ts
@@ -73,6 +73,10 @@ function expandCommaSeparatedGlobals(selectorWithGlobals: string): string {
     }, selectorWithGlobals);
 }
 
+function isSelector(potentialSelector: string): boolean {
+  return potentialSelector.indexOf(':global(') >= 0 || potentialSelector.indexOf(':') === 0;
+}
+
 function expandSelector(newSelector: string, currentSelector: string): string {
   if (newSelector.indexOf(':global(') >= 0) {
     return newSelector.replace(globalSelectorRegExp, '$1');
@@ -138,7 +142,6 @@ function extractRules(
       for (const prop in arg as any) {
         if ((arg as any).hasOwnProperty(prop)) {
           const propValue = (arg as any)[prop];
-
           if (prop === 'selectors') {
             // every child is a selector.
             const selectors: { [key: string]: IStyle } = (arg as any).selectors;
@@ -148,9 +151,9 @@ function extractRules(
                 extractSelector(currentSelector, rules, newSelector, selectors[newSelector], stylesheet);
               }
             }
-          } else if (typeof propValue === 'object') {
+          } else if (typeof propValue === 'object' || isSelector(prop)) {
             // prop is a selector.
-            if (propValue !== null) {
+            if (propValue !== null && propValue !== undefined) {
               extractSelector(currentSelector, rules, prop, propValue, stylesheet);
             }
           } else {


### PR DESCRIPTION
## Previous Behavior

After #31253 was merged and the `selectors` wrapper was removed from every button style, it was discovered that some style customizations were no longer working, such as the one in [this Stackblitz project](https://stackblitz.com/edit/stackblitz-starters-vi7nwj?file=package.json,src%2FApp.tsx) where the `rootFocused` style customizations are not being applied.

After some investigation, I discovered that the `selectors` wrapper forced a path within `extractRules` to actually go through the `extractSelector` process, which ensured that the pseudo selectors were being properly handled. In contrast, not applying the wrapper meant that the logic checked for the value of the pseudo selector being an object, a case that is handled correctly, but the same logic doesn't apply when the value is just a class name as in the example above.

This is something that has never worked but that hadn't been exposed before because most of our components still use the `selectors` wrapper internally.

## New Behavior

I have added an `isSelector` local function that checks for the same set of minimum conditions that the currently used `expandSelector` checks, and use it to determine if something needs to go through the `extractSelector` code path. This ensures that even when the value of a pseudo selector is not an object, it is treated properly.

_Note:_ I tried to add a test to shield this in the future, but since the correct behavior when the value is a string is to not add anything to the stylesheet, since the class name should presumably already be there and is just being applied to that pseudo selector, I could not really check for something else being added to the stylesheet to verify this.