### PR TITLE
chore(react-tabster): ensures useMergedTabsterAttributes supports Partial attributes

### DIFF
--- a/change/@fluentui-react-list-preview-103c8633-2761-40f0-9d31-34c94b7f4dea.json
+++ b/change/@fluentui-react-list-preview-103c8633-2761-40f0-9d31-34c94b7f4dea.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: ensures useMergedTabsterAttributes supports Partial attributes",
+  "packageName": "@fluentui/react-list-preview",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tabster-b8b5ef61-c217-409a-9b04-8c3756addacd.json
+++ b/change/@fluentui-react-tabster-b8b5ef61-c217-409a-9b04-8c3756addacd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: ensures useMergedTabsterAttributes supports Partial attributes",
+  "packageName": "@fluentui/react-tabster",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-list-preview/library/src/components/ListItem/useListItem.tsx
+++ b/packages/react-components/react-list-preview/library/src/components/ListItem/useListItem.tsx
@@ -4,7 +4,6 @@ import {
   MoverMoveFocusEvent,
   GroupperMoveFocusActions,
   MoverKeys,
-  TabsterDOMAttribute,
   useArrowNavigationGroup,
   useFocusableGroup,
   useMergedTabsterAttributes_unstable,
@@ -176,7 +175,7 @@ export const useListItem_unstable = (
   });
 
   const tabsterAttributes = useMergedTabsterAttributes_unstable(
-    focusableItems ? arrowNavigationAttributes : ({} as TabsterDOMAttribute),
+    focusableItems ? arrowNavigationAttributes : {},
     focusableGroupAttrs,
   );
 

--- a/packages/react-components/react-tabster/etc/react-tabster.api.md
+++ b/packages/react-components/react-tabster/etc/react-tabster.api.md
@@ -1486,7 +1486,7 @@ export function useFocusWithin<TElement extends HTMLElement = HTMLElement>(): Re
 export function useKeyboardNavAttribute<E extends HTMLElement>(): RefObject<E>;
 
 // @internal
-export const useMergedTabsterAttributes_unstable: (...attributes: Types.TabsterDOMAttribute[]) => Types.TabsterDOMAttribute;
+export const useMergedTabsterAttributes_unstable: (...attributes: Partial<Types.TabsterDOMAttribute>[]) => Types.TabsterDOMAttribute;
 
 // @public
 export const useModalAttributes: (options?: UseModalAttributesOptions) => {

--- a/packages/react-components/react-tabster/src/hooks/useMergeTabsterAttributes.ts
+++ b/packages/react-components/react-tabster/src/hooks/useMergeTabsterAttributes.ts
@@ -9,9 +9,9 @@ import { Types, TABSTER_ATTRIBUTE_NAME } from 'tabster';
  * @param attributes - collection of tabster attributes from other react-tabster hooks
  * @returns single merged tabster attribute
  */
-export const useMergedTabsterAttributes_unstable: (
-  ...attributes: Types.TabsterDOMAttribute[]
-) => Types.TabsterDOMAttribute = (...attributes) => {
+export const useMergedTabsterAttributes_unstable = (
+  ...attributes: Partial<Types.TabsterDOMAttribute>[]
+): Types.TabsterDOMAttribute => {
   'use no memo';
 
   const stringAttributes = attributes.map(attribute => attribute[TABSTER_ATTRIBUTE_NAME]).filter(Boolean) as string[];


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

Casting is required when providing to `useMergedTabsterAttributes` an object that does not have proper tabster attribute, which is redundant as this is filtered by the function internally.

There's a cast on `useListItem` because of this: https://github.com/microsoft/fluentui/pull/32300/files#diff-d3287bdc67e7afdeb4149b129ca698a5a9eb873eebee2cb3fb998a99d7e46a79L179

Also on `TreeGrid`: https://github.com/microsoft/fluentui-contrib/pull/215/files#diff-3f5ba9155013655901c724d7ce54114b60eb65eae52fd62ec18981897c05f9fdR30 and `TreeGridRow`: https://github.com/microsoft/fluentui-contrib/pull/215/files#diff-716cd94658fd845cd35b2b2bb4d0bcb3d55f01a9cc3394227253be8a445b5b2cR45

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

1. Modifies function signature to support `Partial<Types.TabsterDOMAttribute>` instead of `Types.TabsterDOMAttribute`

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
