### PR TITLE
fix: add autoSize to Combobox positioning

### DIFF
--- a/change/@fluentui-react-combobox-49a36618-f887-4534-a022-f6b4fd32d199.json
+++ b/change/@fluentui-react-combobox-49a36618-f887-4534-a022-f6b4fd32d199.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: add autoSize: true to Combobox and Dropdown by default",
+  "packageName": "@fluentui/react-combobox",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/library/src/utils/useComboboxPositioning.ts
+++ b/packages/react-components/react-combobox/library/src/utils/useComboboxPositioning.ts
@@ -20,6 +20,7 @@ export function useComboboxPositioning(props: ComboboxBaseProps): [
     offset: { crossAxis: 0, mainAxis: 2 },
     fallbackPositions,
     matchTargetSize: 'width' as const,
+    autoSize: true,
     ...resolvePositioningShorthand(positioning),
   };
 


### PR DESCRIPTION
## Previous Behavior

When the Combobox popup is outside the bounds of the viewport, keyboard users can arrow to an option that isn't visible. Since arrowing also moves between options rather than scrolling, there isn't a good way to get the option into view.

I'm adding this specifically to Combobox (and the other related components that use the `react-combobox` hooks) because unlike Menu and other popups, it doesn't actually move keyboard focus into the popup. Arrowing to an out-of-view MenuItem will cause the page to scroll, since keyboard focus is moving out of view.

We might consider adding this by default to Menu as well, but it's more clearly needed in Combobox because of focus remaining on the trigger element.

## New Behavior

Combobox's popup has `autoSize: true`, which forces it to confine itself to the viewport bounds.

## Related Issue(s)

- Fixes [ADO issue](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/18642)
