### PR TITLE
fix(babel-preset-storybook-full-source): use named exports for story detection

### DIFF
--- a/packages/react-components/babel-preset-storybook-full-source/src/__fixtures__/storybook-stories-fullsource/keep-sourcecode-spacing/output.js
+++ b/packages/react-components/babel-preset-storybook-full-source/src/__fixtures__/storybook-stories-fullsource/keep-sourcecode-spacing/output.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-export const ButtonAppearance = () => () =>
+export const ButtonAppearance = () =>
   /*#__PURE__*/ React.createElement(
     React.Fragment,
     null,
@@ -35,4 +35,4 @@ export const ButtonAppearance = () => () =>
   );
 ButtonAppearance.parameters = {};
 ButtonAppearance.parameters.fullSource =
-  'import * as React from "react";\n\nexport const ButtonAppearance = () => () =>\n  (\n    <>\n      <Button>Default button</Button>\n      <Button appearance="primary">Primary button</Button>\n      <Button appearance="outline">Outline button</Button>\n      <Button appearance="subtle">Subtle button</Button>\n      <Button appearance="transparent">Transparent button</Button>\n    </>\n  );\n';
+  'import * as React from "react";\n\nexport const ButtonAppearance = () => (\n  <>\n    <Button>Default button</Button>\n    <Button appearance="primary">Primary button</Button>\n    <Button appearance="outline">Outline button</Button>\n    <Button appearance="subtle">Subtle button</Button>\n    <Button appearance="transparent">Transparent button</Button>\n  </>\n);\n';

--- a/packages/react-components/babel-preset-storybook-full-source/src/__fixtures__/storybook-stories-fullsource/mutilple-components/code.js
+++ b/packages/react-components/babel-preset-storybook-full-source/src/__fixtures__/storybook-stories-fullsource/mutilple-components/code.js
@@ -1,10 +1,22 @@
 import * as React from 'react';
 
-export const ButtonAppearance = () => (
+const Child1 = () => (
   <>
     <Button>Default button</Button>
     <Button appearance="primary">Primary button</Button>
     <Button appearance="outline">Outline button</Button>
+  </>
+);
+
+export const ButtonAppearance = () => (
+  <>
+    <Child1 />
+    <Child2 />
+  </>
+);
+
+const Child2 = () => (
+  <>
     <Button appearance="subtle">Subtle button</Button>
     <Button appearance="transparent">Transparent button</Button>
   </>

--- a/packages/react-components/babel-preset-storybook-full-source/src/__fixtures__/storybook-stories-fullsource/mutilple-components/output.js
+++ b/packages/react-components/babel-preset-storybook-full-source/src/__fixtures__/storybook-stories-fullsource/mutilple-components/output.js
@@ -1,0 +1,50 @@
+import * as React from 'react';
+const Child1 = () =>
+  /*#__PURE__*/ React.createElement(
+    React.Fragment,
+    null,
+    /*#__PURE__*/ React.createElement(Button, null, 'Default button'),
+    /*#__PURE__*/ React.createElement(
+      Button,
+      {
+        appearance: 'primary',
+      },
+      'Primary button',
+    ),
+    /*#__PURE__*/ React.createElement(
+      Button,
+      {
+        appearance: 'outline',
+      },
+      'Outline button',
+    ),
+  );
+export const ButtonAppearance = () =>
+  /*#__PURE__*/ React.createElement(
+    React.Fragment,
+    null,
+    /*#__PURE__*/ React.createElement(Child1, null),
+    /*#__PURE__*/ React.createElement(Child2, null),
+  );
+const Child2 = () =>
+  /*#__PURE__*/ React.createElement(
+    React.Fragment,
+    null,
+    /*#__PURE__*/ React.createElement(
+      Button,
+      {
+        appearance: 'subtle',
+      },
+      'Subtle button',
+    ),
+    /*#__PURE__*/ React.createElement(
+      Button,
+      {
+        appearance: 'transparent',
+      },
+      'Transparent button',
+    ),
+  );
+ButtonAppearance.parameters = {};
+ButtonAppearance.parameters.fullSource =
+  'import * as React from "react";\n\nconst Child1 = () => (\n  <>\n    <Button>Default button</Button>\n    <Button appearance="primary">Primary button</Button>\n    <Button appearance="outline">Outline button</Button>\n  </>\n);\n\nexport const ButtonAppearance = () => (\n  <>\n    <Child1 />\n    <Child2 />\n  </>\n);\n\nconst Child2 = () => (\n  <>\n    <Button appearance="subtle">Subtle button</Button>\n    <Button appearance="transparent">Transparent button</Button>\n  </>\n);\n';

--- a/packages/react-components/babel-preset-storybook-full-source/src/fullsource.ts
+++ b/packages/react-components/babel-preset-storybook-full-source/src/fullsource.ts
@@ -64,15 +64,18 @@ export function fullSourcePlugin(babel: typeof Babel, options: BabelPluginOption
           isComponentLikeName(declaration.id.name)
         ) {
           storyName = declaration.id.name;
+          return;
         }
+
         // Check if it's a variable declaration
-        else if (
+        if (
           t.isVariableDeclaration(declaration) &&
           declaration.declarations.length === 1 &&
           t.isIdentifier(declaration.declarations[0].id) &&
           isComponentLikeName(declaration.declarations[0].id.name)
         ) {
           storyName = declaration.declarations[0].id.name;
+          return;
         }
       },
       // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/packages/react-components/babel-preset-storybook-full-source/src/fullsource.ts
+++ b/packages/react-components/babel-preset-storybook-full-source/src/fullsource.ts
@@ -54,13 +54,25 @@ export function fullSourcePlugin(babel: typeof Babel, options: BabelPluginOption
     name: PLUGIN_NAME,
     visitor: {
       // eslint-disable-next-line @typescript-eslint/naming-convention
-      VariableDeclarator(path) {
+      ExportNamedDeclaration(path) {
+        const declaration = path.node.declaration;
+
+        // Check if it's a function declaration
         if (
-          t.isArrowFunctionExpression(path.node.init) &&
-          t.isIdentifier(path.node.id) &&
-          isComponentLikeName(path.node.id.name)
+          t.isFunctionDeclaration(declaration) &&
+          t.isIdentifier(declaration.id) &&
+          isComponentLikeName(declaration.id.name)
         ) {
-          storyName = path.node.id.name;
+          storyName = declaration.id.name;
+        }
+        // Check if it's a variable declaration
+        else if (
+          t.isVariableDeclaration(declaration) &&
+          declaration.declarations.length === 1 &&
+          t.isIdentifier(declaration.declarations[0].id) &&
+          isComponentLikeName(declaration.declarations[0].id.name)
+        ) {
+          storyName = declaration.declarations[0].id.name;
         }
       },
       // eslint-disable-next-line @typescript-eslint/naming-convention


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

After the SB7 migration, a regression occurred where the `Positioning Components` page is not functioning correctly. This issue arises because the `PositionedComponent` is defined prior to the story component, leading the `babel-full-source-plugin` to mistakenly treat it as a story component.

<img width="1472" alt="image" src="https://github.com/user-attachments/assets/90e4e0a0-815f-49ff-bc50-c35e531bf2ed">

## New Behavior
The `babel-plugin-full-source` detects stories as React components that are exported using named exports.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- introduced at #32018 
