### PR TITLE
chore: introduce bundle aware `build:react-with-umd` task for v8 packages that ship UMD to production(npm registry)

### DIFF
--- a/change/@fluentui-azure-themes-a88a46a2-005b-456c-9295-49ecb3d78029.json
+++ b/change/@fluentui-azure-themes-a88a46a2-005b-456c-9295-49ecb3d78029.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: introduce bundle aware build:react task for v8 packages that ship UMD to production(npm registry)",
+  "packageName": "@fluentui/azure-themes",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-example-data-0df0ac5c-6163-44b1-9333-38d4293de606.json
+++ b/change/@fluentui-example-data-0df0ac5c-6163-44b1-9333-38d4293de606.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: introduce bundle aware build:react task for v8 packages that ship UMD to production(npm registry)",
+  "packageName": "@fluentui/example-data",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-fluent2-theme-d1f89bae-1013-4556-ac95-9c915def48d5.json
+++ b/change/@fluentui-fluent2-theme-d1f89bae-1013-4556-ac95-9c915def48d5.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: introduce bundle aware build:react task for v8 packages that ship UMD to production(npm registry)",
+  "packageName": "@fluentui/fluent2-theme",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-foundation-legacy-8957e624-f5b2-4a0c-a16b-86da8da472f7.json
+++ b/change/@fluentui-foundation-legacy-8957e624-f5b2-4a0c-a16b-86da8da472f7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: introduce bundle aware build:react task for v8 packages that ship UMD to production(npm registry)",
+  "packageName": "@fluentui/foundation-legacy",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-merge-styles-0d7c4310-18e1-4f9f-978b-60c07fb31fc3.json
+++ b/change/@fluentui-merge-styles-0d7c4310-18e1-4f9f-978b-60c07fb31fc3.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: introduce bundle aware build:react task for v8 packages that ship UMD to production(npm registry)",
+  "packageName": "@fluentui/merge-styles",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-9306b15a-c592-4747-b932-8cf7608022ef.json
+++ b/change/@fluentui-react-9306b15a-c592-4747-b932-8cf7608022ef.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: introduce bundle aware build:react task for v8 packages that ship UMD to production(npm registry)",
+  "packageName": "@fluentui/react",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-cards-50c2fe34-9f60-47ed-a454-ea30dac5432f.json
+++ b/change/@fluentui-react-cards-50c2fe34-9f60-47ed-a454-ea30dac5432f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: introduce bundle aware build:react task for v8 packages that ship UMD to production(npm registry)",
+  "packageName": "@fluentui/react-cards",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-charting-6d5e3678-63c3-4b95-adb5-a33b4431ec81.json
+++ b/change/@fluentui-react-charting-6d5e3678-63c3-4b95-adb5-a33b4431ec81.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: introduce bundle aware build:react task for v8 packages that ship UMD to production(npm registry)",
+  "packageName": "@fluentui/react-charting",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-date-time-46a9e53f-5f64-4c22-97f0-8447b64ff79d.json
+++ b/change/@fluentui-react-date-time-46a9e53f-5f64-4c22-97f0-8447b64ff79d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: introduce bundle aware build:react task for v8 packages that ship UMD to production(npm registry)",
+  "packageName": "@fluentui/react-date-time",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-experiments-de338cfe-d9cd-4605-9d79-40a2bf3f5188.json
+++ b/change/@fluentui-react-experiments-de338cfe-d9cd-4605-9d79-40a2bf3f5188.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: introduce bundle aware build:react task for v8 packages that ship UMD to production(npm registry)",
+  "packageName": "@fluentui/react-experiments",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-focus-aebba9e7-af10-43bf-88e4-252abe9359ec.json
+++ b/change/@fluentui-react-focus-aebba9e7-af10-43bf-88e4-252abe9359ec.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: introduce bundle aware build:react task for v8 packages that ship UMD to production(npm registry)",
+  "packageName": "@fluentui/react-focus",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-hooks-89a2461d-331d-4cc4-95cf-db736b2d3582.json
+++ b/change/@fluentui-react-hooks-89a2461d-331d-4cc4-95cf-db736b2d3582.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: introduce bundle aware build:react task for v8 packages that ship UMD to production(npm registry)",
+  "packageName": "@fluentui/react-hooks",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-icon-provider-bc6fd68e-d9f4-447c-a3b3-896cd8304282.json
+++ b/change/@fluentui-react-icon-provider-bc6fd68e-d9f4-447c-a3b3-896cd8304282.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: introduce bundle aware build:react task for v8 packages that ship UMD to production(npm registry)",
+  "packageName": "@fluentui/react-icon-provider",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-icons-mdl2-e38ae97c-5894-4523-bbaf-8b2521709894.json
+++ b/change/@fluentui-react-icons-mdl2-e38ae97c-5894-4523-bbaf-8b2521709894.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: introduce bundle aware build:react task for v8 packages that ship UMD to production(npm registry)",
+  "packageName": "@fluentui/react-icons-mdl2",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-monaco-editor-883741cb-819f-4bf9-aba2-195ab08bc66e.json
+++ b/change/@fluentui-react-monaco-editor-883741cb-819f-4bf9-aba2-195ab08bc66e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: introduce bundle aware build:react task for v8 packages that ship UMD to production(npm registry)",
+  "packageName": "@fluentui/react-monaco-editor",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-scheme-utilities-d13ccd25-3ff2-4dcd-83c3-6b700196b516.json
+++ b/change/@fluentui-scheme-utilities-d13ccd25-3ff2-4dcd-83c3-6b700196b516.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: introduce bundle aware build:react task for v8 packages that ship UMD to production(npm registry)",
+  "packageName": "@fluentui/scheme-utilities",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-theme-samples-d8512518-d0c6-431e-b26d-6310d099a285.json
+++ b/change/@fluentui-theme-samples-d8512518-d0c6-431e-b26d-6310d099a285.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: introduce bundle aware build:react task for v8 packages that ship UMD to production(npm registry)",
+  "packageName": "@fluentui/theme-samples",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/azure-themes/just.config.ts
+++ b/packages/azure-themes/just.config.ts
@@ -1,3 +1,5 @@
-import { preset } from '@fluentui/scripts-tasks';
+import { preset, task } from '@fluentui/scripts-tasks';
 
 preset();
+
+task('build', 'build:react');

--- a/packages/azure-themes/just.config.ts
+++ b/packages/azure-themes/just.config.ts
@@ -2,4 +2,4 @@ import { preset, task } from '@fluentui/scripts-tasks';
 
 preset();
 
-task('build', 'build:react');
+task('build', 'build:react-with-umd');

--- a/packages/azure-themes/package.json
+++ b/packages/azure-themes/package.json
@@ -15,7 +15,6 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
     "lint": "just-scripts lint",
     "just": "just-scripts",
     "code-style": "just-scripts code-style",

--- a/packages/example-data/just.config.ts
+++ b/packages/example-data/just.config.ts
@@ -1,3 +1,5 @@
-import { preset } from '@fluentui/scripts-tasks';
+import { preset, task } from '@fluentui/scripts-tasks';
 
 preset();
+
+task('build', 'build:react');

--- a/packages/example-data/just.config.ts
+++ b/packages/example-data/just.config.ts
@@ -2,4 +2,4 @@ import { preset, task } from '@fluentui/scripts-tasks';
 
 preset();
 
-task('build', 'build:react');
+task('build', 'build:react-with-umd');

--- a/packages/example-data/package.json
+++ b/packages/example-data/package.json
@@ -12,7 +12,6 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
     "lint": "just-scripts lint",
     "test": "just-scripts test",
     "clean": "just-scripts clean",

--- a/packages/fluent2-theme/just.config.ts
+++ b/packages/fluent2-theme/just.config.ts
@@ -1,3 +1,5 @@
-import { preset } from '@fluentui/scripts-tasks';
+import { preset, task } from '@fluentui/scripts-tasks';
 
 preset();
+
+task('build', 'build:react');

--- a/packages/fluent2-theme/just.config.ts
+++ b/packages/fluent2-theme/just.config.ts
@@ -2,4 +2,4 @@ import { preset, task } from '@fluentui/scripts-tasks';
 
 preset();
 
-task('build', 'build:react');
+task('build', 'build:react-with-umd');

--- a/packages/fluent2-theme/package.json
+++ b/packages/fluent2-theme/package.json
@@ -15,7 +15,6 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
     "lint": "just-scripts lint",
     "just": "just-scripts",
     "code-style": "just-scripts code-style",

--- a/packages/foundation-legacy/just.config.ts
+++ b/packages/foundation-legacy/just.config.ts
@@ -1,3 +1,5 @@
-import { preset } from '@fluentui/scripts-tasks';
+import { preset, task } from '@fluentui/scripts-tasks';
 
 preset();
+
+task('build', 'build:react');

--- a/packages/foundation-legacy/just.config.ts
+++ b/packages/foundation-legacy/just.config.ts
@@ -2,4 +2,4 @@ import { preset, task } from '@fluentui/scripts-tasks';
 
 preset();
 
-task('build', 'build:react');
+task('build', 'build:react-with-umd');

--- a/packages/foundation-legacy/package.json
+++ b/packages/foundation-legacy/package.json
@@ -15,7 +15,6 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",

--- a/packages/merge-styles/just.config.ts
+++ b/packages/merge-styles/just.config.ts
@@ -1,3 +1,5 @@
-import { preset } from '@fluentui/scripts-tasks';
+import { preset, task } from '@fluentui/scripts-tasks';
 
 preset();
+
+task('build', 'build:react');

--- a/packages/merge-styles/just.config.ts
+++ b/packages/merge-styles/just.config.ts
@@ -2,4 +2,4 @@ import { preset, task } from '@fluentui/scripts-tasks';
 
 preset();
 
-task('build', 'build:react');
+task('build', 'build:react-with-umd');

--- a/packages/merge-styles/package.json
+++ b/packages/merge-styles/package.json
@@ -15,7 +15,6 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
     "lint": "just-scripts lint",
     "test": "just-scripts test",
     "just": "just-scripts",

--- a/packages/react-cards/just.config.ts
+++ b/packages/react-cards/just.config.ts
@@ -1,3 +1,5 @@
-const { preset } = require('@fluentui/scripts-tasks');
+import { preset, task } from '@fluentui/scripts-tasks';
 
 preset();
+
+task('build', 'build:react');

--- a/packages/react-cards/just.config.ts
+++ b/packages/react-cards/just.config.ts
@@ -2,4 +2,4 @@ import { preset, task } from '@fluentui/scripts-tasks';
 
 preset();
 
-task('build', 'build:react');
+task('build', 'build:react-with-umd');

--- a/packages/react-cards/package.json
+++ b/packages/react-cards/package.json
@@ -15,7 +15,6 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
     "lint": "just-scripts lint",
     "test": "just-scripts test",
     "just": "just-scripts",

--- a/packages/react-charting/just.config.ts
+++ b/packages/react-charting/just.config.ts
@@ -1,3 +1,5 @@
-import { preset } from '@fluentui/scripts-tasks';
+import { preset, task } from '@fluentui/scripts-tasks';
 
 preset();
+
+task('build', 'build:react');

--- a/packages/react-charting/just.config.ts
+++ b/packages/react-charting/just.config.ts
@@ -2,4 +2,4 @@ import { preset, task } from '@fluentui/scripts-tasks';
 
 preset();
 
-task('build', 'build:react');
+task('build', 'build:react-with-umd');

--- a/packages/react-charting/package.json
+++ b/packages/react-charting/package.json
@@ -15,7 +15,6 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
     "lint": "just-scripts lint",
     "test": "cross-env TZ=UTC just-scripts test",
     "just": "just-scripts",

--- a/packages/react-date-time/just.config.ts
+++ b/packages/react-date-time/just.config.ts
@@ -1,3 +1,5 @@
-import { preset } from '@fluentui/scripts-tasks';
+import { preset, task } from '@fluentui/scripts-tasks';
 
 preset();
+
+task('build', 'build:react');

--- a/packages/react-date-time/just.config.ts
+++ b/packages/react-date-time/just.config.ts
@@ -2,4 +2,4 @@ import { preset, task } from '@fluentui/scripts-tasks';
 
 preset();
 
-task('build', 'build:react');
+task('build', 'build:react-with-umd');

--- a/packages/react-date-time/package.json
+++ b/packages/react-date-time/package.json
@@ -15,7 +15,6 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
     "lint": "just-scripts lint",
     "just": "just-scripts",
     "clean": "just-scripts clean",

--- a/packages/react-experiments/just.config.ts
+++ b/packages/react-experiments/just.config.ts
@@ -1,3 +1,5 @@
-import { preset } from '@fluentui/scripts-tasks';
+import { preset, task } from '@fluentui/scripts-tasks';
 
 preset();
+
+task('build', 'build:react');

--- a/packages/react-experiments/just.config.ts
+++ b/packages/react-experiments/just.config.ts
@@ -2,4 +2,4 @@ import { preset, task } from '@fluentui/scripts-tasks';
 
 preset();
 
-task('build', 'build:react');
+task('build', 'build:react-with-umd');

--- a/packages/react-experiments/package.json
+++ b/packages/react-experiments/package.json
@@ -15,7 +15,6 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
     "lint": "just-scripts lint",
     "test": "just-scripts test",
     "just": "just-scripts",

--- a/packages/react-focus/just.config.ts
+++ b/packages/react-focus/just.config.ts
@@ -1,3 +1,5 @@
-import { preset } from '@fluentui/scripts-tasks';
+import { preset, task } from '@fluentui/scripts-tasks';
 
 preset();
+
+task('build', 'build:react');

--- a/packages/react-focus/just.config.ts
+++ b/packages/react-focus/just.config.ts
@@ -2,4 +2,4 @@ import { preset, task } from '@fluentui/scripts-tasks';
 
 preset();
 
-task('build', 'build:react');
+task('build', 'build:react-with-umd');

--- a/packages/react-focus/package.json
+++ b/packages/react-focus/package.json
@@ -15,7 +15,6 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",

--- a/packages/react-hooks/just.config.ts
+++ b/packages/react-hooks/just.config.ts
@@ -1,3 +1,5 @@
-import { preset } from '@fluentui/scripts-tasks';
+import { preset, task } from '@fluentui/scripts-tasks';
 
 preset();
+
+task('build', 'build:react');

--- a/packages/react-hooks/just.config.ts
+++ b/packages/react-hooks/just.config.ts
@@ -2,4 +2,4 @@ import { preset, task } from '@fluentui/scripts-tasks';
 
 preset();
 
-task('build', 'build:react');
+task('build', 'build:react-with-umd');

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -15,7 +15,6 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
     "lint": "just-scripts lint",
     "test": "just-scripts test",
     "clean": "just-scripts clean",

--- a/packages/react-icon-provider/just.config.ts
+++ b/packages/react-icon-provider/just.config.ts
@@ -1,3 +1,5 @@
-import { preset } from '@fluentui/scripts-tasks';
+import { preset, task } from '@fluentui/scripts-tasks';
 
 preset();
+
+task('build', 'build:react');

--- a/packages/react-icon-provider/just.config.ts
+++ b/packages/react-icon-provider/just.config.ts
@@ -2,4 +2,4 @@ import { preset, task } from '@fluentui/scripts-tasks';
 
 preset();
 
-task('build', 'build:react');
+task('build', 'build:react-with-umd');

--- a/packages/react-icon-provider/package.json
+++ b/packages/react-icon-provider/package.json
@@ -15,7 +15,6 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",

--- a/packages/react-icons-mdl2/just.config.ts
+++ b/packages/react-icons-mdl2/just.config.ts
@@ -1,3 +1,5 @@
-import { preset } from '@fluentui/scripts-tasks';
+import { preset, task } from '@fluentui/scripts-tasks';
 
 preset();
+
+task('build', 'build:react');

--- a/packages/react-icons-mdl2/just.config.ts
+++ b/packages/react-icons-mdl2/just.config.ts
@@ -2,4 +2,4 @@ import { preset, task } from '@fluentui/scripts-tasks';
 
 preset();
 
-task('build', 'build:react');
+task('build', 'build:react-with-umd');

--- a/packages/react-icons-mdl2/package.json
+++ b/packages/react-icons-mdl2/package.json
@@ -15,7 +15,6 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "just": "just-scripts",

--- a/packages/react-monaco-editor/package.json
+++ b/packages/react-monaco-editor/package.json
@@ -12,7 +12,6 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
     "lint": "just-scripts lint",
     "test": "just-scripts test",
     "clean": "just-scripts clean",

--- a/packages/react/just.config.ts
+++ b/packages/react/just.config.ts
@@ -2,7 +2,7 @@ import { task, webpackDevServerTask, preset } from '@fluentui/scripts-tasks';
 
 preset();
 
-task('build', 'build:react');
+task('build', 'build:react-with-umd');
 task(
   'mf',
   webpackDevServerTask({

--- a/packages/react/just.config.ts
+++ b/packages/react/just.config.ts
@@ -2,6 +2,7 @@ import { task, webpackDevServerTask, preset } from '@fluentui/scripts-tasks';
 
 preset();
 
+task('build', 'build:react');
 task(
   'mf',
   webpackDevServerTask({

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -16,7 +16,6 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
     "bundle-size": "monosize measure",
     "build-storybook": "cross-env NODE_OPTIONS=--max-old-space-size=3072 just-scripts storybook:build",
     "clean": "just-scripts clean",

--- a/packages/scheme-utilities/just.config.ts
+++ b/packages/scheme-utilities/just.config.ts
@@ -1,3 +1,5 @@
-import { preset } from '@fluentui/scripts-tasks';
+import { preset, task } from '@fluentui/scripts-tasks';
 
 preset();
+
+task('build', 'build:react');

--- a/packages/scheme-utilities/just.config.ts
+++ b/packages/scheme-utilities/just.config.ts
@@ -2,4 +2,4 @@ import { preset, task } from '@fluentui/scripts-tasks';
 
 preset();
 
-task('build', 'build:react');
+task('build', 'build:react-with-umd');

--- a/packages/scheme-utilities/package.json
+++ b/packages/scheme-utilities/package.json
@@ -15,7 +15,6 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
     "lint": "just-scripts lint",
     "just": "just-scripts",
     "clean": "just-scripts clean",

--- a/packages/theme-samples/just.config.ts
+++ b/packages/theme-samples/just.config.ts
@@ -1,3 +1,5 @@
-import { preset } from '@fluentui/scripts-tasks';
+import { preset, task } from '@fluentui/scripts-tasks';
 
 preset();
+
+task('build', 'build:react');

--- a/packages/theme-samples/just.config.ts
+++ b/packages/theme-samples/just.config.ts
@@ -2,4 +2,4 @@ import { preset, task } from '@fluentui/scripts-tasks';
 
 preset();
 
-task('build', 'build:react');
+task('build', 'build:react-with-umd');

--- a/packages/theme-samples/package.json
+++ b/packages/theme-samples/package.json
@@ -15,7 +15,6 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
     "lint": "just-scripts lint",
     "just": "just-scripts",
     "code-style": "just-scripts code-style",

--- a/scripts/tasks/src/metadata-utils.ts
+++ b/scripts/tasks/src/metadata-utils.ts
@@ -48,9 +48,12 @@ export function getRawMetadata(projectRoot: string) {
   function hasBabel() {
     return fs.existsSync(path.join(projectRoot, '.babelrc.json'));
   }
+  function hasWebpack() {
+    return fs.existsSync(path.join(projectRoot, 'webpack.config.js'));
+  }
   function hasSass() {
     return glob.sync(path.join(projectRoot, 'src/**/*.scss')).length > 0;
   }
 
-  return { ...metadata, isConverged, shipsAMD, hasJest, hasBabel, hasSass };
+  return { ...metadata, isConverged, shipsAMD, hasJest, hasBabel, hasSass, hasWebpack };
 }

--- a/scripts/tasks/src/presets.ts
+++ b/scripts/tasks/src/presets.ts
@@ -145,6 +145,13 @@ export function preset() {
     ),
   ).cached!();
 
+  task('build:react', () => {
+    return series(
+      'build',
+      condition('bundle', () => Boolean(args.production)),
+    );
+  });
+
   task('build:react-components', () => {
     return series(
       'clean',
@@ -156,7 +163,7 @@ export function preset() {
 
   task(
     'bundle',
-    condition('webpack', () => fs.existsSync(path.join(process.cwd(), 'webpack.config.js'))),
+    condition('webpack', () => metadata.hasWebpack()),
   );
 
   function resolveModuleCompilation(moduleFlag?: JustArgs['module']) {

--- a/scripts/tasks/src/presets.ts
+++ b/scripts/tasks/src/presets.ts
@@ -132,8 +132,9 @@ export function preset() {
 
   task('build:node-lib', series('clean', 'copy', 'ts:commonjs')).cached!();
 
+  // === React v8 build  tasks / START ===
   task(
-    'build',
+    'build:react',
     series(
       'clean',
       'copy',
@@ -144,13 +145,14 @@ export function preset() {
       condition('lint-imports:amd', () => metadata.isConverged() && metadata.shipsAMD()),
     ),
   ).cached!();
-
-  task('build:react', () => {
+  task('build', 'build:react')?.cached!();
+  task('build:react-with-umd', () => {
     return series(
-      'build',
+      'build:react',
       condition('bundle', () => Boolean(args.production)),
     );
-  });
+  })?.cached!();
+  // === React v8 build  tasks / END ===
 
   task('build:react-components', () => {
     return series(


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Some React v8 packages ship UMD bundle to npm registry and thus they include `bundle` target

## New Behavior

**scripts/tasks:**
 - implements new `react:build` task which will produce UMD via webpack if `--production` argument is present

**React v8 Packages** that ship UMD bundle to npm registry:
- no longer have `bundle` target within their target(task) definition
- use new `build:react-with-umd` just-scripts task that will produce UMD bundle during release only ( if `--production` argument is specified )

**CI Perf improvements:**
This setup conforms with our our `target` definition per project style-guide and also improves PR pipeline speeds as webpack is invoked significantly less than before.

| deploytE2E piipeline `bundle` step | time |
|--------|--------|
| Before | 632s |
| After | 594s / **𝚫 6% FASTER** | 

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows https://github.com/microsoft/fluentui/pull/31926
- Implements partially https://github.com/microsoft/fluentui/issues/30267
