### PR TITLE
chore: normalize project names in whole repo

### DIFF
--- a/.devops/templates/build-test-lint.yml
+++ b/.devops/templates/build-test-lint.yml
@@ -7,7 +7,7 @@ steps:
     displayName: yarn (install packages)
 
   - script: |
-      yarn nx run @fluentui/workspace-plugin:check-graph
+      yarn nx run workspace-plugin:check-graph
       yarn nx g @fluentui/workspace-plugin:tsconfig-base-all --verify
       yarn nx g @fluentui/workspace-plugin:normalize-package-dependencies --verify
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,7 +1,7 @@
 # generated or imported files
 package-deps.json
 CHANGELOG.*
-# generated versopnm files  (@fluentui/react v8 specific)
+# generated version files  (@fluentui/react v8 specific)
 packages/**/version.ts
 apps/**/version.ts
 *.api.md

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,7 +1,9 @@
 # generated or imported files
 package-deps.json
 CHANGELOG.*
-version.ts
+# generated versopnm files  (@fluentui/react v8 specific)
+packages/**/version.ts
+apps/**/version.ts
 *.api.md
 api-report.md
 *.scss.ts

--- a/apps/perf-test-react-components/project.json
+++ b/apps/perf-test-react-components/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/perf-test-react-components",
+  "name": "perf-test-react-components",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "application",
   "implicitDependencies": []

--- a/apps/perf-test/project.json
+++ b/apps/perf-test/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/perf-test",
+  "name": "perf-test",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "application",
   "implicitDependencies": []

--- a/apps/pr-deploy-site/project.json
+++ b/apps/pr-deploy-site/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/pr-deploy-site",
+  "name": "pr-deploy-site",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "application",
   "implicitDependencies": []

--- a/apps/public-docsite-resources/project.json
+++ b/apps/public-docsite-resources/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/public-docsite-resources",
+  "name": "public-docsite-resources",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "application",
   "implicitDependencies": []

--- a/apps/public-docsite-v9/project.json
+++ b/apps/public-docsite-v9/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/public-docsite-v9",
+  "name": "public-docsite-v9",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "application",
   "implicitDependencies": [],

--- a/apps/public-docsite/project.json
+++ b/apps/public-docsite/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/public-docsite",
+  "name": "public-docsite",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "application",
   "implicitDependencies": []

--- a/apps/react-18-tests-v8/project.json
+++ b/apps/react-18-tests-v8/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-18-tests-v8",
+  "name": "react-18-tests-v8",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "application",
   "implicitDependencies": []

--- a/apps/react-18-tests-v9/project.json
+++ b/apps/react-18-tests-v9/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-18-tests-v9",
+  "name": "react-18-tests-v9",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "application",
   "implicitDependencies": []

--- a/apps/ssr-tests-v9/project.json
+++ b/apps/ssr-tests-v9/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/ssr-tests-v9",
+  "name": "ssr-tests-v9",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "application",
   "implicitDependencies": [],

--- a/apps/ssr-tests/project.json
+++ b/apps/ssr-tests/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/ssr-tests",
+  "name": "ssr-tests",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "application",
   "implicitDependencies": []

--- a/apps/theming-designer/project.json
+++ b/apps/theming-designer/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/theming-designer",
+  "name": "theming-designer",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "application",
   "implicitDependencies": []

--- a/apps/ts-minbar-test-react-components/project.json
+++ b/apps/ts-minbar-test-react-components/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/ts-minbar-test-react-components",
+  "name": "ts-minbar-test-react-components",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "application"
 }

--- a/apps/ts-minbar-test-react/project.json
+++ b/apps/ts-minbar-test-react/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/ts-minbar-test-react",
+  "name": "ts-minbar-test-react",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "application"
 }

--- a/apps/vr-tests-react-components/project.json
+++ b/apps/vr-tests-react-components/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/vr-tests-react-components",
+  "name": "vr-tests-react-components",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "application",
   "implicitDependencies": [],

--- a/apps/vr-tests-web-components/project.json
+++ b/apps/vr-tests-web-components/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/vr-tests-web-components",
+  "name": "vr-tests-web-components",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "application",
   "implicitDependencies": [],

--- a/apps/vr-tests/project.json
+++ b/apps/vr-tests/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/vr-tests",
+  "name": "vr-tests",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "application",
   "implicitDependencies": []

--- a/change/@fluentui-api-docs-c3f09ae1-2b39-431c-bcd7-301158790b28.json
+++ b/change/@fluentui-api-docs-c3f09ae1-2b39-431c-bcd7-301158790b28.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/api-docs",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-azure-themes-f278a32e-a86b-44be-baaf-e963267c13aa.json
+++ b/change/@fluentui-azure-themes-f278a32e-a86b-44be-baaf-e963267c13aa.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/azure-themes",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-babel-preset-global-context-d79182ee-d83b-4a22-9061-57f2be8d5462.json
+++ b/change/@fluentui-babel-preset-global-context-d79182ee-d83b-4a22-9061-57f2be8d5462.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/babel-preset-global-context",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-codemods-6dff87cf-65b7-4862-ac1e-2269940c9800.json
+++ b/change/@fluentui-codemods-6dff87cf-65b7-4862-ac1e-2269940c9800.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/codemods",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-common-styles-f1a942ce-99bb-4c6a-8a19-93ad786f02b2.json
+++ b/change/@fluentui-common-styles-f1a942ce-99bb-4c6a-8a19-93ad786f02b2.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/common-styles",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-cra-template-963e3518-cc24-46f4-8992-486130a0603f.json
+++ b/change/@fluentui-cra-template-963e3518-cc24-46f4-8992-486130a0603f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/cra-template",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-date-time-utilities-6efc7ec9-fc02-4bfd-abf0-009c202dc1ba.json
+++ b/change/@fluentui-date-time-utilities-6efc7ec9-fc02-4bfd-abf0-009c202dc1ba.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/date-time-utilities",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-dom-utilities-5815906f-1e1b-48a3-85e6-af173539d282.json
+++ b/change/@fluentui-dom-utilities-5815906f-1e1b-48a3-85e6-af173539d282.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/dom-utilities",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-eslint-plugin-1d38b9b6-d3b1-4606-aff3-d9aba8b1338b.json
+++ b/change/@fluentui-eslint-plugin-1d38b9b6-d3b1-4606-aff3-d9aba8b1338b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: remove npmScope from project name and update react config to accommodate project name change",
+  "packageName": "@fluentui/eslint-plugin",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-example-data-26b458eb-5b9c-449e-81c2-1dca558276d8.json
+++ b/change/@fluentui-example-data-26b458eb-5b9c-449e-81c2-1dca558276d8.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/example-data",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-fluent2-theme-b7273bdb-d4c6-4cfc-979c-0d67f1939509.json
+++ b/change/@fluentui-fluent2-theme-b7273bdb-d4c6-4cfc-979c-0d67f1939509.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/fluent2-theme",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-font-icons-mdl2-c20782ac-cfd5-46e5-91ee-de53b56ae102.json
+++ b/change/@fluentui-font-icons-mdl2-c20782ac-cfd5-46e5-91ee-de53b56ae102.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/font-icons-mdl2",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-foundation-legacy-7e9a62be-bac7-41bf-a02f-9508c7a8ad2c.json
+++ b/change/@fluentui-foundation-legacy-7e9a62be-bac7-41bf-a02f-9508c7a8ad2c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/foundation-legacy",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-global-context-77a30ed7-9ad0-4043-870b-43c4612bfc09.json
+++ b/change/@fluentui-global-context-77a30ed7-9ad0-4043-870b-43c4612bfc09.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/global-context",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-jest-serializer-merge-styles-4df962b5-3f42-4389-94bf-6365e0c6e3e0.json
+++ b/change/@fluentui-jest-serializer-merge-styles-4df962b5-3f42-4389-94bf-6365e0c6e3e0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/jest-serializer-merge-styles",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-keyboard-key-cef561b5-eacb-46b5-a032-d17792c97b0b.json
+++ b/change/@fluentui-keyboard-key-cef561b5-eacb-46b5-a032-d17792c97b0b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/keyboard-key",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-keyboard-keys-0d320658-d4b3-4ca1-a839-6529f9623e12.json
+++ b/change/@fluentui-keyboard-keys-0d320658-d4b3-4ca1-a839-6529f9623e12.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/keyboard-keys",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-merge-styles-84e1d304-b20b-4cb8-bfcb-f44cad51bc01.json
+++ b/change/@fluentui-merge-styles-84e1d304-b20b-4cb8-bfcb-f44cad51bc01.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/merge-styles",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-monaco-editor-39b6c86e-6c70-4c45-b490-48d2db9e8ef7.json
+++ b/change/@fluentui-monaco-editor-39b6c86e-6c70-4c45-b490-48d2db9e8ef7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/monaco-editor",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-priority-overflow-df978580-fd88-4d12-a1c8-a77d97aaea18.json
+++ b/change/@fluentui-priority-overflow-df978580-fd88-4d12-a1c8-a77d97aaea18.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/priority-overflow",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-public-docsite-setup-ca07ca22-e196-4c1d-9afd-02ec76a6c3af.json
+++ b/change/@fluentui-public-docsite-setup-ca07ca22-e196-4c1d-9afd-02ec76a6c3af.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/public-docsite-setup",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-accordion-b085a835-4a65-4250-b705-c73a04155c71.json
+++ b/change/@fluentui-react-accordion-b085a835-4a65-4250-b705-c73a04155c71.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-accordion",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-aria-43ebecf2-67ea-4114-81be-d2f3b9f77ad0.json
+++ b/change/@fluentui-react-aria-43ebecf2-67ea-4114-81be-d2f3b9f77ad0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-aria",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-avatar-ed417507-91b9-468f-b7e6-88ff5e6de97c.json
+++ b/change/@fluentui-react-avatar-ed417507-91b9-468f-b7e6-88ff5e6de97c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-avatar",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-badge-d07d0830-e9ad-4226-8aa0-98784ca41df9.json
+++ b/change/@fluentui-react-badge-d07d0830-e9ad-4226-8aa0-98784ca41df9.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-badge",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-breadcrumb-40eaf64a-e12a-4985-9e6d-5a989b61d346.json
+++ b/change/@fluentui-react-breadcrumb-40eaf64a-e12a-4985-9e6d-5a989b61d346.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-breadcrumb",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-button-4a3a6409-6923-4727-912e-183b62a43506.json
+++ b/change/@fluentui-react-button-4a3a6409-6923-4727-912e-183b62a43506.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-button",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-calendar-compat-3e789243-7c0c-4dc7-8a1f-52f9d35ee720.json
+++ b/change/@fluentui-react-calendar-compat-3e789243-7c0c-4dc7-8a1f-52f9d35ee720.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-calendar-compat",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-card-38486e91-e04f-4246-a286-01ed6c00f845.json
+++ b/change/@fluentui-react-card-38486e91-e04f-4246-a286-01ed6c00f845.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-card",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-cards-0636d8e1-fe24-4fba-ac1d-faa9dd3b3ad0.json
+++ b/change/@fluentui-react-cards-0636d8e1-fe24-4fba-ac1d-faa9dd3b3ad0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-cards",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-charting-4337f81e-3dce-4eed-a1f5-ba352ab730e0.json
+++ b/change/@fluentui-react-charting-4337f81e-3dce-4eed-a1f5-ba352ab730e0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-charting",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-checkbox-f4c8341a-b2ba-4080-a8a0-a8e7b107b47c.json
+++ b/change/@fluentui-react-checkbox-f4c8341a-b2ba-4080-a8a0-a8e7b107b47c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-combobox-a4edb7f4-8e67-4f6e-9544-12259d976060.json
+++ b/change/@fluentui-react-combobox-a4edb7f4-8e67-4f6e-9544-12259d976060.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-combobox",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-components-63438119-c97d-4cf8-b097-e7b51670b3a4.json
+++ b/change/@fluentui-react-components-63438119-c97d-4cf8-b097-e7b51670b3a4.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-components",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-conformance-ea783121-a217-4a7e-95f2-475c7f3edf8d.json
+++ b/change/@fluentui-react-conformance-ea783121-a217-4a7e-95f2-475c7f3edf8d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-conformance",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-conformance-griffel-b09d5844-9080-447f-9437-016b1c36b616.json
+++ b/change/@fluentui-react-conformance-griffel-b09d5844-9080-447f-9437-016b1c36b616.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-conformance-griffel",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-context-selector-8a566642-ed91-441f-a8a4-01d3947728a8.json
+++ b/change/@fluentui-react-context-selector-8a566642-ed91-441f-a8a4-01d3947728a8.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-context-selector",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-date-time-3f02465c-82a9-4a21-a640-94b5630bf246.json
+++ b/change/@fluentui-react-date-time-3f02465c-82a9-4a21-a640-94b5630bf246.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-date-time",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-datepicker-compat-80a19ec6-607f-4050-a3bd-a0f681d4776e.json
+++ b/change/@fluentui-react-datepicker-compat-80a19ec6-607f-4050-a3bd-a0f681d4776e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-datepicker-compat",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-dialog-a5d59242-58b1-4b70-8f0f-926a667aaffc.json
+++ b/change/@fluentui-react-dialog-a5d59242-58b1-4b70-8f0f-926a667aaffc.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-dialog",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-divider-7d1e0636-80c8-4335-8f13-2385dc0c115e.json
+++ b/change/@fluentui-react-divider-7d1e0636-80c8-4335-8f13-2385dc0c115e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-divider",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-docsite-components-eb57a041-7050-4586-846d-923618f06b02.json
+++ b/change/@fluentui-react-docsite-components-eb57a041-7050-4586-846d-923618f06b02.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-docsite-components",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-drawer-58c2c741-4c1e-418b-881a-283b54020fb8.json
+++ b/change/@fluentui-react-drawer-58c2c741-4c1e-418b-881a-283b54020fb8.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-drawer",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-ecfe45f0-4728-4422-a315-3e4f65e7de5b.json
+++ b/change/@fluentui-react-ecfe45f0-4728-4422-a315-3e4f65e7de5b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-experiments-d37dc1f2-c6e5-4656-a504-a03689fc537b.json
+++ b/change/@fluentui-react-experiments-d37dc1f2-c6e5-4656-a504-a03689fc537b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-experiments",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-field-0c1d4447-2fb8-4ecc-952a-57c3b42ff004.json
+++ b/change/@fluentui-react-field-0c1d4447-2fb8-4ecc-952a-57c3b42ff004.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-field",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-file-type-icons-5b277bd3-b763-4811-91b1-f839ea4f2c6c.json
+++ b/change/@fluentui-react-file-type-icons-5b277bd3-b763-4811-91b1-f839ea4f2c6c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-file-type-icons",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-focus-aca07cf5-6acf-4abd-bb39-0b5eaa58a279.json
+++ b/change/@fluentui-react-focus-aca07cf5-6acf-4abd-bb39-0b5eaa58a279.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-focus",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-hooks-05b53e22-647f-4acb-a734-7f52ec8859d2.json
+++ b/change/@fluentui-react-hooks-05b53e22-647f-4acb-a734-7f52ec8859d2.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-hooks",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-icon-provider-86d60e0a-5864-40f4-9150-4dabf5255360.json
+++ b/change/@fluentui-react-icon-provider-86d60e0a-5864-40f4-9150-4dabf5255360.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-icon-provider",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-icons-mdl2-9db5be48-91fb-4782-b5fc-a867b58822c8.json
+++ b/change/@fluentui-react-icons-mdl2-9db5be48-91fb-4782-b5fc-a867b58822c8.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-icons-mdl2",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-icons-mdl2-branded-d65f7b8c-5e52-486b-8585-5d0fb0cc7bce.json
+++ b/change/@fluentui-react-icons-mdl2-branded-d65f7b8c-5e52-486b-8585-5d0fb0cc7bce.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-icons-mdl2-branded",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-image-77c09b53-f9f4-4ae0-b018-23975a764ede.json
+++ b/change/@fluentui-react-image-77c09b53-f9f4-4ae0-b018-23975a764ede.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-image",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-infolabel-ebdd6552-c873-478b-8dc2-0449bcfb5f16.json
+++ b/change/@fluentui-react-infolabel-ebdd6552-c873-478b-8dc2-0449bcfb5f16.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-infolabel",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-input-127585d1-8288-439a-bc56-384a20fca3e5.json
+++ b/change/@fluentui-react-input-127585d1-8288-439a-bc56-384a20fca3e5.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-input",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-jsx-runtime-06f490b4-d497-4cf6-b67e-ae4fae820808.json
+++ b/change/@fluentui-react-jsx-runtime-06f490b4-d497-4cf6-b67e-ae4fae820808.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-jsx-runtime",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-label-d94e8d01-05f6-4d6b-8819-b32c27c50a5c.json
+++ b/change/@fluentui-react-label-d94e8d01-05f6-4d6b-8819-b32c27c50a5c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-label",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-link-1ae2b40e-53ec-4589-8cba-e6b7fc585ad5.json
+++ b/change/@fluentui-react-link-1ae2b40e-53ec-4589-8cba-e6b7fc585ad5.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-link",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-list-preview-cbbb7c4d-3f00-415d-9ad5-fa91239ff9be.json
+++ b/change/@fluentui-react-list-preview-cbbb7c4d-3f00-415d-9ad5-fa91239ff9be.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-list-preview",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-menu-6a2ea5e5-1799-4022-89f4-a274622d697c.json
+++ b/change/@fluentui-react-menu-6a2ea5e5-1799-4022-89f4-a274622d697c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-menu",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-message-bar-9b1f6ee1-684f-4a15-97b1-2909b490b8ff.json
+++ b/change/@fluentui-react-message-bar-9b1f6ee1-684f-4a15-97b1-2909b490b8ff.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-message-bar",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-migration-v0-v9-944abc39-5b70-4680-a2e8-c921f7e886bf.json
+++ b/change/@fluentui-react-migration-v0-v9-944abc39-5b70-4680-a2e8-c921f7e886bf.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-migration-v0-v9",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-migration-v8-v9-12995559-aca0-42cd-866c-085f5f014412.json
+++ b/change/@fluentui-react-migration-v8-v9-12995559-aca0-42cd-866c-085f5f014412.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-migration-v8-v9",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-monaco-editor-7062a3d9-096b-447b-b42b-a3de2880ed8e.json
+++ b/change/@fluentui-react-monaco-editor-7062a3d9-096b-447b-b42b-a3de2880ed8e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-monaco-editor",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-motion-9bda5d25-a262-4f93-a6d6-75086ec76b1b.json
+++ b/change/@fluentui-react-motion-9bda5d25-a262-4f93-a6d6-75086ec76b1b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-motion",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-motion-preview-d12609f4-4276-4c0b-9b3e-b1d9cc52b7a5.json
+++ b/change/@fluentui-react-motion-preview-d12609f4-4276-4c0b-9b3e-b1d9cc52b7a5.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-motion-preview",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-nav-preview-88a94e80-34ef-4036-abef-5580c4d0a69c.json
+++ b/change/@fluentui-react-nav-preview-88a94e80-34ef-4036-abef-5580c4d0a69c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-nav-preview",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-overflow-e89236ed-c411-4444-a4c6-984e88657edb.json
+++ b/change/@fluentui-react-overflow-e89236ed-c411-4444-a4c6-984e88657edb.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-overflow",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-persona-844eda93-133d-498a-90fe-610b10e9ddb8.json
+++ b/change/@fluentui-react-persona-844eda93-133d-498a-90fe-610b10e9ddb8.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-persona",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-popover-4a9229ce-bff4-44a2-a525-57331b67755c.json
+++ b/change/@fluentui-react-popover-4a9229ce-bff4-44a2-a525-57331b67755c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-popover",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-portal-b39a1f57-2361-412c-8002-5670a7933fc0.json
+++ b/change/@fluentui-react-portal-b39a1f57-2361-412c-8002-5670a7933fc0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-portal",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-portal-compat-c19eb9f4-8ab8-42fb-9aad-737befca2eac.json
+++ b/change/@fluentui-react-portal-compat-c19eb9f4-8ab8-42fb-9aad-737befca2eac.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-portal-compat",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-portal-compat-context-b4247515-4e66-45ac-a438-2579d576c9e7.json
+++ b/change/@fluentui-react-portal-compat-context-b4247515-4e66-45ac-a438-2579d576c9e7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-portal-compat-context",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-positioning-8978e097-435e-4dd7-970f-a3b25a7aad85.json
+++ b/change/@fluentui-react-positioning-8978e097-435e-4dd7-970f-a3b25a7aad85.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-positioning",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-progress-dcf61833-7ecb-445e-8aeb-a4613843fc88.json
+++ b/change/@fluentui-react-progress-dcf61833-7ecb-445e-8aeb-a4613843fc88.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-progress",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-provider-e8fb05b6-cfed-4563-8a5e-8f95cb9106c7.json
+++ b/change/@fluentui-react-provider-e8fb05b6-cfed-4563-8a5e-8f95cb9106c7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-provider",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-radio-b9cc3f0d-0c4f-45a3-9e92-052bb59366fb.json
+++ b/change/@fluentui-react-radio-b9cc3f0d-0c4f-45a3-9e92-052bb59366fb.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-radio",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-rating-9a7057cc-14bf-4215-981b-f66139935a13.json
+++ b/change/@fluentui-react-rating-9a7057cc-14bf-4215-981b-f66139935a13.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-rating",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-search-98821e22-c97e-4c83-adff-6e892c115c0d.json
+++ b/change/@fluentui-react-search-98821e22-c97e-4c83-adff-6e892c115c0d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-search",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-select-eace4107-2ceb-4a40-b58d-fa1c55f6968b.json
+++ b/change/@fluentui-react-select-eace4107-2ceb-4a40-b58d-fa1c55f6968b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-select",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-shared-contexts-fd80edfb-74ec-4dbd-aa95-b383d0e0eeca.json
+++ b/change/@fluentui-react-shared-contexts-fd80edfb-74ec-4dbd-aa95-b383d0e0eeca.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-shared-contexts",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-skeleton-dad7de58-7fe3-4300-b31a-755dc42aedc6.json
+++ b/change/@fluentui-react-skeleton-dad7de58-7fe3-4300-b31a-755dc42aedc6.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-skeleton",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-slider-96c54009-ebab-44ed-95e7-c56cceedc485.json
+++ b/change/@fluentui-react-slider-96c54009-ebab-44ed-95e7-c56cceedc485.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-slider",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-spinbutton-93046ebc-f144-49e2-aa75-265ba0857373.json
+++ b/change/@fluentui-react-spinbutton-93046ebc-f144-49e2-aa75-265ba0857373.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-spinbutton",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-spinner-e1a53d05-a73d-433f-b85e-786cd1e2d1e3.json
+++ b/change/@fluentui-react-spinner-e1a53d05-a73d-433f-b85e-786cd1e2d1e3.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-spinner",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-swatch-picker-172c7f45-2f9b-4cf2-af69-1bac5fa28c1b.json
+++ b/change/@fluentui-react-swatch-picker-172c7f45-2f9b-4cf2-af69-1bac5fa28c1b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-swatch-picker",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-switch-2751f5cc-f2c0-403d-9bbd-2f52a3589609.json
+++ b/change/@fluentui-react-switch-2751f5cc-f2c0-403d-9bbd-2f52a3589609.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-switch",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-table-83137256-d4a5-4104-a1a3-dbfb02b0a812.json
+++ b/change/@fluentui-react-table-83137256-d4a5-4104-a1a3-dbfb02b0a812.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-table",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tabs-27605b06-e7d0-4a9c-bd73-00aff07d93ee.json
+++ b/change/@fluentui-react-tabs-27605b06-e7d0-4a9c-bd73-00aff07d93ee.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-tabs",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tabster-466c8564-4abd-4682-8e1a-3af392e63042.json
+++ b/change/@fluentui-react-tabster-466c8564-4abd-4682-8e1a-3af392e63042.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-tabster",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tag-picker-d9ad4d50-abf8-4f7f-9a0e-523762b7c157.json
+++ b/change/@fluentui-react-tag-picker-d9ad4d50-abf8-4f7f-9a0e-523762b7c157.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-tag-picker",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tags-2e6f5266-6abc-457a-bae7-5a82ce0b4b5d.json
+++ b/change/@fluentui-react-tags-2e6f5266-6abc-457a-bae7-5a82ce0b4b5d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-tags",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-teaching-popover-631e3987-08b7-4659-9989-fb5bf73ae493.json
+++ b/change/@fluentui-react-teaching-popover-631e3987-08b7-4659-9989-fb5bf73ae493.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-teaching-popover",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-text-9c7ce39c-3313-4c00-abd5-12ab7ef47e69.json
+++ b/change/@fluentui-react-text-9c7ce39c-3313-4c00-abd5-12ab7ef47e69.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-text",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-textarea-9bb63051-ef88-4ff4-b473-85a064c76a67.json
+++ b/change/@fluentui-react-textarea-9bb63051-ef88-4ff4-b473-85a064c76a67.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-textarea",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-theme-04234c50-8db6-4342-93dd-e7f5876e2325.json
+++ b/change/@fluentui-react-theme-04234c50-8db6-4342-93dd-e7f5876e2325.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-theme",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-theme-sass-96c5ed55-057a-40c3-9571-ebf9da8cd248.json
+++ b/change/@fluentui-react-theme-sass-96c5ed55-057a-40c3-9571-ebf9da8cd248.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-theme-sass",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-timepicker-compat-54c84ffc-1ac2-4a10-83ee-327c4fc07b1f.json
+++ b/change/@fluentui-react-timepicker-compat-54c84ffc-1ac2-4a10-83ee-327c4fc07b1f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-timepicker-compat",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-toast-c7420596-285b-4987-b6e1-e297d9df7820.json
+++ b/change/@fluentui-react-toast-c7420596-285b-4987-b6e1-e297d9df7820.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-toast",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-toolbar-42de1e2b-2140-4d54-b4d8-b7efbf7d1bb4.json
+++ b/change/@fluentui-react-toolbar-42de1e2b-2140-4d54-b4d8-b7efbf7d1bb4.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-toolbar",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tooltip-5a857102-eb87-467b-ba45-594b5cb3f64a.json
+++ b/change/@fluentui-react-tooltip-5a857102-eb87-467b-ba45-594b5cb3f64a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tree-475f5637-0e9c-4366-ac21-9f985e963470.json
+++ b/change/@fluentui-react-tree-475f5637-0e9c-4366-ac21-9f985e963470.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-tree",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-utilities-3d01b438-deaa-4816-9c8d-11ffed9adcb0.json
+++ b/change/@fluentui-react-utilities-3d01b438-deaa-4816-9c8d-11ffed9adcb0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-utilities",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-virtualizer-47e88353-a743-4804-980b-0b7f7b35ea68.json
+++ b/change/@fluentui-react-virtualizer-47e88353-a743-4804-980b-0b7f7b35ea68.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-virtualizer",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-window-provider-bf9acd60-6eb3-4712-ad99-f42b41615197.json
+++ b/change/@fluentui-react-window-provider-bf9acd60-6eb3-4712-ad99-f42b41615197.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/react-window-provider",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-scheme-utilities-9530a2ac-7a93-4314-92a2-70681ac711de.json
+++ b/change/@fluentui-scheme-utilities-9530a2ac-7a93-4314-92a2-70681ac711de.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/scheme-utilities",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-set-version-7b088d9a-0f78-4a7a-9f8b-20b435268389.json
+++ b/change/@fluentui-set-version-7b088d9a-0f78-4a7a-9f8b-20b435268389.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/set-version",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-style-utilities-d1580df0-6d87-47a0-8d48-3c677656521f.json
+++ b/change/@fluentui-style-utilities-d1580df0-6d87-47a0-8d48-3c677656521f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/style-utilities",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-test-utilities-10c211bb-2ba9-4cbe-be55-8c0a97e659b1.json
+++ b/change/@fluentui-test-utilities-10c211bb-2ba9-4cbe-be55-8c0a97e659b1.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/test-utilities",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-theme-be2383da-a2a2-427c-80de-6df8948a2a0e.json
+++ b/change/@fluentui-theme-be2383da-a2a2-427c-80de-6df8948a2a0e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/theme",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-theme-samples-f7b76e35-1fd0-4495-bfb8-145d13594cba.json
+++ b/change/@fluentui-theme-samples-f7b76e35-1fd0-4495-bfb8-145d13594cba.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/theme-samples",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-tokens-60b0d047-0830-4038-82a3-e9ffd3462e3f.json
+++ b/change/@fluentui-tokens-60b0d047-0830-4038-82a3-e9ffd3462e3f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/tokens",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-utilities-89a4a127-bceb-4061-81d3-f186904fdced.json
+++ b/change/@fluentui-utilities-89a4a127-bceb-4061-81d3-f186904fdced.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/utilities",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-web-components-248ce498-7807-42b6-8461-b3936fac5a25.json
+++ b/change/@fluentui-web-components-248ce498-7807-42b6-8461-b3936fac5a25.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/web-components",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-webpack-utilities-746eaa98-cc3a-44e9-b92c-8a7abcb8062a.json
+++ b/change/@fluentui-webpack-utilities-746eaa98-cc3a-44e9-b92c-8a7abcb8062a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: remove npmScope from project name",
+  "packageName": "@fluentui/webpack-utilities",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/docs/react-v9/contributing/command-cheat-sheet.md
+++ b/docs/react-v9/contributing/command-cheat-sheet.md
@@ -1,5 +1,9 @@
 This is a list of helpful commands.
 
+> [!TIP]
+>
+> `<project-name>` is project name without `@npmScope`
+
 ```shell
 yarn # installs everything. It fixes many things.
 yarn buildto package-name # Does a yarn build scoped to a specific package and its dependencies for faster speeds vs building the whole repo.
@@ -12,9 +16,9 @@ yarn build # generates and relinks all packages and temporary files, this can be
 yarn start # runs a package. You can select the package of choice.
 yarn update-snapshots # updates snapshot tests
 yarn run dedupe # dedupes dependencies - necessary to run after any kind of package bump/changes
-yarn nx run <package-name>:generate-api # updates API files
-yarn nx run <package-name>:<target-name> # runs tasks within a package. [More help here](https://nx.dev/features/run-tasks#running-tasks)
-yarn nx run @fluentui/<package-name>:type-check # quickly runs type checks and associated linting
+yarn nx run <project-name>:generate-api # updates API files
+yarn nx run <project-name>:<target-name> # runs tasks within a package. [More help here](https://nx.dev/features/run-tasks#running-tasks)
+yarn nx run <project-name>:type-check # quickly runs type checks and associated linting
 yarn lage build --to react # build v8 so intellisense works.
 ```
 

--- a/docs/react-v9/contributing/dev-workflow.md
+++ b/docs/react-v9/contributing/dev-workflow.md
@@ -81,10 +81,10 @@ In other cases, such as before checking in or running tests, you may need to run
 
 ### Making a pull request
 
-Make sure all your changes are committed, and run `yarn nx run @fluentui/react-components:build` or `yarn buildto @fluentui/react-components` for changes to the v9 components. This will compare your changes and detect if the publicly facing API has changed, and update our API docs accordingly. Commit this file change.
-Note: If you encounter build errors here (especially on non-\*nix systems) a 'yarn build' to ensure packages are correctly updated and linked may be nessecary.
+Make sure all your changes are committed, and run `yarn nx run react-components:build` or `yarn buildto @fluentui/react-components` for changes to the v9 components. This will compare your changes and detect if the publicly facing API has changed, and update our API docs accordingly. Commit this file change.
+Note: If you encounter build errors here (especially on non-\*nix systems) a 'yarn build' to ensure packages are correctly updated and linked may be necessary.
 
-Some of our tests make use of DOM snapshot tests. If your branch makes any changes or additions to the DOM, you may need to run `yarn nx run @fluentui/<package>:test -u` or `yarn workspace @fluentui/<package> test --updateSnapshot`. This will update any necessary files used by our snapshot tests.
+Some of our tests make use of DOM snapshot tests. If your branch makes any changes or additions to the DOM, you may need to run `yarn nx run <project-name>:test -u` or `yarn workspace @fluentui/<project-name> test --updateSnapshot`. This will update any necessary files used by our snapshot tests.
 
 Before creating a pull request, be sure to run `yarn change` and provide a high-level description of your change, which will be used in the release notes. You will need to run this at least once for every PR made to a published package. We follow [semantic versioning](https://semver.org/), so use the guide when selecting a change type:
 

--- a/docs/react-v9/contributing/testing-with-jest.md
+++ b/docs/react-v9/contributing/testing-with-jest.md
@@ -13,7 +13,7 @@ We use various libraries on top of Jest for rendering and interacting with React
 ## Running tests
 
 From your Terminal invoke one of following commands:
-`yarn nx run <package-name>:test` or `yarn lage test --to <package-name>`
+`yarn nx run <project-name>:test` or `yarn lage test --to <project-name>`
 
 > New packages (v9) don't require build step before, which is not true for old fluent libraries like v8.
 > Until v8 lives within our main branch we cannot remove `build` dependency from target task graph thus you'll experience build step even for new packages.

--- a/packages/a11y-testing/project.json
+++ b/packages/a11y-testing/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/a11y-testing",
+  "name": "a11y-testing",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/api-docs/project.json
+++ b/packages/api-docs/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/api-docs",
+  "name": "api-docs",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/azure-themes/project.json
+++ b/packages/azure-themes/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/azure-themes",
+  "name": "azure-themes",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/codemods/project.json
+++ b/packages/codemods/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/codemods",
+  "name": "codemods",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/common-styles/project.json
+++ b/packages/common-styles/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/common-styles",
+  "name": "common-styles",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": []

--- a/packages/cra-template/project.json
+++ b/packages/cra-template/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/cra-template",
+  "name": "cra-template",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/date-time-utilities/project.json
+++ b/packages/date-time-utilities/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/date-time-utilities",
+  "name": "date-time-utilities",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/dom-utilities/project.json
+++ b/packages/dom-utilities/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/dom-utilities",
+  "name": "dom-utilities",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": []

--- a/packages/eslint-plugin/project.json
+++ b/packages/eslint-plugin/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/eslint-plugin",
+  "name": "eslint-plugin",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": []

--- a/packages/eslint-plugin/src/configs/react.js
+++ b/packages/eslint-plugin/src/configs/react.js
@@ -11,9 +11,9 @@ const typeAwareRules = {
 
 const root = configHelpers.findGitRoot();
 const unstableV9Packages = configHelpers.getV9UnstablePackages(root);
-const v9PackageDeps = Object.keys(
-  configHelpers.getPackageJson({ root, name: '@fluentui/react-components' }).dependencies,
-).filter(pkg => !unstableV9Packages.has(pkg));
+const v9PackageDeps = Object.keys(configHelpers.getPackageJson({ root, name: 'react-components' }).dependencies).filter(
+  pkg => !unstableV9Packages.has(pkg),
+);
 
 /** @type {import("eslint").Linter.Config} */
 module.exports = {

--- a/packages/eslint-plugin/src/utils/configHelpers.js
+++ b/packages/eslint-plugin/src/utils/configHelpers.js
@@ -283,7 +283,7 @@ module.exports = {
    * @returns {Set<string>} Returns a set of v9 packages that are currently unstable.
    */
   getV9UnstablePackages: (/** @type {string} */ root) => {
-    const v9ProjectMetaData = getProjectMetadata({ root, name: '@fluentui/react-components' });
+    const v9ProjectMetaData = getProjectMetadata({ root, name: 'react-components' });
     const v9PackagePath = path.join(root, v9ProjectMetaData.sourceRoot ?? '', 'unstable', 'index.ts');
     const unstableV9Packages = new Set();
     fs.readFileSync(v9PackagePath)

--- a/packages/example-data/project.json
+++ b/packages/example-data/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/example-data",
+  "name": "example-data",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/fluent2-theme/project.json
+++ b/packages/fluent2-theme/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/fluent2-theme",
+  "name": "fluent2-theme",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/fluentui/ability-attributes/project.json
+++ b/packages/fluentui/ability-attributes/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/ability-attributes",
+  "name": "ability-attributes",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/fluentui/accessibility/project.json
+++ b/packages/fluentui/accessibility/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/accessibility",
+  "name": "accessibility",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/fluentui/circulars-test/project.json
+++ b/packages/fluentui/circulars-test/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/circulars-test",
+  "name": "circulars-test",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "application",
   "implicitDependencies": [],

--- a/packages/fluentui/code-sandbox/project.json
+++ b/packages/fluentui/code-sandbox/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/code-sandbox",
+  "name": "code-sandbox",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/fluentui/digest/project.json
+++ b/packages/fluentui/digest/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/digest",
+  "name": "digest",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/fluentui/docs-components/project.json
+++ b/packages/fluentui/docs-components/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/docs-components",
+  "name": "docs-components",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/fluentui/docs/project.json
+++ b/packages/fluentui/docs/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/docs",
+  "name": "docs",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "application",
   "implicitDependencies": [],
@@ -8,7 +8,7 @@
     "build": {
       "dependsOn": [
         {
-          "projects": ["@fluentui/react-northstar"],
+          "projects": ["react-northstar"],
           "target": "build:info"
         }
       ]

--- a/packages/fluentui/e2e/project.json
+++ b/packages/fluentui/e2e/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/e2e",
+  "name": "e2e",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "application",
   "implicitDependencies": [],

--- a/packages/fluentui/local-sandbox/project.json
+++ b/packages/fluentui/local-sandbox/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/local-sandbox",
+  "name": "local-sandbox",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "application",
   "implicitDependencies": [],

--- a/packages/fluentui/perf-test-northstar/project.json
+++ b/packages/fluentui/perf-test-northstar/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/perf-test-northstar",
+  "name": "perf-test-northstar",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "application",
   "implicitDependencies": [],

--- a/packages/fluentui/perf/project.json
+++ b/packages/fluentui/perf/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/perf",
+  "name": "perf",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "application",
   "implicitDependencies": [],

--- a/packages/fluentui/projects-test/project.json
+++ b/packages/fluentui/projects-test/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/projects-test",
+  "name": "projects-test",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "application",
   "implicitDependencies": [],

--- a/packages/fluentui/react-bindings/project.json
+++ b/packages/fluentui/react-bindings/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-bindings",
+  "name": "react-bindings",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/fluentui/react-builder/project.json
+++ b/packages/fluentui/react-builder/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-builder",
+  "name": "react-builder",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/fluentui/react-component-event-listener/project.json
+++ b/packages/fluentui/react-component-event-listener/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-component-event-listener",
+  "name": "react-component-event-listener",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/fluentui/react-component-nesting-registry/project.json
+++ b/packages/fluentui/react-component-nesting-registry/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-component-nesting-registry",
+  "name": "react-component-nesting-registry",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/fluentui/react-component-ref/project.json
+++ b/packages/fluentui/react-component-ref/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-component-ref",
+  "name": "react-component-ref",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/fluentui/react-icons-northstar/project.json
+++ b/packages/fluentui/react-icons-northstar/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-icons-northstar",
+  "name": "react-icons-northstar",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/fluentui/react-northstar-emotion-renderer/project.json
+++ b/packages/fluentui/react-northstar-emotion-renderer/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-northstar-emotion-renderer",
+  "name": "react-northstar-emotion-renderer",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/fluentui/react-northstar-fela-renderer/project.json
+++ b/packages/fluentui/react-northstar-fela-renderer/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-northstar-fela-renderer",
+  "name": "react-northstar-fela-renderer",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/fluentui/react-northstar-prototypes/project.json
+++ b/packages/fluentui/react-northstar-prototypes/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-northstar-prototypes",
+  "name": "react-northstar-prototypes",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/fluentui/react-northstar-styles-renderer/project.json
+++ b/packages/fluentui/react-northstar-styles-renderer/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-northstar-styles-renderer",
+  "name": "react-northstar-styles-renderer",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/fluentui/react-northstar/project.json
+++ b/packages/fluentui/react-northstar/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-northstar",
+  "name": "react-northstar",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/fluentui/react-proptypes/project.json
+++ b/packages/fluentui/react-proptypes/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-proptypes",
+  "name": "react-proptypes",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/fluentui/react-telemetry/project.json
+++ b/packages/fluentui/react-telemetry/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-telemetry",
+  "name": "react-telemetry",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/fluentui/state/project.json
+++ b/packages/fluentui/state/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/state",
+  "name": "state",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": []

--- a/packages/fluentui/styles/project.json
+++ b/packages/fluentui/styles/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/styles",
+  "name": "styles",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": []

--- a/packages/font-icons-mdl2/project.json
+++ b/packages/font-icons-mdl2/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/font-icons-mdl2",
+  "name": "font-icons-mdl2",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/foundation-legacy/project.json
+++ b/packages/foundation-legacy/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/foundation-legacy",
+  "name": "foundation-legacy",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/jest-serializer-merge-styles/project.json
+++ b/packages/jest-serializer-merge-styles/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/jest-serializer-merge-styles",
+  "name": "jest-serializer-merge-styles",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/keyboard-key/project.json
+++ b/packages/keyboard-key/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/keyboard-key",
+  "name": "keyboard-key",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": []

--- a/packages/merge-styles/project.json
+++ b/packages/merge-styles/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/merge-styles",
+  "name": "merge-styles",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/monaco-editor/project.json
+++ b/packages/monaco-editor/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/monaco-editor",
+  "name": "monaco-editor",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": []

--- a/packages/public-docsite-setup/project.json
+++ b/packages/public-docsite-setup/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/public-docsite-setup",
+  "name": "public-docsite-setup",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": []

--- a/packages/react-cards/project.json
+++ b/packages/react-cards/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-cards",
+  "name": "react-cards",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": []

--- a/packages/react-charting/project.json
+++ b/packages/react-charting/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-charting",
+  "name": "react-charting",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": []

--- a/packages/react-components/babel-preset-global-context/project.json
+++ b/packages/react-components/babel-preset-global-context/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/babel-preset-global-context",
+  "name": "babel-preset-global-context",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/react-components/babel-preset-storybook-full-source/project.json
+++ b/packages/react-components/babel-preset-storybook-full-source/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/babel-preset-storybook-full-source",
+  "name": "babel-preset-storybook-full-source",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/react-components/global-context/project.json
+++ b/packages/react-components/global-context/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/global-context",
+  "name": "global-context",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/react-components/keyboard-keys/project.json
+++ b/packages/react-components/keyboard-keys/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/keyboard-keys",
+  "name": "keyboard-keys",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/keyboard-keys/src",

--- a/packages/react-components/priority-overflow/project.json
+++ b/packages/react-components/priority-overflow/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/priority-overflow",
+  "name": "priority-overflow",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/react-components/react-accordion/library/project.json
+++ b/packages/react-components/react-accordion/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-accordion",
+  "name": "react-accordion",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-accordion/library/src",

--- a/packages/react-components/react-accordion/stories/project.json
+++ b/packages/react-components/react-accordion/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-accordion-stories",
+  "name": "react-accordion-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-accordion/stories/src",

--- a/packages/react-components/react-aria/library/project.json
+++ b/packages/react-components/react-aria/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-aria",
+  "name": "react-aria",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-aria/library/src",

--- a/packages/react-components/react-aria/stories/project.json
+++ b/packages/react-components/react-aria/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-aria-stories",
+  "name": "react-aria-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-aria/stories/src",

--- a/packages/react-components/react-avatar/library/project.json
+++ b/packages/react-components/react-avatar/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-avatar",
+  "name": "react-avatar",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-avatar/library/src",

--- a/packages/react-components/react-avatar/stories/project.json
+++ b/packages/react-components/react-avatar/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-avatar-stories",
+  "name": "react-avatar-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-avatar/stories/src",

--- a/packages/react-components/react-badge/library/project.json
+++ b/packages/react-components/react-badge/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-badge",
+  "name": "react-badge",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-badge/library/src",

--- a/packages/react-components/react-badge/stories/project.json
+++ b/packages/react-components/react-badge/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-badge-stories",
+  "name": "react-badge-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-badge/stories/src",

--- a/packages/react-components/react-breadcrumb/library/project.json
+++ b/packages/react-components/react-breadcrumb/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-breadcrumb",
+  "name": "react-breadcrumb",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/react-components/react-breadcrumb/stories/project.json
+++ b/packages/react-components/react-breadcrumb/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-breadcrumb-stories",
+  "name": "react-breadcrumb-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/react-components/react-button/library/project.json
+++ b/packages/react-components/react-button/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-button",
+  "name": "react-button",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-button/library/src",

--- a/packages/react-components/react-button/stories/project.json
+++ b/packages/react-components/react-button/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-button-stories",
+  "name": "react-button-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-button/stories/src",

--- a/packages/react-components/react-calendar-compat/library/project.json
+++ b/packages/react-components/react-calendar-compat/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-calendar-compat",
+  "name": "react-calendar-compat",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-calendar-compat/library/src",

--- a/packages/react-components/react-calendar-compat/stories/project.json
+++ b/packages/react-components/react-calendar-compat/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-calendar-compat-stories",
+  "name": "react-calendar-compat-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-calendar-compat/stories/src",

--- a/packages/react-components/react-card/library/project.json
+++ b/packages/react-components/react-card/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-card",
+  "name": "react-card",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-card/library/src",

--- a/packages/react-components/react-card/stories/project.json
+++ b/packages/react-components/react-card/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-card-stories",
+  "name": "react-card-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-card/stories/src",

--- a/packages/react-components/react-carousel-preview/library/project.json
+++ b/packages/react-components/react-carousel-preview/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-carousel-preview",
+  "name": "react-carousel-preview",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-carousel-preview/library/src",

--- a/packages/react-components/react-carousel-preview/stories/project.json
+++ b/packages/react-components/react-carousel-preview/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-carousel-preview-stories",
+  "name": "react-carousel-preview-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-carousel-preview/stories/src",

--- a/packages/react-components/react-checkbox/library/project.json
+++ b/packages/react-components/react-checkbox/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-checkbox",
+  "name": "react-checkbox",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-checkbox/library/src",

--- a/packages/react-components/react-checkbox/stories/project.json
+++ b/packages/react-components/react-checkbox/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-checkbox-stories",
+  "name": "react-checkbox-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-checkbox/stories/src",

--- a/packages/react-components/react-colorpicker-compat/project.json
+++ b/packages/react-components/react-colorpicker-compat/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-colorpicker-compat",
+  "name": "react-colorpicker-compat",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/react-components/react-combobox/library/project.json
+++ b/packages/react-components/react-combobox/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-combobox",
+  "name": "react-combobox",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-combobox/library/src",

--- a/packages/react-components/react-combobox/stories/project.json
+++ b/packages/react-components/react-combobox/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-combobox-stories",
+  "name": "react-combobox-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-combobox/stories/src",

--- a/packages/react-components/react-components/project.json
+++ b/packages/react-components/react-components/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-components",
+  "name": "react-components",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-components/src",

--- a/packages/react-components/react-conformance-griffel/project.json
+++ b/packages/react-components/react-conformance-griffel/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-conformance-griffel",
+  "name": "react-conformance-griffel",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-conformance-griffel/src",

--- a/packages/react-components/react-context-selector/project.json
+++ b/packages/react-components/react-context-selector/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-context-selector",
+  "name": "react-context-selector",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-context-selector/src",

--- a/packages/react-components/react-datepicker-compat/library/project.json
+++ b/packages/react-components/react-datepicker-compat/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-datepicker-compat",
+  "name": "react-datepicker-compat",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/react-components/react-datepicker-compat/stories/project.json
+++ b/packages/react-components/react-datepicker-compat/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-datepicker-compat-stories",
+  "name": "react-datepicker-compat-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/react-components/react-dialog/library/project.json
+++ b/packages/react-components/react-dialog/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-dialog",
+  "name": "react-dialog",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-dialog/library/src",

--- a/packages/react-components/react-dialog/stories/project.json
+++ b/packages/react-components/react-dialog/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-dialog-stories",
+  "name": "react-dialog-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-dialog/stories/src",

--- a/packages/react-components/react-divider/library/project.json
+++ b/packages/react-components/react-divider/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-divider",
+  "name": "react-divider",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-divider/library/src",

--- a/packages/react-components/react-divider/stories/project.json
+++ b/packages/react-components/react-divider/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-divider-stories",
+  "name": "react-divider-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-divider/stories/src",

--- a/packages/react-components/react-drawer/library/project.json
+++ b/packages/react-components/react-drawer/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-drawer",
+  "name": "react-drawer",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/react-components/react-drawer/stories/project.json
+++ b/packages/react-components/react-drawer/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-drawer-stories",
+  "name": "react-drawer-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/react-components/react-field/library/project.json
+++ b/packages/react-components/react-field/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-field",
+  "name": "react-field",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/react-components/react-field/stories/project.json
+++ b/packages/react-components/react-field/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-field-stories",
+  "name": "react-field-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/react-components/react-icons-compat/library/project.json
+++ b/packages/react-components/react-icons-compat/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-icons-compat",
+  "name": "react-icons-compat",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-icons-compat/library/src",

--- a/packages/react-components/react-icons-compat/stories/project.json
+++ b/packages/react-components/react-icons-compat/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-icons-compat-stories",
+  "name": "react-icons-compat-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-icons-compat/stories/src",

--- a/packages/react-components/react-image/library/project.json
+++ b/packages/react-components/react-image/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-image",
+  "name": "react-image",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-image/library/src",

--- a/packages/react-components/react-image/stories/project.json
+++ b/packages/react-components/react-image/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-image-stories",
+  "name": "react-image-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-image/stories/src",

--- a/packages/react-components/react-infolabel/library/project.json
+++ b/packages/react-components/react-infolabel/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-infolabel",
+  "name": "react-infolabel",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-infolabel/library/src",

--- a/packages/react-components/react-infolabel/stories/project.json
+++ b/packages/react-components/react-infolabel/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-infolabel-stories",
+  "name": "react-infolabel-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-infolabel/stories/src",

--- a/packages/react-components/react-input/library/project.json
+++ b/packages/react-components/react-input/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-input",
+  "name": "react-input",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-input/library/src",

--- a/packages/react-components/react-input/stories/project.json
+++ b/packages/react-components/react-input/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-input-stories",
+  "name": "react-input-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-input/stories/src",

--- a/packages/react-components/react-jsx-runtime/project.json
+++ b/packages/react-components/react-jsx-runtime/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-jsx-runtime",
+  "name": "react-jsx-runtime",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/react-components/react-label/library/project.json
+++ b/packages/react-components/react-label/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-label",
+  "name": "react-label",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-label/library/src",

--- a/packages/react-components/react-label/stories/project.json
+++ b/packages/react-components/react-label/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-label-stories",
+  "name": "react-label-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-label/stories/src",

--- a/packages/react-components/react-link/library/project.json
+++ b/packages/react-components/react-link/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-link",
+  "name": "react-link",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-link/library/src",

--- a/packages/react-components/react-link/stories/project.json
+++ b/packages/react-components/react-link/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-link-stories",
+  "name": "react-link-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-link/stories/src",

--- a/packages/react-components/react-list-preview/library/project.json
+++ b/packages/react-components/react-list-preview/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-list-preview",
+  "name": "react-list-preview",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-list-preview/library/src",

--- a/packages/react-components/react-list-preview/stories/project.json
+++ b/packages/react-components/react-list-preview/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-list-preview-stories",
+  "name": "react-list-preview-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-list-preview/stories/src",

--- a/packages/react-components/react-menu/library/project.json
+++ b/packages/react-components/react-menu/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-menu",
+  "name": "react-menu",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-menu/library/src",

--- a/packages/react-components/react-menu/stories/project.json
+++ b/packages/react-components/react-menu/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-menu-stories",
+  "name": "react-menu-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-menu/stories/src",

--- a/packages/react-components/react-message-bar/library/project.json
+++ b/packages/react-components/react-message-bar/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-message-bar",
+  "name": "react-message-bar",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-message-bar/library/src",

--- a/packages/react-components/react-message-bar/stories/project.json
+++ b/packages/react-components/react-message-bar/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-message-bar-stories",
+  "name": "react-message-bar-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-message-bar/stories/src",

--- a/packages/react-components/react-migration-v0-v9/project.json
+++ b/packages/react-components/react-migration-v0-v9/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-migration-v0-v9",
+  "name": "react-migration-v0-v9",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/react-components/react-migration-v8-v9/project.json
+++ b/packages/react-components/react-migration-v8-v9/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-migration-v8-v9",
+  "name": "react-migration-v8-v9",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/react-components/react-motion-components-preview/library/project.json
+++ b/packages/react-components/react-motion-components-preview/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-motion-components-preview",
+  "name": "react-motion-components-preview",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-motion-components-preview/library/src",

--- a/packages/react-components/react-motion-components-preview/stories/project.json
+++ b/packages/react-components/react-motion-components-preview/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-motion-components-preview-stories",
+  "name": "react-motion-components-preview-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-motion-components-preview/stories/src",

--- a/packages/react-components/react-motion-preview/library/project.json
+++ b/packages/react-components/react-motion-preview/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-motion-preview",
+  "name": "react-motion-preview",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-motion-preview/library/src",

--- a/packages/react-components/react-motion-preview/stories/project.json
+++ b/packages/react-components/react-motion-preview/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-motion-preview-stories",
+  "name": "react-motion-preview-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-motion-preview/stories/src",

--- a/packages/react-components/react-motion/library/project.json
+++ b/packages/react-components/react-motion/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-motion",
+  "name": "react-motion",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-motion/library/src",

--- a/packages/react-components/react-motion/stories/project.json
+++ b/packages/react-components/react-motion/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-motion-stories",
+  "name": "react-motion-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-motion/stories/src",

--- a/packages/react-components/react-nav-preview/library/project.json
+++ b/packages/react-components/react-nav-preview/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-nav-preview",
+  "name": "react-nav-preview",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-nav-preview/library/src",

--- a/packages/react-components/react-nav-preview/stories/project.json
+++ b/packages/react-components/react-nav-preview/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-nav-preview-stories",
+  "name": "react-nav-preview-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-nav-preview/stories/src",

--- a/packages/react-components/react-overflow/library/project.json
+++ b/packages/react-components/react-overflow/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-overflow",
+  "name": "react-overflow",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/react-components/react-overflow/stories/project.json
+++ b/packages/react-components/react-overflow/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-overflow-stories",
+  "name": "react-overflow-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/react-components/react-persona/library/project.json
+++ b/packages/react-components/react-persona/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-persona",
+  "name": "react-persona",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/react-components/react-persona/stories/project.json
+++ b/packages/react-components/react-persona/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-persona-stories",
+  "name": "react-persona-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/react-components/react-popover/library/project.json
+++ b/packages/react-components/react-popover/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-popover",
+  "name": "react-popover",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-popover/library/src",

--- a/packages/react-components/react-popover/stories/project.json
+++ b/packages/react-components/react-popover/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-popover-stories",
+  "name": "react-popover-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-popover/stories/src",

--- a/packages/react-components/react-portal-compat-context/project.json
+++ b/packages/react-components/react-portal-compat-context/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-portal-compat-context",
+  "name": "react-portal-compat-context",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/react-components/react-portal-compat/project.json
+++ b/packages/react-components/react-portal-compat/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-portal-compat",
+  "name": "react-portal-compat",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/react-components/react-portal/library/project.json
+++ b/packages/react-components/react-portal/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-portal",
+  "name": "react-portal",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-portal/library/src",

--- a/packages/react-components/react-portal/stories/project.json
+++ b/packages/react-components/react-portal/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-portal-stories",
+  "name": "react-portal-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-portal/stories/src",

--- a/packages/react-components/react-positioning/project.json
+++ b/packages/react-components/react-positioning/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-positioning",
+  "name": "react-positioning",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-positioning/src",

--- a/packages/react-components/react-progress/library/project.json
+++ b/packages/react-components/react-progress/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-progress",
+  "name": "react-progress",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/react-components/react-progress/stories/project.json
+++ b/packages/react-components/react-progress/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-progress-stories",
+  "name": "react-progress-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/react-components/react-provider/library/project.json
+++ b/packages/react-components/react-provider/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-provider",
+  "name": "react-provider",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-provider/library/src",

--- a/packages/react-components/react-provider/stories/project.json
+++ b/packages/react-components/react-provider/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-provider-stories",
+  "name": "react-provider-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-provider/stories/src",

--- a/packages/react-components/react-radio/library/project.json
+++ b/packages/react-components/react-radio/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-radio",
+  "name": "react-radio",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-radio/library/src",

--- a/packages/react-components/react-radio/stories/project.json
+++ b/packages/react-components/react-radio/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-radio-stories",
+  "name": "react-radio-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-radio/stories/src",

--- a/packages/react-components/react-rating/library/project.json
+++ b/packages/react-components/react-rating/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-rating",
+  "name": "react-rating",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-rating/library/src",

--- a/packages/react-components/react-rating/stories/project.json
+++ b/packages/react-components/react-rating/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-rating-stories",
+  "name": "react-rating-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-rating/stories/src",

--- a/packages/react-components/react-search/library/project.json
+++ b/packages/react-components/react-search/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-search",
+  "name": "react-search",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/react-components/react-search/stories/project.json
+++ b/packages/react-components/react-search/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-search-stories",
+  "name": "react-search-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/react-components/react-select/library/project.json
+++ b/packages/react-components/react-select/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-select",
+  "name": "react-select",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-select/library/src",

--- a/packages/react-components/react-select/stories/project.json
+++ b/packages/react-components/react-select/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-select-stories",
+  "name": "react-select-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-select/stories/src",

--- a/packages/react-components/react-shared-contexts/library/project.json
+++ b/packages/react-components/react-shared-contexts/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-shared-contexts",
+  "name": "react-shared-contexts",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-shared-contexts/library/src",

--- a/packages/react-components/react-shared-contexts/stories/project.json
+++ b/packages/react-components/react-shared-contexts/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-shared-contexts-stories",
+  "name": "react-shared-contexts-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-shared-contexts/stories/src",

--- a/packages/react-components/react-skeleton/library/project.json
+++ b/packages/react-components/react-skeleton/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-skeleton",
+  "name": "react-skeleton",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/react-components/react-skeleton/stories/project.json
+++ b/packages/react-components/react-skeleton/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-skeleton-stories",
+  "name": "react-skeleton-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/react-components/react-slider/library/project.json
+++ b/packages/react-components/react-slider/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-slider",
+  "name": "react-slider",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-slider/library/src",

--- a/packages/react-components/react-slider/stories/project.json
+++ b/packages/react-components/react-slider/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-slider-stories",
+  "name": "react-slider-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-slider/stories/src",

--- a/packages/react-components/react-spinbutton/library/project.json
+++ b/packages/react-components/react-spinbutton/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-spinbutton",
+  "name": "react-spinbutton",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-spinbutton/library/src",

--- a/packages/react-components/react-spinbutton/stories/project.json
+++ b/packages/react-components/react-spinbutton/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-spinbutton-stories",
+  "name": "react-spinbutton-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-spinbutton/stories/src",

--- a/packages/react-components/react-spinner/library/project.json
+++ b/packages/react-components/react-spinner/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-spinner",
+  "name": "react-spinner",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/react-components/react-spinner/stories/project.json
+++ b/packages/react-components/react-spinner/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-spinner-stories",
+  "name": "react-spinner-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/react-components/react-storybook-addon-export-to-sandbox/project.json
+++ b/packages/react-components/react-storybook-addon-export-to-sandbox/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-storybook-addon-export-to-sandbox",
+  "name": "react-storybook-addon-export-to-sandbox",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/react-components/react-storybook-addon/project.json
+++ b/packages/react-components/react-storybook-addon/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-storybook-addon",
+  "name": "react-storybook-addon",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-storybook-addon/src",

--- a/packages/react-components/react-swatch-picker/library/project.json
+++ b/packages/react-components/react-swatch-picker/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-swatch-picker",
+  "name": "react-swatch-picker",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-swatch-picker/library/src",

--- a/packages/react-components/react-swatch-picker/stories/project.json
+++ b/packages/react-components/react-swatch-picker/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-swatch-picker-stories",
+  "name": "react-swatch-picker-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-swatch-picker/stories/src",

--- a/packages/react-components/react-switch/library/project.json
+++ b/packages/react-components/react-switch/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-switch",
+  "name": "react-switch",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-switch/library/src",

--- a/packages/react-components/react-switch/stories/project.json
+++ b/packages/react-components/react-switch/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-switch-stories",
+  "name": "react-switch-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-switch/stories/src",

--- a/packages/react-components/react-table/library/project.json
+++ b/packages/react-components/react-table/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-table",
+  "name": "react-table",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/react-components/react-table/stories/project.json
+++ b/packages/react-components/react-table/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-table-stories",
+  "name": "react-table-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/react-components/react-tabs/library/project.json
+++ b/packages/react-components/react-tabs/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-tabs",
+  "name": "react-tabs",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-tabs/library/src",

--- a/packages/react-components/react-tabs/stories/project.json
+++ b/packages/react-components/react-tabs/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-tabs-stories",
+  "name": "react-tabs-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-tabs/stories/src",

--- a/packages/react-components/react-tabster/project.json
+++ b/packages/react-components/react-tabster/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-tabster",
+  "name": "react-tabster",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-tabster/src",

--- a/packages/react-components/react-tag-picker/library/project.json
+++ b/packages/react-components/react-tag-picker/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-tag-picker",
+  "name": "react-tag-picker",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-tag-picker/library/src",

--- a/packages/react-components/react-tag-picker/stories/project.json
+++ b/packages/react-components/react-tag-picker/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-tag-picker-stories",
+  "name": "react-tag-picker-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-tag-picker/stories/src",

--- a/packages/react-components/react-tags/library/project.json
+++ b/packages/react-components/react-tags/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-tags",
+  "name": "react-tags",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/react-components/react-tags/stories/project.json
+++ b/packages/react-components/react-tags/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-tags-stories",
+  "name": "react-tags-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/react-components/react-teaching-popover/library/project.json
+++ b/packages/react-components/react-teaching-popover/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-teaching-popover",
+  "name": "react-teaching-popover",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-teaching-popover/library/src",

--- a/packages/react-components/react-teaching-popover/stories/project.json
+++ b/packages/react-components/react-teaching-popover/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-teaching-popover-stories",
+  "name": "react-teaching-popover-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-teaching-popover/stories/src",

--- a/packages/react-components/react-text/library/project.json
+++ b/packages/react-components/react-text/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-text",
+  "name": "react-text",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-text/library/src",

--- a/packages/react-components/react-text/stories/project.json
+++ b/packages/react-components/react-text/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-text-stories",
+  "name": "react-text-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-text/stories/src",

--- a/packages/react-components/react-textarea/library/project.json
+++ b/packages/react-components/react-textarea/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-textarea",
+  "name": "react-textarea",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/react-components/react-textarea/stories/project.json
+++ b/packages/react-components/react-textarea/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-textarea-stories",
+  "name": "react-textarea-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/react-components/react-theme-sass/project.json
+++ b/packages/react-components/react-theme-sass/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-theme-sass",
+  "name": "react-theme-sass",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/react-components/react-theme/library/project.json
+++ b/packages/react-components/react-theme/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-theme",
+  "name": "react-theme",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-theme/library/src",

--- a/packages/react-components/react-theme/stories/project.json
+++ b/packages/react-components/react-theme/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-theme-stories",
+  "name": "react-theme-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-theme/stories/src",

--- a/packages/react-components/react-timepicker-compat/library/project.json
+++ b/packages/react-components/react-timepicker-compat/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-timepicker-compat",
+  "name": "react-timepicker-compat",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-timepicker-compat/library/src",

--- a/packages/react-components/react-timepicker-compat/stories/project.json
+++ b/packages/react-components/react-timepicker-compat/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-timepicker-compat-stories",
+  "name": "react-timepicker-compat-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-timepicker-compat/stories/src",

--- a/packages/react-components/react-toast/library/project.json
+++ b/packages/react-components/react-toast/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-toast",
+  "name": "react-toast",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/react-components/react-toast/stories/project.json
+++ b/packages/react-components/react-toast/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-toast-stories",
+  "name": "react-toast-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/react-components/react-toolbar/library/project.json
+++ b/packages/react-components/react-toolbar/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-toolbar",
+  "name": "react-toolbar",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-toolbar/library/src",

--- a/packages/react-components/react-toolbar/stories/project.json
+++ b/packages/react-components/react-toolbar/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-toolbar-stories",
+  "name": "react-toolbar-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-toolbar/stories/src",

--- a/packages/react-components/react-tooltip/library/project.json
+++ b/packages/react-components/react-tooltip/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-tooltip",
+  "name": "react-tooltip",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-tooltip/library/src",

--- a/packages/react-components/react-tooltip/stories/project.json
+++ b/packages/react-components/react-tooltip/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-tooltip-stories",
+  "name": "react-tooltip-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-tooltip/stories/src",

--- a/packages/react-components/react-tree/library/project.json
+++ b/packages/react-components/react-tree/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-tree",
+  "name": "react-tree",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-tree/library/src",

--- a/packages/react-components/react-tree/stories/project.json
+++ b/packages/react-components/react-tree/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-tree-stories",
+  "name": "react-tree-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-tree/stories/src",

--- a/packages/react-components/react-utilities-compat/library/project.json
+++ b/packages/react-components/react-utilities-compat/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-utilities-compat",
+  "name": "react-utilities-compat",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-utilities-compat/library/src",

--- a/packages/react-components/react-utilities-compat/stories/project.json
+++ b/packages/react-components/react-utilities-compat/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-utilities-compat-stories",
+  "name": "react-utilities-compat-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-utilities-compat/stories/src",

--- a/packages/react-components/react-utilities/project.json
+++ b/packages/react-components/react-utilities/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-utilities",
+  "name": "react-utilities",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-utilities/src",

--- a/packages/react-components/react-virtualizer/library/project.json
+++ b/packages/react-components/react-virtualizer/library/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-virtualizer",
+  "name": "react-virtualizer",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/react-components/react-virtualizer/stories/project.json
+++ b/packages/react-components/react-virtualizer/stories/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-virtualizer-stories",
+  "name": "react-virtualizer-stories",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/react-components/recipes/project.json
+++ b/packages/react-components/recipes/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/recipes",
+  "name": "recipes",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/recipes/src",

--- a/packages/react-components/theme-designer/project.json
+++ b/packages/react-components/theme-designer/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/theme-designer",
+  "name": "theme-designer",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/react-conformance/project.json
+++ b/packages/react-conformance/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-conformance",
+  "name": "react-conformance",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-conformance/src",

--- a/packages/react-date-time/project.json
+++ b/packages/react-date-time/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-date-time",
+  "name": "react-date-time",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/react-docsite-components/project.json
+++ b/packages/react-docsite-components/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-docsite-components",
+  "name": "react-docsite-components",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/react-examples/project.json
+++ b/packages/react-examples/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-examples",
+  "name": "react-examples",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/react-experiments/project.json
+++ b/packages/react-experiments/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-experiments",
+  "name": "react-experiments",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/react-file-type-icons/project.json
+++ b/packages/react-file-type-icons/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-file-type-icons",
+  "name": "react-file-type-icons",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/react-focus/project.json
+++ b/packages/react-focus/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-focus",
+  "name": "react-focus",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/react-hooks/project.json
+++ b/packages/react-hooks/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-hooks",
+  "name": "react-hooks",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/react-icon-provider/project.json
+++ b/packages/react-icon-provider/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-icon-provider",
+  "name": "react-icon-provider",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": []

--- a/packages/react-icons-mdl2-branded/project.json
+++ b/packages/react-icons-mdl2-branded/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-icons-mdl2-branded",
+  "name": "react-icons-mdl2-branded",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": []

--- a/packages/react-icons-mdl2/project.json
+++ b/packages/react-icons-mdl2/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-icons-mdl2",
+  "name": "react-icons-mdl2",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": []

--- a/packages/react-monaco-editor/project.json
+++ b/packages/react-monaco-editor/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-monaco-editor",
+  "name": "react-monaco-editor",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": []

--- a/packages/react-window-provider/project.json
+++ b/packages/react-window-provider/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react-window-provider",
+  "name": "react-window-provider",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": []

--- a/packages/react/project.json
+++ b/packages/react/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/react",
+  "name": "react",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/scheme-utilities/project.json
+++ b/packages/scheme-utilities/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/scheme-utilities",
+  "name": "scheme-utilities",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/set-version/project.json
+++ b/packages/set-version/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/set-version",
+  "name": "set-version",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/storybook/project.json
+++ b/packages/storybook/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/storybook",
+  "name": "storybook",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/style-utilities/project.json
+++ b/packages/style-utilities/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/style-utilities",
+  "name": "style-utilities",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/test-utilities/project.json
+++ b/packages/test-utilities/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/test-utilities",
+  "name": "test-utilities",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/theme-samples/project.json
+++ b/packages/theme-samples/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/theme-samples",
+  "name": "theme-samples",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/theme/project.json
+++ b/packages/theme/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/theme",
+  "name": "theme",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": []

--- a/packages/tokens/project.json
+++ b/packages/tokens/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/tokens",
+  "name": "tokens",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/utilities/project.json
+++ b/packages/utilities/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/utilities",
+  "name": "utilities",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/web-components/project.json
+++ b/packages/web-components/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/web-components",
+  "name": "web-components",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/packages/webpack-utilities/project.json
+++ b/packages/webpack-utilities/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/webpack-utilities",
+  "name": "webpack-utilities",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],

--- a/project.json
+++ b/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/fluentui-repo",
+  "name": "fluentui-repo",
   "$schema": "node_modules/nx/schemas/project-schema.json",
   "targets": {
     "prepare-local-registry": {

--- a/scripts/api-extractor/project.json
+++ b/scripts/api-extractor/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/scripts-api-extractor",
+  "name": "scripts-api-extractor",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/api-extractor",
   "projectType": "library",

--- a/scripts/babel/project.json
+++ b/scripts/babel/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/scripts-babel",
+  "name": "scripts-babel",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/babel/src",
   "projectType": "library",

--- a/scripts/beachball/project.json
+++ b/scripts/beachball/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/scripts-beachball",
+  "name": "scripts-beachball",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/beachball/src",
   "projectType": "library",

--- a/scripts/cypress/project.json
+++ b/scripts/cypress/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/scripts-cypress",
+  "name": "scripts-cypress",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/cypress/src",
   "projectType": "library",

--- a/scripts/dangerjs/project.json
+++ b/scripts/dangerjs/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/scripts-dangerjs",
+  "name": "scripts-dangerjs",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/dangerjs/src",
   "projectType": "library",

--- a/scripts/executors/project.json
+++ b/scripts/executors/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/scripts-executors",
+  "name": "scripts-executors",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/executors/src",
   "projectType": "library",

--- a/scripts/fluentui-publish/project.json
+++ b/scripts/fluentui-publish/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/scripts-fluentui-publish",
+  "name": "scripts-fluentui-publish",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/fluentui-publish/src",
   "projectType": "library",

--- a/scripts/fluentui-publish/src/utils.spec.ts
+++ b/scripts/fluentui-publish/src/utils.spec.ts
@@ -28,43 +28,43 @@ describe(`utils`, () => {
       const actual = getNorthstarGroup(graph);
 
       expect(Object.keys(actual.crossBoundaryProjects)).toMatchInlineSnapshot(`
-          Array [
-            "@fluentui/react-migration-v0-v9",
-          ]
-        `);
+        Array [
+          "react-migration-v0-v9",
+        ]
+      `);
       expect(Object.keys(actual.app)).toMatchInlineSnapshot(`
-          Array [
-            "@fluentui/perf-test-northstar",
-            "@fluentui/circulars-test",
-            "@fluentui/local-sandbox",
-            "@fluentui/projects-test",
-            "@fluentui/docs",
-            "@fluentui/perf",
-            "@fluentui/e2e",
-          ]
-        `);
+        Array [
+          "perf-test-northstar",
+          "circulars-test",
+          "local-sandbox",
+          "projects-test",
+          "docs",
+          "perf",
+          "e2e",
+        ]
+      `);
       expect(Object.keys(actual.lib)).toMatchInlineSnapshot(`
-          Array [
-            "@fluentui/react-component-nesting-registry",
-            "@fluentui/react-northstar-emotion-renderer",
-            "@fluentui/react-northstar-styles-renderer",
-            "@fluentui/react-component-event-listener",
-            "@fluentui/react-northstar-fela-renderer",
-            "@fluentui/react-northstar-prototypes",
-            "@fluentui/react-icons-northstar",
-            "@fluentui/react-component-ref",
-            "@fluentui/ability-attributes",
-            "@fluentui/docs-components",
-            "@fluentui/react-northstar",
-            "@fluentui/react-proptypes",
-            "@fluentui/react-telemetry",
-            "@fluentui/react-bindings",
-            "@fluentui/accessibility",
-            "@fluentui/react-builder",
-            "@fluentui/code-sandbox",
-            "@fluentui/digest",
-          ]
-        `);
+        Array [
+          "react-component-nesting-registry",
+          "react-northstar-emotion-renderer",
+          "react-northstar-styles-renderer",
+          "react-component-event-listener",
+          "react-northstar-fela-renderer",
+          "react-northstar-prototypes",
+          "react-icons-northstar",
+          "react-component-ref",
+          "ability-attributes",
+          "docs-components",
+          "react-northstar",
+          "react-proptypes",
+          "react-telemetry",
+          "react-bindings",
+          "accessibility",
+          "react-builder",
+          "code-sandbox",
+          "digest",
+        ]
+      `);
     });
   });
 });

--- a/scripts/fluentui-publish/src/version.spec.ts
+++ b/scripts/fluentui-publish/src/version.spec.ts
@@ -43,7 +43,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
         app: {},
         crossBoundaryProjects: {},
         lib: {
-          '@fluentui/react-northstar': { name: '', type: 'lib', data: { root: 'packages/fluentui/react-northstar' } },
+          'react-northstar': { name: '', type: 'lib', data: { root: 'packages/fluentui/react-northstar' } },
         },
       },
     });

--- a/scripts/fluentui-publish/src/version.ts
+++ b/scripts/fluentui-publish/src/version.ts
@@ -83,7 +83,7 @@ export async function changelog(
 [Compare changes](https://github.com/microsoft/fluentui/compare/@fluentui/react-northstar_v${previousReleasedVersion}..@fluentui/react-northstar_v${versionData.workspaceVersion})
   `;
 
-  const northstarLib = group.lib['@fluentui/react-northstar'];
+  const northstarLib = group.lib['react-northstar'];
   const changelogPath = joinPathFragments(northstarLib.data.root, '../CHANGELOG.md');
 
   if (!tree.exists(changelogPath)) {

--- a/scripts/fluentui-publish/src/version.ts
+++ b/scripts/fluentui-publish/src/version.ts
@@ -1,12 +1,31 @@
 /* eslint-disable @typescript-eslint/no-shadow */
-import { execSync } from "node:child_process";
+import { execSync } from 'node:child_process';
 
-import { tree } from "@fluentui/scripts-monorepo";
-import { ChangeType, NxJsonConfiguration, ProjectGraph, StringChange, Tree, applyChangesToString, joinPathFragments, output, readProjectsConfigurationFromProjectGraph, stripIndents, updateJson, workspaceRoot } from "@nx/devkit";
-import { releaseVersion } from "nx/release";
+import { tree } from '@fluentui/scripts-monorepo';
+import {
+  ChangeType,
+  NxJsonConfiguration,
+  ProjectGraph,
+  StringChange,
+  Tree,
+  applyChangesToString,
+  joinPathFragments,
+  output,
+  readProjectsConfigurationFromProjectGraph,
+  stripIndents,
+  updateJson,
+  workspaceRoot,
+} from '@nx/devkit';
+import { releaseVersion } from 'nx/release';
 
-
-import { NorthstarGroup, getGeneratorInformation, getLatestTag, getTagPattern,printAndFlushChanges,stageChanges } from "./utils";
+import {
+  NorthstarGroup,
+  getGeneratorInformation,
+  getLatestTag,
+  getTagPattern,
+  printAndFlushChanges,
+  stageChanges,
+} from './utils';
 
 type NxReleaseVersionResult = Awaited<ReturnType<typeof releaseVersion>>;
 type NxReleaseVersionArgs = Parameters<typeof releaseVersion>[0];
@@ -46,7 +65,6 @@ export async function version(config: {
 
   runChangeTask(args);
 }
-
 
 // ============
 
@@ -163,7 +181,6 @@ async function runWorkspaceGenerators(tree: Tree, graph: ProjectGraph, config: {
   await Promise.all(generatorPromises);
 }
 
-
 function runChangeTask(config: { dryRun: boolean }) {
   const { dryRun } = config;
   const message = dryRun
@@ -183,8 +200,9 @@ function runChangeTask(config: { dryRun: boolean }) {
 function assertSpecifier(specifier: string): asserts specifier is 'patch' | 'minor' {
   const allowedSpecifiers = ['patch', 'minor'];
 
-  if(!allowedSpecifiers.includes(specifier)){
-    throw new Error(`your provided specifier: "${specifier}" is not allowed. Please choose one of "${allowedSpecifiers}"`)
+  if (!allowedSpecifiers.includes(specifier)) {
+    throw new Error(
+      `your provided specifier: "${specifier}" is not allowed. Please choose one of "${allowedSpecifiers}"`,
+    );
   }
 }
-

--- a/scripts/generators/project.json
+++ b/scripts/generators/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/scripts-generators",
+  "name": "scripts-generators",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/generators/src",
   "projectType": "library",

--- a/scripts/generators/src/copy-notices.js
+++ b/scripts/generators/src/copy-notices.js
@@ -19,7 +19,7 @@ async function copyNotices() {
 
   console.log(`NOTICE.txt exists in ${noticeFilePath}`);
 
-  const dependencies = (await monorepo.getDependencies('@fluentui/react-components')).dependencies;
+  const dependencies = (await monorepo.getDependencies('react-components')).dependencies;
   const copyLocations = dependencies.map(dep =>
     path.resolve(monorepo.findGitRoot(), 'packages', dep.name.replace('@fluentui/', ''), 'NOTICE.txt'),
   );

--- a/scripts/github/project.json
+++ b/scripts/github/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/scripts-github",
+  "name": "scripts-github",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/github/src",
   "projectType": "library",

--- a/scripts/gulp/project.json
+++ b/scripts/gulp/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/scripts-gulp",
+  "name": "scripts-gulp",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/gulp/src",
   "projectType": "library",

--- a/scripts/gulp/src/config.ts
+++ b/scripts/gulp/src/config.ts
@@ -21,7 +21,8 @@ function getProjectsExceptV0() {
   for (const projectConfig of projectConfigs) {
     const tags = projectConfig.tags ?? [];
     if (!tags.includes('react-northstar')) {
-      projects.push(projectConfig.name!);
+      // projectConfig.name doesn't contain `@fluentui` scope, but alias key needs to map to real packageName
+      projects.push(`@fluentui/${projectConfig.name}`);
     }
   }
 

--- a/scripts/jest/project.json
+++ b/scripts/jest/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/scripts-jest",
+  "name": "scripts-jest",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/jest/src",
   "projectType": "library",

--- a/scripts/lint-staged/project.json
+++ b/scripts/lint-staged/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/scripts-lint-staged",
+  "name": "scripts-lint-staged",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/lint-staged/src",
   "projectType": "library",

--- a/scripts/monorepo/project.json
+++ b/scripts/monorepo/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/scripts-monorepo",
+  "name": "scripts-monorepo",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/monorepo/src",
   "projectType": "library",

--- a/scripts/monorepo/src/getAllPackageInfo.js
+++ b/scripts/monorepo/src/getAllPackageInfo.js
@@ -37,7 +37,11 @@ function getAllPackageInfo(predicate) {
       continue;
     }
 
-    packageInfo[projectName] = {
+    // NOTE: for compatibility reason we need to name the keys with monorepo scope otherwise there would be clashes with packages
+    // TODO: this whole implementation will be redone/unified once we start using dynamic nx dependency graph where non repo packages are prefixed with `npm:<package-name>`
+    const projectNameWithScope = `@fluentui/${projectName}`;
+
+    packageInfo[projectNameWithScope] = {
       packagePath: projectConfig.root,
       packageJson,
       projectConfig,

--- a/scripts/monorepo/src/getDependencies.spec.js
+++ b/scripts/monorepo/src/getDependencies.spec.js
@@ -15,32 +15,32 @@ describe(`#getDependencies`, () => {
         Object {
           "dependencyType": "dependencies",
           "isTopLevel": true,
-          "name": "@fluentui/react-shared-contexts",
+          "name": "react-shared-contexts",
         },
         Object {
           "dependencyType": "dependencies",
           "isTopLevel": true,
-          "name": "@fluentui/react-theme",
+          "name": "react-theme",
         },
         Object {
           "dependencyType": "dependencies",
           "isTopLevel": true,
-          "name": "@fluentui/react-utilities",
+          "name": "react-utilities",
         },
         Object {
           "dependencyType": "dependencies",
           "isTopLevel": true,
-          "name": "@fluentui/react-jsx-runtime",
+          "name": "react-jsx-runtime",
         },
         Object {
           "dependencyType": "dependencies",
           "isTopLevel": false,
-          "name": "@fluentui/tokens",
+          "name": "tokens",
         },
         Object {
           "dependencyType": "dependencies",
           "isTopLevel": false,
-          "name": "@fluentui/keyboard-keys",
+          "name": "keyboard-keys",
         },
       ]
     `);
@@ -50,47 +50,47 @@ describe(`#getDependencies`, () => {
         Object {
           "dependencyType": "devDependencies",
           "isTopLevel": true,
-          "name": "@fluentui/eslint-plugin",
+          "name": "eslint-plugin",
         },
         Object {
           "dependencyType": "devDependencies",
           "isTopLevel": true,
-          "name": "@fluentui/react-conformance",
+          "name": "react-conformance",
         },
         Object {
           "dependencyType": "devDependencies",
           "isTopLevel": true,
-          "name": "@fluentui/react-conformance-griffel",
+          "name": "react-conformance-griffel",
         },
         Object {
           "dependencyType": "devDependencies",
           "isTopLevel": true,
-          "name": "@fluentui/scripts-api-extractor",
+          "name": "scripts-api-extractor",
         },
         Object {
           "dependencyType": "devDependencies",
           "isTopLevel": true,
-          "name": "@fluentui/scripts-tasks",
+          "name": "scripts-tasks",
         },
         Object {
           "dependencyType": "devDependencies",
           "isTopLevel": false,
-          "name": "@fluentui/scripts-jest",
+          "name": "scripts-jest",
         },
         Object {
           "dependencyType": "dependencies",
           "isTopLevel": false,
-          "name": "@fluentui/scripts-monorepo",
+          "name": "scripts-monorepo",
         },
         Object {
           "dependencyType": "dependencies",
           "isTopLevel": false,
-          "name": "@fluentui/scripts-utils",
+          "name": "scripts-utils",
         },
         Object {
           "dependencyType": "dependencies",
           "isTopLevel": false,
-          "name": "@fluentui/scripts-prettier",
+          "name": "scripts-prettier",
         },
       ]
     `);
@@ -104,5 +104,11 @@ describe(`#getDependencies`, () => {
     expect(packageInfo?.dependencies).toEqual(expect.any(Object));
     expect(packageInfo?.main).toEqual('lib-commonjs/index.js');
     expect(packageInfo?.module).toEqual('lib/index.js');
+
+    const depResultWithoutProjectScope = await getDependencies('react-text');
+
+    expect(
+      depResultWithoutProjectScope.getProjectPackageJsonInfo('react-text', depResultWithoutProjectScope.projectGraph),
+    ).toEqual(packageInfo);
   });
 });

--- a/scripts/monorepo/src/workspace-utils.js
+++ b/scripts/monorepo/src/workspace-utils.js
@@ -19,7 +19,8 @@ function getWorkspaceProjectsAliases(options = {}) {
   const projects = getWorkspaceProjects();
 
   for (const projectName of excludeProjects) {
-    projects.delete(projectName);
+    // getWorkspaceProjects() returns names without `@fluentui` scope, for compatibility reasons we need to support both within `excludeProjects`
+    projects.delete(projectName.replace('@fluentui/', ''));
   }
 
   /**
@@ -28,7 +29,8 @@ function getWorkspaceProjectsAliases(options = {}) {
   const aliases = {};
 
   for (const [projectName, projectConfig] of projects) {
-    const key = getAliasKey[type](projectName);
+    // projectName doesn't contain `@fluentui` scope, but alias key needs to map to real packageName
+    const key = getAliasKey[type](`@fluentui/${projectName}`);
     const sourceRoot = projectConfig.sourceRoot ?? path.join(projectConfig.root, 'src');
     const entry = path.join(sourceRoot, 'index');
     aliases[key] = path.join(workspaceRoot, entry);

--- a/scripts/monorepo/src/workspace-utils.spec.ts
+++ b/scripts/monorepo/src/workspace-utils.spec.ts
@@ -6,14 +6,14 @@ describe(`workspace-utils`, () => {
   describe(`#getWorkspaceProjects`, () => {
     it(`should return Map of all workspace valid/registered projects`, () => {
       const actual = getWorkspaceProjects();
-      expect(actual.has('@fluentui/noop')).toEqual(false);
+      expect(actual.has('noop')).toEqual(false);
 
-      expect(actual.has('@fluentui/react-text')).toBe(true);
-      expect(actual.get('@fluentui/react-text')).toEqual(
+      expect(actual.has('react-text')).toBe(true);
+      expect(actual.get('react-text')).toEqual(
         expect.objectContaining({
           $schema: expect.any(String),
           implicitDependencies: expect.any(Array),
-          name: '@fluentui/react-text',
+          name: 'react-text',
           projectType: 'library',
           root: expect.any(String),
           sourceRoot: expect.any(String),
@@ -38,7 +38,11 @@ describe(`workspace-utils`, () => {
     });
 
     it(`should exclude specified projects`, () => {
-      const actual = getWorkspaceProjectsAliases({ excludeProjects: ['@fluentui/react-components'] });
+      let actual = getWorkspaceProjectsAliases({ excludeProjects: ['react-components'] });
+
+      expect(actual['@fluentui/react-components']).toEqual(undefined);
+
+      actual = getWorkspaceProjectsAliases({ excludeProjects: ['@fluentui/react-components'] });
 
       expect(actual['@fluentui/react-components']).toEqual(undefined);
     });

--- a/scripts/package-manager/project.json
+++ b/scripts/package-manager/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/scripts-package-manager",
+  "name": "scripts-package-manager",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/package-manager/src",
   "projectType": "library",

--- a/scripts/perf-test-flamegrill/project.json
+++ b/scripts/perf-test-flamegrill/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/scripts-perf-test-flamegrill",
+  "name": "scripts-perf-test-flamegrill",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/perf-test-flamegrill/src",
   "projectType": "library",

--- a/scripts/prettier/project.json
+++ b/scripts/prettier/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/scripts-prettier",
+  "name": "scripts-prettier",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/prettier/src",
   "projectType": "library",

--- a/scripts/projects-test/project.json
+++ b/scripts/projects-test/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/scripts-projects-test",
+  "name": "scripts-projects-test",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/projects-test/src",
   "projectType": "library",

--- a/scripts/projects-test/src/packPackages.ts
+++ b/scripts/projects-test/src/packPackages.ts
@@ -6,7 +6,7 @@ import fs from 'fs-extra';
 
 import { createTempDir, shEcho } from './utils';
 
-type PackedPackages = Record<string, string>;
+type PackedPackages = Record</** npmPackageName (including scope) */ string, /** packed package path */ string>;
 
 /** Shared packed packages between tests since they're not modified by any test */
 let packedPackages: PackedPackages;
@@ -61,7 +61,7 @@ export async function packProjectPackages(logger: Function, project: string): Pr
       const entryPointPath = packageMain ? path.join(packagePath, packageMain) : '';
       if (!fs.existsSync(entryPointPath)) {
         throw new Error(
-          `Package ${packageName} does not appear to have been built yet.` +
+          `Package '${packageName}' does not appear to have been built yet.` +
             `Please ensure that package:"${project}" has properly defined dependencies in its package.json`,
         );
       }
@@ -70,8 +70,12 @@ export async function packProjectPackages(logger: Function, project: string): Pr
       // files to include/exclude are specified by .npmignore rather than package.json `files`.
       // (--quiet outputs only the .tgz filename, not all the included files)
       const packFile = (await sh(`npm pack --quiet ${packagePath}`, tmpDirectory, true /*pipeOutputToResult*/)).trim();
-      packedPackages[packageName] = path.join(tmpDirectory, packFile);
-      console.log('Wrote tarball to', packedPackages[packageName]);
+      const packedPackagePath = path.join(tmpDirectory, packFile);
+
+      // need to normalize to include npm Scope for other apis
+      packedPackages[`@fluentui/${packageName}`] = packedPackagePath;
+
+      console.log('Wrote tarball to', packagePath);
     }),
   );
 

--- a/scripts/projects-test/src/packPackages.ts
+++ b/scripts/projects-test/src/packPackages.ts
@@ -35,7 +35,7 @@ export async function packProjectPackages(logger: Function, project: string): Pr
   const { dependencies: projectDependencies, projectGraph, getProjectPackageJsonInfo } = await getDependencies(project);
   // add provided package to be packaged
   projectDependencies.unshift({
-    name: project,
+    name: project.replace('@fluentui/', ''),
     dependencyType: 'dependencies',
     isTopLevel: true,
   });

--- a/scripts/puppeteer/project.json
+++ b/scripts/puppeteer/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/scripts-puppeteer",
+  "name": "scripts-puppeteer",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/puppeteer/src",
   "projectType": "library",

--- a/scripts/storybook/project.json
+++ b/scripts/storybook/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/scripts-storybook",
+  "name": "scripts-storybook",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/storybook/src",
   "projectType": "library",

--- a/scripts/storybook/src/utils.js
+++ b/scripts/storybook/src/utils.js
@@ -27,12 +27,18 @@ const loadWorkspaceAddonDefaultOptions = { workspaceRoot };
  * @param {string} addonName - package name of custom workspace addon
  * @param {Object} options
  * @param {string=} options.workspaceRoot
+ * @param {string=} options.npmScope
  * @param {string} options.tsConfigPath - absolute path to tsConfig that contains path aliases
  * @param {AddonConfiguration=} options.options - addon preset configuration
  */
 function loadWorkspaceAddon(addonName, options) {
   /* eslint-disable no-shadow */
-  const { workspaceRoot, tsConfigPath, options: addonConfig } = { ...loadWorkspaceAddonDefaultOptions, ...options };
+  const {
+    workspaceRoot,
+    npmScope,
+    tsConfigPath,
+    options: addonConfig,
+  } = { ...loadWorkspaceAddonDefaultOptions, ...options };
 
   const inMemoryTsTranspilationTemplate = stripIndents`
       function registerInMemoryTsTranspilation(){
@@ -45,7 +51,7 @@ function loadWorkspaceAddon(addonName, options) {
     `;
 
   function getPaths() {
-    const addonMetadata = getProjectMetadata(addonName, workspaceRoot);
+    const addonMetadata = getProjectMetadata(normalizeProjectName(addonName, npmScope), workspaceRoot);
     const packageRootPath = path.join(workspaceRoot, addonMetadata.root);
     const packageSourceRootPath = path.join(workspaceRoot, addonMetadata.sourceRoot ?? '');
     const packageJsonPath = path.join(packageRootPath, 'package.json');
@@ -216,9 +222,11 @@ function getImportMappingsForExportToSandboxAddon(allPackageInfo = getAllPackage
 function getPackageStoriesGlob(options) {
   const projects = getAllProjects();
 
-  const excludeStoriesInsertionFromPackages = options.excludeStoriesInsertionFromPackages ?? [];
+  const excludeStoriesInsertionFromPackages = (options.excludeStoriesInsertionFromPackages ?? []).map(packageName =>
+    normalizeProjectName(packageName),
+  );
   const projectMetadata = /** @type {NonNullable<ReturnType<typeof getMetadata>>} */ (
-    getMetadata(options.packageName, projects)
+    getMetadata(normalizeProjectName(options.packageName), projects)
   );
 
   /** @type {{name:string;version:string;dependencies?:Record<string,string>}} */
@@ -235,7 +243,7 @@ function getPackageStoriesGlob(options) {
       return acc;
     }
 
-    const pkgMetadata = getMetadata(pkgName, projects, { throwIfNotFound: false });
+    const pkgMetadata = getMetadata(normalizeProjectName(pkgName), projects, { throwIfNotFound: false });
 
     if (!pkgMetadata) {
       return acc;
@@ -420,6 +428,10 @@ function overrideDefaultBabelLoader(options) {
 function getProjectMetadata(projectName, root = workspaceRoot) {
   const tree = new FsTree(root, false);
   return readProjectConfiguration(tree, projectName);
+}
+
+function normalizeProjectName(/** @type {string} */ value, npmScope = 'fluentui') {
+  return value.replace(`@${npmScope}/`, '');
 }
 
 exports.getPackageStoriesGlob = getPackageStoriesGlob;

--- a/scripts/storybook/src/utils.spec.js
+++ b/scripts/storybook/src/utils.spec.js
@@ -23,7 +23,7 @@ describe(`utils`, () => {
      * @param {{packageName:string, presetContent?: string}} options
      */
     function setup(options) {
-      const npmScope = '@proj';
+      const npmScope = 'proj';
       const { name: rootDir } = tmp.dirSync({ prefix: 'sb-utils', unsafeCleanup: true });
       const packageRootPath = path.join('packages', options.packageName);
       const packageRootAbsolutePath = path.join(rootDir, packageRootPath);
@@ -42,7 +42,7 @@ describe(`utils`, () => {
         paths.projectJsonPath,
         JSON.stringify(
           {
-            name: `${npmScope}/${options.packageName}`,
+            name: options.packageName,
             root: packageRootPath,
             sourceRoot: path.join(packageRootPath, 'src'),
           },
@@ -53,7 +53,9 @@ describe(`utils`, () => {
       );
       fs.writeFileSync(
         paths.rootTsconfigPath,
-        JSON.stringify({ compilerOptions: { baseUrl: '.', paths: { '@proj/one': ['packages/one/src/index.ts'] } } }),
+        JSON.stringify({
+          compilerOptions: { baseUrl: '.', paths: { [`@${npmScope}/one`]: ['packages/one/src/index.ts'] } },
+        }),
       );
 
       fs.mkdirSync(packageRootAbsolutePath, { recursive: true });
@@ -96,8 +98,9 @@ describe(`utils`, () => {
     it(`should return path to in memory preset loader root`, () => {
       const { npmScope, workspaceRoot, tsConfigRoot } = setup({ packageName: 'storybook-custom-addon' });
 
-      const actual = loadWorkspaceAddon(`${npmScope}/storybook-custom-addon`, {
+      const actual = loadWorkspaceAddon(`@${npmScope}/storybook-custom-addon`, {
         workspaceRoot,
+        npmScope,
         tsConfigPath: tsConfigRoot,
       });
       const expected = `${workspaceRoot}/packages/storybook-custom-addon/temp/preset.ts`;
@@ -108,8 +111,9 @@ describe(`utils`, () => {
     it(`should return path to in memory preset loader root with options if provided `, () => {
       const { npmScope, workspaceRoot, tsConfigRoot } = setup({ packageName: 'storybook-custom-addon' });
 
-      const actual = loadWorkspaceAddon(`${npmScope}/storybook-custom-addon`, {
+      const actual = loadWorkspaceAddon(`@${npmScope}/storybook-custom-addon`, {
         workspaceRoot,
+        npmScope,
         tsConfigPath: tsConfigRoot,
         options: { who: 'developers' },
       });
@@ -124,7 +128,11 @@ describe(`utils`, () => {
     it(`should create mocked preset registration module with in memory TS compilation`, () => {
       const { tsConfigRoot, npmScope, packageRoot, workspaceRoot } = setup({ packageName: 'storybook-custom-addon' });
 
-      loadWorkspaceAddon(`${npmScope}/storybook-custom-addon`, { workspaceRoot, tsConfigPath: tsConfigRoot });
+      loadWorkspaceAddon(`@${npmScope}/storybook-custom-addon`, {
+        workspaceRoot,
+        npmScope,
+        tsConfigPath: tsConfigRoot,
+      });
 
       const mockedPreset = fs.readFileSync(path.join(packageRoot, 'temp', 'preset.ts'), 'utf-8');
 
@@ -169,7 +177,11 @@ describe(`utils`, () => {
       `,
       });
 
-      loadWorkspaceAddon(`${npmScope}/storybook-custom-addon`, { workspaceRoot, tsConfigPath: tsConfigRoot });
+      loadWorkspaceAddon(`@${npmScope}/storybook-custom-addon`, {
+        workspaceRoot,
+        npmScope,
+        tsConfigPath: tsConfigRoot,
+      });
 
       const mockedPreset = fs.readFileSync(path.join(packageRoot, 'temp', 'preset.ts'), 'utf-8');
 

--- a/scripts/tasks/project.json
+++ b/scripts/tasks/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/scripts-tasks",
+  "name": "scripts-tasks",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/tasks/src",
   "projectType": "library",

--- a/scripts/test-ssr/project.json
+++ b/scripts/test-ssr/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/scripts-test-ssr",
+  "name": "scripts-test-ssr",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/test-ssr/src",
   "projectType": "library",

--- a/scripts/triage-bot/project.json
+++ b/scripts/triage-bot/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/scripts-triage-bot",
+  "name": "scripts-triage-bot",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/triage-bot/src",
   "projectType": "library",

--- a/scripts/ts-node/project.json
+++ b/scripts/ts-node/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/scripts-ts-node",
+  "name": "scripts-ts-node",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/ts-node/src",
   "projectType": "library",

--- a/scripts/update-release-notes/project.json
+++ b/scripts/update-release-notes/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/scripts-update-release-notes",
+  "name": "scripts-update-release-notes",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/update-release-notes/src",
   "projectType": "library",

--- a/scripts/utils/project.json
+++ b/scripts/utils/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/scripts-utils",
+  "name": "scripts-utils",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/utils/src",
   "projectType": "library",

--- a/scripts/webpack/project.json
+++ b/scripts/webpack/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/scripts-webpack",
+  "name": "scripts-webpack",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/webpack/src",
   "projectType": "library",

--- a/tools/workspace-plugin/package.json
+++ b/tools/workspace-plugin/package.json
@@ -5,7 +5,7 @@
   "type": "commonjs",
   "generators": "./generators.json",
   "scripts": {
-    "test": "nx run @fluentui/workspace-plugin:test",
+    "test": "nx run workspace-plugin:test",
     "type-check": "node  ./scripts/type-check.mjs",
     "lint": "eslint --ext .ts,.js,.json ."
   },

--- a/tools/workspace-plugin/project.json
+++ b/tools/workspace-plugin/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/workspace-plugin",
+  "name": "workspace-plugin",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "tools/workspace-plugin/src",
   "projectType": "library",

--- a/tools/workspace-plugin/scripts/check-dep-graph.js
+++ b/tools/workspace-plugin/scripts/check-dep-graph.js
@@ -4,10 +4,14 @@ const fs = require('fs');
 const path = require('path');
 const { createProjectGraphAsync, stripIndents, logger } = require('@nx/devkit');
 
-main().catch(err => {
-  logger.error(err);
-  process.exit(1);
-});
+main()
+  .catch(err => {
+    logger.error(err);
+    process.exit(1);
+  })
+  .then(() => {
+    process.exit(0);
+  });
 
 /**
  * temporary integration check to mitigate AST parsing errors that cause invalid dependency tree creation
@@ -37,4 +41,6 @@ async function main() {
         ${toolsDeps.own.map(depName => `- ${depName}`).join('\n')}`,
     );
   }
+
+  console.log('✅ no workspace-plugin dependency graph issues found');
 }

--- a/tools/workspace-plugin/src/utils.ts
+++ b/tools/workspace-plugin/src/utils.ts
@@ -25,18 +25,26 @@ export function getWorkspaceConfig(tree: Tree): NxJsonConfiguration & { npmScope
     throw new Error('nx.json doesnt exist at root of monorepo');
   }
 
-  const packageJSON = readJson<PackageJson>(tree, '/package.json');
-  const matchedName = NPM_SCOPE_REGEX.exec(packageJSON.name);
-
-  if (!matchedName) {
-    throw new Error('root package.json doesnt provide valid monorepo name');
-  }
-
-  const [, npmScope] = matchedName;
+  const npmScope = getNpmScope(tree);
   return {
     npmScope,
     ...nxConfig,
   };
+}
+
+export function getNpmScope(tree: Tree) {
+  const packageJSON = readJson<PackageJson>(tree, '/package.json');
+  const matchedName = NPM_SCOPE_REGEX.exec(packageJSON.name);
+  if (!matchedName) {
+    throw new Error(`root package.json doesn't provide valid monorepo name`);
+  }
+  if (!matchedName[1]) {
+    throw new Error(
+      'unable to obtain monorepo npmScope. Please make sure that root package.json#name includes npmScope',
+    );
+  }
+
+  return matchedName[1];
 }
 
 export function getProjectNameWithoutScope(projectName: string) {

--- a/typings/project.json
+++ b/typings/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluentui/typings",
+  "name": "typings",
   "$schema": "../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "typings",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

All projects `project.json#name` have been changed to not use `npmScope` as part of their name, in order to to run all commands in more concise fashion.

**Before:**

`yarn nx run @fluentui/react-text:storybook`

**After:**

`yarn nx run react-text:storybook`

**Additional Changes:**

- lot of refactors needed across our tooling utils
- docs updates
- prettierignore pattern fix for `versions.ts`

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes partially #30267 
