### PR TITLE
fix:(react-nav-preview) Adds aria-expanded to NavCategoryItem

### DIFF
--- a/change/@fluentui-react-nav-preview-f6f33648-945e-41b2-a30a-7d90332d3ca8.json
+++ b/change/@fluentui-react-nav-preview-f6f33648-945e-41b2-a30a-7d90332d3ca8.json
@@ -2,6 +2,6 @@
   "type": "patch",
   "comment": "fix: Adds aria-expanded to NavCategoryItem",
   "packageName": "@fluentui/react-nav-preview",
-  "email": "17346018+mltejera@users.noreply.github.com",
+  "email": "matejera@microsoft.com",
   "dependentChangeType": "patch"
 }

--- a/change/@fluentui-react-nav-preview-f6f33648-945e-41b2-a30a-7d90332d3ca8.json
+++ b/change/@fluentui-react-nav-preview-f6f33648-945e-41b2-a30a-7d90332d3ca8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Adds aria-expanded to NavCategoryItem",
+  "packageName": "@fluentui/react-nav-preview",
+  "email": "17346018+mltejera@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-nav-preview/library/src/components/NavCategoryItem/useNavCategoryItem.tsx
+++ b/packages/react-components/react-nav-preview/library/src/components/NavCategoryItem/useNavCategoryItem.tsx
@@ -45,6 +45,7 @@ export const useNavCategoryItem_unstable = (
       getIntrinsicElementProps('button', {
         ref,
         'aria-current': validAriaCurrent,
+        'aria-expanded': open,
         ...props,
         onClick: onNavCategoryItemClick,
       }),


### PR DESCRIPTION
Drafting off AccordionHeader, I'm adding aria-expanded to the NavCategoryItem to indicate to screen readers that it's expanded or collapsed.

Ladders to #26649 

![image](https://github.com/microsoft/fluentui/assets/17346018/e1dee184-084d-4259-a848-c4a583dcc01e)

