### PR TITLE
bugfix(react-table): removes Partial from TableProps usage

### DIFF
--- a/change/@fluentui-react-table-7dd08fe8-65c4-4cad-b27f-d1a3ee6a5e7b.json
+++ b/change/@fluentui-react-table-7dd08fe8-65c4-4cad-b27f-d1a3ee6a5e7b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: removes Partial from TableProps usage",
+  "packageName": "@fluentui/react-table",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-table/library/src/hooks/types.ts
+++ b/packages/react-components/react-table/library/src/hooks/types.ts
@@ -176,7 +176,7 @@ export interface ColumnWidthState {
   padding: number;
 }
 
-export type ColumnSizingTableProps = Partial<TableProps>;
+export type ColumnSizingTableProps = TableProps;
 export type ColumnSizingTableHeaderCellProps = Pick<TableHeaderCellProps, 'style' | 'aside'>;
 export type ColumnSizingTableCellProps = Pick<TableHeaderCellProps, 'style'>;
 
@@ -186,7 +186,7 @@ export interface TableColumnSizingState {
   getOnMouseDown: (columnId: TableColumnId) => (e: React.MouseEvent | React.TouchEvent) => void;
   setColumnWidth: (columnId: TableColumnId, newSize: number) => void;
   getColumnWidths: () => ColumnWidthState[];
-  getTableProps: (props?: Partial<TableProps>) => ColumnSizingTableProps;
+  getTableProps: (props?: TableProps) => ColumnSizingTableProps;
   getTableHeaderCellProps: (columnId: TableColumnId) => ColumnSizingTableHeaderCellProps;
   getTableCellProps: (columnId: TableColumnId) => ColumnSizingTableCellProps;
   enableKeyboardMode: (


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

### Explanation of `Partial<TableProps>` issue

`TableProps` relies on [Discriminated Unions](https://www.typescriptlang.org/docs/handbook/typescript-in-5-minutes-func.html#discriminated-unions) based on the presence of the `as` property to determine whether it's a `div` or a `table` element that is being provided. 

The discrimination is:
1. if `as` is `'table' | undefined` than `table` props are provided
2. if `as` is `div` than `div` props are provided

By using `Partial<TableProps>` we are breaking the discrimination, as the value of `undefined` for the `as` property would not give the compiler enough information to properly discriminate the value.

Here's a [playground](https://www.typescriptlang.org/play/?#code/JYWwDg9gTgLgBAbwMoBsIwDRwMIXBAOwFMCYAFKCMAZwF84AzSkOAcgAEGUBXEmb4AHooRAIYBjGAFpuMYCmByi1VgChVMAJ5gicACqiARiiKp01OAF5EquHbiV0ALjMwAPKxhGTrLKwAmwABurAB8qrTqWjr63kQUVBbWuPjEpAk0bgbGpmgw1OGq4oTU8GCUNE6xORlJNvZwgoJwxeDyRFBw-kQwHSDAxHAwABbAFmNwomxeOb5whkTiotzUugAGonXcBN0MA0T+a7b2hNgK4gDWVQAUREEAlFahNsd2kZFFJWWisMCiKLUqmQfnJ-lk4rVntYEK9Gs1ALwbgGKdpEoxGwprsfJSIgADx0kmxUEonSkz1aYHanSWBAI6C6Y3EUFAA1EvTg22AhHmPQA7kQSNM4qxJjs2IEQrDTucrnBbg8noh3kA) example of the problem

###  Current Problem

[ColumnSizingTableProps](https://github.com/microsoft/fluentui/pull/32159/files#diff-fcc3566edfc551625c6d346c9cff0efe577242a93bcec6e19935ca9b3afdd56cL179) and [TableColumnSizingState.getTableProps](https://github.com/microsoft/fluentui/pull/32159/files#diff-fcc3566edfc551625c6d346c9cff0efe577242a93bcec6e19935ca9b3afdd56cL189) declare their values based on `Partial<TableProps>`, which breaks discrimination



## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

1. removes `Partial<TableProps>` in favor of `TableProps`

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
