### PR TITLE
feat(workspace-plugin): implement clean executor

### DIFF
--- a/tools/workspace-plugin/executors.json
+++ b/tools/workspace-plugin/executors.json
@@ -23,7 +23,7 @@
     "clean": {
       "implementation": "./src/executors/clean/executor",
       "schema": "./src/executors/clean/schema.json",
-      "description": "clean executor"
+      "description": "clean executor - remove build artifacts."
     }
   }
 }

--- a/tools/workspace-plugin/src/executors/clean/executor.spec.ts
+++ b/tools/workspace-plugin/src/executors/clean/executor.spec.ts
@@ -4,7 +4,7 @@ import { CleanExecutorSchema } from './schema';
 import executor from './executor';
 import { join } from 'node:path';
 import { rm } from 'node:fs/promises';
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, rmSync, writeFileSync, existsSync } from 'node:fs';
 
 jest.mock('node:fs/promises', () => {
   return {
@@ -25,23 +25,28 @@ const context: ExecutorContext = {
   isVerbose: true,
 };
 
-function prepareFixture() {
-  const fixtureRoot = context.root;
-  const projRoot = join(fixtureRoot, 'proj');
-  mkdirSync(fixtureRoot);
-  mkdirSync(projRoot);
-  mkdirSync(join(projRoot, 'dist'));
-  writeFileSync(join(projRoot, 'dist', 'file.txt'), 'file', 'utf-8');
-  mkdirSync(join(projRoot, 'lib'));
-  writeFileSync(join(projRoot, 'lib', 'file.txt'), 'file', 'utf-8');
+const noop = () => {
+  return;
+};
+const fixtureRoot = context.root;
+const projRoot = join(fixtureRoot, 'proj');
 
+function prepareFixture() {
+  if (!existsSync(fixtureRoot)) {
+    mkdirSync(fixtureRoot);
+    mkdirSync(projRoot);
+    mkdirSync(join(projRoot, 'dist'));
+    writeFileSync(join(projRoot, 'dist', 'file.txt'), 'file', 'utf-8');
+    mkdirSync(join(projRoot, 'lib'));
+    writeFileSync(join(projRoot, 'lib', 'file.txt'), 'file', 'utf-8');
+  }
   return () => {
     rmSync(fixtureRoot, { recursive: true, force: true });
   };
 }
 
 describe('Clean Executor', () => {
-  let cleanup: () => void;
+  let cleanup = noop;
 
   beforeAll(() => {
     cleanup = prepareFixture();
@@ -51,10 +56,6 @@ describe('Clean Executor', () => {
   });
 
   beforeEach(() => {
-    const noop = () => {
-      return;
-    };
-
     jest.spyOn(logger, 'info').mockImplementation(noop);
     jest.spyOn(logger, 'error').mockImplementation(noop);
   });
@@ -71,6 +72,28 @@ describe('Clean Executor', () => {
         recursive: true,
       },
       expect.stringContaining('tools/workspace-plugin/src/executors/clean/__fixtures__/proj/lib'),
+      {
+        force: true,
+        recursive: true,
+      },
+    ]);
+  });
+
+  it('accepts custom paths that override default ones', async () => {
+    const rmMock = rm as jest.Mock;
+    mkdirSync(join(projRoot, 'foo-bar'));
+    mkdirSync(join(projRoot, 'mr-wick'));
+
+    const output = await executor({ ...options, paths: ['foo-bar', 'mr-wick'] }, context);
+    expect(output.success).toBe(true);
+
+    expect(rmMock.mock.calls.flat()).toEqual([
+      expect.stringContaining('tools/workspace-plugin/src/executors/clean/__fixtures__/proj/foo-bar'),
+      {
+        force: true,
+        recursive: true,
+      },
+      expect.stringContaining('tools/workspace-plugin/src/executors/clean/__fixtures__/proj/mr-wick'),
       {
         force: true,
         recursive: true,

--- a/tools/workspace-plugin/src/executors/clean/executor.spec.ts
+++ b/tools/workspace-plugin/src/executors/clean/executor.spec.ts
@@ -1,18 +1,80 @@
-import { ExecutorContext } from '@nx/devkit';
+import { ExecutorContext, logger } from '@nx/devkit';
 
 import { CleanExecutorSchema } from './schema';
 import executor from './executor';
+import { join } from 'node:path';
+import { rm } from 'node:fs/promises';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+
+jest.mock('node:fs/promises', () => {
+  return {
+    ...jest.requireActual('node:fs/promises'),
+    rm: jest.fn(() => Promise.resolve()),
+  };
+});
 
 const options: CleanExecutorSchema = {};
 const context: ExecutorContext = {
-  root: '',
+  root: join(__dirname, '__fixtures__'),
+  projectName: 'proj',
+  projectsConfigurations: {
+    projects: { proj: { root: 'proj' } },
+    version: 2,
+  },
   cwd: process.cwd(),
-  isVerbose: false,
+  isVerbose: true,
 };
 
+function prepareFixture() {
+  const fixtureRoot = context.root;
+  const projRoot = join(fixtureRoot, 'proj');
+  mkdirSync(fixtureRoot);
+  mkdirSync(projRoot);
+  mkdirSync(join(projRoot, 'dist'));
+  writeFileSync(join(projRoot, 'dist', 'file.txt'), 'file', 'utf-8');
+  mkdirSync(join(projRoot, 'lib'));
+  writeFileSync(join(projRoot, 'lib', 'file.txt'), 'file', 'utf-8');
+
+  return () => {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  };
+}
+
 describe('Clean Executor', () => {
+  let cleanup: () => void;
+
+  beforeAll(() => {
+    cleanup = prepareFixture();
+  });
+  afterAll(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    const noop = () => {
+      return;
+    };
+
+    jest.spyOn(logger, 'info').mockImplementation(noop);
+    jest.spyOn(logger, 'error').mockImplementation(noop);
+  });
+
   it('can run', async () => {
+    const rmMock = rm as jest.Mock;
     const output = await executor(options, context);
     expect(output.success).toBe(true);
+
+    expect(rmMock.mock.calls.flat()).toEqual([
+      expect.stringContaining('tools/workspace-plugin/src/executors/clean/__fixtures__/proj/dist'),
+      {
+        force: true,
+        recursive: true,
+      },
+      expect.stringContaining('tools/workspace-plugin/src/executors/clean/__fixtures__/proj/lib'),
+      {
+        force: true,
+        recursive: true,
+      },
+    ]);
   });
 });

--- a/tools/workspace-plugin/src/executors/clean/executor.ts
+++ b/tools/workspace-plugin/src/executors/clean/executor.ts
@@ -1,11 +1,63 @@
-import { PromiseExecutor } from '@nx/devkit';
+import { ExecutorContext, PromiseExecutor, logger } from '@nx/devkit';
 import { CleanExecutorSchema } from './schema';
+import { join } from 'node:path';
+import { rm } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
 
-const runExecutor: PromiseExecutor<CleanExecutorSchema> = async options => {
-  console.log('Executor ran for Clean', options);
-  return {
-    success: true,
-  };
+const runExecutor: PromiseExecutor<CleanExecutorSchema> = async (schema, context) => {
+  const options = normalizeOptions(schema, context);
+
+  const success = await runClean(options, context);
+
+  return { success };
 };
 
+interface NormalizedOptions extends ReturnType<typeof normalizeOptions> {}
+
+async function runClean(options: NormalizedOptions, context: ExecutorContext): Promise<boolean> {
+  const projectAbsoluteRootPath = join(context.root, options.project.root);
+
+  const directories = [
+    'temp',
+    'dist',
+    'dist-storybook',
+    'storybook-static',
+    'lib',
+    'lib-amd',
+    'lib-commonjs',
+    'coverage',
+  ];
+
+  const results = directories.map(dir => {
+    const dirPath = join(projectAbsoluteRootPath, dir);
+    if (existsSync(dirPath)) {
+      verboseLog(`removing "${dirPath}"`);
+      return rm(dirPath, { force: true, recursive: true });
+    }
+    return Promise.resolve();
+  });
+
+  return Promise.all(results)
+    .then(() => {
+      return true;
+    })
+    .catch(err => {
+      logger.error(err);
+      return false;
+    });
+}
+
 export default runExecutor;
+
+function normalizeOptions(schema: CleanExecutorSchema, context: ExecutorContext) {
+  const defaults = {};
+  const project = context.projectsConfigurations!.projects[context.projectName!];
+
+  return { ...defaults, ...schema, project };
+}
+
+function verboseLog(message: string, kind: keyof typeof logger = 'info') {
+  if (process.env.NX_VERBOSE_LOGGING === 'true') {
+    logger[kind](message);
+  }
+}

--- a/tools/workspace-plugin/src/executors/clean/executor.ts
+++ b/tools/workspace-plugin/src/executors/clean/executor.ts
@@ -1,5 +1,5 @@
-import { ExecutorContext, PromiseExecutor, logger } from '@nx/devkit';
-import { CleanExecutorSchema } from './schema';
+import { type ExecutorContext, type PromiseExecutor, logger } from '@nx/devkit';
+import { type CleanExecutorSchema } from './schema';
 import { join } from 'node:path';
 import { rm } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
@@ -17,18 +17,7 @@ interface NormalizedOptions extends ReturnType<typeof normalizeOptions> {}
 async function runClean(options: NormalizedOptions, context: ExecutorContext): Promise<boolean> {
   const projectAbsoluteRootPath = join(context.root, options.project.root);
 
-  const directories = [
-    'temp',
-    'dist',
-    'dist-storybook',
-    'storybook-static',
-    'lib',
-    'lib-amd',
-    'lib-commonjs',
-    'coverage',
-  ];
-
-  const results = directories.map(dir => {
+  const results = options.paths.map(dir => {
     const dirPath = join(projectAbsoluteRootPath, dir);
     if (existsSync(dirPath)) {
       verboseLog(`removing "${dirPath}"`);
@@ -50,7 +39,9 @@ async function runClean(options: NormalizedOptions, context: ExecutorContext): P
 export default runExecutor;
 
 function normalizeOptions(schema: CleanExecutorSchema, context: ExecutorContext) {
-  const defaults = {};
+  const defaults = {
+    paths: ['temp', 'dist', 'dist-storybook', 'storybook-static', 'lib', 'lib-amd', 'lib-commonjs', 'coverage'],
+  };
   const project = context.projectsConfigurations!.projects[context.projectName!];
 
   return { ...defaults, ...schema, project };

--- a/tools/workspace-plugin/src/executors/clean/schema.d.ts
+++ b/tools/workspace-plugin/src/executors/clean/schema.d.ts
@@ -1,1 +1,1 @@
-export interface CleanExecutorSchema {} // eslint-disable-line
+export interface CleanExecutorSchema {}

--- a/tools/workspace-plugin/src/executors/clean/schema.d.ts
+++ b/tools/workspace-plugin/src/executors/clean/schema.d.ts
@@ -1,1 +1,6 @@
-export interface CleanExecutorSchema {}
+export interface CleanExecutorSchema {
+  /**
+   * Files/Directories to remove (provide relative paths to project root)
+   */
+  paths?: string[];
+}

--- a/tools/workspace-plugin/src/executors/clean/schema.json
+++ b/tools/workspace-plugin/src/executors/clean/schema.json
@@ -4,6 +4,14 @@
   "title": "Clean executor",
   "description": "Remove build artifacts.",
   "type": "object",
-  "properties": {},
+  "properties": {
+    "paths": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Files/Directories to remove (provide relative paths to project root)"
+    }
+  },
   "required": []
 }

--- a/tools/workspace-plugin/src/executors/clean/schema.json
+++ b/tools/workspace-plugin/src/executors/clean/schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/schema",
   "version": 2,
   "title": "Clean executor",
-  "description": "",
+  "description": "Remove build artifacts.",
   "type": "object",
   "properties": {},
   "required": []


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

> 💡 What is nx executor ? https://nx.dev/concepts/executors-and-configurations

- implements `clean` executor
- replacement npm script alias `clean`  that uses `just-scripts clean`

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Implements partially https://github.com/microsoft/fluentui/issues/30267
