### PR TITLE
Added size in toolbar button props

### DIFF
--- a/change/@fluentui-react-toolbar-0a130b67-a04e-48c8-832c-f4dabf86eced.json
+++ b/change/@fluentui-react-toolbar-0a130b67-a04e-48c8-832c-f4dabf86eced.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Bug fix for 32063",
+  "packageName": "@fluentui/react-toolbar",
+  "email": "vmoka@hawk.iit.edu",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-toolbar/library/docs/Spec.md
+++ b/packages/react-components/react-toolbar/library/docs/Spec.md
@@ -47,7 +47,7 @@ It serves as an override on top of `Button` limiting the possible props only to 
 
 ```typescript
 type type ToolbarButtonProps = ComponentProps<ButtonSlots> &
-  Partial<Pick<ButtonProps, 'disabled' | 'disabledFocusable'>> & {
+  Partial<Pick<ButtonProps, 'disabled' | 'disabledFocusable' | 'size'>> & {
 
   /**
    * A button can have its content and borders styled for greater emphasis or to be subtle.

--- a/packages/react-components/react-toolbar/library/etc/react-toolbar.api.md
+++ b/packages/react-components/react-toolbar/library/etc/react-toolbar.api.md
@@ -33,7 +33,7 @@ export const Toolbar: ForwardRefComponent<ToolbarProps>;
 export const ToolbarButton: ForwardRefComponent<ToolbarButtonProps>;
 
 // @public
-export type ToolbarButtonProps = ComponentProps<ButtonSlots> & Partial<Pick<ButtonProps, 'disabled' | 'disabledFocusable'>> & {
+export type ToolbarButtonProps = ComponentProps<ButtonSlots> & Partial<Pick<ButtonProps, 'disabled' | 'disabledFocusable' | 'size'>> & {
     appearance?: 'primary' | 'subtle';
 } & {
     vertical?: boolean;

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarButton/ToolbarButton.types.ts
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarButton/ToolbarButton.types.ts
@@ -5,7 +5,7 @@ import { ButtonProps, ButtonSlots, ButtonState } from '@fluentui/react-button';
  * ToolbarButton Props
  */
 export type ToolbarButtonProps = ComponentProps<ButtonSlots> &
-  Partial<Pick<ButtonProps, 'disabled' | 'disabledFocusable'>> & {
+  Partial<Pick<ButtonProps, 'disabled' | 'disabledFocusable' | 'size'>> & {
     appearance?: 'primary' | 'subtle';
   } & {
     vertical?: boolean;

--- a/packages/react-components/react-toolbar/stories/src/Toolbar/ToolbarLarge.stories.tsx
+++ b/packages/react-components/react-toolbar/stories/src/Toolbar/ToolbarLarge.stories.tsx
@@ -13,9 +13,9 @@ export const Large = (props: Partial<ToolbarProps>) => (
       borderRadius: '8px',
     }}
   >
-    <ToolbarButton aria-label="Increase Font Size" appearance="primary" icon={<FontIncrease24Regular />} />
-    <ToolbarButton aria-label="Decrease Font Size" icon={<FontDecrease24Regular />} />
-    <ToolbarButton aria-label="Reset Font Size" icon={<TextFont24Regular />} />
+    <ToolbarButton size="large" aria-label="Increase Font Size" appearance="primary" icon={<FontIncrease24Regular />} />
+    <ToolbarButton size="large" aria-label="Decrease Font Size" icon={<FontDecrease24Regular />} />
+    <ToolbarButton size="large" aria-label="Reset Font Size" icon={<TextFont24Regular />} />
   </Toolbar>
 );
 

--- a/packages/react-components/react-toolbar/stories/src/Toolbar/ToolbarSmall.stories.tsx
+++ b/packages/react-components/react-toolbar/stories/src/Toolbar/ToolbarSmall.stories.tsx
@@ -13,9 +13,9 @@ export const Small = (props: Partial<ToolbarProps>) => (
       borderRadius: '8px',
     }}
   >
-    <ToolbarButton aria-label="Increase Font Size" appearance="primary" icon={<FontIncrease24Regular />} />
-    <ToolbarButton aria-label="Decrease Font Size" icon={<FontDecrease24Regular />} />
-    <ToolbarButton aria-label="Reset Font Size" icon={<TextFont24Regular />} />
+    <ToolbarButton size="small" aria-label="Increase Font Size" appearance="primary" icon={<FontIncrease24Regular />} />
+    <ToolbarButton size="small" aria-label="Decrease Font Size" icon={<FontDecrease24Regular />} />
+    <ToolbarButton size="small" aria-label="Reset Font Size" icon={<TextFont24Regular />} />
   </Toolbar>
 );
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
Toolbar button is not accepting size.
In the screenshot, button is medium by default
<img width="854" alt="Screenshot 2024-07-26 at 12 26 50 AM" src="https://github.com/user-attachments/assets/b00a5b6e-a4be-444b-95d2-8f59164bee3d">

## Behavior after fix
Now the ToggleButton is accepting size as a prop and applying the size as well
In the screenshot button has become large
<img width="860" alt="Screenshot 2024-07-26 at 12 26 09 AM" src="https://github.com/user-attachments/assets/d05082b1-0d13-4d3f-8f7b-9250223c0ece">


## Related Issue(s)
- Fixes #32063 
