### PR TITLE
chore: manually add change file to trigger new publish for v8 

### DIFF
--- a/change/@fluentui-react-fix-bad-release.json
+++ b/change/@fluentui-react-fix-bad-release.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "chore: fix bad release",
+  "comment": "chore: fix bad release and restore missing files in the dist folder.",
   "packageName": "@fluentui/react",
   "email": "seanmonahan@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-fix-bad-release.json
+++ b/change/@fluentui-react-fix-bad-release.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: fix bad release",
+  "packageName": "@fluentui/react",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
Adds a change file for Fluent v8 will push out a release when triggered.

See: #32189