### PR TITLE
Fix: Removes padding from `fluent-field` host element

### DIFF
--- a/change/@fluentui-web-components-9db7a86a-2608-4f2d-aa56-13b248a527df.json
+++ b/change/@fluentui-web-components-9db7a86a-2608-4f2d-aa56-13b248a527df.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: removed padding from field host element",
+  "packageName": "@fluentui/web-components",
+  "email": "jes@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/field/field.stories.ts
+++ b/packages/web-components/src/field/field.stories.ts
@@ -71,6 +71,7 @@ export const LabelPositions: Story<FluentField> = renderComponent(html<StoryArgs
           <fluent-text-input slot="input" id="${x => x.id}"></fluent-text-input
         ></fluent-field>
       </div>
+      <br />
     `,
   )}
 `).bind({});

--- a/packages/web-components/src/field/field.stories.ts
+++ b/packages/web-components/src/field/field.stories.ts
@@ -71,6 +71,7 @@ export const LabelPositions: Story<FluentField> = renderComponent(html<StoryArgs
           <fluent-text-input slot="input" id="${x => x.id}"></fluent-text-input
         ></fluent-field>
       </div>
+      <br />
     `,
   )}
 `).bind({});
@@ -103,10 +104,12 @@ export const Size: Story<FluentField> = renderComponent(html`
     <label slot="label" for="field-small-size">Small field</label>
     <fluent-text-input control-size="small" slot="input" id="field-small-size"></fluent-text-input>
   </fluent-field>
+  <br />
   <fluent-field size="medium">
     <label slot="label" for="field-medium-size">Medium field</label>
     <fluent-text-input control-size="medium" slot="input" id="field-medium-size"></fluent-text-input>
   </fluent-field>
+  <br />
   <fluent-field size="large">
     <label slot="label" for="field-large-size">Large field</label>
     <fluent-text-input control-size="large" slot="input" id="field-large-size"></fluent-text-input>
@@ -122,7 +125,7 @@ export const ValidationMessage: Story<FluentField> = renderComponent(html<StoryA
         This field is required.
       </fluent-text>
     </fluent-field>
-
+    <br />
     <fluent-field>
       <label slot="label" for="field-pattern-mismatch">Unique ID</label>
       <fluent-text-input
@@ -135,7 +138,7 @@ export const ValidationMessage: Story<FluentField> = renderComponent(html<StoryA
         <span style="vertical-align: middle">Only letters and numbers please, spaces not allowed</span>
       </fluent-text>
     </fluent-field>
-
+    <br />
     <fluent-field>
       <label slot="label" for="field-too-long">Too Long</label>
       <fluent-text-input maxlength="5" value="123456789" slot="input" id="field-too-long"></fluent-text-input>
@@ -143,7 +146,7 @@ export const ValidationMessage: Story<FluentField> = renderComponent(html<StoryA
         This value is too long.
       </fluent-text>
     </fluent-field>
-
+    <br />
     <fluent-field>
       <label slot="label" for="field-too-short">Too Short</label>
       <fluent-text-input minlength="5" value="123" slot="input" id="field-too-short"></fluent-text-input>
@@ -151,7 +154,7 @@ export const ValidationMessage: Story<FluentField> = renderComponent(html<StoryA
         This value is too short.
       </fluent-text>
     </fluent-field>
-
+    <br />
     <fluent-field>
       <label slot="label" for="field-range-overflow">Range Overflow</label>
       <fluent-text-input type="number" max="5" value="7" slot="input" id="field-range-overflow"></fluent-text-input>
@@ -159,7 +162,7 @@ export const ValidationMessage: Story<FluentField> = renderComponent(html<StoryA
         This value must be less than 5.
       </fluent-text>
     </fluent-field>
-
+    <br />
     <fluent-field>
       <label slot="label" for="field-range-underflow">Range Underflow</label>
       <fluent-text-input type="number" min="5" value="3" slot="input" id="field-range-underflow"></fluent-text-input>
@@ -167,7 +170,7 @@ export const ValidationMessage: Story<FluentField> = renderComponent(html<StoryA
         This value must be greater than 5.
       </fluent-text>
     </fluent-field>
-
+    <br />
     <fluent-field>
       <label slot="label" for="field-step-mismatch">Step Mismatch</label>
       <fluent-text-input type="number" step="5" value="0" slot="input" id="field-step-mismatch"></fluent-text-input>
@@ -175,7 +178,7 @@ export const ValidationMessage: Story<FluentField> = renderComponent(html<StoryA
         This value must be a multiple of 5.
       </fluent-text>
     </fluent-field>
-
+    <br />
     <fluent-field>
       <label slot="label" for="field-type-mismatch">Type Mismatch</label>
       <fluent-text-input value="not an email" type="email" slot="input" id="field-type-mismatch"></fluent-text-input>
@@ -220,17 +223,17 @@ export const ComponentExamples: Story<FluentField> = renderComponent(html`
       <label slot="label" for="field-text">Text Input</label>
       <fluent-text-input slot="input" id="field-text"></fluent-text-input>
     </fluent-field>
-
+    <br />
     <fluent-field label-position="above" style="max-width: 400px">
       <label slot="label" for="field-slider">Slider</label>
       <fluent-slider size="medium" slot="input" id="field-slider"></fluent-slider>
     </fluent-field>
-
+    <br />
     <fluent-field label-position="after">
       <label slot="label" for="field-checkbox">Checkbox</label>
       <fluent-checkbox slot="input" id="field-checkbox"></fluent-checkbox>
     </fluent-field>
-
+    <br />
     <fluent-field label-position="above">
       <label slot="label" for="field-radio">Radio Group</label>
       <fluent-radio-group slot="input" name="field-radio" orientation="vertical">
@@ -249,6 +252,7 @@ export const ThirdPartyControls: Story<FluentField> = renderComponent(html`
       <label slot="label" for="native-text-input">Text Input</label>
       <input slot="input" id="native-text-input" required />
     </fluent-field>
+    <br />
     <fluent-field label-position="before">
       <label slot="label" for="native-checkbox">Checkbox</label>
       <input slot="input" type="checkbox" id="native-checkbox" />

--- a/packages/web-components/src/field/field.stories.ts
+++ b/packages/web-components/src/field/field.stories.ts
@@ -71,7 +71,6 @@ export const LabelPositions: Story<FluentField> = renderComponent(html<StoryArgs
           <fluent-text-input slot="input" id="${x => x.id}"></fluent-text-input
         ></fluent-field>
       </div>
-      <br />
     `,
   )}
 `).bind({});
@@ -104,12 +103,10 @@ export const Size: Story<FluentField> = renderComponent(html`
     <label slot="label" for="field-small-size">Small field</label>
     <fluent-text-input control-size="small" slot="input" id="field-small-size"></fluent-text-input>
   </fluent-field>
-  <br />
   <fluent-field size="medium">
     <label slot="label" for="field-medium-size">Medium field</label>
     <fluent-text-input control-size="medium" slot="input" id="field-medium-size"></fluent-text-input>
   </fluent-field>
-  <br />
   <fluent-field size="large">
     <label slot="label" for="field-large-size">Large field</label>
     <fluent-text-input control-size="large" slot="input" id="field-large-size"></fluent-text-input>
@@ -117,7 +114,7 @@ export const Size: Story<FluentField> = renderComponent(html`
 `).bind({});
 
 export const ValidationMessage: Story<FluentField> = renderComponent(html<StoryArgs<FluentField>>`
-  <form id="validation-messages-form" action="#" style="display:flex;flex-flow:column;align-items:start">
+  <form id="validation-messages-form" action="#" style="display:flex;flex-flow:column;align-items:start;gap:10px;">
     <fluent-field>
       <label slot="label" for="field-required">Required</label>
       <fluent-text-input required slot="input" id="field-required"></fluent-text-input>
@@ -125,7 +122,6 @@ export const ValidationMessage: Story<FluentField> = renderComponent(html<StoryA
         This field is required.
       </fluent-text>
     </fluent-field>
-    <br />
     <fluent-field>
       <label slot="label" for="field-pattern-mismatch">Unique ID</label>
       <fluent-text-input
@@ -138,7 +134,6 @@ export const ValidationMessage: Story<FluentField> = renderComponent(html<StoryA
         <span style="vertical-align: middle">Only letters and numbers please, spaces not allowed</span>
       </fluent-text>
     </fluent-field>
-    <br />
     <fluent-field>
       <label slot="label" for="field-too-long">Too Long</label>
       <fluent-text-input maxlength="5" value="123456789" slot="input" id="field-too-long"></fluent-text-input>
@@ -146,7 +141,6 @@ export const ValidationMessage: Story<FluentField> = renderComponent(html<StoryA
         This value is too long.
       </fluent-text>
     </fluent-field>
-    <br />
     <fluent-field>
       <label slot="label" for="field-too-short">Too Short</label>
       <fluent-text-input minlength="5" value="123" slot="input" id="field-too-short"></fluent-text-input>
@@ -154,7 +148,6 @@ export const ValidationMessage: Story<FluentField> = renderComponent(html<StoryA
         This value is too short.
       </fluent-text>
     </fluent-field>
-    <br />
     <fluent-field>
       <label slot="label" for="field-range-overflow">Range Overflow</label>
       <fluent-text-input type="number" max="5" value="7" slot="input" id="field-range-overflow"></fluent-text-input>
@@ -162,7 +155,6 @@ export const ValidationMessage: Story<FluentField> = renderComponent(html<StoryA
         This value must be less than 5.
       </fluent-text>
     </fluent-field>
-    <br />
     <fluent-field>
       <label slot="label" for="field-range-underflow">Range Underflow</label>
       <fluent-text-input type="number" min="5" value="3" slot="input" id="field-range-underflow"></fluent-text-input>
@@ -170,7 +162,6 @@ export const ValidationMessage: Story<FluentField> = renderComponent(html<StoryA
         This value must be greater than 5.
       </fluent-text>
     </fluent-field>
-    <br />
     <fluent-field>
       <label slot="label" for="field-step-mismatch">Step Mismatch</label>
       <fluent-text-input type="number" step="5" value="0" slot="input" id="field-step-mismatch"></fluent-text-input>
@@ -178,7 +169,6 @@ export const ValidationMessage: Story<FluentField> = renderComponent(html<StoryA
         This value must be a multiple of 5.
       </fluent-text>
     </fluent-field>
-    <br />
     <fluent-field>
       <label slot="label" for="field-type-mismatch">Type Mismatch</label>
       <fluent-text-input value="not an email" type="email" slot="input" id="field-type-mismatch"></fluent-text-input>
@@ -223,17 +213,14 @@ export const ComponentExamples: Story<FluentField> = renderComponent(html`
       <label slot="label" for="field-text">Text Input</label>
       <fluent-text-input slot="input" id="field-text"></fluent-text-input>
     </fluent-field>
-    <br />
     <fluent-field label-position="above" style="max-width: 400px">
       <label slot="label" for="field-slider">Slider</label>
       <fluent-slider size="medium" slot="input" id="field-slider"></fluent-slider>
     </fluent-field>
-    <br />
     <fluent-field label-position="after">
       <label slot="label" for="field-checkbox">Checkbox</label>
       <fluent-checkbox slot="input" id="field-checkbox"></fluent-checkbox>
     </fluent-field>
-    <br />
     <fluent-field label-position="above">
       <label slot="label" for="field-radio">Radio Group</label>
       <fluent-radio-group slot="input" name="field-radio" orientation="vertical">
@@ -247,12 +234,11 @@ export const ComponentExamples: Story<FluentField> = renderComponent(html`
 `).bind({});
 
 export const ThirdPartyControls: Story<FluentField> = renderComponent(html`
-  <form action="#" style="display:flex;flex-flow:column;align-items:start">
+  <form action="#" style="display:flex;flex-flow:column;align-items:start;gap:10px">
     <fluent-field label-position="above" style="max-width: 400px">
       <label slot="label" for="native-text-input">Text Input</label>
       <input slot="input" id="native-text-input" required />
     </fluent-field>
-    <br />
     <fluent-field label-position="before">
       <label slot="label" for="native-checkbox">Checkbox</label>
       <input slot="input" type="checkbox" id="native-checkbox" />

--- a/packages/web-components/src/field/field.styles.ts
+++ b/packages/web-components/src/field/field.styles.ts
@@ -114,7 +114,6 @@ export const styles = css`
     align-items: center;
     gap: 0 ${spacingHorizontalM};
     justify-items: start;
-    padding: ${spacingVerticalS} ${spacingHorizontalS};
     position: relative;
   }
 

--- a/packages/web-components/src/radio-group/radio-group.styles.ts
+++ b/packages/web-components/src/radio-group/radio-group.styles.ts
@@ -5,6 +5,7 @@ import {
   colorNeutralForeground2,
   colorNeutralForeground3,
   colorNeutralForegroundDisabled,
+  spacingVerticalS,
 } from '../theme/design-tokens.js';
 import { display } from '../utils/index.js';
 
@@ -17,6 +18,7 @@ export const styles = css`
   :host {
     -webkit-tap-highlight-color: transparent;
     cursor: pointer;
+    gap: ${spacingVerticalS};
   }
 
   :host(${disabledState}),

--- a/packages/web-components/src/radio-group/radio-group.styles.ts
+++ b/packages/web-components/src/radio-group/radio-group.styles.ts
@@ -5,7 +5,7 @@ import {
   colorNeutralForeground2,
   colorNeutralForeground3,
   colorNeutralForegroundDisabled,
-  spacingVerticalS,
+  spacingVerticalL,
 } from '../theme/design-tokens.js';
 import { display } from '../utils/index.js';
 
@@ -18,7 +18,7 @@ export const styles = css`
   :host {
     -webkit-tap-highlight-color: transparent;
     cursor: pointer;
-    gap: ${spacingVerticalS};
+    gap: ${spacingVerticalL};
   }
 
   :host(${disabledState}),


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
The `fluent-field` had padding baked in which goes against the component libraries principles and created awkward styling challenges for the end user.

## New Behavior
Remove any paddings or margins from the `:host` element

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
