### PR TITLE
fix: remove aria-valuenow from native input element

### DIFF
--- a/change/@fluentui-react-4910fb47-83b1-40c5-b50c-817986591a43.json
+++ b/change/@fluentui-react-4910fb47-83b1-40c5-b50c-817986591a43.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove aria-valuenow from native input element",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-spinbutton-50c2d986-4df0-4438-80de-bb73d06f377d.json
+++ b/change/@fluentui-react-spinbutton-50c2d986-4df0-4438-80de-bb73d06f377d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove aria-valuenow from native input element",
+  "packageName": "@fluentui/react-spinbutton",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-spinbutton/library/src/components/SpinButton/SpinButton.test.tsx
+++ b/packages/react-components/react-spinbutton/library/src/components/SpinButton/SpinButton.test.tsx
@@ -27,7 +27,6 @@ describe('SpinButton', () => {
 
     const spinButton = getSpinButtonInput();
     expect(spinButton.value).toEqual('10');
-    expect(spinButton.getAttribute('aria-valuenow')).toEqual('10');
     expect(spinButton.getAttribute('aria-valuetext')).toBeNull();
     expect(spinButton.getAttribute('aria-valuemin')).toBeNull();
     expect(spinButton.getAttribute('aria-valuemax')).toBeNull();
@@ -42,7 +41,6 @@ describe('SpinButton', () => {
 
     const spinButton = getSpinButtonInput();
     expect(spinButton.value).toEqual('1');
-    expect(spinButton.getAttribute('aria-valuenow')).toEqual('1');
     expect(spinButton.getAttribute('aria-valuetext')).toBeNull();
     expect(spinButton.getAttribute('aria-valuemin')).toBeNull();
     expect(spinButton.getAttribute('aria-valuemax')).toBeNull();
@@ -67,7 +65,6 @@ describe('SpinButton', () => {
 
       const spinButton = getSpinButtonInput();
       expect(spinButton.value).toEqual('1');
-      expect(spinButton.getAttribute('aria-valuenow')).toEqual('1');
       expect(spinButton.getAttribute('aria-valuetext')).toBeNull();
       expect(spinButton.getAttribute('aria-valuemin')).toBeNull();
       expect(spinButton.getAttribute('aria-valuemax')).toBeNull();
@@ -78,7 +75,6 @@ describe('SpinButton', () => {
 
       const spinButton = getSpinButtonInput();
       expect(spinButton.value).toEqual('$1.00');
-      expect(spinButton.getAttribute('aria-valuenow')).toEqual('1');
       expect(spinButton.getAttribute('aria-valuetext')).toEqual('$1.00');
       expect(spinButton.getAttribute('aria-valuemin')).toBeNull();
       expect(spinButton.getAttribute('aria-valuemax')).toBeNull();
@@ -89,7 +85,6 @@ describe('SpinButton', () => {
 
       const spinButton = getSpinButtonInput();
       expect(spinButton.value).toEqual('$1.00');
-      expect(spinButton.getAttribute('aria-valuenow')).toEqual('1');
       expect(spinButton.getAttribute('aria-valuetext')).toEqual('Custom value text');
       expect(spinButton.getAttribute('aria-valuemin')).toBeNull();
       expect(spinButton.getAttribute('aria-valuemax')).toBeNull();
@@ -102,7 +97,6 @@ describe('SpinButton', () => {
 
       const spinButton = getSpinButtonInput();
       expect(spinButton.value).toBe('');
-      expect(spinButton.getAttribute('aria-valuenow')).toBeNull();
       expect(spinButton.getAttribute('aria-valuetext')).toBeNull();
     });
 
@@ -111,7 +105,6 @@ describe('SpinButton', () => {
 
       const spinButton = getSpinButtonInput();
       expect(spinButton.value).toBe('');
-      expect(spinButton.getAttribute('aria-valuenow')).toBeNull();
       expect(spinButton.getAttribute('aria-valuetext')).toBeNull();
     });
   });

--- a/packages/react-components/react-spinbutton/library/src/components/SpinButton/useSpinButton.tsx
+++ b/packages/react-components/react-spinbutton/library/src/components/SpinButton/useSpinButton.tsx
@@ -315,7 +315,6 @@ export const useSpinButton_unstable = (props: SpinButtonProps, ref: React.Ref<HT
   state.input.value = valueToDisplay;
   state.input['aria-valuemin'] = min;
   state.input['aria-valuemax'] = max;
-  state.input['aria-valuenow'] = currentValue ?? undefined;
   state.input['aria-valuetext'] = state.input['aria-valuetext'] ?? ((value !== undefined && displayValue) || undefined);
   state.input.onChange = mergeCallbacks(state.input.onChange, handleInputChange);
   state.input.onBlur = mergeCallbacks(state.input.onBlur, handleBlur);

--- a/packages/react/src/components/SpinButton/SpinButton.base.tsx
+++ b/packages/react/src/components/SpinButton/SpinButton.base.tsx
@@ -447,8 +447,6 @@ export const SpinButtonBase: React.FunctionComponent<ISpinButtonProps> = React.f
           autoComplete="off"
           role="spinbutton"
           aria-labelledby={label && labelId}
-          // TODO: test what happens while editing
-          aria-valuenow={ariaValueNow ?? (valueIsNumber ? Number(value) : undefined)}
           aria-valuetext={ariaValueText ?? (valueIsNumber ? undefined : value)}
           aria-valuemin={min}
           aria-valuemax={max}

--- a/packages/react/src/components/SpinButton/SpinButton.base.tsx
+++ b/packages/react/src/components/SpinButton/SpinButton.base.tsx
@@ -448,6 +448,7 @@ export const SpinButtonBase: React.FunctionComponent<ISpinButtonProps> = React.f
           role="spinbutton"
           aria-labelledby={label && labelId}
           aria-valuetext={ariaValueText ?? (valueIsNumber ? undefined : value)}
+          aria-valuenow={ariaValueNow}
           aria-valuemin={min}
           aria-valuemax={max}
           aria-describedby={ariaDescribedBy}

--- a/packages/react/src/components/SpinButton/SpinButton.test.tsx
+++ b/packages/react/src/components/SpinButton/SpinButton.test.tsx
@@ -28,8 +28,7 @@ describe('SpinButton', () => {
 
     // These don't update until editing is complete
     const isNumeric = !!value && !isNaN(Number(value));
-    // aria-valuenow is used for fully numeric values
-    expect(inputDOM.getAttribute('aria-valuenow')).toBe(isNumeric ? value : null);
+
     // aria-valuetext is used for values with suffixes or empty
     expect(inputDOM.getAttribute('aria-valuetext')).toBe(isNumeric ? null : value);
   }

--- a/packages/react/src/components/SpinButton/SpinButton.test.tsx
+++ b/packages/react/src/components/SpinButton/SpinButton.test.tsx
@@ -125,7 +125,7 @@ describe('SpinButton', () => {
 
     it('renders correctly with user-provided values', () => {
       const component = create(
-        <SpinButton min={0} max={100} label="label" value="0" ariaValueNow={0} ariaValueText="0 pt" data-test="test" />,
+        <SpinButton min={0} max={100} label="label" value="0" ariaValueText="0 pt" data-test="test" />,
       );
       const tree = component.toJSON();
       expect(tree).toMatchSnapshot();

--- a/packages/react/src/components/SpinButton/__snapshots__/SpinButton.test.tsx.snap
+++ b/packages/react/src/components/SpinButton/__snapshots__/SpinButton.test.tsx.snap
@@ -97,7 +97,6 @@ exports[`SpinButton snapshots renders correctly 1`] = `
       aria-labelledby="Label1"
       aria-valuemax={100}
       aria-valuemin={0}
-      aria-valuenow={0}
       autoComplete="off"
       className=
           ms-spinButton-input
@@ -580,7 +579,6 @@ exports[`SpinButton snapshots renders correctly with user-provided values 1`] = 
       aria-labelledby="Label1"
       aria-valuemax={100}
       aria-valuemin={0}
-      aria-valuenow={0}
       aria-valuetext="0 pt"
       autoComplete="off"
       className=


### PR DESCRIPTION
## Previous Behavior

We had an `aria-valuenow` attribute on native `<input>` elements in both v8 and v9 SpinButtons. This caused issues for a couple reasons:
- For a native input element, the `value` attribute is primarily used for exposing the current value to AT users, and screen reader users should always be aware of what is currently presented as the input's value in a native control
- the `aria-valuenow` attribute has mixed support when used to conflict with the native input element's value (though it's fine in other fully-ARIA-created non-native form fields)
- We weren't updating the `aria-valuenow` attribute as the user typed, so it was getting out-of-sync with the native value, exacerbating these issues.
- Narrator was announcing first the value, then the `aria-valuenow` after some value changes

## New Behavior

No `aria-valuenow` on native inputs.

## Related Issue(s)

- Fixes [ADO issue](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/19601)
