### PR TITLE
bugfix(react-tag-picker): ensures input behaviour on text selection

### DIFF
--- a/change/@fluentui-react-tag-picker-93adf770-e205-4d89-9513-308f47d37af6.json
+++ b/change/@fluentui-react-tag-picker-93adf770-e205-4d89-9513-308f47d37af6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: ensures input behaviour on text selection",
+  "packageName": "@fluentui/react-tag-picker",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tag-picker/library/src/components/TagPicker/TagPicker.cy.tsx
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPicker/TagPicker.cy.tsx
@@ -302,15 +302,41 @@ describe('TagPicker', () => {
         cy.get(`[data-testid="tag--${options[0]}"]`).focus().realPress('Backspace').should('not.exist');
         cy.get(`[data-testid="tag--${options[1]}"]`).should('be.focused');
       });
-      it('should move to last tag on Backspace key press on input', () => {
-        mount(<TagPickerControlled defaultSelectedOptions={options} />);
-        cy.get('[data-testid="tag-picker-input"]').focus().realPress('Backspace');
-        cy.get(`[data-testid="tag--${options[options.length - 1]}"]`).should('be.focused');
-      });
+
       it('should focus on input once all tags have been removed', () => {
         mount(<TagPickerControlled defaultSelectedOptions={[options[0]]} />);
         cy.get(`[data-testid="tag--${options[0]}"]`).focus().realPress('Backspace').should('not.exist');
         cy.get('[data-testid="tag-picker-input"]').should('be.focused');
+      });
+    });
+    describe('input', () => {
+      it('should move to last tag on Backspace key press on input, when input is empty', () => {
+        mount(<TagPickerControlled defaultSelectedOptions={options} />);
+        cy.get('[data-testid="tag-picker-input"]').focus().realPress('Backspace');
+        cy.get(`[data-testid="tag--${options[options.length - 1]}"]`).should('be.focused');
+      });
+      it('should delete input content on Backspace when input is not empty', () => {
+        mount(<TagPickerControlled defaultSelectedOptions={options} />);
+        cy.get('[data-testid="tag-picker-input"]').focus().realType('Some Text').realPress('Backspace');
+        cy.get(`[data-testid="tag--${options[options.length - 1]}"]`).should('not.be.focused');
+        cy.get('[data-testid="tag-picker-input"]').should('have.value', 'Some Tex').should('be.focused');
+      });
+      it('should move to last tag on Backspace key press on input, when input is not empty but the cursor is on the first character', () => {
+        mount(<TagPickerControlled defaultSelectedOptions={options} />);
+        cy.get('[data-testid="tag-picker-input"]').focus().realType('SomeText').realPress('Backspace');
+        cy.get(`[data-testid="tag--${options[options.length - 1]}"]`).should('not.be.focused');
+        cy.get('[data-testid="tag-picker-input"]').should('have.value', 'SomeTex').should('be.focused');
+        cy.get('[data-testid="tag-picker-input"]').realPress(['ControlLeft', 'ArrowLeft']).realPress('Backspace');
+        cy.get(`[data-testid="tag--${options[options.length - 1]}"]`).should('be.focused');
+      });
+      it('should delete input content on Backspace when input is not empty and selected', () => {
+        mount(<TagPickerControlled defaultSelectedOptions={options} />);
+        cy.get('[data-testid="tag-picker-input"]').focus().realType('SomeText').realPress('Backspace');
+        cy.get(`[data-testid="tag--${options[options.length - 1]}"]`).should('not.be.focused');
+        cy.get('[data-testid="tag-picker-input"]').should('have.value', 'SomeTex').should('be.focused');
+        cy.get('[data-testid="tag-picker-input"]').realPress(['ControlLeft', 'A']).realPress('Backspace');
+        cy.get(`[data-testid="tag--${options[options.length - 1]}"]`).should('not.be.focused');
+        cy.get('[data-testid="tag-picker-input"]').should('have.value', '').should('be.focused');
       });
     });
   });

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerInput/useTagPickerInput.tsx
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerInput/useTagPickerInput.tsx
@@ -85,6 +85,7 @@ export const useTagPickerInput_unstable = (
         if (
           (event.key === ArrowLeft || event.key === Backspace) &&
           event.currentTarget.selectionStart === 0 &&
+          event.currentTarget.selectionEnd === 0 &&
           tagPickerGroupRef.current
         ) {
           findLastFocusable(tagPickerGroupRef.current)?.focus();


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

There's a bug caught by @kkamik, that `TagPickerInput` is not properly deleting selected text `value` when backspacing, instead it's moving the focus to the last tag on `TagPickerGroup`

The issue is caused due to the lack of verification of a range of selected value on key down, we verify `selectionStart` but we do not verify `selectionEnd`

https://github.com/bsunderhus/fluentui/blob/react-tag-picker/bugfix--ensures-input-behaviour-on-text-selection/packages/react-components/react-tag-picker/library/src/components/TagPickerInput/useTagPickerInput.tsx#L87

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

1. Ensures behaviour
2. adds tests

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/32260