### PR TITLE
fix(public-docsite-v9): render args table only for component stories

### DIFF
--- a/apps/public-docsite-v9/src/DocsComponents/FluentDocsPage.stories.tsx
+++ b/apps/public-docsite-v9/src/DocsComponents/FluentDocsPage.stories.tsx
@@ -171,7 +171,7 @@ export const FluentDocsPage = () => {
             {primaryStory.name}
           </HeaderMdx>
           <Primary />
-          <ArgsTable of={primaryStory.component} />
+          {primaryStory.component && <ArgsTable of={primaryStory.component} />}
           {primaryStory.argTypes.as && primaryStory.argTypes.as?.type?.name === 'enum' && (
             <div className={styles.nativeProps}>
               <InfoFilled className={styles.nativePropsIcon} />


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

The Motion documentation is broken because [the `component` is not specified in the Storybook's meta](https://github.com/microsoft/fluentui/blob/master/packages/react-components/react-motion/stories/src/CreateMotionComponent/index.stories.ts#L17), and the `ArgsTable` is attempting to render the component's props table. 

This is not a correct story definition from the Storybook's standpoint, as it doesn't satisfies SB's types.

![image](https://github.com/user-attachments/assets/d604bf93-4a69-4660-9e22-52def5146109)

## New Behavior

As a temporary workaround, we could bypass `ArgsTable` rendering for stories without component specified. However, ideally, we should not create stories without components. Stories are meant for components, and if we need to document something else, we should create an `mdx` file with the documentation.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #32461
