### PR TITLE
fix(docs): update v8-v9 component mapping page

### DIFF
--- a/apps/public-docsite-v9/src/Concepts/Migration/FromV8/ComponentMapping.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/Migration/FromV8/ComponentMapping.stories.mdx
@@ -63,7 +63,7 @@ Check out the latest schedule information on the [v9 Component Roadmap](https://
 | Panel                  | [Drawer](/docs/components-drawer--default)                                                                                                   |
 | Popup                  | [Dialog](/docs/components-dialog--default)                                                                                                   |
 | PrimaryButton          | [Button](/docs/components-button-button--default)                                                                                            |
-| PeoplePicker           |                                                                                                                                              |
+| PeoplePicker           | [TagPicker](/docs/components-tagpicker--default)                                                                                             |
 | Persona                | [Avatar](/docs/components-avatar--default)                                                                                                   |
 | Pickers                |                                                                                                                                              |
 | Pivot, PivotItem       | [TabList, Tab](/docs/components-tablist--default)                                                                                            |
@@ -80,7 +80,7 @@ Check out the latest schedule information on the [v9 Component Roadmap](https://
 | Spinner                | [Spinner](/docs/components-spinner--default)                                                                                                 |
 | Stack                  | [Migration Guide](/docs/concepts-migration-from-v8-components-flex-stack--page), [StackShim](/docs/migration-shims-v8-stackshim--playground) |
 | SwatchColorPicker      | [SwatchPicker](/docs/components-swatchpicker--default)                                                                                       |
-| TagPicker              |                                                                                                                                              |
+| TagPicker              | [TagPicker](/docs/components-tagpicker--default)                                                                                             |
 | TeachingBubble         | [TeachingPopover](/docs/components-teachingpopover--default)                                                                                 |
 | Text                   | [Text](/docs/components-text--default)                                                                                                       |
 | TextField              | [Input](/docs/components-input--default)                                                                                                     |

--- a/apps/public-docsite-v9/src/Concepts/Migration/FromV8/ComponentMapping.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/Migration/FromV8/ComponentMapping.stories.mdx
@@ -38,14 +38,14 @@ Check out the latest schedule information on the [v9 Component Roadmap](https://
 | DefaultButton (anchor) | [Button](/docs/components-button-button--default)                                                                                            |
 | DefaultButton (menu)   | [MenuButton](/docs/components-button-menubutton--default)                                                                                    |
 | DatePicker             | [DatePickerCompat](/docs/compat-components-datepicker--default)                                                                              |
-| DetailsList            | [~DataGrid](/docs/components-datagrid--default)                                                                                              |
+| DetailsList            | [DataGrid](/docs/components-datagrid--default)                                                                                               |
 | Dialog                 | [Dialog](/docs/components-dialog--default)                                                                                                   |
-| DocumentCard           | [~Card](/docs/components-card-card--default)                                                                                                 |
-| Dropdown               | [~Dropdown](/docs/components-dropdown--default)                                                                                              |
-| Facepile               | [~AvatarGroup](/docs/components-avatargroup--default)                                                                                        |
+| DocumentCard           | [Card](/docs/components-card-card--default)                                                                                                  |
+| Dropdown               | [Dropdown](/docs/components-dropdown--default)                                                                                               |
+| Facepile               | [AvatarGroup](/docs/components-avatargroup--default)                                                                                         |
 | FocusZone              | [Tabster](https://tabster.io/)                                                                                                               |
 | FocusTrapZone          | [Tabster](https://tabster.io/)                                                                                                               |
-| GroupedList            | [~Tree](/docs/components-tree--default)                                                                                                      |
+| GroupedList            | [Tree](/docs/components-tree--default)                                                                                                       |
 | HoverCard              |                                                                                                                                              |
 | Icon                   | [@fluentui/react-icons package](/docs/concepts-developer-icons-icons--page)                                                                  |
 | IconButton             | [Button](/docs/components-button-button--default)                                                                                            |
@@ -55,12 +55,12 @@ Check out the latest schedule information on the [v9 Component Roadmap](https://
 | Layer                  | [Portal](/docs/components-portal--default)                                                                                                   |
 | Link                   | [Link](/docs/components-link--default)                                                                                                       |
 | List                   | _[In Progress](https://github.com/orgs/microsoft/projects/786/views/1?pane=issue&itemId=24404181)_                                           |
-| MessageBar             | _[In Progress](https://github.com/orgs/microsoft/projects/786/views/1?pane=issue&itemId=24402474)_                                           |
+| MessageBar             | [MessageBar](/docs/components-messagebar--default)                                                                                           |
 | Modal                  | [Dialog](/docs/components-dialog--default)                                                                                                   |
 | Nav                    | _[In Progress](https://github.com/orgs/microsoft/projects/786/views/1?pane=issue&itemId=24403433)_                                           |
-| OverflowSet            | priority-overflow                                                                                                                            |
+| OverflowSet            | [Dialog](/docs/components-overflow--default)                                                                                                 |
 | Overlay                | [Portal](/docs/components-portal--default)                                                                                                   |
-| Panel                  | _[In Progess](https://github.com/orgs/microsoft/projects/786/views/1?pane=issue&itemId=24402572)_                                            |
+| Panel                  | [Drawer](/docs/components-drawer--default)                                                                                                   |
 | Popup                  | [Dialog](/docs/components-dialog--default)                                                                                                   |
 | PrimaryButton          | [Button](/docs/components-button-button--default)                                                                                            |
 | PeoplePicker           |                                                                                                                                              |
@@ -68,24 +68,24 @@ Check out the latest schedule information on the [v9 Component Roadmap](https://
 | Pickers                |                                                                                                                                              |
 | Pivot, PivotItem       | [TabList, Tab](/docs/components-tablist--default)                                                                                            |
 | ProgressIndicator      | [ProgressBar](/docs/components-progressbar--default)                                                                                         |
-| Rating                 | _[In Progress](https://github.com/orgs/microsoft/projects/786/views/1?pane=issue&itemId=24403184)_                                           |
+| Rating                 | [Rating](/docs/components-rating--default)                                                                                                   |
 | ResizeGroup            |                                                                                                                                              |
 | ScrollablePane         |                                                                                                                                              |
-| SearchBox              |                                                                                                                                              |
+| SearchBox              | [SearchBox](/docs/components-searchbox--default)                                                                                             |
 | Separator              | [Divider](/docs/components-divider--default)                                                                                                 |
 | Shimmer                | [Skeleton](/docs/components-skeleton--default)                                                                                               |
 | Slider                 | [Slider](/docs/components-slider--default)                                                                                                   |
 | SplitButton            | [Menu with SplitButton as the Menu Trigger](/docs/components-button-splitbutton--default)                                                    |
-| SpinButton             | [~SpinButton](/docs/components-spinbutton--default)                                                                                          |
+| SpinButton             | [SpinButton](/docs/components-spinbutton--default)                                                                                           |
 | Spinner                | [Spinner](/docs/components-spinner--default)                                                                                                 |
 | Stack                  | [Migration Guide](/docs/concepts-migration-from-v8-components-flex-stack--page), [StackShim](/docs/migration-shims-v8-stackshim--playground) |
 | SwatchColorPicker      | [SwatchPicker](/docs/components-swatchpicker--default)                                                                                       |
 | TagPicker              |                                                                                                                                              |
-| TeachingBubble         | _[In Progress](https://github.com/orgs/microsoft/projects/786/views/1?pane=issue&itemId=24403213)_                                           |
+| TeachingBubble         | [TeachingPopover](/docs/components-teachingpopover--default)                                                                                 |
 | Text                   | [Text](/docs/components-text--default)                                                                                                       |
 | TextField              | [Input](/docs/components-input--default)                                                                                                     |
 | ThemeProvider          | [FluentProvider](/docs/components-fluentprovider--default)                                                                                   |
-| TimePicker             | _[In Progress](https://github.com/orgs/microsoft/projects/786/views/1?pane=issue&itemId=24403279)_                                           |
+| TimePicker             | [TimePickerCompat](/docs/compat-components-timepicker--default)                                                                              |
 | ToggleButton           | [ToggleButton](/docs/components-button-togglebutton--default)                                                                                |
 | Toggle                 | [Switch](/docs/components-switch--default)                                                                                                   |
 | Tooltip                | [Tooltip](/docs/components-tooltip--default)                                                                                                 |


### PR DESCRIPTION
This PR updates [the v8-v9 component mapping page](https://react.fluentui.dev/?path=/docs/concepts-migration-from-v8-component-mapping--page) with the latest additions / changes.