### PR TITLE
ci(hotfix/5.135.6): make PR checks run again

### DIFF
--- a/azure-pipelines-pr.yml
+++ b/azure-pipelines-pr.yml
@@ -33,23 +33,24 @@ steps:
       npm run buildfast
     displayName: build ci
 
-  - task: AzureUpload@2
-    displayName: Upload website for PR deploy
-    inputs:
-      azureSubscription: $(azureSubscription)
-      BlobPrefix: $(deployBasePath)
-      ContainerName: '$web'
-      SourcePath: 'apps/fabric-website/dist'
-      storage: $(azureStorage)
+  # disable in this branch
+  # - task: AzureUpload@2
+  #   displayName: Upload website for PR deploy
+  #   inputs:
+  #     azureSubscription: $(azureSubscription)
+  #     BlobPrefix: $(deployBasePath)
+  #     ContainerName: '$web'
+  #     SourcePath: 'apps/fabric-website/dist'
+  #     storage: $(azureStorage)
 
-  - task: GithubPRStatus@0
-    displayName: 'Update PR deploy site github status'
-    inputs:
-      githubOwner: microsoft
-      githubRepo: fluentui
-      githubContext: 'Deployed website'
-      githubDescription: 'Click "Details" to go to the deployed website for this pull request'
-      githubTargetLink: $(deployUrl)/index.html
+  # - task: GithubPRStatus@0
+  #   displayName: 'Update PR deploy site github status'
+  #   inputs:
+  #     githubOwner: microsoft
+  #     githubRepo: fluentui
+  #     githubContext: 'Deployed website'
+  #     githubDescription: 'Click "Details" to go to the deployed website for this pull request'
+  #     githubTargetLink: $(deployUrl)/index.html
 
   # disable in this branch due to issues installing old version of ngrok
   #  - script: |


### PR DESCRIPTION
## Changes:
- pipeline was renamed from `azure-pipelines.yml` to `azure-pipelines-pr.yml` in `master` branch and thus the pipeline no longer ran for this hotfix branch. Renaming to add `-pr` suffix to make it run again and unblock PRs