### PR TITLE
Add 'allowParentArrowNavigation' prop to `ComboBox`.

### DIFF
--- a/change/@fluentui-react-4c9ebee6-1e61-4e67-87f3-50ef560ab2dc.json
+++ b/change/@fluentui-react-4c9ebee6-1e61-4e67-87f3-50ef560ab2dc.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add 'allowParentArrowNavigation' to ComboBox.",
+  "packageName": "@fluentui/react",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -3928,6 +3928,7 @@ export interface IComboBoxOptionStyles extends IButtonStyles {
 export interface IComboBoxProps extends ISelectableDroppableTextProps<IComboBox, IComboBox>, React_2.RefAttributes<HTMLDivElement> {
     allowFreeform?: boolean;
     allowFreeInput?: boolean;
+    allowParentArrowNavigation?: boolean;
     ariaDescribedBy?: string;
     autoComplete?: 'on' | 'off';
     autofill?: IAutofillProps;

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -132,6 +132,7 @@ const COMPONENT_NAME = 'ComboBox';
 const DEFAULT_PROPS: Partial<IComboBoxProps> = {
   options: [],
   allowFreeform: false,
+  allowParentArrowNavigation: false,
   autoComplete: 'on',
   buttonIconProps: { iconName: 'ChevronDown' },
 };
@@ -2087,6 +2088,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
       disabled,
       allowFreeform,
       allowFreeInput,
+      allowParentArrowNavigation,
       autoComplete,
       hoisted: { currentOptions },
     } = this.props;
@@ -2254,6 +2256,11 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
         // or meta key, let the event propagate
         // eslint-disable-next-line deprecation/deprecation
         if (ev.keyCode === KeyCodes.alt || ev.key === 'Meta' /* && isOpen */) {
+          return;
+        }
+
+        // eslint-disable-next-line deprecation/deprecation
+        if (allowParentArrowNavigation && (ev.keyCode === KeyCodes.left || ev.keyCode === KeyCodes.right)) {
           return;
         }
 

--- a/packages/react/src/components/ComboBox/ComboBox.types.ts
+++ b/packages/react/src/components/ComboBox/ComboBox.types.ts
@@ -146,6 +146,13 @@ export interface IComboBoxProps
   allowFreeInput?: boolean;
 
   /**
+   * When true this allows the parent element to navigate using left and right arrow keys.
+   *
+   * @defaultvalue false
+   */
+  allowParentArrowNavigation?: boolean;
+
+  /**
    * Whether the ComboBox auto completes. As the user is entering text, potential matches will be
    * suggested from the list of options. If the ComboBox is expanded, this will also scroll to the
    * suggested option and give it a selected style.


### PR DESCRIPTION
## Previous Behavior

When using `ComboBox` inside `DetailsList` arrow navigation would get stuck on `ComboBox`. This is because the code would hit [this break](https://github.com/microsoft/fluentui/blob/master/packages/react/src/components/ComboBox/ComboBox.tsx#L2264) and then [call `stopPropagation()` and `preventDefault()` on the keyboard event](https://github.com/microsoft/fluentui/blob/master/packages/react/src/components/ComboBox/ComboBox.tsx#L2271-L2272), preventing navigation.

## New Behavior

This PR introduces a new prop allowing users to opt in to a behavior that will skip the calls to `stopPropagation()` and `preventDefault()`.

## Related Issue(s)


- Fixes #29885
