### PR TITLE
[chore]: [avatar] move size, color and generate initials out of base class

### DIFF
--- a/change/@fluentui-web-components-a4240e2c-3729-40ec-b1b1-ed2aec906127.json
+++ b/change/@fluentui-web-components-a4240e2c-3729-40ec-b1b1-ed2aec906127.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: move size and generate initials out of base class",
+  "packageName": "@fluentui/web-components",
+  "email": "jes@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/docs/api-report.md
+++ b/packages/web-components/docs/api-report.md
@@ -191,7 +191,10 @@ export type AnchorTarget = ValuesOf<typeof AnchorTarget>;
 // @public
 export class Avatar extends BaseAvatar {
     appearance?: AvatarAppearance | undefined;
+    // @internal
+    generateInitials(): string | void;
     shape?: AvatarShape | undefined;
+    size?: AvatarSize | undefined;
 }
 
 // Warning: (ae-missing-release-tag) "AvatarActive" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -456,12 +459,9 @@ export class BaseAvatar extends FASTElement {
     // @internal
     generateColor(): void;
     // @internal
-    generateInitials(): string | void;
-    // @internal
     handleChange(source: any, propertyName: string): void;
     initials?: string | undefined;
     name?: string | undefined;
-    size?: AvatarSize | undefined;
 }
 
 // @public

--- a/packages/web-components/docs/api-report.md
+++ b/packages/web-components/docs/api-report.md
@@ -191,8 +191,19 @@ export type AnchorTarget = ValuesOf<typeof AnchorTarget>;
 // @public
 export class Avatar extends BaseAvatar {
     appearance?: AvatarAppearance | undefined;
+    color?: AvatarColor | undefined;
+    colorId?: AvatarNamedColor | undefined;
+    static colors: ("anchor" | "dark-red" | "cranberry" | "red" | "pumpkin" | "peach" | "marigold" | "gold" | "brass" | "brown" | "forest" | "seafoam" | "dark-green" | "light-teal" | "teal" | "steel" | "blue" | "royal-blue" | "cornflower" | "navy" | "lavender" | "purple" | "grape" | "lilac" | "pink" | "magenta" | "plum" | "beige" | "mink" | "platinum")[];
+    // (undocumented)
+    connectedCallback(): void;
+    // (undocumented)
+    disconnectedCallback(): void;
+    // @internal
+    generateColor(): void;
     // @internal
     generateInitials(): string | void;
+    // @internal
+    handleChange(source: any, propertyName: string): void;
     shape?: AvatarShape | undefined;
     size?: AvatarSize | undefined;
 }
@@ -447,19 +458,8 @@ export class BaseAccordionItem extends FASTElement {
 export class BaseAvatar extends FASTElement {
     constructor();
     active?: AvatarActive | undefined;
-    color?: AvatarColor | undefined;
-    colorId?: AvatarNamedColor | undefined;
-    static colors: ("anchor" | "dark-red" | "cranberry" | "red" | "pumpkin" | "peach" | "marigold" | "gold" | "brass" | "brown" | "forest" | "seafoam" | "dark-green" | "light-teal" | "teal" | "steel" | "blue" | "royal-blue" | "cornflower" | "navy" | "lavender" | "purple" | "grape" | "lilac" | "pink" | "magenta" | "plum" | "beige" | "mink" | "platinum")[];
-    // (undocumented)
-    connectedCallback(): void;
-    // (undocumented)
-    disconnectedCallback(): void;
     // @internal
     elementInternals: ElementInternals;
-    // @internal
-    generateColor(): void;
-    // @internal
-    handleChange(source: any, propertyName: string): void;
     initials?: string | undefined;
     name?: string | undefined;
 }

--- a/packages/web-components/src/avatar/avatar.ts
+++ b/packages/web-components/src/avatar/avatar.ts
@@ -43,23 +43,6 @@ export class BaseAvatar extends FASTElement {
   public initials?: string | undefined;
 
   /**
-   * Size of the avatar in pixels.
-   *
-   * Size is restricted to a limited set of supported values recommended for most uses (see `AvatarSizeValue`) and
-   * based on design guidelines for the Avatar control.
-   *
-   * If a non-supported size is neeeded, set `size` to the next-smaller supported size, and set `width` and `height`
-   * to override the rendered size.
-   *
-   * @public
-   * @remarks
-   * HTML Attribute: size
-   *
-   */
-  @attr({ converter: nullableNumberConverter })
-  public size?: AvatarSize | undefined;
-
-  /**
    * Optional activity indicator
    * * active: the avatar will be decorated according to activeAppearance
    * * inactive: the avatar will be reduced in size and partially transparent
@@ -156,26 +139,6 @@ export class BaseAvatar extends FASTElement {
   }
 
   /**
-   * Generates and sets the initials for the template
-   * @internal
-   */
-  public generateInitials(): string | void {
-    if (!this.name && !this.initials) {
-      return;
-    }
-
-    // size can be undefined since we default it in CSS only
-    const size = this.size ?? 32;
-
-    return (
-      this.initials ??
-      getInitials(this.name, window.getComputedStyle(this as unknown as HTMLElement).direction === 'rtl', {
-        firstInitialOnly: size <= 16,
-      })
-    );
-  }
-
-  /**
    * An array of the available Avatar named colors
    */
   public static colors = Object.values(AvatarNamedColor);
@@ -207,6 +170,43 @@ export class Avatar extends BaseAvatar {
    */
   @attr
   public appearance?: AvatarAppearance | undefined;
+
+  /**
+   * Size of the avatar in pixels.
+   *
+   * Size is restricted to a limited set of supported values recommended for most uses (see `AvatarSizeValue`) and
+   * based on design guidelines for the Avatar control.
+   *
+   * If a non-supported size is neeeded, set `size` to the next-smaller supported size, and set `width` and `height`
+   * to override the rendered size.
+   *
+   * @public
+   * @remarks
+   * HTML Attribute: size
+   *
+   */
+  @attr({ converter: nullableNumberConverter })
+  public size?: AvatarSize | undefined;
+
+  /**
+   * Generates and sets the initials for the template
+   * @internal
+   */
+  public generateInitials(): string | void {
+    if (!this.name && !this.initials) {
+      return;
+    }
+
+    // size can be undefined since we default it in CSS only
+    const size = this.size ?? 32;
+
+    return (
+      this.initials ??
+      getInitials(this.name, window.getComputedStyle(this as unknown as HTMLElement).direction === 'rtl', {
+        firstInitialOnly: size <= 16,
+      })
+    );
+  }
 }
 
 // copied from React avatar

--- a/packages/web-components/src/avatar/avatar.ts
+++ b/packages/web-components/src/avatar/avatar.ts
@@ -55,93 +55,11 @@ export class BaseAvatar extends FASTElement {
   @attr
   public active?: AvatarActive | undefined;
 
-  /**
-   * The color when displaying either an icon or initials.
-   * * neutral (default): gray
-   * * brand: color from the brand palette
-   * * colorful: picks a color from a set of pre-defined colors, based on a hash of the name (or colorId if provided)
-   * * [AvatarNamedColor]: a specific color from the theme
-   *
-   * @public
-   * @remarks
-   * HTML Attribute: color
-   */
-  @attr
-  public color?: AvatarColor | undefined;
-
-  /**
-   * Specify a string to be used instead of the name, to determine which color to use when color="colorful".
-   * Use this when a name is not available, but there is another unique identifier that can be used instead.
-   */
-  @attr({ attribute: 'color-id' })
-  public colorId?: AvatarNamedColor | undefined;
-
-  /**
-   * Holds the current color state
-   */
-  private currentColor: string | undefined;
-
   constructor() {
     super();
 
     this.elementInternals.role = 'img';
   }
-
-  public connectedCallback(): void {
-    super.connectedCallback();
-
-    Observable.getNotifier(this).subscribe(this);
-
-    this.generateColor();
-  }
-
-  public disconnectedCallback(): void {
-    super.disconnectedCallback();
-
-    Observable.getNotifier(this).unsubscribe(this);
-  }
-
-  /**
-   * Handles changes to observable properties
-   * @internal
-   * @param source - the source of the change
-   * @param propertyName - the property name being changed
-   */
-  public handleChange(source: any, propertyName: string) {
-    switch (propertyName) {
-      case 'color':
-      case 'colorId':
-        this.generateColor();
-        break;
-      default:
-        break;
-    }
-  }
-
-  /**
-   * Sets the data-color attribute used for the visual presentation
-   * @internal
-   */
-  public generateColor(): void {
-    const colorful: boolean = this.color === AvatarColor.colorful;
-    const prev = this.currentColor;
-
-    toggleState(this.elementInternals, `${prev}`, false);
-
-    this.currentColor =
-      colorful && this.colorId
-        ? this.colorId
-        : colorful
-        ? (Avatar.colors[getHashCode(this.name ?? '') % Avatar.colors.length] as AvatarColor)
-        : this.color ?? AvatarColor.neutral;
-
-    toggleState(this.elementInternals, `${this.currentColor}`, true);
-  }
-
-  /**
-   * An array of the available Avatar named colors
-   */
-  public static colors = Object.values(AvatarNamedColor);
 }
 
 /**
@@ -189,6 +107,49 @@ export class Avatar extends BaseAvatar {
   public size?: AvatarSize | undefined;
 
   /**
+   * The color when displaying either an icon or initials.
+   * * neutral (default): gray
+   * * brand: color from the brand palette
+   * * colorful: picks a color from a set of pre-defined colors, based on a hash of the name (or colorId if provided)
+   * * [AvatarNamedColor]: a specific color from the theme
+   *
+   * @public
+   * @remarks
+   * HTML Attribute: color
+   */
+  @attr
+  public color?: AvatarColor | undefined;
+
+  /**
+   * Specify a string to be used instead of the name, to determine which color to use when color="colorful".
+   * Use this when a name is not available, but there is another unique identifier that can be used instead.
+   */
+  @attr({ attribute: 'color-id' })
+  public colorId?: AvatarNamedColor | undefined;
+
+  /**
+   * Holds the current color state
+   */
+  private currentColor: string | undefined;
+
+  /**
+   * Handles changes to observable properties
+   * @internal
+   * @param source - the source of the change
+   * @param propertyName - the property name being changed
+   */
+  public handleChange(source: any, propertyName: string) {
+    switch (propertyName) {
+      case 'color':
+      case 'colorId':
+        this.generateColor();
+        break;
+      default:
+        break;
+    }
+  }
+
+  /**
    * Generates and sets the initials for the template
    * @internal
    */
@@ -206,6 +167,45 @@ export class Avatar extends BaseAvatar {
         firstInitialOnly: size <= 16,
       })
     );
+  }
+
+  /**
+   * Sets the data-color attribute used for the visual presentation
+   * @internal
+   */
+  public generateColor(): void {
+    const colorful: boolean = this.color === AvatarColor.colorful;
+    const prev = this.currentColor;
+
+    toggleState(this.elementInternals, `${prev}`, false);
+
+    this.currentColor =
+      colorful && this.colorId
+        ? this.colorId
+        : colorful
+        ? (Avatar.colors[getHashCode(this.name ?? '') % Avatar.colors.length] as AvatarColor)
+        : this.color ?? AvatarColor.neutral;
+
+    toggleState(this.elementInternals, `${this.currentColor}`, true);
+  }
+
+  /**
+   * An array of the available Avatar named colors
+   */
+  public static colors = Object.values(AvatarNamedColor);
+
+  public connectedCallback(): void {
+    super.connectedCallback();
+
+    Observable.getNotifier(this).subscribe(this);
+
+    this.generateColor();
+  }
+
+  public disconnectedCallback(): void {
+    super.disconnectedCallback();
+
+    Observable.getNotifier(this).unsubscribe(this);
   }
 }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

`generteInitials` referenced `size` and was tightly coupled with `name` and `initial` however it was only used in the template.

## New Behavior

Since `generteInitials` was only used in the template it's easy for us to move it out of the base class along with `size` this takes a lot of dead css out of the base set of styles. `color` is also move from the base class.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #32082 
