### PR TITLE
chore: always trigger build on dependencies for test-integration target

### DIFF
--- a/apps/ts-minbar-test-react-components/project.json
+++ b/apps/ts-minbar-test-react-components/project.json
@@ -2,8 +2,5 @@
   "name": "ts-minbar-test-react-components",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "application",
-  "tags": ["vNext"],
-  "targets": {
-    "test-integration": { "dependsOn": [{ "target": "build", "projects": "react-components" }] }
-  }
+  "tags": ["vNext"]
 }

--- a/apps/ts-minbar-test-react/project.json
+++ b/apps/ts-minbar-test-react/project.json
@@ -2,6 +2,5 @@
   "name": "ts-minbar-test-react",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "application",
-  "tags": ["v8"],
-  "targets": { "test-integration": { "dependsOn": [{ "target": "build", "projects": "react" }] } }
+  "tags": ["v8"]
 }

--- a/nx.json
+++ b/nx.json
@@ -46,7 +46,7 @@
       "cache": true
     },
     "test-integration": {
-      "dependsOn": ["build"],
+      "dependsOn": ["build", "^build"],
       "cache": true
     },
     "test-ssr": {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

issue that surfaced in https://github.com/microsoft/fluentui/pull/32269 is still present in cra project.

## New Behavior

we now always trigger `build` on dependencies ( even if `build` target is not present at "self" -> which was the cause of not triggering anything before )

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows https://github.com/microsoft/fluentui/pull/32269
