### PR TITLE
Fixed popover size and cover target issue

### DIFF
--- a/packages/react-components/react-charts-preview/library/src/components/CommonComponents/Popover.tsx
+++ b/packages/react-components/react-charts-preview/library/src/components/CommonComponents/Popover.tsx
@@ -36,7 +36,11 @@ const PopoverComponent: React.FunctionComponent<IPopoverComponentProps> = React.
   const YValue = props.yCalloutValue ? props.yCalloutValue : props.YValue;
   return (
     <div id={useId('callout')} {...focusAttributes}>
-      <Popover positioning={{ target: virtualElement }} open={props.isPopoverOpen} inline>
+      <Popover
+        positioning={{ target: virtualElement, autoSize: 'always', offset: 20, coverTarget: false }}
+        open={props.isPopoverOpen}
+        inline
+      >
         <PopoverSurface tabIndex={-1}>
           {/** Given custom callout, then it will render */}
           {props.customizedCallout && props.customizedCallout}


### PR DESCRIPTION
Fixed the following issues:
1. Hover card is hiding the hovered point
2. LC Multiple - Hovering over the hover card is expanding the chart area.