### PR TITLE
feat(scripts-executors): implement new `yarn start` experience

### DIFF
--- a/.github/workflows/check-tooling.yml
+++ b/.github/workflows/check-tooling.yml
@@ -26,6 +26,8 @@ jobs:
 
       - run: yarn install --frozen-lockfile
 
+      - run: yarn nx run scripts-executors:test -t start
+
       - run: yarn nx list @fluentui/workspace-plugin
 
       - run: yarn nx g @fluentui/workspace-plugin:react-library --name hello-world --owner '@mrWick' --kind standard --no-interactive

--- a/.github/workflows/check-tooling.yml
+++ b/.github/workflows/check-tooling.yml
@@ -4,10 +4,12 @@ on:
   pull_request:
     paths:
       - 'tools/workspace-plugin/**'
+      - 'scripts/executors/**'
 
 env:
   __FORCE_API_MD_UPDATE__: true
   __FORCE_SNAPSHOT_UPDATE__: true
+  NX_VERBOSE_LOGGING: true
 
 jobs:
   check-tools:

--- a/package.json
+++ b/package.json
@@ -373,8 +373,7 @@
     "eslint": "8.57.0",
     "swc-loader": "^0.2.6",
     "prettier": "2.8.8",
-    "puppeteer": "19.6.0",
-    "enquirer": "2.4.1"
+    "puppeteer": "19.6.0"
   },
   "nx": {
     "includedScripts": []

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "northstar:test:circulars": "gulp test:circulars:run",
     "rename-package": "node -r ./scripts/ts-node/src/register ./scripts/generators/src/rename-package.ts",
     "scrub": "node ./scripts/executors/src/scrub.js",
-    "start": "node ./scripts/executors/src/start.js",
+    "start": "node -r ./scripts/ts-node/src/register ./scripts/executors/src/start",
     "test": "nx run-many -t test --verbose",
     "update-snapshots": "nx run-many -t update-snapshots --verbose"
   },

--- a/package.json
+++ b/package.json
@@ -161,7 +161,6 @@
     "@types/node": "20.12.12",
     "@types/prettier": "2.7.2",
     "@types/progress": "2.0.5",
-    "@types/prompts": "2.4.1",
     "@types/react": "17.0.44",
     "@types/react-dom": "17.0.15",
     "@types/react-is": "17.0.3",
@@ -287,7 +286,6 @@
     "postcss-modules": "4.1.3",
     "prettier": "2.8.8",
     "progress": "2.0.3",
-    "prompts": "2.4.2",
     "puppeteer": "19.6.0",
     "raw-loader": "4.0.2",
     "react": "17.0.2",
@@ -375,7 +373,8 @@
     "eslint": "8.57.0",
     "swc-loader": "^0.2.6",
     "prettier": "2.8.8",
-    "puppeteer": "19.6.0"
+    "puppeteer": "19.6.0",
+    "enquirer": "2.4.1"
   },
   "nx": {
     "includedScripts": []

--- a/scripts/executors/src/enquirer-types.d.ts
+++ b/scripts/executors/src/enquirer-types.d.ts
@@ -1,11 +1,18 @@
 // Enquirer Type definitions are not in best state - https://github.com/enquirer/enquirer/pull/307
 declare module 'enquirer' {
+  type Choice = {
+    name: string;
+    message?: string;
+    value: string;
+  };
   export interface AutoCompleteOptions {
     name: string;
     message: string;
-    choices: Array<string | { name: string; value: string }>;
+    choices: Array<string | Choice>;
     limit?: number;
+    header?: string;
     footer?: () => string;
+    suggest?: (input: string, choices: Array<Choice>) => Array<Choice> | [];
   }
 
   export class AutoComplete {

--- a/scripts/executors/src/enquirer-types.d.ts
+++ b/scripts/executors/src/enquirer-types.d.ts
@@ -1,0 +1,15 @@
+// Enquirer Type definitions are not in best state - https://github.com/enquirer/enquirer/pull/307
+declare module 'enquirer' {
+  export interface AutoCompleteOptions {
+    name: string;
+    message: string;
+    choices: Array<string | { name: string; value: string }>;
+    limit?: number;
+    footer?: () => string;
+  }
+
+  export class AutoComplete {
+    constructor(options: AutoCompleteOptions);
+    public run(): Promise<string>;
+  }
+}

--- a/scripts/executors/src/start.js
+++ b/scripts/executors/src/start.js
@@ -1,77 +1,97 @@
 const { spawnSync } = require('node:child_process');
 
 const { workspaceRoot, output } = require('@nx/devkit');
-const prompts = require('prompts');
+const { AutoComplete } = require('enquirer');
 
 const targetDescription = {
-  build: 'Build the project',
-  'bundle-size': 'Check the bundle size diff of the project',
-  bundle: 'Bundle the project with webpack',
-  storybook: 'Start storybook for the project',
-  'build-storybook': 'Build production version of storybook for project',
-  'generate-api': 're-generate projects api.md',
-  lint: 'Run eslint on the project',
-  'type-check': 'type-check the project',
-  test: 'Run tests for the project',
-  'test-integration': 'Run integration tests for the project',
-  'test-ssr': 'Run server-side rendering tests for the project',
-  'test-vr': 'Run visual regression tests for the project',
-  'test-perf': 'Run performance tests for the project',
-  e2e: 'Run e2e/component tests for the project (cypress)',
-  'verify-packaging': 'Verify npm packaging of the project',
-  start: 'Start the project',
+  build: 'transpile source TS to JS',
+  'bundle-size': 'check the bundle size diff',
+  bundle: 'bundle source with webpack',
+  storybook: 'start storybook in dev mode',
+  'build-storybook': 'build production version of storybook',
+  'generate-api': 're-generate api.md (using api-extractor)',
+  lint: 'validate code with eslint',
+  'type-check': 'validate type correctness via TypeScript',
+  test: 'run jest tests ',
+  'test-integration': 'run integration tests (using @fluentui/scripts-projects-test)',
+  'test-ssr': 'run server-side rendering tests (using @fluentui/scripts-test-ssr)',
+  'test-vr': 'run visual regression tests (using storywright)',
+  'test-perf': 'run performance tests',
+  e2e: 'run e2e/component tests for the project',
+  'verify-packaging': 'verify packaging assets that will be shipped to npm',
+  // non default targets
+  format: 'format code with prettier',
+  'code-style': 'format code with prettier and run eslint',
+  clean: 'remove build artifacts',
+  start: 'start the project',
+  help: 'show project help',
 };
 
 const omitTargets = ['nx-release-publish', 'just'];
 
-/**
- * @type {string[]}
- */
-const allProjects = JSON.parse(
-  spawnSync('nx', ['show', 'projects', '--json'], { cwd: workspaceRoot }).stdout.toString(),
-);
-const extraArgs = process.argv.slice(2) ?? [];
-
-/**
- *
- * @param {string} input
- * @param {import('prompts').Choice[]} choices
- */
-const suggest = (input, choices) => Promise.resolve(choices.filter(i => i.title.includes(input)));
-
 async function main() {
-  const projectPrompt = await prompts({
-    type: 'autocomplete',
-    name: 'project',
+  /**
+   * @type {string[]}
+   */
+  const allProjects = JSON.parse(
+    spawnSync('nx', ['show', 'projects', '--json'], { cwd: workspaceRoot }).stdout.toString(),
+  );
+  const extraArgs = process.argv.slice(2) ?? [];
 
-    message: 'Which project to start (select or type partial name)?',
-    suggest,
-    choices: [...allProjects.map(p => ({ title: p }))],
+  const projectPrompt = new AutoComplete({
+    name: 'project',
+    message: 'Select project to start',
+    choices: allProjects,
+    limit: 10,
+    footer() {
+      return output.dim('(Scroll up and down to reveal more choices)');
+    },
   });
 
+  /** @type {string} */
+  const selectedProject = await projectPrompt.run();
+
   const projectTargets = JSON.parse(
-    spawnSync('nx', ['show', 'project', projectPrompt.project, '--json'], { cwd: workspaceRoot }).stdout.toString(),
+    spawnSync('nx', ['show', 'project', selectedProject, '--json'], { cwd: workspaceRoot }).stdout.toString(),
   );
 
   const availableTargets = /** @type {Array<keyof typeof  targetDescription>} */ (
     Object.keys(projectTargets.targets).filter(targetName => {
       return omitTargets.includes(targetName) ? false : true;
     })
-  );
+  ).concat('help');
 
-  const targetPrompt = await prompts({
-    type: 'autocomplete',
+  const longestTargetName = availableTargets.reduce((acc, targetName) => {
+    return targetName.length > acc ? targetName.length : acc;
+  }, 0);
+
+  const targetChoices = availableTargets.map(targetName => ({
+    name: formatTargetOutput(targetName, createTaskDescription(targetName, projectTargets.targets)),
+    value: targetName,
+  }));
+
+  const targetPrompt = new AutoComplete({
     name: 'target',
-
-    message: 'Which target to start (select or type partial name)?',
-    suggest,
-    choices: [
-      ...availableTargets.map(targetName => ({
-        title: targetName,
-        description: createTaskDescription(targetName, projectTargets.targets),
-      })),
-    ],
+    message: 'Select target to start',
+    choices: targetChoices,
+    limit: 5,
+    footer() {
+      return output.dim('(Scroll up and down to reveal more choices)');
+    },
   });
+
+  /** @type {string} */
+  const selectedTarget = await targetPrompt.run();
+
+  /**
+   *
+   * @param {string} targetName
+   * @param {string} description
+   */
+  function formatTargetOutput(targetName, description) {
+    const padding = ' '.repeat(longestTargetName - targetName.length);
+    return `${targetName}${padding} - ${description}`;
+  }
 
   /**
    *
@@ -80,19 +100,54 @@ async function main() {
    * @returns
    */
   function createTaskDescription(targetName, targetsMetadata) {
+    const description = targetDescription[targetName];
+    const nxTargetDefinition = targetsMetadata[targetName];
+
+    if (!nxTargetDefinition) {
+      return description;
+    }
+
     if (targetName === 'start') {
-      const startTarget = targetsMetadata[targetName];
-      const scriptContent = startTarget.metadata.scriptContent;
+      const scriptContent = nxTargetDefinition.metadata.scriptContent;
       if (scriptContent.includes('storybook')) {
         return `Start the project (Alias of "storybook" target)`;
       }
-      return targetDescription[targetName];
+      return description;
     }
 
-    return targetDescription[targetName];
+    if (targetName === 'e2e') {
+      const scriptContent = nxTargetDefinition.metadata.scriptContent;
+      const runnerType = getRunnerType(scriptContent);
+      return description + ` (using ${runnerType})`;
+    }
+
+    return description ?? nxTargetDefinition.metadata.scriptContent;
+
+    /**
+     * @param {string} scriptContent
+     * @returns {'cypress' | 'playwright'}
+     */
+    function getRunnerType(scriptContent) {
+      if (scriptContent.includes('cypress')) {
+        return 'cypress';
+      }
+      if (scriptContent.includes('playwright')) {
+        return 'playwright';
+      }
+      throw new Error('invalid runner type');
+    }
   }
 
-  const cmd = `${projectPrompt.project}:${targetPrompt.target}`;
+  if (selectedTarget === 'help') {
+    spawnSync('nx', ['show', 'project', selectedProject], {
+      shell: true,
+      stdio: 'inherit',
+    });
+
+    process.exit(0);
+  }
+
+  const cmd = `${selectedProject}:${selectedTarget}`;
 
   output.logSingleLine(`Running nx run ${cmd} ${extraArgs.join(' ')}`);
 

--- a/scripts/executors/src/start.spec.ts
+++ b/scripts/executors/src/start.spec.ts
@@ -1,13 +1,80 @@
-import { spawn } from 'node:child_process';
+import { type ExecSyncOptions, execSync, spawn } from 'node:child_process';
 
-import { workspaceRoot } from '@nx/devkit';
+import { getPackageManagerCommand, output, workspaceRoot } from '@nx/devkit';
+
+function isVerbose() {
+  return process.env.NX_VERBOSE_LOGGING === 'true' || process.argv.includes('--verbose');
+}
+function isVerboseE2ERun() {
+  return process.env.NX_E2E_VERBOSE_LOGGING === 'true' || isVerbose();
+}
+function runCommand(command: string, options?: Partial<ExecSyncOptions> & { failOnError?: boolean }): string {
+  const { failOnError, ...childProcessOptions } = options ?? {};
+  try {
+    const r = execSync(command, {
+      // cwd: tmpProjPath(),
+      cwd: workspaceRoot,
+      stdio: 'pipe',
+      env: {
+        // ...getStrippedEnvironmentVariables(),
+        ...process.env,
+        ...childProcessOptions?.env,
+        FORCE_COLOR: 'false',
+      },
+      encoding: 'utf-8',
+      ...childProcessOptions,
+    });
+
+    if (isVerboseE2ERun()) {
+      output.log({
+        title: `Command: ${command}`,
+        bodyLines: [r as string],
+        color: 'green',
+      });
+    }
+
+    return r as string;
+  } catch (e: unknown) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const err = e as any;
+    // this is intentional
+    // npm ls fails if package is not found
+    console.error(`Original command: ${command}`, `${err.stdout}\n\n${err.stderr}`);
+
+    if (!failOnError && (err.stdout || err.stderr)) {
+      return err.stdout + err.stderr;
+    }
+    throw e;
+  }
+}
 
 describe('start CLI', () => {
-  jest.setTimeout(30000);
-  it('should run start', done => {
+  it(`should behave...`, () => {
+    process.env.NX_VERBOSE_LOGGING = 'true';
+    const command = 'start';
+    const pm = getPackageManagerCommand('yarn');
+    const fullCommand = `${pm.exec} ${command}`;
+
+    const log = runCommand(fullCommand);
+
+    expect(log).toEqual(expect.stringContaining('WELCOME TO FLUENT UI'));
+    expect(log).toEqual(expect.stringContaining('Select project to run'));
+    // const logs = execSync(fullCommand, {
+    //   // cwd: opts.cwd || tmpProjPath(),
+    //   // env: {
+    //   //   CI: 'true',
+    //   //   // ...(opts.env || getStrippedEnvironmentVariables()),
+    //   // },
+    //   encoding: 'utf-8',
+    //   stdio: 'pipe',
+    //   maxBuffer: 50 * 1024 * 1024,
+    // });
+  }, 30000);
+
+  it.skip('should run start', done => {
     const timeout = 2500;
     let timeoutId: NodeJS.Timeout;
-    let output: string;
+    let log: string;
 
     const childProcess = spawn('yarn', ['start'], { cwd: workspaceRoot, stdio: 'pipe', shell: true });
 
@@ -28,7 +95,7 @@ describe('start CLI', () => {
 
     // Set up listeners for stdout and stderr
     childProcess.stdout.on('data', data => {
-      output += data;
+      log += data;
       if (!childProcess.killed) {
         console.log(`stdout: ${data}`);
         resetInactivityTimer();
@@ -45,12 +112,12 @@ describe('start CLI', () => {
     // Set up listener for exit
     childProcess.on('exit', code => {
       console.info(`Child process exited with code ${code}`);
-      console.log('cli output:', { output });
+      console.log('cli output:', { log });
 
       global.clearTimeout(timeoutId); // Clear the timer if the process exits
 
-      expect(output).toEqual(expect.stringContaining('WELCOME TO FLUENT UI'));
-      expect(output).toEqual(expect.stringContaining('Select project to run'));
+      expect(log).toEqual(expect.stringContaining('WELCOME TO FLUENT UI'));
+      expect(log).toEqual(expect.stringContaining('Select project to run'));
 
       done();
     });

--- a/scripts/executors/src/start.spec.ts
+++ b/scripts/executors/src/start.spec.ts
@@ -1,128 +1,35 @@
-import { type ExecSyncOptions, execSync, spawn } from 'node:child_process';
+import { getPackageManagerCommand, workspaceRoot } from '@nx/devkit';
+import { runCommand } from '@nx/plugin/testing';
 
-import { getPackageManagerCommand, output, workspaceRoot } from '@nx/devkit';
+describe('start CLI', () => {
+  const pm = getPackageManagerCommand('yarn');
+
+  it(`should run a smoke test`, () => {
+    const command = 'start';
+    const fullCommand = `${pm.exec} ${command}`;
+    const log = runCommand(fullCommand, { cwd: workspaceRoot });
+
+    if (isVerbose()) {
+      console.log('cli output:', { log: stripConsoleColors(log) });
+    }
+
+    expect(log).toEqual(expect.stringContaining('WELCOME TO FLUENT UI'));
+    expect(log).toEqual(expect.stringContaining('Select project to run'));
+    expect(log).toEqual(expect.stringContaining('(Scroll up and down to reveal more choices)'));
+  }, 30000);
+});
+
+// ===== test utils =====
 
 function isVerbose() {
   return process.env.NX_VERBOSE_LOGGING === 'true' || process.argv.includes('--verbose');
 }
-function isVerboseE2ERun() {
-  return process.env.NX_E2E_VERBOSE_LOGGING === 'true' || isVerbose();
+
+/**
+ * Remove log colors for fail proof string search
+ *
+ * > copied from https://github.com/nrwl/nx/blob/c400ea3002eba058d4e4ca02b3b5144ace306f15/e2e/utils/log-utils.ts#L42
+ */
+export function stripConsoleColors(log: string): string {
+  return log?.replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, '');
 }
-function runCommand(command: string, options?: Partial<ExecSyncOptions> & { failOnError?: boolean }): string {
-  const { failOnError, ...childProcessOptions } = options ?? {};
-  try {
-    const r = execSync(command, {
-      // cwd: tmpProjPath(),
-      cwd: workspaceRoot,
-      stdio: 'pipe',
-      env: {
-        // ...getStrippedEnvironmentVariables(),
-        ...process.env,
-        ...childProcessOptions?.env,
-        FORCE_COLOR: 'false',
-      },
-      encoding: 'utf-8',
-      ...childProcessOptions,
-    });
-
-    if (isVerboseE2ERun()) {
-      output.log({
-        title: `Command: ${command}`,
-        bodyLines: [r as string],
-        color: 'green',
-      });
-    }
-
-    return r as string;
-  } catch (e: unknown) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const err = e as any;
-    // this is intentional
-    // npm ls fails if package is not found
-    console.error(`Original command: ${command}`, `${err.stdout}\n\n${err.stderr}`);
-
-    if (!failOnError && (err.stdout || err.stderr)) {
-      return err.stdout + err.stderr;
-    }
-    throw e;
-  }
-}
-
-describe('start CLI', () => {
-  it(`should behave...`, () => {
-    process.env.NX_VERBOSE_LOGGING = 'true';
-    const command = 'start';
-    const pm = getPackageManagerCommand('yarn');
-    const fullCommand = `${pm.exec} ${command}`;
-
-    const log = runCommand(fullCommand);
-
-    expect(log).toEqual(expect.stringContaining('WELCOME TO FLUENT UI'));
-    expect(log).toEqual(expect.stringContaining('Select project to run'));
-    // const logs = execSync(fullCommand, {
-    //   // cwd: opts.cwd || tmpProjPath(),
-    //   // env: {
-    //   //   CI: 'true',
-    //   //   // ...(opts.env || getStrippedEnvironmentVariables()),
-    //   // },
-    //   encoding: 'utf-8',
-    //   stdio: 'pipe',
-    //   maxBuffer: 50 * 1024 * 1024,
-    // });
-  }, 30000);
-
-  it.skip('should run start', done => {
-    const timeout = 2500;
-    let timeoutId: NodeJS.Timeout;
-    let log: string;
-
-    const childProcess = spawn('yarn', ['start'], { cwd: workspaceRoot, stdio: 'pipe', shell: true });
-
-    // Function to handle inactivity
-    const handleInactivity = () => {
-      if (!childProcess.killed) {
-        console.log('No new data received within the timeout period.');
-      }
-      // Handle the inactivity case, e.g., terminate the child process
-      childProcess.kill();
-    };
-
-    // Function to reset the inactivity timer
-    const resetInactivityTimer = () => {
-      global.clearTimeout(timeoutId);
-      timeoutId = global.setTimeout(handleInactivity, timeout);
-    };
-
-    // Set up listeners for stdout and stderr
-    childProcess.stdout.on('data', data => {
-      log += data;
-      if (!childProcess.killed) {
-        console.log(`stdout: ${data}`);
-        resetInactivityTimer();
-      }
-    });
-
-    childProcess.stderr.on('data', data => {
-      if (!childProcess.killed) {
-        console.error(`stderr: ${data}`);
-        resetInactivityTimer();
-      }
-    });
-
-    // Set up listener for exit
-    childProcess.on('exit', code => {
-      console.info(`Child process exited with code ${code}`);
-      console.log('cli output:', { log });
-
-      global.clearTimeout(timeoutId); // Clear the timer if the process exits
-
-      expect(log).toEqual(expect.stringContaining('WELCOME TO FLUENT UI'));
-      expect(log).toEqual(expect.stringContaining('Select project to run'));
-
-      done();
-    });
-
-    // Initialize the inactivity timer
-    resetInactivityTimer();
-  });
-});

--- a/scripts/executors/src/start.spec.ts
+++ b/scripts/executors/src/start.spec.ts
@@ -1,0 +1,49 @@
+import { spawn } from 'node:child_process';
+
+import { workspaceRoot } from '@nx/devkit';
+
+describe('start CLI', () => {
+  jest.setTimeout(30000);
+  it('should run start', done => {
+    const timeout = 5000;
+    let timeoutId: NodeJS.Timeout;
+    let output: string;
+
+    const childProcess = spawn('yarn', ['start'], { cwd: workspaceRoot, stdio: 'pipe' });
+
+    // Function to handle inactivity
+    const handleInactivity = () => {
+      console.log('No new data received within the timeout period.');
+      // Handle the inactivity case, e.g., terminate the child process
+      childProcess.kill();
+    };
+
+    // Function to reset the inactivity timer
+    const resetInactivityTimer = () => {
+      global.clearTimeout(timeoutId);
+      timeoutId = global.setTimeout(handleInactivity, timeout);
+    };
+
+    // Set up listeners for stdout and stderr
+    childProcess.stdout.on('data', data => {
+      output += data;
+      resetInactivityTimer();
+    });
+
+    childProcess.stderr.on('data', data => {
+      resetInactivityTimer();
+    });
+
+    // Set up listener for exit
+    childProcess.on('exit', code => {
+      console.log(`Child process exited with code ${code}`);
+      clearTimeout(timeoutId); // Clear the timer if the process exits
+      expect(output).toEqual(expect.stringContaining('WELCOME TO FLUENT UI'));
+      expect(output).toEqual(expect.stringContaining('Select project to run'));
+      done();
+    });
+
+    // Initialize the inactivity timer
+    resetInactivityTimer();
+  });
+});

--- a/scripts/executors/src/start.ts
+++ b/scripts/executors/src/start.ts
@@ -1,7 +1,10 @@
-const { spawnSync } = require('node:child_process');
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference -- cannot just import .d.ts as that is causing failures within ts-node/register
+/// <reference types="./enquirer-types.d.ts" />
 
-const { workspaceRoot, output } = require('@nx/devkit');
-const { AutoComplete } = require('enquirer');
+import { spawnSync } from 'node:child_process';
+
+import { output, workspaceRoot } from '@nx/devkit';
+import { AutoComplete } from 'enquirer';
 
 const targetDescription = {
   build: 'transpile source TS to JS',
@@ -30,10 +33,7 @@ const targetDescription = {
 const omitTargets = ['nx-release-publish', 'just'];
 
 async function main() {
-  /**
-   * @type {string[]}
-   */
-  const allProjects = JSON.parse(
+  const allProjects: string[] = JSON.parse(
     spawnSync('nx', ['show', 'projects', '--json'], { cwd: workspaceRoot }).stdout.toString(),
   );
   const extraArgs = process.argv.slice(2) ?? [];
@@ -48,18 +48,17 @@ async function main() {
     },
   });
 
-  /** @type {string} */
-  const selectedProject = await projectPrompt.run();
+  const selectedProject: string = await projectPrompt.run();
 
   const projectTargets = JSON.parse(
     spawnSync('nx', ['show', 'project', selectedProject, '--json'], { cwd: workspaceRoot }).stdout.toString(),
   );
 
-  const availableTargets = /** @type {Array<keyof typeof  targetDescription>} */ (
-    Object.keys(projectTargets.targets).filter(targetName => {
+  const availableTargets = Object.keys(projectTargets.targets)
+    .filter(targetName => {
       return omitTargets.includes(targetName) ? false : true;
     })
-  ).concat('help');
+    .concat('help') as Array<keyof typeof targetDescription>;
 
   const longestTargetName = availableTargets.reduce((acc, targetName) => {
     return targetName.length > acc ? targetName.length : acc;
@@ -80,26 +79,19 @@ async function main() {
     },
   });
 
-  /** @type {string} */
-  const selectedTarget = await targetPrompt.run();
+  const selectedTarget: string = await targetPrompt.run();
 
-  /**
-   *
-   * @param {string} targetName
-   * @param {string} description
-   */
-  function formatTargetOutput(targetName, description) {
+  function formatTargetOutput(targetName: string, description: string) {
     const padding = ' '.repeat(longestTargetName - targetName.length);
     return `${targetName}${padding} - ${description}`;
   }
 
-  /**
-   *
-   * @param {keyof typeof  targetDescription} targetName
-   * @param {{[targetName:string]:{metadata:{executor:string;scriptContent:string;runCommand:string}}}} targetsMetadata
-   * @returns
-   */
-  function createTaskDescription(targetName, targetsMetadata) {
+  function createTaskDescription(
+    targetName: keyof typeof targetDescription,
+    targetsMetadata: {
+      [targetName: string]: { metadata: { executor: string; scriptContent: string; runCommand: string } };
+    },
+  ) {
     const description = targetDescription[targetName];
     const nxTargetDefinition = targetsMetadata[targetName];
 
@@ -123,11 +115,7 @@ async function main() {
 
     return description ?? nxTargetDefinition.metadata.scriptContent;
 
-    /**
-     * @param {string} scriptContent
-     * @returns {'cypress' | 'playwright'}
-     */
-    function getRunnerType(scriptContent) {
+    function getRunnerType(scriptContent: string): 'cypress' | 'playwright' {
       if (scriptContent.includes('cypress')) {
         return 'cypress';
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5522,13 +5522,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/prompts@2.4.1":
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/@types/prompts/-/prompts-2.4.1.tgz#d47adcb608a0afcd48121ff7c75244694a3a04c5"
-  integrity sha512-1Mqzhzi9W5KlooNE4o0JwSXGUDeQXKldbGn9NO4tpxwZbHXYd+WcKpCksG2lbhH7U9I9LigfsdVsP2QAY0lNPA==
-  dependencies:
-    "@types/node" "*"
-
 "@types/prop-types@*", "@types/prop-types@15.7.1":
   version "15.7.1"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.1.tgz#f1a11e7babb0c3cad68100be381d1e064c68f1f6"
@@ -10358,12 +10351,13 @@ enhanced-resolve@^5.0.0, enhanced-resolve@^5.12.0, enhanced-resolve@^5.15.0, enh
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
 
-enquirer@2.3.6, enquirer@^2.3.5, enquirer@^2.3.6, enquirer@~2.3.6:
-  version "2.3.6"
-  resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
-  integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
+enquirer@2.3.6, enquirer@2.4.1, enquirer@^2.3.5, enquirer@^2.3.6, enquirer@~2.3.6:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.4.1.tgz#93334b3fbd74fc7097b224ab4a8fb7e40bf4ae56"
+  integrity sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==
   dependencies:
     ansi-colors "^4.1.1"
+    strip-ansi "^6.0.1"
 
 entities@^1.1.1, entities@~1.1.1:
   version "1.1.2"
@@ -19025,7 +19019,7 @@ promise@^8.1.0:
   dependencies:
     asap "~2.0.6"
 
-prompts@2.4.2, prompts@^2.0.1, prompts@^2.1.0, prompts@^2.4.0:
+prompts@^2.0.1, prompts@^2.1.0, prompts@^2.4.0:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.4.2.tgz#7b57e73b3a48029ad10ebd44f74b01722a4cb069"
   integrity sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -10351,13 +10351,12 @@ enhanced-resolve@^5.0.0, enhanced-resolve@^5.12.0, enhanced-resolve@^5.15.0, enh
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
 
-enquirer@2.3.6, enquirer@2.4.1, enquirer@^2.3.5, enquirer@^2.3.6, enquirer@~2.3.6:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.4.1.tgz#93334b3fbd74fc7097b224ab4a8fb7e40bf4ae56"
-  integrity sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==
+enquirer@2.3.6, enquirer@^2.3.5, enquirer@^2.3.6, enquirer@~2.3.6:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
+  integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
   dependencies:
     ansi-colors "^4.1.1"
-    strip-ansi "^6.0.1"
 
 entities@^1.1.1, entities@~1.1.1:
   version "1.1.2"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

`yarn start` provides primitive alias with not enough context to run a `yarn workspace` `start` npm script

## New Behavior

As we migrated to [Nx](https://nx.dev/getting-started/intro), our `yarn start` experience provides significantly improved DX, taking inspiration from official NX IDE plugin - [Nx Console](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console)

Besides providing every project `target` within the CLI we add artificial `help` target which leverages `nx show project` capabilities in order to provide comprehensive overview about the project.

### Demo

https://github.com/user-attachments/assets/fa164508-820a-4ad5-a27a-1468c505ec82



## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Implements partially https://github.com/microsoft/fluentui/issues/30267
