### PR TITLE
fix: onDismiss in story correctly checks for shiftKey

### DIFF
--- a/packages/react-components/react-migration-v8-v9/stories/MenuButtonShim/index.stories.tsx
+++ b/packages/react-components/react-migration-v8-v9/stories/MenuButtonShim/index.stories.tsx
@@ -66,7 +66,7 @@ export const Default = () => {
   const menuProps: IContextualMenuProps = {
     // For example: disable dismiss if shift key is held down while dismissing
     onDismiss: ev => {
-      if (ev && 'shiftKey' in ev) {
+      if (ev && 'shiftKey' in ev && ev.shiftKey) {
         ev.preventDefault();
       }
     },


### PR DESCRIPTION
Super-simple change, updates the `ev.shiftKey` check, which previously returned true even if `shiftKey` was false :D

Fixes an ADO issue about the menu not closing with escape.