### PR TITLE
chore(scripts/*): replace just-scripts and npm script aliases with nx

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -34,7 +34,8 @@
     },
     "type-check": {
       "dependsOn": ["^build"],
-      "cache": true
+      "cache": true,
+      "executor": "@fluentui/workspace-plugin:type-check"
     },
     "prepare": {
       "dependsOn": ["^prepare"],
@@ -79,6 +80,23 @@
       ],
       "options": {
         "command": "eslint src"
+      }
+    },
+    "format": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "prettier --write {projectRoot}"
+      },
+      "metadata": {
+        "help": {
+          "command": "yarn prettier --help",
+          "options": {}
+        }
+      },
+      "configurations": {
+        "check": {
+          "command": "prettier --check {projectRoot}"
+        }
       }
     },
     "verify-packaging": {

--- a/scripts/api-extractor/just.config.ts
+++ b/scripts/api-extractor/just.config.ts
@@ -1,3 +1,0 @@
-import { preset } from '@fluentui/scripts-tasks';
-
-preset();

--- a/scripts/api-extractor/package.json
+++ b/scripts/api-extractor/package.json
@@ -3,11 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "main": "index.js",
-  "scripts": {
-    "format": "prettier -w --ignore-path ../../.prettierignore .",
-    "format:check": "yarn format -c",
-    "type-check": "just-scripts type-check"
-  },
+  "scripts": {},
   "dependencies": {},
   "devDependencies": {}
 }

--- a/scripts/api-extractor/project.json
+++ b/scripts/api-extractor/project.json
@@ -3,5 +3,9 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/api-extractor",
   "projectType": "library",
-  "tags": ["tools"]
+  "tags": ["tools"],
+  "targets": {
+    "type-check": {},
+    "format": {}
+  }
 }

--- a/scripts/babel/just.config.ts
+++ b/scripts/babel/just.config.ts
@@ -1,3 +1,0 @@
-import { preset } from '@fluentui/scripts-tasks';
-
-preset();

--- a/scripts/babel/package.json
+++ b/scripts/babel/package.json
@@ -3,11 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "main": "src/index.js",
-  "scripts": {
-    "format": "prettier -w --ignore-path ../../.prettierignore .",
-    "format:check": "yarn format -c",
-    "type-check": "just-scripts type-check"
-  },
+  "scripts": {},
   "dependencies": {},
   "devDependencies": {},
   "exports": {

--- a/scripts/babel/project.json
+++ b/scripts/babel/project.json
@@ -3,5 +3,9 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/babel/src",
   "projectType": "library",
-  "tags": ["tools"]
+  "tags": ["tools"],
+  "targets": {
+    "type-check": {},
+    "format": {}
+  }
 }

--- a/scripts/beachball/just.config.ts
+++ b/scripts/beachball/just.config.ts
@@ -1,4 +1,0 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { preset } from '@fluentui/scripts-tasks';
-
-preset();

--- a/scripts/beachball/package.json
+++ b/scripts/beachball/package.json
@@ -3,11 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "main": "src/index.js",
-  "scripts": {
-    "format": "prettier -w --ignore-path ../../.prettierignore .",
-    "format:check": "yarn format -c",
-    "type-check": "just-scripts type-check"
-  },
+  "scripts": {},
   "dependencies": {
     "@fluentui/scripts-github": "*",
     "@fluentui/scripts-monorepo": "*",

--- a/scripts/beachball/project.json
+++ b/scripts/beachball/project.json
@@ -3,5 +3,9 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/beachball/src",
   "projectType": "library",
-  "tags": ["tools"]
+  "tags": ["tools"],
+  "targets": {
+    "type-check": {},
+    "format": {}
+  }
 }

--- a/scripts/cypress/just.config.ts
+++ b/scripts/cypress/just.config.ts
@@ -1,3 +1,0 @@
-import { preset } from '@fluentui/scripts-tasks';
-
-preset();

--- a/scripts/cypress/package.json
+++ b/scripts/cypress/package.json
@@ -3,11 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "main": "src/index.ts",
-  "scripts": {
-    "format": "prettier -w --ignore-path ../../.prettierignore .",
-    "format:check": "yarn format -c",
-    "type-check": "just-scripts type-check"
-  },
+  "scripts": {},
   "dependencies": {},
   "devDependencies": {}
 }

--- a/scripts/cypress/project.json
+++ b/scripts/cypress/project.json
@@ -3,5 +3,9 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/cypress/src",
   "projectType": "library",
-  "tags": ["tools"]
+  "tags": ["tools"],
+  "targets": {
+    "type-check": {},
+    "format": {}
+  }
 }

--- a/scripts/dangerjs/just.config.ts
+++ b/scripts/dangerjs/just.config.ts
@@ -1,3 +1,0 @@
-import { preset } from '@fluentui/scripts-tasks';
-
-preset();

--- a/scripts/dangerjs/package.json
+++ b/scripts/dangerjs/package.json
@@ -3,11 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "main": "src/index.js",
-  "scripts": {
-    "format": "prettier -w --ignore-path ../../.prettierignore .",
-    "format:check": "yarn format -c",
-    "type-check": "just-scripts type-check"
-  },
+  "scripts": {},
   "dependencies": {
     "@fluentui/scripts-monorepo": "*",
     "@fluentui/scripts-utils": "*"

--- a/scripts/dangerjs/project.json
+++ b/scripts/dangerjs/project.json
@@ -3,5 +3,9 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/dangerjs/src",
   "projectType": "library",
-  "tags": ["tools"]
+  "tags": ["tools"],
+  "targets": {
+    "type-check": {},
+    "format": {}
+  }
 }

--- a/scripts/executors/just.config.ts
+++ b/scripts/executors/just.config.ts
@@ -1,4 +1,0 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { preset } from '@fluentui/scripts-tasks';
-
-preset();

--- a/scripts/executors/package.json
+++ b/scripts/executors/package.json
@@ -3,11 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "main": "index.js",
-  "scripts": {
-    "format": "prettier -w --ignore-path ../../.prettierignore .",
-    "format:check": "yarn format -c",
-    "type-check": "just-scripts type-check"
-  },
+  "scripts": {},
   "dependencies": {
     "@fluentui/scripts-utils": "*",
     "@fluentui/scripts-monorepo": "*",

--- a/scripts/executors/project.json
+++ b/scripts/executors/project.json
@@ -3,5 +3,9 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/executors/src",
   "projectType": "library",
-  "tags": ["tools"]
+  "tags": ["tools"],
+  "targets": {
+    "type-check": {},
+    "format": {}
+  }
 }

--- a/scripts/fluentui-publish/just.config.ts
+++ b/scripts/fluentui-publish/just.config.ts
@@ -1,3 +1,0 @@
-import { preset } from '@fluentui/scripts-tasks';
-
-preset();

--- a/scripts/fluentui-publish/package.json
+++ b/scripts/fluentui-publish/package.json
@@ -6,11 +6,8 @@
     "northstar-release": "./bin/northstar-release.js"
   },
   "scripts": {
-    "format": "prettier -w --ignore-path ../../.prettierignore .",
-    "format:check": "yarn format -c",
     "lint": "eslint --ext .ts,.js ./src ./bin",
-    "test": "jest --passWithNoTests",
-    "type-check": "just-scripts type-check"
+    "test": "jest --passWithNoTests"
   },
   "dependencies": {
     "@fluentui/scripts-monorepo": "*"

--- a/scripts/fluentui-publish/project.json
+++ b/scripts/fluentui-publish/project.json
@@ -12,6 +12,8 @@
         "{workspaceRoot}/jest.preset.js",
         "{workspaceRoot}/packages/fluentui/*/project.json"
       ]
-    }
+    },
+    "type-check": {},
+    "format": {}
   }
 }

--- a/scripts/generators/just.config.ts
+++ b/scripts/generators/just.config.ts
@@ -1,4 +1,0 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { preset } from '@fluentui/scripts-tasks';
-
-preset();

--- a/scripts/generators/package.json
+++ b/scripts/generators/package.json
@@ -4,11 +4,8 @@
   "private": true,
   "main": "index.js",
   "scripts": {
-    "format": "prettier -w --ignore-path ../../.prettierignore .",
-    "format:check": "yarn format -c",
     "lint": "eslint --ext .ts,.js --ignore-pattern plop-templates-* ./src",
-    "test": "jest --passWithNoTests",
-    "type-check": "just-scripts type-check"
+    "test": "jest --passWithNoTests"
   },
   "dependencies": {
     "@fluentui/scripts-monorepo": "*",

--- a/scripts/generators/project.json
+++ b/scripts/generators/project.json
@@ -3,5 +3,9 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/generators/src",
   "projectType": "library",
-  "tags": ["tools"]
+  "tags": ["tools"],
+  "targets": {
+    "type-check": {},
+    "format": {}
+  }
 }

--- a/scripts/github/just.config.ts
+++ b/scripts/github/just.config.ts
@@ -1,3 +1,0 @@
-import { preset } from '@fluentui/scripts-tasks';
-
-preset();

--- a/scripts/github/package.json
+++ b/scripts/github/package.json
@@ -3,11 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "main": "src/index.ts",
-  "scripts": {
-    "format": "prettier -w --ignore-path ../../.prettierignore .",
-    "format:check": "yarn format -c",
-    "type-check": "just-scripts type-check"
-  },
+  "scripts": {},
   "dependencies": {},
   "devDependencies": {}
 }

--- a/scripts/github/project.json
+++ b/scripts/github/project.json
@@ -3,5 +3,9 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/github/src",
   "projectType": "library",
-  "tags": ["tools"]
+  "tags": ["tools"],
+  "targets": {
+    "type-check": {},
+    "format": {}
+  }
 }

--- a/scripts/gulp/just.config.ts
+++ b/scripts/gulp/just.config.ts
@@ -1,3 +1,0 @@
-import { preset } from '@fluentui/scripts-tasks';
-
-preset();

--- a/scripts/gulp/package.json
+++ b/scripts/gulp/package.json
@@ -3,11 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "main": "src/index.ts",
-  "scripts": {
-    "format": "prettier -w --ignore-path ../../.prettierignore .",
-    "format:check": "yarn format -c",
-    "type-check": "just-scripts type-check"
-  },
+  "scripts": {},
   "dependencies": {
     "@fluentui/scripts-monorepo": "*",
     "@fluentui/scripts-utils": "*",

--- a/scripts/gulp/project.json
+++ b/scripts/gulp/project.json
@@ -3,5 +3,9 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/gulp/src",
   "projectType": "library",
-  "tags": ["tools"]
+  "tags": ["tools"],
+  "targets": {
+    "type-check": {},
+    "format": {}
+  }
 }

--- a/scripts/jest/just.config.ts
+++ b/scripts/jest/just.config.ts
@@ -1,3 +1,0 @@
-import { preset } from '@fluentui/scripts-tasks';
-
-preset();

--- a/scripts/jest/package.json
+++ b/scripts/jest/package.json
@@ -3,11 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "main": "src/index.js",
-  "scripts": {
-    "format": "prettier -w --ignore-path ../../.prettierignore .",
-    "format:check": "yarn format -c",
-    "type-check": "just-scripts type-check"
-  },
+  "scripts": {},
   "dependencies": {
     "@fluentui/scripts-monorepo": "*",
     "@fluentui/scripts-utils": "*"

--- a/scripts/jest/project.json
+++ b/scripts/jest/project.json
@@ -3,5 +3,9 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/jest/src",
   "projectType": "library",
-  "tags": ["tools"]
+  "tags": ["tools"],
+  "targets": {
+    "type-check": {},
+    "format": {}
+  }
 }

--- a/scripts/lint-staged/just.config.ts
+++ b/scripts/lint-staged/just.config.ts
@@ -1,4 +1,0 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { preset } from '@fluentui/scripts-tasks';
-
-preset();

--- a/scripts/lint-staged/package.json
+++ b/scripts/lint-staged/package.json
@@ -3,11 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "main": "index.js",
-  "scripts": {
-    "format": "prettier -w --ignore-path ../../.prettierignore .",
-    "format:check": "yarn format -c",
-    "type-check": "just-scripts type-check"
-  },
+  "scripts": {},
   "dependencies": {
     "@fluentui/scripts-monorepo": "*",
     "@fluentui/scripts-utils": "*"

--- a/scripts/lint-staged/project.json
+++ b/scripts/lint-staged/project.json
@@ -3,5 +3,9 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/lint-staged/src",
   "projectType": "library",
-  "tags": ["tools"]
+  "tags": ["tools"],
+  "targets": {
+    "type-check": {},
+    "format": {}
+  }
 }

--- a/scripts/monorepo/just.config.ts
+++ b/scripts/monorepo/just.config.ts
@@ -1,3 +1,0 @@
-import { preset } from '@fluentui/scripts-tasks';
-
-preset();

--- a/scripts/monorepo/package.json
+++ b/scripts/monorepo/package.json
@@ -3,11 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "main": "src/index.js",
-  "scripts": {
-    "format": "prettier -w --ignore-path ../../.prettierignore .",
-    "format:check": "yarn format -c",
-    "type-check": "just-scripts type-check"
-  },
+  "scripts": {},
   "dependencies": {
     "@fluentui/scripts-utils": "*"
   },

--- a/scripts/monorepo/project.json
+++ b/scripts/monorepo/project.json
@@ -3,5 +3,9 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/monorepo/src",
   "projectType": "library",
-  "tags": ["tools"]
+  "tags": ["tools"],
+  "targets": {
+    "type-check": {},
+    "format": {}
+  }
 }

--- a/scripts/package-manager/just.config.ts
+++ b/scripts/package-manager/just.config.ts
@@ -1,4 +1,0 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { preset } from '@fluentui/scripts-tasks';
-
-preset();

--- a/scripts/package-manager/package.json
+++ b/scripts/package-manager/package.json
@@ -3,11 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "main": "index.js",
-  "scripts": {
-    "format": "prettier -w --ignore-path ../../.prettierignore .",
-    "format:check": "yarn format -c",
-    "type-check": "just-scripts type-check"
-  },
+  "scripts": {},
   "dependencies": {},
   "devDependencies": {}
 }

--- a/scripts/package-manager/project.json
+++ b/scripts/package-manager/project.json
@@ -3,5 +3,9 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/package-manager/src",
   "projectType": "library",
-  "tags": ["tools"]
+  "tags": ["tools"],
+  "targets": {
+    "type-check": {},
+    "format": {}
+  }
 }

--- a/scripts/perf-test-flamegrill/just.config.ts
+++ b/scripts/perf-test-flamegrill/just.config.ts
@@ -1,3 +1,0 @@
-import { preset } from '@fluentui/scripts-tasks';
-
-preset();

--- a/scripts/perf-test-flamegrill/package.json
+++ b/scripts/perf-test-flamegrill/package.json
@@ -3,11 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "main": "src/index.ts",
-  "scripts": {
-    "format": "prettier -w --ignore-path ../../.prettierignore .",
-    "format:check": "yarn format -c",
-    "type-check": "just-scripts type-check"
-  },
+  "scripts": {},
   "peerDependencies": {
     "@types/react": ">=16.8.0 <19.0.0",
     "@types/react-dom": ">=16.8.0 <19.0.0",
@@ -15,5 +11,6 @@
     "react-dom": ">=16.8.0 <19.0.0",
     "webpack": "^5.75.0"
   },
-  "devDependencies": {}
+  "devDependencies": {},
+  "dependencies": {}
 }

--- a/scripts/perf-test-flamegrill/project.json
+++ b/scripts/perf-test-flamegrill/project.json
@@ -3,5 +3,9 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/perf-test-flamegrill/src",
   "projectType": "library",
-  "tags": ["tools", "platform:any"]
+  "tags": ["tools", "platform:any"],
+  "targets": {
+    "type-check": {},
+    "format": {}
+  }
 }

--- a/scripts/prettier/just.config.ts
+++ b/scripts/prettier/just.config.ts
@@ -1,3 +1,0 @@
-import { preset } from '@fluentui/scripts-tasks';
-
-preset();

--- a/scripts/prettier/package.json
+++ b/scripts/prettier/package.json
@@ -3,11 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "main": "src/index.js",
-  "scripts": {
-    "format": "prettier -w --ignore-path ../../.prettierignore .",
-    "format:check": "yarn format -c",
-    "type-check": "just-scripts type-check"
-  },
+  "scripts": {},
   "dependencies": {
     "@fluentui/scripts-monorepo": "*"
   },

--- a/scripts/prettier/project.json
+++ b/scripts/prettier/project.json
@@ -3,5 +3,9 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/prettier/src",
   "projectType": "library",
-  "tags": ["tools"]
+  "tags": ["tools"],
+  "targets": {
+    "type-check": {},
+    "format": {}
+  }
 }

--- a/scripts/projects-test/just.config.ts
+++ b/scripts/projects-test/just.config.ts
@@ -1,3 +1,0 @@
-import { preset } from '@fluentui/scripts-tasks';
-
-preset();

--- a/scripts/projects-test/package.json
+++ b/scripts/projects-test/package.json
@@ -3,11 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "main": "src/index.ts",
-  "scripts": {
-    "format": "prettier -w --ignore-path ../../.prettierignore .",
-    "format:check": "yarn format -c",
-    "type-check": "just-scripts type-check"
-  },
+  "scripts": {},
   "dependencies": {
     "@fluentui/scripts-utils": "*",
     "@fluentui/scripts-puppeteer": "*",

--- a/scripts/projects-test/project.json
+++ b/scripts/projects-test/project.json
@@ -3,5 +3,9 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/projects-test/src",
   "projectType": "library",
-  "tags": ["tools"]
+  "tags": ["tools"],
+  "targets": {
+    "type-check": {},
+    "format": {}
+  }
 }

--- a/scripts/puppeteer/just.config.ts
+++ b/scripts/puppeteer/just.config.ts
@@ -1,3 +1,0 @@
-import { preset } from '@fluentui/scripts-tasks';
-
-preset();

--- a/scripts/puppeteer/package.json
+++ b/scripts/puppeteer/package.json
@@ -3,11 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "main": "src/index.ts",
-  "scripts": {
-    "format": "prettier -w --ignore-path ../../.prettierignore .",
-    "format:check": "yarn format -c",
-    "type-check": "just-scripts type-check"
-  },
+  "scripts": {},
   "dependencies": {},
   "devDependencies": {}
 }

--- a/scripts/puppeteer/project.json
+++ b/scripts/puppeteer/project.json
@@ -3,5 +3,9 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/puppeteer/src",
   "projectType": "library",
-  "tags": ["tools"]
+  "tags": ["tools"],
+  "targets": {
+    "type-check": {},
+    "format": {}
+  }
 }

--- a/scripts/storybook/just.config.ts
+++ b/scripts/storybook/just.config.ts
@@ -1,3 +1,0 @@
-import { preset } from '@fluentui/scripts-tasks';
-
-preset();

--- a/scripts/storybook/package.json
+++ b/scripts/storybook/package.json
@@ -3,11 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "main": "src/index.js",
-  "scripts": {
-    "format": "prettier -w --ignore-path ../../.prettierignore .",
-    "format:check": "yarn format -c",
-    "type-check": "just-scripts type-check"
-  },
+  "scripts": {},
   "dependencies": {
     "@fluentui/scripts-monorepo": "*"
   },

--- a/scripts/storybook/project.json
+++ b/scripts/storybook/project.json
@@ -3,5 +3,9 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/storybook/src",
   "projectType": "library",
-  "tags": ["tools"]
+  "tags": ["tools"],
+  "targets": {
+    "type-check": {},
+    "format": {}
+  }
 }

--- a/scripts/tasks/just.config.ts
+++ b/scripts/tasks/just.config.ts
@@ -1,3 +1,0 @@
-import { preset } from './src/presets';
-
-preset();

--- a/scripts/tasks/package.json
+++ b/scripts/tasks/package.json
@@ -3,11 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "main": "src/index.ts",
-  "scripts": {
-    "format": "prettier -w --ignore-path ../../.prettierignore .",
-    "format:check": "yarn format -c",
-    "type-check": "just-scripts type-check"
-  },
+  "scripts": {},
   "dependencies": {
     "@fluentui/scripts-monorepo": "*",
     "@fluentui/scripts-utils": "*",

--- a/scripts/tasks/project.json
+++ b/scripts/tasks/project.json
@@ -3,5 +3,9 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/tasks/src",
   "projectType": "library",
-  "tags": ["tools"]
+  "tags": ["tools"],
+  "targets": {
+    "type-check": {},
+    "format": {}
+  }
 }

--- a/scripts/test-ssr/just.config.ts
+++ b/scripts/test-ssr/just.config.ts
@@ -1,3 +1,0 @@
-import { preset } from '@fluentui/scripts-tasks';
-
-preset();

--- a/scripts/test-ssr/package.json
+++ b/scripts/test-ssr/package.json
@@ -6,11 +6,8 @@
     "test-ssr": "./bin/test-ssr.js"
   },
   "scripts": {
-    "format": "prettier -w --ignore-path ../../.prettierignore .",
-    "format:check": "yarn format -c",
     "lint": "eslint --ext .ts,.js ./src ./bin",
-    "test": "jest --passWithNoTests",
-    "type-check": "just-scripts type-check"
+    "test": "jest --passWithNoTests"
   },
   "dependencies": {
     "@fluentui/scripts-puppeteer": "*",

--- a/scripts/test-ssr/project.json
+++ b/scripts/test-ssr/project.json
@@ -3,5 +3,9 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/test-ssr/src",
   "projectType": "library",
-  "tags": ["tools"]
+  "tags": ["tools"],
+  "targets": {
+    "type-check": {},
+    "format": {}
+  }
 }

--- a/scripts/triage-bot/just.config.ts
+++ b/scripts/triage-bot/just.config.ts
@@ -1,3 +1,0 @@
-import { preset } from '@fluentui/scripts-tasks';
-
-preset();

--- a/scripts/triage-bot/package.json
+++ b/scripts/triage-bot/package.json
@@ -3,11 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "main": "src/index.js",
-  "scripts": {
-    "format": "prettier -w --ignore-path ../../.prettierignore .",
-    "format:check": "yarn format -c",
-    "type-check": "just-scripts type-check"
-  },
+  "scripts": {},
   "dependencies": {},
   "devDependencies": {}
 }

--- a/scripts/triage-bot/project.json
+++ b/scripts/triage-bot/project.json
@@ -3,5 +3,9 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/triage-bot/src",
   "projectType": "library",
-  "tags": ["tools"]
+  "tags": ["tools"],
+  "targets": {
+    "type-check": {},
+    "format": {}
+  }
 }

--- a/scripts/ts-node/just.config.ts
+++ b/scripts/ts-node/just.config.ts
@@ -1,4 +1,0 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { preset } from '@fluentui/scripts-tasks';
-
-preset();

--- a/scripts/ts-node/package.json
+++ b/scripts/ts-node/package.json
@@ -3,11 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "main": "index.js",
-  "scripts": {
-    "format": "prettier -w --ignore-path ../../.prettierignore .",
-    "format:check": "yarn format -c",
-    "type-check": "just-scripts type-check"
-  },
+  "scripts": {},
   "dependencies": {},
   "devDependencies": {}
 }

--- a/scripts/ts-node/project.json
+++ b/scripts/ts-node/project.json
@@ -3,5 +3,9 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/ts-node/src",
   "projectType": "library",
-  "tags": ["tools"]
+  "tags": ["tools"],
+  "targets": {
+    "type-check": {},
+    "format": {}
+  }
 }

--- a/scripts/update-release-notes/just.config.ts
+++ b/scripts/update-release-notes/just.config.ts
@@ -1,4 +1,0 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { preset } from '@fluentui/scripts-tasks';
-
-preset();

--- a/scripts/update-release-notes/package.json
+++ b/scripts/update-release-notes/package.json
@@ -3,11 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "main": "index.js",
-  "scripts": {
-    "format": "prettier -w --ignore-path ../../.prettierignore .",
-    "format:check": "yarn format -c",
-    "type-check": "just-scripts type-check"
-  },
+  "scripts": {},
   "dependencies": {
     "@fluentui/scripts-github": "*",
     "@fluentui/scripts-monorepo": "*"

--- a/scripts/update-release-notes/project.json
+++ b/scripts/update-release-notes/project.json
@@ -3,5 +3,9 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/update-release-notes/src",
   "projectType": "library",
-  "tags": ["tools"]
+  "tags": ["tools"],
+  "targets": {
+    "type-check": {},
+    "format": {}
+  }
 }

--- a/scripts/utils/just.config.ts
+++ b/scripts/utils/just.config.ts
@@ -1,3 +1,0 @@
-import { preset } from '@fluentui/scripts-tasks';
-
-preset();

--- a/scripts/utils/package.json
+++ b/scripts/utils/package.json
@@ -3,11 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "main": "src/index.js",
-  "scripts": {
-    "format": "prettier -w --ignore-path ../../.prettierignore .",
-    "format:check": "yarn format -c",
-    "type-check": "just-scripts type-check"
-  },
+  "scripts": {},
   "dependencies": {},
   "devDependencies": {}
 }

--- a/scripts/utils/project.json
+++ b/scripts/utils/project.json
@@ -3,5 +3,9 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/utils/src",
   "projectType": "library",
-  "tags": ["tools"]
+  "tags": ["tools"],
+  "targets": {
+    "type-check": {},
+    "format": {}
+  }
 }

--- a/scripts/webpack/just.config.ts
+++ b/scripts/webpack/just.config.ts
@@ -1,3 +1,0 @@
-import { preset } from '@fluentui/scripts-tasks';
-
-preset();

--- a/scripts/webpack/package.json
+++ b/scripts/webpack/package.json
@@ -3,11 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "main": "src/index.js",
-  "scripts": {
-    "format": "prettier -w --ignore-path ../../.prettierignore .",
-    "format:check": "yarn format -c",
-    "type-check": "just-scripts type-check"
-  },
+  "scripts": {},
   "dependencies": {
     "@fluentui/scripts-monorepo": "*",
     "@fluentui/scripts-utils": "*"

--- a/scripts/webpack/project.json
+++ b/scripts/webpack/project.json
@@ -3,5 +3,9 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/webpack/src",
   "projectType": "library",
-  "tags": ["tools"]
+  "tags": ["tools"],
+  "targets": {
+    "type-check": {},
+    "format": {}
+  }
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## pre-requirement:

- [x] https://github.com/microsoft/fluentui/pull/32370

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

> **💡 NOTE:** 
> this PR changes only projects within `scripts/*` folder ( later on, this approach will be applied to all v9 projects )

- `just-scripts` configs and usage are removed
- `npm.scripts` are removed
- nx.json
  - defines new `format` target with `check` configuration which gives us two commands for formatting project code
    - `format` ( runs prettier CLI )
    - `format:check`  (runs prettier CLI in `--check` mode)
 - `project.json`
   - every project within scripts ads to "empty" target names which use configs specified within nx.json

```jsonc
    "targets": {
          "type-check": {},
          "format": {}
       }
```  

### Breaking Changes

`yarn workspace <npm-script-name>` wont do anything - use `nx run` or `yarn start`

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows https://github.com/microsoft/fluentui/pull/32337
- Implements partially #30267 
