### PR TITLE
fix(web-components): export BaseAnchor

### DIFF
--- a/change/@fluentui-web-components-c8121fc1-57f4-47b4-9707-c96bd0a211fe.json
+++ b/change/@fluentui-web-components-c8121fc1-57f4-47b4-9707-c96bd0a211fe.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "export BaseAnchor class",
+  "packageName": "@fluentui/web-components",
+  "email": "rupertdavid@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/anchor-button/index.ts
+++ b/packages/web-components/src/anchor-button/index.ts
@@ -1,5 +1,5 @@
 export { definition as AnchorButtonDefinition } from './anchor-button.definition.js';
-export { AnchorButton } from './anchor-button.js';
+export { BaseAnchor, AnchorButton } from './anchor-button.js';
 export { AnchorButtonAppearance, AnchorButtonShape, AnchorButtonSize, AnchorTarget } from './anchor-button.options.js';
 export type { AnchorButtonOptions } from './anchor-button.options.js';
 export { template as AnchorButtonTemplate } from './anchor-button.template.js';

--- a/packages/web-components/src/index.ts
+++ b/packages/web-components/src/index.ts
@@ -117,6 +117,7 @@ export { FluentDesignSystem } from './fluent-design-system.js';
 export { Image, ImageDefinition, ImageFit, ImageShape, ImageStyles, ImageTemplate } from './image/index.js';
 export { Label, LabelDefinition, LabelSize, LabelStyles, LabelTemplate, LabelWeight } from './label/index.js';
 export {
+  BaseAnchor,
   AnchorButton,
   AnchorButtonAppearance,
   AnchorButtonDefinition,


### PR DESCRIPTION
## Previous Behavior

<!-- This is the behavior we have today -->

`BaseAnchor` wasn't being properly exported

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

`BaseAnchor` is now exported

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
