### PR TITLE
fix(public-docsite-v9): subcomponents props are not visible on docsite

### DIFF
--- a/apps/public-docsite-v9/src/DocsComponents/FluentDocsPage.stories.tsx
+++ b/apps/public-docsite-v9/src/DocsComponents/FluentDocsPage.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {
   DocsContext,
-  ArgTypes,
+  ArgsTable,
   Title,
   Subtitle,
   Description,
@@ -171,7 +171,7 @@ export const FluentDocsPage = () => {
             {primaryStory.name}
           </HeaderMdx>
           <Primary />
-          <ArgTypes of={primaryStory.component} />
+          <ArgsTable of={primaryStory.component} />
           {primaryStory.argTypes.as && primaryStory.argTypes.as?.type?.name === 'enum' && (
             <div className={styles.nativeProps}>
               <InfoFilled className={styles.nativePropsIcon} />


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

During the migration to https://github.com/microsoft/fluentui/pull/32018, as per [migration guide](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#argstable-block), we [replaced <ArgTable /> with <ArgTypes />](https://github.com/microsoft/fluentui/pull/32018/files#diff-661afe41552bed0a3643e167ff32d3e5f9d1a392edf7fde2dc33296a1449967bR4). However, this has led to an issue where <ArgTypes /> does not support subcomponents, preventing their prop documentation from being displayed on the documentation site.

## New Behavior

The properties of subcomponents are accessible on the documentation site:

![image](https://github.com/user-attachments/assets/3a42c577-8cbe-4536-98d4-e8cacf08f9a9)

The proposed solution is to switch back to the ArgsTable as it's still available in Storybook v7, and switch to ArgTypes after migration to Storybook v8, [where subcomponents support are in place.](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#argstable-doc-block-removed) 

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #32381 
