### PR TITLE
chore(tools/*,scripts/*): enable nx plugins with project crystal for non production projects

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -43,7 +43,10 @@
     "test": {
       "dependsOn": [],
       "inputs": ["default", "^production", "{workspaceRoot}/jest.preset.js"],
-      "cache": true
+      "cache": true,
+      "options": {
+        "passWithNoTests": true
+      }
     },
     "test-integration": {
       "dependsOn": ["build", "^build"],
@@ -73,7 +76,10 @@
         "{workspaceRoot}/.eslintrc.json",
         "{workspaceRoot}/.eslintignore",
         "{workspaceRoot}/eslint.config.js"
-      ]
+      ],
+      "options": {
+        "command": "eslint src"
+      }
     },
     "verify-packaging": {
       "dependsOn": ["build"],
@@ -123,14 +129,14 @@
       "options": {
         "targetName": "test"
       },
-      "include": ["tools/**/*"]
+      "include": ["tools/**/*", "scripts/**/*"]
     },
     {
       "plugin": "@nx/eslint/plugin",
       "options": {
         "targetName": "lint"
       },
-      "include": ["tools/**/*"]
+      "include": ["tools/**/*", "scripts/**/*"]
     }
   ]
 }

--- a/nx.json
+++ b/nx.json
@@ -116,5 +116,21 @@
   },
   "parallel": 3,
   "useInferencePlugins": false,
-  "defaultBase": "master"
+  "defaultBase": "master",
+  "plugins": [
+    {
+      "plugin": "@nx/jest/plugin",
+      "options": {
+        "targetName": "test"
+      },
+      "include": ["tools/**/*"]
+    },
+    {
+      "plugin": "@nx/eslint/plugin",
+      "options": {
+        "targetName": "lint"
+      },
+      "include": ["tools/**/*"]
+    }
+  ]
 }

--- a/scripts/api-extractor/package.json
+++ b/scripts/api-extractor/package.json
@@ -6,8 +6,6 @@
   "scripts": {
     "format": "prettier -w --ignore-path ../../.prettierignore .",
     "format:check": "yarn format -c",
-    "lint": "eslint --ext .ts,.js ./src",
-    "test": "jest --passWithNoTests",
     "type-check": "just-scripts type-check"
   },
   "dependencies": {},

--- a/scripts/babel/package.json
+++ b/scripts/babel/package.json
@@ -6,8 +6,6 @@
   "scripts": {
     "format": "prettier -w --ignore-path ../../.prettierignore .",
     "format:check": "yarn format -c",
-    "lint": "eslint --ext .ts,.js ./src",
-    "test": "jest --passWithNoTests",
     "type-check": "just-scripts type-check"
   },
   "dependencies": {},

--- a/scripts/beachball/package.json
+++ b/scripts/beachball/package.json
@@ -6,8 +6,6 @@
   "scripts": {
     "format": "prettier -w --ignore-path ../../.prettierignore .",
     "format:check": "yarn format -c",
-    "lint": "eslint --ext .ts,.js ./src",
-    "test": "jest --passWithNoTests",
     "type-check": "just-scripts type-check"
   },
   "dependencies": {

--- a/scripts/cypress/package.json
+++ b/scripts/cypress/package.json
@@ -6,8 +6,6 @@
   "scripts": {
     "format": "prettier -w --ignore-path ../../.prettierignore .",
     "format:check": "yarn format -c",
-    "lint": "eslint --ext .ts,.js ./src",
-    "test": "jest --passWithNoTests",
     "type-check": "just-scripts type-check"
   },
   "dependencies": {},

--- a/scripts/dangerjs/package.json
+++ b/scripts/dangerjs/package.json
@@ -6,8 +6,6 @@
   "scripts": {
     "format": "prettier -w --ignore-path ../../.prettierignore .",
     "format:check": "yarn format -c",
-    "lint": "eslint --ext .ts,.js ./src",
-    "test": "jest --passWithNoTests",
     "type-check": "just-scripts type-check"
   },
   "dependencies": {

--- a/scripts/executors/package.json
+++ b/scripts/executors/package.json
@@ -6,8 +6,6 @@
   "scripts": {
     "format": "prettier -w --ignore-path ../../.prettierignore .",
     "format:check": "yarn format -c",
-    "lint": "eslint --ext .ts,.js ./src",
-    "test": "jest --passWithNoTests",
     "type-check": "just-scripts type-check"
   },
   "dependencies": {

--- a/scripts/github/package.json
+++ b/scripts/github/package.json
@@ -6,8 +6,6 @@
   "scripts": {
     "format": "prettier -w --ignore-path ../../.prettierignore .",
     "format:check": "yarn format -c",
-    "lint": "eslint --ext .ts,.js ./src",
-    "test": "jest --passWithNoTests",
     "type-check": "just-scripts type-check"
   },
   "dependencies": {},

--- a/scripts/gulp/package.json
+++ b/scripts/gulp/package.json
@@ -6,8 +6,6 @@
   "scripts": {
     "format": "prettier -w --ignore-path ../../.prettierignore .",
     "format:check": "yarn format -c",
-    "lint": "eslint --ext .ts,.js ./src",
-    "test": "jest --passWithNoTests",
     "type-check": "just-scripts type-check"
   },
   "dependencies": {

--- a/scripts/jest/package.json
+++ b/scripts/jest/package.json
@@ -6,8 +6,6 @@
   "scripts": {
     "format": "prettier -w --ignore-path ../../.prettierignore .",
     "format:check": "yarn format -c",
-    "lint": "eslint --ext .ts,.js ./src",
-    "test": "jest --passWithNoTests",
     "type-check": "just-scripts type-check"
   },
   "dependencies": {

--- a/scripts/lint-staged/package.json
+++ b/scripts/lint-staged/package.json
@@ -6,8 +6,6 @@
   "scripts": {
     "format": "prettier -w --ignore-path ../../.prettierignore .",
     "format:check": "yarn format -c",
-    "lint": "eslint --ext .ts,.js ./src",
-    "test": "jest --passWithNoTests",
     "type-check": "just-scripts type-check"
   },
   "dependencies": {

--- a/scripts/monorepo/jest.config.js
+++ b/scripts/monorepo/jest.config.js
@@ -10,6 +10,7 @@ module.exports = {
     '^.+\\.tsx?$': ['@swc/jest', {}],
   },
   coverageDirectory: './coverage',
+  testTimeout: 20000,
   testEnvironment: 'node',
   setupFiles: ['<rootDir>/jest-setup.js'],
 };

--- a/scripts/monorepo/package.json
+++ b/scripts/monorepo/package.json
@@ -6,8 +6,6 @@
   "scripts": {
     "format": "prettier -w --ignore-path ../../.prettierignore .",
     "format:check": "yarn format -c",
-    "lint": "eslint --ext .ts,.js ./src",
-    "test": "jest --passWithNoTests",
     "type-check": "just-scripts type-check"
   },
   "dependencies": {

--- a/scripts/package-manager/package.json
+++ b/scripts/package-manager/package.json
@@ -6,8 +6,6 @@
   "scripts": {
     "format": "prettier -w --ignore-path ../../.prettierignore .",
     "format:check": "yarn format -c",
-    "lint": "eslint --ext .ts,.js ./src",
-    "test": "jest --passWithNoTests",
     "type-check": "just-scripts type-check"
   },
   "dependencies": {},

--- a/scripts/perf-test-flamegrill/package.json
+++ b/scripts/perf-test-flamegrill/package.json
@@ -6,8 +6,6 @@
   "scripts": {
     "format": "prettier -w --ignore-path ../../.prettierignore .",
     "format:check": "yarn format -c",
-    "lint": "eslint --ext .ts,.js ./src",
-    "test": "jest --passWithNoTests",
     "type-check": "just-scripts type-check"
   },
   "peerDependencies": {

--- a/scripts/prettier/package.json
+++ b/scripts/prettier/package.json
@@ -6,8 +6,6 @@
   "scripts": {
     "format": "prettier -w --ignore-path ../../.prettierignore .",
     "format:check": "yarn format -c",
-    "lint": "eslint --ext .ts,.js ./src",
-    "test": "jest --passWithNoTests",
     "type-check": "just-scripts type-check"
   },
   "dependencies": {

--- a/scripts/projects-test/package.json
+++ b/scripts/projects-test/package.json
@@ -6,8 +6,6 @@
   "scripts": {
     "format": "prettier -w --ignore-path ../../.prettierignore .",
     "format:check": "yarn format -c",
-    "lint": "eslint --ext .ts,.js ./src",
-    "test": "jest --passWithNoTests",
     "type-check": "just-scripts type-check"
   },
   "dependencies": {

--- a/scripts/puppeteer/package.json
+++ b/scripts/puppeteer/package.json
@@ -6,8 +6,6 @@
   "scripts": {
     "format": "prettier -w --ignore-path ../../.prettierignore .",
     "format:check": "yarn format -c",
-    "lint": "eslint --ext .ts,.js ./src",
-    "test": "jest --passWithNoTests",
     "type-check": "just-scripts type-check"
   },
   "dependencies": {},

--- a/scripts/storybook/package.json
+++ b/scripts/storybook/package.json
@@ -6,8 +6,6 @@
   "scripts": {
     "format": "prettier -w --ignore-path ../../.prettierignore .",
     "format:check": "yarn format -c",
-    "lint": "eslint --ext .ts,.js ./src",
-    "test": "jest --passWithNoTests",
     "type-check": "just-scripts type-check"
   },
   "dependencies": {

--- a/scripts/tasks/package.json
+++ b/scripts/tasks/package.json
@@ -6,8 +6,6 @@
   "scripts": {
     "format": "prettier -w --ignore-path ../../.prettierignore .",
     "format:check": "yarn format -c",
-    "lint": "eslint --ext .ts,.js ./src",
-    "test": "jest --passWithNoTests",
     "type-check": "just-scripts type-check"
   },
   "dependencies": {

--- a/scripts/triage-bot/package.json
+++ b/scripts/triage-bot/package.json
@@ -6,8 +6,6 @@
   "scripts": {
     "format": "prettier -w --ignore-path ../../.prettierignore .",
     "format:check": "yarn format -c",
-    "lint": "eslint --ext .ts,.js ./src",
-    "test": "jest --passWithNoTests",
     "type-check": "just-scripts type-check"
   },
   "dependencies": {},

--- a/scripts/ts-node/package.json
+++ b/scripts/ts-node/package.json
@@ -6,8 +6,6 @@
   "scripts": {
     "format": "prettier -w --ignore-path ../../.prettierignore .",
     "format:check": "yarn format -c",
-    "lint": "eslint --ext .ts,.js ./src",
-    "test": "jest --passWithNoTests",
     "type-check": "just-scripts type-check"
   },
   "dependencies": {},

--- a/scripts/update-release-notes/package.json
+++ b/scripts/update-release-notes/package.json
@@ -6,8 +6,6 @@
   "scripts": {
     "format": "prettier -w --ignore-path ../../.prettierignore .",
     "format:check": "yarn format -c",
-    "lint": "eslint --ext .ts,.js ./src",
-    "test": "jest --passWithNoTests",
     "type-check": "just-scripts type-check"
   },
   "dependencies": {

--- a/scripts/utils/package.json
+++ b/scripts/utils/package.json
@@ -6,8 +6,6 @@
   "scripts": {
     "format": "prettier -w --ignore-path ../../.prettierignore .",
     "format:check": "yarn format -c",
-    "lint": "eslint --ext .ts,.js ./src",
-    "test": "jest --passWithNoTests",
     "type-check": "just-scripts type-check"
   },
   "dependencies": {},

--- a/scripts/webpack/package.json
+++ b/scripts/webpack/package.json
@@ -6,8 +6,6 @@
   "scripts": {
     "format": "prettier -w --ignore-path ../../.prettierignore .",
     "format:check": "yarn format -c",
-    "lint": "eslint --ext .ts,.js ./src",
-    "test": "jest --passWithNoTests",
     "type-check": "just-scripts type-check"
   },
   "dependencies": {

--- a/tools/eslint-rules/project.json
+++ b/tools/eslint-rules/project.json
@@ -3,14 +3,6 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "tools/eslint-rules",
   "projectType": "library",
-  "targets": {
-    "test": {
-      "executor": "@nx/jest:jest",
-      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
-      "options": {
-        "jestConfig": "tools/eslint-rules/jest.config.ts"
-      }
-    }
-  },
-  "tags": ["platform:node", "tools"]
+  "tags": ["platform:node", "tools"],
+  "targets": {}
 }

--- a/tools/workspace-plugin/package.json
+++ b/tools/workspace-plugin/package.json
@@ -5,9 +5,7 @@
   "type": "commonjs",
   "generators": "./generators.json",
   "scripts": {
-    "test": "jest --passWithNoTests",
     "type-check": "node  ./scripts/type-check.mjs",
-    "lint": "eslint --ext .ts,.js,.json .",
     "check-graph": "node ./scripts/check-dep-graph.js"
   },
   "dependencies": {

--- a/tools/workspace-plugin/project.json
+++ b/tools/workspace-plugin/project.json
@@ -3,6 +3,7 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "tools/workspace-plugin/src",
   "projectType": "library",
+  "tags": ["platform:node", "tools"],
   "targets": {
     "build": {
       "executor": "@nx/js:tsc",
@@ -35,6 +36,5 @@
         ]
       }
     }
-  },
-  "tags": ["platform:node", "tools"]
+  }
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

- we don't use any nx functionality for actual task execution ( jest/gulp only )

## New Behavior

future of our monorepo setup is via inferred project targets ( project crystal ) - https://nx.dev/concepts/inferred-tasks#inferred-tasks-project-crystal

This PR enables inferred projects for all projects within `scripts/` and `tools/` for initial testing. Once proved valid and bug free all v9 projects will be migrated as well.

**These changes are also a breaking change:** 
- `yarn workspace <package-name> <npm-script-alias>` won't work anymore for `test` and `lint` targets
- `nx run` becomes the only/unified option how to run things

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Implements partially https://github.com/microsoft/fluentui/issues/30267
