### PR TITLE
docs: clarifies FluentProvider/shadow DOM interop

### DIFF
--- a/apps/public-docsite-v9/src/Concepts/WebComponentsInterop/UsingFluentReactWithWebComponents.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/WebComponentsInterop/UsingFluentReactWithWebComponents.stories.mdx
@@ -31,6 +31,8 @@ import { FluentProvider, webLightTheme, Button } from '@fluentui/react-component
 In the above example, note that `FluentProvider` sits outside the shadow DOM. When `FluentProvider` is inside the shadow
 DOM styling/theming will not work as expected.
 
+> ⚠️ `FluentProvider` must be in the light DOM for this method to work.
+
 ```tsx
 // ❌ This will not render correctly, for example purposes only ❌
 import { root } from '@fluentui-contrib/react-shadow';


### PR DESCRIPTION
## Previous Behavior

Based on partner feedback it wasn't very clear that `FluentProvider` had to be in the light DOM.

## New Behavior

The light DOM requirement is explicitly called out.