### PR TITLE
ci(vrt): bump vr-approval-cli to 0.4.5 and use new create policy api

### DIFF
--- a/azure-pipelines.vrt-baseline.yml
+++ b/azure-pipelines.vrt-baseline.yml
@@ -33,8 +33,6 @@ jobs:
         env:
           API_TOKEN: $(fabric-public-pipeline-access-PAT)
           GITHUB_API_TOKEN: $(githubRepoStatusPAT)
-          STORAGE_CONNECTION_STRING: $(BLOB-CONNECTION-STRING)
-          VR_APP_CLIENT_ID: $(VR_APP_CLIENT_ID)
           VR_APP_API_URL: $(VR_APP_API_URL)
           STORAGE_ACCOUNT_ID: $(StorageAccountId)
           TENANT_ID: $(TenantId)
@@ -66,8 +64,6 @@ jobs:
         env:
           API_TOKEN: $(fabric-public-pipeline-access-PAT)
           GITHUB_API_TOKEN: $(githubRepoStatusPAT)
-          STORAGE_CONNECTION_STRING: $(BLOB-CONNECTION-STRING)
-          VR_APP_CLIENT_ID: $(VR_APP_CLIENT_ID)
           VR_APP_API_URL: $(VR_APP_API_URL)
           STORAGE_ACCOUNT_ID: $(StorageAccountId)
           TENANT_ID: $(TenantId)
@@ -99,8 +95,6 @@ jobs:
         env:
           API_TOKEN: $(fabric-public-pipeline-access-PAT)
           GITHUB_API_TOKEN: $(githubRepoStatusPAT)
-          STORAGE_CONNECTION_STRING: $(BLOB-CONNECTION-STRING)
-          VR_APP_CLIENT_ID: $(VR_APP_CLIENT_ID)
           VR_APP_API_URL: $(VR_APP_API_URL)
           STORAGE_ACCOUNT_ID: $(StorageAccountId)
           TENANT_ID: $(TenantId)
@@ -131,8 +125,6 @@ jobs:
         env:
           API_TOKEN: $(fabric-public-pipeline-access-PAT)
           GITHUB_API_TOKEN: $(githubRepoStatusPAT)
-          STORAGE_CONNECTION_STRING: $(BLOB-CONNECTION-STRING)
-          VR_APP_CLIENT_ID: $(VR_APP_CLIENT_ID)
           VR_APP_API_URL: $(VR_APP_API_URL)
           STORAGE_ACCOUNT_ID: $(StorageAccountId)
           TENANT_ID: $(TenantId)

--- a/azure-pipelines.vrt-pr.yml
+++ b/azure-pipelines.vrt-pr.yml
@@ -28,37 +28,16 @@ jobs:
       - template: .devops/templates/tools.yml
 
       - bash: |
-          postPolicy="true";
-          response=$(curl --request POST ${VR_APP_CLIENT_URL} --header 'Content-Type: application/x-www-form-urlencoded' --data-urlencode 'grant_type=client_credentials' --data-urlencode 'client_id='${VR_APP_CLIENT_ID} --data-urlencode 'client_secret='${VR_APPROVAL_CLIENT_SECRET})
-            parsedResponse=${response/*"access_token"/}
-            token=${parsedResponse:3:${#parsedResponse}-5}
-            curl --location --request POST 'https://vrtfunctionappv0.azurewebsites.net/api/policyStateV2' \
-            --header 'Authorization: Bearer '"$token" \
-            --header 'Content-Type: application/json' \
-            --data-raw '	{
-            "organization": "uifabric",
-            "projectName": "fabricpublic",
-            "prId": $(System.PullRequest.PullRequestNumber),
-            "commitId": "$(Build.SourceVersion)",
-              "generate":true,
-              "clientType":"FLUENTUI",
-              "blockingPipeline":{
-              },
-              "nonBlockingPipeline":{
-                "$(pipelineId)": {
-                  "pipelineStatus": "PENDING",
-                  "pipelineName": "$(pipelineName)"
-                }
-              },
-              "postPolicy": '${postPolicy}',
-              "policyType": "OPTIONAL"
-            }'
-        displayName: 'Call policy State Api'
+          set -exuo pipefail
+          vr-app create-policy --nonBlockingPipelines '{"$(pipelineId)":{"pipelineStatus": "PENDING","pipelineName": "$(pipelineName)"}}' --clientType 'FLUENTUI'
+        displayName: VR App - Create Policy
         env:
-          VR_APPROVAL_HOST: $(VR_APPROVAL_HOST)
           VR_APP_CLIENT_ID: $(VR_APP_CLIENT_ID)
-          VR_APPROVAL_CLIENT_SECRET: $(VR-APPROVAL-CLIENT-SECRET)
-          VR_APP_CLIENT_URL: $(VR_APP_CLIENT_URL)
+          VR_APP_API_URL: $(VR_APP_API_URL_NEW)
+          TENANT_ID: $(TenantId)
+          PRINCIPAL_CLIENT_ID: $(PrincipalClientId)
+          SERVICE_CONNECTION_ID: $(ServiceConnectionId)
+          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
       - template: .devops/templates/runpublishvrscreenshot.yml
         parameters:
@@ -102,37 +81,16 @@ jobs:
       - template: .devops/templates/tools.yml
 
       - bash: |
-          postPolicy="true";
-          response=$(curl --request POST ${VR_APP_CLIENT_URL} --header 'Content-Type: application/x-www-form-urlencoded' --data-urlencode 'grant_type=client_credentials' --data-urlencode 'client_id='${VR_APP_CLIENT_ID} --data-urlencode 'client_secret='${VR_APPROVAL_CLIENT_SECRET} )
-            parsedResponse=${response/*"access_token"/}
-            token=${parsedResponse:3:${#parsedResponse}-5}
-            curl --location --request POST 'https://vrtfunctionappv0.azurewebsites.net/api/policyStateV2' \
-            --header 'Authorization: Bearer '"$token" \
-            --header 'Content-Type: application/json' \
-            --data-raw '	{
-            "organization": "uifabric",
-            "projectName": "fabricpublic",
-            "prId": $(System.PullRequest.PullRequestNumber),
-            "commitId": "$(Build.SourceVersion)",
-              "generate":true,
-              "clientType":"FLUENTUI",
-              "blockingPipeline":{
-              },
-              "nonBlockingPipeline":{
-                "$(pipelineId)": {
-                  "pipelineStatus": "PENDING",
-                  "pipelineName": "$(pipelineName)"
-                }
-              },
-              "postPolicy": '${postPolicy}',
-              "policyType": "OPTIONAL"
-            }'
-        displayName: 'Call policy State Api'
+          set -exuo pipefail
+          vr-app create-policy --nonBlockingPipelines '{"$(pipelineId)":{"pipelineStatus": "PENDING","pipelineName": "$(pipelineName)"}}' --clientType 'FLUENTUI'
+        displayName: VR App - Create Policy
         env:
-          VR_APPROVAL_HOST: $(VR_APPROVAL_HOST)
           VR_APP_CLIENT_ID: $(VR_APP_CLIENT_ID)
-          VR_APPROVAL_CLIENT_SECRET: $(VR-APPROVAL-CLIENT-SECRET)
-          VR_APP_CLIENT_URL: $(VR_APP_CLIENT_URL)
+          VR_APP_API_URL: $(VR_APP_API_URL_NEW)
+          TENANT_ID: $(TenantId)
+          PRINCIPAL_CLIENT_ID: $(PrincipalClientId)
+          SERVICE_CONNECTION_ID: $(ServiceConnectionId)
+          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
       - template: .devops/templates/runpublishvrscreenshot.yml
         parameters:
@@ -175,37 +133,16 @@ jobs:
       - template: .devops/templates/tools.yml
 
       - bash: |
-          postPolicy="true";
-          response=$(curl --request POST ${VR_APP_CLIENT_URL} --header 'Content-Type: application/x-www-form-urlencoded' --data-urlencode 'grant_type=client_credentials' --data-urlencode 'client_id='${VR_APP_CLIENT_ID} --data-urlencode 'client_secret='${VR_APPROVAL_CLIENT_SECRET})
-            parsedResponse=${response/*"access_token"/}
-            token=${parsedResponse:3:${#parsedResponse}-5}
-            curl --location --request POST 'https://vrtfunctionappv0.azurewebsites.net/api/policyStateV2' \
-            --header 'Authorization: Bearer '"$token" \
-            --header 'Content-Type: application/json' \
-            --data-raw '	{
-            "organization": "uifabric",
-            "projectName": "fabricpublic",
-            "prId": $(System.PullRequest.PullRequestNumber),
-            "commitId": "$(Build.SourceVersion)",
-              "generate":true,
-              "clientType":"FLUENTUI",
-              "blockingPipeline":{
-              },
-              "nonBlockingPipeline":{
-                "$(pipelineId)": {
-                  "pipelineStatus": "PENDING",
-                  "pipelineName": "$(pipelineName)"
-                }
-              },
-              "postPolicy": '${postPolicy}',
-              "policyType": "OPTIONAL"
-            }'
-        displayName: 'Call policy State Api'
+          set -exuo pipefail
+          vr-app create-policy --nonBlockingPipelines '{"$(pipelineId)":{"pipelineStatus": "PENDING","pipelineName": "$(pipelineName)"}}' --clientType 'FLUENTUI'
+        displayName: VR App - Create Policy
         env:
-          VR_APPROVAL_HOST: $(VR_APPROVAL_HOST)
           VR_APP_CLIENT_ID: $(VR_APP_CLIENT_ID)
-          VR_APPROVAL_CLIENT_SECRET: $(VR-APPROVAL-CLIENT-SECRET)
-          VR_APP_CLIENT_URL: $(VR_APP_CLIENT_URL)
+          VR_APP_API_URL: $(VR_APP_API_URL_NEW)
+          TENANT_ID: $(TenantId)
+          PRINCIPAL_CLIENT_ID: $(PrincipalClientId)
+          SERVICE_CONNECTION_ID: $(ServiceConnectionId)
+          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
       - template: .devops/templates/runpublishvrscreenshot.yml
         parameters:
@@ -249,36 +186,16 @@ jobs:
       - template: .devops/templates/tools.yml
 
       - bash: |
-          postPolicy="true";
-          response=$(curl --request POST ${VR_APP_CLIENT_URL} --header 'Content-Type: application/x-www-form-urlencoded' --data-urlencode 'grant_type=client_credentials' --data-urlencode 'client_id='${VR_APP_CLIENT_ID} --data-urlencode 'client_secret='${VR_APPROVAL_CLIENT_SECRET})
-            parsedResponse=${response/*"access_token"/}
-            token=${parsedResponse:3:${#parsedResponse}-5}
-            curl --location --request POST 'https://vrtfunctionappv0.azurewebsites.net/api/policyStateV2' \
-            --header 'Authorization: Bearer '"$token" \
-            --header 'Content-Type: application/json' \
-            --data-raw '	{
-            "organization": "uifabric",
-            "projectName": "fabricpublic",
-            "prId": $(System.PullRequest.PullRequestNumber),
-            "commitId": "$(Build.SourceVersion)",
-              "generate":true,
-              "clientType":"FLUENTUI",
-              "blockingPipeline":{
-              },
-              "nonBlockingPipeline":{
-                "$(pipelineId)": {
-                  "pipelineStatus": "PENDING",
-                  "pipelineName": "$(pipelineName)"
-                }
-              },
-              "postPolicy": '${postPolicy}',
-              "policyType": "OPTIONAL"
-            }'
-        displayName: 'Call policy State Api'
+          set -exuo pipefail
+          vr-app create-policy --nonBlockingPipelines '{"$(pipelineId)":{"pipelineStatus": "PENDING","pipelineName": "$(pipelineName)"}}' --clientType 'FLUENTUI'
+        displayName: VR App - Create Policy
         env:
           VR_APP_CLIENT_ID: $(VR_APP_CLIENT_ID)
-          VR_APPROVAL_CLIENT_SECRET: $(VR-APPROVAL-CLIENT-SECRET)
-          VR_APP_CLIENT_URL: $(VR_APP_CLIENT_URL)
+          VR_APP_API_URL: $(VR_APP_API_URL_NEW)
+          TENANT_ID: $(TenantId)
+          PRINCIPAL_CLIENT_ID: $(PrincipalClientId)
+          SERVICE_CONNECTION_ID: $(ServiceConnectionId)
+          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
       - template: .devops/templates/runpublishvrscreenshot.yml
         parameters:

--- a/azure-pipelines.vrt-pr.yml
+++ b/azure-pipelines.vrt-pr.yml
@@ -39,7 +39,7 @@ jobs:
         displayName: VR App - Create Policy
         env:
           VR_APP_CLIENT_ID: $(VR_APP_CLIENT_ID)
-          VR_APP_API_URL: $(VR_APP_API_URL_NEW)
+          VR_APP_API_URL: $(VR_APP_API_URL)
           TENANT_ID: $(TenantId)
           PRINCIPAL_CLIENT_ID: $(PrincipalClientId)
           SERVICE_CONNECTION_ID: $(ServiceConnectionId)
@@ -52,7 +52,7 @@ jobs:
           GITHUB_API_TOKEN: $(githubRepoStatusPAT)
           STORAGE_CONNECTION_STRING: $(BLOB-CONNECTION-STRING)
           VR_APP_CLIENT_ID: $(VR_APP_CLIENT_ID)
-          VR_APP_API_URL: $(VR_APP_API_URL_NEW)
+          VR_APP_API_URL: $(VR_APP_API_URL)
           STORAGE_ACCOUNT_ID: $(StorageAccountId)
           TENANT_ID: $(TenantId)
           PRINCIPAL_CLIENT_ID: $(PrincipalClientId)
@@ -92,7 +92,7 @@ jobs:
         displayName: VR App - Create Policy
         env:
           VR_APP_CLIENT_ID: $(VR_APP_CLIENT_ID)
-          VR_APP_API_URL: $(VR_APP_API_URL_NEW)
+          VR_APP_API_URL: $(VR_APP_API_URL)
           TENANT_ID: $(TenantId)
           PRINCIPAL_CLIENT_ID: $(PrincipalClientId)
           SERVICE_CONNECTION_ID: $(ServiceConnectionId)
@@ -105,7 +105,7 @@ jobs:
           GITHUB_API_TOKEN: $(githubRepoStatusPAT)
           STORAGE_CONNECTION_STRING: $(BLOB-CONNECTION-STRING)
           VR_APP_CLIENT_ID: $(VR_APP_CLIENT_ID)
-          VR_APP_API_URL: $(VR_APP_API_URL_NEW)
+          VR_APP_API_URL: $(VR_APP_API_URL)
           STORAGE_ACCOUNT_ID: $(StorageAccountId)
           TENANT_ID: $(TenantId)
           PRINCIPAL_CLIENT_ID: $(PrincipalClientId)
@@ -144,7 +144,7 @@ jobs:
         displayName: VR App - Create Policy
         env:
           VR_APP_CLIENT_ID: $(VR_APP_CLIENT_ID)
-          VR_APP_API_URL: $(VR_APP_API_URL_NEW)
+          VR_APP_API_URL: $(VR_APP_API_URL)
           TENANT_ID: $(TenantId)
           PRINCIPAL_CLIENT_ID: $(PrincipalClientId)
           SERVICE_CONNECTION_ID: $(ServiceConnectionId)
@@ -157,7 +157,7 @@ jobs:
           GITHUB_API_TOKEN: $(githubRepoStatusPAT)
           STORAGE_CONNECTION_STRING: $(BLOB-CONNECTION-STRING)
           VR_APP_CLIENT_ID: $(VR_APP_CLIENT_ID)
-          VR_APP_API_URL: $(VR_APP_API_URL_NEW)
+          VR_APP_API_URL: $(VR_APP_API_URL)
           STORAGE_ACCOUNT_ID: $(StorageAccountId)
           TENANT_ID: $(TenantId)
           PRINCIPAL_CLIENT_ID: $(PrincipalClientId)
@@ -197,7 +197,7 @@ jobs:
         displayName: VR App - Create Policy
         env:
           VR_APP_CLIENT_ID: $(VR_APP_CLIENT_ID)
-          VR_APP_API_URL: $(VR_APP_API_URL_NEW)
+          VR_APP_API_URL: $(VR_APP_API_URL)
           TENANT_ID: $(TenantId)
           PRINCIPAL_CLIENT_ID: $(PrincipalClientId)
           SERVICE_CONNECTION_ID: $(ServiceConnectionId)
@@ -210,7 +210,7 @@ jobs:
           GITHUB_API_TOKEN: $(githubRepoStatusPAT)
           STORAGE_CONNECTION_STRING: $(BLOB-CONNECTION-STRING)
           VR_APP_CLIENT_ID: $(VR_APP_CLIENT_ID)
-          VR_APP_API_URL: $(VR_APP_API_URL_NEW)
+          VR_APP_API_URL: $(VR_APP_API_URL)
           STORAGE_ACCOUNT_ID: $(StorageAccountId)
           TENANT_ID: $(TenantId)
           PRINCIPAL_CLIENT_ID: $(PrincipalClientId)

--- a/azure-pipelines.vrt-pr.yml
+++ b/azure-pipelines.vrt-pr.yml
@@ -38,7 +38,6 @@ jobs:
           yarn vr-app create-policy --nonBlockingPipelines '{"$(pipelineId)":{"pipelineStatus": "PENDING","pipelineName": "$(pipelineName)"}}' --clientType 'FLUENTUI'
         displayName: VR App - Create Policy
         env:
-          VR_APP_CLIENT_ID: $(VR_APP_CLIENT_ID)
           VR_APP_API_URL: $(VR_APP_API_URL)
           TENANT_ID: $(TenantId)
           PRINCIPAL_CLIENT_ID: $(PrincipalClientId)
@@ -50,8 +49,6 @@ jobs:
         env:
           API_TOKEN: $(fabric-public-pipeline-access-PAT)
           GITHUB_API_TOKEN: $(githubRepoStatusPAT)
-          STORAGE_CONNECTION_STRING: $(BLOB-CONNECTION-STRING)
-          VR_APP_CLIENT_ID: $(VR_APP_CLIENT_ID)
           VR_APP_API_URL: $(VR_APP_API_URL)
           STORAGE_ACCOUNT_ID: $(StorageAccountId)
           TENANT_ID: $(TenantId)
@@ -91,7 +88,6 @@ jobs:
           yarn vr-app create-policy --nonBlockingPipelines '{"$(pipelineId)":{"pipelineStatus": "PENDING","pipelineName": "$(pipelineName)"}}' --clientType 'FLUENTUI'
         displayName: VR App - Create Policy
         env:
-          VR_APP_CLIENT_ID: $(VR_APP_CLIENT_ID)
           VR_APP_API_URL: $(VR_APP_API_URL)
           TENANT_ID: $(TenantId)
           PRINCIPAL_CLIENT_ID: $(PrincipalClientId)
@@ -103,8 +99,6 @@ jobs:
         env:
           API_TOKEN: $(fabric-public-pipeline-access-PAT)
           GITHUB_API_TOKEN: $(githubRepoStatusPAT)
-          STORAGE_CONNECTION_STRING: $(BLOB-CONNECTION-STRING)
-          VR_APP_CLIENT_ID: $(VR_APP_CLIENT_ID)
           VR_APP_API_URL: $(VR_APP_API_URL)
           STORAGE_ACCOUNT_ID: $(StorageAccountId)
           TENANT_ID: $(TenantId)
@@ -143,7 +137,6 @@ jobs:
           yarn vr-app create-policy --nonBlockingPipelines '{"$(pipelineId)":{"pipelineStatus": "PENDING","pipelineName": "$(pipelineName)"}}' --clientType 'FLUENTUI'
         displayName: VR App - Create Policy
         env:
-          VR_APP_CLIENT_ID: $(VR_APP_CLIENT_ID)
           VR_APP_API_URL: $(VR_APP_API_URL)
           TENANT_ID: $(TenantId)
           PRINCIPAL_CLIENT_ID: $(PrincipalClientId)
@@ -155,8 +148,6 @@ jobs:
         env:
           API_TOKEN: $(fabric-public-pipeline-access-PAT)
           GITHUB_API_TOKEN: $(githubRepoStatusPAT)
-          STORAGE_CONNECTION_STRING: $(BLOB-CONNECTION-STRING)
-          VR_APP_CLIENT_ID: $(VR_APP_CLIENT_ID)
           VR_APP_API_URL: $(VR_APP_API_URL)
           STORAGE_ACCOUNT_ID: $(StorageAccountId)
           TENANT_ID: $(TenantId)
@@ -196,7 +187,6 @@ jobs:
           yarn vr-app create-policy --nonBlockingPipelines '{"$(pipelineId)":{"pipelineStatus": "PENDING","pipelineName": "$(pipelineName)"}}' --clientType 'FLUENTUI'
         displayName: VR App - Create Policy
         env:
-          VR_APP_CLIENT_ID: $(VR_APP_CLIENT_ID)
           VR_APP_API_URL: $(VR_APP_API_URL)
           TENANT_ID: $(TenantId)
           PRINCIPAL_CLIENT_ID: $(PrincipalClientId)
@@ -208,8 +198,6 @@ jobs:
         env:
           API_TOKEN: $(fabric-public-pipeline-access-PAT)
           GITHUB_API_TOKEN: $(githubRepoStatusPAT)
-          STORAGE_CONNECTION_STRING: $(BLOB-CONNECTION-STRING)
-          VR_APP_CLIENT_ID: $(VR_APP_CLIENT_ID)
           VR_APP_API_URL: $(VR_APP_API_URL)
           STORAGE_ACCOUNT_ID: $(StorageAccountId)
           TENANT_ID: $(TenantId)

--- a/azure-pipelines.vrt-pr.yml
+++ b/azure-pipelines.vrt-pr.yml
@@ -29,7 +29,7 @@ jobs:
 
       - bash: |
           set -exuo pipefail
-          vr-app create-policy --nonBlockingPipelines '{"$(pipelineId)":{"pipelineStatus": "PENDING","pipelineName": "$(pipelineName)"}}' --clientType 'FLUENTUI'
+          yarn vr-app create-policy --nonBlockingPipelines '{"$(pipelineId)":{"pipelineStatus": "PENDING","pipelineName": "$(pipelineName)"}}' --clientType 'FLUENTUI'
         displayName: VR App - Create Policy
         env:
           VR_APP_CLIENT_ID: $(VR_APP_CLIENT_ID)
@@ -82,7 +82,7 @@ jobs:
 
       - bash: |
           set -exuo pipefail
-          vr-app create-policy --nonBlockingPipelines '{"$(pipelineId)":{"pipelineStatus": "PENDING","pipelineName": "$(pipelineName)"}}' --clientType 'FLUENTUI'
+          yarn vr-app create-policy --nonBlockingPipelines '{"$(pipelineId)":{"pipelineStatus": "PENDING","pipelineName": "$(pipelineName)"}}' --clientType 'FLUENTUI'
         displayName: VR App - Create Policy
         env:
           VR_APP_CLIENT_ID: $(VR_APP_CLIENT_ID)
@@ -134,7 +134,7 @@ jobs:
 
       - bash: |
           set -exuo pipefail
-          vr-app create-policy --nonBlockingPipelines '{"$(pipelineId)":{"pipelineStatus": "PENDING","pipelineName": "$(pipelineName)"}}' --clientType 'FLUENTUI'
+          yarn vr-app create-policy --nonBlockingPipelines '{"$(pipelineId)":{"pipelineStatus": "PENDING","pipelineName": "$(pipelineName)"}}' --clientType 'FLUENTUI'
         displayName: VR App - Create Policy
         env:
           VR_APP_CLIENT_ID: $(VR_APP_CLIENT_ID)
@@ -187,7 +187,7 @@ jobs:
 
       - bash: |
           set -exuo pipefail
-          vr-app create-policy --nonBlockingPipelines '{"$(pipelineId)":{"pipelineStatus": "PENDING","pipelineName": "$(pipelineName)"}}' --clientType 'FLUENTUI'
+          yarn vr-app create-policy --nonBlockingPipelines '{"$(pipelineId)":{"pipelineStatus": "PENDING","pipelineName": "$(pipelineName)"}}' --clientType 'FLUENTUI'
         displayName: VR App - Create Policy
         env:
           VR_APP_CLIENT_ID: $(VR_APP_CLIENT_ID)

--- a/azure-pipelines.vrt-pr.yml
+++ b/azure-pipelines.vrt-pr.yml
@@ -27,6 +27,12 @@ jobs:
 
       - template: .devops/templates/tools.yml
 
+      - template: .devops/templates/runpublishvrscreenshot.yml
+        parameters:
+          fluentVersion: webcomponents
+          vrTestPackageName: '@fluentui/vr-tests-web-components'
+          vrTestPackagePath: 'apps/vr-tests-web-components'
+
       - bash: |
           set -exuo pipefail
           yarn vr-app create-policy --nonBlockingPipelines '{"$(pipelineId)":{"pipelineStatus": "PENDING","pipelineName": "$(pipelineName)"}}' --clientType 'FLUENTUI'
@@ -38,12 +44,6 @@ jobs:
           PRINCIPAL_CLIENT_ID: $(PrincipalClientId)
           SERVICE_CONNECTION_ID: $(ServiceConnectionId)
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-
-      - template: .devops/templates/runpublishvrscreenshot.yml
-        parameters:
-          fluentVersion: webcomponents
-          vrTestPackageName: '@fluentui/vr-tests-web-components'
-          vrTestPackagePath: 'apps/vr-tests-web-components'
 
       - task: AzureCLI@2
         displayName: 'Run fluentui-screenshotdiff'
@@ -80,6 +80,12 @@ jobs:
 
       - template: .devops/templates/tools.yml
 
+      - template: .devops/templates/runpublishvrscreenshot.yml
+        parameters:
+          fluentVersion: v9
+          vrTestPackageName: '@fluentui/vr-tests-react-components'
+          vrTestPackagePath: 'apps/vr-tests-react-components'
+
       - bash: |
           set -exuo pipefail
           yarn vr-app create-policy --nonBlockingPipelines '{"$(pipelineId)":{"pipelineStatus": "PENDING","pipelineName": "$(pipelineName)"}}' --clientType 'FLUENTUI'
@@ -91,12 +97,6 @@ jobs:
           PRINCIPAL_CLIENT_ID: $(PrincipalClientId)
           SERVICE_CONNECTION_ID: $(ServiceConnectionId)
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-
-      - template: .devops/templates/runpublishvrscreenshot.yml
-        parameters:
-          fluentVersion: v9
-          vrTestPackageName: '@fluentui/vr-tests-react-components'
-          vrTestPackagePath: 'apps/vr-tests-react-components'
 
       - task: AzureCLI@2
         displayName: 'Run fluentui-screenshotdiff'
@@ -132,6 +132,12 @@ jobs:
 
       - template: .devops/templates/tools.yml
 
+      - template: .devops/templates/runpublishvrscreenshot.yml
+        parameters:
+          fluentVersion: v8
+          vrTestPackageName: '@fluentui/vr-tests'
+          vrTestPackagePath: 'apps/vr-tests'
+
       - bash: |
           set -exuo pipefail
           yarn vr-app create-policy --nonBlockingPipelines '{"$(pipelineId)":{"pipelineStatus": "PENDING","pipelineName": "$(pipelineName)"}}' --clientType 'FLUENTUI'
@@ -143,12 +149,6 @@ jobs:
           PRINCIPAL_CLIENT_ID: $(PrincipalClientId)
           SERVICE_CONNECTION_ID: $(ServiceConnectionId)
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-
-      - template: .devops/templates/runpublishvrscreenshot.yml
-        parameters:
-          fluentVersion: v8
-          vrTestPackageName: '@fluentui/vr-tests'
-          vrTestPackagePath: 'apps/vr-tests'
 
       - task: AzureCLI@2
         displayName: 'Run fluentui-screenshotdiff'
@@ -185,6 +185,12 @@ jobs:
 
       - template: .devops/templates/tools.yml
 
+      - template: .devops/templates/runpublishvrscreenshot.yml
+        parameters:
+          fluentVersion: v0
+          vrTestPackageName: '@fluentui/docs'
+          vrTestPackagePath: 'packages/fluentui/docs'
+
       - bash: |
           set -exuo pipefail
           yarn vr-app create-policy --nonBlockingPipelines '{"$(pipelineId)":{"pipelineStatus": "PENDING","pipelineName": "$(pipelineName)"}}' --clientType 'FLUENTUI'
@@ -196,12 +202,6 @@ jobs:
           PRINCIPAL_CLIENT_ID: $(PrincipalClientId)
           SERVICE_CONNECTION_ID: $(ServiceConnectionId)
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-
-      - template: .devops/templates/runpublishvrscreenshot.yml
-        parameters:
-          fluentVersion: v0
-          vrTestPackageName: '@fluentui/docs'
-          vrTestPackagePath: 'packages/fluentui/docs'
 
       - task: AzureCLI@2
         displayName: 'Run fluentui-screenshotdiff'

--- a/package.json
+++ b/package.json
@@ -341,7 +341,7 @@
     "tslib": "2.6.3",
     "typescript": "5.0.4",
     "vinyl": "2.2.0",
-    "vr-approval-cli": "0.4.4",
+    "vr-approval-cli": "0.4.5",
     "webpack": "5.90.3",
     "webpack-bundle-analyzer": "4.10.1",
     "webpack-cli": "5.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -24603,10 +24603,10 @@ vm-browserify@^1.0.1:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
 
-vr-approval-cli@0.4.4:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/vr-approval-cli/-/vr-approval-cli-0.4.4.tgz#a9377056996a69e2d54fa561118abdf599bab458"
-  integrity sha512-rQ3nFyHds7gy1paVb1pkQJVJuzf2CJyzvq2g4x1Qe9JQHSgAWITdpD0tfPTvCuwLh6JcZ3z3hTr+sTSHg5976Q==
+vr-approval-cli@0.4.5:
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/vr-approval-cli/-/vr-approval-cli-0.4.5.tgz#315b5708f5a6cd6750887f5983f125dbe2d51169"
+  integrity sha512-ahZrf0WphWSx3YZ9JtYCO+FCxAuTmryg035k4Nv3DAZV01KjNrXrk8qfRu/uo2NdTizNUjx483pkeZkgihGHXA==
   dependencies:
     "@azure/identity" "^4.3.0"
     "@azure/storage-blob" "12.11.0"


### PR DESCRIPTION
## Changes:
- bumps `vr-approval-cli` to latest `0.4.5` and uses new `create-policy` API in VR PR pipelines which removes the need for passing client secrets
- cleans up variable names and removes `_NEW` postfix (actual variable value changes have been applied in the pipeline behind the scenes)

## Related Changes:
- Follows #31997