### PR TITLE
fix(Popover): fix shadows on arrows

### DIFF
--- a/change/@fluentui-react-popover-4e04d92a-bcbe-4856-877e-9801c61d5f60.json
+++ b/change/@fluentui-react-popover-4e04d92a-bcbe-4856-877e-9801c61d5f60.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(Popover): fix shadows on arrows",
+  "packageName": "@fluentui/react-popover",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-popover/library/src/components/PopoverSurface/usePopoverSurfaceStyles.styles.ts
+++ b/packages/react-components/react-popover/library/src/components/PopoverSurface/usePopoverSurfaceStyles.styles.ts
@@ -22,11 +22,15 @@ const useStyles = makeStyles({
   root: {
     color: tokens.colorNeutralForeground1,
     backgroundColor: tokens.colorNeutralBackground1,
-    boxShadow: tokens.shadow16,
     borderRadius: tokens.borderRadiusMedium,
     border: `1px solid ${tokens.colorTransparentStroke}`,
     ...typographyStyles.body1,
     ...createSlideStyles(10),
+
+    // TODO need to add versions of tokens.alias.shadow.shadow16, etc. that work with filter
+    filter:
+      `drop-shadow(0 0 2px ${tokens.colorNeutralShadowAmbient}) ` +
+      `drop-shadow(0 8px 16px ${tokens.colorNeutralShadowKey})`,
   },
 
   inline: {


### PR DESCRIPTION
### Before

<img width="377" alt="image" src="https://github.com/user-attachments/assets/313f6434-45f9-449d-a0dd-642904bcebbe">

### After

<img width="413" alt="image" src="https://github.com/user-attachments/assets/baeceb7e-050a-4b26-be03-1c1a7e643774">

Fixes #31990.