### PR TITLE
ci(ts-minbar-test): ensure that dependent suite packages are built before running tests 

### DIFF
--- a/apps/ts-minbar-test-react-components/project.json
+++ b/apps/ts-minbar-test-react-components/project.json
@@ -4,6 +4,6 @@
   "projectType": "application",
   "tags": ["vNext"],
   "targets": {
-    "test-integration": { "dependsOn": [{ "target": "build", "projects": "react" }] }
+    "test-integration": { "dependsOn": [{ "target": "build", "projects": "react-components" }] }
   }
 }

--- a/apps/ts-minbar-test-react-components/project.json
+++ b/apps/ts-minbar-test-react-components/project.json
@@ -2,5 +2,8 @@
   "name": "ts-minbar-test-react-components",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "application",
-  "tags": ["vNext"]
+  "tags": ["vNext"],
+  "targets": {
+    "test-integration": { "dependsOn": [{ "target": "build", "projects": "react" }] }
+  }
 }

--- a/apps/ts-minbar-test-react/project.json
+++ b/apps/ts-minbar-test-react/project.json
@@ -2,5 +2,6 @@
   "name": "ts-minbar-test-react",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "application",
-  "tags": ["v8"]
+  "tags": ["v8"],
+  "targets": { "test-integration": { "dependsOn": [{ "target": "build", "projects": "react" }] } }
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->
- CI pipeline fails because suite packages aren't built before running `test-integration` target (see failing [pipeline run](https://uifabric.visualstudio.com/fabricpublic/_build/results?buildId=356297&view=logs&j=258ec178-2d8b-5611-7b9b-60c5c95dae55&t=254ee48e-1503-524f-f75e-e2c69d0380f5))

```
test:ts-minbar-react : ✔️ Temporary directory for packed packages was created: /tmp/project-packed--13894-bQD0JZChi7fb
================================================================================
+ cd /tmp/project-packed--13894-bQD0JZChi7fb &&
    npx npm-which npm
npm warn exec The following package was not found and will be installed: npm-which@3.0.1
/opt/hostedtoolcache/node/20.16.0/x64/bin/npm
+ cd /tmp/project-packed--13894-bQD0JZChi7fb &&
    npm --version
10.8.1
Something went wrong setting up the test:
Error: Package 'react' does not appear to have been built yet.Please ensure that package:"@fluentui/react" has properly defined dependencies in its package.json
    at /mnt/vss/_work/1/s/scripts/projects-test/src/packPackages.ts:63:15
    at Array.map (<anonymous>)
    at packProjectPackages (/mnt/vss/_work/1/s/scripts/projects-test/src/packPackages.ts:52:25)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async performTest (/mnt/vss/_work/1/s/apps/ts-minbar-test-react/src/index.ts:38:28)
error Command failed with exit code 1.
```
## New Behavior
- `@fluentui/react` and `@fluentui/react-components` are built first prior to running `test-integration` target

<!-- This is the behavior we should expect with the changes in this PR -->


