### PR TITLE
ci(vrt): move VRT steps to runpublishvrscreenshot template to reduce duplication

### DIFF
--- a/.devops/templates/runpublishvrscreenshot.yml
+++ b/.devops/templates/runpublishvrscreenshot.yml
@@ -1,3 +1,6 @@
+variables:
+  - template: .devops/templates/variables.yml
+
 parameters:
   - name: fluentVersion
     type: string
@@ -54,3 +57,15 @@ steps:
       ArtifactName: 'vrscreenshot${{ parameters.fluentVersion }}'
       publishLocation: 'Container'
     condition: eq(variables['vrTestSkip'], 'no')
+
+  - bash: |
+      set -exuo pipefail
+      yarn vr-app create-policy --nonBlockingPipelines '{"$(pipelineId)":{"pipelineStatus": "PENDING","pipelineName": "$(pipelineName)"}}' --clientType 'FLUENTUI'
+    displayName: VR App - Create Policy
+    env:
+      VR_APP_API_URL: $(VR_APP_API_URL)
+      TENANT_ID: $(TenantId)
+      PRINCIPAL_CLIENT_ID: $(PrincipalClientId)
+      SERVICE_CONNECTION_ID: $(ServiceConnectionId)
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+    condition: eq(variables.isPR, true)

--- a/.devops/templates/runpublishvrscreenshot.yml
+++ b/.devops/templates/runpublishvrscreenshot.yml
@@ -1,6 +1,3 @@
-variables:
-  - template: .devops/templates/variables.yml
-
 parameters:
   - name: fluentVersion
     type: string
@@ -25,6 +22,7 @@ steps:
   - script: |
       isPR=${{lower(eq(variables['Build.Reason'], 'PullRequest'))}}
       echo $isPR
+      echo "##vso[task.setvariable variable=isPR;]$isPR"
       if [[ $isPR == true ]]; then
         packageAffected=$(yarn --silent check:affected --package ${{ parameters.vrTestPackageName }})
         if [[ $packageAffected == false ]]; then

--- a/.devops/templates/runpublishvrscreenshot.yml
+++ b/.devops/templates/runpublishvrscreenshot.yml
@@ -8,6 +8,15 @@ parameters:
   - name: vrTestPackagePath
     type: string
     default: 'apps/vr-tests'
+  - name: locationPrefix
+    type: string
+    default: fluentuiv8
+  - name: locationPostfix
+    type: string
+    default: vrscreenshotv8
+  - name: clientName
+    type: string
+    default: fluentuiv8
 
 steps:
   - task: Bash@3
@@ -67,3 +76,23 @@ steps:
       SERVICE_CONNECTION_ID: $(ServiceConnectionId)
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
     condition: eq(variables.isPR, true)
+
+  - task: AzureCLI@2
+    displayName: 'Run fluentui-screenshotdiff'
+    env:
+      API_TOKEN: $(fabric-public-pipeline-access-PAT)
+      GITHUB_API_TOKEN: $(githubRepoStatusPAT)
+      VR_APP_API_URL: $(VR_APP_API_URL)
+      STORAGE_ACCOUNT_ID: $(StorageAccountId)
+      TENANT_ID: $(TenantId)
+      PRINCIPAL_CLIENT_ID: $(PrincipalClientId)
+      SERVICE_CONNECTION_ID: $(ServiceConnectionId)
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+    inputs:
+      azureSubscription: $(AzureSubscription)
+      scriptType: bash
+      scriptLocation: 'inlineScript'
+      # ciDefinitionId is set to 205 because that is the ID of the baseline pipeline (https://uifabric.visualstudio.com/fabricpublic/_build?definitionId=205) used by the master branch
+      inlineScript: |
+        yarn vr-app run-diff --screenshotsDirectory ./screenshots  --buildType pr --clientType "FLUENTUI" --ciDefinitionId 205 --groupName $(pipelineName) --locationPrefix ${{ parameters.locationPrefix }} --locationPostfix ${{ parameters.locationPostfix }} --pipelineId $(pipelineId)  --clientName ${{ parameters.clientName }} --threshold '0.04' --cumThreshold '1'
+    condition: eq(variables['vrTestSkip'], 'no')

--- a/.devops/templates/runpublishvrscreenshot.yml
+++ b/.devops/templates/runpublishvrscreenshot.yml
@@ -95,4 +95,4 @@ steps:
       # ciDefinitionId is set to 205 because that is the ID of the baseline pipeline (https://uifabric.visualstudio.com/fabricpublic/_build?definitionId=205) used by the master branch
       inlineScript: |
         yarn vr-app run-diff --screenshotsDirectory ./screenshots  --buildType pr --clientType "FLUENTUI" --ciDefinitionId 205 --groupName $(pipelineName) --locationPrefix ${{ parameters.locationPrefix }} --locationPostfix ${{ parameters.locationPostfix }} --pipelineId $(pipelineId)  --clientName ${{ parameters.clientName }} --threshold '0.04' --cumThreshold '1'
-    condition: eq(variables['vrTestSkip'], 'no')
+    condition: and(eq(variables.isPR, true), eq(variables['vrTestSkip'], 'no'))

--- a/azure-pipelines.vrt-pr.yml
+++ b/azure-pipelines.vrt-pr.yml
@@ -33,17 +33,6 @@ jobs:
           vrTestPackageName: '@fluentui/vr-tests-web-components'
           vrTestPackagePath: 'apps/vr-tests-web-components'
 
-      - bash: |
-          set -exuo pipefail
-          yarn vr-app create-policy --nonBlockingPipelines '{"$(pipelineId)":{"pipelineStatus": "PENDING","pipelineName": "$(pipelineName)"}}' --clientType 'FLUENTUI'
-        displayName: VR App - Create Policy
-        env:
-          VR_APP_API_URL: $(VR_APP_API_URL)
-          TENANT_ID: $(TenantId)
-          PRINCIPAL_CLIENT_ID: $(PrincipalClientId)
-          SERVICE_CONNECTION_ID: $(ServiceConnectionId)
-          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-
       - task: AzureCLI@2
         displayName: 'Run fluentui-screenshotdiff'
         env:
@@ -83,17 +72,6 @@ jobs:
           vrTestPackageName: '@fluentui/vr-tests-react-components'
           vrTestPackagePath: 'apps/vr-tests-react-components'
 
-      - bash: |
-          set -exuo pipefail
-          yarn vr-app create-policy --nonBlockingPipelines '{"$(pipelineId)":{"pipelineStatus": "PENDING","pipelineName": "$(pipelineName)"}}' --clientType 'FLUENTUI'
-        displayName: VR App - Create Policy
-        env:
-          VR_APP_API_URL: $(VR_APP_API_URL)
-          TENANT_ID: $(TenantId)
-          PRINCIPAL_CLIENT_ID: $(PrincipalClientId)
-          SERVICE_CONNECTION_ID: $(ServiceConnectionId)
-          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-
       - task: AzureCLI@2
         displayName: 'Run fluentui-screenshotdiff'
         env:
@@ -131,17 +109,6 @@ jobs:
           fluentVersion: v8
           vrTestPackageName: '@fluentui/vr-tests'
           vrTestPackagePath: 'apps/vr-tests'
-
-      - bash: |
-          set -exuo pipefail
-          yarn vr-app create-policy --nonBlockingPipelines '{"$(pipelineId)":{"pipelineStatus": "PENDING","pipelineName": "$(pipelineName)"}}' --clientType 'FLUENTUI'
-        displayName: VR App - Create Policy
-        env:
-          VR_APP_API_URL: $(VR_APP_API_URL)
-          TENANT_ID: $(TenantId)
-          PRINCIPAL_CLIENT_ID: $(PrincipalClientId)
-          SERVICE_CONNECTION_ID: $(ServiceConnectionId)
-          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
       - task: AzureCLI@2
         displayName: 'Run fluentui-screenshotdiff'
@@ -181,17 +148,6 @@ jobs:
           fluentVersion: v0
           vrTestPackageName: '@fluentui/docs'
           vrTestPackagePath: 'packages/fluentui/docs'
-
-      - bash: |
-          set -exuo pipefail
-          yarn vr-app create-policy --nonBlockingPipelines '{"$(pipelineId)":{"pipelineStatus": "PENDING","pipelineName": "$(pipelineName)"}}' --clientType 'FLUENTUI'
-        displayName: VR App - Create Policy
-        env:
-          VR_APP_API_URL: $(VR_APP_API_URL)
-          TENANT_ID: $(TenantId)
-          PRINCIPAL_CLIENT_ID: $(PrincipalClientId)
-          SERVICE_CONNECTION_ID: $(ServiceConnectionId)
-          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
       - task: AzureCLI@2
         displayName: 'Run fluentui-screenshotdiff'

--- a/azure-pipelines.vrt-pr.yml
+++ b/azure-pipelines.vrt-pr.yml
@@ -32,26 +32,9 @@ jobs:
           fluentVersion: webcomponents
           vrTestPackageName: '@fluentui/vr-tests-web-components'
           vrTestPackagePath: 'apps/vr-tests-web-components'
-
-      - task: AzureCLI@2
-        displayName: 'Run fluentui-screenshotdiff'
-        env:
-          API_TOKEN: $(fabric-public-pipeline-access-PAT)
-          GITHUB_API_TOKEN: $(githubRepoStatusPAT)
-          VR_APP_API_URL: $(VR_APP_API_URL)
-          STORAGE_ACCOUNT_ID: $(StorageAccountId)
-          TENANT_ID: $(TenantId)
-          PRINCIPAL_CLIENT_ID: $(PrincipalClientId)
-          SERVICE_CONNECTION_ID: $(ServiceConnectionId)
-          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-        inputs:
-          azureSubscription: $(AzureSubscription)
-          scriptType: bash
-          scriptLocation: 'inlineScript'
-          # ciDefinitionId is set to 205 because that is the ID of the baseline pipeline (https://uifabric.visualstudio.com/fabricpublic/_build?definitionId=205) used by the master branch
-          inlineScript: |
-            yarn vr-app run-diff --screenshotsDirectory ./screenshots --buildType pr --clientType "FLUENTUI" --ciDefinitionId 205 --groupName $(pipelineName) --locationPrefix 'FluentUI-web-components' --locationPostfix 'vrscreenshotwebcomponents' --pipelineId $(pipelineId)  --clientName 'fluentui-web-components-v3' --threshold '0.04' --cumThreshold '1'
-        condition: eq(variables['vrTestSkip'], 'no')
+          locationPrefix: 'FluentUI-web-components'
+          locationPostfix: 'vrscreenshotwebcomponents'
+          clientName: 'fluentui-web-components-v3'
 
   - job: VisualRegressionTest_V9
     variables:
@@ -71,26 +54,9 @@ jobs:
           fluentVersion: v9
           vrTestPackageName: '@fluentui/vr-tests-react-components'
           vrTestPackagePath: 'apps/vr-tests-react-components'
-
-      - task: AzureCLI@2
-        displayName: 'Run fluentui-screenshotdiff'
-        env:
-          API_TOKEN: $(fabric-public-pipeline-access-PAT)
-          GITHUB_API_TOKEN: $(githubRepoStatusPAT)
-          VR_APP_API_URL: $(VR_APP_API_URL)
-          STORAGE_ACCOUNT_ID: $(StorageAccountId)
-          TENANT_ID: $(TenantId)
-          PRINCIPAL_CLIENT_ID: $(PrincipalClientId)
-          SERVICE_CONNECTION_ID: $(ServiceConnectionId)
-          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-        inputs:
-          azureSubscription: $(AzureSubscription)
-          scriptType: bash
-          scriptLocation: 'inlineScript'
-          # ciDefinitionId is set to 205 because that is the ID of the baseline pipeline (https://uifabric.visualstudio.com/fabricpublic/_build?definitionId=205) used by the master branch
-          inlineScript: |
-            yarn vr-app run-diff --buildType pr --screenshotsDirectory ./screenshots --clientType "FLUENTUI" --ciDefinitionId 205 --groupName $(pipelineName) --locationPrefix 'fluentuiv9' --locationPostfix 'vrscreenshotv9' --pipelineId $(pipelineId) --clientName 'fluentuiv9' --threshold '0.04' --cumThreshold '1'
-        condition: eq(variables['vrTestSkip'], 'no')
+          locationPrefix: 'fluentuiv9'
+          locationPostfix: 'vrscreenshotv9'
+          clientName: 'fluentuiv9'
 
   - job: VisualRegressionTest_V8
     variables:
@@ -109,26 +75,9 @@ jobs:
           fluentVersion: v8
           vrTestPackageName: '@fluentui/vr-tests'
           vrTestPackagePath: 'apps/vr-tests'
-
-      - task: AzureCLI@2
-        displayName: 'Run fluentui-screenshotdiff'
-        env:
-          API_TOKEN: $(fabric-public-pipeline-access-PAT)
-          GITHUB_API_TOKEN: $(githubRepoStatusPAT)
-          VR_APP_API_URL: $(VR_APP_API_URL)
-          STORAGE_ACCOUNT_ID: $(StorageAccountId)
-          TENANT_ID: $(TenantId)
-          PRINCIPAL_CLIENT_ID: $(PrincipalClientId)
-          SERVICE_CONNECTION_ID: $(ServiceConnectionId)
-          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-        inputs:
-          azureSubscription: $(AzureSubscription)
-          scriptType: bash
-          scriptLocation: 'inlineScript'
-          # ciDefinitionId is set to 205 because that is the ID of the baseline pipeline (https://uifabric.visualstudio.com/fabricpublic/_build?definitionId=205) used by the master branch
-          inlineScript: |
-            yarn vr-app run-diff --screenshotsDirectory ./screenshots  --buildType pr --clientType "FLUENTUI" --ciDefinitionId 205 --groupName $(pipelineName) --locationPrefix 'fluentuiv8' --locationPostfix 'vrscreenshotv8' --pipelineId $(pipelineId)  --clientName 'fluentuiv8' --threshold '0.04' --cumThreshold '1'
-        condition: eq(variables['vrTestSkip'], 'no')
+          locationPrefix: 'fluentuiv8'
+          locationPostfix: 'vrscreenshotv8'
+          clientName: 'fluentuiv8'
 
   - job: VisualRegressionTest_V0
     variables:
@@ -148,23 +97,6 @@ jobs:
           fluentVersion: v0
           vrTestPackageName: '@fluentui/docs'
           vrTestPackagePath: 'packages/fluentui/docs'
-
-      - task: AzureCLI@2
-        displayName: 'Run fluentui-screenshotdiff'
-        env:
-          API_TOKEN: $(fabric-public-pipeline-access-PAT)
-          GITHUB_API_TOKEN: $(githubRepoStatusPAT)
-          VR_APP_API_URL: $(VR_APP_API_URL)
-          STORAGE_ACCOUNT_ID: $(StorageAccountId)
-          TENANT_ID: $(TenantId)
-          PRINCIPAL_CLIENT_ID: $(PrincipalClientId)
-          SERVICE_CONNECTION_ID: $(ServiceConnectionId)
-          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-        inputs:
-          azureSubscription: $(AzureSubscription)
-          scriptType: bash
-          scriptLocation: 'inlineScript'
-          # ciDefinitionId is set to 205 because that is the ID of the baseline pipeline (https://uifabric.visualstudio.com/fabricpublic/_build?definitionId=205) used by the master branch
-          inlineScript: |
-            yarn vr-app run-diff --buildType pr --screenshotsDirectory ./screenshots --clientType "FLUENTUI" --ciDefinitionId 205 --groupName $(pipelineName) --locationPrefix 'FluentUI-v0' --locationPostfix 'vrscreenshotv0' --pipelineId $(pipelineId) --clientName 'FluentUIV0' --threshold '0.04' --cumThreshold '1'
-        condition: eq(variables['vrTestSkip'], 'no')
+          locationPrefix: 'FluentUI-v0'
+          locationPostfix: 'vrscreenshotv0'
+          clientName: 'FluentUIV0'


### PR DESCRIPTION
## Changes:
- moves `create-policy` and `Run fluentui-screenshotdiff` steps to `runpublishvrscreenshot` template to reduce duplication

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows #32110
