### PR TITLE
ci: trigger check tooling pipeline on monorepo dep changes

### DIFF
--- a/.github/workflows/check-tooling.yml
+++ b/.github/workflows/check-tooling.yml
@@ -1,10 +1,11 @@
 name: Check tooling
 on:
-  workflow_dispatch:
   pull_request:
     paths:
-      - 'tools/workspace-plugin/**'
-      - 'scripts/executors/**'
+      - yarn.lock
+      - tools/workspace-plugin/**
+      - scripts/executors/**
+  workflow_dispatch:
 
 env:
   __FORCE_API_MD_UPDATE__: true


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

tools pipeline was not triggered on huge PR that changed `tools/workspace-plugin/...` files , causing merging code that caused issues

## New Behavior

tools pipeline will be checked for any dependency changes

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows https://github.com/microsoft/fluentui/pull/32254
