### PR TITLE
feat(motion): add collapse motion for Tree

### DIFF
--- a/change/@fluentui-react-tree-bd1e1754-9d0e-461f-9f53-d661b31b0a17.json
+++ b/change/@fluentui-react-tree-bd1e1754-9d0e-461f-9f53-d661b31b0a17.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: add collapse motion to Tree",
+  "packageName": "@fluentui/react-tree",
+  "email": "olkatruk@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tree/library/etc/react-tree.api.md
+++ b/packages/react-components/react-tree/library/etc/react-tree.api.md
@@ -26,6 +26,7 @@ import type { EventHandler } from '@fluentui/react-utilities';
 import type { ExtractSlotProps } from '@fluentui/react-utilities';
 import { ForwardRefComponent } from '@fluentui/react-utilities';
 import type { Home } from '@fluentui/keyboard-keys';
+import type { PresenceMotionSlotProps } from '@fluentui/react-motion';
 import { Radio } from '@fluentui/react-radio';
 import { RadioProps } from '@fluentui/react-radio';
 import * as React_2 from 'react';
@@ -46,7 +47,7 @@ export type FlattenTreeItem<Props extends TreeItemProps> = Omit<Props, 'subtree'
 export const FlatTree: ForwardRefComponent<FlatTreeProps>;
 
 // @public (undocumented)
-export const flatTreeClassNames: SlotClassNames<FlatTreeSlots>;
+export const flatTreeClassNames: SlotClassNames<Omit<FlatTreeSlots, 'collapseMotion'>>;
 
 // @public
 export const FlatTreeItem: ForwardRefComponent<FlatTreeItemProps>;
@@ -145,7 +146,7 @@ export type TreeCheckedChangeData = {
 export type TreeCheckedChangeEvent = TreeCheckedChangeData['event'];
 
 // @public (undocumented)
-export const treeClassNames: SlotClassNames<TreeSlots>;
+export const treeClassNames: SlotClassNames<Omit<TreeSlots, 'collapseMotion'>>;
 
 // @public (undocumented)
 export type TreeContextValue = {
@@ -387,6 +388,7 @@ export type TreeSelectionValue = MultiSelectValue | SingleSelectValue;
 // @public (undocumented)
 export type TreeSlots = {
     root: Slot<'div'>;
+    collapseMotion?: Slot<PresenceMotionSlotProps>;
 };
 
 // @public

--- a/packages/react-components/react-tree/library/package.json
+++ b/packages/react-components/react-tree/library/package.json
@@ -40,6 +40,8 @@
     "@fluentui/react-checkbox": "^9.2.33",
     "@fluentui/react-context-selector": "^9.1.65",
     "@fluentui/react-icons": "^2.0.245",
+    "@fluentui/react-motion-components-preview": "^0.1.1",
+    "@fluentui/react-motion": "^9.4.0",
     "@fluentui/react-radio": "^9.2.28",
     "@fluentui/react-shared-contexts": "^9.20.0",
     "@fluentui/react-tabster": "^9.22.3",

--- a/packages/react-components/react-tree/library/src/components/FlatTree/useFlatTreeStyles.styles.ts
+++ b/packages/react-components/react-tree/library/src/components/FlatTree/useFlatTreeStyles.styles.ts
@@ -3,7 +3,7 @@ import type { SlotClassNames } from '@fluentui/react-utilities';
 import { tokens } from '@fluentui/react-theme';
 import { FlatTreeSlots, FlatTreeState } from './FlatTree.types';
 
-export const flatTreeClassNames: SlotClassNames<FlatTreeSlots> = {
+export const flatTreeClassNames: SlotClassNames<Omit<FlatTreeSlots, 'collapseMotion'>> = {
   root: 'fui-FlatTree',
 };
 

--- a/packages/react-components/react-tree/library/src/components/Tree/Tree.types.ts
+++ b/packages/react-components/react-tree/library/src/components/Tree/Tree.types.ts
@@ -1,4 +1,5 @@
 import type * as React from 'react';
+import type { PresenceMotionSlotProps } from '@fluentui/react-motion';
 import type { ComponentProps, ComponentState, SelectionMode, Slot } from '@fluentui/react-utilities';
 import type { TreeContextValue, SubtreeContextValue } from '../../contexts';
 import type { ArrowDown, ArrowLeft, ArrowRight, ArrowUp, End, Enter, Home } from '@fluentui/keyboard-keys';
@@ -12,6 +13,7 @@ export type TreeSelectionValue = MultiSelectValue | SingleSelectValue;
 
 export type TreeSlots = {
   root: Slot<'div'>;
+  collapseMotion?: Slot<PresenceMotionSlotProps>;
 };
 
 // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/packages/react-components/react-tree/library/src/components/Tree/renderTree.tsx
+++ b/packages/react-components/react-tree/library/src/components/Tree/renderTree.tsx
@@ -8,7 +8,13 @@ export const renderTree_unstable = (state: TreeState, contextValues: TreeContext
   assertSlots<TreeSlots>(state);
   return (
     <TreeProvider value={contextValues.tree}>
-      {state.open && <state.root>{state.root.children}</state.root>}
+      {state.collapseMotion ? (
+        <state.collapseMotion>
+          <state.root />
+        </state.collapseMotion>
+      ) : (
+        <state.root />
+      )}
     </TreeProvider>
   );
 };

--- a/packages/react-components/react-tree/library/src/components/Tree/useTreeStyles.styles.ts
+++ b/packages/react-components/react-tree/library/src/components/Tree/useTreeStyles.styles.ts
@@ -3,7 +3,7 @@ import type { TreeSlots, TreeState } from './Tree.types';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import { tokens } from '@fluentui/react-theme';
 
-export const treeClassNames: SlotClassNames<TreeSlots> = {
+export const treeClassNames: SlotClassNames<Omit<TreeSlots, 'collapseMotion'>> = {
   root: 'fui-Tree',
 };
 

--- a/packages/react-components/react-tree/library/src/components/TreeItemChevron.tsx
+++ b/packages/react-components/react-tree/library/src/components/TreeItemChevron.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { useFluent_unstable } from '@fluentui/react-shared-contexts';
 import { ChevronRight12Regular } from '@fluentui/react-icons';
+import { durations, curves } from '@fluentui/react-motion';
 import { useTreeItemContext_unstable } from '../contexts/treeItemContext';
 
 export const TreeItemChevron = React.memo(() => {
@@ -9,7 +10,14 @@ export const TreeItemChevron = React.memo(() => {
   const { dir } = useFluent_unstable();
 
   const expandIconRotation = open ? 90 : dir !== 'rtl' ? 0 : 180;
-  return <ChevronRight12Regular style={expandIconInlineStyles[expandIconRotation]} />;
+  return (
+    <ChevronRight12Regular
+      style={{
+        ...expandIconInlineStyles[expandIconRotation],
+        transition: `transform ${durations.durationNormal}ms ${curves.curveEasyEaseMax}`,
+      }}
+    />
+  );
 });
 TreeItemChevron.displayName = 'TreeItemChevron';
 

--- a/packages/react-components/react-tree/library/src/hooks/useRootTree.ts
+++ b/packages/react-components/react-tree/library/src/hooks/useRootTree.ts
@@ -1,6 +1,8 @@
 import { getIntrinsicElementProps, useEventCallback, slot } from '@fluentui/react-utilities';
 import type { TreeCheckedChangeData, TreeProps, TreeState } from '../Tree';
 import * as React from 'react';
+import { Collapse } from '@fluentui/react-motion-components-preview';
+import { PresenceMotionSlotProps } from '@fluentui/react-motion';
 import { TreeContextValue, TreeItemRequest } from '../contexts/treeContext';
 import { createOpenItems } from '../utils/createOpenItems';
 import { createCheckedItems } from '../utils/createCheckedItems';
@@ -75,7 +77,14 @@ export function useRootTree(
   });
 
   return {
-    components: { root: 'div' },
+    components: {
+      root: 'div',
+      // TODO: remove once React v18 slot API is modified
+      // This is a problem at the moment due to UnknownSlotProps assumption
+      // that `children` property is `ReactNode`, which in this case is not valid
+      // as PresenceComponentProps['children'] is `ReactElement`
+      collapseMotion: Collapse as React.FC<PresenceMotionSlotProps>,
+    },
     contextType: 'root',
     selectionMode,
     open: true,
@@ -97,6 +106,7 @@ export function useRootTree(
       }),
       { elementType: 'div' },
     ),
+    collapseMotion: undefined,
   };
 }
 

--- a/packages/react-components/react-tree/library/src/hooks/useSubtree.ts
+++ b/packages/react-components/react-tree/library/src/hooks/useSubtree.ts
@@ -2,6 +2,8 @@ import * as React from 'react';
 import { TreeProps, TreeState } from '../Tree';
 import { SubtreeContextValue, useSubtreeContext_unstable, useTreeItemContext_unstable } from '../contexts/index';
 import { getIntrinsicElementProps, useMergedRefs, slot } from '@fluentui/react-utilities';
+import { Collapse } from '@fluentui/react-motion-components-preview';
+import { presenceMotionSlot, PresenceMotionSlotProps } from '@fluentui/react-motion';
 
 /**
  * Create the state required to render a sub-level tree.
@@ -24,6 +26,11 @@ export function useSubtree(
     open,
     components: {
       root: 'div',
+      // TODO: remove once React v18 slot API is modified
+      // This is a problem at the moment due to UnknownSlotProps assumption
+      // that `children` property is `ReactNode`, which in this case is not valid
+      // as PresenceComponentProps['children'] is `ReactElement`
+      collapseMotion: Collapse as React.FC<PresenceMotionSlotProps>,
     },
     level: parentLevel + 1,
     root: slot.always(
@@ -37,5 +44,12 @@ export function useSubtree(
       }),
       { elementType: 'div' },
     ),
+    collapseMotion: presenceMotionSlot(props.collapseMotion, {
+      elementType: Collapse,
+      defaultProps: {
+        visible: open,
+        unmountOnExit: true,
+      },
+    }),
   };
 }


### PR DESCRIPTION
## Previous Behavior

`renderTree` didn't have a collapse animation

## New Behavior

- `renderTree` gets the new slot for collapse motion: `collapseMotion`

Motion slots allow to customize or replace built-in motion, see examples in #31984.

## Design Specs
[Fluent Motion Component Defaults](https://loop.cloud.microsoft/p/eyJ3Ijp7InUiOiJodHRwczovL21pY3Jvc29mdC5zaGFyZXBvaW50LWRmLmNvbS8%2FbmF2PWN6MGxNa1ltWkQxaUlVZGtPVkJhWlRGUU1tdFBWSEpxVkdKYWVtbDVaazR4VDI5WGNWbDNSbXhGYTBoS1UzVllRek5qTkdjNWQyUnRZVFYxVUhaVFRHZENYMnBtVjJsdFVVNG1aajB3TVUwM1NVczNXVXd6VjFZMk5FVlBSVlUwVWtOYU4weExVMGd6V0VKUFRGSlFKbU05Sm1ac2RXbGtQVEUlM0QiLCJyIjpmYWxzZX0sInAiOnsidSI6Imh0dHBzOi8vbWljcm9zb2Z0LnNoYXJlcG9pbnQtZGYuY29tLzpmbDovci9jb250ZW50c3RvcmFnZS9DU1BfNjU0ZmRmMTktNGZlZC00M2RhLTkzYWUtMzRkYjY3MzhiMjdjL0RvY3VtZW50JTIwTGlicmFyeS9Mb29wQXBwRGF0YS9VbnRpdGxlZC5sb29wP2Q9d2MzZDcyZjgxNDkwNjQ2ODg5ZDEwOGM3MzZmY2Y5ZjRhJmNzZj0xJndlYj0xJm5hdj1jejBsTWtaamIyNTBaVzUwYzNSdmNtRm5aU1V5UmtOVFVGODJOVFJtWkdZeE9TMDBabVZrTFRRelpHRXRPVE5oWlMwek5HUmlOamN6T0dJeU4yTW1aRDFpSVVka09WQmFaVEZRTW10UFZISnFWR0phZW1sNVprNHhUMjlYY1ZsM1JteEZhMGhLVTNWWVF6TmpOR2M1ZDJSdFlUVjFVSFpUVEdkQ1gycG1WMmx0VVU0bVpqMHdNVTAzU1VzM1dVMUNSamRNTkVkQ1UwcFNRa1JLTWtWRlRVOU9XRFEzU0RKTEptTTlKVEpHSm1ac2RXbGtQVEVtWVQxTWIyOXdRWEJ3Sm5BOUpUUXdabXgxYVdSNEpUSkdiRzl2Y0Mxd1lXZGxMV052Ym5SaGFXNWxjaVo0UFNVM1FpVXlNbmNsTWpJbE0wRWxNakpVTUZKVVZVaDRkR0ZYVG5saU0wNTJXbTVSZFdNeWFHaGpiVlozWWpKc2RXUkRNV3RhYVRWcVlqSXhPRmxwUmtoYVJHeFJWMjFWZUZWRVNuSlVNVko1WVd4U2FWZHVjSEJsVjFwUFRWVTVkbFl6Umxwa01GcHpVbGQwU1ZOc1RqRlhSVTE2V1hwU2JrOVlaR3RpVjBVeFpGWkNNbFV3ZUc1UmJEbHhXbXhrY0dKV1JrOW1SRUY0VkZSa1NsTjZaRnBVUkU1WVZtcFpNRkpWT1VaV1ZGSlRVVEZ2TTFSRmRGUlRSRTVaVVdzNVRWVnNRU1V6UkNVeU1pVXlReVV5TW1rbE1qSWxNMEVsTWpJeFptVTVOVEkyWkMwMU9XSmpMVFJqWTJVdE9HVmxZUzFrTTJWbFpqSTFZVGRpWmpRbE1qSWxOMFElM0QiLCJyIjpmYWxzZX0sImkiOnsiaSI6IjFmZTk1MjZkLTU5YmMtNGNjZS04ZWVhLWQzZWVmMjVhN2JmNCJ9fQ%3D%3D)

## Related issues

- Fixes #32164