### PR TITLE
fix: only call activedescendant focus when combobox/dropdown is opened

### DIFF
--- a/change/@fluentui-react-combobox-d70f6062-309a-423a-9657-e1b8621c8b27.json
+++ b/change/@fluentui-react-combobox-d70f6062-309a-423a-9657-e1b8621c8b27.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: only call activedescendant focus when combobox/dropdown is opened",
+  "packageName": "@fluentui/react-combobox",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/library/src/components/Listbox/useListbox.ts
+++ b/packages/react-components/react-combobox/library/src/components/Listbox/useListbox.ts
@@ -156,10 +156,13 @@ export const useListbox_unstable = (props: ListboxProps, ref: React.Ref<HTMLElem
       };
 
   React.useEffect(() => {
-    if (!hasParentActiveDescendantContext) {
-      // disable focus-visible attributes until focus is received
-      activeDescendantController.hideFocusVisibleAttributes();
+    // if the listbox has a parent context, that parent context should handle the activedescendant
+    if (hasParentActiveDescendantContext) {
+      return;
     }
+
+    // disable focus-visible attributes until focus is received
+    activeDescendantController.hideFocusVisibleAttributes();
 
     if (!disableAutoFocus) {
       // if it is single-select and there is a selected option, start at the selected option

--- a/packages/react-components/react-combobox/library/src/utils/useComboboxBaseState.ts
+++ b/packages/react-components/react-combobox/library/src/utils/useComboboxBaseState.ts
@@ -151,6 +151,23 @@ export const useComboboxBaseState = (
     [onOpenChange, setOpenState, setValue, freeform, disabled],
   );
 
+  // update active option based on change in open state
+  React.useEffect(() => {
+    if (open) {
+      // if it is single-select and there is a selected option, start at the selected option
+      if (!multiselect && selectedOptions.length > 0) {
+        const selectedOption = getOptionsMatchingValue(v => v === selectedOptions[0]).pop();
+        if (selectedOption?.id) {
+          activeDescendantController.focus(selectedOption.id);
+        }
+      }
+    } else {
+      activeDescendantController.blur();
+    }
+    // this should only be run in response to changes in the open state
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, activeDescendantController]);
+
   // Fallback focus when children are updated in an open popover results in no item being focused
   React.useEffect(() => {
     if (open && !disableAutoFocus && !activeDescendantController.active()) {


### PR DESCRIPTION
## Previous Behavior

Related to #31140 and #31415

Moving the activedescendant `.focus()` logic to Listbox's initial render also caused the page to attempt to scroll the active option into view before it was visible on the page (since the listbox is rendered on focus for combobox/dropdown).

Usually this doesn't do anything, but if the scrollParent isn't `null`, it can scroll the page (or closest scroll parent).

## New Behavior

Now Listbox only calls the initial `activeDescendantController.focus()` logic if it does not have a parent context (so if rendered inline in the page, for example). Combobox & Dropdown call it when the listbox is opened, which is what happened previously.

## Related Issue(s)

Fixes a Teams issue raised in chat.
