### PR TITLE
fix: align casing in exports from Accordion and AccordionItem

### DIFF
--- a/packages/web-components/src/accordion-item/index.ts
+++ b/packages/web-components/src/accordion-item/index.ts
@@ -1,6 +1,6 @@
 export { AccordionItem } from './accordion-item.js';
 export type { AccordionItemOptions } from './accordion-item.js';
 export { AccordionItemSize, AccordionItemMarkerPosition } from './accordion-item.options.js';
-export { styles as accordionItemStyles } from './accordion-item.styles.js';
-export { definition as accordionItemDefinition } from './accordion-item.definition.js';
-export { template as accordionItemTemplate } from './accordion-item.template.js';
+export { styles as AccordionItemStyles } from './accordion-item.styles.js';
+export { definition as AccordionItemDefinition } from './accordion-item.definition.js';
+export { template as AccordionItemTemplate } from './accordion-item.template.js';

--- a/packages/web-components/src/accordion/index.ts
+++ b/packages/web-components/src/accordion/index.ts
@@ -1,5 +1,5 @@
 export { Accordion } from './accordion.js';
 export { AccordionExpandMode } from './accordion.options.js';
-export { template as accordionTemplate } from './accordion.template.js';
-export { styles as accordionStyles } from './accordion.styles.js';
-export { definition as accordionDefinition } from './accordion.definition.js';
+export { template as AccordionTemplate } from './accordion.template.js';
+export { styles as AccordionStyles } from './accordion.styles.js';
+export { definition as AccordionDefinition } from './accordion.definition.js';

--- a/packages/web-components/src/index.ts
+++ b/packages/web-components/src/index.ts
@@ -1,18 +1,18 @@
 export {
   AccordionItem,
-  accordionItemDefinition,
+  AccordionItemDefinition,
   AccordionItemMarkerPosition,
   AccordionItemSize,
-  accordionItemStyles,
-  accordionItemTemplate,
+  AccordionItemStyles,
+  AccordionItemTemplate,
 } from './accordion-item/index.js';
 export type { AccordionItemOptions } from './accordion-item/index.js';
 export {
   Accordion,
-  accordionDefinition,
+  AccordionDefinition,
   AccordionExpandMode,
-  accordionStyles,
-  accordionTemplate,
+  AccordionStyles,
+  AccordionTemplate,
 } from './accordion/index.js';
 export { Link, LinkAppearance, LinkDefinition, LinkTemplate, LinkTarget } from './link/index.js';
 export {


### PR DESCRIPTION
## Previous Behavior

Exports for `accordion` and `accordionItem` from `index.ts` were inconsistent, some starting with lower case, some with uppercase. This was inconsistent with other components.

## New Behavior

Exports for `accordion` and `accordionItem` from `index.ts` now all start with uppercase, such that this is in line with other components.
