### PR TITLE
fix(web-components): restore define modules as default exports

### DIFF
--- a/change/@fluentui-web-components-602be538-f67a-46e2-a2ff-4b1a0c38e5e3.json
+++ b/change/@fluentui-web-components-602be538-f67a-46e2-a2ff-4b1a0c38e5e3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "restore define modules as default exports",
+  "packageName": "@fluentui/web-components",
+  "email": "863023+radium-v@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -54,9 +54,13 @@
       "types": "./dist/dts/*/*.template.d.ts",
       "default": "./dist/esm/*/*.template.js"
     },
-    "./*.js": {
+    "./*/index.js": {
       "types": "./dist/dts/*/index.d.ts",
       "default": "./dist/esm/*/index.js"
+    },
+    "./*.js": {
+      "types": "./dist/dts/*/define.d.ts",
+      "default": "./dist/esm/*/define.js"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
## Previous Behavior

The changes introduced in #32451 changed the component exports to point to the component barrel files. This breaks current behavior for downstream users.

## New Behavior

* `<component-name>.js` exports point to `<component-name>/define.js`
* `<component-name>/index.js` exports point to `<component-name>/index.js`

