### PR TITLE
fix: v9 DatePicker compat popup is not hidden from the a11y tree

### DIFF
--- a/change/@fluentui-react-calendar-compat-189eebe0-2fa0-4813-850d-9719b43a9490.json
+++ b/change/@fluentui-react-calendar-compat-189eebe0-2fa0-4813-850d-9719b43a9490.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unnecessary group role, better table accName",
+  "packageName": "@fluentui/react-calendar-compat",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-datepicker-compat-907ec437-a124-4e97-9b54-39587f35bd3c.json
+++ b/change/@fluentui-react-datepicker-compat-907ec437-a124-4e97-9b54-39587f35bd3c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: datepicker popup is not hidden from the a11y tree",
+  "packageName": "@fluentui/react-datepicker-compat",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-calendar-compat/library/etc/react-calendar-compat.api.md
+++ b/packages/react-components/react-calendar-compat/library/etc/react-calendar-compat.api.md
@@ -60,6 +60,7 @@ export interface CalendarDayGridProps extends DayGridOptions {
     firstDayOfWeek: DayOfWeek;
     firstWeekOfYear: FirstWeekOfYear;
     getMarkedDays?: (startingDate: Date, endingDate: Date) => Date[];
+    gridLabel?: string;
     labelledBy?: string;
     lightenDaysOutsideNavigatedMonth?: boolean;
     maxDate?: Date;

--- a/packages/react-components/react-calendar-compat/library/src/components/Calendar/Calendar.tsx
+++ b/packages/react-components/react-calendar-compat/library/src/components/Calendar/Calendar.tsx
@@ -340,19 +340,13 @@ export const Calendar: React.FunctionComponent<CalendarProps> = React.forwardRef
     const selectionAndTodayString = selectedDateString + ', ' + todayDateString;
 
     return (
-      <div
-        id={id}
-        ref={forwardedRef}
-        role="group"
-        aria-label={selectionAndTodayString}
-        className={classes.root}
-        onKeyDown={onDatePickerPopupKeyDown}
-      >
+      <div id={id} ref={forwardedRef} className={classes.root} onKeyDown={onDatePickerPopupKeyDown}>
         <div className={classes.liveRegion} aria-live="polite" aria-atomic="true">
           <span>{selectedDateString}</span>
         </div>
         {isDayPickerVisible && (
           <CalendarDay
+            ariaLabel={selectionAndTodayString}
             selectedDate={selectedDate!}
             navigatedDate={navigatedDay!}
             today={today}

--- a/packages/react-components/react-calendar-compat/library/src/components/Calendar/Calendar.tsx
+++ b/packages/react-components/react-calendar-compat/library/src/components/Calendar/Calendar.tsx
@@ -346,7 +346,7 @@ export const Calendar: React.FunctionComponent<CalendarProps> = React.forwardRef
         </div>
         {isDayPickerVisible && (
           <CalendarDay
-            ariaLabel={selectionAndTodayString}
+            gridLabel={selectionAndTodayString}
             selectedDate={selectedDate!}
             navigatedDate={navigatedDay!}
             today={today}

--- a/packages/react-components/react-calendar-compat/library/src/components/CalendarDay/CalendarDay.tsx
+++ b/packages/react-components/react-calendar-compat/library/src/components/CalendarDay/CalendarDay.tsx
@@ -26,7 +26,7 @@ export const CalendarDay: React.FunctionComponent<CalendarDayProps> = props => {
 
   const {
     strings,
-    ariaLabel,
+    gridLabel,
     navigatedDate,
     dateTimeFormatter,
     className,
@@ -76,7 +76,7 @@ export const CalendarDay: React.FunctionComponent<CalendarDayProps> = props => {
       </div>
       <CalendarDayGrid
         {...propsWithoutStyles}
-        gridLabel={`${monthAndYear}, ${ariaLabel}`}
+        gridLabel={`${monthAndYear}, ${gridLabel}`}
         componentRef={dayGrid}
         strings={strings}
         navigatedDate={navigatedDate!}

--- a/packages/react-components/react-calendar-compat/library/src/components/CalendarDay/CalendarDay.tsx
+++ b/packages/react-components/react-calendar-compat/library/src/components/CalendarDay/CalendarDay.tsx
@@ -76,7 +76,7 @@ export const CalendarDay: React.FunctionComponent<CalendarDayProps> = props => {
       </div>
       <CalendarDayGrid
         {...propsWithoutStyles}
-        ariaLabel={`${monthAndYear}, ${ariaLabel}`}
+        gridLabel={`${monthAndYear}, ${ariaLabel}`}
         componentRef={dayGrid}
         strings={strings}
         navigatedDate={navigatedDate!}

--- a/packages/react-components/react-calendar-compat/library/src/components/CalendarDay/CalendarDay.tsx
+++ b/packages/react-components/react-calendar-compat/library/src/components/CalendarDay/CalendarDay.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { Enter } from '@fluentui/keyboard-keys';
-import { useId } from '@fluentui/react-utilities';
 import { mergeClasses } from '@griffel/react';
 import { addMonths, compareDatePart, getMonthEnd, getMonthStart } from '../../utils';
 import { CalendarDayGrid } from '../CalendarDayGrid/CalendarDayGrid';
@@ -40,7 +39,6 @@ export const CalendarDay: React.FunctionComponent<CalendarDayProps> = props => {
     dateRangeType,
     animationDirection,
   } = props;
-  const monthAndYearId = useId();
 
   const classNames = useCalendarDayStyles_unstable({
     className,
@@ -68,7 +66,7 @@ export const CalendarDay: React.FunctionComponent<CalendarDayProps> = props => {
           onKeyDown={onButtonKeyDown(onHeaderSelect)}
           type="button"
         >
-          <span id={monthAndYearId} aria-live="polite" aria-atomic="true">
+          <span aria-live="polite" aria-atomic="true">
             {monthAndYear}
           </span>
         </HeaderButtonComponentType>

--- a/packages/react-components/react-calendar-compat/library/src/components/CalendarDay/CalendarDay.tsx
+++ b/packages/react-components/react-calendar-compat/library/src/components/CalendarDay/CalendarDay.tsx
@@ -26,6 +26,7 @@ export const CalendarDay: React.FunctionComponent<CalendarDayProps> = props => {
 
   const {
     strings,
+    ariaLabel,
     navigatedDate,
     dateTimeFormatter,
     className,
@@ -75,6 +76,7 @@ export const CalendarDay: React.FunctionComponent<CalendarDayProps> = props => {
       </div>
       <CalendarDayGrid
         {...propsWithoutStyles}
+        ariaLabel={`${monthAndYear}, ${ariaLabel}`}
         componentRef={dayGrid}
         strings={strings}
         navigatedDate={navigatedDate!}
@@ -84,7 +86,6 @@ export const CalendarDay: React.FunctionComponent<CalendarDayProps> = props => {
         maxDate={maxDate}
         restrictedDates={restrictedDates}
         onNavigateDate={onNavigateDate}
-        labelledBy={monthAndYearId}
         dateRangeType={dateRangeType}
       />
     </div>

--- a/packages/react-components/react-calendar-compat/library/src/components/CalendarDayGrid/CalendarDayGrid.tsx
+++ b/packages/react-components/react-calendar-compat/library/src/components/CalendarDayGrid/CalendarDayGrid.tsx
@@ -120,7 +120,7 @@ export const CalendarDayGrid: React.FunctionComponent<CalendarDayGridProps> = pr
   };
 
   const {
-    ariaLabel,
+    gridLabel,
     dateRangeType,
     showWeekNumbers,
     labelledBy,
@@ -156,7 +156,7 @@ export const CalendarDayGrid: React.FunctionComponent<CalendarDayGridProps> = pr
     <table
       className={mergeClasses(classNames.table, props.className)}
       aria-multiselectable="false"
-      aria-label={ariaLabel}
+      aria-label={gridLabel}
       aria-labelledby={labelledBy}
       aria-activedescendant={activeDescendantId}
       role="grid"

--- a/packages/react-components/react-calendar-compat/library/src/components/CalendarDayGrid/CalendarDayGrid.tsx
+++ b/packages/react-components/react-calendar-compat/library/src/components/CalendarDayGrid/CalendarDayGrid.tsx
@@ -119,7 +119,14 @@ export const CalendarDayGrid: React.FunctionComponent<CalendarDayGridProps> = pr
     return dayRefs;
   };
 
-  const { dateRangeType, showWeekNumbers, labelledBy, lightenDaysOutsideNavigatedMonth, animationDirection } = props;
+  const {
+    ariaLabel,
+    dateRangeType,
+    showWeekNumbers,
+    labelledBy,
+    lightenDaysOutsideNavigatedMonth,
+    animationDirection,
+  } = props;
 
   const classNames = useCalendarDayGridStyles_unstable({
     animateBackwards,
@@ -149,6 +156,7 @@ export const CalendarDayGrid: React.FunctionComponent<CalendarDayGridProps> = pr
     <table
       className={mergeClasses(classNames.table, props.className)}
       aria-multiselectable="false"
+      aria-label={ariaLabel}
       aria-labelledby={labelledBy}
       aria-activedescendant={activeDescendantId}
       role="grid"

--- a/packages/react-components/react-calendar-compat/library/src/components/CalendarDayGrid/CalendarDayGrid.types.ts
+++ b/packages/react-components/react-calendar-compat/library/src/components/CalendarDayGrid/CalendarDayGrid.types.ts
@@ -152,6 +152,11 @@ export interface CalendarDayGridProps extends DayGridOptions {
   allFocusable?: boolean;
 
   /**
+   * Label string for the grid
+   */
+  ariaLabel?: string;
+
+  /**
    * The ID of the control that labels this one
    */
   labelledBy?: string;

--- a/packages/react-components/react-calendar-compat/library/src/components/CalendarDayGrid/CalendarDayGrid.types.ts
+++ b/packages/react-components/react-calendar-compat/library/src/components/CalendarDayGrid/CalendarDayGrid.types.ts
@@ -154,7 +154,7 @@ export interface CalendarDayGridProps extends DayGridOptions {
   /**
    * Label string for the grid
    */
-  ariaLabel?: string;
+  gridLabel?: string;
 
   /**
    * The ID of the control that labels this one

--- a/packages/react-components/react-calendar-compat/library/src/components/CalendarDayGrid/CalendarGridDayCell.tsx
+++ b/packages/react-components/react-calendar-compat/library/src/components/CalendarDayGrid/CalendarGridDayCell.tsx
@@ -227,7 +227,6 @@ export const CalendarGridDayCell: React.FunctionComponent<CalendarGridDayCellPro
         day.setRef(element);
         isNavigatedDate && (navigatedDayRef.current = element);
       }}
-      aria-hidden={ariaHidden}
       aria-disabled={!ariaHidden && !day.isInBounds}
       onClick={day.isInBounds && !ariaHidden ? day.onSelected : undefined}
       onMouseOver={!ariaHidden ? onMouseOverDay : undefined}
@@ -242,7 +241,6 @@ export const CalendarGridDayCell: React.FunctionComponent<CalendarGridDayCellPro
     >
       <button
         key={day.key + 'button'}
-        aria-hidden={ariaHidden}
         className={mergeClasses(classNames.dayButton, day.isToday && classNames.dayIsToday)}
         aria-label={ariaLabel}
         id={isNavigatedDate ? activeDescendantId : undefined}
@@ -250,7 +248,7 @@ export const CalendarGridDayCell: React.FunctionComponent<CalendarGridDayCellPro
         type="button"
         tabIndex={-1}
       >
-        <span className={day.isToday ? mergeClasses(classNames.dayTodayMarker) : undefined} aria-hidden="true">
+        <span className={day.isToday ? mergeClasses(classNames.dayTodayMarker) : undefined}>
           {dateTimeFormatter.formatDay(day.originalDate)}
         </span>
         {day.isMarked && <div aria-hidden="true" className={classNames.dayMarker} />}

--- a/packages/react-components/react-calendar-compat/library/src/components/CalendarDayGrid/CalendarGridRow.tsx
+++ b/packages/react-components/react-calendar-compat/library/src/components/CalendarDayGrid/CalendarGridRow.tsx
@@ -29,6 +29,7 @@ export interface CalendarGridRowProps extends CalendarDayGridProps {
  */
 export const CalendarGridRow: React.FunctionComponent<CalendarGridRowProps> = props => {
   const {
+    ariaHidden,
     classNames,
     week,
     weeks,
@@ -50,7 +51,7 @@ export const CalendarGridRow: React.FunctionComponent<CalendarGridRowProps> = pr
     : '';
 
   return (
-    <tr role={ariaRole} className={rowClassName} key={weekIndex + '_' + week[0].key}>
+    <tr role={ariaRole} aria-hidden={ariaHidden} className={rowClassName} key={weekIndex + '_' + week[0].key}>
       {showWeekNumbers && weekNumbers && (
         <th
           className={classNames.weekNumberCell}

--- a/packages/react-components/react-datepicker-compat/library/src/components/DatePicker/DatePicker.cy.tsx
+++ b/packages/react-components/react-datepicker-compat/library/src/components/DatePicker/DatePicker.cy.tsx
@@ -27,13 +27,6 @@ describe('DatePicker', () => {
     cy.get(inputSelector).click({ force: true }).get(popoverSelector).should('not.exist');
   });
 
-  it('should render DatePicker and popupId must exist in the DOM when the popup is open', () => {
-    mount(<DatePicker />);
-    cy.get(inputSelector).click();
-
-    cy.get('body').find('[aria-owns]').should('exist');
-  });
-
   it('should move focus back to the input when the popup is closed', () => {
     mount(<DatePicker inlinePopup />);
     cy.get(inputSelector).focus().realPress('Enter').realPress('Escape');

--- a/packages/react-components/react-datepicker-compat/library/src/components/DatePicker/useDatePicker.tsx
+++ b/packages/react-components/react-datepicker-compat/library/src/components/DatePicker/useDatePicker.tsx
@@ -364,7 +364,6 @@ export const useDatePicker_unstable = (props: DatePickerProps, ref: React.Ref<HT
 
   const inputRoot = slot.always(props.root, {
     defaultProps: {
-      'aria-owns': open ? popupSurfaceId : undefined,
       ref: triggerWrapperRef,
     },
     elementType: 'span',


### PR DESCRIPTION
## Previous Behavior

A stray `aria-owns` from before DatePicker was modal caused the popup to be an a11y child of the hidden tree, which made it inaccessible to screen reader users and voice control users.

Note: this is not an issue in v8, since the DatePicker there is non-modal.

## New Behavior

Removes the `aria-owns` and fixes the breaking a11y bug. Also makes a few incremental improvements, including:

- Removes the unnecessary extra group role between the dialog and the table.
- Moves the selected date & today's date string to the table's accname
- Moves `aria-hidden` for placeholder rows to the `<tr>` element from the cells, preventing empty rows from showing in the a11y tree
- Removes unnecessary `aria-hidden` from the span inside date buttons

## Related Issue(s)
- Fixes #31818
