### PR TITLE
fix(codeowners): update most packages owned by cxe-red with cxe-prg

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -128,7 +128,7 @@ apps/public-docsite-v9 @microsoft/cxe-red @microsoft/cxe-prg @microsoft/teams-pr
 apps/theming-designer @microsoft/fluentui-react
 apps/ssr-tests-v9 @microsoft/fluentui-react-build
 apps/react-18-tests-v8 @microsoft/cxe-red @micahgodbolt
-apps/react-18-tests-v9 @microsoft/cxe-red @micahgodbolt
+apps/react-18-tests-v9 @microsoft/fluentui-react-build
 
 #### Packages
 packages/azure-themes @Jacqueline-ms @robtaft-ms
@@ -163,15 +163,15 @@ packages/react-components/react-positioning @microsoft/teams-prg
 packages/react-components/react-overflow @microsoft/teams-prg
 packages/react-components/react-overflow/library @microsoft/teams-prg
 packages/react-components/react-overflow/stories @microsoft/teams-prg
-packages/react-components/react-shared-contexts @microsoft/teams-prg @microsoft/cxe-red
-packages/react-components/react-shared-contexts/library @microsoft/teams-prg @microsoft/cxe-red
-packages/react-components/react-shared-contexts/stories @microsoft/teams-prg @microsoft/cxe-red
+packages/react-components/react-shared-contexts @microsoft/teams-prg @microsoft/cxe-prg
+packages/react-components/react-shared-contexts/library @microsoft/teams-prg @microsoft/cxe-prg
+packages/react-components/react-shared-contexts/stories @microsoft/teams-prg @microsoft/cxe-prg
 packages/react-components/react-storybook-addon @microsoft/cxe-prg
 packages/react-components/react-tabster @microsoft/teams-prg
 packages/react-components/react-theme @microsoft/teams-prg
 packages/react-components/react-theme/library @microsoft/teams-prg
 packages/react-components/react-theme/stories @microsoft/teams-prg
-packages/react-components/react-utilities @microsoft/teams-prg
+packages/react-components/react-utilities @microsoft/teams-prg @microsoft/cxe-prg
 packages/storybook @microsoft/cxe-prg @microsoft/teams-prg
 packages/style-utilities @dzearing @microsoft/cxe-red
 packages/style-utilities/src/interfaces @phkuo @dzearing @microsoft/cxe-red
@@ -188,50 +188,50 @@ common/_common.scss @microsoft/cxe-red @phkuo
 
 ## vNext packages
 packages/react-components/keyboard-keys @microsoft/teams-prg
-packages/react-components/react-accordion @microsoft/cxe-red
-packages/react-components/react-accordion/library @microsoft/cxe-red
-packages/react-components/react-accordion/stories @microsoft/cxe-red
-packages/react-components/react-avatar @microsoft/cxe-red @behowell @khmakoto @sopranopillow
-packages/react-components/react-avatar/library @microsoft/cxe-red @behowell @khmakoto @sopranopillow
-packages/react-components/react-avatar/stories @microsoft/cxe-red @behowell @khmakoto @sopranopillow
-packages/react-components/react-badge @microsoft/cxe-red @behowell
-packages/react-components/react-badge/library @microsoft/cxe-red @behowell
-packages/react-components/react-badge/stories @microsoft/cxe-red @behowell
+packages/react-components/react-accordion @microsoft/cxe-prg
+packages/react-components/react-accordion/library @microsoft/cxe-prg
+packages/react-components/react-accordion/stories @microsoft/cxe-prg
+packages/react-components/react-avatar @microsoft/cxe-prg
+packages/react-components/react-avatar/library @microsoft/cxe-prg
+packages/react-components/react-avatar/stories @microsoft/cxe-prg
+packages/react-components/react-badge @microsoft/cxe-prg
+packages/react-components/react-badge/library @microsoft/cxe-prg
+packages/react-components/react-badge/stories @microsoft/cxe-prg
 packages/react-components/react-button @microsoft/cxe-red @khmakoto
 packages/react-components/react-button/library @microsoft/cxe-red @khmakoto
 packages/react-components/react-button/stories @microsoft/cxe-red @khmakoto
 packages/react-components/react-card @microsoft/cxe-prg @marcosmoura
 packages/react-components/react-card/library @microsoft/cxe-prg @marcosmoura
 packages/react-components/react-card/stories @microsoft/cxe-prg @marcosmoura
-packages/react-components/react-checkbox @microsoft/cxe-red @khmakoto
-packages/react-components/react-checkbox/library @microsoft/cxe-red @khmakoto
-packages/react-components/react-checkbox/stories @microsoft/cxe-red @khmakoto
-packages/react-components/react-combobox @microsoft/cxe-red @microsoft/teams-prg @smhigley
-packages/react-components/react-combobox/library @microsoft/cxe-red @microsoft/teams-prg @smhigley
-packages/react-components/react-combobox/stories @microsoft/cxe-red @microsoft/teams-prg @smhigley
+packages/react-components/react-checkbox @microsoft/cxe-prg
+packages/react-components/react-checkbox/library @microsoft/cxe-prg
+packages/react-components/react-checkbox/stories @microsoft/cxe-prg
+packages/react-components/react-combobox @microsoft/cxe-prg @microsoft/teams-prg
+packages/react-components/react-combobox/library @microsoft/cxe-prg @microsoft/teams-prg
+packages/react-components/react-combobox/stories @microsoft/cxe-prg @microsoft/teams-prg
 packages/react-components/react-components @microsoft/fluentui-react
 packages/react-components/react-dialog @microsoft/teams-prg
 packages/react-components/react-dialog/library @microsoft/teams-prg
 packages/react-components/react-dialog/stories @microsoft/teams-prg
-packages/react-components/react-divider @microsoft/cxe-red
-packages/react-components/react-divider/library @microsoft/cxe-red
-packages/react-components/react-divider/stories @microsoft/cxe-red
-packages/react-components/react-field @microsoft/cxe-red @behowell
-packages/react-components/react-field/library @microsoft/cxe-red @behowell
-packages/react-components/react-field/stories @microsoft/cxe-red @behowell
+packages/react-components/react-divider @microsoft/cxe-prg
+packages/react-components/react-divider/library @microsoft/cxe-prg
+packages/react-components/react-divider/stories @microsoft/cxe-prg
+packages/react-components/react-field @microsoft/cxe-prg
+packages/react-components/react-field/library @microsoft/cxe-prg
+packages/react-components/react-field/stories @microsoft/cxe-prg
 packages/react-focus @microsoft/cxe-red @khmakoto
 packages/react-components/react-image @microsoft/cxe-prg
 packages/react-components/react-image/library @microsoft/cxe-prg
 packages/react-components/react-image/stories @microsoft/cxe-prg
-packages/react-components/react-input @microsoft/cxe-red @spmonahan
-packages/react-components/react-input/library @microsoft/cxe-red @spmonahan
-packages/react-components/react-input/stories @microsoft/cxe-red @spmonahan
-packages/react-components/react-label @microsoft/cxe-red @sopranopillow @micahgodbolt
-packages/react-components/react-label/library @microsoft/cxe-red @sopranopillow @micahgodbolt
-packages/react-components/react-label/stories @microsoft/cxe-red @sopranopillow @micahgodbolt
-packages/react-components/react-link @microsoft/cxe-red @khmakoto
-packages/react-components/react-link/library @microsoft/cxe-red @khmakoto
-packages/react-components/react-link/stories @microsoft/cxe-red @khmakoto
+packages/react-components/react-input @microsoft/cxe-prg
+packages/react-components/react-input/library @microsoft/cxe-prg
+packages/react-components/react-input/stories @microsoft/cxe-prg
+packages/react-components/react-label @microsoft/cxe-prg
+packages/react-components/react-label/library @microsoft/cxe-prg
+packages/react-components/react-label/stories @microsoft/cxe-prg
+packages/react-components/react-link @microsoft/cxe-prg
+packages/react-components/react-link/library @microsoft/cxe-prg
+packages/react-components/react-link/stories @microsoft/cxe-prg
 packages/react-components/react-menu @microsoft/teams-prg
 packages/react-components/react-menu/library @microsoft/teams-prg
 packages/react-components/react-menu/stories @microsoft/teams-prg
@@ -247,33 +247,33 @@ packages/react-components/react-provider/stories @microsoft/teams-prg
 packages/react-components/react-radio @microsoft/cxe-red @behowell @spmonahan
 packages/react-components/react-radio/library @microsoft/cxe-red @behowell @spmonahan
 packages/react-components/react-radio/stories @microsoft/cxe-red @behowell @spmonahan
-packages/react-components/react-select @microsoft/cxe-red @smhigley
-packages/react-components/react-select/library @microsoft/cxe-red @smhigley
-packages/react-components/react-select/stories @microsoft/cxe-red @smhigley
-packages/react-components/react-slider @microsoft/cxe-red @micahgodbolt
-packages/react-components/react-slider/library @microsoft/cxe-red @micahgodbolt
-packages/react-components/react-slider/stories @microsoft/cxe-red @micahgodbolt
-packages/react-components/react-spinbutton @microsoft/cxe-red @spmonahan
-packages/react-components/react-spinbutton/library @microsoft/cxe-red @spmonahan
-packages/react-components/react-spinbutton/stories @microsoft/cxe-red @spmonahan
-packages/react-components/react-spinner @microsoft/cxe-red @tomi-msft
-packages/react-components/react-spinner/library @microsoft/cxe-red @tomi-msft
-packages/react-components/react-spinner/stories @microsoft/cxe-red @tomi-msft
-packages/react-components/react-switch @microsoft/cxe-red @behowell @khmakoto
-packages/react-components/react-switch/library @microsoft/cxe-red @behowell @khmakoto
-packages/react-components/react-switch/stories @microsoft/cxe-red @behowell @khmakoto
+packages/react-components/react-select @microsoft/cxe-prg
+packages/react-components/react-select/library @microsoft/cxe-prg
+packages/react-components/react-select/stories @microsoft/cxe-prg
+packages/react-components/react-slider @microsoft/cxe-prg
+packages/react-components/react-slider/library @microsoft/cxe-prg
+packages/react-components/react-slider/stories @microsoft/cxe-prg
+packages/react-components/react-spinbutton @microsoft/cxe-prg
+packages/react-components/react-spinbutton/library @microsoft/cxe-prg
+packages/react-components/react-spinbutton/stories @microsoft/cxe-prg
+packages/react-components/react-spinner @microsoft/cxe-prg
+packages/react-components/react-spinner/library @microsoft/cxe-prg
+packages/react-components/react-spinner/stories @microsoft/cxe-prg
+packages/react-components/react-switch @microsoft/cxe-prg
+packages/react-components/react-switch/library @microsoft/cxe-prg
+packages/react-components/react-switch/stories @microsoft/cxe-prg
 packages/react-components/react-tabs @microsoft/cxe-prg @dmytrokirpa
 packages/react-components/react-tabs/library @microsoft/cxe-prg @dmytrokirpa
 packages/react-components/react-tabs/stories @microsoft/cxe-prg @dmytrokirpa
 packages/react-components/react-text @microsoft/cxe-prg @marcosmoura
 packages/react-components/react-text/library @microsoft/cxe-prg @marcosmoura
 packages/react-components/react-text/stories @microsoft/cxe-prg @marcosmoura
-packages/react-components/react-textarea @microsoft/cxe-red @sopranopillow
-packages/react-components/react-textarea/library @microsoft/cxe-red @sopranopillow
-packages/react-components/react-textarea/stories @microsoft/cxe-red @sopranopillow
-packages/react-components/react-tooltip @microsoft/cxe-red @behowell @khmakoto
-packages/react-components/react-tooltip/library @microsoft/cxe-red @behowell @khmakoto
-packages/react-components/react-tooltip/stories @microsoft/cxe-red @behowell @khmakoto
+packages/react-components/react-textarea @microsoft/cxe-prg
+packages/react-components/react-textarea/library @microsoft/cxe-prg
+packages/react-components/react-textarea/stories @microsoft/cxe-prg
+packages/react-components/react-tooltip @microsoft/cxe-prg
+packages/react-components/react-tooltip/library @microsoft/cxe-prg
+packages/react-components/react-tooltip/stories @microsoft/cxe-prg
 packages/react-components/react-toolbar @microsoft/teams-prg @chpalac @ling1726
 packages/react-components/react-toolbar/library @microsoft/teams-prg @chpalac @ling1726
 packages/react-components/react-toolbar/stories @microsoft/teams-prg @chpalac @ling1726
@@ -286,32 +286,32 @@ packages/react-components/babel-preset-global-context @microsoft/teams-prg
 packages/react-components/react-table @microsoft/teams-prg
 packages/react-components/react-table/library @microsoft/teams-prg
 packages/react-components/react-table/stories @microsoft/teams-prg
-packages/react-components/react-progress @microsoft/cxe-red @tomi-msft
-packages/react-components/react-progress/library @microsoft/cxe-red @tomi-msft
-packages/react-components/react-progress/stories @microsoft/cxe-red @tomi-msft
-packages/react-components/react-persona @microsoft/cxe-red @sopranopillow
-packages/react-components/react-persona/library @microsoft/cxe-red @sopranopillow
-packages/react-components/react-persona/stories @microsoft/cxe-red @sopranopillow
+packages/react-components/react-progress @microsoft/cxe-prg
+packages/react-components/react-progress/library @microsoft/cxe-prg
+packages/react-components/react-progress/stories @microsoft/cxe-prg
+packages/react-components/react-persona @microsoft/cxe-prg
+packages/react-components/react-persona/library @microsoft/cxe-prg
+packages/react-components/react-persona/stories @microsoft/cxe-prg
 packages/react-components/react-tree @microsoft/teams-prg
 packages/react-components/react-tree/library @microsoft/teams-prg
 packages/react-components/react-tree/stories @microsoft/teams-prg
 packages/react-components/react-virtualizer @microsoft/xc-uxe @Mitch-At-Work
 packages/react-components/react-virtualizer/library @microsoft/xc-uxe @Mitch-At-Work
 packages/react-components/react-virtualizer/stories @microsoft/xc-uxe @Mitch-At-Work
-packages/react-components/react-skeleton @microsoft/cxe-red
-packages/react-components/react-skeleton/library @microsoft/cxe-red
-packages/react-components/react-skeleton/stories @microsoft/cxe-red
+packages/react-components/react-skeleton @microsoft/cxe-prg
+packages/react-components/react-skeleton/library @microsoft/cxe-prg
+packages/react-components/react-skeleton/stories @microsoft/cxe-prg
 packages/tokens @microsoft/teams-prg
-packages/react-components/react-tags @microsoft/cxe-red @microsoft/teams-prg
-packages/react-components/react-tags/library @microsoft/cxe-red @microsoft/teams-prg
-packages/react-components/react-tags/stories @microsoft/cxe-red @microsoft/teams-prg
+packages/react-components/react-tags @microsoft/cxe-prg @microsoft/teams-prg
+packages/react-components/react-tags/library @microsoft/cxe-prg @microsoft/teams-prg
+packages/react-components/react-tags/stories @microsoft/cxe-prg @microsoft/teams-prg
 packages/react-components/react-migration-v0-v9/library @microsoft/teams-prg
 packages/react-components/react-migration-v0-v9/stories @microsoft/teams-prg
-packages/react-components/react-datepicker-compat @microsoft/cxe-red @sopranopillow @khmakoto
-packages/react-components/react-datepicker-compat/library @microsoft/cxe-red @sopranopillow @khmakoto
-packages/react-components/react-datepicker-compat/stories @microsoft/cxe-red @sopranopillow @khmakoto
-packages/react-components/react-migration-v8-v9/library @microsoft/cxe-red @geoffcoxmsft
-packages/react-components/react-migration-v8-v9/stories @microsoft/cxe-red @geoffcoxmsft
+packages/react-components/react-datepicker-compat @microsoft/cxe-prg
+packages/react-components/react-datepicker-compat/library @microsoft/cxe-prg
+packages/react-components/react-datepicker-compat/stories @microsoft/cxe-prg
+packages/react-components/react-migration-v8-v9/library @microsoft/cxe-prg @geoffcoxmsft
+packages/react-components/react-migration-v8-v9/stories @microsoft/cxe-prg @geoffcoxmsft
 packages/react-components/react-breadcrumb @microsoft/cxe-prg
 packages/react-components/react-breadcrumb/library @microsoft/cxe-prg
 packages/react-components/react-breadcrumb/stories @microsoft/cxe-prg
@@ -324,9 +324,9 @@ packages/react-components/react-jsx-runtime @microsoft/teams-prg
 packages/react-components/react-toast @microsoft/teams-prg
 packages/react-components/react-toast/library @microsoft/teams-prg
 packages/react-components/react-toast/stories @microsoft/teams-prg
-packages/react-components/react-search @microsoft/cxe-red @smhigley
-packages/react-components/react-search/library @microsoft/cxe-red @smhigley
-packages/react-components/react-search/stories @microsoft/cxe-red @smhigley
+packages/react-components/react-search @microsoft/cxe-prg
+packages/react-components/react-search/library @microsoft/cxe-prg
+packages/react-components/react-search/stories @microsoft/cxe-prg
 packages/react-components/react-colorpicker-compat @microsoft/cxe-red @sopranopillow
 packages/react-components/react-nav-preview @microsoft/cxe-red @microsoft/xc-uxe @mltejera
 packages/react-components/react-nav-preview/library @microsoft/cxe-red @microsoft/xc-uxe @mltejera
@@ -334,18 +334,18 @@ packages/react-components/react-nav-preview/stories @microsoft/cxe-red @microsof
 packages/react-components/react-message-bar @microsoft/teams-prg
 packages/react-components/react-message-bar/library @microsoft/teams-prg
 packages/react-components/react-message-bar/stories @microsoft/teams-prg
-packages/react-components/react-rating @microsoft/cxe-red @tomi-msft
-packages/react-components/react-rating/library @microsoft/cxe-red @tomi-msft
-packages/react-components/react-rating/stories @microsoft/cxe-red @tomi-msft
+packages/react-components/react-rating @microsoft/cxe-prg
+packages/react-components/react-rating/library @microsoft/cxe-prg
+packages/react-components/react-rating/stories @microsoft/cxe-prg
 packages/react-components/react-swatch-picker @microsoft/cxe-prg
 packages/react-components/react-swatch-picker/library @microsoft/cxe-prg
 packages/react-components/react-swatch-picker/stories @microsoft/cxe-prg
-packages/react-components/react-calendar-compat @microsoft/cxe-red @sopranopillow
-packages/react-components/react-calendar-compat/library @microsoft/cxe-red @sopranopillow
-packages/react-components/react-calendar-compat/stories @microsoft/cxe-red @sopranopillow
-packages/react-components/react-infolabel @microsoft/cxe-red @sopranopillow
-packages/react-components/react-infolabel/library @microsoft/cxe-red @sopranopillow
-packages/react-components/react-infolabel/stories @microsoft/cxe-red @sopranopillow
+packages/react-components/react-calendar-compat @microsoft/cxe-prg
+packages/react-components/react-calendar-compat/library @microsoft/cxe-prg
+packages/react-components/react-calendar-compat/stories @microsoft/cxe-prg
+packages/react-components/react-infolabel @microsoft/cxe-prg
+packages/react-components/react-infolabel/library @microsoft/cxe-prg
+packages/react-components/react-infolabel/stories @microsoft/cxe-prg
 packages/react-components/react-list-preview @microsoft/teams-prg
 packages/react-components/react-list-preview/library @microsoft/teams-prg
 packages/react-components/react-list-preview/stories @microsoft/teams-prg
@@ -370,8 +370,8 @@ packages/react-components/react-carousel-preview/stories @microsoft/xc-uxe @micr
 packages/react-components/recipes @microsoft/fluentui-react @sopranopillow
 packages/react-components/react-motion-components-preview/library @microsoft/teams-prg
 packages/react-components/react-motion-components-preview/stories @microsoft/teams-prg
-packages/react-components/react-utilities-compat/library @microsoft/cxe-red
-packages/react-components/react-utilities-compat/stories @microsoft/cxe-red
+packages/react-components/react-utilities-compat/library @microsoft/cxe-prg
+packages/react-components/react-utilities-compat/stories @microsoft/cxe-prg
 packages/react-components/react-color-picker-preview/library @microsoft/cxe-prg
 packages/react-components/react-color-picker-preview/stories @microsoft/cxe-prg
 packages/react-components/react-keytips-preview/library @microsoft/cxe-prg


### PR DESCRIPTION
This PR updates most packages owned by `cxe-red` with `cxe-prg` as we're transferring them.