### PR TITLE
feat(workspace-plugin): scaffold executors boilerplate (build,generate-api,type-check,verify-packaging,clean)

### DIFF
--- a/tools/workspace-plugin/.eslintrc.json
+++ b/tools/workspace-plugin/.eslintrc.json
@@ -3,7 +3,13 @@
   "root": true,
   "rules": {
     "import/no-extraneous-dependencies": "off",
-    "@typescript-eslint/no-unused-vars": ["error", { "varsIgnorePattern": "^_", "argsIgnorePattern": "^_" }]
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      {
+        "varsIgnorePattern": "^_",
+        "argsIgnorePattern": "^_"
+      }
+    ]
   },
   "overrides": [
     {
@@ -30,7 +36,7 @@
       "rules": {}
     },
     {
-      "files": ["./package.json", "./generators.json"],
+      "files": ["./package.json", "./generators.json", "./executors.json"],
       "parser": "jsonc-eslint-parser",
       "rules": {
         "@nx/nx-plugin-checks": "error"

--- a/tools/workspace-plugin/executors.json
+++ b/tools/workspace-plugin/executors.json
@@ -1,0 +1,9 @@
+{
+  "executors": {
+    "build": {
+      "implementation": "./src/executors/build/executor",
+      "schema": "./src/executors/build/schema.json",
+      "description": "build executor"
+    }
+  }
+}

--- a/tools/workspace-plugin/executors.json
+++ b/tools/workspace-plugin/executors.json
@@ -14,6 +14,11 @@
       "implementation": "./src/executors/generate-api/executor",
       "schema": "./src/executors/generate-api/schema.json",
       "description": "generate-api executor"
+    },
+    "verify-packaging": {
+      "implementation": "./src/executors/verify-packaging/executor",
+      "schema": "./src/executors/verify-packaging/schema.json",
+      "description": "verify-packaging executor"
     }
   }
 }

--- a/tools/workspace-plugin/executors.json
+++ b/tools/workspace-plugin/executors.json
@@ -4,6 +4,11 @@
       "implementation": "./src/executors/build/executor",
       "schema": "./src/executors/build/schema.json",
       "description": "build executor"
+    },
+    "type-check": {
+      "implementation": "./src/executors/type-check/executor",
+      "schema": "./src/executors/type-check/schema.json",
+      "description": "type-check executor"
     }
   }
 }

--- a/tools/workspace-plugin/executors.json
+++ b/tools/workspace-plugin/executors.json
@@ -9,6 +9,11 @@
       "implementation": "./src/executors/type-check/executor",
       "schema": "./src/executors/type-check/schema.json",
       "description": "type-check executor"
+    },
+    "generate-api": {
+      "implementation": "./src/executors/generate-api/executor",
+      "schema": "./src/executors/generate-api/schema.json",
+      "description": "generate-api executor"
     }
   }
 }

--- a/tools/workspace-plugin/executors.json
+++ b/tools/workspace-plugin/executors.json
@@ -19,6 +19,11 @@
       "implementation": "./src/executors/verify-packaging/executor",
       "schema": "./src/executors/verify-packaging/schema.json",
       "description": "verify-packaging executor"
+    },
+    "clean": {
+      "implementation": "./src/executors/clean/executor",
+      "schema": "./src/executors/clean/schema.json",
+      "description": "clean executor"
     }
   }
 }

--- a/tools/workspace-plugin/package.json
+++ b/tools/workspace-plugin/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "commonjs",
   "generators": "./generators.json",
+  "executors": "./executors.json",
   "scripts": {
     "test": "jest --passWithNoTests",
     "type-check": "node  ./scripts/type-check.mjs",

--- a/tools/workspace-plugin/project.json
+++ b/tools/workspace-plugin/project.json
@@ -3,6 +3,7 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "tools/workspace-plugin/src",
   "projectType": "library",
+  "tags": ["platform:node", "tools"],
   "targets": {
     "build": {
       "executor": "@nx/js:tsc",
@@ -35,6 +36,5 @@
         ]
       }
     }
-  },
-  "tags": ["platform:node", "tools"]
+  }
 }

--- a/tools/workspace-plugin/src/executors/build/executor.spec.ts
+++ b/tools/workspace-plugin/src/executors/build/executor.spec.ts
@@ -1,0 +1,18 @@
+import { ExecutorContext } from '@nx/devkit';
+
+import { BuildExecutorSchema } from './schema';
+import executor from './executor';
+
+const options: BuildExecutorSchema = {};
+const context: ExecutorContext = {
+  root: '',
+  cwd: process.cwd(),
+  isVerbose: false,
+};
+
+describe('Build Executor', () => {
+  it('can run', async () => {
+    const output = await executor(options, context);
+    expect(output.success).toBe(true);
+  });
+});

--- a/tools/workspace-plugin/src/executors/build/executor.ts
+++ b/tools/workspace-plugin/src/executors/build/executor.ts
@@ -1,0 +1,11 @@
+import { PromiseExecutor } from '@nx/devkit';
+import { BuildExecutorSchema } from './schema';
+
+const runExecutor: PromiseExecutor<BuildExecutorSchema> = async options => {
+  console.log('Executor ran for Build', options);
+  return {
+    success: true,
+  };
+};
+
+export default runExecutor;

--- a/tools/workspace-plugin/src/executors/build/schema.d.ts
+++ b/tools/workspace-plugin/src/executors/build/schema.d.ts
@@ -1,0 +1,1 @@
+export interface BuildExecutorSchema {} // eslint-disable-line

--- a/tools/workspace-plugin/src/executors/build/schema.json
+++ b/tools/workspace-plugin/src/executors/build/schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/schema",
+  "version": 2,
+  "title": "Build executor",
+  "description": "",
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/tools/workspace-plugin/src/executors/clean/executor.spec.ts
+++ b/tools/workspace-plugin/src/executors/clean/executor.spec.ts
@@ -1,0 +1,18 @@
+import { ExecutorContext } from '@nx/devkit';
+
+import { CleanExecutorSchema } from './schema';
+import executor from './executor';
+
+const options: CleanExecutorSchema = {};
+const context: ExecutorContext = {
+  root: '',
+  cwd: process.cwd(),
+  isVerbose: false,
+};
+
+describe('Clean Executor', () => {
+  it('can run', async () => {
+    const output = await executor(options, context);
+    expect(output.success).toBe(true);
+  });
+});

--- a/tools/workspace-plugin/src/executors/clean/executor.ts
+++ b/tools/workspace-plugin/src/executors/clean/executor.ts
@@ -1,0 +1,11 @@
+import { PromiseExecutor } from '@nx/devkit';
+import { CleanExecutorSchema } from './schema';
+
+const runExecutor: PromiseExecutor<CleanExecutorSchema> = async options => {
+  console.log('Executor ran for Clean', options);
+  return {
+    success: true,
+  };
+};
+
+export default runExecutor;

--- a/tools/workspace-plugin/src/executors/clean/schema.d.ts
+++ b/tools/workspace-plugin/src/executors/clean/schema.d.ts
@@ -1,0 +1,1 @@
+export interface CleanExecutorSchema {} // eslint-disable-line

--- a/tools/workspace-plugin/src/executors/clean/schema.json
+++ b/tools/workspace-plugin/src/executors/clean/schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/schema",
+  "version": 2,
+  "title": "Clean executor",
+  "description": "",
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/tools/workspace-plugin/src/executors/generate-api/executor.spec.ts
+++ b/tools/workspace-plugin/src/executors/generate-api/executor.spec.ts
@@ -1,0 +1,18 @@
+import { ExecutorContext } from '@nx/devkit';
+
+import { GenerateApiExecutorSchema } from './schema';
+import executor from './executor';
+
+const options: GenerateApiExecutorSchema = {};
+const context: ExecutorContext = {
+  root: '',
+  cwd: process.cwd(),
+  isVerbose: false,
+};
+
+describe('GenerateApi Executor', () => {
+  it('can run', async () => {
+    const output = await executor(options, context);
+    expect(output.success).toBe(true);
+  });
+});

--- a/tools/workspace-plugin/src/executors/generate-api/executor.ts
+++ b/tools/workspace-plugin/src/executors/generate-api/executor.ts
@@ -1,0 +1,11 @@
+import { PromiseExecutor } from '@nx/devkit';
+import { GenerateApiExecutorSchema } from './schema';
+
+const runExecutor: PromiseExecutor<GenerateApiExecutorSchema> = async options => {
+  console.log('Executor ran for GenerateApi', options);
+  return {
+    success: true,
+  };
+};
+
+export default runExecutor;

--- a/tools/workspace-plugin/src/executors/generate-api/schema.d.ts
+++ b/tools/workspace-plugin/src/executors/generate-api/schema.d.ts
@@ -1,0 +1,1 @@
+export interface GenerateApiExecutorSchema {} // eslint-disable-line

--- a/tools/workspace-plugin/src/executors/generate-api/schema.json
+++ b/tools/workspace-plugin/src/executors/generate-api/schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/schema",
+  "version": 2,
+  "title": "GenerateApi executor",
+  "description": "",
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/tools/workspace-plugin/src/executors/type-check/executor.spec.ts
+++ b/tools/workspace-plugin/src/executors/type-check/executor.spec.ts
@@ -1,0 +1,18 @@
+import { ExecutorContext } from '@nx/devkit';
+
+import { TypeCheckExecutorSchema } from './schema';
+import executor from './executor';
+
+const options: TypeCheckExecutorSchema = {};
+const context: ExecutorContext = {
+  root: '',
+  cwd: process.cwd(),
+  isVerbose: false,
+};
+
+describe('TypeCheck Executor', () => {
+  it('can run', async () => {
+    const output = await executor(options, context);
+    expect(output.success).toBe(true);
+  });
+});

--- a/tools/workspace-plugin/src/executors/type-check/executor.ts
+++ b/tools/workspace-plugin/src/executors/type-check/executor.ts
@@ -1,0 +1,11 @@
+import { PromiseExecutor } from '@nx/devkit';
+import { TypeCheckExecutorSchema } from './schema';
+
+const runExecutor: PromiseExecutor<TypeCheckExecutorSchema> = async options => {
+  console.log('Executor ran for TypeCheck', options);
+  return {
+    success: true,
+  };
+};
+
+export default runExecutor;

--- a/tools/workspace-plugin/src/executors/type-check/schema.d.ts
+++ b/tools/workspace-plugin/src/executors/type-check/schema.d.ts
@@ -1,0 +1,1 @@
+export interface TypeCheckExecutorSchema {} // eslint-disable-line

--- a/tools/workspace-plugin/src/executors/type-check/schema.json
+++ b/tools/workspace-plugin/src/executors/type-check/schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/schema",
+  "version": 2,
+  "title": "TypeCheck executor",
+  "description": "",
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/tools/workspace-plugin/src/executors/verify-packaging/executor.spec.ts
+++ b/tools/workspace-plugin/src/executors/verify-packaging/executor.spec.ts
@@ -1,0 +1,18 @@
+import { ExecutorContext } from '@nx/devkit';
+
+import { VerifyPackagingExecutorSchema } from './schema';
+import executor from './executor';
+
+const options: VerifyPackagingExecutorSchema = {};
+const context: ExecutorContext = {
+  root: '',
+  cwd: process.cwd(),
+  isVerbose: false,
+};
+
+describe('VerifyPackaging Executor', () => {
+  it('can run', async () => {
+    const output = await executor(options, context);
+    expect(output.success).toBe(true);
+  });
+});

--- a/tools/workspace-plugin/src/executors/verify-packaging/executor.ts
+++ b/tools/workspace-plugin/src/executors/verify-packaging/executor.ts
@@ -1,0 +1,11 @@
+import { PromiseExecutor } from '@nx/devkit';
+import { VerifyPackagingExecutorSchema } from './schema';
+
+const runExecutor: PromiseExecutor<VerifyPackagingExecutorSchema> = async options => {
+  console.log('Executor ran for VerifyPackaging', options);
+  return {
+    success: true,
+  };
+};
+
+export default runExecutor;

--- a/tools/workspace-plugin/src/executors/verify-packaging/schema.d.ts
+++ b/tools/workspace-plugin/src/executors/verify-packaging/schema.d.ts
@@ -1,0 +1,1 @@
+export interface VerifyPackagingExecutorSchema {} // eslint-disable-line

--- a/tools/workspace-plugin/src/executors/verify-packaging/schema.json
+++ b/tools/workspace-plugin/src/executors/verify-packaging/schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/schema",
+  "version": 2,
+  "title": "VerifyPackaging executor",
+  "description": "",
+  "type": "object",
+  "properties": {},
+  "required": []
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

we will need only 5 executors to start with in order to remove just-scripts in v9 packages. This PR generates boilerplate for those.

> what about lint, e2e etc ?
>
> for lint we will migrate to direct eslint CLI invocation as we do for `jest`, `e2e` will be kept as is ( invoking binary directly ) 


- boilerplate generated via: 
`yarn nx g  @nx/plugin:executor --name <executor-name> --project workspace-plugin --nameAndDirectoryFormat derived`

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Implements partially https://github.com/microsoft/fluentui/issues/30267
