### PR TITLE
Fix for WindowProvider utilities always returning window/document/undefined

### DIFF
--- a/change/@fluentui-react-cc5ae7ec-1f14-415d-915b-88de6d5cb7f0.json
+++ b/change/@fluentui-react-cc5ae7ec-1f14-415d-915b-88de6d5cb7f0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix WindowProvider utilities always returning window/document/undefined",
+  "packageName": "@fluentui/react",
+  "email": "jamie@index.hm",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/utilities/dom.ts
+++ b/packages/react/src/utilities/dom.ts
@@ -17,7 +17,7 @@ import { useDocument, useWindow, WindowProviderProps } from '@fluentui/react-win
  */
 export const useDocumentEx = () => {
   // eslint-disable-next-line no-restricted-globals
-  return useDocument() ?? typeof document !== 'undefined' ? document : undefined;
+  return useDocument() ?? (typeof document !== 'undefined' ? document : undefined);
 };
 
 /**
@@ -27,7 +27,7 @@ export const useDocumentEx = () => {
  */
 export const useWindowEx = () => {
   // eslint-disable-next-line no-restricted-globals
-  return useWindow() ?? typeof window !== 'undefined' ? window : undefined;
+  return useWindow() ?? (typeof window !== 'undefined' ? window : undefined);
 };
 
 /**
@@ -39,7 +39,7 @@ export const useWindowEx = () => {
  */
 export const getDocumentEx = (ctx: Pick<WindowProviderProps, 'window'> | undefined) => {
   // eslint-disable-next-line no-restricted-globals
-  return ctx?.window?.document ?? typeof document !== 'undefined' ? document : undefined;
+  return ctx?.window?.document ?? (typeof document !== 'undefined' ? document : undefined);
 };
 
 /**
@@ -51,5 +51,5 @@ export const getDocumentEx = (ctx: Pick<WindowProviderProps, 'window'> | undefin
  */
 export const getWindowEx = (ctx: Pick<WindowProviderProps, 'window'> | undefined) => {
   // eslint-disable-next-line no-restricted-globals
-  return ctx?.window ?? typeof window !== 'undefined' ? window : undefined;
+  return ctx?.window ?? (typeof window !== 'undefined' ? window : undefined);
 };


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

useWindowEx/useDocumentEx (and related methods) weren't short-circuit returning the value of the useWindow/useDocument hooks 

<!-- This is the behavior we have today -->

## New Behavior

useWindowEx/etc now return the WindowProvider value (if set), window (if defined), or undefined (in that order). 

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #31929
