### PR TITLE
fix(scripts-storybook): make getPackageStoriesGlob properly resolve stories paths based on new project.json#name pattern

### DIFF
--- a/scripts/storybook/src/utils.js
+++ b/scripts/storybook/src/utils.js
@@ -243,7 +243,9 @@ function getPackageStoriesGlob(options) {
       return acc;
     }
 
-    const pkgMetadata = getMetadata(normalizeProjectName(pkgName), projects, { throwIfNotFound: false });
+    const projectName = normalizeProjectName(pkgName);
+
+    const pkgMetadata = getMetadata(projectName, projects, { throwIfNotFound: false });
 
     if (!pkgMetadata) {
       return acc;
@@ -253,7 +255,7 @@ function getPackageStoriesGlob(options) {
 
     // if defined package(project) has stories sibling project, that means we need to look for stories in sibling project as the original project doesn't have stories anymore
     // @see https://github.com/microsoft/fluentui/issues/30516
-    const pkgMetadataStories = projects.get(`${pkgName}-stories`);
+    const pkgMetadataStories = projects.get(`${projectName}-stories`);
     if (pkgMetadataStories) {
       acc.push(`${rootOffset}${pkgMetadataStories.root}/src/${storiesGlob}`);
       return acc;

--- a/scripts/storybook/src/utils.spec.js
+++ b/scripts/storybook/src/utils.spec.js
@@ -248,10 +248,28 @@ describe(`utils`, () => {
       expect(actual).not.toContain(expect.stringContaining('/react-text/stories/'));
     });
 
-    // @TODO: Once we will have at least 1 project migrated to the new structure we can enable/implement this test
-    it.todo(
-      `should generate storybook stories string array of glob based on package.json#dependencies field pointing to sibling /stories project if it exists`,
-    );
+    it(`should generate storybook stories string array of glob based on package.json#dependencies field pointing to sibling /stories project if it exists`, () => {
+      const actual = getPackageStoriesGlob({
+        packageName: '@fluentui/react-menu',
+        callerPath: path.dirname(__dirname),
+      });
+
+      const expected = [
+        expect.stringContaining('../../packages/react-'),
+        expect.stringContaining('/**/@(index.stories.@(ts|tsx)|*.stories.mdx)'),
+      ];
+
+      expect(actual).toEqual(expect.arrayContaining(expected));
+
+      // package without any stories
+      expect(actual).toContain(
+        '../../packages/react-components/keyboard-keys/src/**/@(index.stories.@(ts|tsx)|*.stories.mdx)',
+      );
+      // package with stories ( `*-stories` project adjacent project )
+      expect(actual).toContain(
+        '../../packages/react-components/react-theme/stories/src/**/@(index.stories.@(ts|tsx)|*.stories.mdx)',
+      );
+    });
   });
 
   describe(`#processBabelLoaderOptions`, () => {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

> introduces https://github.com/microsoft/fluentui/pull/31893

sub-package stories are not rendered within public-docsite-v9 storybook

## New Behavior

sub-package stories are rendered within public-docsite-v9 storybook

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows https://github.com/microsoft/fluentui/pull/31937
