### PR TITLE
feat(react-list-preview): pass value to onAction callback

### DIFF
--- a/change/@fluentui-react-list-preview-50c10fe7-4982-4036-9f14-c003dd2ce068.json
+++ b/change/@fluentui-react-list-preview-50c10fe7-4982-4036-9f14-c003dd2ce068.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "feat: Pass value to onAction callback",
+  "comment": "feat: Pass data with value to onAction callback",
   "packageName": "@fluentui/react-list-preview",
   "email": "jirivyhnalek@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-list-preview-50c10fe7-4982-4036-9f14-c003dd2ce068.json
+++ b/change/@fluentui-react-list-preview-50c10fe7-4982-4036-9f14-c003dd2ce068.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: Pass value to onAction callback",
+  "packageName": "@fluentui/react-list-preview",
+  "email": "jirivyhnalek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-list-preview/library/etc/react-list-preview.api.md
+++ b/packages/react-components/react-list-preview/library/etc/react-list-preview.api.md
@@ -33,7 +33,7 @@ export const listItemClassNames: SlotClassNames<ListItemSlots>;
 // @public
 export type ListItemProps = ComponentProps<ListItemSlots> & {
     value?: ListItemValue;
-    onAction?: (e: ListItemActionEvent, data: ListItemOnActionData) => void;
+    onAction?: (e: ListItemActionEvent, data: ListItemActionData) => void;
 };
 
 // @public (undocumented)

--- a/packages/react-components/react-list-preview/library/etc/react-list-preview.api.md
+++ b/packages/react-components/react-list-preview/library/etc/react-list-preview.api.md
@@ -33,7 +33,7 @@ export const listItemClassNames: SlotClassNames<ListItemSlots>;
 // @public
 export type ListItemProps = ComponentProps<ListItemSlots> & {
     value?: ListItemValue;
-    onAction?: EventHandler<ActionEventData>;
+    onAction?: EventHandler<ListItemActionEventData>;
 };
 
 // @public (undocumented)

--- a/packages/react-components/react-list-preview/library/etc/react-list-preview.api.md
+++ b/packages/react-components/react-list-preview/library/etc/react-list-preview.api.md
@@ -33,7 +33,7 @@ export const listItemClassNames: SlotClassNames<ListItemSlots>;
 // @public
 export type ListItemProps = ComponentProps<ListItemSlots> & {
     value?: ListItemValue;
-    onAction?: (e: ListItemActionEvent, value: ListItemValue) => void;
+    onAction?: (e: ListItemActionEvent, data: ListItemOnActionData) => void;
 };
 
 // @public (undocumented)

--- a/packages/react-components/react-list-preview/library/etc/react-list-preview.api.md
+++ b/packages/react-components/react-list-preview/library/etc/react-list-preview.api.md
@@ -32,8 +32,8 @@ export const listItemClassNames: SlotClassNames<ListItemSlots>;
 
 // @public
 export type ListItemProps = ComponentProps<ListItemSlots> & {
-    value?: string | number;
-    onAction?: (e: ListItemActionEvent) => void;
+    value?: ListItemValue;
+    onAction?: (e: ListItemActionEvent, value: ListItemValue) => void;
 };
 
 // @public (undocumented)

--- a/packages/react-components/react-list-preview/library/etc/react-list-preview.api.md
+++ b/packages/react-components/react-list-preview/library/etc/react-list-preview.api.md
@@ -33,7 +33,7 @@ export const listItemClassNames: SlotClassNames<ListItemSlots>;
 // @public
 export type ListItemProps = ComponentProps<ListItemSlots> & {
     value?: ListItemValue;
-    onAction?: (e: ListItemActionEvent, data: ListItemActionData) => void;
+    onAction?: EventHandler<ActionEventData>;
 };
 
 // @public (undocumented)

--- a/packages/react-components/react-list-preview/library/src/components/List/List.test.tsx
+++ b/packages/react-components/react-list-preview/library/src/components/List/List.test.tsx
@@ -349,7 +349,7 @@ describe('List', () => {
 
         const firstItem = result.getByText('First ListItem');
         firstItem.click();
-        expect(onAction).toHaveBeenCalledWith(expect.any(Object), 'first-item');
+        expect(onAction).toHaveBeenCalledWith(expect.any(Object), { value: 'first-item' });
       });
     });
 
@@ -492,7 +492,7 @@ describe('List', () => {
         expect(pressKeyOnListItem('Enter').onAction).toHaveBeenCalledTimes(1);
       });
       it('onAction should be called with list item value', () => {
-        expect(pressKeyOnListItem('Enter').onAction).toHaveBeenCalledWith(expect.any(Object), 'first-item');
+        expect(pressKeyOnListItem('Enter').onAction).toHaveBeenCalledWith(expect.any(Object), { value: 'first-item' });
       });
     });
 

--- a/packages/react-components/react-list-preview/library/src/components/List/List.test.tsx
+++ b/packages/react-components/react-list-preview/library/src/components/List/List.test.tsx
@@ -349,7 +349,11 @@ describe('List', () => {
 
         const firstItem = result.getByText('First ListItem');
         firstItem.click();
-        expect(onAction).toHaveBeenCalledWith(expect.any(Object), { value: 'first-item' });
+        expect(onAction).toHaveBeenCalledWith(expect.any(Object), {
+          event: expect.any(Object),
+          type: 'ListItemAction',
+          value: 'first-item',
+        });
       });
     });
 
@@ -492,7 +496,11 @@ describe('List', () => {
         expect(pressKeyOnListItem('Enter').onAction).toHaveBeenCalledTimes(1);
       });
       it('onAction should be called with list item value', () => {
-        expect(pressKeyOnListItem('Enter').onAction).toHaveBeenCalledWith(expect.any(Object), { value: 'first-item' });
+        expect(pressKeyOnListItem('Enter').onAction).toHaveBeenCalledWith(expect.any(Object), {
+          event: expect.any(Object),
+          type: 'ListItemAction',
+          value: 'first-item',
+        });
       });
     });
 

--- a/packages/react-components/react-list-preview/library/src/components/List/List.test.tsx
+++ b/packages/react-components/react-list-preview/library/src/components/List/List.test.tsx
@@ -335,6 +335,22 @@ describe('List', () => {
         firstItem.click();
         expect(onAction).toHaveBeenCalledTimes(1);
       });
+      it('onAction should be called with the value', () => {
+        const onAction = jest.fn();
+
+        const result = render(
+          <List>
+            <ListItem onAction={onAction} value="first-item">
+              First ListItem
+            </ListItem>
+            <ListItem>Second ListItem</ListItem>
+          </List>,
+        );
+
+        const firstItem = result.getByText('First ListItem');
+        firstItem.click();
+        expect(onAction).toHaveBeenCalledWith(expect.any(Object), 'first-item');
+      });
     });
 
     describe('with selection', () => {
@@ -454,7 +470,9 @@ describe('List', () => {
 
         const result = render(
           <List>
-            <ListItem onAction={onAction}>First ListItem</ListItem>
+            <ListItem onAction={onAction} value="first-item">
+              First ListItem
+            </ListItem>
             <ListItem>Second ListItem</ListItem>
           </List>,
         );
@@ -472,6 +490,9 @@ describe('List', () => {
       });
       it('Enter should trigger onClick', () => {
         expect(pressKeyOnListItem('Enter').onAction).toHaveBeenCalledTimes(1);
+      });
+      it('onAction should be called with list item value', () => {
+        expect(pressKeyOnListItem('Enter').onAction).toHaveBeenCalledWith(expect.any(Object), 'first-item');
       });
     });
 

--- a/packages/react-components/react-list-preview/library/src/components/List/List.test.tsx
+++ b/packages/react-components/react-list-preview/library/src/components/List/List.test.tsx
@@ -4,7 +4,8 @@ import { isConformant } from '../../testing/isConformant';
 import { List } from './List';
 import { ListProps } from './List.types';
 import { ListItem } from '../ListItem/ListItem';
-import { ListItemActionEvent } from '../../events/ListItemActionEvent';
+import { ListItemActionEventData } from '../ListItem/ListItem.types';
+import { EventHandler } from '@fluentui/react-utilities';
 
 function expectListboxItemSelected(item: HTMLElement, selected: boolean) {
   expect(item.getAttribute('aria-selected')).toBe(selected.toString());
@@ -360,7 +361,7 @@ describe('List', () => {
     describe('with selection', () => {
       function interactWithFirstElement(
         interaction: (firstItem: HTMLElement) => void,
-        customAction?: (e: ListItemActionEvent) => void,
+        customAction?: EventHandler<ListItemActionEventData>,
       ) {
         const onAction = jest.fn(customAction);
 
@@ -505,8 +506,8 @@ describe('List', () => {
     });
 
     describe('with selection', () => {
-      function pressOnListItem(key: string, customOnaction?: (e: ListItemActionEvent) => void) {
-        const onAction = jest.fn(customOnaction);
+      function pressOnListItem(key: string, customOnAction?: EventHandler<ListItemActionEventData>) {
+        const onAction = jest.fn(customOnAction);
 
         const result = render(
           <List selectionMode="multiselect">

--- a/packages/react-components/react-list-preview/library/src/components/ListItem/ListItem.types.ts
+++ b/packages/react-components/react-list-preview/library/src/components/ListItem/ListItem.types.ts
@@ -9,7 +9,7 @@ export type ListItemSlots = {
 
 export type ListItemValue = string | number;
 
-export type ListItemOnActionData = { value: ListItemValue };
+export type ListItemActionData = { value: ListItemValue };
 
 /**
  * ListItem Props
@@ -17,7 +17,7 @@ export type ListItemOnActionData = { value: ListItemValue };
 export type ListItemProps = ComponentProps<ListItemSlots> & {
   value?: ListItemValue;
   // eslint-disable-next-line @nx/workspace-consistent-callback-type -- using custom event here with no data
-  onAction?: (e: ListItemActionEvent, data: ListItemOnActionData) => void;
+  onAction?: (e: ListItemActionEvent, data: ListItemActionData) => void;
 };
 
 /**

--- a/packages/react-components/react-list-preview/library/src/components/ListItem/ListItem.types.ts
+++ b/packages/react-components/react-list-preview/library/src/components/ListItem/ListItem.types.ts
@@ -1,6 +1,6 @@
 import { Checkbox } from '@fluentui/react-checkbox';
-import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
-import { ListItemActionEvent } from '../../events/ListItemActionEvent';
+import type { ComponentProps, ComponentState, EventData, EventHandler, Slot } from '@fluentui/react-utilities';
+import { ListItemActionEvent, ListItemActionEventName } from '../../events/ListItemActionEvent';
 
 export type ListItemSlots = {
   root: NonNullable<Slot<'li', 'div'>>;
@@ -11,13 +11,15 @@ export type ListItemValue = string | number;
 
 export type ListItemActionData = { value: ListItemValue };
 
+export type ActionEventData = EventData<typeof ListItemActionEventName, ListItemActionEvent> & {
+  value: ListItemValue;
+};
 /**
  * ListItem Props
  */
 export type ListItemProps = ComponentProps<ListItemSlots> & {
   value?: ListItemValue;
-  // eslint-disable-next-line @nx/workspace-consistent-callback-type -- using custom event here with no data
-  onAction?: (e: ListItemActionEvent, data: ListItemActionData) => void;
+  onAction?: EventHandler<ActionEventData>;
 };
 
 /**

--- a/packages/react-components/react-list-preview/library/src/components/ListItem/ListItem.types.ts
+++ b/packages/react-components/react-list-preview/library/src/components/ListItem/ListItem.types.ts
@@ -9,13 +9,15 @@ export type ListItemSlots = {
 
 export type ListItemValue = string | number;
 
+export type ListItemOnActionData = { value: ListItemValue };
+
 /**
  * ListItem Props
  */
 export type ListItemProps = ComponentProps<ListItemSlots> & {
   value?: ListItemValue;
   // eslint-disable-next-line @nx/workspace-consistent-callback-type -- using custom event here with no data
-  onAction?: (e: ListItemActionEvent, value: ListItemValue) => void;
+  onAction?: (e: ListItemActionEvent, data: ListItemOnActionData) => void;
 };
 
 /**

--- a/packages/react-components/react-list-preview/library/src/components/ListItem/ListItem.types.ts
+++ b/packages/react-components/react-list-preview/library/src/components/ListItem/ListItem.types.ts
@@ -7,13 +7,15 @@ export type ListItemSlots = {
   checkmark?: Slot<typeof Checkbox>;
 };
 
+export type ListItemValue = string | number;
+
 /**
  * ListItem Props
  */
 export type ListItemProps = ComponentProps<ListItemSlots> & {
-  value?: string | number;
+  value?: ListItemValue;
   // eslint-disable-next-line @nx/workspace-consistent-callback-type -- using custom event here with no data
-  onAction?: (e: ListItemActionEvent) => void;
+  onAction?: (e: ListItemActionEvent, value: ListItemValue) => void;
 };
 
 /**

--- a/packages/react-components/react-list-preview/library/src/components/ListItem/ListItem.types.ts
+++ b/packages/react-components/react-list-preview/library/src/components/ListItem/ListItem.types.ts
@@ -9,9 +9,7 @@ export type ListItemSlots = {
 
 export type ListItemValue = string | number;
 
-export type ListItemActionData = { value: ListItemValue };
-
-export type ActionEventData = EventData<typeof ListItemActionEventName, ListItemActionEvent> & {
+export type ListItemActionEventData = EventData<typeof ListItemActionEventName, ListItemActionEvent> & {
   value: ListItemValue;
 };
 /**
@@ -19,7 +17,7 @@ export type ActionEventData = EventData<typeof ListItemActionEventName, ListItem
  */
 export type ListItemProps = ComponentProps<ListItemSlots> & {
   value?: ListItemValue;
-  onAction?: EventHandler<ActionEventData>;
+  onAction?: EventHandler<ListItemActionEventData>;
 };
 
 /**

--- a/packages/react-components/react-list-preview/library/src/components/ListItem/useListItem.tsx
+++ b/packages/react-components/react-list-preview/library/src/components/ListItem/useListItem.tsx
@@ -57,7 +57,7 @@ export const useListItem_unstable = (
   const checkmarkRef = React.useRef<HTMLInputElement | null>(null);
 
   const handleAction: (e: ListItemActionEvent) => void = useEventCallback(e => {
-    onAction?.(e, value);
+    onAction?.(e, { value });
 
     if (e.defaultPrevented) {
       return;

--- a/packages/react-components/react-list-preview/library/src/components/ListItem/useListItem.tsx
+++ b/packages/react-components/react-list-preview/library/src/components/ListItem/useListItem.tsx
@@ -57,7 +57,7 @@ export const useListItem_unstable = (
   const checkmarkRef = React.useRef<HTMLInputElement | null>(null);
 
   const handleAction: (e: ListItemActionEvent) => void = useEventCallback(e => {
-    onAction?.(e);
+    onAction?.(e, value);
 
     if (e.defaultPrevented) {
       return;

--- a/packages/react-components/react-list-preview/library/src/components/ListItem/useListItem.tsx
+++ b/packages/react-components/react-list-preview/library/src/components/ListItem/useListItem.tsx
@@ -22,7 +22,11 @@ import type { ListItemProps, ListItemState } from './ListItem.types';
 import { useListContext_unstable } from '../List/listContext';
 import { Enter, Space, ArrowUp, ArrowDown, ArrowRight, ArrowLeft } from '@fluentui/keyboard-keys';
 import { Checkbox, CheckboxOnChangeData } from '@fluentui/react-checkbox';
-import { createListItemActionEvent, ListItemActionEvent } from '../../events/ListItemActionEvent';
+import {
+  createListItemActionEvent,
+  ListItemActionEvent,
+  ListItemActionEventName,
+} from '../../events/ListItemActionEvent';
 
 const DEFAULT_ROOT_EL_TYPE = 'li';
 
@@ -56,15 +60,15 @@ export const useListItem_unstable = (
   const rootRef = React.useRef<HTMLLIElement | HTMLDivElement>(null);
   const checkmarkRef = React.useRef<HTMLInputElement | null>(null);
 
-  const handleAction: (e: ListItemActionEvent) => void = useEventCallback(e => {
-    onAction?.(e, { value });
+  const handleAction: (event: ListItemActionEvent) => void = useEventCallback(event => {
+    onAction?.(event, { event, value, type: ListItemActionEventName });
 
-    if (e.defaultPrevented) {
+    if (event.defaultPrevented) {
       return;
     }
 
     if (isSelectionEnabled) {
-      toggleItem?.(e.detail.originalEvent, value);
+      toggleItem?.(event.detail.originalEvent, value);
     }
   });
 

--- a/packages/react-components/react-list-preview/stories/src/List/MultipleActionsDifferentPrimary.stories.tsx
+++ b/packages/react-components/react-list-preview/stories/src/List/MultipleActionsDifferentPrimary.stories.tsx
@@ -71,7 +71,7 @@ const CustomListItem = (props: { title: string; value: string }) => {
   const { value } = props;
 
   // This will be triggered by user pressing Enter or clicking on the list item
-  const onAction = React.useCallback((event, value) => {
+  const onAction = React.useCallback((event, { value }) => {
     // This prevents the change in selection on click/Enter
     event.preventDefault();
     alert(`Triggered custom action on ${value}`);

--- a/packages/react-components/react-list-preview/stories/src/List/MultipleActionsDifferentPrimary.stories.tsx
+++ b/packages/react-components/react-list-preview/stories/src/List/MultipleActionsDifferentPrimary.stories.tsx
@@ -71,10 +71,10 @@ const CustomListItem = (props: { title: string; value: string }) => {
   const { value } = props;
 
   // This will be triggered by user pressing Enter or clicking on the list item
-  const onAction = React.useCallback((event, { value }) => {
+  const onAction = React.useCallback((event, { value: val }) => {
     // This prevents the change in selection on click/Enter
     event.preventDefault();
-    alert(`Triggered custom action on ${value}`);
+    alert(`Triggered custom action on ${val}`);
   }, []);
 
   return (

--- a/packages/react-components/react-list-preview/stories/src/List/MultipleActionsDifferentPrimary.stories.tsx
+++ b/packages/react-components/react-list-preview/stories/src/List/MultipleActionsDifferentPrimary.stories.tsx
@@ -71,10 +71,10 @@ const CustomListItem = (props: { title: string; value: string }) => {
   const { value } = props;
 
   // This will be triggered by user pressing Enter or clicking on the list item
-  const onAction = React.useCallback(event => {
+  const onAction = React.useCallback((event, value) => {
     // This prevents the change in selection on click/Enter
     event.preventDefault();
-    alert(`Triggered custom action!`);
+    alert(`Triggered custom action on ${value}`);
   }, []);
 
   return (

--- a/packages/react-components/react-list-preview/stories/src/List/SingleActionSelectionDifferentPrimary.stories.tsx
+++ b/packages/react-components/react-list-preview/stories/src/List/SingleActionSelectionDifferentPrimary.stories.tsx
@@ -27,10 +27,10 @@ export const SingleActionSelectionDifferentPrimary = () => {
   const [selectedItems, setSelectedItems] = React.useState<SelectionItemId[]>(['Demetra Manwaring', 'Bart Merrill']);
 
   // This will be triggered by user pressing Enter or clicking on the list item
-  const onAction = React.useCallback((event, { value }) => {
+  const onAction = React.useCallback((event, { value: val }) => {
     // This prevents the change in selection on click/Enter
     event.preventDefault();
-    alert(`Triggered custom action on ${value}`);
+    alert(`Triggered custom action on ${val}`);
   }, []);
 
   return (

--- a/packages/react-components/react-list-preview/stories/src/List/SingleActionSelectionDifferentPrimary.stories.tsx
+++ b/packages/react-components/react-list-preview/stories/src/List/SingleActionSelectionDifferentPrimary.stories.tsx
@@ -27,10 +27,10 @@ export const SingleActionSelectionDifferentPrimary = () => {
   const [selectedItems, setSelectedItems] = React.useState<SelectionItemId[]>(['Demetra Manwaring', 'Bart Merrill']);
 
   // This will be triggered by user pressing Enter or clicking on the list item
-  const onAction = React.useCallback(event => {
+  const onAction = React.useCallback((event, value) => {
     // This prevents the change in selection on click/Enter
     event.preventDefault();
-    alert(`Triggered custom action!`);
+    alert(`Triggered custom action on ${value}`);
   }, []);
 
   return (

--- a/packages/react-components/react-list-preview/stories/src/List/SingleActionSelectionDifferentPrimary.stories.tsx
+++ b/packages/react-components/react-list-preview/stories/src/List/SingleActionSelectionDifferentPrimary.stories.tsx
@@ -27,7 +27,7 @@ export const SingleActionSelectionDifferentPrimary = () => {
   const [selectedItems, setSelectedItems] = React.useState<SelectionItemId[]>(['Demetra Manwaring', 'Bart Merrill']);
 
   // This will be triggered by user pressing Enter or clicking on the list item
-  const onAction = React.useCallback((event, value) => {
+  const onAction = React.useCallback((event, { value }) => {
     // This prevents the change in selection on click/Enter
     event.preventDefault();
     alert(`Triggered custom action on ${value}`);


### PR DESCRIPTION
## Previous Behavior

Previously `onAction` callback did not receive a `value` prop.

## New Behavior

`onAction` callback receives the `value` prop as second argument.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #31797 
