### PR TITLE
fix(TableHeaderCell): should use hover and pressed tokens

### DIFF
--- a/change/@fluentui-react-table-75ffa08b-d69f-4cb7-8a9e-82553a971c3e.json
+++ b/change/@fluentui-react-table-75ffa08b-d69f-4cb7-8a9e-82553a971c3e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(TableHeaderCell): should use hover and pressed tokens",
+  "packageName": "@fluentui/react-table",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-table/library/src/components/TableHeaderCell/useTableHeaderCellStyles.styles.ts
+++ b/packages/react-components/react-table/library/src/components/TableHeaderCell/useTableHeaderCellStyles.styles.ts
@@ -43,9 +43,11 @@ const useStyles = makeStyles({
 
   rootInteractive: {
     ':hover': {
+      color: tokens.colorNeutralForeground1Hover,
       backgroundColor: tokens.colorSubtleBackgroundHover,
     },
     ':active': {
+      color: tokens.colorNeutralForeground1Pressed,
       backgroundColor: tokens.colorSubtleBackgroundPressed,
     },
   },


### PR DESCRIPTION
Adds
* `colorNeutralForegroundHover`
* `colorNeutralForeground1Pressed`

For hover/pressed states respectively to fix high contrast issues

Before
![image](https://github.com/user-attachments/assets/4bd97ce1-78bb-4b27-a66e-bfc4dacb27ab)


After 
![image](https://github.com/user-attachments/assets/d43a6662-f534-4102-9dc3-5ab25b1e66df)


Fixes #32301

