### PR TITLE
feature(react-tag-picker): support Iterable for selected options

### DIFF
--- a/change/@fluentui-react-tag-picker-4e44aceb-6929-46a4-9e5a-299fa05bcfce.json
+++ b/change/@fluentui-react-tag-picker-4e44aceb-6929-46a4-9e5a-299fa05bcfce.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feature: support Iterable type for selectedOptions props",
+  "packageName": "@fluentui/react-tag-picker",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tag-picker/library/etc/react-tag-picker.api.md
+++ b/packages/react-components/react-tag-picker/library/etc/react-tag-picker.api.md
@@ -216,7 +216,10 @@ export type TagPickerOptionSlots = Pick<OptionSlots, 'root'> & {
 export type TagPickerOptionState = ComponentState<TagPickerOptionSlots> & Pick<OptionState, 'components' | 'root'>;
 
 // @public
-export type TagPickerProps = ComponentProps<TagPickerSlots> & Pick<ComboboxProps, 'positioning' | 'disabled' | 'defaultOpen' | 'selectedOptions' | 'defaultSelectedOptions' | 'open'> & Pick<Partial<TagPickerContextValue>, 'size' | 'appearance'> & {
+export type TagPickerProps = ComponentProps<TagPickerSlots> & Pick<ComboboxProps, 'positioning' | 'disabled' | 'defaultOpen' | 'open'> & Pick<Partial<TagPickerContextValue>, 'size' | 'appearance'> & {
+    selectedOptions?: Iterable<string>;
+    defaultSelectedOptions?: Iterable<string>;
+    noPopover?: boolean;
     onOpenChange?: EventHandler<TagPickerOnOpenChangeData>;
     onOptionSelect?: EventHandler<TagPickerOnOptionSelectData>;
     children: [JSX.Element, JSX.Element] | JSX.Element;

--- a/packages/react-components/react-tag-picker/library/src/components/TagPicker/TagPicker.cy.tsx
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPicker/TagPicker.cy.tsx
@@ -43,7 +43,7 @@ const options = [
 type TagPickerControlledProps = Pick<TagPickerProps, 'open' | 'defaultOpen' | 'defaultSelectedOptions'>;
 
 const TagPickerControlled = ({ open, defaultOpen, defaultSelectedOptions = [] }: TagPickerControlledProps) => {
-  const [selectedOptions, setSelectedOptions] = React.useState<string[]>(defaultSelectedOptions);
+  const [selectedOptions, setSelectedOptions] = React.useState<string[]>(() => Array.from(defaultSelectedOptions));
   const onOptionSelect: TagPickerProps['onOptionSelect'] = (e, data) => {
     setSelectedOptions(data.selectedOptions);
   };

--- a/packages/react-components/react-tag-picker/library/src/components/TagPicker/TagPicker.types.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPicker/TagPicker.types.ts
@@ -28,11 +28,17 @@ export type TagPickerOnOpenChangeData = { open: boolean } & (
  * Picker Props
  */
 export type TagPickerProps = ComponentProps<TagPickerSlots> &
-  Pick<
-    ComboboxProps,
-    'positioning' | 'disabled' | 'defaultOpen' | 'selectedOptions' | 'defaultSelectedOptions' | 'open'
-  > &
+  Pick<ComboboxProps, 'positioning' | 'disabled' | 'defaultOpen' | 'open'> &
   Pick<Partial<TagPickerContextValue>, 'size' | 'appearance'> & {
+    selectedOptions?: Iterable<string>;
+    defaultSelectedOptions?: Iterable<string>;
+    /**
+     * By default, when a single children is provided, the TagPicker will assume that the children
+     * is a popover. By setting this prop to true, the children will be treated as a trigger instead.
+     *
+     * @default false
+     */
+    noPopover?: boolean;
     onOpenChange?: EventHandler<TagPickerOnOpenChangeData>;
     onOptionSelect?: EventHandler<TagPickerOnOptionSelectData>;
 

--- a/packages/react-components/react-tag-picker/library/src/components/TagPicker/useTagPicker.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPicker/useTagPicker.ts
@@ -48,6 +48,16 @@ export const useTagPicker_unstable = (props: TagPickerProps): TagPickerState => 
 
   const comboboxState = useComboboxBaseState({
     ...props,
+    // TODO: Combobox state should support iterables as well, for now converting it to array is fine
+    selectedOptions: React.useMemo(
+      () => props.selectedOptions && arrayFrom(props.selectedOptions),
+      [props.selectedOptions],
+    ),
+    // TODO: Combobox state should support iterables as well, for now converting it to array is fine
+    defaultSelectedOptions: React.useMemo(
+      () => props.defaultSelectedOptions && arrayFrom(props.defaultSelectedOptions),
+      [props.defaultSelectedOptions],
+    ),
     onOptionSelect: useEventCallback((event, data) =>
       props.onOptionSelect?.(event, {
         selectedOptions: data.selectedOptions,
@@ -130,3 +140,9 @@ const childrenToTriggerAndPopover = (children?: React.ReactNode) => {
   }
   return { trigger, popover };
 };
+
+/**
+ * Convert an iterable to an array.
+ * If the value is already an array, it will be returned as is.
+ */
+const arrayFrom = <T>(value: Iterable<T>): T[] => (Array.isArray(value) ? value : Array.from(value));


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

1. `selectedOptions` and `defaultSelectedOptions` are `Iterable<string>` instead of `string[]`

This is useful for scenarios where filtering repeated tags would be desired, like the web picker example:
![image](https://github.com/user-attachments/assets/778f8dcb-d2f3-414f-a630-84c29c5383d1)

Providing a `Set` of urls is simpler and more efficient than providing an array and then iterating over the array on every validation 

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
