### PR TITLE
ci(v0-release): use new service connection which uses compliant Workload Identity Federation

### DIFF
--- a/azure-pipelines.release-fluentui.yml
+++ b/azure-pipelines.release-fluentui.yml
@@ -161,7 +161,7 @@ extends:
               - task: AzureCLI@2
                 displayName: Upload to Azure
                 inputs:
-                  azureSubscription: 'Azure - fluentsite storage'
+                  azureSubscription: 'Azure - fluentsite storage - NEW'
                   scriptType: 'bash'
                   scriptLocation: 'inlineScript'
                   inlineScript: |


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->
- service connection is not compliant and disabled

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
- new [service connection](https://uifabric.visualstudio.com/UI%20Fabric/_settings/adminservices?resourceId=727b1090-e447-4540-9694-3d75b5a557a6) is created and is compliant

**NOTE**: the pipeline has not been tested yet and will be done so after this is merged. If things don't work as expected, work to remedy will be done in the background through Azure

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #31906
