### PR TITLE
[issue 32327] Align positions for Toggles Enable Gradient and Rounded Corners

### DIFF
--- a/packages/react-examples/src/react-charting/GaugeChart/GaugeChart.Basic.Example.tsx
+++ b/packages/react-examples/src/react-charting/GaugeChart/GaugeChart.Basic.Example.tsx
@@ -91,6 +91,7 @@ export class GaugeChartBasicExample extends React.Component<{}, IGCBasicExampleS
             checked={this.state.enableGradient}
             onChange={this._onToggleGradient}
           />
+          &nbsp;&nbsp;
           <Toggle
             label="Rounded Corners"
             onText="ON"

--- a/packages/react-examples/src/react-charting/GaugeChart/GaugeChart.SingleSegment.Example.tsx
+++ b/packages/react-examples/src/react-charting/GaugeChart/GaugeChart.SingleSegment.Example.tsx
@@ -83,6 +83,7 @@ export class GaugeChartSingleSegmentExample extends React.Component<{}, IGCSingl
             checked={this.state.enableGradient}
             onChange={this._onToggleGradient}
           />
+          &nbsp;&nbsp;
           <Toggle
             label="Rounded Corners"
             onText="ON"

--- a/packages/react-examples/src/react-charting/GroupedVerticalBarChart/GroupedVerticalBarChart.Basic.Example.tsx
+++ b/packages/react-examples/src/react-charting/GroupedVerticalBarChart/GroupedVerticalBarChart.Basic.Example.tsx
@@ -232,6 +232,7 @@ export class GroupedVerticalBarChartBasicExample extends React.Component<{}, IGr
         />
         <div style={{ display: 'flex' }}>
           <Toggle label="Enable Gradient" onText="ON" offText="OFF" onChange={this._onEnableGradientChange} />
+          &nbsp;&nbsp;
           <Toggle label="Rounded Corners" onText="ON" offText="OFF" onChange={this._onRoundCornersChange} />
         </div>
         <div style={rootStyle}>

--- a/packages/react-examples/src/react-charting/GroupedVerticalBarChart/GroupedVerticalBarChart.CustomAccessibility.Example.tsx
+++ b/packages/react-examples/src/react-charting/GroupedVerticalBarChart/GroupedVerticalBarChart.CustomAccessibility.Example.tsx
@@ -211,6 +211,7 @@ export class GroupedVerticalBarChartCustomAccessibilityExample extends React.Com
         />
         <div style={{ display: 'flex' }}>
           <Toggle label="Enable Gradient" onText="ON" offText="OFF" onChange={this._onEnableGradientChange} />
+          &nbsp;&nbsp;
           <Toggle label="Rounded Corners" onText="ON" offText="OFF" onChange={this._onRoundCornersChange} />
         </div>
 

--- a/packages/react-examples/src/react-charting/HorizontalBarChart/HorizontalBarChart.Basic.Example.tsx
+++ b/packages/react-examples/src/react-charting/HorizontalBarChart/HorizontalBarChart.Basic.Example.tsx
@@ -155,7 +155,9 @@ export class HorizontalBarChartBasicExample extends React.Component<
             offText="Chart mode absolute"
             onChange={this._onChangeChartMode}
           />
+          &nbsp;&nbsp;
           <Toggle label="Enable Gradient" onText="ON" offText="OFF" onChange={this._onToggleGradient} />
+          &nbsp;&nbsp;
           <Toggle label="Rounded Corners" onText="ON" offText="OFF" onChange={this._onToggleRoundCorners} />
         </div>
 

--- a/packages/react-examples/src/react-charting/HorizontalBarChartWithAxis/HorizontalBarChartWithAxis.Basic.Example.tsx
+++ b/packages/react-examples/src/react-charting/HorizontalBarChartWithAxis/HorizontalBarChartWithAxis.Basic.Example.tsx
@@ -144,8 +144,11 @@ export class HorizontalBarChartWithAxisBasicExample extends React.Component<
           onChange={this._onCheckChange}
           styles={{ root: { marginTop: '20px' } }}
         />
-        <Toggle label="Enable Gradient" onText="ON" offText="OFF" onChange={this._onToggleGradient} />
-        <Toggle label="Rounded Corners" onText="ON" offText="OFF" onChange={this._onToggleRoundCorners} />
+        <div style={{display: "flex"}}>
+          <Toggle label="Enable Gradient" onText="ON" offText="OFF" onChange={this._onToggleGradient} />
+          &nbsp;&nbsp;
+          <Toggle label="Rounded Corners" onText="ON" offText="OFF" onChange={this._onToggleRoundCorners} />
+        </div>
         <br />
 
         <div style={rootStyle}>

--- a/packages/react-examples/src/react-charting/HorizontalBarChartWithAxis/HorizontalBarChartWithAxis.Basic.Example.tsx
+++ b/packages/react-examples/src/react-charting/HorizontalBarChartWithAxis/HorizontalBarChartWithAxis.Basic.Example.tsx
@@ -144,7 +144,7 @@ export class HorizontalBarChartWithAxisBasicExample extends React.Component<
           onChange={this._onCheckChange}
           styles={{ root: { marginTop: '20px' } }}
         />
-        <div style={{display: "flex"}}>
+        <div style={{ display: 'flex' }}>
           <Toggle label="Enable Gradient" onText="ON" offText="OFF" onChange={this._onToggleGradient} />
           &nbsp;&nbsp;
           <Toggle label="Rounded Corners" onText="ON" offText="OFF" onChange={this._onToggleRoundCorners} />

--- a/packages/react-examples/src/react-charting/HorizontalBarChartWithAxis/HorizontalBarChartWithAxis.StringAxisTooltip.Example.tsx
+++ b/packages/react-examples/src/react-charting/HorizontalBarChartWithAxis/HorizontalBarChartWithAxis.StringAxisTooltip.Example.tsx
@@ -80,8 +80,11 @@ export class HorizontalBarChartWithAxisStringAxisTooltipExample extends React.Co
             onChange={(_ev, option) => option && this.setState({ selectedCallout: option.key })}
             label="Pick one"
           />
-          <Toggle label="Enable Gradient" onText="ON" offText="OFF" onChange={this._onToggleGradient} />
-          <Toggle label="Rounded Corners" onText="ON" offText="OFF" onChange={this._onToggleRoundedCorners} />
+          <div style={{display: "flex"}}>
+            <Toggle label="Enable Gradient" onText="ON" offText="OFF" onChange={this._onToggleGradient} />
+            &nbsp;&nbsp;
+            <Toggle label="Rounded Corners" onText="ON" offText="OFF" onChange={this._onToggleRoundedCorners} />
+          </div>
         </div>
 
         <div style={rootStyle}>

--- a/packages/react-examples/src/react-charting/HorizontalBarChartWithAxis/HorizontalBarChartWithAxis.StringAxisTooltip.Example.tsx
+++ b/packages/react-examples/src/react-charting/HorizontalBarChartWithAxis/HorizontalBarChartWithAxis.StringAxisTooltip.Example.tsx
@@ -80,7 +80,7 @@ export class HorizontalBarChartWithAxisStringAxisTooltipExample extends React.Co
             onChange={(_ev, option) => option && this.setState({ selectedCallout: option.key })}
             label="Pick one"
           />
-          <div style={{display: "flex"}}>
+          <div style={{ display: 'flex' }}>
             <Toggle label="Enable Gradient" onText="ON" offText="OFF" onChange={this._onToggleGradient} />
             &nbsp;&nbsp;
             <Toggle label="Rounded Corners" onText="ON" offText="OFF" onChange={this._onToggleRoundedCorners} />

--- a/packages/react-examples/src/react-charting/MultiStackedBarChart/MultiStackedBarChart.Example.tsx
+++ b/packages/react-examples/src/react-charting/MultiStackedBarChart/MultiStackedBarChart.Example.tsx
@@ -173,6 +173,7 @@ export const MultiStackedBarChartBasicExample: React.FunctionComponent = () => {
           // eslint-disable-next-line react/jsx-no-bind
           onChange={(ev: any, checked: boolean) => setEnableGradient(checked)}
         />
+        &nbsp;&nbsp;
         <Toggle
           label="Rounded Corners"
           onText="ON"

--- a/packages/react-examples/src/react-charting/StackedBarChart/MultiStackedBarChart.Example.tsx
+++ b/packages/react-examples/src/react-charting/StackedBarChart/MultiStackedBarChart.Example.tsx
@@ -136,6 +136,7 @@ export const MultiStackedBarChartExample: React.FunctionComponent<{}> = () => {
           // eslint-disable-next-line react/jsx-no-bind
           onChange={onToggleGradient}
         />
+        &nbsp;&nbsp;
         <Toggle
           label="Rounded Corners"
           onText="ON"

--- a/packages/react-examples/src/react-charting/StackedBarChart/StackedBarChart.Basic.Example.tsx
+++ b/packages/react-examples/src/react-charting/StackedBarChart/StackedBarChart.Basic.Example.tsx
@@ -49,7 +49,7 @@ export class StackedBarChartBasicExample extends React.Component<{}, IStackedBar
           onChange={this._onHideTooltipChange}
           styles={{ root: { marginBottom: '20px' } }}
         />
-        <div style={{display: "flex"}}>
+        <div style={{ display: 'flex' }}>
           <Toggle label="Enable Gradient" onText="ON" offText="OFF" onChange={this._onToggleGradient} />
           &nbsp;&nbsp;
           <Toggle label="Rounded Corners" onText="ON" offText="OFF" onChange={this._onToggleRoundCorners} />

--- a/packages/react-examples/src/react-charting/StackedBarChart/StackedBarChart.Basic.Example.tsx
+++ b/packages/react-examples/src/react-charting/StackedBarChart/StackedBarChart.Basic.Example.tsx
@@ -49,8 +49,11 @@ export class StackedBarChartBasicExample extends React.Component<{}, IStackedBar
           onChange={this._onHideTooltipChange}
           styles={{ root: { marginBottom: '20px' } }}
         />
-        <Toggle label="Enable Gradient" onText="ON" offText="OFF" onChange={this._onToggleGradient} />
-        <Toggle label="Rounded Corners" onText="ON" offText="OFF" onChange={this._onToggleRoundCorners} />
+        <div style={{display: "flex"}}>
+          <Toggle label="Enable Gradient" onText="ON" offText="OFF" onChange={this._onToggleGradient} />
+          &nbsp;&nbsp;
+          <Toggle label="Rounded Corners" onText="ON" offText="OFF" onChange={this._onToggleRoundCorners} />
+        </div>
 
         <br />
         <StackedBarChart

--- a/packages/react-examples/src/react-charting/StackedBarChart/StackedBarChart.Dynamic.Example.tsx
+++ b/packages/react-examples/src/react-charting/StackedBarChart/StackedBarChart.Dynamic.Example.tsx
@@ -113,6 +113,7 @@ export class StackedBarChartDynamicExample extends React.Component<{}, IExampleS
       <div>
         <div style={{ display: 'flex' }}>
           <Toggle label="Enable Gradient" onText="ON" offText="OFF" onChange={this._onToggleGradient} />
+          &nbsp;&nbsp;
           <Toggle label="Rounded Corners" onText="ON" offText="OFF" onChange={this._onToggleRoundCorners} />
         </div>
         <br />

--- a/packages/react-examples/src/react-charting/StackedBarChart/StackedBarChart.Multiple.Example.tsx
+++ b/packages/react-examples/src/react-charting/StackedBarChart/StackedBarChart.Multiple.Example.tsx
@@ -45,6 +45,7 @@ export class StackedBarChartMultipleExample extends React.Component<{}, IStacked
       <>
         <div style={{ display: 'flex' }}>
           <Toggle label="Enable Gradient" onText="ON" offText="OFF" onChange={this._onToggleGradient} />
+          &nbsp;&nbsp;
           <Toggle label="Rounded Corners" onText="ON" offText="OFF" onChange={this._onToggleRoundCorners} />
         </div>
         <br />

--- a/packages/react-examples/src/react-charting/VerticalBarChart/VerticalBarChart.AxisTooltip.Example.tsx
+++ b/packages/react-examples/src/react-charting/VerticalBarChart/VerticalBarChart.AxisTooltip.Example.tsx
@@ -214,6 +214,7 @@ export class VerticalBarChartTooltipExample extends React.Component<{}, IVertica
           />
 
           <Toggle label="Enable Gradient" onText="ON" offText="OFF" onChange={this._onToggleGradient} />
+          &nbsp;&nbsp;
           <Toggle label="Rounded Corners" onText="ON" offText="OFF" onChange={this._onToggleRoundedCorners} />
         </Stack>
 

--- a/packages/react-examples/src/react-charting/VerticalBarChart/VerticalBarChart.AxisTooltip.Example.tsx
+++ b/packages/react-examples/src/react-charting/VerticalBarChart/VerticalBarChart.AxisTooltip.Example.tsx
@@ -212,7 +212,6 @@ export class VerticalBarChartTooltipExample extends React.Component<{}, IVertica
             onChange={(_ev, option) => option && this.setState({ selectedCallout: option.key })}
             label="Pick one"
           />
-
           <Toggle label="Enable Gradient" onText="ON" offText="OFF" onChange={this._onToggleGradient} />
           &nbsp;&nbsp;
           <Toggle label="Rounded Corners" onText="ON" offText="OFF" onChange={this._onToggleRoundedCorners} />

--- a/packages/react-examples/src/react-charting/VerticalBarChart/VerticalBarChart.Basic.Example.tsx
+++ b/packages/react-examples/src/react-charting/VerticalBarChart/VerticalBarChart.Basic.Example.tsx
@@ -232,6 +232,7 @@ export class VerticalBarChartBasicExample extends React.Component<IVerticalBarCh
         />
         <div style={{ display: 'flex' }}>
           <Toggle label="Enable Gradient" onText="ON" offText="OFF" onChange={this._onToggleGradient} />
+          &nbsp;&nbsp;
           <Toggle label="Rounded Corners" onText="ON" offText="OFF" onChange={this._onToggleRoundCorners} />
         </div>
         {this.state.showAxisTitles && (

--- a/packages/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.AxisTooltip.Example.tsx
+++ b/packages/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.AxisTooltip.Example.tsx
@@ -219,7 +219,9 @@ export class VerticalStackedBarChartTooltipExample extends React.Component<{}, I
             onChange={(_ev, option) => option && this.setState({ selectedCallout: option.key })}
             label="Pick one"
           />
+          &nbsp;&nbsp;
           <Toggle label="Enable Gradient" onText="ON" offText="OFF" onChange={this._onToggleGradient} />
+          &nbsp;&nbsp;
           <Toggle label="Rounded Corners" onText="ON" offText="OFF" onChange={this._onToggleRoundedCorners} />
         </Stack>
 

--- a/packages/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.Basic.Example.tsx
+++ b/packages/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.Basic.Example.tsx
@@ -303,7 +303,9 @@ export class VerticalStackedBarChartBasicExample extends React.Component<{}, IVe
             checked={this.state.showAxisTitles}
             onChange={this._onToggleAxisTitlesCheckChange}
           />
+          &nbsp;&nbsp;
           <Toggle label="Enable Gradient" onText="ON" offText="OFF" onChange={this._onEnableGradientChange} />
+          &nbsp;&nbsp;
           <Toggle label="Rounded Corners" onText="ON" offText="OFF" onChange={this._onRoundCornersChange} />
         </div>
         {this.state.showAxisTitles && (

--- a/packages/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.Styled.Example.tsx
+++ b/packages/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.Styled.Example.tsx
@@ -176,7 +176,9 @@ export class VerticalStackedBarChartStyledExample extends React.Component<{}, IV
               onChange={(_ev, option) => option && this.setState({ selectedCallout: option.key })}
               label="Pick one"
             />
+            &nbsp;&nbsp;
             <Toggle label="Enable Gradient" onText="ON" offText="OFF" onChange={this._onToggleGradient} />
+            &nbsp;&nbsp;
             <Toggle label="Rounded Corners" onText="ON" offText="OFF" onChange={this._onToggleRoundedCorners} />
           </div>
         </div>
@@ -214,7 +216,6 @@ export class VerticalStackedBarChartStyledExample extends React.Component<{}, IV
                 },
               },
             }}
-            // eslint-disable-next-line react/jsx-no-bind
             {...(this.state.selectedCallout === 'singleCallout' && {
               onRenderCalloutPerDataPoint: (props: IVSChartDataPoint) => {
                 return props ? (


### PR DESCRIPTION
## Previous Behavior
Toggle positions Enable Gradient and rounder corners are not aligned properly for all the charts.
for some charts it is in a single line, some one above the other, and for some charts there is no gap between them

## New Behavior

Toggles for Enable Gradient and Rounded Corners are all horizontally aligned with equal space between for all chart

## Related Issue(s)
#32327 
