### PR TITLE
chore: make utils a package export

### DIFF
--- a/change/@fluentui-web-components-0d6c3009-cdd8-43fb-8c57-81d2866ab734.json
+++ b/change/@fluentui-web-components-0d6c3009-cdd8-43fb-8c57-81d2866ab734.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Make utils a package export since it replaces fluentui/foundation",
+  "packageName": "@fluentui/web-components",
+  "email": "mmansour@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -174,6 +174,10 @@
       "types": "./dist/dts/theme/index.d.ts",
       "default": "./dist/esm/theme/index.js"
     },
+    "./utilities.js": {
+      "types": "./dist/dts/utils/index.d.ts",
+      "default": "./dist/esm/utils/index.js"
+    },
     "./package.json": "./package.json"
   },
   "sideEffects": [


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [X] Code is up-to-date with the `master` branch
* [X] Your changes are covered by tests (if possible)
* [X] You've run `yarn change` locally


PR flow tips:
* [X] Try to start with a Draft PR
* [X] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Previously we used to use `@microsoft/fast-foundation/utilities.js` and since `fast-foundation` is now merged into `fluentui/web-components` we don't want to carry both packages, so exporting the utilities.js is needed (so bundle bloat doesn't happen) due to sideEffected packages.

## New Behavior

This creates `@fluentui/web-components/utilities.js`
