### PR TITLE
fix: remove unnecessary aria-hidden attributes from Tree

### DIFF
--- a/change/@fluentui-react-provider-3bd9a3d1-66ee-4ddd-a588-4705107c3820.json
+++ b/change/@fluentui-react-provider-3bd9a3d1-66ee-4ddd-a588-4705107c3820.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "docs: remove now-uneeded comment on tree",
+  "packageName": "@fluentui/react-provider",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tree-a5434551-fc6b-46b6-8aed-3f40515ba2b0.json
+++ b/change/@fluentui-react-tree-a5434551-fc6b-46b6-8aed-3f40515ba2b0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unnecessary aria-hidden attributes that were causing accessibility issues",
+  "packageName": "@fluentui/react-tree",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-provider/library/etc/react-provider.api.md
+++ b/packages/react-components/react-provider/library/etc/react-provider.api.md
@@ -23,7 +23,7 @@ import type { TooltipVisibilityContextValue_unstable } from '@fluentui/react-sha
 export function createCSSRuleFromTheme(selector: string, theme: PartialTheme | undefined): string;
 
 // @public (undocumented)
-export const FluentProvider: React_2.ForwardRefExoticComponent<Omit<ComponentProps<FluentProviderSlots, "root">, "dir"> & {
+export const FluentProvider: React_2.ForwardRefExoticComponent<Omit<ComponentProps<FluentProviderSlots>, "dir"> & {
     applyStylesToPortals?: boolean | undefined;
     customStyleHooks_unstable?: Partial<{
         useAccordionHeaderStyles_unstable: (state: unknown) => void;

--- a/packages/react-components/react-provider/library/etc/react-provider.api.md
+++ b/packages/react-components/react-provider/library/etc/react-provider.api.md
@@ -23,7 +23,7 @@ import type { TooltipVisibilityContextValue_unstable } from '@fluentui/react-sha
 export function createCSSRuleFromTheme(selector: string, theme: PartialTheme | undefined): string;
 
 // @public (undocumented)
-export const FluentProvider: React_2.ForwardRefExoticComponent<Omit<ComponentProps<FluentProviderSlots>, "dir"> & {
+export const FluentProvider: React_2.ForwardRefExoticComponent<Omit<ComponentProps<FluentProviderSlots, "root">, "dir"> & {
     applyStylesToPortals?: boolean | undefined;
     customStyleHooks_unstable?: Partial<{
         useAccordionHeaderStyles_unstable: (state: unknown) => void;

--- a/packages/react-components/react-tree/library/src/components/TreeItemLayout/TreeItemLayout.types.ts
+++ b/packages/react-components/react-tree/library/src/components/TreeItemLayout/TreeItemLayout.types.ts
@@ -48,7 +48,6 @@ export type TreeItemLayoutSlots = {
   expandIcon?: Slot<'div'>;
   /**
    * Aside content is normally used to render a badge or other non-actionable content
-   * It is aria-hidden by default and is only meant to be used as visual aid.
    */
   aside?: Slot<'div'>;
   /**

--- a/packages/react-components/react-tree/library/src/components/TreeItemLayout/useTreeItemLayout.tsx
+++ b/packages/react-components/react-tree/library/src/components/TreeItemLayout/useTreeItemLayout.tsx
@@ -208,12 +208,10 @@ export const useTreeItemLayout_unstable = (
         elementType: 'div',
       },
     ),
-    iconBefore: slot.optional(iconBefore, { defaultProps: { 'aria-hidden': true }, elementType: 'div' }),
+    iconBefore: slot.optional(iconBefore, { elementType: 'div' }),
     main: slot.always(main, { elementType: 'div' }),
-    iconAfter: slot.optional(iconAfter, { defaultProps: { 'aria-hidden': true }, elementType: 'div' }),
-    aside: !isActionsVisible
-      ? slot.optional(props.aside, { defaultProps: { 'aria-hidden': true }, elementType: 'div' })
-      : undefined,
+    iconAfter: slot.optional(iconAfter, { elementType: 'div' }),
+    aside: !isActionsVisible ? slot.optional(props.aside, { elementType: 'div' }) : undefined,
     actions,
     expandIcon,
     selector: slot.optional(props.selector, {

--- a/packages/react-components/react-tree/stories/src/Tree/TreeA11y.md
+++ b/packages/react-components/react-tree/stories/src/Tree/TreeA11y.md
@@ -11,7 +11,6 @@ VoiceOver/Chromium
 
 1. [Issue 1273540: Tree as table in Mac > VoiceOver narrates " 0 items enclosed " when user navigates to expaded treeitem](https://bugs.chromium.org/p/chromium/issues/detail?id=1273540)
 2. [Issue 1273544: Tree as table in Mac > VoiceOver doesn't narrate aria-labelledby element on treeitem](https://bugs.chromium.org/p/chromium/issues/detail?id=1273544)
-3. [Issue 1377818: Tree - Treeitem - Accessibility name received from content includes the aria-hidden button name](https://bugs.chromium.org/p/chromium/issues/detail?id=1377818)
 
 VoiceOver
 

--- a/packages/react-components/react-tree/stories/src/Tree/TreeAside.stories.tsx
+++ b/packages/react-components/react-tree/stories/src/Tree/TreeAside.stories.tsx
@@ -58,8 +58,6 @@ Aside.parameters = {
     description: {
       story: `
 Both tree item layouts supports \`aside\` content that is displayed on the right side of a tree item. It can be used to display additional information, such as a badge with notification count or an icon indicating importance.
-
-> ⚠️ Aside content is \`aria-hidden\` by default
       `,
     },
   },

--- a/packages/react-components/react-tree/stories/src/Tree/TreeIconBeforeAndAfter.stories.tsx
+++ b/packages/react-components/react-tree/stories/src/Tree/TreeIconBeforeAndAfter.stories.tsx
@@ -37,9 +37,7 @@ IconBeforeAndAfter.parameters = {
     name: 'Icon Before/After',
     description: {
       story: `
-\`TreeItemLayout\` component allows you to add icons before or after the content.
-
-> ⚠️ iconBefore and  iconAfter are marked as \`aria-hidden\` by default`,
+\`TreeItemLayout\` component allows you to add icons before or after the content.`,
     },
   },
 };

--- a/packages/react-components/react-tree/stories/src/Tree/TreeManipulation.stories.tsx
+++ b/packages/react-components/react-tree/stories/src/Tree/TreeManipulation.stories.tsx
@@ -58,7 +58,6 @@ const CustomTreeItem = React.forwardRef(
             <TreeItemLayout
               actions={
                 isItemRemovable ? (
-                  // this button is accessible via context menu, hence aria-hidden='true'
                   <Button
                     aria-label="Remove item"
                     appearance="subtle"


### PR DESCRIPTION
## Previous Behavior

We had `aria-hidden` attributes scattered around tree slots that hide potentially meaningful information (and a currently meaningful button) from screen reader users.

Those include:
- The `iconBefore` and `iconAfter` slots. If authors put an icon without an accName in there, it will already have `aria-hidden` because of our icon's internal logic. Adding `aria-hidden` to the slot only ends up hiding meaningful icons.
- `aside`: since this contains actions and information relevant to the user, putting `aria-hidden` on here causes user-impacting issues. The TreeManipulation story shows an example of this (the remove button, in that story) being a problem.

## New Behavior

`aria-hidden` is not added to those slots

## Related Issue(s)

not logged as an issue, but a partner team had a problem caused by Tree adding `aria-hidden` to `aside`
