### PR TITLE
chore(eslint-plugin): removes type dependency on @fluentui/react-utilities internals in ban-instanceof-html-element rule

### DIFF
--- a/change/@fluentui-eslint-plugin-c622c77c-61e2-4433-b4cf-da2ad0984040.json
+++ b/change/@fluentui-eslint-plugin-c622c77c-61e2-4433-b4cf-da2ad0984040.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: removes type dependency on @fluentui/react-utilities internals in ban-instanceof-html-element",
+  "packageName": "@fluentui/eslint-plugin",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-utilities-8376a788-0cd7-4976-b302-c88844a11938.json
+++ b/change/@fluentui-react-utilities-8376a788-0cd7-4976-b302-c88844a11938.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: stops leaking HTMLElementConstructorName type",
+  "packageName": "@fluentui/react-utilities",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/eslint-plugin/src/rules/ban-instanceof-html-element/index.js
+++ b/packages/eslint-plugin/src/rules/ban-instanceof-html-element/index.js
@@ -3,7 +3,7 @@ const { AST_NODE_TYPES } = require('@typescript-eslint/utils');
 const createRule = require('../../utils/createRule');
 
 /**
- * @typedef {import("@fluentui/react-utilities/src/utils/isHTMLElement").HTMLElementConstructorName} HTMLElementConstructorName
+ * @typedef {import('./types').HTMLElementConstructorName} HTMLElementConstructorName
  *
  */
 
@@ -56,7 +56,6 @@ const constructorNames = [
   'HTMLDataElement',
   'HTMLDataListElement',
   'HTMLDetailsElement',
-  // @ts-expect-error - NOTE: dialog is not supported in safari 14, also it was removed from lib-dom starting typescript 4.4
   'HTMLDialogElement',
   'HTMLDivElement',
   'HTMLDListElement',

--- a/packages/eslint-plugin/src/rules/ban-instanceof-html-element/types.d.ts
+++ b/packages/eslint-plugin/src/rules/ban-instanceof-html-element/types.d.ts
@@ -1,35 +1,7 @@
 /**
- * Verifies if a given node is an HTMLElement,
- * this method works seamlessly with frames and elements from different documents
- *
- * This is preferred over simply using `instanceof`.
- * Since `instanceof` might be problematic while operating with [multiple realms](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/instanceof#instanceof_and_multiple_realms)
- *
- * @example
- * ```ts
- * isHTMLElement(event.target) && event.target.focus()
- * isHTMLElement(event.target, {constructorName: 'HTMLInputElement'}) && event.target.value // some value
- * ```
- *
+ * All the possible HTML element constructor names.
  */
-export function isHTMLElement<ConstructorName extends HTMLElementConstructorName = 'HTMLElement'>(
-  element?: unknown,
-  options?: {
-    /**
-     * Can be used to provide a custom constructor instead of `HTMLElement`,
-     * Like `HTMLInputElement` for example.
-     */
-    constructorName?: ConstructorName;
-  },
-): element is InstanceType<(typeof globalThis)[ConstructorName]> {
-  const typedElement = element as Node | null | undefined;
-  return Boolean(
-    typedElement?.ownerDocument?.defaultView &&
-      typedElement instanceof typedElement.ownerDocument.defaultView[options?.constructorName ?? 'HTMLElement'],
-  );
-}
-
-type HTMLElementConstructorName =
+export type HTMLElementConstructorName =
   | 'HTMLElement'
   | 'HTMLAnchorElement'
   | 'HTMLAreaElement'
@@ -42,8 +14,7 @@ type HTMLElementConstructorName =
   | 'HTMLDataElement'
   | 'HTMLDataListElement'
   | 'HTMLDetailsElement'
-  // NOTE: dialog is not supported in safari 14, also it was removed from lib-dom starting typescript 4.4
-  // | 'HTMLDialogElement'
+  | 'HTMLDialogElement'
   | 'HTMLDivElement'
   | 'HTMLDListElement'
   | 'HTMLEmbedElement'


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

1. removes dependency on `"@fluentui/react-utilities/src/utils/isHTMLElement"` file from `ban-instanceof-html-element` eslint rule

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
