### PR TITLE
chore(web-components): [button] move style related api out of base class

### DIFF
--- a/change/@fluentui-web-components-7f113354-6b0a-4b3d-8b04-92de3da35083.json
+++ b/change/@fluentui-web-components-7f113354-6b0a-4b3d-8b04-92de3da35083.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: [button] move style related api out of base class",
+  "packageName": "@fluentui/web-components",
+  "email": "jes@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/docs/api-report.md
+++ b/packages/web-components/docs/api-report.md
@@ -134,9 +134,8 @@ export const accordionTemplate: ElementViewTemplate<Accordion>;
 // Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
 // Warning: (ae-forgotten-export) The symbol "BaseAnchor" needs to be exported by the entry point index.d.ts
 // Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "AnchorButton" because one of its declarations is marked as @internal
-// Warning: (ae-missing-release-tag) "AnchorButton" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
-// @public (undocumented)
+// @public
 export class AnchorButton extends BaseAnchor {
     appearance?: AnchorButtonAppearance | undefined;
     appearanceChanged(prev: AnchorButtonAppearance | undefined, next: AnchorButtonAppearance | undefined): void;
@@ -479,9 +478,8 @@ export const borderRadiusXLarge = "var(--borderRadiusXLarge)";
 // Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
 // Warning: (ae-forgotten-export) The symbol "BaseButton" needs to be exported by the entry point index.d.ts
 // Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "Button" because one of its declarations is marked as @internal
-// Warning: (ae-missing-release-tag) "Button" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
-// @public (undocumented)
+// @public
 export class Button extends BaseButton {
     appearance?: ButtonAppearance;
     appearanceChanged(prev: ButtonAppearance | undefined, next: ButtonAppearance | undefined): void;

--- a/packages/web-components/docs/api-report.md
+++ b/packages/web-components/docs/api-report.md
@@ -477,50 +477,20 @@ export const borderRadiusSmall = "var(--borderRadiusSmall)";
 export const borderRadiusXLarge = "var(--borderRadiusXLarge)";
 
 // Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
+// Warning: (ae-forgotten-export) The symbol "BaseButton" needs to be exported by the entry point index.d.ts
 // Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "Button" because one of its declarations is marked as @internal
+// Warning: (ae-missing-release-tag) "Button" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
-// @public
-export class Button extends FASTElement {
-    constructor();
+// @public (undocumented)
+export class Button extends BaseButton {
     appearance?: ButtonAppearance;
     appearanceChanged(prev: ButtonAppearance | undefined, next: ButtonAppearance | undefined): void;
-    autofocus: boolean;
-    // @internal
-    clickHandler(e: Event): boolean | void;
-    // (undocumented)
-    connectedCallback(): void;
-    defaultSlottedContent: HTMLElement[];
-    disabled?: boolean;
-    disabledFocusable: boolean;
-    // @internal
-    disabledFocusableChanged(previous: boolean, next: boolean): void;
-    // @internal
-    elementInternals: ElementInternals;
-    get form(): HTMLFormElement | null;
-    formAction?: string;
-    static readonly formAssociated = true;
-    formAttribute?: string;
-    // @internal
-    formDisabledCallback(disabled: boolean): void;
-    formEnctype?: string;
-    formMethod?: string;
-    formNoValidate?: boolean;
-    formTarget?: ButtonFormTarget;
     iconOnly: boolean;
     iconOnlyChanged(prev: boolean, next: boolean): void;
-    keypressHandler(e: KeyboardEvent): boolean | void;
-    get labels(): ReadonlyArray<Node>;
-    name?: string;
-    protected press(): void;
-    resetForm(): void;
     shape?: ButtonShape;
     shapeChanged(prev: ButtonShape | undefined, next: ButtonShape | undefined): void;
     size?: ButtonSize;
     sizeChanged(prev: ButtonSize | undefined, next: ButtonSize | undefined): void;
-    type: ButtonType;
-    // @internal
-    typeChanged(previous: ButtonType, next: ButtonType): void;
-    value?: string;
 }
 
 // @internal (undocumented)
@@ -2000,7 +1970,7 @@ export class Drawer extends FASTElement {
 
 // Warning: (ae-missing-release-tag) "DrawerBody" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
-// @public (undocumented)
+// @public
 export class DrawerBody extends FASTElement {
 }
 

--- a/packages/web-components/src/anchor-button/anchor-button.ts
+++ b/packages/web-components/src/anchor-button/anchor-button.ts
@@ -243,7 +243,7 @@ export class BaseAnchor extends FASTElement {
 }
 
 /**
- * A Anchor Custom HTML Element.
+ * An Anchor Custom HTML Element.
  * Based on BaseAnchor and includes style and layout specific attributes
  *
  * @public

--- a/packages/web-components/src/anchor-button/anchor-button.ts
+++ b/packages/web-components/src/anchor-button/anchor-button.ts
@@ -242,6 +242,12 @@ export class BaseAnchor extends FASTElement {
   }
 }
 
+/**
+ * A Anchor Custom HTML Element.
+ * Based on BaseAnchor and includes style and layout specific attributes
+ *
+ * @public
+ */
 export class AnchorButton extends BaseAnchor {
   /**
    * The appearance the anchor button should have.

--- a/packages/web-components/src/button/button.ts
+++ b/packages/web-components/src/button/button.ts
@@ -424,6 +424,12 @@ export class BaseButton extends FASTElement {
   }
 }
 
+/**
+ * A Button Custom HTML Element.
+ * Based on BaseButton and includes style and layout specific attributes
+ *
+ * @public
+ */
 export class Button extends BaseButton {
   /**
    * Indicates the styled appearance of the button.

--- a/packages/web-components/src/button/button.ts
+++ b/packages/web-components/src/button/button.ts
@@ -17,31 +17,7 @@ import { ButtonType } from './button.options.js';
  *
  * @public
  */
-export class Button extends FASTElement {
-  /**
-   * Indicates the styled appearance of the button.
-   *
-   * @public
-   * @remarks
-   * HTML Attribute: `appearance`
-   */
-  @attr
-  public appearance?: ButtonAppearance;
-
-  /**
-   * Handles changes to appearance attribute custom states
-   * @param prev - the previous state
-   * @param next - the next state
-   */
-  public appearanceChanged(prev: ButtonAppearance | undefined, next: ButtonAppearance | undefined) {
-    if (prev) {
-      toggleState(this.elementInternals, `${prev}`, false);
-    }
-    if (next) {
-      toggleState(this.elementInternals, `${next}`, true);
-    }
-  }
-
+export class BaseButton extends FASTElement {
   /**
    * Indicates the button should be focused when the page is loaded.
    * @see The {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#autofocus | `autofocus`} attribute
@@ -210,25 +186,6 @@ export class Button extends FASTElement {
   public formTarget?: ButtonFormTarget;
 
   /**
-   * Indicates that the button should only display as an icon with no text content.
-   *
-   * @public
-   * @remarks
-   * HTML Attribute: `icon-only`
-   */
-  @attr({ attribute: 'icon-only', mode: 'boolean' })
-  public iconOnly: boolean = false;
-
-  /**
-   * Handles changes to icon only custom states
-   * @param prev - the previous state
-   * @param next - the next state
-   */
-  public iconOnlyChanged(prev: boolean, next: boolean) {
-    toggleState(this.elementInternals, 'icon', next);
-  }
-
-  /**
    * A reference to all associated label elements.
    *
    * @public
@@ -247,54 +204,6 @@ export class Button extends FASTElement {
    */
   @attr
   public name?: string;
-
-  /**
-   * The shape of the button.
-   *
-   * @public
-   * @remarks
-   * HTML Attribute: `shape`
-   */
-  @attr
-  public shape?: ButtonShape;
-
-  /**
-   * Handles changes to shape attribute custom states
-   * @param prev - the previous state
-   * @param next - the next state
-   */
-  public shapeChanged(prev: ButtonShape | undefined, next: ButtonShape | undefined) {
-    if (prev) {
-      toggleState(this.elementInternals, `${prev}`, false);
-    }
-    if (next) {
-      toggleState(this.elementInternals, `${next}`, true);
-    }
-  }
-
-  /**
-   * The size of the button.
-   *
-   * @public
-   * @remarks
-   * HTML Attribute: `size`
-   */
-  @attr
-  public size?: ButtonSize;
-
-  /**
-   * Handles changes to size attribute custom states
-   * @param prev - the previous state
-   * @param next - the next state
-   */
-  public sizeChanged(prev: ButtonSize | undefined, next: ButtonSize | undefined) {
-    if (prev) {
-      toggleState(this.elementInternals, `${prev}`, false);
-    }
-    if (next) {
-      toggleState(this.elementInternals, `${next}`, true);
-    }
-  }
 
   /**
    * The button type.
@@ -512,6 +421,99 @@ export class Button extends FASTElement {
       this.elementInternals.setFormValue(null);
       this.elementInternals.form.requestSubmit(this.formSubmissionFallbackControl);
     }
+  }
+}
+
+export class Button extends BaseButton {
+  /**
+   * Indicates the styled appearance of the button.
+   *
+   * @public
+   * @remarks
+   * HTML Attribute: `appearance`
+   */
+  @attr
+  public appearance?: ButtonAppearance;
+
+  /**
+   * Handles changes to appearance attribute custom states
+   * @param prev - the previous state
+   * @param next - the next state
+   */
+  public appearanceChanged(prev: ButtonAppearance | undefined, next: ButtonAppearance | undefined) {
+    if (prev) {
+      toggleState(this.elementInternals, `${prev}`, false);
+    }
+    if (next) {
+      toggleState(this.elementInternals, `${next}`, true);
+    }
+  }
+
+  /**
+   * The shape of the button.
+   *
+   * @public
+   * @remarks
+   * HTML Attribute: `shape`
+   */
+  @attr
+  public shape?: ButtonShape;
+
+  /**
+   * Handles changes to shape attribute custom states
+   * @param prev - the previous state
+   * @param next - the next state
+   */
+  public shapeChanged(prev: ButtonShape | undefined, next: ButtonShape | undefined) {
+    if (prev) {
+      toggleState(this.elementInternals, `${prev}`, false);
+    }
+    if (next) {
+      toggleState(this.elementInternals, `${next}`, true);
+    }
+  }
+
+  /**
+   * The size of the button.
+   *
+   * @public
+   * @remarks
+   * HTML Attribute: `size`
+   */
+  @attr
+  public size?: ButtonSize;
+
+  /**
+   * Handles changes to size attribute custom states
+   * @param prev - the previous state
+   * @param next - the next state
+   */
+  public sizeChanged(prev: ButtonSize | undefined, next: ButtonSize | undefined) {
+    if (prev) {
+      toggleState(this.elementInternals, `${prev}`, false);
+    }
+    if (next) {
+      toggleState(this.elementInternals, `${next}`, true);
+    }
+  }
+
+  /**
+   * Indicates that the button should only display as an icon with no text content.
+   *
+   * @public
+   * @remarks
+   * HTML Attribute: `icon-only`
+   */
+  @attr({ attribute: 'icon-only', mode: 'boolean' })
+  public iconOnly: boolean = false;
+
+  /**
+   * Handles changes to icon only custom states
+   * @param prev - the previous state
+   * @param next - the next state
+   */
+  public iconOnlyChanged(prev: boolean, next: boolean) {
+    toggleState(this.elementInternals, 'icon', next);
   }
 }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
Style specific parts of Button's API were bundled into the class. 

## New Behavior
Style specific parts of Button's API are kept in the `Button` class while functional parts of the API are moved into a new `BaseButton` class. This allows consumers to opt out of style specifics they may not need.

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
