### PR TITLE
Carousel: Drag scroll

### DIFF
--- a/change/@fluentui-react-carousel-preview-fd37cbb3-3f11-4223-90f6-6ad05568e151.json
+++ b/change/@fluentui-react-carousel-preview-fd37cbb3-3f11-4223-90f6-6ad05568e151.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: Add enableDrag option for mouse/touch scroll support",
+  "packageName": "@fluentui/react-carousel-preview",
+  "email": "mifraser@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-carousel-preview/library/etc/react-carousel-preview.api.md
+++ b/packages/react-components/react-carousel-preview/library/etc/react-carousel-preview.api.md
@@ -173,6 +173,7 @@ export type CarouselProps = ComponentProps<CarouselSlots> & {
     onActiveIndexChange?: EventHandler<CarouselIndexChangeData>;
     circular?: boolean;
     groupSize?: number | 'auto';
+    enableDrag?: boolean;
 };
 
 // @public

--- a/packages/react-components/react-carousel-preview/library/src/components/Carousel/Carousel.types.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/Carousel/Carousel.types.ts
@@ -43,7 +43,7 @@ export type CarouselProps = ComponentProps<CarouselSlots> & {
    * Enables mouse/touch drag on carousel items.
    * Defaults to: False
    */
-  watchDrag?: boolean;
+  enableDrag?: boolean;
 };
 
 /**

--- a/packages/react-components/react-carousel-preview/library/src/components/Carousel/Carousel.types.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/Carousel/Carousel.types.ts
@@ -38,6 +38,12 @@ export type CarouselProps = ComponentProps<CarouselSlots> & {
    * Recommended to set to '1' when using full page carousel cards.
    */
   groupSize?: number | 'auto';
+
+  /**
+   * Enables mouse/touch drag on carousel items.
+   * Defaults to: False
+   */
+  watchDrag?: boolean;
 };
 
 /**

--- a/packages/react-components/react-carousel-preview/library/src/components/Carousel/useCarousel.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/Carousel/useCarousel.ts
@@ -18,7 +18,7 @@ import { useEmblaCarousel } from '../useEmblaCarousel';
 export function useCarousel_unstable(props: CarouselProps, ref: React.Ref<HTMLDivElement>): CarouselState {
   'use no memo';
 
-  const { align = 'center', circular = false, onActiveIndexChange, groupSize = 'auto' } = props;
+  const { align = 'center', circular = false, onActiveIndexChange, groupSize = 'auto', enableDrag = false } = props;
 
   const { dir } = useFluent();
   const { activeIndex, carouselApi, containerRef, subscribeForValues, enableAutoplay } = useEmblaCarousel({
@@ -28,6 +28,7 @@ export function useCarousel_unstable(props: CarouselProps, ref: React.Ref<HTMLDi
     slidesToScroll: groupSize,
     defaultActiveIndex: props.defaultActiveIndex,
     activeIndex: props.activeIndex,
+    watchDrag: enableDrag,
   });
 
   const selectPageByElement: CarouselContextValue['selectPageByElement'] = useEventCallback((event, element, jump) => {

--- a/packages/react-components/react-carousel-preview/library/src/components/Carousel/useCarouselStyles.styles.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/Carousel/useCarouselStyles.styles.ts
@@ -12,6 +12,7 @@ export const carouselClassNames: SlotClassNames<CarouselSlots> = {
 const useStyles = makeStyles({
   root: {
     overflow: 'hidden',
+    overflowAnchor: 'none',
   },
 });
 

--- a/packages/react-components/react-carousel-preview/library/src/components/CarouselCard/useCarouselCard.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/CarouselCard/useCarouselCard.ts
@@ -74,8 +74,7 @@ export const useCarouselCard_unstable = (
 
   const handleFocusCapture = React.useCallback(
     (e: React.FocusEvent) => {
-      console.log('Event:', e);
-      if (isHTMLElement(e.currentTarget) && !isMouseEvent.current) {
+      if (!e.defaultPrevented && isHTMLElement(e.currentTarget) && !isMouseEvent.current) {
         selectPageByElement(e, e.currentTarget, true);
       }
     },

--- a/packages/react-components/react-carousel-preview/library/src/components/CarouselCard/useCarouselCard.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/CarouselCard/useCarouselCard.ts
@@ -38,6 +38,7 @@ export const useCarouselCard_unstable = (
 ): CarouselCardState => {
   const { focusMode = 'off' } = props;
   const elementRef = React.useRef<HTMLDivElement>(null);
+  const isMouseEvent = React.useRef<boolean>(false);
   const selectPageByElement = useCarouselContext(ctx => ctx.selectPageByElement);
 
   const focusAttr = useFocusableGroup({
@@ -73,15 +74,28 @@ export const useCarouselCard_unstable = (
 
   const handleFocusCapture = React.useCallback(
     (e: React.FocusEvent) => {
-      if (isHTMLElement(e.currentTarget)) {
+      console.log('Event:', e);
+      if (isHTMLElement(e.currentTarget) && !isMouseEvent.current) {
         selectPageByElement(e, e.currentTarget, true);
       }
     },
     [selectPageByElement],
   );
 
-  const onFocusCapture = mergeCallbacks(props.onFocusCapture, handleFocusCapture);
+  const handleMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (!e.defaultPrevented) {
+      isMouseEvent.current = true;
+    }
+  };
+  const handleMouseUp = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (!e.defaultPrevented) {
+      isMouseEvent.current = false;
+    }
+  };
 
+  const onFocusCapture = mergeCallbacks(props.onFocusCapture, handleFocusCapture);
+  const onMouseUp = mergeCallbacks(props.onMouseUp, handleMouseUp);
+  const onMouseDown = mergeCallbacks(props.onMouseDown, handleMouseDown);
   const state: CarouselCardState = {
     components: {
       root: 'div',
@@ -93,6 +107,8 @@ export const useCarouselCard_unstable = (
         ...props,
         id,
         onFocusCapture,
+        onMouseDown,
+        onMouseUp,
         ...focusAttrProps,
       }),
       { elementType: 'div' },

--- a/packages/react-components/react-carousel-preview/library/src/components/CarouselSlider/useCarouselSliderStyles.styles.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/CarouselSlider/useCarouselSliderStyles.styles.ts
@@ -13,6 +13,7 @@ export const carouselSliderClassNames: SlotClassNames<CarouselSliderSlots> = {
 const useStyles = makeStyles({
   root: {
     display: 'flex',
+    overflowAnchor: 'none',
   },
 });
 

--- a/packages/react-components/react-carousel-preview/library/src/components/useEmblaCarousel.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/useEmblaCarousel.ts
@@ -19,12 +19,12 @@ const DEFAULT_EMBLA_OPTIONS: EmblaOptionsType = {
 export const EMBLA_VISIBILITY_EVENT = 'embla:visibilitychange';
 
 export function useEmblaCarousel(
-  options: Pick<EmblaOptionsType, 'align' | 'direction' | 'loop' | 'slidesToScroll'> & {
+  options: Pick<EmblaOptionsType, 'align' | 'direction' | 'loop' | 'slidesToScroll' | 'watchDrag'> & {
     defaultActiveIndex: number | undefined;
     activeIndex: number | undefined;
   },
 ) {
-  const { align, direction, loop, slidesToScroll } = options;
+  const { align, direction, loop, slidesToScroll, watchDrag } = options;
   const [activeIndex, setActiveIndex] = useControllableState({
     defaultState: options.defaultActiveIndex,
     state: options.activeIndex,
@@ -37,6 +37,7 @@ export function useEmblaCarousel(
     loop,
     slidesToScroll,
     startIndex: activeIndex,
+    watchDrag,
   });
 
   const emblaApi = React.useRef<EmblaCarouselType | null>(null);
@@ -113,8 +114,8 @@ export function useEmblaCarousel(
           emblaApi.current = EmblaCarousel(
             newElement,
             {
-              ...emblaOptions.current,
               ...DEFAULT_EMBLA_OPTIONS,
+              ...emblaOptions.current,
             },
             [
               Autoplay({
@@ -173,11 +174,11 @@ export function useEmblaCarousel(
   }, [activeIndex]);
 
   React.useEffect(() => {
-    emblaOptions.current = { align, direction, loop, slidesToScroll };
+    emblaOptions.current = { align, direction, loop, slidesToScroll, watchDrag };
     emblaApi.current?.reInit(
       {
-        ...emblaOptions.current,
         ...DEFAULT_EMBLA_OPTIONS,
+        ...emblaOptions.current,
       },
       [
         Autoplay({
@@ -188,7 +189,7 @@ export function useEmblaCarousel(
         }),
       ],
     );
-  }, [align, direction, loop, slidesToScroll]);
+  }, [align, direction, loop, slidesToScroll, watchDrag]);
 
   return {
     activeIndex,

--- a/packages/react-components/react-carousel-preview/library/src/components/useEmblaCarousel.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/useEmblaCarousel.ts
@@ -11,7 +11,7 @@ const DEFAULT_EMBLA_OPTIONS: EmblaOptionsType = {
   containScroll: false,
   inViewThreshold: 0.99,
   watchDrag: false,
-
+  skipSnaps: true,
   container: `.${carouselSliderClassNames.root}`,
   slides: `.${carouselCardClassNames.root}`,
 };


### PR DESCRIPTION
## Previous Behavior
Drag behavior disabled
Clicking an out of view item will jump index

## New Behavior
Enables drag scroll behavior on carousel, will disable mouse click focus on non-visible items so that the view does not jump when grabbed from edges.
Focusing an out of view item (either by keyboard or accessibility tooling) will still enable index jump.