### PR TITLE
chore:(docs) Adds doc explaining _unstable suffix

### DIFF
--- a/docs/react-v9/contributing/unstable-hooks.md
+++ b/docs/react-v9/contributing/unstable-hooks.md
@@ -1,0 +1,15 @@
+# How to treat API's marked with the `unstable` suffix
+
+There are many hooks and functions throughout this library marked with the `_unstable` suffix.
+
+This is due to legacy decisions in the early days of v9 development, when there was a chance these API's might change.
+
+Since then, the library has continued to move and grow. However stability was something we've learned partners value highly, so we've also embraced that value.It was concluded that these API's should not be changed, even to rename them.
+
+Renaming an API to remove the suffix would be a breaking change. Marking the `_unstable` API's as `@deprecated`with JSDocs and re-exporting them would also trip many teams linters and cause friction for consuming teams.
+
+**We treat API's with the `_unstable` suffix as stable, and our consumers should do also consider them stable.**
+
+One step consuming teams can do to reduce friction as they import `_unstable` API's is to rename and re-export them at an abstraction layer local to their project.
+
+We are actively working towards a solution that removes this point of friction for consuming teams, and will update this document accordingly.

--- a/docs/react-v9/contributing/unstable-hooks.md
+++ b/docs/react-v9/contributing/unstable-hooks.md
@@ -1,15 +1,15 @@
-# How to treat API's marked with the `unstable` suffix
+# How to treat API's marked with the `_unstable` suffix
 
 There are many hooks and functions throughout this library marked with the `_unstable` suffix.
 
 This is due to legacy decisions in the early days of v9 development, when there was a chance these API's might change.
 
-Since then, the library has continued to move and grow. However stability was something we've learned partners value highly, so we've also embraced that value.It was concluded that these API's should not be changed, even to rename them.
+Since then, the library has continued to move and grow. We've learned stability was something partners treasured, so we've also embraced that value. It was concluded that these API's should not be changed, even to rename them in the v9 iteration of Fluent UI React.
 
 Renaming an API to remove the suffix would be a breaking change. Marking the `_unstable` API's as `@deprecated`with JSDocs and re-exporting them would also trip many teams linters and cause friction for consuming teams.
 
-**We treat API's with the `_unstable` suffix as stable, and our consumers should do also consider them stable.**
+**We treat API's with the `_unstable` suffix as stable, and our consumers should do also consider them stable. This should be considered simply a naming bug at this point.**
 
 One step consuming teams can do to reduce friction as they import `_unstable` API's is to rename and re-export them at an abstraction layer local to their project.
 
-We are actively working towards a solution that removes this point of friction for consuming teams, and will update this document accordingly.
+We are actively working towards a solution that gracefully removes this point of friction for consuming teams, and will update this document accordingly.

--- a/docs/react-v9/contributing/unstable-hooks.md
+++ b/docs/react-v9/contributing/unstable-hooks.md
@@ -4,12 +4,25 @@ There are many hooks and functions throughout this library marked with the `_uns
 
 This is due to legacy decisions in the early days of v9 development, when there was a chance these API's might change.
 
-Since then, the library has continued to move and grow. We've learned stability was something partners treasured, so we've also embraced that value. It was concluded that these API's should not be changed, even to rename them in the v9 iteration of Fluent UI React.
+Since then, the library has continued to move and grow. We've learned stability is something partners treasure, so we've also embraced that value. It was concluded that these API's should not be changed, even to rename them in the v9 iteration of Fluent UI React.
 
 Renaming an API to remove the suffix would be a breaking change. Marking the `_unstable` API's as `@deprecated`with JSDocs and re-exporting them would also trip many teams linters and cause friction for consuming teams.
 
-**We treat API's with the `_unstable` suffix as stable, and our consumers should do also consider them stable. This should be considered simply a naming bug at this point.**
+**In our stable packages, we treat API's with the `_unstable` suffix as stable. Our consumers should also consider them stable.** This should be considered simply a naming bug at this point.
 
-One step consuming teams can do to reduce friction as they import `_unstable` API's is to rename and re-export them at an abstraction layer local to their project.
+**Stable packages :**
+
+- Are under "Components" on react.fluentui.dev
+- Has a 9.x.y version number
+- Is exported from @fluentui/react-components
+
+**Unstable packages :**
+
+- Are under "Preview Components" on react.fluentui.dev
+- Have a 0.x.y version number
+- Have `-preview` suffix on the package name
+- Are never exported from @fluentui/react-components
+
+Consuming teams can reduce friction as they import `_unstable` API's by renaming and re-exporting them at an abstraction layer local to their project.
 
 We are actively working towards a solution that gracefully removes this point of friction for consuming teams, and will update this document accordingly.


### PR DESCRIPTION
We've heard from partners that there is a lot of confusion over the `_unstable` suffix attached to many of our APIs. 

It's a source of friction and hesitation in adopting v9.

We burn a lot of time re-assuring folks that our `_unstable` API's are in fact stable.

This doc provides a vehicle to speed up and re-enforce that. Hopefully we can point people to it to save ourselves time and convince folks that we won't break `_unstable` APIs in stable packages.