### PR TITLE
Carousel: NavButton styles and appearance

### DIFF
--- a/change/@fluentui-react-carousel-preview-78c536bb-5cc0-4518-b9ee-0c6639e9fff6.json
+++ b/change/@fluentui-react-carousel-preview-78c536bb-5cc0-4518-b9ee-0c6639e9fff6.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: Add brand appearance to nav buttons, update action states",
+  "packageName": "@fluentui/react-carousel-preview",
+  "email": "mifraser@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-carousel-preview/library/etc/react-carousel-preview.api.md
+++ b/packages/react-components/react-carousel-preview/library/etc/react-carousel-preview.api.md
@@ -218,7 +218,7 @@ export const renderCarouselCard_unstable: (state: CarouselCardState) => JSX.Elem
 export const renderCarouselFooter_unstable: (state: CarouselFooterState) => JSX.Element;
 
 // @public
-export const renderCarouselNav_unstable: (state: CarouselNavState) => JSX.Element;
+export const renderCarouselNav_unstable: (state: CarouselNavState, contextValues: CarouselNavContextValues) => JSX.Element;
 
 // @public
 export const renderCarouselNavButton_unstable: (state: CarouselNavButtonState) => JSX.Element;

--- a/packages/react-components/react-carousel-preview/library/etc/react-carousel-preview.api.md
+++ b/packages/react-components/react-carousel-preview/library/etc/react-carousel-preview.api.md
@@ -122,7 +122,7 @@ export type CarouselNavButtonSlots = {
 // @public
 export type CarouselNavButtonState = ComponentState<CarouselNavButtonSlots> & {
     selected?: boolean;
-};
+} & Pick<CarouselNavState, 'appearance'>;
 
 // @public (undocumented)
 export const carouselNavClassNames: SlotClassNames<CarouselNavSlots>;
@@ -150,7 +150,7 @@ export type CarouselNavImageButtonState = ComponentState<CarouselNavImageButtonS
 // @public (undocumented)
 export type CarouselNavProps = Omit<ComponentProps<Partial<CarouselNavSlots>>, 'children'> & {
     children: NavButtonRenderFunction;
-};
+} & Pick<CarouselNavState, 'appearance'>;
 
 // @public (undocumented)
 export type CarouselNavSlots = {
@@ -161,6 +161,7 @@ export type CarouselNavSlots = {
 export type CarouselNavState = ComponentState<CarouselNavSlots> & {
     totalSlides: number;
     renderNavButton: NavButtonRenderFunction;
+    appearance?: 'brand';
 };
 
 // @public

--- a/packages/react-components/react-carousel-preview/library/src/components/CarouselNav/CarouselNav.tsx
+++ b/packages/react-components/react-carousel-preview/library/src/components/CarouselNav/CarouselNav.tsx
@@ -4,6 +4,7 @@ import { useCarouselNav_unstable } from './useCarouselNav';
 import { renderCarouselNav_unstable } from './renderCarouselNav';
 import { useCarouselNavStyles_unstable } from './useCarouselNavStyles.styles';
 import type { CarouselNavProps } from './CarouselNav.types';
+import { useCarouselNavContextValues_unstable } from './CarouselNavContext';
 
 /**
  * Used to jump to a card based on index, using arrow navigation via Tabster.
@@ -15,10 +16,13 @@ export const CarouselNav: ForwardRefComponent<CarouselNavProps> = React.forwardR
   const state = useCarouselNav_unstable(props, ref);
 
   useCarouselNavStyles_unstable(state);
+
+  const contextValues = useCarouselNavContextValues_unstable(state);
+
   // TODO update types in packages/react-components/react-shared-contexts/src/CustomStyleHooksContext/CustomStyleHooksContext.ts
   // https://github.com/microsoft/fluentui/blob/master/rfcs/react-components/convergence/custom-styling.md
   // useCustomStyleHook_unstable('useCarouselNavStyles_unstable')(state);
-  return renderCarouselNav_unstable(state);
+  return renderCarouselNav_unstable(state, contextValues);
 });
 
 CarouselNav.displayName = 'CarouselNav';

--- a/packages/react-components/react-carousel-preview/library/src/components/CarouselNav/CarouselNav.types.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/CarouselNav/CarouselNav.types.ts
@@ -20,8 +20,17 @@ export type CarouselNavState = ComponentState<CarouselNavSlots> & {
    * The function that will render nav items based on total slides and their index.
    */
   renderNavButton: NavButtonRenderFunction;
+
+  /**
+   * Enables an alternate brand style when set to 'brand'
+   */
+  appearance?: 'brand';
 };
 
 export type CarouselNavProps = Omit<ComponentProps<Partial<CarouselNavSlots>>, 'children'> & {
   children: NavButtonRenderFunction;
-};
+} & Pick<CarouselNavState, 'appearance'>;
+
+export type CarouselNavContextValue = {
+  index: number;
+} & Pick<CarouselNavState, 'appearance'>;

--- a/packages/react-components/react-carousel-preview/library/src/components/CarouselNav/CarouselNavContext.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/CarouselNav/CarouselNavContext.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { CarouselNavContextValue } from './CarouselNav.types';
+import { CarouselNavContextValue, CarouselNavState } from './CarouselNav.types';
 
 const carouselNavContext = React.createContext<CarouselNavContextValue | undefined>(undefined);
 
@@ -11,3 +11,24 @@ export const carouselNavContextDefaultValue: CarouselNavContextValue = {
 export const useCarouselNavContext = () => React.useContext(carouselNavContext) ?? carouselNavContextDefaultValue;
 
 export const CarouselNavContextProvider = carouselNavContext.Provider;
+
+/**
+ * Context shared between CarouselNav and its children components
+ */
+export type CarouselNavContextValues = {
+  carouselNav: CarouselNavContextValue;
+};
+
+export function useCarouselNavContextValues_unstable(state: CarouselNavState): CarouselNavContextValues {
+  const { appearance } = state;
+
+  const carouselNav = React.useMemo(
+    () => ({
+      index: 0,
+      appearance,
+    }),
+    [appearance],
+  );
+
+  return { carouselNav };
+}

--- a/packages/react-components/react-carousel-preview/library/src/components/CarouselNav/CarouselNavContext.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/CarouselNav/CarouselNavContext.ts
@@ -1,8 +1,12 @@
 import * as React from 'react';
+import { CarouselNavContextValue } from './CarouselNav.types';
 
-const carouselNavContext = React.createContext<number | undefined>(undefined);
+const carouselNavContext = React.createContext<CarouselNavContextValue | undefined>(undefined);
 
-export const carouselNavContextDefaultValue = 0;
+export const carouselNavContextDefaultValue: CarouselNavContextValue = {
+  index: 0,
+  appearance: undefined,
+};
 
 export const useCarouselNavContext = () => React.useContext(carouselNavContext) ?? carouselNavContextDefaultValue;
 

--- a/packages/react-components/react-carousel-preview/library/src/components/CarouselNav/renderCarouselNav.tsx
+++ b/packages/react-components/react-carousel-preview/library/src/components/CarouselNav/renderCarouselNav.tsx
@@ -10,12 +10,12 @@ import { CarouselNavContextProvider } from './CarouselNavContext';
  */
 export const renderCarouselNav_unstable = (state: CarouselNavState) => {
   assertSlots<CarouselNavSlots>(state);
-  const { totalSlides, renderNavButton } = state;
+  const { totalSlides, renderNavButton, appearance } = state;
 
   return (
     <state.root>
       {new Array(totalSlides).fill(null).map((_, index) => (
-        <CarouselNavContextProvider value={index} key={index}>
+        <CarouselNavContextProvider value={{ index, appearance }} key={`CarouselNavContextProvider-${index}`}>
           {renderNavButton(index)}
         </CarouselNavContextProvider>
       ))}

--- a/packages/react-components/react-carousel-preview/library/src/components/CarouselNav/renderCarouselNav.tsx
+++ b/packages/react-components/react-carousel-preview/library/src/components/CarouselNav/renderCarouselNav.tsx
@@ -3,19 +3,22 @@
 
 import { assertSlots } from '@fluentui/react-utilities';
 import type { CarouselNavState, CarouselNavSlots } from './CarouselNav.types';
-import { CarouselNavContextProvider } from './CarouselNavContext';
+import { CarouselNavContextProvider, CarouselNavContextValues } from './CarouselNavContext';
 
 /**
  * Render the final JSX of CarouselNav
  */
-export const renderCarouselNav_unstable = (state: CarouselNavState) => {
+export const renderCarouselNav_unstable = (state: CarouselNavState, contextValues: CarouselNavContextValues) => {
   assertSlots<CarouselNavSlots>(state);
-  const { totalSlides, renderNavButton, appearance } = state;
+  const { totalSlides, renderNavButton } = state;
 
   return (
     <state.root>
       {new Array(totalSlides).fill(null).map((_, index) => (
-        <CarouselNavContextProvider value={{ index, appearance }} key={`CarouselNavContextProvider-${index}`}>
+        <CarouselNavContextProvider
+          value={{ ...contextValues.carouselNav, index }}
+          key={`CarouselNavContextProvider-${index}`}
+        >
           {renderNavButton(index)}
         </CarouselNavContextProvider>
       ))}

--- a/packages/react-components/react-carousel-preview/library/src/components/CarouselNav/useCarouselNav.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/CarouselNav/useCarouselNav.ts
@@ -15,6 +15,7 @@ import type { CarouselNavProps, CarouselNavState } from './CarouselNav.types';
  * @param ref - reference to root HTMLDivElement of CarouselNav
  */
 export const useCarouselNav_unstable = (props: CarouselNavProps, ref: React.Ref<HTMLDivElement>): CarouselNavState => {
+  const { appearance } = props;
   const focusableGroupAttr = useArrowNavigationGroup({
     circular: false,
     axis: 'horizontal',
@@ -34,6 +35,7 @@ export const useCarouselNav_unstable = (props: CarouselNavProps, ref: React.Ref<
 
   return {
     totalSlides,
+    appearance,
     renderNavButton: props.children,
     components: {
       root: 'div',

--- a/packages/react-components/react-carousel-preview/library/src/components/CarouselNavButton/CarouselNavButton.types.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/CarouselNavButton/CarouselNavButton.types.ts
@@ -1,5 +1,6 @@
 import { ARIAButtonSlotProps } from '@fluentui/react-aria';
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+import { CarouselNavState } from '../CarouselNav/CarouselNav.types';
 
 export type CarouselNavButtonSlots = {
   /**
@@ -21,4 +22,4 @@ export type CarouselNavButtonState = ComponentState<CarouselNavButtonSlots> & {
    * Enables selection state control
    */
   selected?: boolean;
-};
+} & Pick<CarouselNavState, 'appearance'>;

--- a/packages/react-components/react-carousel-preview/library/src/components/CarouselNavButton/useCarouselNavButton.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/CarouselNavButton/useCarouselNavButton.ts
@@ -22,7 +22,7 @@ export const useCarouselNavButton_unstable = (
 ): CarouselNavButtonState => {
   const { onClick, as = 'button' } = props;
 
-  const index = useCarouselNavContext();
+  const { index, appearance } = useCarouselNavContext();
   const selectPageByIndex = useCarouselContext(ctx => ctx.selectPageByIndex);
   const selected = useCarouselContext(ctx => ctx.activeIndex === index);
 
@@ -56,6 +56,7 @@ export const useCarouselNavButton_unstable = (
 
   const state: CarouselNavButtonState = {
     selected,
+    appearance,
     components: {
       root: 'button',
     },

--- a/packages/react-components/react-carousel-preview/library/src/components/CarouselNavButton/useCarouselNavButtonStyles.styles.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/CarouselNavButton/useCarouselNavButtonStyles.styles.ts
@@ -16,7 +16,7 @@ const useStyles = makeStyles({
     cursor: 'pointer',
     width: tokens.spacingHorizontalS,
     height: tokens.spacingVerticalS,
-    padding: `${tokens.spacingVerticalS} ${tokens.spacingHorizontalXS}`,
+    padding: `${tokens.spacingVerticalS} ${tokens.spacingHorizontalS}`,
     boxSizing: 'content-box',
     backgroundColor: tokens.colorTransparentBackground,
     ...shorthands.borderWidth(0),
@@ -40,11 +40,22 @@ const useStyles = makeStyles({
       borderRadius: tokens.borderRadiusMedium,
     }),
     '::after': {
-      opacity: 0.3,
+      opacity: 0.65,
+    },
+    ':hover': {
+      '::after': {
+        opacity: 0.75,
+      },
+    },
+    ':active': {
+      '::after': {
+        opacity: 1,
+      },
     },
   },
   rootSelected: {
-    width: '16px',
+    width: tokens.spacingHorizontalL,
+    padding: `${tokens.spacingVerticalS} ${tokens.spacingHorizontalXS}`,
     outline: `${tokens.strokeWidthThin} solid transparent`, // For high contrast
     ...createCustomFocusIndicatorStyle({
       border: `${tokens.strokeWidthThick} solid ${tokens.colorStrokeFocus2}`,
@@ -52,8 +63,41 @@ const useStyles = makeStyles({
       borderRadius: tokens.borderRadiusMedium,
     }),
     '::after': {
-      width: '16px',
+      width: tokens.spacingHorizontalL,
       borderRadius: '4px',
+    },
+    ':hover': {
+      '::after': {
+        opacity: 0.75,
+      },
+    },
+    ':active': {
+      '::after': {
+        opacity: 0.65,
+      },
+    },
+  },
+  brand: {
+    '::after': {
+      backgroundColor: tokens.colorBrandBackground,
+      opacity: 1,
+    },
+    ':hover': {
+      '::after': {
+        backgroundColor: tokens.colorBrandBackgroundHover,
+        opacity: 1,
+      },
+    },
+    ':active': {
+      '::after': {
+        backgroundColor: tokens.colorBrandBackgroundPressed,
+        opacity: 1,
+      },
+    },
+  },
+  unselectedBrand: {
+    '::after': {
+      opacity: 0.6,
     },
   },
 });
@@ -66,12 +110,14 @@ export const useCarouselNavButtonStyles_unstable = (state: CarouselNavButtonStat
 
   const styles = useStyles();
 
-  const { selected } = state;
+  const { selected, appearance } = state;
 
   state.root.className = mergeClasses(
     carouselNavButtonClassNames.root,
     styles.root,
     selected ? styles.rootSelected : styles.rootUnselected,
+    appearance === 'brand' && styles.brand,
+    !selected && appearance === 'brand' && styles.unselectedBrand,
     state.root.className,
   );
 

--- a/packages/react-components/react-carousel-preview/library/src/components/CarouselNavImageButton/useCarouselNavImageButton.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/CarouselNavImageButton/useCarouselNavImageButton.ts
@@ -22,7 +22,7 @@ export const useCarouselNavImageButton_unstable = (
 ): CarouselNavImageButtonState => {
   const { onClick, as = 'button' } = props;
 
-  const index = useCarouselNavContext();
+  const { index } = useCarouselNavContext();
   const selectPageByIndex = useCarouselContext(ctx => ctx.selectPageByIndex);
   const selected = useCarouselContext(ctx => ctx.activeIndex === index);
 

--- a/packages/react-components/react-carousel-preview/stories/src/Carousel/CarouselDefault.stories.tsx
+++ b/packages/react-components/react-carousel-preview/stories/src/Carousel/CarouselDefault.stories.tsx
@@ -63,6 +63,7 @@ export const Default = () => (
       }}
     >
       <CarouselButton navType="prev" />
+      <CarouselNav appearance="brand">{() => <CarouselNavButton />}</CarouselNav>
       <CarouselNav>{() => <CarouselNavButton />}</CarouselNav>
       <CarouselButton navType="next" />
     </div>

--- a/packages/react-components/react-carousel-preview/stories/src/Carousel/CarouselDefault.stories.tsx
+++ b/packages/react-components/react-carousel-preview/stories/src/Carousel/CarouselDefault.stories.tsx
@@ -63,7 +63,6 @@ export const Default = () => (
       }}
     >
       <CarouselButton navType="prev" />
-      <CarouselNav appearance="brand">{() => <CarouselNavButton />}</CarouselNav>
       <CarouselNav>{() => <CarouselNavButton />}</CarouselNav>
       <CarouselButton navType="next" />
     </div>


### PR DESCRIPTION
Add 'brand' appearance to buttons
Implement hover/active state in styles based on latest design

## Previous Behavior
CarouselNavContext was a number (index) of buttons
No hover/active state
No appearance variants

## New Behavior
CarouselNavContext now an object with both index and appearance
Hover active states added for both appearances
