### PR TITLE
fix(react-swatch-picker): fixed colors of selected and pressed states

### DIFF
--- a/change/@fluentui-react-swatch-picker-b41c2591-d9f2-4b08-a688-17107035ea27.json
+++ b/change/@fluentui-react-swatch-picker-b41c2591-d9f2-4b08-a688-17107035ea27.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(react-swatch-picker): fixed colors of selected and pressed states",
+  "packageName": "@fluentui/react-swatch-picker",
+  "email": "vkozlova@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-swatch-picker/library/src/components/ColorSwatch/useColorSwatchStyles.styles.ts
+++ b/packages/react-components/react-swatch-picker/library/src/components/ColorSwatch/useColorSwatchStyles.styles.ts
@@ -37,7 +37,7 @@ const useResetStyles = makeResetStyles({
   },
   ':hover:active': {
     border: 'none',
-    boxShadow: `inset 0 0 0 ${tokens.strokeWidthThicker} ${tokens.colorBrandStroke1}, inset 0 0 0 ${tokens.strokeWidthThickest} ${tokens.colorStrokeFocus1}`,
+    boxShadow: `inset 0 0 0 ${tokens.strokeWidthThicker} ${tokens.colorCompoundBrandStrokePressed}, inset 0 0 0 ${tokens.strokeWidthThickest} ${tokens.colorStrokeFocus1}`,
   },
   ':focus': {
     outline: 'none',
@@ -70,15 +70,20 @@ const useStyles = makeStyles({
       cursor: 'not-allowed',
       boxShadow: 'none',
     },
+    '@media (forced-colors: active)': {
+      ':hover': {
+        boxShadow: 'none',
+      },
+    },
   },
   selected: {
     border: 'none',
     boxShadow: `inset 0 0 0 ${tokens.strokeWidthThicker} ${tokens.colorBrandStroke1}, inset 0 0 0 5px ${tokens.colorStrokeFocus1}`,
     ':hover': {
-      boxShadow: `inset 0 0 0 ${tokens.strokeWidthThickest} ${tokens.colorBrandStroke1}, inset 0 0 0 6px ${tokens.colorStrokeFocus1}`,
+      boxShadow: `inset 0 0 0 ${tokens.strokeWidthThickest} ${tokens.colorCompoundBrandStrokeHover}, inset 0 0 0 6px ${tokens.colorStrokeFocus1}`,
     },
     ':hover:active': {
-      boxShadow: `inset 0 0 0 ${tokens.strokeWidthThickest} ${tokens.colorBrandStroke1}, inset 0 0 0 7px ${tokens.colorStrokeFocus1}`,
+      boxShadow: `inset 0 0 0 ${tokens.strokeWidthThickest} ${tokens.colorCompoundBrandStrokePressed}, inset 0 0 0 7px ${tokens.colorStrokeFocus1}`,
     },
     ...createCustomFocusIndicatorStyle({
       boxShadow: `inset 0 0 0 ${tokens.strokeWidthThicker} ${tokens.colorStrokeFocus2}, inset 0 0 0 5px ${tokens.colorStrokeFocus1}`,

--- a/packages/react-components/react-swatch-picker/library/src/components/ImageSwatch/useImageSwatchStyles.styles.ts
+++ b/packages/react-components/react-swatch-picker/library/src/components/ImageSwatch/useImageSwatchStyles.styles.ts
@@ -25,7 +25,7 @@ const useStyles = makeResetStyles({
   },
   ':hover:active': {
     border: 'none',
-    boxShadow: `inset 0 0 0 ${tokens.strokeWidthThicker} ${tokens.colorBrandStroke1}, inset 0 0 0 ${tokens.strokeWidthThickest} ${tokens.colorStrokeFocus1}`,
+    boxShadow: `inset 0 0 0 ${tokens.strokeWidthThicker} ${tokens.colorCompoundBrandStrokePressed}, inset 0 0 0 ${tokens.strokeWidthThickest} ${tokens.colorStrokeFocus1}`,
   },
   ':focus': {
     outline: 'none',
@@ -57,10 +57,10 @@ const useStylesSelected = makeStyles({
     border: 'none',
     boxShadow: `inset 0 0 0 ${tokens.strokeWidthThicker} ${tokens.colorBrandStroke1}, inset 0 0 0 5px ${tokens.colorStrokeFocus1}`,
     ':hover': {
-      boxShadow: `inset 0 0 0 ${tokens.strokeWidthThickest} ${tokens.colorBrandStroke1}, inset 0 0 0 6px ${tokens.colorStrokeFocus1}`,
+      boxShadow: `inset 0 0 0 ${tokens.strokeWidthThickest} ${tokens.colorCompoundBrandStrokeHover}, inset 0 0 0 6px ${tokens.colorStrokeFocus1}`,
     },
     ':hover:active': {
-      boxShadow: `inset 0 0 0 ${tokens.strokeWidthThickest} ${tokens.colorBrandStroke1}, inset 0 0 0 7px ${tokens.colorStrokeFocus1}`,
+      boxShadow: `inset 0 0 0 ${tokens.strokeWidthThickest} ${tokens.colorCompoundBrandStrokePressed}, inset 0 0 0 7px ${tokens.colorStrokeFocus1}`,
     },
     ...createCustomFocusIndicatorStyle({
       boxShadow: `inset 0 0 0 ${tokens.strokeWidthThicker} ${tokens.colorStrokeFocus2}, inset 0 0 0 5px ${tokens.colorStrokeFocus1}`,


### PR DESCRIPTION
While building UI kit we decided to make selected and pressed states darker.

## Previous Behavior
selected hover 
![image](https://github.com/microsoft/fluentui/assets/11574680/b625624f-0c7e-4d68-8f0a-2129e10e2489)

selected pressed
![image](https://github.com/microsoft/fluentui/assets/11574680/8d4b883e-d25e-485f-b676-155f106dc14a)

## New Behavior
selected hover 
![image](https://github.com/microsoft/fluentui/assets/11574680/fc9dca6b-bb69-43f6-a6f3-8efe2400b174)

selected pressed
![image](https://github.com/microsoft/fluentui/assets/11574680/131ee1c4-9b99-423f-9534-eb52f5724fca)
