### PR TITLE
fix: Card does not override specified focusMode based on event listeners

### DIFF
--- a/change/@fluentui-react-card-83adc37b-ffe3-4cbd-a1f8-93b6f41549a3.json
+++ b/change/@fluentui-react-card-83adc37b-ffe3-4cbd-a1f8-93b6f41549a3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Card does not override specified focusMode based on event listeners",
+  "packageName": "@fluentui/react-card",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-card/library/src/components/Card/Card.test.tsx
+++ b/packages/react-components/react-card/library/src/components/Card/Card.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { Card } from './Card';
 import { isConformant } from '../../testing/isConformant';
 import { CardProps } from './Card.types';
@@ -40,5 +41,50 @@ describe('Card', () => {
   it('renders a default state', () => {
     const result = render(<Card>Default Card</Card>);
     expect(result.container).toMatchSnapshot();
+  });
+
+  it('does not manage focus by default for non-interactive cards', () => {
+    const { getByTestId } = render(
+      <Card data-testid="card">
+        Default Card
+        <button data-testid="button">focusable</button>
+      </Card>,
+    );
+    userEvent.tab();
+
+    expect(getByTestId('card').getAttribute('tabindex')).toBeNull();
+    expect(document.activeElement).toEqual(getByTestId('button'));
+  });
+
+  it('does tab-only focus by default for interactive cards', () => {
+    const clickFn = jest.fn();
+    const { getByTestId } = render(
+      <Card data-testid="card" onClick={clickFn}>
+        Default Card
+        <button data-testid="button">focusable</button>
+      </Card>,
+    );
+    userEvent.tab();
+
+    expect(getByTestId('card').getAttribute('tabindex')).toEqual('0');
+    expect(document.activeElement).toEqual(getByTestId('card'));
+
+    userEvent.tab();
+
+    expect(document.activeElement).toEqual(getByTestId('button'));
+  });
+
+  it('allows explicit focusMode attribute to override default for interactive cards', () => {
+    const clickFn = jest.fn();
+    const { getByTestId } = render(
+      <Card data-testid="card" onClick={clickFn} focusMode="off">
+        Default Card
+        <button data-testid="button">focusable</button>
+      </Card>,
+    );
+    userEvent.tab();
+
+    expect(getByTestId('card').getAttribute('tabindex')).toBeNull();
+    expect(document.activeElement).toEqual(getByTestId('button'));
   });
 });

--- a/packages/react-components/react-card/library/src/components/Card/useCard.ts
+++ b/packages/react-components/react-card/library/src/components/Card/useCard.ts
@@ -21,7 +21,7 @@ const focusMap = {
  *
  * @param props - props from this instance of Card
  */
-const useCardInteractive = ({ focusMode = 'off', ...props }: CardProps) => {
+const useCardInteractive = ({ focusMode: initialFocusMode, ...props }: CardProps) => {
   const interactive = (
     [
       'onClick',
@@ -37,8 +37,11 @@ const useCardInteractive = ({ focusMode = 'off', ...props }: CardProps) => {
     ] as (keyof React.HTMLAttributes<HTMLElement>)[]
   ).some(prop => props[prop]);
 
+  // default focusMode to tab-only when interactive, and off when not
+  const focusMode = initialFocusMode ?? (interactive ? 'no-tab' : 'off');
+
   const groupperAttrs = useFocusableGroup({
-    tabBehavior: focusMap[interactive ? 'no-tab' : focusMode],
+    tabBehavior: focusMap[focusMode],
   });
 
   const interactiveFocusAttributes = {
@@ -48,7 +51,7 @@ const useCardInteractive = ({ focusMode = 'off', ...props }: CardProps) => {
 
   return {
     interactive,
-    focusAttributes: !interactive && focusMode === 'off' ? null : interactiveFocusAttributes,
+    focusAttributes: focusMode === 'off' ? null : interactiveFocusAttributes,
   };
 };
 


### PR DESCRIPTION
## Previous Behavior

It was impossible to have both a `focusMode=off` or `focusMode=tab-only` card with a click handler on the root. There are several reasons to do this (e.g. the card as a whole can be clicked as a larger hit target, and there's also a link or button within that does the same thing). The change in `focusMode` actually interferes with accessibility, because it makes it impossible to have a card with both a root click and enter/space handler, since a card with any `focusMode` apart from `off` will prevent enter from doing an author-defined action.

Authors already must provide a secondary method for performing any action put onto the card root, since any such actions will not be accessible to voice control, touch screen readers, etc.

## New Behavior

This updates the default `focusMode` to be `tab-only` when cards are interactive, but still allows users to override that with there own explicit `focusMode`. I chose `tab-only` instead of `no-tab` as the least heavy-handed tabster behavior, and the least different from the non-interactive default of `off`.

We could also consider having the default always be `off`, and not looking at whether or not there are event handlers attached to the root. I wasn't sure if there was another non-a11y reason to ensure cards are focusable when they have certain event handlers.

## Related Issue(s)

- Fixes #31529 and an [ADO issue](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/19325).
