### PR TITLE
fix(react-utilities): ensures assertSlots keeps non nullables

### DIFF
--- a/change/@fluentui-react-card-c7210dae-bb58-40a1-99ee-7334aaaa6ad7.json
+++ b/change/@fluentui-react-card-c7210dae-bb58-40a1-99ee-7334aaaa6ad7.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "chore: follow up on assertSlots fixes",
+  "comment": "fix: follow up on assertSlots fixes",
   "packageName": "@fluentui/react-card",
   "email": "bernardo.sunderhus@gmail.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-card-c7210dae-bb58-40a1-99ee-7334aaaa6ad7.json
+++ b/change/@fluentui-react-card-c7210dae-bb58-40a1-99ee-7334aaaa6ad7.json
@@ -1,7 +1,7 @@
 {
   "type": "patch",
   "comment": "chore: follow up on assertSlots fixes",
-  "packageName": "@fluentui/react-utilities",
+  "packageName": "@fluentui/react-card",
   "email": "bernardo.sunderhus@gmail.com",
   "dependentChangeType": "patch"
 }

--- a/change/@fluentui-react-carousel-preview-f78217f2-d0d0-4954-827d-b3c45758e8d7.json
+++ b/change/@fluentui-react-carousel-preview-f78217f2-d0d0-4954-827d-b3c45758e8d7.json
@@ -1,7 +1,7 @@
 {
   "type": "patch",
   "comment": "chore: follow up on assertSlots fixes",
-  "packageName": "@fluentui/react-utilities",
+  "packageName": "@fluentui/react-carousel-preview",
   "email": "bernardo.sunderhus@gmail.com",
   "dependentChangeType": "patch"
 }

--- a/change/@fluentui-react-checkbox-1746366e-d12f-4331-a559-41f4f5255f47.json
+++ b/change/@fluentui-react-checkbox-1746366e-d12f-4331-a559-41f4f5255f47.json
@@ -1,7 +1,7 @@
 {
   "type": "patch",
   "comment": "chore: follow up on assertSlots fixes",
-  "packageName": "@fluentui/react-utilities",
+  "packageName": "@fluentui/react-checkbox",
   "email": "bernardo.sunderhus@gmail.com",
   "dependentChangeType": "patch"
 }

--- a/change/@fluentui-react-dialog-7cf46de8-6bff-4b17-a484-c87cb1a43539.json
+++ b/change/@fluentui-react-dialog-7cf46de8-6bff-4b17-a484-c87cb1a43539.json
@@ -1,7 +1,7 @@
 {
   "type": "patch",
   "comment": "chore: follow up on assertSlots fixes",
-  "packageName": "@fluentui/react-utilities",
+  "packageName": "@fluentui/react-dialog",
   "email": "bernardo.sunderhus@gmail.com",
   "dependentChangeType": "patch"
 }

--- a/change/@fluentui-react-drawer-c22ff307-e061-4632-a59b-cdc1791669e0.json
+++ b/change/@fluentui-react-drawer-c22ff307-e061-4632-a59b-cdc1791669e0.json
@@ -1,7 +1,7 @@
 {
   "type": "patch",
   "comment": "chore: follow up on assertSlots fixes",
-  "packageName": "@fluentui/react-utilities",
+  "packageName": "@fluentui/react-drawer",
   "email": "bernardo.sunderhus@gmail.com",
   "dependentChangeType": "patch"
 }

--- a/change/@fluentui-react-select-e83d2ef3-b053-4d9e-b8e0-5eacc561d58f.json
+++ b/change/@fluentui-react-select-e83d2ef3-b053-4d9e-b8e0-5eacc561d58f.json
@@ -1,7 +1,7 @@
 {
   "type": "patch",
   "comment": "chore: follow up on assertSlots fixes",
-  "packageName": "@fluentui/react-utilities",
+  "packageName": "@fluentui/react-select",
   "email": "bernardo.sunderhus@gmail.com",
   "dependentChangeType": "patch"
 }

--- a/change/@fluentui-react-utilities-7f549d04-8b5c-4106-a0ab-2d7ded381d9f.json
+++ b/change/@fluentui-react-utilities-7f549d04-8b5c-4106-a0ab-2d7ded381d9f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: ensures assertSlots keeps non nullables",
+  "packageName": "@fluentui/react-utilities",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-card/library/src/components/CardHeader/renderCardHeader.tsx
+++ b/packages/react-components/react-card/library/src/components/CardHeader/renderCardHeader.tsx
@@ -13,7 +13,7 @@ export const renderCardHeader_unstable = (state: CardHeaderState) => {
   return (
     <state.root>
       {state.image && <state.image />}
-      <state.header />
+      {state.header && <state.header />}
       {state.description && <state.description />}
       {state.action && <state.action />}
     </state.root>

--- a/packages/react-components/react-carousel-preview/library/etc/react-carousel-preview.api.md
+++ b/packages/react-components/react-carousel-preview/library/etc/react-carousel-preview.api.md
@@ -140,7 +140,7 @@ export type CarouselNavImageButtonProps = ComponentProps<CarouselNavImageButtonS
 // @public (undocumented)
 export type CarouselNavImageButtonSlots = {
     root: NonNullable<Slot<ARIAButtonSlotProps>>;
-    image: Slot<'img'>;
+    image: NonNullable<Slot<'img'>>;
 };
 
 // @public

--- a/packages/react-components/react-carousel-preview/library/src/components/CarouselNavImageButton/CarouselNavImageButton.types.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/CarouselNavImageButton/CarouselNavImageButton.types.ts
@@ -9,7 +9,7 @@ export type CarouselNavImageButtonSlots = {
   /**
    * Required: The image within the button
    */
-  image: Slot<'img'>;
+  image: NonNullable<Slot<'img'>>;
 };
 
 /**

--- a/packages/react-components/react-checkbox/library/src/components/Checkbox/renderCheckbox.tsx
+++ b/packages/react-components/react-checkbox/library/src/components/Checkbox/renderCheckbox.tsx
@@ -11,7 +11,7 @@ export const renderCheckbox_unstable = (state: CheckboxState) => {
     <state.root>
       <state.input />
       {state.labelPosition === 'before' && state.label && <state.label />}
-      <state.indicator />
+      {state.indicator && <state.indicator />}
       {state.labelPosition === 'after' && state.label && <state.label />}
     </state.root>
   );

--- a/packages/react-components/react-dialog/library/etc/react-dialog.api.md
+++ b/packages/react-components/react-dialog/library/etc/react-dialog.api.md
@@ -143,7 +143,7 @@ export type DialogSlots = {
 };
 
 // @public (undocumented)
-export type DialogState = ComponentState<DialogSlots> & DialogContextValue & {
+export type DialogState = ComponentState<InternalDialogSlots> & DialogContextValue & {
     content: React_2.ReactNode;
     trigger: React_2.ReactNode;
 };

--- a/packages/react-components/react-dialog/library/src/components/Dialog/Dialog.types.ts
+++ b/packages/react-components/react-dialog/library/src/components/Dialog/Dialog.types.ts
@@ -9,6 +9,11 @@ export type DialogSlots = {
   surfaceMotion: Slot<PresenceMotionSlotProps>;
 };
 
+export type InternalDialogSlots = {
+  // motion slots cannot be nullable
+  surfaceMotion: NonNullable<Slot<PresenceMotionSlotProps>>;
+};
+
 export type DialogOpenChangeEvent = DialogOpenChangeData['event'];
 
 export type DialogOpenChangeData =
@@ -101,7 +106,7 @@ export type DialogProps = ComponentProps<Partial<DialogSlots>> & {
   inertTrapFocus?: boolean;
 };
 
-export type DialogState = ComponentState<DialogSlots> &
+export type DialogState = ComponentState<InternalDialogSlots> &
   DialogContextValue & {
     content: React.ReactNode;
     trigger: React.ReactNode;

--- a/packages/react-components/react-dialog/library/src/components/Dialog/renderDialog.tsx
+++ b/packages/react-components/react-dialog/library/src/components/Dialog/renderDialog.tsx
@@ -18,15 +18,18 @@ export const renderDialog_unstable = (state: DialogState, contextValues: DialogC
     <DialogProvider value={contextValues.dialog}>
       <DialogSurfaceProvider value={contextValues.dialogSurface}>
         {state.trigger}
-        {state.content && (
-          <state.surfaceMotion>
-            <MotionRefForwarder>
-              {/* Casting here as content should be equivalent to <DialogSurface/> */}
-              {/* FIXME: content should not be ReactNode it should be ReactElement instead. */}
-              {state.content as React.ReactElement}
-            </MotionRefForwarder>
-          </state.surfaceMotion>
-        )}
+        {state.content &&
+          // TODO: state.surfaceMotion is non nullable, but assertSlots asserts it as nullable
+          // FIXME: this should be resolved by properly splitting props and state slots declaration
+          state.surfaceMotion && (
+            <state.surfaceMotion>
+              <MotionRefForwarder>
+                {/* Casting here as content should be equivalent to <DialogSurface/> */}
+                {/* FIXME: content should not be ReactNode it should be ReactElement instead. */}
+                {state.content as React.ReactElement}
+              </MotionRefForwarder>
+            </state.surfaceMotion>
+          )}
       </DialogSurfaceProvider>
     </DialogProvider>
   );

--- a/packages/react-components/react-dialog/library/src/components/Dialog/renderDialog.tsx
+++ b/packages/react-components/react-dialog/library/src/components/Dialog/renderDialog.tsx
@@ -6,30 +6,27 @@ import * as React from 'react';
 
 import { MotionRefForwarder } from '../MotionRefForwarder';
 import { DialogProvider, DialogSurfaceProvider } from '../../contexts';
-import type { DialogState, DialogContextValues, DialogSlots } from './Dialog.types';
+import type { DialogState, DialogContextValues, InternalDialogSlots } from './Dialog.types';
 
 /**
  * Render the final JSX of Dialog
  */
 export const renderDialog_unstable = (state: DialogState, contextValues: DialogContextValues) => {
-  assertSlots<DialogSlots>(state);
+  assertSlots<InternalDialogSlots>(state);
 
   return (
     <DialogProvider value={contextValues.dialog}>
       <DialogSurfaceProvider value={contextValues.dialogSurface}>
         {state.trigger}
-        {state.content &&
-          // TODO: state.surfaceMotion is non nullable, but assertSlots asserts it as nullable
-          // FIXME: this should be resolved by properly splitting props and state slots declaration
-          state.surfaceMotion && (
-            <state.surfaceMotion>
-              <MotionRefForwarder>
-                {/* Casting here as content should be equivalent to <DialogSurface/> */}
-                {/* FIXME: content should not be ReactNode it should be ReactElement instead. */}
-                {state.content as React.ReactElement}
-              </MotionRefForwarder>
-            </state.surfaceMotion>
-          )}
+        {state.content && (
+          <state.surfaceMotion>
+            <MotionRefForwarder>
+              {/* Casting here as content should be equivalent to <DialogSurface/> */}
+              {/* FIXME: content should not be ReactNode it should be ReactElement instead. */}
+              {state.content as React.ReactElement}
+            </MotionRefForwarder>
+          </state.surfaceMotion>
+        )}
       </DialogSurfaceProvider>
     </DialogProvider>
   );

--- a/packages/react-components/react-dialog/library/src/components/DialogSurface/renderDialogSurface.tsx
+++ b/packages/react-components/react-dialog/library/src/components/DialogSurface/renderDialogSurface.tsx
@@ -15,11 +15,14 @@ export const renderDialogSurface_unstable = (state: DialogSurfaceState, contextV
 
   return (
     <Portal mountNode={state.mountNode}>
-      {state.backdrop && (
-        <state.backdropMotion>
-          <state.backdrop />
-        </state.backdropMotion>
-      )}
+      {state.backdrop &&
+        // TODO: state.backdropMotion is non nullable, but assertSlots asserts it as nullable
+        // FIXME: this should be resolved by properly splitting props and state slots declaration
+        state.backdropMotion && (
+          <state.backdropMotion>
+            <state.backdrop />
+          </state.backdropMotion>
+        )}
       <DialogSurfaceProvider value={contextValues.dialogSurface}>
         <state.root />
       </DialogSurfaceProvider>

--- a/packages/react-components/react-drawer/library/src/components/OverlayDrawer/OverlayDrawer.types.ts
+++ b/packages/react-components/react-drawer/library/src/components/OverlayDrawer/OverlayDrawer.types.ts
@@ -26,7 +26,7 @@ export type OverlayDrawerInternalSlots = Pick<OverlayDrawerSlots, 'root'> & {
   /**
    * Slot for the dialog component that wraps the drawer.
    */
-  dialog: Slot<DialogProps>;
+  dialog: NonNullable<Slot<DialogProps>>;
 };
 
 /**

--- a/packages/react-components/react-drawer/library/src/components/OverlayDrawer/renderOverlayDrawer.tsx
+++ b/packages/react-components/react-drawer/library/src/components/OverlayDrawer/renderOverlayDrawer.tsx
@@ -13,9 +13,15 @@ export const renderOverlayDrawer_unstable = (state: OverlayDrawerState, contextV
 
   return (
     <DrawerProvider value={contextValue}>
-      <state.dialog>
-        <state.root />
-      </state.dialog>
+      {
+        // TODO: state.dialog is non nullable, but assertSlots asserts it as nullable
+        // FIXME: this should be resolved by properly splitting props and state slots declaration
+        state.dialog && (
+          <state.dialog>
+            <state.root />
+          </state.dialog>
+        )
+      }
     </DrawerProvider>
   );
 };

--- a/packages/react-components/react-drawer/library/src/components/OverlayDrawer/renderOverlayDrawer.tsx
+++ b/packages/react-components/react-drawer/library/src/components/OverlayDrawer/renderOverlayDrawer.tsx
@@ -13,15 +13,9 @@ export const renderOverlayDrawer_unstable = (state: OverlayDrawerState, contextV
 
   return (
     <DrawerProvider value={contextValue}>
-      {
-        // TODO: state.dialog is non nullable, but assertSlots asserts it as nullable
-        // FIXME: this should be resolved by properly splitting props and state slots declaration
-        state.dialog && (
-          <state.dialog>
-            <state.root />
-          </state.dialog>
-        )
-      }
+      <state.dialog>
+        <state.root />
+      </state.dialog>
     </DrawerProvider>
   );
 };

--- a/packages/react-components/react-motion/library/src/slots/presenceMotionSlot.test.tsx
+++ b/packages/react-components/react-motion/library/src/slots/presenceMotionSlot.test.tsx
@@ -37,9 +37,15 @@ const TestComponent: React.FC<TestComponentProps> = props => {
 
   return (
     <div data-testid="root">
-      <state.presenceMotion>
-        <div data-testid="content" />
-      </state.presenceMotion>
+      {
+        // TODO: state.presenceMotion is non nullable, but assertSlots asserts it as nullable
+        // FIXME: this should be resolved by properly splitting props and state slots declaration
+        state.presenceMotion && (
+          <state.presenceMotion>
+            <div data-testid="content" />
+          </state.presenceMotion>
+        )
+      }
     </div>
   );
 };

--- a/packages/react-components/react-select/library/src/components/Select/renderSelect.tsx
+++ b/packages/react-components/react-select/library/src/components/Select/renderSelect.tsx
@@ -12,7 +12,7 @@ export const renderSelect_unstable = (state: SelectState) => {
   return (
     <state.root>
       <state.select>{state.select.children}</state.select>
-      <state.icon />
+      {state.icon && <state.icon />}
     </state.root>
   );
 };

--- a/packages/react-components/react-utilities/src/compose/assertSlots.test.tsx
+++ b/packages/react-components/react-utilities/src/compose/assertSlots.test.tsx
@@ -59,4 +59,14 @@ describe('assertSlots', () => {
     expect(consoleWarnMock).toHaveBeenCalledTimes(1);
     consoleWarnMock.mockRestore();
   });
+  it('should keep non nullable types', () => {
+    type Slots = { slot: Slot<'div'> };
+    const state: ComponentState<Slots> = {
+      components: { slot: 'div' },
+      slot: undefined,
+    };
+    assertSlots<Slots>(state);
+    // @ts-expect-error - slot can be undefined
+    expect(() => state.slot.about).toThrow();
+  });
 });

--- a/packages/react-components/react-utilities/src/compose/assertSlots.ts
+++ b/packages/react-components/react-utilities/src/compose/assertSlots.ts
@@ -4,8 +4,8 @@ import { isSlot } from './isSlot';
 import { ComponentState, ExtractSlotProps, SlotComponentType, SlotPropsRecord } from './types';
 import * as slot from './slot';
 
-type SlotComponents<Slots extends SlotPropsRecord> = {
-  [K in keyof Slots]: SlotComponentType<ExtractSlotProps<Slots[K]>>;
+export type SlotComponents<Slots extends SlotPropsRecord> = {
+  [K in keyof Slots]: SlotComponentType<ExtractSlotProps<Slots[K]>> | (null extends Slots[K] ? undefined : never);
 };
 
 /**

--- a/packages/react-components/react-utilities/src/compose/assertSlots.ts
+++ b/packages/react-components/react-utilities/src/compose/assertSlots.ts
@@ -4,7 +4,7 @@ import { isSlot } from './isSlot';
 import { ComponentState, ExtractSlotProps, SlotComponentType, SlotPropsRecord } from './types';
 import * as slot from './slot';
 
-export type SlotComponents<Slots extends SlotPropsRecord> = {
+type SlotComponents<Slots extends SlotPropsRecord> = {
   [K in keyof Slots]: SlotComponentType<ExtractSlotProps<Slots[K]>> | (null extends Slots[K] ? undefined : never);
 };
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

1. adds to `assertSlot` a verification to ensure that if the slot declaration is `NonNullable` this will be respected
2. updates types accordingly on:
    * `react-dialog`
    * `react-checkbox`
    * `react-card`
    * `react-drawer`
    * `react-select`
    * `react-carousel-preview`
3. adds internal slots for components with motion slots. Motion slots have an incompatible signature between `Props` and `State`, on `Props` they support being nullable while in `State` a motion slot should never be nullable.
> This is a _band-aid_ 🩹🤕, not a proper solution. The problem here lies on a previous generalization where we use the same slot type declaration for both `Props` and `State` declaration. This generalization is problematic as there are differences between internal and external values. A proper solution should be discussed through a RFC

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/32321
