### PR TITLE
docs: fix icons catalog

### DIFF
--- a/apps/public-docsite-v9/src/DocsComponents/ReactIconGridLazy.tsx
+++ b/apps/public-docsite-v9/src/DocsComponents/ReactIconGridLazy.tsx
@@ -1,0 +1,12 @@
+import { Spinner } from '@fluentui/react-components';
+import * as React from 'react';
+
+const IconGrid = React.lazy(() => import('../DocsComponents/ReactIconGrid.stories'));
+
+const ReactIconGridLazy: React.FunctionComponent = () => (
+  <React.Suspense fallback={<Spinner label="Loading..." />}>
+    <IconGrid />
+  </React.Suspense>
+);
+
+export default ReactIconGridLazy;

--- a/apps/public-docsite-v9/src/Icons/IconsCatalog.stories.mdx
+++ b/apps/public-docsite-v9/src/Icons/IconsCatalog.stories.mdx
@@ -1,9 +1,9 @@
 import { Meta } from '@storybook/addon-docs';
-import { Spinner } from '@fluentui/react-spinner';
+import ReactIconGridLazy from '../DocsComponents/ReactIconGridLazy';
 
 <Meta title="Icons/Catalog" />
 
-<h1 class="sbdocs-title">Icons catalog</h1>
+<h1 className="sbdocs-title">Icons catalog</h1>
 
 This page contains a list of available icons under `@fluentui/react-icons` package. To use icons install the package and select an icon to use.
 
@@ -17,6 +17,4 @@ function App() {
 }
 ```
 
-<React.Suspense fallback={<Spinner label="Loading..." />}>
-  {React.createElement(React.lazy(() => import('../DocsComponents/ReactIconGrid.stories')))}
-</React.Suspense>
+<ReactIconGridLazy />


### PR DESCRIPTION
## Previous Behavior

<img width="625" alt="image" src="https://github.com/user-attachments/assets/8c3cb649-550b-408a-9de6-c3fe8753fbb4">


## New Behavior

Icon catalog renders again

## Related Issue(s)

Fixes #32312
