### PR TITLE
feat(react-combobox): Add disableAutoFocus to Combobox and Listbox for cases when the popover is open on focus

### DIFF
--- a/change/@fluentui-react-combobox-80d33447-531e-488a-bd06-4aa351ec2915.json
+++ b/change/@fluentui-react-combobox-80d33447-531e-488a-bd06-4aa351ec2915.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: Add disableAutoFocus to Combobox and Listbox for cases when the popover is open on focus.",
+  "packageName": "@fluentui/react-combobox",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/library/etc/react-combobox.api.md
+++ b/packages/react-components/react-combobox/library/etc/react-combobox.api.md
@@ -35,6 +35,7 @@ export type ComboboxBaseProps = SelectionProps & HighlightedOptionProps & Pick<P
     clearable?: boolean;
     defaultOpen?: boolean;
     defaultValue?: string;
+    disableAutoFocus?: boolean;
     inlinePopup?: boolean;
     onOpenChange?: (e: ComboboxBaseOpenEvents, data: ComboboxBaseOpenChangeData) => void;
     open?: boolean;
@@ -156,7 +157,9 @@ export type ListboxContextValues = {
 };
 
 // @public
-export type ListboxProps = ComponentProps<ListboxSlots> & SelectionProps;
+export type ListboxProps = ComponentProps<ListboxSlots> & SelectionProps & {
+    disableAutoFocus?: boolean;
+};
 
 // @public (undocumented)
 export const ListboxProvider: React_2.Provider<ListboxContextValue | undefined> & React_2.FC<React_2.ProviderProps<ListboxContextValue | undefined>>;

--- a/packages/react-components/react-combobox/library/src/components/Combobox/useCombobox.tsx
+++ b/packages/react-components/react-combobox/library/src/components/Combobox/useCombobox.tsx
@@ -46,7 +46,7 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLIn
   const { clearable, clearSelection, disabled, multiselect, open, selectedOptions, setOpen, value, hasFocus } =
     baseState;
   const [comboboxPopupRef, comboboxTargetRef] = useComboboxPositioning(props);
-  const { freeform, inlinePopup } = props;
+  const { disableAutoFocus, freeform, inlinePopup } = props;
   const comboId = useId('combobox-');
 
   const { primary: triggerNativeProps, root: rootNativeProps } = getPartitionedNativeProps({
@@ -62,6 +62,7 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLIn
     triggerRef,
     defaultProps: {
       children: props.children,
+      disableAutoFocus,
     },
   });
 

--- a/packages/react-components/react-combobox/library/src/components/Combobox/useCombobox.tsx
+++ b/packages/react-components/react-combobox/library/src/components/Combobox/useCombobox.tsx
@@ -46,7 +46,7 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLIn
   const { clearable, clearSelection, disabled, multiselect, open, selectedOptions, setOpen, value, hasFocus } =
     baseState;
   const [comboboxPopupRef, comboboxTargetRef] = useComboboxPositioning(props);
-  const { disableAutoFocus, freeform, inlinePopup } = props;
+  const { disableAutoFocus = false, freeform, inlinePopup } = props;
   const comboId = useId('combobox-');
 
   const { primary: triggerNativeProps, root: rootNativeProps } = getPartitionedNativeProps({

--- a/packages/react-components/react-combobox/library/src/components/Listbox/Listbox.types.ts
+++ b/packages/react-components/react-combobox/library/src/components/Listbox/Listbox.types.ts
@@ -16,7 +16,15 @@ export type ListboxSlots = {
 /**
  * Listbox Props
  */
-export type ListboxProps = ComponentProps<ListboxSlots> & SelectionProps;
+export type ListboxProps = ComponentProps<ListboxSlots> &
+  SelectionProps & {
+    /**
+     * Disable auto-focusing on the first item when mounting.
+     *
+     * @default false
+     */
+    disableAutoFocus?: boolean;
+  };
 
 /**
  * State used in rendering Listbox

--- a/packages/react-components/react-combobox/library/src/components/Listbox/useListbox.ts
+++ b/packages/react-components/react-combobox/library/src/components/Listbox/useListbox.ts
@@ -40,7 +40,7 @@ const UNSAFE_noLongerUsed = {
 export const useListbox_unstable = (props: ListboxProps, ref: React.Ref<HTMLElement>): ListboxState => {
   'use no memo';
 
-  const { multiselect } = props;
+  const { multiselect, disableAutoFocus = false } = props;
   const optionCollection = useOptionCollection();
 
   const {
@@ -161,18 +161,20 @@ export const useListbox_unstable = (props: ListboxProps, ref: React.Ref<HTMLElem
       activeDescendantController.hideFocusVisibleAttributes();
     }
 
-    // if it is single-select and there is a selected option, start at the selected option
-    if (!multiselect && optionContextValues.selectedOptions.length > 0) {
-      const selectedOption = getOptionsMatchingValue(v => v === optionContextValues.selectedOptions[0]).pop();
+    if (!disableAutoFocus) {
+      // if it is single-select and there is a selected option, start at the selected option
+      if (!multiselect && optionContextValues.selectedOptions.length > 0) {
+        const selectedOption = getOptionsMatchingValue(v => v === optionContextValues.selectedOptions[0]).pop();
 
-      if (selectedOption?.id) {
-        activeDescendantController.focus(selectedOption.id);
+        if (selectedOption?.id) {
+          activeDescendantController.focus(selectedOption.id);
+        }
       }
-    }
 
-    // otherwise start at the first option
-    else {
-      activeDescendantController.first();
+      // otherwise start at the first option
+      else {
+        activeDescendantController.first();
+      }
     }
 
     return () => {

--- a/packages/react-components/react-combobox/library/src/utils/ComboboxBase.types.ts
+++ b/packages/react-components/react-combobox/library/src/utils/ComboboxBase.types.ts
@@ -37,6 +37,13 @@ export type ComboboxBaseProps = SelectionProps &
     defaultValue?: string;
 
     /**
+     * Disable auto-focusing on the first item when mounting.
+     *
+     * @default false
+     */
+    disableAutoFocus?: boolean;
+
+    /**
      * Render the combobox's popup inline in the DOM.
      * This has accessibility benefits, particularly for touch screen readers.
      */

--- a/packages/react-components/react-combobox/library/src/utils/useComboboxBaseState.ts
+++ b/packages/react-components/react-combobox/library/src/utils/useComboboxBaseState.ts
@@ -25,6 +25,7 @@ export const useComboboxBaseState = (
 
   const {
     appearance = 'outline',
+    disableAutoFocus = false,
     children,
     clearable = false,
     editable = false,
@@ -152,13 +153,11 @@ export const useComboboxBaseState = (
 
   // Fallback focus when children are updated in an open popover results in no item being focused
   React.useEffect(() => {
-    if (open) {
-      if (!activeDescendantController.active()) {
-        activeDescendantController.first();
-      }
+    if (open && !disableAutoFocus && !activeDescendantController.active()) {
+      activeDescendantController.first();
     }
     // this should only be run in response to changes in the open state or children
-  }, [open, children, activeDescendantController, getOptionById]);
+  }, [open, children, disableAutoFocus, activeDescendantController, getOptionById]);
 
   const onActiveDescendantChange = useEventCallback((event: ActiveDescendantChangeEvent) => {
     const previousOption = event.detail.previousId ? optionCollection.getOptionById(event.detail.previousId) : null;

--- a/packages/react-components/react-combobox/library/src/utils/useComboboxBaseState.ts
+++ b/packages/react-components/react-combobox/library/src/utils/useComboboxBaseState.ts
@@ -25,7 +25,7 @@ export const useComboboxBaseState = (
 
   const {
     appearance = 'outline',
-    disableAutoFocus = false,
+    disableAutoFocus,
     children,
     clearable = false,
     editable = false,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Opening the combobox focuses on the first option. While this is fine, there are use cases where the combobox opens on focus therefore moving to the first option even though the combobox might be freeform.

## New Behavior

To allow such use cases to work correctly, this PR adds a way to disable auto focus, but leaving autofocus as default.

