### PR TITLE
Fix slider design

### DIFF
--- a/change/@fluentui-react-slider-abb37681-b1fa-47f5-bdf0-d166119927f8.json
+++ b/change/@fluentui-react-slider-abb37681-b1fa-47f5-bdf0-d166119927f8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: slider adjust design",
+  "packageName": "@fluentui/react-slider",
+  "email": "joao.lopes@softplan.com.br",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-slider/library/src/components/Slider/useSliderStyles.styles.ts
+++ b/packages/react-components/react-slider/library/src/components/Slider/useSliderStyles.styles.ts
@@ -157,7 +157,7 @@ const useRailStyles = makeStyles({
   },
 
   horizontal: {
-    width: '100%',
+    width: '118%',
     height: `var(${railSizeVar})`,
     '::before': {
       left: '-1px',
@@ -168,7 +168,7 @@ const useRailStyles = makeStyles({
 
   vertical: {
     width: `var(${railSizeVar})`,
-    height: '100%',
+    height: '118%',
     '::before': {
       width: `var(${railSizeVar})`,
       top: '-1px',


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

In the slider component, when entering values ​​less than 10 or greater than 90 (thinking of a slider with min 0 and max 100), we get the impression of values ​​0 or 100, as shown in the image:


![image](https://github.com/user-attachments/assets/5a55ea88-a2e8-41d6-afcd-d2a957b9ec72)


## New Behavior

Adjusted height (for vertical slider) and width (for horizontal slider)

![image](https://github.com/user-attachments/assets/a8dff295-6162-46db-87be-06a6583ed228)

![image](https://github.com/user-attachments/assets/a0a0a6f8-a435-4d9e-8228-d9f058541491)


## Related Issue(s)


- Fixes #31985
