### PR TITLE
feat(script-executors): implement default target pre-selection to start CLI

### DIFF
--- a/scripts/executors/src/enquirer-types.d.ts
+++ b/scripts/executors/src/enquirer-types.d.ts
@@ -9,6 +9,11 @@ declare module 'enquirer' {
     name: string;
     message: string;
     choices: Array<string | Choice>;
+    /**
+     * Preselected item in the list of choices.
+     * @default 0
+     */
+    initial?: number;
     limit?: number;
     header?: string;
     footer?: () => string;

--- a/tools/eslint-rules/project.json
+++ b/tools/eslint-rules/project.json
@@ -2,6 +2,7 @@
   "name": "eslint-rules",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "tools/eslint-rules",
+  "projectType": "library",
   "targets": {
     "test": {
       "executor": "@nx/jest:jest",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

no targets is selected - user needs to do one additional step manually which might feel slower in comparison with original "start" UX

## New Behavior

Based on package context the UI will pre-select most common (default) target so user don't have to type/choose just confirm the default.


https://github.com/user-attachments/assets/5f5e91dd-ae8e-4d2b-9e23-2e1cbcfec065



## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows https://github.com/microsoft/fluentui/pull/32108
