### PR TITLE
fix: react-combobox check icon slot does not collapse

### DIFF
--- a/change/@fluentui-react-combobox-7d75d97b-877f-4f43-92d4-cfadb37677da.json
+++ b/change/@fluentui-react-combobox-7d75d97b-877f-4f43-92d4-cfadb37677da.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: check icon slot does not collapse",
+  "packageName": "@fluentui/react-combobox",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/library/src/components/Option/useOptionStyles.styles.ts
+++ b/packages/react-components/react-combobox/library/src/components/Option/useOptionStyles.styles.ts
@@ -79,6 +79,7 @@ const useStyles = makeStyles({
   selected: {},
 
   checkIcon: {
+    flexShrink: 0,
     fontSize: tokens.fontSizeBase400,
     // Shift icon(s) to the left to give text content extra spacing without needing an extra node
     // This is done instead of gap since the extra space only exists between icon > content, not icon > icon

--- a/packages/react-components/react-combobox/stories/src/Dropdown/DropdownTruncation.stories.tsx
+++ b/packages/react-components/react-combobox/stories/src/Dropdown/DropdownTruncation.stories.tsx
@@ -40,7 +40,7 @@ export const TruncatedValue = (props: Partial<DropdownProps>) => {
     'Fox',
     'Hamster',
     'Snake',
-    'SuperLongName_123456789@soyouwantalongurl.com',
+    'SuperLongName_123456789_SomeMoreStuffToMakeItLonger@fluentui.dev',
     'Screaming hairy armadillo (Chaetophractus vellerosus)',
   ];
   const styles = useStyles();

--- a/packages/react-components/react-combobox/stories/src/Dropdown/DropdownTruncation.stories.tsx
+++ b/packages/react-components/react-combobox/stories/src/Dropdown/DropdownTruncation.stories.tsx
@@ -20,6 +20,11 @@ const useStyles = makeStyles({
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
   },
+  // these styles allow option text to break and wrap on long words, e.g. emails
+  optionText: {
+    overflow: 'hidden',
+    overflowWrap: 'break-word',
+  },
 });
 
 export const TruncatedValue = (props: Partial<DropdownProps>) => {
@@ -35,6 +40,7 @@ export const TruncatedValue = (props: Partial<DropdownProps>) => {
     'Fox',
     'Hamster',
     'Snake',
+    'SuperLongName_123456789@soyouwantalongurl.com',
     'Screaming hairy armadillo (Chaetophractus vellerosus)',
   ];
   const styles = useStyles();
@@ -42,7 +48,7 @@ export const TruncatedValue = (props: Partial<DropdownProps>) => {
   const placeholder = 'Select an animal';
 
   // show truncated option by default
-  const defaultValue = options[10];
+  const defaultValue = options[11];
   const [value, setValue] = React.useState(defaultValue);
 
   return (
@@ -58,8 +64,8 @@ export const TruncatedValue = (props: Partial<DropdownProps>) => {
         {...props}
       >
         {options.map(option => (
-          <Option key={option} disabled={option === 'Ferret'}>
-            {option}
+          <Option key={option} text={option} disabled={option === 'Ferret'}>
+            <span className={styles.optionText}>{option}</span>
           </Option>
         ))}
       </Dropdown>
@@ -71,7 +77,8 @@ TruncatedValue.parameters = {
   docs: {
     description: {
       story:
-        'The Dropdown button slot can be customized to render child JSX, which can be used to truncate the selected value text.',
+        'The Dropdown button slot can be customized to render child JSX, which can be used to truncate the selected value text. ' +
+        'Dropdown options can also be customized to overflow in various ways, e.g. by allowing long words to break and wrap.',
     },
   },
 };


### PR DESCRIPTION
Adds one style fix and one story.

## Previous Behavior

When the text of an option was longer than could fit in the available space, the check icon would collapse:
![screenshot showing the check icon appearing as a single vertical line](https://github.com/user-attachments/assets/cb247935-9838-4a69-b258-0b3f1bea072b)

## New Behavior

Fixes the icon slot collapsing with `flex-shrink: 0`, and adds a story showing how to add `overflow-wrap` styles to option text.

## Related Issue(s)

- Fixes #32227 and #32228
