### PR TITLE
feat(web-components): relax setTheme() argument type to allow custom tokens

### DIFF
--- a/change/@fluentui-web-components-664a860d-0606-46e5-9e2d-c1d7508e2e62.json
+++ b/change/@fluentui-web-components-664a860d-0606-46e5-9e2d-c1d7508e2e62.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat(web-components): relax setTheme() argument type to allow custom tokens",
+  "packageName": "@fluentui/web-components",
+  "email": "machi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/docs/api-report.md
+++ b/packages/web-components/docs/api-report.md
@@ -17,7 +17,6 @@ import type { HostController } from '@microsoft/fast-element';
 import { HTMLDirective } from '@microsoft/fast-element';
 import { Orientation } from '@microsoft/fast-web-utilities';
 import type { SyntheticViewTemplate } from '@microsoft/fast-element';
-import type { Theme } from '@fluentui/tokens';
 import { ViewTemplate } from '@microsoft/fast-element';
 
 // @public
@@ -3540,6 +3539,11 @@ export const TextWeight: {
 
 // @public
 export type TextWeight = ValuesOf<typeof TextWeight>;
+
+// Warning: (ae-internal-missing-underscore) The name "Theme" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal
+export type Theme = Record<string, string | number>;
 
 // @public
 export class ToggleButton extends Button {

--- a/packages/web-components/src/index.ts
+++ b/packages/web-components/src/index.ts
@@ -244,7 +244,7 @@ export {
   TextWeight,
 } from './text/index.js';
 export * from './theme/design-tokens.js';
-export { setTheme, setThemeFor } from './theme/index.js';
+export { setTheme, setThemeFor, type Theme } from './theme/index.js';
 export {
   ToggleButton,
   ToggleButtonAppearance,

--- a/packages/web-components/src/theme/index.ts
+++ b/packages/web-components/src/theme/index.ts
@@ -384,4 +384,4 @@ export {
   shadow28Brand,
   shadow64Brand,
 } from './design-tokens.js';
-export { setTheme, setThemeFor } from './set-theme.js';
+export { setTheme, setThemeFor, type Theme } from './set-theme.js';

--- a/packages/web-components/src/theme/set-theme.ts
+++ b/packages/web-components/src/theme/set-theme.ts
@@ -1,5 +1,11 @@
-import type { Theme } from '@fluentui/tokens';
 import * as tokens from './design-tokens.js';
+
+/**
+ * Not using the `Theme` type from `@fluentui/tokens` package to allow custom
+ * tokens to be added.
+ * @internal
+ */
+export type Theme = Record<string, string | number>;
 
 const tokenNames = Object.keys(tokens) as (keyof Theme)[];
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [X] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

The `theme` argument in `setTheme(theme)` is required to be the `Theme` type from `@fluentui/tokens`.

## New Behavior

In order to allow custom tokens to be set in the same mechanism, we relax this type requirement, so product teams can extend and override existing themes with their own tokens.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
