### PR TITLE
fix(Tooltip): Do not prevent showing tooltip in keyboard mode

### DIFF
--- a/change/@fluentui-react-tabster-eab71fef-90f6-4251-97bf-a6fdb14d98bb.json
+++ b/change/@fluentui-react-tabster-eab71fef-90f6-4251-97bf-a6fdb14d98bb.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Expose keyboard navigation state getter",
+  "packageName": "@fluentui/react-tabster",
+  "email": "jukapsia@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tabster-eab71fef-90f6-4251-97bf-a6fdb14d98bb.json
+++ b/change/@fluentui-react-tabster-eab71fef-90f6-4251-97bf-a6fdb14d98bb.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Expose keyboard navigation state getter",
+  "comment": "feat: expose keyboard navigation state getter",
   "packageName": "@fluentui/react-tabster",
   "email": "jukapsia@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-tooltip-7716dcaf-b67a-4edf-a80a-b57ea86298ef.json
+++ b/change/@fluentui-react-tooltip-7716dcaf-b67a-4edf-a80a-b57ea86298ef.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Do not prevent showing tooltip in keyboard mode",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "jukapsia@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tooltip-7716dcaf-b67a-4edf-a80a-b57ea86298ef.json
+++ b/change/@fluentui-react-tooltip-7716dcaf-b67a-4edf-a80a-b57ea86298ef.json
@@ -1,6 +1,6 @@
 {
-  "type": "minor",
-  "comment": "Do not prevent showing tooltip in keyboard mode",
+  "type": "patch",
+  "comment": "fix: do not prevent showing tooltip in keyboard mode",
   "packageName": "@fluentui/react-tooltip",
   "email": "jukapsia@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/react-components/react-tabster/etc/react-tabster.api.md
+++ b/packages/react-components/react-tabster/etc/react-tabster.api.md
@@ -1483,7 +1483,7 @@ export function useFocusVisible<TElement extends HTMLElement = HTMLElement>(opti
 export function useFocusWithin<TElement extends HTMLElement = HTMLElement>(): React_2.RefObject<TElement>;
 
 // @public
-export function useGetKeyboardNavigation(): () => boolean | undefined;
+export function useIsNavigatingWithKeyboard(): () => boolean;
 
 // @public
 export function useKeyboardNavAttribute<E extends HTMLElement>(): RefObject<E>;

--- a/packages/react-components/react-tabster/etc/react-tabster.api.md
+++ b/packages/react-components/react-tabster/etc/react-tabster.api.md
@@ -1483,6 +1483,9 @@ export function useFocusVisible<TElement extends HTMLElement = HTMLElement>(opti
 export function useFocusWithin<TElement extends HTMLElement = HTMLElement>(): React_2.RefObject<TElement>;
 
 // @public
+export function useGetKeyboardNavigation(): () => boolean | undefined;
+
+// @public
 export function useKeyboardNavAttribute<E extends HTMLElement>(): RefObject<E>;
 
 // @internal

--- a/packages/react-components/react-tabster/src/hooks/index.ts
+++ b/packages/react-components/react-tabster/src/hooks/index.ts
@@ -12,5 +12,6 @@ export * from './useMergeTabsterAttributes';
 export * from './useFocusObserved';
 export * from './useRestoreFocus';
 export * from './useUncontrolledFocus';
+export * from './useGetKeyboardNavigation';
 export * from './useSetKeyboardNavigation';
 export * from './useFocusedElementChange';

--- a/packages/react-components/react-tabster/src/hooks/index.ts
+++ b/packages/react-components/react-tabster/src/hooks/index.ts
@@ -12,6 +12,6 @@ export * from './useMergeTabsterAttributes';
 export * from './useFocusObserved';
 export * from './useRestoreFocus';
 export * from './useUncontrolledFocus';
-export * from './useGetKeyboardNavigation';
+export * from './useIsNavigatingWithKeyboard';
 export * from './useSetKeyboardNavigation';
 export * from './useFocusedElementChange';

--- a/packages/react-components/react-tabster/src/hooks/useGetKeyboardNavigation.ts
+++ b/packages/react-components/react-tabster/src/hooks/useGetKeyboardNavigation.ts
@@ -2,6 +2,8 @@ import * as React from 'react';
 import { useKeyborgRef } from './useKeyborgRef';
 
 /**
+ * Instantiates [keyborg](https://github.com/microsoft/keyborg) and checks if the user is navigating with the keyboard.
+ * @returns {() => boolean}
  */
 export function useGetKeyboardNavigation() {
   const keyborgRef = useKeyborgRef();

--- a/packages/react-components/react-tabster/src/hooks/useGetKeyboardNavigation.ts
+++ b/packages/react-components/react-tabster/src/hooks/useGetKeyboardNavigation.ts
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import { useKeyborgRef } from './useKeyborgRef';
+
+/**
+ */
+export function useGetKeyboardNavigation() {
+  const keyborgRef = useKeyborgRef();
+
+  return React.useCallback(() => {
+    return keyborgRef.current?.isNavigatingWithKeyboard();
+  }, [keyborgRef]);
+}

--- a/packages/react-components/react-tabster/src/hooks/useIsNavigatingWithKeyboard.ts
+++ b/packages/react-components/react-tabster/src/hooks/useIsNavigatingWithKeyboard.ts
@@ -5,10 +5,10 @@ import { useKeyborgRef } from './useKeyborgRef';
  * Instantiates [keyborg](https://github.com/microsoft/keyborg) and checks if the user is navigating with the keyboard.
  * @returns {() => boolean}
  */
-export function useGetKeyboardNavigation() {
+export function useIsNavigatingWithKeyboard(): () => boolean {
   const keyborgRef = useKeyborgRef();
 
   return React.useCallback(() => {
-    return keyborgRef.current?.isNavigatingWithKeyboard();
+    return keyborgRef.current?.isNavigatingWithKeyboard() ?? false;
   }, [keyborgRef]);
 }

--- a/packages/react-components/react-tabster/src/index.ts
+++ b/packages/react-components/react-tabster/src/index.ts
@@ -14,6 +14,7 @@ export {
   useRestoreFocusTarget,
   useUncontrolledFocus,
   useOnKeyboardNavigationChange,
+  useGetKeyboardNavigation,
   useSetKeyboardNavigation,
   useFocusedElementChange,
 } from './hooks/index';

--- a/packages/react-components/react-tabster/src/index.ts
+++ b/packages/react-components/react-tabster/src/index.ts
@@ -14,7 +14,7 @@ export {
   useRestoreFocusTarget,
   useUncontrolledFocus,
   useOnKeyboardNavigationChange,
-  useGetKeyboardNavigation,
+  useIsNavigatingWithKeyboard,
   useSetKeyboardNavigation,
   useFocusedElementChange,
 } from './hooks/index';

--- a/packages/react-components/react-tooltip/library/src/components/Tooltip/useTooltip.tsx
+++ b/packages/react-components/react-tooltip/library/src/components/Tooltip/useTooltip.tsx
@@ -5,7 +5,7 @@ import {
   useFluent_unstable as useFluent,
 } from '@fluentui/react-shared-contexts';
 import type { KeyborgFocusInEvent } from '@fluentui/react-tabster';
-import { KEYBORG_FOCUSIN } from '@fluentui/react-tabster';
+import { KEYBORG_FOCUSIN, useGetKeyboardNavigation } from '@fluentui/react-tabster';
 import {
   applyTriggerPropsToChildren,
   useControllableState,
@@ -177,6 +177,8 @@ export const useTooltip_unstable = (props: TooltipProps): TooltipState => {
     [setDelayTimeout, setVisible, state.showDelay, context],
   );
 
+  const getKeyboardNavigation = useGetKeyboardNavigation();
+
   // Callback ref that attaches a keyborg:focusin event listener.
   const [keyborgListenerCallbackRef] = React.useState(() => {
     const onKeyborgFocusIn = ((ev: KeyborgFocusInEvent) => {
@@ -184,7 +186,7 @@ export const useTooltip_unstable = (props: TooltipProps): TooltipState => {
       // For example, we don't want to show the tooltip when a dialog is closed
       // and Tabster programmatically restores focus to the trigger button.
       // See https://github.com/microsoft/fluentui/issues/27576
-      if (ev.detail?.isFocusedProgrammatically) {
+      if (ev.detail?.isFocusedProgrammatically && !getKeyboardNavigation()) {
         ignoreNextFocusEventRef.current = true;
       }
     }) as EventListener;

--- a/packages/react-components/react-tooltip/library/src/components/Tooltip/useTooltip.tsx
+++ b/packages/react-components/react-tooltip/library/src/components/Tooltip/useTooltip.tsx
@@ -5,7 +5,7 @@ import {
   useFluent_unstable as useFluent,
 } from '@fluentui/react-shared-contexts';
 import type { KeyborgFocusInEvent } from '@fluentui/react-tabster';
-import { KEYBORG_FOCUSIN, useGetKeyboardNavigation } from '@fluentui/react-tabster';
+import { KEYBORG_FOCUSIN, useIsNavigatingWithKeyboard } from '@fluentui/react-tabster';
 import {
   applyTriggerPropsToChildren,
   useControllableState,
@@ -177,7 +177,7 @@ export const useTooltip_unstable = (props: TooltipProps): TooltipState => {
     [setDelayTimeout, setVisible, state.showDelay, context],
   );
 
-  const getKeyboardNavigation = useGetKeyboardNavigation();
+  const isNavigatingWithKeyboard = useIsNavigatingWithKeyboard()();
 
   // Callback ref that attaches a keyborg:focusin event listener.
   const [keyborgListenerCallbackRef] = React.useState(() => {
@@ -186,7 +186,7 @@ export const useTooltip_unstable = (props: TooltipProps): TooltipState => {
       // For example, we don't want to show the tooltip when a dialog is closed
       // and Tabster programmatically restores focus to the trigger button.
       // See https://github.com/microsoft/fluentui/issues/27576
-      if (ev.detail?.isFocusedProgrammatically && !getKeyboardNavigation()) {
+      if (ev.detail?.isFocusedProgrammatically && !isNavigatingWithKeyboard) {
         ignoreNextFocusEventRef.current = true;
       }
     }) as EventListener;


### PR DESCRIPTION
Fixes #31862

Tooltip should not be displayed if trigger element was focused programatically.
This however does not work well when user is already in keyboard more. For example, opening a popover with focus trap moves focus programatically inside of the popover. In this case, tooltip should be shown as the interaction initiating the focus move was keyboard.

