### PR TITLE
fix(react-search): Expand hit target when there's no content after

### DIFF
--- a/change/@fluentui-react-search-ef1e9132-0d99-40b3-8598-04d52166921f.json
+++ b/change/@fluentui-react-search-ef1e9132-0d99-40b3-8598-04d52166921f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Expand hit target when there's no content after.",
+  "packageName": "@fluentui/react-search",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-search/library/src/components/SearchBox/useSearchBox.tsx
+++ b/packages/react-components/react-search/library/src/components/SearchBox/useSearchBox.tsx
@@ -90,7 +90,7 @@ export const useSearchBox_unstable = (props: SearchBoxProps, ref: React.Ref<HTML
         elementType: 'span',
       }),
       contentAfter: slot.optional(contentAfter, {
-        renderByDefault: focused || !!contentAfter,
+        renderByDefault: true,
         elementType: 'span',
       }),
       ...inputProps,

--- a/packages/react-components/react-search/library/src/components/SearchBox/useSearchBox.tsx
+++ b/packages/react-components/react-search/library/src/components/SearchBox/useSearchBox.tsx
@@ -90,7 +90,7 @@ export const useSearchBox_unstable = (props: SearchBoxProps, ref: React.Ref<HTML
         elementType: 'span',
       }),
       contentAfter: slot.optional(contentAfter, {
-        renderByDefault: true,
+        renderByDefault: focused || !!contentAfter,
         elementType: 'span',
       }),
       ...inputProps,

--- a/packages/react-components/react-search/library/src/components/SearchBox/useSearchBoxStyles.styles.ts
+++ b/packages/react-components/react-search/library/src/components/SearchBox/useSearchBoxStyles.styles.ts
@@ -56,6 +56,18 @@ const useRootStyles = makeStyles({
   },
 });
 
+const useInputStyles = makeStyles({
+  small: {
+    paddingRight: tokens.spacingHorizontalSNudge,
+  },
+  medium: {
+    paddingRight: tokens.spacingHorizontalS,
+  },
+  large: {
+    paddingRight: tokens.spacingHorizontalMNudge,
+  },
+});
+
 const useContentAfterStyles = makeStyles({
   contentAfter: {
     paddingLeft: tokens.spacingHorizontalM,
@@ -103,6 +115,7 @@ export const useSearchBoxStyles_unstable = (state: SearchBoxState): SearchBoxSta
   const { disabled, focused, size } = state;
 
   const rootStyles = useRootStyles();
+  const inputStyles = useInputStyles();
   const contentAfterStyles = useContentAfterStyles();
   const dismissClassName = useDismissClassName();
   const dismissStyles = useDismissStyles();
@@ -113,7 +126,12 @@ export const useSearchBoxStyles_unstable = (state: SearchBoxState): SearchBoxSta
     !state.contentAfter && rootStyles.unfocusedNoContentAfter,
     state.root.className,
   );
-  state.input.className = mergeClasses(searchBoxClassNames.input, rootStyles.input, state.input.className);
+  state.input.className = mergeClasses(
+    searchBoxClassNames.input,
+    rootStyles.input,
+    !state.contentAfter && inputStyles[size],
+    state.input.className,
+  );
 
   if (state.dismiss) {
     state.dismiss.className = mergeClasses(

--- a/packages/react-components/react-search/library/src/components/SearchBox/useSearchBoxStyles.styles.ts
+++ b/packages/react-components/react-search/library/src/components/SearchBox/useSearchBoxStyles.styles.ts
@@ -77,6 +77,7 @@ const useContentAfterStyles = makeStyles({
     opacity: 0,
     height: 0,
     width: 0,
+    paddingLeft: 0,
   },
 });
 
@@ -123,13 +124,13 @@ export const useSearchBoxStyles_unstable = (state: SearchBoxState): SearchBoxSta
   state.root.className = mergeClasses(
     searchBoxClassNames.root,
     rootStyles[size],
-    !state.contentAfter && rootStyles.unfocusedNoContentAfter,
+    !focused && rootStyles.unfocusedNoContentAfter,
     state.root.className,
   );
   state.input.className = mergeClasses(
     searchBoxClassNames.input,
     rootStyles.input,
-    !state.contentAfter && inputStyles[size],
+    !focused && inputStyles[size],
     state.input.className,
   );
 

--- a/packages/react-components/react-search/library/src/components/SearchBox/useSearchBoxStyles.styles.ts
+++ b/packages/react-components/react-search/library/src/components/SearchBox/useSearchBoxStyles.styles.ts
@@ -50,6 +50,10 @@ const useRootStyles = makeStyles({
       display: 'none',
     },
   },
+
+  unfocusedNoContentAfter: {
+    paddingRight: 0,
+  },
 });
 
 const useContentAfterStyles = makeStyles({
@@ -103,7 +107,12 @@ export const useSearchBoxStyles_unstable = (state: SearchBoxState): SearchBoxSta
   const dismissClassName = useDismissClassName();
   const dismissStyles = useDismissStyles();
 
-  state.root.className = mergeClasses(searchBoxClassNames.root, rootStyles[size], state.root.className);
+  state.root.className = mergeClasses(
+    searchBoxClassNames.root,
+    rootStyles[size],
+    !state.contentAfter && rootStyles.unfocusedNoContentAfter,
+    state.root.className,
+  );
   state.input.className = mergeClasses(searchBoxClassNames.input, rootStyles.input, state.input.className);
 
   if (state.dismiss) {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Padding was applied on the root therefore shortening the hit target and leaving 20px of dead space. 

I also noticed that a 14px padding was added to the content after even when it is hidden.

## New Behavior

Padding is applied to the input instead when there's no content after to allow clicking and triggering focus.

only add the padding to the content after when it's visible.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #32014
