### PR TITLE
chore: use tokens directly in css for badge partial

### DIFF
--- a/change/@fluentui-web-components-d72dcdbe-ace1-4bd1-b429-2565a3ab8c39.json
+++ b/change/@fluentui-web-components-d72dcdbe-ace1-4bd1-b429-2565a3ab8c39.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: use tokens directly in css for badge partial",
+  "packageName": "@fluentui/web-components",
+  "email": "mmansour@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/styles/partials/badge.partials.ts
+++ b/packages/web-components/src/styles/partials/badge.partials.ts
@@ -68,8 +68,6 @@ import {
   warningState,
 } from '../states/index.js';
 
-const textPadding = spacingHorizontalXXS;
-
 export const badgeBaseStyles = css.partial`
   ${display('inline-flex')} :host {
     position: relative;
@@ -82,7 +80,7 @@ export const badgeBaseStyles = css.partial`
     line-height: ${lineHeightBase200};
     min-width: 20px;
     height: 20px;
-    padding-inline: calc(${spacingHorizontalXS} + ${textPadding});
+    padding-inline: calc(${spacingHorizontalXS} + ${spacingHorizontalXXS});
     border-radius: ${borderRadiusCircular};
     border-color: ${colorTransparentStroke};
     background-color: ${colorBrandBackground};
@@ -140,7 +138,7 @@ export const badgeSizeStyles = css.partial`
     height: 16px;
     font-size: ${fontSizeBase100};
     line-height: ${lineHeightBase100};
-    padding-inline: calc(${spacingHorizontalXXS} + ${textPadding});
+    padding-inline: calc(${spacingHorizontalXXS} + ${spacingHorizontalXXS});
   }
   :host(${smallState}) ::slotted(svg) {
     font-size: 12px;
@@ -150,7 +148,7 @@ export const badgeSizeStyles = css.partial`
     height: 24px;
     font-size: ${fontSizeBase200};
     line-height: ${lineHeightBase200};
-    padding-inline: calc(${spacingHorizontalXS} + ${textPadding});
+    padding-inline: calc(${spacingHorizontalXS} + ${spacingHorizontalXXS});
   }
   :host(${largeState}) ::slotted(svg) {
     font-size: 16px;
@@ -160,7 +158,7 @@ export const badgeSizeStyles = css.partial`
     height: 32px;
     font-size: ${fontSizeBase200};
     line-height: ${lineHeightBase200};
-    padding-inline: calc(${spacingHorizontalSNudge} + ${textPadding});
+    padding-inline: calc(${spacingHorizontalSNudge} + ${spacingHorizontalXXS});
   }
   :host(${extraLargeState}) ::slotted(svg) {
     font-size: 20px;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [X] Code is up-to-date with the `master` branch
* [X] Your changes are covered by tests (if possible)
* [X] You've run `yarn change` locally


PR flow tips:
* [X] Try to start with a Draft PR
* [X] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Caching local variable for `spacingHorizontalXXS`

## New Behavior

Uses the local variable directly in the css.

## Related Issue(s)

This is to help do CSS Hoisting, tokens should be used in CSS not outside.


