### PR TITLE
feat: use browser default autofocus behavior and add story for button web component

### DIFF
--- a/change/@fluentui-web-components-c8b28354-32da-4e69-95bd-b3e4f19fc051.json
+++ b/change/@fluentui-web-components-c8b28354-32da-4e69-95bd-b3e4f19fc051.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "remove autofocus attribute in favor of browser inheritance for button web component",
+  "packageName": "@fluentui/web-components",
+  "email": "13071055+chrisdholt@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/button/button.stories.ts
+++ b/packages/web-components/src/button/button.stories.ts
@@ -74,6 +74,10 @@ export default {
 
 export const Button: Story<FluentButton> = renderComponent(storyTemplate).bind({});
 
+export const Autofocus: Story<FluentButton> = renderComponent(html<StoryArgs<FluentButton>>`
+  <fluent-button autofocus>Default</fluent-button>
+`);
+
 export const Appearance: Story<FluentButton> = renderComponent(html<StoryArgs<FluentButton>>`
   <fluent-button>Default</fluent-button>
   <fluent-button appearance="primary">Primary</fluent-button>

--- a/packages/web-components/src/button/button.ts
+++ b/packages/web-components/src/button/button.ts
@@ -19,17 +19,6 @@ import { ButtonType } from './button.options.js';
  */
 export class BaseButton extends FASTElement {
   /**
-   * Indicates the button should be focused when the page is loaded.
-   * @see The {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#autofocus | `autofocus`} attribute
-   *
-   * @public
-   * @remarks
-   * HTML Attribute: `autofocus`
-   */
-  @attr({ mode: 'boolean' })
-  public autofocus!: boolean;
-
-  /**
    * Default slotted content.
    *
    * @public


### PR DESCRIPTION
## Previous Behavior
Autofocus was included as a custom attribute.

## New Behavior
We rely on the browser attribute itself rather than including an attribute.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
