### PR TITLE
ci(.github): introduce check-tooling CI pipeline

### DIFF
--- a/.github/workflows/check-tooling.yml
+++ b/.github/workflows/check-tooling.yml
@@ -6,7 +6,8 @@ on:
       - 'tools/workspace-plugin/**'
 
 env:
-  __LOCAL_API_GENERATION__: true
+  __FORCE_API_MD_UPDATE__: true
+  __FORCE_SNAPSHOT_UPDATE__: true
 
 jobs:
   check-tools:

--- a/.github/workflows/check-tooling.yml
+++ b/.github/workflows/check-tooling.yml
@@ -29,7 +29,9 @@ jobs:
           yarn nx g @fluentui/workspace-plugin:react-library --name hello-world --owner '@mrWick' --kind standard --no-interactive &&
           yarn nx g @fluentui/workspace-plugin:react-component --project hello-world-preview --name Aiur --no-interactive &&
           yarn nx g @fluentui/workspace-plugin:cypress-component-configuration --project hello-world-preview --no-interactive &&
-          yarn nx g @fluentui/workspace-plugin:bundle-size-configuration --project hello-world-preview --name=Aiur --no-interactive &&
+          yarn nx g @fluentui/workspace-plugin:bundle-size-configuration --project hello-world-preview --no-interactive &&
           yarn nx g @fluentui/workspace-plugin:prepare-initial-release --project hello-world-preview --phase=preview --no-interactive &&
           yarn nx g @fluentui/workspace-plugin:prepare-initial-release --project hello-world-preview --phase=stable --no-interactive &&
-          yarn nx g @nx/workspace:remove --project hello-world --forceRemove --no-interactive
+          yarn nx g @nx/workspace:remove --project hello-world --forceRemove --no-interactive &&
+          yarn nx g @nx/workspace:remove --project hello-world-stories --forceRemove --no-interactive &&
+          yarn nx g @fluentui/workspace-plugin:tsconfig-base-all --no-interactive

--- a/.github/workflows/check-tooling.yml
+++ b/.github/workflows/check-tooling.yml
@@ -1,6 +1,8 @@
 name: Check tooling
 on:
   pull_request:
+    paths:
+      - 'tools/workspace-plugin/**'
 
 jobs:
   check-tools:
@@ -22,11 +24,11 @@ jobs:
       - run: yarn nx list @fluentui/workspace-plugin
 
       - name: test generators contributor flow
-        run: |
-          yarn nx g @fluentui/workspace-plugin:react-library --name hello-world --owner '@mrWick' --kind standard --no-interactive
-          yarn nx g @fluentui/workspace-plugin:react-component --project hello-world --name Aiur --no-interactive
-          yarn nx g @fluentui/workspace-plugin:cypress-component-configuration --project hello-world --no-interactive
-          yarn nx g @fluentui/workspace-plugin:bundle-size-configuration --project=hello-world --name=Aiur --no-interactive
-          yarn nx g @fluentui/workspace-plugin:prepare-initial-release --project hello-world --phase=preview --no-interactive
-          yarn nx g @fluentui/workspace-plugin:prepare-initial-release --project hello-world --phase=stable --no-interactive
+        run: >
+          yarn nx g @fluentui/workspace-plugin:react-library --name hello-world --owner '@mrWick' --kind standard --no-interactive &&
+          yarn nx g @fluentui/workspace-plugin:react-component --project hello-world --name Aiur --no-interactive &&
+          yarn nx g @fluentui/workspace-plugin:cypress-component-configuration --project hello-world --no-interactive &&
+          yarn nx g @fluentui/workspace-plugin:bundle-size-configuration --project=hello-world --name=Aiur --no-interactive &&
+          yarn nx g @fluentui/workspace-plugin:prepare-initial-release --project hello-world --phase=preview --no-interactive &&
+          yarn nx g @fluentui/workspace-plugin:prepare-initial-release --project hello-world --phase=stable --no-interactive &&
           yarn nx g @nx/workspace:remove --project hello-world --forceRemove --no-interactive

--- a/.github/workflows/check-tooling.yml
+++ b/.github/workflows/check-tooling.yml
@@ -1,5 +1,6 @@
 name: Check tooling
 on:
+  workflow_dispatch:
   pull_request:
     paths:
       - 'tools/workspace-plugin/**'

--- a/.github/workflows/check-tooling.yml
+++ b/.github/workflows/check-tooling.yml
@@ -24,14 +24,12 @@ jobs:
 
       - run: yarn nx list @fluentui/workspace-plugin
 
-      - name: test generators contributor flow
-        run: >
-          yarn nx g @fluentui/workspace-plugin:react-library --name hello-world --owner '@mrWick' --kind standard --no-interactive &&
-          yarn nx g @fluentui/workspace-plugin:react-component --project hello-world-preview --name Aiur --no-interactive &&
-          yarn nx g @fluentui/workspace-plugin:cypress-component-configuration --project hello-world-preview --no-interactive &&
-          yarn nx g @fluentui/workspace-plugin:bundle-size-configuration --project hello-world-preview --no-interactive &&
-          yarn nx g @fluentui/workspace-plugin:prepare-initial-release --project hello-world-preview --phase=preview --no-interactive &&
-          yarn nx g @fluentui/workspace-plugin:prepare-initial-release --project hello-world-preview --phase=stable --no-interactive &&
-          yarn nx g @nx/workspace:remove --project hello-world --forceRemove --no-interactive &&
-          yarn nx g @nx/workspace:remove --project hello-world-stories --forceRemove --no-interactive &&
-          yarn nx g @fluentui/workspace-plugin:tsconfig-base-all --no-interactive
+      - run: yarn nx g @fluentui/workspace-plugin:react-library --name hello-world --owner '@mrWick' --kind standard --no-interactive
+      - run: yarn nx g @fluentui/workspace-plugin:react-component --project hello-world-preview --name Aiur --no-interactive
+      - run: yarn nx g @fluentui/workspace-plugin:cypress-component-configuration --project hello-world-preview --no-interactive
+      - run: yarn nx g @fluentui/workspace-plugin:bundle-size-configuration --project hello-world-preview --no-interactive
+      - run: yarn nx g @fluentui/workspace-plugin:prepare-initial-release --project hello-world-preview --phase=preview --no-interactive
+      - run: yarn nx g @fluentui/workspace-plugin:prepare-initial-release --project hello-world-preview --phase=stable --no-interactive
+      - run: yarn nx g @nx/workspace:remove --project hello-world --forceRemove --no-interactive
+      - run: yarn nx g @nx/workspace:remove --project hello-world-stories --forceRemove --no-interactive
+      - run: yarn nx g @fluentui/workspace-plugin:tsconfig-base-all --no-interactive

--- a/.github/workflows/check-tooling.yml
+++ b/.github/workflows/check-tooling.yml
@@ -26,9 +26,9 @@ jobs:
       - name: test generators contributor flow
         run: >
           yarn nx g @fluentui/workspace-plugin:react-library --name hello-world --owner '@mrWick' --kind standard --no-interactive &&
-          yarn nx g @fluentui/workspace-plugin:react-component --project hello-world --name Aiur --no-interactive &&
-          yarn nx g @fluentui/workspace-plugin:cypress-component-configuration --project hello-world --no-interactive &&
-          yarn nx g @fluentui/workspace-plugin:bundle-size-configuration --project=hello-world --name=Aiur --no-interactive &&
-          yarn nx g @fluentui/workspace-plugin:prepare-initial-release --project hello-world --phase=preview --no-interactive &&
-          yarn nx g @fluentui/workspace-plugin:prepare-initial-release --project hello-world --phase=stable --no-interactive &&
+          yarn nx g @fluentui/workspace-plugin:react-component --project hello-world-preview --name Aiur --no-interactive &&
+          yarn nx g @fluentui/workspace-plugin:cypress-component-configuration --project hello-world-preview --no-interactive &&
+          yarn nx g @fluentui/workspace-plugin:bundle-size-configuration --project hello-world-preview --name=Aiur --no-interactive &&
+          yarn nx g @fluentui/workspace-plugin:prepare-initial-release --project hello-world-preview --phase=preview --no-interactive &&
+          yarn nx g @fluentui/workspace-plugin:prepare-initial-release --project hello-world-preview --phase=stable --no-interactive &&
           yarn nx g @nx/workspace:remove --project hello-world --forceRemove --no-interactive

--- a/.github/workflows/check-tooling.yml
+++ b/.github/workflows/check-tooling.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - 'tools/workspace-plugin/**'
 
+env:
+  __LOCAL_API_GENERATION__: true
+
 jobs:
   check-tools:
     strategy:

--- a/.github/workflows/check-tooling.yml
+++ b/.github/workflows/check-tooling.yml
@@ -1,0 +1,32 @@
+name: Check tooling
+on:
+  pull_request:
+
+jobs:
+  check-tools:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - run: yarn install --frozen-lockfile
+
+      - run: yarn nx list @fluentui/workspace-plugin
+
+      - name: test generators contributor flow
+        run: |
+          yarn nx g @fluentui/workspace-plugin:react-library --name hello-world --owner '@mrWick' --kind standard --no-interactive
+          yarn nx g @fluentui/workspace-plugin:react-component --project hello-world --name Aiur --no-interactive
+          yarn nx g @fluentui/workspace-plugin:cypress-component-configuration --project hello-world --no-interactive
+          yarn nx g @fluentui/workspace-plugin:bundle-size-configuration --project=hello-world --name=Aiur --no-interactive
+          yarn nx g @fluentui/workspace-plugin:prepare-initial-release --project hello-world --phase=preview --no-interactive
+          yarn nx g @fluentui/workspace-plugin:prepare-initial-release --project hello-world --phase=stable --no-interactive
+          yarn nx g @nx/workspace:remove --project hello-world --forceRemove --no-interactive

--- a/change/@fluentui-react-jsx-runtime-b0f83b29-f3d8-4f8b-89c9-75e48160f4cc.json
+++ b/change/@fluentui-react-jsx-runtime-b0f83b29-f3d8-4f8b-89c9-75e48160f4cc.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "fix: make generate-api build valid d.ts file structure on par with build target",
+  "packageName": "@fluentui/react-jsx-runtime",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-jsx-runtime/package.json
+++ b/packages/react-components/react-jsx-runtime/package.json
@@ -19,7 +19,7 @@
     "lint": "just-scripts lint",
     "test": "jest --passWithNoTests",
     "type-check": "tsc -b tsconfig.json",
-    "generate-api": "just-scripts generate-api",
+    "generate-api": "just-scripts copy && just-scripts generate-api",
     "test-ssr": "test-ssr \"./stories/**/*.stories.tsx\"",
     "bundle-size": "monosize measure"
   },

--- a/scripts/tasks/src/api-extractor.ts
+++ b/scripts/tasks/src/api-extractor.ts
@@ -67,7 +67,7 @@ export function apiExtractor(): TaskFunction {
    * overrides api-extractor default `true` to be `false` on local dev machine
    * Triggers if path aliases will be used or yarn workspaces (that needs to be build based on package dependency tree)
    */
-  const isLocalBuild = Boolean((args.local || process.env.__LOCAL_API_GENERATION__) ?? !(process.env.TF_BUILD || isCI));
+  const isLocalBuild = Boolean((args.local || process.env.__FORCE_API_MD_UPDATE__) ?? !(process.env.TF_BUILD || isCI));
 
   const tasks = configsToExecute.map(([configPath, configName]) => {
     const taskName = `api-extractor:${configName}`;

--- a/scripts/tasks/src/api-extractor.ts
+++ b/scripts/tasks/src/api-extractor.ts
@@ -67,7 +67,7 @@ export function apiExtractor(): TaskFunction {
    * overrides api-extractor default `true` to be `false` on local dev machine
    * Triggers if path aliases will be used or yarn workspaces (that needs to be build based on package dependency tree)
    */
-  const isLocalBuild = args.local ?? !(process.env.TF_BUILD || isCI);
+  const isLocalBuild = Boolean((args.local || process.env.__LOCAL_API_GENERATION__) ?? !(process.env.TF_BUILD || isCI));
 
   const tasks = configsToExecute.map(([configPath, configName]) => {
     const taskName = `api-extractor:${configName}`;

--- a/tools/workspace-plugin/src/generators/bundle-size-configuration/generator.spec.ts
+++ b/tools/workspace-plugin/src/generators/bundle-size-configuration/generator.spec.ts
@@ -14,7 +14,7 @@ import { BundleSizeConfigurationGeneratorSchema } from './schema';
 
 describe('bundle-size-configuration generator', () => {
   let tree: Tree;
-  const options: BundleSizeConfigurationGeneratorSchema = { name: 'react-continental' };
+  const options: BundleSizeConfigurationGeneratorSchema = { project: 'react-continental' };
 
   beforeEach(async () => {
     tree = createTreeWithEmptyWorkspace();
@@ -24,7 +24,7 @@ describe('bundle-size-configuration generator', () => {
 
   it('should add setup bundle size', async () => {
     await bundleSizeConfigurationGenerator(tree, options);
-    const config = readProjectConfiguration(tree, options.name);
+    const config = readProjectConfiguration(tree, options.project);
 
     const packageJson = readJson(tree, joinPathFragments(config.root, 'package.json'));
 
@@ -45,12 +45,12 @@ describe('bundle-size-configuration generator', () => {
   });
 
   it(`should not add index.fixture.js if there are already existing fixtures`, async () => {
-    const config = readProjectConfiguration(tree, options.name);
+    const config = readProjectConfiguration(tree, options.project);
 
     tree.write(
       joinPathFragments(config.root, 'bundle-size/Foo.fixture.js'),
       stripIndents`
-    import {Foo} from '${options.name}'
+    import {Foo} from '${options.project}'
 
     export default {
       name: 'Foo',
@@ -66,7 +66,7 @@ describe('bundle-size-configuration generator', () => {
   it(`should add monosize config within project if overrideBaseConfig was specified`, async () => {
     await bundleSizeConfigurationGenerator(tree, { ...options, overrideBaseConfig: true });
 
-    const config = readProjectConfiguration(tree, options.name);
+    const config = readProjectConfiguration(tree, options.project);
 
     expect(tree.read(joinPathFragments(config.root, 'monosize.config.mjs'), 'utf-8')).toMatchInlineSnapshot(`
       "// @ts-check

--- a/tools/workspace-plugin/src/generators/bundle-size-configuration/generator.ts
+++ b/tools/workspace-plugin/src/generators/bundle-size-configuration/generator.ts
@@ -21,7 +21,7 @@ import { BundleSizeConfigurationGeneratorSchema } from './schema';
 export async function bundleSizeConfigurationGenerator(tree: Tree, schema: BundleSizeConfigurationGeneratorSchema) {
   const options = normalizeOptions(tree, schema);
 
-  const project = readProjectConfiguration(tree, options.name);
+  const project = readProjectConfiguration(tree, options.project);
 
   assertOptions(tree, { isSplitProject: isSplitProject(tree, project), project });
 

--- a/tools/workspace-plugin/src/generators/bundle-size-configuration/schema.d.ts
+++ b/tools/workspace-plugin/src/generators/bundle-size-configuration/schema.d.ts
@@ -1,5 +1,5 @@
 export interface BundleSizeConfigurationGeneratorSchema {
-  name: string;
+  project: string;
   /**
    * @default false
    */

--- a/tools/workspace-plugin/src/generators/bundle-size-configuration/schema.json
+++ b/tools/workspace-plugin/src/generators/bundle-size-configuration/schema.json
@@ -4,7 +4,7 @@
   "title": "",
   "type": "object",
   "properties": {
-    "name": {
+    "project": {
       "type": "string",
       "description": "Project for which to generate bundle-size configuration.",
       "$default": {

--- a/tools/workspace-plugin/src/generators/bundle-size-configuration/schema.json
+++ b/tools/workspace-plugin/src/generators/bundle-size-configuration/schema.json
@@ -6,12 +6,12 @@
   "properties": {
     "project": {
       "type": "string",
-      "description": "Project for which to generate bundle-size configuration.",
+      "description": "The name of the project to add bundle-size configuration.",
       "$default": {
         "$source": "argv",
         "index": 0
       },
-      "x-prompt": "For which project do you want to generate bundle-size configuration?",
+      "x-prompt": "For which project do you want to add bundle-size configuration?",
       "x-dropdown": "projects"
     },
     "overrideBaseConfig": {
@@ -21,5 +21,5 @@
       "default": false
     }
   },
-  "required": ["name"]
+  "required": ["project"]
 }

--- a/tools/workspace-plugin/src/generators/cypress-component-configuration/schema.json
+++ b/tools/workspace-plugin/src/generators/cypress-component-configuration/schema.json
@@ -13,7 +13,7 @@
         "$source": "argv",
         "index": 0
       },
-      "x-prompt": "What project should we add Cypress component testing to?"
+      "x-prompt": "For which project do you want to add Cypress component testing?"
     }
   },
   "required": ["project"]

--- a/tools/workspace-plugin/src/generators/prepare-initial-release/schema.json
+++ b/tools/workspace-plugin/src/generators/prepare-initial-release/schema.json
@@ -16,6 +16,7 @@
     "phase": {
       "type": "string",
       "description": "Phase of npm release life cycle for fluent v9 core package",
+      "enum": ["compat", "preview", "stable"],
       "x-prompt": {
         "message": "Which initial phase of release life cycle you wanna trigger?",
         "type": "list",

--- a/tools/workspace-plugin/src/generators/react-component/files/component/__componentName__.tsx__tmpl__
+++ b/tools/workspace-plugin/src/generators/react-component/files/component/__componentName__.tsx__tmpl__
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
-import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 import { use<%= componentName %>_unstable } from './use<%= componentName %>';
 import { render<%= componentName %>_unstable } from './render<%= componentName %>';
 import { use<%= componentName %>Styles_unstable } from './use<%= componentName %>Styles.styles';
@@ -13,9 +12,17 @@ export const <%= componentName %>: ForwardRefComponent<<%= componentName %>Props
   const state = use<%= componentName %>_unstable(props, ref);
 
   use<%= componentName %>Styles_unstable(state);
-  // TODO update types in packages/react-components/react-shared-contexts/src/CustomStyleHooksContext/CustomStyleHooksContext.ts
-  // https://github.com/microsoft/fluentui/blob/master/rfcs/react-components/convergence/custom-styling.md
-  useCustomStyleHook_unstable('use<%= componentName %>Styles_unstable')(state);
+
+  /**
+   * @see https://github.com/microsoft/fluentui/blob/master/docs/react-v9/contributing/rfcs/react-components/convergence/custom-styling.md
+   *
+   * TODO: 💡 once package will become stable (PR which will be part of promoting PREVIEW package to STABLE),
+   *      - uncomment this line
+   *      - update types {@link file://./<%= rootOffset %>packages/react-components/react-shared-contexts/library/src/CustomStyleHooksContext/CustomStyleHooksContext.ts#CustomStyleHooksContextValue}
+   *      - verify that custom global style override works for your component
+   */
+  // useCustomStyleHook_unstable('use<%= componentName %>Styles_unstable')(state);
+
   return render<%= componentName %>_unstable(state);
 });
 

--- a/tools/workspace-plugin/src/generators/react-component/index.spec.ts
+++ b/tools/workspace-plugin/src/generators/react-component/index.spec.ts
@@ -1,5 +1,5 @@
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
-import { Tree, addProjectConfiguration, writeJson, joinPathFragments } from '@nx/devkit';
+import { Tree, addProjectConfiguration, writeJson, joinPathFragments, offsetFromRoot } from '@nx/devkit';
 
 import generator from './index';
 
@@ -56,6 +56,8 @@ describe('react-component generator', () => {
             : 'packages/react-components/react-one/library/src';
         const componentRootPath = `${projectSourceRootPath}/components/MyOne`;
 
+        const rootOffset = offsetFromRoot(componentRootPath);
+
         expect(tree.read(joinPathFragments(projectSourceRootPath, 'MyOne.ts'), 'utf-8')).toMatchInlineSnapshot(`
       "export * from './components/MyOne/index';
       "
@@ -76,7 +78,6 @@ describe('react-component generator', () => {
         expect(tree.read(joinPathFragments(componentRootPath, 'MyOne.tsx'), 'utf-8')).toMatchInlineSnapshot(`
       "import * as React from 'react';
       import type { ForwardRefComponent } from '@fluentui/react-utilities';
-      import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
       import { useMyOne_unstable } from './useMyOne';
       import { renderMyOne_unstable } from './renderMyOne';
       import { useMyOneStyles_unstable } from './useMyOneStyles.styles';
@@ -90,9 +91,17 @@ describe('react-component generator', () => {
           const state = useMyOne_unstable(props, ref);
 
           useMyOneStyles_unstable(state);
-          // TODO update types in packages/react-components/react-shared-contexts/src/CustomStyleHooksContext/CustomStyleHooksContext.ts
-          // https://github.com/microsoft/fluentui/blob/master/rfcs/react-components/convergence/custom-styling.md
-          useCustomStyleHook_unstable('useMyOneStyles_unstable')(state);
+
+          /**
+           * @see https://github.com/microsoft/fluentui/blob/master/docs/react-v9/contributing/rfcs/react-components/convergence/custom-styling.md
+           *
+           * TODO: 💡 once package will become stable (PR which will be part of promoting PREVIEW package to STABLE),
+           *      - uncomment this line
+           *      - update types {@link file://./${rootOffset}packages/react-components/react-shared-contexts/library/src/CustomStyleHooksContext/CustomStyleHooksContext.ts#CustomStyleHooksContextValue}
+           *      - verify that custom global style override works for your component
+           */
+          // useCustomStyleHook_unstable('useMyOneStyles_unstable')(state);
+
           return renderMyOne_unstable(state);
         }
       );

--- a/tools/workspace-plugin/src/generators/react-component/index.ts
+++ b/tools/workspace-plugin/src/generators/react-component/index.ts
@@ -29,7 +29,12 @@ export default async function (tree: Tree, schema: ReactComponentGeneratorSchema
       stdio: 'inherit',
     });
 
-    execSync(`yarn workspace ${npmPackageName} test -t ${componentName}`, {
+    // This is used only for integration testing purposes on CI as jest disables snapshot updates by default
+    const forceSnapshotUpdate = Boolean(process.env.FORCE_SNAPSHOT_UPDATE);
+    const updateSnapshotCmd =
+      `yarn workspace ${npmPackageName} test -t ${componentName}` + (forceSnapshotUpdate ? ' -u' : '');
+
+    execSync(updateSnapshotCmd, {
       cwd: root,
       stdio: 'inherit',
     });

--- a/tools/workspace-plugin/src/generators/react-component/index.ts
+++ b/tools/workspace-plugin/src/generators/react-component/index.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { execSync } from 'child_process';
-import { Tree, formatFiles, names, generateFiles, joinPathFragments, workspaceRoot } from '@nx/devkit';
+import { Tree, formatFiles, names, generateFiles, joinPathFragments, workspaceRoot, offsetFromRoot } from '@nx/devkit';
 
 import { getProjectConfig, isPackageConverged } from '../../utils';
 import { assertStoriesProject, isSplitProject } from '../split-library-in-two/shared';
@@ -82,6 +82,7 @@ function addFiles(tree: Tree, options: NormalizedSchema) {
 
   const templateOptions = {
     ...options,
+    rootOffset: offsetFromRoot(joinPathFragments(sourceRoot, options.directory, options.componentName)),
     storiesTitle: createStoriesTitle(options),
     tmpl: '',
   };

--- a/tools/workspace-plugin/src/generators/react-component/index.ts
+++ b/tools/workspace-plugin/src/generators/react-component/index.ts
@@ -31,10 +31,9 @@ export default async function (tree: Tree, schema: ReactComponentGeneratorSchema
 
     // This is used only for integration testing purposes on CI as jest disables snapshot updates by default
     const forceSnapshotUpdate = Boolean(process.env.__FORCE_SNAPSHOT_UPDATE__);
-    const updateSnapshotCmd =
-      `yarn workspace ${npmPackageName} test -t ${componentName}` + (forceSnapshotUpdate ? ' -u' : '');
+    const testCmd = `yarn workspace ${npmPackageName} test -t ${componentName}` + (forceSnapshotUpdate ? ' -u' : '');
 
-    execSync(updateSnapshotCmd, {
+    execSync(testCmd, {
       cwd: root,
       stdio: 'inherit',
     });

--- a/tools/workspace-plugin/src/generators/react-component/index.ts
+++ b/tools/workspace-plugin/src/generators/react-component/index.ts
@@ -30,7 +30,7 @@ export default async function (tree: Tree, schema: ReactComponentGeneratorSchema
     });
 
     // This is used only for integration testing purposes on CI as jest disables snapshot updates by default
-    const forceSnapshotUpdate = Boolean(process.env.FORCE_SNAPSHOT_UPDATE);
+    const forceSnapshotUpdate = Boolean(process.env.__FORCE_SNAPSHOT_UPDATE__);
     const updateSnapshotCmd =
       `yarn workspace ${npmPackageName} test -t ${componentName}` + (forceSnapshotUpdate ? ' -u' : '');
 

--- a/tools/workspace-plugin/src/generators/react-library/index.spec.ts
+++ b/tools/workspace-plugin/src/generators/react-library/index.spec.ts
@@ -250,12 +250,9 @@ describe('react-library generator', () => {
       ['@proj/react-one-preview']: ['packages/react-components/react-one-preview/library/src/index.ts'],
       ['@proj/react-one-preview-stories']: ['packages/react-components/react-one-preview/stories/src/index.ts'],
     };
-    expect(readJson(tree, `tsconfig.base.json`).compilerOptions.paths).toEqual(
-      expect.objectContaining(expectedPathAlias),
-    );
-    expect(readJson(tree, `tsconfig.base.all.json`).compilerOptions.paths).toEqual(
-      expect.objectContaining(expectedPathAlias),
-    );
+
+    expect(readJson(tree, `tsconfig.base.json`).compilerOptions.paths).toEqual(expectedPathAlias);
+    expect(readJson(tree, `tsconfig.base.all.json`).compilerOptions.paths).toEqual(expectedPathAlias);
 
     expect(tree.read('.github/CODEOWNERS', 'utf-8')).toEqual(
       expect.stringContaining(stripIndents`

--- a/tools/workspace-plugin/src/generators/react-library/index.ts
+++ b/tools/workspace-plugin/src/generators/react-library/index.ts
@@ -28,6 +28,7 @@ export default async function (tree: Tree, schema: ReactLibraryGeneratorSchema) 
   const options = normalizeOptions(tree, schema);
 
   addFiles(tree, options);
+
   updatePackageJsonDependencies(tree, options);
 
   updateTsConfigBase(tree, options);
@@ -35,7 +36,12 @@ export default async function (tree: Tree, schema: ReactLibraryGeneratorSchema) 
 
   addCodeowner(tree, { packageName: options.projectConfig.name as string, owner: schema.owner });
 
-  await splitLibraryInTwoGenerator(tree, { project: options.projectConfig.name, skipFormat: true });
+  console.log('generated files from tmpl:', {
+    root: tree.children(options.projectConfig.root),
+    sb: tree.children(joinPathFragments(options.projectConfig.root, '.storybook')),
+    sbStories: tree.children(joinPathFragments(options.projectConfig.root, 'stories')),
+  });
+  await splitLibraryInTwoGenerator(tree, { project: options.projectConfig.name, skipFormat: true, logs: true });
 
   await formatFiles(tree);
 

--- a/tools/workspace-plugin/src/generators/react-library/index.ts
+++ b/tools/workspace-plugin/src/generators/react-library/index.ts
@@ -36,12 +36,7 @@ export default async function (tree: Tree, schema: ReactLibraryGeneratorSchema) 
 
   addCodeowner(tree, { packageName: options.projectConfig.name as string, owner: schema.owner });
 
-  console.log('generated files from tmpl:', {
-    root: tree.children(options.projectConfig.root),
-    sb: tree.children(joinPathFragments(options.projectConfig.root, '.storybook')),
-    sbStories: tree.children(joinPathFragments(options.projectConfig.root, 'stories')),
-  });
-  await splitLibraryInTwoGenerator(tree, { project: options.projectConfig.name, skipFormat: true, logs: true });
+  await splitLibraryInTwoGenerator(tree, { project: options.projectConfig.name, skipFormat: true });
 
   await formatFiles(tree);
 

--- a/tools/workspace-plugin/src/generators/react-library/index.ts
+++ b/tools/workspace-plugin/src/generators/react-library/index.ts
@@ -141,12 +141,12 @@ function updatePackageJsonDependencies(tree: Tree, options: NormalizedSchema) {
 }
 
 function updateTsConfigBase(tree: Tree, options: NormalizedSchema) {
+  const npmName = `@${options.workspaceConfig.npmScope}/${options.projectConfig.name}`;
+
   updateJson<TsConfig>(tree, options.paths.rootTsconfig, json => {
     json.compilerOptions.paths = json.compilerOptions.paths ?? {};
 
-    json.compilerOptions.paths[options.projectConfig.name as string] = [
-      joinPathFragments(options.projectConfig.sourceRoot as string, 'index.ts'),
-    ];
+    json.compilerOptions.paths[npmName] = [joinPathFragments(options.projectConfig.sourceRoot as string, 'index.ts')];
     return json;
   });
 

--- a/tools/workspace-plugin/src/generators/split-library-in-two/generator.ts
+++ b/tools/workspace-plugin/src/generators/split-library-in-two/generator.ts
@@ -167,11 +167,14 @@ function makeSrcLibrary(tree: Tree, options: Options, logger: CLIOutput) {
   const newProjectSourceRoot = joinPathFragments(newProjectRoot, 'src');
 
   visitNotIgnoredFiles(tree, oldProjectRoot, file => {
-    if (file.includes('/stories/') || file.includes('/.storybook/')) {
+    console.log('makeSrcLibrary not ignored files:', file);
+
+    if (file.includes(path.normalize('/stories/')) || file.includes(path.normalize('/.storybook/'))) {
+      console.log('makeSrcLibrary skipping:', file);
       return;
     }
 
-    const newFileName = `${newProjectRoot}/${path.relative(oldProjectRoot, file)}`;
+    const newFileName = joinPathFragments(newProjectRoot, path.relative(oldProjectRoot, file));
 
     tree.rename(file, newFileName);
   });
@@ -278,6 +281,8 @@ function makeStoriesLibrary(tree: Tree, options: Options, logger: CLIOutput) {
   const newProjectSourceRoot = joinPathFragments(newProjectRoot, 'src');
   const newProjectName = `${options.projectConfig.name}-stories`;
 
+  console.log('BEFORE:', tree.children(oldProjectRoot), tree.children(joinPathFragments(oldProjectRoot, '.storybook')));
+
   // move stories/
   moveFilesToNewDirectory(tree, joinPathFragments(oldProjectRoot, 'stories'), newProjectSourceRoot);
 
@@ -286,6 +291,12 @@ function makeStoriesLibrary(tree: Tree, options: Options, logger: CLIOutput) {
     tree,
     joinPathFragments(oldProjectRoot, '.storybook'),
     joinPathFragments(newProjectRoot, '.storybook'),
+  );
+
+  console.log(
+    'AFTER:',
+    tree.children(newProjectSourceRoot),
+    tree.children(joinPathFragments(newProjectRoot, '.storybook')),
   );
 
   const storiesWorkspaceDeps = getWorkspaceDependencies(
@@ -389,18 +400,18 @@ function makeStoriesLibrary(tree: Tree, options: Options, logger: CLIOutput) {
   writeJson(tree, joinPathFragments(newProjectRoot, 'tsconfig.json'), templates.tsconfig.root);
   writeJson(tree, joinPathFragments(newProjectRoot, 'tsconfig.lib.json'), templates.tsconfig.lib);
   writeJson(tree, joinPathFragments(newProjectRoot, 'package.json'), templates.packageJson);
-  updateJson(tree, joinPathFragments(newProjectRoot, '.storybook/tsconfig.json'), (json: TsConfig) => {
+  updateJson(tree, joinPathFragments(newProjectRoot, '.storybook', 'tsconfig.json'), (json: TsConfig) => {
     json.include = ['*.js'];
     return json;
   });
-  updateFileContent(tree, joinPathFragments(newProjectRoot, '.storybook/main.js'), content => {
+  updateFileContent(tree, joinPathFragments(newProjectRoot, '.storybook', 'main.js'), content => {
     content = content
       .replace(new RegExp('../stories/', 'g'), '../src/')
       .replace(new RegExp(options.projectOffsetFromRoot.old, 'g'), options.projectOffsetFromRoot.updated);
 
     return content;
   });
-  updateFileContent(tree, joinPathFragments(newProjectRoot, '.storybook/preview.js'), content => {
+  updateFileContent(tree, joinPathFragments(newProjectRoot, '.storybook', 'preview.js'), content => {
     content = content.replace(
       new RegExp(options.projectOffsetFromRoot.old, 'g'),
       options.projectOffsetFromRoot.updated,

--- a/tools/workspace-plugin/src/generators/split-library-in-two/generator.ts
+++ b/tools/workspace-plugin/src/generators/split-library-in-two/generator.ts
@@ -167,10 +167,7 @@ function makeSrcLibrary(tree: Tree, options: Options, logger: CLIOutput) {
   const newProjectSourceRoot = joinPathFragments(newProjectRoot, 'src');
 
   visitNotIgnoredFiles(tree, oldProjectRoot, file => {
-    console.log('makeSrcLibrary not ignored files:', file);
-
     if (file.includes(path.normalize('/stories/')) || file.includes(path.normalize('/.storybook/'))) {
-      console.log('makeSrcLibrary skipping:', file);
       return;
     }
 
@@ -281,8 +278,6 @@ function makeStoriesLibrary(tree: Tree, options: Options, logger: CLIOutput) {
   const newProjectSourceRoot = joinPathFragments(newProjectRoot, 'src');
   const newProjectName = `${options.projectConfig.name}-stories`;
 
-  console.log('BEFORE:', tree.children(oldProjectRoot), tree.children(joinPathFragments(oldProjectRoot, '.storybook')));
-
   // move stories/
   moveFilesToNewDirectory(tree, joinPathFragments(oldProjectRoot, 'stories'), newProjectSourceRoot);
 
@@ -291,12 +286,6 @@ function makeStoriesLibrary(tree: Tree, options: Options, logger: CLIOutput) {
     tree,
     joinPathFragments(oldProjectRoot, '.storybook'),
     joinPathFragments(newProjectRoot, '.storybook'),
-  );
-
-  console.log(
-    'AFTER:',
-    tree.children(newProjectSourceRoot),
-    tree.children(joinPathFragments(newProjectRoot, '.storybook')),
   );
 
   const storiesWorkspaceDeps = getWorkspaceDependencies(
@@ -400,18 +389,18 @@ function makeStoriesLibrary(tree: Tree, options: Options, logger: CLIOutput) {
   writeJson(tree, joinPathFragments(newProjectRoot, 'tsconfig.json'), templates.tsconfig.root);
   writeJson(tree, joinPathFragments(newProjectRoot, 'tsconfig.lib.json'), templates.tsconfig.lib);
   writeJson(tree, joinPathFragments(newProjectRoot, 'package.json'), templates.packageJson);
-  updateJson(tree, joinPathFragments(newProjectRoot, '.storybook', 'tsconfig.json'), (json: TsConfig) => {
+  updateJson(tree, joinPathFragments(newProjectRoot, '.storybook/tsconfig.json'), (json: TsConfig) => {
     json.include = ['*.js'];
     return json;
   });
-  updateFileContent(tree, joinPathFragments(newProjectRoot, '.storybook', 'main.js'), content => {
+  updateFileContent(tree, joinPathFragments(newProjectRoot, '.storybook/main.js'), content => {
     content = content
       .replace(new RegExp('../stories/', 'g'), '../src/')
       .replace(new RegExp(options.projectOffsetFromRoot.old, 'g'), options.projectOffsetFromRoot.updated);
 
     return content;
   });
-  updateFileContent(tree, joinPathFragments(newProjectRoot, '.storybook', 'preview.js'), content => {
+  updateFileContent(tree, joinPathFragments(newProjectRoot, '.storybook/preview.js'), content => {
     content = content.replace(
       new RegExp(options.projectOffsetFromRoot.old, 'g'),
       options.projectOffsetFromRoot.updated,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

- v9 package implementation automation flows are failing on Windows Shell ( PowerShell, cmd.exe )

## New Behavior

- Fixes
  -  windows path resolution issues within split-library-in-two generator
  - uses `lage build` instead of `lage generate-api` in order to properly build assets after generator execution
- Feats
  - unifies generator options to use `project` when referencing project name instead of generic/not-explicit `name`
  - adds CI GHA job to test most common DEV flow on windows and linux
  - introduces two new "private" variables prefixed and suffixed with `__` as part of our tooling logic in order to make integration tests for dev flow pass on ci.

**v9 flow update**

- updates `react-component` generation to not add global style hook overrides - that is responsibility of component author after promoting package from PREVIEW to STABLE

<img width="1455" alt="image" src="https://github.com/user-attachments/assets/651e2c2c-b1f1-4bd6-ab89-abfe4e48ac4a">


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/31987
- Fixes https://github.com/microsoft/fluentui/pull/31976#discussion_r1674150683
