### PR TITLE
fix(docsite-v9): make motion docs work

### DIFF
--- a/apps/public-docsite-v9/src/DocsComponents/FluentDocsPage.stories.tsx
+++ b/apps/public-docsite-v9/src/DocsComponents/FluentDocsPage.stories.tsx
@@ -8,6 +8,7 @@ import {
   HeaderMdx,
   Primary,
   Stories,
+  type DocsContextProps,
 } from '@storybook/addon-docs';
 import type { SBEnumType } from '@storybook/csf';
 import { makeStyles, shorthands, tokens, Link, Text } from '@fluentui/react-components';
@@ -135,6 +136,8 @@ export const FluentDocsPage = () => {
   const primaryStory = stories[0];
   const primaryStoryContext = context.getStoryContext(primaryStory);
 
+  assertStoryMetaValues(primaryStory);
+
   const dir = primaryStoryContext.parameters?.dir ?? primaryStoryContext.globals?.[DIR_ID] ?? 'ltr';
   const selectedTheme = themes.find(theme => theme.id === primaryStoryContext.globals![THEME_ID]);
 
@@ -196,3 +199,15 @@ export const FluentDocsPage = () => {
     </div>
   );
 };
+
+function assertStoryMetaValues(story: ReturnType<DocsContextProps['componentStories']>[number]) {
+  if (story.component === null) {
+    throw new Error(
+      [
+        '🚨 Invalid Story Meta declaration:',
+        `- primaryStory.component of componentId:${story.componentId} is "null"`,
+        '- to resolve this error, please update "component" property value in your story definition to reference a React Component or remove it if it is not needed.',
+      ].join('\n'),
+    );
+  }
+}

--- a/packages/react-components/react-motion/stories/src/CreateMotionComponent/index.stories.ts
+++ b/packages/react-components/react-motion/stories/src/CreateMotionComponent/index.stories.ts
@@ -1,3 +1,4 @@
+import type { Meta } from '@storybook/react';
 import CreateMotionComponentDescription from './CreateMotionComponentDescription.md';
 
 export { CreateMotionComponentDefault as Default } from './CreateMotionComponentDefault.stories';
@@ -14,7 +15,6 @@ export { MotionFunctionParams as functionParams } from './MotionFunctionParams.s
 
 export default {
   title: 'Motion/APIs/createMotionComponent',
-  component: null,
   parameters: {
     docs: {
       description: {
@@ -22,4 +22,4 @@ export default {
       },
     },
   },
-};
+} satisfies Meta;

--- a/packages/react-components/react-motion/stories/src/CreatePresenceComponent/index.stories.ts
+++ b/packages/react-components/react-motion/stories/src/CreatePresenceComponent/index.stories.ts
@@ -1,3 +1,4 @@
+import type { Meta } from '@storybook/react';
 import CreatePresenceComponentDescription from './CreatePresenceComponentDescription.md';
 
 export { CreatePresenceComponentDefault as Default } from './CreatePresenceComponentDefault.stories';
@@ -14,7 +15,6 @@ export { PresenceMotionFunctionParams as functionParams } from './PresenceMotion
 
 export default {
   title: 'Motion/APIs/createPresenceComponent',
-  component: null,
   parameters: {
     docs: {
       description: {
@@ -22,4 +22,4 @@ export default {
       },
     },
   },
-};
+} satisfies Meta;

--- a/packages/react-components/react-motion/stories/src/PresenceGroup/index.stories.ts
+++ b/packages/react-components/react-motion/stories/src/PresenceGroup/index.stories.ts
@@ -1,10 +1,10 @@
+import type { Meta } from '@storybook/react';
 import PresenceGroupDescription from './PresenceGroupDescription.md';
 
 export { PresenceGroupDefault as Default } from './PresenceGroupDefault.stories';
 
 export default {
   title: 'Motion/APIs/PresenceGroup',
-  component: null,
   parameters: {
     docs: {
       description: {
@@ -12,4 +12,4 @@ export default {
       },
     },
   },
-};
+} satisfies Meta;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

motion stories provided invalid `Meta` configuration resulting in throwing error when rendering stories 

## New Behavior

Motion stories render

- motion stories provide valid `Meta`
- docsite-v9 adds extra `primaryStory` assertion in order to provide better DX what went wrong 
  - <img width="971" alt="image" src="https://github.com/user-attachments/assets/56391be5-c737-46f1-9f2e-b07a9053221c">


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/32461
- Follows https://github.com/microsoft/fluentui/pull/32382
