### PR TITLE
fix(web-components): scope submenu fallback positioning to non-anchor browsers only

### DIFF
--- a/change/@fluentui-web-components-198bc628-0ffa-41a6-a30f-b159efd70210.json
+++ b/change/@fluentui-web-components-198bc628-0ffa-41a6-a30f-b159efd70210.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: scope menu fallback positioning to non-anchor browsers only",
+  "packageName": "@fluentui/web-components",
+  "email": "rupertdavid@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/menu-item/menu-item.styles.ts
+++ b/packages/web-components/src/menu-item/menu-item.styles.ts
@@ -151,7 +151,6 @@ export const styles = css`
     }
 
     ::slotted([popover]) {
-      align-self: start; /* Fallback for no anchor-positioning */
       inset-area: inline-end span-block-end;
       margin: 0;
       max-height: var(--menu-max-height, auto);
@@ -167,6 +166,13 @@ export const styles = css`
 
     ::slotted([popover]:popover-open) {
       inset: unset;
+    }
+
+    /* Fallback for no anchor-positioning */
+    @supports not (anchor-name: --menu-trigger) {
+      ::slotted([popover]) {
+        align-self: start;
+      }
     }
   }
 `.withBehaviors(


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

In an attempt to fix submenu fallback positioning for non-anchor-supported browsers (Safari/Firefox), I broke positioning in Edge/Chrome.

See submenu in last example in Edge/Chrome: https://web-components.fluentui.dev/?path=/docs/components-menu--menu

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

This scopes the position fallback position rule needed for older browsers into an `@supports not` rule to fix the regression in Edge/Chrome while still providing support to non-Anchor browsers. 

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
