### PR TITLE
Carousel: Groups

### DIFF
--- a/packages/react-components/react-carousel-preview/library/etc/react-carousel-preview.api.md
+++ b/packages/react-components/react-carousel-preview/library/etc/react-carousel-preview.api.md
@@ -157,6 +157,7 @@ export type CarouselNavSlots = {
 export type CarouselNavState = ComponentState<CarouselNavSlots> & {
     values: string[];
     renderNavButton: NavButtonRenderFunction;
+    groupSize?: number;
 };
 
 // @public
@@ -166,6 +167,8 @@ export type CarouselProps = ComponentProps<CarouselSlots> & {
     value?: string;
     onValueChange?: EventHandler<CarouselValueChangeData>;
     circular?: boolean;
+    groupSize?: number;
+    containScroll?: false | 'keepSnaps' | 'trimSnaps';
 };
 
 // @public
@@ -194,7 +197,7 @@ export type CarouselSlots = {
 export type CarouselState = ComponentState<CarouselSlots> & CarouselContextValue;
 
 // @public (undocumented)
-export type NavButtonRenderFunction = (value: string) => React_2.ReactNode;
+export type NavButtonRenderFunction = (value: string[]) => React_2.ReactNode;
 
 // @public
 export const renderCarousel_unstable: (state: CarouselState, contextValues: CarouselContextValues) => JSX.Element;

--- a/packages/react-components/react-carousel-preview/library/src/components/Carousel/Carousel.test.tsx
+++ b/packages/react-components/react-carousel-preview/library/src/components/Carousel/Carousel.test.tsx
@@ -22,7 +22,12 @@ describe('Carousel', () => {
     requiredProps: {
       defaultValue: 'test',
     },
-  });
+    testOptions: {
+      'make-styles-overrides-win': {
+        callCount: 2,
+      },
+    },
+  } as any);
 
   // TODO add more tests here, and create visual regression tests in /apps/vr-tests
 

--- a/packages/react-components/react-carousel-preview/library/src/components/Carousel/Carousel.types.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/Carousel/Carousel.types.ts
@@ -33,6 +33,17 @@ export type CarouselProps = ComponentProps<CarouselSlots> & {
    * Circular enables the carousel to loop back around on navigation past trailing index.
    */
   circular?: boolean;
+
+  /**
+   * Group size enables pagination of multiple cards as a single slide
+   */
+  groupSize?: number;
+
+  /**
+   * Controls whether the scrollView will trim whitespace in order to position trailing items via alignment
+   * Default: false.
+   */
+  containScroll?: false | 'keepSnaps' | 'trimSnaps';
 };
 
 /**

--- a/packages/react-components/react-carousel-preview/library/src/components/Carousel/useCarouselContextValues.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/Carousel/useCarouselContextValues.ts
@@ -4,7 +4,7 @@ import type { CarouselContextValues } from '../CarouselContext.types';
 import type { CarouselState } from './Carousel.types';
 
 export function useCarouselContextValues_unstable(state: CarouselState): CarouselContextValues {
-  const { store, selectPageByDirection, selectPageByValue, circular } = state;
+  const { store, selectPageByDirection, selectPageByValue, circular, groupSize } = state;
 
   const carousel = React.useMemo(
     () => ({
@@ -12,8 +12,9 @@ export function useCarouselContextValues_unstable(state: CarouselState): Carouse
       selectPageByDirection,
       selectPageByValue,
       circular,
+      groupSize,
     }),
-    [store, selectPageByDirection, selectPageByValue, circular],
+    [store, selectPageByDirection, selectPageByValue, circular, groupSize],
   );
 
   return { carousel };

--- a/packages/react-components/react-carousel-preview/library/src/components/CarouselContext.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/CarouselContext.ts
@@ -12,6 +12,7 @@ export const carouselContextDefaultValue: CarouselContextValue = {
     /** noop */
   },
   circular: false,
+  groupSize: undefined,
 };
 
 const CarouselContext = React.createContext<CarouselContextValue | undefined>(undefined);

--- a/packages/react-components/react-carousel-preview/library/src/components/CarouselContext.types.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/CarouselContext.types.ts
@@ -36,6 +36,7 @@ export type CarouselContextValue = {
   ) => void;
   selectPageByValue: (event: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>, value: string) => void;
   circular: boolean;
+  groupSize?: number;
 };
 
 /**

--- a/packages/react-components/react-carousel-preview/library/src/components/CarouselNav/CarouselNav.types.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/CarouselNav/CarouselNav.types.ts
@@ -8,12 +8,14 @@ export type CarouselNavSlots = {
   root: NonNullable<Slot<'div'>>;
 };
 
-export type NavButtonRenderFunction = (value: string) => React.ReactNode;
+export type NavButtonRenderFunction = (value: string[]) => React.ReactNode;
 
 export type CarouselNavState = ComponentState<CarouselNavSlots> & {
   values: string[];
 
   renderNavButton: NavButtonRenderFunction;
+
+  groupSize?: number;
 };
 
 export type CarouselNavProps = Omit<ComponentProps<Partial<CarouselNavSlots>>, 'children'> & {

--- a/packages/react-components/react-carousel-preview/library/src/components/CarouselNav/CarouselNavContext.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/CarouselNav/CarouselNavContext.ts
@@ -1,8 +1,8 @@
 import * as React from 'react';
 
-const carouselNavContext = React.createContext<string | undefined>(undefined);
+const carouselNavContext = React.createContext<string[] | undefined>(undefined);
 
-export const carouselNavContextDefaultValue = '';
+export const carouselNavContextDefaultValue = [''];
 
 export const useCarouselNavContext = () => React.useContext(carouselNavContext) ?? carouselNavContextDefaultValue;
 

--- a/packages/react-components/react-carousel-preview/library/src/components/CarouselNav/renderCarouselNav.tsx
+++ b/packages/react-components/react-carousel-preview/library/src/components/CarouselNav/renderCarouselNav.tsx
@@ -10,13 +10,35 @@ import { CarouselNavContextProvider } from './CarouselNavContext';
  */
 export const renderCarouselNav_unstable = (state: CarouselNavState) => {
   assertSlots<CarouselNavSlots>(state);
-  const { values, renderNavButton } = state;
+  const { values, renderNavButton, groupSize } = state;
+
+  if (groupSize) {
+    const groupValues: string[][] = [];
+    let groupIndex = -1;
+    values.forEach((value, index) => {
+      if (index % groupSize === 0) {
+        groupIndex++;
+        groupValues[groupIndex] = [];
+      }
+      groupValues[groupIndex].push(value);
+    });
+
+    return (
+      <state.root>
+        {groupValues.map(value => (
+          <CarouselNavContextProvider value={value} key={value.join('-')}>
+            {renderNavButton(value)}
+          </CarouselNavContextProvider>
+        ))}
+      </state.root>
+    );
+  }
 
   return (
     <state.root>
       {values.map(value => (
-        <CarouselNavContextProvider value={value} key={value}>
-          {renderNavButton(value)}
+        <CarouselNavContextProvider value={[value]} key={value}>
+          {renderNavButton([value])}
         </CarouselNavContextProvider>
       ))}
     </state.root>

--- a/packages/react-components/react-carousel-preview/library/src/components/CarouselNav/useCarouselNav.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/CarouselNav/useCarouselNav.ts
@@ -3,6 +3,7 @@ import { getIntrinsicElementProps, slot } from '@fluentui/react-utilities';
 import type { CarouselNavProps, CarouselNavState } from './CarouselNav.types';
 import { useArrowNavigationGroup } from '@fluentui/react-tabster';
 import { useCarouselStore_unstable } from '../useCarouselStore';
+import { useCarouselContext_unstable } from '../CarouselContext';
 
 /**
  * Create the state required to render CarouselNav.
@@ -24,8 +25,11 @@ export const useCarouselNav_unstable = (props: CarouselNavProps, ref: React.Ref<
 
   const values = useCarouselStore_unstable(snapshot => snapshot.values);
 
+  const { groupSize } = useCarouselContext_unstable();
+
   return {
     values,
+    groupSize,
     renderNavButton: props.children,
     components: {
       root: 'div',

--- a/packages/react-components/react-carousel-preview/library/src/components/CarouselNavButton/__snapshots__/CarouselNavButton.test.tsx.snap
+++ b/packages/react-components/react-carousel-preview/library/src/components/CarouselNavButton/__snapshots__/CarouselNavButton.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`CarouselNavButton renders a default state 1`] = `
 <div>
   <button
     class="fui-CarouselNavButton"
-    data-tabster="{\\"focusable\\":{\\"isDefault\\":false}}"
+    data-tabster="{\\"focusable\\":{\\"isDefault\\":true}}"
     role="tab"
     type="button"
   >

--- a/packages/react-components/react-carousel-preview/library/src/components/CarouselNavButton/useCarouselNavButton.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/CarouselNavButton/useCarouselNavButton.ts
@@ -25,13 +25,13 @@ export const useCarouselNavButton_unstable = (
   const value = useCarouselNavContext();
 
   const { selectPageByValue } = useCarouselContext_unstable();
-  const selected = useCarouselStore_unstable(snapshot => snapshot.activeValue === value);
+  const selected = useCarouselStore_unstable(snapshot => value.includes(snapshot.activeValue ?? ''));
 
   const handleClick: ARIAButtonSlotProps['onClick'] = useEventCallback(event => {
     onClick?.(event);
 
     if (!event.defaultPrevented && isHTMLElement(event.target)) {
-      selectPageByValue(event, value);
+      selectPageByValue(event, value[0]);
     }
   });
 

--- a/packages/react-components/react-carousel-preview/library/src/components/CarouselNavImageButton/__snapshots__/CarouselNavImageButton.test.tsx.snap
+++ b/packages/react-components/react-carousel-preview/library/src/components/CarouselNavImageButton/__snapshots__/CarouselNavImageButton.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`CarouselNavImageButton renders a default state 1`] = `
 <div>
   <button
     class="fui-CarouselNavImageButton"
-    data-tabster="{\\"focusable\\":{\\"isDefault\\":false}}"
+    data-tabster="{\\"focusable\\":{\\"isDefault\\":true}}"
     role="tab"
     type="button"
   >

--- a/packages/react-components/react-carousel-preview/library/src/components/CarouselNavImageButton/useCarouselNavImageButton.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/CarouselNavImageButton/useCarouselNavImageButton.ts
@@ -25,13 +25,13 @@ export const useCarouselNavImageButton_unstable = (
   const value = useCarouselNavContext();
 
   const { selectPageByValue } = useCarouselContext_unstable();
-  const selected = useCarouselStore_unstable(snapshot => snapshot.activeValue === value);
+  const selected = useCarouselStore_unstable(snapshot => value.includes(snapshot.activeValue ?? ''));
 
   const handleClick: ARIAButtonSlotProps['onClick'] = useEventCallback(event => {
     onClick?.(event);
 
     if (!event.defaultPrevented && isHTMLElement(event.target)) {
-      selectPageByValue(event, value);
+      selectPageByValue(event, value[0]);
     }
   });
 

--- a/packages/react-components/react-carousel-preview/library/src/components/useCarouselWalker.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/useCarouselWalker.ts
@@ -11,7 +11,7 @@ export type CarouselWalker = {
   active(): { el: HTMLElement; value: string } | null;
 };
 
-export const useCarouselWalker_unstable = () => {
+export const useCarouselWalker_unstable = (groupSize: number = 1) => {
   const { targetDocument } = useFluent();
 
   const treeWalkerRef = React.useRef<TreeWalker | undefined>(targetDocument?.createTreeWalker(targetDocument.body));
@@ -92,6 +92,12 @@ export const useCarouselWalker_unstable = () => {
           treeWalkerRef.current.currentNode = res.el;
 
           let next = treeWalkerRef.current.nextNode();
+          let groupCount = 0;
+
+          while (++groupCount < groupSize) {
+            next = treeWalkerRef.current.nextNode();
+          }
+
           if (circular && !isHTMLElement(next) && htmlRef.current) {
             treeWalkerRef.current.currentNode = htmlRef.current;
             next = treeWalkerRef.current.firstChild();
@@ -114,6 +120,11 @@ export const useCarouselWalker_unstable = () => {
 
           treeWalkerRef.current.currentNode = res.el;
           let next = treeWalkerRef.current.previousNode();
+          let groupCount = 0;
+
+          while (++groupCount < groupSize) {
+            next = treeWalkerRef.current.previousNode();
+          }
 
           if (circular && !isHTMLElement(next) && htmlRef.current) {
             treeWalkerRef.current.currentNode = htmlRef.current;
@@ -130,7 +141,7 @@ export const useCarouselWalker_unstable = () => {
           return null;
         },
       }),
-      [],
+      [groupSize],
     ),
   };
 };

--- a/packages/react-components/react-carousel-preview/library/src/components/useEmblaCarousel.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/useEmblaCarousel.ts
@@ -12,12 +12,29 @@ const DEFAULT_EMBLA_OPTIONS: EmblaOptionsType = {
 
   container: `.${carouselSliderClassNames.root}`,
   slides: `.${carouselCardClassNames.root}`,
+
+  slidesToScroll: undefined,
+  startIndex: 0,
 };
 
 export const EMBLA_VISIBILITY_EVENT = 'embla:visibilitychange';
 
-export function useEmblaCarousel({ align, direction, loop }: Pick<EmblaOptionsType, 'align' | 'direction' | 'loop'>) {
-  const emblaOptions = React.useRef<EmblaOptionsType>({ align, direction, loop });
+export function useEmblaCarousel({
+  align,
+  direction,
+  loop,
+  slidesToScroll,
+  startIndex,
+  containScroll,
+}: Pick<EmblaOptionsType, 'align' | 'direction' | 'loop' | 'slidesToScroll' | 'startIndex' | 'containScroll'>) {
+  const emblaOptions = React.useRef<EmblaOptionsType>({
+    align,
+    direction,
+    loop,
+    slidesToScroll,
+    startIndex,
+    containScroll,
+  });
   const emblaApi = React.useRef<EmblaCarouselType | null>(null);
 
   const ref = React.useMemo(() => {
@@ -74,12 +91,12 @@ export function useEmblaCarousel({ align, direction, loop }: Pick<EmblaOptionsTy
   );
 
   React.useEffect(() => {
-    emblaOptions.current = { align, direction, loop };
+    emblaOptions.current = { align, direction, loop, slidesToScroll, startIndex, containScroll };
     emblaApi.current?.reInit({
-      ...emblaOptions.current,
       ...DEFAULT_EMBLA_OPTIONS,
+      ...emblaOptions.current,
     });
-  }, [align, direction, loop]);
+  }, [align, containScroll, direction, loop, slidesToScroll, startIndex]);
 
   return [ref, api] as const;
 }

--- a/packages/react-components/react-carousel-preview/stories/src/Carousel/CarouselGroup.stories.tsx
+++ b/packages/react-components/react-carousel-preview/stories/src/Carousel/CarouselGroup.stories.tsx
@@ -1,0 +1,79 @@
+import { makeStyles, tokens, typographyStyles } from '@fluentui/react-components';
+import {
+  Carousel,
+  CarouselButton,
+  CarouselCard,
+  CarouselNav,
+  CarouselNavImageButton,
+  CarouselSlider,
+} from '@fluentui/react-carousel-preview';
+import * as React from 'react';
+
+const SWAP_IMAGE = 'https://fabricweb.azureedge.net/fabric-website/assets/images/wireframe/image-square.png';
+const useClasses = makeStyles({
+  card: {
+    flex: '0 0 calc(33.33% - 20px)',
+    margin: '0px 10px',
+  },
+  test: {
+    ...typographyStyles.largeTitle,
+    alignContent: 'center',
+    borderRadius: tokens.borderRadiusLarge,
+    height: '200px',
+    textAlign: 'center',
+  },
+});
+
+const TestComponent: React.FC<{ accentColor: string; children: string }> = props => {
+  const { accentColor, children } = props;
+  const classes = useClasses();
+
+  return (
+    <div className={classes.test} style={{ backgroundColor: accentColor }}>
+      {children}
+    </div>
+  );
+};
+
+export const CarouselGroup = () => {
+  const classes = useClasses();
+
+  return (
+    <Carousel groupSize={3} defaultValue="card-5">
+      <CarouselSlider>
+        <CarouselCard className={classes.card} value="card-1">
+          <TestComponent accentColor="#B99095">Card 1</TestComponent>
+        </CarouselCard>
+        <CarouselCard className={classes.card} value="card-2">
+          <TestComponent accentColor="#FCB5AC">Card 2</TestComponent>
+        </CarouselCard>
+        <CarouselCard className={classes.card} value="card-3">
+          <TestComponent accentColor="#B5E5CF">Card 3</TestComponent>
+        </CarouselCard>
+        <CarouselCard className={classes.card} value="card-4">
+          <TestComponent accentColor="#3D5B59">Card 4</TestComponent>
+        </CarouselCard>
+        <CarouselCard className={classes.card} value="card-5">
+          <TestComponent accentColor="#F9EAC2">Card 5</TestComponent>
+        </CarouselCard>
+        <CarouselCard className={classes.card} value="card-6">
+          <TestComponent accentColor="#FEE7E6">Card 6</TestComponent>
+        </CarouselCard>
+        <CarouselCard className={classes.card} value="card-7">
+          <TestComponent accentColor="#FFD898">Card 7</TestComponent>
+        </CarouselCard>
+      </CarouselSlider>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'row',
+          justifyContent: 'center',
+        }}
+      >
+        <CarouselButton navType="prev" />
+        <CarouselNav>{() => <CarouselNavImageButton image={{ src: SWAP_IMAGE }} />}</CarouselNav>
+        <CarouselButton navType="next" />
+      </div>
+    </Carousel>
+  );
+};

--- a/packages/react-components/react-carousel-preview/stories/src/Carousel/index.stories.tsx
+++ b/packages/react-components/react-carousel-preview/stories/src/Carousel/index.stories.tsx
@@ -7,6 +7,7 @@ export { Default } from './CarouselDefault.stories';
 export { Circular } from './CarouselCircular.stories';
 export { MultipleCards } from './CarouselMultipleCards.stories';
 export { FreeLayout } from './CarouselFreeLayout.stories';
+export { CarouselGroup } from './CarouselGroup.stories';
 
 export default {
   title: 'Preview Components/Carousel',


### PR DESCRIPTION
## Previous Behavior
Users could place multiple items in the carousel view, with one navigation item per item.
Users could have multiple items within a single CarouselCard, but would require custom logic that would separate the visual cards from the actual carousel slides - this will cause future issues with our focus and accessibility implementations, so we need a way to group internally via carousel hooks.

## New Behavior
GroupSize variable enables users to define groups of elements as a single navigation point, without having to build custom logic to place items in a single card.
Carousel nav buttons will now take a list of items, and will use the first index as the navigation points.
We ensure that the first item is the active value so that movement for next/previous is consistent every time.
