### PR TITLE
fix(web-components): use `slotchange` events for slotted accordion items

### DIFF
--- a/change/@fluentui-web-components-3bc7b3f2-fc7a-4dc6-9e85-4985cb56ea11.json
+++ b/change/@fluentui-web-components-3bc7b3f2-fc7a-4dc6-9e85-4985cb56ea11.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "use slotchange events for slotted accordion items",
+  "packageName": "@fluentui/web-components",
+  "email": "863023+radium-v@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/docs/api-report.md
+++ b/packages/web-components/docs/api-report.md
@@ -27,6 +27,8 @@ export class Accordion extends FASTElement {
     expandmodeChanged(prev: AccordionExpandMode, next: AccordionExpandMode): void;
     // @internal
     handleChange(source: any, propertyName: string): void;
+    // @internal
+    slotchangeHandler(event: Event): void;
     // @internal (undocumented)
     slottedAccordionItems: HTMLElement[];
     // @internal (undocumented)

--- a/packages/web-components/src/accordion/accordion.spec.ts
+++ b/packages/web-components/src/accordion/accordion.spec.ts
@@ -358,8 +358,6 @@ test.describe('Accordion', () => {
   });
 
   test('should allow disabled items to be expanded when in single mode', async ({ page }) => {
-    test.slow();
-
     const element = page.locator('fluent-accordion');
 
     await page.setContent(/* html */ `

--- a/packages/web-components/src/accordion/accordion.template.ts
+++ b/packages/web-components/src/accordion/accordion.template.ts
@@ -7,7 +7,7 @@ import type { Accordion } from './accordion.js';
 export function accordionTemplate<T extends Accordion>(): ElementViewTemplate<T> {
   return html<T>`
     <template>
-      <slot ${slotted({ property: 'slottedAccordionItems', filter: elements() })}></slot>
+      <slot @slotchange="${(x, c) => x.slotchangeHandler(c.event as Event)}"></slot>
     </template>
   `;
 }

--- a/packages/web-components/src/accordion/accordion.ts
+++ b/packages/web-components/src/accordion/accordion.ts
@@ -1,5 +1,4 @@
-import { Observable } from '@microsoft/fast-element';
-import { attr, FASTElement, observable } from '@microsoft/fast-element';
+import { attr, FASTElement, observable, Observable, Updates } from '@microsoft/fast-element';
 import { BaseAccordionItem } from '../accordion-item/accordion-item.js';
 import { AccordionExpandMode } from './accordion.options.js';
 
@@ -198,4 +197,18 @@ export class Accordion extends FASTElement {
       this.$emit('change');
     }
   };
+
+  /**
+   * Updates the collection of child accordion items when the slot changes.
+   *
+   * @param event - The slotchange event
+   * @internal
+   */
+  public slotchangeHandler(event: Event): void {
+    Updates.enqueue(() => {
+      this.slottedAccordionItems = [...this.querySelectorAll('*')].filter(
+        x => x instanceof BaseAccordionItem,
+      ) as BaseAccordionItem[];
+    });
+  }
 }


### PR DESCRIPTION
## Previous Behavior

When inserting child nodes into the DOM via something like `innerHTML`, the `slotted()` directive sometimes doesn't trigger. This bug is most often experienced in Webkit browsers.

## New Behavior

This PR updates the Accordion component to use the same technique as the RadioGroup component for handling changes to slotted child elements.

## Related Issue(s)

- This is partially related to #32294.
