### PR TITLE
fix: v8 icons do not inherit textDecoration from links

### DIFF
--- a/packages/react/src/components/Icon/Icon.styles.ts
+++ b/packages/react/src/components/Icon/Icon.styles.ts
@@ -5,6 +5,7 @@ import type { IIconStyleProps, IIconStyles } from './Icon.types';
 export const classNames = mergeStyleSets({
   root: {
     display: 'inline-block',
+    textDecoration: 'inherit',
   },
   placeholder: [
     'ms-Icon-placeHolder',


### PR DESCRIPTION


## Previous Behavior

<!-- This is the behavior we have today -->
When links are hovered, the icon does not inherit underline styles from inline parents, since they are rendered with `inline-block`.
<img width="74" alt="image" src="https://github.com/user-attachments/assets/f886c5ef-7c22-46a8-b4fd-21c6734e5cc8">


## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

The icons should inherit underline styles from inline parents.
<img width="367" alt="image" src="https://github.com/user-attachments/assets/9937a769-64d3-47cf-a352-e8b51d042f28">



## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes [ADO issue](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/19408)
