### PR TITLE
chore(react-tabster): nits on useMergedTabsterAttributes internals

### DIFF
--- a/change/@fluentui-react-tabster-cc5de3db-3b7c-4231-a070-8f3fb7ed4b21.json
+++ b/change/@fluentui-react-tabster-cc5de3db-3b7c-4231-a070-8f3fb7ed4b21.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: simplifies useMergedTabsterAttributes internals",
+  "packageName": "@fluentui/react-tabster",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tabster/src/hooks/useMergeTabsterAttributes.test.ts
+++ b/packages/react-components/react-tabster/src/hooks/useMergeTabsterAttributes.test.ts
@@ -1,0 +1,29 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useMergedTabsterAttributes_unstable } from './useMergeTabsterAttributes';
+
+describe('useMergedTabsterAttributes', () => {
+  it('should merge tabster attributes', () => {
+    const { result } = renderHook(() =>
+      useMergedTabsterAttributes_unstable(
+        { 'data-tabster': '{"a":"1"}' },
+        { 'data-tabster': '{"b":"2"}' },
+        { 'data-tabster': '{"c":"3"}' },
+      ),
+    );
+    expect(result.current).toEqual({ 'data-tabster': '{"a":"1","b":"2","c":"3"}' });
+  });
+  it('should merge tabster attributes, the order of attributes matters, the latter has priority', () => {
+    const { result } = renderHook(() =>
+      useMergedTabsterAttributes_unstable(
+        { 'data-tabster': '{"a":"1"}' },
+        { 'data-tabster': '{"a":"2"}' },
+        { 'data-tabster': '{"a":"3"}' },
+      ),
+    );
+    expect(result.current).toEqual({ 'data-tabster': '{"a":"3"}' });
+  });
+  it('should return an object with an empty tabster attribute if no attribute is provided', () => {
+    const { result } = renderHook(() => useMergedTabsterAttributes_unstable());
+    expect(result.current).toEqual({ 'data-tabster': undefined });
+  });
+});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
1. adds tests to ensure behavior
2. reduces amount of iterations by using `reduce` instead of `map` + `filter`
3. reduces object creation by using `Object.assign` instead of spreading (super nit)
4.  reduces implementation in 10 loc
5. adds verification to ensure attributes are stable throughout runtime

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
