### PR TITLE
chore:(react-nav-preview) Add tool tips to hamburgers

### DIFF
--- a/packages/react-components/react-nav-preview/stories/src/NavDrawer/NavDrawerDefault.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/src/NavDrawer/NavDrawerDefault.stories.tsx
@@ -13,7 +13,7 @@ import {
   NavSubItemGroup,
 } from '@fluentui/react-nav-preview';
 import { DrawerProps } from '@fluentui/react-drawer';
-import { Label, Radio, RadioGroup, Switch, makeStyles, tokens, useId } from '@fluentui/react-components';
+import { Label, Radio, RadioGroup, Switch, Tooltip, makeStyles, tokens, useId } from '@fluentui/react-components';
 import {
   Board20Filled,
   Board20Regular,
@@ -94,12 +94,18 @@ export const NavDrawerDefault = (props: Partial<NavDrawerProps>) => {
 
   const linkDestination = enabledLinks ? 'https://www.bing.com' : '';
 
+  const renderHamburgerWithToolTip = () => {
+    return (
+      <Tooltip content="Navigation" relationship="label">
+        <Hamburger onClick={() => setIsOpen(!isOpen)} />
+      </Tooltip>
+    );
+  };
+
   return (
     <div className={styles.root}>
       <NavDrawer defaultSelectedValue="2" defaultSelectedCategoryValue="1" open={isOpen} type={type}>
-        <NavDrawerHeader>
-          <Hamburger onClick={() => setIsOpen(false)} />
-        </NavDrawerHeader>
+        <NavDrawerHeader>{renderHamburgerWithToolTip()}</NavDrawerHeader>
         <NavDrawerBody>
           <NavSectionHeader>Home</NavSectionHeader>
           <NavItem href={linkDestination} icon={<Dashboard />} value="1">
@@ -178,7 +184,7 @@ export const NavDrawerDefault = (props: Partial<NavDrawerProps>) => {
         </NavDrawerBody>
       </NavDrawer>
       <div className={styles.content}>
-        {!isOpen && <Hamburger onClick={() => setIsOpen(true)} />}
+        {!isOpen && renderHamburgerWithToolTip()}
         <div className={styles.field}>
           <Label id={typeLableId}>Type</Label>
           <RadioGroup

--- a/packages/react-components/react-nav-preview/stories/src/NavDrawer/NavDrawerSize.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/src/NavDrawer/NavDrawerSize.stories.tsx
@@ -13,7 +13,7 @@ import {
   NavSubItemGroup,
   NavSize,
 } from '@fluentui/react-nav-preview';
-import { Divider, Label, Radio, RadioGroup, Tooltip, makeStyles, tokens, useId } from '@fluentui/react-components';
+import { Label, Radio, RadioGroup, Tooltip, makeStyles, tokens, useId } from '@fluentui/react-components';
 import {
   Board20Filled,
   Board20Regular,

--- a/packages/react-components/react-nav-preview/stories/src/NavDrawer/NavDrawerSize.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/src/NavDrawer/NavDrawerSize.stories.tsx
@@ -13,7 +13,7 @@ import {
   NavSubItemGroup,
   NavSize,
 } from '@fluentui/react-nav-preview';
-import { Label, Radio, RadioGroup, makeStyles, tokens, useId } from '@fluentui/react-components';
+import { Divider, Label, Radio, RadioGroup, Tooltip, makeStyles, tokens, useId } from '@fluentui/react-components';
 import {
   Board20Filled,
   Board20Regular,
@@ -86,11 +86,14 @@ export const NavDrawerSize = (props: Partial<NavDrawerProps>) => {
   const labelId = useId('type-label');
 
   const [size, setNavSize] = React.useState<NavSize>('small');
+
   return (
     <div className={styles.root}>
       <NavDrawer defaultSelectedValue="7" defaultSelectedCategoryValue="6" open={true} type={'inline'} size={size}>
         <NavDrawerHeader>
-          <Hamburger />
+          <Tooltip content="Navigation" relationship="label">
+            <Hamburger />
+          </Tooltip>
         </NavDrawerHeader>
         <NavDrawerBody>
           <NavSectionHeader>Home</NavSectionHeader>
@@ -159,8 +162,6 @@ export const NavDrawerSize = (props: Partial<NavDrawerProps>) => {
               </NavSubItem>
             </NavSubItemGroup>
           </NavCategory>
-
-          <NavSectionHeader>Analytics</NavSectionHeader>
           <NavItem target="_blank" icon={<Analytics />} value="19">
             Workforce Data
           </NavItem>


### PR DESCRIPTION
The Nav hamburger buttons should have tool tips for a11y. This PR adds them.

![image](https://github.com/microsoft/fluentui/assets/17346018/e89287e4-b29f-42e7-acc7-3477a94b0d82)

ladders to #26649 
