### PR TITLE
chore(web-components): add missing export for textarea

### DIFF
--- a/change/@fluentui-web-components-fbe83ca6-95b0-48ac-a8c5-dcdd07033e4d.json
+++ b/change/@fluentui-web-components-fbe83ca6-95b0-48ac-a8c5-dcdd07033e4d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: add missing export for textarea",
+  "packageName": "@fluentui/web-components",
+  "email": "rupertdavid@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/docs/api-report.md
+++ b/packages/web-components/docs/api-report.md
@@ -2277,7 +2277,6 @@ export const DividerAppearance: {
     readonly strong: "strong";
     readonly brand: "brand";
     readonly subtle: "subtle";
-    readonly default: "default";
 };
 
 // @public
@@ -2544,7 +2543,6 @@ export const ImageFit: {
     readonly center: "center";
     readonly contain: "contain";
     readonly cover: "cover";
-    readonly default: "default";
 };
 
 // @public
@@ -2666,6 +2664,11 @@ export type LinkAppearance = ValuesOf<typeof LinkAppearance>;
 
 // @public (undocumented)
 export const LinkDefinition: FASTElementDefinition<typeof Link>;
+
+// Warning: (ae-missing-release-tag) "styles" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export const LinkStyles: ElementStyles;
 
 // @public
 export const LinkTarget: {
@@ -2891,6 +2894,66 @@ export const MenuStyles: ElementStyles;
 //
 // @public (undocumented)
 export const MenuTemplate: ElementViewTemplate<Menu>;
+
+// @public
+export class MessageBar extends FASTElement {
+    constructor();
+    dismissMessageBar: () => void;
+    // @internal
+    elementInternals: ElementInternals;
+    intent?: MessageBarIntent;
+    intentChanged(prev: MessageBarIntent | undefined, next: MessageBarIntent | undefined): void;
+    layout?: MessageBarLayout;
+    layoutChanged(prev: MessageBarLayout | undefined, next: MessageBarLayout | undefined): void;
+    shape?: MessageBarShape;
+    shapeChanged(prev: MessageBarShape | undefined, next: MessageBarShape | undefined): void;
+}
+
+// @public
+export const MessageBarDefinition: FASTElementDefinition<typeof MessageBar>;
+
+// Warning: (ae-missing-release-tag) "MessageBarIntent" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export const MessageBarIntent: {
+    readonly success: "success";
+    readonly warning: "warning";
+    readonly error: "error";
+    readonly info: "info";
+};
+
+// @public (undocumented)
+export type MessageBarIntent = ValuesOf<typeof MessageBarIntent>;
+
+// Warning: (ae-missing-release-tag) "MessageBarLayout" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export const MessageBarLayout: {
+    readonly multiline: "multiline";
+    readonly singleline: "singleline";
+};
+
+// @public (undocumented)
+export type MessageBarLayout = ValuesOf<typeof MessageBarLayout>;
+
+// Warning: (ae-missing-release-tag) "MessageBarShape" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export const MessageBarShape: {
+    readonly rounded: "rounded";
+    readonly square: "square";
+};
+
+// @public (undocumented)
+export type MessageBarShape = ValuesOf<typeof MessageBarShape>;
+
+// @public
+export const MessageBarStyles: ElementStyles;
+
+// Warning: (ae-missing-release-tag) "template" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export const MessageBarTemplate: ElementViewTemplate<MessageBar>;
 
 // @public
 class ProgressBar_2 extends BaseProgressBar {
@@ -3738,6 +3801,11 @@ export const TextAreaAppearance: {
 
 // @public (undocumented)
 export type TextAreaAppearance = ValuesOf<typeof TextAreaAppearance>;
+
+// Warning: (ae-missing-release-tag) "TextAreaAppearancesForDisplayShadow" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export const TextAreaAppearancesForDisplayShadow: Partial<TextAreaAppearance[]>;
 
 // Warning: (ae-missing-release-tag) "TextAreaAutocomplete" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/packages/web-components/src/index.ts
+++ b/packages/web-components/src/index.ts
@@ -254,6 +254,7 @@ export {
   BaseTextArea,
   TextArea,
   TextAreaAppearance,
+  TextAreaAppearancesForDisplayShadow,
   TextAreaAutocomplete,
   TextAreaDefinition,
   TextAreaResize,

--- a/packages/web-components/src/textarea/index.ts
+++ b/packages/web-components/src/textarea/index.ts
@@ -4,9 +4,6 @@ export {
   TextAreaAppearance,
   TextAreaAppearancesForDisplayShadow,
   TextAreaAutocomplete,
-  TextAreaResizableResize,
-  TextAreaHorizontallyResizableResize,
-  TextAreaVerticallyResizableResize,
   TextAreaResize,
   TextAreaSize,
 } from './textarea.options.js';

--- a/packages/web-components/src/textarea/textarea.options.ts
+++ b/packages/web-components/src/textarea/textarea.options.ts
@@ -26,6 +26,11 @@ export const TextAreaAppearance = {
 
 export type TextAreaAppearance = ValuesOf<typeof TextAreaAppearance>;
 
+/**
+ * Allowed values for `appearance` when `display-shadow` is set to true.
+ *
+ * @public
+ */
 export const TextAreaAppearancesForDisplayShadow: Partial<TextAreaAppearance[]> = [
   TextAreaAppearance.filledLighter,
   TextAreaAppearance.filledDarker,
@@ -54,19 +59,3 @@ export const TextAreaResize = {
 } as const;
 
 export type TextAreaResize = ValuesOf<typeof TextAreaResize>;
-
-export const TextAreaResizableResize: Partial<TextAreaResize[]> = [
-  TextAreaResize.both,
-  TextAreaResize.horizontal,
-  TextAreaResize.vertical,
-];
-
-export const TextAreaVerticallyResizableResize: Partial<TextAreaResize[]> = [
-  TextAreaResize.both,
-  TextAreaResize.vertical,
-];
-
-export const TextAreaHorizontallyResizableResize: Partial<TextAreaResize[]> = [
-  TextAreaResize.both,
-  TextAreaResize.horizontal,
-];

--- a/packages/web-components/src/textarea/textarea.ts
+++ b/packages/web-components/src/textarea/textarea.ts
@@ -274,7 +274,13 @@ export class BaseTextArea extends FASTElement {
       toggleState(this.elementInternals, `resize-${next}`, true);
     }
 
-    toggleState(this.elementInternals, `resize`, this.resize !== TextAreaResize.none);
+    toggleState(
+      this.elementInternals,
+      `resize`,
+      ([TextAreaResize.both, TextAreaResize.horizontal, TextAreaResize.vertical] as Partial<TextAreaResize[]>).includes(
+        this.resize,
+      ),
+    );
   }
 
   /**

--- a/packages/web-components/src/textarea/textarea.ts
+++ b/packages/web-components/src/textarea/textarea.ts
@@ -5,7 +5,6 @@ import {
   TextAreaAppearance,
   TextAreaAppearancesForDisplayShadow,
   TextAreaAutocomplete,
-  TextAreaResizableResize,
   TextAreaResize,
   TextAreaSize,
 } from './textarea.options.js';
@@ -275,7 +274,7 @@ export class BaseTextArea extends FASTElement {
       toggleState(this.elementInternals, `resize-${next}`, true);
     }
 
-    toggleState(this.elementInternals, `resize`, TextAreaResizableResize.includes(this.resize));
+    toggleState(this.elementInternals, `resize`, this.resize !== TextAreaResize.none);
   }
 
   /**


### PR DESCRIPTION
## Previous Behavior

<!-- This is the behavior we have today -->

- No export for `TextAreasAppearanceForDisplayShadow`

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

- Add export for `TextAreaAppearancesForDisplayShadow`
- Removed unused `TextArea(Horizontally|Vertically)ResizableResize` options
- Removed `TextAreaResizableResize` and updated `toggleState` logic.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
