### PR TITLE
fix: SplitButton menuButton is at least 24px wide

### DIFF
--- a/change/@fluentui-react-button-e7f98b68-84a6-495a-81fa-cc5ac0eda06f.json
+++ b/change/@fluentui-react-button-e7f98b68-84a6-495a-81fa-cc5ac0eda06f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: medium and large SplitButton menuButton is at least 24px wide",
+  "packageName": "@fluentui/react-button",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-button/library/src/components/SplitButton/useSplitButtonStyles.styles.ts
+++ b/packages/react-components/react-button/library/src/components/SplitButton/useSplitButtonStyles.styles.ts
@@ -48,13 +48,6 @@ const useRootStyles = makeStyles({
     },
   },
 
-  // small size menubutton width override
-  small: {
-    [`& .${splitButtonClassNames.menuButton}`]: {
-      minWidth: 0,
-    },
-  },
-
   // Appearance variations
   outline: {
     /* No styles */
@@ -184,12 +177,11 @@ export const useSplitButtonStyles_unstable = (state: SplitButtonState): SplitBut
   const rootStyles = useRootStyles();
   const focusStyles = useFocusStyles();
 
-  const { appearance, disabled, disabledFocusable, size } = state;
+  const { appearance, disabled, disabledFocusable } = state;
 
   state.root.className = mergeClasses(
     splitButtonClassNames.root,
     rootStyles.base,
-    size === 'small' && rootStyles.small,
     appearance && rootStyles[appearance],
     (disabled || disabledFocusable) && rootStyles.disabled,
     (disabled || disabledFocusable) && rootStyles.disabledHighContrast,

--- a/packages/react-components/react-button/library/src/components/SplitButton/useSplitButtonStyles.styles.ts
+++ b/packages/react-components/react-button/library/src/components/SplitButton/useSplitButtonStyles.styles.ts
@@ -10,6 +10,10 @@ export const splitButtonClassNames: SlotClassNames<SplitButtonSlots> = {
   primaryActionButton: 'fui-SplitButton__primaryActionButton',
 };
 
+// WCAG minimum target size for pointer targets that are immediately adjacent to other targets:
+// https://w3c.github.io/wcag/guidelines/22/#target-size-minimum
+const MIN_TARGET_SIZE = '24px';
+
 const useFocusStyles = makeStyles({
   primaryActionButton: createCustomFocusIndicatorStyle({
     borderTopRightRadius: 0,
@@ -40,6 +44,13 @@ const useRootStyles = makeStyles({
       borderLeftWidth: 0,
       borderTopLeftRadius: 0,
       borderBottomLeftRadius: 0,
+      minWidth: MIN_TARGET_SIZE,
+    },
+  },
+
+  // small size menubutton width override
+  small: {
+    [`& .${splitButtonClassNames.menuButton}`]: {
       minWidth: 0,
     },
   },
@@ -173,11 +184,12 @@ export const useSplitButtonStyles_unstable = (state: SplitButtonState): SplitBut
   const rootStyles = useRootStyles();
   const focusStyles = useFocusStyles();
 
-  const { appearance, disabled, disabledFocusable } = state;
+  const { appearance, disabled, disabledFocusable, size } = state;
 
   state.root.className = mergeClasses(
     splitButtonClassNames.root,
     rootStyles.base,
+    size === 'small' && rootStyles.small,
     appearance && rootStyles[appearance],
     (disabled || disabledFocusable) && rootStyles.disabled,
     (disabled || disabledFocusable) && rootStyles.disabledHighContrast,


### PR DESCRIPTION
## Previous Behavior

The menuButton was 23px wide by default, failing the new WCAG 2.2 minimum target size requirement by 1px.
<img width="740" alt="Screenshot of the splitbutton appearance story, with the menubutton being inspected in devtools, showing a 23px width" src="https://github.com/user-attachments/assets/7a315523-a39c-4db2-9916-e9aa010485b1">

## New Behavior
The `min-width` of the menubutton is set to `24px` for all sizes of splitbuttons. Toshie already got sign-off on the change (including for small splitbuttons) from partners, so we should be good to change the visuals.

<img width="664" alt="Screenshot of the same splitbuttons, with devtools showing the menubutton at 24px" src="https://github.com/user-attachments/assets/c307f1f6-6836-4449-8ade-fbc486cd4e65">

<img width="393" alt="Screenshot of small-size splitbuttons, with the menubuttons also at 24px wide" src="https://github.com/user-attachments/assets/9c6bfbcd-75d0-4869-8847-12069b0bc105">

