### PR TITLE
fix(web-components): move spinner animation off of mainthread

### DIFF
--- a/change/@fluentui-web-components-1dc0a126-f4ed-4776-b348-eaaef1b65a6a.json
+++ b/change/@fluentui-web-components-1dc0a126-f4ed-4776-b348-eaaef1b65a6a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: move spinner animation off of main thread",
+  "packageName": "@fluentui/web-components",
+  "email": "rupertdavid@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/spinner/spinner.styles.ts
+++ b/packages/web-components/src/spinner/spinner.styles.ts
@@ -5,6 +5,9 @@ import {
   colorBrandStroke2,
   colorNeutralStrokeOnBrand2,
   curveEasyEase,
+  strokeWidthThick,
+  strokeWidthThicker,
+  strokeWidthThickest,
 } from '../theme/design-tokens.js';
 import {
   extraLargeState,
@@ -20,35 +23,37 @@ export const styles = css`
   ${display('inline-flex')}
 
   :host {
-    --size: 32px;
     --duration: 1.5s;
-    --indicatorSize: calc(0.09375 * var(--size));
-
+    --indicatorSize: ${strokeWidthThicker};
+    --size: 32px;
     height: var(--size);
     width: var(--size);
-    position: relative;
-    align-items: center;
-    justify-content: center;
     contain: strict;
     content-visibility: auto;
   }
 
   :host(${tinyState}) {
+    --indicatorSize: ${strokeWidthThick};
     --size: 20px;
   }
   :host(${extraSmallState}) {
+    --indicatorSize: ${strokeWidthThick};
     --size: 24px;
   }
   :host(${smallState}) {
+    --indicatorSize: ${strokeWidthThick};
     --size: 28px;
   }
   :host(${largeState}) {
+    --indicatorSize: ${strokeWidthThicker};
     --size: 36px;
   }
   :host(${extraLargeState}) {
+    --indicatorSize: ${strokeWidthThicker};
     --size: 40px;
   }
   :host(${hugeState}) {
+    --indicatorSize: ${strokeWidthThickest};
     --size: 44px;
   }
 
@@ -62,14 +67,15 @@ export const styles = css`
     inset: 0;
   }
 
-  .progress {
-    flex: 1;
-    align-self: stretch;
+  .progress,
+  .spinner,
+  .indicator {
+    animation: none var(--duration) infinite ${curveEasyEase};
+  }
 
-    animation-duration: var(--duration);
-    animation-iteration-count: infinite;
+  .progress {
     animation-timing-function: linear;
-    animation-name: spin;
+    animation-name: spin-linear;
   }
 
   .background {
@@ -82,10 +88,7 @@ export const styles = css`
   }
 
   .spinner {
-    animation-duration: var(--duration);
-    animation-iteration-count: infinite;
-    animation-timing-function: ${curveEasyEase};
-    animation-name: spin-mask;
+    animation-name: spin-swing;
   }
 
   .start {
@@ -105,10 +108,6 @@ export const styles = css`
     border: var(--indicatorSize) solid transparent;
     border-block-start-color: currentcolor;
     border-inline-end-color: currentcolor;
-
-    animation-duration: var(--duration);
-    animation-iteration-count: infinite;
-    animation-timing-function: ${curveEasyEase};
   }
 
   :host(${invertedState}) .indicator {
@@ -116,27 +115,24 @@ export const styles = css`
   }
 
   .start .indicator {
-    rotate: 135deg; /* 9 o'clock */
+    rotate: 135deg; /* Starts 9 o'clock */
     inset: 0 -100% 0 0;
     animation-name: spin-start;
   }
 
   .end .indicator {
-    rotate: 135deg; /* 3 o'clock */
+    rotate: 135deg; /* Ends at 3 o'clock */
     inset: 0 0 0 -100%;
     animation-name: spin-end;
   }
 
-  @keyframes spin {
-    0% {
-      transform: rotate(0deg);
-    }
+  @keyframes spin-linear {
     100% {
       transform: rotate(360deg);
     }
   }
 
-  @keyframes spin-mask {
+  @keyframes spin-swing {
     0% {
       transform: rotate(-135deg);
     }
@@ -149,27 +145,22 @@ export const styles = css`
   }
 
   @keyframes spin-start {
-    0% {
+    0%,
+    100% {
       transform: rotate(0deg);
     }
     50% {
       transform: rotate(-80deg);
     }
-    100% {
-      transform: rotate(0deg);
-    }
   }
 
   @keyframes spin-end {
-    0% {
-      transform: rotate(0deg);
-    }
-
-    50% {
-      transform: rotate(70deg);
-    }
+    0%,
     100% {
       transform: rotate(0deg);
+    }
+    50% {
+      transform: rotate(70deg);
     }
   }
 `.withBehaviors(

--- a/packages/web-components/src/spinner/spinner.styles.ts
+++ b/packages/web-components/src/spinner/spinner.styles.ts
@@ -1,6 +1,11 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '../utils/index.js';
-import { colorBrandStroke1, colorBrandStroke2, colorNeutralStrokeOnBrand2 } from '../theme/design-tokens.js';
+import { display, forcedColorsStylesheetBehavior } from '../utils/index.js';
+import {
+  colorBrandStroke1,
+  colorBrandStroke2,
+  colorNeutralStrokeOnBrand2,
+  curveEasyEase,
+} from '../theme/design-tokens.js';
 import {
   extraLargeState,
   extraSmallState,
@@ -12,81 +17,170 @@ import {
 } from '../styles/states/index.js';
 
 export const styles = css`
-  ${display('flex')}
+  ${display('inline-flex')}
 
   :host {
-    display: flex;
+    --size: 32px;
+    --duration: 1.5s;
+    --indicatorSize: calc(0.09375 * var(--size));
+
+    height: var(--size);
+    width: var(--size);
+    position: relative;
     align-items: center;
-    height: 32px;
-    width: 32px;
-    contain: content;
+    justify-content: center;
+    contain: strict;
+    content-visibility: auto;
   }
+
   :host(${tinyState}) {
-    height: 20px;
-    width: 20px;
+    --size: 20px;
   }
   :host(${extraSmallState}) {
-    height: 24px;
-    width: 24px;
+    --size: 24px;
   }
   :host(${smallState}) {
-    height: 28px;
-    width: 28px;
+    --size: 28px;
   }
   :host(${largeState}) {
-    height: 36px;
-    width: 36px;
+    --size: 36px;
   }
   :host(${extraLargeState}) {
-    height: 40px;
-    width: 40px;
+    --size: 40px;
   }
   :host(${hugeState}) {
-    height: 44px;
-    width: 44px;
+    --size: 44px;
   }
+
+  .progress,
+  .background,
+  .spinner,
+  .start,
+  .end,
+  .indicator {
+    position: absolute;
+    inset: 0;
+  }
+
   .progress {
-    height: 100%;
-    width: 100%;
+    flex: 1;
+    align-self: stretch;
+
+    animation-duration: var(--duration);
+    animation-iteration-count: infinite;
+    animation-timing-function: linear;
+    animation-name: spin;
   }
 
   .background {
-    fill: none;
-    stroke: ${colorBrandStroke2};
-    stroke-width: 1.5px;
+    border: var(--indicatorSize) solid ${colorBrandStroke2};
+    border-radius: 50%;
   }
 
   :host(${invertedState}) .background {
-    stroke: rgba(255, 255, 255, 0.2);
+    border-color: rgba(255, 255, 255, 0.2);
+  }
+
+  .spinner {
+    animation-duration: var(--duration);
+    animation-iteration-count: infinite;
+    animation-timing-function: ${curveEasyEase};
+    animation-name: spin-mask;
+  }
+
+  .start {
+    overflow: hidden;
+    inset-inline-end: 50%;
+  }
+
+  .end {
+    overflow: hidden;
+    inset-inline-start: 50%;
   }
 
   .indicator {
-    stroke: ${colorBrandStroke1};
-    fill: none;
-    stroke-width: 1.5px;
-    stroke-linecap: round;
-    transform-origin: 50% 50%;
-    transform: rotate(-90deg);
-    transition: all 0.2s ease-in-out;
-    animation: spin-infinite 3s cubic-bezier(0.53, 0.21, 0.29, 0.67) infinite;
+    color: ${colorBrandStroke1};
+    box-sizing: border-box;
+    border-radius: 50%;
+    border: var(--indicatorSize) solid transparent;
+    border-block-start-color: currentcolor;
+    border-inline-end-color: currentcolor;
+
+    animation-duration: var(--duration);
+    animation-iteration-count: infinite;
+    animation-timing-function: ${curveEasyEase};
   }
 
   :host(${invertedState}) .indicator {
-    stroke: ${colorNeutralStrokeOnBrand2};
+    color: ${colorNeutralStrokeOnBrand2};
   }
 
-  @keyframes spin-infinite {
+  .start .indicator {
+    rotate: 135deg; /* 9 o'clock */
+    inset: 0 -100% 0 0;
+    animation-name: spin-start;
+  }
+
+  .end .indicator {
+    rotate: 135deg; /* 3 o'clock */
+    inset: 0 0 0 -100%;
+    animation-name: spin-end;
+  }
+
+  @keyframes spin {
     0% {
-      stroke-dasharray: 0.01px 43.97px;
+      transform: rotate(0deg);
+    }
+    100% {
+      transform: rotate(360deg);
+    }
+  }
+
+  @keyframes spin-mask {
+    0% {
+      transform: rotate(-135deg);
+    }
+    50% {
+      transform: rotate(0deg);
+    }
+    100% {
+      transform: rotate(225deg);
+    }
+  }
+
+  @keyframes spin-start {
+    0% {
       transform: rotate(0deg);
     }
     50% {
-      stroke-dasharray: 21.99px 21.99px;
-      transform: rotate(450deg);
+      transform: rotate(-80deg);
     }
     100% {
-      stroke-dasharray: 0.01px 43.97px;
-      transform: rotate(1080deg);
+      transform: rotate(0deg);
     }
   }
-`;
+
+  @keyframes spin-end {
+    0% {
+      transform: rotate(0deg);
+    }
+
+    50% {
+      transform: rotate(70deg);
+    }
+    100% {
+      transform: rotate(0deg);
+    }
+  }
+`.withBehaviors(
+  forcedColorsStylesheetBehavior(css`
+    .background {
+      display: none;
+    }
+    .indicator {
+      border-color: Canvas;
+      border-block-start-color: Highlight;
+      border-inline-end-color: Highlight;
+    }
+  `),
+);

--- a/packages/web-components/src/spinner/spinner.template.ts
+++ b/packages/web-components/src/spinner/spinner.template.ts
@@ -2,9 +2,17 @@ import { html } from '@microsoft/fast-element';
 import { Spinner } from './spinner.js';
 
 export const template = html<Spinner>`
-  <slot name="indicator"
-    ><svg class="progress" part="progress" viewBox="0 0 16 16">
-      <circle class="background" cx="8px" cy="8px" r="7px"></circle>
-      <circle class="indicator" cx="8px" cy="8px" r="7px"></circle></svg
-  ></slot>
+  <slot name="indicator">
+    <div class="background"></div>
+    <div class="progress">
+      <div class="spinner">
+        <div class="start">
+          <div class="indicator"></div>
+        </div>
+        <div class="end">
+          <div class="indicator"></div>
+        </div>
+      </div>
+    </div>
+  </slot>
 `;


### PR DESCRIPTION
A PR to change how we're animating the Spinner component in Fluent Web Components

## Previous Behavior

<!-- This is the behavior we have today -->

It was reported this week that the Web Component spinner was animating on the main thread and not the compositor. 

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

Convert SVG animation to `div` animation à la the React implementation.

- Moves all spinner animation off the main thread to the compositor
- 120 layouts per second → 0 layouts per second
- 120 style recalcs per second → 0 style recalcs per second (at rest)
- No more paint flashes in `DevTools > More Tools > Rendering`
- 5~9% CPU usage → 0.2% CPU usage

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
