### PR TITLE
fix(react-tabster): bump tabster to 8.0.1 to fix memorized elements focusing

### DIFF
--- a/change/@fluentui-react-tabster-7873879f-bbad-4e1a-ada9-c76ac1dc61d3.json
+++ b/change/@fluentui-react-tabster-7873879f-bbad-4e1a-ada9-c76ac1dc61d3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bump tabster to 8.0.1 to fix memorized elements focusing",
+  "packageName": "@fluentui/react-tabster",
+  "email": "marata@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tabster/package.json
+++ b/packages/react-components/react-tabster/package.json
@@ -37,7 +37,7 @@
     "@griffel/react": "^1.5.22",
     "@swc/helpers": "^0.5.1",
     "keyborg": "^2.6.0",
-    "tabster": "^8.0.0"
+    "tabster": "^8.0.1"
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <19.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22713,10 +22713,10 @@ table@^6.0.7, table@^6.0.9:
     string-width "^4.2.3"
     strip-ansi "^6.0.1"
 
-tabster@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/tabster/-/tabster-8.0.0.tgz#a4412ab92643a70ff6c4f20fc82b04602fb63949"
-  integrity sha512-82pqhDwH3uq7hVcy1nOo7lyYgCJcVUPqb30hvoHtX8DQ5pxEtRz9+FqVcW5w7J6kTjNBBu7cwKvuMy9qoeQt1g==
+tabster@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/tabster/-/tabster-8.0.1.tgz#07540bf5939b23bb6cdbb1e2c506cdaa2d0a427c"
+  integrity sha512-Df8La4+IkdbHjupybEDv4rCPSOwx8L3Xh7UVbl0tzyrkiVTKvZg3IRID6KHd/tXbyerO4cXwhY9aOQ+mbEP04w==
   dependencies:
     keyborg "2.6.0"
     tslib "^2.3.1"


### PR DESCRIPTION
- CHANGELOG https://github.com/microsoft/tabster/blob/master/CHANGELOG.md#v801
- including fix for https://github.com/microsoft/fluentui/issues/30556.