### PR TITLE
Fix undefined reference in older browsers in useMessageBarReflow

### DIFF
--- a/change/@fluentui-react-message-bar-bfb5f0c1-b637-4cbd-96e4-9ea0283c03d2.json
+++ b/change/@fluentui-react-message-bar-bfb5f0c1-b637-4cbd-96e4-9ea0283c03d2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix undefined reference in older browsers in useMessageBarReflow",
+  "packageName": "@fluentui/react-message-bar",
+  "email": "miclo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-message-bar/library/src/components/MessageBar/useMessageBarReflow.ts
+++ b/packages/react-components/react-message-bar/library/src/components/MessageBar/useMessageBarReflow.ts
@@ -29,7 +29,7 @@ export function useMessageBarReflow(enabled: boolean = false) {
       const entry = entries[0];
       // `borderBoxSize` is not supported before Chrome 84, Firefox 92, nor Safari 15.4
       const inlineSize = entry?.borderBoxSize?.[0].inlineSize ?? entry?.target.getBoundingClientRect().width;
-      if (!inlineSize || !entry) {
+      if (inlineSize === undefined || !entry) {
         return;
       }
 

--- a/packages/react-components/react-message-bar/library/src/components/MessageBar/useMessageBarReflow.ts
+++ b/packages/react-components/react-message-bar/library/src/components/MessageBar/useMessageBarReflow.ts
@@ -27,7 +27,8 @@ export function useMessageBarReflow(enabled: boolean = false) {
       }
 
       const entry = entries[0];
-      const borderBoxSize = entry?.borderBoxSize[0];
+      // `borderBoxSize` is not supported before Chrome 84, Firefox 92, nor Safari 15.4
+      const borderBoxSize = entry?.borderBoxSize?.[0];
       if (!borderBoxSize || !entry) {
         return;
       }

--- a/packages/react-components/react-message-bar/library/src/components/MessageBar/useMessageBarReflow.ts
+++ b/packages/react-components/react-message-bar/library/src/components/MessageBar/useMessageBarReflow.ts
@@ -28,12 +28,11 @@ export function useMessageBarReflow(enabled: boolean = false) {
 
       const entry = entries[0];
       // `borderBoxSize` is not supported before Chrome 84, Firefox 92, nor Safari 15.4
-      const borderBoxSize = entry?.borderBoxSize?.[0];
-      if (!borderBoxSize || !entry) {
+      const inlineSize = entry?.borderBoxSize?.[0].inlineSize ?? entry?.target.getBoundingClientRect().width;
+      if (!inlineSize || !entry) {
         return;
       }
 
-      const { inlineSize } = borderBoxSize;
       const { target } = entry;
 
       if (!isHTMLElement(target)) {


### PR DESCRIPTION
## Previous Behavior

In older browsers, such as Chrome 80, `ResizeObserverEntry.borderBoxSize` is not implemented, and returns undefined. The unguarded dereference in `useMessageBarReflow` causes a TypeError in such cases.

## New Behavior

Added an optional chaining guard `?.` to the code, and a comment explaining the reason for it.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #32237
