### PR TITLE
feat(workspace-plugin): implement inferred plugins for clean,format,type-check targets

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -76,23 +76,7 @@
         "command": "eslint src"
       }
     },
-    "format": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "prettier --write {projectRoot}"
-      },
-      "metadata": {
-        "help": {
-          "command": "yarn prettier --help",
-          "options": {}
-        }
-      },
-      "configurations": {
-        "check": {
-          "command": "prettier --check {projectRoot}"
-        }
-      }
-    },
+    "format": {},
     "verify-packaging": {
       "dependsOn": ["build"],
       "cache": true
@@ -147,6 +131,27 @@
       "plugin": "@nx/eslint/plugin",
       "options": {
         "targetName": "lint"
+      },
+      "include": ["tools/**/*", "scripts/**/*"]
+    },
+    {
+      "plugin": "./tools/workspace-plugin/src/plugins/format-plugin.ts",
+      "options": {
+        "targetName": "format"
+      },
+      "include": ["tools/**/*", "scripts/**/*"]
+    },
+    {
+      "plugin": "./tools/workspace-plugin/src/plugins/type-check-plugin.ts",
+      "options": {
+        "targetName": "type-check"
+      },
+      "include": ["tools/**/*", "scripts/**/*"]
+    },
+    {
+      "plugin": "./tools/workspace-plugin/src/plugins/clean-plugin.ts",
+      "options": {
+        "targetName": "clean"
       },
       "include": ["tools/**/*", "scripts/**/*"]
     }

--- a/nx.json
+++ b/nx.json
@@ -76,7 +76,23 @@
         "command": "eslint src"
       }
     },
-    "format": {},
+    "format": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "prettier --write {projectRoot}"
+      },
+      "metadata": {
+        "help": {
+          "command": "yarn prettier --help",
+          "options": {}
+        }
+      },
+      "configurations": {
+        "check": {
+          "command": "prettier --check {projectRoot}"
+        }
+      }
+    },
     "verify-packaging": {
       "dependsOn": ["build"],
       "cache": true
@@ -131,27 +147,6 @@
       "plugin": "@nx/eslint/plugin",
       "options": {
         "targetName": "lint"
-      },
-      "include": ["tools/**/*", "scripts/**/*"]
-    },
-    {
-      "plugin": "./tools/workspace-plugin/src/plugins/format-plugin.ts",
-      "options": {
-        "targetName": "format"
-      },
-      "include": ["tools/**/*", "scripts/**/*"]
-    },
-    {
-      "plugin": "./tools/workspace-plugin/src/plugins/type-check-plugin.ts",
-      "options": {
-        "targetName": "type-check"
-      },
-      "include": ["tools/**/*", "scripts/**/*"]
-    },
-    {
-      "plugin": "./tools/workspace-plugin/src/plugins/clean-plugin.ts",
-      "options": {
-        "targetName": "clean"
       },
       "include": ["tools/**/*", "scripts/**/*"]
     }

--- a/tools/workspace-plugin/src/plugins/clean-plugin.spec.ts
+++ b/tools/workspace-plugin/src/plugins/clean-plugin.spec.ts
@@ -1,0 +1,63 @@
+import { CreateNodesContext } from '@nx/devkit';
+
+import { TempFs } from './testing-utils/index';
+import { createNodesV2 } from './clean-plugin';
+
+describe(`clean-plugin`, () => {
+  const [, createNodesFunction] = createNodesV2;
+  let context: CreateNodesContext;
+  let tempFs: TempFs;
+  let cwd: string;
+
+  beforeEach(async () => {
+    tempFs = new TempFs('test');
+    cwd = process.cwd();
+    process.chdir(tempFs.tempDir);
+
+    context = {
+      nxJsonConfiguration: {
+        namedInputs: {
+          default: ['{projectRoot}/**/*'],
+          production: ['!{projectRoot}/**/*.spec.ts'],
+        },
+      },
+      workspaceRoot: tempFs.tempDir,
+
+      configFiles: [],
+    };
+
+    await tempFs.createFiles({
+      'proj/project.json': '{}',
+      'proj/package.json': '{}',
+    });
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+    tempFs.cleanup();
+    process.chdir(cwd);
+  });
+
+  it('should create nodes', async () => {
+    const results = await createNodesFunction(['proj/project.json'], { targetName: 'clean' }, context);
+
+    expect(results).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          "proj/project.json",
+          Object {
+            "projects": Object {
+              "proj": Object {
+                "targets": Object {
+                  "clean": Object {
+                    "executor": "@fluentui/workspace-plugin:clean",
+                  },
+                },
+              },
+            },
+          },
+        ],
+      ]
+    `);
+  });
+});

--- a/tools/workspace-plugin/src/plugins/clean-plugin.ts
+++ b/tools/workspace-plugin/src/plugins/clean-plugin.ts
@@ -1,0 +1,65 @@
+/* eslint-disable @typescript-eslint/no-shadow */
+import {
+  CreateNodesContextV2,
+  CreateNodesResult,
+  CreateNodesV2,
+  TargetConfiguration,
+  createNodesFromFiles,
+} from '@nx/devkit';
+import { dirname } from 'node:path';
+
+import { assertProjectExists, projectConfigGlob } from './shared';
+
+interface CleanPluginOptions {
+  targetName?: string;
+}
+
+export const createNodesV2: CreateNodesV2<CleanPluginOptions> = [
+  projectConfigGlob,
+  (configFiles, options, context) => {
+    return createNodesFromFiles(
+      (configFile, options, context) => {
+        return createNodesInternal(configFile, options ?? {}, context);
+      },
+      configFiles,
+      options,
+      context,
+    );
+  },
+];
+
+// ===================================================================================================================
+function normalizeOptions(options: CleanPluginOptions | undefined): Required<CleanPluginOptions> {
+  options ??= {};
+  options.targetName ??= 'type-check';
+
+  return options as Required<CleanPluginOptions>;
+}
+
+function createNodesInternal(
+  configFilePath: string,
+  options: CleanPluginOptions,
+  context: CreateNodesContextV2,
+): CreateNodesResult {
+  const projectRoot = dirname(configFilePath);
+
+  if (!assertProjectExists(projectRoot, context)) {
+    return {};
+  }
+
+  const normalizedOptions = normalizeOptions(options);
+
+  const targetConfig: TargetConfiguration = {
+    executor: '@fluentui/workspace-plugin:clean',
+  };
+
+  return {
+    projects: {
+      [projectRoot]: {
+        targets: {
+          [normalizedOptions.targetName]: targetConfig,
+        },
+      },
+    },
+  };
+}

--- a/tools/workspace-plugin/src/plugins/format-plugin.spec.ts
+++ b/tools/workspace-plugin/src/plugins/format-plugin.spec.ts
@@ -1,0 +1,89 @@
+import { CreateNodesContext } from '@nx/devkit';
+
+import { TempFs } from './testing-utils/index';
+import { createNodesV2 } from './format-plugin';
+
+describe(`format-plugin`, () => {
+  const [, createNodesFunction] = createNodesV2;
+  let context: CreateNodesContext;
+  let tempFs: TempFs;
+  let cwd: string;
+
+  beforeEach(async () => {
+    tempFs = new TempFs('test');
+    cwd = process.cwd();
+    process.chdir(tempFs.tempDir);
+
+    context = {
+      nxJsonConfiguration: {
+        namedInputs: {
+          default: ['{projectRoot}/**/*'],
+          production: ['!{projectRoot}/**/*.spec.ts'],
+        },
+      },
+      workspaceRoot: tempFs.tempDir,
+
+      configFiles: [],
+    };
+
+    await tempFs.createFiles({
+      'proj/project.json': '{}',
+      'proj/package.json': '{}',
+    });
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+    tempFs.cleanup();
+    process.chdir(cwd);
+  });
+
+  it('should create nodes', async () => {
+    // await tempFs.createFiles({
+
+    // });
+    const results = await createNodesFunction(['proj/project.json'], { targetName: 'format' }, context);
+
+    expect(results).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          "proj/project.json",
+          Object {
+            "projects": Object {
+              "proj": Object {
+                "targets": Object {
+                  "format": Object {
+                    "cache": true,
+                    "command": "prettier --write {projectRoot}",
+                    "configurations": Object {
+                      "check": Object {
+                        "command": "prettier --check {projectRoot}",
+                      },
+                    },
+                    "inputs": Array [
+                      "default",
+                      "{workspaceRoot}/.prettierignore",
+                      "{workspaceRoot}/prettier.config.js",
+                      "{workspaceRoot}/prettier.config.json",
+                      "{projectRoot}/**",
+                    ],
+                    "metadata": Object {
+                      "description": "Format code with prettier",
+                      "help": Object {
+                        "command": "npx prettier --help",
+                        "example": Object {},
+                      },
+                      "technologies": Array [
+                        "prettier",
+                      ],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        ],
+      ]
+    `);
+  });
+});

--- a/tools/workspace-plugin/src/plugins/format-plugin.ts
+++ b/tools/workspace-plugin/src/plugins/format-plugin.ts
@@ -1,0 +1,89 @@
+/* eslint-disable @typescript-eslint/no-shadow */
+import {
+  type CreateNodesV2,
+  createNodesFromFiles,
+  TargetConfiguration,
+  CreateNodesContextV2,
+  CreateNodesResult,
+  getPackageManagerCommand,
+} from '@nx/devkit';
+import { dirname } from 'node:path';
+
+import { assertProjectExists, projectConfigGlob } from './shared';
+
+interface FormatPluginOptions {
+  targetName?: string;
+}
+
+const pmc = getPackageManagerCommand();
+
+export const createNodesV2: CreateNodesV2<FormatPluginOptions> = [
+  projectConfigGlob,
+  (configFiles, options, context) => {
+    return createNodesFromFiles(
+      (configFile, options, context) => {
+        return createNodesInternal(configFile, options ?? {}, context);
+      },
+      configFiles,
+      options,
+      context,
+    );
+  },
+];
+
+// ===================================================================================================================
+function normalizeOptions(options: FormatPluginOptions | undefined): Required<FormatPluginOptions> {
+  options ??= {};
+  options.targetName ??= 'format';
+
+  return options as Required<FormatPluginOptions>;
+}
+
+function createNodesInternal(
+  configFilePath: string,
+  options: FormatPluginOptions,
+  context: CreateNodesContextV2,
+): CreateNodesResult {
+  const projectRoot = dirname(configFilePath);
+
+  if (!assertProjectExists(projectRoot, context)) {
+    return {};
+  }
+
+  const normalizedOptions = normalizeOptions(options);
+
+  const targetConfig: TargetConfiguration = {
+    command: 'prettier --write {projectRoot}',
+    cache: true,
+    inputs: [
+      'default',
+      '{workspaceRoot}/.prettierignore',
+      '{workspaceRoot}/prettier.config.js',
+      '{workspaceRoot}/prettier.config.json',
+      '{projectRoot}/**',
+    ],
+    metadata: {
+      technologies: ['prettier'],
+      description: 'Format code with prettier',
+      help: {
+        command: `${pmc.exec} prettier --help`,
+        example: {},
+      },
+    },
+    configurations: {
+      check: {
+        command: 'prettier --check {projectRoot}',
+      },
+    },
+  };
+
+  return {
+    projects: {
+      [projectRoot]: {
+        targets: {
+          [normalizedOptions.targetName]: targetConfig,
+        },
+      },
+    },
+  };
+}

--- a/tools/workspace-plugin/src/plugins/shared.ts
+++ b/tools/workspace-plugin/src/plugins/shared.ts
@@ -1,0 +1,14 @@
+import { type CreateNodesContextV2 } from '@nx/devkit';
+import { readdirSync } from 'node:fs';
+import { join } from 'node:path';
+export const projectConfigGlob = '**/project.json';
+
+export function assertProjectExists(projectRoot: string, context: CreateNodesContextV2) {
+  const siblingFiles = readdirSync(join(context.workspaceRoot, projectRoot));
+
+  if (siblingFiles.includes('package.json') && siblingFiles.includes('project.json')) {
+    return true;
+  }
+
+  return false;
+}

--- a/tools/workspace-plugin/src/plugins/testing-utils/index.ts
+++ b/tools/workspace-plugin/src/plugins/testing-utils/index.ts
@@ -1,0 +1,1 @@
+export { TempFs } from './temp-fs';

--- a/tools/workspace-plugin/src/plugins/testing-utils/temp-fs.ts
+++ b/tools/workspace-plugin/src/plugins/testing-utils/temp-fs.ts
@@ -1,0 +1,101 @@
+/* eslint-disable @typescript-eslint/explicit-member-accessibility */
+
+/**
+ COPIED from https://github.com/nrwl/nx/blob/master/packages/nx/src/internal-testing-utils/temp-fs.ts
+ */
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'path';
+import { tmpdir } from 'os';
+import { joinPathFragments, workspaceRoot } from '@nx/devkit';
+import { setWorkspaceRoot } from 'nx/src/utils/workspace-root';
+
+type NestedFiles = {
+  [fileName: string]: string;
+};
+
+export class TempFs {
+  readonly tempDir: string;
+  private readonly directoryName: string;
+
+  private readonly previousWorkspaceRoot: string;
+
+  constructor(directoryName: string, overrideWorkspaceRoot = true) {
+    this.directoryName = directoryName;
+    this.tempDir = realpathSync(mkdtempSync(join(tmpdir(), this.directoryName)));
+    this.previousWorkspaceRoot = workspaceRoot;
+
+    if (overrideWorkspaceRoot) {
+      setWorkspaceRoot(this.tempDir);
+    }
+  }
+
+  async createFiles(fileObject: NestedFiles) {
+    await Promise.all(
+      Object.keys(fileObject).map(async path => {
+        await this.createFile(path, fileObject[path]);
+      }),
+    );
+  }
+
+  createFilesSync(fileObject: NestedFiles) {
+    for (const path of Object.keys(fileObject)) {
+      this.createFileSync(path, fileObject[path]);
+    }
+  }
+
+  async createFile(filePath: string, content: string) {
+    const dir = joinPathFragments(this.tempDir, dirname(filePath));
+    if (!existsSync(dir)) {
+      await mkdir(dir, { recursive: true });
+    }
+    await writeFile(joinPathFragments(this.tempDir, filePath), content);
+  }
+
+  createFileSync(filePath: string, content: string) {
+    const dir = joinPathFragments(this.tempDir, dirname(filePath));
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+    writeFileSync(joinPathFragments(this.tempDir, filePath), content);
+  }
+
+  async readFile(filePath: string): Promise<string> {
+    return readFile(joinPathFragments(this.tempDir, filePath), 'utf-8');
+  }
+
+  removeFileSync(filePath: string): void {
+    unlinkSync(joinPathFragments(this.tempDir, filePath));
+  }
+
+  appendFile(filePath: string, content: string) {
+    appendFileSync(joinPathFragments(this.tempDir, filePath), content);
+  }
+
+  writeFile(filePath: string, content: string) {
+    writeFileSync(joinPathFragments(this.tempDir, filePath), content);
+  }
+  renameFile(oldPath: string, newPath: string) {
+    renameSync(joinPathFragments(this.tempDir, oldPath), joinPathFragments(this.tempDir, newPath));
+  }
+
+  cleanup() {
+    rmSync(this.tempDir, { recursive: true, force: true });
+    setWorkspaceRoot(this.previousWorkspaceRoot);
+  }
+
+  reset() {
+    rmSync(this.tempDir, { recursive: true, force: true });
+    mkdirSync(this.tempDir, { recursive: true });
+  }
+}

--- a/tools/workspace-plugin/src/plugins/type-check-plugin.spec.ts
+++ b/tools/workspace-plugin/src/plugins/type-check-plugin.spec.ts
@@ -1,0 +1,80 @@
+import { CreateNodesContext } from '@nx/devkit';
+
+import { TempFs } from './testing-utils/index';
+import { createNodesV2 } from './type-check-plugin';
+
+describe(`type-check-plugin`, () => {
+  const [, createNodesFunction] = createNodesV2;
+  let context: CreateNodesContext;
+  let tempFs: TempFs;
+  let cwd: string;
+
+  beforeEach(async () => {
+    tempFs = new TempFs('test');
+    cwd = process.cwd();
+    process.chdir(tempFs.tempDir);
+
+    context = {
+      nxJsonConfiguration: {
+        namedInputs: {
+          default: ['{projectRoot}/**/*'],
+          production: ['!{projectRoot}/**/*.spec.ts'],
+        },
+      },
+      workspaceRoot: tempFs.tempDir,
+
+      configFiles: [],
+    };
+
+    await tempFs.createFiles({
+      'proj/project.json': '{}',
+      'proj/package.json': '{}',
+    });
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+    tempFs.cleanup();
+    process.chdir(cwd);
+  });
+
+  it('should create nodes', async () => {
+    await tempFs.createFiles({
+      'proj/tsconfig.json': `{}`,
+      'proj/tsconfig.lib.json': '{}',
+      'proj/tsconfig.spec.json': '{}',
+    });
+    const results = await createNodesFunction(['proj/tsconfig.json'], { targetName: 'type-check' }, context);
+
+    expect(results).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          "proj/tsconfig.json",
+          Object {
+            "projects": Object {
+              "proj": Object {
+                "targets": Object {
+                  "type-check": Object {
+                    "cache": true,
+                    "executor": "@fluentui/workspace-plugin:type-check",
+                    "inputs": Array [
+                      "default",
+                      "{projectRoot}/tsconfig.json",
+                      "{projectRoot}/tsconfig.*.json",
+                    ],
+                    "metadata": Object {
+                      "description": "Type check code with TypeScript",
+                      "technologies": Array [
+                        "typescript",
+                      ],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        ],
+      ]
+    `);
+  });
+});

--- a/tools/workspace-plugin/src/plugins/type-check-plugin.ts
+++ b/tools/workspace-plugin/src/plugins/type-check-plugin.ts
@@ -1,0 +1,74 @@
+/* eslint-disable @typescript-eslint/no-shadow */
+import {
+  type CreateNodesV2,
+  createNodesFromFiles,
+  TargetConfiguration,
+  CreateNodesContextV2,
+  CreateNodesResult,
+} from '@nx/devkit';
+import { dirname } from 'node:path';
+
+import { assertProjectExists } from './shared';
+
+interface TypeCheckPluginOptions {
+  targetName?: string;
+}
+
+const typescriptConfigGlob = '**/tsconfig.json';
+
+export const createNodesV2: CreateNodesV2<TypeCheckPluginOptions> = [
+  typescriptConfigGlob,
+  (configFiles, options, context) => {
+    return createNodesFromFiles(
+      (configFile, options, context) => {
+        return createNodesInternal(configFile, options, context);
+      },
+      configFiles,
+      options,
+      context,
+    );
+  },
+];
+
+// ===================================================================================================================
+
+function normalizeOptions(options: TypeCheckPluginOptions | undefined): Required<TypeCheckPluginOptions> {
+  options ??= {};
+  options.targetName ??= 'type-check';
+
+  return options as Required<TypeCheckPluginOptions>;
+}
+
+function createNodesInternal(
+  configFilePath: string,
+  options: TypeCheckPluginOptions | undefined,
+  context: CreateNodesContextV2,
+): CreateNodesResult {
+  const projectRoot = dirname(configFilePath);
+
+  if (!assertProjectExists(projectRoot, context)) {
+    return {};
+  }
+
+  const normalizedOptions = normalizeOptions(options);
+
+  const targetConfig: TargetConfiguration = {
+    executor: '@fluentui/workspace-plugin:type-check',
+    cache: true,
+    inputs: ['default', '{projectRoot}/tsconfig.json', '{projectRoot}/tsconfig.*.json'],
+    metadata: {
+      technologies: ['typescript'],
+      description: 'Type check code with TypeScript',
+    },
+  };
+
+  return {
+    projects: {
+      [projectRoot]: {
+        targets: {
+          [normalizedOptions.targetName]: targetConfig,
+        },
+      },
+    },
+  };
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

- implements [inferred (project crystal) workspace plugins](https://nx.dev/concepts/inferred-tasks) in order to generate following task
  - clean
  - format, format:check
  - type-check
- implements internal testing utils in order to provide testing capabilities to internal plugins 

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Implements partially https://github.com/microsoft/fluentui/issues/30267
