### PR TITLE
Carousel: Grouping - 2.0

### DIFF
--- a/packages/react-components/react-carousel-preview/library/etc/react-carousel-preview.api.md
+++ b/packages/react-components/react-carousel-preview/library/etc/react-carousel-preview.api.md
@@ -155,7 +155,7 @@ export type CarouselNavSlots = {
 
 // @public (undocumented)
 export type CarouselNavState = ComponentState<CarouselNavSlots> & {
-    values: string[];
+    values: string[][];
     renderNavButton: NavButtonRenderFunction;
 };
 
@@ -166,6 +166,7 @@ export type CarouselProps = ComponentProps<CarouselSlots> & {
     value?: string;
     onValueChange?: EventHandler<CarouselValueChangeData>;
     circular?: boolean;
+    groupSize?: number | 'auto';
 };
 
 // @public
@@ -194,7 +195,7 @@ export type CarouselSlots = {
 export type CarouselState = ComponentState<CarouselSlots> & CarouselContextValue;
 
 // @public (undocumented)
-export type NavButtonRenderFunction = (value: string) => React_2.ReactNode;
+export type NavButtonRenderFunction = (value: string[]) => React_2.ReactNode;
 
 // @public
 export const renderCarousel_unstable: (state: CarouselState, contextValues: CarouselContextValues) => JSX.Element;

--- a/packages/react-components/react-carousel-preview/library/src/components/Carousel/Carousel.types.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/Carousel/Carousel.types.ts
@@ -33,6 +33,11 @@ export type CarouselProps = ComponentProps<CarouselSlots> & {
    * Circular enables the carousel to loop back around on navigation past trailing index.
    */
   circular?: boolean;
+
+  /**
+   * Circular enables the carousel to loop back around on navigation past trailing index.
+   */
+  groupSize?: number | 'auto';
 };
 
 /**
@@ -45,3 +50,9 @@ export interface CarouselVisibilityEventDetail {
 }
 
 export type CarouselVisibilityChangeEvent = CustomEvent<CarouselVisibilityEventDetail>;
+
+export interface CarouselGroupEventDetail {
+  groupIndex: number[][];
+}
+
+export type CarouselGroupChangeEvent = CustomEvent<CarouselGroupEventDetail>;

--- a/packages/react-components/react-carousel-preview/library/src/components/Carousel/useCarouselContextValues.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/Carousel/useCarouselContextValues.ts
@@ -4,7 +4,7 @@ import type { CarouselContextValues } from '../CarouselContext.types';
 import type { CarouselState } from './Carousel.types';
 
 export function useCarouselContextValues_unstable(state: CarouselState): CarouselContextValues {
-  const { store, selectPageByDirection, selectPageByValue, circular } = state;
+  const { store, selectPageByDirection, selectPageByValue, circular, groupSize, groupIndexList } = state;
 
   const carousel = React.useMemo(
     () => ({
@@ -12,8 +12,10 @@ export function useCarouselContextValues_unstable(state: CarouselState): Carouse
       selectPageByDirection,
       selectPageByValue,
       circular,
+      groupSize,
+      groupIndexList,
     }),
-    [store, selectPageByDirection, selectPageByValue, circular],
+    [store, selectPageByDirection, selectPageByValue, circular, groupSize, groupIndexList],
   );
 
   return { carousel };

--- a/packages/react-components/react-carousel-preview/library/src/components/CarouselButton/useCarouselButton.tsx
+++ b/packages/react-components/react-carousel-preview/library/src/components/CarouselButton/useCarouselButton.tsx
@@ -23,10 +23,17 @@ export const useCarouselButton_unstable = (
 ): CarouselButtonState => {
   const { navType } = props;
 
-  const { circular, selectPageByDirection } = useCarouselContext_unstable();
+  const { circular, selectPageByDirection, groupIndexList, groupSize } = useCarouselContext_unstable();
   const isTrailing = useCarouselStore_unstable(snapshot => {
     if (!snapshot.activeValue || circular) {
       return false;
+    }
+
+    if (groupSize !== undefined && groupIndexList !== undefined) {
+      const trailingGroup = navType === 'prev' ? groupIndexList[0] : groupIndexList[groupIndexList?.length - 1];
+      const activeIndex = snapshot.values.indexOf(snapshot.activeValue);
+
+      return trailingGroup.includes(activeIndex);
     }
 
     if (navType === 'prev') {

--- a/packages/react-components/react-carousel-preview/library/src/components/CarouselCard/useCarouselCard.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/CarouselCard/useCarouselCard.ts
@@ -36,8 +36,6 @@ export const useCarouselCard_unstable = (
 
         element.ariaHidden = hidden.toString();
         element.inert = hidden;
-
-        // TODO: handle "tabIndex" ?
       };
 
       element.addEventListener(EMBLA_VISIBILITY_EVENT, listener);

--- a/packages/react-components/react-carousel-preview/library/src/components/CarouselContext.types.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/CarouselContext.types.ts
@@ -36,6 +36,8 @@ export type CarouselContextValue = {
   ) => void;
   selectPageByValue: (event: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>, value: string) => void;
   circular: boolean;
+  groupSize?: number | 'auto';
+  groupIndexList?: number[][];
 };
 
 /**

--- a/packages/react-components/react-carousel-preview/library/src/components/CarouselNav/CarouselNav.types.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/CarouselNav/CarouselNav.types.ts
@@ -8,10 +8,14 @@ export type CarouselNavSlots = {
   root: NonNullable<Slot<'div'>>;
 };
 
-export type NavButtonRenderFunction = (value: string) => React.ReactNode;
+export type NavButtonRenderFunction = (value: string[]) => React.ReactNode;
 
 export type CarouselNavState = ComponentState<CarouselNavSlots> & {
-  values: string[];
+  /*
+   * Values contains the nodes for each navigation button
+   * Can be a list of multiple items when grouped.
+   */
+  values: string[][];
 
   renderNavButton: NavButtonRenderFunction;
 };

--- a/packages/react-components/react-carousel-preview/library/src/components/CarouselNav/CarouselNavContext.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/CarouselNav/CarouselNavContext.ts
@@ -1,8 +1,8 @@
 import * as React from 'react';
 
-const carouselNavContext = React.createContext<string | undefined>(undefined);
+const carouselNavContext = React.createContext<string[] | undefined>(undefined);
 
-export const carouselNavContextDefaultValue = '';
+export const carouselNavContextDefaultValue = [''];
 
 export const useCarouselNavContext = () => React.useContext(carouselNavContext) ?? carouselNavContextDefaultValue;
 

--- a/packages/react-components/react-carousel-preview/library/src/components/CarouselNav/renderCarouselNav.tsx
+++ b/packages/react-components/react-carousel-preview/library/src/components/CarouselNav/renderCarouselNav.tsx
@@ -15,7 +15,7 @@ export const renderCarouselNav_unstable = (state: CarouselNavState) => {
   return (
     <state.root>
       {values.map(value => (
-        <CarouselNavContextProvider value={value} key={value}>
+        <CarouselNavContextProvider value={value} key={`carousel-nav-${value.join('-')}`}>
           {renderNavButton(value)}
         </CarouselNavContextProvider>
       ))}

--- a/packages/react-components/react-carousel-preview/library/src/components/CarouselNav/useCarouselNav.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/CarouselNav/useCarouselNav.ts
@@ -3,6 +3,7 @@ import { getIntrinsicElementProps, slot } from '@fluentui/react-utilities';
 import type { CarouselNavProps, CarouselNavState } from './CarouselNav.types';
 import { useArrowNavigationGroup } from '@fluentui/react-tabster';
 import { useCarouselStore_unstable } from '../useCarouselStore';
+import { useCarouselContext_unstable } from '../CarouselContext';
 
 /**
  * Create the state required to render CarouselNav.
@@ -22,7 +23,24 @@ export const useCarouselNav_unstable = (props: CarouselNavProps, ref: React.Ref<
     unstable_hasDefault: true,
   });
 
-  const values = useCarouselStore_unstable(snapshot => snapshot.values);
+  const values: string[][] = [];
+  const _values = useCarouselStore_unstable(snapshot => snapshot.values);
+  const { groupSize, groupIndexList } = useCarouselContext_unstable();
+
+  if (groupSize !== undefined) {
+    const indexing = groupIndexList ?? [];
+    indexing.forEach(groupIndexes => {
+      const _group: string[] = [];
+      groupIndexes.forEach(index => {
+        if (index < _values.length) {
+          _group.push(_values[index]);
+        }
+      });
+      values.push(_group);
+    });
+  } else {
+    _values.forEach(value => values.push([value]));
+  }
 
   return {
     values,

--- a/packages/react-components/react-carousel-preview/library/src/components/CarouselNavButton/__snapshots__/CarouselNavButton.test.tsx.snap
+++ b/packages/react-components/react-carousel-preview/library/src/components/CarouselNavButton/__snapshots__/CarouselNavButton.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`CarouselNavButton renders a default state 1`] = `
 <div>
   <button
     class="fui-CarouselNavButton"
-    data-tabster="{\\"focusable\\":{\\"isDefault\\":false}}"
+    data-tabster="{\\"focusable\\":{\\"isDefault\\":true}}"
     role="tab"
     type="button"
   >

--- a/packages/react-components/react-carousel-preview/library/src/components/CarouselNavButton/useCarouselNavButton.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/CarouselNavButton/useCarouselNavButton.ts
@@ -25,13 +25,13 @@ export const useCarouselNavButton_unstable = (
   const value = useCarouselNavContext();
 
   const { selectPageByValue } = useCarouselContext_unstable();
-  const selected = useCarouselStore_unstable(snapshot => snapshot.activeValue === value);
+  const selected = useCarouselStore_unstable(snapshot => value.includes(snapshot.activeValue ?? ''));
 
   const handleClick: ARIAButtonSlotProps['onClick'] = useEventCallback(event => {
     onClick?.(event);
 
     if (!event.defaultPrevented && isHTMLElement(event.target)) {
-      selectPageByValue(event, value);
+      selectPageByValue(event, value[0]);
     }
   });
 

--- a/packages/react-components/react-carousel-preview/library/src/components/CarouselNavImageButton/__snapshots__/CarouselNavImageButton.test.tsx.snap
+++ b/packages/react-components/react-carousel-preview/library/src/components/CarouselNavImageButton/__snapshots__/CarouselNavImageButton.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`CarouselNavImageButton renders a default state 1`] = `
 <div>
   <button
     class="fui-CarouselNavImageButton"
-    data-tabster="{\\"focusable\\":{\\"isDefault\\":false}}"
+    data-tabster="{\\"focusable\\":{\\"isDefault\\":true}}"
     role="tab"
     type="button"
   >

--- a/packages/react-components/react-carousel-preview/library/src/components/CarouselNavImageButton/useCarouselNavImageButton.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/CarouselNavImageButton/useCarouselNavImageButton.ts
@@ -25,13 +25,13 @@ export const useCarouselNavImageButton_unstable = (
   const value = useCarouselNavContext();
 
   const { selectPageByValue } = useCarouselContext_unstable();
-  const selected = useCarouselStore_unstable(snapshot => snapshot.activeValue === value);
+  const selected = useCarouselStore_unstable(snapshot => value.includes(snapshot.activeValue ?? ''));
 
   const handleClick: ARIAButtonSlotProps['onClick'] = useEventCallback(event => {
     onClick?.(event);
 
     if (!event.defaultPrevented && isHTMLElement(event.target)) {
-      selectPageByValue(event, value);
+      selectPageByValue(event, value[0]);
     }
   });
 

--- a/packages/react-components/react-carousel-preview/library/src/components/useEmblaCarousel.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/useEmblaCarousel.ts
@@ -23,7 +23,12 @@ export function useEmblaCarousel({
   loop,
   slidesToScroll,
 }: Pick<EmblaOptionsType, 'align' | 'direction' | 'loop' | 'slidesToScroll'>) {
-  const emblaOptions = React.useRef<EmblaOptionsType>({ align, direction, loop, slidesToScroll });
+  const emblaOptions = React.useRef<EmblaOptionsType>({
+    align,
+    direction,
+    loop,
+    slidesToScroll: slidesToScroll ?? 1, // Default to 1
+  });
   const emblaApi = React.useRef<EmblaCarouselType | null>(null);
   const carouselGroupRef = React.useRef<number[][]>([[0]]);
 
@@ -45,8 +50,11 @@ export function useEmblaCarousel({
     };
 
     const handleReinit = () => {
+      if (slidesToScroll === undefined) {
+        // We only need this when grouping enabled
+        return;
+      }
       const carouselGroups = emblaApi.current?.internalEngine().slideRegistry;
-
       // TODO: Check if we have cases where the length is the same but nav points change, if so, compare array equality
       // Values array should handle id changes, we're just concerned with number of nav points.
       if (carouselGroups?.length !== carouselGroupRef.current.length) {

--- a/packages/react-components/react-carousel-preview/library/src/components/useEmblaCarousel.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/useEmblaCarousel.ts
@@ -90,7 +90,7 @@ export function useEmblaCarousel({
         }
       },
     };
-  }, []);
+  }, [slidesToScroll]);
 
   const api = React.useMemo(
     () => ({

--- a/packages/react-components/react-carousel-preview/stories/src/Carousel/CarouselDefault.stories.tsx
+++ b/packages/react-components/react-carousel-preview/stories/src/Carousel/CarouselDefault.stories.tsx
@@ -32,7 +32,7 @@ const TestComponent: React.FC<{ accentColor: string; children: string }> = props
 };
 
 export const Default = () => (
-  <Carousel defaultValue="card-1">
+  <Carousel defaultValue="card-5">
     <CarouselSlider>
       <CarouselCard value="card-1">
         <TestComponent accentColor="#B99095">Card 1</TestComponent>

--- a/packages/react-components/react-carousel-preview/stories/src/Carousel/CarouselGroups.stories.tsx
+++ b/packages/react-components/react-carousel-preview/stories/src/Carousel/CarouselGroups.stories.tsx
@@ -1,0 +1,80 @@
+import { makeStyles, tokens, typographyStyles } from '@fluentui/react-components';
+import {
+  Carousel,
+  CarouselButton,
+  CarouselCard,
+  CarouselNav,
+  CarouselNavImageButton,
+  CarouselSlider,
+} from '@fluentui/react-carousel-preview';
+import * as React from 'react';
+
+const SWAP_IMAGE = 'https://fabricweb.azureedge.net/fabric-website/assets/images/wireframe/image-square.png';
+const useClasses = makeStyles({
+  card: {
+    flex: '0 0 calc(33.33% - 20px)',
+    minWidth: '500px',
+    margin: '0px 10px',
+  },
+  test: {
+    ...typographyStyles.largeTitle,
+    alignContent: 'center',
+    borderRadius: tokens.borderRadiusLarge,
+    height: '200px',
+    textAlign: 'center',
+  },
+});
+
+const TestComponent: React.FC<{ accentColor: string; children: string }> = props => {
+  const { accentColor, children } = props;
+  const classes = useClasses();
+
+  return (
+    <div className={classes.test} style={{ backgroundColor: accentColor }}>
+      {children}
+    </div>
+  );
+};
+
+export const CarouselGroup = () => {
+  const classes = useClasses();
+
+  return (
+    <Carousel groupSize={'auto'} defaultValue="card-5">
+      <CarouselSlider>
+        <CarouselCard className={classes.card} value="card-1">
+          <TestComponent accentColor="#B99095">Card 1</TestComponent>
+        </CarouselCard>
+        <CarouselCard className={classes.card} value="card-2">
+          <TestComponent accentColor="#FCB5AC">Card 2</TestComponent>
+        </CarouselCard>
+        <CarouselCard className={classes.card} value="card-3">
+          <TestComponent accentColor="#B5E5CF">Card 3</TestComponent>
+        </CarouselCard>
+        <CarouselCard className={classes.card} value="card-4">
+          <TestComponent accentColor="#3D5B59">Card 4</TestComponent>
+        </CarouselCard>
+        <CarouselCard className={classes.card} value="card-5">
+          <TestComponent accentColor="#F9EAC2">Card 5</TestComponent>
+        </CarouselCard>
+        <CarouselCard className={classes.card} value="card-6">
+          <TestComponent accentColor="#FEE7E6">Card 6</TestComponent>
+        </CarouselCard>
+        <CarouselCard className={classes.card} value="card-7">
+          <TestComponent accentColor="#FFD898">Card 7</TestComponent>
+        </CarouselCard>
+      </CarouselSlider>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'row',
+          justifyContent: 'center',
+        }}
+      >
+        <CarouselButton navType="prev" />
+        <CarouselNav>{() => <CarouselNavImageButton image={{ src: SWAP_IMAGE }} />}</CarouselNav>
+        <CarouselButton navType="next" />
+      </div>
+    </Carousel>
+  );
+};

--- a/packages/react-components/react-carousel-preview/stories/src/Carousel/index.stories.tsx
+++ b/packages/react-components/react-carousel-preview/stories/src/Carousel/index.stories.tsx
@@ -7,6 +7,7 @@ export { Default } from './CarouselDefault.stories';
 export { Circular } from './CarouselCircular.stories';
 export { MultipleCards } from './CarouselMultipleCards.stories';
 export { FreeLayout } from './CarouselFreeLayout.stories';
+export { CarouselGroup } from './CarouselGroups.stories';
 
 export default {
   title: 'Preview Components/Carousel',


### PR DESCRIPTION
## Previous Behavior
Users could place multiple items in the carousel view, with one navigation item per item.
Users could have multiple items within a single CarouselCard, but would require custom logic that would separate the visual cards from the actual carousel slides - this will cause future issues with our focus and accessibility implementations, so we need a way to group internally via carousel hooks.

## New Behavior
GroupSize variable enables users to define groups of elements as a single navigation point, without having to build custom logic to place items in a single card **Can use 'auto' for responsive grouping**
Carousel nav buttons will now take a list of items, and will use the first index as the navigation points.
We ensure that the first item is the active value so that movement for next/previous is consistent every time - but it's not mandatory, a user can set any active value and it will select the appropriate group as well as be maintained during any resize or group changes.
