### PR TITLE
fix(scripts-prettier): escape file names that are being passed to prettier bin via shell

### DIFF
--- a/scripts/prettier/src/prettier-helpers.js
+++ b/scripts/prettier/src/prettier-helpers.js
@@ -47,10 +47,18 @@ function runPrettier(files, config = {}) {
 
   const prettierSupportedFiles = fileIsGlob
     ? files
-    : files.filter(file => {
+    : files.reduce((acc, file) => {
         const ext = path.extname(file).replace('.', '');
-        return prettierSupportedFileExtensions.includes(ext);
-      });
+
+        if (prettierSupportedFileExtensions.includes(ext)) {
+          // WHY IGNORE IS NEEDED?: prettier removes one of the '\' within replaceValue
+          // prettier-ignore
+          const escapedFileName = `"${file.replace(/\$/g, '\\\$')}"`;
+
+          acc.push(escapedFileName);
+        }
+        return acc;
+      }, /** @type {string[]} */ ([]));
 
   if (!prettierSupportedFiles.length) {
     console.log('prettier: No supported files found');


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

we don't escape special characters when passing file list to prettier bin

## New Behavior

we properly escape special characters when passing file list to prettier bin

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Unblocks https://github.com/microsoft/fluentui/pull/31202
