### PR TITLE
ci(.github): resolve due_on UTC time creation issues

### DIFF
--- a/.github/workflows/create-milestone.yml
+++ b/.github/workflows/create-milestone.yml
@@ -20,7 +20,7 @@ jobs:
           quarter=$(date +"%q")
           year=$(date +"%Y")
           title="${month} Project Cycle Q${quarter} ${year}"
-          due_on=$(date -d "$(date -d "next month" +%Y-%m-01) -1 day" +"%Y-%m-%dT%H:%M:%S%z")
+          due_on=$(date -u -d "$(date -d "next month" +%Y-%m-01) -1 day" +"%Y-%m-%dT%H:%M:%SZ")
           echo "Using title '${title}' and setting due date: '${due_on}'"
           gh api --method POST repos/microsoft/fluentui/milestones -f title="${title}" -f due_on="${due_on}"
         env:


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

milestone action `due_on` is not proper UTC and keeps filing agains GitHub REST API

- failing run: https://github.com/microsoft/fluentui/actions/runs/9325872420/job/25673575388
- GH REST docs: https://docs.github.com/en/rest/issues/milestones?apiVersion=2022-11-28#create-a-milestone

## New Behavior

`due_on` is valid UTC

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
