### PR TITLE
fix(web-components): slotted elements within fluent-text-input can't be focused

### DIFF
--- a/change/@fluentui-web-components-8868e960-0d34-4f03-a229-48c64055ce4b.json
+++ b/change/@fluentui-web-components-8868e960-0d34-4f03-a229-48c64055ce4b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix text-input focus handling when focusable slotted start and end elements are present",
+  "packageName": "@fluentui/web-components",
+  "email": "863023+radium-v@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/text-input/text-input.spec.ts
+++ b/packages/web-components/src/text-input/text-input.spec.ts
@@ -799,4 +799,38 @@ test.describe('TextInput', () => {
 
     expect(page.url()).toMatch(/foo\?testinput=hello%40example\.com%2Cworld%40example\.com/);
   });
+
+  test('should allow focusable start and end slotted content to be focused', async ({ page }) => {
+    const element = page.locator('fluent-text-input');
+    const control = element.locator('input');
+    const start = element.locator('[slot="start"]');
+    const end = element.locator('[slot="end"]');
+    const label = element.locator('text=Label');
+
+    await page.setContent(/* html */ `
+      <fluent-text-input>
+        <span>Label</span>
+        <button slot="start">start</button>
+        <button slot="end">end</button>
+      </fluent-text-input>
+    `);
+
+    await page.keyboard.press('Tab');
+
+    await expect(start).toBeFocused();
+
+    await page.keyboard.press('Tab');
+
+    await expect(control).toBeFocused();
+
+    await page.keyboard.press('Tab');
+
+    await expect(end).toBeFocused();
+
+    await test.step('should focus the control when the label is clicked', async () => {
+      await label.click();
+
+      await expect(control).toBeFocused();
+    });
+  });
 });

--- a/packages/web-components/src/text-input/text-input.stories.ts
+++ b/packages/web-components/src/text-input/text-input.stories.ts
@@ -272,3 +272,11 @@ export const WithoutLabel: Story<FluentTextInput> = renderComponent(html<StoryAr
     <span slot="end">${Person20Regular}</span>
   </fluent-text-input>
 `);
+
+export const slottedEndButton: Story<FluentTextInput> = renderComponent(html<StoryArgs<FluentTextInput>>`
+  <fluent-text-input>
+    <fluent-button slot="start" size="small" appearance="subtle">Button</fluent-button>
+    <fluent-button slot="end" size="small" appearance="subtle">Button</fluent-button>
+    <fluent-label>Input with slotted end button</fluent-label>
+  </fluent-text-input>
+`);

--- a/packages/web-components/src/text-input/text-input.ts
+++ b/packages/web-components/src/text-input/text-input.ts
@@ -474,9 +474,11 @@ export class TextInput extends FASTElement {
    * @param e - the event object
    */
   public clickHandler(e: MouseEvent): boolean | void {
-    if (this.isSameNode(e.target as Node | null)) {
+    if (e.target === this) {
       this.control?.click();
     }
+
+    return true;
   }
 
   public connectedCallback(): void {
@@ -493,7 +495,11 @@ export class TextInput extends FASTElement {
    * @public
    */
   public focusinHandler(e: FocusEvent): boolean | void {
-    this.control?.focus();
+    if (e.target === this) {
+      this.control?.focus();
+    }
+
+    return true;
   }
 
   /**


### PR DESCRIPTION
## Previous Behavior

The `focusin` and `click` handlers don't allow events from slotted `start` and `end` elements to be handled.

## New Behavior

This PR updates `focusinHandler` and `clickHandler` methods to return `true` so FAST's event binding doesn't automatically prevent default. This should allow events from start/end slotted elements to be focusable and clickable.

## Related Issue(s)

- Fixes #31902 
