### PR TITLE
fix(workspace-tools): make generators work with new project.json#name pattern which doesn't include npmScope

### DIFF
--- a/tools/workspace-plugin/src/generators/bundle-size-configuration/files/bundle-size/index.fixture.js.template
+++ b/tools/workspace-plugin/src/generators/bundle-size-configuration/files/bundle-size/index.fixture.js.template
@@ -1,7 +1,7 @@
-import * as p from '<%= packageName %>'
+import * as p from '<%= npmPackageName %>'
 
 console.log(p);
 
 export default {
-  name: '<%= packageName %> - package',
+  name: '<%= projectName %> - package',
 };

--- a/tools/workspace-plugin/src/generators/bundle-size-configuration/generator.spec.ts
+++ b/tools/workspace-plugin/src/generators/bundle-size-configuration/generator.spec.ts
@@ -14,7 +14,7 @@ import { BundleSizeConfigurationGeneratorSchema } from './schema';
 
 describe('bundle-size-configuration generator', () => {
   let tree: Tree;
-  const options: BundleSizeConfigurationGeneratorSchema = { name: '@proj/react-continental' };
+  const options: BundleSizeConfigurationGeneratorSchema = { name: 'react-continental' };
 
   beforeEach(async () => {
     tree = createTreeWithEmptyWorkspace();
@@ -38,7 +38,7 @@ describe('bundle-size-configuration generator', () => {
       console.log(p);
 
       export default {
-        name: '@proj/react-continental - package',
+        name: 'react-continental - package',
       };
       "
     `);
@@ -90,11 +90,12 @@ describe('bundle-size-configuration generator', () => {
 });
 
 function createLibrary(tree: Tree, name: string) {
-  const projectName = '@proj/' + name;
+  const projectName = name;
+  const npmProjectName = '@proj/' + projectName;
   const root = `packages/react-components/${name}`;
   addProjectConfiguration(tree, projectName, { root, tags: ['vNext'] });
   writeJson(tree, joinPathFragments(root, 'package.json'), {
-    name: projectName,
+    name: npmProjectName,
     version: '9.0.0',
     scripts: {},
   });

--- a/tools/workspace-plugin/src/generators/bundle-size-configuration/generator.ts
+++ b/tools/workspace-plugin/src/generators/bundle-size-configuration/generator.ts
@@ -13,6 +13,7 @@ import {
 import * as path from 'path';
 
 import { PackageJson } from '../../types';
+import { getNpmScope } from '../../utils';
 import { assertStoriesProject, isSplitProject } from '../split-library-in-two/shared';
 
 import { BundleSizeConfigurationGeneratorSchema } from './schema';
@@ -30,7 +31,8 @@ export async function bundleSizeConfigurationGenerator(tree: Tree, schema: Bundl
   };
 
   generateFiles(tree, path.join(__dirname, 'files'), project.root, {
-    packageName: options.name,
+    projectName: project.name,
+    npmPackageName: `@${options.npmScope}/${project.name}`,
     rootOffset: offsetFromRoot(project.root),
   });
 
@@ -61,6 +63,7 @@ export async function bundleSizeConfigurationGenerator(tree: Tree, schema: Bundl
 function normalizeOptions(tree: Tree, schema: BundleSizeConfigurationGeneratorSchema) {
   return {
     overrideBaseConfig: false,
+    npmScope: getNpmScope(tree),
     ...schema,
   };
 }

--- a/tools/workspace-plugin/src/generators/cypress-component-configuration/index.spec.ts
+++ b/tools/workspace-plugin/src/generators/cypress-component-configuration/index.spec.ts
@@ -18,7 +18,7 @@ describe(`cypress-component-configuration`, () => {
   });
 
   it(`should not create component testing for application`, async () => {
-    const project = '@proj/app-one';
+    const project = 'app-one';
     tree = setupDummyPackage(tree, { name: project, projectType: 'application' });
 
     await generator(tree, { project });
@@ -27,7 +27,7 @@ describe(`cypress-component-configuration`, () => {
   });
 
   it(`should setup cypress component testing for existing project`, async () => {
-    const project = '@proj/one';
+    const project = 'one';
     tree = setupDummyPackage(tree, { name: project });
 
     await generator(tree, { project });
@@ -97,7 +97,7 @@ function setupDummyPackage(tree: Tree, options: { name: string; projectType?: 'a
 
   const templates = {
     packageJson: {
-      name: pkgName,
+      name: '@proj/' + pkgName,
       version: '0.0.1',
       typings: 'lib/index.d.ts',
       main: 'lib-commonjs/index.js',

--- a/tools/workspace-plugin/src/generators/migrate-fixed-versions/README.md
+++ b/tools/workspace-plugin/src/generators/migrate-fixed-versions/README.md
@@ -32,10 +32,10 @@ yarn nx g @fluentui/workspace-plugin:migrate-fixed-versions --dry-run
 
 ### Examples
 
-Run migration on package named `@fluentui/example`
+Run migration on project named `example`
 
 ```sh
-yarn nx g @fluentui/workspace-plugin:migrate-fixed-versions --name='@fluentui/example'
+yarn nx g @fluentui/workspace-plugin:migrate-fixed-versions --name=example
 ```
 
 Run migration on all vNext web packages
@@ -50,7 +50,7 @@ yarn nx g @fluentui/workspace-plugin:migrate-fixed-versions --all
 
 Type: `string`
 
-Package/library name (needs to be full name of the package, scope included - e.g. `@fluentui/<package-name>`)
+Project name (without @npmScope prefix - e.g. `<project-name>`)
 
 > NOTE: will trigger CLI prompt if you didn't provide this option
 

--- a/tools/workspace-plugin/src/generators/migrate-fixed-versions/index.spec.ts
+++ b/tools/workspace-plugin/src/generators/migrate-fixed-versions/index.spec.ts
@@ -24,7 +24,7 @@ describe('migrate-fixed-versions generator', () => {
 
   it('should successfully migrate depedencies', async () => {
     tree = setupDummyPackage(tree, {
-      name: '@proj/react-button',
+      name: 'react-button',
       version: '9.0.0-alpha.0',
       dependencies: {
         '@proj/make-styles': '^9.0.0-alpha.1',
@@ -32,12 +32,12 @@ describe('migrate-fixed-versions generator', () => {
       projectConfiguration: { tags: ['vNext', 'platform:web'], sourceRoot: 'packages/react-button/src' },
     });
     tree = setupDummyPackage(tree, {
-      name: '@proj/make-styles',
+      name: 'make-styles',
       version: '9.0.0-alpha.0',
       projectConfiguration: { tags: ['vNext', 'platform:web'], sourceRoot: 'packages/make-styles/src' },
     });
 
-    await generator(tree, { name: '@proj/react-button' });
+    await generator(tree, { name: 'react-button' });
 
     const packageJson = readJson(tree, 'packages/react-button/package.json');
     expect(packageJson.dependencies).toMatchInlineSnapshot(`
@@ -49,7 +49,7 @@ describe('migrate-fixed-versions generator', () => {
 
   it('should successfully migrate dev depedencies', async () => {
     tree = setupDummyPackage(tree, {
-      name: '@proj/react-button',
+      name: 'react-button',
       version: '9.0.0-alpha.0',
       dependencies: {},
       devDependencies: {
@@ -58,12 +58,12 @@ describe('migrate-fixed-versions generator', () => {
       projectConfiguration: { tags: ['vNext', 'platform:web'], sourceRoot: 'packages/react-button/src' },
     });
     tree = setupDummyPackage(tree, {
-      name: '@proj/make-styles',
+      name: 'make-styles',
       version: '9.0.0-alpha.0',
       projectConfiguration: { tags: ['vNext', 'platform:web'], sourceRoot: 'packages/make-styles/src' },
     });
 
-    await generator(tree, { name: '@proj/react-button' });
+    await generator(tree, { name: 'react-button' });
 
     const packageJson = readJson(tree, 'packages/react-button/package.json');
     expect(packageJson.devDependencies).toMatchInlineSnapshot(`
@@ -75,14 +75,14 @@ describe('migrate-fixed-versions generator', () => {
 
   it('should not migrate third party dependencies', async () => {
     tree = setupDummyPackage(tree, {
-      name: '@proj/react-positioning',
+      name: 'react-positioning',
       version: '9.0.0-alpha.0',
       dependencies: {
         'popperjs/core': '^1.0.0',
       },
       projectConfiguration: { tags: ['vNext', 'platform:web'], sourceRoot: 'packages/react-positioning/src' },
     });
-    await generator(tree, { name: '@proj/react-positioning' });
+    await generator(tree, { name: 'react-positioning' });
 
     const packageJson = readJson(tree, 'packages/react-positioning/package.json');
     expect(packageJson.dependencies).toMatchInlineSnapshot(`
@@ -94,7 +94,7 @@ describe('migrate-fixed-versions generator', () => {
 
   it('should not migrate third party dev dependencies', async () => {
     tree = setupDummyPackage(tree, {
-      name: '@proj/react-positioning',
+      name: 'react-positioning',
       version: '9.0.0-alpha.0',
       dependencies: {},
       devDependencies: {
@@ -102,7 +102,7 @@ describe('migrate-fixed-versions generator', () => {
       },
       projectConfiguration: { tags: ['vNext', 'platform:web'], sourceRoot: 'packages/react-positioning/src' },
     });
-    await generator(tree, { name: '@proj/react-positioning' });
+    await generator(tree, { name: 'react-positioning' });
 
     const packageJson = readJson(tree, 'packages/react-positioning/package.json');
     expect(packageJson.devDependencies).toMatchInlineSnapshot(`
@@ -114,7 +114,7 @@ describe('migrate-fixed-versions generator', () => {
 
   it('should throw error when if package is not converged', async () => {
     tree = setupDummyPackage(tree, {
-      name: '@proj/babel-make-styles',
+      name: 'babel-make-styles',
       version: '8.0.0-alpha.0',
       dependencies: {
         '@proj/make-styles': '^9.0.0-alpha.1',
@@ -122,10 +122,10 @@ describe('migrate-fixed-versions generator', () => {
       projectConfiguration: { tags: ['vNext', 'platform:node'], sourceRoot: 'packages/babel-make-styles/src' },
     });
 
-    const result = generator(tree, { name: '@proj/babel-make-styles' });
+    const result = generator(tree, { name: 'babel-make-styles' });
 
     await expect(result).rejects.toMatchInlineSnapshot(`
-            [Error: @proj/babel-make-styles is not converged package consumed by customers.
+            [Error: babel-make-styles is not converged package consumed by customers.
                     Make sure to run the migration on packages with version 9.x.x and has tag]
           `);
   });
@@ -133,7 +133,7 @@ describe('migrate-fixed-versions generator', () => {
   describe('--all', () => {
     beforeEach(() => {
       tree = setupDummyPackage(tree, {
-        name: '@proj/react-button',
+        name: 'react-button',
         version: '9.0.0-alpha.0',
         dependencies: {
           '@proj/make-styles': '^9.0.0-alpha.1',
@@ -142,7 +142,7 @@ describe('migrate-fixed-versions generator', () => {
         projectConfiguration: { tags: ['vNext', 'platform:web'], sourceRoot: 'packages/react-button/src' },
       });
       tree = setupDummyPackage(tree, {
-        name: '@proj/make-styles',
+        name: 'make-styles',
         version: '9.0.0-alpha.0',
         dependencies: {
           '@proj/react-utilities': '^9.0.0-alpha.1',
@@ -150,12 +150,12 @@ describe('migrate-fixed-versions generator', () => {
         projectConfiguration: { tags: ['vNext', 'platform:web'], sourceRoot: 'packages/make-styles/src' },
       });
       tree = setupDummyPackage(tree, {
-        name: '@proj/react-utilities',
+        name: 'react-utilities',
         version: '9.0.0-alpha.0',
         projectConfiguration: { tags: ['vNext', 'platform:web'], sourceRoot: 'packages/react-utilities/src' },
       });
       tree = setupDummyPackage(tree, {
-        name: '@proj/babel-make-styles',
+        name: 'babel-make-styles',
         version: '1.0.0',
         dependencies: {
           '@proj/make-styles': '^9.0.0-alpha.1',
@@ -207,15 +207,15 @@ function setupDummyPackage(
   };
 
   const normalizedOptions = { ...defaults, ...options };
-  const pkgName = normalizedOptions.name || '';
-  const normalizedPkgName = pkgName.replace(`@${workspaceConfig.npmScope}/`, '');
+  const projectName = normalizedOptions.name || '';
+  const projectNpmName = `@${workspaceConfig.npmScope}/${projectName}`;
   const paths = {
-    root: `packages/${normalizedPkgName}`,
+    root: `packages/${projectName}`,
   };
 
   const templates = {
     packageJson: {
-      name: pkgName,
+      name: projectNpmName,
       version: normalizedOptions.version,
       dependencies: normalizedOptions.dependencies,
       devDependencies: normalizedOptions.devDependencies,
@@ -224,7 +224,7 @@ function setupDummyPackage(
 
   tree.write(`${paths.root}/package.json`, serializeJson(templates.packageJson));
 
-  addProjectConfiguration(tree, pkgName, {
+  addProjectConfiguration(tree, projectName, {
     root: paths.root,
     projectType: 'library',
     targets: {},

--- a/tools/workspace-plugin/src/generators/prepare-initial-release/index.spec.ts
+++ b/tools/workspace-plugin/src/generators/prepare-initial-release/index.spec.ts
@@ -73,10 +73,8 @@ describe('prepare-initial-release generator', () => {
         },
       });
 
-      await expect(
-        generator(tree, { project: '@proj/react-one-stable', phase: 'stable' }),
-      ).rejects.toMatchInlineSnapshot(
-        `[Error: @proj/react-one-stable is already prepared for stable release. Please trigger RELEASE pipeline.]`,
+      await expect(generator(tree, { project: 'react-one-stable', phase: 'stable' })).rejects.toMatchInlineSnapshot(
+        `[Error: react-one-stable is already prepared for stable release. Please trigger RELEASE pipeline.]`,
       );
 
       updateJson<PackageJson>(tree, 'packages/react-one-stable/package.json', json => {
@@ -84,9 +82,9 @@ describe('prepare-initial-release generator', () => {
         return json;
       });
 
-      await expect(
-        generator(tree, { project: '@proj/react-one-stable', phase: 'stable' }),
-      ).rejects.toMatchInlineSnapshot(`[Error: @proj/react-one-stable is already released as stable.]`);
+      await expect(generator(tree, { project: 'react-one-stable', phase: 'stable' })).rejects.toMatchInlineSnapshot(
+        `[Error: react-one-stable is already released as stable.]`,
+      );
     });
 
     it(`should throw error if executed with invalid 'phase' option`, async () => {
@@ -97,10 +95,8 @@ describe('prepare-initial-release generator', () => {
         },
       });
 
-      await expect(
-        generator(tree, { project: '@proj/react-one-preview', phase: 'compat' }),
-      ).rejects.toMatchInlineSnapshot(
-        `[Error: Invalid phase(compat) option provided. @proj/react-one-preview is a PREVIEW package thus phase needs to be one of 'preview'|'stable'.]`,
+      await expect(generator(tree, { project: 'react-one-preview', phase: 'compat' })).rejects.toMatchInlineSnapshot(
+        `[Error: Invalid phase(compat) option provided. react-one-preview is a PREVIEW package thus phase needs to be one of 'preview'|'stable'.]`,
       );
 
       createProject(tree, 'react-one-compat', {
@@ -111,15 +107,11 @@ describe('prepare-initial-release generator', () => {
         },
       });
 
-      await expect(
-        generator(tree, { project: '@proj/react-one-compat', phase: 'preview' }),
-      ).rejects.toMatchInlineSnapshot(
-        `[Error: Invalid phase(preview) option provided. @proj/react-one-compat is a COMPAT package thus phase needs to be 'compat'.]`,
+      await expect(generator(tree, { project: 'react-one-compat', phase: 'preview' })).rejects.toMatchInlineSnapshot(
+        `[Error: Invalid phase(preview) option provided. react-one-compat is a COMPAT package thus phase needs to be 'compat'.]`,
       );
-      await expect(
-        generator(tree, { project: '@proj/react-one-compat', phase: 'stable' }),
-      ).rejects.toMatchInlineSnapshot(
-        `[Error: Invalid phase(stable) option provided. @proj/react-one-compat is a COMPAT package thus phase needs to be 'compat'.]`,
+      await expect(generator(tree, { project: 'react-one-compat', phase: 'stable' })).rejects.toMatchInlineSnapshot(
+        `[Error: Invalid phase(stable) option provided. react-one-compat is a COMPAT package thus phase needs to be 'compat'.]`,
       );
     });
   });
@@ -143,7 +135,7 @@ describe('prepare-initial-release generator', () => {
           }),
         };
 
-        const sideEffects = await generator(tree, { project: '@proj/react-one-compat', phase: 'compat' });
+        const sideEffects = await generator(tree, { project: 'react-one-compat', phase: 'compat' });
 
         expect(utils.project.pkgJson()).toMatchInlineSnapshot(`
           Object {
@@ -197,7 +189,7 @@ describe('prepare-initial-release generator', () => {
           }),
         };
 
-        await generator(tree, { project: '@proj/react-one-compat', phase: 'compat' });
+        await generator(tree, { project: 'react-one-compat', phase: 'compat' });
 
         expect(utils.project.library.pkgJson()).toMatchInlineSnapshot(`
           Object {
@@ -239,7 +231,7 @@ describe('prepare-initial-release generator', () => {
           }),
         };
 
-        const sideEffects = await generator(tree, { project: '@proj/react-one-preview', phase: 'preview' });
+        const sideEffects = await generator(tree, { project: 'react-one-preview', phase: 'preview' });
 
         expect(utils.project.pkgJson()).toMatchInlineSnapshot(`
           Object {
@@ -293,7 +285,7 @@ describe('prepare-initial-release generator', () => {
           }),
         };
 
-        await generator(tree, { project: '@proj/react-one-preview', phase: 'preview' });
+        await generator(tree, { project: 'react-one-preview', phase: 'preview' });
 
         expect(utils.project.library.pkgJson()).toMatchInlineSnapshot(`
           Object {
@@ -318,7 +310,7 @@ describe('prepare-initial-release generator', () => {
     });
 
     describe(`stable`, () => {
-      const projectName = '@proj/react-one-preview';
+      const projectName = 'react-one-preview';
       type Utils = ReturnType<typeof createProject>;
       const utils = { project: {} as Utils, suite: {} as Utils, docsite: {} as Utils, vrTest: {} as Utils };
 
@@ -347,7 +339,7 @@ describe('prepare-initial-release generator', () => {
                 console.log(One);
 
                 export default {
-                   name: '@proj/react-one-preview - package',
+                   name: 'react-one-preview - package',
                 }
           `,
             },
@@ -385,7 +377,7 @@ describe('prepare-initial-release generator', () => {
             {
               filePath: 'apps/public-docsite-v9/src/example.stories.tsx',
               content: stripIndents`
-             import { One } from '${projectName}';
+             import { One } from '@proj/${projectName}';
              import * as suite from '@proj/react-components';
 
              export const Example = () => { return <suite.Root><One/></suite.Root>; }
@@ -400,7 +392,7 @@ describe('prepare-initial-release generator', () => {
             {
               filePath: 'apps/vr-tests-react-components/src/stories/One.stories.tsx',
               content: stripIndents`
-             import { One } from '${projectName}';
+             import { One } from '@proj/${projectName}';
              import * as suite from '@proj/react-components';
 
              export const VrTest = () => { return <suite.Root><One/></suite.Root>; }
@@ -421,7 +413,7 @@ describe('prepare-initial-release generator', () => {
         `);
         expect(utils.project.projectJson()).toEqual(
           expect.objectContaining({
-            name: '@proj/react-one',
+            name: 'react-one',
             sourceRoot: 'packages/react-one/src',
           }),
         );
@@ -433,7 +425,7 @@ describe('prepare-initial-release generator', () => {
           console.log(One);
 
           export default {
-          name: '@proj/react-one - package',
+          name: 'react-one - package',
           };",
           }
         `);
@@ -505,7 +497,7 @@ describe('prepare-initial-release generator', () => {
         // v9 vr-tests
         const vrTestDeps = utils.vrTest.pkgJson().dependencies ?? {};
         expect(vrTestDeps).toEqual(expect.objectContaining({ '@proj/react-one': '>=9.0.0-alpha' }));
-        expect(vrTestDeps[projectName]).toEqual(undefined);
+        expect(vrTestDeps[`@proj/${projectName}`]).toEqual(undefined);
         expect(tree.read('apps/vr-tests-react-components/src/stories/One.stories.tsx', 'utf-8')).toEqual(
           expect.stringContaining(stripIndents`
             import { One } from '@proj/react-one';
@@ -556,7 +548,7 @@ describe('prepare-initial-release generator', () => {
         `,
         );
 
-        expect(execCalls[2].cmd).toMatchInlineSnapshot(`"yarn lage generate-api --to @proj/react-components"`);
+        expect(execCalls[2].cmd).toMatchInlineSnapshot(`"yarn lage generate-api --to react-components"`);
         expect(execCalls[2].args).toMatchInlineSnapshot(
           { cwd: expect.any(String) },
           `
@@ -589,7 +581,7 @@ describe('prepare-initial-release generator', () => {
         await generator(tree, { project: projectName, phase: 'stable' });
 
         const dependencies = utils.pkgJson().dependencies ?? {};
-        expect(dependencies[projectName]).toEqual(undefined);
+        expect(dependencies[`@proj/${projectName}`]).toEqual(undefined);
         expect(dependencies).toEqual(
           expect.objectContaining({
             '@proj/react-components': '*',
@@ -605,7 +597,7 @@ describe('prepare-initial-release generator', () => {
     });
 
     describe(`stable - isSplit`, () => {
-      const projectName = '@proj/react-one-preview';
+      const projectName = 'react-one-preview';
 
       type Utils = ReturnType<typeof createProject>;
       const utils = {
@@ -632,7 +624,7 @@ describe('prepare-initial-release generator', () => {
                 console.log(One);
 
                 export default {
-                   name: '@proj/react-one-preview - package',
+                   name: 'react-one-preview - package',
                 }
           `,
               },
@@ -672,7 +664,7 @@ describe('prepare-initial-release generator', () => {
             {
               filePath: 'apps/public-docsite-v9/src/example.stories.tsx',
               content: stripIndents`
-             import { One } from '${projectName}';
+             import { One } from '@proj/${projectName}';
              import * as suite from '@proj/react-components';
 
              export const Example = () => { return <suite.Root><One/></suite.Root>; }
@@ -687,7 +679,7 @@ describe('prepare-initial-release generator', () => {
             {
               filePath: 'apps/vr-tests-react-components/src/stories/One.stories.tsx',
               content: stripIndents`
-             import { One } from '${projectName}';
+             import { One } from '@proj/${projectName}';
              import * as suite from '@proj/react-components';
 
              export const VrTest = () => { return <suite.Root><One/></suite.Root>; }
@@ -718,13 +710,13 @@ describe('prepare-initial-release generator', () => {
 
         expect(utils.project.library.projectJson()).toEqual(
           expect.objectContaining({
-            name: '@proj/react-one',
+            name: 'react-one',
             sourceRoot: 'packages/react-one/library/src',
           }),
         );
         expect(utils.project.stories.projectJson()).toEqual(
           expect.objectContaining({
-            name: '@proj/react-one-stories',
+            name: 'react-one-stories',
             sourceRoot: 'packages/react-one/stories/src',
           }),
         );
@@ -736,7 +728,7 @@ describe('prepare-initial-release generator', () => {
           console.log(One);
 
           export default {
-          name: '@proj/react-one - package',
+          name: 'react-one - package',
           };",
           }
         `);
@@ -750,7 +742,7 @@ describe('prepare-initial-release generator', () => {
           "
         `);
         expect(utils.project.stories.md.readme()).toMatchInlineSnapshot(`
-          "# @fluentui/react-one-stories
+          "# @proj/react-one-stories
 
           Storybook stories for packages/react-components/react-one-stories
 
@@ -845,7 +837,7 @@ function createSplitProject(
       {
         filePath: joinPathFragments(storiesProject.root, 'README.md'),
         content: stripIndents`
-        # @fluentui/${storiesProjectName}
+        # @proj/${storiesProjectName}
 
         Storybook stories for packages/react-components/${storiesProjectName}
 
@@ -896,7 +888,11 @@ function createProject(
     name: npmName,
   });
 
-  addProjectConfiguration(tree, npmName, { root: options.root, sourceRoot, tags: ['vNext', ...(options.tags ?? [])] });
+  addProjectConfiguration(tree, projectName, {
+    root: options.root,
+    sourceRoot,
+    tags: ['vNext', ...(options.tags ?? [])],
+  });
 
   tree.write(
     indexFile,
@@ -947,13 +943,13 @@ These are not production-ready components and **should never be used in product*
 
   const depKeys = [...Object.keys(options.pkgJson.dependencies ?? {})];
 
-  graphMock.dependencies[npmName] = depKeys.map(value => {
-    return { source: npmName, target: value, type: 'static' };
+  graphMock.dependencies[projectName] = depKeys.map(value => {
+    return { source: projectName, target: value.replace('@proj/', ''), type: 'static' };
   });
-  graphMock.nodes[npmName] = {
-    name: npmName,
+  graphMock.nodes[projectName] = {
+    name: projectName,
     type: projectType === 'library' ? 'lib' : 'app',
-    data: { name: npmName, root: npmName },
+    data: { name: projectName, root: projectName },
   };
 
   if (options.files) {

--- a/tools/workspace-plugin/src/generators/prepare-initial-release/index.ts
+++ b/tools/workspace-plugin/src/generators/prepare-initial-release/index.ts
@@ -281,7 +281,7 @@ function stableReleaseForSplitProject(tree: Tree, options: NormalizedSchema) {
     name: options.projectConfig.name + '-stories',
     npmName: options.npmPackageName + '-stories',
   };
-  // const currentStoriesNormalizedPackageName = getProjectNameWithoutScope(currentStoriesPackageName);
+
   const storiesProjectPaths = {
     root: storiesProjectRoot,
     sourceRoot: joinPathFragments(storiesProjectRoot, 'src'),

--- a/tools/workspace-plugin/src/generators/prepare-initial-release/index.ts
+++ b/tools/workspace-plugin/src/generators/prepare-initial-release/index.ts
@@ -17,7 +17,7 @@ import {
 } from '@nrwl/devkit';
 import * as tsquery from '@phenomnomnominal/tsquery';
 
-import { getProjectConfig, getProjectNameWithoutScope, workspacePaths } from '../../utils';
+import { getProjectConfig, workspacePaths } from '../../utils';
 
 import { PackageJson, TsConfig } from '../../types';
 
@@ -61,6 +61,7 @@ function normalizeOptions(tree: Tree, options: ReleasePackageGeneratorSchema) {
     ...options,
     ...project,
     ...names(options.project),
+    npmPackageName: `@${project.workspaceConfig.npmScope}/${project.projectConfig.name}`,
   };
 }
 
@@ -75,18 +76,18 @@ function initialRelease(tree: Tree, options: NormalizedSchema) {
     return json;
   });
 
-  const docsiteProjectName = '@' + options.workspaceConfig.npmScope + '/public-docsite-v9';
+  const docsiteProjectName = 'public-docsite-v9';
   const docsite = getProjectConfig(tree, { packageName: docsiteProjectName });
 
   updateJson<PackageJson>(tree, docsite.paths.packageJson, json => {
     json.dependencies = json.dependencies ?? {};
-    json.dependencies[options.project] = '*';
+    json.dependencies[options.npmPackageName] = '*';
     return json;
   });
 
   return (_tree: Tree) => {
     const changeTypes = { preview: 'minor', compat: 'patch' } as const;
-    generateChangefileTask(tree, options.project, {
+    generateChangefileTask(tree, options.npmPackageName, {
       changeType: changeTypes[phase],
       message: `feat: release ${options.phase} package`,
     });
@@ -94,29 +95,33 @@ function initialRelease(tree: Tree, options: NormalizedSchema) {
 }
 
 async function stableRelease(tree: Tree, options: NormalizedSchema & { isSplitProject: boolean }) {
-  const suitePackageName = '@' + options.workspaceConfig.npmScope + '/react-components';
-  const currentPackageName = options.projectConfig.name as string;
+  const suiteProjectName = 'react-components';
+  const suiteNpmProjectName = `@${options.workspaceConfig.npmScope}/${suiteProjectName}`;
+  const currentPackage = {
+    name: options.projectConfig.name as string,
+    npmName: options.npmPackageName,
+  };
 
   const newPackage = {
-    name: currentPackageName.replace('-preview', ''),
-    normalizedName: options.normalizedPkgName.replace('-preview', ''),
+    name: currentPackage.name.replace('-preview', ''),
+    npmName: currentPackage.npmName.replace('-preview', ''),
     version: '9.0.0-alpha.0',
     root: options.projectConfig.root.replace('-preview', ''),
     sourceRoot: options.projectConfig.sourceRoot?.replace('-preview', '') as string,
   };
 
   const contentNameUpdater = (content: string) => {
-    const regexp = new RegExp(options.normalizedPkgName, 'g');
-    return content.replace(regexp, newPackage.normalizedName);
+    const regexp = new RegExp(options.project, 'g');
+    return content.replace(regexp, newPackage.name);
   };
   const contentNameToSuiteUpdater = (content: string) => {
-    const regexp = new RegExp(options.normalizedPkgName, 'g');
+    const regexp = new RegExp(options.project, 'g');
     return content.replace(regexp, 'react-components');
   };
 
   updateJson<PackageJson>(tree, options.paths.packageJson, json => {
     delete json.private;
-    json.name = newPackage.name;
+    json.name = newPackage.npmName;
     json.version = newPackage.version;
     return json;
   });
@@ -141,8 +146,8 @@ async function stableRelease(tree: Tree, options: NormalizedSchema & { isSplitPr
 
   const mdFilePath = {
     readme: joinPathFragments(options.projectConfig.root, 'README.md'),
-    api: joinPathFragments(options.projectConfig.root, 'etc', options.normalizedPkgName + '.api.md'),
-    apiNew: joinPathFragments(options.projectConfig.root, 'etc', newPackage.normalizedName + '.api.md'),
+    api: joinPathFragments(options.projectConfig.root, 'etc', options.project + '.api.md'),
+    apiNew: joinPathFragments(options.projectConfig.root, 'etc', newPackage.name + '.api.md'),
   };
 
   updateFileContent(tree, {
@@ -162,8 +167,8 @@ async function stableRelease(tree: Tree, options: NormalizedSchema & { isSplitPr
   updateJson<TsConfig>(tree, options.paths.rootTsconfig, json => {
     json.compilerOptions.paths = json.compilerOptions.paths ?? {};
 
-    delete json.compilerOptions.paths[currentPackageName];
-    json.compilerOptions.paths[newPackage.name] = [joinPathFragments(newPackage.sourceRoot, 'index.ts')];
+    delete json.compilerOptions.paths[currentPackage.npmName];
+    json.compilerOptions.paths[newPackage.npmName] = [joinPathFragments(newPackage.sourceRoot, 'index.ts')];
 
     return json;
   });
@@ -174,11 +179,11 @@ async function stableRelease(tree: Tree, options: NormalizedSchema & { isSplitPr
 
   // add to suite (react-components)
   const reactComponentsProject = getProjectConfig(tree, {
-    packageName: suitePackageName,
+    packageName: suiteProjectName,
   });
   updateJson<PackageJson>(tree, reactComponentsProject.paths.packageJson, json => {
     json.dependencies = json.dependencies ?? {};
-    json.dependencies[newPackage.name] = newPackage.version;
+    json.dependencies[newPackage.npmName] = newPackage.version;
     return json;
   });
 
@@ -187,13 +192,13 @@ async function stableRelease(tree: Tree, options: NormalizedSchema & { isSplitPr
     updater: content => {
       const currentBarrelFilePath = joinPathFragments(options.projectConfig.sourceRoot as string, 'index.ts');
       const currentBarrelFile = tree.read(currentBarrelFilePath, 'utf-8') as string;
-      return content + '\n' + createExportsInSuite(currentBarrelFile, newPackage.name);
+      return content + '\n' + createExportsInSuite(currentBarrelFile, newPackage.npmName);
     },
   });
 
   const knownProjectsToBeUpdated = {
-    docsite: '@' + options.workspaceConfig.npmScope + '/public-docsite-v9',
-    vrTests: '@' + options.workspaceConfig.npmScope + '/vr-tests-react-components',
+    docsite: 'public-docsite-v9',
+    vrTests: 'vr-tests-react-components',
   };
 
   // update other projects that might still contain dependency to old -preview package
@@ -208,7 +213,7 @@ async function stableRelease(tree: Tree, options: NormalizedSchema & { isSplitPr
   });
   updateJson<PackageJson>(tree, reactComponentsDocsiteProject.paths.packageJson, json => {
     json.dependencies = json.dependencies ?? {};
-    delete json.dependencies[currentPackageName];
+    delete json.dependencies[currentPackage.npmName];
     return json;
   });
   visitNotIgnoredFiles(tree, joinPathFragments(reactComponentsDocsiteProject.projectConfig.root, 'src'), filePath => {
@@ -221,11 +226,11 @@ async function stableRelease(tree: Tree, options: NormalizedSchema & { isSplitPr
   });
   updateJson<PackageJson>(tree, reactComponentsVrTestsProject.paths.packageJson, json => {
     json.dependencies = json.dependencies ?? {};
-    delete json.dependencies[currentPackageName];
+    delete json.dependencies[currentPackage.npmName];
     // when going from preview to stable, package version changes to `9.0.0-alpha` in order to beachball properly bump to `9.0.0` stable.
     // thus dependency on the package within workspace packages cannot use `*` but `>=9.0.0-alpha`
     // on CI (release,pr) this is being checked normalized via [normalize-package-dependencies generator](tools/workspace-plugin/src/generators/normalize-package-dependencies/index.ts)
-    json.dependencies[newPackage.name] = '>=9.0.0-alpha';
+    json.dependencies[newPackage.npmName] = '>=9.0.0-alpha';
     return json;
   });
   visitNotIgnoredFiles(
@@ -245,8 +250,8 @@ async function stableRelease(tree: Tree, options: NormalizedSchema & { isSplitPr
     });
     updateJson<PackageJson>(tree, joinPathFragments(projectConfig.projectConfig.root, 'package.json'), json => {
       json.dependencies = json.dependencies ?? {};
-      delete json.dependencies[currentPackageName];
-      json.dependencies[suitePackageName] = '*';
+      delete json.dependencies[currentPackage.npmName];
+      json.dependencies[suiteNpmProjectName] = '*';
       return json;
     });
   });
@@ -261,19 +266,22 @@ async function stableRelease(tree: Tree, options: NormalizedSchema & { isSplitPr
 
   return (_tree: Tree) => {
     installPackagesTask(tree, true);
-    generateChangefileTask(tree, newPackage.name, { message: 'feat: release stable', changeType: 'minor' });
-    generateChangefileTask(tree, suitePackageName, {
-      message: `feat: add ${newPackage.name} to suite`,
+    generateChangefileTask(tree, newPackage.npmName, { message: 'feat: release stable', changeType: 'minor' });
+    generateChangefileTask(tree, suiteNpmProjectName, {
+      message: `feat: add ${newPackage.npmName} to suite`,
       changeType: 'minor',
     });
-    generateApiMarkdownTask(tree, suitePackageName);
+    generateApiMarkdownTask(tree, suiteProjectName);
   };
 }
 
 function stableReleaseForSplitProject(tree: Tree, options: NormalizedSchema) {
   const storiesProjectRoot = joinPathFragments(options.projectConfig.root, '../stories');
-  const currentStoriesPackageName = options.projectConfig.name + '-stories';
-  const currentStoriesNormalizedPackageName = getProjectNameWithoutScope(currentStoriesPackageName);
+  const currentStoriesPackage = {
+    name: options.projectConfig.name + '-stories',
+    npmName: options.npmPackageName + '-stories',
+  };
+  // const currentStoriesNormalizedPackageName = getProjectNameWithoutScope(currentStoriesPackageName);
   const storiesProjectPaths = {
     root: storiesProjectRoot,
     sourceRoot: joinPathFragments(storiesProjectRoot, 'src'),
@@ -282,19 +290,19 @@ function stableReleaseForSplitProject(tree: Tree, options: NormalizedSchema) {
     readme: joinPathFragments(storiesProjectRoot, 'README.md'),
   };
   const newStoriesProject = {
-    name: currentStoriesPackageName.replace('-preview', ''),
-    normalizedName: currentStoriesNormalizedPackageName.replace('-preview', ''),
+    name: currentStoriesPackage.name.replace('-preview', ''),
+    npmName: currentStoriesPackage.npmName.replace('-preview', ''),
     root: storiesProjectPaths.root.replace('-preview', ''),
     sourceRoot: storiesProjectPaths.sourceRoot.replace('-preview', ''),
   };
 
   const contentNameUpdaterStories = (content: string) => {
-    const regexp = new RegExp(currentStoriesNormalizedPackageName, 'g');
-    return content.replace(regexp, newStoriesProject.normalizedName);
+    const regexp = new RegExp(currentStoriesPackage.name, 'g');
+    return content.replace(regexp, newStoriesProject.name);
   };
 
   updateJson<PackageJson>(tree, storiesProjectPaths.packageJson, json => {
-    json.name = newStoriesProject.name;
+    json.name = newStoriesProject.npmName;
 
     return json;
   });
@@ -315,8 +323,10 @@ function stableReleaseForSplitProject(tree: Tree, options: NormalizedSchema) {
   updateJson<TsConfig>(tree, options.paths.rootTsconfig, json => {
     json.compilerOptions.paths = json.compilerOptions.paths ?? {};
 
-    delete json.compilerOptions.paths[currentStoriesPackageName];
-    json.compilerOptions.paths[newStoriesProject.name] = [joinPathFragments(newStoriesProject.sourceRoot, 'index.ts')];
+    delete json.compilerOptions.paths[currentStoriesPackage.npmName];
+    json.compilerOptions.paths[newStoriesProject.npmName] = [
+      joinPathFragments(newStoriesProject.sourceRoot, 'index.ts'),
+    ];
 
     return json;
   });

--- a/tools/workspace-plugin/src/generators/rc-caret/README.md
+++ b/tools/workspace-plugin/src/generators/rc-caret/README.md
@@ -55,7 +55,7 @@ yarn nx g @fluentui/workspace-plugin:rc-caret --dry-run
 Check `@fluentui/react-components` for pinned rc deps and convert them to carets
 
 ```sh
-yarn nx g @fluentui/workspace-plugin:rc-caret --name='@fluentui/react-components'
+yarn nx g @fluentui/workspace-plugin:rc-caret --name=react-components
 ```
 
 Check all packages for pinned rc deps and convert them to carets
@@ -70,7 +70,7 @@ yarn nx g @fluentui/workspace-plugin:rc-caret --all
 
 Type: `string`
 
-Package/library name (needs to be full name of the package, scope included - e.g. `@fluentui/<package-name>`)
+Project name (without npmScope - e.g. `react-one`)
 
 > NOTE: will trigger CLI prompt if you didn't provide this option
 

--- a/tools/workspace-plugin/src/generators/rc-caret/index.spec.ts
+++ b/tools/workspace-plugin/src/generators/rc-caret/index.spec.ts
@@ -28,7 +28,7 @@ describe('rc-caret generator', () => {
       },
     });
 
-    await generator(tree, { name: `@${npmScope}/react-components` });
+    await generator(tree, { name: 'react-components' });
     const packageJson = readJson(tree, 'packages/react-components/package.json');
 
     expect(packageJson.dependencies[`@${npmScope}/react-button`]).toMatchInlineSnapshot(`"^9.0.0-rc.1"`);
@@ -41,7 +41,7 @@ describe('rc-caret generator', () => {
       },
     });
 
-    await generator(tree, { name: `@${npmScope}/react-components` });
+    await generator(tree, { name: 'react-components' });
     const packageJson = readJson(tree, 'packages/react-components/package.json');
 
     expect(packageJson.devDependencies[`@${npmScope}/react-button`]).toMatchInlineSnapshot(`"^9.0.0-rc.1"`);
@@ -54,7 +54,7 @@ describe('rc-caret generator', () => {
       },
     });
 
-    await generator(tree, { name: `@${npmScope}/react-components` });
+    await generator(tree, { name: 'react-components' });
     const packageJson = readJson(tree, 'packages/react-components/package.json');
 
     expect(packageJson.dependencies[`@${npmScope}/react-button`]).toMatchInlineSnapshot(`"^9.0.0-rc.1"`);
@@ -68,7 +68,7 @@ describe('rc-caret generator', () => {
       },
     });
 
-    await generator(tree, { name: `@${npmScope}/react-components` });
+    await generator(tree, { name: 'react-components' });
     const packageJson = readJson(tree, 'packages/react-components/package.json');
 
     expect(packageJson.dependencies).toMatchInlineSnapshot(`
@@ -86,7 +86,7 @@ describe('rc-caret generator', () => {
       },
     });
 
-    await generator(tree, { name: `@${npmScope}/react-components` });
+    await generator(tree, { name: 'react-components' });
     const packageJson = readJson(tree, 'packages/react-components/package.json');
 
     expect(packageJson.dependencies).toMatchInlineSnapshot(`
@@ -104,7 +104,7 @@ describe('rc-caret generator', () => {
       },
     });
 
-    await generator(tree, { name: `@${npmScope}/react-components` });
+    await generator(tree, { name: 'react-components' });
     const packageJson = readJson(tree, 'packages/react-components/package.json');
 
     expect(packageJson.dependencies).toMatchInlineSnapshot(`
@@ -127,7 +127,7 @@ function setupDummyPackage(
 ) {
   const workspaceConfig = getWorkspaceConfig(tree);
   const defaults = {
-    name: `@${workspaceConfig.npmScope}/react-components`,
+    name: `react-components`,
     version: '9.0.0-alpha.40',
     dependencies: {
       [`@${workspaceConfig.npmScope}/react-button`]: '^9.0.0-rc.38',
@@ -138,15 +138,15 @@ function setupDummyPackage(
   };
 
   const normalizedOptions = { ...defaults, ...options };
-  const pkgName = normalizedOptions.name || '';
-  const normalizedPkgName = pkgName.replace(`@${workspaceConfig.npmScope}/`, '');
+  const npmPkgName = `@${workspaceConfig.npmScope}/${normalizedOptions.name}` || '';
+  const projectName = normalizedOptions.name;
   const paths = {
-    root: `packages/${normalizedPkgName}`,
+    root: `packages/${projectName}`,
   };
 
   const templates = {
     packageJson: {
-      name: pkgName,
+      name: npmPkgName,
       version: normalizedOptions.version,
       dependencies: normalizedOptions.dependencies,
       devDependencies: normalizedOptions.devDependencies,
@@ -155,7 +155,7 @@ function setupDummyPackage(
 
   tree.write(`${paths.root}/package.json`, serializeJson(templates.packageJson));
 
-  addProjectConfiguration(tree, pkgName, {
+  addProjectConfiguration(tree, projectName, {
     root: paths.root,
     projectType: 'library',
     targets: {},

--- a/tools/workspace-plugin/src/generators/react-component/index.spec.ts
+++ b/tools/workspace-plugin/src/generators/react-component/index.spec.ts
@@ -14,20 +14,18 @@ describe('react-component generator', () => {
     it(`should throw error if one wants to add component to non v9 package`, async () => {
       createLibrary(tree, 'react-old', { tags: ['v8'], version: '8.123.4' });
       try {
-        await generator(tree, { project: '@proj/react-old', name: 'MyOne' });
+        await generator(tree, { project: 'react-old', name: 'MyOne' });
       } catch (err) {
-        expect(err).toMatchInlineSnapshot(
-          `[Error: this generator works only with v9 packages. "@proj/react-old" is not!]`,
-        );
+        expect(err).toMatchInlineSnapshot(`[Error: this generator works only with v9 packages. "react-old" is not!]`);
       }
     });
 
     it(`should throw error if component already exists`, async () => {
       createLibrary(tree, 'react-one');
-      await generator(tree, { project: '@proj/react-one', name: 'MyOne' });
+      await generator(tree, { project: 'react-one', name: 'MyOne' });
 
       try {
-        await generator(tree, { project: '@proj/react-one', name: 'MyOne' });
+        await generator(tree, { project: 'react-one', name: 'MyOne' });
       } catch (err) {
         expect(err).toMatchInlineSnapshot(`[Error: The component "MyOne" already exists]`);
       }
@@ -50,7 +48,7 @@ describe('react-component generator', () => {
           createSplitProject(tree, 'react-one');
         }
 
-        await generator(tree, { project: '@proj/react-one', name: 'MyOne' });
+        await generator(tree, { project: 'react-one', name: 'MyOne' });
 
         const projectSourceRootPath =
           type === 'old'
@@ -158,7 +156,7 @@ describe('react-component generator', () => {
           createSplitProject(tree, 'react-one');
         }
 
-        await generator(tree, { project: '@proj/react-one', name: 'MyOne' });
+        await generator(tree, { project: 'react-one', name: 'MyOne' });
 
         const projectSourceRootPath =
           type === 'old'
@@ -171,7 +169,7 @@ describe('react-component generator', () => {
       "
     `);
 
-        await generator(tree, { project: '@proj/react-one', name: 'MyTwo' });
+        await generator(tree, { project: 'react-one', name: 'MyTwo' });
 
         expect(tree.read(barrelPath, 'utf-8')).toMatchInlineSnapshot(`
       "export * from './MyOne';
@@ -188,7 +186,7 @@ describe('react-component generator', () => {
       const gitkeepPath = joinPathFragments(joinPathFragments(metadata.paths.root, 'stories'), '.gitkeep');
       expect(tree.exists(gitkeepPath)).toBe(true);
 
-      await generator(tree, { project: '@proj/react-one', name: 'MyOne' });
+      await generator(tree, { project: 'react-one', name: 'MyOne' });
 
       expect(tree.exists(gitkeepPath)).toBe(false);
     });
@@ -218,7 +216,7 @@ describe('react-component generator', () => {
           type === 'old'
             ? 'packages/react-components/react-one/stories/MyOne'
             : 'packages/react-components/react-one/stories/src/MyOne';
-        await generator(tree, { project: '@proj/react-one', name: 'MyOne' });
+        await generator(tree, { project: 'react-one', name: 'MyOne' });
 
         expect(tree.children(componentStoryRootPath)).toMatchInlineSnapshot(`
       Array [
@@ -261,7 +259,7 @@ describe('react-component generator', () => {
             ? `packages/react-components/${packageFolderName[phase]}/stories/MyOne`
             : `packages/react-components/${packageFolderName[phase]}/stories/src/MyOne`;
 
-        await generator(tree, { project: `@proj/${packageFolderName[phase]}`, name: 'MyOne' });
+        await generator(tree, { project: packageFolderName[phase], name: 'MyOne' });
 
         expect(tree.read(joinPathFragments(componentStoryRootPath, 'index.stories.tsx'), 'utf-8'))
           .toMatchInlineSnapshot(`
@@ -313,12 +311,13 @@ function createLibrary(
     ...options,
   };
   const root = _options.root ?? `packages/react-components/${name}`;
-  const projectName = '@proj/' + name;
+  const projectName = name;
+  const npmProjectName = '@proj/' + projectName;
 
   const sourceRoot = `${root}/src`;
   addProjectConfiguration(tree, projectName, { root, tags: _options.tags, sourceRoot });
   writeJson(tree, joinPathFragments(root, 'package.json'), {
-    name: projectName,
+    name: npmProjectName,
     version: _options.version,
   });
   tree.write(joinPathFragments(root, 'stories/.gitkeep'), '');

--- a/tools/workspace-plugin/src/generators/react-component/index.ts
+++ b/tools/workspace-plugin/src/generators/react-component/index.ts
@@ -51,7 +51,7 @@ function normalizeOptions(tree: Tree, options: ReactComponentGeneratorSchema) {
     ...nameCasings,
     directory: 'components',
     componentName: nameCasings.className,
-    npmPackageName: project.projectConfig.name as string,
+    npmPackageName: `@${project.workspaceConfig.npmScope}/${project.projectConfig.name}`,
     isSplitProject: isSplitProject(tree, project.projectConfig),
   };
 }

--- a/tools/workspace-plugin/src/generators/react-library/files/LICENSE__tmpl__
+++ b/tools/workspace-plugin/src/generators/react-library/files/LICENSE__tmpl__
@@ -1,4 +1,4 @@
-<%= npmPackageName %>
+@<%= npmScope %>/<%= projectName %>
 
 Copyright (c) Microsoft Corporation
 

--- a/tools/workspace-plugin/src/generators/react-library/files/README.md__tmpl__
+++ b/tools/workspace-plugin/src/generators/react-library/files/README.md__tmpl__
@@ -1,4 +1,4 @@
-# <%= npmPackageName %>
+# @<%= npmScope %>/<%= projectName %>
 
 **<%= title %> components for [Fluent UI React](https://react.fluentui.dev/)**
 

--- a/tools/workspace-plugin/src/generators/react-library/files/docs/Spec.md__tmpl__
+++ b/tools/workspace-plugin/src/generators/react-library/files/docs/Spec.md__tmpl__
@@ -1,4 +1,4 @@
-# <%= npmPackageName %> Spec
+# @<%= npmScope %>/<%= projectName %> Spec
 
 ## Background
 

--- a/tools/workspace-plugin/src/generators/react-library/files/jest.config.js__tmpl__
+++ b/tools/workspace-plugin/src/generators/react-library/files/jest.config.js__tmpl__
@@ -4,7 +4,7 @@
  * @type {import('@jest/types').Config.InitialOptions}
  */
 module.exports = {
-  displayName: '<%= packageName %>',
+  displayName: '<%= projectName %>',
   preset: '../../../jest.preset.js',
   transform: {
     '^.+\\.tsx?$': [

--- a/tools/workspace-plugin/src/generators/react-library/files/package.json__tmpl__
+++ b/tools/workspace-plugin/src/generators/react-library/files/package.json__tmpl__
@@ -1,5 +1,5 @@
 {
-  "name": "<%= npmPackageName %>",
+  "name": "@<%= npmScope %>/<%= projectName %>",
   "version": "0.0.0",
   "private": true,
   "description": "New fluentui react package",
@@ -30,17 +30,17 @@
     "type-check": "tsc -b tsconfig.json"
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/react-conformance": "*",
-    "@fluentui/react-conformance-griffel": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@<%= npmScope %>/eslint-plugin": "*",
+    "@<%= npmScope %>/react-conformance": "*",
+    "@<%= npmScope %>/react-conformance-griffel": "*",
+    "@<%= npmScope %>/scripts-api-extractor": "*",
+    "@<%= npmScope %>/scripts-tasks": "*"
   },
   "dependencies": {
-    "@fluentui/react-jsx-runtime": "",
-    "@fluentui/react-shared-contexts": "",
-    "@fluentui/react-theme": "",
-    "@fluentui/react-utilities": "",
+    "@<%= npmScope %>/react-jsx-runtime": "",
+    "@<%= npmScope %>/react-shared-contexts": "",
+    "@<%= npmScope %>/react-theme": "",
+    "@<%= npmScope %>/react-utilities": "",
     "@griffel/react": "",
     "@swc/helpers": ""
   },

--- a/tools/workspace-plugin/src/generators/react-library/index.spec.ts
+++ b/tools/workspace-plugin/src/generators/react-library/index.spec.ts
@@ -47,8 +47,8 @@ describe('react-library generator', () => {
 
     await generator(tree, { name: 'react-one', owner: '@org/chosen-one' });
 
-    const library = readProjectConfiguration(tree, '@proj/react-one-preview');
-    const stories = readProjectConfiguration(tree, '@proj/react-one-preview-stories');
+    const library = readProjectConfiguration(tree, 'react-one-preview');
+    const stories = readProjectConfiguration(tree, 'react-one-preview-stories');
 
     // library
     expect(tree.children(library.root)).toMatchInlineSnapshot(`
@@ -81,7 +81,7 @@ describe('react-library generator', () => {
       Object {
         "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
         "implicitDependencies": Array [],
-        "name": "@proj/react-one-preview",
+        "name": "react-one-preview",
         "projectType": "library",
         "root": "packages/react-components/react-one-preview/library",
         "sourceRoot": "packages/react-components/react-one-preview/library/src",
@@ -107,10 +107,10 @@ describe('react-library generator', () => {
         version: '0.0.0',
         files: ['*.md', 'dist/*.d.ts', 'lib', 'lib-commonjs'],
         dependencies: {
-          '@fluentui/react-jsx-runtime': '^9.0.0',
-          '@fluentui/react-shared-contexts': '^9.0.0',
-          '@fluentui/react-theme': '^9.0.0',
-          '@fluentui/react-utilities': '^9.0.0',
+          '@proj/react-jsx-runtime': '^9.0.0',
+          '@proj/react-shared-contexts': '^9.0.0',
+          '@proj/react-theme': '^9.0.0',
+          '@proj/react-utilities': '^9.0.0',
           '@griffel/react': '^1.2.3',
           '@swc/helpers': '^0.4.5',
         },
@@ -187,11 +187,11 @@ describe('react-library generator', () => {
       version: '0.0.0',
       private: true,
       devDependencies: {
-        '@fluentui/eslint-plugin': '*',
-        '@fluentui/react-storybook-addon': '*',
-        '@fluentui/react-storybook-addon-export-to-sandbox': '*',
-        '@fluentui/scripts-storybook': '*',
-        '@fluentui/scripts-tasks': '*',
+        '@proj/eslint-plugin': '*',
+        '@proj/react-storybook-addon': '*',
+        '@proj/react-storybook-addon-export-to-sandbox': '*',
+        '@proj/scripts-storybook': '*',
+        '@proj/scripts-tasks': '*',
       },
       scripts: {
         format: 'just-scripts prettier',
@@ -207,7 +207,7 @@ describe('react-library generator', () => {
       Object {
         "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
         "implicitDependencies": Array [],
-        "name": "@proj/react-one-preview-stories",
+        "name": "react-one-preview-stories",
         "projectType": "library",
         "root": "packages/react-components/react-one-preview/stories",
         "sourceRoot": "packages/react-components/react-one-preview/stories/src",
@@ -269,8 +269,8 @@ describe('react-library generator', () => {
     setup(tree);
 
     await generator(tree, { name: 'react-one', owner: '@org/chosen-one', kind: 'compat' });
-    const library = readProjectConfiguration(tree, '@proj/react-one-compat');
-    const stories = readProjectConfiguration(tree, '@proj/react-one-compat-stories');
+    const library = readProjectConfiguration(tree, 'react-one-compat');
+    const stories = readProjectConfiguration(tree, 'react-one-compat-stories');
 
     // library
 
@@ -341,11 +341,12 @@ function setup(tree: Tree) {
 }
 
 function createLibrary(tree: Tree, name: string) {
-  const projectName = '@fluentui/' + name;
+  const projectName = name;
+  const npmProjectName = '@proj/' + projectName;
   const root = `packages/react-components/${name}`;
   addProjectConfiguration(tree, projectName, { root, tags: ['vNext'] });
   writeJson(tree, joinPathFragments(root, 'package.json'), {
-    name: projectName,
+    name: npmProjectName,
     version: '9.0.0',
   });
 

--- a/tools/workspace-plugin/src/generators/recipe-generator/index.spec.ts
+++ b/tools/workspace-plugin/src/generators/recipe-generator/index.spec.ts
@@ -10,7 +10,7 @@ const recipeName = 'Hello World';
 const recipePackageName = 'hello-world';
 
 const setup = (tree: Tree) => {
-  const generateApp = () => {
+  const generateProject = () => {
     const paths = { root: 'packages/react-components/recipes' };
     writeJson(tree, path.join(paths.root, 'package.json'), {
       name: '@proj/recipes',
@@ -18,7 +18,7 @@ const setup = (tree: Tree) => {
     });
     tree.write(path.join(paths.root, 'src/recipes/.gitkeep'), '');
 
-    addProjectConfiguration(tree, '@proj/recipes', {
+    addProjectConfiguration(tree, 'recipes', {
       root: paths.root,
       sourceRoot: path.join(paths.root, 'src'),
       projectType: 'application',
@@ -26,7 +26,7 @@ const setup = (tree: Tree) => {
     });
   };
 
-  generateApp();
+  generateProject();
   return tree;
 };
 

--- a/tools/workspace-plugin/src/generators/recipe-generator/index.ts
+++ b/tools/workspace-plugin/src/generators/recipe-generator/index.ts
@@ -1,6 +1,6 @@
 import { Tree, formatFiles, generateFiles, joinPathFragments } from '@nx/devkit';
 import { RecipeGeneratorGeneratorSchema } from './schema';
-import { getProjectConfig, getWorkspaceConfig } from '../../utils';
+import { getProjectConfig } from '../../utils';
 
 export default async function (tree: Tree, schema: RecipeGeneratorGeneratorSchema) {
   const validatedSchema = validateSchema(tree, schema);
@@ -13,9 +13,8 @@ export default async function (tree: Tree, schema: RecipeGeneratorGeneratorSchem
 }
 
 function normalizeOptions(tree: Tree, schema: RecipeGeneratorGeneratorSchema) {
-  const workspaceConfig = getWorkspaceConfig(tree);
   const recipesProject = getProjectConfig(tree, {
-    packageName: `@${workspaceConfig.npmScope}/recipes`,
+    packageName: 'recipes',
   });
 
   const recipesRoot = joinPathFragments(recipesProject.paths.sourceRoot, 'recipes');

--- a/tools/workspace-plugin/src/generators/split-library-in-two/generator.spec.ts
+++ b/tools/workspace-plugin/src/generators/split-library-in-two/generator.spec.ts
@@ -23,7 +23,7 @@ const noop = () => {
 
 describe('split-library-in-two generator', () => {
   let tree: Tree;
-  const options = { project: '@proj/react-hello', logs: true };
+  const options = { project: 'react-hello', logs: true };
 
   beforeEach(() => {
     tree = createTreeWithEmptyWorkspace();
@@ -79,7 +79,7 @@ describe('split-library-in-two generator', () => {
     expect(newConfig).toMatchInlineSnapshot(`
       Object {
         "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
-        "name": "@proj/react-hello",
+        "name": "react-hello",
         "projectType": "library",
         "root": "packages/react-components/react-hello/library",
         "sourceRoot": "packages/react-components/react-hello/library/src",
@@ -138,7 +138,7 @@ describe('split-library-in-two generator', () => {
 
     expect(tree.read(`${newConfig.root}/jest.config.js`, 'utf-8')).toMatchInlineSnapshot(`
       "module.exports = {
-        displayName: 'react-text',
+        displayName: 'react-hello',
         preset: '../../../../jest.preset.js',
         transform: {
           '^.+\\\\\\\\.tsx?$': [
@@ -162,7 +162,7 @@ describe('split-library-in-two generator', () => {
     expect(storiesConfig).toMatchInlineSnapshot(`
       Object {
         "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
-        "name": "@proj/react-hello-stories",
+        "name": "react-hello-stories",
         "projectType": "library",
         "root": "packages/react-components/react-hello/stories",
         "sourceRoot": "packages/react-components/react-hello/stories/src",
@@ -177,14 +177,14 @@ describe('split-library-in-two generator', () => {
     expect(readJson(tree, `${storiesConfig.root}/package.json`)).toMatchInlineSnapshot(`
       Object {
         "devDependencies": Object {
-          "@fluentui/eslint-plugin": "*",
-          "@fluentui/react-storybook-addon": "*",
-          "@fluentui/react-storybook-addon-export-to-sandbox": "*",
-          "@fluentui/scripts-storybook": "*",
-          "@fluentui/scripts-tasks": "*",
+          "@proj/eslint-plugin": "*",
           "@proj/react-components": "*",
           "@proj/react-one-compat": "*",
+          "@proj/react-storybook-addon": "*",
+          "@proj/react-storybook-addon-export-to-sandbox": "*",
           "@proj/react-two-preview": "*",
+          "@proj/scripts-storybook": "*",
+          "@proj/scripts-tasks": "*",
         },
         "name": "@proj/react-hello-stories",
         "private": true,
@@ -425,7 +425,7 @@ function setupDummyPackage(tree: Tree, options: { projectName: string }) {
     },
     jestConfig: stripIndents`
       module.exports = {
-        displayName: 'react-text',
+        displayName: '${options.projectName}',
         preset: '../../../jest.preset.js',
         transform: {
           '^.+\\.tsx?$': [
@@ -584,14 +584,14 @@ function setupDummyPackage(tree: Tree, options: { projectName: string }) {
   );
   tree.write(`${rootPath}/stories/Hello.md`, stripIndents``);
 
-  addProjectConfiguration(tree, npmProjectName, {
+  addProjectConfiguration(tree, options.projectName, {
     root: rootPath,
     sourceRoot: `${rootPath}/src`,
     projectType: 'library',
     tags: ['vNext', 'platform:web'],
   });
 
-  addCodeowner(tree, { owner: 'Mr.Wick', packageName: npmProjectName });
+  addCodeowner(tree, { owner: 'Mr.Wick', packageName: options.projectName });
 
   updateJson(tree, '/tsconfig.base.json', (json: TsConfig) => {
     json.compilerOptions.paths = json.compilerOptions.paths ?? {};

--- a/tools/workspace-plugin/src/generators/split-library-in-two/generator.ts
+++ b/tools/workspace-plugin/src/generators/split-library-in-two/generator.ts
@@ -22,7 +22,7 @@ import { tsquery } from '@phenomnomnominal/tsquery';
 
 import tsConfigBaseAllGenerator from '../tsconfig-base-all/index';
 import { TsConfig } from '../../types';
-import { workspacePaths } from '../../utils';
+import { getNpmScope, workspacePaths } from '../../utils';
 import { SplitLibraryInTwoGeneratorSchema } from './schema';
 
 export { isSplitProject, assertStoriesProject } from './shared';
@@ -30,6 +30,7 @@ export { isSplitProject, assertStoriesProject } from './shared';
 type CLIOutput = typeof output;
 
 interface Options extends SplitLibraryInTwoGeneratorSchema {
+  npmScope: string;
   projectConfig: ReturnType<typeof readProjectConfiguration>;
   projectOffsetFromRoot: { old: string; updated: string };
   oldContent: {
@@ -122,6 +123,7 @@ function splitLibraryInTwoInternal(
 
   const packageJSON = readJson(tree, joinPathFragments(projectConfig.root, 'package.json'));
   const normalizedOptions = {
+    npmScope: getNpmScope(tree),
     projectName,
     projectConfig,
     projectOffsetFromRoot: {
@@ -260,7 +262,9 @@ function makeSrcLibrary(tree: Tree, options: Options, logger: CLIOutput) {
 
   updateJson(tree, filePaths.rootTsConfig, (json: TsConfig) => {
     json.compilerOptions.paths = json.compilerOptions.paths ?? {};
-    json.compilerOptions.paths[options.projectConfig.name!] = [`${newProjectSourceRoot}/index.ts`];
+    json.compilerOptions.paths[`@${options.npmScope}/${options.projectConfig.name}`] = [
+      `${newProjectSourceRoot}/index.ts`,
+    ];
     return json;
   });
 
@@ -297,7 +301,7 @@ function makeStoriesLibrary(tree: Tree, options: Options, logger: CLIOutput) {
 
   const templates = {
     readme: stripIndents`
-      # ${newProjectName}
+      # @${options.npmScope}/${newProjectName}
 
       Storybook stories for ${options.projectConfig.root}
 
@@ -316,7 +320,7 @@ function makeStoriesLibrary(tree: Tree, options: Options, logger: CLIOutput) {
       no public API available
     `,
     packageJson: {
-      name: newProjectName,
+      name: `@${options.npmScope}/${newProjectName}`,
       version: '0.0.0',
       private: true,
       scripts: {
@@ -330,11 +334,11 @@ function makeStoriesLibrary(tree: Tree, options: Options, logger: CLIOutput) {
       devDependencies: {
         ...storiesWorkspaceDeps,
         // always added
-        '@fluentui/react-storybook-addon': '*',
-        '@fluentui/react-storybook-addon-export-to-sandbox': '*',
-        '@fluentui/scripts-storybook': '*',
-        '@fluentui/eslint-plugin': '*',
-        '@fluentui/scripts-tasks': '*',
+        [`@${options.npmScope}/react-storybook-addon`]: '*',
+        [`@${options.npmScope}/react-storybook-addon-export-to-sandbox`]: '*',
+        [`@${options.npmScope}/scripts-storybook`]: '*',
+        [`@${options.npmScope}/eslint-plugin`]: '*',
+        [`@${options.npmScope}/scripts-tasks`]: '*',
       },
     },
     justConfig: stripIndents`
@@ -418,7 +422,7 @@ function makeStoriesLibrary(tree: Tree, options: Options, logger: CLIOutput) {
 
   updateJson(tree, '/tsconfig.base.json', (json: TsConfig) => {
     json.compilerOptions.paths = json.compilerOptions.paths ?? {};
-    json.compilerOptions.paths[newProjectName] = [`${newProjectSourceRoot}/index.ts`];
+    json.compilerOptions.paths[`@${options.npmScope}/${newProjectName}`] = [`${newProjectSourceRoot}/index.ts`];
     return json;
   });
 }
@@ -517,9 +521,12 @@ function getImportsFromSourceFiles(tree: Tree, root: string, filter: (file: stri
 
 function getWorkspaceDependencies(tree: Tree, imports: string[]) {
   const allProjects = getProjects(tree);
+  const npmScope = getNpmScope(tree);
+  const npmPackagePrefix = `@${npmScope}/`;
   const dependencies: Record<string, string> = {};
   imports.forEach(importPath => {
-    if (allProjects.has(importPath)) {
+    const projectName = importPath.replace(npmPackagePrefix, '');
+    if (importPath.startsWith(npmPackagePrefix) && allProjects.has(projectName)) {
       dependencies[importPath] = '*';
     }
   });

--- a/tools/workspace-plugin/src/generators/version-bump/README.md
+++ b/tools/workspace-plugin/src/generators/version-bump/README.md
@@ -52,7 +52,7 @@ yarn nx g @fluentui/workspace-plugin:version-bump --dry-run
 Bump `@fluentui/example@9.0.0-alpha.1` to beta
 
 ```sh
-yarn nx g @fluentui/workspace-plugin:version-bump --name='@fluentui/example' --bumpType prerelease --prereleaseTag beta
+yarn nx g @fluentui/workspace-plugin:version-bump --name=example --bumpType prerelease --prereleaseTag beta
 ```
 
 Bump all vNext packages from alpha to beta
@@ -79,7 +79,7 @@ yarn nx g @fluentui/workspace-plugin:version-bump --all --bumpType nightly --pre
 
 Type: `string`
 
-Package/library name (needs to be full name of the package, scope included - e.g. `@fluentui/<package-name>`)
+Project name (without @npmScope prefix - e.g. `<project-name>`)
 
 > NOTE: will trigger CLI prompt if you didn't provide this option
 

--- a/tools/workspace-plugin/src/generators/version-bump/index.spec.ts
+++ b/tools/workspace-plugin/src/generators/version-bump/index.spec.ts
@@ -27,12 +27,12 @@ describe('version-string-replace generator', () => {
 
   it('should bump alpha package to beta', async () => {
     tree = setupDummyPackage(tree, {
-      name: '@proj/make-styles',
+      name: 'make-styles',
       version: '9.0.0-alpha.0',
       projectConfiguration: { tags: ['vNext', 'platform:web'], sourceRoot: 'packages/make-styles/src' },
     });
 
-    await generator(tree, { name: '@proj/make-styles', bumpType: 'prerelease', prereleaseTag: 'beta' });
+    await generator(tree, { name: 'make-styles', bumpType: 'prerelease', prereleaseTag: 'beta' });
 
     const packageJson = readJson(tree, 'packages/make-styles/package.json');
     expect(packageJson.version).toMatchInlineSnapshot(`"9.0.0-beta.0"`);
@@ -40,20 +40,20 @@ describe('version-string-replace generator', () => {
 
   it('should remove prerelease tag', async () => {
     tree = setupDummyPackage(tree, {
-      name: '@proj/make-styles',
+      name: 'make-styles',
       version: '9.0.0-beta.69',
       projectConfiguration: { tags: ['vNext', 'platform:web'], sourceRoot: 'packages/make-styles/src' },
     });
 
-    await generator(tree, { name: '@proj/make-styles', bumpType: 'minor', prereleaseTag: '' });
+    await generator(tree, { name: 'make-styles', bumpType: 'minor', prereleaseTag: '' });
 
     const packageJson = readJson(tree, 'packages/make-styles/package.json');
     expect(packageJson.version).toMatchInlineSnapshot(`"9.0.0"`);
   });
 
-  it('should bump dependent depedencies', async () => {
+  it('should bump dependent dependencies', async () => {
     tree = setupDummyPackage(tree, {
-      name: '@proj/react-button',
+      name: 'react-button',
       version: '9.0.0-alpha.0',
       dependencies: {
         '@proj/make-styles': '9.0.0-alpha.1',
@@ -61,12 +61,12 @@ describe('version-string-replace generator', () => {
       projectConfiguration: { tags: ['vNext', 'platform:web'], sourceRoot: 'packages/react-button/src' },
     });
     tree = setupDummyPackage(tree, {
-      name: '@proj/make-styles',
+      name: 'make-styles',
       version: '9.0.0-alpha.0',
       projectConfiguration: { tags: ['vNext', 'platform:web'], sourceRoot: 'packages/make-styles/src' },
     });
 
-    await generator(tree, { name: '@proj/make-styles', ...defaultTestOptions });
+    await generator(tree, { name: 'make-styles', ...defaultTestOptions });
 
     const packageJson = readJson(tree, 'packages/react-button/package.json');
     expect(packageJson.dependencies).toMatchInlineSnapshot(`
@@ -78,7 +78,7 @@ describe('version-string-replace generator', () => {
 
   it('should bump dependent dev depedencies', async () => {
     tree = setupDummyPackage(tree, {
-      name: '@proj/react-button',
+      name: 'react-button',
       version: '9.0.0-alpha.0',
       dependencies: {},
       devDependencies: {
@@ -87,12 +87,12 @@ describe('version-string-replace generator', () => {
       projectConfiguration: { tags: ['vNext', 'platform:web'], sourceRoot: 'packages/react-button/src' },
     });
     tree = setupDummyPackage(tree, {
-      name: '@proj/make-styles',
+      name: 'make-styles',
       version: '9.0.0-alpha.0',
       projectConfiguration: { tags: ['vNext', 'platform:web'], sourceRoot: 'packages/make-styles/src' },
     });
 
-    await generator(tree, { name: '@proj/make-styles', ...defaultTestOptions });
+    await generator(tree, { name: 'make-styles', ...defaultTestOptions });
 
     const packageJson = readJson(tree, 'packages/react-button/package.json');
     expect(packageJson.dependencies).toMatchInlineSnapshot(`Object {}`);
@@ -100,13 +100,13 @@ describe('version-string-replace generator', () => {
 
   it('should downgrade the version to 0.0.0 when `nightly` is selected as the bump type', async () => {
     tree = setupDummyPackage(tree, {
-      name: '@proj/make-styles',
+      name: 'make-styles',
       version: '9.0.0-alpha.0',
       projectConfiguration: { tags: ['vNext', 'platform:web'], sourceRoot: 'packages/make-styles/src' },
     });
 
     tree = setupDummyPackage(tree, {
-      name: '@proj/react-button',
+      name: 'react-button',
       version: '9.0.0-alpha.0',
       dependencies: {
         '@proj/make-styles': '^9.0.0',
@@ -117,7 +117,7 @@ describe('version-string-replace generator', () => {
       projectConfiguration: { tags: ['vNext', 'platform:web'], sourceRoot: 'packages/react-button/src' },
     });
 
-    await generator(tree, { name: '@proj/make-styles', bumpType: 'nightly', prereleaseTag: 'nightly' });
+    await generator(tree, { name: 'make-styles', bumpType: 'nightly', prereleaseTag: 'nightly' });
 
     const packageJson = readJson(tree, 'packages/react-button/package.json');
     expect(packageJson.dependencies).toMatchInlineSnapshot(`
@@ -134,12 +134,12 @@ describe('version-string-replace generator', () => {
 
   it('should remove carets for dependents when `nightly` is selected as the bump type', async () => {
     tree = setupDummyPackage(tree, {
-      name: '@proj/make-styles',
+      name: 'make-styles',
       version: '^9.0.0',
       projectConfiguration: { tags: ['vNext', 'platform:web'], sourceRoot: 'packages/make-styles/src' },
     });
 
-    await generator(tree, { name: '@proj/make-styles', bumpType: 'nightly', prereleaseTag: 'nightly' });
+    await generator(tree, { name: 'make-styles', bumpType: 'nightly', prereleaseTag: 'nightly' });
 
     const packageJson = readJson(tree, 'packages/make-styles/package.json');
     expect(packageJson.version).toMatchInlineSnapshot(`"0.0.0-nightly.0"`);
@@ -147,7 +147,7 @@ describe('version-string-replace generator', () => {
 
   it('should remove beachball disallowedChangeType config when bumping nightly', async () => {
     tree = setupDummyPackage(tree, {
-      name: '@proj/make-styles',
+      name: 'make-styles',
       version: '9.0.0-alpha.0',
       projectConfiguration: { tags: ['vNext', 'platform:web'], sourceRoot: 'packages/make-styles/src' },
       beachball: {
@@ -159,7 +159,7 @@ describe('version-string-replace generator', () => {
       readJson<PackageJsonWithBeachball>(tree, 'packages/make-styles/package.json').beachball?.disallowedChangeTypes,
     ).toEqual(['prerelease']);
 
-    await generator(tree, { name: '@proj/make-styles', bumpType: 'nightly', prereleaseTag: 'nightly' });
+    await generator(tree, { name: 'make-styles', bumpType: 'nightly', prereleaseTag: 'nightly' });
 
     const packageJson = readJson<PackageJsonWithBeachball>(tree, 'packages/make-styles/package.json');
     expect(packageJson.version).toMatchInlineSnapshot(`"0.0.0-nightly.0"`);
@@ -169,7 +169,7 @@ describe('version-string-replace generator', () => {
   describe('--all', () => {
     beforeEach(() => {
       tree = setupDummyPackage(tree, {
-        name: '@proj/react-button',
+        name: 'react-button',
         version: '9.0.0-alpha.0',
         dependencies: {
           '@proj/make-styles': '^9.0.0-alpha.1',
@@ -178,7 +178,7 @@ describe('version-string-replace generator', () => {
         projectConfiguration: { tags: ['vNext', 'platform:web'], sourceRoot: 'packages/react-button/src' },
       });
       tree = setupDummyPackage(tree, {
-        name: '@proj/make-styles',
+        name: 'make-styles',
         version: '9.0.0-alpha.0',
         dependencies: {},
         devDependencies: {
@@ -187,19 +187,19 @@ describe('version-string-replace generator', () => {
         projectConfiguration: { tags: ['vNext', 'platform:web'], sourceRoot: 'packages/make-styles/src' },
       });
       tree = setupDummyPackage(tree, {
-        name: '@proj/react-theme',
+        name: 'react-theme',
         version: '9.0.0-alpha.0',
         dependencies: {},
         devDependencies: {},
         projectConfiguration: { tags: ['vNext', 'platform:web'], sourceRoot: 'packages/make-styles/src' },
       });
       tree = setupDummyPackage(tree, {
-        name: '@proj/react-utilities',
+        name: 'react-utilities',
         version: '9.0.0-alpha.0',
         projectConfiguration: { tags: ['vNext', 'platform:web'], sourceRoot: 'packages/react-utilities/src' },
       });
       tree = setupDummyPackage(tree, {
-        name: '@proj/babel-make-styles',
+        name: 'babel-make-styles',
         version: '1.0.0',
         dependencies: {
           '@proj/make-styles': '^9.0.0-alpha.1',
@@ -207,7 +207,7 @@ describe('version-string-replace generator', () => {
         projectConfiguration: { tags: ['platform:node'], sourceRoot: 'packages/babel-make-styles/src' },
       });
       tree = setupDummyPackage(tree, {
-        name: '@proj/tokens',
+        name: 'tokens',
         version: '1.0.0',
         dependencies: {
           '@proj/make-styles': '^9.0.0-alpha.1',
@@ -215,7 +215,7 @@ describe('version-string-replace generator', () => {
         projectConfiguration: { tags: ['vNext', 'platform:web'], sourceRoot: 'packages/tokens/src' },
       });
       tree = setupDummyPackage(tree, {
-        name: '@proj/react-menu',
+        name: 'react-menu',
         version: '9.0.0-beta.11',
         dependencies: {
           '@proj/make-styles': '^9.0.0-alpha.1',
@@ -265,7 +265,7 @@ describe('version-string-replace generator', () => {
       await generator(tree, {
         all: true,
         ...defaultTestOptions,
-        exclude: '@proj/react-utilities,@proj/react-theme',
+        exclude: 'react-utilities,react-theme',
       });
 
       const reactThemePackageJson = readJson(tree, 'packages/react-theme/package.json');
@@ -315,15 +315,14 @@ function setupDummyPackage(
   };
 
   const normalizedOptions = { ...defaults, ...options };
-  const pkgName = normalizedOptions.name || '';
-  const normalizedPkgName = pkgName.replace(`@${workspaceConfig.npmScope}/`, '');
+  const projectName = normalizedOptions.name || '';
   const paths = {
-    root: `packages/${normalizedPkgName}`,
+    root: `packages/${projectName}`,
   };
 
   const templates = {
     packageJson: {
-      name: pkgName,
+      name: `@${workspaceConfig.npmScope}/${projectName}`,
       version: normalizedOptions.version,
       dependencies: normalizedOptions.dependencies,
       devDependencies: normalizedOptions.devDependencies,
@@ -333,7 +332,7 @@ function setupDummyPackage(
 
   tree.write(`${paths.root}/package.json`, serializeJson(templates.packageJson));
 
-  addProjectConfiguration(tree, pkgName, {
+  addProjectConfiguration(tree, projectName, {
     root: paths.root,
     projectType: 'library',
     targets: {},

--- a/tools/workspace-plugin/src/generators/version-bump/index.ts
+++ b/tools/workspace-plugin/src/generators/version-bump/index.ts
@@ -11,25 +11,25 @@ import {
 } from '../../utils';
 import { PackageJson } from '../../types';
 
-export default async function (host: Tree, schema: VersionBumpGeneratorSchema) {
+export default async function (tree: Tree, schema: VersionBumpGeneratorSchema) {
   const userLog: UserLog = [];
-  const validatedSchema = validateSchema(host, schema);
+  const validatedSchema = validateSchema(tree, schema);
 
   if (validatedSchema.all) {
-    runBatchMigration(host, validatedSchema, userLog);
+    runBatchMigration(tree, validatedSchema, userLog);
   } else {
-    runMigrationOnProject(host, validatedSchema, userLog);
+    runMigrationOnProject(tree, validatedSchema, userLog);
   }
 
-  await formatFiles(host);
+  await formatFiles(tree);
 
   return () => {
     printUserLogs(userLog);
   };
 }
 
-function runMigrationOnProject(host: Tree, schema: ValidatedSchema, userLog: UserLog) {
-  const options = normalizeOptions(host, schema);
+function runMigrationOnProject(tree: Tree, schema: ValidatedSchema, userLog: UserLog) {
+  const options = normalizeOptions(tree, schema);
   const packageJsonPath = options.paths.packageJson;
   let nextVersion = '';
 
@@ -38,7 +38,7 @@ function runMigrationOnProject(host: Tree, schema: ValidatedSchema, userLog: Use
     return;
   }
 
-  updateJson(host, packageJsonPath, (packageJson: PackageJson) => {
+  updateJson(tree, packageJsonPath, (packageJson: PackageJson) => {
     nextVersion = bumpVersion(packageJson, schema.bumpType, schema.prereleaseTag);
 
     // nightly releases should bypass beachball disallowed changetypes
@@ -55,7 +55,7 @@ function runMigrationOnProject(host: Tree, schema: ValidatedSchema, userLog: Use
   });
 
   if (nextVersion) {
-    updatePackageDependents({ tree: host, nextVersion, userLog, schema });
+    updatePackageDependents({ tree, nextVersion, userLog, schema });
   }
 }
 
@@ -168,9 +168,9 @@ function bumpVersion(packageJson: PackageJson, bumpType: ValidatedSchema['bumpTy
   return semverVersion.version;
 }
 
-function normalizeOptions(host: Tree, options: ValidatedSchema) {
+function normalizeOptions(tree: Tree, options: ValidatedSchema) {
   const defaults = {};
-  const project = getProjectConfig(host, { packageName: options.name });
+  const project = getProjectConfig(tree, { packageName: options.name });
 
   return {
     ...defaults,

--- a/tools/workspace-plugin/src/generators/version-bump/schema.json
+++ b/tools/workspace-plugin/src/generators/version-bump/schema.json
@@ -26,7 +26,7 @@
     },
     "exclude": {
       "type": "string",
-      "description": "Comma-delimited list of packages that should not be bumped when using the --all flag"
+      "description": "Comma-delimited list of projects that should not be bumped when using the --all flag"
     }
   },
   "required": ["bumpType"]

--- a/tools/workspace-plugin/src/generators/version-bump/schema.ts
+++ b/tools/workspace-plugin/src/generators/version-bump/schema.ts
@@ -10,7 +10,7 @@ export interface VersionBumpGeneratorSchema {
   all?: boolean;
 
   /**
-   * Comma-delimited list of packages that should not be bumped when using the `--all` flag
+   * Comma-delimited list of projects that should not be bumped when using the `--all` flag
    */
   exclude?: string;
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

> introduced https://github.com/microsoft/fluentui/pull/31893

all workspace generators are broken

![image](https://github.com/microsoft/fluentui/assets/1223799/b5cf2c84-50c0-429f-b100-bf618194f79f)


## New Behavior

all workspace generators work

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows https://github.com/microsoft/fluentui/pull/31937
