### PR TITLE
feat(motion): add Scale motion component

### DIFF
--- a/change/@fluentui-react-motion-components-preview-b1579edb-605b-4bec-a5dd-2d858369e7aa.json
+++ b/change/@fluentui-react-motion-components-preview-b1579edb-605b-4bec-a5dd-2d858369e7aa.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat(motion): add Scale motion component",
+  "packageName": "@fluentui/react-motion-components-preview",
+  "email": "olkatruk@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-motion-components-preview/library/etc/react-motion-components-preview.api.md
+++ b/packages/react-components/react-motion-components-preview/library/etc/react-motion-components-preview.api.md
@@ -30,6 +30,21 @@ export const FadeExaggerated: PresenceComponent<    {}>;
 // @public (undocumented)
 export const FadeSnappy: PresenceComponent<    {}>;
 
+// @public
+export const Scale: PresenceComponent<    {
+animateOpacity?: boolean | undefined;
+}>;
+
+// @public (undocumented)
+export const ScaleExaggerated: PresenceComponent<    {
+animateOpacity?: boolean | undefined;
+}>;
+
+// @public (undocumented)
+export const ScaleSnappy: PresenceComponent<    {
+animateOpacity?: boolean | undefined;
+}>;
+
 // (No @packageDocumentation comment for this package)
 
 ```

--- a/packages/react-components/react-motion-components-preview/library/src/components/Scale/Scale.test.ts
+++ b/packages/react-components/react-motion-components-preview/library/src/components/Scale/Scale.test.ts
@@ -1,0 +1,12 @@
+import { expectPresenceMotionFunction, expectPresenceMotionObject } from '../../testing/testUtils';
+import { Scale } from './Scale';
+
+describe('Scale', () => {
+  it('stores its motion definition as a static function', () => {
+    expectPresenceMotionFunction(Scale);
+  });
+
+  it('generates a motion definition from the static function', () => {
+    expectPresenceMotionObject(Scale);
+  });
+});

--- a/packages/react-components/react-motion-components-preview/library/src/components/Scale/Scale.ts
+++ b/packages/react-components/react-motion-components-preview/library/src/components/Scale/Scale.ts
@@ -1,0 +1,46 @@
+import {
+  motionTokens,
+  PresenceMotionFn,
+  createPresenceComponent,
+  createPresenceComponentVariant,
+} from '@fluentui/react-motion';
+
+/** Define a presence motion for scale in/out */
+const scaleMotion: PresenceMotionFn<{ animateOpacity?: boolean }> = ({ animateOpacity = true }) => {
+  const fromOpacity = animateOpacity ? 0 : 1;
+  const toOpacity = 1;
+  const fromScale = 0.9; // Could be a custom param in the future
+  const toScale = 1;
+
+  const enterKeyframes = [
+    { opacity: fromOpacity, transform: `scale3d(${fromScale}, ${fromScale}, 1)`, visibility: 'visible' },
+    { opacity: toOpacity, transform: `scale3d(${toScale}, ${toScale}, 1)` },
+  ];
+
+  const exitKeyframes = [
+    { opacity: toOpacity, transform: `scale3d(${toScale}, ${toScale}, 1)` },
+    { opacity: fromOpacity, transform: `scale3d(${fromScale}, ${fromScale}, 1)`, visibility: 'hidden' },
+  ];
+
+  return {
+    enter: {
+      duration: motionTokens.durationGentle,
+      easing: motionTokens.curveDecelerateMax,
+      keyframes: enterKeyframes,
+    },
+    exit: { duration: motionTokens.durationNormal, easing: motionTokens.curveAccelerateMax, keyframes: exitKeyframes },
+  };
+};
+
+/** A React component that applies scale in/out transitions to its children. */
+export const Scale = createPresenceComponent(scaleMotion);
+
+export const ScaleSnappy = createPresenceComponentVariant(Scale, {
+  enter: { duration: motionTokens.durationNormal, easing: motionTokens.curveDecelerateMax },
+  exit: { duration: motionTokens.durationFast, easing: motionTokens.curveAccelerateMax },
+});
+
+export const ScaleExaggerated = createPresenceComponentVariant(Scale, {
+  enter: { duration: motionTokens.durationSlow, easing: motionTokens.curveDecelerateMax },
+  exit: { duration: motionTokens.durationGentle, easing: motionTokens.curveAccelerateMax },
+});

--- a/packages/react-components/react-motion-components-preview/library/src/components/Scale/index.ts
+++ b/packages/react-components/react-motion-components-preview/library/src/components/Scale/index.ts
@@ -1,0 +1,1 @@
+export * from './Scale';

--- a/packages/react-components/react-motion-components-preview/library/src/index.ts
+++ b/packages/react-components/react-motion-components-preview/library/src/index.ts
@@ -1,2 +1,3 @@
 export { Collapse, CollapseSnappy, CollapseExaggerated } from './components/Collapse';
 export { Fade, FadeSnappy, FadeExaggerated } from './components/Fade';
+export { Scale, ScaleSnappy, ScaleExaggerated } from './components/Scale';

--- a/packages/react-components/react-motion-components-preview/stories/src/Scale/ScaleCustomization.stories.md
+++ b/packages/react-components/react-motion-components-preview/stories/src/Scale/ScaleCustomization.stories.md
@@ -1,0 +1,18 @@
+- `duration` and `easing` can be customized for each transition separately using `createPresenceComponentVariant()`.
+- The predefined fade transition can be disabled by setting `animateOpacity` to `false`.
+
+```tsx
+import { motionTokens, createPresenceComponentVariant } from '@fluentui/react-components';
+import { Scale } from '@fluentui/react-motion-components-preview';
+
+const CustomScaleVariant = createPresenceComponentVariant(Scale, {
+  enter: { duration: motionTokens.durationSlow, easing: motionTokens.curveEasyEaseMax },
+  exit: { duration: motionTokens.durationNormal, easing: motionTokens.curveEasyEaseMax },
+});
+
+const CustomScale = ({ visible }) => (
+  <CustomScaleVariant animateOpacity={false} unmountOnExit visible={visible}>
+    {/* Content */}
+  </CustomScaleVariant>
+);
+```

--- a/packages/react-components/react-motion-components-preview/stories/src/Scale/ScaleCustomization.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Scale/ScaleCustomization.stories.tsx
@@ -1,0 +1,149 @@
+import * as React from 'react';
+import {
+  createPresenceComponentVariant,
+  Field,
+  makeStyles,
+  mergeClasses,
+  type MotionImperativeRef,
+  motionTokens,
+  Slider,
+  Switch,
+  tokens,
+} from '@fluentui/react-components';
+import { Scale } from '@fluentui/react-motion-components-preview';
+
+import description from './ScaleCustomization.stories.md';
+
+const useClasses = makeStyles({
+  container: {
+    display: 'grid',
+    gridTemplate: `"controls ." "card card" / 1fr 1fr`,
+    gap: '20px 10px',
+  },
+  card: {
+    gridArea: 'card',
+    padding: '10px',
+  },
+  controls: {
+    display: 'flex',
+    flexDirection: 'column',
+    gridArea: 'controls',
+
+    border: `${tokens.strokeWidthThicker} solid ${tokens.colorNeutralForeground3}`,
+    borderRadius: tokens.borderRadiusMedium,
+    boxShadow: tokens.shadow16,
+    padding: '10px',
+  },
+  field: {
+    flex: 1,
+  },
+  sliderField: {
+    gridTemplateColumns: 'min-content 1fr',
+  },
+  sliderLabel: {
+    textWrap: 'nowrap',
+  },
+
+  item: {
+    backgroundColor: tokens.colorBrandBackground,
+    border: `${tokens.strokeWidthThicker} solid ${tokens.colorTransparentStroke}`,
+    borderRadius: '50%',
+
+    width: '100px',
+    height: '100px',
+  },
+});
+
+const CustomScaleVariant = createPresenceComponentVariant(Scale, {
+  enter: { duration: motionTokens.durationSlow, easing: motionTokens.curveEasyEaseMax },
+  exit: { duration: motionTokens.durationNormal, easing: motionTokens.curveEasyEaseMax },
+});
+
+const LoremIpsum = () => (
+  <>
+    {'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. '.repeat(
+      10,
+    )}
+  </>
+);
+
+export const Customization = () => {
+  const classes = useClasses();
+  const motionRef = React.useRef<MotionImperativeRef>();
+
+  const [animateOpacity, setAnimateOpacity] = React.useState(true);
+  const [playbackRate, setPlaybackRate] = React.useState<number>(30);
+  const [visible, setVisible] = React.useState<boolean>(true);
+  const [unmountOnExit, setUnmountOnExit] = React.useState<boolean>(false);
+
+  // Heads up!
+  // This is optional and is intended solely to slow down the animations, making motions more visible in the examples.
+  React.useEffect(() => {
+    motionRef.current?.setPlaybackRate(playbackRate / 100);
+  }, [playbackRate, visible]);
+
+  return (
+    <div className={classes.container}>
+      <div className={classes.controls}>
+        <Field className={classes.field}>
+          <Switch label="Visible" checked={visible} onChange={() => setVisible(v => !v)} />
+        </Field>
+        <Field className={classes.field}>
+          <Switch
+            label={<code>animateOpacity</code>}
+            checked={animateOpacity}
+            onChange={() => setAnimateOpacity(v => !v)}
+          />
+        </Field>
+        <Field className={classes.field}>
+          <Switch
+            label={<code>unmountOnExit</code>}
+            checked={unmountOnExit}
+            onChange={() => setUnmountOnExit(v => !v)}
+          />
+        </Field>
+        <Field
+          className={mergeClasses(classes.field, classes.sliderField)}
+          label={{
+            children: (
+              <>
+                <code>playbackRate</code>: {playbackRate}%
+              </>
+            ),
+            className: classes.sliderLabel,
+          }}
+          orientation="horizontal"
+        >
+          <Slider
+            aria-valuetext={`Value is ${playbackRate}%`}
+            className={mergeClasses(classes.field, classes.sliderField)}
+            value={playbackRate}
+            onChange={(ev, data) => setPlaybackRate(data.value)}
+            min={0}
+            max={100}
+            step={5}
+          />
+        </Field>
+      </div>
+
+      <CustomScaleVariant
+        animateOpacity={animateOpacity}
+        imperativeRef={motionRef}
+        visible={visible}
+        unmountOnExit={unmountOnExit}
+      >
+        <div className={classes.card}>
+          <LoremIpsum />
+        </div>
+      </CustomScaleVariant>
+    </div>
+  );
+};
+
+Customization.parameters = {
+  docs: {
+    description: {
+      story: description,
+    },
+  },
+};

--- a/packages/react-components/react-motion-components-preview/stories/src/Scale/ScaleDefault.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Scale/ScaleDefault.stories.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import { Field, makeStyles, tokens, Switch } from '@fluentui/react-components';
+import { Scale } from '@fluentui/react-motion-components-preview';
+
+const useClasses = makeStyles({
+  container: {
+    display: 'grid',
+    gridTemplate: `"controls ." "card card" / 1fr 1fr`,
+    gap: '20px 10px',
+  },
+  card: {
+    gridArea: 'card',
+    padding: '10px',
+  },
+  controls: {
+    display: 'flex',
+    flexDirection: 'column',
+    gridArea: 'controls',
+
+    border: `${tokens.strokeWidthThicker} solid ${tokens.colorNeutralForeground3}`,
+    borderRadius: tokens.borderRadiusMedium,
+    boxShadow: tokens.shadow16,
+    padding: '10px',
+  },
+  field: {
+    flex: 1,
+  },
+});
+
+const LoremIpsum = () => (
+  <>
+    {'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. '.repeat(
+      10,
+    )}
+  </>
+);
+
+export const Default = () => {
+  const classes = useClasses();
+  const [visible, setVisible] = React.useState<boolean>(true);
+
+  return (
+    <div className={classes.container}>
+      <div className={classes.controls}>
+        <Field className={classes.field}>
+          <Switch label="Visible" checked={visible} onChange={() => setVisible(v => !v)} />
+        </Field>
+      </div>
+
+      <Scale visible={visible}>
+        <div className={classes.card}>
+          <LoremIpsum />
+        </div>
+      </Scale>
+    </div>
+  );
+};

--- a/packages/react-components/react-motion-components-preview/stories/src/Scale/ScaleDescription.md
+++ b/packages/react-components/react-motion-components-preview/stories/src/Scale/ScaleDescription.md
@@ -1,0 +1,15 @@
+The `Scale` component manages content presence, using scale in/out.
+
+> **⚠️ Preview components are considered unstable**
+
+```tsx
+import { Scale } from '@fluentui/react-motion-components-preview';
+
+function Component({ visible }) {
+  return (
+    <Scale visible={visible}>
+      <div style={{ background: 'lightblue' }}>Content</div>
+    </Scale>
+  );
+}
+```

--- a/packages/react-components/react-motion-components-preview/stories/src/Scale/ScaleExaggerated.stories.md
+++ b/packages/react-components/react-motion-components-preview/stories/src/Scale/ScaleExaggerated.stories.md
@@ -1,0 +1,1 @@
+The exaggerated variant of `Scale` is available as `ScaleExaggerated` component.

--- a/packages/react-components/react-motion-components-preview/stories/src/Scale/ScaleExaggerated.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Scale/ScaleExaggerated.stories.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react';
+import { Field, makeStyles, tokens, Switch } from '@fluentui/react-components';
+import { ScaleExaggerated } from '@fluentui/react-motion-components-preview';
+
+import description from './ScaleExaggerated.stories.md';
+
+const useClasses = makeStyles({
+  container: {
+    display: 'grid',
+    gridTemplate: `"controls ." "card card" / 1fr 1fr`,
+    gap: '20px 10px',
+  },
+  card: {
+    gridArea: 'card',
+    padding: '10px',
+  },
+  controls: {
+    display: 'flex',
+    flexDirection: 'column',
+    gridArea: 'controls',
+
+    border: `${tokens.strokeWidthThicker} solid ${tokens.colorNeutralForeground3}`,
+    borderRadius: tokens.borderRadiusMedium,
+    boxShadow: tokens.shadow16,
+    padding: '10px',
+  },
+  field: {
+    flex: 1,
+  },
+});
+
+const LoremIpsum = () => (
+  <>
+    {'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. '.repeat(
+      10,
+    )}
+  </>
+);
+
+export const Exaggerated = () => {
+  const classes = useClasses();
+  const [visible, setVisible] = React.useState<boolean>(true);
+
+  return (
+    <div className={classes.container}>
+      <div className={classes.controls}>
+        <Field className={classes.field}>
+          <Switch label="Visible" checked={visible} onChange={() => setVisible(v => !v)} />
+        </Field>
+      </div>
+
+      <ScaleExaggerated visible={visible}>
+        <div className={classes.card}>
+          <LoremIpsum />
+        </div>
+      </ScaleExaggerated>
+    </div>
+  );
+};
+
+Exaggerated.parameters = {
+  docs: {
+    description: {
+      story: description,
+    },
+  },
+};

--- a/packages/react-components/react-motion-components-preview/stories/src/Scale/ScaleSnappy.stories.md
+++ b/packages/react-components/react-motion-components-preview/stories/src/Scale/ScaleSnappy.stories.md
@@ -1,0 +1,1 @@
+The snappy variant of `Scale` is available as `ScaleSnappy` component.

--- a/packages/react-components/react-motion-components-preview/stories/src/Scale/ScaleSnappy.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Scale/ScaleSnappy.stories.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react';
+import { Field, makeStyles, tokens, Switch } from '@fluentui/react-components';
+import { ScaleSnappy } from '@fluentui/react-motion-components-preview';
+
+import description from './ScaleSnappy.stories.md';
+
+const useClasses = makeStyles({
+  container: {
+    display: 'grid',
+    gridTemplate: `"controls ." "card card" / 1fr 1fr`,
+    gap: '20px 10px',
+  },
+  card: {
+    gridArea: 'card',
+    padding: '10px',
+  },
+  controls: {
+    display: 'flex',
+    flexDirection: 'column',
+    gridArea: 'controls',
+
+    border: `${tokens.strokeWidthThicker} solid ${tokens.colorNeutralForeground3}`,
+    borderRadius: tokens.borderRadiusMedium,
+    boxShadow: tokens.shadow16,
+    padding: '10px',
+  },
+  field: {
+    flex: 1,
+  },
+});
+
+const LoremIpsum = () => (
+  <>
+    {'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. '.repeat(
+      10,
+    )}
+  </>
+);
+
+export const Snappy = () => {
+  const classes = useClasses();
+  const [visible, setVisible] = React.useState<boolean>(true);
+
+  return (
+    <div className={classes.container}>
+      <div className={classes.controls}>
+        <Field className={classes.field}>
+          <Switch label="Visible" checked={visible} onChange={() => setVisible(v => !v)} />
+        </Field>
+      </div>
+
+      <ScaleSnappy visible={visible}>
+        <div className={classes.card}>
+          <LoremIpsum />
+        </div>
+      </ScaleSnappy>
+    </div>
+  );
+};
+
+Snappy.parameters = {
+  docs: {
+    description: {
+      story: description,
+    },
+  },
+};

--- a/packages/react-components/react-motion-components-preview/stories/src/Scale/index.stories.ts
+++ b/packages/react-components/react-motion-components-preview/stories/src/Scale/index.stories.ts
@@ -1,0 +1,19 @@
+import { Scale } from '@fluentui/react-motion-components-preview';
+import ScaleDescription from './ScaleDescription.md';
+
+export { Default } from './ScaleDefault.stories';
+export { Snappy } from './ScaleSnappy.stories';
+export { Exaggerated } from './ScaleExaggerated.stories';
+export { Customization } from './ScaleCustomization.stories';
+
+export default {
+  title: 'Utilities/Motion/Components (preview)/Scale',
+  component: Scale,
+  parameters: {
+    docs: {
+      description: {
+        component: ScaleDescription,
+      },
+    },
+  },
+};


### PR DESCRIPTION
Fixes #32017.

- Implemented `Scale` component in `react-motion-components-preview`
- Added unit tests for `Scale` component
- Created stories for different scenarios including Default, Exaggerated, Snappy and Custom.
- Enhanced index and utility files to support new component.
- Documented usage and configuration in Storybook

## New Behavior
PR adds Scale motion component:
```tsx
import { Scale } from '@fluentui/react-motion-components-preview';

function Component({ visible }) {
  return (
    <Scale visible={visible}>
      <div style={{ background: 'lightblue' }}>Content</div>
    </Scale>
  );
}
```

The `Scale` component manages content presence, using scale in/out.