### PR TITLE
fix(Toolbar): hardcode size of `ToolbarButton`

### DIFF
--- a/change/@fluentui-react-toolbar-412d5b87-74d8-44b4-8215-ab53b873e174.json
+++ b/change/@fluentui-react-toolbar-412d5b87-74d8-44b4-8215-ab53b873e174.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: hardcode size of `ToolbarButton`",
+  "packageName": "@fluentui/react-toolbar",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarButton/useToolbarButton.ts
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarButton/useToolbarButton.ts
@@ -13,7 +13,15 @@ export const useToolbarButton_unstable = (
   ref: React.Ref<HTMLButtonElement | HTMLAnchorElement>,
 ): ToolbarButtonState => {
   const { vertical = false, ...buttonProps } = props;
-  const state = useButton_unstable({ appearance: 'subtle', ...buttonProps }, ref);
+  const state = useButton_unstable(
+    {
+      appearance: 'subtle',
+      ...buttonProps,
+      size: 'medium',
+    },
+    ref,
+  );
+
   return {
     vertical,
     ...state,


### PR DESCRIPTION
## Previous Behavior

TS will scream on `size` prop, but it still can be passed an affect `ToolbarButton`.

## New Behavior

`ToolbarButton` has hardcoded size according to the design spec.

## Related Issue(s)

Fixes #32063.
