### PR TITLE
fix(web-components): add button primary forced colors

### DIFF
--- a/change/@fluentui-web-components-46c9b695-18dc-4cad-a957-29ebaf4b1645.json
+++ b/change/@fluentui-web-components-46c9b695-18dc-4cad-a957-29ebaf4b1645.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: add primary button state and improved button disabled state in forced-colors mode",
+  "packageName": "@fluentui/web-components",
+  "email": "rupertdavid@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/button/button.styles.ts
+++ b/packages/web-components/src/button/button.styles.ts
@@ -58,6 +58,7 @@ import {
 } from '../theme/design-tokens.js';
 import {
   circularState,
+  disabledState,
   iconOnlyState,
   largeState,
   outlineState,
@@ -322,7 +323,19 @@ export const styles = css`
     }
 
     :host(:is(:hover, :focus-visible)) {
-      border-color: Highlight;
+      border-color: Highlight !important;
+    }
+
+    :host(${primaryState}:not(:is(:hover, :focus-visible))) {
+      background: Highlight;
+      color: HighlightText;
+      forced-color-adjust: none;
+    }
+
+    :host(:is(:disabled, [disabled-focusable], [appearance]:disabled, [appearance][disabled-focusable])) {
+      background: ButtonFace;
+      color: GrayText;
+      border-color: ButtonText;
     }
   `),
 );

--- a/packages/web-components/src/button/button.styles.ts
+++ b/packages/web-components/src/button/button.styles.ts
@@ -58,7 +58,6 @@ import {
 } from '../theme/design-tokens.js';
 import {
   circularState,
-  disabledState,
   iconOnlyState,
   largeState,
   outlineState,
@@ -318,7 +317,7 @@ export const styles = css`
 `.withBehaviors(
   forcedColorsStylesheetBehavior(css`
     :host {
-      background: ButtonFace;
+      background-color: ButtonFace;
       color: ButtonText;
     }
 
@@ -327,13 +326,13 @@ export const styles = css`
     }
 
     :host(${primaryState}:not(:is(:hover, :focus-visible))) {
-      background: Highlight;
+      background-color: Highlight;
       color: HighlightText;
       forced-color-adjust: none;
     }
 
     :host(:is(:disabled, [disabled-focusable], [appearance]:disabled, [appearance][disabled-focusable])) {
-      background: ButtonFace;
+      background-color: ButtonFace;
       color: GrayText;
       border-color: ButtonText;
     }


### PR DESCRIPTION

## Previous Behavior

<!-- This is the behavior we have today -->

- Missing Primary button appearance in forced-colors mode

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

- Add primary button appearance in forced-colors mode
- Improve disabled state in forced-colors mode

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #32408 

## Screenshots

| | Before | After |
|---|---|---|
|Light | ![Screenshot 2024-08-29 at 10 33 54 AM](https://github.com/user-attachments/assets/03cd71c1-e841-43c3-a794-b7310da6ddbb) | ![Screenshot 2024-08-29 at 10 27 41 AM](https://github.com/user-attachments/assets/ec78eb2e-4164-412c-a7ed-1c84a2cea72a) |
| Dark | ![Screenshot 2024-08-29 at 10 34 04 AM](https://github.com/user-attachments/assets/9eb7a32d-6710-4dbb-a93d-6d02739cb573) | ![Screenshot 2024-08-29 at 10 27 10 AM](https://github.com/user-attachments/assets/fd3e7210-9f70-46b7-be39-283da2e41deb) |






