### PR TITLE
bugfix: fix reflow problems when layout is automatic

### DIFF
--- a/change/@fluentui-react-message-bar-1b660455-10b7-4111-981f-7aba0c1b6d69.json
+++ b/change/@fluentui-react-message-bar-1b660455-10b7-4111-981f-7aba0c1b6d69.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: fix reflow problems with layout automatic",
+  "packageName": "@fluentui/react-message-bar",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->


Seems like there's some race conditions happening and our internal resize observer handler is not being called properly in some cases

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
1. uses `useIsomorphicLayoutEffect`  instead of ref callbacks

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/31950
