### PR TITLE
fix(react-storybook-addon): transform decorator to function in withAriaLive()

### DIFF
--- a/apps/vr-tests-react-components/.storybook/preview.js
+++ b/apps/vr-tests-react-components/.storybook/preview.js
@@ -69,4 +69,10 @@ setAddon({
 });
 
 /** @type {import("@fluentui/react-storybook-addon").FluentParameters} */
-export const parameters = { layout: 'none', mode: 'vr-test' };
+export const parameters = {
+  layout: 'none',
+  mode: 'vr-test',
+  reactStorybookAddon: {
+    disabledDecorators: ['AriaLive'],
+  },
+};

--- a/packages/react-components/react-storybook-addon/etc/react-storybook-addon.api.md
+++ b/packages/react-components/react-storybook-addon/etc/react-storybook-addon.api.md
@@ -31,6 +31,10 @@ export interface FluentParameters extends Parameters_2 {
     fluentTheme?: ThemeIds;
     // (undocumented)
     mode?: 'default' | 'vr-test';
+    // (undocumented)
+    reactStorybookAddon?: {
+        disabledDecorators: ['AriaLive' | 'FluentProvider' | 'ReactStrictMode'];
+    };
 }
 
 // @public (undocumented)
@@ -46,6 +50,9 @@ export function parameters(options?: FluentParameters): {
     dir: string;
     fluentTheme: string;
     mode: string;
+    reactStorybookAddon?: {
+        disabledDecorators: ["AriaLive" | "FluentProvider" | "ReactStrictMode"];
+    } | undefined;
     fileName?: string | undefined;
     options?: OptionsParameter | undefined;
     layout?: "centered" | "fullscreen" | "padded" | "none" | undefined;

--- a/packages/react-components/react-storybook-addon/src/decorators/withAriaLive.tsx
+++ b/packages/react-components/react-storybook-addon/src/decorators/withAriaLive.tsx
@@ -2,11 +2,10 @@ import { AriaLiveAnnouncer } from '@fluentui/react-aria';
 import * as React from 'react';
 
 import { FluentStoryContext } from '../hooks';
+import { isDecoratorDisabled } from '../utils/isDecoratorDisabled';
 
 export const withAriaLive = (Story: () => JSX.Element, context: FluentStoryContext) => {
-  const shouldDisable = context.parameters.reactStorybookAddon?.disabledDecorators?.includes('AriaLive');
-
-  if (shouldDisable) {
+  if (isDecoratorDisabled(context, 'AriaLive')) {
     return Story();
   }
 

--- a/packages/react-components/react-storybook-addon/src/decorators/withAriaLive.tsx
+++ b/packages/react-components/react-storybook-addon/src/decorators/withAriaLive.tsx
@@ -1,17 +1,30 @@
+import { AriaLiveAnnouncer } from '@fluentui/react-aria';
 import * as React from 'react';
 
-import { AriaLiveAnnouncer } from '@fluentui/react-aria';
+import { FluentStoryContext } from '../hooks';
 
-export const withAriaLive = (StoryFn: () => JSX.Element) => {
-  return <AriaLiveWrapper>{StoryFn()}</AriaLiveWrapper>;
+export const withAriaLive = (Story: () => JSX.Element, context: FluentStoryContext) => {
+  const shouldDisable = context.parameters.reactStorybookAddon?.disabledDecorators?.includes('AriaLive');
+
+  if (shouldDisable) {
+    return Story();
+  }
+
+  return (
+    <AriaLiveWrapper>
+      <Story />
+    </AriaLiveWrapper>
+  );
 };
 
 const AriaLiveWrapper: React.FC<{ children: React.ReactNode }> = props => {
   const [mounted, setMounted] = React.useState(false);
+
   React.useEffect(() => {
     // The AriaLiveAnnouncer appends an element to DOM in an effect
     // Trigger an extra renderer to make sure that doc examples that need to announce on mount can do so
     setMounted(true);
   }, []);
+
   return <AriaLiveAnnouncer>{mounted && props.children}</AriaLiveAnnouncer>;
 };

--- a/packages/react-components/react-storybook-addon/src/decorators/withFluentProvider.tsx
+++ b/packages/react-components/react-storybook-addon/src/decorators/withFluentProvider.tsx
@@ -5,6 +5,7 @@ import { Theme } from '@fluentui/react-theme';
 import { themes, defaultTheme, ThemeIds } from '../theme';
 import { DIR_ID, THEME_ID } from '../constants';
 import { FluentGlobals, FluentStoryContext } from '../hooks';
+import { isDecoratorDisabled } from '../utils/isDecoratorDisabled';
 
 const findTheme = (themeId?: ThemeIds) => {
   if (!themeId) {
@@ -24,9 +25,7 @@ export const withFluentProvider = (StoryFn: () => JSX.Element, context: FluentSt
   const { globals, parameters } = context;
   const { mode } = parameters;
 
-  const shouldDisable = parameters.reactStorybookAddon?.disabledDecorators?.includes('FluentProvider');
-
-  if (shouldDisable) {
+  if (isDecoratorDisabled(context, 'FluentProvider')) {
     return StoryFn();
   }
 

--- a/packages/react-components/react-storybook-addon/src/decorators/withFluentProvider.tsx
+++ b/packages/react-components/react-storybook-addon/src/decorators/withFluentProvider.tsx
@@ -23,8 +23,14 @@ const getActiveFluentTheme = (globals: FluentGlobals) => {
 export const withFluentProvider = (StoryFn: () => JSX.Element, context: FluentStoryContext) => {
   const { globals, parameters } = context;
   const { mode } = parameters;
-  const isVrTest = mode === 'vr-test';
 
+  const shouldDisable = parameters.reactStorybookAddon?.disabledDecorators?.includes('FluentProvider');
+
+  if (shouldDisable) {
+    return StoryFn();
+  }
+
+  const isVrTest = mode === 'vr-test';
   const dir = parameters.dir ?? globals[DIR_ID] ?? 'ltr';
   const globalTheme = getActiveFluentTheme(globals);
   const paramTheme = findTheme(parameters.fluentTheme);

--- a/packages/react-components/react-storybook-addon/src/decorators/withReactStrictMode.tsx
+++ b/packages/react-components/react-storybook-addon/src/decorators/withReactStrictMode.tsx
@@ -4,6 +4,12 @@ import { STRICT_MODE_ID } from '../constants';
 import { FluentStoryContext } from '../hooks';
 
 export const withReactStrictMode = (StoryFn: () => JSX.Element, context: FluentStoryContext) => {
+  const shouldDisable = context.parameters.reactStorybookAddon?.disabledDecorators?.includes('ReactStrictMode');
+
+  if (shouldDisable) {
+    return StoryFn();
+  }
+
   const isActive = context.globals[STRICT_MODE_ID] ?? false;
 
   return <StrictModeWrapper strictMode={isActive}>{StoryFn()}</StrictModeWrapper>;

--- a/packages/react-components/react-storybook-addon/src/decorators/withReactStrictMode.tsx
+++ b/packages/react-components/react-storybook-addon/src/decorators/withReactStrictMode.tsx
@@ -2,11 +2,10 @@ import * as React from 'react';
 
 import { STRICT_MODE_ID } from '../constants';
 import { FluentStoryContext } from '../hooks';
+import { isDecoratorDisabled } from '../utils/isDecoratorDisabled';
 
 export const withReactStrictMode = (StoryFn: () => JSX.Element, context: FluentStoryContext) => {
-  const shouldDisable = context.parameters.reactStorybookAddon?.disabledDecorators?.includes('ReactStrictMode');
-
-  if (shouldDisable) {
+  if (isDecoratorDisabled(context, 'ReactStrictMode')) {
     return StoryFn();
   }
 

--- a/packages/react-components/react-storybook-addon/src/hooks.ts
+++ b/packages/react-components/react-storybook-addon/src/hooks.ts
@@ -25,6 +25,7 @@ export interface FluentParameters extends Parameters {
   dir?: 'ltr' | 'rtl';
   fluentTheme?: ThemeIds;
   mode?: 'default' | 'vr-test';
+  reactStorybookAddon?: { disabledDecorators: ['AriaLive' | 'FluentProvider' | 'ReactStrictMode'] };
 }
 
 export function useGlobals(): [FluentGlobals, (newGlobals: FluentGlobals) => void] {

--- a/packages/react-components/react-storybook-addon/src/utils/isDecoratorDisabled.ts
+++ b/packages/react-components/react-storybook-addon/src/utils/isDecoratorDisabled.ts
@@ -1,0 +1,7 @@
+import type { FluentParameters, FluentStoryContext } from '../hooks';
+
+type DecoratorName = NonNullable<FluentParameters['reactStorybookAddon']>['disabledDecorators'][number];
+
+export function isDecoratorDisabled(context: FluentStoryContext, decoratorName: DecoratorName): boolean {
+  return context.parameters.reactStorybookAddon?.disabledDecorators?.includes(decoratorName) ?? false;
+}


### PR DESCRIPTION
## Previous Behavior

#31794 added a new decorator `withAriaLive()`. That decorator has conditional rendering:

https://github.com/microsoft/fluentui/blob/1c2c2003bff234ce6a4a043453479889c153a4b1/packages/react-components/react-storybook-addon/src/decorators/withAriaLive.tsx#L16

The problem is that it's implemented according to Storybook 6 docs and stories as a function:

https://github.com/microsoft/fluentui/blob/1c2c2003bff234ce6a4a043453479889c153a4b1/packages/react-components/react-storybook-addon/src/decorators/withAriaLive.tsx#L6

That causes an issue with a conditional rendering due effect order:

```
- useEffect: in story (as `withAriaLive()` call a function) [RENDER 1]
- useEffect: AriaLiveWrapper (mount) [RENDER 1]
```

This issue breaks stories that rely on `useEffect(fn, [])` as they are executed in wrong order.

## New Behavior

~The PR changes decorators to be called as React components. The same is suggested in Storybook 7 & 8 docs (https://storybook.js.org/docs/writing-stories/decorators#component-decorators).~ The PR updates `withAriaLive()` with an explicit condition for VR tests as VR tooling will fail to get stories for steps otherwise (see `findSteps()` in `node_modules/storywright/src/StoryWrightProcessor/GetStories.js`) 

This fixed the order or effects:

```
- useEffect: AriaLiveWrapper (mount) [RENDER 1]
- useEffect: in story [RENDER 2]
```

## Related Issue(s)

Fixes #32010.
