### PR TITLE
fix(scripts-executors): emit script contents if invalid e2e target declaration is present

### DIFF
--- a/change/@fluentui-react-af6b7f2e-0fe5-41bc-97f6-f46116fb2f68.json
+++ b/change/@fluentui-react-af6b7f2e-0fe5-41bc-97f6-f46116fb2f68.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: use nx to run e2e:local from different project",
+  "packageName": "@fluentui/react",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -22,7 +22,7 @@
     "code-style": "just-scripts code-style",
     "codepen": "node ../../scripts/executors/src/local-codepen.js",
     "e2e": "yarn nx run react-examples:e2e --verbose",
-    "e2e:local": "yarn workspace @fluentui/react-examples e2e:local",
+    "e2e:local": "yarn nx run react-examples:e2e:local",
     "just": "just-scripts",
     "lint": "just-scripts lint",
     "start": "cross-env NODE_OPTIONS=--max-old-space-size=3072 just-scripts dev:storybook",

--- a/scripts/executors/src/start.ts
+++ b/scripts/executors/src/start.ts
@@ -287,13 +287,12 @@ function createTargetDescription(
   if (targetName === 'e2e') {
     const scriptContent = nxTargetConfiguration.metadata?.scriptContent;
     const runnerType = getRunnerType(scriptContent);
-    const descriptionSuffix = runnerType ? ` (using ${runnerType})` : null;
 
-    if (descriptionSuffix) {
-      return description + descriptionSuffix;
+    if (!runnerType) {
+      return scriptContent;
     }
 
-    return scriptContent;
+    return description + ` (using ${runnerType})`;
   }
 
   return description ?? nxTargetConfiguration.metadata?.scriptContent;

--- a/scripts/executors/src/start.ts
+++ b/scripts/executors/src/start.ts
@@ -293,7 +293,7 @@ function createTargetDescription(
       return description + descriptionSuffix;
     }
 
-    return descriptionSuffix ? description + descriptionSuffix : nxTargetConfiguration.metadata?.scriptContent;
+    return nxTargetConfiguration.metadata?.scriptContent;
   }
 
   return description ?? nxTargetConfiguration.metadata?.scriptContent;

--- a/scripts/executors/src/start.ts
+++ b/scripts/executors/src/start.ts
@@ -287,19 +287,26 @@ function createTargetDescription(
   if (targetName === 'e2e') {
     const scriptContent = nxTargetConfiguration.metadata?.scriptContent;
     const runnerType = getRunnerType(scriptContent);
-    return description + ` (using ${runnerType})`;
+    const descriptionSuffix = runnerType ? ` (using ${runnerType})` : null;
+
+    if (descriptionSuffix) {
+      return description + descriptionSuffix;
+    }
+
+    return descriptionSuffix ? description + descriptionSuffix : nxTargetConfiguration.metadata?.scriptContent;
   }
 
   return description ?? nxTargetConfiguration.metadata?.scriptContent;
 
-  function getRunnerType(scriptContent: string): 'cypress' | 'playwright' {
+  function getRunnerType(scriptContent: string): 'cypress' | 'playwright' | null {
     if (scriptContent.includes('cypress')) {
       return 'cypress';
     }
     if (scriptContent.includes('playwright')) {
       return 'playwright';
     }
-    throw new Error('invalid runner type');
+
+    return null;
   }
 }
 

--- a/scripts/executors/src/start.ts
+++ b/scripts/executors/src/start.ts
@@ -293,7 +293,7 @@ function createTargetDescription(
       return description + descriptionSuffix;
     }
 
-    return nxTargetConfiguration.metadata?.scriptContent;
+    return scriptContent;
   }
 
   return description ?? nxTargetConfiguration.metadata?.scriptContent;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

For non generic commands we will print only `scriptContent` in order to not assume things that might be not valid

<img width="495" alt="image" src="https://github.com/user-attachments/assets/fe61d64e-8a34-4416-ab8d-7f60e3606410">


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/32262
