### PR TITLE
chore:(react-nav-preview) Scaffolds AppNode and NavDivider

### DIFF
--- a/change/@fluentui-react-nav-preview-3f2ae530-e57c-4609-8fcf-96cb742db233.json
+++ b/change/@fluentui-react-nav-preview-3f2ae530-e57c-4609-8fcf-96cb742db233.json
@@ -2,6 +2,6 @@
   "type": "patch",
   "comment": "Scaffolds NavDivider and AppNode",
   "packageName": "@fluentui/react-nav-preview",
-  "email": "17346018+mltejera@users.noreply.github.com",
+  "email": "matejera@microsoft.com",
   "dependentChangeType": "patch"
 }

--- a/change/@fluentui-react-nav-preview-3f2ae530-e57c-4609-8fcf-96cb742db233.json
+++ b/change/@fluentui-react-nav-preview-3f2ae530-e57c-4609-8fcf-96cb742db233.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Scaffolds NavDivider and AppNode",
+  "packageName": "@fluentui/react-nav-preview",
+  "email": "17346018+mltejera@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-nav-preview/library/etc/react-nav-preview.api.md
+++ b/packages/react-components/react-nav-preview/library/etc/react-nav-preview.api.md
@@ -33,6 +33,23 @@ import type { Slot } from '@fluentui/react-utilities';
 import { SlotClassNames } from '@fluentui/react-utilities';
 
 // @public
+export const AppNode: ForwardRefComponent<AppNodeProps>;
+
+// @public (undocumented)
+export const appNodeClassNames: SlotClassNames<AppNodeSlots>;
+
+// @public
+export type AppNodeProps = ComponentProps<AppNodeSlots> & {};
+
+// @public (undocumented)
+export type AppNodeSlots = {
+    root: Slot<'div'>;
+};
+
+// @public
+export type AppNodeState = ComponentState<AppNodeSlots>;
+
+// @public
 export const Hamburger: ForwardRefComponent<HamburgerProps>;
 
 // @public (undocumented)
@@ -104,6 +121,23 @@ export type NavContextValue = Pick<NavProps, 'onNavItemSelect' | 'selectedValue'
 export type NavContextValues = {
     nav: NavContextValue;
 };
+
+// @public
+export const NavDivider: ForwardRefComponent<NavDividerProps>;
+
+// @public (undocumented)
+export const navDividerClassNames: SlotClassNames<NavDividerSlots>;
+
+// @public
+export type NavDividerProps = ComponentProps<NavDividerSlots> & {};
+
+// @public (undocumented)
+export type NavDividerSlots = {
+    root: Slot<'div'>;
+};
+
+// @public
+export type NavDividerState = ComponentState<NavDividerSlots>;
 
 // @public
 export const NavDrawer: ForwardRefComponent<NavDrawerProps>;
@@ -287,6 +321,9 @@ export type NavSubItemState = ComponentState<NavSubItemSlots> & Pick<NavSubItemP
 // @public (undocumented)
 export type RegisterNavItemEventHandler = (data: NavItemRegisterData) => void;
 
+// @public
+export const renderAppNode_unstable: (state: AppNodeState) => JSX.Element;
+
 // @public (undocumented)
 export const renderNav_unstable: (state: NavState, contextValues: NavContextValues) => JSX.Element;
 
@@ -295,6 +332,9 @@ export const renderNavCategory_unstable: (state: NavCategoryState, contextValues
 
 // @public
 export const renderNavCategoryItem_unstable: (state: NavCategoryItemState, contextValues: NavCategoryItemContextValues) => JSX.Element;
+
+// @public
+export const renderNavDivider_unstable: (state: NavDividerState) => JSX.Element;
 
 // @public (undocumented)
 export const renderNavDrawer_unstable: (state: NavDrawerState, contextValues: NavContextValues) => JSX.Element;
@@ -310,6 +350,12 @@ export const renderNavSubItem_unstable: (state: NavSubItemState) => JSX.Element;
 
 // @public
 export const renderNavSubItemGroup_unstable: (state: NavSubItemGroupState) => JSX.Element | null;
+
+// @public
+export const useAppNode_unstable: (props: AppNodeProps, ref: React_2.Ref<HTMLDivElement>) => AppNodeState;
+
+// @public
+export const useAppNodeStyles_unstable: (state: AppNodeState) => AppNodeState;
 
 // @public
 export const useHamburger_unstable: (props: HamburgerProps, ref: React_2.Ref<HTMLButtonElement | HTMLAnchorElement>) => HamburgerState;
@@ -331,6 +377,12 @@ export const useNavCategoryItemStyles_unstable: (state: NavCategoryItemState) =>
 
 // @public (undocumented)
 export const useNavContext_unstable: () => NavContextValue;
+
+// @public
+export const useNavDivider_unstable: (props: NavDividerProps, ref: React_2.Ref<HTMLDivElement>) => NavDividerState;
+
+// @public
+export const useNavDividerStyles_unstable: (state: NavDividerState) => NavDividerState;
 
 // @public
 export const useNavDrawer_unstable: (props: NavDrawerProps, ref: React_2.Ref<HTMLDivElement>) => NavDrawerState;

--- a/packages/react-components/react-nav-preview/library/src/AppNode.ts
+++ b/packages/react-components/react-nav-preview/library/src/AppNode.ts
@@ -1,0 +1,1 @@
+export * from './components/AppNode/index';

--- a/packages/react-components/react-nav-preview/library/src/NavDivider.ts
+++ b/packages/react-components/react-nav-preview/library/src/NavDivider.ts
@@ -1,0 +1,1 @@
+export * from './components/NavDivider/index';

--- a/packages/react-components/react-nav-preview/library/src/components/AppNode/AppNode.test.tsx
+++ b/packages/react-components/react-nav-preview/library/src/components/AppNode/AppNode.test.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { isConformant } from '../../testing/isConformant';
+import { AppNode } from './AppNode';
+
+describe('AppNode', () => {
+  isConformant({
+    Component: AppNode,
+    displayName: 'AppNode',
+  });
+
+  // TODO add more tests here, and create visual regression tests in /apps/vr-tests
+
+  it('renders a default state', () => {
+    const result = render(<AppNode>Default AppNode</AppNode>);
+    expect(result.container).toMatchSnapshot();
+  });
+});

--- a/packages/react-components/react-nav-preview/library/src/components/AppNode/AppNode.tsx
+++ b/packages/react-components/react-nav-preview/library/src/components/AppNode/AppNode.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import type { ForwardRefComponent } from '@fluentui/react-utilities';
+import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
+import { useAppNode_unstable } from './useAppNode';
+import { renderAppNode_unstable } from './renderAppNode';
+import { useAppNodeStyles_unstable } from './useAppNodeStyles.styles';
+import type { AppNodeProps } from './AppNode.types';
+
+/**
+ * AppNode component - TODO: add more docs
+ */
+export const AppNode: ForwardRefComponent<AppNodeProps> = React.forwardRef((props, ref) => {
+  const state = useAppNode_unstable(props, ref);
+
+  useAppNodeStyles_unstable(state);
+  // TODO update types in packages/react-components/react-shared-contexts/src/CustomStyleHooksContext/CustomStyleHooksContext.ts
+  // https://github.com/microsoft/fluentui/blob/master/rfcs/react-components/convergence/custom-styling.md
+  useCustomStyleHook_unstable('useAppNodeStyles_unstable')(state);
+  return renderAppNode_unstable(state);
+});
+
+AppNode.displayName = 'AppNode';

--- a/packages/react-components/react-nav-preview/library/src/components/AppNode/AppNode.tsx
+++ b/packages/react-components/react-nav-preview/library/src/components/AppNode/AppNode.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
-import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 import { useAppNode_unstable } from './useAppNode';
 import { renderAppNode_unstable } from './renderAppNode';
 import { useAppNodeStyles_unstable } from './useAppNodeStyles.styles';
@@ -15,7 +14,7 @@ export const AppNode: ForwardRefComponent<AppNodeProps> = React.forwardRef((prop
   useAppNodeStyles_unstable(state);
   // TODO update types in packages/react-components/react-shared-contexts/src/CustomStyleHooksContext/CustomStyleHooksContext.ts
   // https://github.com/microsoft/fluentui/blob/master/rfcs/react-components/convergence/custom-styling.md
-  useCustomStyleHook_unstable('useAppNodeStyles_unstable')(state);
+  // useCustomStyleHook_unstable('useAppNodeStyles_unstable')(state);
   return renderAppNode_unstable(state);
 });
 

--- a/packages/react-components/react-nav-preview/library/src/components/AppNode/AppNode.types.ts
+++ b/packages/react-components/react-nav-preview/library/src/components/AppNode/AppNode.types.ts
@@ -1,0 +1,17 @@
+import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+
+export type AppNodeSlots = {
+  root: Slot<'div'>;
+};
+
+/**
+ * AppNode Props
+ */
+export type AppNodeProps = ComponentProps<AppNodeSlots> & {};
+
+/**
+ * State used in rendering AppNode
+ */
+export type AppNodeState = ComponentState<AppNodeSlots>;
+// TODO: Remove semicolon from previous line, uncomment next line, and provide union of props to pick from AppNodeProps.
+// & Required<Pick<AppNodeProps, 'propName'>>

--- a/packages/react-components/react-nav-preview/library/src/components/AppNode/__snapshots__/AppNode.test.tsx.snap
+++ b/packages/react-components/react-nav-preview/library/src/components/AppNode/__snapshots__/AppNode.test.tsx.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AppNode renders a default state 1`] = `
+<div>
+  <div
+    class="fui-AppNode"
+  >
+    Default AppNode
+  </div>
+</div>
+`;

--- a/packages/react-components/react-nav-preview/library/src/components/AppNode/index.ts
+++ b/packages/react-components/react-nav-preview/library/src/components/AppNode/index.ts
@@ -1,0 +1,5 @@
+export * from './AppNode';
+export * from './AppNode.types';
+export * from './renderAppNode';
+export * from './useAppNode';
+export * from './useAppNodeStyles.styles';

--- a/packages/react-components/react-nav-preview/library/src/components/AppNode/renderAppNode.tsx
+++ b/packages/react-components/react-nav-preview/library/src/components/AppNode/renderAppNode.tsx
@@ -1,0 +1,15 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource @fluentui/react-jsx-runtime */
+
+import { assertSlots } from '@fluentui/react-utilities';
+import type { AppNodeState, AppNodeSlots } from './AppNode.types';
+
+/**
+ * Render the final JSX of AppNode
+ */
+export const renderAppNode_unstable = (state: AppNodeState) => {
+  assertSlots<AppNodeSlots>(state);
+
+  // TODO Add additional slots in the appropriate place
+  return <state.root />;
+};

--- a/packages/react-components/react-nav-preview/library/src/components/AppNode/useAppNode.ts
+++ b/packages/react-components/react-nav-preview/library/src/components/AppNode/useAppNode.ts
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { getIntrinsicElementProps, slot } from '@fluentui/react-utilities';
+import type { AppNodeProps, AppNodeState } from './AppNode.types';
+
+/**
+ * Create the state required to render AppNode.
+ *
+ * The returned state can be modified with hooks such as useAppNodeStyles_unstable,
+ * before being passed to renderAppNode_unstable.
+ *
+ * @param props - props from this instance of AppNode
+ * @param ref - reference to root HTMLDivElement of AppNode
+ */
+export const useAppNode_unstable = (props: AppNodeProps, ref: React.Ref<HTMLDivElement>): AppNodeState => {
+  return {
+    // TODO add appropriate props/defaults
+    components: {
+      // TODO add each slot's element type or component
+      root: 'div',
+    },
+    // TODO add appropriate slots, for example:
+    // mySlot: resolveShorthand(props.mySlot),
+    root: slot.always(
+      getIntrinsicElementProps('div', {
+        ref,
+        ...props,
+      }),
+      { elementType: 'div' },
+    ),
+  };
+};

--- a/packages/react-components/react-nav-preview/library/src/components/AppNode/useAppNodeStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/library/src/components/AppNode/useAppNodeStyles.styles.ts
@@ -1,0 +1,35 @@
+import { makeStyles, mergeClasses } from '@griffel/react';
+import type { SlotClassNames } from '@fluentui/react-utilities';
+import type { AppNodeSlots, AppNodeState } from './AppNode.types';
+
+export const appNodeClassNames: SlotClassNames<AppNodeSlots> = {
+  root: 'fui-AppNode',
+  // TODO: add class names for all slots on AppNodeSlots.
+  // Should be of the form `<slotName>: 'fui-AppNode__<slotName>`
+};
+
+/**
+ * Styles for the root slot
+ */
+const useStyles = makeStyles({
+  root: {
+    // TODO Add default styles for the root element
+  },
+
+  // TODO add additional classes for different states and/or slots
+});
+
+/**
+ * Apply styling to the AppNode slots based on the state
+ */
+export const useAppNodeStyles_unstable = (state: AppNodeState): AppNodeState => {
+  'use no memo';
+
+  const styles = useStyles();
+  state.root.className = mergeClasses(appNodeClassNames.root, styles.root, state.root.className);
+
+  // TODO Add class names to slots, for example:
+  // state.mySlot.className = mergeClasses(styles.mySlot, state.mySlot.className);
+
+  return state;
+};

--- a/packages/react-components/react-nav-preview/library/src/components/NavDivider/NavDivider.test.tsx
+++ b/packages/react-components/react-nav-preview/library/src/components/NavDivider/NavDivider.test.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { isConformant } from '../../testing/isConformant';
+import { NavDivider } from './NavDivider';
+
+describe('NavDivider', () => {
+  isConformant({
+    Component: NavDivider,
+    displayName: 'NavDivider',
+  });
+
+  // TODO add more tests here, and create visual regression tests in /apps/vr-tests
+
+  it('renders a default state', () => {
+    const result = render(<NavDivider>Default NavDivider</NavDivider>);
+    expect(result.container).toMatchSnapshot();
+  });
+});

--- a/packages/react-components/react-nav-preview/library/src/components/NavDivider/NavDivider.tsx
+++ b/packages/react-components/react-nav-preview/library/src/components/NavDivider/NavDivider.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
-import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 import { useNavDivider_unstable } from './useNavDivider';
 import { renderNavDivider_unstable } from './renderNavDivider';
 import { useNavDividerStyles_unstable } from './useNavDividerStyles.styles';
@@ -15,7 +14,7 @@ export const NavDivider: ForwardRefComponent<NavDividerProps> = React.forwardRef
   useNavDividerStyles_unstable(state);
   // TODO update types in packages/react-components/react-shared-contexts/src/CustomStyleHooksContext/CustomStyleHooksContext.ts
   // https://github.com/microsoft/fluentui/blob/master/rfcs/react-components/convergence/custom-styling.md
-  useCustomStyleHook_unstable('useNavDividerStyles_unstable')(state);
+  // useCustomStyleHook_unstable('useNavDividerStyles_unstable')(state);
   return renderNavDivider_unstable(state);
 });
 

--- a/packages/react-components/react-nav-preview/library/src/components/NavDivider/NavDivider.tsx
+++ b/packages/react-components/react-nav-preview/library/src/components/NavDivider/NavDivider.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import type { ForwardRefComponent } from '@fluentui/react-utilities';
+import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
+import { useNavDivider_unstable } from './useNavDivider';
+import { renderNavDivider_unstable } from './renderNavDivider';
+import { useNavDividerStyles_unstable } from './useNavDividerStyles.styles';
+import type { NavDividerProps } from './NavDivider.types';
+
+/**
+ * NavDivider component - TODO: add more docs
+ */
+export const NavDivider: ForwardRefComponent<NavDividerProps> = React.forwardRef((props, ref) => {
+  const state = useNavDivider_unstable(props, ref);
+
+  useNavDividerStyles_unstable(state);
+  // TODO update types in packages/react-components/react-shared-contexts/src/CustomStyleHooksContext/CustomStyleHooksContext.ts
+  // https://github.com/microsoft/fluentui/blob/master/rfcs/react-components/convergence/custom-styling.md
+  useCustomStyleHook_unstable('useNavDividerStyles_unstable')(state);
+  return renderNavDivider_unstable(state);
+});
+
+NavDivider.displayName = 'NavDivider';

--- a/packages/react-components/react-nav-preview/library/src/components/NavDivider/NavDivider.types.ts
+++ b/packages/react-components/react-nav-preview/library/src/components/NavDivider/NavDivider.types.ts
@@ -1,0 +1,17 @@
+import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+
+export type NavDividerSlots = {
+  root: Slot<'div'>;
+};
+
+/**
+ * NavDivider Props
+ */
+export type NavDividerProps = ComponentProps<NavDividerSlots> & {};
+
+/**
+ * State used in rendering NavDivider
+ */
+export type NavDividerState = ComponentState<NavDividerSlots>;
+// TODO: Remove semicolon from previous line, uncomment next line, and provide union of props to pick from NavDividerProps.
+// & Required<Pick<NavDividerProps, 'propName'>>

--- a/packages/react-components/react-nav-preview/library/src/components/NavDivider/__snapshots__/NavDivider.test.tsx.snap
+++ b/packages/react-components/react-nav-preview/library/src/components/NavDivider/__snapshots__/NavDivider.test.tsx.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NavDivider renders a default state 1`] = `
+<div>
+  <div
+    class="fui-NavDivider"
+  >
+    Default NavDivider
+  </div>
+</div>
+`;

--- a/packages/react-components/react-nav-preview/library/src/components/NavDivider/index.ts
+++ b/packages/react-components/react-nav-preview/library/src/components/NavDivider/index.ts
@@ -1,0 +1,5 @@
+export * from './NavDivider';
+export * from './NavDivider.types';
+export * from './renderNavDivider';
+export * from './useNavDivider';
+export * from './useNavDividerStyles.styles';

--- a/packages/react-components/react-nav-preview/library/src/components/NavDivider/renderNavDivider.tsx
+++ b/packages/react-components/react-nav-preview/library/src/components/NavDivider/renderNavDivider.tsx
@@ -1,0 +1,15 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource @fluentui/react-jsx-runtime */
+
+import { assertSlots } from '@fluentui/react-utilities';
+import type { NavDividerState, NavDividerSlots } from './NavDivider.types';
+
+/**
+ * Render the final JSX of NavDivider
+ */
+export const renderNavDivider_unstable = (state: NavDividerState) => {
+  assertSlots<NavDividerSlots>(state);
+
+  // TODO Add additional slots in the appropriate place
+  return <state.root />;
+};

--- a/packages/react-components/react-nav-preview/library/src/components/NavDivider/useNavDivider.ts
+++ b/packages/react-components/react-nav-preview/library/src/components/NavDivider/useNavDivider.ts
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { getIntrinsicElementProps, slot } from '@fluentui/react-utilities';
+import type { NavDividerProps, NavDividerState } from './NavDivider.types';
+
+/**
+ * Create the state required to render NavDivider.
+ *
+ * The returned state can be modified with hooks such as useNavDividerStyles_unstable,
+ * before being passed to renderNavDivider_unstable.
+ *
+ * @param props - props from this instance of NavDivider
+ * @param ref - reference to root HTMLDivElement of NavDivider
+ */
+export const useNavDivider_unstable = (props: NavDividerProps, ref: React.Ref<HTMLDivElement>): NavDividerState => {
+  return {
+    // TODO add appropriate props/defaults
+    components: {
+      // TODO add each slot's element type or component
+      root: 'div',
+    },
+    // TODO add appropriate slots, for example:
+    // mySlot: resolveShorthand(props.mySlot),
+    root: slot.always(
+      getIntrinsicElementProps('div', {
+        ref,
+        ...props,
+      }),
+      { elementType: 'div' },
+    ),
+  };
+};

--- a/packages/react-components/react-nav-preview/library/src/components/NavDivider/useNavDividerStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/library/src/components/NavDivider/useNavDividerStyles.styles.ts
@@ -1,0 +1,35 @@
+import { makeStyles, mergeClasses } from '@griffel/react';
+import type { SlotClassNames } from '@fluentui/react-utilities';
+import type { NavDividerSlots, NavDividerState } from './NavDivider.types';
+
+export const navDividerClassNames: SlotClassNames<NavDividerSlots> = {
+  root: 'fui-NavDivider',
+  // TODO: add class names for all slots on NavDividerSlots.
+  // Should be of the form `<slotName>: 'fui-NavDivider__<slotName>`
+};
+
+/**
+ * Styles for the root slot
+ */
+const useStyles = makeStyles({
+  root: {
+    // TODO Add default styles for the root element
+  },
+
+  // TODO add additional classes for different states and/or slots
+});
+
+/**
+ * Apply styling to the NavDivider slots based on the state
+ */
+export const useNavDividerStyles_unstable = (state: NavDividerState): NavDividerState => {
+  'use no memo';
+
+  const styles = useStyles();
+  state.root.className = mergeClasses(navDividerClassNames.root, styles.root, state.root.className);
+
+  // TODO Add class names to slots, for example:
+  // state.mySlot.className = mergeClasses(styles.mySlot, state.mySlot.className);
+
+  return state;
+};

--- a/packages/react-components/react-nav-preview/library/src/index.ts
+++ b/packages/react-components/react-nav-preview/library/src/index.ts
@@ -104,4 +104,10 @@ export {
   useNavDivider_unstable,
 } from './NavDivider';
 export type { AppNodeProps, AppNodeSlots, AppNodeState } from './AppNode';
-export { AppNode, appNodeClassNames, renderAppNode_unstable, useAppNodeStyles_unstable, useAppNode_unstable } from './AppNode';
+export {
+  AppNode,
+  appNodeClassNames,
+  renderAppNode_unstable,
+  useAppNodeStyles_unstable,
+  useAppNode_unstable,
+} from './AppNode';

--- a/packages/react-components/react-nav-preview/library/src/index.ts
+++ b/packages/react-components/react-nav-preview/library/src/index.ts
@@ -95,3 +95,13 @@ export {
   useNavSectionHeaderStyles_unstable,
   useNavSectionHeader_unstable,
 } from './NavSectionHeader';
+export type { NavDividerProps, NavDividerSlots, NavDividerState } from './NavDivider';
+export {
+  NavDivider,
+  navDividerClassNames,
+  renderNavDivider_unstable,
+  useNavDividerStyles_unstable,
+  useNavDivider_unstable,
+} from './NavDivider';
+export type { AppNodeProps, AppNodeSlots, AppNodeState } from './AppNode';
+export { AppNode, appNodeClassNames, renderAppNode_unstable, useAppNodeStyles_unstable, useAppNode_unstable } from './AppNode';

--- a/packages/react-components/react-nav-preview/stories/src/AppNode/AppNodeBestPractices.md
+++ b/packages/react-components/react-nav-preview/stories/src/AppNode/AppNodeBestPractices.md
@@ -1,0 +1,5 @@
+## Best practices
+
+### Do
+
+### Don't

--- a/packages/react-components/react-nav-preview/stories/src/AppNode/AppNodeDefault.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/src/AppNode/AppNodeDefault.stories.tsx
@@ -1,0 +1,4 @@
+import * as React from 'react';
+import { AppNode, AppNodeProps } from '@fluentui/react-nav-preview';
+
+export const Default = (props: Partial<AppNodeProps>) => <AppNode {...props} />;

--- a/packages/react-components/react-nav-preview/stories/src/AppNode/index.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/src/AppNode/index.stories.tsx
@@ -1,0 +1,18 @@
+import { AppNode } from '@fluentui/react-nav-preview';
+
+import descriptionMd from './AppNodeDescription.md';
+import bestPracticesMd from './AppNodeBestPractices.md';
+
+// export { Default } from './AppNodeDefault.stories';
+
+export default {
+  title: 'Preview Components/AppNode',
+  component: AppNode,
+  parameters: {
+    docs: {
+      description: {
+        component: [descriptionMd, bestPracticesMd].join('\n'),
+      },
+    },
+  },
+};

--- a/packages/react-components/react-nav-preview/stories/src/NavDivider/NavDividerBestPractices.md
+++ b/packages/react-components/react-nav-preview/stories/src/NavDivider/NavDividerBestPractices.md
@@ -1,0 +1,5 @@
+## Best practices
+
+### Do
+
+### Don't

--- a/packages/react-components/react-nav-preview/stories/src/NavDivider/NavDividerDefault.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/src/NavDivider/NavDividerDefault.stories.tsx
@@ -1,0 +1,4 @@
+import * as React from 'react';
+import { NavDivider, NavDividerProps } from '@fluentui/react-nav-preview';
+
+export const Default = (props: Partial<NavDividerProps>) => <NavDivider {...props} />;

--- a/packages/react-components/react-nav-preview/stories/src/NavDivider/index.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/src/NavDivider/index.stories.tsx
@@ -1,0 +1,18 @@
+import { NavDivider } from '@fluentui/react-nav-preview';
+
+import descriptionMd from './NavDividerDescription.md';
+import bestPracticesMd from './NavDividerBestPractices.md';
+
+// export { Default } from './NavDividerDefault.stories';
+
+export default {
+  title: 'Preview Components/NavDivider',
+  component: NavDivider,
+  parameters: {
+    docs: {
+      description: {
+        component: [descriptionMd, bestPracticesMd].join('\n'),
+      },
+    },
+  },
+};


### PR DESCRIPTION
Scaffolds the App Node (combination of text + icon) and NavDivider (opinionated Divider)

Result of running `yarn create-component` and commenting out the default exports in the stories to prevent publishing.

Ladders to #26649 

![image](https://github.com/microsoft/fluentui/assets/17346018/2e08d6c7-f57b-4f9d-a391-d4585bc11f9d)
