### PR TITLE
feature(react-tag-picker): single line layout

### DIFF
--- a/change/@fluentui-react-components-2c418aac-078d-45dc-ad47-4bf796a2e600.json
+++ b/change/@fluentui-react-components-2c418aac-078d-45dc-ad47-4bf796a2e600.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feature: re-export react-tag-picker context",
+  "packageName": "@fluentui/react-components",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tag-picker-7ed3243d-60b5-4678-9762-f1b1722ca0fe.json
+++ b/change/@fluentui-react-tag-picker-7ed3243d-60b5-4678-9762-f1b1722ca0fe.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feature: single line layout",
+  "packageName": "@fluentui/react-tag-picker",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-components/etc/react-components.api.md
+++ b/packages/react-components/react-components/etc/react-components.api.md
@@ -1135,6 +1135,7 @@ import { tagPickerButtonClassNames } from '@fluentui/react-tag-picker';
 import { TagPickerButtonProps } from '@fluentui/react-tag-picker';
 import { TagPickerButtonSlots } from '@fluentui/react-tag-picker';
 import { TagPickerButtonState } from '@fluentui/react-tag-picker';
+import { TagPickerContextValue } from '@fluentui/react-tag-picker';
 import { TagPickerContextValues } from '@fluentui/react-tag-picker';
 import { TagPickerControl } from '@fluentui/react-tag-picker';
 import { tagPickerControlClassNames } from '@fluentui/react-tag-picker';
@@ -1734,6 +1735,7 @@ import { useTagGroupStyles_unstable } from '@fluentui/react-tags';
 import { useTagPicker_unstable } from '@fluentui/react-tag-picker';
 import { useTagPickerButton_unstable } from '@fluentui/react-tag-picker';
 import { useTagPickerButtonStyles_unstable } from '@fluentui/react-tag-picker';
+import { useTagPickerContext_unstable } from '@fluentui/react-tag-picker';
 import { useTagPickerControl_unstable } from '@fluentui/react-tag-picker';
 import { useTagPickerControlStyles_unstable } from '@fluentui/react-tag-picker';
 import { useTagPickerFilter } from '@fluentui/react-tag-picker';
@@ -4087,6 +4089,8 @@ export { TagPickerButtonSlots }
 
 export { TagPickerButtonState }
 
+export { TagPickerContextValue }
+
 export { TagPickerContextValues }
 
 export { TagPickerControl }
@@ -5284,6 +5288,8 @@ export { useTagPicker_unstable }
 export { useTagPickerButton_unstable }
 
 export { useTagPickerButtonStyles_unstable }
+
+export { useTagPickerContext_unstable }
 
 export { useTagPickerControl_unstable }
 

--- a/packages/react-components/react-components/src/index.ts
+++ b/packages/react-components/react-components/src/index.ts
@@ -1782,6 +1782,7 @@ export {
   useTagPickerOptionGroupStyles,
   useTagPickerOptionGroup,
   useTagPickerFilter,
+  useTagPickerContext_unstable,
 } from '@fluentui/react-tag-picker';
 export type {
   TagPickerContextValues,
@@ -1812,6 +1813,7 @@ export type {
   TagPickerOptionGroupProps,
   TagPickerOptionGroupSlots,
   TagPickerOptionGroupState,
+  TagPickerContextValue,
 } from '@fluentui/react-tag-picker';
 
 export {

--- a/packages/react-components/react-tag-picker/library/etc/react-tag-picker.api.md
+++ b/packages/react-components/react-tag-picker/library/etc/react-tag-picker.api.md
@@ -13,6 +13,7 @@ import { ComboboxSlots } from '@fluentui/react-combobox';
 import type { ComboboxState } from '@fluentui/react-combobox';
 import { ComponentProps } from '@fluentui/react-utilities';
 import { ComponentState } from '@fluentui/react-utilities';
+import { ContextSelector } from '@fluentui/react-context-selector';
 import { DropdownProps } from '@fluentui/react-combobox';
 import type { EventData } from '@fluentui/react-utilities';
 import type { EventHandler } from '@fluentui/react-utilities';
@@ -79,6 +80,26 @@ export type TagPickerButtonSlots = {
 export type TagPickerButtonState = ComponentState<TagPickerButtonSlots> & Pick<TagPickerContextValue, 'size'> & {
     hasSelectedOption: boolean;
 };
+
+// @public (undocumented)
+export interface TagPickerContextValue extends Pick<ComboboxBaseState, 'open' | 'clearSelection' | 'getOptionById' | 'selectedOptions' | 'selectOption' | 'setHasFocus' | 'setOpen' | 'setValue' | 'value' | 'appearance' | 'disabled'> {
+    // (undocumented)
+    noPopover?: boolean;
+    // (undocumented)
+    popoverId: string;
+    // (undocumented)
+    popoverRef: React_2.RefObject<HTMLDivElement>;
+    // (undocumented)
+    secondaryActionRef: React_2.RefObject<HTMLSpanElement>;
+    // (undocumented)
+    size: TagPickerSize;
+    // (undocumented)
+    tagPickerGroupRef: React_2.RefObject<HTMLDivElement>;
+    // (undocumented)
+    targetRef: React_2.RefObject<HTMLDivElement>;
+    // (undocumented)
+    triggerRef: React_2.RefObject<HTMLInputElement | HTMLButtonElement>;
+}
 
 // @public (undocumented)
 export type TagPickerContextValues = {
@@ -245,6 +266,9 @@ export const useTagPickerButton_unstable: (props: TagPickerButtonProps, ref: Rea
 
 // @public
 export const useTagPickerButtonStyles_unstable: (state: TagPickerButtonState) => TagPickerButtonState;
+
+// @public (undocumented)
+export const useTagPickerContext_unstable: <T>(selector: ContextSelector<TagPickerContextValue, T>) => T;
 
 // @public
 export const useTagPickerControl_unstable: (props: TagPickerControlProps, ref: React_2.Ref<HTMLDivElement>) => TagPickerControlState;

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerControl/useTagPickerControlStyles.styles.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerControl/useTagPickerControlStyles.styles.ts
@@ -154,13 +154,10 @@ const useStyles = makeStyles({
 
 const useAsideStyles = makeStyles({
   root: {
-    display: 'grid',
-    alignItems: 'center',
+    display: 'flex',
     position: 'absolute',
     top: '0',
     right: tokens.spacingHorizontalM,
-    gridTemplateColumns: 'repeat(2, auto)',
-    gridTemplateRows: 'minmax(32px, auto) 1fr',
     height: '100%',
     cursor: 'text',
   },
@@ -187,7 +184,10 @@ const useIconStyles = makeStyles({
     boxSizing: 'border-box',
     color: tokens.colorNeutralStrokeAccessible,
     cursor: 'pointer',
-    display: 'block',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    alignSelf: 'flex-start',
     fontSize: tokens.fontSizeBase500,
     // the SVG must have display: block for accurate positioning
     // otherwise an extra inline space is inserted after the svg element
@@ -199,19 +199,26 @@ const useIconStyles = makeStyles({
   medium: {
     fontSize: iconSizes.small,
     marginLeft: tokens.spacingHorizontalXXS,
+    minHeight: '32px',
   },
   large: {
     fontSize: iconSizes.medium,
     marginLeft: tokens.spacingHorizontalXXS,
+    minHeight: '40px',
   },
   'extra-large': {
     fontSize: iconSizes.large,
     marginLeft: tokens.spacingHorizontalSNudge,
+    minHeight: '44px',
   },
   disabled: {
     color: tokens.colorNeutralForegroundDisabled,
     cursor: 'not-allowed',
   },
+});
+
+const useSecondaryActionStyles = makeStyles({
+  root: { display: 'flex' },
 });
 
 /**
@@ -223,6 +230,7 @@ export const useTagPickerControlStyles_unstable = (state: TagPickerControlState)
   const styles = useStyles();
   const iconStyles = useIconStyles();
   const asideStyles = useAsideStyles();
+  const secondaryActionStyles = useSecondaryActionStyles();
   state.root.className = mergeClasses(
     tagPickerControlClassNames.root,
     styles.root,
@@ -257,6 +265,7 @@ export const useTagPickerControlStyles_unstable = (state: TagPickerControlState)
   if (state.secondaryAction) {
     state.secondaryAction.className = mergeClasses(
       tagPickerControlClassNames.secondaryAction,
+      secondaryActionStyles.root,
       state.secondaryAction.className,
     );
   }

--- a/packages/react-components/react-tag-picker/library/src/index.ts
+++ b/packages/react-components/react-tag-picker/library/src/index.ts
@@ -71,3 +71,6 @@ export type {
 } from './TagPickerOptionGroup';
 
 export { useTagPickerFilter } from './utils/useTagPickerFilter';
+
+export { useTagPickerContext_unstable } from './contexts/TagPickerContext';
+export type { TagPickerContextValue } from './contexts/TagPickerContext';

--- a/packages/react-components/react-tag-picker/stories/src/TagPicker/TagPickerSingleLine.stories.tsx
+++ b/packages/react-components/react-tag-picker/stories/src/TagPicker/TagPickerSingleLine.stories.tsx
@@ -1,0 +1,199 @@
+import * as React from 'react';
+import {
+  TagPicker,
+  TagPickerList,
+  TagPickerInput,
+  TagPickerControl,
+  TagPickerProps,
+  TagPickerOption,
+  TagPickerGroup,
+  makeStyles,
+  tagPickerGroupClassNames,
+  useOverflowCount,
+  TagPickerInputProps,
+  useTagPickerContext_unstable,
+  TagProps,
+  Tag,
+  Avatar,
+  Overflow,
+  OverflowItem,
+} from '@fluentui/react-components';
+import { ChevronDownRegular, ChevronUpRegular } from '@fluentui/react-icons';
+
+const useStyles = makeStyles({
+  focusedExpandIcon: { alignSelf: 'flex-end' },
+  countButton: { minWidth: 0 },
+  control: {
+    flexWrap: 'nowrap',
+    display: 'flex',
+    flexGrow: 1,
+    minWidth: 0,
+    overflow: 'hidden',
+    [`& > .${tagPickerGroupClassNames.root}`]: {
+      flexWrap: 'nowrap',
+    },
+    ':focus-within': {
+      flexWrap: 'wrap',
+      [`& > .${tagPickerGroupClassNames.root}`]: {
+        flexWrap: 'wrap',
+      },
+    },
+  },
+});
+
+const options = [
+  'John Doe',
+  'Jane Doe',
+  'Max Mustermann',
+  'Erika Mustermann',
+  'Pierre Dupont',
+  'Amelie Dupont',
+  'Mario Rossi',
+  'Maria Rossi',
+];
+
+type ExpandIconProps = { open: boolean; focus: boolean };
+
+const ExpandIcon = (props: ExpandIconProps) => {
+  const overflowCount = useOverflowCount();
+
+  if (props.open) {
+    return <ChevronUpRegular />;
+  }
+  if (overflowCount === 0 || props.focus) {
+    return <ChevronDownRegular />;
+  }
+  return null;
+};
+
+const OverFlowCountTag = (props: TagProps) => {
+  const overflowCount = useOverflowCount();
+  const styles = useStyles();
+  if (overflowCount === 0) {
+    return null;
+  }
+  return (
+    <Tag
+      as="span"
+      role={undefined}
+      dismissible={false}
+      aria-hidden
+      tabIndex={-1}
+      {...props}
+      className={styles.countButton}
+    >
+      +{overflowCount}
+    </Tag>
+  );
+};
+
+type CustomTagPickerInputProps = TagPickerInputProps & { focus: boolean };
+
+const CustomTagPickerInput = React.forwardRef<HTMLInputElement, CustomTagPickerInputProps>(
+  ({ focus, onMouseDown, placeholder, ...rest }, ref) => {
+    const overflowCount = useOverflowCount();
+    const selectedOptionsAmount = useTagPickerContext_unstable(ctx => ctx.selectedOptions.length);
+    return (
+      <TagPickerInput
+        ref={ref}
+        {...rest}
+        placeholder={selectedOptionsAmount === 0 || (overflowCount > 0 && focus) ? placeholder : undefined}
+      />
+    );
+  },
+);
+
+export const SingleLine = () => {
+  const styles = useStyles();
+  const [open, setOpen] = React.useState(false);
+  const [selectedOptions, setSelectedOptions] = React.useState<string[]>([]);
+  const inputRef = React.useRef<HTMLInputElement>(null);
+  const onOptionSelect: TagPickerProps['onOptionSelect'] = (e, data) => {
+    setSelectedOptions(data.selectedOptions);
+  };
+  const tagPickerOptions = options.filter(option => !selectedOptions.includes(option));
+
+  const [hasFocus, setFocus] = React.useState(false);
+
+  const handleOpenChange: TagPickerProps['onOpenChange'] = (_, data) => setOpen(data.open);
+
+  const handleFocus = () => {
+    setFocus(true);
+  };
+
+  const handleBlur = (event: React.FocusEvent) => {
+    if (event.currentTarget.contains(event.relatedTarget as Node)) {
+      return;
+    }
+    setFocus(false);
+  };
+
+  const handleOverflowCountTagMouseDown = (event: React.MouseEvent) => {
+    event.preventDefault();
+    inputRef.current?.focus();
+  };
+
+  return (
+    <TagPicker
+      open={open}
+      onOpenChange={handleOpenChange}
+      onOptionSelect={onOptionSelect}
+      selectedOptions={selectedOptions}
+    >
+      {/* 24 = min input size */}
+      {/* 30 = padding right */}
+      {/* 2 = gap between input and tags */}
+      {/* 4 = gap between tags */}
+      <Overflow minimumVisible={1} padding={24 + 30 + 2 + selectedOptions.length * 4}>
+        <TagPickerControl
+          style={{ maxWidth: 400 }}
+          expandIcon={{
+            className: hasFocus ? styles.focusedExpandIcon : undefined,
+            children: <ExpandIcon focus={hasFocus} open={open} />,
+          }}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
+          className={styles.control}
+        >
+          <TagPickerGroup>
+            {selectedOptions.map(option => (
+              <OverflowItem id={option} key={option}>
+                <Tag
+                  // force style to display the tag even if it's overflowing when focused
+                  style={hasFocus ? { display: 'inline-grid' } : undefined}
+                  key={option}
+                  shape="rounded"
+                  media={<Avatar aria-hidden name={option} color="colorful" />}
+                  value={option}
+                >
+                  {option}
+                </Tag>
+              </OverflowItem>
+            ))}
+            {!open && !hasFocus ? <OverFlowCountTag onMouseDown={handleOverflowCountTagMouseDown} /> : null}
+          </TagPickerGroup>
+          <CustomTagPickerInput
+            ref={inputRef}
+            focus={hasFocus}
+            placeholder="Select Employees"
+            aria-label="Select Employees"
+          />
+        </TagPickerControl>
+      </Overflow>
+      <TagPickerList>
+        {tagPickerOptions.length > 0
+          ? tagPickerOptions.map(option => (
+              <TagPickerOption
+                secondaryContent="Microsoft FTE"
+                media={<Avatar shape="square" aria-hidden name={option} color="colorful" />}
+                value={option}
+                key={option}
+              >
+                {option}
+              </TagPickerOption>
+            ))
+          : 'No options available'}
+      </TagPickerList>
+    </TagPicker>
+  );
+};

--- a/packages/react-components/react-tag-picker/stories/src/TagPicker/index.stories.tsx
+++ b/packages/react-components/react-tag-picker/stories/src/TagPicker/index.stories.tsx
@@ -24,6 +24,7 @@ export { Grouped } from './TagPickerGrouped.stories';
 export { TruncatedText } from './TagPickerTruncatedText.stories';
 export { SingleSelect } from './TagPickerSingleSelect.stories';
 export { NoPopover } from './TagPickerNoPopover.stories';
+export { SingleLine } from './TagPickerSingleLine.stories';
 
 export default {
   title: 'Components/TagPicker',


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

Implements single line layout example:

![image](https://github.com/user-attachments/assets/c29df04b-313b-48b9-8fd2-9918dac05ebb)

1. modifies internal styling from `TagPickerControl` from `grid` to `flex`
2. adds story showcasing how to achieve single line layout
3. exports `TagPickerContext` hooks and types

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/31666
