### PR TITLE
chore: update CODEOWNERS on react-tabs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -263,8 +263,8 @@ packages/react-components/react-switch @microsoft/cxe-red @behowell @khmakoto
 packages/react-components/react-switch/library @microsoft/cxe-red @behowell @khmakoto
 packages/react-components/react-switch/stories @microsoft/cxe-red @behowell @khmakoto
 packages/react-components/react-tabs @microsoft/cxe-red @geoffcoxmsft
-packages/react-components/react-tabs/library @microsoft/teams-prg @geoffcoxmsft
-packages/react-components/react-tabs/stories @microsoft/teams-prg @geoffcoxmsft
+packages/react-components/react-tabs/library @microsoft/cxe-red @geoffcoxmsft
+packages/react-components/react-tabs/stories @microsoft/cxe-red @geoffcoxmsft
 packages/react-components/react-text @microsoft/cxe-prg @marcosmoura
 packages/react-components/react-text/library @microsoft/cxe-prg @marcosmoura
 packages/react-components/react-text/stories @microsoft/cxe-prg @marcosmoura


### PR DESCRIPTION
## New Behavior

Updates CODEOWNERS on `react-tabs`, #31581 added `teams-prg` by a mistake.

/cc @Hotell 