### PR TITLE
Popover: Fix arrow shadow

### DIFF
--- a/change/@fluentui-react-popover-e8ab1f66-cf35-4308-a6ee-45f3788a6195.json
+++ b/change/@fluentui-react-popover-e8ab1f66-cf35-4308-a6ee-45f3788a6195.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Enable box shadow on popover arrow when it is outside surface shadow (above)",
+  "packageName": "@fluentui/react-popover",
+  "email": "mifraser@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-popover/library/src/components/PopoverSurface/usePopoverSurfaceStyles.styles.ts
+++ b/packages/react-components/react-popover/library/src/components/PopoverSurface/usePopoverSurfaceStyles.styles.ts
@@ -54,6 +54,17 @@ const useStyles = makeStyles({
   smallArrow: createArrowHeightStyles(arrowHeights.small),
   mediumLargeArrow: createArrowHeightStyles(arrowHeights.medium),
   arrow: createArrowStyles({ arrowHeight: undefined }),
+  arrowTopShadow: {
+    /* When arrow is 'above' popover it is outside of surface box shadow,
+    This will provide a local shadow when above so that it remains visible.
+    */
+    ':global([data-popper-placement^="bottom"])': {
+      '::before': {
+        boxShadow: tokens.shadow16,
+        clipPath: `inset(0px -${tokens.strokeWidthThickest} -${tokens.strokeWidthThickest} 0px)`,
+      },
+    },
+  },
 });
 
 /**
@@ -77,6 +88,7 @@ export const usePopoverSurfaceStyles_unstable = (state: PopoverSurfaceState): Po
 
   state.arrowClassName = mergeClasses(
     styles.arrow,
+    styles.arrowTopShadow,
     state.size === 'small' ? styles.smallArrow : styles.mediumLargeArrow,
   );
 


### PR DESCRIPTION
## Previous Behavior
Arrow is outside of surface shadow bounds when placed above, causing it to be non-visible on similar backgrounds.

## New Behavior
When placed above, arrow will have it's own shadow cast to remain visible while not affecting underlying shadow token direction.

## Related Issue(s)
- Fixes #31990
