### PR TITLE
feat(web-components): add support for `popovertarget` and `popovertargetaction` to button

### DIFF
--- a/change/@fluentui-web-components-c80213f4-0da2-4267-bcf7-614b2aa6bc5f.json
+++ b/change/@fluentui-web-components-c80213f4-0da2-4267-bcf7-614b2aa6bc5f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "add support for popovertarget and popovertargetaction in button web component",
+  "packageName": "@fluentui/web-components",
+  "email": "13071055+chrisdholt@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/button/button.stories.ts
+++ b/packages/web-components/src/button/button.stories.ts
@@ -220,3 +220,10 @@ export const ResetAndSubmitButtonsInForm: Story<FluentButton> = renderComponent(
   <div id="something">Div Label</div>
   <output id="output"></output>
 `);
+
+export const Popover: Story<FluentButton> = renderComponent(html<StoryArgs<FluentButton>>`
+  <fluent-button popovertarget="foo" popovertargetaction="show">Show Popover</fluent-button>
+  <fluent-button popovertarget="foo" popovertargetaction="hide">Hide Popover</fluent-button>
+  <fluent-button popovertarget="foo" popovertargetaction="toggle">Toggle Popover</fluent-button>
+  <div id="foo" popover open>This is a popover</div>
+`);


### PR DESCRIPTION
## Previous Behavior
No support for declarative popovers

## New Behavior
While custom elements currently cannot take advantage of the `popovertarget` and `popovertargetaction` API's, this PR adds capabilities to replicate the behavior to provide basic support for declarative popovers.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
