### PR TITLE
ci: separate build and bundle for v8 release in order to mitigate accidental clean task runs that would remove /dist assets

### DIFF
--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -118,6 +118,13 @@ extends:
                 displayName: bundle
 
               - script: |
+                  ls -la packages/react/dist
+                  ls -la packages/react/lib
+                  ls -la packages/react/lib-commonjs
+                  ls -la packages/react/lib-amd
+                displayName: verify packaged react assets
+
+              - script: |
                   yarn publish:beachball -n $(npmToken) --config scripts/beachball/src/release-v8.config.js --message 'release: applying package updates - react v8'
                   git reset --hard origin/master
                 env:

--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -102,16 +102,20 @@ extends:
                 displayName: Generate version files
 
               - script: |
-                  yarn nx run-many -t build bundle -p tag:v8 --exclude tag:vNext,tag:tools,ssr-tests,vr-tests,perf-test --nxBail --production
-                displayName: build,bundle
+                  FLUENT_PROD_BUILD=true yarn nx run-many -t build -p tag:v8 --exclude tag:vNext,tag:tools,ssr-tests,vr-tests,perf-test --nxBail
+                displayName: build
 
               - script: |
-                  yarn nx run-many -t test -p tag:v8 --exclude tag:vNext,tag:tools,ssr-tests,vr-tests,perf-test --nxBail
+                  FLUENT_PROD_BUILD=true yarn nx run-many -t test -p tag:v8 --exclude tag:vNext,tag:tools,ssr-tests,vr-tests,perf-test --nxBail
                 displayName: test
 
               - script: |
-                  yarn nx run-many -t lint -p tag:v8 --exclude tag:vNext,tag:tools,ssr-tests,vr-tests,perf-test --nxBail
+                  FLUENT_PROD_BUILD=true yarn nx run-many -t lint -p tag:v8 --exclude tag:vNext,tag:tools,ssr-tests,vr-tests,perf-test --nxBail
                 displayName: lint
+
+              - script: |
+                  FLUENT_PROD_BUILD=true yarn nx run-many -t bundle -p tag:v8 --exclude tag:vNext,tag:tools,ssr-tests,vr-tests,perf-test --nxBail
+                displayName: bundle
 
               - script: |
                   yarn publish:beachball -n $(npmToken) --config scripts/beachball/src/release-v8.config.js --message 'release: applying package updates - react v8'

--- a/scripts/tasks/src/argv.ts
+++ b/scripts/tasks/src/argv.ts
@@ -14,7 +14,13 @@ export interface JustArgs extends Arguments {
 }
 
 export function getJustArgv() {
-  return parseModule(argv()) as Partial<JustArgs>;
+  const production = Boolean(process.env.FLUENT_PROD_BUILD);
+  const cliArgs = argv();
+  if (production) {
+    cliArgs.production = true;
+  }
+
+  return parseModule(cliArgs) as Partial<JustArgs>;
 }
 
 const moduleDefaults = { esm: false, cjs: false, amd: false };


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

- adds ability to set `--production` flag via env variable
- splits `bundle` and `build` step for v8 as it was before migration 
- adds logs to verify react build assets on release 
- PERF: test/lint will use cached assets from `build` steps

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/32189
