### PR TITLE
fix: v8 picker suggestion actions have focus outline

### DIFF
--- a/change/@fluentui-react-c4edf12d-d8dd-4265-90c4-7524b6c8f401.json
+++ b/change/@fluentui-react-c4edf12d-d8dd-4265-90c4-7524b6c8f401.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: picker suggestion actions have focus outline",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/pickers/Suggestions/Suggestions.styles.ts
+++ b/packages/react/src/components/pickers/Suggestions/Suggestions.styles.ts
@@ -65,6 +65,16 @@ export function getStyles(props: ISuggestionsStyleProps): ISuggestionsStyles {
         color: 'HighlightText',
         ...getHighContrastNoAdjustStyle(),
       },
+      ':after': {
+        pointerEvents: 'none',
+        content: '""',
+        position: 'absolute',
+        left: 0,
+        top: 0,
+        bottom: 0,
+        right: 0,
+        border: `1px solid ${theme.semanticColors.focusBorder}`,
+      },
     },
   };
 


### PR DESCRIPTION
## Previous Behavior

The focus outline in the suggestions popup was implemented in the SuggestionItem control's styles, so since actions were not wrapped in a SuggestionItem, they had no contrast-y focus indicator (the light blue bg color does not meet 3:1 contrast against white).
<img width="288" alt="screenshot of an open picker, the last item is highlighted with a light blue background and says load all results" src="https://github.com/user-attachments/assets/98492ed2-e8b2-40d1-b289-bb224715a1e0">

## New Behavior

I didn't want to change up the DOM of the control by wrapping the actions in a SuggestionItem, so I copy/pasted the SuggestionItem focus style over to the actionItem focus className. New visuals:
<img width="295" alt="a screenshot of the same open picker, but the last item also has a 1px black outline" src="https://github.com/user-attachments/assets/a45c09b3-22be-48bd-a733-507a0e37a60b">


## Related Issue(s)

- Fixes [ADO issue](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/19656)
