### PR TITLE
chore(web-components): update web types for TS 4.9

### DIFF
--- a/apps/vr-tests-web-components/package.json
+++ b/apps/vr-tests-web-components/package.json
@@ -13,9 +13,6 @@
     "vr:build": "yarn build",
     "vr:test": "storywright  --browsers chromium --url dist/storybook --destpath dist/screenshots --waitTimeScreenshot 500 --concurrency 4 --headless true"
   },
-  "devDependencies": {
-    "@types/web": "^0.0.142"
-  },
   "dependencies": {
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/apps/vr-tests-web-components/tsconfig.json
+++ b/apps/vr-tests-web-components/tsconfig.json
@@ -8,7 +8,7 @@
     "resolveJsonModule": true,
     "allowJs": true,
     "jsx": "react",
-    "types": ["jest", "node", "web"]
+    "types": ["jest", "node", "web", "es2023-shim"]
   },
   "include": ["./src", "./.storybook/*"],
   "files": ["./typings/html-react-parser/index.d.ts"]

--- a/change/@fluentui-web-components-ddb6dbe0-ec62-4b5c-af88-b061151bc2bb.json
+++ b/change/@fluentui-web-components-ddb6dbe0-ec62-4b5c-af88-b061151bc2bb.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: update web types and add es2023-shim",
+  "packageName": "@fluentui/web-components",
+  "email": "863023+radium-v@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/package.json
+++ b/package.json
@@ -177,6 +177,7 @@
     "@types/tmp": "0.2.0",
     "@types/use-sync-external-store": "0.0.6",
     "@types/vinyl": "2.0.7",
+    "@types/web": "^0.0.142",
     "@types/webpack-bundle-analyzer": "4.7.0",
     "@types/webpack-dev-middleware": "5.3.0",
     "@types/webpack-env": "1.18.4",

--- a/packages/web-components/.storybook/tsconfig.json
+++ b/packages/web-components/.storybook/tsconfig.json
@@ -4,7 +4,7 @@
     "allowJs": true,
     "checkJs": true,
     "noEmit": true,
-    "types": ["node", "web"]
+    "types": ["node", "web", "es2023-shim"]
   },
   "include": ["*", "../public", "../src/**/*.stories.*"]
 }

--- a/packages/web-components/docs/api-report.md
+++ b/packages/web-components/docs/api-report.md
@@ -1967,6 +1967,72 @@ export const DividerStyles: ElementStyles;
 // @public
 export const DividerTemplate: ElementViewTemplate<Divider>;
 
+// Warning: (ae-missing-release-tag) "Drawer" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export class Drawer extends FASTElement {
+    ariaDescribedby?: string;
+    ariaLabelledby?: string;
+    // (undocumented)
+    clickHandler(event: Event): boolean;
+    dialog: HTMLDialogElement;
+    emitBeforeToggle: () => void;
+    emitToggle: () => void;
+    hide(): void;
+    position: DrawerPosition;
+    show(): void;
+    // (undocumented)
+    size: DrawerSize;
+    type: DrawerType;
+}
+
+// @public (undocumented)
+export const DrawerDefinition: FASTElementDefinition<typeof Drawer>;
+
+// Warning: (ae-missing-release-tag) "DrawerPosition" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export const DrawerPosition: {
+    readonly start: "start";
+    readonly end: "end";
+};
+
+// @public
+export type DrawerPosition = ValuesOf<typeof DrawerPosition>;
+
+// Warning: (ae-missing-release-tag) "DrawerSize" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export const DrawerSize: {
+    readonly small: "small";
+    readonly medium: "medium";
+    readonly large: "large";
+    readonly full: "full";
+};
+
+// @public
+export type DrawerSize = ValuesOf<typeof DrawerSize>;
+
+// @public
+export const DrawerStyles: ElementStyles;
+
+// Warning: (ae-missing-release-tag) "template" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export const DrawerTemplate: ElementViewTemplate<Drawer>;
+
+// Warning: (ae-missing-release-tag) "DrawerType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export const DrawerType: {
+    readonly nonModal: "non-modal";
+    readonly modal: "modal";
+    readonly inline: "inline";
+};
+
+// @public
+export type DrawerType = ValuesOf<typeof DrawerType>;
+
 // @public
 export const durationFast = "var(--durationFast)";
 
@@ -2631,6 +2697,7 @@ export const RadioTemplate: ElementViewTemplate<Radio>;
 export class RatingDisplay extends FASTElement {
     constructor();
     color?: RatingDisplayColor;
+    colorChanged(prev: RatingDisplayColor | undefined, next: RatingDisplayColor | undefined): void;
     compact: boolean;
     count?: number;
     // @internal
@@ -2641,6 +2708,7 @@ export class RatingDisplay extends FASTElement {
     generateIcons(): string;
     max?: number;
     size?: RatingDisplaySize;
+    sizeChanged(prev: RatingDisplaySize | undefined, next: RatingDisplaySize | undefined): void;
     value?: number;
 }
 

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -235,7 +235,6 @@
   "devDependencies": {
     "@microsoft/fast-element": "2.0.0-beta.26",
     "@tensile-perf/web-components": "~0.2.0",
-    "@types/web": "^0.0.142",
     "@storybook/html": "6.5.15",
     "chromedriver": "^125.0.0"
   },

--- a/packages/web-components/tsconfig.json
+++ b/packages/web-components/tsconfig.json
@@ -1,11 +1,11 @@
 {
   "extends": "../../tsconfig.base.wc.json",
   "compilerOptions": {
-    "target": "ES2019",
-    "module": "ESNext",
     "experimentalDecorators": true,
     "resolveJsonModule": true,
-    "allowJs": true
+    "allowJs": true,
+    "lib": ["ESNext", "DOM"],
+    "types": ["web", "es2023-shim"]
   },
   "files": [],
   "references": [

--- a/packages/web-components/tsconfig.lib.json
+++ b/packages/web-components/tsconfig.lib.json
@@ -1,14 +1,10 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "target": "ES2019",
-    "module": "ESNext",
-    "lib": ["ESNext", "DOM"],
     "declaration": true,
     "declarationDir": "dist/dts",
     "outDir": "dist/esm",
-    "importHelpers": true,
-    "types": ["web"]
+    "importHelpers": true
   },
   "include": ["src"],
   "exclude": ["**/*.stories.*", "**/*.test.*", "**/*.spec.*"]

--- a/packages/web-components/tsconfig.spec.json
+++ b/packages/web-components/tsconfig.spec.json
@@ -1,9 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "ESNext",
-    "outDir": "dist/esm",
-    "types": ["web", "node", "webpack-env"]
+    "outDir": "dist/esm"
   },
   "include": ["src/**/*.test.*", "src/**/*.spec.*"]
 }

--- a/typings/es2023-shim/README.md
+++ b/typings/es2023-shim/README.md
@@ -1,0 +1,14 @@
+# es2023-shim
+
+This package contains type definitions which are present in the ECMAScript 2023 specification but aren't available in TypeScript 4.9. Once the project is updated to TypeScript 5+, this package should be removed.
+
+## Usage
+
+```json
+{
+  "compilerOptions": {
+    "typeRoots": ["../../node_modules/@types", "../../typings"],
+    "types": ["es2023-shim"] // and any other types you reference
+  }
+}
+```

--- a/typings/es2023-shim/index.d.ts
+++ b/typings/es2023-shim/index.d.ts
@@ -1,0 +1,29 @@
+// TODO: Remove this when we upgrade to TypeScript 5
+
+// Adopted from https://github.com/microsoft/TypeScript/blob/main/src/lib/es2023.array.d.ts
+declare interface Array<T> {
+  /**
+   * Returns the value of the last element in the array where predicate is true, and undefined
+   * otherwise.
+   * @param predicate find calls predicate once for each element of the array, in descending
+   * order, until it finds one where predicate returns true. If such an element is found, find
+   * immediately returns that element value. Otherwise, find returns undefined.
+   * @param thisArg If provided, it will be used as the this value for each invocation of
+   * predicate. If it is not provided, undefined is used instead.
+   */
+  findLast<S extends T>(
+    predicate: (this: void, value: T, index: number, obj: T[]) => value is S,
+    thisArg?: any,
+  ): S | undefined;
+  findLast(predicate: (value: T, index: number, obj: T[]) => unknown, thisArg?: any): T | undefined;
+
+  /**
+   * Returns the index of the last element in the array where predicate is true, and -1 otherwise.
+   * @param predicate findLastIndex calls predicate once for each element of the array, in descending order, until it
+   * finds one where predicate returns true. If such an element is found, findLastIndex immediately returns that
+   * element index. Otherwise, findLastIndex returns -1.
+   * @param thisArg If provided, it will be used as the this value for each invocation of predicate. If it is not
+   * provided, undefined is used instead.
+   */
+  findLastIndex(predicate: (value: T, index: number, obj: T[]) => unknown, thisArg?: any): number;
+}

--- a/typings/es2023-shim/index.d.ts
+++ b/typings/es2023-shim/index.d.ts
@@ -1,4 +1,4 @@
-// TODO: Remove this when we upgrade to TypeScript 5
+// TODO: Remove this when we upgrade to TypeScript 5 https://github.com/microsoft/fluentui/issues/31857
 
 // Adopted from https://github.com/microsoft/TypeScript/blob/main/src/lib/es2023.array.d.ts
 declare interface Array<T> {

--- a/typings/es2023-shim/tsconfig.json
+++ b/typings/es2023-shim/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {},
+  "include": ["*.d.ts"]
+}

--- a/typings/tsconfig.json
+++ b/typings/tsconfig.json
@@ -30,6 +30,9 @@
     },
     {
       "path": "./find-free-port/tsconfig.json"
+    },
+    {
+      "path": "./es2023-shim/tsconfig.json"
     }
   ]
 }


### PR DESCRIPTION
## Previous Behavior

For the `@fluentui/web-components` package, we use `@types/web` to work with modern browser features that older versions of TypeScript aren't familiar with. The way that this types package needs to be configured depends on the TypeScript version in use.

Additionally, certain ES2023 core features aren't available in TypeScript 4.9. The browsers we target all support `findLast` and `findLastIndex`, but TS 4.9 can't utilize ES2023 types.

## New Behavior

- Hoists the `@types/web` package to the root as a `devDependency`
- Removes duplicate properties from our `tsconfig` files
- Adds a `es2023-shim` types package to support `findLast` and `findLastIndex`