### PR TITLE
fix(nx): update target dependencies so all targets work as expected

### DIFF
--- a/apps/public-docsite-resources/package.json
+++ b/apps/public-docsite-resources/package.json
@@ -18,6 +18,7 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
+    "prebundle": "yarn build",
     "bundle": "just-scripts bundle",
     "lint": "eslint --ext .js,.ts,.tsx ./src",
     "just": "just-scripts",

--- a/nx.json
+++ b/nx.json
@@ -11,12 +11,12 @@
   },
   "targetDefaults": {
     "bundle-size": {
-      "dependsOn": ["build", "^build"],
+      "dependsOn": ["build"],
       "cache": true
     },
     "bundle": {
       "cache": true,
-      "dependsOn": ["build", "^build"]
+      "dependsOn": ["^build"]
     },
     "build": {
       "dependsOn": ["^build"],
@@ -76,7 +76,7 @@
       ]
     },
     "verify-packaging": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["build"],
       "cache": true
     },
     "@nx/jest:jest": {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

- `verify-packaging` wont run build on project (`self`) which will fail the task 
  -  https://uifabric.visualstudio.com/fabricpublic/_build/results?buildId=354914&view=logs&j=258ec178-2d8b-5611-7b9b-60c5c95dae55&t=254ee48e-1503-524f-f75e-e2c69d0380f5
  - https://uifabric.visualstudio.com/fabricpublic/_build/results?buildId=354990&view=logs&j=258ec178-2d8b-5611-7b9b-60c5c95dae55&t=254ee48e-1503-524f-f75e-e2c69d0380f5
- `bundle` has dependency on self `build`, but when project has `bundle` task we dissallow `build` task ( only exception is public-docsite-resource which is an antipattern/hybrid between application/library )

## New Behavior

- `verify-packaging` runs self `build` and deps `^build`
- `bundle` runs only deps `^build`

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows https://github.com/microsoft/fluentui/pull/31949
