### PR TITLE
fix: ensure menu keydown logic allows shift+tab to navigate as expected

### DIFF
--- a/change/@fluentui-web-components-d7ebd73e-6662-488f-a6c8-3715eea02229.json
+++ b/change/@fluentui-web-components-d7ebd73e-6662-488f-a6c8-3715eea02229.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: ensure menu keydown logic allows shift+tab to navigate as expected",
+  "packageName": "@fluentui/web-components",
+  "email": "13071055+chrisdholt@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/menu/menu.ts
+++ b/packages/web-components/src/menu/menu.ts
@@ -349,7 +349,11 @@ export class Menu extends FASTElement {
         break;
       case keyTab:
         if (this._open) this.closeMenu();
-        if (e.shiftKey) this.focusTrigger();
+        if (e.shiftKey && e.composedPath()[0] !== this._trigger) {
+          this.focusTrigger();
+        } else if (e.shiftKey) {
+          return true;
+        }
       default:
         return true;
     }


### PR DESCRIPTION
## Previous Behavior
Shift+Tab was being suppressed due to the logic of menu not accounting for the trigger being focused already when the menu was closed

## New Behavior
Shift+Tab when the menu is closed works as expected

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
