### PR TITLE
chore(web-components): remove type-check definition and follow repo target defaults for consistency and type-check speeds

### DIFF
--- a/change/@fluentui-web-components-48c87f5d-af00-464e-8236-1bee7ec2f9c2.json
+++ b/change/@fluentui-web-components-48c87f5d-af00-464e-8236-1bee7ec2f9c2.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: revert type-check definition and follow repo target defaults for consistency and type-check speeds",
+  "packageName": "@fluentui/web-components",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/project.json
+++ b/packages/web-components/project.json
@@ -5,7 +5,6 @@
   "implicitDependencies": [],
   "tags": ["platform:web", "web-components"],
   "targets": {
-    "e2e": { "dependsOn": ["build-storybook"] },
-    "type-check": { "dependsOn": ["build"] }
+    "e2e": { "dependsOn": ["build-storybook"] }
   }
 }

--- a/packages/web-components/public/theme-switch.ts
+++ b/packages/web-components/public/theme-switch.ts
@@ -1,5 +1,5 @@
 import { teamsDarkTheme, teamsLightTheme, webDarkTheme, webLightTheme } from '@fluentui/tokens';
-import { setTheme } from '@fluentui/web-components';
+import { setTheme } from '../src/theme/set-theme.js';
 
 const themes = {
   'web-light': webLightTheme,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

- wc use custom target dep override that is not consistent with monorepo best practices for lates code
- this behaviour also breaks domain boundaries 

## New Behavior

- wc project follows monorepo targetDefaults how to run `type-check` target
- if folks want we can migrate package to follow our best practices ( splitting project into two `/libary` and `/stories` - https://github.com/microsoft/fluentui/pull/31565 )

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows https://github.com/microsoft/fluentui/pull/32202
