### PR TITLE
fix(public-docsite-v9): fix toMountNodeProps and UseAnnounce broken pages

### DIFF
--- a/packages/react-components/react-portal/stories/src/toMountNodeProps/index.stories.tsx
+++ b/packages/react-components/react-portal/stories/src/toMountNodeProps/index.stories.tsx
@@ -1,10 +1,10 @@
+import type { Meta } from '@storybook/react';
 import descriptionMd from './toMountNodePropsDescription.md';
 
 export { Default } from './Default.stories';
 
 export default {
   title: 'Components/Portal/toMountNodeProps',
-  component: null,
   parameters: {
     docs: {
       description: {
@@ -12,4 +12,4 @@ export default {
       },
     },
   },
-};
+} as Meta;

--- a/packages/react-components/react-portal/stories/src/toMountNodeProps/index.stories.tsx
+++ b/packages/react-components/react-portal/stories/src/toMountNodeProps/index.stories.tsx
@@ -12,4 +12,4 @@ export default {
       },
     },
   },
-} as Meta;
+} satisfies Meta;

--- a/packages/react-components/react-shared-contexts/stories/src/UseAnnouce/index.stories.tsx
+++ b/packages/react-components/react-shared-contexts/stories/src/UseAnnouce/index.stories.tsx
@@ -1,10 +1,10 @@
+import type { Meta } from '@storybook/react';
 import descriptionMd from './UseAnnounceDescription.md';
 
 export { Default } from './UseAnnounceDefault.stories';
 
 export default {
   title: 'Utilities/ARIA live/useAnnounce',
-  component: null,
   parameters: {
     docs: {
       description: {
@@ -12,4 +12,4 @@ export default {
       },
     },
   },
-};
+} as Meta;

--- a/packages/react-components/react-shared-contexts/stories/src/UseAnnouce/index.stories.tsx
+++ b/packages/react-components/react-shared-contexts/stories/src/UseAnnouce/index.stories.tsx
@@ -12,4 +12,4 @@ export default {
       },
     },
   },
-} as Meta;
+} satisfies Meta;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

https://react.fluentui.dev/?path=/docs/utilities-aria-live-useannounce--docs and https://react.fluentui.dev/?path=/docs/components-portal-tomountnodeprops--docs were broken because of not valid story meta definition, `component: null` is not supported by Storybook.

## New Behavior

Eliminate the `component: null` and include the `as Meta` type to ensure the Storybook's meta is valid.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #32468 
- Followup for https://github.com/microsoft/fluentui/pull/32465#issuecomment-2331263715
