### PR TITLE
fix(positioning): improve arrow styles implementation

### DIFF
--- a/change/@fluentui-react-positioning-2c2ce771-85d7-4485-9269-448fac6cdda2.json
+++ b/change/@fluentui-react-positioning-2c2ce771-85d7-4485-9269-448fac6cdda2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: improve arrow styles implementation",
+  "packageName": "@fluentui/react-positioning",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-positioning/etc/react-positioning.api.md
+++ b/packages/react-components/react-positioning/etc/react-positioning.api.md
@@ -17,10 +17,7 @@ export type AutoSize = 'height' | 'height-always' | 'width' | 'width-always' | '
 export type Boundary = HTMLElement | Array<HTMLElement> | 'clippingParents' | 'scrollParent' | 'window';
 
 // @internal
-export function createArrowHeightStyles(arrowHeight: number): {
-    width: string;
-    height: string;
-};
+export function createArrowHeightStyles(arrowHeight: number): GriffelStyle;
 
 // @internal
 export function createArrowStyles(options: CreateArrowStylesOptions): GriffelStyle;

--- a/packages/react-components/react-positioning/src/createArrowStyles.ts
+++ b/packages/react-components/react-positioning/src/createArrowStyles.ts
@@ -80,6 +80,7 @@ export function createArrowStyles(options: CreateArrowStylesOptions): GriffelSty
     borderBottomLeftRadius: `${tokens.borderRadiusSmall} /* @noflip */`,
     transform: 'rotate(var(--fui-positioning-arrow-angle)) /* @noflip */',
 
+    padding: borderWidth,
     height: 'var(--fui-positioning-arrow-height)',
     width: 'var(--fui-positioning-arrow-height)',
 

--- a/packages/react-components/react-positioning/src/createArrowStyles.ts
+++ b/packages/react-components/react-positioning/src/createArrowStyles.ts
@@ -68,43 +68,48 @@ export function createArrowStyles(options: CreateArrowStylesOptions): GriffelSty
   } = options;
 
   return {
+    boxSizing: 'border-box',
     position: 'absolute',
-    backgroundColor: 'inherit',
-    visibility: 'hidden',
     zIndex: -1,
 
     ...(arrowHeight && createArrowHeightStyles(arrowHeight)),
 
+    backgroundColor: 'inherit',
+    backgroundClip: 'content-box',
+
+    borderBottomLeftRadius: `${tokens.borderRadiusSmall} /* @noflip */`,
+    transform: 'rotate(var(--fui-positioning-angle)) /* @noflip */',
+
     '::before': {
       content: '""',
-      visibility: 'visible',
-      position: 'absolute',
-      boxSizing: 'border-box',
-      width: 'inherit',
-      height: 'inherit',
-      backgroundColor: 'inherit',
-      borderRight: `${borderWidth} ${borderStyle} ${borderColor} /* @noflip */`,
-      borderBottom: `${borderWidth} ${borderStyle} ${borderColor}`,
-      borderBottomRightRadius: tokens.borderRadiusSmall,
-      transform: 'rotate(var(--fui-positioning-angle)) translate(0, 50%) rotate(45deg) /* @noflip */',
+
+      display: 'block',
+      margin: `-${borderWidth}`,
+      width: '100%',
+      height: '100%',
+
+      border: `${borderWidth} ${borderStyle} ${borderColor}`,
+      borderBottomLeftRadius: `${tokens.borderRadiusSmall} /* @noflip */`,
+
+      clipPath: 'polygon(0% 0%, 100% 100%, 0% 100%)',
     },
 
     // Popper sets data-popper-placement on the root element, which is used to align the arrow
     ':global([data-popper-placement^="top"])': {
-      bottom: `-${borderWidth}`,
-      '--fui-positioning-angle': '0',
+      bottom: 'var(--fui-positioning-arrow-offset)',
+      '--fui-positioning-angle': '-45deg',
     },
     ':global([data-popper-placement^="right"])': {
-      left: `-${borderWidth} /* @noflip */`,
-      '--fui-positioning-angle': '90deg',
+      left: `var(--fui-positioning-arrow-offset) /* @noflip */`,
+      '--fui-positioning-angle': '45deg',
     },
     ':global([data-popper-placement^="bottom"])': {
-      top: `-${borderWidth}`,
-      '--fui-positioning-angle': '180deg',
+      top: 'var(--fui-positioning-arrow-offset)',
+      '--fui-positioning-angle': '135deg',
     },
     ':global([data-popper-placement^="left"])': {
-      right: `-${borderWidth} /* @noflip */`,
-      '--fui-positioning-angle': '270deg',
+      right: `var(--fui-positioning-arrow-offset) /* @noflip */`,
+      '--fui-positioning-angle': '225deg',
     },
   };
 }
@@ -116,9 +121,14 @@ export function createArrowStyles(options: CreateArrowStylesOptions): GriffelSty
  * Use this when you need to create classes for several different arrow sizes. If you only need a
  * constant arrow size, you can pass the `arrowHeight` param to createArrowStyles instead.
  */
-export function createArrowHeightStyles(arrowHeight: number) {
+export function createArrowHeightStyles(arrowHeight: number): GriffelStyle {
   // The arrow is a square rotated 45 degrees to have its bottom and right edges form a right triangle.
   // Multiply the triangle's height by sqrt(2) to get length of its edges.
-  const edgeLength = `${1.414 * arrowHeight}px`;
-  return { width: edgeLength, height: edgeLength };
+  const edgeLength = 1.414 * arrowHeight;
+
+  return {
+    width: `${edgeLength}px`,
+    height: `${edgeLength}px`,
+    '--fui-positioning-arrow-offset': `${(edgeLength / 2) * -1}px`,
+  };
 }

--- a/packages/react-components/react-positioning/src/createArrowStyles.ts
+++ b/packages/react-components/react-positioning/src/createArrowStyles.ts
@@ -80,7 +80,6 @@ export function createArrowStyles(options: CreateArrowStylesOptions): GriffelSty
     borderBottomLeftRadius: `${tokens.borderRadiusSmall} /* @noflip */`,
     transform: 'rotate(var(--fui-positioning-arrow-angle)) /* @noflip */',
 
-    padding: borderWidth,
     height: 'var(--fui-positioning-arrow-height)',
     width: 'var(--fui-positioning-arrow-height)',
 
@@ -88,6 +87,7 @@ export function createArrowStyles(options: CreateArrowStylesOptions): GriffelSty
       content: '""',
 
       display: 'block',
+      backgroundColor: 'inherit',
       margin: `-${borderWidth}`,
       width: '100%',
       height: '100%',

--- a/packages/react-components/react-positioning/src/createArrowStyles.ts
+++ b/packages/react-components/react-positioning/src/createArrowStyles.ts
@@ -78,7 +78,10 @@ export function createArrowStyles(options: CreateArrowStylesOptions): GriffelSty
     backgroundClip: 'content-box',
 
     borderBottomLeftRadius: `${tokens.borderRadiusSmall} /* @noflip */`,
-    transform: 'rotate(var(--fui-positioning-angle)) /* @noflip */',
+    transform: 'rotate(var(--fui-positioning-arrow-angle)) /* @noflip */',
+
+    height: 'var(--fui-positioning-arrow-height)',
+    width: 'var(--fui-positioning-arrow-height)',
 
     '::before': {
       content: '""',
@@ -97,19 +100,19 @@ export function createArrowStyles(options: CreateArrowStylesOptions): GriffelSty
     // Popper sets data-popper-placement on the root element, which is used to align the arrow
     ':global([data-popper-placement^="top"])': {
       bottom: 'var(--fui-positioning-arrow-offset)',
-      '--fui-positioning-angle': '-45deg',
+      '--fui-positioning-arrow-angle': '-45deg',
     },
     ':global([data-popper-placement^="right"])': {
       left: `var(--fui-positioning-arrow-offset) /* @noflip */`,
-      '--fui-positioning-angle': '45deg',
+      '--fui-positioning-arrow-angle': '45deg',
     },
     ':global([data-popper-placement^="bottom"])': {
       top: 'var(--fui-positioning-arrow-offset)',
-      '--fui-positioning-angle': '135deg',
+      '--fui-positioning-arrow-angle': '135deg',
     },
     ':global([data-popper-placement^="left"])': {
       right: `var(--fui-positioning-arrow-offset) /* @noflip */`,
-      '--fui-positioning-angle': '225deg',
+      '--fui-positioning-arrow-angle': '225deg',
     },
   };
 }
@@ -127,8 +130,7 @@ export function createArrowHeightStyles(arrowHeight: number): GriffelStyle {
   const edgeLength = 1.414 * arrowHeight;
 
   return {
-    width: `${edgeLength}px`,
-    height: `${edgeLength}px`,
+    '--fui-positioning-arrow-height': `${edgeLength}px`,
     '--fui-positioning-arrow-offset': `${(edgeLength / 2) * -1}px`,
   };
 }


### PR DESCRIPTION
## New Behavior

An arrow `div` itself renders a box with `border-radius` on one of edges.

<img width="463" alt="image" src="https://github.com/user-attachments/assets/0bdbb6c7-d451-47ed-b70b-c135a05751ef">

This box is positioned in a way that it overlap with a border and will prevent appearing any "crashed angles".

---

On before `clip-path` is used to produce a proper triangle:

<img width="232" alt="image" src="https://github.com/user-attachments/assets/86d4d89c-6234-402c-acba-49495acbd829">

An `div` also uses [`background-clip`](https://developer.mozilla.org/en-US/docs/Web/CSS/background-clip) that ensures that `background` from it won't be under a border on `::before` (to ensure that background will not appear on edges):

<img width="222" alt="image" src="https://github.com/user-attachments/assets/aef244af-9c1f-4580-9c55-cd9b7de7abab">


## Related Issue(s)

Fixes #32093.
