### PR TITLE
bugfix(react-tree): ensure onClick handler is not called on every click

### DIFF
--- a/change/@fluentui-react-tree-c00b8f2d-0e5d-4f88-8d83-28cac9a82913.json
+++ b/change/@fluentui-react-tree-c00b8f2d-0e5d-4f88-8d83-28cac9a82913.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: ensure onClick handler is not called on every click",
+  "packageName": "@fluentui/react-tree",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tree/library/src/components/Tree/Tree.cy.tsx
+++ b/packages/react-components/react-tree/library/src/components/Tree/Tree.cy.tsx
@@ -465,6 +465,34 @@ describe('Tree', () => {
   });
 });
 
+describe('TreeItem', () => {
+  it('should not call onClick when clicking on: expand icon, actions or subtree', () => {
+    const handleClick = cy.stub().as('onClick');
+    mount(
+      <TreeTest id="tree" aria-label="Tree">
+        <TreeItem open onClick={handleClick} itemType="branch" value="item1" data-testid="item1">
+          <TreeItemLayout
+            expandIcon={{ 'data-testid': 'item1__expandIcon' } as {}}
+            actions={{ visible: true, children: <Button id="action">action!</Button> }}
+          >
+            level 1, item 1
+          </TreeItemLayout>
+          <Tree>
+            <TreeItem itemType="leaf" value="item1__item1" data-testid="item1__item1">
+              <TreeItemLayout>level 2, item 1</TreeItemLayout>
+            </TreeItem>
+          </Tree>
+        </TreeItem>
+      </TreeTest>,
+    );
+    cy.get('[data-testid="item1__item1"]').should('exist');
+    cy.get(`#action`).realClick();
+    cy.get('[data-testid="item1__item1"]').realClick();
+    cy.get('[data-testid="item1__expandIcon"]').realClick();
+    cy.get('@onClick').should('not.have.been.called');
+  });
+});
+
 declare global {
   namespace Cypress {
     interface Chainable<Subject> {

--- a/packages/react-components/react-tree/library/src/components/TreeItem/useTreeItem.tsx
+++ b/packages/react-components/react-tree/library/src/components/TreeItem/useTreeItem.tsx
@@ -92,13 +92,6 @@ export function useTreeItem_unstable(props: TreeItemProps, ref: React.Ref<HTMLDi
   const checked = useTreeContext_unstable(ctx => ctx.checkedItems.get(value) ?? false);
 
   const handleClick = useEventCallback((event: React.MouseEvent<HTMLDivElement>) => {
-    onClick?.(event);
-    if (event.isDefaultPrevented()) {
-      return;
-    }
-    if (itemType === 'leaf') {
-      return;
-    }
     const isEventFromActions = actionsRef.current && elementContains(actionsRef.current, event.target as Node);
     if (isEventFromActions) {
       return;
@@ -112,6 +105,15 @@ export function useTreeItem_unstable(props: TreeItemProps, ref: React.Ref<HTMLDi
       return;
     }
     const isEventFromExpandIcon = expandIconRef.current && elementContains(expandIconRef.current, event.target as Node);
+    if (!isEventFromExpandIcon) {
+      onClick?.(event);
+    }
+    if (event.isDefaultPrevented()) {
+      return;
+    }
+    if (itemType === 'leaf') {
+      return;
+    }
 
     ReactDOM.unstable_batchedUpdates(() => {
       const data = {

--- a/packages/react-components/react-tree/library/src/components/TreeItem/useTreeItem.tsx
+++ b/packages/react-components/react-tree/library/src/components/TreeItem/useTreeItem.tsx
@@ -92,26 +92,20 @@ export function useTreeItem_unstable(props: TreeItemProps, ref: React.Ref<HTMLDi
   const checked = useTreeContext_unstable(ctx => ctx.checkedItems.get(value) ?? false);
 
   const handleClick = useEventCallback((event: React.MouseEvent<HTMLDivElement>) => {
-    const isEventFromActions = actionsRef.current && elementContains(actionsRef.current, event.target as Node);
-    if (isEventFromActions) {
+    const isEventFromActions = () => actionsRef.current && elementContains(actionsRef.current, event.target as Node);
+
+    const isEventFromSubtree = () => subtreeRef.current && elementContains(subtreeRef.current, event.target as Node);
+
+    const isEventFromSelection = () => selectionRef.current?.contains(event.target as Node);
+
+    const isEventFromExpandIcon = expandIconRef.current?.contains(event.target as Node);
+
+    if (isEventFromActions() || isEventFromSubtree() || isEventFromSelection()) {
       return;
-    }
-    const isEventFromSubtree = subtreeRef.current && elementContains(subtreeRef.current, event.target as Node);
-    if (isEventFromSubtree) {
-      return;
-    }
-    const isEventFromSelection = selectionRef.current && elementContains(selectionRef.current, event.target as Node);
-    if (isEventFromSelection) {
-      return;
-    }
-    const isEventFromExpandIcon = expandIconRef.current && elementContains(expandIconRef.current, event.target as Node);
-    if (!isEventFromExpandIcon) {
+    } else if (!isEventFromExpandIcon) {
       onClick?.(event);
     }
-    if (event.isDefaultPrevented()) {
-      return;
-    }
-    if (itemType === 'leaf') {
+    if (event.isDefaultPrevented() || itemType === 'leaf') {
       return;
     }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

`TreeItem.onClick` is being called on:
1. `expandIcon` click
2. `actions` click
3. `selection` click
4. subtree click

Since https://github.com/microsoft/fluentui/pull/31766 we do not support `onOpenChange` for non branch `TreeItem`, users will have to rely more on `onClick` handler.

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

1. Ensures that `onClick` handler is not called if the click comes from an inner part of the `TreeITem`
2. Adds test to ensure behavior

Click events are still being emitted, we're just not calling `props.onClick` from `TreeItem` level, if you listen to the click event from another DOM element that event can still be captured as it was emitted
