### PR TITLE
ci(releases): properly cache build target execution between ci tasks to leverage cache and avoid accidental artifacts removal

### DIFF
--- a/azure-pipelines.release-vnext.yml
+++ b/azure-pipelines.release-vnext.yml
@@ -70,15 +70,15 @@ extends:
                 displayName: yarn
 
               - script: |
-                  yarn nx run-many -t build -p tag:vNext --exclude 'tag:tools,apps/**' --nxBail --production
+                  FLUENT_PROD_BUILD=true yarn nx run-many -t build -p tag:vNext --exclude 'tag:tools,apps/**' --nxBail
                 displayName: build
 
               - script: |
-                  yarn nx run-many -t test -p tag:vNext --exclude 'tag:tools,apps/**' --nxBail
+                  FLUENT_PROD_BUILD=true yarn nx run-many -t test -p tag:vNext --exclude 'tag:tools,apps/**' --nxBail
                 displayName: test
 
               - script: |
-                  yarn nx run-many -t lint -p tag:vNext --exclude 'tag:tools,apps/**' --nxBail
+                  FLUENT_PROD_BUILD=true yarn nx run-many -t lint -p tag:vNext --exclude 'tag:tools,apps/**' --nxBail
                 displayName: lint
 
               - script: |

--- a/azure-pipelines.release-vnext.yml
+++ b/azure-pipelines.release-vnext.yml
@@ -70,15 +70,15 @@ extends:
                 displayName: yarn
 
               - script: |
-                  FLUENT_PROD_BUILD=true yarn nx run-many -t build -p tag:vNext --exclude 'tag:tools,apps/**' --nxBail
+                  FLUENT_PROD_BUILD=true yarn nx run-many -t build -p tag:vNext --exclude 'tag:tools,tag:type:stories,apps/**' --nxBail
                 displayName: build
 
               - script: |
-                  FLUENT_PROD_BUILD=true yarn nx run-many -t test -p tag:vNext --exclude 'tag:tools,apps/**' --nxBail
+                  FLUENT_PROD_BUILD=true yarn nx run-many -t test -p tag:vNext --exclude 'tag:tools,tag:type:stories,apps/**' --nxBail
                 displayName: test
 
               - script: |
-                  FLUENT_PROD_BUILD=true yarn nx run-many -t lint -p tag:vNext --exclude 'tag:tools,apps/**' --nxBail
+                  FLUENT_PROD_BUILD=true yarn nx run-many -t lint -p tag:vNext --exclude 'tag:tools,tag:type:stories,apps/**' --nxBail
                 displayName: lint
 
               - script: |

--- a/azure-pipelines.release.tools.yml
+++ b/azure-pipelines.release.tools.yml
@@ -59,15 +59,15 @@ extends:
                 displayName: yarn
 
               - script: |
-                  yarn nx run-many -t build -p tag:tools --exclude 'apps/**' --nxBail --production
+                  FLUENT_PROD_BUILD=true yarn nx run-many -t build -p tag:tools --exclude 'apps/**' --nxBail
                 displayName: build
 
               - script: |
-                  yarn nx run-many -t test -p tag:tools --exclude 'apps/**' --nxBail
+                  FLUENT_PROD_BUILD=true yarn nx run-many -t test -p tag:tools --exclude 'apps/**' --nxBail
                 displayName: test
 
               - script: |
-                  yarn nx run-many -t lint -p tag:tools --exclude 'apps/**' --nxBail
+                  FLUENT_PROD_BUILD=true yarn nx run-many -t lint -p tag:tools --exclude 'apps/**' --nxBail
                 displayName: lint
 
               - script: |


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

Not using `--production` flag in consecutive pipeline tasks invalided cache, which might be causing possible artifacts regression that we've been publishing.

> this can happen because `lint` requires `build` , but `build` is run with `--production` first, making it run again when `lint` is executed ( every `build` removes everything - this should be removed in future )

## New Behavior

- we use common env variable to set production mode which won't invalidate cache = making releases FASTER
- we don't run tasks on `-stories` projects during v9 release = making releases FASTER 

_TODO:_  add pipeline data comparison after we trigger release
 - before (current): build 6m40s / test 4m40s / lint 10m23s
 - after : TBA

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows https://github.com/microsoft/fluentui/pull/32195
