### PR TITLE
TeachingPopover: Fix popover width and image bounds

### DIFF
--- a/change/@fluentui-react-teaching-popover-1b16f4a4-81fe-422a-8c82-df7ce282508f.json
+++ b/change/@fluentui-react-teaching-popover-1b16f4a4-81fe-422a-8c82-df7ce282508f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Update popover size to match design guidance 320px, enable image to auto size based on popover surface bounds",
+  "packageName": "@fluentui/react-teaching-popover",
+  "email": "mifraser@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverBody/useTeachingPopoverBodyStyles.styles.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverBody/useTeachingPopoverBodyStyles.styles.ts
@@ -13,7 +13,7 @@ export const useMediaStyles = makeStyles({
   base: {
     gridArea: 'media',
     overflow: 'hidden',
-    width: `${popoverBodyDimension}px`,
+    width: 'auto',
     marginBottom: '12px',
     verticalAlign: 'middle',
     justifyContent: 'center',
@@ -32,7 +32,7 @@ export const useMediaStyles = makeStyles({
     },
   },
   tall: {
-    aspectRatio: popoverBodyDimension / popoverBodyDimension,
+    aspectRatio: 1,
     '@supports not (aspect-ratio)': {
       height: `${popoverBodyDimension}px`,
     },

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverSurface/useTeachingPopoverSurfaceStyles.styles.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverSurface/useTeachingPopoverSurfaceStyles.styles.ts
@@ -12,8 +12,8 @@ const useStyles = makeStyles({
   root: {
     padding: `${tokens.spacingVerticalL} ${tokens.spacingVerticalL}`,
     borderRadius: tokens.borderRadiusXLarge,
-    width: '288px',
-    boxSizing: 'content-box',
+    minWidth: '320px',
+    boxSizing: 'border-box',
   },
 });
 


### PR DESCRIPTION
## Previous Behavior
Image was hardcoded to width: 288px
TeachingPopoverSurface was incorrectly hardcoded to width:288px (should be 320px)
Image was reduced in size but overflowed when autosizing was enabled.
![image](https://github.com/user-attachments/assets/997b8b47-d90c-46cc-942e-6e15a740d693)

## New Behavior
TeachingPopoverSurface now set to correct 320px bound width
TeachingPopoverBody now does not set a width on image, and instead lets it grow within bounds while respecting height/aspect ratio
![image](https://github.com/user-attachments/assets/dd6626fe-1318-42a4-bb9e-09dbca7b5d8d)

## Related Issue(s)
- Fixes #32362 
