### PR TITLE
bugfix(react-utilities): fix useMergedRefs signature to include null

### DIFF
--- a/change/@fluentui-react-utilities-eac70f99-2c2a-4360-930d-3c926b0b4755.json
+++ b/change/@fluentui-react-utilities-eac70f99-2c2a-4360-930d-3c926b0b4755.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: fix useMergedRefs signature to include null",
+  "packageName": "@fluentui/react-utilities",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-utilities/etc/react-utilities.api.md
+++ b/packages/react-components/react-utilities/etc/react-utilities.api.md
@@ -189,7 +189,7 @@ export interface PriorityQueue<T> {
 export type ReactTouchOrMouseEvent = React_2.MouseEvent | React_2.TouchEvent;
 
 // @public
-export type RefObjectFunction<T> = React_2.RefObject<T> & ((value: T) => void);
+export type RefObjectFunction<T> = React_2.RefObject<T> & ((value: T | null) => void);
 
 // @public
 export function resetIdsForTests(): void;

--- a/packages/react-components/react-utilities/src/hooks/useMergedRefs.test.tsx
+++ b/packages/react-components/react-utilities/src/hooks/useMergedRefs.test.tsx
@@ -66,4 +66,23 @@ describe('useMergedRefs', () => {
     expect(firstRefValue).toBe(true);
     expect(secondRefValue).toBe(true);
   });
+  describe('type tests', () => {
+    it('should be assignable to distributive types', () => {
+      const {
+        result: { current: mergedRef },
+      } = renderHook(() => useMergedRefs<1 | 2>());
+
+      const refO: React.RefObject<1> | React.RefObject<2> = mergedRef;
+      const refF: React.RefCallback<1> | React.RefCallback<2> = mergedRef;
+      refF;
+      refO;
+    });
+    `  `;
+    it('should accept null as a value', () => {
+      const {
+        result: { current: mergedRef },
+      } = renderHook(() => useMergedRefs<1 | 2>());
+      mergedRef(null);
+    });
+  });
 });

--- a/packages/react-components/react-utilities/src/hooks/useMergedRefs.ts
+++ b/packages/react-components/react-utilities/src/hooks/useMergedRefs.ts
@@ -4,7 +4,7 @@ import * as React from 'react';
  * A Ref function which can be treated like a ref object in that it has an attached
  * current property, which will be updated as the ref is evaluated.
  */
-export type RefObjectFunction<T> = React.RefObject<T> & ((value: T) => void);
+export type RefObjectFunction<T> = React.RefObject<T> & ((value: T | null) => void);
 
 /**
  * React hook to merge multiple React refs (either MutableRefObjects or ref callbacks) into a single ref callback that
@@ -16,22 +16,22 @@ export function useMergedRefs<T>(...refs: (React.Ref<T> | undefined)[]): RefObje
   'use no memo';
 
   const mergedCallback: RefObjectFunction<T> = React.useCallback(
-    (value: T) => {
+    (value: T | null) => {
       // Update the "current" prop hanging on the function.
-      (mergedCallback as unknown as React.MutableRefObject<T>).current = value;
+      (mergedCallback as React.MutableRefObject<T | null>).current = value;
 
       for (const ref of refs) {
         if (typeof ref === 'function') {
           ref(value);
         } else if (ref) {
           // work around the immutability of the React.Ref type
-          (ref as unknown as React.MutableRefObject<T>).current = value;
+          (ref as React.MutableRefObject<T | null>).current = value;
         }
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps -- already exhaustive
     [...refs],
-  ) as unknown as RefObjectFunction<T>;
+  ) as RefObjectFunction<T>;
 
   return mergedCallback;
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

`useMergedRefs` does not support `null` as a proper value for its callback, although it is a possible value to be provided to a reference in React.

This generates two problems:

1. you can't pass `null` directly to the callback https://github.com/microsoft/fluentui/pull/31951/files#diff-d524dc66988c13bc9d0c1a74557845b89dd19656e8e3e90f5292d2d446fe070aR81-R86
2. you can't use it to assign into an union due to conflict on types https://github.com/microsoft/fluentui/pull/31951/files#diff-d524dc66988c13bc9d0c1a74557845b89dd19656e8e3e90f5292d2d446fe070aR70-R79

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

1. Adds `null` as a possible value for the callback reference, equivalent to `React.RefCallback`
2. Adds tests to ensure both breaking cases are passing now

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
