### PR TITLE
Feat(DetailsList): Add `onColumnKeyDown` prop to `IColumn` interface

### DIFF
--- a/change/@fluentui-react-51415e29-94e2-48bb-b540-0e14ac4ec79f.json
+++ b/change/@fluentui-react-51415e29-94e2-48bb-b540-0e14ac4ec79f.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Expose onKeyDown handling for header cells through columns onColumnKeyDown",
+  "packageName": "@fluentui/react",
+  "email": "destinywu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-examples/src/react/DetailsList/DetailsList.KeyboardAccessibleResizeAndReorder.Example.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.KeyboardAccessibleResizeAndReorder.Example.tsx
@@ -11,10 +11,8 @@ import {
   IDragDropContext,
   ColumnActionsMode,
   IDetailsList,
-  IDetailsColumnRenderTooltipProps,
 } from '@fluentui/react/lib/DetailsList';
 import { MarqueeSelection } from '@fluentui/react/lib/MarqueeSelection';
-import { TooltipHost } from '@fluentui/react/lib/Tooltip';
 import { createListItems, IExampleItem } from '@fluentui/example-data';
 import { TextField, ITextFieldStyles, ITextField } from '@fluentui/react/lib/TextField';
 import { Toggle, IToggleStyles } from '@fluentui/react/lib/Toggle';
@@ -53,7 +51,7 @@ export const DetailsListKeyboardAccessibleResizeAndReorderExample: React.Functio
   const handleColumnReorder = (draggedIndex: number, targetIndex: number) => {
     const draggedItems = columns[draggedIndex];
     const newColumns: IColumn[] = [...columns];
-    console.log('handleColumnReorder', draggedIndex, targetIndex);
+
     // insert before the dropped item
     newColumns.splice(draggedIndex, 1);
     newColumns.splice(targetIndex, 0, draggedItems);
@@ -115,7 +113,6 @@ export const DetailsListKeyboardAccessibleResizeAndReorderExample: React.Functio
         detailsList.updateColumn(columnToEdit.current, { width: width });
       } else if (clickHandler.current === REORDER) {
         const targetIndex = selection.mode ? input.current + 1 : input.current;
-        console.log(columnToEdit.current.key, targetIndex);
         detailsList.updateColumn(columnToEdit.current, { newColumnIndex: targetIndex });
       }
     }
@@ -204,11 +201,6 @@ export const DetailsListKeyboardAccessibleResizeAndReorderExample: React.Functio
       if (ev.shiftKey) {
         const indexOffset = 1 + selection.mode ? 1 : 0;
         const columnIndex = columns.findIndex(x => x.key === column.key) + indexOffset;
-        console.log(
-          column,
-          columnIndex,
-          columns.map(x => x.key),
-        );
         switch (ev.key) {
           case 'ArrowLeft':
             if (columnIndex > 0) {

--- a/packages/react-examples/src/react/DetailsList/DetailsList.KeyboardAccessibleResizeAndReorder.Example.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.KeyboardAccessibleResizeAndReorder.Example.tsx
@@ -51,7 +51,7 @@ export const DetailsListKeyboardAccessibleResizeAndReorderExample: React.Functio
   const handleColumnReorder = (draggedIndex: number, targetIndex: number) => {
     const draggedItems = columns[draggedIndex];
     const newColumns: IColumn[] = [...columns];
-    console.log('handleColumnReorder', draggedIndex, targetIndex);
+
     // insert before the dropped item
     newColumns.splice(draggedIndex, 1);
     newColumns.splice(targetIndex, 0, draggedItems);
@@ -113,7 +113,6 @@ export const DetailsListKeyboardAccessibleResizeAndReorderExample: React.Functio
         detailsList.updateColumn(columnToEdit.current, { width: width });
       } else if (clickHandler.current === REORDER) {
         const targetIndex = selection.mode ? input.current + 1 : input.current;
-        console.log(columnToEdit.current.key, targetIndex);
         detailsList.updateColumn(columnToEdit.current, { newColumnIndex: targetIndex });
       }
     }

--- a/packages/react-examples/src/react/DetailsList/DetailsList.KeyboardAccessibleResizeAndReorder.Example.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.KeyboardAccessibleResizeAndReorder.Example.tsx
@@ -204,12 +204,12 @@ export const DetailsListKeyboardAccessibleResizeAndReorderExample: React.Functio
         switch (ev.key) {
           case 'ArrowLeft':
             if (columnIndex > 0) {
-              detailsList.updateColumn(column, { newColumnIndex: columnIndex + indexOffset - 1 });
+              detailsList?.updateColumn(column, { newColumnIndex: columnIndex + indexOffset - 1 });
             }
             break;
           case 'ArrowRight':
             if (columnIndex < columns.length - 1) {
-              detailsList.updateColumn(column, { newColumnIndex: columnIndex + indexOffset + 1 });
+              detailsList?.updateColumn(column, { newColumnIndex: columnIndex + indexOffset + 1 });
             }
             break;
         }
@@ -218,10 +218,14 @@ export const DetailsListKeyboardAccessibleResizeAndReorderExample: React.Functio
         ev.preventDefault();
         switch (ev.key) {
           case 'ArrowLeft':
-            detailsList.updateColumn(column, { width: column.currentWidth * 0.9 });
+            detailsList?.updateColumn(column, {
+              width: column?.currentWidth ? column?.currentWidth * 0.9 : column.minWidth,
+            });
             break;
           case 'ArrowRight':
-            detailsList.updateColumn(column, { width: column.currentWidth * 1.1 });
+            detailsList?.updateColumn(column, {
+              width: column?.currentWidth ? column?.currentWidth * 1.1 : column.minWidth,
+            });
             break;
         }
       }

--- a/packages/react-examples/src/react/DetailsList/DetailsList.KeyboardAccessibleResizeAndReorder.Example.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.KeyboardAccessibleResizeAndReorder.Example.tsx
@@ -196,6 +196,7 @@ export const DetailsListKeyboardAccessibleResizeAndReorderExample: React.Functio
   const input = React.useRef<number | null>(null);
   const focusZoneRef = React.useRef<IFocusZone>(null);
 
+  /** This callback provides support for keyboard shortcuts to resize & reorder columns */
   const onColumnKeyDown = React.useCallback(
     (ev: React.KeyboardEvent, column: IColumn): void => {
       const detailsList = detailsListRef.current;
@@ -233,7 +234,7 @@ export const DetailsListKeyboardAccessibleResizeAndReorderExample: React.Functio
         }
       }
     },
-    [columns],
+    [columns, selection.mode],
   );
 
   const insertBeforeItem = React.useCallback(

--- a/packages/react-examples/src/react/DetailsList/DetailsList.KeyboardAccessibleResizeAndReorder.Example.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.KeyboardAccessibleResizeAndReorder.Example.tsx
@@ -11,10 +11,8 @@ import {
   IDragDropContext,
   ColumnActionsMode,
   IDetailsList,
-  IDetailsColumnRenderTooltipProps,
 } from '@fluentui/react/lib/DetailsList';
 import { MarqueeSelection } from '@fluentui/react/lib/MarqueeSelection';
-import { TooltipHost } from '@fluentui/react/lib/Tooltip';
 import { createListItems, IExampleItem } from '@fluentui/example-data';
 import { TextField, ITextFieldStyles, ITextField } from '@fluentui/react/lib/TextField';
 import { Toggle, IToggleStyles } from '@fluentui/react/lib/Toggle';
@@ -53,7 +51,7 @@ export const DetailsListKeyboardAccessibleResizeAndReorderExample: React.Functio
   const handleColumnReorder = (draggedIndex: number, targetIndex: number) => {
     const draggedItems = columns[draggedIndex];
     const newColumns: IColumn[] = [...columns];
-    console.log('handleColumnReorder', draggedIndex, targetIndex);
+
     // insert before the dropped item
     newColumns.splice(draggedIndex, 1);
     newColumns.splice(targetIndex, 0, draggedItems);
@@ -115,7 +113,6 @@ export const DetailsListKeyboardAccessibleResizeAndReorderExample: React.Functio
         detailsList.updateColumn(columnToEdit.current, { width: width });
       } else if (clickHandler.current === REORDER) {
         const targetIndex = selection.mode ? input.current + 1 : input.current;
-        console.log(columnToEdit.current.key, targetIndex);
         detailsList.updateColumn(columnToEdit.current, { newColumnIndex: targetIndex });
       }
     }

--- a/packages/react-examples/src/react/DetailsList/DetailsList.KeyboardAccessibleResizeAndReorder.Example.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.KeyboardAccessibleResizeAndReorder.Example.tsx
@@ -11,8 +11,10 @@ import {
   IDragDropContext,
   ColumnActionsMode,
   IDetailsList,
+  IDetailsColumnRenderTooltipProps,
 } from '@fluentui/react/lib/DetailsList';
 import { MarqueeSelection } from '@fluentui/react/lib/MarqueeSelection';
+import { TooltipHost } from '@fluentui/react/lib/Tooltip';
 import { createListItems, IExampleItem } from '@fluentui/example-data';
 import { TextField, ITextFieldStyles, ITextField } from '@fluentui/react/lib/TextField';
 import { Toggle, IToggleStyles } from '@fluentui/react/lib/Toggle';
@@ -127,6 +129,22 @@ export const DetailsListKeyboardAccessibleResizeAndReorderExample: React.Functio
     }
   };
 
+  const onColumnKeyDown = (ev: React.KeyboardEvent, column: IColumn): void => {
+    const detailsList = detailsListRef.current;
+
+    if (ev.ctrlKey) {
+      ev.preventDefault();
+      switch (ev.key) {
+        case 'ArrowLeft':
+          detailsList.updateColumn(column, { width: column.currentWidth * 0.9 });
+          break;
+        case 'ArrowRight':
+          detailsList.updateColumn(column, { width: column.currentWidth * 1.1 });
+          break;
+      }
+    }
+  };
+
   const getContextualMenuProps = (ev: React.MouseEvent<HTMLElement>, column: IColumn): IContextualMenuProps => {
     const items = [
       { key: 'resize', text: 'Resize', onClick: () => resizeColumn(column) },
@@ -179,7 +197,9 @@ export const DetailsListKeyboardAccessibleResizeAndReorderExample: React.Functio
   const [items, setItems] = React.useState<IExampleItem[]>(createListItems(5, 0));
   const [sortedItems, setSortedItems] = React.useState<IExampleItem[]>(items);
   const [columns, setColumns] = React.useState<IColumn[]>(
-    buildColumns(items, true, onColumnClick, undefined, false, undefined, undefined, ColumnActionsMode.hasDropdown),
+    buildColumns(items, true, onColumnClick, undefined, false, undefined, undefined, ColumnActionsMode.hasDropdown).map(
+      column => ({ ...column, onColumnKeyDown }),
+    ),
   );
   const [isColumnReorderEnabled, setIsColumnReorderEnabled] = React.useState<boolean>(true);
   const [frozenColumnCountFromStart, setFrozenColumnCountFromStart] = React.useState<string>('0');

--- a/packages/react-examples/src/react/DetailsList/DetailsList.KeyboardAccessibleResizeAndReorder.Example.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.KeyboardAccessibleResizeAndReorder.Example.tsx
@@ -11,10 +11,8 @@ import {
   IDragDropContext,
   ColumnActionsMode,
   IDetailsList,
-  IDetailsColumnRenderTooltipProps,
 } from '@fluentui/react/lib/DetailsList';
 import { MarqueeSelection } from '@fluentui/react/lib/MarqueeSelection';
-import { TooltipHost } from '@fluentui/react/lib/Tooltip';
 import { createListItems, IExampleItem } from '@fluentui/example-data';
 import { TextField, ITextFieldStyles, ITextField } from '@fluentui/react/lib/TextField';
 import { Toggle, IToggleStyles } from '@fluentui/react/lib/Toggle';
@@ -53,7 +51,7 @@ export const DetailsListKeyboardAccessibleResizeAndReorderExample: React.Functio
   const handleColumnReorder = (draggedIndex: number, targetIndex: number) => {
     const draggedItems = columns[draggedIndex];
     const newColumns: IColumn[] = [...columns];
-
+    console.log('handleColumnReorder', draggedIndex, targetIndex);
     // insert before the dropped item
     newColumns.splice(draggedIndex, 1);
     newColumns.splice(targetIndex, 0, draggedItems);
@@ -115,6 +113,7 @@ export const DetailsListKeyboardAccessibleResizeAndReorderExample: React.Functio
         detailsList.updateColumn(columnToEdit.current, { width: width });
       } else if (clickHandler.current === REORDER) {
         const targetIndex = selection.mode ? input.current + 1 : input.current;
+        console.log(columnToEdit.current.key, targetIndex);
         detailsList.updateColumn(columnToEdit.current, { newColumnIndex: targetIndex });
       }
     }
@@ -126,22 +125,6 @@ export const DetailsListKeyboardAccessibleResizeAndReorderExample: React.Functio
   const onColumnClick = (ev: React.MouseEvent<HTMLElement>, column: IColumn): void => {
     if (column.columnActionsMode !== ColumnActionsMode.disabled) {
       setContextualMenuProps(getContextualMenuProps(ev, column));
-    }
-  };
-
-  const onColumnKeyDown = (ev: React.KeyboardEvent, column: IColumn): void => {
-    const detailsList = detailsListRef.current;
-
-    if (ev.ctrlKey) {
-      ev.preventDefault();
-      switch (ev.key) {
-        case 'ArrowLeft':
-          detailsList.updateColumn(column, { width: column.currentWidth * 0.9 });
-          break;
-        case 'ArrowRight':
-          detailsList.updateColumn(column, { width: column.currentWidth * 1.1 });
-          break;
-      }
     }
   };
 
@@ -197,9 +180,7 @@ export const DetailsListKeyboardAccessibleResizeAndReorderExample: React.Functio
   const [items, setItems] = React.useState<IExampleItem[]>(createListItems(5, 0));
   const [sortedItems, setSortedItems] = React.useState<IExampleItem[]>(items);
   const [columns, setColumns] = React.useState<IColumn[]>(
-    buildColumns(items, true, onColumnClick, undefined, false, undefined, undefined, ColumnActionsMode.hasDropdown).map(
-      column => ({ ...column, onColumnKeyDown }),
-    ),
+    buildColumns(items, true, onColumnClick, undefined, false, undefined, undefined, ColumnActionsMode.hasDropdown),
   );
   const [isColumnReorderEnabled, setIsColumnReorderEnabled] = React.useState<boolean>(true);
   const [frozenColumnCountFromStart, setFrozenColumnCountFromStart] = React.useState<string>('0');

--- a/packages/react-examples/src/react/DetailsList/DetailsList.KeyboardAccessibleResizeAndReorder.Example.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.KeyboardAccessibleResizeAndReorder.Example.tsx
@@ -53,7 +53,7 @@ export const DetailsListKeyboardAccessibleResizeAndReorderExample: React.Functio
   const handleColumnReorder = (draggedIndex: number, targetIndex: number) => {
     const draggedItems = columns[draggedIndex];
     const newColumns: IColumn[] = [...columns];
-
+    console.log('handleColumnReorder', draggedIndex, targetIndex);
     // insert before the dropped item
     newColumns.splice(draggedIndex, 1);
     newColumns.splice(targetIndex, 0, draggedItems);
@@ -115,6 +115,7 @@ export const DetailsListKeyboardAccessibleResizeAndReorderExample: React.Functio
         detailsList.updateColumn(columnToEdit.current, { width: width });
       } else if (clickHandler.current === REORDER) {
         const targetIndex = selection.mode ? input.current + 1 : input.current;
+        console.log(columnToEdit.current.key, targetIndex);
         detailsList.updateColumn(columnToEdit.current, { newColumnIndex: targetIndex });
       }
     }
@@ -126,22 +127,6 @@ export const DetailsListKeyboardAccessibleResizeAndReorderExample: React.Functio
   const onColumnClick = (ev: React.MouseEvent<HTMLElement>, column: IColumn): void => {
     if (column.columnActionsMode !== ColumnActionsMode.disabled) {
       setContextualMenuProps(getContextualMenuProps(ev, column));
-    }
-  };
-
-  const onColumnKeyDown = (ev: React.KeyboardEvent, column: IColumn): void => {
-    const detailsList = detailsListRef.current;
-
-    if (ev.ctrlKey) {
-      ev.preventDefault();
-      switch (ev.key) {
-        case 'ArrowLeft':
-          detailsList.updateColumn(column, { width: column.currentWidth * 0.9 });
-          break;
-        case 'ArrowRight':
-          detailsList.updateColumn(column, { width: column.currentWidth * 1.1 });
-          break;
-      }
     }
   };
 
@@ -197,9 +182,7 @@ export const DetailsListKeyboardAccessibleResizeAndReorderExample: React.Functio
   const [items, setItems] = React.useState<IExampleItem[]>(createListItems(5, 0));
   const [sortedItems, setSortedItems] = React.useState<IExampleItem[]>(items);
   const [columns, setColumns] = React.useState<IColumn[]>(
-    buildColumns(items, true, onColumnClick, undefined, false, undefined, undefined, ColumnActionsMode.hasDropdown).map(
-      column => ({ ...column, onColumnKeyDown }),
-    ),
+    buildColumns(items, true, onColumnClick, undefined, false, undefined, undefined, ColumnActionsMode.hasDropdown),
   );
   const [isColumnReorderEnabled, setIsColumnReorderEnabled] = React.useState<boolean>(true);
   const [frozenColumnCountFromStart, setFrozenColumnCountFromStart] = React.useState<string>('0');
@@ -212,6 +195,46 @@ export const DetailsListKeyboardAccessibleResizeAndReorderExample: React.Functio
   const detailsListRef = React.useRef<IDetailsList>(null);
   const input = React.useRef<number | null>(null);
   const focusZoneRef = React.useRef<IFocusZone>(null);
+
+  const onColumnKeyDown = React.useCallback(
+    (ev: React.KeyboardEvent, column: IColumn): void => {
+      const detailsList = detailsListRef.current;
+
+      if (ev.shiftKey) {
+        const indexOffset = 1 + selection.mode ? 1 : 0;
+        const columnIndex = columns.findIndex(x => x.key === column.key) + indexOffset;
+        console.log(
+          column,
+          columnIndex,
+          columns.map(x => x.key),
+        );
+        switch (ev.key) {
+          case 'ArrowLeft':
+            if (columnIndex > 0) {
+              detailsList.updateColumn(column, { newColumnIndex: columnIndex + indexOffset - 1 });
+            }
+            break;
+          case 'ArrowRight':
+            if (columnIndex < columns.length - 1) {
+              detailsList.updateColumn(column, { newColumnIndex: columnIndex + indexOffset + 1 });
+            }
+            break;
+        }
+      }
+      if (ev.ctrlKey) {
+        ev.preventDefault();
+        switch (ev.key) {
+          case 'ArrowLeft':
+            detailsList.updateColumn(column, { width: column.currentWidth * 0.9 });
+            break;
+          case 'ArrowRight':
+            detailsList.updateColumn(column, { width: column.currentWidth * 1.1 });
+            break;
+        }
+      }
+    },
+    [columns],
+  );
 
   const insertBeforeItem = React.useCallback(
     (item: IExampleItem) => {
@@ -332,7 +355,7 @@ export const DetailsListKeyboardAccessibleResizeAndReorderExample: React.Functio
           focusZoneProps={{ componentRef: focusZoneRef }}
           setKey="items"
           items={sortedItems}
-          columns={columns}
+          columns={columns.map(x => ({ ...x, onColumnKeyDown }))}
           selection={selection}
           selectionPreservedOnEmptyClick={true}
           onItemInvoked={onItemInvoked}

--- a/packages/react-examples/src/react/DetailsList/DetailsList.KeyboardAccessibleResizeAndReorder.Example.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.KeyboardAccessibleResizeAndReorder.Example.tsx
@@ -53,7 +53,7 @@ export const DetailsListKeyboardAccessibleResizeAndReorderExample: React.Functio
   const handleColumnReorder = (draggedIndex: number, targetIndex: number) => {
     const draggedItems = columns[draggedIndex];
     const newColumns: IColumn[] = [...columns];
-
+    console.log('handleColumnReorder', draggedIndex, targetIndex);
     // insert before the dropped item
     newColumns.splice(draggedIndex, 1);
     newColumns.splice(targetIndex, 0, draggedItems);
@@ -115,6 +115,7 @@ export const DetailsListKeyboardAccessibleResizeAndReorderExample: React.Functio
         detailsList.updateColumn(columnToEdit.current, { width: width });
       } else if (clickHandler.current === REORDER) {
         const targetIndex = selection.mode ? input.current + 1 : input.current;
+        console.log(columnToEdit.current.key, targetIndex);
         detailsList.updateColumn(columnToEdit.current, { newColumnIndex: targetIndex });
       }
     }
@@ -126,22 +127,6 @@ export const DetailsListKeyboardAccessibleResizeAndReorderExample: React.Functio
   const onColumnClick = (ev: React.MouseEvent<HTMLElement>, column: IColumn): void => {
     if (column.columnActionsMode !== ColumnActionsMode.disabled) {
       setContextualMenuProps(getContextualMenuProps(ev, column));
-    }
-  };
-
-  const onColumnKeyDown = (ev: React.KeyboardEvent, column: IColumn): void => {
-    const detailsList = detailsListRef.current;
-
-    if (ev.ctrlKey) {
-      ev.preventDefault();
-      switch (ev.key) {
-        case 'ArrowLeft':
-          detailsList.updateColumn(column, { width: column.currentWidth * 0.9 });
-          break;
-        case 'ArrowRight':
-          detailsList.updateColumn(column, { width: column.currentWidth * 1.1 });
-          break;
-      }
     }
   };
 
@@ -197,9 +182,7 @@ export const DetailsListKeyboardAccessibleResizeAndReorderExample: React.Functio
   const [items, setItems] = React.useState<IExampleItem[]>(createListItems(5, 0));
   const [sortedItems, setSortedItems] = React.useState<IExampleItem[]>(items);
   const [columns, setColumns] = React.useState<IColumn[]>(
-    buildColumns(items, true, onColumnClick, undefined, false, undefined, undefined, ColumnActionsMode.hasDropdown).map(
-      column => ({ ...column, onColumnKeyDown }),
-    ),
+    buildColumns(items, true, onColumnClick, undefined, false, undefined, undefined, ColumnActionsMode.hasDropdown),
   );
   const [isColumnReorderEnabled, setIsColumnReorderEnabled] = React.useState<boolean>(true);
   const [frozenColumnCountFromStart, setFrozenColumnCountFromStart] = React.useState<string>('0');

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -3820,6 +3820,7 @@ export interface IColumn {
     name: string;
     onColumnClick?: (ev: React_2.MouseEvent<HTMLElement>, column: IColumn) => void;
     onColumnContextMenu?: (column?: IColumn, ev?: React_2.MouseEvent<HTMLElement>) => void;
+    onColumnKeyDown?: (ev: React.KeyboardEvent, column: IColumn) => void;
     onColumnResize?: (width?: number) => void;
     onRender?: (item?: any, index?: number, column?: IColumn) => any;
     onRenderDivider?: IRenderFunction<IDetailsColumnProps>;
@@ -4508,6 +4509,7 @@ export interface IDetailsColumnProps extends React_2.ClassAttributes<DetailsColu
     isDropped?: boolean;
     onColumnClick?: (ev: React_2.MouseEvent<HTMLElement>, column: IColumn) => void;
     onColumnContextMenu?: (column: IColumn, ev: React_2.MouseEvent<HTMLElement>) => void;
+    onColumnKeyDown?: (ev: React.KeyboardEvent, column: IColumn) => void;
     onRenderColumnHeaderTooltip?: IRenderFunction<IDetailsColumnRenderTooltipProps>;
     parentId?: string;
     // @deprecated (undocumented)

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -3820,7 +3820,7 @@ export interface IColumn {
     name: string;
     onColumnClick?: (ev: React_2.MouseEvent<HTMLElement>, column: IColumn) => void;
     onColumnContextMenu?: (column?: IColumn, ev?: React_2.MouseEvent<HTMLElement>) => void;
-    onColumnKeyDown?: (ev: React.KeyboardEvent, column: IColumn) => void;
+    onColumnKeyDown?: (ev: React_2.KeyboardEvent, column: IColumn) => void;
     onColumnResize?: (width?: number) => void;
     onRender?: (item?: any, index?: number, column?: IColumn) => any;
     onRenderDivider?: IRenderFunction<IDetailsColumnProps>;
@@ -4509,7 +4509,7 @@ export interface IDetailsColumnProps extends React_2.ClassAttributes<DetailsColu
     isDropped?: boolean;
     onColumnClick?: (ev: React_2.MouseEvent<HTMLElement>, column: IColumn) => void;
     onColumnContextMenu?: (column: IColumn, ev: React_2.MouseEvent<HTMLElement>) => void;
-    onColumnKeyDown?: (ev: React.KeyboardEvent, column: IColumn) => void;
+    onColumnKeyDown?: (ev: React_2.KeyboardEvent, column: IColumn) => void;
     onRenderColumnHeaderTooltip?: IRenderFunction<IDetailsColumnRenderTooltipProps>;
     parentId?: string;
     // @deprecated (undocumented)

--- a/packages/react/src/components/DetailsList/DetailsColumn.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsColumn.base.tsx
@@ -156,6 +156,7 @@ export class DetailsColumnBase extends React.Component<IDetailsColumnProps> {
                   {...(hasInnerButton && accNameDescription)}
                   onContextMenu={this._onColumnContextMenu}
                   onClick={this._onColumnClick}
+                  onKeyDown={this._onColumnKeyDown}
                   aria-haspopup={column.columnActionsMode === ColumnActionsMode.hasDropdown ? 'menu' : undefined}
                   aria-expanded={
                     column.columnActionsMode === ColumnActionsMode.hasDropdown ? !!column.isMenuOpen : undefined
@@ -273,6 +274,18 @@ export class DetailsColumnBase extends React.Component<IDetailsColumnProps> {
 
     if (onColumnClick) {
       onColumnClick(ev, column);
+    }
+  };
+
+  private _onColumnKeyDown = (ev: React.KeyboardEvent): void => {
+    const { onColumnKeyDown, column } = this.props;
+
+    if (column.onColumnKeyDown) {
+      column.onColumnKeyDown(ev, column);
+    }
+
+    if (onColumnKeyDown) {
+      onColumnKeyDown(ev, column);
     }
   };
 

--- a/packages/react/src/components/DetailsList/DetailsColumn.types.ts
+++ b/packages/react/src/components/DetailsList/DetailsColumn.types.ts
@@ -60,6 +60,10 @@ export interface IDetailsColumnProps extends React.ClassAttributes<DetailsColumn
    */
   onColumnContextMenu?: (column: IColumn, ev: React.MouseEvent<HTMLElement>) => void;
   /**
+   * Callback fired when keydown event occurs.
+   */
+  onColumnKeyDown?: (ev: React.KeyboardEvent, column: IColumn) => void;
+  /**
    * The drag and drop helper for the component instance.
    */
   dragDropHelper?: IDragDropHelper | null;

--- a/packages/react/src/components/DetailsList/DetailsList.types.ts
+++ b/packages/react/src/components/DetailsList/DetailsList.types.ts
@@ -481,6 +481,9 @@ export interface IColumn {
   /** Callback for when the user opens the column header context menu. */
   onColumnContextMenu?: (column?: IColumn, ev?: React.MouseEvent<HTMLElement>) => void;
 
+  /** Callback for when the user performs a keyboard action on the column header */
+  onColumnKeyDown?: (ev: React.KeyboardEvent, column: IColumn) => void;
+
   /**
    * Callback for when the column is resized (`width` is the current width).
    *

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsColumn.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsColumn.test.tsx.snap
@@ -494,6 +494,7 @@ exports[`DetailsColumn renders a sortable icon on an unsorted column when showSo
                 id="header1-1"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
                 role="button"
               >
                 <span

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
@@ -451,6 +451,7 @@ exports[`DetailsHeader can render 1`] = `
         id="header0-a"
         onClick={[Function]}
         onContextMenu={[Function]}
+        onKeyDown={[Function]}
       >
         <span
           className=
@@ -664,6 +665,7 @@ exports[`DetailsHeader can render 1`] = `
         id="header0-b"
         onClick={[Function]}
         onContextMenu={[Function]}
+        onKeyDown={[Function]}
       >
         <span
           className=
@@ -909,6 +911,7 @@ exports[`DetailsHeader can render 1`] = `
         id="header0-c"
         onClick={[Function]}
         onContextMenu={[Function]}
+        onKeyDown={[Function]}
       >
         <span
           className=
@@ -1331,6 +1334,7 @@ exports[`DetailsHeader can render a hidden select all checkbox in single selecti
         id="header2-a"
         onClick={[Function]}
         onContextMenu={[Function]}
+        onKeyDown={[Function]}
       >
         <span
           className=
@@ -1544,6 +1548,7 @@ exports[`DetailsHeader can render a hidden select all checkbox in single selecti
         id="header2-b"
         onClick={[Function]}
         onContextMenu={[Function]}
+        onKeyDown={[Function]}
       >
         <span
           className=
@@ -1789,6 +1794,7 @@ exports[`DetailsHeader can render a hidden select all checkbox in single selecti
         id="header2-c"
         onClick={[Function]}
         onContextMenu={[Function]}
+        onKeyDown={[Function]}
       >
         <span
           className=
@@ -2373,6 +2379,7 @@ exports[`DetailsHeader renders accessible labels 1`] = `
         id="header6-a"
         onClick={[Function]}
         onContextMenu={[Function]}
+        onKeyDown={[Function]}
       >
         <span
           className=
@@ -2587,6 +2594,7 @@ exports[`DetailsHeader renders accessible labels 1`] = `
         id="header6-b"
         onClick={[Function]}
         onContextMenu={[Function]}
+        onKeyDown={[Function]}
       >
         <span
           className=
@@ -2858,6 +2866,7 @@ exports[`DetailsHeader renders accessible labels 1`] = `
         id="header6-c"
         onClick={[Function]}
         onContextMenu={[Function]}
+        onKeyDown={[Function]}
       >
         <span
           className=

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -2341,6 +2341,7 @@ exports[`DetailsList renders List correctly 1`] = `
                 id="header1-key"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -2553,6 +2554,7 @@ exports[`DetailsList renders List correctly 1`] = `
                 id="header1-name"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -2765,6 +2767,7 @@ exports[`DetailsList renders List correctly 1`] = `
                 id="header1-value"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -3423,6 +3426,7 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
                 id="header1-column_key_0"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -3579,6 +3583,7 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
                 id="header1-column_key_1"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -3735,6 +3740,7 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
                 id="header1-column_key_2"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -3891,6 +3897,7 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
                 id="header1-column_key_3"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -4047,6 +4054,7 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
                 id="header1-column_key_4"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -4650,6 +4658,7 @@ exports[`DetailsList renders List in compact mode correctly 1`] = `
                 id="header1-key"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -4862,6 +4871,7 @@ exports[`DetailsList renders List in compact mode correctly 1`] = `
                 id="header1-name"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -5074,6 +5084,7 @@ exports[`DetailsList renders List in compact mode correctly 1`] = `
                 id="header1-value"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -5733,6 +5744,7 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
                 id="header1-key"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -5945,6 +5957,7 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
                 id="header1-name"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -6157,6 +6170,7 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
                 id="header1-value"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -6815,6 +6829,7 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                 id="header1-column_key_0"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -6974,6 +6989,7 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                 id="header1-column_key_1"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -7133,6 +7149,7 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                 id="header1-column_key_2"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -7292,6 +7309,7 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                 id="header1-column_key_3"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -7451,6 +7469,7 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                 id="header1-column_key_4"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -7903,6 +7922,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                 id="header1-key"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -8115,6 +8135,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                 id="header1-name"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -8327,6 +8348,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                 id="header1-value"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsListV2.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsListV2.test.tsx.snap
@@ -1813,6 +1813,7 @@ exports[`DetailsListV2 renders List correctly 1`] = `
                 id="header1-key"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -2025,6 +2026,7 @@ exports[`DetailsListV2 renders List correctly 1`] = `
                 id="header1-name"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -2237,6 +2239,7 @@ exports[`DetailsListV2 renders List correctly 1`] = `
                 id="header1-value"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -2895,6 +2898,7 @@ exports[`DetailsListV2 renders List correctly with onRenderDivider props 1`] = `
                 id="header1-column_key_0"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -3051,6 +3055,7 @@ exports[`DetailsListV2 renders List correctly with onRenderDivider props 1`] = `
                 id="header1-column_key_1"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -3207,6 +3212,7 @@ exports[`DetailsListV2 renders List correctly with onRenderDivider props 1`] = `
                 id="header1-column_key_2"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -3363,6 +3369,7 @@ exports[`DetailsListV2 renders List correctly with onRenderDivider props 1`] = `
                 id="header1-column_key_3"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -3519,6 +3526,7 @@ exports[`DetailsListV2 renders List correctly with onRenderDivider props 1`] = `
                 id="header1-column_key_4"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -4122,6 +4130,7 @@ exports[`DetailsListV2 renders List in compact mode correctly 1`] = `
                 id="header1-key"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -4334,6 +4343,7 @@ exports[`DetailsListV2 renders List in compact mode correctly 1`] = `
                 id="header1-name"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -4546,6 +4556,7 @@ exports[`DetailsListV2 renders List in compact mode correctly 1`] = `
                 id="header1-value"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -5205,6 +5216,7 @@ exports[`DetailsListV2 renders List in fixed constrained layout correctly 1`] = 
                 id="header1-key"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -5417,6 +5429,7 @@ exports[`DetailsListV2 renders List in fixed constrained layout correctly 1`] = 
                 id="header1-name"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -5629,6 +5642,7 @@ exports[`DetailsListV2 renders List in fixed constrained layout correctly 1`] = 
                 id="header1-value"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -6287,6 +6301,7 @@ exports[`DetailsListV2 renders List with custom icon as column divider 1`] = `
                 id="header1-column_key_0"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -6446,6 +6461,7 @@ exports[`DetailsListV2 renders List with custom icon as column divider 1`] = `
                 id="header1-column_key_1"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -6605,6 +6621,7 @@ exports[`DetailsListV2 renders List with custom icon as column divider 1`] = `
                 id="header1-column_key_2"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -6764,6 +6781,7 @@ exports[`DetailsListV2 renders List with custom icon as column divider 1`] = `
                 id="header1-column_key_3"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -6923,6 +6941,7 @@ exports[`DetailsListV2 renders List with custom icon as column divider 1`] = `
                 id="header1-column_key_4"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -7375,6 +7394,7 @@ exports[`DetailsListV2 renders List with hidden checkboxes correctly 1`] = `
                 id="header1-key"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -7587,6 +7607,7 @@ exports[`DetailsListV2 renders List with hidden checkboxes correctly 1`] = `
                 id="header1-name"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -7799,6 +7820,7 @@ exports[`DetailsListV2 renders List with hidden checkboxes correctly 1`] = `
                 id="header1-value"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=

--- a/packages/react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
+++ b/packages/react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
@@ -493,6 +493,7 @@ exports[`DetailsRow renders details list row correctly 1`] = `
                 id="header1-key"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -649,6 +650,7 @@ exports[`DetailsRow renders details list row correctly 1`] = `
                 id="header1-name"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -805,6 +807,7 @@ exports[`DetailsRow renders details list row correctly 1`] = `
                 id="header1-value"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -1427,6 +1430,7 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
                 id="header13-key"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -1583,6 +1587,7 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
                 id="header13-name"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -1739,6 +1744,7 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
                 id="header13-value"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -2928,6 +2934,7 @@ exports[`DetailsRow renders details list row with multiple selections correctly 
                 id="header5-key"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -3084,6 +3091,7 @@ exports[`DetailsRow renders details list row with multiple selections correctly 
                 id="header5-name"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -3240,6 +3248,7 @@ exports[`DetailsRow renders details list row with multiple selections correctly 
                 id="header5-value"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -3862,6 +3871,7 @@ exports[`DetailsRow renders details list row with one row selected correctly 1`]
                 id="header9-key"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -4018,6 +4028,7 @@ exports[`DetailsRow renders details list row with one row selected correctly 1`]
                 id="header9-name"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=
@@ -4174,6 +4185,7 @@ exports[`DetailsRow renders details list row with one row selected correctly 1`]
                 id="header9-value"
                 onClick={[Function]}
                 onContextMenu={[Function]}
+                onKeyDown={[Function]}
               >
                 <span
                   className=


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

No way for custom keydown handling to take place on `DetailsList` column headers

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

Consumers of Fluent UI can provide custom keyboard input handling for `DetailsList` headers, to address needs such as keyboard shortcut accessibility for resizing/reordering columns. Use new `IColumn` prop `onColumnKeyDown` to do so. 

Example added in `DetailsList.KeyboardAccessibleResizeAndReorder.Example.tsx`

**Demo**

![onColumnKeyDown demo](https://github.com/user-attachments/assets/cd46b5f3-f8a6-401c-b9c4-1824a7857229)

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #23041 
