### PR TITLE
chore(web-components): convert toggleState to decorators

### DIFF
--- a/packages/web-components/docs/api-report.md
+++ b/packages/web-components/docs/api-report.md
@@ -667,8 +667,6 @@ export class BaseTablist extends FASTElement {
     connectedCallback(): void;
     disabled: boolean;
     // @internal
-    protected disabledChanged(prev: boolean, next: boolean): void;
-    // @internal
     elementInternals: ElementInternals;
     orientation: TablistOrientation;
     // @internal (undocumented)
@@ -3471,11 +3469,7 @@ export const TabDefinition: FASTElementDefinition<typeof Tab>;
 export class Tablist extends BaseTablist {
     activeidChanged(oldValue: string, newValue: string): void;
     appearance?: TablistAppearance;
-    // @internal (undocumented)
-    protected appearanceChanged(prev: TablistAppearance, next: TablistAppearance): void;
     size?: TablistSize;
-    // @internal (undocumented)
-    protected sizeChanged(prev: TablistSize, next: TablistSize): void;
     tabsChanged(): void;
 }
 

--- a/packages/web-components/docs/api-report.md
+++ b/packages/web-components/docs/api-report.md
@@ -2249,7 +2249,6 @@ export const DividerAppearance: {
     readonly strong: "strong";
     readonly brand: "brand";
     readonly subtle: "subtle";
-    readonly default: "default";
 };
 
 // @public
@@ -2512,7 +2511,6 @@ export const ImageFit: {
     readonly center: "center";
     readonly contain: "contain";
     readonly cover: "cover";
-    readonly default: "default";
 };
 
 // @public
@@ -2629,6 +2627,11 @@ export type LinkAppearance = ValuesOf<typeof LinkAppearance>;
 
 // @public (undocumented)
 export const LinkDefinition: FASTElementDefinition<typeof Link>;
+
+// Warning: (ae-missing-release-tag) "styles" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export const LinkStyles: ElementStyles;
 
 // @public
 export const LinkTarget: {
@@ -2856,6 +2859,63 @@ export const MenuStyles: ElementStyles;
 export const MenuTemplate: ElementViewTemplate<Menu>;
 
 // @public
+export class MessageBar extends FASTElement {
+    constructor();
+    dismissMessageBar: () => void;
+    // @internal
+    elementInternals: ElementInternals;
+    intent?: MessageBarIntent;
+    layout?: MessageBarLayout;
+    shape?: MessageBarShape;
+}
+
+// @public
+export const MessageBarDefinition: FASTElementDefinition<typeof MessageBar>;
+
+// Warning: (ae-missing-release-tag) "MessageBarIntent" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export const MessageBarIntent: {
+    readonly success: "success";
+    readonly warning: "warning";
+    readonly error: "error";
+    readonly info: "info";
+};
+
+// @public (undocumented)
+export type MessageBarIntent = ValuesOf<typeof MessageBarIntent>;
+
+// Warning: (ae-missing-release-tag) "MessageBarLayout" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export const MessageBarLayout: {
+    readonly multiline: "multiline";
+    readonly singleline: "singleline";
+};
+
+// @public (undocumented)
+export type MessageBarLayout = ValuesOf<typeof MessageBarLayout>;
+
+// Warning: (ae-missing-release-tag) "MessageBarShape" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export const MessageBarShape: {
+    readonly rounded: "rounded";
+    readonly square: "square";
+};
+
+// @public (undocumented)
+export type MessageBarShape = ValuesOf<typeof MessageBarShape>;
+
+// @public
+export const MessageBarStyles: ElementStyles;
+
+// Warning: (ae-missing-release-tag) "template" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export const MessageBarTemplate: ElementViewTemplate<MessageBar>;
+
+// @public
 class ProgressBar_2 extends BaseProgressBar {
     shape?: ProgressBarShape;
     thickness?: ProgressBarThickness;
@@ -3027,7 +3087,6 @@ export class RatingDisplay extends BaseRatingDisplay {
     // @override
     protected getSelectedValue(): number;
     size?: RatingDisplaySize;
-    sizeChanged(prev: RatingDisplaySize | undefined, next: RatingDisplaySize | undefined): void;
 }
 
 // @public

--- a/packages/web-components/docs/api-report.md
+++ b/packages/web-components/docs/api-report.md
@@ -53,11 +53,9 @@ export type AccordionExpandMode = ValuesOf<typeof AccordionExpandMode>;
 // @public
 export class AccordionItem extends BaseAccordionItem {
     block: boolean;
-    blockChanged(prev: boolean, next: boolean): void;
     markerPosition?: AccordionItemMarkerPosition;
     markerPositionChanged(prev: AccordionItemMarkerPosition, next: AccordionItemMarkerPosition): void;
     size?: AccordionItemSize;
-    sizeChanged(prev: AccordionItemSize, next: AccordionItemSize): void;
 }
 
 // @internal
@@ -121,13 +119,10 @@ export const accordionTemplate: ElementViewTemplate<Accordion>;
 // @public
 export class AnchorButton extends BaseAnchor {
     appearance?: AnchorButtonAppearance | undefined;
-    appearanceChanged(prev: AnchorButtonAppearance | undefined, next: AnchorButtonAppearance | undefined): void;
     iconOnly: boolean;
     iconOnlyChanged(prev: boolean, next: boolean): void;
     shape?: AnchorButtonShape | undefined;
-    shapeChanged(prev: AnchorButtonShape | undefined, next: AnchorButtonShape | undefined): void;
     size?: AnchorButtonSize;
-    sizeChanged(prev: AnchorButtonSize | undefined, next: AnchorButtonSize | undefined): void;
 }
 
 // @internal
@@ -359,15 +354,11 @@ export const AvatarTemplate: ElementViewTemplate<Avatar>;
 // @public
 export class Badge extends FASTElement {
     appearance: BadgeAppearance;
-    appearanceChanged(prev: BadgeAppearance | undefined, next: BadgeAppearance | undefined): void;
     color: BadgeColor;
-    colorChanged(prev: BadgeColor | undefined, next: BadgeColor | undefined): void;
     // @internal
     elementInternals: ElementInternals;
     shape?: BadgeShape;
-    shapeChanged(prev: BadgeShape | undefined, next: BadgeShape | undefined): void;
     size?: BadgeSize;
-    sizeChanged(prev: BadgeSize | undefined, next: BadgeSize | undefined): void;
 }
 
 // @internal
@@ -437,13 +428,11 @@ export const BadgeTemplate: ElementViewTemplate<Badge>;
 // @public (undocumented)
 export class BaseAccordionItem extends FASTElement {
     disabled: boolean;
-    disabledChanged(prev: boolean, next: boolean): void;
     // @internal
     elementInternals: ElementInternals;
     // @internal (undocumented)
     expandbutton: HTMLElement;
     expanded: boolean;
-    expandedChanged(prev: boolean, next: boolean): void;
     headinglevel: 1 | 2 | 3 | 4 | 5 | 6;
     id: string;
 }
@@ -2085,14 +2074,11 @@ export const CompoundButtonTemplate: ElementViewTemplate<CompoundButton>;
 // @public
 export class CounterBadge extends FASTElement {
     appearance?: CounterBadgeAppearance;
-    appearanceChanged(prev: CounterBadgeAppearance | undefined, next: CounterBadgeAppearance | undefined): void;
     color?: CounterBadgeColor;
-    colorChanged(prev: CounterBadgeColor | undefined, next: CounterBadgeColor | undefined): void;
     count: number;
     // (undocumented)
     protected countChanged(): void;
     dot: boolean;
-    dotChanged(prev: boolean | undefined, next: boolean | undefined): void;
     // @internal
     elementInternals: ElementInternals;
     overflowCount: number;
@@ -2101,10 +2087,8 @@ export class CounterBadge extends FASTElement {
     // @internal
     setCount(): string | void;
     shape?: CounterBadgeShape;
-    shapeChanged(prev: CounterBadgeShape | undefined, next: CounterBadgeShape | undefined): void;
     showZero: boolean;
     size?: CounterBadgeSize;
-    sizeChanged(prev: CounterBadgeSize | undefined, next: CounterBadgeSize | undefined): void;
 }
 
 // @internal
@@ -2521,17 +2505,13 @@ export const getDirection: (rootNode: HTMLElement) => Direction;
 // @public
 class Image_2 extends FASTElement {
     block?: boolean;
-    blockChanged(prev: boolean, next: boolean): void;
     bordered?: boolean;
-    borderedChanged(prev: boolean, next: boolean): void;
     // @internal
     elementInternals: ElementInternals;
     fit?: ImageFit;
     fitChanged(prev: ImageFit | undefined, next: ImageFit | undefined): void;
     shadow?: boolean;
-    shadowChanged(prev: boolean, next: boolean): void;
     shape?: ImageShape;
-    shapeChanged(prev: ImageShape | undefined, next: ImageShape | undefined): void;
 }
 export { Image_2 as Image }
 
@@ -3376,9 +3356,7 @@ export const spacingVerticalXXXL = "var(--spacingVerticalXXXL)";
 // @public
 export class Spinner extends BaseSpinner {
     appearance?: SpinnerAppearance;
-    appearanceChanged(prev: SpinnerAppearance | undefined, next: SpinnerAppearance | undefined): void;
     size?: SpinnerSize;
-    sizeChanged(prev: SpinnerSize | undefined, next: SpinnerSize | undefined): void;
 }
 
 // @public

--- a/packages/web-components/docs/api-report.md
+++ b/packages/web-components/docs/api-report.md
@@ -627,7 +627,6 @@ export class BaseProgressBar extends FASTElement {
     // @internal
     get percentComplete(): number;
     validationState: ProgressBarValidationState | null;
-    validationStateChanged(prev: ProgressBarValidationState | undefined, next: ProgressBarValidationState | undefined): void;
     // @internal
     value?: number;
     // @internal
@@ -851,13 +850,10 @@ export const borderRadiusXLarge = "var(--borderRadiusXLarge)";
 // @public
 export class Button extends BaseButton {
     appearance?: ButtonAppearance;
-    appearanceChanged(prev: ButtonAppearance | undefined, next: ButtonAppearance | undefined): void;
     iconOnly: boolean;
     iconOnlyChanged(prev: boolean, next: boolean): void;
     shape?: ButtonShape;
-    shapeChanged(prev: ButtonShape | undefined, next: ButtonShape | undefined): void;
     size?: ButtonSize;
-    sizeChanged(prev: ButtonSize | undefined, next: ButtonSize | undefined): void;
 }
 
 // @internal (undocumented)
@@ -937,11 +933,7 @@ export class Checkbox extends BaseCheckbox {
     // @internal @override
     protected setAriaChecked(value?: boolean): void;
     shape?: CheckboxShape;
-    // @internal
-    protected shapeChanged(prev: CheckboxShape | undefined, next: CheckboxShape | undefined): void;
     size?: CheckboxSize;
-    // @internal
-    protected sizeChanged(prev: CheckboxSize | undefined, next: CheckboxSize | undefined): void;
     toggleChecked(force?: boolean): void;
 }
 
@@ -2240,10 +2232,8 @@ export class Divider extends BaseDivider {
     alignContentChanged(prev: DividerAlignContent | undefined, next: DividerAlignContent | undefined): void;
     // (undocumented)
     appearance?: DividerAppearance;
-    appearanceChanged(prev: DividerAppearance | undefined, next: DividerAppearance | undefined): void;
     // (undocumented)
     inset?: boolean;
-    insetChanged(prev: boolean, next: boolean): void;
 }
 
 // @public
@@ -2551,14 +2541,11 @@ export const ImageTemplate: ElementViewTemplate<Image_2>;
 // @public
 export class Label extends FASTElement {
     disabled: boolean;
-    disabledChanged(prev: boolean | undefined, next: boolean | undefined): void;
     // @internal
     elementInternals: ElementInternals;
     required: boolean;
     size?: LabelSize;
-    sizeChanged(prev: LabelSize | undefined, next: LabelSize | undefined): void;
     weight?: LabelWeight;
-    weightChanged(prev: LabelWeight | undefined, next: LabelWeight | undefined): void;
 }
 
 // @public
@@ -2631,9 +2618,7 @@ export const lineHeightHero900 = "var(--lineHeightHero900)";
 // @public
 export class Link extends BaseAnchor {
     appearance?: LinkAppearance | undefined;
-    appearanceChanged(prev: LinkAppearance | undefined, next: LinkAppearance | undefined): void;
     inline: boolean;
-    inlineChanged(prev: boolean, next: boolean): void;
 }
 
 // @public
@@ -2875,9 +2860,7 @@ export const MenuTemplate: ElementViewTemplate<Menu>;
 // @public
 class ProgressBar_2 extends BaseProgressBar {
     shape?: ProgressBarShape;
-    shapeChanged(prev: ProgressBarShape | undefined, next: ProgressBarShape | undefined): void;
     thickness?: ProgressBarThickness;
-    thicknessChanged(prev: ProgressBarThickness | undefined, next: ProgressBarThickness | undefined): void;
 }
 export { ProgressBar_2 as ProgressBar }
 
@@ -3040,7 +3023,6 @@ export const RadioTemplate: ElementViewTemplate<Radio>;
 // @public
 export class RatingDisplay extends BaseRatingDisplay {
     color?: RatingDisplayColor;
-    colorChanged(prev: RatingDisplayColor | undefined, next: RatingDisplayColor | undefined): void;
     compact: boolean;
     // @override
     protected getMaxIcons(): number;
@@ -3188,8 +3170,6 @@ export class Slider extends FASTElement implements SliderConfiguration {
     // @internal
     setValidity(flags?: Partial<ValidityState>, message?: string, anchor?: HTMLElement): void;
     size?: SliderSize;
-    // (undocumented)
-    protected sizeChanged(prev: string, next: string): void;
     step: string;
     // (undocumented)
     protected stepChanged(): void;
@@ -3647,7 +3627,6 @@ export const TabTemplate: ElementViewTemplate<Tab, any>;
 // @public
 class Text_2 extends FASTElement {
     align?: TextAlign;
-    alignChanged(prev: TextAlign | undefined, next: TextAlign | undefined): void;
     block: boolean;
     // (undocumented)
     connectedCallback(): void;
@@ -3656,7 +3635,6 @@ class Text_2 extends FASTElement {
     // @internal
     elementInternals: ElementInternals;
     font?: TextFont;
-    fontChanged(prev: TextFont | undefined, next: TextFont | undefined): void;
     // @internal
     handleChange(source: any, propertyName: string): void;
     italic: boolean;
@@ -3667,7 +3645,6 @@ class Text_2 extends FASTElement {
     truncate: boolean;
     underline: boolean;
     weight?: TextWeight;
-    weightChanged(prev: TextWeight | undefined, next: TextWeight | undefined): void;
 }
 export { Text_2 as Text }
 
@@ -3784,9 +3761,7 @@ export type TextFont = ValuesOf<typeof TextFont>;
 // @public
 export class TextInput extends BaseTextInput {
     appearance?: TextInputAppearance;
-    appearanceChanged(prev: TextInputAppearance | undefined, next: TextInputAppearance | undefined): void;
     controlSize?: TextInputControlSize;
-    controlSizeChanged(prev: TextInputControlSize | undefined, next: TextInputControlSize | undefined): void;
 }
 
 // @internal (undocumented)

--- a/packages/web-components/src/accordion-item/accordion-item.ts
+++ b/packages/web-components/src/accordion-item/accordion-item.ts
@@ -4,7 +4,7 @@ import type { StaticallyComposableHTML } from '../utils/index.js';
 import { StartEnd } from '../patterns/index.js';
 import type { StartEndOptions } from '../patterns/index.js';
 import { applyMixins } from '../utils/apply-mixins.js';
-import { toggleState } from '../utils/element-internals.js';
+import { toggleAttrState, toggleState } from '../utils/element-internals.js';
 import { AccordionItemMarkerPosition, AccordionItemSize } from './accordion-item.options.js';
 
 /**
@@ -59,17 +59,9 @@ export class BaseAccordionItem extends FASTElement {
    * @remarks
    * HTML attribute: expanded
    */
+  @toggleAttrState
   @attr({ mode: 'boolean' })
   public expanded: boolean = false;
-
-  /**
-   * Handles expanded changes
-   * @param prev - previous value
-   * @param next - next value
-   */
-  public expandedChanged(prev: boolean, next: boolean): void {
-    toggleState(this.elementInternals, 'expanded', next);
-  }
 
   /**
    * Disables an accordion item
@@ -78,17 +70,9 @@ export class BaseAccordionItem extends FASTElement {
    * @remarks
    * HTML attribute: disabled
    */
+  @toggleAttrState
   @attr({ mode: 'boolean' })
   public disabled: boolean = false;
-
-  /**
-   * Handles disabled changes
-   * @param prev - previous value
-   * @param next - next value
-   */
-  public disabledChanged(prev: boolean, next: boolean): void {
-    toggleState(this.elementInternals, 'disabled', next);
-  }
 
   /**
    * The item ID
@@ -120,22 +104,9 @@ export class AccordionItem extends BaseAccordionItem {
    * @remarks
    * HTML Attribute: size
    */
+  @toggleAttrState
   @attr
   public size?: AccordionItemSize;
-
-  /**
-   * Handles changes to size attribute
-   * @param prev - previous value
-   * @param next - next value
-   */
-  public sizeChanged(prev: AccordionItemSize, next: AccordionItemSize): void {
-    if (prev) {
-      toggleState(this.elementInternals, prev, false);
-    }
-    if (next) {
-      toggleState(this.elementInternals, next, true);
-    }
-  }
 
   /**
    * Sets expand and collapsed icon position.
@@ -168,17 +139,9 @@ export class AccordionItem extends BaseAccordionItem {
    * @remarks
    * HTML Attribute: block
    */
+  @toggleAttrState
   @attr({ mode: 'boolean' })
   public block: boolean = false;
-
-  /**
-   * Handles changes to block attribute
-   * @param prev - previous value
-   * @param next - next value
-   */
-  public blockChanged(prev: boolean, next: boolean): void {
-    toggleState(this.elementInternals, 'block', next);
-  }
 }
 
 /**

--- a/packages/web-components/src/anchor-button/anchor-button.ts
+++ b/packages/web-components/src/anchor-button/anchor-button.ts
@@ -3,7 +3,7 @@ import { keyEnter } from '@microsoft/fast-web-utilities';
 import { StartEnd } from '../patterns/index.js';
 import type { StartEndOptions } from '../patterns/index.js';
 import { applyMixins } from '../utils/apply-mixins.js';
-import { toggleState } from '../utils/element-internals.js';
+import { toggleAttrState, toggleState } from '../utils/element-internals.js';
 import {
   AnchorAttributes,
   type AnchorButtonAppearance,
@@ -256,22 +256,9 @@ export class AnchorButton extends BaseAnchor {
    * @remarks
    * HTML Attribute: `appearance`
    */
+  @toggleAttrState
   @attr
   public appearance?: AnchorButtonAppearance | undefined;
-
-  /**
-   * Handles changes to appearance attribute custom states
-   * @param prev - the previous state
-   * @param next - the next state
-   */
-  public appearanceChanged(prev: AnchorButtonAppearance | undefined, next: AnchorButtonAppearance | undefined) {
-    if (prev) {
-      toggleState(this.elementInternals, `${prev}`, false);
-    }
-    if (next) {
-      toggleState(this.elementInternals, `${next}`, true);
-    }
-  }
 
   /**
    * The shape the anchor button should have.
@@ -280,22 +267,9 @@ export class AnchorButton extends BaseAnchor {
    * @remarks
    * HTML Attribute: `shape`
    */
+  @toggleAttrState
   @attr
   public shape?: AnchorButtonShape | undefined;
-
-  /**
-   * Handles changes to shape attribute custom states
-   * @param prev - the previous state
-   * @param next - the next state
-   */
-  public shapeChanged(prev: AnchorButtonShape | undefined, next: AnchorButtonShape | undefined) {
-    if (prev) {
-      toggleState(this.elementInternals, `${prev}`, false);
-    }
-    if (next) {
-      toggleState(this.elementInternals, `${next}`, true);
-    }
-  }
 
   /**
    * The size the anchor button should have.
@@ -304,22 +278,9 @@ export class AnchorButton extends BaseAnchor {
    * @remarks
    * HTML Attribute: `size`
    */
+  @toggleAttrState
   @attr
   public size?: AnchorButtonSize;
-
-  /**
-   * Handles changes to size attribute custom states
-   * @param prev - the previous state
-   * @param next - the next state
-   */
-  public sizeChanged(prev: AnchorButtonSize | undefined, next: AnchorButtonSize | undefined) {
-    if (prev) {
-      toggleState(this.elementInternals, `${prev}`, false);
-    }
-    if (next) {
-      toggleState(this.elementInternals, `${next}`, true);
-    }
-  }
 
   /**
    * The anchor button has an icon only, no text content

--- a/packages/web-components/src/badge/badge.ts
+++ b/packages/web-components/src/badge/badge.ts
@@ -2,7 +2,7 @@ import { attr, FASTElement } from '@microsoft/fast-element';
 // TODO: Remove with https://github.com/microsoft/fast/pull/6797
 import { applyMixins } from '../utils/apply-mixins.js';
 import { StartEnd } from '../patterns/index.js';
-import { toggleState } from '../utils/element-internals.js';
+import { toggleAttrState } from '../utils/element-internals.js';
 import { BadgeAppearance, BadgeColor, BadgeShape, BadgeSize } from './badge.options.js';
 
 /**
@@ -24,22 +24,9 @@ export class Badge extends FASTElement {
    * @remarks
    * HTML Attribute: appearance
    */
+  @toggleAttrState
   @attr
   public appearance: BadgeAppearance = BadgeAppearance.filled;
-
-  /**
-   * Handles changes to appearance attribute custom states
-   * @param prev - the previous state
-   * @param next - the next state
-   */
-  public appearanceChanged(prev: BadgeAppearance | undefined, next: BadgeAppearance | undefined) {
-    if (prev) {
-      toggleState(this.elementInternals, `${prev}`, false);
-    }
-    if (next) {
-      toggleState(this.elementInternals, `${next}`, true);
-    }
-  }
 
   /**
    * The color the badge should have.
@@ -48,22 +35,9 @@ export class Badge extends FASTElement {
    * @remarks
    * HTML Attribute: color
    */
+  @toggleAttrState
   @attr
   public color: BadgeColor = BadgeColor.brand;
-
-  /**
-   * Handles changes to color attribute custom states
-   * @param prev - the previous state
-   * @param next - the next state
-   */
-  public colorChanged(prev: BadgeColor | undefined, next: BadgeColor | undefined) {
-    if (prev) {
-      toggleState(this.elementInternals, `${prev}`, false);
-    }
-    if (next) {
-      toggleState(this.elementInternals, `${next}`, true);
-    }
-  }
 
   /**
    * The shape the badge should have.
@@ -72,22 +46,9 @@ export class Badge extends FASTElement {
    * @remarks
    * HTML Attribute: shape
    */
+  @toggleAttrState
   @attr
   public shape?: BadgeShape;
-
-  /**
-   * Handles changes to shape attribute custom states
-   * @param prev - the previous state
-   * @param next - the next state
-   */
-  public shapeChanged(prev: BadgeShape | undefined, next: BadgeShape | undefined) {
-    if (prev) {
-      toggleState(this.elementInternals, `${prev}`, false);
-    }
-    if (next) {
-      toggleState(this.elementInternals, `${next}`, true);
-    }
-  }
 
   /**
    * The size the badge should have.
@@ -96,22 +57,9 @@ export class Badge extends FASTElement {
    * @remarks
    * HTML Attribute: size
    */
+  @toggleAttrState
   @attr
   public size?: BadgeSize;
-
-  /**
-   * Handles changes to size attribute custom states
-   * @param prev - the previous state
-   * @param next - the next state
-   */
-  public sizeChanged(prev: BadgeSize | undefined, next: BadgeSize | undefined) {
-    if (prev) {
-      toggleState(this.elementInternals, `${prev}`, false);
-    }
-    if (next) {
-      toggleState(this.elementInternals, `${next}`, true);
-    }
-  }
 }
 
 /**

--- a/packages/web-components/src/button/button.ts
+++ b/packages/web-components/src/button/button.ts
@@ -2,7 +2,7 @@ import { attr, FASTElement, nullableNumberConverter, observable } from '@microso
 import { keyEnter, keySpace } from '@microsoft/fast-web-utilities';
 import { StartEnd } from '../patterns/index.js';
 import { applyMixins } from '../utils/apply-mixins.js';
-import { toggleState } from '../utils/element-internals.js';
+import { toggleAttrState, toggleState } from '../utils/element-internals.js';
 import type { ButtonAppearance, ButtonFormTarget, ButtonShape, ButtonSize } from './button.options.js';
 import { ButtonType } from './button.options.js';
 
@@ -438,22 +438,9 @@ export class Button extends BaseButton {
    * @remarks
    * HTML Attribute: `appearance`
    */
+  @toggleAttrState
   @attr
   public appearance?: ButtonAppearance;
-
-  /**
-   * Handles changes to appearance attribute custom states
-   * @param prev - the previous state
-   * @param next - the next state
-   */
-  public appearanceChanged(prev: ButtonAppearance | undefined, next: ButtonAppearance | undefined) {
-    if (prev) {
-      toggleState(this.elementInternals, `${prev}`, false);
-    }
-    if (next) {
-      toggleState(this.elementInternals, `${next}`, true);
-    }
-  }
 
   /**
    * The shape of the button.
@@ -462,22 +449,9 @@ export class Button extends BaseButton {
    * @remarks
    * HTML Attribute: `shape`
    */
+  @toggleAttrState
   @attr
   public shape?: ButtonShape;
-
-  /**
-   * Handles changes to shape attribute custom states
-   * @param prev - the previous state
-   * @param next - the next state
-   */
-  public shapeChanged(prev: ButtonShape | undefined, next: ButtonShape | undefined) {
-    if (prev) {
-      toggleState(this.elementInternals, `${prev}`, false);
-    }
-    if (next) {
-      toggleState(this.elementInternals, `${next}`, true);
-    }
-  }
 
   /**
    * The size of the button.
@@ -486,22 +460,9 @@ export class Button extends BaseButton {
    * @remarks
    * HTML Attribute: `size`
    */
+  @toggleAttrState
   @attr
   public size?: ButtonSize;
-
-  /**
-   * Handles changes to size attribute custom states
-   * @param prev - the previous state
-   * @param next - the next state
-   */
-  public sizeChanged(prev: ButtonSize | undefined, next: ButtonSize | undefined) {
-    if (prev) {
-      toggleState(this.elementInternals, `${prev}`, false);
-    }
-    if (next) {
-      toggleState(this.elementInternals, `${next}`, true);
-    }
-  }
 
   /**
    * Indicates that the button should only display as an icon with no text content.

--- a/packages/web-components/src/checkbox/checkbox.ts
+++ b/packages/web-components/src/checkbox/checkbox.ts
@@ -1,5 +1,5 @@
 import { attr, FASTElement, Observable, observable } from '@microsoft/fast-element';
-import { toggleState } from '../utils/element-internals.js';
+import { toggleAttrState, toggleState } from '../utils/element-internals.js';
 import { CheckboxShape, CheckboxSize } from './checkbox.options.js';
 
 /**
@@ -43,6 +43,7 @@ export class BaseCheckbox extends FASTElement {
    *
    * @public
    */
+  @toggleAttrState
   @observable
   public disabled?: boolean;
 
@@ -53,7 +54,6 @@ export class BaseCheckbox extends FASTElement {
    */
   protected disabledChanged(prev: boolean | undefined, next: boolean | undefined): void {
     this.elementInternals.ariaDisabled = this.disabled ? 'true' : 'false';
-    toggleState(this.elementInternals, 'disabled', this.disabled);
   }
 
   /**
@@ -482,6 +482,7 @@ export class Checkbox extends BaseCheckbox {
    *
    * @public
    */
+  @toggleAttrState
   @observable
   public indeterminate?: boolean;
 
@@ -494,7 +495,6 @@ export class Checkbox extends BaseCheckbox {
    */
   protected indeterminateChanged(prev: boolean | undefined, next: boolean | undefined): void {
     this.setAriaChecked();
-    toggleState(this.elementInternals, 'indeterminate', next);
   }
 
   /**
@@ -504,24 +504,9 @@ export class Checkbox extends BaseCheckbox {
    * @remarks
    * HTML Attribute: `shape`
    */
+  @toggleAttrState
   @attr
   public shape?: CheckboxShape;
-
-  /**
-   * Applies shape states when the `shape` property changes.
-   *
-   * @param prev - the previous shape value
-   * @param next - the next shape value
-   * @internal
-   */
-  protected shapeChanged(prev: CheckboxShape | undefined, next: CheckboxShape | undefined) {
-    if (prev) {
-      toggleState(this.elementInternals, prev, false);
-    }
-    if (next) {
-      toggleState(this.elementInternals, next, true);
-    }
-  }
 
   /**
    * Indicates the size of the control.
@@ -530,24 +515,9 @@ export class Checkbox extends BaseCheckbox {
    * @remarks
    * HTML Attribute: `size`
    */
+  @toggleAttrState
   @attr
   public size?: CheckboxSize;
-
-  /**
-   * Applies size states when the `size` property changes.
-   *
-   * @param prev - the previous state
-   * @param next - the next state
-   * @internal
-   */
-  protected sizeChanged(prev: CheckboxSize | undefined, next: CheckboxSize | undefined) {
-    if (prev) {
-      toggleState(this.elementInternals, prev, false);
-    }
-    if (next) {
-      toggleState(this.elementInternals, next, true);
-    }
-  }
 
   constructor() {
     super();

--- a/packages/web-components/src/counter-badge/counter-badge.ts
+++ b/packages/web-components/src/counter-badge/counter-badge.ts
@@ -2,7 +2,7 @@ import { attr, FASTElement, nullableNumberConverter } from '@microsoft/fast-elem
 // TODO: Remove with https://github.com/microsoft/fast/pull/6797
 import { applyMixins } from '../utils/apply-mixins.js';
 import { StartEnd } from '../patterns/index.js';
-import { toggleState } from '../utils/element-internals.js';
+import { toggleAttrState } from '../utils/element-internals.js';
 import {
   CounterBadgeAppearance,
   CounterBadgeColor,
@@ -29,22 +29,9 @@ export class CounterBadge extends FASTElement {
    * @remarks
    * HTML Attribute: appearance
    */
+  @toggleAttrState
   @attr
   public appearance?: CounterBadgeAppearance;
-
-  /**
-   * Handles changes to appearance attribute custom states
-   * @param prev - the previous state
-   * @param next - the next state
-   */
-  public appearanceChanged(prev: CounterBadgeAppearance | undefined, next: CounterBadgeAppearance | undefined) {
-    if (prev) {
-      toggleState(this.elementInternals, `${prev}`, false);
-    }
-    if (next) {
-      toggleState(this.elementInternals, `${next}`, true);
-    }
-  }
 
   /**
    * The color the badge should have.
@@ -53,22 +40,9 @@ export class CounterBadge extends FASTElement {
    * @remarks
    * HTML Attribute: color
    */
+  @toggleAttrState
   @attr
   public color?: CounterBadgeColor;
-
-  /**
-   * Handles changes to color attribute custom states
-   * @param prev - the previous state
-   * @param next - the next state
-   */
-  public colorChanged(prev: CounterBadgeColor | undefined, next: CounterBadgeColor | undefined) {
-    if (prev) {
-      toggleState(this.elementInternals, `${prev}`, false);
-    }
-    if (next) {
-      toggleState(this.elementInternals, `${next}`, true);
-    }
-  }
 
   /**
    * The shape the badge should have.
@@ -77,22 +51,9 @@ export class CounterBadge extends FASTElement {
    * @remarks
    * HTML Attribute: shape
    */
+  @toggleAttrState
   @attr
   public shape?: CounterBadgeShape;
-
-  /**
-   * Handles changes to shape attribute custom states
-   * @param prev - the previous state
-   * @param next - the next state
-   */
-  public shapeChanged(prev: CounterBadgeShape | undefined, next: CounterBadgeShape | undefined) {
-    if (prev) {
-      toggleState(this.elementInternals, `${prev}`, false);
-    }
-    if (next) {
-      toggleState(this.elementInternals, `${next}`, true);
-    }
-  }
 
   /**
    * The size the badge should have.
@@ -101,22 +62,9 @@ export class CounterBadge extends FASTElement {
    * @remarks
    * HTML Attribute: size
    */
+  @toggleAttrState
   @attr
   public size?: CounterBadgeSize;
-
-  /**
-   * Handles changes to size attribute custom states
-   * @param prev - the previous state
-   * @param next - the next state
-   */
-  public sizeChanged(prev: CounterBadgeSize | undefined, next: CounterBadgeSize | undefined) {
-    if (prev) {
-      toggleState(this.elementInternals, `${prev}`, false);
-    }
-    if (next) {
-      toggleState(this.elementInternals, `${next}`, true);
-    }
-  }
 
   /**
    * The count the badge should have.
@@ -161,17 +109,9 @@ export class CounterBadge extends FASTElement {
    * @remarks
    * HTML Attribute: dot
    */
+  @toggleAttrState
   @attr({ mode: 'boolean' })
   public dot: boolean = false;
-
-  /**
-   * Handles changes to dot attribute custom states
-   * @param prev - the previous state
-   * @param next - the next state
-   */
-  public dotChanged(prev: boolean | undefined, next: boolean | undefined) {
-    toggleState(this.elementInternals, 'dot', !!next);
-  }
 
   /**
    * @internal

--- a/packages/web-components/src/divider/divider.ts
+++ b/packages/web-components/src/divider/divider.ts
@@ -1,5 +1,5 @@
 import { attr, FASTElement } from '@microsoft/fast-element';
-import { toggleState } from '../utils/element-internals.js';
+import { toggleAttrState, toggleState } from '../utils/element-internals.js';
 import { DividerAlignContent, DividerAppearance, DividerOrientation, DividerRole } from './divider.options.js';
 
 /**
@@ -33,6 +33,7 @@ export class BaseDivider extends FASTElement {
    * @remarks
    * HTML Attribute: orientation
    */
+  @toggleAttrState
   @attr
   public orientation?: DividerOrientation;
 
@@ -72,14 +73,6 @@ export class BaseDivider extends FASTElement {
    */
   public orientationChanged(previous: string | null, next: string | null): void {
     this.elementInternals.ariaOrientation = this.role !== DividerRole.presentation ? next : null;
-
-    if (previous) {
-      toggleState(this.elementInternals, `${previous}`, false);
-    }
-
-    if (next) {
-      toggleState(this.elementInternals, `${next}`, true);
-    }
   }
 }
 
@@ -117,37 +110,16 @@ export class Divider extends BaseDivider {
    * @remarks
    * A divider can have one of the preset appearances. Select from strong, brand, subtle. When not specified, the divider has its default appearance.
    */
+  @toggleAttrState
   @attr
   public appearance?: DividerAppearance;
-
-  /**
-   * Handles changes to appearance attribute custom states
-   * @param prev - the previous state
-   * @param next - the next state
-   */
-  public appearanceChanged(prev: DividerAppearance | undefined, next: DividerAppearance | undefined) {
-    if (prev) {
-      toggleState(this.elementInternals, `${prev}`, false);
-    }
-    if (next) {
-      toggleState(this.elementInternals, `${next}`, true);
-    }
-  }
 
   /**
    * @public
    * @remarks
    * Adds padding to the beginning and end of the divider.
    */
+  @toggleAttrState
   @attr({ mode: 'boolean' })
   public inset?: boolean;
-
-  /**
-   * Handles changes to inset custom states
-   * @param prev - the previous state
-   * @param next - the next state
-   */
-  public insetChanged(prev: boolean, next: boolean) {
-    toggleState(this.elementInternals, 'inset', next);
-  }
 }

--- a/packages/web-components/src/image/image.ts
+++ b/packages/web-components/src/image/image.ts
@@ -1,5 +1,5 @@
 import { attr, FASTElement } from '@microsoft/fast-element';
-import { toggleState } from '../utils/element-internals.js';
+import { toggleAttrState, toggleState } from '../utils/element-internals.js';
 import { ImageFit, ImageShape } from './image.options.js';
 
 /**
@@ -21,17 +21,9 @@ export class Image extends FASTElement {
    * @remarks
    * HTML attribute: block.
    */
+  @toggleAttrState
   @attr({ mode: 'boolean' })
   public block?: boolean;
-
-  /**
-   * Handles changes to block custom states
-   * @param prev - the previous state
-   * @param next - the next state
-   */
-  public blockChanged(prev: boolean, next: boolean) {
-    toggleState(this.elementInternals, 'block', next);
-  }
 
   /**
    * Image border
@@ -40,17 +32,9 @@ export class Image extends FASTElement {
    * @remarks
    * HTML attribute: border.
    */
+  @toggleAttrState
   @attr({ mode: 'boolean' })
   public bordered?: boolean;
-
-  /**
-   * Handles changes to bordered custom states
-   * @param prev - the previous state
-   * @param next - the next state
-   */
-  public borderedChanged(prev: boolean, next: boolean) {
-    toggleState(this.elementInternals, 'bordered', next);
-  }
 
   /**
    * Image shadow
@@ -59,17 +43,9 @@ export class Image extends FASTElement {
    * @remarks
    * HTML attribute: shadow.
    */
+  @toggleAttrState
   @attr({ mode: 'boolean' })
   public shadow?: boolean;
-
-  /**
-   * Handles changes to shadow custom states
-   * @param prev - the previous state
-   * @param next - the next state
-   */
-  public shadowChanged(prev: boolean, next: boolean) {
-    toggleState(this.elementInternals, 'shadow', next);
-  }
 
   /**
    * Image fit
@@ -102,20 +78,7 @@ export class Image extends FASTElement {
    * @remarks
    * HTML attribute: shape.
    */
+  @toggleAttrState
   @attr
   public shape?: ImageShape;
-
-  /**
-   * Handles changes to shape attribute custom states
-   * @param prev - the previous state
-   * @param next - the next state
-   */
-  public shapeChanged(prev: ImageShape | undefined, next: ImageShape | undefined) {
-    if (prev) {
-      toggleState(this.elementInternals, `${prev}`, false);
-    }
-    if (next) {
-      toggleState(this.elementInternals, `${next}`, true);
-    }
-  }
 }

--- a/packages/web-components/src/label/label.ts
+++ b/packages/web-components/src/label/label.ts
@@ -1,5 +1,5 @@
 import { attr, FASTElement } from '@microsoft/fast-element';
-import { toggleState } from '../utils/element-internals.js';
+import { toggleAttrState } from '../utils/element-internals.js';
 import { LabelSize, LabelWeight } from './label.options.js';
 
 /**
@@ -21,22 +21,9 @@ export class Label extends FASTElement {
    * @remarks
    * HTML Attribute: size
    */
+  @toggleAttrState
   @attr
   public size?: LabelSize;
-
-  /**
-   * Handles changes to size attribute custom states
-   * @param prev - the previous state
-   * @param next - the next state
-   */
-  public sizeChanged(prev: LabelSize | undefined, next: LabelSize | undefined) {
-    if (prev) {
-      toggleState(this.elementInternals, `${prev}`, false);
-    }
-    if (next) {
-      toggleState(this.elementInternals, `${next}`, true);
-    }
-  }
 
   /**
    * 	Specifies font weight of a label
@@ -45,22 +32,9 @@ export class Label extends FASTElement {
    * @remarks
    * HTML Attribute: weight
    */
+  @toggleAttrState
   @attr
   public weight?: LabelWeight;
-
-  /**
-   * Handles changes to weight attribute custom states
-   * @param prev - the previous state
-   * @param next - the next state
-   */
-  public weightChanged(prev: LabelWeight | undefined, next: LabelWeight | undefined) {
-    if (prev) {
-      toggleState(this.elementInternals, `${prev}`, false);
-    }
-    if (next) {
-      toggleState(this.elementInternals, `${next}`, true);
-    }
-  }
 
   /**
    * 	Specifies styles for label when associated input is disabled
@@ -69,17 +43,9 @@ export class Label extends FASTElement {
    * @remarks
    * HTML Attribute: disabled
    */
+  @toggleAttrState
   @attr({ mode: 'boolean' })
   public disabled: boolean = false;
-
-  /**
-   * Handles changes to disabled attribute custom states
-   * @param prev - the previous state
-   * @param next - the next state
-   */
-  public disabledChanged(prev: boolean | undefined, next: boolean | undefined) {
-    toggleState(this.elementInternals, 'disabled', next);
-  }
 
   /**
    * 	Specifies styles for label when associated input is a required field

--- a/packages/web-components/src/link/link.ts
+++ b/packages/web-components/src/link/link.ts
@@ -1,6 +1,6 @@
 import { attr } from '@microsoft/fast-element';
 import { BaseAnchor } from '../anchor-button/anchor-button.js';
-import { toggleState } from '../utils/element-internals.js';
+import { toggleAttrState } from '../utils/element-internals.js';
 import { type LinkAppearance } from './link.options.js';
 
 /**
@@ -21,22 +21,9 @@ export class Link extends BaseAnchor {
    * @remarks
    * HTML Attribute: `appearance`
    */
+  @toggleAttrState
   @attr
   public appearance?: LinkAppearance | undefined;
-
-  /**
-   * Handles changes to appearance attribute custom states
-   * @param prev - the previous state
-   * @param next - the next state
-   */
-  public appearanceChanged(prev: LinkAppearance | undefined, next: LinkAppearance | undefined) {
-    if (prev) {
-      toggleState(this.elementInternals, `${prev}`, false);
-    }
-    if (next) {
-      toggleState(this.elementInternals, `${next}`, true);
-    }
-  }
 
   /**
    * The link is inline with text
@@ -48,15 +35,7 @@ export class Link extends BaseAnchor {
    * @remarks
    * HTML Attribute: `inline`
    */
+  @toggleAttrState
   @attr({ mode: 'boolean' })
   public inline: boolean = false;
-
-  /**
-   * Handles changes to inline attribute custom states
-   * @param prev - the previous state
-   * @param next - the next state
-   */
-  public inlineChanged(prev: boolean, next: boolean) {
-    toggleState(this.elementInternals, 'inline', next);
-  }
 }

--- a/packages/web-components/src/menu-item/menu-item.ts
+++ b/packages/web-components/src/menu-item/menu-item.ts
@@ -4,7 +4,7 @@ import { MenuList } from '../menu-list/menu-list.js';
 import type { StartEndOptions } from '../patterns/start-end.js';
 import { StartEnd } from '../patterns/start-end.js';
 import { applyMixins } from '../utils/apply-mixins.js';
-import { toggleState } from '../utils/element-internals.js';
+import { toggleAttrState, toggleState } from '../utils/element-internals.js';
 import type { StaticallyComposableHTML } from '../utils/template-helpers.js';
 import { MenuItemRole, roleForMenuItem } from './menu-item.options.js';
 
@@ -58,6 +58,7 @@ export class MenuItem extends FASTElement {
    * @remarks
    * HTML Attribute: disabled
    */
+  @toggleAttrState
   @attr({ mode: 'boolean' })
   public disabled!: boolean;
 
@@ -68,7 +69,6 @@ export class MenuItem extends FASTElement {
    */
   public disabledChanged(prev: boolean | undefined, next: boolean | undefined) {
     this.elementInternals.ariaDisabled = !!next ? `${next}` : null;
-    toggleState(this.elementInternals, 'disabled', next);
   }
 
   /**

--- a/packages/web-components/src/message-bar/message-bar.ts
+++ b/packages/web-components/src/message-bar/message-bar.ts
@@ -1,5 +1,5 @@
 import { attr, FASTElement } from '@microsoft/fast-element';
-import { toggleState } from '../utils/element-internals.js';
+import { toggleAttrState } from '../utils/element-internals.js';
 import { MessageBarIntent, MessageBarLayout, MessageBarShape } from './message-bar.options.js';
 
 /**
@@ -30,22 +30,9 @@ export class MessageBar extends FASTElement {
    * @remarks
    * HTML Attribute: `shape`
    */
+  @toggleAttrState
   @attr
   public shape?: MessageBarShape;
-
-  /**
-   * Handles changes to shape attribute custom states
-   * @param prev - the previous state
-   * @param next - the next state
-   */
-  public shapeChanged(prev: MessageBarShape | undefined, next: MessageBarShape | undefined) {
-    if (prev) {
-      toggleState(this.elementInternals, prev, false);
-    }
-    if (next) {
-      toggleState(this.elementInternals, next, true);
-    }
-  }
 
   /**
    * Sets the layout of the control.
@@ -54,22 +41,9 @@ export class MessageBar extends FASTElement {
    * @remarks
    * HTML Attribute: `layout`
    */
+  @toggleAttrState
   @attr
   public layout?: MessageBarLayout;
-
-  /**
-   * Handles changes to the layout attribute custom states
-   * @param prev - the previous state
-   * @param next - the next state
-   */
-  public layoutChanged(prev: MessageBarLayout | undefined, next: MessageBarLayout | undefined) {
-    if (prev) {
-      toggleState(this.elementInternals, prev, false);
-    }
-    if (next) {
-      toggleState(this.elementInternals, next, true);
-    }
-  }
 
   /**
    * Sets the intent of the control.
@@ -78,22 +52,9 @@ export class MessageBar extends FASTElement {
    * @remarks
    * HTML Attribute: `intent`
    */
+  @toggleAttrState
   @attr
   public intent?: MessageBarIntent;
-
-  /**
-   * Handles changes to the intent attribute custom states
-   * @param prev - the previous state
-   * @param next - the next state
-   */
-  public intentChanged(prev: MessageBarIntent | undefined, next: MessageBarIntent | undefined) {
-    if (prev) {
-      toggleState(this.elementInternals, prev, false);
-    }
-    if (next) {
-      toggleState(this.elementInternals, next, true);
-    }
-  }
 
   /**
    * @public

--- a/packages/web-components/src/progress-bar/progress-bar.ts
+++ b/packages/web-components/src/progress-bar/progress-bar.ts
@@ -1,5 +1,5 @@
 import { attr, FASTElement, nullableNumberConverter, volatile } from '@microsoft/fast-element';
-import { toggleState } from '../utils/element-internals.js';
+import { toggleAttrState, toggleState } from '../utils/element-internals.js';
 import { ProgressBarShape, ProgressBarThickness, ProgressBarValidationState } from './progress-bar.options.js';
 
 /**
@@ -21,25 +21,9 @@ export class BaseProgressBar extends FASTElement {
    * @public
    * HTML Attribute: `validation-state`
    */
+  @toggleAttrState
   @attr({ attribute: 'validation-state' })
   public validationState: ProgressBarValidationState | null = null;
-
-  /**
-   * Handles changes to validation-state attribute custom states
-   * @param prev - the previous state
-   * @param next - the next state
-   */
-  public validationStateChanged(
-    prev: ProgressBarValidationState | undefined,
-    next: ProgressBarValidationState | undefined,
-  ) {
-    if (prev) {
-      toggleState(this.elementInternals, `${prev}`, false);
-    }
-    if (next) {
-      toggleState(this.elementInternals, `${next}`, true);
-    }
-  }
 
   /**
    * The value of the progress
@@ -129,42 +113,16 @@ export class ProgressBar extends BaseProgressBar {
    * @public
    * HTML Attribute: `thickness`
    */
+  @toggleAttrState
   @attr
   public thickness?: ProgressBarThickness;
-
-  /**
-   * Handles changes to thickness attribute custom states
-   * @param prev - the previous state
-   * @param next - the next state
-   */
-  public thicknessChanged(prev: ProgressBarThickness | undefined, next: ProgressBarThickness | undefined) {
-    if (prev) {
-      toggleState(this.elementInternals, `${prev}`, false);
-    }
-    if (next) {
-      toggleState(this.elementInternals, `${next}`, true);
-    }
-  }
 
   /**
    * The shape of the progress bar
    * @public
    * HTML Attribute: `shape`
    */
+  @toggleAttrState
   @attr
   public shape?: ProgressBarShape;
-
-  /**
-   * Handles changes to shape attribute custom states
-   * @param prev - the previous state
-   * @param next - the next state
-   */
-  public shapeChanged(prev: ProgressBarShape | undefined, next: ProgressBarShape | undefined) {
-    if (prev) {
-      toggleState(this.elementInternals, `${prev}`, false);
-    }
-    if (next) {
-      toggleState(this.elementInternals, `${next}`, true);
-    }
-  }
 }

--- a/packages/web-components/src/rating-display/rating-display.ts
+++ b/packages/web-components/src/rating-display/rating-display.ts
@@ -1,5 +1,5 @@
 import { attr, FASTElement, nullableNumberConverter } from '@microsoft/fast-element';
-import { toggleState } from '../utils/element-internals.js';
+import { toggleAttrState } from '../utils/element-internals.js';
 import { RatingDisplayColor, RatingDisplaySize } from './rating-display.options.js';
 
 /**

--- a/packages/web-components/src/rating-display/rating-display.ts
+++ b/packages/web-components/src/rating-display/rating-display.ts
@@ -120,19 +120,9 @@ export class RatingDisplay extends BaseRatingDisplay {
    * @remarks
    * HTML Attribute: `color`
    */
+  @toggleAttrState
   @attr
   public color?: RatingDisplayColor;
-
-  /**
-   * Handles changes to the color attribute.
-   *
-   * @param prev - The previous state
-   * @param next - The next state
-   */
-  public colorChanged(prev: RatingDisplayColor | undefined, next: RatingDisplayColor | undefined): void {
-    if (prev) toggleState(this.elementInternals, prev, false);
-    if (next) toggleState(this.elementInternals, next, true);
-  }
 
   /**
    * The size of the component.
@@ -142,19 +132,9 @@ export class RatingDisplay extends BaseRatingDisplay {
    * @remarks
    * HTML Attribute: `size`
    */
+  @toggleAttrState
   @attr
   public size?: RatingDisplaySize;
-
-  /**
-   * Handles changes to the size attribute.
-   *
-   * @param prev - The previous state
-   * @param next - The next state
-   */
-  public sizeChanged(prev: RatingDisplaySize | undefined, next: RatingDisplaySize | undefined): void {
-    if (prev) toggleState(this.elementInternals, prev, false);
-    if (next) toggleState(this.elementInternals, next, true);
-  }
 
   /**
    * Renders a single filled icon with a label next to it.

--- a/packages/web-components/src/slider/slider.ts
+++ b/packages/web-components/src/slider/slider.ts
@@ -13,7 +13,7 @@ import {
 } from '@microsoft/fast-web-utilities';
 import { numberLikeStringConverter } from '../utils/converters.js';
 import { getDirection } from '../utils/direction.js';
-import { toggleState } from '../utils/element-internals.js';
+import { toggleAttrState } from '../utils/element-internals.js';
 import { SliderConfiguration, SliderMode, SliderOrientation, SliderSize } from './slider.options.js';
 import { convertPixelToPercent } from './slider-utilities.js';
 
@@ -58,16 +58,9 @@ export class Slider extends FASTElement implements SliderConfiguration {
    * @remarks
    * HTML Attribute: size
    */
+  @toggleAttrState
   @attr
   public size?: SliderSize;
-  protected sizeChanged(prev: string, next: string): void {
-    if (prev) {
-      toggleState(this.elementInternals, `${prev}`, false);
-    }
-    if (next) {
-      toggleState(this.elementInternals, `${next}`, true);
-    }
-  }
 
   public handleChange(_: any, propertyName: string): void {
     switch (propertyName) {
@@ -499,17 +492,11 @@ export class Slider extends FASTElement implements SliderConfiguration {
    * orientation-related behavior should consider horizontal as default, and
    * apply different behavior when it’s vertical.
    */
+  @toggleAttrState
   @attr
   public orientation?: Orientation;
   protected orientationChanged(prev: string | undefined, next: string | undefined): void {
     this.elementInternals.ariaOrientation = next ?? Orientation.horizontal;
-
-    if (prev) {
-      toggleState(this.elementInternals, `${prev}`, false);
-    }
-    if (next) {
-      toggleState(this.elementInternals, `${next}`, true);
-    }
 
     if (this.$fastController.isConnected) {
       this.setSliderPosition(this.direction);

--- a/packages/web-components/src/spinner/spinner.ts
+++ b/packages/web-components/src/spinner/spinner.ts
@@ -1,5 +1,5 @@
 import { attr, FASTElement } from '@microsoft/fast-element';
-import { toggleState } from '../utils/element-internals.js';
+import { toggleAttrState } from '../utils/element-internals.js';
 import type { SpinnerAppearance, SpinnerSize } from './spinner.options.js';
 
 /**
@@ -34,22 +34,9 @@ export class Spinner extends BaseSpinner {
    * @remarks
    * HTML Attribute: size
    */
+  @toggleAttrState
   @attr
   public size?: SpinnerSize;
-
-  /**
-   * Handles changes to size attribute custom states
-   * @param prev - the previous state
-   * @param next - the next state
-   */
-  public sizeChanged(prev: SpinnerSize | undefined, next: SpinnerSize | undefined) {
-    if (prev) {
-      toggleState(this.elementInternals, `${prev}`, false);
-    }
-    if (next) {
-      toggleState(this.elementInternals, `${next}`, true);
-    }
-  }
 
   /**
    * The appearance of the spinner
@@ -57,20 +44,7 @@ export class Spinner extends BaseSpinner {
    * @remarks
    * HTML Attribute: appearance
    */
+  @toggleAttrState
   @attr
   public appearance?: SpinnerAppearance;
-
-  /**
-   * Handles changes to appearance attribute custom states
-   * @param prev - the previous state
-   * @param next - the next state
-   */
-  public appearanceChanged(prev: SpinnerAppearance | undefined, next: SpinnerAppearance | undefined) {
-    if (prev) {
-      toggleState(this.elementInternals, `${prev}`, false);
-    }
-    if (next) {
-      toggleState(this.elementInternals, `${next}`, true);
-    }
-  }
 }

--- a/packages/web-components/src/tablist/tablist.ts
+++ b/packages/web-components/src/tablist/tablist.ts
@@ -10,7 +10,7 @@ import {
   uniqueId,
 } from '@microsoft/fast-web-utilities';
 import { getDirection } from '../utils/index.js';
-import { toggleState } from '../utils/element-internals.js';
+import { toggleAttrState, toggleState } from '../utils/element-internals.js';
 import { isFocusableElement } from '../utils/focusable-element.js';
 import { Tab } from '../index.js';
 import { TablistAppearance, TablistOrientation, TablistSize } from './tablist.options.js';
@@ -34,19 +34,9 @@ export class BaseTablist extends FASTElement {
    * @remarks
    * HTML Attribute: disabled.
    */
+  @toggleAttrState
   @attr({ mode: 'boolean' })
   public disabled: boolean = false;
-
-  /**
-   * Handles disabled changes
-   * @param prev - previous value
-   * @param next - next value
-   *
-   * @internal
-   */
-  protected disabledChanged(prev: boolean, next: boolean): void {
-    toggleState(this.elementInternals, 'disabled', next);
-  }
 
   /**
    * The orientation
@@ -54,6 +44,7 @@ export class BaseTablist extends FASTElement {
    * @remarks
    * HTML Attribute: orientation
    */
+  @toggleAttrState
   @attr
   public orientation: TablistOrientation = TablistOrientation.horizontal;
   /**
@@ -61,13 +52,6 @@ export class BaseTablist extends FASTElement {
    */
   protected orientationChanged(prev: TablistOrientation, next: TablistOrientation): void {
     this.elementInternals.ariaOrientation = next ?? TablistOrientation.horizontal;
-
-    if (prev) {
-      toggleState(this.elementInternals, `${prev}`, false);
-    }
-    if (next) {
-      toggleState(this.elementInternals, `${next}`, true);
-    }
 
     if (this.$fastController.isConnected) {
       this.setTabs();
@@ -301,40 +285,18 @@ export class Tablist extends BaseTablist {
    * appearance
    * There are two modes of appearance: transparent and subtle.
    */
+  @toggleAttrState
   @attr
   public appearance?: TablistAppearance = TablistAppearance.transparent;
-
-  /**
-   * @internal
-   */
-  protected appearanceChanged(prev: TablistAppearance, next: TablistAppearance): void {
-    if (prev) {
-      toggleState(this.elementInternals, `${prev}`, false);
-    }
-    if (next) {
-      toggleState(this.elementInternals, `${next}`, true);
-    }
-  }
 
   /**
    * size
    * defaults to medium.
    * Used to set the size of all the tab controls, which effects text size and margins. Three sizes: small, medium and large.
    */
+  @toggleAttrState
   @attr
   public size?: TablistSize;
-
-  /**
-   * @internal
-   */
-  protected sizeChanged(prev: TablistSize, next: TablistSize): void {
-    if (prev) {
-      toggleState(this.elementInternals, `${prev}`, false);
-    }
-    if (next) {
-      toggleState(this.elementInternals, `${next}`, true);
-    }
-  }
 
   /**
    * calculateAnimationProperties

--- a/packages/web-components/src/text-input/text-input.ts
+++ b/packages/web-components/src/text-input/text-input.ts
@@ -1,7 +1,7 @@
 import { attr, FASTElement, nullableNumberConverter, Observable, observable } from '@microsoft/fast-element';
 import { StartEnd } from '../patterns/start-end.js';
 import { applyMixins } from '../utils/apply-mixins.js';
-import { toggleState } from '../utils/element-internals.js';
+import { toggleAttrState, toggleState } from '../utils/element-internals.js';
 import type { TextInputControlSize } from './text-input.options.js';
 import { ImplicitSubmissionBlockingTypes, TextInputAppearance, TextInputType } from './text-input.options.js';
 
@@ -609,22 +609,9 @@ export class TextInput extends BaseTextInput {
    * @remarks
    * HTML Attribute: `appearance`
    */
+  @toggleAttrState
   @attr
   public appearance?: TextInputAppearance;
-
-  /**
-   * Handles changes to appearance attribute custom states
-   * @param prev - the previous state
-   * @param next - the next state
-   */
-  public appearanceChanged(prev: TextInputAppearance | undefined, next: TextInputAppearance | undefined) {
-    if (prev) {
-      toggleState(this.elementInternals, `${prev}`, false);
-    }
-    if (next) {
-      toggleState(this.elementInternals, `${next}`, true);
-    }
-  }
 
   /**
    * Sets the size of the control.
@@ -633,22 +620,9 @@ export class TextInput extends BaseTextInput {
    * @remarks
    * HTML Attribute: `control-size`
    */
+  @toggleAttrState
   @attr({ attribute: 'control-size' })
   public controlSize?: TextInputControlSize;
-
-  /**
-   * Handles changes to `control-size` attribute custom states
-   * @param prev - the previous state
-   * @param next - the next state
-   */
-  public controlSizeChanged(prev: TextInputControlSize | undefined, next: TextInputControlSize | undefined) {
-    if (prev) {
-      toggleState(this.elementInternals, `${prev}`, false);
-    }
-    if (next) {
-      toggleState(this.elementInternals, `${next}`, true);
-    }
-  }
 }
 
 /**

--- a/packages/web-components/src/text/text.ts
+++ b/packages/web-components/src/text/text.ts
@@ -1,5 +1,5 @@
 import { attr, FASTElement, Observable } from '@microsoft/fast-element';
-import { toggleState } from '../utils/element-internals.js';
+import { toggleAttrState, toggleState } from '../utils/element-internals.js';
 import type { TextAlign, TextFont, TextSize, TextWeight } from './text.options.js';
 
 /**
@@ -108,22 +108,9 @@ export class Text extends FASTElement {
    * @remarks
    * HTML Attribute: font
    */
+  @toggleAttrState
   @attr
   font?: TextFont;
-
-  /**
-   * Handles changes to font attribute custom states
-   * @param prev - the previous state
-   * @param next - the next state
-   */
-  public fontChanged(prev: TextFont | undefined, next: TextFont | undefined) {
-    if (prev) {
-      toggleState(this.elementInternals, prev, false);
-    }
-    if (next) {
-      toggleState(this.elementInternals, next, true);
-    }
-  }
 
   /**
    * The Text weight
@@ -132,22 +119,9 @@ export class Text extends FASTElement {
    * @remarks
    * HTML Attribute: weight
    */
+  @toggleAttrState
   @attr
   weight?: TextWeight;
-
-  /**
-   * Handles changes to weight attribute custom states
-   * @param prev - the previous state
-   * @param next - the next state
-   */
-  public weightChanged(prev: TextWeight | undefined, next: TextWeight | undefined) {
-    if (prev) {
-      toggleState(this.elementInternals, prev, false);
-    }
-    if (next) {
-      toggleState(this.elementInternals, next, true);
-    }
-  }
 
   /**
    * THe Text align
@@ -156,22 +130,9 @@ export class Text extends FASTElement {
    * @remarks
    * HTML Attribute: align
    */
+  @toggleAttrState
   @attr
   align?: TextAlign;
-
-  /**
-   * Handles changes to align attribute custom states
-   * @param prev - the previous state
-   * @param next - the next state
-   */
-  public alignChanged(prev: TextAlign | undefined, next: TextAlign | undefined) {
-    if (prev) {
-      toggleState(this.elementInternals, prev, false);
-    }
-    if (next) {
-      toggleState(this.elementInternals, next, true);
-    }
-  }
 
   public connectedCallback(): void {
     super.connectedCallback();

--- a/packages/web-components/src/utils/element-internals.ts
+++ b/packages/web-components/src/utils/element-internals.ts
@@ -43,11 +43,9 @@ export function toggleAttrState(target: any, attr: string): any {
   const method = target[`${attr}Changed`];
 
   // Replace the attrChanged method with a new one
-  target[`${attr}Changed`] = function (prev: string | boolean | undefined, next: string | boolean | undefined): void {
+  target[`${attr}Changed`] = function (prev: any, next: any): void {
     // Call original method
-    if (method) {
-      method.call(this, prev, next);
-    }
+    method?.call(this, prev, next);
 
     // Update elementInternals state for booleans
     if (typeof next === 'boolean') {
@@ -56,7 +54,7 @@ export function toggleAttrState(target: any, attr: string): any {
     }
 
     // Update elementInternals state for strings
-    // NOTE: Change to `${attr}-${next}`?
+    // TODO: Change to `${attr}-${next}` https://github.com/microsoft/fluentui/issues/32069
     if (prev) {
       toggleState(this.elementInternals, `${prev}`, false);
     }

--- a/packages/web-components/src/utils/element-internals.ts
+++ b/packages/web-components/src/utils/element-internals.ts
@@ -48,6 +48,7 @@ export function toggleAttrState(target: any, attr: string): any {
     if (method) {
       method.call(this, prev, next);
     }
+
     // Update elementInternals state for booleans
     if (typeof next === 'boolean') {
       toggleState(this.elementInternals, attr, next);
@@ -55,7 +56,7 @@ export function toggleAttrState(target: any, attr: string): any {
     }
 
     // Update elementInternals state for strings
-    // TODO: Flip to `${attr}-${next}` when Custom States are supported
+    // NOTE: Change to `${attr}-${next}`?
     if (prev) {
       toggleState(this.elementInternals, `${prev}`, false);
     }

--- a/packages/web-components/src/utils/element-internals.ts
+++ b/packages/web-components/src/utils/element-internals.ts
@@ -32,3 +32,35 @@ export function toggleState(elementInternals: ElementInternals, state: string, f
   // @ts-expect-error - Baseline 2024
   elementInternals.states.delete(state);
 }
+
+/**
+ * A decorator for toggling the element internals of an element
+ *
+ * @internal
+ */
+export function toggleAttrState(target: any, attr: string): any {
+  // Stash the original method
+  const method = target[`${attr}Changed`];
+
+  // Replace the attrChanged method with a new one
+  target[`${attr}Changed`] = function (prev: string | boolean | undefined, next: string | boolean | undefined): void {
+    // Call original method
+    if (method) {
+      method.call(this, prev, next);
+    }
+    // Update elementInternals state for booleans
+    if (typeof next === 'boolean') {
+      toggleState(this.elementInternals, attr, next);
+      return;
+    }
+
+    // Update elementInternals state for strings
+    // TODO: Flip to `${attr}-${next}` when Custom States are supported
+    if (prev) {
+      toggleState(this.elementInternals, `${prev}`, false);
+    }
+    if (next) {
+      toggleState(this.elementInternals, `${next}`, true);
+    }
+  };
+}


### PR DESCRIPTION
## Previous Behavior

<!-- This is the behavior we have today -->

Converting to ElementInternals `:state()` creates a lot of redundant code around toggling attribute states in the `{attr}Changed` callbacks.

```ts
@attr
public stringAttr: StringAttrOptions = StringAttrOptions.default;

stringAttrChanged(prev, next) {
  if(prev) {
    toggleState(this.elementInternals, `${prev}`, false)
  }
  if(next) {
    toggleState(this.elementInternals, `${next}`, true)
  }
}

@attr({ mode: boolean })
public booleanAttr: boolean = false;

booleanAttrChanged(prev, next) {
  toggleState(this.elementInternals, 'booleanAttr', next)
}
```

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

Created a new decorater called `@toggleAttrState` to handle attribute state switching.

```ts
@toggleAttrState
@attr
public stringAttr: StringAttrOptions = StringAttrOptions.default;

@toggleAttrState
@attr({ mode: boolean })
public booleanAttr: boolean = false;
```

## Estimated Impact

| Compression | KiB Before | KiB After
|---|---|---|
| Minified         | 197.05 KiB | 193.14 KiB |
| Min+Gzipped      | 46.62 KiB | 46.35 KiB |

These are local measurements, final bundle size on unpkg tends to be +15 KiB more or so. It doesn't seem to impact the final gzipped transfer size (repetitive text compresses better) but does lead to 2% less script overall.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
