### PR TITLE
fix(react-search): replace useEventCallback with useCallback

### DIFF
--- a/change/@fluentui-react-search-151576f1-89e3-425a-8b4e-070acb37ef9a.json
+++ b/change/@fluentui-react-search-151576f1-89e3-425a-8b4e-070acb37ef9a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: replace useEventCallback with useCallback for focus",
+  "packageName": "@fluentui/react-search",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-search/library/src/components/SearchBox/useSearchBox.tsx
+++ b/packages/react-components/react-search/library/src/components/SearchBox/useSearchBox.tsx
@@ -46,13 +46,16 @@ export const useSearchBox_unstable = (props: SearchBoxProps, ref: React.Ref<HTML
   // Tracks the focus of the component for the contentAfter and dismiss button
   const [focused, setFocused] = React.useState(false);
 
-  const onFocus = useEventCallback(() => {
+  const onFocus = React.useCallback(() => {
     setFocused(true);
-  });
+  }, [setFocused]);
 
-  const onBlur: React.FocusEventHandler<HTMLSpanElement> = useEventCallback(ev => {
-    setFocused(!!searchBoxRootRef.current?.contains(ev.relatedTarget));
-  });
+  const onBlur: React.FocusEventHandler<HTMLSpanElement> = React.useCallback(
+    ev => {
+      setFocused(!!searchBoxRootRef.current?.contains(ev.relatedTarget));
+    },
+    [setFocused],
+  );
 
   const rootProps = slot.resolveShorthand(root);
 
@@ -75,8 +78,8 @@ export const useSearchBox_unstable = (props: SearchBoxProps, ref: React.Ref<HTML
         {
           ...rootProps,
           ref: useMergedRefs(rootProps?.ref, searchBoxRootRef),
-          onFocus: useEventCallback(mergeCallbacks(rootProps?.onFocus, onFocus)),
-          onBlur: useEventCallback(mergeCallbacks(rootProps?.onBlur, onBlur)),
+          onFocus: mergeCallbacks(rootProps?.onFocus, onFocus),
+          onBlur: mergeCallbacks(rootProps?.onBlur, onBlur),
         },
         {
           elementType: 'span',


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

`Uncaught Error: Cannot call an event handler while render` error, caused by [useEventCallback hook](https://github.com/microsoft/fluentui/blob/a00c100890d82e5133f909994dfe383e44b45782/packages/react-components/react-utilities/src/hooks/useEventCallback.ts#L19) when `autoFocus` is on.

![Screenshot 2024-07-23 at 18 06 37](https://github.com/user-attachments/assets/8e1ea811-c6fc-4db9-a127-72467dc4a632)

## New Behavior

No error 🙂 

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #31166
