### PR TITLE
feat(motion): add createPresenceComponentVariant() factory

### DIFF
--- a/change/@fluentui-react-components-ff5aa06c-fdea-44ae-81a7-0fedc3f30a15.json
+++ b/change/@fluentui-react-components-ff5aa06c-fdea-44ae-81a7-0fedc3f30a15.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: add createPresenceComponentVariant()",
+  "packageName": "@fluentui/react-components",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-motion-58a20a26-2ffb-45e0-965d-0a344d604779.json
+++ b/change/@fluentui-react-motion-58a20a26-2ffb-45e0-965d-0a344d604779.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: add createPresenceComponentVariant()",
+  "packageName": "@fluentui/react-motion",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-components/etc/react-components.api.md
+++ b/packages/react-components/react-components/etc/react-components.api.md
@@ -198,6 +198,7 @@ import { createHighContrastTheme } from '@fluentui/react-theme';
 import { createLightTheme } from '@fluentui/react-theme';
 import { createMotionComponent } from '@fluentui/react-motion';
 import { createPresenceComponent } from '@fluentui/react-motion';
+import { createPresenceComponentVariant } from '@fluentui/react-motion';
 import { createTableColumn } from '@fluentui/react-table';
 import { CreateTableColumnOptions } from '@fluentui/react-table';
 import { createTeamsDarkTheme } from '@fluentui/react-theme';
@@ -2105,6 +2106,8 @@ export { createLightTheme }
 export { createMotionComponent }
 
 export { createPresenceComponent }
+
+export { createPresenceComponentVariant }
 
 export { createTableColumn }
 

--- a/packages/react-components/react-components/src/index.ts
+++ b/packages/react-components/react-components/src/index.ts
@@ -1869,7 +1869,13 @@ export type {
   EmptySwatchState,
 } from '@fluentui/react-swatch-picker';
 
-export { motionTokens, createMotionComponent, createPresenceComponent, PresenceGroup } from '@fluentui/react-motion';
+export {
+  motionTokens,
+  createMotionComponent,
+  createPresenceComponent,
+  createPresenceComponentVariant,
+  PresenceGroup,
+} from '@fluentui/react-motion';
 export type {
   AtomMotion,
   AtomMotionFn,

--- a/packages/react-components/react-motion/library/etc/react-motion.api.md
+++ b/packages/react-components/react-motion/library/etc/react-motion.api.md
@@ -20,7 +20,10 @@ export type AtomMotionFn<MotionParams extends Record<string, MotionParam> = {}> 
 export function createMotionComponent<MotionParams extends Record<string, MotionParam> = {}>(value: AtomMotion | AtomMotion[] | AtomMotionFn<MotionParams>): React_2.FC<MotionComponentProps & MotionParams>;
 
 // @public (undocumented)
-export function createPresenceComponent<MotionParams extends Record<string, MotionParam> = {}>(value: PresenceMotion | PresenceMotionFn<MotionParams>): React_2.FC<PresenceComponentProps & MotionParams>;
+export function createPresenceComponent<MotionParams extends Record<string, MotionParam> = {}>(value: PresenceMotion | PresenceMotionFn<MotionParams>): PresenceComponent<MotionParams>;
+
+// @public (undocumented)
+export function createPresenceComponentVariant<MotionParams extends Record<string, MotionParam> = {}>(component: PresenceComponent<MotionParams>, override: PresenceOverride): PresenceComponent<MotionParams>;
 
 // @public (undocumented)
 export const curves: {
@@ -81,6 +84,12 @@ export const motionTokens: {
     durationSlow: 300;
     durationSlower: 400;
     durationUltraSlow: 500;
+};
+
+// @public (undocumented)
+export type PresenceComponent<MotionParams extends Record<string, MotionParam> = {}> = {
+    (props: PresenceComponentProps & MotionParams): React_2.ReactElement | null;
+    [MOTION_DEFINITION]: PresenceMotionFn<MotionParams>;
 };
 
 // @public (undocumented)

--- a/packages/react-components/react-motion/library/src/factories/createPresenceComponent.ts
+++ b/packages/react-components/react-motion/library/src/factories/createPresenceComponent.ts
@@ -9,6 +9,11 @@ import { useIsReducedMotion } from '../hooks/useIsReducedMotion';
 import { getChildElement } from '../utils/getChildElement';
 import type { MotionParam, PresenceMotion, MotionImperativeRef, PresenceMotionFn, PresenceDirection } from '../types';
 
+/**
+ * @internal A private symbol to store the motion definition on the component for variants.
+ */
+export const MOTION_DEFINITION = Symbol('MOTION_DEFINITION');
+
 export type PresenceComponentProps = {
   /**
    * By default, the child component won't execute the "enter" motion when it initially mounts, regardless of the value
@@ -61,115 +66,126 @@ export type PresenceComponentProps = {
   unmountOnExit?: boolean;
 };
 
+export type PresenceComponent<MotionParams extends Record<string, MotionParam> = {}> = {
+  (props: PresenceComponentProps & MotionParams): React.ReactElement | null;
+  [MOTION_DEFINITION]: PresenceMotionFn<MotionParams>;
+};
+
 function shouldSkipAnimation(appear: boolean | undefined, isFirstMount: boolean, visible: boolean | undefined) {
   return !appear && isFirstMount && !!visible;
 }
 
 export function createPresenceComponent<MotionParams extends Record<string, MotionParam> = {}>(
   value: PresenceMotion | PresenceMotionFn<MotionParams>,
-) {
-  const Presence: React.FC<PresenceComponentProps & MotionParams> = props => {
-    'use no memo';
+): PresenceComponent<MotionParams> {
+  return Object.assign(
+    (props: PresenceComponentProps & MotionParams) => {
+      'use no memo';
 
-    const itemContext = React.useContext(PresenceGroupChildContext);
-    const merged = { ...itemContext, ...props };
+      const itemContext = React.useContext(PresenceGroupChildContext);
+      const merged = { ...itemContext, ...props };
 
-    const {
-      appear,
-      children,
-      imperativeRef,
-      onExit,
-      onMotionFinish,
-      onMotionStart,
-      onMotionCancel,
-      visible,
-      unmountOnExit,
-      ..._rest
-    } = merged;
-    const params = _rest as Exclude<typeof merged, PresenceComponentProps | typeof itemContext>;
+      const {
+        appear,
+        children,
+        imperativeRef,
+        onExit,
+        onMotionFinish,
+        onMotionStart,
+        onMotionCancel,
+        visible,
+        unmountOnExit,
+        ..._rest
+      } = merged;
+      const params = _rest as Exclude<typeof merged, PresenceComponentProps | typeof itemContext>;
 
-    const [mounted, setMounted] = useMountedState(visible, unmountOnExit);
-    const child = getChildElement(children);
+      const [mounted, setMounted] = useMountedState(visible, unmountOnExit);
+      const child = getChildElement(children);
 
-    const handleRef = useMotionImperativeRef(imperativeRef);
-    const elementRef = React.useRef<HTMLElement>();
-    const ref = useMergedRefs(elementRef, child.ref);
-    const optionsRef = React.useRef<{ appear?: boolean; params: MotionParams }>({ appear, params });
+      const handleRef = useMotionImperativeRef(imperativeRef);
+      const elementRef = React.useRef<HTMLElement>();
+      const ref = useMergedRefs(elementRef, child.ref);
+      const optionsRef = React.useRef<{ appear?: boolean; params: MotionParams }>({ appear, params });
 
-    const animateAtoms = useAnimateAtoms();
-    const isFirstMount = useFirstMount();
-    const isReducedMotion = useIsReducedMotion();
+      const animateAtoms = useAnimateAtoms();
+      const isFirstMount = useFirstMount();
+      const isReducedMotion = useIsReducedMotion();
 
-    const handleMotionStart = useEventCallback((direction: PresenceDirection) => {
-      onMotionStart?.(null, { direction });
-    });
-    const handleMotionFinish = useEventCallback((direction: PresenceDirection) => {
-      onMotionFinish?.(null, { direction });
+      const handleMotionStart = useEventCallback((direction: PresenceDirection) => {
+        onMotionStart?.(null, { direction });
+      });
+      const handleMotionFinish = useEventCallback((direction: PresenceDirection) => {
+        onMotionFinish?.(null, { direction });
 
-      if (direction === 'exit' && unmountOnExit) {
-        setMounted(false);
-        onExit?.();
+        if (direction === 'exit' && unmountOnExit) {
+          setMounted(false);
+          onExit?.();
+        }
+      });
+
+      const handleMotionCancel = useEventCallback((direction: PresenceDirection) => {
+        onMotionCancel?.(null, { direction });
+      });
+
+      useIsomorphicLayoutEffect(() => {
+        // Heads up!
+        // We store the params in a ref to avoid re-rendering the component when the params change.
+        optionsRef.current = { appear, params };
+      });
+
+      useIsomorphicLayoutEffect(
+        () => {
+          const element = elementRef.current;
+
+          if (!element || shouldSkipAnimation(optionsRef.current.appear, isFirstMount, visible)) {
+            return;
+          }
+
+          const presenceMotion =
+            typeof value === 'function' ? value({ element, ...optionsRef.current.params }) : (value as PresenceMotion);
+          const atoms = visible ? presenceMotion.enter : presenceMotion.exit;
+
+          const direction: PresenceDirection = visible ? 'enter' : 'exit';
+          const forceFinishMotion = !visible && isFirstMount;
+
+          if (!forceFinishMotion) {
+            handleMotionStart(direction);
+          }
+
+          const handle = animateAtoms(element, atoms, { isReducedMotion: isReducedMotion() });
+
+          if (forceFinishMotion) {
+            // Heads up!
+            // .finish() is used there to skip animation on first mount, but apply animation styles immediately
+            handle.finish();
+            return;
+          }
+
+          handleRef.current = handle;
+          handle.setMotionEndCallbacks(
+            () => handleMotionFinish(direction),
+            () => handleMotionCancel(direction),
+          );
+
+          return () => {
+            handle.cancel();
+          };
+        },
+        // Excluding `isFirstMount` from deps to prevent re-triggering the animation on subsequent renders
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [animateAtoms, handleRef, isReducedMotion, handleMotionFinish, handleMotionStart, handleMotionCancel, visible],
+      );
+
+      if (mounted) {
+        return React.cloneElement(child, { ref });
       }
-    });
 
-    const handleMotionCancel = useEventCallback((direction: PresenceDirection) => {
-      onMotionCancel?.(null, { direction });
-    });
-
-    useIsomorphicLayoutEffect(() => {
+      return null;
+    },
+    {
       // Heads up!
-      // We store the params in a ref to avoid re-rendering the component when the params change.
-      optionsRef.current = { appear, params };
-    });
-
-    useIsomorphicLayoutEffect(
-      () => {
-        const element = elementRef.current;
-
-        if (!element || shouldSkipAnimation(optionsRef.current.appear, isFirstMount, visible)) {
-          return;
-        }
-
-        const presenceMotion = typeof value === 'function' ? value({ element, ...optionsRef.current.params }) : value;
-        const atoms = visible ? presenceMotion.enter : presenceMotion.exit;
-
-        const direction: PresenceDirection = visible ? 'enter' : 'exit';
-        const forceFinishMotion = !visible && isFirstMount;
-
-        if (!forceFinishMotion) {
-          handleMotionStart(direction);
-        }
-
-        const handle = animateAtoms(element, atoms, { isReducedMotion: isReducedMotion() });
-
-        if (forceFinishMotion) {
-          // Heads up!
-          // .finish() is used there to skip animation on first mount, but apply animation styles immediately
-          handle.finish();
-          return;
-        }
-
-        handleRef.current = handle;
-        handle.setMotionEndCallbacks(
-          () => handleMotionFinish(direction),
-          () => handleMotionCancel(direction),
-        );
-
-        return () => {
-          handle.cancel();
-        };
-      },
-      // Excluding `isFirstMount` from deps to prevent re-triggering the animation on subsequent renders
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-      [animateAtoms, handleRef, isReducedMotion, handleMotionFinish, handleMotionStart, handleMotionCancel, visible],
-    );
-
-    if (mounted) {
-      return React.cloneElement(child, { ref });
-    }
-
-    return null;
-  };
-
-  return Presence;
+      // Always normalize it to a function to simplify types
+      [MOTION_DEFINITION]: typeof value === 'function' ? value : () => value,
+    },
+  );
 }

--- a/packages/react-components/react-motion/library/src/factories/createPresenceComponentVariant.test.tsx
+++ b/packages/react-components/react-motion/library/src/factories/createPresenceComponentVariant.test.tsx
@@ -1,0 +1,114 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+
+import type { PresenceMotionFn } from '../types';
+import { createPresenceComponent } from './createPresenceComponent';
+import { overridePresenceMotion, createPresenceComponentVariant } from './createPresenceComponentVariant';
+
+jest.mock('./createPresenceComponent', () => {
+  const module = jest.requireActual('./createPresenceComponent');
+
+  return {
+    ...module,
+    createPresenceComponent: jest.fn().mockImplementation(module.createPresenceComponent),
+  };
+});
+
+const PRESENCE_MOTION: PresenceMotionFn<{ direction: 'start' | 'end' }> = () => ({
+  enter: { keyframes: [], duration: 1000, easing: 'linear' },
+  exit: { keyframes: [], duration: 1000, easing: 'linear' },
+});
+const PRESENCE_COMPONENT = createPresenceComponent<{ direction: 'start' | 'end' }>(PRESENCE_MOTION);
+
+const MOTION_PARAMS = {
+  element: document.createElement('div'),
+  direction: 'start' as const,
+};
+
+describe('overridePresenceMotion', () => {
+  it('overrides "all"', () => {
+    expect(
+      overridePresenceMotion(PRESENCE_MOTION, { all: { duration: 500, easing: 'ease-in-out' } })(MOTION_PARAMS),
+    ).toEqual({
+      enter: {
+        duration: 500,
+        easing: 'ease-in-out',
+        keyframes: [],
+      },
+      exit: {
+        duration: 500,
+        easing: 'ease-in-out',
+        keyframes: [],
+      },
+    });
+  });
+
+  it('overrides "enter"', () => {
+    expect(
+      overridePresenceMotion(PRESENCE_MOTION, { enter: { duration: 500, easing: 'ease-in-out' } })(MOTION_PARAMS),
+    ).toEqual({
+      enter: {
+        duration: 500,
+        easing: 'ease-in-out',
+        keyframes: [],
+      },
+      exit: {
+        keyframes: [],
+        duration: 1000,
+        easing: 'linear',
+      },
+    });
+  });
+
+  it('overrides "exit"', () => {
+    expect(
+      overridePresenceMotion(PRESENCE_MOTION, { exit: { duration: 500, easing: 'ease-in-out' } })(MOTION_PARAMS),
+    ).toEqual({
+      enter: {
+        keyframes: [],
+        duration: 1000,
+        easing: 'linear',
+      },
+      exit: {
+        duration: 500,
+        easing: 'ease-in-out',
+        keyframes: [],
+      },
+    });
+  });
+});
+
+describe('createPresenceComponentVariant', () => {
+  it('appends override to the original motion', () => {
+    const PresenceVariant = createPresenceComponentVariant(PRESENCE_COMPONENT, {
+      all: { duration: 500, easing: 'ease-in-out' },
+    });
+    const overrideFn = (createPresenceComponent as jest.Mock).mock.calls[0][0];
+
+    const { getByText } = render(
+      <PresenceVariant direction="start" visible>
+        <div>Hello world!</div>
+      </PresenceVariant>,
+    );
+
+    expect(PresenceVariant).not.toBe(PRESENCE_COMPONENT);
+    expect(getByText('Hello world!')).toBeInTheDocument();
+
+    expect(createPresenceComponent).toHaveBeenCalledTimes(1);
+    expect(createPresenceComponent).toHaveBeenCalledWith(expect.any(Function));
+
+    expect(overrideFn).toBeInstanceOf(Function);
+    expect(overrideFn(MOTION_PARAMS)).toEqual({
+      enter: {
+        duration: 500,
+        easing: 'ease-in-out',
+        keyframes: [],
+      },
+      exit: {
+        duration: 500,
+        easing: 'ease-in-out',
+        keyframes: [],
+      },
+    });
+  });
+});

--- a/packages/react-components/react-motion/library/src/factories/createPresenceComponentVariant.ts
+++ b/packages/react-components/react-motion/library/src/factories/createPresenceComponentVariant.ts
@@ -1,0 +1,55 @@
+import type { MotionParam, PresenceDirection, PresenceMotionFn } from '../types';
+import { MOTION_DEFINITION, createPresenceComponent, PresenceComponent } from './createPresenceComponent';
+
+/**
+ * @internal
+ */
+type PresenceOverrideFields = {
+  duration: KeyframeEffectOptions['duration'];
+  easing: KeyframeEffectOptions['easing'];
+};
+
+/**
+ * @internal
+ *
+ * Override properties for presence transitions.
+ *
+ * @example <caption>Override duration for all transitions</caption>
+ * ```
+ * const override: PresenceOverride = {
+ *  all: { duration: 1000 },
+ * };
+ * ```
+ *
+ * @example <caption>Override easing for exit transition</caption>
+ * ```
+ * const override: PresenceOverride = {
+ *  exit: { easing: 'ease-out' },
+ * };
+ * ```
+ */
+type PresenceOverride = Partial<Record<PresenceDirection | 'all', Partial<PresenceOverrideFields>>>;
+
+/**
+ * @internal
+ */
+export function overridePresenceMotion<MotionParams extends Record<string, MotionParam> = {}>(
+  presenceMotion: PresenceMotionFn<MotionParams>,
+  override: PresenceOverride,
+): PresenceMotionFn<MotionParams> {
+  return (...args: Parameters<PresenceMotionFn<MotionParams>>) => {
+    const { enter, exit } = presenceMotion(...args);
+
+    return {
+      enter: { ...enter, ...override.all, ...override.enter },
+      exit: { ...exit, ...override.all, ...override.exit },
+    };
+  };
+}
+
+export function createPresenceComponentVariant<MotionParams extends Record<string, MotionParam> = {}>(
+  component: PresenceComponent<MotionParams>,
+  override: PresenceOverride,
+): PresenceComponent<MotionParams> {
+  return createPresenceComponent(overridePresenceMotion(component[MOTION_DEFINITION], override));
+}

--- a/packages/react-components/react-motion/library/src/index.ts
+++ b/packages/react-components/react-motion/library/src/index.ts
@@ -1,7 +1,12 @@
 export { motionTokens, durations, curves } from './motions/motionTokens';
 
 export { createMotionComponent, type MotionComponentProps } from './factories/createMotionComponent';
-export { createPresenceComponent, type PresenceComponentProps } from './factories/createPresenceComponent';
+export {
+  createPresenceComponent,
+  type PresenceComponentProps,
+  type PresenceComponent,
+} from './factories/createPresenceComponent';
+export { createPresenceComponentVariant } from './factories/createPresenceComponentVariant';
 
 export { PresenceGroup } from './components/PresenceGroup';
 


### PR DESCRIPTION
## New Behavior

PR adds `createPresenceComponentVariant()` that allows to customize `easing` & `duration` of a motion component created with `createPresenceComponent()`.

```ts
import { createPresenceComponentVariant } from '@fluentui/react-components';

const PresenceComponent = createPresenceComponent(/* --- */);
const PresenceVariant = createPresenceComponentVariant(PresenceComponent, {
  all: { duration: 500, easing: 'ease-in-out' },
});
```