### PR TITLE
fix(web-components): fix for setTheme in Firefox

### DIFF
--- a/change/@fluentui-web-components-5704d052-a860-40bb-b956-9b445a49e171.json
+++ b/change/@fluentui-web-components-5704d052-a860-40bb-b956-9b445a49e171.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix for setTheme in Firefox",
+  "packageName": "@fluentui/web-components",
+  "email": "rupertdavid@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/theme/set-theme.ts
+++ b/packages/web-components/src/theme/set-theme.ts
@@ -42,13 +42,12 @@ export const setTheme = (theme: Theme) => {
     themeStyleTextMap.set(theme, `html{${tokenDeclarations.join('')}}`);
   }
 
+  // Update the CSSStyleSheet with the new theme
+  themeStyleSheet.replaceSync(themeStyleTextMap.get(theme)!);
+
+  // Adopt the updated CSSStyleSheet if it hasn't been adopted yet
   if (!document.adoptedStyleSheets.includes(themeStyleSheet)) {
     document.adoptedStyleSheets.push(themeStyleSheet);
-  } else {
-    // The very first call to `setTheme()` within a document doesn’t need to
-    // call `replaceSync()`, because `CSS.registerProperty()` above is
-    // sufficient to set the tokens.
-    themeStyleSheet.replaceSync(themeStyleTextMap.get(theme)!);
   }
 };
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

The default theme was not being set in Firefox. Firefox currently `SUPPORTS_ADOPTED_STYLESHEETS` but does not `SUPPORTS_REGISTER_PROPERTY`. The CSSStylesheet being adopted on the first pass was an empty stylesheet. And because there were no tokens registered, styles weren't applied.

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

This change will always update the stylesheet to the new theme and then adopt the stylesheet if it hasn't been adopted already.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
