### PR TITLE
fix(docsite-v9): fix layout of description

### DIFF
--- a/apps/public-docsite-v9/src/DocsComponents/FluentDocsPage.stories.tsx
+++ b/apps/public-docsite-v9/src/DocsComponents/FluentDocsPage.stories.tsx
@@ -46,7 +46,8 @@ const useStyles = makeStyles({
     display: 'flex',
   },
   description: {
-    display: 'flex',
+    display: 'grid',
+    gridTemplateColumns: '1fr min-content',
   },
   nativeProps: {
     display: 'flex',


### PR DESCRIPTION
## Previous Behavior

### Virtualizer page (broken) 🚨

<img width="1356" alt="image" src="https://github.com/user-attachments/assets/cc045804-b23d-4af5-89b7-85b0e781cdfa">

### Icons page

<img width="1321" alt="image" src="https://github.com/user-attachments/assets/386b7d54-7153-4e41-9355-302d8f14689e">

## New Behavior

### Virtualizer page 

<img width="1335" alt="image" src="https://github.com/user-attachments/assets/fd8bfe34-3b6d-4639-9af0-2f796420697a">

### Icons page

<img width="1272" alt="image" src="https://github.com/user-attachments/assets/e1f5054c-ae7b-426c-a3f8-51fefcefa219">


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #32013
