### PR TITLE
Virtualizer: Optimize IO usage and export useMeasureList

### DIFF
--- a/change/@fluentui-react-virtualizer-bab73d05-7372-4052-8d22-ca75b5fadfe2.json
+++ b/change/@fluentui-react-virtualizer-bab73d05-7372-4052-8d22-ca75b5fadfe2.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: Export useMeasureList and type for consumption",
+  "packageName": "@fluentui/react-virtualizer",
+  "email": "mifraser@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-virtualizer-bab73d05-7372-4052-8d22-ca75b5fadfe2.json
+++ b/change/@fluentui-react-virtualizer-bab73d05-7372-4052-8d22-ca75b5fadfe2.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "fix: Export useMeasureList and type for consumption",
+  "comment": "BREAKING CHANGE (useVirtualizerDynamicMeasure): optimized with scrollPos state and children height reference, updated algorithm to be more accurate, and exported measurement hook",
   "packageName": "@fluentui/react-virtualizer",
   "email": "mifraser@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/react-components/react-carousel-preview/stories/src/Carousel/CarouselDefault.stories.tsx
+++ b/packages/react-components/react-carousel-preview/stories/src/Carousel/CarouselDefault.stories.tsx
@@ -14,7 +14,7 @@ const useClasses = makeStyles({
     ...typographyStyles.largeTitle,
     alignContent: 'center',
     borderRadius: tokens.borderRadiusLarge,
-    height: '450px',
+    minHeight: '450px',
     textAlign: 'center',
   },
 });
@@ -31,7 +31,7 @@ const TestComponent: React.FC<{ accentColor: string; children: React.ReactNode }
 };
 
 export const Default = () => (
-  <Carousel groupSize={1}>
+  <Carousel groupSize={1} enableDrag align="start">
     <CarouselSlider>
       <CarouselCard>
         <TestComponent accentColor="#B99095">

--- a/packages/react-components/react-carousel-preview/stories/src/Carousel/CarouselDefault.stories.tsx
+++ b/packages/react-components/react-carousel-preview/stories/src/Carousel/CarouselDefault.stories.tsx
@@ -14,7 +14,7 @@ const useClasses = makeStyles({
     ...typographyStyles.largeTitle,
     alignContent: 'center',
     borderRadius: tokens.borderRadiusLarge,
-    minHeight: '450px',
+    height: '450px',
     textAlign: 'center',
   },
 });
@@ -31,7 +31,7 @@ const TestComponent: React.FC<{ accentColor: string; children: React.ReactNode }
 };
 
 export const Default = () => (
-  <Carousel groupSize={1} enableDrag align="start">
+  <Carousel groupSize={1}>
     <CarouselSlider>
       <CarouselCard>
         <TestComponent accentColor="#B99095">

--- a/packages/react-components/react-combobox/stories/src/Combobox/ComboboxVirtualizer.stories.tsx
+++ b/packages/react-components/react-combobox/stories/src/Combobox/ComboboxVirtualizer.stories.tsx
@@ -17,7 +17,8 @@ const useStyles = makeStyles({
 export const ComboboxVirtualizer = (props: Partial<ComboboxProps>) => {
   const comboId = useId('combobox');
 
-  const itemHeight = 32; //This should match the height of each item in the listbox
+  //This should include the item height (32px) and account for rowGap (2px)
+  const itemHeight = 34;
   const numberOfItems = 10000;
 
   const { virtualizerLength, bufferItems, bufferSize, scrollRef, containerSizeRef } = useStaticVirtualizerMeasure({

--- a/packages/react-components/react-combobox/stories/src/Combobox/ComboboxVirtualizer.stories.tsx
+++ b/packages/react-components/react-combobox/stories/src/Combobox/ComboboxVirtualizer.stories.tsx
@@ -20,7 +20,7 @@ export const ComboboxVirtualizer = (props: Partial<ComboboxProps>) => {
   const itemHeight = 32; //This should match the height of each item in the listbox
   const numberOfItems = 10000;
 
-  const { virtualizerLength, bufferItems, bufferSize, scrollRef } = useStaticVirtualizerMeasure({
+  const { virtualizerLength, bufferItems, bufferSize, scrollRef, containerSizeRef } = useStaticVirtualizerMeasure({
     defaultItemSize: itemHeight,
     direction: 'vertical',
   });
@@ -43,6 +43,7 @@ export const ComboboxVirtualizer = (props: Partial<ComboboxProps>) => {
             bufferItems={bufferItems}
             bufferSize={bufferSize}
             itemSize={itemHeight}
+            containerSizeRef={containerSizeRef}
           >
             {index => {
               return (

--- a/packages/react-components/react-virtualizer/library/etc/react-virtualizer.api.md
+++ b/packages/react-components/react-virtualizer/library/etc/react-virtualizer.api.md
@@ -16,6 +16,12 @@ import type { Slot } from '@fluentui/react-utilities';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 
 // @public (undocumented)
+export interface IndexedResizeCallbackElement {
+    // (undocumented)
+    handleResize: () => void;
+}
+
+// @public (undocumented)
 export const renderVirtualizer_unstable: (state: VirtualizerState) => JSX.Element;
 
 // @public (undocumented)
@@ -78,6 +84,15 @@ export const useIntersectionObserver: (callback: IntersectionObserverCallback, o
     setObserverList: Dispatch<SetStateAction<Element[] | undefined>>;
     setObserverInit: (newInit: IntersectionObserverInit | undefined) => void;
     observer: MutableRefObject<IntersectionObserver | undefined>;
+};
+
+// @public
+export function useMeasureList<TElement extends HTMLElement & IndexedResizeCallbackElement = HTMLElement & IndexedResizeCallbackElement>(currentIndex: number, refLength: number, totalLength: number, defaultItemSize: number): {
+    widthArray: React_2.MutableRefObject<any[]>;
+    heightArray: React_2.MutableRefObject<any[]>;
+    createIndexedRef: (index: number) => (el: TElement) => void;
+    refArray: React_2.MutableRefObject<(TElement | null | undefined)[]>;
+    sizeUpdateCount: number;
 };
 
 // @public

--- a/packages/react-components/react-virtualizer/library/etc/react-virtualizer.api.md
+++ b/packages/react-components/react-virtualizer/library/etc/react-virtualizer.api.md
@@ -77,6 +77,7 @@ export const useDynamicVirtualizerMeasure: <TElement extends HTMLElement>(virtua
     bufferItems: number;
     bufferSize: number;
     scrollRef: (instance: TElement | null) => void;
+    containerSizeRef: React_2.MutableRefObject<number>;
 };
 
 // @public
@@ -104,6 +105,7 @@ export const useStaticVirtualizerMeasure: <TElement extends HTMLElement>(virtual
     bufferItems: number;
     bufferSize: number;
     scrollRef: (instance: TElement | null) => void;
+    containerSizeRef: React_2.MutableRefObject<number>;
 };
 
 // @public (undocumented)
@@ -160,12 +162,16 @@ export type VirtualizerMeasureDynamicProps = {
     numItems: number;
     getItemSize: (index: number) => number;
     direction?: 'vertical' | 'horizontal';
+    bufferItems?: number;
+    bufferSize?: number;
 };
 
 // @public (undocumented)
 export type VirtualizerMeasureProps = {
     defaultItemSize: number;
     direction?: 'vertical' | 'horizontal';
+    bufferItems?: number;
+    bufferSize?: number;
 };
 
 // @public (undocumented)

--- a/packages/react-components/react-virtualizer/library/etc/react-virtualizer.api.md
+++ b/packages/react-components/react-virtualizer/library/etc/react-virtualizer.api.md
@@ -135,7 +135,7 @@ export const useVirtualizerStyles_unstable: (state: VirtualizerState) => Virtual
 // @public
 export const Virtualizer: FC<VirtualizerProps>;
 
-// @public (undocumented)
+// @public
 export type VirtualizerChildRenderFunction = (index: number, isScrolling: boolean) => React_2.ReactNode;
 
 // @public (undocumented)
@@ -203,7 +203,7 @@ export type VirtualizerScrollViewDynamicProps = ComponentProps<Partial<Virtualiz
     children: VirtualizerChildRenderFunction;
     imperativeRef?: RefObject<ScrollToInterface>;
     enablePagination?: boolean;
-    virtualizerContext: DynamicVirtualizerContextProps;
+    virtualizerContext?: DynamicVirtualizerContextProps;
 };
 
 // @public (undocumented)

--- a/packages/react-components/react-virtualizer/library/etc/react-virtualizer.api.md
+++ b/packages/react-components/react-virtualizer/library/etc/react-virtualizer.api.md
@@ -15,6 +15,9 @@ import type { SetStateAction } from 'react';
 import type { Slot } from '@fluentui/react-utilities';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 
+// @public
+export type DynamicVirtualizerContextProps = Required<VirtualizerContextProps>;
+
 // @public (undocumented)
 export interface IndexedResizeCallbackElement {
     // (undocumented)
@@ -142,6 +145,9 @@ export const virtualizerClassNames: SlotClassNames<VirtualizerSlots>;
 export type VirtualizerContextProps = {
     contextIndex: number;
     setContextIndex: (index: number) => void;
+    contextPosition?: number;
+    setContextPosition?: (index: number) => void;
+    childProgressiveSizes?: React_2.MutableRefObject<number[]>;
 };
 
 // @public (undocumented)
@@ -158,7 +164,7 @@ export type VirtualizerDataRef = {
 // @public (undocumented)
 export type VirtualizerMeasureDynamicProps = {
     defaultItemSize: number;
-    currentIndex: number;
+    virtualizerContext: DynamicVirtualizerContextProps;
     numItems: number;
     getItemSize: (index: number) => number;
     direction?: 'vertical' | 'horizontal';
@@ -190,13 +196,14 @@ export const VirtualizerScrollViewDynamic: React_2.FC<VirtualizerScrollViewDynam
 export const virtualizerScrollViewDynamicClassNames: SlotClassNames<VirtualizerScrollViewDynamicSlots>;
 
 // @public (undocumented)
-export type VirtualizerScrollViewDynamicProps = ComponentProps<Partial<VirtualizerScrollViewDynamicSlots>> & Partial<Omit<VirtualizerConfigProps, 'itemSize' | 'numItems' | 'getItemSize' | 'children' | 'flagIndex'>> & {
+export type VirtualizerScrollViewDynamicProps = ComponentProps<Partial<VirtualizerScrollViewDynamicSlots>> & Partial<Omit<VirtualizerConfigProps, 'itemSize' | 'numItems' | 'getItemSize' | 'children' | 'flagIndex' | 'virtualizerContext'>> & {
     itemSize: number;
     getItemSize?: (index: number) => number;
     numItems: number;
     children: VirtualizerChildRenderFunction;
     imperativeRef?: RefObject<ScrollToInterface>;
     enablePagination?: boolean;
+    virtualizerContext: DynamicVirtualizerContextProps;
 };
 
 // @public (undocumented)

--- a/packages/react-components/react-virtualizer/library/etc/react-virtualizer.api.md
+++ b/packages/react-components/react-virtualizer/library/etc/react-virtualizer.api.md
@@ -80,7 +80,7 @@ export const useDynamicVirtualizerMeasure: <TElement extends HTMLElement>(virtua
     bufferItems: number;
     bufferSize: number;
     scrollRef: (instance: TElement | null) => void;
-    containerSizeRef: React_2.MutableRefObject<number>;
+    containerSizeRef: React_2.RefObject<number>;
 };
 
 // @public

--- a/packages/react-components/react-virtualizer/library/src/components/Virtualizer/Virtualizer.types.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/Virtualizer/Virtualizer.types.ts
@@ -171,6 +171,11 @@ export type VirtualizerConfigProps = {
    * Imperative ref contains our scrollTo index functionality for user control.
    */
   imperativeVirtualizerRef?: RefObject<VirtualizerDataRef>;
+
+  /**
+   * A ref that provides the size of container (vertical - height, horizontal - width), set by a resize observer.
+   */
+  containerSizeRef: MutableRefObject<number>;
 };
 
 export type VirtualizerProps = ComponentProps<Partial<VirtualizerSlots>> & VirtualizerConfigProps;

--- a/packages/react-components/react-virtualizer/library/src/components/Virtualizer/Virtualizer.types.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/Virtualizer/Virtualizer.types.ts
@@ -131,7 +131,7 @@ export type VirtualizerConfigProps = {
   /**
    * Enables users to override the intersectionObserverRoot.
    */
-  scrollViewRef?: React.MutableRefObject<HTMLElement | null>;
+  scrollViewRef: React.MutableRefObject<HTMLElement | null>;
 
   /**
    * The scroll direction

--- a/packages/react-components/react-virtualizer/library/src/components/Virtualizer/Virtualizer.types.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/Virtualizer/Virtualizer.types.ts
@@ -109,16 +109,19 @@ export type VirtualizerConfigProps = {
   virtualizerLength: number;
 
   /**
-   * Defaults to 1/4th of virtualizerLength.
+   * Defaults to 1/4th (or 1/3rd for dynamic items) of virtualizerLength.
+   * RECOMMEND: Override this with a consistent value if using a dynamic virtualizer.
+   *
    * Controls the number of elements rendered before the current index entering the virtualized viewport.
    * Constraints:
    * - Large enough to cover bufferSize (prevents buffers intersecting into the viewport during rest state).
-   * - Small enough that the end buffer and end index (start index + virtualizerLength) is not within viewport at rest.
+   * - Small enough that the virtualizer only renders a few items outside of view.
    */
   bufferItems?: number;
 
   /**
    * Defaults to half of bufferItems * itemSize size (in pixels).
+   * RECOMMEND: Override this with a consistent minimum item size value if using a dynamic virtualizer.
    * The length (in pixels) before the end/start DOM index where the virtualizer recalculation will be triggered.
    * Increasing this reduces whitespace on ultra-fast scroll, as additional elements
    * are buffered to appear while virtualization recalculates.
@@ -130,6 +133,8 @@ export type VirtualizerConfigProps = {
 
   /**
    * Enables users to override the intersectionObserverRoot.
+   * RECOMMEND: DO NOT PASS THIS IN, as it can cause side effects
+   * when overlapping with other scroll views
    */
   scrollViewRef?: React.MutableRefObject<HTMLElement | null>;
 

--- a/packages/react-components/react-virtualizer/library/src/components/Virtualizer/Virtualizer.types.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/Virtualizer/Virtualizer.types.ts
@@ -118,7 +118,7 @@ export type VirtualizerConfigProps = {
   bufferItems?: number;
 
   /**
-   * Defaults to half of bufferItems size (in pixels).
+   * Defaults to half of bufferItems * itemSize size (in pixels).
    * The length (in pixels) before the end/start DOM index where the virtualizer recalculation will be triggered.
    * Increasing this reduces whitespace on ultra-fast scroll, as additional elements
    * are buffered to appear while virtualization recalculates.
@@ -131,7 +131,7 @@ export type VirtualizerConfigProps = {
   /**
    * Enables users to override the intersectionObserverRoot.
    */
-  scrollViewRef: React.MutableRefObject<HTMLElement | null>;
+  scrollViewRef?: React.MutableRefObject<HTMLElement | null>;
 
   /**
    * The scroll direction

--- a/packages/react-components/react-virtualizer/library/src/components/Virtualizer/Virtualizer.types.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/Virtualizer/Virtualizer.types.ts
@@ -192,6 +192,7 @@ export type VirtualizerConfigProps = {
 
   /**
    * A ref that provides the size of container (vertical - height, horizontal - width), set by a resize observer.
+   * Virtualizer Measure hooks provide a suitable reference.
    */
   containerSizeRef: MutableRefObject<number>;
 };

--- a/packages/react-components/react-virtualizer/library/src/components/Virtualizer/Virtualizer.types.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/Virtualizer/Virtualizer.types.ts
@@ -194,7 +194,7 @@ export type VirtualizerConfigProps = {
    * A ref that provides the size of container (vertical - height, horizontal - width), set by a resize observer.
    * Virtualizer Measure hooks provide a suitable reference.
    */
-  containerSizeRef: MutableRefObject<number>;
+  containerSizeRef: RefObject<number>;
 };
 
 export type VirtualizerProps = ComponentProps<Partial<VirtualizerSlots>> & VirtualizerConfigProps;

--- a/packages/react-components/react-virtualizer/library/src/components/Virtualizer/Virtualizer.types.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/Virtualizer/Virtualizer.types.ts
@@ -53,6 +53,11 @@ export type VirtualizerConfigState = {
    */
   reversed?: boolean;
   /**
+   * Enables the isScrolling property in the child render function
+   * Default: false - to prevent nessecary render function calls
+   */
+  enableScrollLoad?: boolean;
+  /**
    * Pixel size of intersection observers and how much they 'cross over' into the bufferItems index.
    * Minimum 1px.
    */
@@ -69,8 +74,10 @@ export type VirtualizerConfigState = {
 
 export type VirtualizerState = ComponentState<VirtualizerSlots> & VirtualizerConfigState;
 
-// Virtualizer render function to procedurally generate children elements as rows or columns via index.
-// Q: Use generic typing and passing through object data or a simple index system?
+/**
+ * The main child render method of Virtualization
+ * isScrolling will only be enabled when enableScrollLoad is set to true.
+ */
 export type VirtualizerChildRenderFunction = (index: number, isScrolling: boolean) => React.ReactNode;
 
 export type VirtualizerDataRef = {
@@ -149,6 +156,12 @@ export type VirtualizerConfigProps = {
    * This value should be flipped in RTL implementation (TBD whether automate RTL).
    */
   reversed?: boolean;
+
+  /**
+   * Enables the isScrolling property in the child render function
+   * Default: false - to prevent nessecary render function calls
+   */
+  enableScrollLoad?: boolean;
 
   /**
    * Callback for acquiring size of individual items

--- a/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
@@ -332,7 +332,6 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
            */
           let measurementPos = 0;
           if (latestEntry.target === afterElementRef.current) {
-            console.log('AFTER');
             // Get after buffers position - static
             measurementPos = calculateTotalSize() - calculateAfter();
 
@@ -354,9 +353,13 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
             const widthOverflow = reversed ? wOverflowReversed : wOverflow;
             const heightOverflow = reversed ? hOverflowReversed : hOverflow;
             const additionalOverflow = axis === 'vertical' ? heightOverflow : widthOverflow;
-            measurementPos -= additionalOverflow;
+
+            if (reversed) {
+              measurementPos += additionalOverflow;
+            } else {
+              measurementPos -= additionalOverflow;
+            }
           } else if (latestEntry.target === beforeElementRef.current) {
-            console.log('BEFORE');
             // Get before buffers position
             measurementPos = calculateBefore();
             // Get exact intersection position based on overflow size (how far into window did we scroll IO?)
@@ -375,7 +378,12 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
             const widthOverflow = reversed ? wOverflowReversed : wOverflow;
             const heightOverflow = reversed ? hOverflowReversed : hOverflow;
             const additionalOverflow = axis === 'vertical' ? heightOverflow : widthOverflow;
-            measurementPos -= additionalOverflow;
+
+            if (reversed) {
+              measurementPos += additionalOverflow;
+            } else {
+              measurementPos -= additionalOverflow;
+            }
           }
 
           return measurementPos;

--- a/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
@@ -155,38 +155,43 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
 
       const calculateOverBuffer = (): number => {
         let measurementPos = 0;
-        if (latestEntry.target === afterElementRef.current) {
-          measurementPos = reversed ? calculateAfter() : calculateTotalSize() - calculateAfter();
-          const afterAmount =
-            axis === 'vertical' ? latestEntry.boundingClientRect.top : latestEntry.boundingClientRect.left;
-          const reversedAfterAmount =
-            axis === 'vertical' ? latestEntry.boundingClientRect.bottom : latestEntry.boundingClientRect.right;
-          if (!reversed) {
+        if (!reversed) {
+          if (latestEntry.target === afterElementRef.current) {
+            console.log('AFTER ELE');
+            measurementPos = calculateTotalSize() - calculateAfter();
+            const afterAmount =
+              axis === 'vertical' ? latestEntry.boundingClientRect.top : latestEntry.boundingClientRect.left;
             measurementPos -= afterAmount;
-          } else if (reversed) {
-            measurementPos -= reversedAfterAmount;
-          }
-        } else if (latestEntry.target === beforeElementRef.current) {
-          measurementPos = reversed ? calculateTotalSize() - calculateBefore() : calculateBefore();
-          const afterAmount =
-            axis === 'vertical' ? latestEntry.boundingClientRect.bottom : latestEntry.boundingClientRect.right;
-          const reversedAfterAmount =
-            axis === 'vertical' ? latestEntry.boundingClientRect.top : latestEntry.boundingClientRect.left;
-          if (!reversed) {
+          } else if (latestEntry.target === beforeElementRef.current) {
+            console.log('BEFORE ELE');
+            measurementPos = calculateBefore();
+            const afterAmount =
+              axis === 'vertical' ? latestEntry.boundingClientRect.bottom : latestEntry.boundingClientRect.right;
             measurementPos -= afterAmount;
-          } else if (reversed) {
-            measurementPos -= reversedAfterAmount;
           }
+        } else {
+          if (latestEntry.target === afterElementRef.current) {
+            console.log('REVERSED AFTER ELE');
+            measurementPos = calculateAfter();
+            // const reversedAfterAmount =
+            //   axis === 'vertical' ? latestEntry.boundingClientRect.bottom : latestEntry.boundingClientRect.right;
+
+            // measurementPos += reversedAfterAmount;
+          } else if (latestEntry.target === beforeElementRef.current) {
+            console.log('REVERSED BEFORE ELE');
+            measurementPos = calculateTotalSize() - calculateBefore();
+            // const reversedAfterAmount =
+            //   axis === 'vertical' ? latestEntry.boundingClientRect.top : latestEntry.boundingClientRect.left;
+
+            // measurementPos += reversedAfterAmount;
+          }
+          measurementPos = Math.max(calculateTotalSize() - measurementPos, 0);
         }
 
         return measurementPos;
       };
       /* IO initiates this function when needed (bookend entering view) */
       let measurementPos = calculateOverBuffer();
-      if (reversed) {
-        // We're reversed, up is down, left is right, invert the scroll measure.
-        measurementPos = Math.max(calculateTotalSize() - measurementPos, 0);
-      }
 
       const dirMod = latestEntry.target === beforeElementRef.current ? -1 : 1;
       // For now lets use hardcoded size to assess current element to paginate on

--- a/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
@@ -159,6 +159,12 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
       }
 
       const calculateOverBuffer = (): number => {
+        /**
+         * We avoid using the scroll ref scrollTop, it may be incorrect
+         * as virtualization may exist within a scroll view with other elements
+         * The benefit of using IO is that we can detect relative scrolls,
+         * so any items can be placed around the virtualizer in the scroll view
+         */
         let measurementPos = 0;
         if (latestEntry.target === afterElementRef.current) {
           // Get after buffers position

--- a/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
@@ -58,6 +58,9 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
   /* We keep track of the progressive sizing/placement down the list,
   this helps us skip re-calculations unless children/size changes */
   const childProgressiveSizes = useRef<number[]>(new Array<number>(getItemSize ? numItems : 0));
+  if (virtualizerContext) {
+    virtualizerContext.childProgressiveSizes.current = childProgressiveSizes.current;
+  }
 
   // The internal tracking REF for child array (updates often).
   const childArray = useRef<ReactNode[]>(new Array(virtualizerLength));
@@ -77,6 +80,9 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
 
     if (numItems !== childProgressiveSizes.current.length) {
       childProgressiveSizes.current = new Array<number>(numItems);
+      if (virtualizerContext) {
+        virtualizerContext.childProgressiveSizes.current = childProgressiveSizes.current;
+      }
     }
 
     for (let index = 0; index < numItems; index++) {
@@ -410,11 +416,13 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
           actualIndex < newStartIndex &&
           actualIndex + virtualizerLength >= numItems &&
           newStartIndex + virtualizerLength >= numItems;
+        _virtualizerContext.setContextPosition(measurementPos);
         if (actualIndex !== newStartIndex && !endAlreadyReached) {
           batchUpdateNewIndex(newStartIndex);
         }
       },
       [
+        _virtualizerContext,
         actualIndex,
         axis,
         batchUpdateNewIndex,
@@ -504,7 +512,7 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
   // Only fire on mount (no deps).
   useEffect(() => {
     if (actualIndex < 0) {
-      batchUpdateNewIndex(0);
+      batchUpdateNewIndex(0, 0);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
@@ -167,6 +167,7 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
          */
         let measurementPos = 0;
         if (latestEntry.target === afterElementRef.current) {
+          console.log('After');
           // Get after buffers position
           measurementPos = calculateTotalSize() - calculateAfter();
           // Get exact intersection position based on overflow size (how far into IO did we scroll?)
@@ -185,6 +186,7 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
           const additionalOverflow = axis === 'vertical' ? hOverflow : wOverflow;
           measurementPos -= additionalOverflow;
         } else if (latestEntry.target === beforeElementRef.current) {
+          console.log('Before');
           // Get before buffers position
           measurementPos = calculateBefore();
           // Get exact intersection position based on overflow size (how far into window did we scroll IO?)
@@ -193,7 +195,7 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
           // Add to original after position
           measurementPos -= overflowAmount;
           // Ignore buffer size (IO offset)
-          measurementPos += bufferSize;
+          measurementPos -= bufferSize;
 
           // Calculate how far past the window bounds we are (this will be zero if IO is within window)
           const hOverflow = latestEntry.boundingClientRect.bottom - latestEntry.intersectionRect.bottom;
@@ -211,11 +213,7 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
       /* dirMod: Set the index to before/after the current scroll top element (depending on direction) */
       const maxIndex = Math.max(numItems - virtualizerLength, 0);
       const halfBuffer = Math.ceil(bufferItems / 2);
-      const dirMod = latestEntry.target === afterElementRef.current ? 1 : -1;
-      let startIndex = getIndexFromScrollPosition(measurementPos) - halfBuffer;
-      if (startIndex > 0 && startIndex < maxIndex && startIndex === actualIndex) {
-        startIndex += dirMod;
-      }
+      const startIndex = getIndexFromScrollPosition(measurementPos) - halfBuffer;
 
       // Safety limits
       const newStartIndex = Math.min(Math.max(startIndex, 0), maxIndex);

--- a/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
@@ -161,9 +161,9 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
             axis === 'vertical' ? latestEntry.boundingClientRect.top : latestEntry.boundingClientRect.left;
           const reversedAfterAmount =
             axis === 'vertical' ? latestEntry.boundingClientRect.bottom : latestEntry.boundingClientRect.right;
-          if (!reversed && afterAmount < 0) {
+          if (!reversed) {
             measurementPos -= afterAmount;
-          } else if (reversed && reversedAfterAmount > 0) {
+          } else if (reversed) {
             measurementPos -= reversedAfterAmount;
           }
         } else if (latestEntry.target === beforeElementRef.current) {
@@ -172,9 +172,9 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
             axis === 'vertical' ? latestEntry.boundingClientRect.bottom : latestEntry.boundingClientRect.right;
           const reversedAfterAmount =
             axis === 'vertical' ? latestEntry.boundingClientRect.top : latestEntry.boundingClientRect.left;
-          if (!reversed && afterAmount > 0) {
+          if (!reversed) {
             measurementPos -= afterAmount;
-          } else if (reversed && reversedAfterAmount < 0) {
+          } else if (reversed) {
             measurementPos -= reversedAfterAmount;
           }
         }
@@ -185,17 +185,21 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
       let measurementPos = calculateOverBuffer();
       if (reversed) {
         // We're reversed, up is down, left is right, invert the scroll measure.
-        measurementPos = Math.max(calculateTotalSize() - Math.abs(measurementPos), 0);
+        measurementPos = Math.max(calculateTotalSize() - measurementPos, 0);
       }
 
+      const dirMod = latestEntry.target === beforeElementRef.current ? -1 : 1;
       // For now lets use hardcoded size to assess current element to paginate on
-      const startIndex = getIndexFromScrollPosition(measurementPos);
-      const dirMod =
-        latestEntry.target === beforeElementRef.current ? bufferItems : virtualizerLength - 1 - bufferItems * 2;
+      let startIndex = getIndexFromScrollPosition(measurementPos);
+
+      if (startIndex === actualIndex) {
+        startIndex += dirMod;
+      }
 
       // Safety limits
       const maxIndex = Math.max(numItems - virtualizerLength, 0);
-      const newStartIndex = Math.min(Math.max(startIndex - dirMod, 0), maxIndex);
+      const newStartIndex = Math.min(Math.max(startIndex, 0), maxIndex);
+
       if (actualIndex !== newStartIndex) {
         // We flush sync this and perform an immediate state update
         flushSync(() => {

--- a/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
@@ -334,7 +334,7 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
             // Add to original after position
             measurementPos += overflowAmount;
             // Ignore buffer size (IO offset)
-            measurementPos -= bufferSize;
+            measurementPos += bufferSize;
             // we hit the after buffer and detected the end of view, we need to find the start index.
             measurementPos -= containerSizeRef.current;
 
@@ -358,10 +358,10 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
             // Get exact intersection position based on overflow size (how far into window did we scroll IO?)
             const overflowAmount =
               axis === 'vertical' ? latestEntry.intersectionRect.height : latestEntry.intersectionRect.width;
-            // Add to original after position
+            // Minus from original before position
             measurementPos -= overflowAmount;
             // Ignore buffer size (IO offset)
-            measurementPos += bufferSize;
+            measurementPos -= bufferSize;
 
             // Calculate how far past the window bounds we are (this will be zero if IO is within window)
             const hOverflow = latestEntry.boundingClientRect.bottom - latestEntry.intersectionRect.bottom;

--- a/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
@@ -331,6 +331,7 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
            */
           let measurementPos = 0;
           if (latestEntry.target === afterElementRef.current) {
+            console.log('AFTER');
             // Get after buffers position
             measurementPos = calculateTotalSize() - calculateAfter();
 
@@ -359,6 +360,7 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
               measurementPos -= additionalOverflow;
             }
           } else if (latestEntry.target === beforeElementRef.current) {
+            console.log('BEFORE');
             // Get before buffers position
             measurementPos = calculateBefore();
             // Get exact intersection position based on overflow size (how far into window did we scroll IO?)

--- a/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
@@ -173,13 +173,15 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
           // we hit the after buffer and detected the end of view, we need to find the start index.
           measurementPos -= containerSizeRef.current;
 
-          console.log('AFTER - target:', latestEntry.target);
-          console.log('AFTER - Measure:', measurementPos);
-          console.log('AFTER - Scroll:', scrollViewRef?.current?.scrollTop);
+          // Calculate how far past the window bounds we are (this will be zero if IO is within window)
+          const hOverflow = latestEntry.boundingClientRect.top - latestEntry.intersectionRect.top;
+          const wOverflow = latestEntry.boundingClientRect.left - latestEntry.intersectionRect.left;
+          const additionalOverflow = axis === 'vertical' ? hOverflow : wOverflow;
+          measurementPos -= additionalOverflow;
         } else if (latestEntry.target === beforeElementRef.current) {
           // Get before buffers position
           measurementPos = calculateBefore();
-          // // Get exact intersection position based on overflow size (how far into IO did we scroll?)
+          // Get exact intersection position based on overflow size (how far into window did we scroll IO?)
           const overflowAmount =
             axis === 'vertical' ? latestEntry.intersectionRect.height : latestEntry.intersectionRect.width;
           // Add to original after position
@@ -187,9 +189,11 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
           // Ignore buffer size (IO offset)
           measurementPos += bufferSize;
 
-          console.log('BEFORE - target:', latestEntry.target);
-          console.log('BEFORE - Measure:', measurementPos);
-          console.log('BEFORE - Scroll:', scrollViewRef?.current?.scrollTop);
+          // Calculate how far past the window bounds we are (this will be zero if IO is within window)
+          const hOverflow = latestEntry.boundingClientRect.bottom - latestEntry.intersectionRect.bottom;
+          const wOverflow = latestEntry.boundingClientRect.right - latestEntry.intersectionRect.right;
+          const additionalOverflow = axis === 'vertical' ? hOverflow : wOverflow;
+          measurementPos -= additionalOverflow;
         }
 
         return measurementPos;

--- a/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
@@ -514,7 +514,7 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
   // Only fire on mount (no deps).
   useEffect(() => {
     if (actualIndex < 0) {
-      batchUpdateNewIndex(0, 0);
+      batchUpdateNewIndex(0);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
@@ -385,10 +385,8 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
         // Get exact relative 'scrollTop' via IO values
         const measurementPos = calculateOverBuffer();
 
-        const maxIndex = Math.max(numItems - (virtualizerLength - 1), 0);
+        const maxIndex = Math.max(numItems - virtualizerLength, 0);
 
-        // const offset = latestEntry.target === beforeElementRef.current ? bufferItems : Math.max(bufferItems - 1, 1);
-        // const offset = Math.max(bufferItems - 1, 1);
         let startIndex = getIndexFromScrollPosition(measurementPos) - bufferItems;
 
         const dirMod = latestEntry.target === beforeElementRef.current ? -1 : 1;

--- a/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
@@ -153,7 +153,7 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
         return;
       }
 
-      const calculateOverBuffer = (latestEntry: IntersectionObserverEntry): number => {
+      const calculateOverBuffer = (): number => {
         let measurementPos = 0;
         if (latestEntry.target === afterElementRef.current) {
           measurementPos = reversed ? calculateAfter() : calculateTotalSize() - calculateAfter();
@@ -182,7 +182,7 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
         return measurementPos;
       };
       /* IO initiates this function when needed (bookend entering view) */
-      let measurementPos = calculateOverBuffer(latestEntry);
+      let measurementPos = calculateOverBuffer();
       if (reversed) {
         // We're reversed, up is down, left is right, invert the scroll measure.
         measurementPos = Math.max(calculateTotalSize() - Math.abs(measurementPos), 0);

--- a/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
@@ -3,7 +3,6 @@ import type { VirtualizerProps, VirtualizerState } from './Virtualizer.types';
 
 import { useEffect, useRef, useCallback, useReducer, useImperativeHandle, useState } from 'react';
 import { useIntersectionObserver } from '../../hooks/useIntersectionObserver';
-import { flushSync } from 'react-dom';
 import { useVirtualizerContextState_unstable } from '../../Utilities';
 import { slot, useTimeout } from '@fluentui/react-utilities';
 

--- a/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 import type { VirtualizerProps, VirtualizerState } from './Virtualizer.types';
 
-import { useEffect, useRef, useCallback, useReducer, useImperativeHandle, useState } from 'react';
+import { useEffect, useRef, useCallback, useImperativeHandle, useState } from 'react';
 import { useIntersectionObserver } from '../../hooks/useIntersectionObserver';
 import { useVirtualizerContextState_unstable } from '../../Utilities';
 import { slot, useTimeout } from '@fluentui/react-utilities';

--- a/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
@@ -66,9 +66,6 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
   // The internal tracking REF for child array (updates often).
   const childArray = useRef<ReactNode[]>(new Array(virtualizerLength));
 
-  // We want to be methodical about updating the render with child reference array
-  const forceUpdate = useReducer(() => ({}), {})[1];
-
   const populateSizeArrays = () => {
     if (!getItemSize) {
       // Static sizes, never mind!
@@ -332,7 +329,6 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
            */
           let measurementPos = 0;
           if (latestEntry.target === afterElementRef.current) {
-            console.log('AFTER');
             // Get after buffers position
             measurementPos = calculateTotalSize() - calculateAfter();
 
@@ -361,7 +357,6 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
               measurementPos -= additionalOverflow;
             }
           } else if (latestEntry.target === beforeElementRef.current) {
-            console.log('BEFORE');
             // Get before buffers position
             measurementPos = calculateBefore();
             // Get exact intersection position based on overflow size (how far into window did we scroll IO?)
@@ -527,7 +522,6 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
   useEffect(() => {
     if (actualIndex >= 0) {
       updateChildRows(actualIndex);
-      // forceUpdate();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [renderChild, isScrolling]);

--- a/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
@@ -345,7 +345,7 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
             // Ignore buffer size (IO offset)
             measurementPos -= bufferSize;
             // we hit the after buffer and detected the end of view, we need to find the start index.
-            measurementPos -= containerSizeRef.current;
+            measurementPos -= containerSizeRef.current ?? 0;
 
             // Calculate how far past the window bounds we are (this will be zero if IO is within window)
             const hOverflow = latestEntry.boundingClientRect.top - latestEntry.intersectionRect.top;

--- a/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
@@ -396,7 +396,7 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
 
         const maxIndex = Math.max(numItems - virtualizerLength, 0);
 
-        let startIndex = getIndexFromScrollPosition(measurementPos) - bufferItems;
+        const startIndex = getIndexFromScrollPosition(measurementPos) - bufferItems;
 
         // Safety limits
         const newStartIndex = Math.min(Math.max(startIndex, 0), maxIndex);
@@ -420,7 +420,6 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
         calculateTotalSize,
         containerSizeRef,
         getIndexFromScrollPosition,
-        getItemSize,
         numItems,
         reversed,
         updateCurrentItemSizes,

--- a/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollView/VirtualizerScrollView.types.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollView/VirtualizerScrollView.types.ts
@@ -6,7 +6,7 @@ import type {
   VirtualizerChildRenderFunction,
 } from '../Virtualizer/Virtualizer.types';
 import type { ScrollToInterface } from '../../Utilities';
-import type { MutableRefObject, RefObject } from 'react';
+import type { RefObject } from 'react';
 
 export type VirtualizerScrollViewSlots = VirtualizerSlots & {
   /**

--- a/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollView/VirtualizerScrollView.types.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollView/VirtualizerScrollView.types.ts
@@ -6,7 +6,7 @@ import type {
   VirtualizerChildRenderFunction,
 } from '../Virtualizer/Virtualizer.types';
 import type { ScrollToInterface } from '../../Utilities';
-import type { RefObject } from 'react';
+import type { MutableRefObject, RefObject } from 'react';
 
 export type VirtualizerScrollViewSlots = VirtualizerSlots & {
   /**

--- a/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollView/useVirtualizerScrollView.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollView/useVirtualizerScrollView.ts
@@ -61,7 +61,6 @@ export function useVirtualizerScrollView_unstable(props: VirtualizerScrollViewPr
     virtualizerLength,
     bufferItems,
     bufferSize,
-    scrollViewRef,
     onRenderedFlaggedIndex: handleRenderedIndex,
     imperativeVirtualizerRef,
     containerSizeRef,

--- a/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollView/useVirtualizerScrollView.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollView/useVirtualizerScrollView.ts
@@ -10,7 +10,7 @@ import { useStaticVirtualizerPagination } from '../../hooks/useStaticPagination'
 
 export function useVirtualizerScrollView_unstable(props: VirtualizerScrollViewProps): VirtualizerScrollViewState {
   const { imperativeRef, itemSize, numItems, axis = 'vertical', reversed, enablePagination = false } = props;
-  const { virtualizerLength, bufferItems, bufferSize, scrollRef } = useStaticVirtualizerMeasure({
+  const { virtualizerLength, bufferItems, bufferSize, scrollRef, containerSizeRef } = useStaticVirtualizerMeasure({
     defaultItemSize: props.itemSize,
     direction: props.axis ?? 'vertical',
   });
@@ -64,6 +64,7 @@ export function useVirtualizerScrollView_unstable(props: VirtualizerScrollViewPr
     scrollViewRef,
     onRenderedFlaggedIndex: handleRenderedIndex,
     imperativeVirtualizerRef,
+    containerSizeRef,
   });
 
   return {

--- a/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollViewDynamic/VirtualizerScrollViewDynamic.types.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollViewDynamic/VirtualizerScrollViewDynamic.types.ts
@@ -6,7 +6,7 @@ import type {
 } from '../Virtualizer/Virtualizer.types';
 
 import type { VirtualizerScrollViewSlots } from '../VirtualizerScrollView/VirtualizerScrollView.types';
-import type { MutableRefObject, RefObject } from 'react';
+import type { RefObject } from 'react';
 import type { ScrollToInterface } from '../../Utilities';
 
 export type VirtualizerScrollViewDynamicSlots = VirtualizerScrollViewSlots;

--- a/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollViewDynamic/VirtualizerScrollViewDynamic.types.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollViewDynamic/VirtualizerScrollViewDynamic.types.ts
@@ -6,7 +6,7 @@ import type {
 } from '../Virtualizer/Virtualizer.types';
 
 import type { VirtualizerScrollViewSlots } from '../VirtualizerScrollView/VirtualizerScrollView.types';
-import type { RefObject } from 'react';
+import type { MutableRefObject, RefObject } from 'react';
 import type { ScrollToInterface } from '../../Utilities';
 
 export type VirtualizerScrollViewDynamicSlots = VirtualizerScrollViewSlots;

--- a/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollViewDynamic/VirtualizerScrollViewDynamic.types.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollViewDynamic/VirtualizerScrollViewDynamic.types.ts
@@ -7,12 +7,17 @@ import type {
 
 import type { VirtualizerScrollViewSlots } from '../VirtualizerScrollView/VirtualizerScrollView.types';
 import type { RefObject } from 'react';
-import type { ScrollToInterface } from '../../Utilities';
+import type { DynamicVirtualizerContextProps, ScrollToInterface } from '../../Utilities';
 
 export type VirtualizerScrollViewDynamicSlots = VirtualizerScrollViewSlots;
 
 export type VirtualizerScrollViewDynamicProps = ComponentProps<Partial<VirtualizerScrollViewDynamicSlots>> &
-  Partial<Omit<VirtualizerConfigProps, 'itemSize' | 'numItems' | 'getItemSize' | 'children' | 'flagIndex'>> & {
+  Partial<
+    Omit<
+      VirtualizerConfigProps,
+      'itemSize' | 'numItems' | 'getItemSize' | 'children' | 'flagIndex' | 'virtualizerContext'
+    >
+  > & {
     /**
      * Set as the minimum item size.
      * Axis: 'vertical' = Height
@@ -43,6 +48,10 @@ export type VirtualizerScrollViewDynamicProps = ComponentProps<Partial<Virtualiz
      * Imperative ref contains our scrollTo index functionality for user control.
      */
     enablePagination?: boolean;
+    /**
+     * Enables override of dynamic virtualizer context if required.
+     */
+    virtualizerContext: DynamicVirtualizerContextProps;
   };
 
 export type VirtualizerScrollViewDynamicState = ComponentState<VirtualizerScrollViewDynamicSlots> &

--- a/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollViewDynamic/VirtualizerScrollViewDynamic.types.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollViewDynamic/VirtualizerScrollViewDynamic.types.ts
@@ -51,7 +51,7 @@ export type VirtualizerScrollViewDynamicProps = ComponentProps<Partial<Virtualiz
     /**
      * Enables override of dynamic virtualizer context if required.
      */
-    virtualizerContext: DynamicVirtualizerContextProps;
+    virtualizerContext?: DynamicVirtualizerContextProps;
   };
 
 export type VirtualizerScrollViewDynamicState = ComponentState<VirtualizerScrollViewDynamicSlots> &

--- a/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollViewDynamic/useVirtualizerScrollViewDynamic.tsx
+++ b/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollViewDynamic/useVirtualizerScrollViewDynamic.tsx
@@ -123,7 +123,6 @@ export function useVirtualizerScrollViewDynamic_unstable(
     virtualizerLength,
     bufferItems,
     bufferSize,
-    scrollViewRef,
     virtualizerContext: contextState,
     imperativeVirtualizerRef: _imperativeVirtualizerRef,
     onRenderedFlaggedIndex: handleRenderedIndex,

--- a/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollViewDynamic/useVirtualizerScrollViewDynamic.tsx
+++ b/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollViewDynamic/useVirtualizerScrollViewDynamic.tsx
@@ -53,7 +53,7 @@ export function useVirtualizerScrollViewDynamic_unstable(
     defaultItemSize: props.itemSize,
     direction: props.axis ?? 'vertical',
     getItemSize: props.getItemSize ?? getChildSizeAuto,
-    currentIndex: contextState?.contextIndex ?? 0,
+    virtualizerContext: contextState,
     numItems: props.numItems,
     bufferItems: _bufferItems,
     bufferSize: _bufferSize,

--- a/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollViewDynamic/useVirtualizerScrollViewDynamic.tsx
+++ b/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollViewDynamic/useVirtualizerScrollViewDynamic.tsx
@@ -41,7 +41,7 @@ export function useVirtualizerScrollViewDynamic_unstable(
     [sizeTrackingArray, props.itemSize, sizeUpdateCount],
   );
 
-  const { virtualizerLength, bufferItems, bufferSize, scrollRef } = useDynamicVirtualizerMeasure({
+  const { virtualizerLength, bufferItems, bufferSize, scrollRef, containerSizeRef } = useDynamicVirtualizerMeasure({
     defaultItemSize: props.itemSize,
     direction: props.axis ?? 'vertical',
     getItemSize: props.getItemSize ?? getChildSizeAuto,
@@ -117,6 +117,7 @@ export function useVirtualizerScrollViewDynamic_unstable(
     virtualizerContext: contextState,
     imperativeVirtualizerRef: _imperativeVirtualizerRef,
     onRenderedFlaggedIndex: handleRenderedIndex,
+    containerSizeRef,
   });
 
   const measureObject = useMeasureList(

--- a/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollViewDynamic/useVirtualizerScrollViewDynamic.tsx
+++ b/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollViewDynamic/useVirtualizerScrollViewDynamic.tsx
@@ -19,7 +19,15 @@ export function useVirtualizerScrollViewDynamic_unstable(
   'use no memo';
 
   const contextState = useVirtualizerContextState_unstable(props.virtualizerContext);
-  const { imperativeRef, axis = 'vertical', reversed, imperativeVirtualizerRef, enablePagination = false } = props;
+  const {
+    imperativeRef,
+    axis = 'vertical',
+    reversed,
+    imperativeVirtualizerRef,
+    enablePagination = false,
+    bufferItems: _bufferItems,
+    bufferSize: _bufferSize,
+  } = props;
 
   let sizeTrackingArray = React.useRef<number[]>(new Array(props.numItems).fill(props.itemSize));
 
@@ -47,6 +55,8 @@ export function useVirtualizerScrollViewDynamic_unstable(
     getItemSize: props.getItemSize ?? getChildSizeAuto,
     currentIndex: contextState?.contextIndex ?? 0,
     numItems: props.numItems,
+    bufferItems: _bufferItems,
+    bufferSize: _bufferSize,
   });
 
   const _imperativeVirtualizerRef = useMergedRefs(React.useRef<VirtualizerDataRef>(null), imperativeVirtualizerRef);

--- a/packages/react-components/react-virtualizer/library/src/hooks/hooks.types.ts
+++ b/packages/react-components/react-virtualizer/library/src/hooks/hooks.types.ts
@@ -3,6 +3,16 @@ import { MutableRefObject, RefObject } from 'react';
 export type VirtualizerMeasureProps = {
   defaultItemSize: number;
   direction?: 'vertical' | 'horizontal';
+
+  /**
+   * Override recommended number of buffer items
+   */
+  bufferItems?: number;
+
+  /**
+   * Override recommended buffer size (px)
+   */
+  bufferSize?: number;
 };
 
 export type VirtualizerMeasureDynamicProps = {
@@ -11,6 +21,16 @@ export type VirtualizerMeasureDynamicProps = {
   numItems: number;
   getItemSize: (index: number) => number;
   direction?: 'vertical' | 'horizontal';
+
+  /**
+   * Override recommended number of buffer items
+   */
+  bufferItems?: number;
+
+  /**
+   * Override recommended buffer size (px)
+   */
+  bufferSize?: number;
 };
 
 export type VirtualizerStaticPaginationProps = {

--- a/packages/react-components/react-virtualizer/library/src/hooks/hooks.types.ts
+++ b/packages/react-components/react-virtualizer/library/src/hooks/hooks.types.ts
@@ -1,5 +1,5 @@
 import { MutableRefObject, RefObject } from 'react';
-import { VirtualizerContextProps } from '../Utilities';
+import { DynamicVirtualizerContextProps } from '../Utilities';
 
 export type VirtualizerMeasureProps = {
   defaultItemSize: number;
@@ -18,7 +18,7 @@ export type VirtualizerMeasureProps = {
 
 export type VirtualizerMeasureDynamicProps = {
   defaultItemSize: number;
-  virtualizerContext: VirtualizerContextProps;
+  virtualizerContext: DynamicVirtualizerContextProps;
   numItems: number;
   getItemSize: (index: number) => number;
   direction?: 'vertical' | 'horizontal';

--- a/packages/react-components/react-virtualizer/library/src/hooks/hooks.types.ts
+++ b/packages/react-components/react-virtualizer/library/src/hooks/hooks.types.ts
@@ -1,4 +1,5 @@
 import { MutableRefObject, RefObject } from 'react';
+import { VirtualizerContextProps } from '../Utilities';
 
 export type VirtualizerMeasureProps = {
   defaultItemSize: number;
@@ -17,7 +18,7 @@ export type VirtualizerMeasureProps = {
 
 export type VirtualizerMeasureDynamicProps = {
   defaultItemSize: number;
-  currentIndex: number;
+  virtualizerContext: VirtualizerContextProps;
   numItems: number;
   getItemSize: (index: number) => number;
   direction?: 'vertical' | 'horizontal';

--- a/packages/react-components/react-virtualizer/library/src/hooks/index.ts
+++ b/packages/react-components/react-virtualizer/library/src/hooks/index.ts
@@ -3,3 +3,4 @@ export * from './useVirtualizerMeasure';
 export * from './useDynamicVirtualizerMeasure';
 export * from './useResizeObserverRef';
 export * from './hooks.types';
+export * from './useMeasureList';

--- a/packages/react-components/react-virtualizer/library/src/hooks/useDynamicVirtualizerMeasure.ts
+++ b/packages/react-components/react-virtualizer/library/src/hooks/useDynamicVirtualizerMeasure.ts
@@ -62,7 +62,7 @@ export const useDynamicVirtualizerMeasure = <TElement extends HTMLElement>(
       }
 
       let indexSizer = 0;
-      let length = 0;
+      let length = 1;
 
       while (indexSizer <= containerSizeRef.current && length < numItems) {
         const iItemSize = getItemSize(indexRef.current + length);
@@ -74,13 +74,14 @@ export const useDynamicVirtualizerMeasure = <TElement extends HTMLElement>(
 
       /*
        * Number of items to append at each end, i.e. 'preload' each side before entering view.
+       * Minimum: 2 - we give slightly more buffer for dynamic version.
        */
-      const newBufferItems = bufferItems ?? Math.max(Math.ceil(length / 4), 1);
+      const newBufferItems = bufferItems ?? Math.max(Math.ceil(length / 3), 1);
 
       /*
        * This is how far we deviate into the bufferItems to detect a redraw.
        */
-      const newBufferSize = bufferSize ?? Math.max(defaultItemSize / 2.0, 5);
+      const newBufferSize = bufferSize ?? Math.max(defaultItemSize / 2.0, 1);
       const totalLength = length + newBufferItems * 2;
       setState({
         virtualizerLength: totalLength,

--- a/packages/react-components/react-virtualizer/library/src/hooks/useDynamicVirtualizerMeasure.ts
+++ b/packages/react-components/react-virtualizer/library/src/hooks/useDynamicVirtualizerMeasure.ts
@@ -14,6 +14,7 @@ export const useDynamicVirtualizerMeasure = <TElement extends HTMLElement>(
   bufferItems: number;
   bufferSize: number;
   scrollRef: (instance: TElement | null) => void;
+  containerSizeRef: React.MutableRefObject<number>;
 } => {
   const { defaultItemSize, direction = 'vertical', numItems, getItemSize, currentIndex } = virtualizerProps;
   const indexRef = useRef<number>(currentIndex);
@@ -25,6 +26,7 @@ export const useDynamicVirtualizerMeasure = <TElement extends HTMLElement>(
     virtualizerBufferSize: 0,
   });
 
+  const containerSizeRef = React.useRef<number>(0);
   const { virtualizerLength, virtualizerBufferItems, virtualizerBufferSize } = state;
 
   const container = React.useRef<HTMLElement | null>(null);
@@ -43,6 +45,8 @@ export const useDynamicVirtualizerMeasure = <TElement extends HTMLElement>(
         direction === 'vertical'
           ? scrollRef.current.getBoundingClientRect().height
           : scrollRef.current.getBoundingClientRect().width;
+
+      containerSizeRef.current = containerSize;
 
       let indexSizer = 0;
       let length = 0;
@@ -130,5 +134,6 @@ export const useDynamicVirtualizerMeasure = <TElement extends HTMLElement>(
     bufferItems: virtualizerBufferItems,
     bufferSize: virtualizerBufferSize,
     scrollRef,
+    containerSizeRef,
   };
 };

--- a/packages/react-components/react-virtualizer/library/src/hooks/useDynamicVirtualizerMeasure.ts
+++ b/packages/react-components/react-virtualizer/library/src/hooks/useDynamicVirtualizerMeasure.ts
@@ -58,7 +58,7 @@ export const useDynamicVirtualizerMeasure = <TElement extends HTMLElement>(
       /*
        * Number of items to append at each end, i.e. 'preload' each side before entering view.
        */
-      const bufferItems = Math.max(Math.floor(length / 3), 1);
+      const bufferItems = Math.max(Math.ceil(length / 3), 2);
 
       /*
        * This is how far we deviate into the bufferItems to detect a redraw.

--- a/packages/react-components/react-virtualizer/library/src/hooks/useDynamicVirtualizerMeasure.ts
+++ b/packages/react-components/react-virtualizer/library/src/hooks/useDynamicVirtualizerMeasure.ts
@@ -121,8 +121,7 @@ export const useDynamicVirtualizerMeasure = <TElement extends HTMLElement>(
 
       const newLength = i - currentIndex;
 
-      const bufferItems = Math.max(Math.floor(newLength / 4), 2);
-      const totalNewLength = newLength + bufferItems * 2 + 4;
+      const totalNewLength = newLength + virtualizerBufferItems * 2;
       const compareLengths = totalNewLength < virtualizerLength;
 
       if (recheckTotal > containerSize && compareLengths) {
@@ -135,7 +134,15 @@ export const useDynamicVirtualizerMeasure = <TElement extends HTMLElement>(
     if (recheckTotal < containerSize || couldBeSmaller) {
       handleScrollResize(container);
     }
-  }, [getItemSize, currentIndex, direction, virtualizerLength, resizeCallback, handleScrollResize]);
+  }, [
+    getItemSize,
+    currentIndex,
+    direction,
+    virtualizerLength,
+    resizeCallback,
+    handleScrollResize,
+    virtualizerBufferItems,
+  ]);
 
   return {
     virtualizerLength,

--- a/packages/react-components/react-virtualizer/library/src/hooks/useDynamicVirtualizerMeasure.ts
+++ b/packages/react-components/react-virtualizer/library/src/hooks/useDynamicVirtualizerMeasure.ts
@@ -75,12 +75,12 @@ export const useDynamicVirtualizerMeasure = <TElement extends HTMLElement>(
       /*
        * Number of items to append at each end, i.e. 'preload' each side before entering view.
        */
-      const newBufferItems = bufferItems ?? Math.max(Math.ceil(length / 3), 2);
+      const newBufferItems = bufferItems ?? Math.max(Math.ceil(length / 4), 1);
 
       /*
        * This is how far we deviate into the bufferItems to detect a redraw.
        */
-      const newBufferSize = bufferSize ?? Math.min(defaultItemSize / 2.0, 100);
+      const newBufferSize = bufferSize ?? Math.max(defaultItemSize / 2.0, 5);
       const totalLength = length + newBufferItems * 2;
       setState({
         virtualizerLength: totalLength,

--- a/packages/react-components/react-virtualizer/library/src/hooks/useDynamicVirtualizerMeasure.ts
+++ b/packages/react-components/react-virtualizer/library/src/hooks/useDynamicVirtualizerMeasure.ts
@@ -58,14 +58,13 @@ export const useDynamicVirtualizerMeasure = <TElement extends HTMLElement>(
       /*
        * Number of items to append at each end, i.e. 'preload' each side before entering view.
        */
-      const bufferItems = Math.max(Math.floor(length / 4), 4);
+      const bufferItems = Math.max(Math.floor(length / 3), 1);
 
       /*
        * This is how far we deviate into the bufferItems to detect a redraw.
        */
-      const bufferSize = Math.max(Math.floor((length / 8) * defaultItemSize), 1);
-
-      const totalLength = length + bufferItems * 2 + 1;
+      const bufferSize = Math.max(defaultItemSize / 2.0, 1);
+      const totalLength = length + bufferItems * 2;
       setState({
         virtualizerLength: totalLength,
         virtualizerBufferSize: bufferSize,
@@ -99,8 +98,8 @@ export const useDynamicVirtualizerMeasure = <TElement extends HTMLElement>(
 
     const containerSize =
       direction === 'vertical'
-        ? container.current?.getBoundingClientRect().height * 1.5
-        : container.current?.getBoundingClientRect().width * 1.5;
+        ? container.current?.getBoundingClientRect().height
+        : container.current?.getBoundingClientRect().width;
 
     let couldBeSmaller = false;
     let recheckTotal = 0;

--- a/packages/react-components/react-virtualizer/library/src/hooks/useDynamicVirtualizerMeasure.ts
+++ b/packages/react-components/react-virtualizer/library/src/hooks/useDynamicVirtualizerMeasure.ts
@@ -63,7 +63,7 @@ export const useDynamicVirtualizerMeasure = <TElement extends HTMLElement>(
       /*
        * This is how far we deviate into the bufferItems to detect a redraw.
        */
-      const bufferSize = Math.max(defaultItemSize / 2.0, 1);
+      const bufferSize = Math.min(defaultItemSize / 2.0, 100);
       const totalLength = length + bufferItems * 2;
       setState({
         virtualizerLength: totalLength,

--- a/packages/react-components/react-virtualizer/library/src/hooks/useDynamicVirtualizerMeasure.ts
+++ b/packages/react-components/react-virtualizer/library/src/hooks/useDynamicVirtualizerMeasure.ts
@@ -16,7 +16,15 @@ export const useDynamicVirtualizerMeasure = <TElement extends HTMLElement>(
   scrollRef: (instance: TElement | null) => void;
   containerSizeRef: React.MutableRefObject<number>;
 } => {
-  const { defaultItemSize, direction = 'vertical', numItems, getItemSize, currentIndex } = virtualizerProps;
+  const {
+    defaultItemSize,
+    direction = 'vertical',
+    numItems,
+    getItemSize,
+    currentIndex,
+    bufferItems,
+    bufferSize,
+  } = virtualizerProps;
   const indexRef = useRef<number>(currentIndex);
   indexRef.current = currentIndex;
 
@@ -62,20 +70,20 @@ export const useDynamicVirtualizerMeasure = <TElement extends HTMLElement>(
       /*
        * Number of items to append at each end, i.e. 'preload' each side before entering view.
        */
-      const bufferItems = Math.max(Math.ceil(length / 3), 2);
+      const newBufferItems = bufferItems ?? Math.max(Math.ceil(length / 3), 2);
 
       /*
        * This is how far we deviate into the bufferItems to detect a redraw.
        */
-      const bufferSize = Math.min(defaultItemSize / 2.0, 100);
-      const totalLength = length + bufferItems * 2;
+      const newBufferSize = bufferSize ?? Math.min(defaultItemSize / 2.0, 100);
+      const totalLength = length + newBufferItems * 2;
       setState({
         virtualizerLength: totalLength,
-        virtualizerBufferSize: bufferSize,
-        virtualizerBufferItems: bufferItems,
+        virtualizerBufferSize: newBufferSize,
+        virtualizerBufferItems: newBufferItems,
       });
     },
-    [defaultItemSize, direction, getItemSize, numItems],
+    [bufferItems, bufferSize, defaultItemSize, direction, getItemSize, numItems],
   );
 
   const resizeCallback = React.useCallback(

--- a/packages/react-components/react-virtualizer/library/src/hooks/useDynamicVirtualizerMeasure.ts
+++ b/packages/react-components/react-virtualizer/library/src/hooks/useDynamicVirtualizerMeasure.ts
@@ -67,7 +67,8 @@ export const useDynamicVirtualizerMeasure = <TElement extends HTMLElement>(
       while (indexSizer <= sizeToBeat && i + virtualizerContext.contextIndex < numItems) {
         const iItemSize = getItemSize(indexRef.current + i);
         if (virtualizerContext.childProgressiveSizes.current.length < numItems) {
-          /* We are in unknown territory, either an initial render or an update has occurred.
+          /* We are in unknown territory, either an initial render or an update
+            in virtualizer item length has occurred.
             We need to let the new items render first then we can accurately assess.*/
           return virtualizerLength - virtualizerBufferSize * 2;
         }
@@ -75,16 +76,16 @@ export const useDynamicVirtualizerMeasure = <TElement extends HTMLElement>(
         const currentScrollPos = virtualizerContext.contextPosition;
         const currentItemPos = virtualizerContext.childProgressiveSizes.current[indexRef.current + i] - iItemSize;
 
-        let variance = 0;
         if (currentScrollPos > currentItemPos + iItemSize) {
           // The item isn't in view, ignore for now.
           i++;
           continue;
         } else if (currentScrollPos > currentItemPos) {
-          // The item is partially out of view, ignore the out of bounds
-          variance = currentItemPos + iItemSize - currentScrollPos;
+          // The item is partially out of view, ignore the out of bounds portion
+          const variance = currentItemPos + iItemSize - currentScrollPos;
           indexSizer += variance;
         } else {
+          // Item is in view
           indexSizer += iItemSize;
         }
         // Increment

--- a/packages/react-components/react-virtualizer/library/src/hooks/useDynamicVirtualizerMeasure.ts
+++ b/packages/react-components/react-virtualizer/library/src/hooks/useDynamicVirtualizerMeasure.ts
@@ -67,14 +67,14 @@ export const useDynamicVirtualizerMeasure = <TElement extends HTMLElement>(
       while (indexSizer <= sizeToBeat && i + virtualizerContext.contextIndex < numItems) {
         const iItemSize = getItemSize(indexRef.current + i);
         if (
-          !virtualizerContext.childProgressiveSizes?.current ||
-          virtualizerContext.childProgressiveSizes?.current.length < numItems
+          !virtualizerContext.childProgressiveSizes.current ||
+          virtualizerContext.childProgressiveSizes.current.length < numItems
         ) {
           return virtualizerLength - virtualizerBufferSize * 2;
         }
 
         const currentScrollPos = virtualizerContext.contextPosition;
-        const currentItemPos = virtualizerContext.childProgressiveSizes?.current[indexRef.current + i] - iItemSize;
+        const currentItemPos = virtualizerContext.childProgressiveSizes.current[indexRef.current + i] - iItemSize;
 
         let variance = 0;
         if (currentScrollPos > currentItemPos + iItemSize) {

--- a/packages/react-components/react-virtualizer/library/src/hooks/useDynamicVirtualizerMeasure.ts
+++ b/packages/react-components/react-virtualizer/library/src/hooks/useDynamicVirtualizerMeasure.ts
@@ -15,7 +15,7 @@ export const useDynamicVirtualizerMeasure = <TElement extends HTMLElement>(
   bufferItems: number;
   bufferSize: number;
   scrollRef: (instance: TElement | null) => void;
-  containerSizeRef: React.MutableRefObject<number>;
+  containerSizeRef: React.RefObject<number>;
 } => {
   const {
     defaultItemSize,

--- a/packages/react-components/react-virtualizer/library/src/hooks/useDynamicVirtualizerMeasure.ts
+++ b/packages/react-components/react-virtualizer/library/src/hooks/useDynamicVirtualizerMeasure.ts
@@ -66,10 +66,9 @@ export const useDynamicVirtualizerMeasure = <TElement extends HTMLElement>(
       const sizeToBeat = containerSizeRef.current + virtualizerBufferSize * 2;
       while (indexSizer <= sizeToBeat && i + virtualizerContext.contextIndex < numItems) {
         const iItemSize = getItemSize(indexRef.current + i);
-        if (
-          !virtualizerContext.childProgressiveSizes.current ||
-          virtualizerContext.childProgressiveSizes.current.length < numItems
-        ) {
+        if (virtualizerContext.childProgressiveSizes.current.length < numItems) {
+          /* We are in unknown territory, either an initial render or an update has occurred.
+            We need to let the new items render first then we can accurately assess.*/
           return virtualizerLength - virtualizerBufferSize * 2;
         }
 

--- a/packages/react-components/react-virtualizer/library/src/hooks/useMeasureList.ts
+++ b/packages/react-components/react-virtualizer/library/src/hooks/useMeasureList.ts
@@ -58,8 +58,14 @@ export function useMeasureList<
   };
 
   React.useEffect(() => {
-    widthArray.current = new Array(totalLength).fill(defaultItemSize);
-    heightArray.current = new Array(totalLength).fill(defaultItemSize);
+    const newHeightLength = totalLength - heightArray.current.length;
+    const newWidthLength = totalLength - widthArray.current.length;
+    if (newWidthLength > 0) {
+      widthArray.current = widthArray.current.concat(new Array(newWidthLength).fill(defaultItemSize));
+    }
+    if (newHeightLength > 0) {
+      heightArray.current = heightArray.current.concat(new Array(newHeightLength).fill(defaultItemSize));
+    }
   }, [defaultItemSize, totalLength]);
 
   // Keep the reference of ResizeObserver as a ref, as it should live through renders

--- a/packages/react-components/react-virtualizer/library/src/hooks/useMeasureList.ts
+++ b/packages/react-components/react-virtualizer/library/src/hooks/useMeasureList.ts
@@ -60,11 +60,16 @@ export function useMeasureList<
   React.useEffect(() => {
     const newHeightLength = totalLength - heightArray.current.length;
     const newWidthLength = totalLength - widthArray.current.length;
+    // Ensure we grow or truncate arrays with prior properties
     if (newWidthLength > 0) {
       widthArray.current = widthArray.current.concat(new Array(newWidthLength).fill(defaultItemSize));
+    } else if (newWidthLength < 0) {
+      widthArray.current = widthArray.current.slice(0, totalLength);
     }
     if (newHeightLength > 0) {
       heightArray.current = heightArray.current.concat(new Array(newHeightLength).fill(defaultItemSize));
+    } else if (newHeightLength < 0) {
+      heightArray.current = heightArray.current.slice(0, totalLength);
     }
   }, [defaultItemSize, totalLength]);
 

--- a/packages/react-components/react-virtualizer/library/src/hooks/useMeasureList.ts
+++ b/packages/react-components/react-virtualizer/library/src/hooks/useMeasureList.ts
@@ -60,7 +60,9 @@ export function useMeasureList<
   React.useEffect(() => {
     const newHeightLength = totalLength - heightArray.current.length;
     const newWidthLength = totalLength - widthArray.current.length;
-    // Ensure we grow or truncate arrays with prior properties
+    /* Ensure we grow or truncate arrays with prior properties,
+    keeping the existing values is important for whitespace assumptions.
+    Even if items in the 'middle' are deleted, we will recalc the whitespace as it is explored.*/
     if (newWidthLength > 0) {
       widthArray.current = widthArray.current.concat(new Array(newWidthLength).fill(defaultItemSize));
     } else if (newWidthLength < 0) {

--- a/packages/react-components/react-virtualizer/library/src/hooks/useResizeObserverRef.ts
+++ b/packages/react-components/react-virtualizer/library/src/hooks/useResizeObserverRef.ts
@@ -12,11 +12,21 @@ export const useResizeObserverRef_unstable = (resizeCallback: ResizeCallbackWith
 
   const { targetDocument } = useFluent();
   const container = React.useRef<HTMLElement | null>(null);
+  const containerHeightRef = React.useRef<number>(0);
+  const containerWidthRef = React.useRef<number>(0);
   // the handler for resize observer
   // TODO: exclude types from this lint rule: https://github.com/microsoft/fluentui/issues/31286
   // eslint-disable-next-line no-restricted-globals
   const handleResize = debounce((entries: ResizeObserverEntry[], observer: ResizeObserver) => {
-    resizeCallback(entries, observer, container);
+    const containerHeight = container.current?.clientHeight;
+    const containerWidth = container.current?.clientWidth;
+    console.log('Resize observer - 1');
+    if (containerHeightRef.current !== containerHeight || containerWidth !== containerWidthRef.current) {
+      console.log('Resize observer - 2');
+      containerWidthRef.current = containerWidth ?? 0;
+      containerHeightRef.current = containerHeight ?? 0;
+      resizeCallback(entries, observer, container);
+    }
   });
 
   // Keep the reference of ResizeObserver in the state, as it should live through renders

--- a/packages/react-components/react-virtualizer/library/src/hooks/useResizeObserverRef.ts
+++ b/packages/react-components/react-virtualizer/library/src/hooks/useResizeObserverRef.ts
@@ -20,9 +20,8 @@ export const useResizeObserverRef_unstable = (resizeCallback: ResizeCallbackWith
   const handleResize = debounce((entries: ResizeObserverEntry[], observer: ResizeObserver) => {
     const containerHeight = container.current?.clientHeight;
     const containerWidth = container.current?.clientWidth;
-    console.log('Resize observer - 1');
+    // Our resize observer will fire on scroll resize, let index change handle that instead.
     if (containerHeightRef.current !== containerHeight || containerWidth !== containerWidthRef.current) {
-      console.log('Resize observer - 2');
       containerWidthRef.current = containerWidth ?? 0;
       containerHeightRef.current = containerHeight ?? 0;
       resizeCallback(entries, observer, container);

--- a/packages/react-components/react-virtualizer/library/src/hooks/useVirtualizerMeasure.ts
+++ b/packages/react-components/react-virtualizer/library/src/hooks/useVirtualizerMeasure.ts
@@ -14,17 +14,17 @@ export const useStaticVirtualizerMeasure = <TElement extends HTMLElement>(
   scrollRef: (instance: TElement | null) => void;
   containerSizeRef: React.MutableRefObject<number>;
 } => {
-  const { defaultItemSize, direction = 'vertical' } = virtualizerProps;
+  const { defaultItemSize, direction = 'vertical', bufferItems, bufferSize } = virtualizerProps;
 
   const [state, setState] = React.useState({
     virtualizerLength: 0,
-    bufferSize: 0,
-    bufferItems: 0,
+    _bufferSize: 0,
+    _bufferItems: 0,
   });
 
   const containerSizeRef = React.useRef<number>(0);
 
-  const { virtualizerLength, bufferItems, bufferSize } = state;
+  const { virtualizerLength, _bufferItems, _bufferSize } = state;
 
   const resizeCallback = React.useCallback(
     (
@@ -53,32 +53,30 @@ export const useStaticVirtualizerMeasure = <TElement extends HTMLElement>(
       /*
        * Number of items to append at each end, i.e. 'preload' each side before entering view.
        */
-      // const newBufferItems = Math.max(Math.floor(length / 4), 2);
-      const newBufferItems = 1;
+      const newBufferItems = bufferItems ?? Math.max(Math.floor(length / 4), 1);
 
       /*
        * This is how far we deviate into the bufferItems to detect a redraw.
        */
-      // const newBufferSize = Math.max(Math.floor((length / 8) * defaultItemSize), 1);
-      const newBufferSize = 5;
+      const newBufferSize = bufferSize ?? Math.max(Math.floor((length / 8) * defaultItemSize), 1);
 
-      const totalLength = length + newBufferItems * 2 + 1;
+      const totalLength = length + newBufferItems * 2 - 1;
 
       setState({
         virtualizerLength: totalLength,
-        bufferItems: newBufferItems,
-        bufferSize: newBufferSize,
+        _bufferItems: newBufferItems,
+        _bufferSize: newBufferSize,
       });
     },
-    [defaultItemSize, direction],
+    [bufferItems, bufferSize, defaultItemSize, direction],
   );
 
   const scrollRef = useResizeObserverRef_unstable(resizeCallback);
 
   return {
     virtualizerLength,
-    bufferItems,
-    bufferSize,
+    bufferItems: _bufferItems,
+    bufferSize: _bufferSize,
     scrollRef,
     containerSizeRef,
   };

--- a/packages/react-components/react-virtualizer/library/src/hooks/useVirtualizerMeasure.ts
+++ b/packages/react-components/react-virtualizer/library/src/hooks/useVirtualizerMeasure.ts
@@ -12,6 +12,7 @@ export const useStaticVirtualizerMeasure = <TElement extends HTMLElement>(
   bufferItems: number;
   bufferSize: number;
   scrollRef: (instance: TElement | null) => void;
+  containerSizeRef: React.MutableRefObject<number>;
 } => {
   const { defaultItemSize, direction = 'vertical' } = virtualizerProps;
 
@@ -20,6 +21,8 @@ export const useStaticVirtualizerMeasure = <TElement extends HTMLElement>(
     bufferSize: 0,
     bufferItems: 0,
   });
+
+  const containerSizeRef = React.useRef<number>(0);
 
   const { virtualizerLength, bufferItems, bufferSize } = state;
 
@@ -40,6 +43,8 @@ export const useStaticVirtualizerMeasure = <TElement extends HTMLElement>(
           ? scrollRef?.current.getBoundingClientRect().height
           : scrollRef?.current.getBoundingClientRect().width;
 
+      containerSizeRef.current = containerSize;
+
       /*
        * Number of items required to cover viewport.
        */
@@ -48,12 +53,14 @@ export const useStaticVirtualizerMeasure = <TElement extends HTMLElement>(
       /*
        * Number of items to append at each end, i.e. 'preload' each side before entering view.
        */
-      const newBufferItems = Math.max(Math.floor(length / 4), 2);
+      // const newBufferItems = Math.max(Math.floor(length / 4), 2);
+      const newBufferItems = 1;
 
       /*
        * This is how far we deviate into the bufferItems to detect a redraw.
        */
-      const newBufferSize = Math.max(Math.floor((length / 8) * defaultItemSize), 1);
+      // const newBufferSize = Math.max(Math.floor((length / 8) * defaultItemSize), 1);
+      const newBufferSize = 5;
 
       const totalLength = length + newBufferItems * 2 + 1;
 
@@ -73,5 +80,6 @@ export const useStaticVirtualizerMeasure = <TElement extends HTMLElement>(
     bufferItems,
     bufferSize,
     scrollRef,
+    containerSizeRef,
   };
 };

--- a/packages/react-components/react-virtualizer/library/src/hooks/useVirtualizerMeasure.ts
+++ b/packages/react-components/react-virtualizer/library/src/hooks/useVirtualizerMeasure.ts
@@ -60,7 +60,7 @@ export const useStaticVirtualizerMeasure = <TElement extends HTMLElement>(
        */
       const newBufferSize = bufferSize ?? Math.max(Math.floor((length / 8) * defaultItemSize), 1);
 
-      const totalLength = length + newBufferItems * 2 - 1;
+      const totalLength = length + newBufferItems * 2;
 
       setState({
         virtualizerLength: totalLength,

--- a/packages/react-components/react-virtualizer/library/src/hooks/useVirtualizerMeasure.ts
+++ b/packages/react-components/react-virtualizer/library/src/hooks/useVirtualizerMeasure.ts
@@ -61,12 +61,12 @@ export const useStaticVirtualizerMeasure = <TElement extends HTMLElement>(
       /*
        * Number of items to append at each end, i.e. 'preload' each side before entering view.
        */
-      const newBufferItems = bufferItems ?? Math.max(Math.floor(length / 4), 1);
+      const newBufferItems = bufferItems ?? Math.max(Math.ceil(length / 4), 1);
 
       /*
        * This is how far we deviate into the bufferItems to detect a redraw.
        */
-      const newBufferSize = bufferSize ?? Math.max(Math.floor((length / 8) * defaultItemSize), 1);
+      const newBufferSize = bufferSize ?? Math.max(defaultItemSize / 2.0, 5);
 
       const totalLength = length + newBufferItems * 2;
 
@@ -76,7 +76,7 @@ export const useStaticVirtualizerMeasure = <TElement extends HTMLElement>(
         _bufferSize: newBufferSize,
       });
     },
-    [bufferItems, bufferSize, defaultItemSize, direction],
+    [bufferItems, bufferSize, defaultItemSize, direction, targetDocument?.body, targetDocument?.defaultView],
   );
 
   const scrollRef = useResizeObserverRef_unstable(resizeCallback);

--- a/packages/react-components/react-virtualizer/library/src/hooks/useVirtualizerMeasure.ts
+++ b/packages/react-components/react-virtualizer/library/src/hooks/useVirtualizerMeasure.ts
@@ -60,13 +60,14 @@ export const useStaticVirtualizerMeasure = <TElement extends HTMLElement>(
 
       /*
        * Number of items to append at each end, i.e. 'preload' each side before entering view.
+       * Minimum: 1
        */
       const newBufferItems = bufferItems ?? Math.max(Math.ceil(length / 4), 1);
 
       /*
        * This is how far we deviate into the bufferItems to detect a redraw.
        */
-      const newBufferSize = bufferSize ?? Math.max(defaultItemSize / 2.0, 5);
+      const newBufferSize = bufferSize ?? Math.max(defaultItemSize / 2.0, 1);
 
       const totalLength = length + newBufferItems * 2;
 

--- a/packages/react-components/react-virtualizer/library/src/hooks/useVirtualizerMeasure.ts
+++ b/packages/react-components/react-virtualizer/library/src/hooks/useVirtualizerMeasure.ts
@@ -42,12 +42,10 @@ export const useStaticVirtualizerMeasure = <TElement extends HTMLElement>(
 
       if (scrollRef.current !== targetDocument?.body) {
         // We have a local scroll container
-        const containerSize =
+        containerSizeRef.current =
           direction === 'vertical'
             ? scrollRef?.current.getBoundingClientRect().height
             : scrollRef?.current.getBoundingClientRect().width;
-
-        containerSizeRef.current = containerSize;
       } else if (targetDocument?.defaultView) {
         // If our scroll ref is the document body, we should check window height
         containerSizeRef.current =

--- a/packages/react-components/react-virtualizer/library/src/index.ts
+++ b/packages/react-components/react-virtualizer/library/src/index.ts
@@ -19,9 +19,15 @@ export {
   useStaticVirtualizerMeasure,
   useDynamicVirtualizerMeasure,
   useResizeObserverRef_unstable,
+  useMeasureList,
 } from './Hooks';
 
-export type { ResizeCallbackWithRef, VirtualizerMeasureDynamicProps, VirtualizerMeasureProps } from './Hooks';
+export type {
+  ResizeCallbackWithRef,
+  VirtualizerMeasureDynamicProps,
+  VirtualizerMeasureProps,
+  IndexedResizeCallbackElement,
+} from './Hooks';
 
 export type { ScrollToItemDynamicParams, ScrollToItemStaticParams, ScrollToInterface } from './Utilities';
 

--- a/packages/react-components/react-virtualizer/library/src/index.ts
+++ b/packages/react-components/react-virtualizer/library/src/index.ts
@@ -38,7 +38,7 @@ export {
   scrollToItemDynamic,
 } from './Utilities';
 
-export type { VirtualizerContextProps } from './Utilities';
+export type { VirtualizerContextProps, DynamicVirtualizerContextProps } from './Utilities';
 
 export {
   VirtualizerScrollView,

--- a/packages/react-components/react-virtualizer/library/src/testing/useVirtualizer.test.ts
+++ b/packages/react-components/react-virtualizer/library/src/testing/useVirtualizer.test.ts
@@ -1,5 +1,6 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { useVirtualizer_unstable } from '../components/Virtualizer/useVirtualizer';
+import { useRef } from 'react';
 
 describe('useVirtualizer', () => {
   beforeEach(() => {
@@ -17,6 +18,7 @@ describe('useVirtualizer', () => {
     const virtualizerLength = 50;
     const actualLength = 250;
     const divArr = new Array(actualLength).fill('Test-Node');
+    const containerSizeRef = useRef<number>(300);
 
     const rowFunc = (index: number) => {
       return divArr[index];
@@ -27,6 +29,7 @@ describe('useVirtualizer', () => {
         virtualizerLength,
         itemSize: 100, // 100 pixels
         children: rowFunc,
+        containerSizeRef,
       }),
     );
 

--- a/packages/react-components/react-virtualizer/library/src/testing/useVirtualizer.test.ts
+++ b/packages/react-components/react-virtualizer/library/src/testing/useVirtualizer.test.ts
@@ -1,6 +1,5 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { useVirtualizer_unstable } from '../components/Virtualizer/useVirtualizer';
-import { useRef } from 'react';
 
 describe('useVirtualizer', () => {
   beforeEach(() => {

--- a/packages/react-components/react-virtualizer/library/src/testing/useVirtualizer.test.ts
+++ b/packages/react-components/react-virtualizer/library/src/testing/useVirtualizer.test.ts
@@ -18,7 +18,9 @@ describe('useVirtualizer', () => {
     const virtualizerLength = 50;
     const actualLength = 250;
     const divArr = new Array(actualLength).fill('Test-Node');
-    const containerSizeRef = useRef<number>(300);
+    const containerSizeRef = {
+      current: 300,
+    };
 
     const rowFunc = (index: number) => {
       return divArr[index];

--- a/packages/react-components/react-virtualizer/library/src/utilities/VirtualizerContext/VirtualizerContext.ts
+++ b/packages/react-components/react-virtualizer/library/src/utilities/VirtualizerContext/VirtualizerContext.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import type { VirtualizerContextProps } from './types';
-import { useMemo, useState } from 'react';
+import { useMemo, useState, useRef } from 'react';
 
 const VirtualizerContext = React.createContext<VirtualizerContextProps | undefined>(
   undefined,
@@ -17,17 +17,40 @@ export const useVirtualizerContextState_unstable = (
 ): VirtualizerContextProps => {
   const virtualizerContext = useVirtualizerContext_unstable();
   const [_contextIndex, _setContextIndex] = useState<number>(-1);
+  const [_contextPosition, _setContextPosition] = useState<number>(0);
+  const childProgressiveSizes = useRef<number[]>([]);
 
   /* We respect any wrapped providers while also ensuring defaults or passed through
    * Order of usage -> Passed Prop -> Provider Context -> Internal State default
    */
   const _context = useMemo(
-    () => passedContext ?? virtualizerContext ?? { contextIndex: _contextIndex, setContextIndex: _setContextIndex },
-    [_contextIndex, passedContext, virtualizerContext],
+    () =>
+      passedContext ??
+      virtualizerContext ?? {
+        contextIndex: _contextIndex,
+        setContextIndex: _setContextIndex,
+        contextPosition: _contextPosition,
+        setContextPosition: _setContextPosition,
+        childProgressiveSizes,
+      },
+    [_contextIndex, _contextPosition, passedContext, virtualizerContext],
   );
+
   const context = useMemo(() => {
-    return { contextIndex: _context.contextIndex, setContextIndex: _context.setContextIndex };
-  }, [_context]);
+    return {
+      contextIndex: _context.contextIndex,
+      setContextIndex: _context.setContextIndex,
+      contextPosition: _context.contextPosition,
+      setContextPosition: _context.setContextPosition,
+      childProgressiveSizes,
+    };
+  }, [
+    _context.contextIndex,
+    _context.contextPosition,
+    _context.setContextIndex,
+    _context.setContextPosition,
+    childProgressiveSizes,
+  ]);
 
   return context;
 };

--- a/packages/react-components/react-virtualizer/library/src/utilities/VirtualizerContext/VirtualizerContext.ts
+++ b/packages/react-components/react-virtualizer/library/src/utilities/VirtualizerContext/VirtualizerContext.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import type { VirtualizerContextProps } from './types';
+import type { DynamicVirtualizerContextProps, VirtualizerContextProps } from './types';
 import { useMemo, useState, useRef } from 'react';
 
 const VirtualizerContext = React.createContext<VirtualizerContextProps | undefined>(
@@ -14,7 +14,7 @@ export const useVirtualizerContext_unstable = () => {
 
 export const useVirtualizerContextState_unstable = (
   passedContext?: VirtualizerContextProps,
-): VirtualizerContextProps => {
+): DynamicVirtualizerContextProps => {
   const virtualizerContext = useVirtualizerContext_unstable();
   const [_contextIndex, _setContextIndex] = useState<number>(-1);
   const [_contextPosition, _setContextPosition] = useState<number>(0);
@@ -23,34 +23,17 @@ export const useVirtualizerContextState_unstable = (
   /* We respect any wrapped providers while also ensuring defaults or passed through
    * Order of usage -> Passed Prop -> Provider Context -> Internal State default
    */
-  const _context = useMemo(
-    () =>
-      passedContext ??
-      virtualizerContext ?? {
-        contextIndex: _contextIndex,
-        setContextIndex: _setContextIndex,
-        contextPosition: _contextPosition,
-        setContextPosition: _setContextPosition,
-        childProgressiveSizes,
-      },
+  const context = useMemo(
+    () => ({
+      contextIndex: passedContext?.contextIndex ?? virtualizerContext?.contextIndex ?? _contextIndex,
+      setContextIndex: passedContext?.setContextIndex ?? virtualizerContext?.setContextIndex ?? _setContextIndex,
+      contextPosition: passedContext?.contextPosition ?? virtualizerContext?.contextPosition ?? _contextPosition,
+      setContextPosition:
+        passedContext?.setContextPosition ?? virtualizerContext?.setContextPosition ?? _setContextPosition,
+      childProgressiveSizes,
+    }),
     [_contextIndex, _contextPosition, passedContext, virtualizerContext],
   );
-
-  const context = useMemo(() => {
-    return {
-      contextIndex: _context.contextIndex,
-      setContextIndex: _context.setContextIndex,
-      contextPosition: _context.contextPosition,
-      setContextPosition: _context.setContextPosition,
-      childProgressiveSizes,
-    };
-  }, [
-    _context.contextIndex,
-    _context.contextPosition,
-    _context.setContextIndex,
-    _context.setContextPosition,
-    childProgressiveSizes,
-  ]);
 
   return context;
 };

--- a/packages/react-components/react-virtualizer/library/src/utilities/VirtualizerContext/types.ts
+++ b/packages/react-components/react-virtualizer/library/src/utilities/VirtualizerContext/types.ts
@@ -5,7 +5,12 @@ import * as React from 'react';
 export type VirtualizerContextProps = {
   contextIndex: number;
   setContextIndex: (index: number) => void;
-  contextPosition: number;
-  setContextPosition: (index: number) => void;
-  childProgressiveSizes: React.MutableRefObject<number[]>;
+  /*
+   * These option props are used in dynamic virtualizer
+   */
+  contextPosition?: number;
+  setContextPosition?: (index: number) => void;
+  childProgressiveSizes?: React.MutableRefObject<number[]>;
 };
+
+export type DynamicVirtualizerContextProps = Required<VirtualizerContextProps>;

--- a/packages/react-components/react-virtualizer/library/src/utilities/VirtualizerContext/types.ts
+++ b/packages/react-components/react-virtualizer/library/src/utilities/VirtualizerContext/types.ts
@@ -1,7 +1,11 @@
+import * as React from 'react';
 /**
  * {@docCategory Virtualizer}
  */
 export type VirtualizerContextProps = {
   contextIndex: number;
   setContextIndex: (index: number) => void;
+  contextPosition: number;
+  setContextPosition: (index: number) => void;
+  childProgressiveSizes: React.MutableRefObject<number[]>;
 };

--- a/packages/react-components/react-virtualizer/library/src/utilities/VirtualizerContext/types.ts
+++ b/packages/react-components/react-virtualizer/library/src/utilities/VirtualizerContext/types.ts
@@ -13,4 +13,7 @@ export type VirtualizerContextProps = {
   childProgressiveSizes?: React.MutableRefObject<number[]>;
 };
 
+/**
+ * Some props are optional on static virtualizer, but required for dynamic.
+ */
 export type DynamicVirtualizerContextProps = Required<VirtualizerContextProps>;

--- a/packages/react-components/react-virtualizer/stories/.storybook/preview-body.html
+++ b/packages/react-components/react-virtualizer/stories/.storybook/preview-body.html
@@ -1,5 +1,5 @@
 <style>
   body {
-    max-height: 100vh;
+    max-height: 85vh;
   }
 </style>

--- a/packages/react-components/react-virtualizer/stories/.storybook/preview-body.html
+++ b/packages/react-components/react-virtualizer/stories/.storybook/preview-body.html
@@ -1,5 +1,0 @@
-<style>
-  body {
-    max-height: 85vh;
-  }
-</style>

--- a/packages/react-components/react-virtualizer/stories/src/Virtualizer/Default.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/Virtualizer/Default.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Virtualizer, useStaticVirtualizerMeasure } from '@fluentui/react-components/unstable';
-import { makeStyles, useMergedRefs } from '@fluentui/react-components';
+import { makeStyles, useMergedRefs, Button } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   container: {
@@ -31,28 +31,44 @@ export const Default = () => {
   const mergedRef = useMergedRefs(scrollRef);
 
   return (
-    <div aria-label="Virtualizer Example" className={styles.container} role={'list'} ref={mergedRef}>
-      <Virtualizer
-        numItems={childLength}
-        virtualizerLength={virtualizerLength}
-        bufferItems={bufferItems}
-        bufferSize={bufferSize}
-        itemSize={25}
-        containerSizeRef={containerSizeRef}
-        scrollViewRef={mergedRef}
-      >
-        {index => {
-          return (
-            <span
-              role={'listitem'}
-              aria-posinset={index}
-              aria-setsize={childLength}
-              key={`test-virtualizer-child-${index}`}
-              className={styles.child}
-            >{`Node-${index}`}</span>
-          );
+    <div>
+      <Button
+        onClick={() => {
+          mergedRef.current?.scrollTo({ top: 1000 });
         }}
-      </Virtualizer>
+      >
+        {'Go to pos: 1000'}
+      </Button>
+      <Button
+        onClick={() => {
+          mergedRef.current?.scrollTo({ top: 8000 });
+        }}
+      >
+        {'Go to pos: 8000'}
+      </Button>
+      <div aria-label="Virtualizer Example" className={styles.container} role={'list'} ref={mergedRef}>
+        <Virtualizer
+          numItems={childLength}
+          virtualizerLength={virtualizerLength}
+          bufferItems={bufferItems}
+          bufferSize={bufferSize}
+          itemSize={25}
+          containerSizeRef={containerSizeRef}
+          scrollViewRef={mergedRef}
+        >
+          {index => {
+            return (
+              <span
+                role={'listitem'}
+                aria-posinset={index}
+                aria-setsize={childLength}
+                key={`test-virtualizer-child-${index}`}
+                className={styles.child}
+              >{`Node-${index}`}</span>
+            );
+          }}
+        </Virtualizer>
+      </div>
     </div>
   );
 };

--- a/packages/react-components/react-virtualizer/stories/src/Virtualizer/Default.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/Virtualizer/Default.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Virtualizer, useStaticVirtualizerMeasure } from '@fluentui/react-components/unstable';
-import { makeStyles, useMergedRefs } from '@fluentui/react-components';
+import { makeStyles } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   container: {
@@ -13,8 +13,9 @@ const useStyles = makeStyles({
   },
   child: {
     height: '25px',
-    lineHeight: '25px',
+    lineHeight: '100px',
     width: '100%',
+    minHeight: '100px',
   },
 });
 
@@ -23,24 +24,19 @@ export const Default = () => {
   const childLength = 1000;
 
   const { virtualizerLength, bufferItems, bufferSize, scrollRef, containerSizeRef } = useStaticVirtualizerMeasure({
-    defaultItemSize: 25,
-    bufferItems: 1,
-    bufferSize: 12,
+    defaultItemSize: 100,
   });
-
-  const mergedRef = useMergedRefs(scrollRef);
 
   return (
     <div>
-      <div aria-label="Virtualizer Example" className={styles.container} role={'list'} ref={mergedRef}>
+      <div aria-label="Virtualizer Example" className={styles.container} role={'list'} ref={scrollRef}>
         <Virtualizer
           numItems={childLength}
           virtualizerLength={virtualizerLength}
           bufferItems={bufferItems}
           bufferSize={bufferSize}
-          itemSize={25}
+          itemSize={100}
           containerSizeRef={containerSizeRef}
-          scrollViewRef={mergedRef}
         >
           {index => {
             return (

--- a/packages/react-components/react-virtualizer/stories/src/Virtualizer/Default.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/Virtualizer/Default.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Virtualizer, useStaticVirtualizerMeasure } from '@fluentui/react-components/unstable';
-import { makeStyles, useMergedRefs, Button } from '@fluentui/react-components';
+import { makeStyles, useMergedRefs } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   container: {
@@ -32,20 +32,6 @@ export const Default = () => {
 
   return (
     <div>
-      <Button
-        onClick={() => {
-          mergedRef.current?.scrollTo({ top: 1000 });
-        }}
-      >
-        {'Go to pos: 1000'}
-      </Button>
-      <Button
-        onClick={() => {
-          mergedRef.current?.scrollTo({ top: 8000 });
-        }}
-      >
-        {'Go to pos: 8000'}
-      </Button>
       <div aria-label="Virtualizer Example" className={styles.container} role={'list'} ref={mergedRef}>
         <Virtualizer
           numItems={childLength}

--- a/packages/react-components/react-virtualizer/stories/src/Virtualizer/Default.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/Virtualizer/Default.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Virtualizer, useStaticVirtualizerMeasure } from '@fluentui/react-components/unstable';
-import { makeStyles, useMergedRefs } from '@fluentui/react-components';
+import { makeStyles } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   container: {
@@ -27,11 +27,9 @@ export const Default = () => {
     defaultItemSize: 100,
   });
 
-  const mergedref = useMergedRefs(scrollRef);
-
   return (
     <div>
-      <div aria-label="Virtualizer Example" className={styles.container} role={'list'} ref={mergedref}>
+      <div aria-label="Virtualizer Example" className={styles.container} role={'list'} ref={scrollRef}>
         <Virtualizer
           numItems={childLength}
           virtualizerLength={virtualizerLength}
@@ -39,7 +37,6 @@ export const Default = () => {
           bufferSize={bufferSize}
           itemSize={100}
           containerSizeRef={containerSizeRef}
-          scrollViewRef={mergedref}
         >
           {index => {
             return (

--- a/packages/react-components/react-virtualizer/stories/src/Virtualizer/Default.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/Virtualizer/Default.stories.tsx
@@ -9,7 +9,7 @@ const useStyles = makeStyles({
     overflowY: 'auto',
     width: '100%',
     height: '100%',
-    maxHeight: '750px',
+    maxHeight: '60vh',
   },
   child: {
     height: '25px',
@@ -24,6 +24,8 @@ export const Default = () => {
 
   const { virtualizerLength, bufferItems, bufferSize, scrollRef, containerSizeRef } = useStaticVirtualizerMeasure({
     defaultItemSize: 25,
+    bufferItems: 1,
+    bufferSize: 12,
   });
 
   const mergedRef = useMergedRefs(scrollRef);

--- a/packages/react-components/react-virtualizer/stories/src/Virtualizer/Default.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/Virtualizer/Default.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Virtualizer, useStaticVirtualizerMeasure } from '@fluentui/react-components/unstable';
-import { makeStyles } from '@fluentui/react-components';
+import { makeStyles, useMergedRefs } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   container: {
@@ -27,9 +27,11 @@ export const Default = () => {
     defaultItemSize: 100,
   });
 
+  const mergedref = useMergedRefs(scrollRef);
+
   return (
     <div>
-      <div aria-label="Virtualizer Example" className={styles.container} role={'list'} ref={scrollRef}>
+      <div aria-label="Virtualizer Example" className={styles.container} role={'list'} ref={mergedref}>
         <Virtualizer
           numItems={childLength}
           virtualizerLength={virtualizerLength}
@@ -37,6 +39,7 @@ export const Default = () => {
           bufferSize={bufferSize}
           itemSize={100}
           containerSizeRef={containerSizeRef}
+          scrollViewRef={mergedref}
         >
           {index => {
             return (

--- a/packages/react-components/react-virtualizer/stories/src/Virtualizer/Default.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/Virtualizer/Default.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Virtualizer, useStaticVirtualizerMeasure } from '@fluentui/react-components/unstable';
-import { makeStyles } from '@fluentui/react-components';
+import { makeStyles, useMergedRefs } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   container: {
@@ -12,8 +12,8 @@ const useStyles = makeStyles({
     maxHeight: '750px',
   },
   child: {
-    height: '100px',
-    lineHeight: '100px',
+    height: '25px',
+    lineHeight: '25px',
     width: '100%',
   },
 });
@@ -22,18 +22,22 @@ export const Default = () => {
   const styles = useStyles();
   const childLength = 1000;
 
-  const { virtualizerLength, bufferItems, bufferSize, scrollRef } = useStaticVirtualizerMeasure({
-    defaultItemSize: 100,
+  const { virtualizerLength, bufferItems, bufferSize, scrollRef, containerSizeRef } = useStaticVirtualizerMeasure({
+    defaultItemSize: 25,
   });
 
+  const mergedRef = useMergedRefs(scrollRef);
+
   return (
-    <div aria-label="Virtualizer Example" className={styles.container} role={'list'} ref={scrollRef}>
+    <div aria-label="Virtualizer Example" className={styles.container} role={'list'} ref={mergedRef}>
       <Virtualizer
         numItems={childLength}
         virtualizerLength={virtualizerLength}
         bufferItems={bufferItems}
         bufferSize={bufferSize}
-        itemSize={100}
+        itemSize={25}
+        containerSizeRef={containerSizeRef}
+        scrollViewRef={mergedRef}
       >
         {index => {
           return (

--- a/packages/react-components/react-virtualizer/stories/src/Virtualizer/Default.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/Virtualizer/Default.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Virtualizer, useStaticVirtualizerMeasure } from '@fluentui/react-components/unstable';
+import { Virtualizer, useStaticVirtualizerMeasure } from '@fluentui/react-virtualizer';
 import { makeStyles } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
@@ -9,13 +9,13 @@ const useStyles = makeStyles({
     overflowY: 'auto',
     width: '100%',
     height: '100%',
-    maxHeight: '60vh',
+    maxHeight: '80vh',
   },
   child: {
     height: '25px',
-    lineHeight: '100px',
+    lineHeight: '25px',
     width: '100%',
-    minHeight: '100px',
+    minHeight: '25px',
   },
 });
 
@@ -24,7 +24,7 @@ export const Default = () => {
   const childLength = 1000;
 
   const { virtualizerLength, bufferItems, bufferSize, scrollRef, containerSizeRef } = useStaticVirtualizerMeasure({
-    defaultItemSize: 100,
+    defaultItemSize: 25,
   });
 
   return (
@@ -35,7 +35,7 @@ export const Default = () => {
           virtualizerLength={virtualizerLength}
           bufferItems={bufferItems}
           bufferSize={bufferSize}
-          itemSize={100}
+          itemSize={25}
           containerSizeRef={containerSizeRef}
         >
           {index => {

--- a/packages/react-components/react-virtualizer/stories/src/Virtualizer/DefaultUnbounded.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/Virtualizer/DefaultUnbounded.stories.tsx
@@ -20,7 +20,6 @@ const useStyles = makeStyles({
   },
   child: {
     display: 'flex',
-    height: '100px',
     lineHeight: '100px',
     width: '100%',
   },
@@ -30,6 +29,7 @@ const useStyles = makeStyles({
     paddingBottom: '100px',
     fontSize: '36px',
     textAlign: 'center',
+    minHeight: '100px',
   },
 });
 

--- a/packages/react-components/react-virtualizer/stories/src/Virtualizer/DefaultUnbounded.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/Virtualizer/DefaultUnbounded.stories.tsx
@@ -36,7 +36,7 @@ const useStyles = makeStyles({
 export const DefaultUnbounded = () => {
   const styles = useStyles();
   const childLength = 1000;
-  const { virtualizerLength, bufferItems, bufferSize, scrollRef } = useStaticVirtualizerMeasure({
+  const { virtualizerLength, bufferItems, bufferSize, scrollRef, containerSizeRef } = useStaticVirtualizerMeasure({
     defaultItemSize: 100,
   });
 
@@ -54,6 +54,7 @@ export const DefaultUnbounded = () => {
         bufferItems={bufferItems}
         bufferSize={bufferSize}
         itemSize={100}
+        containerSizeRef={containerSizeRef}
       >
         {(index, isScrolling) => {
           return (

--- a/packages/react-components/react-virtualizer/stories/src/Virtualizer/DefaultUnbounded.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/Virtualizer/DefaultUnbounded.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Virtualizer, useStaticVirtualizerMeasure } from '@fluentui/react-components/unstable';
+import { Virtualizer, useStaticVirtualizerMeasure } from '@fluentui/react-virtualizer';
 import { makeStyles } from '@fluentui/react-components';
 
 import { useFluent } from '@fluentui/react-components';

--- a/packages/react-components/react-virtualizer/stories/src/Virtualizer/Dynamic.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/Virtualizer/Dynamic.stories.tsx
@@ -4,6 +4,7 @@ import {
   useDynamicVirtualizerMeasure,
   VirtualizerContextProvider,
 } from '@fluentui/react-components/unstable';
+import type { DynamicVirtualizerContextProps } from '@fluentui/react-components/unstable';
 import { makeStyles } from '@fluentui/react-components';
 import { useCallback, useRef } from 'react';
 
@@ -35,6 +36,7 @@ const useStyles = makeStyles({
 export const Dynamic = () => {
   const [currentIndex, setCurrentIndex] = React.useState(-1);
   const [currentPosition, setCurrentPosition] = React.useState(0);
+  const childProgressiveSizes = React.useRef<number[]>([]);
   const [flag, toggleFlag] = React.useState(false);
   const styles = useStyles();
   const childLength = 1000;
@@ -64,11 +66,12 @@ export const Dynamic = () => {
     [flag],
   );
 
-  const contextState = {
+  const contextState: DynamicVirtualizerContextProps = {
     contextIndex: currentIndex,
     setContextIndex: setCurrentIndex,
     contextPosition: currentPosition,
     setContextPosition: setCurrentPosition,
+    childProgressiveSizes,
   };
 
   const { virtualizerLength, bufferItems, bufferSize, scrollRef, containerSizeRef } = useDynamicVirtualizerMeasure({

--- a/packages/react-components/react-virtualizer/stories/src/Virtualizer/Dynamic.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/Virtualizer/Dynamic.stories.tsx
@@ -4,7 +4,7 @@ import {
   useDynamicVirtualizerMeasure,
   VirtualizerContextProvider,
 } from '@fluentui/react-components/unstable';
-import { makeStyles, useMergedRefs } from '@fluentui/react-components';
+import { makeStyles } from '@fluentui/react-components';
 import { useCallback, useRef } from 'react';
 
 const smallSize = 100;

--- a/packages/react-components/react-virtualizer/stories/src/Virtualizer/Dynamic.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/Virtualizer/Dynamic.stories.tsx
@@ -70,8 +70,6 @@ export const Dynamic = () => {
     currentIndex,
   });
 
-  const combineRefs = useMergedRefs(scrollRef);
-
   return (
     <VirtualizerContextProvider value={{ contextIndex: currentIndex, setContextIndex: setCurrentIndex }}>
       <div aria-label="Dynamic Virtualizer Example" className={styles.container} role={'list'} ref={scrollRef}>
@@ -82,7 +80,6 @@ export const Dynamic = () => {
           bufferItems={bufferItems}
           virtualizerLength={virtualizerLength}
           itemSize={100}
-          scrollViewRef={combineRefs}
           containerSizeRef={containerSizeRef}
         >
           {useCallback(

--- a/packages/react-components/react-virtualizer/stories/src/Virtualizer/Dynamic.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/Virtualizer/Dynamic.stories.tsx
@@ -92,6 +92,7 @@ export const Dynamic = () => {
           virtualizerLength={virtualizerLength}
           itemSize={100}
           containerSizeRef={containerSizeRef}
+          virtualizerContext={contextState}
         >
           {useCallback(
             (index: number) => {

--- a/packages/react-components/react-virtualizer/stories/src/Virtualizer/Dynamic.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/Virtualizer/Dynamic.stories.tsx
@@ -63,7 +63,7 @@ export const Dynamic = () => {
     [flag],
   );
 
-  const { virtualizerLength, bufferItems, bufferSize, scrollRef } = useDynamicVirtualizerMeasure({
+  const { virtualizerLength, bufferItems, bufferSize, scrollRef, containerSizeRef } = useDynamicVirtualizerMeasure({
     defaultItemSize: 100,
     getItemSize: getSizeForIndex,
     numItems: childLength,
@@ -83,6 +83,7 @@ export const Dynamic = () => {
           virtualizerLength={virtualizerLength}
           itemSize={100}
           scrollViewRef={combineRefs}
+          containerSizeRef={containerSizeRef}
         >
           {useCallback(
             (index: number) => {

--- a/packages/react-components/react-virtualizer/stories/src/Virtualizer/Dynamic.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/Virtualizer/Dynamic.stories.tsx
@@ -4,7 +4,7 @@ import {
   useDynamicVirtualizerMeasure,
   VirtualizerContextProvider,
 } from '@fluentui/react-components/unstable';
-import { makeStyles } from '@fluentui/react-components';
+import { makeStyles, useMergedRefs } from '@fluentui/react-components';
 import { useCallback, useRef } from 'react';
 
 const smallSize = 100;
@@ -70,6 +70,8 @@ export const Dynamic = () => {
     currentIndex,
   });
 
+  const combineRefs = useMergedRefs(scrollRef);
+
   return (
     <VirtualizerContextProvider value={{ contextIndex: currentIndex, setContextIndex: setCurrentIndex }}>
       <div aria-label="Dynamic Virtualizer Example" className={styles.container} role={'list'} ref={scrollRef}>
@@ -80,6 +82,7 @@ export const Dynamic = () => {
           bufferItems={bufferItems}
           virtualizerLength={virtualizerLength}
           itemSize={100}
+          scrollViewRef={combineRefs}
         >
           {useCallback(
             (index: number) => {

--- a/packages/react-components/react-virtualizer/stories/src/Virtualizer/Dynamic.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/Virtualizer/Dynamic.stories.tsx
@@ -34,6 +34,7 @@ const useStyles = makeStyles({
 
 export const Dynamic = () => {
   const [currentIndex, setCurrentIndex] = React.useState(-1);
+  const [currentPosition, setCurrentPosition] = React.useState(0);
   const [flag, toggleFlag] = React.useState(false);
   const styles = useStyles();
   const childLength = 1000;
@@ -63,15 +64,22 @@ export const Dynamic = () => {
     [flag],
   );
 
+  const contextState = {
+    contextIndex: currentIndex,
+    setContextIndex: setCurrentIndex,
+    contextPosition: currentPosition,
+    setContextPosition: setCurrentPosition,
+  };
+
   const { virtualizerLength, bufferItems, bufferSize, scrollRef, containerSizeRef } = useDynamicVirtualizerMeasure({
     defaultItemSize: 100,
     getItemSize: getSizeForIndex,
     numItems: childLength,
-    currentIndex,
+    virtualizerContext: contextState,
   });
 
   return (
-    <VirtualizerContextProvider value={{ contextIndex: currentIndex, setContextIndex: setCurrentIndex }}>
+    <VirtualizerContextProvider value={contextState}>
       <div aria-label="Dynamic Virtualizer Example" className={styles.container} role={'list'} ref={scrollRef}>
         <Virtualizer
           getItemSize={getSizeForIndex}

--- a/packages/react-components/react-virtualizer/stories/src/Virtualizer/Dynamic.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/Virtualizer/Dynamic.stories.tsx
@@ -1,10 +1,6 @@
 import * as React from 'react';
-import {
-  Virtualizer,
-  useDynamicVirtualizerMeasure,
-  VirtualizerContextProvider,
-} from '@fluentui/react-components/unstable';
-import type { DynamicVirtualizerContextProps } from '@fluentui/react-components/unstable';
+import { Virtualizer, useDynamicVirtualizerMeasure, VirtualizerContextProvider } from '@fluentui/react-virtualizer';
+import type { DynamicVirtualizerContextProps } from '@fluentui/react-virtualizer';
 import { makeStyles } from '@fluentui/react-components';
 import { useCallback, useRef } from 'react';
 

--- a/packages/react-components/react-virtualizer/stories/src/Virtualizer/Horizontal.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/Virtualizer/Horizontal.stories.tsx
@@ -23,7 +23,7 @@ export const Horizontal = () => {
   const childLength = 1000;
   const itemWidth = 100;
 
-  const { virtualizerLength, bufferItems, bufferSize, scrollRef } = useStaticVirtualizerMeasure({
+  const { virtualizerLength, bufferItems, bufferSize, scrollRef, containerSizeRef } = useStaticVirtualizerMeasure({
     defaultItemSize: itemWidth,
     direction: 'horizontal',
   });
@@ -37,6 +37,7 @@ export const Horizontal = () => {
         bufferItems={bufferItems}
         bufferSize={bufferSize}
         itemSize={itemWidth}
+        containerSizeRef={containerSizeRef}
       >
         {index => {
           return (

--- a/packages/react-components/react-virtualizer/stories/src/Virtualizer/Horizontal.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/Virtualizer/Horizontal.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useStaticVirtualizerMeasure, Virtualizer } from '@fluentui/react-components/unstable';
+import { useStaticVirtualizerMeasure, Virtualizer } from '@fluentui/react-virtualizer';
 import { makeStyles } from '@fluentui/react-components';
 
 const useStyles = makeStyles({

--- a/packages/react-components/react-virtualizer/stories/src/Virtualizer/MultiUnbounded.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/Virtualizer/MultiUnbounded.stories.tsx
@@ -36,7 +36,7 @@ export const MultiUnbounded = () => {
   const childLength = 100;
   const repeatingVirtualizers = 5;
 
-  const { virtualizerLength, bufferItems, bufferSize, scrollRef } = useStaticVirtualizerMeasure({
+  const { virtualizerLength, bufferItems, bufferSize, scrollRef, containerSizeRef } = useStaticVirtualizerMeasure({
     defaultItemSize: 100,
   });
 
@@ -58,6 +58,7 @@ export const MultiUnbounded = () => {
         bufferSize={bufferSize}
         itemSize={100}
         key={`virtualizer-container-${index}`}
+        containerSizeRef={containerSizeRef}
       >
         {rowIndex => {
           return (

--- a/packages/react-components/react-virtualizer/stories/src/Virtualizer/MultiUnbounded.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/Virtualizer/MultiUnbounded.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Virtualizer, useStaticVirtualizerMeasure } from '@fluentui/react-components/unstable';
+import { Virtualizer, useStaticVirtualizerMeasure } from '@fluentui/react-virtualizer';
 import { makeStyles, useFluent } from '@fluentui/react-components';
 
 const useStyles = makeStyles({

--- a/packages/react-components/react-virtualizer/stories/src/Virtualizer/RTL.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/Virtualizer/RTL.stories.tsx
@@ -24,7 +24,7 @@ export const RTL = () => {
   const childLength = 1000;
 
   const itemWidth = 100;
-  const { virtualizerLength, bufferItems, bufferSize, scrollRef } = useStaticVirtualizerMeasure({
+  const { virtualizerLength, bufferItems, bufferSize, scrollRef, containerSizeRef } = useStaticVirtualizerMeasure({
     defaultItemSize: itemWidth,
     direction: 'horizontal',
   });
@@ -39,6 +39,7 @@ export const RTL = () => {
         bufferItems={bufferItems}
         bufferSize={bufferSize}
         itemSize={100}
+        containerSizeRef={containerSizeRef}
       >
         {index => {
           return (

--- a/packages/react-components/react-virtualizer/stories/src/Virtualizer/RTL.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/Virtualizer/RTL.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useStaticVirtualizerMeasure, Virtualizer } from '@fluentui/react-components/unstable';
+import { useStaticVirtualizerMeasure, Virtualizer } from '@fluentui/react-virtualizer';
 import { makeStyles } from '@fluentui/react-components';
 
 const useStyles = makeStyles({

--- a/packages/react-components/react-virtualizer/stories/src/Virtualizer/Reversed.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/Virtualizer/Reversed.stories.tsx
@@ -23,7 +23,7 @@ export const Reversed = () => {
   const childLength = 1000;
   const itemSize = 100;
 
-  const { virtualizerLength, bufferItems, bufferSize, scrollRef } = useStaticVirtualizerMeasure({
+  const { virtualizerLength, bufferItems, bufferSize, scrollRef, containerSizeRef } = useStaticVirtualizerMeasure({
     defaultItemSize: itemSize,
   });
 
@@ -36,6 +36,7 @@ export const Reversed = () => {
         bufferItems={bufferItems}
         bufferSize={bufferSize}
         itemSize={itemSize}
+        containerSizeRef={containerSizeRef}
       >
         {index => {
           return (

--- a/packages/react-components/react-virtualizer/stories/src/Virtualizer/Reversed.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/Virtualizer/Reversed.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useStaticVirtualizerMeasure, Virtualizer } from '@fluentui/react-components/unstable';
-import { makeStyles } from '@fluentui/react-components';
+import { makeStyles, useMergedRefs } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   container: {
@@ -27,8 +27,10 @@ export const Reversed = () => {
     defaultItemSize: itemSize,
   });
 
+  const mergedRef = useMergedRefs(scrollRef);
+
   return (
-    <div aria-label="Reversed Virtualizer Example" className={styles.container} role={'list'} ref={scrollRef}>
+    <div aria-label="Reversed Virtualizer Example" className={styles.container} role={'list'} ref={mergedRef}>
       <Virtualizer
         numItems={childLength}
         reversed
@@ -37,6 +39,7 @@ export const Reversed = () => {
         bufferSize={bufferSize}
         itemSize={itemSize}
         containerSizeRef={containerSizeRef}
+        scrollViewRef={mergedRef}
       >
         {index => {
           return (

--- a/packages/react-components/react-virtualizer/stories/src/Virtualizer/Reversed.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/Virtualizer/Reversed.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useStaticVirtualizerMeasure, Virtualizer } from '@fluentui/react-components/unstable';
-import { makeStyles, useMergedRefs } from '@fluentui/react-components';
+import { makeStyles } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   container: {
@@ -27,10 +27,8 @@ export const Reversed = () => {
     defaultItemSize: itemSize,
   });
 
-  const mergedRef = useMergedRefs(scrollRef);
-
   return (
-    <div aria-label="Reversed Virtualizer Example" className={styles.container} role={'list'} ref={mergedRef}>
+    <div aria-label="Reversed Virtualizer Example" className={styles.container} role={'list'} ref={scrollRef}>
       <Virtualizer
         numItems={childLength}
         reversed
@@ -39,7 +37,6 @@ export const Reversed = () => {
         bufferSize={bufferSize}
         itemSize={itemSize}
         containerSizeRef={containerSizeRef}
-        scrollViewRef={mergedRef}
       >
         {index => {
           return (

--- a/packages/react-components/react-virtualizer/stories/src/Virtualizer/Reversed.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/Virtualizer/Reversed.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useStaticVirtualizerMeasure, Virtualizer } from '@fluentui/react-components/unstable';
+import { useStaticVirtualizerMeasure, Virtualizer } from '@fluentui/react-virtualizer';
 import { makeStyles } from '@fluentui/react-components';
 
 const useStyles = makeStyles({

--- a/packages/react-components/react-virtualizer/stories/src/Virtualizer/ReversedHorizontal.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/Virtualizer/ReversedHorizontal.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useStaticVirtualizerMeasure, Virtualizer } from '@fluentui/react-components/unstable';
-import { makeStyles } from '@fluentui/react-components';
+import { makeStyles, useMergedRefs } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   container: {
@@ -29,8 +29,10 @@ export const ReversedHorizontal = () => {
     direction: 'horizontal',
   });
 
+  const mergedRef = useMergedRefs(scrollRef);
+
   return (
-    <div className={styles.container} role={'list'} ref={scrollRef}>
+    <div className={styles.container} role={'list'} ref={mergedRef}>
       <Virtualizer
         numItems={childLength}
         reversed
@@ -40,6 +42,7 @@ export const ReversedHorizontal = () => {
         bufferSize={bufferSize}
         itemSize={itemWidth}
         containerSizeRef={containerSizeRef}
+        scrollViewRef={mergedRef}
       >
         {index => {
           return (

--- a/packages/react-components/react-virtualizer/stories/src/Virtualizer/ReversedHorizontal.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/Virtualizer/ReversedHorizontal.stories.tsx
@@ -24,7 +24,7 @@ export const ReversedHorizontal = () => {
 
   const itemWidth = 100;
 
-  const { virtualizerLength, bufferItems, bufferSize, scrollRef } = useStaticVirtualizerMeasure({
+  const { virtualizerLength, bufferItems, bufferSize, scrollRef, containerSizeRef } = useStaticVirtualizerMeasure({
     defaultItemSize: itemWidth,
     direction: 'horizontal',
   });
@@ -39,6 +39,7 @@ export const ReversedHorizontal = () => {
         bufferItems={bufferItems}
         bufferSize={bufferSize}
         itemSize={itemWidth}
+        containerSizeRef={containerSizeRef}
       >
         {index => {
           return (

--- a/packages/react-components/react-virtualizer/stories/src/Virtualizer/ReversedHorizontal.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/Virtualizer/ReversedHorizontal.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useStaticVirtualizerMeasure, Virtualizer } from '@fluentui/react-components/unstable';
-import { makeStyles, useMergedRefs } from '@fluentui/react-components';
+import { makeStyles } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   container: {
@@ -29,10 +29,8 @@ export const ReversedHorizontal = () => {
     direction: 'horizontal',
   });
 
-  const mergedRef = useMergedRefs(scrollRef);
-
   return (
-    <div className={styles.container} role={'list'} ref={mergedRef}>
+    <div className={styles.container} role={'list'} ref={scrollRef}>
       <Virtualizer
         numItems={childLength}
         reversed
@@ -42,7 +40,6 @@ export const ReversedHorizontal = () => {
         bufferSize={bufferSize}
         itemSize={itemWidth}
         containerSizeRef={containerSizeRef}
-        scrollViewRef={mergedRef}
       >
         {index => {
           return (

--- a/packages/react-components/react-virtualizer/stories/src/Virtualizer/ReversedHorizontal.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/Virtualizer/ReversedHorizontal.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useStaticVirtualizerMeasure, Virtualizer } from '@fluentui/react-components/unstable';
+import { useStaticVirtualizerMeasure, Virtualizer } from '@fluentui/react-virtualizer';
 import { makeStyles } from '@fluentui/react-components';
 
 const useStyles = makeStyles({

--- a/packages/react-components/react-virtualizer/stories/src/Virtualizer/VirtualizerDescription.md
+++ b/packages/react-components/react-virtualizer/stories/src/Virtualizer/VirtualizerDescription.md
@@ -4,7 +4,7 @@
 >
 > ```jsx
 >
-> import { Virtualizer } from '@fluentui/react-components/unstable';
+> import { Virtualizer } from '@fluentui/react-virtualizer';
 >
 > ```
 >

--- a/packages/react-components/react-virtualizer/stories/src/Virtualizer/index.stories.ts
+++ b/packages/react-components/react-virtualizer/stories/src/Virtualizer/index.stories.ts
@@ -1,4 +1,4 @@
-import { Virtualizer } from '@fluentui/react-components/unstable';
+import { Virtualizer } from '@fluentui/react-virtualizer';
 import descriptionMd from './VirtualizerDescription.md';
 
 export { Default } from './Default.stories';

--- a/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollView/Default.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollView/Default.stories.tsx
@@ -18,7 +18,7 @@ export const Default = () => {
     <VirtualizerScrollView
       numItems={childLength}
       itemSize={100}
-      container={{ role: 'list', style: { maxHeight: '100vh' } }}
+      container={{ role: 'list', style: { maxHeight: '80vh' } }}
     >
       {(index: number) => {
         return (

--- a/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollView/Default.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollView/Default.stories.tsx
@@ -12,7 +12,7 @@ const useStyles = makeStyles({
 
 export const Default = () => {
   const styles = useStyles();
-  const childLength = 100;
+  const childLength = 10000;
 
   return (
     <VirtualizerScrollView

--- a/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollView/Default.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollView/Default.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { VirtualizerScrollView } from '@fluentui/react-components/unstable';
+import { VirtualizerScrollView } from '@fluentui/react-virtualizer';
 import { makeStyles } from '@fluentui/react-components';
 
 const useStyles = makeStyles({

--- a/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollView/ScrollTo.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollView/ScrollTo.stories.tsx
@@ -42,7 +42,7 @@ export const ScrollTo = () => {
       <VirtualizerScrollView
         numItems={childLength}
         itemSize={100}
-        container={{ role: 'list', style: { maxHeight: '100vh' } }}
+        container={{ role: 'list', style: { maxHeight: '80vh' } }}
         imperativeRef={scrollRef}
       >
         {(index: number) => {

--- a/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollView/ScrollTo.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollView/ScrollTo.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { VirtualizerScrollView } from '@fluentui/react-components/unstable';
-import type { ScrollToInterface } from '@fluentui/react-components/unstable';
+import { VirtualizerScrollView } from '@fluentui/react-virtualizer';
+import type { ScrollToInterface } from '@fluentui/react-virtualizer';
 import { Text, Input, makeStyles } from '@fluentui/react-components';
 import { Button } from '@fluentui/react-components';
 

--- a/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollView/SnapToAlignment.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollView/SnapToAlignment.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { VirtualizerScrollView } from '@fluentui/react-components/unstable';
+import { VirtualizerScrollView } from '@fluentui/react-virtualizer';
 import { makeStyles } from '@fluentui/react-components';
 
 const useStyles = makeStyles({

--- a/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollView/VirtualizerScrollViewDescription.md
+++ b/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollView/VirtualizerScrollViewDescription.md
@@ -4,7 +4,7 @@
 >
 > ```jsx
 >
-> import { VirtualizerScrollView } from '@fluentui/react-components/unstable';
+> import { VirtualizerScrollView } from '@fluentui/react-virtualizer';
 >
 > ```
 >

--- a/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollView/index.stories.ts
+++ b/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollView/index.stories.ts
@@ -1,4 +1,4 @@
-import { VirtualizerScrollView } from '@fluentui/react-components/unstable';
+import { VirtualizerScrollView } from '@fluentui/react-virtualizer';
 import descriptionMd from './VirtualizerScrollViewDescription.md';
 
 export { Default } from './Default.stories';

--- a/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollViewDynamic/AutoMeasure.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollViewDynamic/AutoMeasure.stories.tsx
@@ -29,11 +29,11 @@ export const AutoMeasure = () => {
   return (
     <VirtualizerScrollViewDynamic
       numItems={childLength}
-      // We can use itemSize to set average height
-      itemSize={(minHeight + maxHeightIncrease) / 2.0}
+      // We can use itemSize to set average height and reduce unknown whitespace
+      itemSize={minHeight + maxHeightIncrease / 2.0}
       container={{ role: 'list', style: { maxHeight: '80vh' } }}
       bufferItems={1}
-      bufferSize={25}
+      bufferSize={minHeight / 2.0}
     >
       {(index: number) => {
         const backgroundColor = index % 2 ? '#FFFFFF' : '#ABABAB';

--- a/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollViewDynamic/AutoMeasure.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollViewDynamic/AutoMeasure.stories.tsx
@@ -13,7 +13,7 @@ const useStyles = makeStyles({
 
 export const AutoMeasure = () => {
   const styles = useStyles();
-  const childLength = 1000;
+  const childLength = 100;
   const minHeight = 50;
   const maxHeightIncrease = 500;
   // Array size ref stores a list of random num for div sizing and callbacks

--- a/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollViewDynamic/AutoMeasure.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollViewDynamic/AutoMeasure.stories.tsx
@@ -5,9 +5,9 @@ import { useEffect } from 'react';
 
 const useStyles = makeStyles({
   child: {
-    lineHeight: '42px',
+    lineHeight: '25px',
     width: '100%',
-    minHeight: '42px',
+    minHeight: '25px',
   },
 });
 

--- a/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollViewDynamic/AutoMeasure.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollViewDynamic/AutoMeasure.stories.tsx
@@ -32,6 +32,8 @@ export const AutoMeasure = () => {
       // We can use itemSize to set average height
       itemSize={(minHeight + maxHeightIncrease) / 2.0}
       container={{ role: 'list', style: { maxHeight: '80vh' } }}
+      bufferItems={1}
+      bufferSize={25}
     >
       {(index: number) => {
         const backgroundColor = index % 2 ? '#FFFFFF' : '#ABABAB';

--- a/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollViewDynamic/AutoMeasure.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollViewDynamic/AutoMeasure.stories.tsx
@@ -14,8 +14,8 @@ const useStyles = makeStyles({
 export const AutoMeasure = () => {
   const styles = useStyles();
   const childLength = 1000;
-  const minHeight = 300;
-  const maxHeightIncrease = 200;
+  const minHeight = 50;
+  const maxHeightIncrease = 500;
   // Array size ref stores a list of random num for div sizing and callbacks
   const arraySize = React.useRef(new Array<number>(childLength).fill(minHeight));
 
@@ -29,8 +29,8 @@ export const AutoMeasure = () => {
   return (
     <VirtualizerScrollViewDynamic
       numItems={childLength}
-      // We can use itemSize to set an average height for minimal size change impact
-      itemSize={minHeight}
+      // We can use itemSize to set average height
+      itemSize={(minHeight + maxHeightIncrease) / 2.0}
       container={{ role: 'list', style: { maxHeight: '80vh' } }}
     >
       {(index: number) => {

--- a/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollViewDynamic/AutoMeasure.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollViewDynamic/AutoMeasure.stories.tsx
@@ -14,8 +14,8 @@ const useStyles = makeStyles({
 export const AutoMeasure = () => {
   const styles = useStyles();
   const childLength = 1000;
-  const minHeight = 42;
-  const maxHeightIncrease = 150;
+  const minHeight = 300;
+  const maxHeightIncrease = 200;
   // Array size ref stores a list of random num for div sizing and callbacks
   const arraySize = React.useRef(new Array<number>(childLength).fill(minHeight));
 
@@ -30,8 +30,8 @@ export const AutoMeasure = () => {
     <VirtualizerScrollViewDynamic
       numItems={childLength}
       // We can use itemSize to set an average height for minimal size change impact
-      itemSize={minHeight + maxHeightIncrease / 2}
-      container={{ role: 'list', style: { maxHeight: '100vh' } }}
+      itemSize={minHeight}
+      container={{ role: 'list', style: { maxHeight: '80vh' } }}
     >
       {(index: number) => {
         const backgroundColor = index % 2 ? '#FFFFFF' : '#ABABAB';

--- a/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollViewDynamic/AutoMeasure.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollViewDynamic/AutoMeasure.stories.tsx
@@ -14,15 +14,22 @@ const useStyles = makeStyles({
 export const AutoMeasure = () => {
   const styles = useStyles();
   const childLength = 100;
-  const minHeight = 50;
-  const maxHeightIncrease = 500;
+  const minHeight = 25;
+  const maxHeightIncrease = 55;
   // Array size ref stores a list of random num for div sizing and callbacks
   const arraySize = React.useRef(new Array<number>(childLength).fill(minHeight));
 
   useEffect(() => {
     // Set random heights on init (to be measured)
     for (let i = 0; i < childLength; i++) {
-      arraySize.current[i] = Math.floor(Math.random() * maxHeightIncrease + minHeight);
+      // if (i % 10 == 0) {
+      if (i < 10) {
+        arraySize.current[i] = 1000;
+      } else {
+        arraySize.current[i] = Math.floor(Math.random() * maxHeightIncrease + minHeight);
+      }
+
+      // arraySize.current[i] = Math.floor(Math.random() * maxHeightIncrease + minHeight);
     }
   }, []);
 
@@ -30,7 +37,7 @@ export const AutoMeasure = () => {
     <VirtualizerScrollViewDynamic
       numItems={childLength}
       // We can use itemSize to set average height and reduce unknown whitespace
-      itemSize={minHeight + maxHeightIncrease / 2.0}
+      itemSize={minHeight + maxHeightIncrease / 2.0 + 100}
       container={{ role: 'list', style: { maxHeight: '80vh' } }}
       bufferItems={1}
       bufferSize={minHeight / 2.0}

--- a/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollViewDynamic/AutoMeasure.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollViewDynamic/AutoMeasure.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { VirtualizerScrollViewDynamic } from '@fluentui/react-components/unstable';
+import { VirtualizerScrollViewDynamic } from '@fluentui/react-virtualizer';
 import { makeStyles } from '@fluentui/react-components';
 import { useEffect } from 'react';
 

--- a/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollViewDynamic/Default.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollViewDynamic/Default.stories.tsx
@@ -13,7 +13,7 @@ const useStyles = makeStyles({
 
 export const Default = () => {
   const styles = useStyles();
-  const childLength = 1000;
+  const childLength = 10000;
   const minHeight = 42;
   const maxHeightMod = 150;
   // Array size ref stores a list of random num for div sizing and callbacks

--- a/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollViewDynamic/Default.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollViewDynamic/Default.stories.tsx
@@ -42,7 +42,7 @@ export const Default = () => {
       numItems={childLength}
       itemSize={minHeight}
       getItemSize={getItemSizeCallback}
-      container={{ role: 'list', style: { maxHeight: '100vh' } }}
+      container={{ role: 'list', style: { maxHeight: '80vh' } }}
     >
       {(index: number) => {
         const backgroundColor = index % 2 ? '#FFFFFF' : '#ABABAB';

--- a/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollViewDynamic/Default.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollViewDynamic/Default.stories.tsx
@@ -44,6 +44,8 @@ export const Default = () => {
       itemSize={minHeight + maxHeightMod / 2.0}
       getItemSize={getItemSizeCallback}
       container={{ role: 'list', style: { maxHeight: '80vh' } }}
+      bufferItems={1}
+      bufferSize={minHeight / 2.0}
     >
       {(index: number) => {
         const backgroundColor = index % 2 ? '#FFFFFF' : '#ABABAB';

--- a/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollViewDynamic/Default.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollViewDynamic/Default.stories.tsx
@@ -15,6 +15,7 @@ export const Default = () => {
   const styles = useStyles();
   const childLength = 1000;
   const minHeight = 42;
+  const maxHeightMod = 150;
   // Array size ref stores a list of random num for div sizing and callbacks
   const arraySize = React.useRef(new Array<number>(childLength).fill(minHeight));
   // totalSize flag drives our callback update
@@ -23,7 +24,7 @@ export const Default = () => {
   useEffect(() => {
     let _totalSize = 0;
     for (let i = 0; i < childLength; i++) {
-      arraySize.current[i] = Math.floor(Math.random() * 150 + minHeight);
+      arraySize.current[i] = Math.floor(Math.random() * maxHeightMod + minHeight);
       _totalSize += arraySize.current[i];
     }
     setTotalSize(_totalSize);
@@ -40,7 +41,7 @@ export const Default = () => {
   return (
     <VirtualizerScrollViewDynamic
       numItems={childLength}
-      itemSize={minHeight}
+      itemSize={minHeight + maxHeightMod / 2.0}
       getItemSize={getItemSizeCallback}
       container={{ role: 'list', style: { maxHeight: '80vh' } }}
     >

--- a/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollViewDynamic/Default.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollViewDynamic/Default.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { VirtualizerScrollViewDynamic } from '@fluentui/react-components/unstable';
+import { VirtualizerScrollViewDynamic } from '@fluentui/react-virtualizer';
 import { makeStyles } from '@fluentui/react-components';
 import { useEffect } from 'react';
 

--- a/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollViewDynamic/ScrollLoading.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollViewDynamic/ScrollLoading.stories.tsx
@@ -42,7 +42,7 @@ export const ScrollLoading = () => {
       numItems={childLength}
       itemSize={minHeight}
       getItemSize={getItemSizeCallback}
-      container={{ role: 'list', style: { maxHeight: '100vh' } }}
+      container={{ role: 'list', style: { maxHeight: '80vh' } }}
     >
       {(index: number, isScrolling = false) => {
         const backgroundColor = index % 2 ? '#FFFFFF' : '#ABABAB';

--- a/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollViewDynamic/ScrollLoading.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollViewDynamic/ScrollLoading.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { VirtualizerScrollViewDynamic } from '@fluentui/react-components/unstable';
+import { VirtualizerScrollViewDynamic } from '@fluentui/react-virtualizer';
 import { makeStyles } from '@fluentui/react-components';
 import { useEffect } from 'react';
 
@@ -43,6 +43,7 @@ export const ScrollLoading = () => {
       itemSize={minHeight}
       getItemSize={getItemSizeCallback}
       container={{ role: 'list', style: { maxHeight: '80vh' } }}
+      enableScrollLoad={true}
     >
       {(index: number, isScrolling = false) => {
         const backgroundColor = index % 2 ? '#FFFFFF' : '#ABABAB';

--- a/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollViewDynamic/ScrollTo.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollViewDynamic/ScrollTo.stories.tsx
@@ -70,7 +70,7 @@ export const ScrollTo = () => {
         getItemSize={getItemSizeCallback}
         imperativeRef={scrollRef}
         imperativeVirtualizerRef={sizeRef}
-        container={{ role: 'list', style: { maxHeight: '100vh' } }}
+        container={{ role: 'list', style: { maxHeight: '80vh' } }}
       >
         {(index: number) => {
           const backgroundColor = index % 2 ? '#FFFFFF' : '#ABABAB';

--- a/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollViewDynamic/ScrollTo.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollViewDynamic/ScrollTo.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { VirtualizerScrollViewDynamic } from '@fluentui/react-components/unstable';
-import type { ScrollToInterface } from '@fluentui/react-components/unstable';
+import { VirtualizerScrollViewDynamic } from '@fluentui/react-virtualizer';
+import type { ScrollToInterface } from '@fluentui/react-virtualizer';
 import type { VirtualizerDataRef } from '@fluentui/react-virtualizer';
 import { Button, Input, makeStyles, Text } from '@fluentui/react-components';
 import { useEffect } from 'react';

--- a/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollViewDynamic/SnapToAlignment.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollViewDynamic/SnapToAlignment.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { VirtualizerScrollViewDynamic } from '@fluentui/react-components/unstable';
+import { VirtualizerScrollViewDynamic } from '@fluentui/react-virtualizer';
 import { makeStyles } from '@fluentui/react-components';
 import { useEffect } from 'react';
 

--- a/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollViewDynamic/VirtualizerScrollViewDynamicDescription.md
+++ b/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollViewDynamic/VirtualizerScrollViewDynamicDescription.md
@@ -4,7 +4,7 @@
 >
 > ```jsx
 >
-> import { VirtualizerScrollViewDynamic } from '@fluentui/react-components/unstable';
+> import { VirtualizerScrollViewDynamic } from '@fluentui/react-virtualizer';
 >
 > ```
 >

--- a/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollViewDynamic/index.stories.ts
+++ b/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollViewDynamic/index.stories.ts
@@ -1,4 +1,4 @@
-import { VirtualizerScrollViewDynamic } from '@fluentui/react-components/unstable';
+import { VirtualizerScrollViewDynamic } from '@fluentui/react-virtualizer';
 import descriptionMd from './VirtualizerScrollViewDynamicDescription.md';
 
 export { AutoMeasure } from './AutoMeasure.stories';


### PR DESCRIPTION
Breaking change: Additional info was required to be shared between hooks, this added new properties to our hook inputs which are required for accurate calculation of IO depth (Virtualizer is still in old preview format)

## Previous Behavior
useMeasureList was not exported
IO would iterate based on it's current position

## New Behavior
useMeasureList is now exported
IO now iterates based on how far into the IO the user scrolls, cutting down re-renders significantly