### PR TITLE
feat: Add context to configure motion behaviour

### DIFF
--- a/change/@fluentui-react-motion-051564b3-04af-45b4-b634-c0494efb621b.json
+++ b/change/@fluentui-react-motion-051564b3-04af-45b4-b634-c0494efb621b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: Add context to disable motions",
+  "packageName": "@fluentui/react-motion",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-motion-051564b3-04af-45b4-b634-c0494efb621b.json
+++ b/change/@fluentui-react-motion-051564b3-04af-45b4-b634-c0494efb621b.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "feat: Add context to disable motions",
+  "comment": "feat: Add context to configure motion behaviour",
   "packageName": "@fluentui/react-motion",
   "email": "lingfangao@hotmail.com",
   "dependentChangeType": "patch"

--- a/packages/react-components/react-motion/library/etc/react-motion.api.md
+++ b/packages/react-components/react-motion/library/etc/react-motion.api.md
@@ -62,6 +62,9 @@ export type MotionComponentProps = {
 };
 
 // @public (undocumented)
+export const MotionDisableProvider: React_2.Provider<boolean | undefined>;
+
+// @public (undocumented)
 export type MotionImperativeRef = {
     setPlaybackRate: (rate: number) => void;
     setPlayState: (state: 'running' | 'paused') => void;
@@ -152,6 +155,9 @@ export type PresenceMotionSlotProps<MotionParams extends Record<string, MotionPa
         children: React_2.ReactElement;
     }>;
 };
+
+// @public (undocumented)
+export const useMotionDisableContext: () => boolean;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react-components/react-motion/library/etc/react-motion.api.md
+++ b/packages/react-components/react-motion/library/etc/react-motion.api.md
@@ -62,7 +62,7 @@ export type MotionComponentProps = {
 };
 
 // @public (undocumented)
-export const MotionDisableProvider: React_2.Provider<boolean | undefined>;
+export const MotionBehaviourProvider: React_2.Provider<boolean | undefined>;
 
 // @public (undocumented)
 export type MotionImperativeRef = {
@@ -157,7 +157,7 @@ export type PresenceMotionSlotProps<MotionParams extends Record<string, MotionPa
 };
 
 // @public (undocumented)
-export const useMotionDisableContext: () => boolean;
+export const useMotionBehaviourContext: () => boolean;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react-components/react-motion/library/etc/react-motion.api.md
+++ b/packages/react-components/react-motion/library/etc/react-motion.api.md
@@ -53,6 +53,9 @@ export const durations: {
 };
 
 // @public (undocumented)
+export const MotionBehaviourProvider: React_2.Provider<MotionBehaviourType | undefined>;
+
+// @public (undocumented)
 export type MotionComponentProps = {
     children: React_2.ReactElement;
     imperativeRef?: React_2.Ref<MotionImperativeRef | undefined>;
@@ -60,9 +63,6 @@ export type MotionComponentProps = {
     onMotionCancel?: (ev: null) => void;
     onMotionStart?: (ev: null) => void;
 };
-
-// @public (undocumented)
-export const MotionBehaviourProvider: React_2.Provider<boolean | undefined>;
 
 // @public (undocumented)
 export type MotionImperativeRef = {
@@ -155,9 +155,6 @@ export type PresenceMotionSlotProps<MotionParams extends Record<string, MotionPa
         children: React_2.ReactElement;
     }>;
 };
-
-// @public (undocumented)
-export const useMotionBehaviourContext: () => boolean;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react-components/react-motion/library/src/contexts/MotionBehaviourContext.ts
+++ b/packages/react-components/react-motion/library/src/contexts/MotionBehaviourContext.ts
@@ -5,6 +5,6 @@ import * as React from 'react';
  */
 export type MotionBehaviourType = 'skip' | 'default';
 
-export const MotionBehaviourContext = React.createContext<MotionBehaviourType | undefined>(undefined);
+const MotionBehaviourContext = React.createContext<MotionBehaviourType | undefined>(undefined);
 export const MotionBehaviourProvider = MotionBehaviourContext.Provider;
 export const useMotionBehaviourContext = () => React.useContext(MotionBehaviourContext) ?? 'default';

--- a/packages/react-components/react-motion/library/src/contexts/MotionBehaviourContext.ts
+++ b/packages/react-components/react-motion/library/src/contexts/MotionBehaviourContext.ts
@@ -1,0 +1,10 @@
+import * as React from 'react';
+
+/**
+ * Specifies the behaviour of child motion component under @see MotionBehaviourProvider.
+ */
+export type MotionBehaviourType = 'skip' | 'default';
+
+export const MotionBehaviourContext = React.createContext<MotionBehaviourType | undefined>(undefined);
+export const MotionBehaviourProvider = MotionBehaviourContext.Provider;
+export const useMotionBehaviourContext = () => React.useContext(MotionBehaviourContext) ?? 'default';

--- a/packages/react-components/react-motion/library/src/contexts/MotionDisableContext.ts
+++ b/packages/react-components/react-motion/library/src/contexts/MotionDisableContext.ts
@@ -1,0 +1,5 @@
+import * as React from 'react';
+
+export const MotionDisableContext = React.createContext<boolean | undefined>(undefined);
+export const MotionDisableProvider = MotionDisableContext.Provider;
+export const useMotionDisableContext = () => React.useContext(MotionDisableContext) ?? false;

--- a/packages/react-components/react-motion/library/src/contexts/MotionDisableContext.ts
+++ b/packages/react-components/react-motion/library/src/contexts/MotionDisableContext.ts
@@ -1,5 +1,0 @@
-import * as React from 'react';
-
-export const MotionDisableContext = React.createContext<boolean | undefined>(undefined);
-export const MotionDisableProvider = MotionDisableContext.Provider;
-export const useMotionDisableContext = () => React.useContext(MotionDisableContext) ?? false;

--- a/packages/react-components/react-motion/library/src/factories/createMotionComponent.test.tsx
+++ b/packages/react-components/react-motion/library/src/factories/createMotionComponent.test.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 
 import type { AtomMotion } from '../types';
 import { createMotionComponent } from './createMotionComponent';
+import { MotionDisableContext, MotionDisableProvider } from '../contexts/MotionDisableContext';
 
 const motion: AtomMotion = {
   keyframes: [{ opacity: 0 }, { opacity: 1 }],
@@ -89,5 +90,29 @@ describe('createMotionComponent', () => {
 
     expect(onMotionStart).toHaveBeenCalledTimes(1);
     expect(onMotionFinish).toHaveBeenCalledTimes(1);
+  });
+
+  it('finishes motion when wrapped in motion disable context', async () => {
+    const TestAtom = createMotionComponent(motion);
+    const onMotionStart = jest.fn();
+    const onMotionFinish = jest.fn();
+
+    const { finishMock, ElementMock } = createElementMock();
+
+    render(
+      <MotionDisableProvider value={true}>
+        <TestAtom onMotionFinish={onMotionFinish} onMotionStart={onMotionStart}>
+          <ElementMock />
+        </TestAtom>
+      </MotionDisableProvider>,
+    );
+
+    await act(async () => {
+      await new Promise<void>(process.nextTick);
+    });
+
+    expect(onMotionStart).toHaveBeenCalledTimes(0);
+    expect(onMotionFinish).toHaveBeenCalledTimes(0);
+    expect(finishMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/react-components/react-motion/library/src/factories/createMotionComponent.test.tsx
+++ b/packages/react-components/react-motion/library/src/factories/createMotionComponent.test.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 import type { AtomMotion } from '../types';
 import { createMotionComponent } from './createMotionComponent';
-import { MotionDisableProvider } from '../contexts/MotionDisableContext';
+import { MotionBehaviourProvider } from '../contexts/MotionBehaviourContext';
 
 const motion: AtomMotion = {
   keyframes: [{ opacity: 0 }, { opacity: 1 }],
@@ -92,7 +92,7 @@ describe('createMotionComponent', () => {
     expect(onMotionFinish).toHaveBeenCalledTimes(1);
   });
 
-  it('finishes motion when wrapped in motion disable context', async () => {
+  it('finishes motion when wrapped in motion context with skip behaviour', async () => {
     const TestAtom = createMotionComponent(motion);
     const onMotionStart = jest.fn();
     const onMotionFinish = jest.fn();
@@ -100,11 +100,11 @@ describe('createMotionComponent', () => {
     const { finishMock, ElementMock } = createElementMock();
 
     render(
-      <MotionDisableProvider value={true}>
+      <MotionBehaviourProvider value="skip">
         <TestAtom onMotionFinish={onMotionFinish} onMotionStart={onMotionStart}>
           <ElementMock />
         </TestAtom>
-      </MotionDisableProvider>,
+      </MotionBehaviourProvider>,
     );
 
     await act(async () => {

--- a/packages/react-components/react-motion/library/src/factories/createMotionComponent.test.tsx
+++ b/packages/react-components/react-motion/library/src/factories/createMotionComponent.test.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 import type { AtomMotion } from '../types';
 import { createMotionComponent } from './createMotionComponent';
-import { MotionDisableContext, MotionDisableProvider } from '../contexts/MotionDisableContext';
+import { MotionDisableProvider } from '../contexts/MotionDisableContext';
 
 const motion: AtomMotion = {
   keyframes: [{ opacity: 0 }, { opacity: 1 }],
@@ -111,8 +111,8 @@ describe('createMotionComponent', () => {
       await new Promise<void>(process.nextTick);
     });
 
-    expect(onMotionStart).toHaveBeenCalledTimes(0);
-    expect(onMotionFinish).toHaveBeenCalledTimes(0);
+    expect(onMotionStart).toHaveBeenCalledTimes(1);
+    expect(onMotionFinish).toHaveBeenCalledTimes(1);
     expect(finishMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/react-components/react-motion/library/src/factories/createMotionComponent.test.tsx
+++ b/packages/react-components/react-motion/library/src/factories/createMotionComponent.test.tsx
@@ -100,11 +100,10 @@ describe('createMotionComponent', () => {
     const { finishMock, ElementMock } = createElementMock();
 
     render(
-      <MotionBehaviourProvider value="skip">
-        <TestAtom onMotionFinish={onMotionFinish} onMotionStart={onMotionStart}>
-          <ElementMock />
-        </TestAtom>
-      </MotionBehaviourProvider>,
+      <TestAtom onMotionFinish={onMotionFinish} onMotionStart={onMotionStart}>
+        <ElementMock />
+      </TestAtom>,
+      { wrapper: ({ children }) => <MotionBehaviourProvider value="skip">{children}</MotionBehaviourProvider> },
     );
 
     await act(async () => {

--- a/packages/react-components/react-motion/library/src/factories/createMotionComponent.ts
+++ b/packages/react-components/react-motion/library/src/factories/createMotionComponent.ts
@@ -100,11 +100,11 @@ export function createMotionComponent<MotionParams extends Record<string, Motion
       if (element) {
         const atoms = typeof value === 'function' ? value({ element, ...paramsRef.current }) : value;
 
+        onMotionStart();
         const handle = animateAtoms(element, atoms, { isReducedMotion: isReducedMotion() });
         handleRef.current = handle;
         handle.setMotionEndCallbacks(onMotionFinish, onMotionCancel);
 
-        onMotionStart();
 
         if (optionsRef.current.skipMotions) {
           handle.finish();

--- a/packages/react-components/react-motion/library/src/factories/createMotionComponent.ts
+++ b/packages/react-components/react-motion/library/src/factories/createMotionComponent.ts
@@ -6,7 +6,7 @@ import { useMotionImperativeRef } from '../hooks/useMotionImperativeRef';
 import { useIsReducedMotion } from '../hooks/useIsReducedMotion';
 import { getChildElement } from '../utils/getChildElement';
 import type { AtomMotion, AtomMotionFn, MotionParam, MotionImperativeRef } from '../types';
-import { useMotionDisableContext } from '../contexts/MotionDisableContext';
+import { useMotionBehaviourContext } from '../contexts/MotionBehaviourContext';
 
 export type MotionComponentProps = {
   children: React.ReactElement;
@@ -68,7 +68,7 @@ export function createMotionComponent<MotionParams extends Record<string, Motion
     const handleRef = useMotionImperativeRef(imperativeRef);
     const elementRef = React.useRef<HTMLElement>();
     const paramsRef = React.useRef<MotionParams>(params);
-    const disableMotions = useMotionDisableContext();
+    const skipMotions = useMotionBehaviourContext() === "skip";
 
     const animateAtoms = useAnimateAtoms();
     const isReducedMotion = useIsReducedMotion();
@@ -103,16 +103,15 @@ export function createMotionComponent<MotionParams extends Record<string, Motion
 
         onMotionStart();
 
-        if (disableMotions) {
+        if (skipMotions) {
           handle.finish();
         }
-
 
         return () => {
           handle.cancel();
         };
       }
-    }, [animateAtoms, handleRef, isReducedMotion, onMotionFinish, onMotionStart, onMotionCancel, disableMotions]);
+    }, [animateAtoms, handleRef, isReducedMotion, onMotionFinish, onMotionStart, onMotionCancel, skipMotions]);
 
     return React.cloneElement(children, { ref: useMergedRefs(elementRef, child.ref) });
   };

--- a/packages/react-components/react-motion/library/src/factories/createMotionComponent.ts
+++ b/packages/react-components/react-motion/library/src/factories/createMotionComponent.ts
@@ -68,7 +68,10 @@ export function createMotionComponent<MotionParams extends Record<string, Motion
     const handleRef = useMotionImperativeRef(imperativeRef);
     const elementRef = React.useRef<HTMLElement>();
     const paramsRef = React.useRef<MotionParams>(params);
-    const skipMotions = useMotionBehaviourContext() === "skip";
+    const skipMotions = useMotionBehaviourContext() === 'skip';
+    const optionsRef = React.useRef<{ skipMotions: boolean }>({
+      skipMotions,
+    });
 
     const animateAtoms = useAnimateAtoms();
     const isReducedMotion = useIsReducedMotion();
@@ -103,7 +106,7 @@ export function createMotionComponent<MotionParams extends Record<string, Motion
 
         onMotionStart();
 
-        if (skipMotions) {
+        if (optionsRef.current.skipMotions) {
           handle.finish();
         }
 
@@ -111,7 +114,7 @@ export function createMotionComponent<MotionParams extends Record<string, Motion
           handle.cancel();
         };
       }
-    }, [animateAtoms, handleRef, isReducedMotion, onMotionFinish, onMotionStart, onMotionCancel, skipMotions]);
+    }, [animateAtoms, handleRef, isReducedMotion, onMotionFinish, onMotionStart, onMotionCancel]);
 
     return React.cloneElement(children, { ref: useMergedRefs(elementRef, child.ref) });
   };

--- a/packages/react-components/react-motion/library/src/factories/createMotionComponent.ts
+++ b/packages/react-components/react-motion/library/src/factories/createMotionComponent.ts
@@ -98,18 +98,15 @@ export function createMotionComponent<MotionParams extends Record<string, Motion
         const atoms = typeof value === 'function' ? value({ element, ...paramsRef.current }) : value;
 
         const handle = animateAtoms(element, atoms, { isReducedMotion: isReducedMotion() });
+        handleRef.current = handle;
+        handle.setMotionEndCallbacks(onMotionFinish, onMotionCancel);
 
-        if (!disableMotions) {
-          onMotionStart();
-        }
+        onMotionStart();
 
         if (disableMotions) {
           handle.finish();
-          return;
         }
 
-        handle.setMotionEndCallbacks(onMotionFinish, onMotionCancel);
-        handleRef.current = handle;
 
         return () => {
           handle.cancel();

--- a/packages/react-components/react-motion/library/src/factories/createMotionComponent.ts
+++ b/packages/react-components/react-motion/library/src/factories/createMotionComponent.ts
@@ -67,10 +67,10 @@ export function createMotionComponent<MotionParams extends Record<string, Motion
 
     const handleRef = useMotionImperativeRef(imperativeRef);
     const elementRef = React.useRef<HTMLElement>();
-    const paramsRef = React.useRef<MotionParams>(params);
     const skipMotions = useMotionBehaviourContext() === 'skip';
-    const optionsRef = React.useRef<{ skipMotions: boolean }>({
+    const optionsRef = React.useRef<{ skipMotions: boolean; params: MotionParams }>({
       skipMotions,
+      params,
     });
 
     const animateAtoms = useAnimateAtoms();
@@ -91,14 +91,14 @@ export function createMotionComponent<MotionParams extends Record<string, Motion
     useIsomorphicLayoutEffect(() => {
       // Heads up!
       // We store the params in a ref to avoid re-rendering the component when the params change.
-      paramsRef.current = params;
+      optionsRef.current = { skipMotions, params };
     });
 
     useIsomorphicLayoutEffect(() => {
       const element = elementRef.current;
 
       if (element) {
-        const atoms = typeof value === 'function' ? value({ element, ...paramsRef.current }) : value;
+        const atoms = typeof value === 'function' ? value({ element, ...optionsRef.current.params }) : value;
 
         onMotionStart();
         const handle = animateAtoms(element, atoms, { isReducedMotion: isReducedMotion() });

--- a/packages/react-components/react-motion/library/src/factories/createMotionComponent.ts
+++ b/packages/react-components/react-motion/library/src/factories/createMotionComponent.ts
@@ -105,7 +105,6 @@ export function createMotionComponent<MotionParams extends Record<string, Motion
         handleRef.current = handle;
         handle.setMotionEndCallbacks(onMotionFinish, onMotionCancel);
 
-
         if (optionsRef.current.skipMotions) {
           handle.finish();
         }

--- a/packages/react-components/react-motion/library/src/factories/createPresenceComponent.cy.tsx
+++ b/packages/react-components/react-motion/library/src/factories/createPresenceComponent.cy.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { mount } from '@cypress/react';
 import { createPresenceComponent } from './createPresenceComponent';
+import { MotionDisableProvider } from '../contexts/MotionDisableContext';
 
 describe('createPresenceComponent', () => {
   it('should call onMotionCancel', () => {
@@ -35,5 +36,32 @@ describe('createPresenceComponent', () => {
     mount(<TestComponent />);
 
     cy.get('#toggle').click().wait(100).click().get('#cancel').should('have.text', '1');
+  });
+
+  it('should disable motion with motion disable provider', () => {
+    const TestMotion = createPresenceComponent({
+      enter: { keyframes: [{ opacity: 0 }, { opacity: 0, offset: 0.9 }], duration: 60000 },
+      exit: { keyframes: [{ opacity: 1 }, { opacity: 0 }], duration: 60000 },
+    });
+
+    const TestComponent = () => {
+      const [visible, setVisible] = React.useState(true);
+
+      return (
+        <>
+          <button id="toggle" onClick={() => setVisible(!visible)}>
+            Toggle
+          </button>
+          <MotionDisableProvider value={true}>
+            <TestMotion appear visible={visible}>
+              <div>Hello World</div>
+            </TestMotion>
+          </MotionDisableProvider>
+        </>
+      );
+    };
+
+    mount(<TestComponent />);
+    cy.contains('Hello World', { timeout: 100 }).should('be.visible');
   });
 });

--- a/packages/react-components/react-motion/library/src/factories/createPresenceComponent.cy.tsx
+++ b/packages/react-components/react-motion/library/src/factories/createPresenceComponent.cy.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { mount } from '@cypress/react';
 import { createPresenceComponent } from './createPresenceComponent';
-import { MotionDisableProvider } from '../contexts/MotionDisableContext';
+import { MotionBehaviourProvider } from '../contexts/MotionBehaviourContext';
 
 describe('createPresenceComponent', () => {
   it('should call onMotionCancel', () => {
@@ -52,11 +52,11 @@ describe('createPresenceComponent', () => {
           <button id="toggle" onClick={() => setVisible(!visible)}>
             Toggle
           </button>
-          <MotionDisableProvider value={true}>
+          <MotionBehaviourProvider value="skip">
             <TestMotion appear visible={visible}>
               <div>Hello World</div>
             </TestMotion>
-          </MotionDisableProvider>
+          </MotionBehaviourProvider>
         </>
       );
     };

--- a/packages/react-components/react-motion/library/src/factories/createPresenceComponent.test.tsx
+++ b/packages/react-components/react-motion/library/src/factories/createPresenceComponent.test.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import type { PresenceMotion } from '../types';
 import { createPresenceComponent } from './createPresenceComponent';
 import { PresenceGroupChildContext } from '../contexts/PresenceGroupChildContext';
+import { MotionDisableProvider } from '../contexts/MotionDisableContext';
 
 const enterKeyframes = [{ opacity: 0 }, { opacity: 1 }];
 const exitKeyframes = [{ opacity: 1 }, { opacity: 0 }];
@@ -311,6 +312,27 @@ describe('createPresenceComponent', () => {
       expect(queryByText('ElementMock')).toBeTruthy();
       expect(animateMock).toHaveBeenCalledWith(enterKeyframes, options);
       expect(onRender).toHaveBeenCalledTimes(1);
+    });
+
+    it('finishes motion when wrapped in disabled context', () => {
+      const TestPresence = createPresenceComponent(motion);
+      const onRender = jest.fn();
+      const { finishMock, ElementMock } = createElementMock();
+      const onMotionStart = jest.fn();
+      const onMotionFinish = jest.fn();
+
+      const { queryByText } = render(
+        <MotionDisableProvider value={true}>
+          <TestPresence visible appear onMotionStart={onMotionStart} onMotionFinish={onMotionFinish}>
+            <ElementMock onRender={onRender} />
+          </TestPresence>
+        </MotionDisableProvider>,
+      );
+
+      expect(queryByText('ElementMock')).toBeTruthy();
+      expect(finishMock).toHaveBeenCalledTimes(1);
+      expect(onMotionStart).toHaveBeenCalledTimes(0);
+      expect(onMotionFinish).toHaveBeenCalledTimes(0);
     });
   });
 

--- a/packages/react-components/react-motion/library/src/factories/createPresenceComponent.test.tsx
+++ b/packages/react-components/react-motion/library/src/factories/createPresenceComponent.test.tsx
@@ -67,6 +67,31 @@ describe('createPresenceComponent', () => {
 
       expect(animateMock).toHaveBeenCalledWith(enterKeyframes, options);
     });
+
+    it('finishes motion when wrapped in disabled context', async () => {
+      const TestPresence = createPresenceComponent(motion);
+      const onRender = jest.fn();
+      const { finishMock, ElementMock } = createElementMock();
+      const onMotionStart = jest.fn();
+      const onMotionFinish = jest.fn();
+
+      const { queryByText } = render(
+        <MotionDisableProvider value={true}>
+          <TestPresence visible appear onMotionStart={onMotionStart} onMotionFinish={onMotionFinish}>
+            <ElementMock onRender={onRender} />
+          </TestPresence>
+        </MotionDisableProvider>,
+      );
+
+      await act(async () => {
+        await new Promise<void>(process.nextTick);
+      });
+
+      expect(queryByText('ElementMock')).toBeTruthy();
+      expect(finishMock).toHaveBeenCalledTimes(1);
+      expect(onMotionStart).toHaveBeenCalledTimes(1);
+      expect(onMotionFinish).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('onMotionStart', () => {
@@ -314,26 +339,6 @@ describe('createPresenceComponent', () => {
       expect(onRender).toHaveBeenCalledTimes(1);
     });
 
-    it('finishes motion when wrapped in disabled context', () => {
-      const TestPresence = createPresenceComponent(motion);
-      const onRender = jest.fn();
-      const { finishMock, ElementMock } = createElementMock();
-      const onMotionStart = jest.fn();
-      const onMotionFinish = jest.fn();
-
-      const { queryByText } = render(
-        <MotionDisableProvider value={true}>
-          <TestPresence visible appear onMotionStart={onMotionStart} onMotionFinish={onMotionFinish}>
-            <ElementMock onRender={onRender} />
-          </TestPresence>
-        </MotionDisableProvider>,
-      );
-
-      expect(queryByText('ElementMock')).toBeTruthy();
-      expect(finishMock).toHaveBeenCalledTimes(1);
-      expect(onMotionStart).toHaveBeenCalledTimes(0);
-      expect(onMotionFinish).toHaveBeenCalledTimes(0);
-    });
   });
 
   describe('definitions', () => {

--- a/packages/react-components/react-motion/library/src/factories/createPresenceComponent.test.tsx
+++ b/packages/react-components/react-motion/library/src/factories/createPresenceComponent.test.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import type { PresenceMotion } from '../types';
 import { createPresenceComponent } from './createPresenceComponent';
 import { PresenceGroupChildContext } from '../contexts/PresenceGroupChildContext';
-import { MotionDisableProvider } from '../contexts/MotionDisableContext';
+import { MotionBehaviourProvider } from '../contexts/MotionBehaviourContext';
 
 const enterKeyframes = [{ opacity: 0 }, { opacity: 1 }];
 const exitKeyframes = [{ opacity: 1 }, { opacity: 0 }];
@@ -68,7 +68,7 @@ describe('createPresenceComponent', () => {
       expect(animateMock).toHaveBeenCalledWith(enterKeyframes, options);
     });
 
-    it('finishes motion when wrapped in disabled context', async () => {
+    it('finishes motion when wrapped in motion behaviour context with skip behaviour', async () => {
       const TestPresence = createPresenceComponent(motion);
       const onRender = jest.fn();
       const { finishMock, ElementMock } = createElementMock();
@@ -76,11 +76,11 @@ describe('createPresenceComponent', () => {
       const onMotionFinish = jest.fn();
 
       const { queryByText } = render(
-        <MotionDisableProvider value={true}>
+        <MotionBehaviourProvider value="skip">
           <TestPresence visible appear onMotionStart={onMotionStart} onMotionFinish={onMotionFinish}>
             <ElementMock onRender={onRender} />
           </TestPresence>
-        </MotionDisableProvider>,
+        </MotionBehaviourProvider>,
       );
 
       await act(async () => {
@@ -338,7 +338,6 @@ describe('createPresenceComponent', () => {
       expect(animateMock).toHaveBeenCalledWith(enterKeyframes, options);
       expect(onRender).toHaveBeenCalledTimes(1);
     });
-
   });
 
   describe('definitions', () => {

--- a/packages/react-components/react-motion/library/src/factories/createPresenceComponent.test.tsx
+++ b/packages/react-components/react-motion/library/src/factories/createPresenceComponent.test.tsx
@@ -70,17 +70,15 @@ describe('createPresenceComponent', () => {
 
     it('finishes motion when wrapped in motion behaviour context with skip behaviour', async () => {
       const TestPresence = createPresenceComponent(motion);
-      const onRender = jest.fn();
       const { finishMock, ElementMock } = createElementMock();
       const onMotionStart = jest.fn();
       const onMotionFinish = jest.fn();
 
       const { queryByText } = render(
-        <MotionBehaviourProvider value="skip">
-          <TestPresence visible appear onMotionStart={onMotionStart} onMotionFinish={onMotionFinish}>
-            <ElementMock onRender={onRender} />
-          </TestPresence>
-        </MotionBehaviourProvider>,
+        <TestPresence visible appear onMotionStart={onMotionStart} onMotionFinish={onMotionFinish}>
+          <ElementMock />
+        </TestPresence>,
+        { wrapper: ({ children }) => <MotionBehaviourProvider value="skip">{children}</MotionBehaviourProvider> },
       );
 
       await act(async () => {

--- a/packages/react-components/react-motion/library/src/factories/createPresenceComponent.ts
+++ b/packages/react-components/react-motion/library/src/factories/createPresenceComponent.ts
@@ -8,7 +8,7 @@ import { useMountedState } from '../hooks/useMountedState';
 import { useIsReducedMotion } from '../hooks/useIsReducedMotion';
 import { getChildElement } from '../utils/getChildElement';
 import type { MotionParam, PresenceMotion, MotionImperativeRef, PresenceMotionFn, PresenceDirection } from '../types';
-import { useMotionDisableContext } from '../contexts/MotionDisableContext';
+import { useMotionBehaviourContext } from '../contexts/MotionBehaviourContext';
 
 /**
  * @internal A private symbol to store the motion definition on the component for variants.
@@ -85,7 +85,7 @@ export function createPresenceComponent<MotionParams extends Record<string, Moti
 
       const itemContext = React.useContext(PresenceGroupChildContext);
       const merged = { ...itemContext, ...props };
-      const disableMotions = useMotionDisableContext();
+      const skipMotions = useMotionBehaviourContext() === 'skip';
 
       const {
         appear,
@@ -107,10 +107,10 @@ export function createPresenceComponent<MotionParams extends Record<string, Moti
       const handleRef = useMotionImperativeRef(imperativeRef);
       const elementRef = React.useRef<HTMLElement>();
       const ref = useMergedRefs(elementRef, child.ref);
-      const optionsRef = React.useRef<{ appear?: boolean; params: MotionParams; disableMotions: boolean }>({
+      const optionsRef = React.useRef<{ appear?: boolean; params: MotionParams; skipMotions: boolean }>({
         appear,
         params,
-        disableMotions,
+        skipMotions,
       });
 
       const animateAtoms = useAnimateAtoms();
@@ -136,7 +136,7 @@ export function createPresenceComponent<MotionParams extends Record<string, Moti
       useIsomorphicLayoutEffect(() => {
         // Heads up!
         // We store the params in a ref to avoid re-rendering the component when the params change.
-        optionsRef.current = { appear, params, disableMotions };
+        optionsRef.current = { appear, params, skipMotions };
       });
 
       useIsomorphicLayoutEffect(
@@ -153,7 +153,7 @@ export function createPresenceComponent<MotionParams extends Record<string, Moti
 
           const direction: PresenceDirection = visible ? 'enter' : 'exit';
           const applyInitialStyles = !visible && isFirstMount;
-          const skipAnimation = optionsRef.current.disableMotions;
+          const skipAnimation = optionsRef.current.skipMotions;
 
           if (!applyInitialStyles) {
             handleMotionStart(direction);

--- a/packages/react-components/react-motion/library/src/factories/createPresenceComponent.ts
+++ b/packages/react-components/react-motion/library/src/factories/createPresenceComponent.ts
@@ -160,22 +160,23 @@ export function createPresenceComponent<MotionParams extends Record<string, Moti
           }
 
           const handle = animateAtoms(element, atoms, { isReducedMotion: isReducedMotion() });
+
+          if (applyInitialStyles) {
+            // Heads up!
+            // .finish() is used in this case to skip animation and apply animation styles immediately
+            handle.finish();
+            return;
+          }
+
+          handleRef.current = handle;
           handle.setMotionEndCallbacks(
             () => handleMotionFinish(direction),
             () => handleMotionCancel(direction),
           );
 
-          if (skipAnimation || applyInitialStyles) {
+          if (skipAnimation) {
             handle.finish();
-
-            if (applyInitialStyles) {
-              // Heads up!
-              // .finish() is used in this case to skip animation and apply animation styles immediately
-              return;
-            }
           }
-
-          handleRef.current = handle;
 
           return () => {
             handle.cancel();

--- a/packages/react-components/react-motion/library/src/factories/createPresenceComponent.ts
+++ b/packages/react-components/react-motion/library/src/factories/createPresenceComponent.ts
@@ -152,27 +152,30 @@ export function createPresenceComponent<MotionParams extends Record<string, Moti
           const atoms = visible ? presenceMotion.enter : presenceMotion.exit;
 
           const direction: PresenceDirection = visible ? 'enter' : 'exit';
-          const skipAnimationOnFirstMount = !visible && isFirstMount;
-          const skipAnimation = optionsRef.current.disableMotions || skipAnimationOnFirstMount;
+          const applyInitialStyles = !visible && isFirstMount;
+          const skipAnimation = optionsRef.current.disableMotions;
 
-          if (!skipAnimation) {
+          if (!applyInitialStyles) {
             handleMotionStart(direction);
           }
 
           const handle = animateAtoms(element, atoms, { isReducedMotion: isReducedMotion() });
-
-          if (skipAnimation) {
-            // Heads up!
-            // .finish() is used there to skip animation, but apply animation styles immediately
-            handle.finish();
-            return;
-          }
-
-          handleRef.current = handle;
           handle.setMotionEndCallbacks(
             () => handleMotionFinish(direction),
             () => handleMotionCancel(direction),
           );
+
+          if (skipAnimation || applyInitialStyles) {
+            handle.finish();
+
+            if (applyInitialStyles) {
+              // Heads up!
+              // .finish() is used in this case to skip animation and apply animation styles immediately
+              return;
+            }
+          }
+
+          handleRef.current = handle;
 
           return () => {
             handle.cancel();

--- a/packages/react-components/react-motion/library/src/index.ts
+++ b/packages/react-components/react-motion/library/src/index.ts
@@ -20,3 +20,5 @@ export type {
   PresenceDirection,
   MotionImperativeRef,
 } from './types';
+
+export { useMotionDisableContext, MotionDisableProvider } from "./contexts/MotionDisableContext";

--- a/packages/react-components/react-motion/library/src/index.ts
+++ b/packages/react-components/react-motion/library/src/index.ts
@@ -21,4 +21,4 @@ export type {
   MotionImperativeRef,
 } from './types';
 
-export { useMotionDisableContext, MotionDisableProvider } from "./contexts/MotionDisableContext";
+export { useMotionDisableContext, MotionDisableProvider } from './contexts/MotionDisableContext';

--- a/packages/react-components/react-motion/library/src/index.ts
+++ b/packages/react-components/react-motion/library/src/index.ts
@@ -21,4 +21,4 @@ export type {
   MotionImperativeRef,
 } from './types';
 
-export { useMotionDisableContext, MotionDisableProvider } from './contexts/MotionDisableContext';
+export { MotionDisableProvider } from './contexts/MotionDisableContext';

--- a/packages/react-components/react-motion/library/src/index.ts
+++ b/packages/react-components/react-motion/library/src/index.ts
@@ -21,4 +21,4 @@ export type {
   MotionImperativeRef,
 } from './types';
 
-export { MotionDisableProvider } from './contexts/MotionDisableContext';
+export { MotionBehaviourProvider } from './contexts/MotionBehaviourContext';


### PR DESCRIPTION
Adds a context with a new `skip` behaviour for motions. This behaviour will **immediately complete the motion** and apply final motion styles.

> ℹ️ Note that `onMotionStart` `onMotionFinish` will still be called


Fixes #32046