### PR TITLE
fix (react-dialog): Use consistent rounding for clientHeight and innerHeight

### DIFF
--- a/change/@fluentui-react-dialog-a4232c34-ea7b-4222-a164-74574abfa9e1.json
+++ b/change/@fluentui-react-dialog-a4232c34-ea7b-4222-a164-74574abfa9e1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Adjust window height comparison in fractional cases.",
+  "packageName": "@fluentui/react-dialog",
+  "email": "owcampbe@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-dialog/library/src/utils/useDisableBodyScroll.ts
+++ b/packages/react-components/react-dialog/library/src/utils/useDisableBodyScroll.ts
@@ -20,7 +20,9 @@ export function useDisableBodyScroll(): {
       return;
     }
     const isHorizontalScrollbarVisible =
-      targetDocument.body.clientHeight > (targetDocument.defaultView?.innerHeight ?? 0);
+      // When the window is a fractional height, `innerHeight` always rounds down but `clientHeight` rounds either up or down depending on the value.
+      // To properly compare the body clientHeight to the window innerHeight, manually round down the fractional value to match innerHeight's calculation.
+      Math.floor(targetDocument.body.getBoundingClientRect().height) > (targetDocument.defaultView?.innerHeight ?? 0);
     if (!isHorizontalScrollbarVisible) {
       return;
     }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->
When calculating whether scrollbars are present, we compare the body's clientHeight to the window's innerHeight.

In the case when this height is a fractional value, `clientHeight` rounds to the nearest integer whereas `innerHeight` always rounds down. This means when the body is set to 100% height and the browser is at a fractional height (usually due to a non-100% zoom factor), clientHeight often reports being 1 pixel taller than innerHeight. 

This causes the `scrollbar-gutter: stable` style to be added, which reserves space for the non-existent scrollbar, shifting the layout.

Repro: 

https://stackblitz.com/edit/u47vqq?file=index.html

![image](https://github.com/user-attachments/assets/15d1679f-8fc6-4a6b-91c2-d25dd3cdcf90)
![image](https://github.com/user-attachments/assets/acf14cba-4f45-40fc-a0ff-1b9cbc7a39e3)


## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
Match `innerHeight`'s rounding behaviour by using `body.getBoundingClientRect().height` and manually rounding down.

According to mdn, `getBoundingClientRect()` is the equivalent to `clientHeight` except it returns the real fractional value: https://developer.mozilla.org/en-US/docs/Web/API/Element/clientHeight


Fixes #32481 