### PR TITLE
feat: convert menu list and items to use element internals

### DIFF
--- a/change/@fluentui-web-components-5a2991af-51c1-4e3b-b0f8-5d19cbaa2a13.json
+++ b/change/@fluentui-web-components-5a2991af-51c1-4e3b-b0f8-5d19cbaa2a13.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "convert menu list and menu item to use element internals",
+  "packageName": "@fluentui/web-components",
+  "email": "13071055+chrisdholt@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/docs/api-report.md
+++ b/packages/web-components/docs/api-report.md
@@ -600,11 +600,13 @@ export class Checkbox extends BaseCheckbox {
     indeterminate?: boolean;
     // @internal
     protected indeterminateChanged(prev: boolean | undefined, next: boolean | undefined): void;
-    // @override
+    // @internal @override
     protected setAriaChecked(value?: boolean): void;
     shape?: CheckboxShape;
+    // @internal
     protected shapeChanged(prev: CheckboxShape | undefined, next: CheckboxShape | undefined): void;
     size?: CheckboxSize;
+    // @internal
     protected sizeChanged(prev: CheckboxSize | undefined, next: CheckboxSize | undefined): void;
     toggleChecked(force?: boolean): void;
 }
@@ -2449,9 +2451,13 @@ export const MenuDefinition: FASTElementDefinition<typeof Menu>;
 // @public
 export class MenuItem extends FASTElement {
     checked: boolean;
+    protected checkedChanged(prev: boolean, next: boolean): void;
     // (undocumented)
-    protected checkedChanged(oldValue: boolean, newValue: boolean): void;
+    connectedCallback(): void;
     disabled: boolean;
+    disabledChanged(prev: boolean | undefined, next: boolean | undefined): void;
+    // @internal
+    elementInternals: ElementInternals;
     // @internal (undocumented)
     handleMenuItemClick: (e: MouseEvent) => boolean;
     // @internal (undocumented)
@@ -2462,6 +2468,7 @@ export class MenuItem extends FASTElement {
     handleMouseOver: (e: MouseEvent) => boolean;
     hidden: boolean;
     role: MenuItemRole;
+    roleChanged(prev: MenuItemRole | undefined, next: MenuItemRole | undefined): void;
     // @internal
     setSubmenuPosition: () => void;
     // @internal
@@ -2512,10 +2519,13 @@ export const MenuItemTemplate: ElementViewTemplate<MenuItem>;
 
 // @public
 export class MenuList extends FASTElement {
+    constructor();
     // @internal (undocumented)
     connectedCallback(): void;
     // @internal (undocumented)
     disconnectedCallback(): void;
+    // @internal
+    elementInternals: ElementInternals;
     focus(): void;
     handleChange(source: any, propertyName: string): void;
     // @internal

--- a/packages/web-components/src/menu-item/menu-item.styles.ts
+++ b/packages/web-components/src/menu-item/menu-item.styles.ts
@@ -2,7 +2,6 @@ import { css } from '@microsoft/fast-element';
 import { display, forcedColorsStylesheetBehavior } from '../utils/index.js';
 import {
   borderRadiusMedium,
-  colorCompoundBrandForeground1Hover,
   colorCompoundBrandForeground1Pressed,
   colorNeutralBackground1,
   colorNeutralBackground1Hover,
@@ -21,6 +20,13 @@ import {
   lineHeightBase200,
   lineHeightBase300,
 } from '../theme/design-tokens.js';
+import { checkedState, disabledState } from '../styles/states/index.js';
+
+/**
+ * Selector for the `submenu` state.
+ * @public
+ */
+export const submenuState = css.partial`:is([state--submenu], :state(submenu))`;
 
 /** MenuItem styles
  * @public
@@ -51,10 +57,6 @@ export const styles = css`
     color: ${colorNeutralForeground2Hover};
   }
 
-  :host([icon]:hover) ::slotted([slot='start']) {
-    color: ${colorCompoundBrandForeground1Hover};
-  }
-
   :host(:active) {
     background-color: ${colorNeutralBackground1Selected};
     color: ${colorNeutralForeground2Pressed};
@@ -64,13 +66,13 @@ export const styles = css`
     color: ${colorCompoundBrandForeground1Pressed};
   }
 
-  :host([disabled]) {
+  :host(${disabledState}) {
     background-color: ${colorNeutralBackgroundDisabled};
     color: ${colorNeutralForegroundDisabled};
   }
 
-  :host([disabled]) ::slotted([slot='start']),
-  :host([disabled]) ::slotted([slot='end']) {
+  :host(${disabledState}) ::slotted([slot='start']),
+  :host(${disabledState}) ::slotted([slot='end']) {
     color: ${colorNeutralForegroundDisabled};
   }
 
@@ -86,10 +88,10 @@ export const styles = css`
     padding: 0 2px;
   }
 
-  :host(:not([checked])) .indicator,
-  :host(:not([checked])) ::slotted([slot='indicator']),
-  :host(:not([aria-haspopup='menu'])) .submenu-glyph,
-  :host(:not([aria-haspopup='menu'])) ::slotted([slot='submenu-glyph']) {
+  :host(:not(${checkedState})) .indicator,
+  :host(:not(${checkedState})) ::slotted([slot='indicator']),
+  :host(:not(${submenuState})) .submenu-glyph,
+  :host(:not(${submenuState})) ::slotted([slot='submenu-glyph']) {
     display: none;
   }
 
@@ -108,11 +110,11 @@ export const styles = css`
     grid-template-columns: 20px 20px auto auto;
   }
 
-  :host([aria-haspopup='menu']) {
+  :host(${submenuState}) {
     grid-template-columns: 20px auto auto 20px;
   }
 
-  :host([data-indent='2'][aria-haspopup='menu']) {
+  :host([data-indent='2']${submenuState}) {
     grid-template-columns: 20px 20px auto auto 20px;
   }
 
@@ -169,9 +171,9 @@ export const styles = css`
   }
 `.withBehaviors(
   forcedColorsStylesheetBehavior(css`
-    :host([disabled]),
-    :host([disabled]) ::slotted([slot='start']),
-    :host([disabled]) ::slotted([slot='end']) {
+    :host(${disabledState}),
+    :host(${disabledState}) ::slotted([slot='start']),
+    :host(${disabledState}) ::slotted([slot='end']) {
       color: GrayText;
     }
   `),

--- a/packages/web-components/src/menu-item/menu-item.template.ts
+++ b/packages/web-components/src/menu-item/menu-item.template.ts
@@ -2,7 +2,6 @@ import type { ElementViewTemplate } from '@microsoft/fast-element';
 import { elements, html, slotted } from '@microsoft/fast-element';
 import { staticallyCompose } from '../utils/template-helpers.js';
 import { endSlotTemplate, startSlotTemplate } from '../patterns/index.js';
-import { MenuItemRole } from './menu-item.js';
 import type { MenuItem, MenuItemOptions } from './menu-item.js';
 
 const Checkmark16Filled = html.partial(
@@ -15,10 +14,6 @@ const chevronRight16Filled = html.partial(
 export function menuItemTemplate<T extends MenuItem>(options: MenuItemOptions = {}): ElementViewTemplate<T> {
   return html<T>`
     <template
-      aria-haspopup="${x => (!!x.submenu ? 'menu' : void 0)}"
-      aria-checked="${x => (x.role !== MenuItemRole.menuitem ? x.checked : void 0)}"
-      aria-disabled="${x => x.disabled}"
-      aria-expanded="${x => (!!x.submenu ? 'false' : void 0)}"
       @keydown="${(x, c) => x.handleMenuItemKeyDown(c.event as KeyboardEvent)}"
       @click="${(x, c) => x.handleMenuItemClick(c.event as MouseEvent)}"
       @mouseover="${(x, c) => x.handleMouseOver(c.event as MouseEvent)}"

--- a/packages/web-components/src/menu-item/menu-item.template.ts
+++ b/packages/web-components/src/menu-item/menu-item.template.ts
@@ -1,8 +1,8 @@
 import type { ElementViewTemplate } from '@microsoft/fast-element';
-import { elements, html, slotted } from '@microsoft/fast-element';
+import { html, slotted } from '@microsoft/fast-element';
 import { staticallyCompose } from '../utils/template-helpers.js';
 import { endSlotTemplate, startSlotTemplate } from '../patterns/index.js';
-import type { MenuItem, MenuItemOptions } from './menu-item.js';
+import { menuFilter, type MenuItem, type MenuItemOptions } from './menu-item.js';
 
 const Checkmark16Filled = html.partial(
   `<svg class="indicator" fill="currentColor" aria-hidden="true" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M14.05 3.49c.28.3.27.77-.04 1.06l-7.93 7.47A.85.85 0 014.9 12L2.22 9.28a.75.75 0 111.06-1.06l2.24 2.27 7.47-7.04a.75.75 0 011.06.04z" fill="currentColor"></path></svg>`,
@@ -27,7 +27,7 @@ export function menuItemTemplate<T extends MenuItem>(options: MenuItemOptions = 
       </div>
       ${endSlotTemplate(options)}
       <slot name="submenu-glyph"> ${staticallyCompose(options.submenuGlyph)} </slot>
-      <slot name="submenu" ${slotted({ property: 'slottedSubmenu', filter: elements("[role='menu']") })}></slot>
+      <slot name="submenu" ${slotted({ property: 'slottedSubmenu', filter: menuFilter() })}></slot>
     </template>
   `;
 }

--- a/packages/web-components/src/menu-item/menu-item.ts
+++ b/packages/web-components/src/menu-item/menu-item.ts
@@ -140,8 +140,6 @@ export class MenuItem extends FASTElement {
    */
   protected slottedSubmenuChanged(prev: HTMLElement[] | undefined, next: HTMLElement[]) {
     this.submenu?.removeEventListener('toggle', this.toggleHandler);
-    this.elementInternals.ariaHasPopup = null;
-    toggleState(this.elementInternals, 'submenu', false);
 
     if (next.length) {
       this.submenu = next[0];
@@ -149,6 +147,9 @@ export class MenuItem extends FASTElement {
       this.submenu.addEventListener('toggle', this.toggleHandler);
       this.elementInternals.ariaHasPopup = 'menu';
       toggleState(this.elementInternals, 'submenu', true);
+    } else {
+      this.elementInternals.ariaHasPopup = null;
+      toggleState(this.elementInternals, 'submenu', false);
     }
   }
 

--- a/packages/web-components/src/menu-item/menu-item.ts
+++ b/packages/web-components/src/menu-item/menu-item.ts
@@ -106,8 +106,9 @@ export class MenuItem extends FASTElement {
    * @param next - the next state
    */
   protected checkedChanged(prev: boolean, next: boolean): void {
-    this.elementInternals.ariaChecked = !!next ? `${next}` : null;
-    toggleState(this.elementInternals, 'checked', next);
+    const checkableMenuItem = this.role !== MenuItemRole.menuitem;
+    this.elementInternals.ariaChecked = checkableMenuItem ? `${!!next}` : null;
+    toggleState(this.elementInternals, 'checked', checkableMenuItem ? next : false);
 
     if (this.$fastController.isConnected) {
       this.$emit('change');
@@ -161,6 +162,7 @@ export class MenuItem extends FASTElement {
     super.connectedCallback();
 
     this.elementInternals.role = this.role ?? MenuItemRole.menuitem;
+    this.elementInternals.ariaChecked = this.role !== MenuItemRole.menuitem ? `${!!this.checked}` : null;
   }
 
   /**
@@ -190,6 +192,8 @@ export class MenuItem extends FASTElement {
         //close submenu
         if (this.parentElement?.hasAttribute('popover')) {
           this.parentElement.togglePopover(false);
+          // focus the menu item containing the submenu
+          this.parentElement.parentElement?.focus();
         }
 
         return false;

--- a/packages/web-components/src/menu-item/menu-item.ts
+++ b/packages/web-components/src/menu-item/menu-item.ts
@@ -1,6 +1,7 @@
 import { attr, FASTElement, observable } from '@microsoft/fast-element';
 import { keyArrowLeft, keyArrowRight, keyEnter, keySpace } from '@microsoft/fast-web-utilities';
 import type { StaticallyComposableHTML } from '../utils/template-helpers.js';
+import { toggleState } from '../utils/element-internals.js';
 import type { StartEndOptions } from '../patterns/start-end.js';
 import { StartEnd } from '../patterns/start-end.js';
 import { applyMixins } from '../utils/apply-mixins.js';
@@ -36,6 +37,13 @@ export type MenuItemOptions = StartEndOptions<MenuItem> & {
  */
 export class MenuItem extends FASTElement {
   /**
+   * The internal {@link https://developer.mozilla.org/docs/Web/API/ElementInternals | `ElementInternals`} instance for the component.
+   *
+   * @internal
+   */
+  public elementInternals: ElementInternals = this.attachInternals();
+
+  /**
    * The disabled state of the element.
    *
    * @public
@@ -44,6 +52,16 @@ export class MenuItem extends FASTElement {
    */
   @attr({ mode: 'boolean' })
   public disabled!: boolean;
+
+  /**
+   * Handles changes to disabled attribute custom states and element internals
+   * @param prev - the previous state
+   * @param next - the next state
+   */
+  public disabledChanged(prev: boolean | undefined, next: boolean | undefined) {
+    this.elementInternals.ariaDisabled = !!next ? `${next}` : null;
+    toggleState(this.elementInternals, 'disabled', next);
+  }
 
   /**
    * The role of the element.
@@ -56,6 +74,15 @@ export class MenuItem extends FASTElement {
   public role: MenuItemRole = MenuItemRole.menuitem;
 
   /**
+   * Handles changes to role attribute element internals properties
+   * @param prev - the previous state
+   * @param next - the next state
+   */
+  public roleChanged(prev: MenuItemRole | undefined, next: MenuItemRole | undefined) {
+    this.elementInternals.role = next ?? MenuItemRole.menuitem;
+  }
+
+  /**
    * The checked value of the element.
    *
    * @public
@@ -64,7 +91,16 @@ export class MenuItem extends FASTElement {
    */
   @attr({ mode: 'boolean' })
   public checked: boolean = false;
-  protected checkedChanged(oldValue: boolean, newValue: boolean): void {
+
+  /**
+   * Handles changes to checked attribute custom states and element internals
+   * @param prev - the previous state
+   * @param next - the next state
+   */
+  protected checkedChanged(prev: boolean, next: boolean): void {
+    this.elementInternals.ariaChecked = !!next ? `${next}` : null;
+    toggleState(this.elementInternals, 'checked', next);
+
     if (this.$fastController.isConnected) {
       this.$emit('change');
     }
@@ -95,11 +131,15 @@ export class MenuItem extends FASTElement {
    */
   protected slottedSubmenuChanged(prev: HTMLElement[] | undefined, next: HTMLElement[]) {
     this.submenu?.removeEventListener('toggle', this.toggleHandler);
+    this.elementInternals.ariaHasPopup = null;
+    toggleState(this.elementInternals, 'submenu', false);
 
     if (next.length) {
       this.submenu = next[0];
       this.submenu.toggleAttribute('popover', true);
       this.submenu.addEventListener('toggle', this.toggleHandler);
+      this.elementInternals.ariaHasPopup = 'menu';
+      toggleState(this.elementInternals, 'submenu', true);
     }
   }
 
@@ -108,6 +148,12 @@ export class MenuItem extends FASTElement {
    */
   @observable
   public submenu: HTMLElement | undefined;
+
+  public connectedCallback(): void {
+    super.connectedCallback();
+
+    this.elementInternals.role = this.role ?? MenuItemRole.menuitem;
+  }
 
   /**
    * @internal
@@ -188,11 +234,11 @@ export class MenuItem extends FASTElement {
   public toggleHandler = (e: ToggleEvent | Event): void => {
     if (e instanceof ToggleEvent && e.newState === 'open') {
       this.setAttribute('tabindex', '-1');
-      this.setAttribute('aria-expanded', 'true');
+      this.elementInternals.ariaExpanded = 'true';
       this.setSubmenuPosition();
     }
     if (e instanceof ToggleEvent && e.newState === 'closed') {
-      this.setAttribute('aria-expanded', 'false');
+      this.elementInternals.ariaExpanded = 'false';
       this.setAttribute('tabindex', '0');
     }
   };

--- a/packages/web-components/src/menu-item/menu-item.ts
+++ b/packages/web-components/src/menu-item/menu-item.ts
@@ -1,10 +1,11 @@
-import { attr, FASTElement, observable } from '@microsoft/fast-element';
+import { attr, ElementsFilter, FASTElement, observable } from '@microsoft/fast-element';
 import { keyArrowLeft, keyArrowRight, keyEnter, keySpace } from '@microsoft/fast-web-utilities';
 import type { StaticallyComposableHTML } from '../utils/template-helpers.js';
 import { toggleState } from '../utils/element-internals.js';
 import type { StartEndOptions } from '../patterns/start-end.js';
 import { StartEnd } from '../patterns/start-end.js';
 import { applyMixins } from '../utils/apply-mixins.js';
+import { MenuList } from '../menu-list/menu-list.js';
 import { MenuItemRole, roleForMenuItem } from './menu-item.options.js';
 
 export type MenuItemColumnCount = 0 | 1 | 2;
@@ -19,6 +20,13 @@ export type MenuItemOptions = StartEndOptions<MenuItem> & {
   indicator?: StaticallyComposableHTML<MenuItem>;
   submenuGlyph?: StaticallyComposableHTML<MenuItem>;
 };
+
+/**
+ * Creates a function that can be used to filter a Node array, selecting only elements with elementInternals role of "menu".
+ * @public
+ */
+export const menuFilter = (): ElementsFilter => value =>
+  value.nodeType === 1 && (value as MenuList).elementInternals.role === 'menu';
 
 /**
  * A Switch Custom HTML Element.

--- a/packages/web-components/src/menu-list/menu-list.spec.ts
+++ b/packages/web-components/src/menu-list/menu-list.spec.ts
@@ -34,7 +34,7 @@ test.describe('Menu', () => {
             `;
     });
 
-    await expect(element).toHaveAttribute('role', 'menu');
+    await expect(element).toHaveJSProperty('elementInternals.role', 'menu');
   });
 
   test('should set `tabindex` of the first focusable menu item to 0', async () => {
@@ -232,15 +232,15 @@ test.describe('Menu', () => {
     for (let i = 0; i < menuItemsCount; i++) {
       const item = menuItems.nth(i);
 
-      await expect(item).toHaveAttribute('aria-checked', 'false');
+      await expect(item).toHaveJSProperty('elementInternals.ariaChecked', 'false');
 
       await item.click();
 
-      await expect(item).toHaveAttribute('aria-checked', 'true');
+      await expect(item).toHaveJSProperty('elementInternals.ariaChecked', 'true');
 
       await item.click();
 
-      await expect(item).toHaveAttribute('aria-checked', 'false');
+      await expect(item).toHaveJSProperty('elementInternals.ariaChecked', 'false');
     }
   });
 
@@ -257,27 +257,27 @@ test.describe('Menu', () => {
 
     await menuItems.first().click();
 
-    await expect(menuItems.first()).toHaveAttribute('aria-checked', 'true');
+    await expect(menuItems.first()).toHaveJSProperty('elementInternals.ariaChecked', 'true');
 
-    await expect(menuItems.nth(1)).toHaveAttribute('aria-checked', 'false');
+    await expect(menuItems.nth(1)).toHaveJSProperty('elementInternals.ariaChecked', 'false');
 
-    await expect(menuItems.nth(2)).toHaveAttribute('aria-checked', 'false');
+    await expect(menuItems.nth(2)).toHaveJSProperty('elementInternals.ariaChecked', 'false');
 
     await menuItems.nth(1).click();
 
-    await expect(menuItems.first()).toHaveAttribute('aria-checked', 'false');
+    await expect(menuItems.first()).toHaveJSProperty('elementInternals.ariaChecked', 'false');
 
-    await expect(menuItems.nth(1)).toHaveAttribute('aria-checked', 'true');
+    await expect(menuItems.nth(1)).toHaveJSProperty('elementInternals.ariaChecked', 'true');
 
-    await expect(menuItems.nth(2)).toHaveAttribute('aria-checked', 'false');
+    await expect(menuItems.nth(2)).toHaveJSProperty('elementInternals.ariaChecked', 'false');
 
     await menuItems.nth(2).click();
 
-    await expect(menuItems.first()).toHaveAttribute('aria-checked', 'false');
+    await expect(menuItems.first()).toHaveJSProperty('elementInternals.ariaChecked', 'false');
 
-    await expect(menuItems.nth(1)).toHaveAttribute('aria-checked', 'false');
+    await expect(menuItems.nth(1)).toHaveJSProperty('elementInternals.ariaChecked', 'false');
 
-    await expect(menuItems.nth(2)).toHaveAttribute('aria-checked', 'true');
+    await expect(menuItems.nth(2)).toHaveJSProperty('elementInternals.ariaChecked', 'true');
   });
 
   test('should use elements with `[role="separator"]` to divide radio menu items into different radio groups', async () => {
@@ -295,31 +295,31 @@ test.describe('Menu', () => {
 
     await menuItems.nth(0).click();
 
-    await expect(menuItems.nth(0)).toHaveAttribute('aria-checked', 'true');
-    await expect(menuItems.nth(1)).toHaveAttribute('aria-checked', 'false');
-    await expect(menuItems.nth(2)).toHaveAttribute('aria-checked', 'false');
-    await expect(menuItems.nth(3)).toHaveAttribute('aria-checked', 'false');
+    await expect(menuItems.nth(0)).toHaveJSProperty('elementInternals.ariaChecked', 'true');
+    await expect(menuItems.nth(1)).toHaveJSProperty('elementInternals.ariaChecked', 'false');
+    await expect(menuItems.nth(2)).toHaveJSProperty('elementInternals.ariaChecked', 'false');
+    await expect(menuItems.nth(3)).toHaveJSProperty('elementInternals.ariaChecked', 'false');
 
     await menuItems.nth(1).click();
 
-    await expect(menuItems.nth(0)).toHaveAttribute('aria-checked', 'false');
-    await expect(menuItems.nth(1)).toHaveAttribute('aria-checked', 'true');
-    await expect(menuItems.nth(2)).toHaveAttribute('aria-checked', 'false');
-    await expect(menuItems.nth(3)).toHaveAttribute('aria-checked', 'false');
+    await expect(menuItems.nth(0)).toHaveJSProperty('elementInternals.ariaChecked', 'false');
+    await expect(menuItems.nth(1)).toHaveJSProperty('elementInternals.ariaChecked', 'true');
+    await expect(menuItems.nth(2)).toHaveJSProperty('elementInternals.ariaChecked', 'false');
+    await expect(menuItems.nth(3)).toHaveJSProperty('elementInternals.ariaChecked', 'false');
 
     await menuItems.nth(2).click();
 
-    await expect(menuItems.nth(0)).toHaveAttribute('aria-checked', 'false');
-    await expect(menuItems.nth(1)).toHaveAttribute('aria-checked', 'true');
-    await expect(menuItems.nth(2)).toHaveAttribute('aria-checked', 'true');
-    await expect(menuItems.nth(3)).toHaveAttribute('aria-checked', 'false');
+    await expect(menuItems.nth(0)).toHaveJSProperty('elementInternals.ariaChecked', 'false');
+    await expect(menuItems.nth(1)).toHaveJSProperty('elementInternals.ariaChecked', 'true');
+    await expect(menuItems.nth(2)).toHaveJSProperty('elementInternals.ariaChecked', 'true');
+    await expect(menuItems.nth(3)).toHaveJSProperty('elementInternals.ariaChecked', 'false');
 
     await menuItems.nth(3).click();
 
-    await expect(menuItems.nth(0)).toHaveAttribute('aria-checked', 'false');
-    await expect(menuItems.nth(1)).toHaveAttribute('aria-checked', 'true');
-    await expect(menuItems.nth(2)).toHaveAttribute('aria-checked', 'false');
-    await expect(menuItems.nth(3)).toHaveAttribute('aria-checked', 'true');
+    await expect(menuItems.nth(0)).toHaveJSProperty('elementInternals.ariaChecked', 'false');
+    await expect(menuItems.nth(1)).toHaveJSProperty('elementInternals.ariaChecked', 'true');
+    await expect(menuItems.nth(2)).toHaveJSProperty('elementInternals.ariaChecked', 'false');
+    await expect(menuItems.nth(3)).toHaveJSProperty('elementInternals.ariaChecked', 'true');
   });
 
   test('should navigate the menu on arrow up/down keys', async () => {

--- a/packages/web-components/src/menu-list/menu-list.spec.ts
+++ b/packages/web-components/src/menu-list/menu-list.spec.ts
@@ -130,7 +130,8 @@ test.describe('Menu', () => {
 
     const firstMenuItem = menuItems.first();
 
-    await expect(firstMenuItem).toBeDisabled();
+    await expect(firstMenuItem).toHaveAttribute('disabled');
+    await expect(firstMenuItem).toHaveJSProperty('elementInternals.ariaDisabled', 'true');
 
     await expect(firstMenuItem).toHaveAttribute('tabindex', '0');
 

--- a/packages/web-components/src/menu-list/menu-list.template.ts
+++ b/packages/web-components/src/menu-list/menu-list.template.ts
@@ -5,7 +5,6 @@ export function menuTemplate<T extends MenuList>(): ElementViewTemplate<T> {
   return html<T>`
     <template
       slot="${x => (x.slot ? x.slot : x.isNestedMenu() ? 'submenu' : void 0)}"
-      role="menu"
       @keydown="${(x, c) => x.handleMenuKeyDown(c.event as KeyboardEvent)}"
       @focusout="${(x, c) => x.handleFocusOut(c.event as FocusEvent)}"
     >

--- a/packages/web-components/src/menu-list/menu-list.ts
+++ b/packages/web-components/src/menu-list/menu-list.ts
@@ -118,7 +118,6 @@ export class MenuList extends FASTElement {
         // set focus on first item
         this.setFocus(0, 1);
         return;
-
       default:
         // if we are not handling the event, do not prevent default
         return true;

--- a/packages/web-components/src/menu-list/menu-list.ts
+++ b/packages/web-components/src/menu-list/menu-list.ts
@@ -14,6 +14,13 @@ import { MenuItemRole } from '../menu-item/menu-item.options.js';
  */
 export class MenuList extends FASTElement {
   /**
+   * The internal {@link https://developer.mozilla.org/docs/Web/API/ElementInternals | `ElementInternals`} instance for the component.
+   *
+   * @internal
+   */
+  public elementInternals: ElementInternals = this.attachInternals();
+
+  /**
    * @internal
    */
   @observable
@@ -36,6 +43,12 @@ export class MenuList extends FASTElement {
   private focusIndex: number = -1;
 
   private static focusableElementRoles = MenuItemRole;
+
+  constructor() {
+    super();
+
+    this.elementInternals.role = 'menu';
+  }
 
   /**
    * @internal

--- a/packages/web-components/src/menu/menu.ts
+++ b/packages/web-components/src/menu/menu.ts
@@ -48,7 +48,6 @@ export class Menu extends FASTElement {
    * Determines if the menu should open on hover.
    * @public
    */
-  @observable
   @attr({ attribute: 'open-on-hover', mode: 'boolean' })
   public openOnHover?: boolean = false;
 
@@ -56,7 +55,6 @@ export class Menu extends FASTElement {
    * Determines if the menu should open on right click.
    * @public
    */
-  @observable
   @attr({ attribute: 'open-on-context', mode: 'boolean' })
   public openOnContext?: boolean = false;
 
@@ -64,7 +62,6 @@ export class Menu extends FASTElement {
    * Determines if the menu should close on scroll.
    * @public
    */
-  @observable
   @attr({ attribute: 'close-on-scroll', mode: 'boolean' })
   public closeOnScroll?: boolean = false;
 
@@ -72,7 +69,6 @@ export class Menu extends FASTElement {
    * Determines if the menu open state should persis on click of menu item
    * @public
    */
-  @observable
   @attr({ attribute: 'persist-on-item-click', mode: 'boolean' })
   public persistOnItemClick?: boolean = false;
 


### PR DESCRIPTION
## Previous Behavior
ARIA was bound in the template and states were based on attributes

## New Behavior
Migrates to use Element Internals for custom states and ARIA

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
