### PR TITLE
fix(public-docsite-v9): hide storybook's toolbar

### DIFF
--- a/apps/public-docsite-v9/.storybook/manager.js
+++ b/apps/public-docsite-v9/.storybook/manager.js
@@ -7,6 +7,7 @@ addons.setConfig({
   enableShortcuts: false,
   theme: fluentStorybookTheme,
   showPanel: false,
+  showToolbar: false,
 });
 
 addons.register('application-insights', api => {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

After upgrading to Storybook v7, the toolbar becomes visible on the documentation site.

<img width="1472" alt="Screenshot 2024-08-09 at 11 51 59" src="https://github.com/user-attachments/assets/3d6953af-0ffc-4449-b48d-061b4f866c00">

## New Behavior

The Storybook toolbar is not visible on the documentation site.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- introduced at #32018 
