### PR TITLE
fix(web-components): export BaseCheckbox

### DIFF
--- a/change/@fluentui-web-components-a9a5cfab-dd85-4c06-9d8f-e1c5445647b2.json
+++ b/change/@fluentui-web-components-a9a5cfab-dd85-4c06-9d8f-e1c5445647b2.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "export BaseCheckbox class",
+  "packageName": "@fluentui/web-components",
+  "email": "rupertdavid@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/checkbox/index.ts
+++ b/packages/web-components/src/checkbox/index.ts
@@ -1,5 +1,5 @@
 export { definition as CheckboxDefinition } from './checkbox.definition.js';
-export { Checkbox } from './checkbox.js';
+export { BaseCheckbox, Checkbox } from './checkbox.js';
 export { CheckboxShape, CheckboxSize } from './checkbox.options.js';
 export type { CheckboxOptions } from './checkbox.options.js';
 export { styles as CheckboxStyles } from './checkbox.styles.js';

--- a/packages/web-components/src/index.ts
+++ b/packages/web-components/src/index.ts
@@ -53,6 +53,7 @@ export {
 } from './button/index.js';
 export type { ButtonOptions } from './button/index.js';
 export {
+  BaseCheckbox,
   Checkbox,
   CheckboxDefinition,
   CheckboxShape,


### PR DESCRIPTION

## Previous Behavior

<!-- This is the behavior we have today -->

- BaseCheckbox not exported

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

- BaseCheckbox is exported

I went through and confirmed this is the last of the base classes that needs to be exported. 

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
