### PR TITLE
[chore]: [rating-display] move size, color and compact. 

### DIFF
--- a/change/@fluentui-web-components-77c45460-67de-4189-a7f9-c04db87cf6d9.json
+++ b/change/@fluentui-web-components-77c45460-67de-4189-a7f9-c04db87cf6d9.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[chore]: [rating-display] move size, color and generate icons out of base class",
+  "packageName": "@fluentui/web-components",
+  "email": "jes@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/docs/api-report.md
+++ b/packages/web-components/docs/api-report.md
@@ -578,6 +578,10 @@ export class BaseRatingDisplay extends FASTElement {
     get formattedCount(): string;
     // @internal
     generateIcons(): string;
+    // @internal
+    getMaxIcons(): number;
+    // @internal
+    getSelectedValue(): number;
     max?: number;
     value?: number;
 }
@@ -2905,8 +2909,10 @@ export class RatingDisplay extends BaseRatingDisplay {
     color?: RatingDisplayColor;
     colorChanged(prev: RatingDisplayColor | undefined, next: RatingDisplayColor | undefined): void;
     compact: boolean;
-    // @internal
-    generateIcons(): string;
+    // @override
+    getMaxIcons(): number;
+    // @override
+    getSelectedValue(): number;
     size?: RatingDisplaySize;
     sizeChanged(prev: RatingDisplaySize | undefined, next: RatingDisplaySize | undefined): void;
 }

--- a/packages/web-components/docs/api-report.md
+++ b/packages/web-components/docs/api-report.md
@@ -578,9 +578,7 @@ export class BaseRatingDisplay extends FASTElement {
     get formattedCount(): string;
     // @internal
     generateIcons(): string;
-    // @internal
     getMaxIcons(): number;
-    // @internal
     getSelectedValue(): number;
     max?: number;
     value?: number;

--- a/packages/web-components/docs/api-report.md
+++ b/packages/web-components/docs/api-report.md
@@ -569,6 +569,20 @@ export class BaseProgressBar extends FASTElement {
 }
 
 // @public
+export class BaseRatingDisplay extends FASTElement {
+    constructor();
+    count?: number;
+    // @internal
+    elementInternals: ElementInternals;
+    // @internal
+    get formattedCount(): string;
+    // @internal
+    generateIcons(): string;
+    max?: number;
+    value?: number;
+}
+
+// @public
 export class BaseSpinner extends FASTElement {
     constructor();
     // @internal
@@ -2887,22 +2901,14 @@ export const RadioStyles: ElementStyles;
 export const RadioTemplate: ElementViewTemplate<Radio>;
 
 // @public
-export class RatingDisplay extends FASTElement {
-    constructor();
+export class RatingDisplay extends BaseRatingDisplay {
     color?: RatingDisplayColor;
     colorChanged(prev: RatingDisplayColor | undefined, next: RatingDisplayColor | undefined): void;
     compact: boolean;
-    count?: number;
-    // @internal
-    elementInternals: ElementInternals;
-    // @internal
-    get formattedCount(): string;
     // @internal
     generateIcons(): string;
-    max?: number;
     size?: RatingDisplaySize;
     sizeChanged(prev: RatingDisplaySize | undefined, next: RatingDisplaySize | undefined): void;
-    value?: number;
 }
 
 // @public

--- a/packages/web-components/docs/api-report.md
+++ b/packages/web-components/docs/api-report.md
@@ -578,8 +578,8 @@ export class BaseRatingDisplay extends FASTElement {
     get formattedCount(): string;
     // @internal
     generateIcons(): string;
-    getMaxIcons(): number;
-    getSelectedValue(): number;
+    protected getMaxIcons(): number;
+    protected getSelectedValue(): number;
     max?: number;
     value?: number;
 }
@@ -2908,9 +2908,9 @@ export class RatingDisplay extends BaseRatingDisplay {
     colorChanged(prev: RatingDisplayColor | undefined, next: RatingDisplayColor | undefined): void;
     compact: boolean;
     // @override
-    getMaxIcons(): number;
+    protected getMaxIcons(): number;
     // @override
-    getSelectedValue(): number;
+    protected getSelectedValue(): number;
     size?: RatingDisplaySize;
     sizeChanged(prev: RatingDisplaySize | undefined, next: RatingDisplaySize | undefined): void;
 }

--- a/packages/web-components/src/index.ts
+++ b/packages/web-components/src/index.ts
@@ -168,6 +168,7 @@ export {
 export { Radio, RadioDefinition, RadioStyles, RadioTemplate } from './radio/index.js';
 export type { RadioControl, RadioOptions } from './radio/index.js';
 export {
+  BaseRatingDisplay,
   RatingDisplay,
   RatingDisplayColor,
   RatingDisplayDefinition,

--- a/packages/web-components/src/rating-display/index.ts
+++ b/packages/web-components/src/rating-display/index.ts
@@ -1,4 +1,4 @@
-export { RatingDisplay } from './rating-display.js';
+export { BaseRatingDisplay, RatingDisplay } from './rating-display.js';
 export { RatingDisplayColor, RatingDisplaySize } from './rating-display.options.js';
 export { template as RatingDisplayTemplate } from './rating-display.template.js';
 export { styles as RatingDisplayStyles } from './rating-display.styles.js';

--- a/packages/web-components/src/rating-display/rating-display.ts
+++ b/packages/web-components/src/rating-display/rating-display.ts
@@ -6,45 +6,13 @@ import { RatingDisplayColor, RatingDisplaySize } from './rating-display.options.
  * The base class used for constructing a fluent-rating-display custom element
  * @public
  */
-export class RatingDisplay extends FASTElement {
+export class BaseRatingDisplay extends FASTElement {
   /**
    * The internal {@link https://developer.mozilla.org/docs/Web/API/ElementInternals | `ElementInternals`} instance for the component.
    *
    * @internal
    */
   public elementInternals: ElementInternals = this.attachInternals();
-
-  /**
-   * The color of the rating display icons.
-   *
-   * @public
-   * @default `marigold`
-   * @remarks
-   * HTML Attribute: `color`
-   */
-  @attr
-  public color?: RatingDisplayColor;
-
-  /**
-   * Handles changes to the color attribute.
-   *
-   * @param prev - The previous state
-   * @param next - The next state
-   */
-  public colorChanged(prev: RatingDisplayColor | undefined, next: RatingDisplayColor | undefined): void {
-    if (prev) toggleState(this.elementInternals, prev, false);
-    if (next) toggleState(this.elementInternals, next, true);
-  }
-
-  /**
-   * Renders a single filled icon with a label next to it.
-   *
-   * @public
-   * @remarks
-   * HTML Attribute: `compact`
-   */
-  @attr({ mode: 'boolean' })
-  public compact: boolean = false;
 
   /**
    * The number of ratings.
@@ -67,28 +35,6 @@ export class RatingDisplay extends FASTElement {
    */
   @attr({ converter: nullableNumberConverter })
   public max?: number;
-
-  /**
-   * The size of the component.
-   *
-   * @public
-   * @default 'medium'
-   * @remarks
-   * HTML Attribute: `size`
-   */
-  @attr
-  public size?: RatingDisplaySize;
-
-  /**
-   * Handles changes to the size attribute.
-   *
-   * @param prev - The previous state
-   * @param next - The next state
-   */
-  public sizeChanged(prev: RatingDisplaySize | undefined, next: RatingDisplaySize | undefined): void {
-    if (prev) toggleState(this.elementInternals, prev, false);
-    if (next) toggleState(this.elementInternals, next, true);
-  }
 
   /**
    * The value of the rating.
@@ -123,6 +69,92 @@ export class RatingDisplay extends FASTElement {
    * @internal
    */
   public generateIcons(): string {
+    let htmlString: string = '';
+
+    // The value of the selected icon. Based on the "value" attribute, rounded to the nearest half.
+    const selectedValue: number = Math.round((this.value ?? 0) * 2) / 2;
+
+    // Render the icons based on the "max" attribute. If "max" is not set, render 5 icons.
+    // If "compact" is true, only render one filled icon.
+    for (let i: number = 0; i < (this.max ?? 5) * 2; i++) {
+      const iconValue: number = (i + 1) / 2;
+
+      htmlString += `<svg aria-hidden="true" ${
+        iconValue === selectedValue ? 'selected' : ''
+      }><use href="#star"></use></svg>`;
+    }
+
+    return htmlString;
+  }
+}
+
+/**
+ * A Rating Dislpay Custom HTML Element.
+ * Based on BaseRatingDisplay and includes style and layout specific attributes
+ *
+ * @public
+ */
+export class RatingDisplay extends BaseRatingDisplay {
+  /**
+   * The color of the rating display icons.
+   *
+   * @public
+   * @default `marigold`
+   * @remarks
+   * HTML Attribute: `color`
+   */
+  @attr
+  public color?: RatingDisplayColor;
+
+  /**
+   * Handles changes to the color attribute.
+   *
+   * @param prev - The previous state
+   * @param next - The next state
+   */
+  public colorChanged(prev: RatingDisplayColor | undefined, next: RatingDisplayColor | undefined): void {
+    if (prev) toggleState(this.elementInternals, prev, false);
+    if (next) toggleState(this.elementInternals, next, true);
+  }
+
+  /**
+   * The size of the component.
+   *
+   * @public
+   * @default 'medium'
+   * @remarks
+   * HTML Attribute: `size`
+   */
+  @attr
+  public size?: RatingDisplaySize;
+
+  /**
+   * Handles changes to the size attribute.
+   *
+   * @param prev - The previous state
+   * @param next - The next state
+   */
+  public sizeChanged(prev: RatingDisplaySize | undefined, next: RatingDisplaySize | undefined): void {
+    if (prev) toggleState(this.elementInternals, prev, false);
+    if (next) toggleState(this.elementInternals, next, true);
+  }
+
+  /**
+   * Renders a single filled icon with a label next to it.
+   *
+   * @public
+   * @remarks
+   * HTML Attribute: `compact`
+   */
+  @attr({ mode: 'boolean' })
+  public compact: boolean = false;
+
+  /**
+   * Generates the icon SVG elements based on the "max" and "compact" attribute.
+   *
+   * @internal
+   */
+  public override generateIcons(): string {
     let htmlString: string = '';
 
     // The value of the selected icon. Based on the "value" attribute, rounded to the nearest half.

--- a/packages/web-components/src/rating-display/rating-display.ts
+++ b/packages/web-components/src/rating-display/rating-display.ts
@@ -64,6 +64,24 @@ export class BaseRatingDisplay extends FASTElement {
   }
 
   /**
+   * Gets the selected value
+   *
+   * @internal
+   */
+  public getSelectedValue(): number {
+    return Math.round((this.value ?? 0) * 2) / 2;
+  }
+
+  /**
+   * Gets the maximum icons to render
+   *
+   * @internal
+   */
+  public getMaxIcons(): number {
+    return (this.max ?? 5) * 2;
+  }
+
+  /**
    * Generates the icon SVG elements based on the "max" attribute.
    *
    * @internal
@@ -72,11 +90,10 @@ export class BaseRatingDisplay extends FASTElement {
     let htmlString: string = '';
 
     // The value of the selected icon. Based on the "value" attribute, rounded to the nearest half.
-    const selectedValue: number = Math.round((this.value ?? 0) * 2) / 2;
+    const selectedValue: number = this.getSelectedValue();
 
     // Render the icons based on the "max" attribute. If "max" is not set, render 5 icons.
-    // If "compact" is true, only render one filled icon.
-    for (let i: number = 0; i < (this.max ?? 5) * 2; i++) {
+    for (let i: number = 0; i < this.getMaxIcons(); i++) {
       const iconValue: number = (i + 1) / 2;
 
       htmlString += `<svg aria-hidden="true" ${
@@ -150,26 +167,20 @@ export class RatingDisplay extends BaseRatingDisplay {
   public compact: boolean = false;
 
   /**
-   * Generates the icon SVG elements based on the "max" and "compact" attribute.
+   * Overrides the selected value and returns 1 if compact is true.
    *
-   * @internal
+   * @override
    */
-  public override generateIcons(): string {
-    let htmlString: string = '';
+  public override getSelectedValue(): number {
+    return Math.round((this.compact ? 1 : this.value ?? 0) * 2) / 2;
+  }
 
-    // The value of the selected icon. Based on the "value" attribute, rounded to the nearest half.
-    const selectedValue: number = Math.round((this.compact ? 1 : this.value ?? 0) * 2) / 2;
-
-    // Render the icons based on the "max" attribute. If "max" is not set, render 5 icons.
-    // If "compact" is true, only render one filled icon.
-    for (let i: number = 0; i < (this.compact ? 1 : this.max ?? 5) * 2; i++) {
-      const iconValue: number = (i + 1) / 2;
-
-      htmlString += `<svg aria-hidden="true" ${
-        iconValue === selectedValue ? 'selected' : ''
-      }><use href="#star"></use></svg>`;
-    }
-
-    return htmlString;
+  /**
+   * Overrides the maximum icons and returns a max of 1 if compact is true.
+   *
+   * @override
+   */
+  public override getMaxIcons(): number {
+    return (this.compact ? 1 : this.max ?? 5) * 2;
   }
 }

--- a/packages/web-components/src/rating-display/rating-display.ts
+++ b/packages/web-components/src/rating-display/rating-display.ts
@@ -66,7 +66,7 @@ export class BaseRatingDisplay extends FASTElement {
   /**
    * Gets the selected value
    *
-   * @internal
+   * @protected
    */
   public getSelectedValue(): number {
     return Math.round((this.value ?? 0) * 2) / 2;
@@ -75,7 +75,7 @@ export class BaseRatingDisplay extends FASTElement {
   /**
    * Gets the maximum icons to render
    *
-   * @internal
+   * @protected
    */
   public getMaxIcons(): number {
     return (this.max ?? 5) * 2;

--- a/packages/web-components/src/rating-display/rating-display.ts
+++ b/packages/web-components/src/rating-display/rating-display.ts
@@ -68,7 +68,7 @@ export class BaseRatingDisplay extends FASTElement {
    *
    * @protected
    */
-  public getSelectedValue(): number {
+  protected getSelectedValue(): number {
     return Math.round((this.value ?? 0) * 2) / 2;
   }
 
@@ -77,7 +77,7 @@ export class BaseRatingDisplay extends FASTElement {
    *
    * @protected
    */
-  public getMaxIcons(): number {
+  protected getMaxIcons(): number {
     return (this.max ?? 5) * 2;
   }
 
@@ -171,7 +171,7 @@ export class RatingDisplay extends BaseRatingDisplay {
    *
    * @override
    */
-  public override getSelectedValue(): number {
+  protected override getSelectedValue(): number {
     return Math.round((this.compact ? 1 : this.value ?? 0) * 2) / 2;
   }
 
@@ -180,7 +180,7 @@ export class RatingDisplay extends BaseRatingDisplay {
    *
    * @override
    */
-  public override getMaxIcons(): number {
+  protected override getMaxIcons(): number {
     return (this.compact ? 1 : this.max ?? 5) * 2;
   }
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

`compact`, `size` and `color` are style and layout specific to fluent. `generateIcons` needs to exist in both the base class and extended class to keep base class functional.

## New Behavior

moves `compact`, `size` and `color`.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
