### PR TITLE
fix: MenuButton is styled correctly when aria-expanded is a string

### DIFF
--- a/change/@fluentui-react-button-9d0e8c6a-5acc-4b52-a96f-57d04ac83672.json
+++ b/change/@fluentui-react-button-9d0e8c6a-5acc-4b52-a96f-57d04ac83672.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: MenuButton is styled correctly when aria-expanded is a string",
+  "packageName": "@fluentui/react-button",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-button/library/src/components/MenuButton/useMenuButton.tsx
+++ b/packages/react-components/react-button/library/src/components/MenuButton/useMenuButton.tsx
@@ -14,7 +14,10 @@ export const useMenuButton_unstable = (
   'use no memo';
 
   const buttonState = useButton_unstable(props, ref);
-  buttonState.root['aria-expanded'] = props['aria-expanded'] ?? false;
+  // force aria-expanded to be a boolean, not a string
+  buttonState.root['aria-expanded'] = props['aria-expanded']
+    ? props['aria-expanded'] === 'true' || props['aria-expanded'] === true
+    : false;
 
   return {
     // Button state


### PR DESCRIPTION
## Previous Behavior

When `MenuButton` was passed in `aria-expanded` as a string, the `useMenuButtonStyles` would incorrectly apply the expanded styles even when the value was `'false'`.

## New Behavior

`useMenuButton` normalizes the value to always be a boolean.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #31804
