### PR TITLE
docs(react-combobox): adjust Combobox examples

### DIFF
--- a/change/@fluentui-react-combobox-3a0b4412-7326-4ac8-a23d-144408d18d72.json
+++ b/change/@fluentui-react-combobox-3a0b4412-7326-4ac8-a23d-144408d18d72.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "docs: update combobox examples and positioning description",
+  "packageName": "@fluentui/react-combobox",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-combobox/library/src/utils/ComboboxBase.types.ts
+++ b/packages/react-components/react-combobox/library/src/utils/ComboboxBase.types.ts
@@ -67,7 +67,9 @@ export type ComboboxBaseProps = SelectionProps &
     placeholder?: string;
 
     /**
-     * Configure the positioning of the combobox dropdown
+     * Configure the positioning of the combobox dropdown.
+     * Please refer to the [positioning documentation](https://react.fluentui.dev/?path=/docs/concepts-developer-positioning-components--default#anchor-to-target)
+     * for more details.
      *
      * @defaultvalue below
      */

--- a/packages/react-components/react-combobox/stories/src/Combobox/ComboboxCustomOptions.stories.tsx
+++ b/packages/react-components/react-combobox/stories/src/Combobox/ComboboxCustomOptions.stories.tsx
@@ -31,9 +31,6 @@ const useStyles = makeStyles({
     gap: '2px',
     maxWidth: '400px',
   },
-  listbox: {
-    maxHeight: '200px',
-  },
 });
 
 export const CustomOptions = (props: Partial<ComboboxProps>) => {
@@ -44,12 +41,7 @@ export const CustomOptions = (props: Partial<ComboboxProps>) => {
   return (
     <div className={styles.root}>
       <label id={comboId}>Best pet</label>
-      <Combobox
-        aria-labelledby={comboId}
-        listbox={{ className: styles.listbox }}
-        placeholder="Select an animal"
-        {...props}
-      >
+      <Combobox aria-labelledby={comboId} placeholder="Select an animal" {...props}>
         <CustomOptionGroup label="Land" options={land} />
         <CustomOptionGroup label="Sea" options={water} />
       </Combobox>

--- a/packages/react-components/react-combobox/stories/src/Combobox/ComboboxVirtualizer.stories.tsx
+++ b/packages/react-components/react-combobox/stories/src/Combobox/ComboboxVirtualizer.stories.tsx
@@ -6,6 +6,7 @@ import { Virtualizer, useStaticVirtualizerMeasure } from '@fluentui/react-compon
 
 const useStyles = makeStyles({
   listbox: {
+    // maxHeight will be applied only positioning autoSize set.
     maxHeight: '250px',
   },
   option: {
@@ -33,6 +34,7 @@ export const ComboboxVirtualizer = (props: Partial<ComboboxProps>) => {
         <Combobox
           id={`${comboId}`}
           placeholder="Select a number"
+          positioning={{ autoSize: 'width' }}
           listbox={{ ref: scrollRef, className: styles.listbox }}
         >
           <Virtualizer
@@ -62,7 +64,9 @@ export const ComboboxVirtualizer = (props: Partial<ComboboxProps>) => {
 ComboboxVirtualizer.parameters = {
   docs: {
     description: {
-      story: 'A Combobox can use Virtualizer to display a large number of options.',
+      story:
+        'A Combobox can use Virtualizer to display a large number of options\n' +
+        `To manually control the maxHeight of the listbox, refer to the [positioning autoSize property](https://react.fluentui.dev/?path=/docs/concepts-developer-positioning-components--default#anchor-to-target)`,
     },
   },
 };


### PR DESCRIPTION
It was multiple times asked (#31972, #32040) about setting  `maxHeight` for `Combobox`, when the user tries to override it. I adjusted the examples to prevent further confusion and questions.

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->


