### PR TITLE
chore(web-components): Normalize exports paths

### DIFF
--- a/change/@fluentui-web-components-2580bc63-8c6b-4d6e-aaa2-774cabe4b080.json
+++ b/change/@fluentui-web-components-2580bc63-8c6b-4d6e-aaa2-774cabe4b080.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "normalize export paths",
+  "packageName": "@fluentui/web-components",
+  "email": "863023+radium-v@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -30,202 +30,38 @@
       "types": "./dist/dts/index.d.ts",
       "default": "./dist/esm/index.js"
     },
-    "./accordion.js": {
-      "types": "./dist/dts/accordion/define.d.ts",
-      "default": "./dist/esm/accordion/define.js"
-    },
-    "./accordion-item.js": {
-      "types": "./dist/dts/accordion-item/define.d.ts",
-      "default": "./dist/esm/accordion-item/define.js"
-    },
-    "./anchor-button.js": {
-      "types": "./dist/dts/anchor-button/define.d.ts",
-      "default": "./dist/esm/anchor-button/define.js"
-    },
-    "./avatar.js": {
-      "types": "./dist/dts/avatar/define.d.ts",
-      "default": "./dist/esm/avatar/define.js"
-    },
-    "./badge.js": {
-      "types": "./dist/dts/badge/define.d.ts",
-      "default": "./dist/esm/badge/define.js"
-    },
-    "./button.js": {
-      "types": "./dist/dts/button/define.d.ts",
-      "default": "./dist/esm/button/define.js"
-    },
-    "./checkbox.js": {
-      "types": "./dist/dts/checkbox/define.d.ts",
-      "default": "./dist/esm/checkbox/define.js"
-    },
-    "./compound-button.js": {
-      "types": "./dist/dts/compound-button/define.d.ts",
-      "default": "./dist/esm/compound-button/define.js"
-    },
-    "./counter-badge.js": {
-      "types": "./dist/dts/counter-badge/define.d.ts",
-      "default": "./dist/esm/counter-badge/define.js"
-    },
-    "./dialog.js": {
-      "types": "./dist/dts/dialog/define.d.ts",
-      "default": "./dist/esm/dialog/define.js"
-    },
-    "./dialog-body.js": {
-      "types": "./dist/dts/dialog-body/define.d.ts",
-      "default": "./dist/esm/dialog-body/define.js"
-    },
-    "./divider.js": {
-      "types": "./dist/dts/divider/define.d.ts",
-      "default": "./dist/esm/divider/define.js"
-    },
-    "./drawer.js": {
-      "types": "./dist/dts/drawer/define.d.ts",
-      "default": "./dist/esm/drawer/define.js"
-    },
-    "./drawer-body.js": {
-      "types": "./dist/dts/drawer-body/define.d.ts",
-      "default": "./dist/esm/drawer-body/define.js"
-    },
-    "./field.js": {
-      "types": "./dist/dts/field/define.d.ts",
-      "default": "./dist/esm/field/define.js"
-    },
-    "./image.js": {
-      "types": "./dist/dts/image/define.d.ts",
-      "default": "./dist/esm/image/define.js"
-    },
-    "./label.js": {
-      "types": "./dist/dts/label/define.d.ts",
-      "default": "./dist/esm/label/define.js"
-    },
-    "./link.js": {
-      "types": "./dist/dts/link/define.d.ts",
-      "default": "./dist/esm/link/define.js"
-    },
-    "./menu.js": {
-      "types": "./dist/dts/menu/define.d.ts",
-      "default": "./dist/esm/menu/define.js"
-    },
-    "./menu-list.js": {
-      "types": "./dist/dts/menu-list/define.d.ts",
-      "default": "./dist/esm/menu-list/define.js"
-    },
-    "./menu-button.js": {
-      "types": "./dist/dts/menu-button/define.d.ts",
-      "default": "./dist/esm/menu-button/define.js"
-    },
-    "./menu-item.js": {
-      "types": "./dist/dts/menu-item/define.d.ts",
-      "default": "./dist/esm/menu-item/define.js"
-    },
-    "./message-bar.js": {
-      "types": "./dist/dts/message-bar/define.d.ts",
-      "default": "./dist/esm/message-bar/define.js"
-    },
-    "./progress-bar.js": {
-      "types": "./dist/dts/progress-bar/define.d.ts",
-      "default": "./dist/esm/progress-bar/define.js"
-    },
-    "./radio.js": {
-      "types": "./dist/dts/radio/define.d.ts",
-      "default": "./dist/esm/radio/define.js"
-    },
-    "./radio-group.js": {
-      "types": "./dist/dts/radio-group/define.d.ts",
-      "default": "./dist/esm/radio-group/define.js"
-    },
-    "./rating-display.js": {
-      "types": "./dist/dts/rating-display/define.d.ts",
-      "default": "./dist/esm/rating-display/define.js"
-    },
-    "./slider.js": {
-      "types": "./dist/dts/slider/define.d.ts",
-      "default": "./dist/esm/slider/define.js"
-    },
-    "./spinner.js": {
-      "types": "./dist/dts/spinner/define.d.ts",
-      "default": "./dist/esm/spinner/define.js"
-    },
-    "./switch.js": {
-      "types": "./dist/dts/switch/define.d.ts",
-      "default": "./dist/esm/switch/define.js"
-    },
-    "./tab.js": {
-      "types": "./dist/dts/tab/define.d.ts",
-      "default": "./dist/esm/tab/define.js"
-    },
-    "./tabs.js": {
-      "types": "./dist/dts/tabs/define.d.ts",
-      "default": "./dist/esm/tabs/define.js"
-    },
-    "./tab-panel.js": {
-      "types": "./dist/dts/tab-panel/define.d.ts",
-      "default": "./dist/esm/tab-panel/define.js"
-    },
-    "./text.js": {
-      "types": "./dist/dts/text/define.d.ts",
-      "default": "./dist/esm/text/define.js"
-    },
-    "./textarea.js": {
-      "types": "./dist/dts/textarea/define.d.ts",
-      "default": "./dist/esm/textarea/define.js"
-    },
-    "./text-input.js": {
-      "types": "./dist/dts/text-input/define.d.ts",
-      "default": "./dist/esm/text-input/define.js"
-    },
-    "./toggle-button.js": {
-      "types": "./dist/dts/toggle-button/define.d.ts",
-      "default": "./dist/esm/toggle-button/define.js"
-    },
-    "./theme.js": {
-      "types": "./dist/dts/theme/index.d.ts",
-      "default": "./dist/esm/theme/index.js"
-    },
     "./utilities.js": {
       "types": "./dist/dts/utils/index.d.ts",
       "default": "./dist/esm/utils/index.js"
     },
+    "./*/define.js": {
+      "types": "./dist/dts/*/*.define.d.ts",
+      "default": "./dist/esm/*/*.define.js"
+    },
+    "./*/definition.js": {
+      "types": "./dist/dts/*/*.definition.d.ts",
+      "default": "./dist/esm/*/*.definition.js"
+    },
+    "./*/options.js": {
+      "types": "./dist/dts/*/*.options.d.ts",
+      "default": "./dist/esm/*/*.options.js"
+    },
+    "./*/styles.js": {
+      "types": "./dist/dts/*/*.styles.d.ts",
+      "default": "./dist/esm/*/*.styles.js"
+    },
+    "./*/template.js": {
+      "types": "./dist/dts/*/*.template.d.ts",
+      "default": "./dist/esm/*/*.template.js"
+    },
+    "./*.js": {
+      "types": "./dist/dts/*/index.d.ts",
+      "default": "./dist/esm/*/index.js"
+    },
     "./package.json": "./package.json"
   },
   "sideEffects": [
-    "./dist/esm/accordion/define.js",
-    "./dist/esm/accordion-item/define.js",
-    "./dist/esm/anchor-button/define.js",
-    "./dist/esm/avatar/define.js",
-    "./dist/esm/badge/define.js",
-    "./dist/esm/button/define.js",
-    "./dist/esm/checkbox/define.js",
-    "./dist/esm/compound-button/define.js",
-    "./dist/esm/counter-badge/define.js",
-    "./dist/esm/dialog/define.js",
-    "./dist/esm/dialog-body/define.js",
-    "./dist/esm/divider/define.js",
-    "./dist/esm/drawer/define.js",
-    "./dist/esm/drawer-body/define.js",
-    "./dist/esm/field/define.js",
-    "./dist/esm/image/define.js",
-    "./dist/esm/label/define.js",
-    "./dist/esm/link/define.js",
-    "./dist/esm/menu/define.js",
-    "./dist/esm/menu-list/define.js",
-    "./dist/esm/menu-button/define.js",
-    "./dist/esm/menu-item/define.js",
-    "./dist/esm/progress-bar/define.js",
-    "./dist/esm/radio/define.js",
-    "./dist/esm/radio-group/define.js",
-    "./dist/esm/rating-display/define.js",
-    "./dist/esm/slider/define.js",
-    "./dist/esm/spinner/define.js",
-    "./dist/esm/switch/define.js",
-    "./dist/esm/tab/define.js",
-    "./dist/esm/tabs/define.js",
-    "./dist/esm/tablist/define.js",
-    "./dist/esm/tab-panel/define.js",
-    "./dist/esm/text/define.js",
-    "./dist/esm/textarea/define.js",
-    "./dist/esm/text-input/define.js",
-    "./dist/esm/toggle-button/define.js",
+    "./dist/esm/**/define.js",
     "./dist/web-components.js",
     "./dist/web-components.min.js"
   ],


### PR DESCRIPTION
## Previous Behavior

The default exports for components pointed to the `define.js` files. This is convenient when you want to import the side-effectful `define()` calls for the browser. However, importing specific exports from components has to be done at the top level.

## New Behavior

* The default exports for all components come from `<component-name>.js`
* Modules with `define()` calls can be imported at `<component-name>/define.js`
* Option exports can be imported from `<component-name>/options.js`
* Per-component template exports can be imported directly from `<component-name>/template.js`
* Per-component style exports can be imported directly from `<component-name>/styles.js`
* Per-component definitions can be imported directly from `<component-name>/definition.js`

## Reviewer Notes

This PR also changes the `sideEffects` array to use `./dist/esm/**/define.js` instead of individual entries for every `define.js` file. `sideEffects` is a nonstandard feature mainly used by Webpack, so I'm not sure if this will work everywhere. [Here's the documentation for that feature](https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free).
