### PR TITLE
Carousel: Public preview

### DIFF
--- a/apps/public-docsite-v9/package.json
+++ b/apps/public-docsite-v9/package.json
@@ -46,6 +46,7 @@
     "react-hook-form": "^5.7.2",
     "@fluentui/react-nav-preview": "*",
     "@fluentui/react-motion-components-preview": "*",
-    "@fluentui/react-icons-compat": "*"
+    "@fluentui/react-icons-compat": "*",
+    "@fluentui/react-carousel-preview": "*"
   }
 }

--- a/change/@fluentui-react-carousel-preview-75862e4b-2f1a-48ba-9ae7-ea7011d5e40a.json
+++ b/change/@fluentui-react-carousel-preview-75862e4b-2f1a-48ba-9ae7-ea7011d5e40a.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "'feat: Release react-carousel-preview to public preview",
+  "comment": "feat: Release react-carousel-preview to public preview",
   "packageName": "@fluentui/react-carousel-preview",
   "email": "mifraser@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-carousel-preview-75862e4b-2f1a-48ba-9ae7-ea7011d5e40a.json
+++ b/change/@fluentui-react-carousel-preview-75862e4b-2f1a-48ba-9ae7-ea7011d5e40a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "'feat: Release react-carousel-preview to public preview",
+  "packageName": "@fluentui/react-carousel-preview",
+  "email": "mifraser@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-carousel-preview/library/package.json
+++ b/packages/react-components/react-carousel-preview/library/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@fluentui/react-carousel-preview",
   "version": "0.0.0",
-  "private": true,
   "description": "A composable carousel component that enables pagination with minimal rerenders",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",


### PR DESCRIPTION
## Previous Behavior
React-Carousel-Preview was a private package.

## New Behavior
React-Carousel-Preview is now a public package that can be consumed and appears in public storybook previews.