### PR TITLE
fix(react-drawer): do not create global header/footer roles

### DIFF
--- a/change/@fluentui-react-drawer-036ac4c0-092d-474a-aed8-6d84906978f2.json
+++ b/change/@fluentui-react-drawer-036ac4c0-092d-474a-aed8-6d84906978f2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: do not create global header/footer roles in Drawer",
+  "packageName": "@fluentui/react-drawer",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-drawer/library/src/components/DrawerFooter/DrawerFooter.test.tsx
+++ b/packages/react-components/react-drawer/library/src/components/DrawerFooter/DrawerFooter.test.tsx
@@ -15,6 +15,7 @@ describe('DrawerFooter', () => {
       <div>
         <footer
           class="fui-DrawerFooter"
+          role="none"
         >
           Default DrawerFooter
         </footer>

--- a/packages/react-components/react-drawer/library/src/components/DrawerFooter/useDrawerFooter.ts
+++ b/packages/react-components/react-drawer/library/src/components/DrawerFooter/useDrawerFooter.ts
@@ -24,6 +24,7 @@ export const useDrawerFooter_unstable = (props: DrawerFooterProps, ref: React.Re
     root: slot.always(
       getIntrinsicElementProps('footer', {
         ref,
+        role: 'none', // until header and footer elements can be scoped to a dialog, this is needed
         ...props,
       }),
       { elementType: 'footer' },

--- a/packages/react-components/react-drawer/library/src/components/DrawerHeader/DrawerHeader.test.tsx
+++ b/packages/react-components/react-drawer/library/src/components/DrawerHeader/DrawerHeader.test.tsx
@@ -15,6 +15,7 @@ describe('DrawerHeader', () => {
       <div>
         <header
           class="fui-DrawerHeader"
+          role="none"
         >
           Default DrawerHeader
         </header>

--- a/packages/react-components/react-drawer/library/src/components/DrawerHeader/useDrawerHeader.ts
+++ b/packages/react-components/react-drawer/library/src/components/DrawerHeader/useDrawerHeader.ts
@@ -25,6 +25,7 @@ export const useDrawerHeader_unstable = (props: DrawerHeaderProps, ref: React.Re
     root: slot.always(
       getIntrinsicElementProps('header', {
         ref,
+        role: 'none', // until header and footer elements can be scoped to a dialog, this is needed
         ...props,
       }),
       { elementType: 'header' },


### PR DESCRIPTION
## Previous Behavior

The native `<header>` and `<footer>` elements create global landmarks unless they are wrapped by a sectioning element (not just `section`, there are a few more). Right now, `dialog` does not count as a sectioning element, though it probably should.

Till it does, we should override the auto-calculated roles for the header/footer elements.

## New Behavior

Adds `role=none`, so header/footer elements in the Drawer are given globally scoped landmark roles.

## Related Issue(s)

- Fixes an [ADO issue](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/18697)
