### PR TITLE
docs: replace polyfill.io with Cloudflare equivalent

### DIFF
--- a/packages/fluentui/docs/src/index.html
+++ b/packages/fluentui/docs/src/index.html
@@ -6,7 +6,7 @@
       name="description"
       content="Docisite shell to handle multi-version support and redirects, should not be the end content for users"
     />
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=fetch%2CURL"></script>
+    <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=fetch%2CURL"></script>
     <script src="https://cdn.jsdelivr.net/npm/compare-versions@3.6.0/index.min.js"></script>
   </head>
   <body>


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

We were using `polyfill.io` for adding polyfills to the documentation site

<!-- This is the behavior we have today -->

## New Behavior

We will use `cdnjs.cloudflare.com/polyfill` for adding polyfills to the documentation site instead

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes [https://github.com/microsoft/fluentui/security/advisories/GHSA-3443-vgvj-vf9g](https://github.com/microsoft/fluentui/security/advisories/GHSA-3443-vgvj-vf9g)
