### PR TITLE
chore: update repo targetDefaults for test target to not run build and update specific v8 target dependants that needs build before test 

### DIFF
--- a/apps/react-18-tests-v8/jest.config.js
+++ b/apps/react-18-tests-v8/jest.config.js
@@ -11,14 +11,6 @@ const config = createConfig({
   snapshotSerializers: ['@fluentui/jest-serializer-merge-styles'],
 });
 
-if (config.globals) {
-  // override ts-jest config, otherwise it gets merged
-  config.globals['ts-jest'] = {
-    tsconfig: '<rootDir>/tsconfig.spec.json',
-    isolatedModules: true,
-  };
-}
-
 // use default jest config to properly resolve react-18
 delete config.moduleDirectories;
 

--- a/apps/react-18-tests-v8/project.json
+++ b/apps/react-18-tests-v8/project.json
@@ -2,6 +2,11 @@
   "name": "react-18-tests-v8",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "application",
+  "tags": ["v8"],
   "implicitDependencies": [],
-  "tags": ["v8"]
+  "targets": {
+    "test": {
+      "dependsOn": ["^build"]
+    }
+  }
 }

--- a/change/@fluentui-font-icons-mdl2-601dc64e-998a-424d-87f2-330ce8a1808c.json
+++ b/change/@fluentui-font-icons-mdl2-601dc64e-998a-424d-87f2-330ce8a1808c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: define scoped test target dependants in v8 projects",
+  "packageName": "@fluentui/font-icons-mdl2",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-foundation-legacy-1bc0f288-5ec3-4619-bdb7-70fe17c96d99.json
+++ b/change/@fluentui-foundation-legacy-1bc0f288-5ec3-4619-bdb7-70fe17c96d99.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: define scoped test target dependants in v8 projects",
+  "packageName": "@fluentui/foundation-legacy",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-9c572701-10b8-49cc-b801-80f2649d2a36.json
+++ b/change/@fluentui-react-9c572701-10b8-49cc-b801-80f2649d2a36.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: define scoped test target dependants in v8 projects",
+  "packageName": "@fluentui/react",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-cards-da8e72a3-8d79-4803-a505-5535b2ca6a31.json
+++ b/change/@fluentui-react-cards-da8e72a3-8d79-4803-a505-5535b2ca6a31.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: define scoped test target dependants in v8 projects",
+  "packageName": "@fluentui/react-cards",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-charting-fdf31321-0e57-42ca-8626-0091a2f61c56.json
+++ b/change/@fluentui-react-charting-fdf31321-0e57-42ca-8626-0091a2f61c56.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: define scoped test target dependants in v8 projects",
+  "packageName": "@fluentui/react-charting",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-docsite-components-5fc145eb-b365-4b20-8083-e3083740d1b2.json
+++ b/change/@fluentui-react-docsite-components-5fc145eb-b365-4b20-8083-e3083740d1b2.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: define scoped test target dependants in v8 projects",
+  "packageName": "@fluentui/react-docsite-components",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-experiments-75df14df-d289-43fc-8d53-184359b05a76.json
+++ b/change/@fluentui-react-experiments-75df14df-d289-43fc-8d53-184359b05a76.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: define scoped test target dependants in v8 projects",
+  "packageName": "@fluentui/react-experiments",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-file-type-icons-97f8a72d-2af1-4db5-a525-4ab25eaf6760.json
+++ b/change/@fluentui-react-file-type-icons-97f8a72d-2af1-4db5-a525-4ab25eaf6760.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: define scoped test target dependants in v8 projects",
+  "packageName": "@fluentui/react-file-type-icons",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-focus-4f7dc4cf-6b84-4301-b68c-91107be46978.json
+++ b/change/@fluentui-react-focus-4f7dc4cf-6b84-4301-b68c-91107be46978.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: define scoped test target dependants in v8 projects",
+  "packageName": "@fluentui/react-focus",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-hooks-a82047b8-d274-416d-8b5a-2cf4faa13032.json
+++ b/change/@fluentui-react-hooks-a82047b8-d274-416d-8b5a-2cf4faa13032.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: define scoped test target dependants in v8 projects",
+  "packageName": "@fluentui/react-hooks",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-icon-provider-9d375b17-71f1-4041-96d0-a9d3d6bb0c69.json
+++ b/change/@fluentui-react-icon-provider-9d375b17-71f1-4041-96d0-a9d3d6bb0c69.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: define scoped test target dependants in v8 projects",
+  "packageName": "@fluentui/react-icon-provider",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-icons-mdl2-70d2a399-6ded-49f4-8e95-3bbd704ba9f7.json
+++ b/change/@fluentui-react-icons-mdl2-70d2a399-6ded-49f4-8e95-3bbd704ba9f7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: define scoped test target dependants in v8 projects",
+  "packageName": "@fluentui/react-icons-mdl2",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-migration-v8-v9-39c92dae-d585-4b90-86c3-032d688b3734.json
+++ b/change/@fluentui-react-migration-v8-v9-39c92dae-d585-4b90-86c3-032d688b3734.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: define scoped test target dependants in v8 projects",
+  "packageName": "@fluentui/react-migration-v8-v9",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-monaco-editor-81063960-bc80-49b7-923f-b8ccf15b87e2.json
+++ b/change/@fluentui-react-monaco-editor-81063960-bc80-49b7-923f-b8ccf15b87e2.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: define scoped test target dependants in v8 projects",
+  "packageName": "@fluentui/react-monaco-editor",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-style-utilities-75eaca89-386d-4c8f-865f-7490a4de4377.json
+++ b/change/@fluentui-style-utilities-75eaca89-386d-4c8f-865f-7490a4de4377.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: define scoped test target dependants in v8 projects",
+  "packageName": "@fluentui/style-utilities",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-theme-d69aa471-3717-4a3e-a403-b7c9bf9e0b66.json
+++ b/change/@fluentui-theme-d69aa471-3717-4a3e-a403-b7c9bf9e0b66.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: define scoped test target dependants in v8 projects",
+  "packageName": "@fluentui/theme",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-utilities-c5cad464-d07e-464b-b71a-9d89f22e668f.json
+++ b/change/@fluentui-utilities-c5cad464-d07e-464b-b71a-9d89f22e668f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: define scoped test target dependants in v8 projects",
+  "packageName": "@fluentui/utilities",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/nx.json
+++ b/nx.json
@@ -41,7 +41,7 @@
       "cache": true
     },
     "test": {
-      "dependsOn": ["^build"],
+      "dependsOn": [],
       "inputs": ["default", "^production", "{workspaceRoot}/jest.preset.js"],
       "cache": true
     },

--- a/packages/font-icons-mdl2/project.json
+++ b/packages/font-icons-mdl2/project.json
@@ -2,7 +2,12 @@
   "name": "font-icons-mdl2",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
-  "implicitDependencies": [],
   "sourceRoot": "packages/font-icons-mdl2/src",
-  "tags": ["v8"]
+  "tags": ["v8"],
+  "implicitDependencies": [],
+  "targets": {
+    "test": {
+      "dependsOn": ["^build"]
+    }
+  }
 }

--- a/packages/foundation-legacy/project.json
+++ b/packages/foundation-legacy/project.json
@@ -2,7 +2,12 @@
   "name": "foundation-legacy",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
-  "implicitDependencies": [],
   "sourceRoot": "packages/foundation-legacy/src",
-  "tags": ["v8", "ships-bundle"]
+  "tags": ["v8", "ships-bundle"],
+  "implicitDependencies": [],
+  "targets": {
+    "test": {
+      "dependsOn": ["^build"]
+    }
+  }
 }

--- a/packages/react-cards/project.json
+++ b/packages/react-cards/project.json
@@ -2,6 +2,11 @@
   "name": "react-cards",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
+  "tags": ["v8", "ships-bundle"],
   "implicitDependencies": [],
-  "tags": ["v8", "ships-bundle"]
+  "targets": {
+    "test": {
+      "dependsOn": ["^build"]
+    }
+  }
 }

--- a/packages/react-charting/project.json
+++ b/packages/react-charting/project.json
@@ -2,6 +2,11 @@
   "name": "react-charting",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
+  "tags": ["v8", "ships-bundle"],
   "implicitDependencies": [],
-  "tags": ["v8", "ships-bundle"]
+  "targets": {
+    "test": {
+      "dependsOn": ["^build"]
+    }
+  }
 }

--- a/packages/react-components/react-migration-v8-v9/library/project.json
+++ b/packages/react-components/react-migration-v8-v9/library/project.json
@@ -4,5 +4,15 @@
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-migration-v8-v9/library/src",
   "tags": ["vNext", "v8", "platform:web"],
-  "implicitDependencies": []
+  "implicitDependencies": [],
+  "targets": {
+    "test": {
+      "dependsOn": [
+        {
+          "target": "build",
+          "projects": ["react", "react-hooks", "fluent2-theme"]
+        }
+      ]
+    }
+  }
 }

--- a/packages/react-components/react-migration-v8-v9/library/tsconfig.json
+++ b/packages/react-components/react-migration-v8-v9/library/tsconfig.json
@@ -8,8 +8,7 @@
     "importHelpers": true,
     "jsx": "react",
     "noUnusedLocals": true,
-    "preserveConstEnums": true,
-    "paths": {}
+    "preserveConstEnums": true
   },
   "include": [],
   "files": [],

--- a/packages/react-docsite-components/project.json
+++ b/packages/react-docsite-components/project.json
@@ -2,7 +2,12 @@
   "name": "react-docsite-components",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
-  "implicitDependencies": [],
   "sourceRoot": "packages/react-docsite-components/src",
-  "tags": ["v8"]
+  "tags": ["v8"],
+  "implicitDependencies": [],
+  "targets": {
+    "test": {
+      "dependsOn": ["^build"]
+    }
+  }
 }

--- a/packages/react-experiments/project.json
+++ b/packages/react-experiments/project.json
@@ -2,7 +2,12 @@
   "name": "react-experiments",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
-  "implicitDependencies": [],
   "sourceRoot": "packages/react-experiments/src",
-  "tags": ["v8", "ships-bundle"]
+  "tags": ["v8", "ships-bundle"],
+  "implicitDependencies": [],
+  "targets": {
+    "test": {
+      "dependsOn": ["^build"]
+    }
+  }
 }

--- a/packages/react-file-type-icons/project.json
+++ b/packages/react-file-type-icons/project.json
@@ -2,7 +2,12 @@
   "name": "react-file-type-icons",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
-  "implicitDependencies": [],
   "sourceRoot": "packages/react-file-type-icons/src",
-  "tags": ["v8"]
+  "tags": ["v8"],
+  "implicitDependencies": [],
+  "targets": {
+    "test": {
+      "dependsOn": ["^build"]
+    }
+  }
 }

--- a/packages/react-focus/project.json
+++ b/packages/react-focus/project.json
@@ -2,7 +2,12 @@
   "name": "react-focus",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
-  "implicitDependencies": [],
   "sourceRoot": "packages/react-focus/src",
-  "tags": ["v8", "ships-bundle"]
+  "tags": ["v8", "ships-bundle"],
+  "implicitDependencies": [],
+  "targets": {
+    "test": {
+      "dependsOn": ["^build"]
+    }
+  }
 }

--- a/packages/react-hooks/project.json
+++ b/packages/react-hooks/project.json
@@ -2,7 +2,12 @@
   "name": "react-hooks",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
-  "implicitDependencies": [],
   "sourceRoot": "packages/react-hooks/src",
-  "tags": ["v8", "ships-bundle"]
+  "tags": ["v8", "ships-bundle"],
+  "implicitDependencies": [],
+  "targets": {
+    "test": {
+      "dependsOn": ["^build"]
+    }
+  }
 }

--- a/packages/react-icon-provider/project.json
+++ b/packages/react-icon-provider/project.json
@@ -2,6 +2,11 @@
   "name": "react-icon-provider",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
+  "tags": ["v8", "ships-bundle"],
   "implicitDependencies": [],
-  "tags": ["v8", "ships-bundle"]
+  "targets": {
+    "test": {
+      "dependsOn": ["^build"]
+    }
+  }
 }

--- a/packages/react-icons-mdl2/project.json
+++ b/packages/react-icons-mdl2/project.json
@@ -2,6 +2,11 @@
   "name": "react-icons-mdl2",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
+  "tags": ["v8", "ships-bundle"],
   "implicitDependencies": [],
-  "tags": ["v8", "ships-bundle"]
+  "targets": {
+    "test": {
+      "dependsOn": ["^build"]
+    }
+  }
 }

--- a/packages/react-monaco-editor/project.json
+++ b/packages/react-monaco-editor/project.json
@@ -2,6 +2,11 @@
   "name": "react-monaco-editor",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
+  "tags": ["v8"],
   "implicitDependencies": [],
-  "tags": ["v8"]
+  "targets": {
+    "test": {
+      "dependsOn": ["^build"]
+    }
+  }
 }

--- a/packages/react/project.json
+++ b/packages/react/project.json
@@ -2,7 +2,12 @@
   "name": "react",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
-  "implicitDependencies": [],
   "sourceRoot": "packages/react/src",
-  "tags": ["v8", "ships-bundle", "ships-umd"]
+  "tags": ["v8", "ships-bundle", "ships-umd"],
+  "implicitDependencies": [],
+  "targets": {
+    "test": {
+      "dependsOn": ["^build"]
+    }
+  }
 }

--- a/packages/style-utilities/project.json
+++ b/packages/style-utilities/project.json
@@ -2,7 +2,12 @@
   "name": "style-utilities",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
-  "implicitDependencies": [],
   "sourceRoot": "packages/style-utilities/src",
-  "tags": ["v8"]
+  "tags": ["v8"],
+  "implicitDependencies": [],
+  "targets": {
+    "test": {
+      "dependsOn": ["^build"]
+    }
+  }
 }

--- a/packages/theme/project.json
+++ b/packages/theme/project.json
@@ -2,6 +2,11 @@
   "name": "theme",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
+  "tags": ["v8"],
   "implicitDependencies": [],
-  "tags": ["v8"]
+  "targets": {
+    "test": {
+      "dependsOn": ["^build"]
+    }
+  }
 }

--- a/packages/utilities/project.json
+++ b/packages/utilities/project.json
@@ -2,7 +2,12 @@
   "name": "utilities",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
-  "implicitDependencies": [],
   "sourceRoot": "packages/utilities/src",
-  "tags": ["v8"]
+  "tags": ["v8"],
+  "implicitDependencies": [],
+  "targets": {
+    "test": {
+      "dependsOn": ["^build"]
+    }
+  }
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

`nx run <project-name>:test` executes `build` on all dependencies before running `test` for all projects

## New Behavior

`nx run <project-name>:test` executes build on all dependencies only if necessary ( some v8 projects )

this improves pipeline orchestration as `test` targets can be executed before/in parallel with other tasks like `build`

### Perf

| `nx run react-migration-v8-v9:test` | time |
|--------|--------|
| before | 259s |
| after | 92s / **65% FASTER** | 

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Implements partially https://github.com/microsoft/fluentui/issues/30267
