### PR TITLE
docs: add target size information to relevant v9 component docs

### DIFF
--- a/packages/react-components/react-avatar/stories/src/Avatar/AvatarSize.stories.tsx
+++ b/packages/react-components/react-avatar/stories/src/Avatar/AvatarSize.stories.tsx
@@ -23,7 +23,10 @@ export const Size = () => (
 Size.parameters = {
   docs: {
     description: {
-      story: 'An avatar supports a range of sizes from 16 to 128. The default is 32.',
+      story:
+        'An avatar supports a range of sizes from 16 to 128. The default is 32. \n\n' +
+        'Avoid using sizes 16 and 20 for interactive Avatars, ' +
+        'or ensure that there is at least 8px or 4px spacing respectively to meet WCAG target size requirements.',
     },
   },
 };

--- a/packages/react-components/react-avatar/stories/src/AvatarGroup/AvatarGroupSizeStack.stories.tsx
+++ b/packages/react-components/react-avatar/stories/src/AvatarGroup/AvatarGroupSizeStack.stories.tsx
@@ -62,7 +62,10 @@ export const SizeStack = () => {
 SizeStack.parameters = {
   docs: {
     description: {
-      story: 'An AvatarGroup with `stack` layout supports a range of sizes from 16 to 128. The default is 32.',
+      story:
+        'An AvatarGroup with `stack` layout supports a range of sizes from 16 to 128. The default is 32. \n\n' +
+        'WARNING: do not make multiple avatars in a stack interactive unless the size is at least 28. ' +
+        'Smaller sizes with overlapping click targets will fail to meet the WCAG target size requirement.',
     },
   },
 };

--- a/packages/react-components/react-button/stories/src/Button/ButtonBestPractices.md
+++ b/packages/react-components/react-button/stories/src/Button/ButtonBestPractices.md
@@ -12,6 +12,8 @@
   "Next" buttons may be used.
 - Don't place the default focus on a button that destroys data. Instead, place the default focus on the button that
   performs the "safe act" and retains the content (such as "Save") or cancels the action (such as "Cancel").
+- When overriding layout styles, ensure buttons are always at least 24px by 24px to meet [WCAG target size requirements](https://w3c.github.io/wcag/understanding/target-size-minimum.html). This is already covered by our default styles for all buttons but SplitButton for all size variants if no style customizations are used.
+- Only use a small SplitButton if the user has specifically chosen a compact layout, or if there is an equally efficient alternative method to perform the same action.
 
 ### Content
 

--- a/packages/react-components/react-button/stories/src/SplitButton/SplitButtonSizeSmall.stories.tsx
+++ b/packages/react-components/react-button/stories/src/SplitButton/SplitButtonSizeSmall.stories.tsx
@@ -93,3 +93,14 @@ export const SizeSmall = () => {
 };
 
 SizeSmall.storyName = 'Size: small';
+
+SizeSmall.parameters = {
+  docs: {
+    description: {
+      story:
+        'WARNING: the small SplitButton does not meet WCAG target size requirements. ' +
+        'Only use this variant if there is an equally accessible alternative way to perform the same action, ' +
+        'or if it is part of a user-selected compact theme.',
+    },
+  },
+};

--- a/packages/react-components/react-combobox/stories/src/Dropdown/DropdownCustomOptions.stories.tsx
+++ b/packages/react-components/react-combobox/stories/src/Dropdown/DropdownCustomOptions.stories.tsx
@@ -81,6 +81,7 @@ export const CustomOptions = (props: Partial<DropdownProps>) => {
         aria-labelledby={dropdownId}
         listbox={{ className: styles.listbox }}
         placeholder="Select an animal"
+        open
         {...props}
       >
         <CustomOptionGroup label="Land" options={land} />

--- a/packages/react-components/react-combobox/stories/src/Dropdown/DropdownCustomOptions.stories.tsx
+++ b/packages/react-components/react-combobox/stories/src/Dropdown/DropdownCustomOptions.stories.tsx
@@ -81,7 +81,6 @@ export const CustomOptions = (props: Partial<DropdownProps>) => {
         aria-labelledby={dropdownId}
         listbox={{ className: styles.listbox }}
         placeholder="Select an animal"
-        open
         {...props}
       >
         <CustomOptionGroup label="Land" options={land} />

--- a/packages/react-components/react-infolabel/stories/src/InfoLabel/InfoLabelBestPractices.md
+++ b/packages/react-components/react-infolabel/stories/src/InfoLabel/InfoLabelBestPractices.md
@@ -1,5 +1,12 @@
 ## Best practices
 
+### Do
+
+- Use the medium (default) or large sizes when possible to ensure the InfoButton meets the [minimum target size requirement](https://w3c.github.io/wcag/understanding/target-size-minimum.html).
+- When using the small size, ensure one of the following is true:
+  - The InfoButton has at least 2px of space between it and the closest interactive control on all sides (this is already guaranteed if using a small InfoLabel with a small Field component).
+  - Only use the small variant if the end user has chosen a compact/small layout (i.e. not as the default layout)
+
 ### Don't
 
 - Because the Popover isn't always visible, don't include information in the `info` prop that people must know in order to complete the field.

--- a/packages/react-components/react-infolabel/stories/src/InfoLabel/InfoLabelSize.stories.tsx
+++ b/packages/react-components/react-infolabel/stories/src/InfoLabel/InfoLabelSize.stories.tsx
@@ -32,7 +32,9 @@ export const Size = () => {
 Size.parameters = {
   docs: {
     description: {
-      story: "InfoLabel's `size` prop affects the size of the Label and InfoButton. The default size is medium.",
+      story:
+        "InfoLabel's `size` prop affects the size of the Label and InfoButton. The default size is medium. " +
+        "The small size only meets WCAG's minimum target size requirement if it has at least 2px of non-interactive space on all sides.",
     },
   },
 };

--- a/packages/react-components/react-swatch-picker/stories/src/SwatchPicker/SwatchPickerBestPractices.md
+++ b/packages/react-components/react-swatch-picker/stories/src/SwatchPicker/SwatchPickerBestPractices.md
@@ -11,7 +11,7 @@
 ### Don't
 
 - Avoid using rounded corners in a grid layout for the SwatchPicker, as it may cause the [Hermann grid illusion](https://en.wikipedia.org/wiki/Grid_illusion).
-- When using `extra small` or smaller swatches spacing should be not less than 4px.
+- When using `extra small` or smaller swatches spacing should be not less than 4px to ensure they pass the [WCAG target size requirement](https://w3c.github.io/wcag/understanding/target-size-minimum.html).
 - Avoid showing more than 4 disabled swatches.
 
 ### Accessibility


### PR DESCRIPTION
docs-only updates, adds wording to best practices & individual stories about the new WCAG 2.2 target size criterion.