### PR TITLE
Fixed legend related bugs

### DIFF
--- a/packages/react-components/react-charts-preview/library/src/components/Legends/Legends.styles.ts
+++ b/packages/react-components/react-charts-preview/library/src/components/Legends/Legends.styles.ts
@@ -1,6 +1,7 @@
 import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import { ILegendsProps, ILegendsStyles } from './Legends.types';
+import { tokens } from '@fluentui/react-theme';
 
 /**
  * @internal
@@ -63,6 +64,7 @@ const useStyles = makeStyles({
   // TO DO Add props when these styles are used in the component
   text: {
     lineHeight: '16px',
+    fontSize: tokens.fontSizeBase200,
   },
   // TO DO Add props when these styles are used in the component
   hoverChange: {
@@ -74,7 +76,7 @@ const useStyles = makeStyles({
   resizableArea: {
     position: 'relative',
     textAlign: 'center',
-    transform: 'translate(-50%, -50%)',
+    transform: 'translate(-50%, 0)',
     top: 'auto',
     left: '50%',
     minWidth: '200px',

--- a/packages/react-components/react-charts-preview/library/src/components/Legends/OverflowMenu.tsx
+++ b/packages/react-components/react-charts-preview/library/src/components/Legends/OverflowMenu.tsx
@@ -18,7 +18,7 @@ export const OverflowMenu: React.FC<{ itemIds: string[]; title: string; items: J
   const remainingItemsCount = itemIds.length - overflowCount;
   const menuList = [];
   for (let i = remainingItemsCount; i < itemIds.length; i++) {
-    menuList.push(<MenuItem key={i}>{items[i]}</MenuItem>);
+    menuList.push(items[i]);
   }
   return (
     <Menu>


### PR DESCRIPTION
Fixed the following legend related bugs:
1. Axis titles are getting cropped by legends
2. Legends overflow - Hovering over the button is showing 2 areas. One in white and one in grey. Moving from 1 selection to next resets the selection briefly