### PR TITLE
ci: make public-docsite-v9 deploy pipeline work and make it faster

### DIFF
--- a/.github/workflows/docsite-publish-ghpages.yml
+++ b/.github/workflows/docsite-publish-ghpages.yml
@@ -43,9 +43,6 @@ jobs:
       - name: Install packages
         run: yarn install --frozen-lockfile
 
-      - name: Build dependencies
-        run: yarn nx run public-docsite-v9:build --nxBail
-
       - name: Build storybook
         run: yarn nx run public-docsite-v9:build-storybook --nxBail
         env:

--- a/apps/public-docsite-v9/project.json
+++ b/apps/public-docsite-v9/project.json
@@ -3,5 +3,12 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "application",
   "implicitDependencies": ["tag:type:stories"],
-  "tags": ["platform:web", "vNext"]
+  "tags": ["platform:web", "vNext"],
+  "targets": {
+    "build-storybook": {
+      "dependsOn": [
+        { "projects": ["react-storybook-addon", "react-storybook-addon-export-to-sandbox"], "target": "build" }
+      ]
+    }
+  }
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

After [target normalization](https://github.com/microsoft/fluentui/pull/31926), apps are not allowed to specify `build` rather `bundle` or `build-storybook`. we forgot to reflect this to v9 docsite publish pipeline which is causing  [failures](https://github.com/microsoft/fluentui/actions/runs/10256997462/job/28377201953#step:5:7)

## New Behavior

v9 publish(deploy) pipeline
- now runs only `build-storybook` target 
- this target is optimised to actually build only what is really necessary (workspace addons) instead of all fluent frameworks (v0,v8,v9)

| deploy v9 docsite | time |
|--------|--------|
| Before | 393ms |
| After | 114ms  / **𝚫 71% FASTER** | 


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
