### PR TITLE
fix(react-tabs): Improve animation for active tab indicator on tabs with falsy values

### DIFF
--- a/change/@fluentui-react-tabs-00427f46-b6ea-45d8-989f-a7e2d94bd0bf.json
+++ b/change/@fluentui-react-tabs-00427f46-b6ea-45d8-989f-a7e2d94bd0bf.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Tab component skips animation for falsy values",
+  "comment": "fix: Improve animation for active tab indicator on tabs with falsy values",
   "packageName": "@fluentui/react-tabs",
   "email": "kirpadv@gmail.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-tabs-00427f46-b6ea-45d8-989f-a7e2d94bd0bf.json
+++ b/change/@fluentui-react-tabs-00427f46-b6ea-45d8-989f-a7e2d94bd0bf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Tab component skips animation for falsy values",
+  "packageName": "@fluentui/react-tabs",
+  "email": "kirpadv@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tabs/library/src/components/Tab/useTabAnimatedIndicator.styles.ts
+++ b/packages/react-components/react-tabs/library/src/components/Tab/useTabAnimatedIndicator.styles.ts
@@ -62,12 +62,12 @@ const calculateTabRect = (element: HTMLElement) => {
 };
 
 const getRegisteredTabRect = (registeredTabs: Record<string, TabRegisterData>, value?: TabValue) => {
-  const element =
-    value !== undefined && value !== null ? registeredTabs[JSON.stringify(value)]?.ref.current : undefined;
+  const element = isValueDefined(value) ? registeredTabs[JSON.stringify(value)]?.ref.current : undefined;
   return element ? calculateTabRect(element) : undefined;
 };
 
-const isDefined = (value: TabValue) => value !== undefined && value !== null;
+// eslint-disable-next-line eqeqeq
+const isValueDefined = (value: TabValue) => value != null;
 
 /**
  * Adds additional styling to the active tab selection indicator to create a sliding animation.
@@ -81,7 +81,7 @@ export const useTabAnimatedIndicatorStyles_unstable = (state: TabState): TabStat
   const getRegisteredTabs = useTabListContext_unstable(ctx => ctx.getRegisteredTabs);
 
   React.useEffect(() => {
-    if (isDefined(lastAnimatedFrom)) {
+    if (isValueDefined(lastAnimatedFrom)) {
       setAnimationValues({ offset: 0, scale: 1 });
     }
   }, [lastAnimatedFrom]);
@@ -89,7 +89,7 @@ export const useTabAnimatedIndicatorStyles_unstable = (state: TabState): TabStat
   if (selected) {
     const { previousSelectedValue, selectedValue, registeredTabs } = getRegisteredTabs();
 
-    if (isDefined(previousSelectedValue) && lastAnimatedFrom !== previousSelectedValue) {
+    if (isValueDefined(previousSelectedValue) && lastAnimatedFrom !== previousSelectedValue) {
       const previousSelectedTabRect = getRegisteredTabRect(registeredTabs, previousSelectedValue);
       const selectedTabRect = getRegisteredTabRect(registeredTabs, selectedValue);
 
@@ -106,7 +106,7 @@ export const useTabAnimatedIndicatorStyles_unstable = (state: TabState): TabStat
         setLastAnimatedFrom(previousSelectedValue);
       }
     }
-  } else if (isDefined(lastAnimatedFrom)) {
+  } else if (isValueDefined(lastAnimatedFrom)) {
     // need to clear the last animated from so that if this tab is selected again
     // from the same previous tab as last time, that animation still happens.
     setLastAnimatedFrom(undefined);

--- a/packages/react-components/react-tabs/library/src/components/Tab/useTabAnimatedIndicator.styles.ts
+++ b/packages/react-components/react-tabs/library/src/components/Tab/useTabAnimatedIndicator.styles.ts
@@ -67,10 +67,7 @@ const getRegisteredTabRect = (registeredTabs: Record<string, TabRegisterData>, v
   return element ? calculateTabRect(element) : undefined;
 };
 
-/**
- * Checks if a tab value is neither null nor undefined.
- */
-const isDefined = (value: TabValue): boolean => value !== undefined && value !== null;
+const isDefined = (value: TabValue) => value !== undefined && value !== null;
 
 /**
  * Adds additional styling to the active tab selection indicator to create a sliding animation.

--- a/packages/react-components/react-tabs/library/src/components/Tab/useTabAnimatedIndicator.styles.ts
+++ b/packages/react-components/react-tabs/library/src/components/Tab/useTabAnimatedIndicator.styles.ts
@@ -68,6 +68,11 @@ const getRegisteredTabRect = (registeredTabs: Record<string, TabRegisterData>, v
 };
 
 /**
+ * Checks if a tab value is neither null nor undefined.
+ */
+const isDefined = (value: TabValue): boolean => value !== undefined && value !== null;
+
+/**
  * Adds additional styling to the active tab selection indicator to create a sliding animation.
  */
 export const useTabAnimatedIndicatorStyles_unstable = (state: TabState): TabState => {
@@ -79,7 +84,7 @@ export const useTabAnimatedIndicatorStyles_unstable = (state: TabState): TabStat
   const getRegisteredTabs = useTabListContext_unstable(ctx => ctx.getRegisteredTabs);
 
   React.useEffect(() => {
-    if (lastAnimatedFrom) {
+    if (isDefined(lastAnimatedFrom)) {
       setAnimationValues({ offset: 0, scale: 1 });
     }
   }, [lastAnimatedFrom]);
@@ -87,7 +92,7 @@ export const useTabAnimatedIndicatorStyles_unstable = (state: TabState): TabStat
   if (selected) {
     const { previousSelectedValue, selectedValue, registeredTabs } = getRegisteredTabs();
 
-    if (previousSelectedValue && lastAnimatedFrom !== previousSelectedValue) {
+    if (isDefined(previousSelectedValue) && lastAnimatedFrom !== previousSelectedValue) {
       const previousSelectedTabRect = getRegisteredTabRect(registeredTabs, previousSelectedValue);
       const selectedTabRect = getRegisteredTabRect(registeredTabs, selectedValue);
 
@@ -104,7 +109,7 @@ export const useTabAnimatedIndicatorStyles_unstable = (state: TabState): TabStat
         setLastAnimatedFrom(previousSelectedValue);
       }
     }
-  } else if (lastAnimatedFrom) {
+  } else if (isDefined(lastAnimatedFrom)) {
     // need to clear the last animated from so that if this tab is selected again
     // from the same previous tab as last time, that animation still happens.
     setLastAnimatedFrom(undefined);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Tab component skips animation for falsy values.

This is valid example of usage of tab components (`value={0}`), but the animation is skiped because 

```tsx
<TabList {...props}>
  <Tab value={0}>First Tab</Tab> /* <= Nullable value */
  <Tab value={1}>Second Tab</Tab>
  <Tab value={2}>Third Tab</Tab>
</TabList>
```

https://github.com/user-attachments/assets/888e2ea3-9241-4fc4-a7b6-1f41305094fa


## New Behavior

The animation for the Tab component works as expected for tabs with all types of values, including the falsy ones.


https://github.com/user-attachments/assets/6235020c-620a-4080-9f0c-d91bda37b994

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #32293
