### PR TITLE
fix: SwatchColorPicker story a11y bug, docs wording

### DIFF
--- a/packages/react-components/react-swatch-picker/stories/src/SwatchPicker/ColorSwatchVariants.stories.tsx
+++ b/packages/react-components/react-swatch-picker/stories/src/SwatchPicker/ColorSwatchVariants.stories.tsx
@@ -24,13 +24,13 @@ export const ColorSwatchVariants = () => {
         color="#c8eeff"
         icon={<HeartFilled color="red" className={styles.icon} />}
         value="icon"
-        aria-label="heart-icon"
+        aria-label="heart icon"
       />
       <ColorSwatch color="#016ab0" disabled value="blue" aria-label="blue" />
       <ColorSwatch color="#ff659a" value="initials" aria-label="initials">
         A
       </ColorSwatch>
-      <ColorSwatch disabled color="#c8eeff" value="icon" aria-label="heart-icon" />
+      <ColorSwatch disabled color="#c8eeff" value="light-blue" aria-label="light blue" />
     </div>
   );
 };

--- a/packages/react-components/react-swatch-picker/stories/src/SwatchPicker/EmptySwatch.stories.tsx
+++ b/packages/react-components/react-swatch-picker/stories/src/SwatchPicker/EmptySwatch.stories.tsx
@@ -37,6 +37,8 @@ export const EmptySwatchExample = () => {
   const [selectedColor, setSelectedColor] = React.useState('#00B053');
 
   const inputRef = React.useRef<HTMLInputElement>(null);
+  const colorFocusTargetRef = React.useRef<HTMLButtonElement>(null);
+  const [colorFocusTarget, setColorFocusTarget] = React.useState<string | null>(null);
   const [items, setItems] = React.useState<Array<{ color: string; value: string; 'aria-label': string }>>(defaultItems);
   const emptyItems = new Array(ITEMS_LIMIT - items.length).fill(null);
 
@@ -49,43 +51,41 @@ export const EmptySwatchExample = () => {
     // "value" should be unique as it's used as a key and for selection
     const newValue = `custom-${newColor} [${items.length - ITEMS_LIMIT}]`;
 
-    setItems([...items, { color: newColor, value: newValue, 'aria-label': `swatch-${newColor}` }]);
+    setItems([...items, { color: newColor, value: newValue, 'aria-label': newColor }]);
+    setColorFocusTarget(newValue);
   };
+
+  const resetColors = () => {
+    setItems(defaultItems);
+    setColorFocusTarget(selectedValue);
+  };
+
+  React.useEffect(() => {
+    if (colorFocusTarget) {
+      colorFocusTargetRef.current?.focus();
+    }
+  }, [colorFocusTarget]);
 
   return (
     <>
       <SwatchPicker
-        aria-label="SwatchPicker with empty swatch"
+        aria-label="SwatchPicker with empty swatches"
         selectedValue={selectedValue}
         onSelectionChange={handleSelect}
       >
         {items.map(item => (
-          <ColorSwatch key={item.value} aria-live="polite" aria-controls="add-new-color" {...item} />
+          <ColorSwatch key={item.value} ref={item.value === colorFocusTarget ? colorFocusTargetRef : null} {...item} />
         ))}
         {emptyItems.map((_, index) => (
-          <EmptySwatch
-            disabled
-            key={index}
-            aria-label={`empty-swatch-${index}`}
-            aria-live="polite"
-            aria-controls="reset-example"
-          />
+          <EmptySwatch disabled key={index} aria-label="empty swatch" />
         ))}
       </SwatchPicker>
 
       <div className={styles.example} style={{ backgroundColor: selectedColor }} />
       <Label htmlFor="color-select">Add more colors:</Label>
-      <input
-        aria-label="Open color picker"
-        className={styles.input}
-        ref={inputRef}
-        type="color"
-        id="color-select"
-        name="color-select"
-      />
+      <input className={styles.input} ref={inputRef} type="color" id="color-select" name="color-select" />
       <Button
         id="add-new-color"
-        aria-label="Add new color"
         className={styles.button}
         appearance="primary"
         disabled={items.length >= ITEMS_LIMIT}
@@ -93,12 +93,7 @@ export const EmptySwatchExample = () => {
       >
         Add new color
       </Button>
-      <Button
-        id="reset-example"
-        aria-label="Reset example"
-        className={styles.button}
-        onClick={() => setItems(defaultItems)}
-      >
+      <Button id="reset-example" className={styles.button} onClick={resetColors}>
         Reset example
       </Button>
     </>

--- a/packages/react-components/react-swatch-picker/stories/src/SwatchPicker/SwatchPickerBestPractices.md
+++ b/packages/react-components/react-swatch-picker/stories/src/SwatchPicker/SwatchPickerBestPractices.md
@@ -16,12 +16,11 @@
 
 ### Accessibility
 
-- Use contrast borders for swatches when contrast ratio between background and swatch is less than 3.
-- Minimum size of the target for pointer inputs should be at least 24 by 24 CSS pixels. It's not recommended to use smaller size.
-- Labels for the swathces are part of `aria-label` and a tooltip.
+- Use contrasting borders for swatches when contrast ratio between background and swatch is less than 3.
+- The minimum size of the target for pointer inputs should be at least 24 by 24 CSS pixels. This is required to meet the [WCAG target size requirement](https://w3c.github.io/wcag/guidelines/22/#target-size-minimum).
+- Labels for the swatches can be handled with either `aria-label` or a Tooltip. These are required for both voice control and screen reader users.
 
 _Known limitations:_
 
-- `radiogroup` role is not expected for the SwatchPicker because color selection must be confirmed by pressing enter/space unlike Radiogroup. But because `aria-checked` attribute is supported everywhere the role `radiogroup` will be used for the `row` layout.
-
-- For the `grid` layout role `grid` is used with rows inside and swatches with a role `gridcell`. But `aria-selected` attribute is not supported on Mac and there is no better alternative.
+- The `radiogroup` role used for the SwatchPicker does not fully match standard radio keyboard behavior because color selection must be confirmed by pressing enter/space, unlike Radiogroup. But because this pattern has more robust cross-platform support, the `radiogroup` role will be used for the `row` layout.
+- For the `grid` layout the `grid` role is used, and swatches have a role of `gridcell`. This is because the grid pattern is the only one that supports a two-dimensional layout and arrowing behavior, even though the `aria-selected` attribute on `gridcell` is not well-supported on all screen readers, and there is no better alternative.

--- a/packages/react-components/react-swatch-picker/stories/src/SwatchPicker/SwatchPickerImage.stories.tsx
+++ b/packages/react-components/react-swatch-picker/stories/src/SwatchPicker/SwatchPickerImage.stories.tsx
@@ -56,7 +56,11 @@ export const SwatchPickerImage = () => {
 
   return (
     <>
-      <SwatchPicker aria-label="SwatchPicker default" selectedValue={selectedValue} onSelectionChange={handleSelect}>
+      <SwatchPicker
+        aria-label="SwatchPicker with images"
+        selectedValue={selectedValue}
+        onSelectionChange={handleSelect}
+      >
         {images.map(image => (
           <ImageSwatch
             className={styles.swatch}

--- a/packages/react-components/react-swatch-picker/stories/src/SwatchPicker/SwatchPickerMixedSwatches.stories.tsx
+++ b/packages/react-components/react-swatch-picker/stories/src/SwatchPicker/SwatchPickerMixedSwatches.stories.tsx
@@ -67,7 +67,7 @@ export const SwatchPickerMixedSwatches = () => {
     <>
       <SwatchPicker
         layout="grid"
-        aria-label="SwatchPicker grid layout"
+        aria-label="SwatchPicker with both colors and images"
         selectedValue={selectedValue}
         onSelectionChange={handleSelect}
       >

--- a/packages/react-components/react-swatch-picker/stories/src/SwatchPicker/SwatchPickerPopup.stories.tsx
+++ b/packages/react-components/react-swatch-picker/stories/src/SwatchPicker/SwatchPickerPopup.stories.tsx
@@ -86,7 +86,7 @@ const colorSet2 = [
     color:
       'linear-gradient(0deg, #FF1921 0%, #FFC12E 10%, #FEFF37 20%, #90D057 30%, #00B053 40%, #00AFED 50%, #006EBD 60%, #011F5E 70%, #712F9E 80%)',
     value: 'gradient',
-    'aria-label': 'gradient',
+    'aria-label': 'gradient rainbow',
   },
 ];
 
@@ -109,7 +109,7 @@ export const SwatchPickerPopup = () => {
     <>
       <Popover open={popoverOpen} trapFocus onOpenChange={(_, data) => setPopoverOpen(data.open)}>
         <PopoverTrigger disableButtonEnhancement>
-          <Button aria-label="Choose color">Choose color</Button>
+          <Button>Choose color</Button>
         </PopoverTrigger>
 
         <PopoverSurface>

--- a/packages/react-components/react-swatch-picker/stories/src/SwatchPicker/SwatchPickerWithTooltip.stories.tsx
+++ b/packages/react-components/react-swatch-picker/stories/src/SwatchPicker/SwatchPickerWithTooltip.stories.tsx
@@ -39,7 +39,7 @@ export const SwatchPickerWithTooltip = () => {
   return (
     <>
       <h3>Row layout</h3>
-      <SwatchPicker aria-label="SwatchPicker default" selectedValue={selectedValue} onSelectionChange={handleSelect}>
+      <SwatchPicker aria-label="SwatchPicker row layout" selectedValue={selectedValue} onSelectionChange={handleSelect}>
         {colors.map(color => {
           return <ColorSwatchWithTooltip key={color.value} {...color} />;
         })}
@@ -47,7 +47,7 @@ export const SwatchPickerWithTooltip = () => {
       <h3>Grid layout</h3>
       <SwatchPicker
         layout="grid"
-        aria-label="SwatchPicker default"
+        aria-label="SwatchPicker grid layout"
         selectedValue={selectedValue}
         onSelectionChange={handleSelect}
       >
@@ -75,7 +75,7 @@ const ColorSwatchWithTooltip = (props: ColorSwatchProps) => {
   const label = props['aria-label'] ?? 'color swatch';
   return (
     <Tooltip withArrow content={label} relationship="label">
-      <ColorSwatch color={color} value={value} aria-label={label} />
+      <ColorSwatch color={color} value={value} />
     </Tooltip>
   );
 };


### PR DESCRIPTION
## Previous Behavior

The Empty swatch example didn't have a confirmation that the add new color/reset buttons had successfully added a new color or reset the colors.

## New Behavior

Adds the following a11y updates:
- In the Empty example, moves focus on adding a new color or resetting as a confirmation of action
- Removes `aria-live` attributes from the ColorSwatch components (these didn't really do anything)
- Removes unnecessary `aria-label`s
- Updates a few missed labels to match content
- Minor docs wording updates

## Related Issue(s)

- Fixes [ADO issue](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/19222)
