### PR TITLE
e2e(react-18-tests-v8): setup cypress webpack to use v8 TS path aliases in order to work without build step

### DIFF
--- a/apps/react-18-tests-v8/cypress.config.ts
+++ b/apps/react-18-tests-v8/cypress.config.ts
@@ -1,3 +1,11 @@
+import * as path from 'node:path';
 import { baseConfig } from '@fluentui/scripts-cypress';
+const { registerTsPaths } = require('@fluentui/scripts-storybook');
 
-export default baseConfig;
+const tsConfigPath = path.resolve(__dirname, '../../tsconfig.base.v8.json');
+
+const config = { ...baseConfig };
+
+registerTsPaths({ config: config.component.devServer.webpackConfig, configFile: tsConfigPath });
+
+export default config;

--- a/apps/react-18-tests-v8/package.json
+++ b/apps/react-18-tests-v8/package.json
@@ -18,7 +18,8 @@
     "@fluentui/scripts-cypress": "*",
     "@fluentui/scripts-jest": "*",
     "@fluentui/scripts-tasks": "*",
-    "@fluentui/scripts-webpack": "*"
+    "@fluentui/scripts-webpack": "*",
+    "@fluentui/scripts-storybook": "*"
   },
   "dependencies": {
     "@fluentui/react": "*",

--- a/apps/react-18-tests-v8/tsconfig.json
+++ b/apps/react-18-tests-v8/tsconfig.json
@@ -9,6 +9,7 @@
     "jsx": "react",
     "noUnusedLocals": true,
     "preserveConstEnums": true,
+    "experimentalDecorators": true,
     "skipLibCheck": true
   },
   "include": [],


### PR DESCRIPTION

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

`e2e` targets don't run without `build`  step for all projects

https://uifabric.visualstudio.com/fabricpublic/_build/results?buildId=354795&view=logs&j=df65131f-49fe-5f4e-72c0-55655bbfd745&t=ce789735-18bf-559a-842b-052b9b2ccc06

## New Behavior

`e2e` targets run without `build` step for all projects

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows https://github.com/microsoft/fluentui/pull/32172
