### PR TITLE
feat: add verify-packaging to react v8 release pipeline

### DIFF
--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -118,11 +118,8 @@ extends:
                 displayName: bundle
 
               - script: |
-                  ls -la packages/react/dist
-                  ls -la packages/react/lib
-                  ls -la packages/react/lib-commonjs
-                  ls -la packages/react/lib-amd
-                displayName: verify packaged react assets
+                  FLUENT_PROD_BUILD=true yarn nx run-many -t verify-packaging -p tag:v8 --exclude tag:vNext,tag:tools,ssr-tests,vr-tests,perf-test --nxBail
+                displayName: verify packaged assets
 
               - script: |
                   yarn publish:beachball -n $(npmToken) --config scripts/beachball/src/release-v8.config.js --message 'release: applying package updates - react v8'

--- a/change/@fluentui-azure-themes-19ea5446-30d5-478e-b04e-41d042df5e08.json
+++ b/change/@fluentui-azure-themes-19ea5446-30d5-478e-b04e-41d042df5e08.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: ship bundled and umd code to registry",
+  "packageName": "@fluentui/azure-themes",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-example-data-bb5abc87-aa6f-4d0e-9cd5-42e62eb82b77.json
+++ b/change/@fluentui-example-data-bb5abc87-aa6f-4d0e-9cd5-42e62eb82b77.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: ship bundled and umd code to registry",
+  "packageName": "@fluentui/example-data",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-fluent2-theme-68d647c8-0999-48ad-b85f-d01b7e0c742c.json
+++ b/change/@fluentui-fluent2-theme-68d647c8-0999-48ad-b85f-d01b7e0c742c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: ship bundled and umd code to registry",
+  "packageName": "@fluentui/fluent2-theme",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-foundation-legacy-130d572d-08a6-48f4-a079-b0ef919ea914.json
+++ b/change/@fluentui-foundation-legacy-130d572d-08a6-48f4-a079-b0ef919ea914.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: ship bundled and umd code to registry",
+  "packageName": "@fluentui/foundation-legacy",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-merge-styles-5ad53bf8-f1c1-42c7-bd3b-8d9fad4ae8c7.json
+++ b/change/@fluentui-merge-styles-5ad53bf8-f1c1-42c7-bd3b-8d9fad4ae8c7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: ship bundled and umd code to registry",
+  "packageName": "@fluentui/merge-styles",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-cards-4be95f5a-eb90-4bf4-8917-725ecefde46e.json
+++ b/change/@fluentui-react-cards-4be95f5a-eb90-4bf4-8917-725ecefde46e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: ship bundled and umd code to registry",
+  "packageName": "@fluentui/react-cards",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-charting-60fdbbb6-89a8-4a61-8e5b-1480d8866203.json
+++ b/change/@fluentui-react-charting-60fdbbb6-89a8-4a61-8e5b-1480d8866203.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: ship bundled and umd code to registry",
+  "packageName": "@fluentui/react-charting",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-d75b502a-ae08-480e-93c2-560f0c041f62.json
+++ b/change/@fluentui-react-d75b502a-ae08-480e-93c2-560f0c041f62.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: ship bundled and umd code to registry",
+  "packageName": "@fluentui/react",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-date-time-472971c5-1d84-425b-a7d2-5d99b0b58353.json
+++ b/change/@fluentui-react-date-time-472971c5-1d84-425b-a7d2-5d99b0b58353.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: ship bundled and umd code to registry",
+  "packageName": "@fluentui/react-date-time",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-experiments-6a4a7a63-9484-4dbb-bdae-74424161ace0.json
+++ b/change/@fluentui-react-experiments-6a4a7a63-9484-4dbb-bdae-74424161ace0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: ship bundled and umd code to registry",
+  "packageName": "@fluentui/react-experiments",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-focus-9cc5b082-b50e-4b90-8777-cc326efafdc2.json
+++ b/change/@fluentui-react-focus-9cc5b082-b50e-4b90-8777-cc326efafdc2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: ship bundled and umd code to registry",
+  "packageName": "@fluentui/react-focus",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-hooks-5b0071a2-8257-43bc-9a8a-44c43e7a2ff3.json
+++ b/change/@fluentui-react-hooks-5b0071a2-8257-43bc-9a8a-44c43e7a2ff3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: ship bundled and umd code to registry",
+  "packageName": "@fluentui/react-hooks",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-icon-provider-f57fab7c-c944-4949-acc1-79c29fe2a8c6.json
+++ b/change/@fluentui-react-icon-provider-f57fab7c-c944-4949-acc1-79c29fe2a8c6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: ship bundled and umd code to registry",
+  "packageName": "@fluentui/react-icon-provider",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-icons-mdl2-68bde439-b100-413c-b349-17735423c6eb.json
+++ b/change/@fluentui-react-icons-mdl2-68bde439-b100-413c-b349-17735423c6eb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: ship bundled and umd code to registry",
+  "packageName": "@fluentui/react-icons-mdl2",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-scheme-utilities-3e0d9b33-830f-4a8b-ac51-104bd8543a11.json
+++ b/change/@fluentui-scheme-utilities-3e0d9b33-830f-4a8b-ac51-104bd8543a11.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: ship bundled and umd code to registry",
+  "packageName": "@fluentui/scheme-utilities",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-theme-samples-81dbadf9-4edc-4df6-928a-8da8c29372f1.json
+++ b/change/@fluentui-theme-samples-81dbadf9-4edc-4df6-928a-8da8c29372f1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: ship bundled and umd code to registry",
+  "packageName": "@fluentui/theme-samples",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/azure-themes/project.json
+++ b/packages/azure-themes/project.json
@@ -4,5 +4,5 @@
   "projectType": "library",
   "implicitDependencies": [],
   "sourceRoot": "packages/azure-themes/src",
-  "tags": ["v8"]
+  "tags": ["v8", "ships-bundle"]
 }

--- a/packages/example-data/project.json
+++ b/packages/example-data/project.json
@@ -4,5 +4,5 @@
   "projectType": "library",
   "implicitDependencies": [],
   "sourceRoot": "packages/example-data/src",
-  "tags": ["v8"]
+  "tags": ["v8", "ships-bundle"]
 }

--- a/packages/fluent2-theme/project.json
+++ b/packages/fluent2-theme/project.json
@@ -4,5 +4,5 @@
   "projectType": "library",
   "implicitDependencies": [],
   "sourceRoot": "packages/fluent2-theme/src",
-  "tags": ["v8"]
+  "tags": ["v8", "ships-bundle"]
 }

--- a/packages/foundation-legacy/project.json
+++ b/packages/foundation-legacy/project.json
@@ -4,5 +4,5 @@
   "projectType": "library",
   "implicitDependencies": [],
   "sourceRoot": "packages/foundation-legacy/src",
-  "tags": ["v8"]
+  "tags": ["v8", "ships-bundle"]
 }

--- a/packages/merge-styles/project.json
+++ b/packages/merge-styles/project.json
@@ -4,5 +4,5 @@
   "projectType": "library",
   "implicitDependencies": [],
   "sourceRoot": "packages/merge-styles/src",
-  "tags": ["v8"]
+  "tags": ["v8", "ships-bundle"]
 }

--- a/packages/react-cards/project.json
+++ b/packages/react-cards/project.json
@@ -3,5 +3,5 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],
-  "tags": ["v8"]
+  "tags": ["v8", "ships-bundle"]
 }

--- a/packages/react-charting/project.json
+++ b/packages/react-charting/project.json
@@ -3,5 +3,5 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],
-  "tags": ["v8"]
+  "tags": ["v8", "ships-bundle"]
 }

--- a/packages/react-date-time/project.json
+++ b/packages/react-date-time/project.json
@@ -4,5 +4,5 @@
   "projectType": "library",
   "implicitDependencies": [],
   "sourceRoot": "packages/react-date-time/src",
-  "tags": ["v8"]
+  "tags": ["v8", "ships-bundle"]
 }

--- a/packages/react-experiments/project.json
+++ b/packages/react-experiments/project.json
@@ -4,5 +4,5 @@
   "projectType": "library",
   "implicitDependencies": [],
   "sourceRoot": "packages/react-experiments/src",
-  "tags": ["v8"]
+  "tags": ["v8", "ships-bundle"]
 }

--- a/packages/react-focus/project.json
+++ b/packages/react-focus/project.json
@@ -4,5 +4,5 @@
   "projectType": "library",
   "implicitDependencies": [],
   "sourceRoot": "packages/react-focus/src",
-  "tags": ["v8"]
+  "tags": ["v8", "ships-bundle"]
 }

--- a/packages/react-hooks/project.json
+++ b/packages/react-hooks/project.json
@@ -4,5 +4,5 @@
   "projectType": "library",
   "implicitDependencies": [],
   "sourceRoot": "packages/react-hooks/src",
-  "tags": ["v8"]
+  "tags": ["v8", "ships-bundle"]
 }

--- a/packages/react-icon-provider/project.json
+++ b/packages/react-icon-provider/project.json
@@ -3,5 +3,5 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],
-  "tags": ["v8"]
+  "tags": ["v8", "ships-bundle"]
 }

--- a/packages/react-icons-mdl2/project.json
+++ b/packages/react-icons-mdl2/project.json
@@ -3,5 +3,5 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],
-  "tags": ["v8"]
+  "tags": ["v8", "ships-bundle"]
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -30,7 +30,8 @@
     "start-test": "just-scripts jest-watch",
     "test": "just-scripts test",
     "update-snapshots": "just-scripts jest -u",
-    "mf": "just-scripts mf"
+    "mf": "just-scripts mf",
+    "verify-packaging": "just-scripts verify-packaging"
   },
   "devDependencies": {
     "@fluentui/common-styles": "*",

--- a/packages/react/project.json
+++ b/packages/react/project.json
@@ -4,5 +4,5 @@
   "projectType": "library",
   "implicitDependencies": [],
   "sourceRoot": "packages/react/src",
-  "tags": ["v8"]
+  "tags": ["v8", "ships-bundle", "ships-umd"]
 }

--- a/packages/scheme-utilities/project.json
+++ b/packages/scheme-utilities/project.json
@@ -4,5 +4,5 @@
   "projectType": "library",
   "implicitDependencies": [],
   "sourceRoot": "packages/scheme-utilities/src",
-  "tags": ["v8"]
+  "tags": ["v8", "ships-bundle"]
 }

--- a/packages/theme-samples/project.json
+++ b/packages/theme-samples/project.json
@@ -4,5 +4,5 @@
   "projectType": "library",
   "implicitDependencies": [],
   "sourceRoot": "packages/theme-samples/src",
-  "tags": ["v8"]
+  "tags": ["v8", "ships-bundle"]
 }

--- a/scripts/tasks/src/verify-packaging.ts
+++ b/scripts/tasks/src/verify-packaging.ts
@@ -41,7 +41,7 @@ export function verifyPackaging(options: Options) {
 
   const processedResult = npmPackResult.output
     .toString()
-    .replace(/\bnpm notice\b\s+[\d.]+[kB]+\s+/gi, '')
+    .replace(/\bnpm notice\b\s+[\d.]+[MkB]+\s+/gi, '')
     .replace(/[ ]+/g, '');
   const processedResultArr = processedResult.split('\n');
 
@@ -59,11 +59,14 @@ export function verifyPackaging(options: Options) {
     0,
     `wont ship non production code related folders/files`,
   );
-  assert.equal(micromatch(processedResultArr, rootConfigFiles).length, 0, `wont ship configuration files`);
   assert.ok(micromatch(processedResultArr, 'CHANGELOG.md').length, 'ships changelog markdown file');
   assert.ok(micromatch(processedResultArr, 'dist/*.d.ts').length, 'ships rolluped dts');
   assert.ok(micromatch(processedResultArr, 'lib-commonjs/**/*.(js|map)').length, 'ships cjs');
   assert.equal(micromatch(processedResultArr, 'src/*').length, 0, `wont ship source code from "/src"`);
+
+  if (!isV8package) {
+    assert.equal(micromatch(processedResultArr, rootConfigFiles).length, 0, `wont ship configuration files`);
+  }
 
   if (!platform.node) {
     assert.ok(micromatch(processedResultArr, 'lib/**/*.(js|map)').length, 'ships esm');
@@ -78,10 +81,11 @@ export function verifyPackaging(options: Options) {
     assert.ok(micromatch(processedResultArr, '(lib|lib-commonjs)/**/*.d.ts').length, `ships dts`);
 
     if (options.production && shipsBundle) {
-      assert.ok(micromatch(processedResultArr, '(dist/**/*.(min)?.js').length, `ships bundle (*.min.js,*.js)`);
+      assert.ok(micromatch(processedResultArr, 'dist/*.js').length, `ships bundle`);
+      assert.ok(micromatch(processedResultArr, 'dist/*.min.js').length, `ships minified bundle`);
     }
     if (options.production && shipsUmd) {
-      assert.ok(micromatch(processedResultArr, '(dist/**/*.umd.js').length, `ships umd`);
+      assert.ok(micromatch(processedResultArr, 'dist/*.umd.js').length, `ships umd`);
     }
   }
 

--- a/scripts/tasks/src/verify-packaging.ts
+++ b/scripts/tasks/src/verify-packaging.ts
@@ -48,6 +48,8 @@ export function verifyPackaging(options: Options) {
   const isV8package = tags.indexOf('v8') !== -1;
   const isV9package = tags.indexOf('vNext') !== -1;
   const shipsAMD = isV8package || tags.indexOf('ships-amd') !== -1;
+  const shipsBundle = tags.indexOf('ships-bundle') !== -1;
+  const shipsUmd = tags.indexOf('ships-umd') !== -1;
   const platform = { web: tags.indexOf('platform:web') !== -1, node: tags.indexOf('platform:node') !== -1 };
 
   // shared assertions
@@ -74,6 +76,13 @@ export function verifyPackaging(options: Options) {
 
   if (isV8package) {
     assert.ok(micromatch(processedResultArr, '(lib|lib-commonjs)/**/*.d.ts').length, `ships dts`);
+
+    if (options.production && shipsBundle) {
+      assert.ok(micromatch(processedResultArr, '(dist/**/*.(min)?.js').length, `ships bundle (*.min.js,*.js)`);
+    }
+    if (options.production && shipsUmd) {
+      assert.ok(micromatch(processedResultArr, '(dist/**/*.umd.js').length, `ships umd`);
+    }
   }
 
   // @FIXME `amd` is created only on release pipeline where `--production` flag is used on build commands which triggers it


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

- projects that ship bundled code now have new tag `ships-bundle`
- projects that ship umd code now have new tag `ships-umd`
- `verify-packaging` has been adjusted with new logic and added to `react` package
- `verify-packaging` is now invoked as part of v8 release
- after merge this will ship all v8 affected packages instead only having partial fix for react

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows https://github.com/microsoft/fluentui/pull/32195, https://github.com/microsoft/fluentui/pull/32198
