### PR TITLE
feat(web-components): add tablist

### DIFF
--- a/change/@fluentui-web-components-1b78a1eb-0122-4dd8-b56f-fd3aac7b3ef6.json
+++ b/change/@fluentui-web-components-1b78a1eb-0122-4dd8-b56f-fd3aac7b3ef6.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add Tablist component",
+  "packageName": "@fluentui/web-components",
+  "email": "rupertdavid@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/docs/api-report.md
+++ b/packages/web-components/docs/api-report.md
@@ -576,6 +576,30 @@ export class BaseSpinner extends FASTElement {
 }
 
 // @public
+export class BaseTablist extends FASTElement {
+    activeid: string;
+    // @internal (undocumented)
+    protected activeidChanged(oldValue: string, newValue: string): void;
+    activetab: HTMLElement;
+    adjust(adjustment: number): void;
+    // @internal (undocumented)
+    connectedCallback(): void;
+    disabled: boolean;
+    // @internal
+    protected disabledChanged(prev: boolean, next: boolean): void;
+    // @internal
+    elementInternals: ElementInternals;
+    orientation: TablistOrientation;
+    // @internal (undocumented)
+    protected orientationChanged(prev: TablistOrientation, next: TablistOrientation): void;
+    protected setTabs(): void;
+    // @internal (undocumented)
+    tabs: HTMLElement[];
+    // @internal (undocumented)
+    protected tabsChanged(): void;
+}
+
+// @public
 export class BaseTextInput extends FASTElement {
     autocomplete?: string;
     autofocus: boolean;
@@ -640,29 +664,6 @@ export class BaseTextInput extends FASTElement {
     get value(): string;
     set value(value: string);
     get willValidate(): boolean;
-}
-
-export class BaseTablist extends FASTElement {
-    activeid: string;
-    // @internal (undocumented)
-    protected activeidChanged(oldValue: string, newValue: string): void;
-    activetab: HTMLElement;
-    adjust(adjustment: number): void;
-    // @internal (undocumented)
-    connectedCallback(): void;
-    disabled: boolean;
-    // @internal
-    protected disabledChanged(prev: boolean, next: boolean): void;
-    // @internal
-    elementInternals: ElementInternals;
-    orientation: TablistOrientation;
-    // @internal (undocumented)
-    protected orientationChanged(prev: TablistOrientation, next: TablistOrientation): void;
-    protected setTabs(): void;
-    // @internal (undocumented)
-    tabs: HTMLElement[];
-    // @internal (undocumented)
-    protected tabsChanged(): void;
 }
 
 // @public

--- a/packages/web-components/docs/api-report.md
+++ b/packages/web-components/docs/api-report.md
@@ -650,6 +650,7 @@ export class BaseTablist extends FASTElement {
     adjust(adjustment: number): void;
     // @internal (undocumented)
     connectedCallback(): void;
+    disabled?: boolean;
     orientation: TablistOrientation;
     // @internal (undocumented)
     orientationChanged(): void;
@@ -3343,7 +3344,6 @@ export class Tablist extends BaseTablist {
     // (undocumented)
     activeidChanged(oldValue: string, newValue: string): void;
     appearance?: TablistAppearance;
-    disabled?: boolean;
     size?: TablistSize;
     // (undocumented)
     tabsChanged(): void;

--- a/packages/web-components/docs/api-report.md
+++ b/packages/web-components/docs/api-report.md
@@ -642,6 +642,24 @@ export class BaseTextInput extends FASTElement {
     get willValidate(): boolean;
 }
 
+export class BaseTablist extends FASTElement {
+    activeid: string;
+    // @internal (undocumented)
+    activeidChanged(oldValue: string, newValue: string): void;
+    activetab: HTMLElement;
+    adjust(adjustment: number): void;
+    // @internal (undocumented)
+    connectedCallback(): void;
+    orientation: TablistOrientation;
+    // @internal (undocumented)
+    orientationChanged(): void;
+    protected setTabs(): void;
+    // @internal (undocumented)
+    tabs: HTMLElement[];
+    // @internal (undocumented)
+    tabsChanged(): void;
+}
+
 // @public
 export const borderRadiusCircular = "var(--borderRadiusCircular)";
 
@@ -3319,6 +3337,57 @@ export interface Tab extends StartEnd {
 //
 // @public (undocumented)
 export const TabDefinition: FASTElementDefinition<typeof Tab>;
+
+// @public
+export class Tablist extends BaseTablist {
+    // (undocumented)
+    activeidChanged(oldValue: string, newValue: string): void;
+    appearance?: TablistAppearance;
+    disabled?: boolean;
+    size?: TablistSize;
+    // (undocumented)
+    tabsChanged(): void;
+}
+
+// @public
+export const TablistAppearance: {
+    readonly subtle: "subtle";
+    readonly transparent: "transparent";
+};
+
+// @public
+export type TablistAppearance = ValuesOf<typeof TablistAppearance>;
+
+// @public (undocumented)
+export const TablistDefinition: FASTElementDefinition<typeof Tablist>;
+
+// @public
+export const TablistOrientation: {
+    readonly horizontal: "horizontal"; /**
+    * The appearance of the component
+    * @public
+    */
+    readonly vertical: "vertical";
+};
+
+// @public
+export type TablistOrientation = ValuesOf<typeof TablistOrientation>;
+
+// @public
+export const TablistSize: {
+    readonly small: "small";
+    readonly medium: "medium";
+    readonly large: "large";
+};
+
+// @public
+export type TablistSize = ValuesOf<typeof TablistSize>;
+
+// @public (undocumented)
+export const TablistStyles: ElementStyles;
+
+// @public (undocumented)
+export const TablistTemplate: ViewTemplate<Tablist, any>;
 
 // @public
 export type TabOptions = StartEndOptions<Tab>;

--- a/packages/web-components/docs/api-report.md
+++ b/packages/web-components/docs/api-report.md
@@ -645,20 +645,24 @@ export class BaseTextInput extends FASTElement {
 export class BaseTablist extends FASTElement {
     activeid: string;
     // @internal (undocumented)
-    activeidChanged(oldValue: string, newValue: string): void;
+    protected activeidChanged(oldValue: string, newValue: string): void;
     activetab: HTMLElement;
     adjust(adjustment: number): void;
     // @internal (undocumented)
     connectedCallback(): void;
-    disabled?: boolean;
+    disabled: boolean;
+    // @internal
+    protected disabledChanged(prev: boolean, next: boolean): void;
+    // @internal
+    elementInternals: ElementInternals;
     orientation: TablistOrientation;
     // @internal (undocumented)
-    orientationChanged(): void;
+    protected orientationChanged(prev: TablistOrientation, next: TablistOrientation): void;
     protected setTabs(): void;
     // @internal (undocumented)
     tabs: HTMLElement[];
     // @internal (undocumented)
-    tabsChanged(): void;
+    protected tabsChanged(): void;
 }
 
 // @public
@@ -3341,11 +3345,13 @@ export const TabDefinition: FASTElementDefinition<typeof Tab>;
 
 // @public
 export class Tablist extends BaseTablist {
-    // (undocumented)
     activeidChanged(oldValue: string, newValue: string): void;
     appearance?: TablistAppearance;
+    // @internal (undocumented)
+    protected appearanceChanged(prev: TablistAppearance, next: TablistAppearance): void;
     size?: TablistSize;
-    // (undocumented)
+    // @internal (undocumented)
+    protected sizeChanged(prev: TablistSize, next: TablistSize): void;
     tabsChanged(): void;
 }
 

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -215,6 +215,7 @@
     "./dist/esm/spinner/define.js",
     "./dist/esm/switch/define.js",
     "./dist/esm/tab/define.js",
+    "./dist/esm/tabs/define.js",
     "./dist/esm/tablist/define.js",
     "./dist/esm/tab-panel/define.js",
     "./dist/esm/text/define.js",

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -215,7 +215,7 @@
     "./dist/esm/spinner/define.js",
     "./dist/esm/switch/define.js",
     "./dist/esm/tab/define.js",
-    "./dist/esm/tabs/define.js",
+    "./dist/esm/tablist/define.js",
     "./dist/esm/tab-panel/define.js",
     "./dist/esm/text/define.js",
     "./dist/esm/text-input/define.js",

--- a/packages/web-components/src/index-rollup.ts
+++ b/packages/web-components/src/index-rollup.ts
@@ -31,6 +31,7 @@ import './switch/define.js';
 import './tab-panel/define.js';
 import './tab/define.js';
 import './tabs/define.js';
+import './tablist/define.js';
 import './text-input/define.js';
 import './text/define.js';
 import './toggle-button/define.js';

--- a/packages/web-components/src/index.ts
+++ b/packages/web-components/src/index.ts
@@ -227,6 +227,15 @@ export {
   TabsStyles,
   TabsTemplate,
 } from './tabs/index.js';
+export {
+  Tablist,
+  TablistAppearance,
+  TablistDefinition,
+  TablistOrientation,
+  TablistSize,
+  TablistStyles,
+  TablistTemplate,
+} from './tablist/index.js';
 export type { TabsOptions } from './tabs/index.js';
 export {
   BaseTextInput,

--- a/packages/web-components/src/index.ts
+++ b/packages/web-components/src/index.ts
@@ -228,6 +228,7 @@ export {
   TabsTemplate,
 } from './tabs/index.js';
 export {
+  BaseTablist,
   Tablist,
   TablistAppearance,
   TablistDefinition,

--- a/packages/web-components/src/tablist/define.ts
+++ b/packages/web-components/src/tablist/define.ts
@@ -1,0 +1,4 @@
+import { FluentDesignSystem } from '../fluent-design-system.js';
+import { definition } from './tablist.definition.js';
+
+definition.define(FluentDesignSystem.registry);

--- a/packages/web-components/src/tablist/index.ts
+++ b/packages/web-components/src/tablist/index.ts
@@ -1,0 +1,5 @@
+export { definition as TablistDefinition } from './tablist.definition.js';
+export { Tablist } from './tablist.js';
+export { TablistAppearance, TablistOrientation, TablistSize } from './tablist.options.js';
+export { styles as TablistStyles } from './tablist.styles.js';
+export { template as TablistTemplate } from './tablist.template.js';

--- a/packages/web-components/src/tablist/index.ts
+++ b/packages/web-components/src/tablist/index.ts
@@ -1,5 +1,5 @@
 export { definition as TablistDefinition } from './tablist.definition.js';
-export { Tablist } from './tablist.js';
+export { BaseTablist, Tablist } from './tablist.js';
 export { TablistAppearance, TablistOrientation, TablistSize } from './tablist.options.js';
 export { styles as TablistStyles } from './tablist.styles.js';
 export { template as TablistTemplate } from './tablist.template.js';

--- a/packages/web-components/src/tablist/readme.md
+++ b/packages/web-components/src/tablist/readme.md
@@ -1,4 +1,4 @@
-# Tabs
+# Tablist
 
 Tablists allow for navigation between two or more content views and relies on text headers to articulate the different sections of content. Tablist wraps a set of Tab components and manages the roving tabindex (aka "focusgroup") around the elements.
 

--- a/packages/web-components/src/tablist/readme.md
+++ b/packages/web-components/src/tablist/readme.md
@@ -20,7 +20,7 @@ Tablists allow for navigation between two or more content views and relies on te
 
 ### Outputs
 
-- [activeid: unkown] - the selected value of the currently selected tab
+- [activeid: unknown] - the selected value of the currently selected tab
 
 ### Events
 
@@ -67,7 +67,7 @@ The Fluent/FAST web component differs from the Fluent React Control as follows:
 
 ### Default
 
-By default Tablists are arranged horizontally. The developer sets `activeid` Tablist attribute. The Component handles the logic of what is shown and hidden when user clicks on the tabs. For switcing to work correctly the tab list requires that the indexing of the tabs and tab-panels be organized to correspond to their matching items - the order of the tabs must match the order of the tab panels:
+By default Tablists are arranged horizontally. The developer sets `activeid` Tablist attribute. The Component handles the logic of what is shown and hidden when user clicks on the tabs. For switching to work correctly the tab list requires that the indexing of the tabs and tab-panels be organized to correspond to their matching items - the order of the tabs must match the order of the tab panels:
 
 ```html
 <fluent-tablist>

--- a/packages/web-components/src/tablist/readme.md
+++ b/packages/web-components/src/tablist/readme.md
@@ -1,0 +1,100 @@
+# Tabs
+
+Tablists allow for navigation between two or more content views and relies on text headers to articulate the different sections of content. Tablist wraps a set of Tab components and manages the roving tabindex (aka "focusgroup") around the elements.
+
+## Design Spec
+
+[Link to Design Spec in Figma](https://www.figma.com/file/dK5AnDvvnSTWV9lduQWeDk/TabList?node-id=3942%3A9316&t=we0hQaRaKSJc6IeM-0)
+
+## Engineering Spec
+
+### Inputs
+
+| attribute   | type                           | default       | description                                                             |
+| ----------- | ------------------------------ | ------------- | ----------------------------------------------------------------------- |
+| activeid    | string                         | -             | sets the selected tab                                                   |
+| appearance  | "subtle" \| "transparent       | "transparent" | -                                                                       |
+| disabled    | boolean                        | -             | blocks control and all tab children from all keyboard and mouse events. |
+| size        | "small" \| "medium" \| "large" | "medium"      |                                                                         |
+| orientation | "vertical" \| "horizontal"     | "horizontal"  | sets the orientation of the tab list to vertical display                |
+
+### Outputs
+
+- [activeid: unkown] - the selected value of the currently selected tab
+
+### Events
+
+- change: html event handler - event fires on keyboard or mouse click
+
+### Slots
+
+- default - slot for the tab controls
+
+## Accessibility
+
+- [x] Tabs WCAG's patterns: https://www.w3.org/WAI/ARIA/apg/patterns/tabs/
+  - recommended that tabs activate on focus
+  - content of table is preloaded
+  - when tab list is aria-orientation vertical: `down arrow` performs as right arrow and `up arrow` performs as left arrow
+  - Horizontal tab list does not listen for `down arrow` or `up arrow`
+  - when tabpanel does not contain any focusable elements or the first element is not focusable the tab panel should set `tabindex="0"`
+- [x] Are there any accessibility elements unique to this component? yes, many see link above.
+- [x] List ARIA attributes: `role, aria-labelledby, aria-label, aria-controls, aria-selected, aria-haspopup, aria-orientation`
+- [x] Does the component support 400% zoom?
+
+## Differences from Fluent UI to FAST
+
+The Fluent/FAST web component differs from the Fluent React Control as follows:
+
+| difference                                      | Tabs - Fluent Web Component                                                                                     | TabList - Fluent React Component                                                             |
+| ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| active indicator control / id control selection | managed by control                                                                                              | managed by user with application state                                                       |
+| keyboard and focus selection                    | selects active tab on arrow key focus change                                                                    | reselects tab on space bar or enter after arrow refocus                                      |
+| icon slotting                                   | favors composition (dev chooses how to slot which icon)                                                         | favors automation (dev supplies icon name and control handles the rendering of icon)         |
+| icon slotting filled / unfilled icons           | favors composition over automated handling. requires dev to add interactivity to render filled or unfilled icon | favors automated handling of icons and provides filled and unfilled iconography on selection |
+| tab-panels                                      | requires tab panel control to set content on tab selection                                                      | does not require or include a tab panel control / template                                   |
+| reserve-selected-tab-space                      | has reserve selected tab space defaulting to true and gives user the option to set to false                     | removes attribute                                                                            |
+
+[Link to FAST Web Component API](https://www.fast.design/docs/components/tabs/#class-tab)
+
+| fluent api name | fast api Equivalent |
+| --------------- | ------------------- |
+| vertical        | orientation         |
+| selected-value  | activeid            |
+| value           | id                  |
+
+## Implementation - Sample Code
+
+### Default
+
+By default Tablists are arranged horizontally. The developer sets `activeid` Tablist attribute. The Component handles the logic of what is shown and hidden when user clicks on the tabs. For switcing to work correctly the tab list requires that the indexing of the tabs and tab-panels be organized to correspond to their matching items - the order of the tabs must match the order of the tab panels:
+
+```html
+<fluent-tablist>
+  <fluent-tab>One / Left</fluent-tab>
+  <fluent-tab>Two / Middle</fluent-tab>
+  <fluent-tab>Three / Right</fluent-tab>
+</fluent-tablist>
+```
+
+### Controlled
+
+If the developer wants to control the selected tab, tab values can be provided.
+
+```html
+<fluent-tablist activeid="tab-one">
+  <fluent-tab id="tab-one">One / Left</fluent-tab>
+  <fluent-tab id="tab-two">Two / Middle</fluent-tab>
+  <fluent-tab id="tab-three">Three / Right</fluent-tab>
+</fluent-tablist>
+```
+
+### Vertical
+
+```html
+<fluent-tablist orientation="vertical">
+  <fluent-tab>One / Left</fluent-tab>
+  <fluent-tab>Two / Middle</fluent-tab>
+  <fluent-tab>Three / Right</fluent-tab>
+</fluent-tablist>
+```

--- a/packages/web-components/src/tablist/tablist.bench.ts
+++ b/packages/web-components/src/tablist/tablist.bench.ts
@@ -1,0 +1,26 @@
+import { FluentDesignSystem } from '../fluent-design-system.js';
+import { definition as tabDefinition } from '../tab/tab.definition.js';
+import { definition as tablistDefinition } from './tablist.definition.js';
+
+tabDefinition.define(FluentDesignSystem.registry);
+tablistDefinition.define(FluentDesignSystem.registry);
+
+const itemRenderer = () => {
+  const tablist = document.createElement('fluent-tablist');
+  const tab = document.createElement('fluent-tab');
+  const tab2 = document.createElement('fluent-tab');
+  const tab3 = document.createElement('fluent-tab');
+
+  tab.appendChild(document.createTextNode('Tab 1'));
+  tab2.appendChild(document.createTextNode('Tab 2'));
+  tab3.appendChild(document.createTextNode('Tab 3'));
+
+  tablist.appendChild(tab);
+  tablist.appendChild(tab2);
+  tablist.appendChild(tab3);
+
+  return tablist;
+};
+
+export default itemRenderer;
+export { tests } from '../utils/benchmark-wrapper.js';

--- a/packages/web-components/src/tablist/tablist.definition.ts
+++ b/packages/web-components/src/tablist/tablist.definition.ts
@@ -1,0 +1,10 @@
+import { FluentDesignSystem } from '../fluent-design-system.js';
+import { Tablist } from './tablist.js';
+import { template } from './tablist.template.js';
+import { styles } from './tablist.styles.js';
+
+export const definition = Tablist.compose({
+  name: `${FluentDesignSystem.prefix}-tablist`,
+  template,
+  styles,
+});

--- a/packages/web-components/src/tablist/tablist.definition.ts
+++ b/packages/web-components/src/tablist/tablist.definition.ts
@@ -3,6 +3,11 @@ import { Tablist } from './tablist.js';
 import { template } from './tablist.template.js';
 import { styles } from './tablist.styles.js';
 
+/**
+ * @public
+ * @remarks
+ * HTML Element: \<fluent-tablist\>
+ */
 export const definition = Tablist.compose({
   name: `${FluentDesignSystem.prefix}-tablist`,
   template,

--- a/packages/web-components/src/tablist/tablist.options.ts
+++ b/packages/web-components/src/tablist/tablist.options.ts
@@ -1,0 +1,29 @@
+import { Orientation } from '@microsoft/fast-web-utilities';
+import type { ValuesOf } from '../utils/index.js';
+
+export const TablistAppearance = {
+  subtle: 'subtle',
+  transparent: 'transparent',
+} as const;
+
+export type TablistAppearance = ValuesOf<typeof TablistAppearance>;
+
+export const TablistSize = {
+  small: 'small',
+  medium: 'medium',
+  large: 'large',
+} as const;
+
+export type TablistSize = ValuesOf<typeof TablistSize>;
+
+/**
+ * The orientation of the component
+ * @public
+ */
+export const TablistOrientation = Orientation;
+
+/**
+ * The types for the Tablist component
+ * @public
+ */
+export type TablistOrientation = ValuesOf<typeof TablistOrientation>;

--- a/packages/web-components/src/tablist/tablist.options.ts
+++ b/packages/web-components/src/tablist/tablist.options.ts
@@ -1,19 +1,35 @@
 import { Orientation } from '@microsoft/fast-web-utilities';
 import type { ValuesOf } from '../utils/index.js';
 
+/**
+ * The appearance of the component
+ * @public
+ */
 export const TablistAppearance = {
   subtle: 'subtle',
   transparent: 'transparent',
 } as const;
 
+/**
+ * The types for the Tablist appearance
+ * @public
+ */
 export type TablistAppearance = ValuesOf<typeof TablistAppearance>;
 
+/**
+ * The size of the component
+ * @public
+ */
 export const TablistSize = {
   small: 'small',
   medium: 'medium',
   large: 'large',
 } as const;
 
+/**
+ * The types for the Tablist size
+ * @public
+ */
 export type TablistSize = ValuesOf<typeof TablistSize>;
 
 /**
@@ -23,7 +39,7 @@ export type TablistSize = ValuesOf<typeof TablistSize>;
 export const TablistOrientation = Orientation;
 
 /**
- * The types for the Tablist component
+ * The types for the Tablist orientation
  * @public
  */
 export type TablistOrientation = ValuesOf<typeof TablistOrientation>;

--- a/packages/web-components/src/tablist/tablist.spec.ts
+++ b/packages/web-components/src/tablist/tablist.spec.ts
@@ -10,12 +10,12 @@ test.describe('Tablist', () => {
   let tabs: Locator;
 
   const template = /* html */ `
-        <fluent-tablist>
-            <fluent-tab>Tab one</fluent-tab>
-            <fluent-tab>Tab two</fluent-tab>
-            <fluent-tab>Tab three</fluent-tab>
-        </fluent-tablist>
-    `;
+    <fluent-tablist>
+        <fluent-tab>Tab one</fluent-tab>
+        <fluent-tab>Tab two</fluent-tab>
+        <fluent-tab>Tab three</fluent-tab>
+    </fluent-tablist>
+  `;
 
   test.beforeAll(async ({ browser }) => {
     page = await browser.newPage();
@@ -192,11 +192,11 @@ test.describe('Tablist', () => {
 
   test('should not allow selecting a tab that has been disabled after it has been connected', async () => {
     await page.setContent(/* html */ `
-          <fluent-tablist>
-              <fluent-tab id="tab-1">Tab one</fluent-tab>
-              <fluent-tab id="tab-2">Tab two</fluent-tab>
-              <fluent-tab id="tab-3">Tab three</fluent-tab>
-          </fluent-tablist>
+        <fluent-tablist>
+            <fluent-tab id="tab-1">Tab one</fluent-tab>
+            <fluent-tab id="tab-2">Tab two</fluent-tab>
+            <fluent-tab id="tab-3">Tab three</fluent-tab>
+        </fluent-tablist>
       `);
 
     await (await element.elementHandle())?.waitForElementState('stable');
@@ -240,12 +240,12 @@ test.describe('Tablist', () => {
     test.slow();
 
     await page.setContent(/* html */ `
-          <fluent-tablist>
-                      <fluent-tab>Tab one</fluent-tab>
-                      <fluent-tab disabled>Tab two</fluent-tab>
-                      <fluent-tab>Tab three</fluent-tab>
-                  </fluent-tablist>
-      `);
+      <fluent-tablist>
+          <fluent-tab>Tab one</fluent-tab>
+          <fluent-tab disabled>Tab two</fluent-tab>
+          <fluent-tab>Tab three</fluent-tab>
+      </fluent-tablist>
+    `);
 
     const firstTab = tabs.nth(0);
 
@@ -325,7 +325,7 @@ test.describe('Tablist', () => {
           <fluent-tab>Tab two</fluent-tab>
           <fluent-tab hidden>Tab three</fluent-tab>
       </fluent-tablist>
-  `);
+    `);
 
     const firstTab = tabs.nth(0);
 

--- a/packages/web-components/src/tablist/tablist.spec.ts
+++ b/packages/web-components/src/tablist/tablist.spec.ts
@@ -1,0 +1,345 @@
+import type { Locator, Page } from '@playwright/test';
+import { expect, test } from '@playwright/test';
+import { fixtureURL } from '../helpers.tests.js';
+import type { Tab } from '../tab/tab.js';
+import type { Tablist } from './tablist.js';
+
+test.describe('Tablist', () => {
+  let page: Page;
+  let element: Locator;
+  let tabs: Locator;
+
+  const template = /* html */ `
+        <fluent-tablist>
+            <fluent-tab>Tab one</fluent-tab>
+            <fluent-tab>Tab two</fluent-tab>
+            <fluent-tab>Tab three</fluent-tab>
+        </fluent-tablist>
+    `;
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage();
+
+    element = page.locator('fluent-tablist');
+
+    tabs = element.locator('fluent-tab');
+
+    await page.goto(fixtureURL('components-tabs--tabs-default'));
+    await page.setContent(template);
+  });
+
+  test.afterAll(async () => {
+    await page.close();
+  });
+
+  test('should reset tab indicator offset and scale for horizontal orientation after animation', async () => {
+    const tab = tabs.nth(2);
+    await tab.click();
+
+    const tabIndicatorValues = await page.evaluate(() => {
+      const tabsElement = document.querySelector('fluent-tablist') as Element;
+      return {
+        offset: getComputedStyle(tabsElement).getPropertyValue('--tabIndicatorOffset').trim(),
+        scale: getComputedStyle(tabsElement).getPropertyValue('--tabIndicatorScale').trim(),
+      };
+    });
+
+    expect(tabIndicatorValues.offset).toBe('0px');
+    expect(tabIndicatorValues.scale).toBe('1');
+  });
+
+  test('should animate the active tab indicator', async () => {
+    // Reset the page content to ensure the tab indicator is reset
+    page.setContent(template);
+
+    const tab = tabs.nth(2);
+
+    const valueBeforeClick = await page.evaluate(() => {
+      const tabElement = document.querySelector('fluent-tab:nth-child(3)') as Element;
+      return tabElement.getAttribute('data-animate');
+    });
+
+    expect(valueBeforeClick).toBe(null);
+
+    await tab.click();
+
+    const valueAfterClick = await page.evaluate(() => {
+      const tabElement = document.querySelector('fluent-tab:nth-child(3)') as Element;
+      return tabElement.getAttribute('data-animate');
+    });
+
+    expect(valueAfterClick).toBe('true');
+  });
+
+  test('should have reflect disabled attribute on control', async () => {
+    await expect(element).not.toHaveAttribute('disabled', '');
+
+    await element.evaluate((node: Tablist) => {
+      node.disabled = true;
+    });
+
+    await expect(element).toHaveAttribute('disabled', '');
+  });
+
+  test('should have role of `tablist`', async () => {
+    await expect(element).toHaveAttribute('role', 'tablist');
+  });
+
+  test('should set a default orientation value of `horizontal` when `orientation` is not provided', async () => {
+    await expect(element).toHaveJSProperty('orientation', 'horizontal');
+  });
+
+  test('should set an `id` attribute on the active tab when an `id` is provided', async () => {
+    const tabCount = await tabs.count();
+
+    for (let i = 0; i < tabCount; i++) {
+      const tab = tabs.nth(i);
+
+      await tab.evaluate((node, i) => {
+        node.id = `custom-id-${i}`;
+      }, i);
+
+      await expect(tab).toHaveAttribute('id', `custom-id-${i}`);
+    }
+  });
+
+  test.describe('`id` NOT provided', () => {
+    test('should set an `id` attribute on tab items with a unique ID when an `id` is NOT provided', async () => {
+      const tabCount = await tabs.count();
+
+      for (let i = 0; i < tabCount; i++) {
+        const tab = tabs.nth(i);
+
+        const id = await tab.getAttribute('id');
+
+        // The ID function may not start at 0 so we need to check that the ID is unique
+        expect(id).toMatch(/tab-\d+/);
+
+        const tabPanel = element.locator(`#${id}`);
+
+        await expect(tabPanel).toHaveCount(1);
+      }
+    });
+
+    test('should default the first tab as the active index if `activeid` is NOT provided', async () => {
+      await expect(tabs.nth(0)).toHaveAttribute('aria-selected', 'true');
+
+      await expect(element).toHaveJSProperty('activeTabIndex', 0);
+    });
+  });
+
+  test.describe('active tab', () => {
+    test('should set an `aria-selected` attribute on the active tab when `activeid` is provided', async () => {
+      const secondTab = tabs.nth(1);
+
+      const secondTabId = `${await secondTab.getAttribute('id')}`;
+
+      await element.evaluate((node: Tablist, secondTabId) => {
+        node.activeid = secondTabId;
+      }, secondTabId);
+
+      await expect(secondTab).toHaveAttribute('aria-selected', 'true');
+    });
+
+    test('should update `aria-selected` attribute on the active tab when `activeId` is updated', async () => {
+      await expect(tabs.nth(0)).toHaveAttribute('aria-selected', 'true');
+
+      const secondTab = tabs.nth(1);
+
+      const secondTabId = `${await secondTab.getAttribute('id')}`;
+
+      await element.evaluate((node: Tablist, secondTabId) => {
+        node.setAttribute('activeId', secondTabId);
+      }, secondTabId);
+
+      await expect(secondTab).toHaveAttribute('aria-selected', 'true');
+    });
+  });
+
+  test('should reflect appearance attribute values', async () => {
+    await element.evaluate((node: Tablist) => {
+      node.appearance = 'subtle';
+    });
+    await expect(element).toHaveAttribute('appearance', 'subtle');
+    await expect(element).toHaveJSProperty('appearance', 'subtle');
+
+    await element.evaluate((node: Tablist) => {
+      node.appearance = 'transparent';
+    });
+    await expect(element).toHaveAttribute('appearance', 'transparent');
+    await expect(element).toHaveJSProperty('appearance', 'transparent');
+  });
+
+  test('should reflect size attribute values', async () => {
+    await element.evaluate((node: Tablist) => {
+      node.size = 'small';
+    });
+    await expect(element).toHaveAttribute('size', 'small');
+    await expect(element).toHaveJSProperty('size', 'small');
+
+    await element.evaluate((node: Tablist) => {
+      node.size = 'medium';
+    });
+    await expect(element).toHaveAttribute('size', 'medium');
+    await expect(element).toHaveJSProperty('size', 'medium');
+
+    await element.evaluate((node: Tablist) => {
+      node.size = 'large';
+    });
+    await expect(element).toHaveAttribute('size', 'large');
+    await expect(element).toHaveJSProperty('size', 'large');
+  });
+
+  test('should not allow selecting a tab that has been disabled after it has been connected', async () => {
+    await page.setContent(/* html */ `
+          <fluent-tablist>
+              <fluent-tab id="tab-1">Tab one</fluent-tab>
+              <fluent-tab id="tab-2">Tab two</fluent-tab>
+              <fluent-tab id="tab-3">Tab three</fluent-tab>
+          </fluent-tablist>
+      `);
+
+    await (await element.elementHandle())?.waitForElementState('stable');
+
+    const firstTab = tabs.nth(0);
+
+    const firstTabId = await firstTab.getAttribute('id');
+
+    expect(firstTabId).toBe('tab-1');
+
+    await element.evaluate((node: Tablist, firstTabId) => {
+      node.activeid = `${firstTabId}`;
+    }, firstTabId);
+
+    await (await element.elementHandle())?.waitForElementState('stable');
+
+    await expect(element).toHaveJSProperty('activeid', firstTabId);
+
+    const secondTab = tabs.nth(1);
+
+    await secondTab.evaluate((node: Tab) => {
+      node.disabled = true;
+    });
+
+    await (await element.elementHandle())?.waitForElementState('stable');
+
+    await secondTab.evaluate(node => {
+      node.dispatchEvent(
+        new MouseEvent('click', {
+          bubbles: true,
+          cancelable: true,
+          view: window,
+        }),
+      );
+    });
+
+    await expect(element).toHaveJSProperty('activeid', firstTabId);
+  });
+
+  test('should allow selecting tab that has been enabled after it has been connected', async () => {
+    test.slow();
+
+    await page.setContent(/* html */ `
+          <fluent-tablist>
+                      <fluent-tab>Tab one</fluent-tab>
+                      <fluent-tab disabled>Tab two</fluent-tab>
+                      <fluent-tab>Tab three</fluent-tab>
+                  </fluent-tablist>
+      `);
+
+    const firstTab = tabs.nth(0);
+
+    const secondTab = tabs.nth(1);
+
+    const firstTabId = `${await firstTab.getAttribute('id')}`;
+    const secondTabId = `${await secondTab.getAttribute('id')}`;
+
+    await element.evaluate((node: Tablist, firstTabId) => {
+      node.activeid = firstTabId;
+    }, firstTabId);
+
+    await expect(element).toHaveJSProperty('activeid', firstTabId);
+
+    await secondTab.evaluate(node => {
+      node.dispatchEvent(
+        new MouseEvent('click', {
+          bubbles: true,
+          cancelable: true,
+          view: window,
+        }),
+      );
+    });
+
+    await expect(element).toHaveJSProperty('activeid', firstTabId);
+
+    await secondTab.evaluate((node: Tab) => {
+      node.disabled = false;
+    });
+
+    await (await element.elementHandle())?.waitForElementState('stable');
+
+    await secondTab.evaluate(node => {
+      node.dispatchEvent(
+        new MouseEvent('click', {
+          bubbles: true,
+          cancelable: true,
+          view: window,
+        }),
+      );
+    });
+    await expect(element).toHaveJSProperty('activeid', secondTabId);
+  });
+
+  test('should not allow selecting hidden tab using arrow keys', async () => {
+    test.slow();
+
+    page.setContent(/* html */ `
+      <fluent-tablist>
+          <fluent-tab>Tab one</fluent-tab>
+          <fluent-tab hidden>Tab two</fluent-tab>
+          <fluent-tab>Tab three</fluent-tab>
+      </fluent-tablist>
+    `);
+
+    const firstTab = tabs.nth(0);
+
+    const thirdTab = tabs.nth(2);
+
+    const firstTabId = `${await firstTab.getAttribute('id')}`;
+    const thirdTabId = `${await thirdTab.getAttribute('id')}`;
+
+    await element.evaluate((node: Tablist, firstTabId) => {
+      node.activeid = firstTabId;
+    }, firstTabId);
+
+    await firstTab.press('ArrowRight');
+
+    await expect(element).toHaveJSProperty('activeid', thirdTabId);
+  });
+
+  test('should not allow selecting hidden tab by pressing End', async () => {
+    test.slow();
+    page.setContent(/* html */ `
+      <fluent-tablist>
+          <fluent-tab>Tab one</fluent-tab>
+          <fluent-tab>Tab two</fluent-tab>
+          <fluent-tab hidden>Tab three</fluent-tab>
+      </fluent-tablist>
+  `);
+
+    const firstTab = tabs.nth(0);
+
+    const secondTab = tabs.nth(1);
+
+    const firstTabId = `${await firstTab.getAttribute('id')}`;
+    const secondTabId = `${await secondTab.getAttribute('id')}`;
+
+    await element.evaluate((node: Tablist, firstTabId) => {
+      node.activeid = firstTabId;
+    }, firstTabId);
+
+    await firstTab.press('End');
+
+    await expect(element).toHaveJSProperty('activeid', secondTabId);
+  });
+});

--- a/packages/web-components/src/tablist/tablist.stories.ts
+++ b/packages/web-components/src/tablist/tablist.stories.ts
@@ -1,0 +1,166 @@
+import { html } from '@microsoft/fast-element';
+import type { Args, Meta } from '@storybook/html';
+import { renderComponent } from '../helpers.stories.js';
+import type { Tablist as FluentTablist } from './tablist.js';
+import { TablistAppearance as TablistAppearanceValues, TablistOrientation, TablistSize } from './tablist.options.js';
+
+type TablistStoryArgs = Args & FluentTablist;
+type TablistStoryMeta = Meta<TablistStoryArgs>;
+
+const tabIds = ['first-tab', 'second-tab', 'third-tab', 'fourth-tab'];
+
+const tabsDefault = html`
+  <fluent-tablist
+    orientation=${x => x.orientation}
+    appearance=${x => x.appearance}
+    ?disabled=${x => x.disabled}
+    size=${x => x.size}
+    activeid=${x => x.activeid}
+  >
+    <fluent-tab id=${tabIds[0]}> First Tab </fluent-tab>
+    <fluent-tab id=${tabIds[1]}> Second Tab</fluent-tab>
+    <fluent-tab id=${tabIds[2]}> Third Tab</fluent-tab>
+    <fluent-tab id=${tabIds[3]}> Fourth Tab</fluent-tab>
+  </fluent-tablist>
+`;
+export const TablistDefault = renderComponent(tabsDefault).bind({});
+
+const tabsHorizontal = html`
+  <fluent-tablist orientation="horizontal">
+    <fluent-tab> First Tab </fluent-tab>
+    <fluent-tab> Second Tab</fluent-tab>
+    <fluent-tab> Third Tab</fluent-tab>
+    <fluent-tab> Fourth Tab</fluent-tab>
+  </fluent-tabs>
+`;
+export const TablistHorizontal = renderComponent(tabsHorizontal).bind({});
+
+const tabsVertical = html`
+  <fluent-tablist orientation="vertical">
+    <fluent-tab> First Tab </fluent-tab>
+    <fluent-tab> Second Tab</fluent-tab>
+    <fluent-tab> Third Tab</fluent-tab>
+    <fluent-tab> Fourth Tab</fluent-tab>
+  </fluent-tabs>
+`;
+export const TablistVertical = renderComponent(tabsVertical).bind({});
+
+const tabsAppearance = html`
+  <fluent-tablist appearance="transparent">
+    <fluent-tab> First Tab </fluent-tab>
+    <fluent-tab> Second Tab</fluent-tab>
+    <fluent-tab> Third Tab</fluent-tab>
+    <fluent-tab> Fourth Tab</fluent-tab>
+  </fluent-tabs>
+  <fluent-tablist appearance="subtle">
+    <fluent-tab active> First Tab </fluent-tab>
+    <fluent-tab> Second Tab</fluent-tab>
+    <fluent-tab> Third Tab</fluent-tab>
+    <fluent-tab> Fourth Tab</fluent-tab>
+  </fluent-tabs>
+`;
+export const TablistAppearance = renderComponent(tabsAppearance).bind({});
+
+const tabsDisabledTablist = html`
+  <fluent-tablist disabled>
+    <fluent-tab> First Tab </fluent-tab>
+    <fluent-tab> Second Tab</fluent-tab>
+    <fluent-tab> Third Tab</fluent-tab>
+    <fluent-tab> Fourth Tab</fluent-tab>
+  </fluent-tabs>
+
+  <fluent-tablist>
+    <fluent-tab> First Tab </fluent-tab>
+    <fluent-tab disabled> Second Tab</fluent-tab>
+    <fluent-tab> Third Tab</fluent-tab>
+    <fluent-tab> Fourth Tab</fluent-tab>
+  </fluent-tabs>
+`;
+export const TablistDisabled = renderComponent(tabsDisabledTablist).bind({});
+
+const tabsSizeSmall = html`
+  <fluent-tablist size="small">
+    <fluent-tab> First Tab </fluent-tab>
+    <fluent-tab> Second Tab</fluent-tab>
+    <fluent-tab> Third Tab</fluent-tab>
+    <fluent-tab> Fourth Tab</fluent-tab>
+  </fluent-tablist>
+  <fluent-tablist size="small" orientation="vertical">
+    <fluent-tab> First Tab </fluent-tab>
+    <fluent-tab> Second Tab</fluent-tab>
+    <fluent-tab> Third Tab</fluent-tab>
+    <fluent-tab> Fourth Tab</fluent-tab>
+  </fluent-tablist>
+`;
+export const TablistSizeSmall = renderComponent(tabsSizeSmall).bind({});
+
+const tabsSizeMedium = html`
+  <fluent-tablist size="medium">
+    <fluent-tab> First Tab </fluent-tab>
+    <fluent-tab> Second Tab</fluent-tab>
+    <fluent-tab> Third Tab</fluent-tab>
+    <fluent-tab> Fourth Tab</fluent-tab>
+  </fluent-tablist>
+  <fluent-tablist size="medium" orientation="vertical">
+    <fluent-tab> First Tab </fluent-tab>
+    <fluent-tab> Second Tab</fluent-tab>
+    <fluent-tab> Third Tab</fluent-tab>
+    <fluent-tab> Fourth Tab</fluent-tab>
+  </fluent-tablist>
+`;
+export const TablistSizeMedium = renderComponent(tabsSizeMedium).bind({});
+
+const tabsSizeLarge = html`
+  <fluent-tablist size="large">
+    <fluent-tab> First Tab </fluent-tab>
+    <fluent-tab> Second Tab</fluent-tab>
+    <fluent-tab> Third Tab</fluent-tab>
+    <fluent-tab> Fourth Tab</fluent-tab>
+  </fluent-tablist>
+  <fluent-tablist size="large" orientation="vertical">
+    <fluent-tab> First Tab </fluent-tab>
+    <fluent-tab> Second Tab</fluent-tab>
+    <fluent-tab> Third Tab</fluent-tab>
+    <fluent-tab> Fourth Tab</fluent-tab>
+  </fluent-tablist>
+`;
+export const TablistSizeLarge = renderComponent(tabsSizeLarge).bind({});
+
+export default {
+  title: 'Components/Tablist',
+  args: {
+    appearance: 'transparent',
+    disabled: false,
+    orientation: 'horizontal',
+    size: 'medium',
+  },
+  argTypes: {
+    appearance: {
+      options: Object.values(TablistAppearanceValues),
+      defaultValue: TablistAppearanceValues.transparent,
+      control: {
+        type: 'select',
+      },
+    },
+    activeid: {
+      options: tabIds,
+      defaultValue: tabIds[0],
+      control: { type: 'select' },
+    },
+    disabled: {
+      options: [true, false],
+      defaultValue: false,
+      control: { type: 'select' },
+    },
+    size: {
+      options: Object.values(TablistSize),
+      defaultValue: TablistSize.medium,
+      control: { type: 'select' },
+    },
+    orientation: {
+      options: Object.values(TablistOrientation),
+      defaultValue: TablistOrientation.horizontal,
+      control: { type: 'select' },
+    },
+  },
+} as TablistStoryMeta;

--- a/packages/web-components/src/tablist/tablist.stories.ts
+++ b/packages/web-components/src/tablist/tablist.stories.ts
@@ -31,7 +31,7 @@ const tabsHorizontal = html`
     <fluent-tab> Second Tab</fluent-tab>
     <fluent-tab> Third Tab</fluent-tab>
     <fluent-tab> Fourth Tab</fluent-tab>
-  </fluent-tabs>
+  </fluent-tablist>
 `;
 export const TablistHorizontal = renderComponent(tabsHorizontal).bind({});
 
@@ -41,7 +41,7 @@ const tabsVertical = html`
     <fluent-tab> Second Tab</fluent-tab>
     <fluent-tab> Third Tab</fluent-tab>
     <fluent-tab> Fourth Tab</fluent-tab>
-  </fluent-tabs>
+  </fluent-tablist>
 `;
 export const TablistVertical = renderComponent(tabsVertical).bind({});
 
@@ -51,13 +51,13 @@ const tabsAppearance = html`
     <fluent-tab> Second Tab</fluent-tab>
     <fluent-tab> Third Tab</fluent-tab>
     <fluent-tab> Fourth Tab</fluent-tab>
-  </fluent-tabs>
+  </fluent-tablist>
   <fluent-tablist appearance="subtle">
     <fluent-tab active> First Tab </fluent-tab>
     <fluent-tab> Second Tab</fluent-tab>
     <fluent-tab> Third Tab</fluent-tab>
     <fluent-tab> Fourth Tab</fluent-tab>
-  </fluent-tabs>
+  </fluent-tablist>
 `;
 export const TablistAppearance = renderComponent(tabsAppearance).bind({});
 
@@ -67,14 +67,14 @@ const tabsDisabledTablist = html`
     <fluent-tab> Second Tab</fluent-tab>
     <fluent-tab> Third Tab</fluent-tab>
     <fluent-tab> Fourth Tab</fluent-tab>
-  </fluent-tabs>
+  </fluent-tablist>
 
   <fluent-tablist>
     <fluent-tab> First Tab </fluent-tab>
     <fluent-tab disabled> Second Tab</fluent-tab>
     <fluent-tab> Third Tab</fluent-tab>
     <fluent-tab> Fourth Tab</fluent-tab>
-  </fluent-tabs>
+  </fluent-tablist>
 `;
 export const TablistDisabled = renderComponent(tabsDisabledTablist).bind({});
 

--- a/packages/web-components/src/tablist/tablist.stories.ts
+++ b/packages/web-components/src/tablist/tablist.stories.ts
@@ -9,19 +9,43 @@ type TablistStoryMeta = Meta<TablistStoryArgs>;
 
 const tabIds = ['first-tab', 'second-tab', 'third-tab', 'fourth-tab'];
 
+function changeTab() {
+  const tablist = document.querySelector('fluent-tablist') as FluentTablist;
+  const panelPlaceholder = document.querySelector('#panel-placeholder')!;
+  // there's a million ways to do this, but this is the simplest
+  panelPlaceholder.innerHTML = `
+  <div role="tabpanel" aria-labelledby="tablist.activeid">
+    Tab changed to ${tablist.activeid}
+  </div>`;
+}
+
 const tabsDefault = html`
-  <fluent-tablist
-    orientation=${x => x.orientation}
-    appearance=${x => x.appearance}
-    ?disabled=${x => x.disabled}
-    size=${x => x.size}
-    activeid=${x => x.activeid}
-  >
-    <fluent-tab id=${tabIds[0]}> First Tab </fluent-tab>
-    <fluent-tab id=${tabIds[1]}> Second Tab</fluent-tab>
-    <fluent-tab id=${tabIds[2]}> Third Tab</fluent-tab>
-    <fluent-tab id=${tabIds[3]}> Fourth Tab</fluent-tab>
-  </fluent-tablist>
+  <style>
+    #demo-layout {
+      display: grid;
+      gap: 1rem;
+    }
+    #demo-layout:has(fluent-tablist[orientation='vertical']) {
+      grid-template-columns: max-content 1fr;
+    }
+  </style>
+  <div id="demo-layout">
+    <fluent-tablist
+      orientation=${x => x.orientation}
+      appearance=${x => x.appearance}
+      ?disabled=${x => x.disabled}
+      size=${x => x.size}
+      activeid=${x => x.activeid}
+      @change="${() => changeTab()}"
+    >
+      <fluent-tab id=${tabIds[0]}> First Tab </fluent-tab>
+      <fluent-tab id=${tabIds[1]}> Second Tab</fluent-tab>
+      <fluent-tab id=${tabIds[2]}> Third Tab</fluent-tab>
+      <fluent-tab id=${tabIds[3]}> Fourth Tab</fluent-tab>
+    </fluent-tablist>
+
+    <div id="panel-placeholder"></div>
+  </div>
 `;
 export const TablistDefault = renderComponent(tabsDefault).bind({});
 
@@ -125,6 +149,24 @@ const tabsSizeLarge = html`
   </fluent-tablist>
 `;
 export const TablistSizeLarge = renderComponent(tabsSizeLarge).bind({});
+
+const rtl = html`
+  <div dir="rtl">
+    <fluent-tablist>
+      <fluent-tab> First Tab </fluent-tab>
+      <fluent-tab> Second Tab</fluent-tab>
+      <fluent-tab> Third Tab</fluent-tab>
+      <fluent-tab> Fourth Tab</fluent-tab>
+    </fluent-tablist>
+    <fluent-tablist orientation="vertical">
+      <fluent-tab> First Tab </fluent-tab>
+      <fluent-tab> Second Tab</fluent-tab>
+      <fluent-tab> Third Tab</fluent-tab>
+      <fluent-tab> Fourth Tab</fluent-tab>
+    </fluent-tablist>
+  </div>
+`;
+export const RTL = renderComponent(rtl).bind({});
 
 export default {
   title: 'Components/Tablist',

--- a/packages/web-components/src/tablist/tablist.stories.ts
+++ b/packages/web-components/src/tablist/tablist.stories.ts
@@ -92,7 +92,6 @@ const tabsDisabledTablist = html`
     <fluent-tab> Third Tab</fluent-tab>
     <fluent-tab> Fourth Tab</fluent-tab>
   </fluent-tablist>
-
   <fluent-tablist>
     <fluent-tab> First Tab </fluent-tab>
     <fluent-tab disabled> Second Tab</fluent-tab>
@@ -109,6 +108,7 @@ const tabsSizeSmall = html`
     <fluent-tab> Third Tab</fluent-tab>
     <fluent-tab> Fourth Tab</fluent-tab>
   </fluent-tablist>
+  <br />
   <fluent-tablist size="small" orientation="vertical">
     <fluent-tab> First Tab </fluent-tab>
     <fluent-tab> Second Tab</fluent-tab>
@@ -125,6 +125,7 @@ const tabsSizeMedium = html`
     <fluent-tab> Third Tab</fluent-tab>
     <fluent-tab> Fourth Tab</fluent-tab>
   </fluent-tablist>
+  <br />
   <fluent-tablist size="medium" orientation="vertical">
     <fluent-tab> First Tab </fluent-tab>
     <fluent-tab> Second Tab</fluent-tab>
@@ -141,6 +142,7 @@ const tabsSizeLarge = html`
     <fluent-tab> Third Tab</fluent-tab>
     <fluent-tab> Fourth Tab</fluent-tab>
   </fluent-tablist>
+  <br />
   <fluent-tablist size="large" orientation="vertical">
     <fluent-tab> First Tab </fluent-tab>
     <fluent-tab> Second Tab</fluent-tab>
@@ -158,6 +160,7 @@ const rtl = html`
       <fluent-tab> Third Tab</fluent-tab>
       <fluent-tab> Fourth Tab</fluent-tab>
     </fluent-tablist>
+    <br />
     <fluent-tablist orientation="vertical">
       <fluent-tab> First Tab </fluent-tab>
       <fluent-tab> Second Tab</fluent-tab>

--- a/packages/web-components/src/tablist/tablist.styles.ts
+++ b/packages/web-components/src/tablist/tablist.styles.ts
@@ -24,7 +24,7 @@ import {
   spacingVerticalXXS,
   strokeWidthThicker,
 } from '../theme/design-tokens.js';
-import { largeState, smallState, verticalState } from '../styles/states/index.js';
+import { disabledState, largeState, smallState, subtleState, verticalState } from '../styles/states/index.js';
 /**
  * @public
  */
@@ -179,36 +179,36 @@ export const styles = css`
   }
 
   /* disabled styles */
-  :host([disabled]) {
+  :host(${disabledState}) {
     cursor: not-allowed;
     color: ${colorNeutralForegroundDisabled};
   }
 
-  :host([disabled]) ::slotted([slot='tab']) {
+  :host(${disabledState}) ::slotted([slot='tab']) {
     pointer-events: none;
     cursor: not-allowed;
     color: ${colorNeutralForegroundDisabled};
   }
 
-  :host([disabled]) ::slotted([slot='tab']:after) {
+  :host(${disabledState}) ::slotted([slot='tab']:after) {
     background-color: ${colorNeutralForegroundDisabled};
   }
 
-  :host([disabled]) ::slotted([slot='tab'][aria-selected='true'])::after {
+  :host(${disabledState}) ::slotted([slot='tab'][aria-selected='true'])::after {
     background-color: ${colorNeutralForegroundDisabled};
   }
 
-  :host([disabled]) ::slotted([slot='tab']:hover):before {
+  :host(${disabledState}) ::slotted([slot='tab']:hover):before {
     content: unset;
   }
 
-  :host([appearance='subtle']) ::slotted([slot='tab']:hover) {
+  :host(${subtleState}) ::slotted([slot='tab']:hover) {
     background-color: ${colorSubtleBackgroundHover};
     color: ${colorNeutralForeground1Hover};
     fill: ${colorCompoundBrandForeground1Hover};
   }
 
-  :host([appearance='subtle']) ::slotted([slot='tab']:active) {
+  :host(${subtleState}) ::slotted([slot='tab']:active) {
     background-color: ${colorSubtleBackgroundPressed};
     fill: ${colorSubtleBackgroundPressed};
     color: ${colorNeutralForeground1};

--- a/packages/web-components/src/tablist/tablist.styles.ts
+++ b/packages/web-components/src/tablist/tablist.styles.ts
@@ -36,7 +36,6 @@ export const styles = css`
     --tabPaddingBlock: inherit;
     --tabIndicatorInsetInline: 0;
     --tabIndicatorInsetBlock: 0;
-
     box-sizing: border-box;
     color: ${colorNeutralForeground2};
     flex-direction: row;

--- a/packages/web-components/src/tablist/tablist.styles.ts
+++ b/packages/web-components/src/tablist/tablist.styles.ts
@@ -1,0 +1,214 @@
+import { css } from '@microsoft/fast-element';
+import { display } from '../utils/index.js';
+import {
+  borderRadiusCircular,
+  colorCompoundBrandForeground1Hover,
+  colorNeutralForeground1,
+  colorNeutralForeground1Hover,
+  colorNeutralForeground2,
+  colorNeutralForegroundDisabled,
+  colorSubtleBackgroundHover,
+  colorSubtleBackgroundPressed,
+  curveDecelerateMax,
+  durationSlow,
+  fontSizeBase300,
+  fontSizeBase400,
+  lineHeightBase300,
+  lineHeightBase400,
+  spacingHorizontalMNudge,
+  spacingHorizontalSNudge,
+  spacingVerticalL,
+  spacingVerticalMNudge,
+  spacingVerticalS,
+  spacingVerticalSNudge,
+  spacingVerticalXXS,
+  strokeWidthThicker,
+} from '../theme/design-tokens.js';
+
+export const styles = css`
+  ${display('flex')}
+
+  :host {
+    --tabPaddingInline: inherit;
+    --tabPaddingBlock: inherit;
+    --tabIndicatorInsetInline: 0;
+    --tabIndicatorInsetBlock: 0;
+
+    box-sizing: border-box;
+    color: ${colorNeutralForeground2};
+    flex-direction: row;
+  }
+
+  :host([orientation='vertical']) {
+    flex-direction: column;
+  }
+
+  :host ::slotted([role='tab']) {
+    align-items: flex-start;
+  }
+
+  /* indicator animation  */
+  :host ::slotted([role='tab'][data-animate='true'])::after {
+    transition-property: transform;
+    transition-duration: ${durationSlow};
+    transition-timing-function: ${curveDecelerateMax};
+  }
+
+  :host ::slotted([role='tab'])::after {
+    height: ${strokeWidthThicker};
+    margin-block-start: auto;
+    transform-origin: left;
+    transform: translateX(var(--tabIndicatorOffset)) scaleX(var(--tabIndicatorScale));
+  }
+
+  :host([orientation='vertical']) ::slotted([role='tab'])::after {
+    width: ${strokeWidthThicker};
+    height: unset;
+    margin-block-start: unset;
+    transform-origin: top;
+    transform: translateY(var(--tabIndicatorOffset)) scaleY(var(--tabIndicatorScale));
+  }
+
+  /* ::before adds a secondary indicator placeholder that appears right after click on the active tab */
+  :host ::slotted([role='tab'])::before {
+    height: ${strokeWidthThicker};
+    border-radius: ${borderRadiusCircular};
+    content: '';
+    inset-inline: var(--tabIndicatorInsetInline);
+    inset-block: var(--tabIndicatorInsetBlock);
+    position: absolute;
+    margin-top: auto;
+  }
+
+  :host ::slotted([role='tab'])::before {
+    inset-inline: var(--tabIndicatorInsetInline);
+    inset-block: var(--tabIndicatorInsetBlock);
+  }
+
+  :host ::slotted([role='tab'][aria-selected='true'])::before {
+    background-color: ${colorNeutralForegroundDisabled};
+  }
+
+  :host ::slotted([role='tab'][aria-selected='false']:hover)::after {
+    height: ${strokeWidthThicker};
+    margin-block-start: auto;
+    transform-origin: left;
+  }
+
+  :host([orientation='vertical']) ::slotted([role='tab'])::before,
+  :host([orientation='vertical']) ::slotted([role='tab'][aria-selected='false']:hover)::after {
+    height: unset;
+    width: ${strokeWidthThicker};
+    margin-inline-end: auto;
+    transform-origin: top;
+  }
+
+  :host(:where([size='small'], [size='large'])) ::slotted([role='tab']) {
+    padding-inline: var(--tabPaddingInline);
+    padding-block: var(--tabPaddingBlock);
+  }
+
+  :host([size='small']) ::slotted([role='tab']) {
+    --tabPaddingBlock: ${spacingVerticalSNudge};
+    --tabPaddingInline: ${spacingHorizontalSNudge};
+    font-size: ${fontSizeBase300};
+    line-height: ${lineHeightBase300};
+  }
+
+  :host([size='large']) ::slotted([role='tab']) {
+    --tabPaddingBlock: ${spacingVerticalL};
+    --tabPaddingInline: ${spacingHorizontalMNudge};
+    font-size: ${fontSizeBase400};
+    line-height: ${lineHeightBase400};
+  }
+
+  /* horizontal spacing for indicator */
+  :host ::slotted([role='tab'])::after,
+  :host ::slotted([role='tab'])::before,
+  :host ::slotted([role='tab']:hover)::after {
+    inset-inline: var(--tabIndicatorInsetInline);
+  }
+
+  :host ::slotted([role='tab']) {
+    --tabIndicatorInsetInline: ${spacingHorizontalMNudge};
+  }
+
+  :host([size='small']) ::slotted([role='tab']) {
+    --tabIndicatorInsetInline: ${spacingHorizontalSNudge};
+  }
+
+  :host([size='large']) ::slotted([role='tab']) {
+    --tabIndicatorInsetInline: ${spacingHorizontalMNudge};
+  }
+
+  :host([orientation='vertical']) ::slotted([role='tab']) {
+    padding-block: var(--tabPaddingBlock);
+  }
+
+  :host([orientation='vertical']) ::slotted([role='tab']) {
+    --tabPaddingBlock: ${spacingVerticalS};
+  }
+
+  :host([orientation='vertical'][size='small']) ::slotted([role='tab']) {
+    --tabPaddingBlock: ${spacingVerticalXXS};
+  }
+
+  :host([orientation='vertical'][size='large']) ::slotted([role='tab']) {
+    --tabPaddingBlock: ${spacingVerticalS};
+  }
+
+  :host([orientation='vertical']) ::slotted([role='tab'])::after,
+  :host([orientation='vertical']) ::slotted([role='tab'])::before,
+  :host([orientation='vertical']) ::slotted([role='tab']:hover)::after {
+    inset-inline: 0;
+    inset-block: var(--tabIndicatorInsetBlock);
+  }
+
+  :host([orientation='vertical']) {
+    --tabIndicatorInsetBlock: ${spacingVerticalS};
+  }
+
+  :host([orientation='vertical'][size='small']) {
+    --tabIndicatorInsetBlock: ${spacingVerticalSNudge};
+  }
+
+  :host([orientation='vertical'][size='large']) {
+    --tabIndicatorInsetBlock: ${spacingVerticalMNudge};
+  }
+
+  /* disabled styles */
+  :host([disabled]) {
+    cursor: not-allowed;
+    color: ${colorNeutralForegroundDisabled};
+  }
+
+  :host([disabled]) ::slotted([role='tab']) {
+    pointer-events: none;
+    cursor: not-allowed;
+    color: ${colorNeutralForegroundDisabled};
+  }
+
+  :host([disabled]) ::slotted([role='tab']:after) {
+    background-color: ${colorNeutralForegroundDisabled};
+  }
+
+  :host([disabled]) ::slotted([role='tab'][aria-selected='true'])::after {
+    background-color: ${colorNeutralForegroundDisabled};
+  }
+
+  :host([disabled]) ::slotted([role='tab']:hover):before {
+    content: unset;
+  }
+
+  :host([appearance='subtle']) ::slotted([role='tab']:hover) {
+    background-color: ${colorSubtleBackgroundHover};
+    color: ${colorNeutralForeground1Hover};
+    fill: ${colorCompoundBrandForeground1Hover};
+  }
+
+  :host([appearance='subtle']) ::slotted([role='tab']:active) {
+    background-color: ${colorSubtleBackgroundPressed};
+    fill: ${colorSubtleBackgroundPressed};
+    color: ${colorNeutralForeground1};
+  }
+`;

--- a/packages/web-components/src/tablist/tablist.styles.ts
+++ b/packages/web-components/src/tablist/tablist.styles.ts
@@ -25,6 +25,9 @@ import {
   strokeWidthThicker,
 } from '../theme/design-tokens.js';
 
+/**
+ * @public
+ */
 export const styles = css`
   ${display('flex')}
 

--- a/packages/web-components/src/tablist/tablist.styles.ts
+++ b/packages/web-components/src/tablist/tablist.styles.ts
@@ -24,7 +24,7 @@ import {
   spacingVerticalXXS,
   strokeWidthThicker,
 } from '../theme/design-tokens.js';
-
+import { largeState, smallState, verticalState } from '../styles/states/index.js';
 /**
  * @public
  */
@@ -41,7 +41,7 @@ export const styles = css`
     flex-direction: row;
   }
 
-  :host([orientation='vertical']) {
+  :host(${verticalState}) {
     flex-direction: column;
   }
 
@@ -50,20 +50,20 @@ export const styles = css`
   }
 
   /* indicator animation  */
-  :host ::slotted([role='tab'][data-animate='true'])::after {
+  :host ::slotted([slot='tab'][data-animate='true'])::after {
     transition-property: transform;
     transition-duration: ${durationSlow};
     transition-timing-function: ${curveDecelerateMax};
   }
 
-  :host ::slotted([role='tab'])::after {
+  :host ::slotted([slot='tab'])::after {
     height: ${strokeWidthThicker};
     margin-block-start: auto;
     transform-origin: left;
     transform: translateX(var(--tabIndicatorOffset)) scaleX(var(--tabIndicatorScale));
   }
 
-  :host([orientation='vertical']) ::slotted([role='tab'])::after {
+  :host(${verticalState}) ::slotted([slot='tab'])::after {
     width: ${strokeWidthThicker};
     height: unset;
     margin-block-start: unset;
@@ -72,7 +72,7 @@ export const styles = css`
   }
 
   /* ::before adds a secondary indicator placeholder that appears right after click on the active tab */
-  :host ::slotted([role='tab'])::before {
+  :host ::slotted([slot='tab'])::before {
     height: ${strokeWidthThicker};
     border-radius: ${borderRadiusCircular};
     content: '';
@@ -82,42 +82,42 @@ export const styles = css`
     margin-top: auto;
   }
 
-  :host ::slotted([role='tab'])::before {
+  :host ::slotted([slot='tab'])::before {
     inset-inline: var(--tabIndicatorInsetInline);
     inset-block: var(--tabIndicatorInsetBlock);
   }
 
-  :host ::slotted([role='tab'][aria-selected='true'])::before {
+  :host ::slotted([slot='tab'][aria-selected='true'])::before {
     background-color: ${colorNeutralForegroundDisabled};
   }
 
-  :host ::slotted([role='tab'][aria-selected='false']:hover)::after {
+  :host ::slotted([slot='tab'][aria-selected='false']:hover)::after {
     height: ${strokeWidthThicker};
     margin-block-start: auto;
     transform-origin: left;
   }
 
-  :host([orientation='vertical']) ::slotted([role='tab'])::before,
-  :host([orientation='vertical']) ::slotted([role='tab'][aria-selected='false']:hover)::after {
+  :host(${verticalState}) ::slotted([slot='tab'])::before,
+  :host(${verticalState}) ::slotted([slot='tab'][aria-selected='false']:hover)::after {
     height: unset;
     width: ${strokeWidthThicker};
     margin-inline-end: auto;
     transform-origin: top;
   }
 
-  :host(:where([size='small'], [size='large'])) ::slotted([role='tab']) {
+  :host(:where(${smallState}, ${largeState})) ::slotted([slot='tab']) {
     padding-inline: var(--tabPaddingInline);
     padding-block: var(--tabPaddingBlock);
   }
 
-  :host([size='small']) ::slotted([role='tab']) {
+  :host(${smallState}) ::slotted([slot='tab']) {
     --tabPaddingBlock: ${spacingVerticalSNudge};
     --tabPaddingInline: ${spacingHorizontalSNudge};
     font-size: ${fontSizeBase300};
     line-height: ${lineHeightBase300};
   }
 
-  :host([size='large']) ::slotted([role='tab']) {
+  :host(${largeState}) ::slotted([slot='tab']) {
     --tabPaddingBlock: ${spacingVerticalL};
     --tabPaddingInline: ${spacingHorizontalMNudge};
     font-size: ${fontSizeBase400};
@@ -125,56 +125,56 @@ export const styles = css`
   }
 
   /* horizontal spacing for indicator */
-  :host ::slotted([role='tab'])::after,
-  :host ::slotted([role='tab'])::before,
-  :host ::slotted([role='tab']:hover)::after {
+  :host ::slotted([slot='tab'])::after,
+  :host ::slotted([slot='tab'])::before,
+  :host ::slotted([slot='tab']:hover)::after {
     inset-inline: var(--tabIndicatorInsetInline);
   }
 
-  :host ::slotted([role='tab']) {
+  :host ::slotted([slot='tab']) {
     --tabIndicatorInsetInline: ${spacingHorizontalMNudge};
   }
 
-  :host([size='small']) ::slotted([role='tab']) {
+  :host(${smallState}) ::slotted([slot='tab']) {
     --tabIndicatorInsetInline: ${spacingHorizontalSNudge};
   }
 
-  :host([size='large']) ::slotted([role='tab']) {
+  :host(${largeState}) ::slotted([slot='tab']) {
     --tabIndicatorInsetInline: ${spacingHorizontalMNudge};
   }
 
-  :host([orientation='vertical']) ::slotted([role='tab']) {
+  :host(${verticalState}) ::slotted([slot='tab']) {
     padding-block: var(--tabPaddingBlock);
   }
 
-  :host([orientation='vertical']) ::slotted([role='tab']) {
+  :host(${verticalState}) ::slotted([slot='tab']) {
     --tabPaddingBlock: ${spacingVerticalS};
   }
 
-  :host([orientation='vertical'][size='small']) ::slotted([role='tab']) {
+  :host(${verticalState}${smallState}) ::slotted([slot='tab']) {
     --tabPaddingBlock: ${spacingVerticalXXS};
   }
 
-  :host([orientation='vertical'][size='large']) ::slotted([role='tab']) {
+  :host(${verticalState}${largeState}) ::slotted([slot='tab']) {
     --tabPaddingBlock: ${spacingVerticalS};
   }
 
-  :host([orientation='vertical']) ::slotted([role='tab'])::after,
-  :host([orientation='vertical']) ::slotted([role='tab'])::before,
-  :host([orientation='vertical']) ::slotted([role='tab']:hover)::after {
+  :host(${verticalState}) ::slotted([slot='tab'])::after,
+  :host(${verticalState}) ::slotted([slot='tab'])::before,
+  :host(${verticalState}) ::slotted([slot='tab']:hover)::after {
     inset-inline: 0;
     inset-block: var(--tabIndicatorInsetBlock);
   }
 
-  :host([orientation='vertical']) {
+  :host(${verticalState}) {
     --tabIndicatorInsetBlock: ${spacingVerticalS};
   }
 
-  :host([orientation='vertical'][size='small']) {
+  :host(${verticalState}${smallState}) {
     --tabIndicatorInsetBlock: ${spacingVerticalSNudge};
   }
 
-  :host([orientation='vertical'][size='large']) {
+  :host(${verticalState}${largeState}) {
     --tabIndicatorInsetBlock: ${spacingVerticalMNudge};
   }
 
@@ -184,31 +184,31 @@ export const styles = css`
     color: ${colorNeutralForegroundDisabled};
   }
 
-  :host([disabled]) ::slotted([role='tab']) {
+  :host([disabled]) ::slotted([slot='tab']) {
     pointer-events: none;
     cursor: not-allowed;
     color: ${colorNeutralForegroundDisabled};
   }
 
-  :host([disabled]) ::slotted([role='tab']:after) {
+  :host([disabled]) ::slotted([slot='tab']:after) {
     background-color: ${colorNeutralForegroundDisabled};
   }
 
-  :host([disabled]) ::slotted([role='tab'][aria-selected='true'])::after {
+  :host([disabled]) ::slotted([slot='tab'][aria-selected='true'])::after {
     background-color: ${colorNeutralForegroundDisabled};
   }
 
-  :host([disabled]) ::slotted([role='tab']:hover):before {
+  :host([disabled]) ::slotted([slot='tab']:hover):before {
     content: unset;
   }
 
-  :host([appearance='subtle']) ::slotted([role='tab']:hover) {
+  :host([appearance='subtle']) ::slotted([slot='tab']:hover) {
     background-color: ${colorSubtleBackgroundHover};
     color: ${colorNeutralForeground1Hover};
     fill: ${colorCompoundBrandForeground1Hover};
   }
 
-  :host([appearance='subtle']) ::slotted([role='tab']:active) {
+  :host([appearance='subtle']) ::slotted([slot='tab']:active) {
     background-color: ${colorSubtleBackgroundPressed};
     fill: ${colorSubtleBackgroundPressed};
     color: ${colorNeutralForeground1};

--- a/packages/web-components/src/tablist/tablist.template.ts
+++ b/packages/web-components/src/tablist/tablist.template.ts
@@ -1,6 +1,9 @@
 import { html, slotted } from '@microsoft/fast-element';
 import { Tablist } from './tablist.js';
 
+/**
+ * @public
+ */
 export const template = html<Tablist>`
   <template role="tablist">
     <slot name="tab" ${slotted('tabs')}></slot>

--- a/packages/web-components/src/tablist/tablist.template.ts
+++ b/packages/web-components/src/tablist/tablist.template.ts
@@ -1,0 +1,8 @@
+import { html, slotted } from '@microsoft/fast-element';
+import { Tablist } from './tablist.js';
+
+export const template = html<Tablist>`
+  <template role="tablist">
+    <slot name="tab" ${slotted('tabs')}></slot>
+  </template>
+`;

--- a/packages/web-components/src/tablist/tablist.ts
+++ b/packages/web-components/src/tablist/tablist.ts
@@ -1,4 +1,5 @@
 import { attr, FASTElement, observable } from '@microsoft/fast-element';
+import { wrapInBounds } from '@microsoft/fast-web-utilities';
 import {
   keyArrowDown,
   keyArrowLeft,
@@ -6,7 +7,6 @@ import {
   keyArrowUp,
   keyEnd,
   keyHome,
-  limit,
   uniqueId,
 } from '@microsoft/fast-web-utilities';
 import { Tab } from '../index.js';
@@ -219,7 +219,7 @@ export class BaseTablist extends FASTElement {
     const focusableTabs = this.tabs.filter(t => this.isFocusableElement(t));
     const currentActiveTabIndex = focusableTabs.indexOf(this.activetab);
 
-    const nextTabIndex = limit(0, focusableTabs.length - 1, currentActiveTabIndex + adjustment);
+    const nextTabIndex = wrapInBounds(0, focusableTabs.length - 1, currentActiveTabIndex + adjustment);
 
     // the index of the next focusable tab within the context of all available tabs
     const nextIndex = this.tabs.indexOf(focusableTabs[nextTabIndex]);
@@ -331,8 +331,7 @@ export class Tablist extends BaseTablist {
    */
   private applyUpdatedCSSValues(tab: Tab) {
     this.calculateAnimationProperties(tab);
-    this.setTabScaleCSSVar();
-    this.setTabOffsetCSSVar();
+    this.setAnimationVars();
   }
 
   /**
@@ -384,11 +383,8 @@ export class Tablist extends BaseTablist {
     }
   }
 
-  private setTabOffsetCSSVar() {
+  private setAnimationVars() {
     this.style.setProperty('--tabIndicatorOffset', `${this.activeTabOffset}px`);
-  }
-
-  private setTabScaleCSSVar() {
     this.style.setProperty('--tabIndicatorScale', this.activeTabScale.toString());
   }
 

--- a/packages/web-components/src/tablist/tablist.ts
+++ b/packages/web-components/src/tablist/tablist.ts
@@ -173,28 +173,28 @@ export class BaseTablist extends FASTElement {
           return;
         }
         event.preventDefault();
-        this.adjustBackward(event);
+        this.adjust(-1);
         break;
       case keyArrowRight:
         if (!this.isHorizontal()) {
           return;
         }
         event.preventDefault();
-        this.adjustForward(event);
+        this.adjust(1);
         break;
       case keyArrowUp:
         if (this.isHorizontal()) {
           return;
         }
         event.preventDefault();
-        this.adjustBackward(event);
+        this.adjust(-1);
         break;
       case keyArrowDown:
         if (this.isHorizontal()) {
           return;
         }
         event.preventDefault();
-        this.adjustForward(event);
+        this.adjust(1);
         break;
       case keyHome:
         event.preventDefault();
@@ -224,48 +224,6 @@ export class BaseTablist extends FASTElement {
 
     if (nextIndex > -1) {
       this.moveToTabByIndex(this.tabs, nextIndex);
-    }
-  }
-
-  private adjustForward(e: KeyboardEvent): void {
-    const group: HTMLElement[] = this.tabs;
-    let index: number = 0;
-
-    index = this.activetab ? group.indexOf(this.activetab) + 1 : 1;
-    if (index === group.length) {
-      index = 0;
-    }
-
-    while (index < group.length && group.length > 1) {
-      if (this.isFocusableElement(group[index])) {
-        this.moveToTabByIndex(group, index);
-        break;
-      } else if (this.activetab && index === group.indexOf(this.activetab)) {
-        break;
-      } else if (index + 1 >= group.length) {
-        index = 0;
-      } else {
-        index += 1;
-      }
-    }
-  }
-
-  private adjustBackward(e: KeyboardEvent): void {
-    const group: HTMLElement[] = this.tabs;
-    let index: number = 0;
-
-    index = this.activetab ? group.indexOf(this.activetab) - 1 : 0;
-    index = index < 0 ? group.length - 1 : index;
-
-    while (index >= 0 && group.length > 1) {
-      if (this.isFocusableElement(group[index])) {
-        this.moveToTabByIndex(group, index);
-        break;
-      } else if (index - 1 < 0) {
-        index = group.length - 1;
-      } else {
-        index -= 1;
-      }
     }
   }
 

--- a/packages/web-components/src/tablist/tablist.ts
+++ b/packages/web-components/src/tablist/tablist.ts
@@ -36,6 +36,15 @@ export class BaseTablist extends FASTElement {
   public disabled: boolean = false;
 
   /**
+   * Handles disabled changes
+   * @param prev - previous value
+   * @param next - next value
+   */
+  public disabledChanged(prev: boolean, next: boolean): void {
+    toggleState(this.elementInternals, 'disabled', next);
+  }
+
+  /**
    * The orientation
    * @public
    * @remarks
@@ -298,6 +307,18 @@ export class Tablist extends BaseTablist {
    */
   @attr
   public appearance?: TablistAppearance = TablistAppearance.transparent;
+
+  /**
+   * @internal
+   */
+  protected appearanceChanged(prev: TablistAppearance, next: TablistAppearance): void {
+    if (prev) {
+      toggleState(this.elementInternals, `${prev}`, false);
+    }
+    if (next) {
+      toggleState(this.elementInternals, `${next}`, true);
+    }
+  }
 
   /**
    * size

--- a/packages/web-components/src/tablist/tablist.ts
+++ b/packages/web-components/src/tablist/tablist.ts
@@ -15,8 +15,7 @@ import { TablistAppearance, TablistOrientation, TablistSize } from './tablist.op
 type TabData = Omit<DOMRect, 'top' | 'bottom' | 'left' | 'right' | 'toJSON'>;
 
 /**
- * A Tabs component that wraps a collection of tab and tab panel elements.
- *
+ * A Tablist element that wraps a collection of tab elements
  * @public
  */
 export class BaseTablist extends FASTElement {
@@ -280,6 +279,10 @@ export class BaseTablist extends FASTElement {
   }
 }
 
+/**
+ * A BaseTablist component with extra logic for handling the styled active tab indicator.
+ * @public
+ */
 export class Tablist extends BaseTablist {
   /**
    * activeTabData

--- a/packages/web-components/src/tablist/tablist.ts
+++ b/packages/web-components/src/tablist/tablist.ts
@@ -24,8 +24,10 @@ type TabData = Omit<DOMRect, 'top' | 'bottom' | 'left' | 'right' | 'toJSON'>;
 export class BaseTablist extends FASTElement {
   /**
    * The internal {@link https://developer.mozilla.org/docs/Web/API/ElementInternals | `ElementInternals`} instance for the component.
+   *
+   * @internal
    */
-  elementInternals: ElementInternals = this.attachInternals();
+  public elementInternals: ElementInternals = this.attachInternals();
   /**
    * Used for disabling all click and keyboard events for the tabs, child tab elements.
    * @public
@@ -39,8 +41,10 @@ export class BaseTablist extends FASTElement {
    * Handles disabled changes
    * @param prev - previous value
    * @param next - next value
+   *
+   * @internal
    */
-  public disabledChanged(prev: boolean, next: boolean): void {
+  protected disabledChanged(prev: boolean, next: boolean): void {
     toggleState(this.elementInternals, 'disabled', next);
   }
 
@@ -421,11 +425,20 @@ export class Tablist extends BaseTablist {
     }
   }
 
+  /**
+   * Sets the css variables for the active tab indicator.
+   * @internal
+   */
   private setAnimationVars() {
     this.style.setProperty('--tabIndicatorOffset', `${this.activeTabOffset}px`);
-    this.style.setProperty('--tabIndicatorScale', this.activeTabScale.toString());
+    this.style.setProperty('--tabIndicatorScale', `${this.activeTabScale}`);
   }
 
+  /**
+   * Initiates the active tab indicator animation loop when activeid changes.
+   * @param oldValue - the previous tabId
+   * @param newValue - the new tabId
+   */
   public activeidChanged(oldValue: string, newValue: string) {
     super.activeidChanged(oldValue, newValue);
     this.setTabData();
@@ -435,6 +448,9 @@ export class Tablist extends BaseTablist {
     }
   }
 
+  /**
+   * Initiates the active tab indicator animation loop when tabs change.
+   */
   public tabsChanged(): void {
     super.tabsChanged();
     this.setTabData();

--- a/packages/web-components/src/tablist/tablist.ts
+++ b/packages/web-components/src/tablist/tablist.ts
@@ -9,6 +9,7 @@ import {
   keyHome,
   uniqueId,
 } from '@microsoft/fast-web-utilities';
+import { getDirection } from '../utils/index.js';
 import { Tab } from '../index.js';
 import { TablistAppearance, TablistOrientation, TablistSize } from './tablist.options.js';
 
@@ -26,7 +27,7 @@ export class BaseTablist extends FASTElement {
    * HTML Attribute: disabled.
    */
   @attr({ mode: 'boolean' })
-  public disabled?: boolean;
+  public disabled: boolean = false;
 
   /**
    * The orientation
@@ -39,11 +40,12 @@ export class BaseTablist extends FASTElement {
   /**
    * @internal
    */
-  public orientationChanged(): void {
+  protected orientationChanged(): void {
     if (this.$fastController.isConnected) {
       this.setTabs();
     }
   }
+
   /**
    * The id of the active tab
    *
@@ -56,7 +58,7 @@ export class BaseTablist extends FASTElement {
   /**
    * @internal
    */
-  public activeidChanged(oldValue: string, newValue: string): void {
+  protected activeidChanged(oldValue: string, newValue: string): void {
     if (this.$fastController.isConnected && this.tabs.length > 0) {
       this.prevActiveTabIndex = this.tabs.findIndex((item: HTMLElement) => item.id === oldValue);
       this.setTabs();
@@ -71,7 +73,7 @@ export class BaseTablist extends FASTElement {
   /**
    * @internal
    */
-  public tabsChanged(): void {
+  protected tabsChanged(): void {
     if (this.$fastController.isConnected && this.tabs.length > 0) {
       this.tabIds = this.getTabIds();
       this.setTabs();
@@ -156,7 +158,8 @@ export class BaseTablist extends FASTElement {
 
   private handleTabClick = (event: MouseEvent): void => {
     const selectedTab = event.currentTarget as HTMLElement;
-    if (selectedTab.nodeType === 1 && this.isFocusableElement(selectedTab)) {
+    console.log('selectedTab', selectedTab.nodeType === Node.ELEMENT_NODE);
+    if (selectedTab.nodeType === Node.ELEMENT_NODE && this.isFocusableElement(selectedTab)) {
       this.prevActiveTabIndex = this.activeTabIndex;
       this.activeTabIndex = this.tabs.indexOf(selectedTab);
       this.setComponent();
@@ -168,7 +171,7 @@ export class BaseTablist extends FASTElement {
   }
 
   private handleTabKeyDown = (event: KeyboardEvent): void => {
-    const dir = window.getComputedStyle(this).direction;
+    const dir = getDirection(this);
     switch (event.key) {
       case keyArrowLeft:
         if (!this.isHorizontal()) {
@@ -225,11 +228,11 @@ export class BaseTablist extends FASTElement {
     const nextIndex = this.tabs.indexOf(focusableTabs[nextTabIndex]);
 
     if (nextIndex > -1) {
-      this.moveToTabByIndex(this.tabs, nextIndex);
+      this.activateTabByIndex(this.tabs, nextIndex);
     }
   }
 
-  private moveToTabByIndex(group: HTMLElement[], index: number) {
+  private activateTabByIndex(group: HTMLElement[], index: number) {
     const tab: HTMLElement = group[index] as HTMLElement;
     this.activetab = tab;
     this.prevActiveTabIndex = this.activeTabIndex;

--- a/packages/web-components/src/tablist/tablist.ts
+++ b/packages/web-components/src/tablist/tablist.ts
@@ -1,0 +1,438 @@
+import { attr, FASTElement, observable } from '@microsoft/fast-element';
+import {
+  keyArrowDown,
+  keyArrowLeft,
+  keyArrowRight,
+  keyArrowUp,
+  keyEnd,
+  keyHome,
+  limit,
+  uniqueId,
+} from '@microsoft/fast-web-utilities';
+import { Tab } from '../index.js';
+import { TablistAppearance, TablistOrientation, TablistSize } from './tablist.options.js';
+
+type TabData = Omit<DOMRect, 'top' | 'bottom' | 'left' | 'right' | 'toJSON'>;
+
+/**
+ * A Tabs component that wraps a collection of tab and tab panel elements.
+ *
+ * @public
+ */
+export class BaseTablist extends FASTElement {
+  /**
+   * The orientation
+   * @public
+   * @remarks
+   * HTML Attribute: orientation
+   */
+  @attr
+  public orientation: TablistOrientation = TablistOrientation.horizontal;
+  /**
+   * @internal
+   */
+  public orientationChanged(): void {
+    if (this.$fastController.isConnected) {
+      this.setTabs();
+    }
+  }
+  /**
+   * The id of the active tab
+   *
+   * @public
+   * @remarks
+   * HTML Attribute: activeid
+   */
+  @attr
+  public activeid!: string;
+  /**
+   * @internal
+   */
+  public activeidChanged(oldValue: string, newValue: string): void {
+    if (this.$fastController.isConnected && this.tabs.length > 0) {
+      this.prevActiveTabIndex = this.tabs.findIndex((item: HTMLElement) => item.id === oldValue);
+      this.setTabs();
+    }
+  }
+
+  /**
+   * @internal
+   */
+  @observable
+  public tabs!: HTMLElement[];
+  /**
+   * @internal
+   */
+  public tabsChanged(): void {
+    if (this.$fastController.isConnected && this.tabs.length > 0) {
+      this.tabIds = this.getTabIds();
+      this.setTabs();
+    }
+  }
+
+  /**
+   * A reference to the active tab
+   * @public
+   */
+  public activetab!: HTMLElement;
+
+  private prevActiveTabIndex: number = 0;
+  private activeTabIndex: number = 0;
+  private tabIds!: Array<string>;
+
+  private change = (): void => {
+    this.$emit('change', this.activetab);
+  };
+
+  private isDisabledElement = (el: Element): el is HTMLElement => {
+    return el.getAttribute('aria-disabled') === 'true';
+  };
+
+  private isHiddenElement = (el: Element): el is HTMLElement => {
+    return el.hasAttribute('hidden');
+  };
+
+  private isFocusableElement = (el: Element): el is HTMLElement => {
+    return !this.isDisabledElement(el) && !this.isHiddenElement(el);
+  };
+
+  private getActiveIndex(): number {
+    const id: string = this.activeid;
+    if (id !== undefined) {
+      return this.tabIds.indexOf(this.activeid) === -1 ? 0 : this.tabIds.indexOf(this.activeid);
+    } else {
+      return 0;
+    }
+  }
+
+  /**
+   * Function that is invoked whenever the selected tab or the tab collection changes.
+   *
+   * @public
+   */
+  protected setTabs(): void {
+    this.activeTabIndex = this.getActiveIndex();
+
+    this.tabs.forEach((tab: HTMLElement, index: number) => {
+      if (tab.slot === 'tab') {
+        const isActiveTab = this.activeTabIndex === index && this.isFocusableElement(tab);
+
+        const tabId: string = this.tabIds[index];
+        tab.setAttribute('id', tabId);
+        tab.setAttribute('aria-selected', isActiveTab ? 'true' : 'false');
+        tab.addEventListener('click', this.handleTabClick);
+        tab.addEventListener('keydown', this.handleTabKeyDown);
+        tab.setAttribute('tabindex', isActiveTab ? '0' : '-1');
+        if (isActiveTab) {
+          this.activetab = tab;
+          this.activeid = tabId;
+        }
+      }
+    });
+  }
+
+  private getTabIds(): Array<string> {
+    return this.tabs.map((tab: HTMLElement) => {
+      return tab.getAttribute('id') ?? `tab-${uniqueId()}`;
+    });
+  }
+
+  private setComponent(): void {
+    if (this.activeTabIndex !== this.prevActiveTabIndex) {
+      this.activeid = this.tabIds[this.activeTabIndex] as string;
+      this.focusTab();
+      this.change();
+    }
+  }
+
+  private handleTabClick = (event: MouseEvent): void => {
+    const selectedTab = event.currentTarget as HTMLElement;
+    if (selectedTab.nodeType === 1 && this.isFocusableElement(selectedTab)) {
+      this.prevActiveTabIndex = this.activeTabIndex;
+      this.activeTabIndex = this.tabs.indexOf(selectedTab);
+      this.setComponent();
+    }
+  };
+
+  private isHorizontal(): boolean {
+    return this.orientation === TablistOrientation.horizontal;
+  }
+
+  private handleTabKeyDown = (event: KeyboardEvent): void => {
+    if (this.isHorizontal()) {
+      switch (event.key) {
+        case keyArrowLeft:
+          event.preventDefault();
+          this.adjustBackward(event);
+          break;
+        case keyArrowRight:
+          event.preventDefault();
+          this.adjustForward(event);
+          break;
+      }
+    } else {
+      switch (event.key) {
+        case keyArrowUp:
+          event.preventDefault();
+          this.adjustBackward(event);
+          break;
+        case keyArrowDown:
+          event.preventDefault();
+          this.adjustForward(event);
+          break;
+      }
+    }
+    switch (event.key) {
+      case keyHome:
+        event.preventDefault();
+        this.adjust(-this.activeTabIndex);
+        break;
+      case keyEnd:
+        event.preventDefault();
+        this.adjust(this.tabs.length - this.activeTabIndex - 1);
+        break;
+    }
+  };
+
+  /**
+   * The adjust method for FASTTabs
+   * @public
+   * @remarks
+   * This method allows the active index to be adjusted by numerical increments
+   */
+  public adjust(adjustment: number): void {
+    const focusableTabs = this.tabs.filter(t => this.isFocusableElement(t));
+    const currentActiveTabIndex = focusableTabs.indexOf(this.activetab);
+
+    const nextTabIndex = limit(0, focusableTabs.length - 1, currentActiveTabIndex + adjustment);
+
+    // the index of the next focusable tab within the context of all available tabs
+    const nextIndex = this.tabs.indexOf(focusableTabs[nextTabIndex]);
+
+    if (nextIndex > -1) {
+      this.moveToTabByIndex(this.tabs, nextIndex);
+    }
+  }
+
+  private adjustForward(e: KeyboardEvent): void {
+    const group: HTMLElement[] = this.tabs;
+    let index: number = 0;
+
+    index = this.activetab ? group.indexOf(this.activetab) + 1 : 1;
+    if (index === group.length) {
+      index = 0;
+    }
+
+    while (index < group.length && group.length > 1) {
+      if (this.isFocusableElement(group[index])) {
+        this.moveToTabByIndex(group, index);
+        break;
+      } else if (this.activetab && index === group.indexOf(this.activetab)) {
+        break;
+      } else if (index + 1 >= group.length) {
+        index = 0;
+      } else {
+        index += 1;
+      }
+    }
+  }
+
+  private adjustBackward(e: KeyboardEvent): void {
+    const group: HTMLElement[] = this.tabs;
+    let index: number = 0;
+
+    index = this.activetab ? group.indexOf(this.activetab) - 1 : 0;
+    index = index < 0 ? group.length - 1 : index;
+
+    while (index >= 0 && group.length > 1) {
+      if (this.isFocusableElement(group[index])) {
+        this.moveToTabByIndex(group, index);
+        break;
+      } else if (index - 1 < 0) {
+        index = group.length - 1;
+      } else {
+        index -= 1;
+      }
+    }
+  }
+
+  private moveToTabByIndex(group: HTMLElement[], index: number) {
+    const tab: HTMLElement = group[index] as HTMLElement;
+    this.activetab = tab;
+    this.prevActiveTabIndex = this.activeTabIndex;
+    this.activeTabIndex = index;
+    tab.focus();
+    this.setComponent();
+  }
+
+  private focusTab(): void {
+    this.tabs[this.activeTabIndex].focus();
+  }
+
+  /**
+   * @internal
+   */
+  public connectedCallback(): void {
+    super.connectedCallback();
+
+    this.tabIds = this.getTabIds();
+    this.activeTabIndex = this.getActiveIndex();
+  }
+}
+
+export class Tablist extends BaseTablist {
+  /**
+   * activeTabData
+   * The positional coordinates and size dimensions of the active tab. Used for calculating the offset and scale of the tab active indicator.
+   */
+  private activeTabData: TabData = { x: 0, y: 0, height: 0, width: 0 };
+  /**
+   * previousActiveTabData
+   * The positional coordinates and size dimensions of the active tab. Used for calculating the offset and scale of the tab active indicator.
+   */
+  private previousActiveTabData: TabData = { x: 0, y: 0, height: 0, width: 0 };
+  /**
+   * activeTabOffset
+   * Used to position the active indicator for animations of the active indicator on active tab changes.
+   */
+  private activeTabOffset = 0;
+  /**
+   * activeTabScale
+   * Used to scale the tab active indicator up or down as animations of the active indicator occur.
+   */
+  private activeTabScale = 1;
+
+  /**
+   * appearance
+   * There are two modes of appearance: transparent and subtle.
+   */
+  @attr
+  public appearance?: TablistAppearance = TablistAppearance.transparent;
+
+  /**
+   * disabled
+   * Used for disabling all click and keyboard events for the tabs, child tab elements and tab panel elements. UI styling of content and tabs will appear as "grayed out."
+   */
+  @attr({ mode: 'boolean' })
+  public disabled?: boolean;
+
+  /**
+   * size
+   * defaults to medium.
+   * Used to set the size of all the tab controls, which effects text size and margins. Three sizes: small, medium and large.
+   */
+  @attr
+  public size?: TablistSize;
+
+  /**
+   * calculateAnimationProperties
+   *
+   * Recalculates the active tab offset and scale.
+   * These values will be applied to css variables that control the tab active indicator position animations
+   */
+  private calculateAnimationProperties(tab: Tab) {
+    this.activeTabOffset = this.getTabPosition(tab);
+    this.activeTabScale = this.getTabScale(tab);
+  }
+
+  /**
+   * getSelectedTabPosition - gets the x or y coordinates of the tab
+   */
+  private getTabPosition(tab: Tab): number {
+    if (this.orientation === TablistOrientation.horizontal) {
+      return this.previousActiveTabData.x - (tab.getBoundingClientRect().x - this.getBoundingClientRect().x);
+    } else return this.previousActiveTabData.y - (tab.getBoundingClientRect().y - this.getBoundingClientRect().y);
+  }
+
+  /**
+   * getSelectedTabScale - gets the scale of the tab
+   */
+  private getTabScale(tab: Tab): number {
+    if (this.orientation === TablistOrientation.horizontal) {
+      return this.previousActiveTabData.width / tab.getBoundingClientRect().width;
+    } else return this.previousActiveTabData.height / tab.getBoundingClientRect().height;
+  }
+
+  /**
+   * Calculates and applies updated values to CSS variables.
+   *
+   * @param tab - the tab element to apply the updated values to
+   * @internal
+   */
+  private applyUpdatedCSSValues(tab: Tab) {
+    this.calculateAnimationProperties(tab);
+    this.setTabScaleCSSVar();
+    this.setTabOffsetCSSVar();
+  }
+
+  /**
+   * Runs through all the operations required for setting the tab active indicator to its starting location, ending
+   * location, and applying the animated css class to the tab.
+   *
+   * @param tab - the tab element to apply the updated values to
+   * @internal
+   */
+  private animationLoop(tab: Tab) {
+    // remove the animated class so nothing animates yet
+    tab.setAttribute('data-animate', 'false');
+    // animation start - this applyUpdatedCSSValues sets the active indicator to the location of the previously selected tab
+    this.applyUpdatedCSSValues(tab);
+    // changing the previously active tab allows the applyUpdatedCSSValues method to calculate the correct end to the animation.
+    this.previousActiveTabData = this.activeTabData;
+    // calculate and apply updated css values for animation.
+    this.applyUpdatedCSSValues(tab);
+    // add the css class and active indicator will animate from the previous tab location to its tab location
+    tab.setAttribute('data-animate', 'true');
+  }
+
+  /**
+   * Sets the data from the active tab onto the class. used for making all the animation calculations for the active
+   * tab indicator.
+   *
+   * @internal
+   */
+  private setTabData(): void {
+    if (this.tabs && this.tabs.length > 0) {
+      const tabs = this.tabs as Tab[];
+      const activeTab = this.activetab || tabs[0];
+      const activeRect = activeTab?.getBoundingClientRect();
+      const parentRect = this.getBoundingClientRect();
+
+      this.activeTabData = {
+        x: activeRect.x - parentRect.x,
+        y: activeRect.y - parentRect.y,
+        height: activeRect.height,
+        width: activeRect.width,
+      } as TabData;
+
+      if (
+        this.previousActiveTabData?.x !== this.activeTabData?.x &&
+        this.previousActiveTabData?.y !== this.activeTabData?.y
+      ) {
+        this.previousActiveTabData = this.activeTabData;
+      }
+    }
+  }
+
+  private setTabOffsetCSSVar() {
+    this.style.setProperty('--tabIndicatorOffset', `${this.activeTabOffset}px`);
+  }
+
+  private setTabScaleCSSVar() {
+    this.style.setProperty('--tabIndicatorScale', this.activeTabScale.toString());
+  }
+
+  public activeidChanged(oldValue: string, newValue: string) {
+    super.activeidChanged(oldValue, newValue);
+    this.setTabData();
+
+    if (this.activetab) {
+      this.animationLoop(this.activetab as Tab);
+    }
+  }
+
+  public tabsChanged(): void {
+    super.tabsChanged();
+    this.setTabData();
+  }
+}

--- a/packages/web-components/src/tablist/tablist.ts
+++ b/packages/web-components/src/tablist/tablist.ts
@@ -133,10 +133,6 @@ export class BaseTablist extends FASTElement {
    * @public
    */
   protected setTabs(): void {
-    if (this.disabled) {
-      return;
-    }
-
     this.activeTabIndex = this.getActiveIndex();
 
     this.tabs.forEach((tab: HTMLElement, index: number) => {
@@ -148,7 +144,7 @@ export class BaseTablist extends FASTElement {
         tab.setAttribute('aria-selected', isActiveTab ? 'true' : 'false');
         tab.addEventListener('click', this.handleTabClick);
         tab.addEventListener('keydown', this.handleTabKeyDown);
-        tab.setAttribute('tabindex', isActiveTab ? '0' : '-1');
+        tab.setAttribute('tabindex', isActiveTab && !this.disabled ? '0' : '-1');
         if (isActiveTab) {
           this.activetab = tab;
           this.activeid = tabId;
@@ -234,10 +230,6 @@ export class BaseTablist extends FASTElement {
    * This method allows the active index to be adjusted by numerical increments
    */
   public adjust(adjustment: number): void {
-    if (this.disabled) {
-      return;
-    }
-
     const focusableTabs = this.tabs.filter(t => isFocusableElement(t));
     const currentActiveTabIndex = focusableTabs.indexOf(this.activetab);
 

--- a/packages/web-components/src/tablist/tablist.ts
+++ b/packages/web-components/src/tablist/tablist.ts
@@ -222,7 +222,7 @@ export class BaseTablist extends FASTElement {
         break;
       case keyEnd:
         event.preventDefault();
-        this.adjust(this.tabs.length - this.activeTabIndex - 1);
+        this.adjust(this.tabs.filter(t => isFocusableElement(t)).length - this.activeTabIndex - 1);
         break;
     }
   };

--- a/packages/web-components/src/tablist/tablist.ts
+++ b/packages/web-components/src/tablist/tablist.ts
@@ -20,6 +20,15 @@ type TabData = Omit<DOMRect, 'top' | 'bottom' | 'left' | 'right' | 'toJSON'>;
  */
 export class BaseTablist extends FASTElement {
   /**
+   * Used for disabling all click and keyboard events for the tabs, child tab elements.
+   * @public
+   * @remarks
+   * HTML Attribute: disabled.
+   */
+  @attr({ mode: 'boolean' })
+  public disabled?: boolean;
+
+  /**
    * The orientation
    * @public
    * @remarks
@@ -158,30 +167,35 @@ export class BaseTablist extends FASTElement {
   }
 
   private handleTabKeyDown = (event: KeyboardEvent): void => {
-    if (this.isHorizontal()) {
-      switch (event.key) {
-        case keyArrowLeft:
-          event.preventDefault();
-          this.adjustBackward(event);
-          break;
-        case keyArrowRight:
-          event.preventDefault();
-          this.adjustForward(event);
-          break;
-      }
-    } else {
-      switch (event.key) {
-        case keyArrowUp:
-          event.preventDefault();
-          this.adjustBackward(event);
-          break;
-        case keyArrowDown:
-          event.preventDefault();
-          this.adjustForward(event);
-          break;
-      }
-    }
     switch (event.key) {
+      case keyArrowLeft:
+        if (!this.isHorizontal()) {
+          return;
+        }
+        event.preventDefault();
+        this.adjustBackward(event);
+        break;
+      case keyArrowRight:
+        if (!this.isHorizontal()) {
+          return;
+        }
+        event.preventDefault();
+        this.adjustForward(event);
+        break;
+      case keyArrowUp:
+        if (this.isHorizontal()) {
+          return;
+        }
+        event.preventDefault();
+        this.adjustBackward(event);
+        break;
+      case keyArrowDown:
+        if (this.isHorizontal()) {
+          return;
+        }
+        event.preventDefault();
+        this.adjustForward(event);
+        break;
       case keyHome:
         event.preventDefault();
         this.adjust(-this.activeTabIndex);
@@ -311,13 +325,6 @@ export class Tablist extends BaseTablist {
    */
   @attr
   public appearance?: TablistAppearance = TablistAppearance.transparent;
-
-  /**
-   * disabled
-   * Used for disabling all click and keyboard events for the tabs, child tab elements and tab panel elements. UI styling of content and tabs will appear as "grayed out."
-   */
-  @attr({ mode: 'boolean' })
-  public disabled?: boolean;
 
   /**
    * size

--- a/packages/web-components/src/tablist/tablist.ts
+++ b/packages/web-components/src/tablist/tablist.ts
@@ -135,6 +135,7 @@ export class BaseTablist extends FASTElement {
           this.activetab = tab;
           this.activeid = tabId;
         }
+        this.change();
       }
     });
   }
@@ -167,20 +168,21 @@ export class BaseTablist extends FASTElement {
   }
 
   private handleTabKeyDown = (event: KeyboardEvent): void => {
+    const dir = window.getComputedStyle(this).direction;
     switch (event.key) {
       case keyArrowLeft:
         if (!this.isHorizontal()) {
           return;
         }
         event.preventDefault();
-        this.adjust(-1);
+        this.adjust(dir === 'ltr' ? -1 : 1);
         break;
       case keyArrowRight:
         if (!this.isHorizontal()) {
           return;
         }
         event.preventDefault();
-        this.adjust(1);
+        this.adjust(dir === 'ltr' ? 1 : -1);
         break;
       case keyArrowUp:
         if (this.isHorizontal()) {
@@ -402,5 +404,9 @@ export class Tablist extends BaseTablist {
   public tabsChanged(): void {
     super.tabsChanged();
     this.setTabData();
+
+    if (this.activetab) {
+      this.animationLoop(this.activetab as Tab);
+    }
   }
 }

--- a/packages/web-components/src/utils/focusable-element.ts
+++ b/packages/web-components/src/utils/focusable-element.ts
@@ -1,0 +1,11 @@
+export const isARIADisabledElement = (el: Element): boolean => {
+  return el.getAttribute('aria-disabled') === 'true';
+};
+
+export const isHiddenElement = (el: Element): boolean => {
+  return el.hasAttribute('hidden');
+};
+
+export const isFocusableElement = (el: Element): boolean => {
+  return !isARIADisabledElement(el) && !isHiddenElement(el);
+};


### PR DESCRIPTION
## Previous Behavior

Current Tabs web component is an assembly of three components (`-tabs`, `-tab`, and `-tabpanel`) which is very explicit but very DOM heavy and doesn't easily support scenarios like ajax'ing in content.

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

This new `Tablist` component is more on par with the React implementation and is much simpler in its approach, providing only the`-tab` and `-tablist` components and allowing the consumer to react to the `change` event (when the active tab changes) as necessary.
