### PR TITLE
fix: v8 ColorPicker initializes focus outlines

### DIFF
--- a/change/@fluentui-react-cf56ad85-cf3b-42ac-9943-864995577608.json
+++ b/change/@fluentui-react-cf56ad85-cf3b-42ac-9943-864995577608.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: ColorPicker initializes focus outlines",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/ColorPicker/ColorPicker.base.tsx
+++ b/packages/react/src/components/ColorPicker/ColorPicker.base.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { classNamesFunction, initializeComponentRef, warnDeprecations, warn } from '../../Utilities';
+import { classNamesFunction, FocusRects, initializeComponentRef, warnDeprecations, warn } from '../../Utilities';
 import { TextField } from '../../TextField';
 import { TooltipHost } from '../../Tooltip';
 import { DirectionalHint } from '../../common/DirectionalHint';
@@ -291,6 +291,7 @@ export class ColorPickerBase extends React.Component<IColorPickerProps, IColorPi
             </tbody>
           </table>
         </div>
+        <FocusRects />
       </div>
     );
   }


### PR DESCRIPTION
## Previous Behavior

Since ColorPicker never used FocusRects within its own code, it will not show focus outlines unless another v8 Fluent component also exists on the page.

## New Behavior

Includes `<FocusRects>`

## Related Issue(s)

Fixes a partner bug where ColorPicker was the only remaining v8 control in the UI, and did not show focus outlines.
