### PR TITLE
ci: build pr deploy site in CI runs to fix failing pipeline step

### DIFF
--- a/.devops/templates/deployE2E.yml
+++ b/.devops/templates/deployE2E.yml
@@ -29,7 +29,6 @@ steps:
   - script: |
       yarn nx run pr-deploy-site:generate:site
     displayName: generate PR Deploy Site
-    condition: eq(variables.isPR, true)
 
   - task: AzureCLI@2
     displayName: Upload PR deploy site


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
- CI pipeline runs are failing due to missing assets:
https://uifabric.visualstudio.com/fabricpublic/_build/results?buildId=354836&view=logs&j=df65131f-49fe-5f4e-72c0-55655bbfd745&t=500ae3fd-d581-5ecf-52f7-fd3683672b6b
<img width="823" alt="image" src="https://github.com/user-attachments/assets/7346163b-6ae8-439e-a3f9-437c36b01b6c">


<!-- This is the behavior we have today -->

## New Behavior
- assets are now built before step
<!-- This is the behavior we should expect with the changes in this PR -->

