### PR TITLE
feat(react-tags): Adds disabled property to TagGroup

### DIFF
--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerGroup/useTagPickerGroup.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerGroup/useTagPickerGroup.ts
@@ -27,6 +27,7 @@ export const useTagPickerGroup_unstable = (
   const selectOption = useTagPickerContext_unstable(ctx => ctx.selectOption);
   const size = useTagPickerContext_unstable(ctx => tagPickerSizeToTagSize(ctx.size));
   const appearance = useTagPickerContext_unstable(ctx => ctx.appearance);
+  const disabled = useTagPickerContext_unstable(ctx => ctx.disabled);
 
   const arrowNavigationProps = useArrowNavigationGroup({
     circular: false,
@@ -37,6 +38,7 @@ export const useTagPickerGroup_unstable = (
   const state = useTagGroup_unstable(
     {
       role: 'listbox',
+      disabled,
       ...props,
       ...arrowNavigationProps,
       size,

--- a/packages/react-components/react-tags/library/src/components/InteractionTag/useInteractionTag.tsx
+++ b/packages/react-components/react-tags/library/src/components/InteractionTag/useInteractionTag.tsx
@@ -16,7 +16,12 @@ export const useInteractionTag_unstable = (
   props: InteractionTagProps,
   ref: React.Ref<HTMLDivElement>,
 ): InteractionTagState => {
-  const { handleTagDismiss, size: contextSize, appearance: contextAppearance } = useTagGroupContext_unstable();
+  const {
+    handleTagDismiss,
+    size: contextSize,
+    disabled: contextDisabled,
+    appearance: contextAppearance,
+  } = useTagGroupContext_unstable();
 
   const id = useId('fui-InteractionTag-', props.id);
 
@@ -24,7 +29,7 @@ export const useInteractionTag_unstable = (
 
   const {
     appearance = contextAppearance ?? 'filled',
-    disabled = false,
+    disabled = contextDisabled ?? false,
     shape = 'rounded',
     size = contextSize,
     value = id,

--- a/packages/react-components/react-tags/library/src/components/Tag/useTag.tsx
+++ b/packages/react-components/react-tags/library/src/components/Tag/useTag.tsx
@@ -29,6 +29,7 @@ export const useTag_unstable = (props: TagProps, ref: React.Ref<HTMLSpanElement 
   const {
     handleTagDismiss,
     size: contextSize,
+    disabled: contextDisabled,
     appearance: contextAppearance,
     dismissible: contextDismissible,
     role: tagGroupRole,
@@ -38,7 +39,7 @@ export const useTag_unstable = (props: TagProps, ref: React.Ref<HTMLSpanElement 
 
   const {
     appearance = contextAppearance ?? 'filled',
-    disabled = false,
+    disabled = contextDisabled ?? false,
     dismissible = contextDismissible ?? false,
     shape = 'rounded',
     size = contextSize,

--- a/packages/react-components/react-tags/library/src/components/TagGroup/TagGroup.types.ts
+++ b/packages/react-components/react-tags/library/src/components/TagGroup/TagGroup.types.ts
@@ -21,6 +21,13 @@ export type TagGroupProps<Value = TagValue> = ComponentProps<TagGroupSlots> & {
   // eslint-disable-next-line @nx/workspace-consistent-callback-type -- can't change type of existing callback
   onDismiss?: TagDismissHandler<Value>;
 
+  /**
+   * A TagGroup can show that it cannot be interacted with.
+   *
+   * @default false
+   */
+  disabled?: boolean;
+
   size?: TagSize;
   appearance?: TagAppearance;
   dismissible?: boolean;
@@ -30,7 +37,7 @@ export type TagGroupProps<Value = TagValue> = ComponentProps<TagGroupSlots> & {
  * State used in rendering TagGroup
  */
 export type TagGroupState<Value = TagValue> = ComponentState<TagGroupSlots> &
-  Required<Pick<TagGroupProps, 'size' | 'appearance' | 'dismissible'>> & {
+  Required<Pick<TagGroupProps, 'disabled' | 'size' | 'appearance' | 'dismissible'>> & {
     handleTagDismiss: TagDismissHandler<Value>;
     role?: React.AriaRole;
   };

--- a/packages/react-components/react-tags/library/src/components/TagGroup/useTagGroup.ts
+++ b/packages/react-components/react-tags/library/src/components/TagGroup/useTagGroup.ts
@@ -15,7 +15,14 @@ import { interactionTagSecondaryClassNames } from '../InteractionTagSecondary/us
  * @param ref - reference to root HTMLDivElement of TagGroup
  */
 export const useTagGroup_unstable = (props: TagGroupProps, ref: React.Ref<HTMLDivElement>): TagGroupState => {
-  const { onDismiss, size = 'medium', appearance = 'filled', dismissible = false, role = 'toolbar' } = props;
+  const {
+    onDismiss,
+    disabled = false,
+    size = 'medium',
+    appearance = 'filled',
+    dismissible = false,
+    role = 'toolbar',
+  } = props;
 
   const innerRef = React.useRef<HTMLElement>();
   const { targetDocument } = useFluent();
@@ -55,6 +62,7 @@ export const useTagGroup_unstable = (props: TagGroupProps, ref: React.Ref<HTMLDi
     handleTagDismiss,
     role,
     size,
+    disabled,
     appearance,
     dismissible,
     components: {
@@ -68,6 +76,7 @@ export const useTagGroup_unstable = (props: TagGroupProps, ref: React.Ref<HTMLDi
         // but since it would be a breaking change to fix it, we are casting ref to it's proper type
         ref: useMergedRefs(ref, innerRef) as React.Ref<HTMLDivElement>,
         role,
+        'aria-disabled': disabled,
         ...arrowNavigationProps,
         ...props,
       }),

--- a/packages/react-components/react-tags/library/src/components/TagGroup/useTagGroupContextValues.ts
+++ b/packages/react-components/react-tags/library/src/components/TagGroup/useTagGroupContextValues.ts
@@ -2,11 +2,11 @@ import * as React from 'react';
 import type { TagGroupContextValues, TagGroupState } from './TagGroup.types';
 
 export function useTagGroupContextValues_unstable(state: TagGroupState): TagGroupContextValues {
-  const { handleTagDismiss, size, appearance, dismissible, role } = state;
+  const { handleTagDismiss, size, disabled, appearance, dismissible, role } = state;
   return {
     tagGroup: React.useMemo(
-      () => ({ handleTagDismiss, size, appearance, dismissible, role }),
-      [handleTagDismiss, size, appearance, dismissible, role],
+      () => ({ handleTagDismiss, size, disabled, appearance, dismissible, role }),
+      [handleTagDismiss, size, disabled, appearance, dismissible, role],
     ),
   };
 }

--- a/packages/react-components/react-tags/library/src/contexts/tagGroupContext.tsx
+++ b/packages/react-components/react-tags/library/src/contexts/tagGroupContext.tsx
@@ -13,7 +13,7 @@ const tagGroupContextDefaultValue: TagGroupContextValue = {
  * Context shared between TagGroup and its children components
  */
 export type TagGroupContextValue = Required<Pick<TagGroupState, 'handleTagDismiss' | 'size'>> &
-  Partial<Pick<TagGroupState, 'appearance' | 'dismissible' | 'role'>>;
+  Partial<Pick<TagGroupState, `disabled` | 'appearance' | 'dismissible' | 'role'>>;
 
 export const TagGroupContextProvider = TagGroupContext.Provider;
 

--- a/packages/react-components/react-tags/stories/src/TagGroup/TagGroupDisabled.stories.tsx
+++ b/packages/react-components/react-tags/stories/src/TagGroup/TagGroupDisabled.stories.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import { TagGroup, InteractionTag, InteractionTagPrimary, Tag, makeStyles } from '@fluentui/react-components';
+
+const WithTags = () => (
+  <TagGroup disabled aria-label="Disabled tag group with Tag" role="list">
+    <Tag role="listitem">Tag 1</Tag>
+    <Tag role="listitem">Tag 2</Tag>
+    <Tag role="listitem">Tag 3</Tag>
+  </TagGroup>
+);
+
+const WithInteractionTags = () => (
+  <TagGroup disabled aria-label="Disabled tag group with InteractionTag">
+    <InteractionTag>
+      <InteractionTagPrimary>Tag 1</InteractionTagPrimary>
+    </InteractionTag>
+    <InteractionTag>
+      <InteractionTagPrimary>Tag 2</InteractionTagPrimary>
+    </InteractionTag>
+    <InteractionTag>
+      <InteractionTagPrimary>Tag 3</InteractionTagPrimary>
+    </InteractionTag>
+  </TagGroup>
+);
+
+const useStyles = makeStyles({
+  container: {
+    display: 'flex',
+    flexDirection: 'column',
+    rowGap: '10px',
+  },
+});
+
+export const Disabled = () => {
+  const styles = useStyles();
+  return (
+    <div className={styles.container}>
+      Disabled example with Tag:
+      <WithTags />
+      Disabled example with InteractionTag:
+      <WithInteractionTags />
+    </div>
+  );
+};
+
+Disabled.storyName = 'Disabled';
+Disabled.parameters = {
+  docs: {
+    description: {
+      story: 'A TagGroup can be disabled. The collection of Tag/InteractionTag will also be disabled.',
+    },
+  },
+};

--- a/packages/react-components/react-tags/stories/src/TagGroup/index.stories.tsx
+++ b/packages/react-components/react-tags/stories/src/TagGroup/index.stories.tsx
@@ -7,6 +7,7 @@ export { Default } from './TagGroupDefault.stories';
 export { Dismiss } from './TagGroupDismiss.stories';
 export { Sizes } from './TagGroupSizes.stories';
 export { WithOverflow } from './TagGroupOverflow.stories';
+export { Disabled } from './TagGroupDisabled.stories';
 
 export default {
   title: 'Components/Tag/TagGroup',


### PR DESCRIPTION
## Previous Behavior

TagGroup could not be disabled, causing some a11y checkers to be flagging it for contrast issues.

## New Behavior

TagGroup can now be disabled, and it disables all tags within it.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Part of #32297
- Fixes [ADO issue](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/19976)
