### PR TITLE
bugfix(react-tree): ensures Tree width grows with content

### DIFF
--- a/change/@fluentui-react-tree-fc112f7a-3c5a-4302-bca4-4c367d5266c5.json
+++ b/change/@fluentui-react-tree-fc112f7a-3c5a-4302-bca4-4c367d5266c5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: ensures Tree width grows with content",
+  "packageName": "@fluentui/react-tree",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tree/library/src/components/FlatTree/useFlatTreeStyles.styles.ts
+++ b/packages/react-components/react-tree/library/src/components/FlatTree/useFlatTreeStyles.styles.ts
@@ -11,6 +11,7 @@ const useBaseStyles = makeResetStyles({
   display: 'flex',
   flexDirection: 'column',
   rowGap: tokens.spacingVerticalXXS,
+  width: 'max-content',
 });
 
 export const useFlatTreeStyles_unstable = (state: FlatTreeState): FlatTreeState => {

--- a/packages/react-components/react-tree/library/src/components/Tree/useTreeStyles.styles.ts
+++ b/packages/react-components/react-tree/library/src/components/Tree/useTreeStyles.styles.ts
@@ -11,6 +11,7 @@ const useBaseStyles = makeResetStyles({
   display: 'flex',
   flexDirection: 'column',
   rowGap: tokens.spacingVerticalXXS,
+  width: 'max-content',
 });
 
 const useStyles = makeStyles({


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
1. add `width: max-content` style to `Tree` and `FlatTree` components

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/32221
