### PR TITLE
fix(v8 DetailsList): Add underline to all links

### DIFF
--- a/packages/react-examples/src/react/DetailsList/DetailsList.Advanced.Example.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.Advanced.Example.tsx
@@ -209,7 +209,7 @@ export class DetailsListAdvancedExample extends React.Component<{}, IDetailsList
           selectionZoneProps={{
             selection: this._selection,
             disableAutoSelectOnInputElements: true,
-            selectionMode: selectionMode,
+            selectionMode,
           }}
           ariaLabelForListHeader="Column headers. Click to sort."
           ariaLabelForSelectAllCheckbox="Toggle selection for all items"
@@ -266,7 +266,7 @@ export class DetailsListAdvancedExample extends React.Component<{}, IDetailsList
     isLazyLoaded = !isLazyLoaded;
 
     this.setState({
-      isLazyLoaded: isLazyLoaded,
+      isLazyLoaded,
       items: isLazyLoaded
         ? this._allItems.slice(0, PAGING_SIZE).concat(new Array(ITEMS_COUNT - PAGING_SIZE))
         : this._allItems,
@@ -284,7 +284,7 @@ export class DetailsListAdvancedExample extends React.Component<{}, IDetailsList
     canResizeColumns = !canResizeColumns;
 
     this.setState({
-      canResizeColumns: canResizeColumns,
+      canResizeColumns,
       columns: this._buildColumns(items, canResizeColumns, this._onColumnClick, sortedColumnKey, isSortedDescending),
     });
   };
@@ -514,7 +514,7 @@ export class DetailsListAdvancedExample extends React.Component<{}, IDetailsList
       });
     }
     return {
-      items: items,
+      items,
       target: ev.currentTarget as HTMLElement,
       directionalHint: DirectionalHint.bottomLeftEdge,
       gapSpace: 10,
@@ -545,7 +545,7 @@ export class DetailsListAdvancedExample extends React.Component<{}, IDetailsList
 
     if (index > -1) {
       this.setState({
-        contextualMenuProps: contextualMenuProps,
+        contextualMenuProps,
       });
     }
 
@@ -590,7 +590,7 @@ export class DetailsListAdvancedExample extends React.Component<{}, IDetailsList
         undefined,
         this._onColumnContextMenu,
       ),
-      isSortedDescending: isSortedDescending,
+      isSortedDescending,
       sortedColumnKey: columnKey,
     });
   };
@@ -733,14 +733,14 @@ export class DetailsListAdvancedExample extends React.Component<{}, IDetailsList
         column.minWidth = 200;
       } else if (column.key === 'name') {
         column.onRender = (item: IExampleItem) => (
-          <Link href="#" data-selection-invoke={true}>
+          <Link href="#" data-selection-invoke={true} underline>
             {item.name}
           </Link>
         );
       } else if (column.key === 'key') {
         column.columnActionsMode = ColumnActionsMode.disabled;
         column.onRender = (item: IExampleItem) => (
-          <Link className={classNames.linkField} href="https://microsoft.com" target="_blank" rel="noopener">
+          <Link className={classNames.linkField} href="https://microsoft.com" target="_blank" rel="noopener" underline>
             {item.key}
           </Link>
         );

--- a/packages/react-examples/src/react/DetailsList/DetailsList.CustomColumns.Example.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.CustomColumns.Example.tsx
@@ -54,7 +54,7 @@ export class DetailsListCustomColumnsExample extends React.Component<{}, IDetail
 
     // Reset the items and columns to match the state.
     this.setState({
-      sortedItems: sortedItems,
+      sortedItems,
       columns: columns.map(col => {
         col.isSorted = col.key === column.key;
 
@@ -107,7 +107,11 @@ function _renderItemColumn(item: IExampleItem, index: number, column: IColumn) {
       return <Image src={fieldContent} width={50} height={50} imageFit={ImageFit.cover} />;
 
     case 'name':
-      return <Link href="#">{fieldContent}</Link>;
+      return (
+        <Link href="#" underline>
+          {fieldContent}
+        </Link>
+      );
 
     case 'color':
       return (

--- a/packages/react-examples/src/react/DetailsList/DetailsList.CustomGroupHeaders.Example.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.CustomGroupHeaders.Example.tsx
@@ -123,11 +123,11 @@ export class DetailsListCustomGroupHeadersExample extends React.Component<{}, { 
             <div className={classNames.headerTitle}>{`Custom header for ${props.group!.name}`}</div>
             <div className={classNames.headerLinkSet}>
               {props.selectionMode !== SelectionMode.none ? (
-                <Link className={classNames.headerLink} onClick={this._onToggleSelectGroup(props)}>
+                <Link className={classNames.headerLink} onClick={this._onToggleSelectGroup(props)} underline>
                   {props.selected ? 'Remove selection' : 'Select group'}
                 </Link>
               ) : null}
-              <Link className={classNames.headerLink} onClick={this._onToggleCollapse(props)}>
+              <Link className={classNames.headerLink} onClick={this._onToggleCollapse(props)} underline>
                 {props.group!.isCollapsed ? 'Expand group' : 'Collapse group'}
               </Link>
             </div>

--- a/packages/react-examples/src/react/DetailsList/DetailsList.DragDrop.Example.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.DragDrop.Example.tsx
@@ -25,7 +25,7 @@ const controlWrapperClass = mergeStyles({
   flexWrap: 'wrap',
 });
 const textFieldStyles: Partial<ITextFieldStyles> = {
-  root: { margin: margin },
+  root: { margin },
   fieldGroup: { maxWidth: '100px' },
 };
 const togglesStyles: Partial<IToggleStyles> = { root: { margin } };
@@ -53,7 +53,7 @@ export class DetailsListDragDropExample extends React.Component<{}, IDetailsList
     const items = createListItems(10, 0);
 
     this.state = {
-      items: items,
+      items,
       columns: buildColumns(items, true),
       isColumnReorderEnabled: true,
       frozenColumnCountFromStart: '1',
@@ -188,7 +188,11 @@ export class DetailsListDragDropExample extends React.Component<{}, IDetailsList
   private _onRenderItemColumn = (item: IExampleItem, index: number, column: IColumn): JSX.Element | string => {
     const key = column.key as keyof IExampleItem;
     if (key === 'name') {
-      return <Link data-selection-invoke={true}>{item[key]}</Link>;
+      return (
+        <Link data-selection-invoke={true} underline>
+          {item[key]}
+        </Link>
+      );
     }
 
     return String(item[key]);

--- a/packages/react-examples/src/react/DetailsList/DetailsList.KeyboardAccessibleResizeAndReorder.Example.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.KeyboardAccessibleResizeAndReorder.Example.tsx
@@ -83,7 +83,11 @@ export const DetailsListKeyboardAccessibleResizeAndReorderExample: React.Functio
   const onRenderItemColumn = (item: IExampleItem, index: number, column: IColumn): JSX.Element | string => {
     const key = column.key as keyof IExampleItem;
     if (key === 'name') {
-      return <Link data-selection-invoke={true}>{item[key]}</Link>;
+      return (
+        <Link data-selection-invoke={true} underline>
+          {item[key]}
+        </Link>
+      );
     }
     return String(item[key]);
   };

--- a/packages/react-examples/src/react/DetailsList/DetailsList.NavigatingFocus.Example.tsx
+++ b/packages/react-examples/src/react/DetailsList/DetailsList.NavigatingFocus.Example.tsx
@@ -20,7 +20,7 @@ export class DetailsListNavigatingFocusExample extends React.Component<{}, IDeta
       name: 'File path',
       onRender: item => (
         // eslint-disable-next-line react/jsx-no-bind
-        <Link key={item} onClick={() => this._navigate(item)}>
+        <Link key={item} onClick={() => this._navigate(item)} underline>
           {item}
         </Link>
       ),


### PR DESCRIPTION
## Previous Behavior

Underlines were not provided for links in the table and they did not have a 3:1 contrast against the other text, so it was not obvious the text in the DetailsList examples were links.

<!-- This is the behavior we have today -->

<img width="236" alt="image" src="https://github.com/user-attachments/assets/6b299468-228b-4ce6-b68d-135fcd173b84">


## New Behavior

Links in DetailsList now have underlines.
<img width="366" alt="image" src="https://github.com/user-attachments/assets/208464fe-9a18-4bb6-9a96-dce1c6f7c5e0">

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes [ADO issue](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/19430)
