### PR TITLE
feat(react-tabs): export Tab component style hooks

### DIFF
--- a/change/@fluentui-react-tabs-3a54a623-3c3d-41e3-93c7-4bbe197234e2.json
+++ b/change/@fluentui-react-tabs-3a54a623-3c3d-41e3-93c7-4bbe197234e2.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "export Tab component style hooks",
+  "packageName": "@fluentui/react-tabs",
+  "email": "kirpadv@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tabs/library/etc/react-tabs.api.md
+++ b/packages/react-components/react-tabs/library/etc/react-tabs.api.md
@@ -124,6 +124,15 @@ export type TabValue = unknown;
 export const useTab_unstable: (props: TabProps, ref: React_2.Ref<HTMLElement>) => TabState;
 
 // @public
+export const useTabButtonStyles_unstable: (state: TabState, slot: TabState['root']) => TabState;
+
+// @public
+export const useTabContentStyles_unstable: (state: TabState) => TabState;
+
+// @public
+export const useTabIndicatorStyles_unstable: (state: TabState) => TabState;
+
+// @public
 export const useTabList_unstable: (props: TabListProps, ref: React_2.Ref<HTMLElement>) => TabListState;
 
 // @public (undocumented)

--- a/packages/react-components/react-tabs/library/src/components/Tab/useTabStyles.styles.ts
+++ b/packages/react-components/react-tabs/library/src/components/Tab/useTabStyles.styles.ts
@@ -1,9 +1,8 @@
-import type { TabSlots, TabState } from './Tab.types';
-
 import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
 import { createCustomFocusIndicatorStyle } from '@fluentui/react-tabster';
 import { tokens, typographyStyles } from '@fluentui/react-theme';
-import { SlotClassNames } from '@fluentui/react-utilities';
+import type { SlotClassNames } from '@fluentui/react-utilities';
+import type { TabSlots, TabState } from './Tab.types';
 import { useTabAnimatedIndicatorStyles_unstable } from './useTabAnimatedIndicator.styles';
 
 export const tabClassNames: SlotClassNames<TabSlots> = {
@@ -26,9 +25,18 @@ const iconClassNames = {
 /**
  * Styles for the root slot
  */
-/* eslint-disable @typescript-eslint/naming-convention */
 const useRootStyles = makeStyles({
-  base: {
+  root: {
+    alignItems: 'center',
+    display: 'grid',
+    flexShrink: 0,
+    gridAutoFlow: 'column',
+    gridTemplateColumns: 'auto',
+    gridTemplateRows: 'auto',
+    outlineStyle: 'none',
+    position: 'relative',
+  },
+  button: {
     alignItems: 'center',
     border: 'none',
     borderRadius: tokens.borderRadiusMedium,
@@ -164,7 +172,6 @@ const useRootStyles = makeStyles({
     },
   },
 });
-/* eslint-enable @typescript-eslint/naming-convention */
 
 /**
  * Focus styles for the root slot
@@ -409,7 +416,7 @@ const useContentStyles = makeStyles({
   base: {
     ...typographyStyles.body1,
     overflow: 'hidden',
-    // content padding is the same for medium & small, horiztonal & vertical
+    // content padding is the same for medium & small, horizontal & vertical
     padding: `${tokens.spacingVerticalNone} ${tokens.spacingHorizontalXXS}`,
   },
   selected: {
@@ -440,27 +447,28 @@ const useContentStyles = makeStyles({
 export const useTabStyles_unstable = (state: TabState): TabState => {
   'use no memo';
 
+  useTabIndicatorStyles_unstable(state);
+
+  useTabButtonStyles_unstable(state, state.root);
+
+  useTabContentStyles_unstable(state);
+
+  return state;
+};
+
+/** Apply styling to the Tab indicator slot based on the state */
+export const useTabIndicatorStyles_unstable = (state: TabState): TabState => {
+  'use no memo';
+
   const rootStyles = useRootStyles();
-  const focusStyles = useFocusStyles();
   const pendingIndicatorStyles = usePendingIndicatorStyles();
   const activeIndicatorStyles = useActiveIndicatorStyles();
-  const iconStyles = useIconStyles();
-  const contentStyles = useContentStyles();
 
-  const { appearance, disabled, selected, size, vertical } = state;
+  const { disabled, selected, size, vertical } = state;
 
   state.root.className = mergeClasses(
     tabClassNames.root,
-    rootStyles.base,
-    vertical ? rootStyles.vertical : rootStyles.horizontal,
-    size === 'small' && (vertical ? rootStyles.smallVertical : rootStyles.smallHorizontal),
-    size === 'medium' && (vertical ? rootStyles.mediumVertical : rootStyles.mediumHorizontal),
-    size === 'large' && (vertical ? rootStyles.largeVertical : rootStyles.largeHorizontal),
-    focusStyles.base,
-    !disabled && appearance === 'subtle' && rootStyles.subtle,
-    !disabled && appearance === 'transparent' && rootStyles.transparent,
-    !disabled && selected && rootStyles.selected,
-    disabled && rootStyles.disabled,
+    rootStyles.root,
 
     // pending indicator (before pseudo element)
     pendingIndicatorStyles.base,
@@ -485,6 +493,47 @@ export const useTabStyles_unstable = (state: TabState): TabState => {
 
     state.root.className,
   );
+
+  useTabAnimatedIndicatorStyles_unstable(state);
+
+  return state;
+};
+
+/** Apply styling to the Tab button slot based on the state */
+export const useTabButtonStyles_unstable = (state: TabState, slot: TabState['root']): TabState => {
+  'use no memo';
+
+  const rootStyles = useRootStyles();
+  const focusStyles = useFocusStyles();
+
+  const { appearance, disabled, selected, size, vertical } = state;
+
+  slot.className = mergeClasses(
+    rootStyles.button,
+    vertical ? rootStyles.vertical : rootStyles.horizontal,
+    size === 'small' && (vertical ? rootStyles.smallVertical : rootStyles.smallHorizontal),
+    size === 'medium' && (vertical ? rootStyles.mediumVertical : rootStyles.mediumHorizontal),
+    size === 'large' && (vertical ? rootStyles.largeVertical : rootStyles.largeHorizontal),
+    focusStyles.base,
+    !disabled && appearance === 'subtle' && rootStyles.subtle,
+    !disabled && appearance === 'transparent' && rootStyles.transparent,
+    !disabled && selected && rootStyles.selected,
+    disabled && rootStyles.disabled,
+
+    slot.className,
+  );
+
+  return state;
+};
+
+/** Apply styling to the Tab content slot based on the state */
+export const useTabContentStyles_unstable = (state: TabState): TabState => {
+  'use no memo';
+
+  const iconStyles = useIconStyles();
+  const contentStyles = useContentStyles();
+
+  const { selected, size } = state;
 
   if (state.icon) {
     state.icon.className = mergeClasses(
@@ -520,8 +569,6 @@ export const useTabStyles_unstable = (state: TabState): TabState => {
     state.icon ? contentStyles.iconBefore : contentStyles.noIconBefore,
     state.content.className,
   );
-
-  useTabAnimatedIndicatorStyles_unstable(state);
 
   return state;
 };

--- a/packages/react-components/react-tabs/library/src/components/Tab/useTabStyles.styles.ts
+++ b/packages/react-components/react-tabs/library/src/components/Tab/useTabStyles.styles.ts
@@ -456,7 +456,15 @@ export const useTabStyles_unstable = (state: TabState): TabState => {
   return state;
 };
 
-/** Apply styling to the Tab indicator slot based on the state */
+/**
+ * Applies styles for the Tab indicator based on its current state.
+ *
+ * This hook is typically used internally by `useTabStyles_unstable`. You should
+ * only use it directly if you're creating a custom `Tab` component.
+ *
+ * @param state - The `Tab` component's current state
+ * @returns The state object with updated button styles
+ */
 export const useTabIndicatorStyles_unstable = (state: TabState): TabState => {
   'use no memo';
 
@@ -499,7 +507,16 @@ export const useTabIndicatorStyles_unstable = (state: TabState): TabState => {
   return state;
 };
 
-/** Apply styling to the Tab button slot based on the state */
+/**
+ * Applies styles to the Tab button slot based on its current state.
+ *
+ * This hook is typically used internally by `useTabStyles_unstable`. You should
+ * only use it directly if you're creating a custom `Tab` component.
+ *
+ * @param state - The Tab component's current state
+ * @param slot - The button slot of the Tab component
+ * @returns The state object with updated button styles
+ */
 export const useTabButtonStyles_unstable = (state: TabState, slot: TabState['root']): TabState => {
   'use no memo';
 
@@ -526,7 +543,15 @@ export const useTabButtonStyles_unstable = (state: TabState, slot: TabState['roo
   return state;
 };
 
-/** Apply styling to the Tab content slot based on the state */
+/**
+ * Applies styles to the Tab content slot based on its current state.
+ *
+ * This hook is typically used internally by `useTabStyles_unstable`. You should
+ * only use it directly if you're creating a custom `Tab` component.
+ *
+ * @param state - The Tab component's current state
+ * @returns The state object with updated content styles
+ */
 export const useTabContentStyles_unstable = (state: TabState): TabState => {
   'use no memo';
 

--- a/packages/react-components/react-tabs/library/src/index.ts
+++ b/packages/react-components/react-tabs/library/src/index.ts
@@ -1,5 +1,14 @@
 export type { TabProps, TabSlots, TabState, TabValue } from './Tab';
-export { renderTab_unstable, Tab, tabClassNames, useTabStyles_unstable, useTab_unstable } from './Tab';
+export {
+  renderTab_unstable,
+  Tab,
+  tabClassNames,
+  useTabButtonStyles_unstable,
+  useTabContentStyles_unstable,
+  useTabIndicatorStyles_unstable,
+  useTabStyles_unstable,
+  useTab_unstable,
+} from './Tab';
 export type {
   TabRegisterData,
   RegisterTabEventHandler,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Previously, TabList did not support interactive tabs, such as a tab with a dismiss/close button to remove the tab, or a tab featuring a dropdown or search box.

The primary slot for a Tab was a button with `role=tab`. According to Aria guidelines, elements with `role=tab` should only contain presentational children.

## New Behavior

This PR introduces the `InteractiveTab` component, which is derived from `Tab`, but instead uses a div as its root. It includes three additional slots: `button` (where `role=tab` is assigned), `beforeContent`, and `afterContent`. This design, akin to the Input component, allows users to insert interactive content before or after the tab button.

The styling hook for Tab has been segmented into sub-hooks to differentiate the application of tab button styles from indicator styles. The `InteractiveTab` assigns indicator styles to the root div and button styles to the `button` slot. The Tab's styling hook utilizes these sub-hooks internally to apply both styles to the root button, ensuring no breaking changes to the Tab.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #32078 
