### PR TITLE
chore(web-components): cleanup drawer storybook

### DIFF
--- a/change/@fluentui-web-components-7af277b6-1e65-46b2-89d4-412861c9d3bb.json
+++ b/change/@fluentui-web-components-7af277b6-1e65-46b2-89d4-412861c9d3bb.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: cleanup drawer storybook",
+  "packageName": "@fluentui/web-components",
+  "email": "rupertdavid@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/drawer-body/drawer-body.ts
+++ b/packages/web-components/src/drawer-body/drawer-body.ts
@@ -1,3 +1,10 @@
 import { FASTElement } from '@microsoft/fast-element';
 
-export class DrawerBody extends FASTElement {}
+export class DrawerBody extends FASTElement {
+  /**
+   * @slot title - The title slot
+   * @slot close - The close button slot
+   * @slot - The default slot
+   * @slot footer - The footer slot
+   */
+}

--- a/packages/web-components/src/drawer-body/drawer-body.ts
+++ b/packages/web-components/src/drawer-body/drawer-body.ts
@@ -1,10 +1,20 @@
 import { FASTElement } from '@microsoft/fast-element';
 
-export class DrawerBody extends FASTElement {
-  /**
-   * @slot title - The title slot
-   * @slot close - The close button slot
-   * @slot - The default slot
-   * @slot footer - The footer slot
-   */
-}
+/**
+ * A DrawerBody component to layout drawer content
+ * @extends FASTElement
+ *
+ * @slot title - The title slot
+ * @slot close - The close button slot
+ * @slot - The default content slot
+ * @slot footer - The footer slot
+ *
+ * @csspart header - The header part of the drawer
+ * @csspart content - The content part of the drawer
+ * @csspart footer - The footer part of the drawer
+ *
+ * @summary A component that provides a drawer body for displaying content in a side panel.
+ *
+ * @tag fluent-drawer-body
+ */
+export class DrawerBody extends FASTElement {}

--- a/packages/web-components/src/drawer/drawer.stories.ts
+++ b/packages/web-components/src/drawer/drawer.stories.ts
@@ -1,7 +1,5 @@
 import { html } from '@microsoft/fast-element';
 import { Meta, renderComponent, Story, StoryArgs } from '../helpers.stories.js';
-import { RadioGroup } from '../radio-group/radio-group.js';
-import type { TextInput as FluentTextInput } from '../text-input/text-input.js';
 import type { Drawer as FluentDrawer } from './drawer.js';
 import { DrawerPosition, DrawerSize, DrawerType } from './drawer.options.js';
 
@@ -21,41 +19,13 @@ const dismissed20Regular = html<StoryArgs<FluentDrawer>>`<svg
 
 const toggleDrawer = (drawerID: string, containerID?: string) => {
   const drawer = document.getElementById(drawerID) as FluentDrawer;
-  if (containerID) {
-    const container = document.querySelector(`#${containerID}`);
-    const drawers = container!.querySelectorAll(`fluent-drawer:not(#${drawerID})`);
-    drawers.forEach(drawerElement => {
-      const drawer = drawerElement as FluentDrawer;
-      if (drawer.dialog.open) {
-        drawer.hide();
-      }
-    });
-  }
+
   if (drawer.dialog.open) {
     drawer.hide();
   } else {
     drawer.show();
   }
 };
-
-const toggleSelectedDrawer = (radioGroupId: string) => {
-  const radioGroup = document.getElementById(radioGroupId) as RadioGroup;
-  const idSubString = radioGroup.value;
-  const drawerToOpen = document.querySelector(`#drawer-${idSubString}`) as FluentDrawer;
-  const drawersToClose = document.querySelectorAll(`fluent-drawer:not(#drawer-${idSubString})`);
-  if (drawerToOpen.dialog.open) {
-    drawerToOpen.hide();
-  } else {
-    drawerToOpen.show();
-  }
-  drawersToClose.forEach(d => {
-    const drawer = d as FluentDrawer;
-    if (drawer.dialog.open) {
-      drawer.hide();
-    }
-  });
-};
-
 const hideDrawer = (drawerID: string) => {
   const drawer = document.getElementById(drawerID) as FluentDrawer;
   if (drawer.dialog.open) {
@@ -64,133 +34,101 @@ const hideDrawer = (drawerID: string) => {
 };
 
 const storyTemplate = html<StoryArgs<FluentDrawer>>`
-  <div class="full-height">
-    <style>
-      div.docs-story > div:first-child,
-      #docs-root .innerZoomElementWrapper > div > div {
-        height: 30em;
-        overflow: hidden;
-        padding: 0;
-      }
-      #docs-root .innerZoomElementWrapper > div {
-        padding: 0;
-      }
-      .full-height,
-      .innerZoomElementWrapper > div > div > div {
-        height: 100%;
-      }
-      .justify--space-betweendocs-content {
-        max-width: 1200px;
-      }
-      .story-container {
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        height: 100%;
-        width: 100%;
-      }
-      .grid {
-        display: grid;
-      }
-      .flex {
-        display: flex;
-      }
-      .column {
-        flex-direction: column;
-      }
-      .justify--center {
-        justify-content: center;
-      }
-      .justify--space-between {
-        justify-content: space-between;
-      }
-      .gap--16 {
-        gap: 16px;
-      }
-      .col-gap--8 {
-        column-gap: 8px;
-      }
-      .padding--16 {
-        padding: 16px;
-      }
-      .width-400 {
-        width: 400px;
-      }
-    </style>
-    <div class="flex justify--space-between full-height">
-      <fluent-drawer id="drawer-default-start" position="start" size="${x => x.size}" type="${x => x.type}">
-        <fluent-drawer-body>
-          <span slot="title"> Drawer Header</span>
+  <style>
+    #docs-root .innerZoomElementWrapper > div,
+    #docs-root .innerZoomElementWrapper > div > div {
+      padding: 0;
+    }
+
+    .demo {
+      display: flex;
+      align-items: center;
+      min-height: 22rem;
+      width: 100%;
+    }
+
+    .demo-content {
+      grid-area: content;
+      padding: 48px 24px;
+    }
+
+    .demo:has([position='end']) [position='end'] {
+      order: 1;
+    }
+  </style>
+
+  <div class="demo">
+    <fluent-drawer
+      id="drawer-default"
+      position="${x => x.position}"
+      size="${x => x.size}"
+      type="${x => x.type}"
+      style="${x => (x['--drawer-width'] !== '' ? `--drawer-width: ${x['--drawer-width']}` : void 0)}"
+    >
+      <fluent-drawer-body>
+        <span slot="title"> Drawer Header</span>
+        <fluent-button
+          slot="close"
+          appearance="transparent"
+          icon-only
+          aria-label="close"
+          @click="${() => hideDrawer('drawer-default')}"
+        >
+          ${dismissed20Regular}
+        </fluent-button>
+        <div>
+          <fluent-text>
+            The drawer gives users a quick entry point to configuration and information. It should be used when
+            retaining context is beneficial to users. An overlay is optional depending on whether or not interacting
+            with the background content is beneficial to the user's context/scenario. An overlay makes the drawer
+            blocking and signifies that the users full attention is required when making configurations.
+          </fluent-text>
+
           <div>
-            <fluent-text>
-              The drawer gives users a quick entry point to configuration and information. It should be used when
-              retaining context is beneficial to users. An overlay is optional depending on whether or not interacting
-              with the backgroun d content is beneficial to the user's context/scenario. An overlay makes the drawer
-              blocking and signifies that the users full attention is required when making configurations.
-            </fluent-text>
-            <div>
-              <fluent-radio-group>
-                <fluent-label slot="label">Please select an option</fluent-label>
-                <fluent-radio value="1">Option 1</fluent-radio>
-                <fluent-radio value="2">Option 2</fluent-radio>
-                <fluent-radio value="3">Option 3</fluent-radio>
+            <fluent-field>
+              <label slot="label">Please select an option</label>
+              <fluent-radio-group id="demo-options" slot="input" orientation="vertical">
+                <fluent-field label-position="after">
+                  <label for="option-one" slot="label">Option 1</label>
+                  <fluent-radio id="option-one" slot="input" name="demo-options" value="1"></fluent-radio>
+                </fluent-field>
+                <fluent-field label-position="after">
+                  <label for="option-two" slot="label">Option 2</label>
+                  <fluent-radio id="option-two" slot="input" name="demo-options" value="2"></fluent-radio>
+                </fluent-field>
+                <fluent-field label-position="after">
+                  <label for="option-three" slot="label">Option 3</label>
+                  <fluent-radio id="option-three" slot="input" name="demo-options" value="3"></fluent-radio>
+                </fluent-field>
               </fluent-radio-group>
-            </div>
+            </fluent-field>
           </div>
-          <div slot="footer" class="flex gap--16">
-            <fluent-button appearance="primary" @click="${() => hideDrawer('drawer-default-start')}"
-              >Close</fluent-button
-            >
-            <fluent-button appearance="secondary">Do Something</fluent-button>
-          </div>
-        </fluent-drawer-body>
-      </fluent-drawer>
-      <div class="gap--16 column flex justify--center padding--16 width-400">
-        <fluent-text weight="bold" size="400" as="h3"><h3>Drawer</h3></fluent-text>
-        <fluent-text font="base" size="300" weight="regular" as="p">
-          <p>
-            The Drawer gives users a quick entry point to configuration and information. It should be used when
-            retaining context is beneficial to users.
-          </p>
-        </fluent-text>
-        <fluent-text font="monospace" size="300" weight="regular">
-          <code>fluent-drawer</code>
-        </fluent-text>
-        <fluent-radio-group id="drawer-radio-default" orientation="horizontal">
-          <fluent-label weight="semibold">Position</fluent-label>
-          <fluent-radio value="default-start" checked>Start</fluent-radio>
-          <fluent-radio value="default-end">End</fluent-radio>
-        </fluent-radio-group>
-        <fluent-button appearance="primary" @click="${() => toggleSelectedDrawer('drawer-radio-default')}"
+        </div>
+        <div slot="footer">
+          <fluent-button appearance="primary" @click="${() => hideDrawer('drawer-default')}">Close</fluent-button>
+          <fluent-button appearance="secondary">Do Something</fluent-button>
+        </div>
+      </fluent-drawer-body>
+    </fluent-drawer>
+    <div class="demo-content">
+      <fluent-text font="base" size="300" weight="regular" as="p">
+        <p>
+          The Drawer gives users a quick entry point to configuration and information. It should be used when retaining
+          context is beneficial to users.
+        </p>
+      </fluent-text>
+      <br />
+      <br />
+      <fluent-text font="monospace" size="300" weight="regular">
+        <code>fluent-drawer</code>
+      </fluent-text>
+      <br />
+      <br />
+      <div>
+        <fluent-button appearance="primary" @click="${() => toggleDrawer('drawer-default')}"
           >Toggle Drawer</fluent-button
         >
       </div>
-      <fluent-drawer id="drawer-default-end" position="end" size="${x => x.size}" type="${x => x.type}">
-        <fluent-drawer-body>
-          <span slot="title"> Drawer Header</span>
-
-          <div>
-            <fluent-text>
-              The drawer gives users a quick entry point to configuration and information. It should be used when
-              retaining context is beneficial to users. An overlay is optional depending on whether or not interacting
-              with the backgroun d content is beneficial to the user's context/scenario. An overlay makes the drawer
-              blocking and signifies that the users full attention is required when making configurations.
-            </fluent-text>
-            <div>
-              <fluent-radio-group>
-                <fluent-label slot="label">Please select an option</fluent-label>
-                <fluent-radio value="1">Option 1</fluent-radio>
-                <fluent-radio value="2">Option 2</fluent-radio>
-                <fluent-radio value="3">Option 3</fluent-radio>
-              </fluent-radio-group>
-            </div>
-          </div>
-          <div slot="footer" class="flex gap--16">
-            <fluent-button appearance="primary" @click="${() => hideDrawer('drawer-default-end')}">Close</fluent-button>
-            <fluent-button appearance="secondary">Do Something</fluent-button>
-          </div>
-        </fluent-drawer-body>
-      </fluent-drawer>
     </div>
   </div>
 `;
@@ -200,10 +138,15 @@ export default {
   args: {
     type: DrawerType.modal,
     size: DrawerSize.medium,
+    position: DrawerPosition.start,
+    '--drawer-width': '',
   },
   argTypes: {
     position: {
       options: Object.values(DrawerPosition),
+      control: {
+        type: 'select',
+      },
       table: {
         type: {
           summary: 'Sets the position of drawer',
@@ -241,409 +184,16 @@ export default {
         },
       },
     },
+    '--drawer-width': {
+      control: 'text',
+      required: false,
+      table: {
+        type: {
+          summary: 'Sets the custom width of drawer, e.g. 300px',
+        },
+      },
+    },
   },
 } as Meta<FluentDrawer>;
 
 export const Drawer: Story<FluentDrawer> = renderComponent(storyTemplate).bind({});
-
-export const Modal: Story<FluentDrawer> = renderComponent(html<StoryArgs<FluentDrawer>>`
-  <div class="flex justify--center full-height">
-    <div>
-      <fluent-drawer id="drawer-modal" type="modal">
-        <fluent-drawer-body>
-          <span slot="title"> Drawer Header</span>
-          <fluent-button
-            slot="close"
-            appearance="transparent"
-            icon-only
-            aria-label="close"
-            @click="${() => hideDrawer('drawer-modal')}"
-          >
-            ${dismissed20Regular}
-          </fluent-button>
-          <div>
-            <fluent-text font="base" size="300" weight="regular" as="p">
-              <p>
-                When a modal dialog is open, the rest of the page is dimmed out and cannot be interacted with. The tab
-                sequence is kept within the dialog and moving the focus outside the dialog will imply closing it. This
-                is the default type of the component.
-              </p>
-            </fluent-text>
-            <br />
-            <br />
-            <fluent-text font="monospace" size="300" weight="regular" as="p">
-              <code>type="modal"</code>
-            </fluent-text>
-          </div>
-          <div slot="footer" class="flex gap--16">
-            <fluent-button appearance="primary" @click="${() => hideDrawer('drawer-default-start')}"
-              >Close</fluent-button
-            >
-            <fluent-button appearance="secondary">Do Something</fluent-button>
-          </div>
-        </fluent-drawer-body>
-      </fluent-drawer>
-    </div>
-    <div class="gap--16 column flex justify--center padding--16 width-400">
-      <fluent-text weight="bold" size="400" as="h3"><h3>Modal</h3></fluent-text>
-      <fluent-text weight="regular" size="300" as="p" block="true">
-        <p>
-          When a modal dialog is open, the rest of the page is dimmed out and cannot be interacted with. The tab
-          sequence is kept within the dialog and moving the focus outside the dialog will imply closing it. This is the
-          default type of the component.
-        </p>
-      </fluent-text>
-      <fluent-text font="monospace" size="300" weight="regular" as="p" block="true">
-        <code>type="modal"</code>
-      </fluent-text>
-      <fluent-button appearance="primary" @click="${() => toggleDrawer('drawer-modal')}">Toggle Drawer</fluent-button>
-    </div>
-  </div>
-`);
-
-export const NonModal: Story<FluentDrawer> = renderComponent(html<StoryArgs<FluentDrawer>>`
-  <div class="flex justify--center full-height">
-    <div>
-      <fluent-drawer id="drawer-nonmodal" type="non-modal">
-        <fluent-drawer-body>
-          <span slot="title">Non modal</span>
-          <fluent-button
-            slot="close"
-            appearance="transparent"
-            icon-only
-            aria-label="close"
-            @click="${() => hideDrawer('drawer-nonmodal')}"
-          >
-            ${dismissed20Regular}
-          </fluent-button>
-          <fluent-text font="base" size="300" weight="regular" as="p" block="true">
-            <p>
-              When a non-modal dialog is open, the rest of the page is not dimmed out and users can interact with the
-              rest of the page. This also implies that the tab focus can move outside the dialog when it reaches the
-              last focusable element.
-            </p>
-          </fluent-text>
-          <br />
-          <fluent-text font="monospace" size="300" weight="regular" as="p" block="true">
-            <code>type="non-modal"</code>
-          </fluent-text>
-        </fluent-drawer-body>
-      </fluent-drawer>
-    </div>
-    <div class="gap--16 column flex justify--center padding--16 width-400">
-      <fluent-text weight="bold" size="400" as="h3"><h3>Non Modal</h3></fluent-text>
-      <fluent-text weight="regular" size="300" as="p">
-        <p>
-          When a non-modal dialog is open, the rest of the page is not dimmed out and users can interact with the rest
-          of the page. This also implies that the tab focus can move outside the dialog when it reaches the last
-          focusable element.
-        </p>
-      </fluent-text>
-      <fluent-text font="monospace" size="300" weight="regular" as="p">
-        <code>type="non-modal"</code>
-      </fluent-text>
-      <fluent-button appearance="primary" @click="${() => toggleDrawer('drawer-nonmodal')}"
-        >Toggle Drawer</fluent-button
-      >
-    </div>
-  </div>
-`);
-
-export const Inline: Story<FluentDrawer> = renderComponent(html<StoryArgs<FluentDrawer>>`
-  <div class="flex justify--center full-height">
-    <div>
-      <fluent-drawer id="drawer-inline" type="inline" size="large">
-        <fluent-drawer-body>
-          <span slot="title">Drawer Inline</span>
-          <fluent-button
-            slot="close"
-            appearance="transparent"
-            icon-only
-            aria-label="close"
-            @click="${() => hideDrawer('drawer-inline')}"
-          >
-            ${dismissed20Regular}
-          </fluent-button>
-          <fluent-text font="base" size="300" weight="regular" as="p">
-            <p>
-              An inline Drawer is often used for navigation that is not dismissible. As it is on the same level as the
-              main surface, users can still interact with other UI elements. This could be useful for swapping between
-              different items in the main surface.
-            </p>
-          </fluent-text>
-          <br />
-          <fluent-text font="monospace" size="300" weight="regular" as="p" block="true">
-            <code>type="inline"</code>
-          </fluent-text>
-        </fluent-drawer-body>
-      </fluent-drawer>
-    </div>
-    <div class="gap--16 column flex justify--center padding--16 width-400">
-      <fluent-text weight="bold" size="400" as="h3"><h3>Inline</h3></fluent-text>
-      <fluent-text font="base" size="300" weight="regular" as="p">
-        <p>
-          An inline Drawer is often used for navigation that is not dismissible. As it is on the same level as the main
-          surface, users can still interact with other UI elements. This could be useful for swapping between different
-          items in the main surface.
-        </p>
-      </fluent-text>
-      <fluent-text font="monospace" size="300" weight="regular" as="p">
-        <code>type="inline"</code>
-      </fluent-text>
-      <fluent-button appearance="primary" @click="${() => toggleDrawer('drawer-inline')}">Toggle Drawer</fluent-button>
-    </div>
-  </div>
-`);
-
-export const Position: Story<FluentDrawer> = renderComponent(html<StoryArgs<FluentDrawer>>`
-  <div class="flex justify--space-between full-height">
-    <div>
-      <fluent-drawer type="modal" id="drawer-position-start" size="small">
-        <fluent-drawer-body>
-          <span slot="title">Drawer position start</span>
-
-          <fluent-button
-            slot="close"
-            appearance="transparent"
-            icon-only
-            aria-label="close"
-            @click="${() => hideDrawer('drawer-position-start')}"
-          >
-            ${dismissed20Regular}
-          </fluent-button>
-          <fluent-text font="base" size="300" weight="regular" as="p">
-            <p>
-              When a Drawer is invoked, it slides in from either the left or right side of the screen. This can be
-              specified by the position attribute.
-            </p>
-          </fluent-text>
-          <br />
-
-          <fluent-text font="monospace" size="300" weight="regular">
-            <code>default</code>
-          </fluent-text>
-          <div slot="footer" class="flex gap--16">
-            <fluent-button appearance="primary">Primary</fluent-button>
-            <fluent-button appearance="secondary">Secondary</fluent-button>
-          </div>
-        </fluent-drawer-body>
-      </fluent-drawer>
-    </div>
-    <div class="gap--16 column flex justify--center padding--16 width-400">
-      <fluent-text weight="bold" size="400" as="h3"><h3>Position</h3></fluent-text>
-
-      <fluent-text font="base" size="300" weight="regular" as="p">
-        <p>
-          When a Drawer is invoked, it slides in from either the left or right side of the screen. This can be specified
-          by the position attribute.
-        </p>
-      </fluent-text>
-      <br />
-      <fluent-text font="monospace" size="300" weight="regular">
-        <code>position="start"</code>
-      </fluent-text>
-      <fluent-label weight="semibold">Select a Drawer Position</fluent-label>
-      <fluent-radio-group id="drawer-radiogroup-position">
-        <fluent-radio value="position-start" checked>Start</fluent-radio>
-        <fluent-radio value="position-end">End</fluent-radio>
-      </fluent-radio-group>
-      <fluent-button appearance="primary" @click="${() => toggleSelectedDrawer('drawer-radiogroup-position')}"
-        >Toggle Drawer</fluent-button
-      >
-    </div>
-    <div>
-      <fluent-drawer position="end" type="modal" id="drawer-position-end" size="small">
-        <fluent-drawer-body>
-          <span slot="title">Drawer position end</span>
-          <fluent-button
-            slot="close"
-            appearance="transparent"
-            icon-only
-            aria-label="close"
-            @click="${() => hideDrawer('drawer-position-end')}"
-          >
-            ${dismissed20Regular}
-          </fluent-button>
-          <fluent-text font="base" size="300" weight="regular" as="p">
-            <p>
-              The drawer component offers flexible positioning options to suit your layout needs. By using the position
-              attribute, you can easily place the drawer on either side of the screen. The attribute accepts values of
-              type DrawerPosition, which includes two options: 'start' and 'end'. The default position of the Drawer is
-              'end'.
-            </p>
-          </fluent-text>
-          <br />
-          <fluent-text font="monospace" size="300" weight="regular">
-            <code>position="end"</code>
-          </fluent-text>
-          <div slot="footer" class="flex gap--16">
-            <fluent-button appearance="primary">Primary</fluent-button>
-            <fluent-button appearance="secondary">Secondary</fluent-button>
-          </div>
-        </fluent-drawer-body>
-      </fluent-drawer>
-    </div>
-  </div>
-`);
-
-export const Size: Story<FluentDrawer> = renderComponent(html<StoryArgs<FluentDrawer>>`
-  <div class="flex justify--center full-height">
-    <div class="gap--16 column flex justify--center padding--16 width-400">
-      <fluent-text weight="bold" size="400" as="h3"><h3>Size</h3></fluent-text>
-
-      <fluent-text font="base" size="300" weight="regular" as="p">
-        <p>The size attribute controls the width of the drawer. The default is medium.</p>
-      </fluent-text>
-      <fluent-text font="monospace" size="300" weight="regular">
-        <code>size="small"</code>
-      </fluent-text>
-      <fluent-label weight="semibold">Select a Drawer Size</fluent-label>
-      <fluent-radio-group id="drawer-radiogroup-sizes">
-        <fluent-radio value="size-small">Small</fluent-radio>
-        <fluent-radio value="size-medium" checked>Medium</fluent-radio>
-        <fluent-radio value="size-large">Large</fluent-radio>
-        <fluent-radio value="size-full">Full</fluent-radio>
-      </fluent-radio-group>
-      <fluent-button appearance="primary" @click="${() => toggleSelectedDrawer('drawer-radiogroup-sizes')}"
-        >Toggle Drawer</fluent-button
-      >
-    </div>
-    <fluent-drawer size="small" id="drawer-size-small" type="modal">
-      <fluent-drawer-body>
-      <span slot="title">Drawer small</span>
-        <fluent-button
-          slot="close"
-          appearance="transparent"
-          icon-only
-          aria-label="close"
-          @click="${() => hideDrawer('drawer-size-small')}"
-        >
-          ${dismissed20Regular}
-        </fluent-button>
-        <fluent-text font="base" size="300" weight="regular" as="p">
-          <p>The size attribute controls the width of the drawer. The default is medium.</p>
-        </fluent-text>
-        <br />
-        <fluent-text font="monospace" size="300" weight="regular">
-          <code>size="small"</code>
-        </fluent-text>
-      </fluent-drawer-body>
-    </fluent-drawer>
-    <fluent-drawer size="medium" id="drawer-size-medium" type="modal">
-      <fluent-drawer-body>
-      <span slot="title">Drawer medium</span>
-        <fluent-button
-          slot="close"
-          appearance="transparent"
-          icon-only
-          aria-label="close"
-          @click="${() => hideDrawer('drawer-size-medium')}"
-        >
-          ${dismissed20Regular}
-        </fluent-button>
-        <fluent-text font="base" size="300" weight="regular" as="p">
-          <p>The size attribute controls the width of the drawer. The default is medium.</p>
-        </fluent-text>
-        <br />
-        <fluent-text font="monospace" size="300" weight="regular">
-          <code>default</code>
-        </fluent-text>
-      </fluent-drawer-body>
-    </fluent-drawer>
-    <fluent-drawer size="large" id="drawer-size-large" type="modal">
-      <fluent-drawer-body>
-      <span slot="title">Drawer large</span>
-              <fluent-button
-                slot="close"
-                appearance="transparent"
-                icon-only
-                aria-label="close"
-                @click="${() => hideDrawer('drawer-size-large')}"
-              >
-                ${dismissed20Regular}
-              </fluent-button>
-            <p>The size attribute controls the width of the drawer. The default is medium.</p>
-          </fluent-text>
-          <br />
-          <br />
-          <fluent-text font="monospace" size="300" weight="regular">
-            <code>size="large"</code>
-          </fluent-text>
-          </fluent-drawer-body>
-    </fluent-drawer>
-    <fluent-drawer size="full" id="drawer-size-full" type="modal">
-           <fluent-drawer-body>
-           <span slot="title">Drawer full</span>
-            <fluent-button
-              slot="close"
-              appearance="transparent"
-              icon-only
-              aria-label="close"
-              @click="${() => hideDrawer('drawer-size-full')}"
-            >
-              ${dismissed20Regular}
-            </fluent-button>
-          <fluent-text font="base" size="300" weight="regular" as="p">
-            <p>The size attribute controls the width of the drawer. The default is medium.</p>
-          </fluent-text>
-          <br />
-          <br />
-          <fluent-text font="monospace" size="300" weight="regular">
-            <code>size="full"</code>
-          </fluent-text>
-          </fluent-drawer-body>
-    </fluent-drawer>
-  </div>
-`);
-
-export const CustomSize: Story<FluentDrawer> = renderComponent(html`
-  <div class="flex justify--center full-height">
-    <div class="gap--16 column flex justify--center padding--16 width-400">
-      <fluent-text weight="bold" size="400" as="h3"><h3>Custom Size</h3></fluent-text>
-
-      <fluent-text font="base" size="300" weight="regular" as="p">
-        <p>The Drawer can be sized to any custom width, by overriding the drawer-width CSS variable:</p>
-      </fluent-text>
-      <fluent-text font="monospace" size="300" weight="regular">
-        <code>var(--drawer-width)</code>
-      </fluent-text>
-      <fluent-label weight="semibold">Set a Drawer Size (in px)</fluent-label>
-      <fluent-text-input
-        id="custom-size-input"
-        pattern="^[0-9]*$"
-        type="text"
-        @input="${(x, c) => {
-          (document.getElementById('drawer-width-custom') as FluentDrawer).style.setProperty(
-            '--drawer-width',
-            `${(c.event.target as FluentTextInput).value}px`,
-          );
-        }}"
-      ></fluent-text-input>
-      <fluent-button appearance="primary" @click="${() => toggleDrawer('drawer-width-custom')}"
-        >Toggle Drawer</fluent-button
-      >
-    </div>
-    <fluent-drawer id="drawer-width-custom" type="modal">
-      <fluent-drawer-body>
-        <span slot="title">Custom size</span>
-        <fluent-button
-          slot="close"
-          appearance="transparent"
-          icon-only
-          aria-label="close"
-          @click="${() => hideDrawer('drawer-width-custom')}"
-        >
-          ${dismissed20Regular}
-        </fluent-button>
-        <fluent-text font="base" size="300" weight="regular" as="p">
-          <p>The Drawer can be sized to any custom width, by overriding the drawer-width CSS variable:</p>
-        </fluent-text>
-        <br />
-        <br />
-        <fluent-text font="monospace" size="300" weight="regular">
-          <code>var(--drawer-width)</code>
-        </fluent-text>
-      </fluent-drawer-body>
-    </fluent-drawer>
-  </div>
-`);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

Found a visual regression for radio inputs on the Drawer component. 

View issue: https://web-components.fluentui.dev/?path=/docs/components-drawer--drawer

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

- Updates the story to use the new RadioGroup syntax.
- Refactors all Drawer stories into a single story with more control options.

## Questions

1. Rolling up the stories into a single story loses a bit of context, how much context do we need? 
2. If we need more context, where should that live?

> [!NOTE]
> This exposes a defect where you can't use labels to select a radioitem inside a drawer. Unclear if this is a problem with Drawer or with RadioGroup. I filed a separate issue for that: https://github.com/microsoft/fluentui/issues/31992