### PR TITLE
fix(ContextualMenu): item.onClick is called when SplitMenuItem checkmark is clicked

### DIFF
--- a/change/@fluentui-react-31dc521a-eeaf-47a8-b020-ffb9b3a9db8d.json
+++ b/change/@fluentui-react-31dc521a-eeaf-47a8-b020-ffb9b3a9db8d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: item.onClick is called when SplitMenuItem checkmark is clicked",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.test.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.test.tsx
@@ -570,6 +570,54 @@ describe('ContextualMenu', () => {
     expect(document.querySelector('.is-expanded')).toBeTruthy();
   });
 
+  it('toggles a split button', () => {
+    const onPrimaryClick = jest.fn();
+    const onItemClick = jest.fn();
+    const items: IContextualMenuItem[] = [
+      {
+        text: 'TestText 1',
+        key: 'TestKey1',
+        split: true,
+        canCheck: true,
+        onClick: onPrimaryClick,
+        subMenuProps: {
+          items: [
+            {
+              text: 'SubmenuText 1',
+              key: 'SubmenuKey1',
+              className: 'SubMenuClass',
+            },
+          ],
+        },
+      },
+    ];
+
+    ReactTestUtils.act(() => {
+      ReactTestUtils.renderIntoDocument<IContextualMenuProps>(
+        <ContextualMenu items={items} onItemClick={onItemClick} />,
+      );
+    });
+
+    const menuItem = document.getElementsByTagName('button')[0] as HTMLButtonElement;
+
+    ReactTestUtils.act(() => {
+      ReactTestUtils.Simulate.click(menuItem);
+    });
+
+    const checkIcon = document.querySelector('.ms-ContextualMenu-checkmarkIcon') as HTMLElement;
+
+    expect(checkIcon).toBeTruthy();
+    expect(onPrimaryClick).toHaveBeenCalled();
+    onPrimaryClick.mockClear();
+
+    ReactTestUtils.act(() => {
+      ReactTestUtils.Simulate.click(checkIcon);
+    });
+
+    expect(onPrimaryClick).toHaveBeenCalled();
+    expect(onItemClick).not.toHaveBeenCalled();
+  });
+
   it('can focus on disabled items', () => {
     const items: IContextualMenuItem[] = [
       {

--- a/packages/react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuSplitButton.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuSplitButton.tsx
@@ -183,6 +183,7 @@ export class ContextualMenuSplitButton extends ContextualMenuItemWrapper {
       checked: item.checked,
       iconProps: item.iconProps,
       id: this._dismissLabelId,
+      onClick: item.onClick,
       onRenderIcon: item.onRenderIcon,
       data: item.data,
       'data-is-focusable': false,


### PR DESCRIPTION
## Previous Behavior

Because `item.onClick` was not passed through to the item data on the split menu item's primary button, it was not called in `onCheckmarkClick`. This resulted in the default menu-level `onItemClick` was called, and dismissed the menu instead of toggling selection:

https://github.com/microsoft/fluentui/assets/3819570/73644f29-a3f3-455e-b76e-194b193e8561

## New Behavior

`onCheckmarkClick` calls `item.onClick` when available, still defaulting to `onItemClick` when not.

## Related Issue(s)

- Fixes #31817
