### PR TITLE
chore(nx): enable analyzeSourceFiles in order to build dependency graph based on source files instead statically defined package.json dependencies

### DIFF
--- a/.nxignore
+++ b/.nxignore
@@ -9,8 +9,19 @@ packages/fluentui/CONTRIBUTING.md
 packages/fluentui/README.md
 packages/fluentui/.browserslistrc
 
+
+; build output
 **/dist/**
+
+; known directories to not incorporate into the workspace graph creation
 **/fixtures/**
 **/__fixtures__/**
 **/bundle-size/**
+
+; scaffolding templates
+**/generators/**/files/**
+plop-templates
+plop-templates-*
+
+; TODO: temporary ignore - remove once https://github.com/microsoft/fluentui/pull/32371 is merged
 scripts/*/just.config.ts

--- a/.nxignore
+++ b/.nxignore
@@ -10,3 +10,6 @@ packages/fluentui/README.md
 packages/fluentui/.browserslistrc
 
 **/dist/**
+**/fixtures/**
+**/bundle-size/**
+scripts/*/just.config.ts

--- a/.nxignore
+++ b/.nxignore
@@ -11,5 +11,6 @@ packages/fluentui/.browserslistrc
 
 **/dist/**
 **/fixtures/**
+**/__fixtures__/**
 **/bundle-size/**
 scripts/*/just.config.ts

--- a/change/@fluentui-babel-preset-global-context-7315ea8d-11d8-4f60-8609-1607fad9033e.json
+++ b/change/@fluentui-babel-preset-global-context-7315ea8d-11d8-4f60-8609-1607fad9033e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: add missing workspace scripts-cypress devDependencies",
+  "packageName": "@fluentui/babel-preset-global-context",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-eslint-plugin-bfd756b0-f796-4aae-a6e0-5b55d89dba44.json
+++ b/change/@fluentui-eslint-plugin-bfd756b0-f796-4aae-a6e0-5b55d89dba44.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: resolve circular dependencies and remove ban-context-export tests tight coupling to monorepo setup/package",
+  "packageName": "@fluentui/eslint-plugin",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-aria-1618f661-53d5-4a10-b243-2e86afa6b257.json
+++ b/change/@fluentui-react-aria-1618f661-53d5-4a10-b243-2e86afa6b257.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: add missing workspace scripts-cypress devDependencies",
+  "packageName": "@fluentui/react-aria",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-conformance-4282f4cc-cb8b-4817-930e-afe56e143bf3.json
+++ b/change/@fluentui-react-conformance-4282f4cc-cb8b-4817-930e-afe56e143bf3.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: reflect package.json dependencies to match actual dep graph",
+  "packageName": "@fluentui/react-conformance",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-datepicker-compat-28a5f8d4-19a1-4724-b89b-fc87036b9424.json
+++ b/change/@fluentui-react-datepicker-compat-28a5f8d4-19a1-4724-b89b-fc87036b9424.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: add missing workspace scripts-cypress devDependencies",
+  "packageName": "@fluentui/react-datepicker-compat",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-infolabel-ee3a8fd8-9522-4f84-b345-c9a0292730cd.json
+++ b/change/@fluentui-react-infolabel-ee3a8fd8-9522-4f84-b345-c9a0292730cd.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: add missing workspace scripts-cypress devDependencies",
+  "packageName": "@fluentui/react-infolabel",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-list-preview-3e3b4786-e7ca-47f6-9876-0a9e7f8e7416.json
+++ b/change/@fluentui-react-list-preview-3e3b4786-e7ca-47f6-9876-0a9e7f8e7416.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: add missing workspace scripts-cypress devDependencies",
+  "packageName": "@fluentui/react-list-preview",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-migration-v8-v9-61b66157-b0c6-48a4-9087-c32eff308bae.json
+++ b/change/@fluentui-react-migration-v8-v9-61b66157-b0c6-48a4-9087-c32eff308bae.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: cleanup production dependencies and fix forbidden sub-package import within Menu",
+  "packageName": "@fluentui/react-migration-v8-v9",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-table-8a5112c5-b6a7-4b60-94ea-cca71d8f054d.json
+++ b/change/@fluentui-react-table-8a5112c5-b6a7-4b60-94ea-cca71d8f054d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: add missing workspace scripts-cypress devDependencies",
+  "packageName": "@fluentui/react-table",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tag-picker-19a4c535-9d2f-4bf4-bdf8-646f51cd0930.json
+++ b/change/@fluentui-react-tag-picker-19a4c535-9d2f-4bf4-bdf8-646f51cd0930.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: add missing workspace scripts-cypress devDependencies",
+  "packageName": "@fluentui/react-tag-picker",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-timepicker-compat-952aa2df-f90e-4cae-a0b5-341d5b4af632.json
+++ b/change/@fluentui-react-timepicker-compat-952aa2df-f90e-4cae-a0b5-341d5b4af632.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: add missing workspace scripts-cypress devDependencies",
+  "packageName": "@fluentui/react-timepicker-compat",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-toast-f54ca38d-fce3-425f-8c36-7453496e6cdb.json
+++ b/change/@fluentui-react-toast-f54ca38d-fce3-425f-8c36-7453496e6cdb.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: add missing workspace scripts-cypress devDependencies",
+  "packageName": "@fluentui/react-toast",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-utilities-424ef027-dedc-45ae-97b0-9eff344bd020.json
+++ b/change/@fluentui-react-utilities-424ef027-dedc-45ae-97b0-9eff344bd020.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: reflect package.json dependencies to match actual dep graph",
+  "packageName": "@fluentui/react-utilities",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/nx.json
+++ b/nx.json
@@ -4,11 +4,6 @@
     "libsDir": "packages",
     "appsDir": "apps"
   },
-  "pluginsConfig": {
-    "@nx/js": {
-      "analyzeSourceFiles": false
-    }
-  },
   "targetDefaults": {
     "bundle-size": {
       "dependsOn": ["build"],

--- a/packages/eslint-plugin/.eslintrc.json
+++ b/packages/eslint-plugin/.eslintrc.json
@@ -9,6 +9,12 @@
         // too many false positives on node types
         "@typescript-eslint/naming-convention": "off"
       }
+    },
+    {
+      "files": ["src/rules/**/fixtures/**/*.{js,ts}"],
+      "rules": {
+        "import/no-extraneous-dependencies": "off"
+      }
     }
   ]
 }

--- a/packages/eslint-plugin/src/configs/react.js
+++ b/packages/eslint-plugin/src/configs/react.js
@@ -30,6 +30,7 @@ module.exports = {
     '@fluentui/no-context-default-value': [
       'error',
       {
+        // nx-ignore-next-line
         imports: ['react', '@fluentui/react-context-selector', '@fluentui/global-context'],
       },
     ],

--- a/packages/eslint-plugin/src/configs/react.js
+++ b/packages/eslint-plugin/src/configs/react.js
@@ -30,7 +30,7 @@ module.exports = {
     '@fluentui/no-context-default-value': [
       'error',
       {
-        // nx-ignore-next-line
+        // nx-ignore-next-line - this is a valid use case to ignore workspace packages. keeping  them part of the project dependencies would be wrong assumption
         imports: ['react', '@fluentui/react-context-selector', '@fluentui/global-context'],
       },
     ],

--- a/packages/eslint-plugin/src/rules/ban-context-export/fixtures/context-selector/src/context.ts
+++ b/packages/eslint-plugin/src/rules/ban-context-export/fixtures/context-selector/src/context.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { createContext } from '@fluentui/react-context-selector';
+import { createContext } from '@proj/react-context-selector';
 
 export const MyContext = createContext({});

--- a/packages/eslint-plugin/src/rules/ban-context-export/fixtures/context-selector/tsconfig.json
+++ b/packages/eslint-plugin/src/rules/ban-context-export/fixtures/context-selector/tsconfig.json
@@ -6,6 +6,10 @@
     "outDir": "dist",
     "declaration": true,
     "declarationDir": "dist/types",
-    "types": ["static-assets", "environment"]
+    "types": ["static-assets", "environment"],
+    "baseUrl": ".",
+    "paths": {
+      "@proj/react-context-selector": ["../react-context-selector-pkg/index.ts"]
+    }
   }
 }

--- a/packages/eslint-plugin/src/rules/ban-context-export/fixtures/export-specifier/src/context.ts
+++ b/packages/eslint-plugin/src/rules/ban-context-export/fixtures/export-specifier/src/context.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import * as React from 'react';
 
 export const MyContext = React.createContext({});

--- a/packages/eslint-plugin/src/rules/ban-context-export/fixtures/internal-export/src/internal/context.ts
+++ b/packages/eslint-plugin/src/rules/ban-context-export/fixtures/internal-export/src/internal/context.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import * as React from 'react';
 
 export const MyContext = React.createContext({});

--- a/packages/eslint-plugin/src/rules/ban-context-export/fixtures/named-export/tsconfig.json
+++ b/packages/eslint-plugin/src/rules/ban-context-export/fixtures/named-export/tsconfig.json
@@ -6,6 +6,10 @@
     "outDir": "dist",
     "declaration": true,
     "declarationDir": "dist/types",
-    "types": ["static-assets", "environment"]
+    "types": ["static-assets", "environment"],
+    "baseUrl": ".",
+    "paths": {
+      "@proj/react-context-selector": ["../react-context-selector-pkg/index.ts"]
+    }
   }
 }

--- a/packages/eslint-plugin/src/rules/ban-context-export/fixtures/react-context-selector-pkg/context.ts
+++ b/packages/eslint-plugin/src/rules/ban-context-export/fixtures/react-context-selector-pkg/context.ts
@@ -1,0 +1,5 @@
+import type { Context } from './types';
+
+export const createContext = <T>(value: T): Context<T> => {
+  return {} as Context<T>;
+};

--- a/packages/eslint-plugin/src/rules/ban-context-export/fixtures/react-context-selector-pkg/index.ts
+++ b/packages/eslint-plugin/src/rules/ban-context-export/fixtures/react-context-selector-pkg/index.ts
@@ -1,0 +1,1 @@
+export { createContext } from './context';

--- a/packages/eslint-plugin/src/rules/ban-context-export/fixtures/react-context-selector-pkg/types.ts
+++ b/packages/eslint-plugin/src/rules/ban-context-export/fixtures/react-context-selector-pkg/types.ts
@@ -1,0 +1,6 @@
+import * as React from 'react';
+
+export type Context<Value> = React.Context<Value> & {
+  Provider: React.FC<React.ProviderProps<Value>>;
+  Consumer: never;
+};

--- a/packages/eslint-plugin/src/rules/ban-context-export/index.test.js
+++ b/packages/eslint-plugin/src/rules/ban-context-export/index.test.js
@@ -77,7 +77,7 @@ ruleTester.run('ban-context-export', rule, {
       errors: [{ messageId: 'contextSelector' }],
       parserOptions: getParserOptions('named-export'),
       code: `
-      import { createContext } from '@fluentui/react-context-selector';
+      import { createContext } from '@proj/react-context-selector';
       export const MyContext = createContext({});
       `,
       filename: 'src/index.ts',

--- a/packages/eslint-plugin/src/rules/no-context-default-value/index.test.js
+++ b/packages/eslint-plugin/src/rules/no-context-default-value/index.test.js
@@ -10,52 +10,52 @@ ruleTester.run('no-context-default-value', rule, {
     {
       code: `
         import {createContext as createContext1} from 'react'
-        import {createContext as createContext2} from '@fluentui/react-context-selector'
+        import {createContext as createContext2} from '@proj/react-context-selector'
         const context1 = createContext1();
         const context2 = createContext2();
       `,
       options: [
         {
-          imports: ['react', '@fluentui/react-context-selector'],
+          imports: ['react', '@proj/react-context-selector'],
         },
       ],
     },
     {
       code: `
         import {createContext as createContext1} from 'react'
-        import {createContext as createContext2} from '@fluentui/react-context-selector'
+        import {createContext as createContext2} from '@proj/react-context-selector'
         const context1 = createContext1(undefined);
         const context2 = createContext2(undefined);
       `,
       options: [
         {
-          imports: ['react', '@fluentui/react-context-selector'],
+          imports: ['react', '@proj/react-context-selector'],
         },
       ],
     },
     {
       code: `
         import * as React from 'react'
-        import * as ContextSelector from '@fluentui/react-context-selector'
+        import * as ContextSelector from '@proj/react-context-selector'
         const context1 = React.createContext(undefined);
         const context2 = ContextSelector.createContext(undefined);
       `,
       options: [
         {
-          imports: ['react', '@fluentui/react-context-selector'],
+          imports: ['react', '@proj/react-context-selector'],
         },
       ],
     },
     {
       code: `
         import React from 'react'
-        import ContextSelector from '@fluentui/react-context-selector'
+        import ContextSelector from '@proj/react-context-selector'
         const context1 = React.createContext(undefined);
         const context2 = ContextSelector.createContext(undefined);
       `,
       options: [
         {
-          imports: ['react', '@fluentui/react-context-selector'],
+          imports: ['react', '@proj/react-context-selector'],
         },
       ],
     },
@@ -64,13 +64,13 @@ ruleTester.run('no-context-default-value', rule, {
     {
       code: `
         import {createContext as createContext1} from 'react'
-        import {createContext as createContext2} from '@fluentui/react-context-selector'
+        import {createContext as createContext2} from '@proj/react-context-selector'
         const context1 = createContext1(null);
         const context2 = createContext2(null);
       `,
       options: [
         {
-          imports: ['react', '@fluentui/react-context-selector'],
+          imports: ['react', '@proj/react-context-selector'],
         },
       ],
       errors: [{ messageId: 'invalidDefaultValue' }, { messageId: 'invalidDefaultValue' }],
@@ -78,13 +78,13 @@ ruleTester.run('no-context-default-value', rule, {
     {
       code: `
         import {createContext as createContext1} from 'react'
-        import {createContext as createContext2} from '@fluentui/react-context-selector'
+        import {createContext as createContext2} from '@proj/react-context-selector'
         const context1 = createContext1({});
         const context2 = createContext2({});
       `,
       options: [
         {
-          imports: ['react', '@fluentui/react-context-selector'],
+          imports: ['react', '@proj/react-context-selector'],
         },
       ],
       errors: [{ messageId: 'invalidDefaultValue' }, { messageId: 'invalidDefaultValue' }],
@@ -92,13 +92,13 @@ ruleTester.run('no-context-default-value', rule, {
     {
       code: `
         import {createContext as createContext1} from 'react'
-        import {createContext as createContext2} from '@fluentui/react-context-selector'
+        import {createContext as createContext2} from '@proj/react-context-selector'
         const context1 = createContext1(defaultValue);
         const context2 = createContext2(defaultValue);
       `,
       options: [
         {
-          imports: ['react', '@fluentui/react-context-selector'],
+          imports: ['react', '@proj/react-context-selector'],
         },
       ],
       errors: [{ messageId: 'invalidDefaultValue' }, { messageId: 'invalidDefaultValue' }],
@@ -106,13 +106,13 @@ ruleTester.run('no-context-default-value', rule, {
     {
       code: `
         import * as React from 'react'
-        import * as ContextSelector from '@fluentui/react-context-selector'
+        import * as ContextSelector from '@proj/react-context-selector'
         const context1 = React.createContext(defaultValue);
         const context2 = ContextSelector.createContext(defaultValue);
       `,
       options: [
         {
-          imports: ['react', '@fluentui/react-context-selector'],
+          imports: ['react', '@proj/react-context-selector'],
         },
       ],
       errors: [{ messageId: 'invalidDefaultValue' }, { messageId: 'invalidDefaultValue' }],
@@ -120,13 +120,13 @@ ruleTester.run('no-context-default-value', rule, {
     {
       code: `
         import React from 'react'
-        import ContextSelector from '@fluentui/react-context-selector'
+        import ContextSelector from '@proj/react-context-selector'
         const context1 = React.createContext(defaultValue);
         const context2 = ContextSelector.createContext(defaultValue);
       `,
       options: [
         {
-          imports: ['react', '@fluentui/react-context-selector'],
+          imports: ['react', '@proj/react-context-selector'],
         },
       ],
       errors: [{ messageId: 'invalidDefaultValue' }, { messageId: 'invalidDefaultValue' }],

--- a/packages/fluentui/accessibility/test/behaviors/behavior-test.tsx
+++ b/packages/fluentui/accessibility/test/behaviors/behavior-test.tsx
@@ -108,7 +108,7 @@ import { TestHelper } from './testHelper';
 import { definitions } from './testDefinitions';
 
 // @{link 'file://./../../../docs/src/behaviorMenu.json'}
-// nx-ignore-next-line
+// nx-ignore-next-line - following pragma ignores 'docs' project(application) being part of this package dependencies from nx - 🚨 NOTE: this is wrong as without docs project json files generated this test wont work.
 const behaviorMenuItems = require('../../../docs/src/behaviorMenu');
 
 const testHelper = new TestHelper();

--- a/packages/fluentui/accessibility/test/behaviors/behavior-test.tsx
+++ b/packages/fluentui/accessibility/test/behaviors/behavior-test.tsx
@@ -107,6 +107,8 @@ import {
 import { TestHelper } from './testHelper';
 import { definitions } from './testDefinitions';
 
+// @{link 'file://./../../../docs/src/behaviorMenu.json'}
+// nx-ignore-next-line
 const behaviorMenuItems = require('../../../docs/src/behaviorMenu');
 
 const testHelper = new TestHelper();

--- a/packages/fluentui/perf-test-northstar/.digest/config.tsx
+++ b/packages/fluentui/perf-test-northstar/.digest/config.tsx
@@ -3,6 +3,7 @@ import { Provider, teamsTheme } from '@fluentui/react-northstar';
 
 const reqContexts = [
   // TODO: Relative pathing isn't the best here, but docs containing perf stories isn't a package that can be added as a dep.
+  // nx-ignore-next-line
   require.context('../../docs/src', true, /\.perf\.tsx$/),
   // TODO: why does this break index.html?? seems to pull in stories the same way...
   // require.context('../stories', true, /\.perf\.tsx$/),

--- a/packages/fluentui/perf-test-northstar/.digest/config.tsx
+++ b/packages/fluentui/perf-test-northstar/.digest/config.tsx
@@ -3,7 +3,7 @@ import { Provider, teamsTheme } from '@fluentui/react-northstar';
 
 const reqContexts = [
   // TODO: Relative pathing isn't the best here, but docs containing perf stories isn't a package that can be added as a dep.
-  // nx-ignore-next-line
+  // nx-ignore-next-line - ignoring from nx dep graph because this is resolved via storybook behind the scenes without no build assets needed.
   require.context('../../docs/src', true, /\.perf\.tsx$/),
   // TODO: why does this break index.html?? seems to pull in stories the same way...
   // require.context('../stories', true, /\.perf\.tsx$/),

--- a/packages/react-components/babel-preset-global-context/package.json
+++ b/packages/react-components/babel-preset-global-context/package.json
@@ -13,7 +13,6 @@
     "build": "just-scripts build --module cjs",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
-    "pree2e": "yarn build",
     "e2e": "cypress run --component",
     "e2e:local": "cypress open --component",
     "just": "just-scripts",

--- a/packages/react-components/react-aria/library/package.json
+++ b/packages/react-components/react-aria/library/package.json
@@ -29,7 +29,8 @@
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-tasks": "*",
+    "@fluentui/scripts-cypress": "*"
   },
   "dependencies": {
     "@fluentui/keyboard-keys": "^9.0.7",

--- a/packages/react-components/react-badge/library/src/components/Badge/Badge.test.tsx
+++ b/packages/react-components/react-badge/library/src/components/Badge/Badge.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Badge } from './Badge';
 import * as renderer from 'react-test-renderer';
-import { ReactWrapper } from 'enzyme';
+
 import { isConformant } from '../../testing/isConformant';
 
 describe('Badge', () => {
@@ -15,15 +15,6 @@ describe('Badge', () => {
         },
       ],
     },
-  });
-
-  let wrapper: ReactWrapper | undefined;
-
-  afterEach(() => {
-    if (wrapper) {
-      wrapper.unmount();
-      wrapper = undefined;
-    }
   });
 
   /**

--- a/packages/react-components/react-badge/library/src/components/CounterBadge/CounterBadge.test.tsx
+++ b/packages/react-components/react-badge/library/src/components/CounterBadge/CounterBadge.test.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { CounterBadge } from './CounterBadge';
 import * as renderer from 'react-test-renderer';
-import { ReactWrapper } from 'enzyme';
 import { isConformant } from '../../testing/isConformant';
 
 describe('CounterBadge', () => {
@@ -15,15 +14,6 @@ describe('CounterBadge', () => {
         },
       ],
     },
-  });
-
-  let wrapper: ReactWrapper | undefined;
-
-  afterEach(() => {
-    if (wrapper) {
-      wrapper.unmount();
-      wrapper = undefined;
-    }
   });
 
   it('renders a default state', () => {

--- a/packages/react-components/react-badge/library/src/components/PresenceBadge/PresenceBadge.test.tsx
+++ b/packages/react-components/react-badge/library/src/components/PresenceBadge/PresenceBadge.test.tsx
@@ -1,22 +1,12 @@
 import * as React from 'react';
 import { PresenceBadge } from './PresenceBadge';
 import * as renderer from 'react-test-renderer';
-import { ReactWrapper } from 'enzyme';
 import { isConformant } from '../../testing/isConformant';
 
 describe('PresenceBadge', () => {
   isConformant({
     Component: PresenceBadge,
     displayName: 'PresenceBadge',
-  });
-
-  let wrapper: ReactWrapper | undefined;
-
-  afterEach(() => {
-    if (wrapper) {
-      wrapper.unmount();
-      wrapper = undefined;
-    }
   });
 
   it('renders a default state', () => {

--- a/packages/react-components/react-datepicker-compat/library/package.json
+++ b/packages/react-components/react-datepicker-compat/library/package.json
@@ -32,7 +32,8 @@
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
     "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-tasks": "*",
+    "@fluentui/scripts-cypress": "*"
   },
   "dependencies": {
     "@fluentui/keyboard-keys": "^9.0.7",

--- a/packages/react-components/react-infolabel/library/package.json
+++ b/packages/react-components/react-infolabel/library/package.json
@@ -29,7 +29,8 @@
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
     "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-tasks": "*",
+    "@fluentui/scripts-cypress": "*"
   },
   "dependencies": {
     "@fluentui/react-icons": "^2.0.245",

--- a/packages/react-components/react-list-preview/library/package.json
+++ b/packages/react-components/react-list-preview/library/package.json
@@ -36,7 +36,8 @@
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
     "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-tasks": "*",
+    "@fluentui/scripts-cypress": "*"
   },
   "dependencies": {
     "@fluentui/react-checkbox": "^9.2.36",

--- a/packages/react-components/react-migration-v0-v9/library/src/components/Primitive/Primitive.test.tsx
+++ b/packages/react-components/react-migration-v0-v9/library/src/components/Primitive/Primitive.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { isConformant } from '@fluentui/react-conformance';
-import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
 import { Primitive } from './Primitive';
 
 // eslint-disable-next-line
@@ -17,7 +17,7 @@ xdescribe('Primitive', () => {
     ${'hi'}            | ${'auto'}
     ${(<div>hi</div>)} | ${undefined}
   `(`uses 'dir=auto' only when children is plain text`, ({ children, dir }) => {
-    const wrapper = mount(<Primitive>{children}</Primitive>);
-    expect(wrapper.childAt(0).prop('dir')).toBe(dir);
+    const { container } = render(<Primitive>{children}</Primitive>);
+    expect(container.firstChild).toHaveAttribute('dir', dir);
   });
 });

--- a/packages/react-components/react-migration-v8-v9/library/etc/react-migration-v8-v9.api.md
+++ b/packages/react-components/react-migration-v8-v9/library/etc/react-migration-v8-v9.api.md
@@ -16,7 +16,7 @@ import type { IContextualMenuProps } from '@fluentui/react';
 import type { IPalette } from '@fluentui/react';
 import type { IStackItemProps } from '@fluentui/react';
 import type { IStackProps } from '@fluentui/react';
-import type { MenuProps } from '@fluentui/react-menu';
+import type { MenuProps } from '@fluentui/react-components';
 import * as React_2 from 'react';
 import { Theme } from '@fluentui/react-components';
 import { Theme as Theme_2 } from '@fluentui/react';

--- a/packages/react-components/react-migration-v8-v9/library/package.json
+++ b/packages/react-components/react-migration-v8-v9/library/package.json
@@ -37,8 +37,6 @@
     "@fluentui/react-components": "^9.54.15",
     "@fluentui/react-icons": "^2.0.245",
     "@fluentui/react-hooks": "^8.8.12",
-    "@fluentui/react-theme": "^9.1.19",
-    "@fluentui/react-utilities": "^9.18.14",
     "@griffel/react": "^1.5.22",
     "@swc/helpers": "^0.5.1"
   },

--- a/packages/react-components/react-migration-v8-v9/library/src/components/Menu/shimMenuProps.tsx
+++ b/packages/react-components/react-migration-v8-v9/library/src/components/Menu/shimMenuProps.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { Icon } from '@fluentui/react';
 import type { IContextualMenuItem, IContextualMenuProps } from '@fluentui/react';
-import type { MenuItemProps, MenuGroupHeaderProps, MenuItemCheckboxProps, MenuProps } from '@fluentui/react-menu';
+import type { MenuItemProps, MenuGroupHeaderProps, MenuItemCheckboxProps, MenuProps } from '@fluentui/react-components';
 
 export const shimMenuProps = (props: IContextualMenuProps): Partial<MenuProps> => {
   return {

--- a/packages/react-components/react-table/library/package.json
+++ b/packages/react-components/react-table/library/package.json
@@ -32,7 +32,8 @@
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
     "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-tasks": "*",
+    "@fluentui/scripts-cypress": "*"
   },
   "dependencies": {
     "@fluentui/keyboard-keys": "^9.0.7",

--- a/packages/react-components/react-tag-picker/library/package.json
+++ b/packages/react-components/react-tag-picker/library/package.json
@@ -38,7 +38,8 @@
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
     "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-tasks": "*",
+    "@fluentui/scripts-cypress": "*"
   },
   "dependencies": {
     "@fluentui/react-jsx-runtime": "^9.0.43",

--- a/packages/react-components/react-timepicker-compat/library/package.json
+++ b/packages/react-components/react-timepicker-compat/library/package.json
@@ -37,7 +37,8 @@
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
     "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-tasks": "*",
+    "@fluentui/scripts-cypress": "*"
   },
   "dependencies": {
     "@fluentui/keyboard-keys": "^9.0.7",

--- a/packages/react-components/react-toast/library/package.json
+++ b/packages/react-components/react-toast/library/package.json
@@ -32,7 +32,8 @@
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
     "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-tasks": "*",
+    "@fluentui/scripts-cypress": "*"
   },
   "dependencies": {
     "@fluentui/keyboard-keys": "^9.0.7",

--- a/packages/react-components/react-utilities/package.json
+++ b/packages/react-components/react-utilities/package.json
@@ -28,7 +28,8 @@
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-tasks": "*",
+    "@fluentui/scripts-cypress": "*"
   },
   "dependencies": {
     "@fluentui/keyboard-keys": "^9.0.7",

--- a/packages/react-conformance/package.json
+++ b/packages/react-conformance/package.json
@@ -27,7 +27,6 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-jest": "*",
     "@fluentui/scripts-tasks": "*"
   },
   "dependencies": {

--- a/scripts/generators/src/create-package/plop-templates-node/just.config.ts
+++ b/scripts/generators/src/create-package/plop-templates-node/just.config.ts
@@ -1,4 +1,3 @@
-// nxt-ignore-next-line
 import { preset } from '@fluentui/scripts-tasks';
 
 preset();

--- a/scripts/generators/src/create-package/plop-templates-node/just.config.ts
+++ b/scripts/generators/src/create-package/plop-templates-node/just.config.ts
@@ -1,3 +1,4 @@
+// nxt-ignore-next-line
 import { preset } from '@fluentui/scripts-tasks';
 
 preset();

--- a/scripts/monorepo/src/getDependencies.spec.js
+++ b/scripts/monorepo/src/getDependencies.spec.js
@@ -50,6 +50,11 @@ describe(`#getDependencies`, () => {
         Object {
           "dependencyType": "devDependencies",
           "isTopLevel": true,
+          "name": "scripts-tasks",
+        },
+        Object {
+          "dependencyType": "devDependencies",
+          "isTopLevel": true,
           "name": "eslint-plugin",
         },
         Object {
@@ -68,16 +73,6 @@ describe(`#getDependencies`, () => {
           "name": "scripts-api-extractor",
         },
         Object {
-          "dependencyType": "devDependencies",
-          "isTopLevel": true,
-          "name": "scripts-tasks",
-        },
-        Object {
-          "dependencyType": "devDependencies",
-          "isTopLevel": false,
-          "name": "scripts-jest",
-        },
-        Object {
           "dependencyType": "dependencies",
           "isTopLevel": false,
           "name": "scripts-monorepo",
@@ -91,6 +86,11 @@ describe(`#getDependencies`, () => {
           "dependencyType": "dependencies",
           "isTopLevel": false,
           "name": "scripts-prettier",
+        },
+        Object {
+          "dependencyType": "devDependencies",
+          "isTopLevel": false,
+          "name": "scripts-cypress",
         },
       ]
     `);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

monorepo dependency graph is build from manually maintained `package.json`

## New Behavior

**TL;DR:**
monorepo dependency graph is build dynamically by analyzing actual source code = no need to maintain things manually.

**More context:**

nx dep graph resolution also exposed various forbidden patterns in dependency land which this PR also partially addresses:
- tight coupling within eslint-plugin test that created circular dependency ( context related rules )
- using `enzyme` in v9 packages
- missing `scripts-cypress` workspace devDependencies in packages that use it
- cleaning up unused/missused production dependencies in react-migration-v8-v9 

**Todo:** 
- [x] write a validator that will compare current package.json dependencies agains nx graph dependencies (using analyzeSourceFiles)
- [x] verify the comparison data and proceed if everything (dep graph) is valid

> full data source: [analyze-source-dep-graph-comparison.tgz](https://github.com/user-attachments/files/16727693/analyze-source-dep-graph-comparison.tgz)


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Implements partially https://github.com/microsoft/fluentui/issues/30267, https://github.com/microsoft/fluentui/issues/32292
