### PR TITLE
chore: add "@griffel/pseudo-element-naming": "error" eslint rule

### DIFF
--- a/change/@fluentui-eslint-plugin-1d3bf32e-cc52-4d02-8ff0-c047c300984a.json
+++ b/change/@fluentui-eslint-plugin-1d3bf32e-cc52-4d02-8ff0-c047c300984a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: add Griffel's pseudo element lint rule",
+  "packageName": "@fluentui/eslint-plugin",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-carousel-preview-0376635f-0565-4580-93eb-e8c5897fea84.json
+++ b/change/@fluentui-react-carousel-preview-0376635f-0565-4580-93eb-e8c5897fea84.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: change :after to ::after",
+  "packageName": "@fluentui/react-carousel-preview",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-drawer-272fabef-7078-4ffa-979d-dac3e8971ca1.json
+++ b/change/@fluentui-react-drawer-272fabef-7078-4ffa-979d-dac3e8971ca1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: change :after to ::after.",
+  "packageName": "@fluentui/react-drawer",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-table-2814c80d-d032-49e8-945b-c06f4746d07e.json
+++ b/change/@fluentui-react-table-2814c80d-d032-49e8-945b-c06f4746d07e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: change :after to ::after",
+  "packageName": "@fluentui/react-table",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/eslint-plugin/src/configs/react-config.js
+++ b/packages/eslint-plugin/src/configs/react-config.js
@@ -28,6 +28,7 @@ module.exports = {
      */
     '@griffel/hook-naming': 'error',
     '@griffel/no-shorthands': 'error',
+    '@griffel/pseudo-element-naming': 'error',
     '@griffel/styles-file': 'error',
     'no-restricted-globals': restrictedGlobals,
     /**

--- a/packages/react-components/react-carousel-preview/library/src/components/CarouselNavButton/useCarouselNavButtonStyles.styles.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/CarouselNavButton/useCarouselNavButtonStyles.styles.ts
@@ -39,7 +39,7 @@ const useStyles = makeStyles({
       margin: `calc(-1 * ${tokens.strokeWidthThick})`,
       borderRadius: tokens.borderRadiusMedium,
     }),
-    ':after': {
+    '::after': {
       opacity: 0.3,
     },
   },
@@ -51,7 +51,7 @@ const useStyles = makeStyles({
       margin: `calc(-1 * ${tokens.strokeWidthThick})`,
       borderRadius: tokens.borderRadiusMedium,
     }),
-    ':after': {
+    '::after': {
       width: '16px',
       borderRadius: '4px',
     },

--- a/packages/react-components/react-drawer/library/src/components/DrawerFooter/useDrawerFooterStyles.styles.ts
+++ b/packages/react-components/react-drawer/library/src/components/DrawerFooter/useDrawerFooterStyles.styles.ts
@@ -28,14 +28,14 @@ const useStyles = makeResetStyles({
 
 const useDrawerFooterStyles = makeStyles({
   separator: {
-    ':before': {
+    '::before': {
       ...drawerSeparatorStyles,
       top: 0,
     },
   },
 
   separatorVisible: {
-    ':before': {
+    '::before': {
       opacity: 1,
     },
   },

--- a/packages/react-components/react-drawer/library/src/components/DrawerHeader/useDrawerHeaderStyles.styles.ts
+++ b/packages/react-components/react-drawer/library/src/components/DrawerHeader/useDrawerHeaderStyles.styles.ts
@@ -28,14 +28,14 @@ const useStyles = makeResetStyles({
 
 const useDrawerHeaderStyles = makeStyles({
   separator: {
-    ':after': {
+    '::after': {
       ...drawerSeparatorStyles,
       bottom: 0,
     },
   },
 
   separatorVisible: {
-    ':after': {
+    '::after': {
       opacity: 1,
     },
   },

--- a/packages/react-components/react-table/library/src/components/TableResizeHandle/useTableResizeHandleStyles.styles.ts
+++ b/packages/react-components/react-table/library/src/components/TableResizeHandle/useTableResizeHandleStyles.styles.ts
@@ -37,7 +37,7 @@ const useStyles = makeStyles({
       opacity: 1,
     },
 
-    ':after': {
+    '::after': {
       content: '" "',
       display: 'block',
       width: '1px',


### PR DESCRIPTION
## Previous Behavior

We allowed pseudo elements to be selected with a single colon rather than enforce the double colon syntax.

E.g.,
```css
:after {
  / * rules here */
}
```

## New Behavior

Pseudo elements must be selected with double colon syntax. E.g.:

```css
::after {
  /* rules here */
}
```

## Related Issue(s)

See: https://github.com/microsoft/fluentui/pull/32077#discussion_r1705107306
