### PR TITLE
fix: remove circular dependency in shadow DOM code path

### DIFF
--- a/change/@fluentui-utilities-5b080929-96b5-4f77-9f6f-f35fb0a3912c.json
+++ b/change/@fluentui-utilities-5b080929-96b5-4f77-9f6f-f35fb0a3912c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove circular dependency to better support AMD loaders",
+  "packageName": "@fluentui/utilities",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/utilities/etc/utilities.api.md
+++ b/packages/utilities/etc/utilities.api.md
@@ -1363,7 +1363,7 @@ export const useMergeStylesHooks: () => {
     useMergeStylesShadowRootContext: MergeStylesShadowRootContetHook;
     useHasMergeStylesShadowRootContext: HasMergeStylesShadowRootContextHook;
     useMergeStylesRootStylesheets: MergeStylesRootStylesheetsHook;
-    useWindow: () => Window | undefined;
+    useWindow: UseWindowHook;
     useStyled: UseStyledHook;
 };
 
@@ -1405,9 +1405,9 @@ export function warnMutuallyExclusive<P>(componentName: string, props: P, exclus
 
 // Warnings were encountered during analysis:
 //
-// lib/shadowDom/contexts/MergeStylesRootContext.d.ts:23:5 - (ae-forgotten-export) The symbol "MergeStylesShadowRootContetHook" needs to be exported by the entry point index.d.ts
-// lib/shadowDom/contexts/MergeStylesRootContext.d.ts:25:5 - (ae-forgotten-export) The symbol "MergeStylesRootStylesheetsHook" needs to be exported by the entry point index.d.ts
-// lib/shadowDom/contexts/MergeStylesRootContext.d.ts:26:5 - (ae-forgotten-export) The symbol "UseWindowHook" needs to be exported by the entry point index.d.ts
+// lib/shadowDom/contexts/MergeStylesRootContext.d.ts:20:5 - (ae-forgotten-export) The symbol "MergeStylesShadowRootContetHook" needs to be exported by the entry point index.d.ts
+// lib/shadowDom/contexts/MergeStylesRootContext.d.ts:22:5 - (ae-forgotten-export) The symbol "MergeStylesRootStylesheetsHook" needs to be exported by the entry point index.d.ts
+// lib/shadowDom/contexts/MergeStylesRootContext.d.ts:23:5 - (ae-forgotten-export) The symbol "UseWindowHook" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/utilities/src/shadowDom/contexts/MergeStylesDefaultContext.tsx
+++ b/packages/utilities/src/shadowDom/contexts/MergeStylesDefaultContext.tsx
@@ -1,0 +1,46 @@
+import { DEFAULT_SHADOW_CONFIG, ExtendedCSSStyleSheet } from '@fluentui/merge-styles';
+import * as React from 'react';
+
+import type { AdoptedStylesheetExHook, AdoptedStylesheetHook } from '../hooks/useAdoptedStylesheet';
+import type { ShadowConfigHook } from '../hooks/useShadowConfig';
+import type {
+  HasMergeStylesShadowRootContextHook,
+  MergeStylesShadowRootContetHook,
+} from '../hooks/useMergeStylesShadowRoot';
+import type { MergeStylesRootStylesheetsHook } from '../hooks/useMergeStylesRootStylesheets';
+import type { UseStyledHook } from '../hooks/useStyled';
+
+export const noop = () => false;
+export const noopShadow = () => DEFAULT_SHADOW_CONFIG;
+export const noopRootStylesheets = () => new Map();
+export const noopUndefined = () => undefined;
+
+export const getNewContext = (): MergeStylesDefaultContextValue => {
+  return {
+    stylesheets: new Map(),
+    useAdoptedStylesheetEx: noop,
+    useAdoptedStylesheet: noop,
+    useShadowConfig: noopShadow,
+    useMergeStylesShadowRootContext: noopUndefined,
+    useHasMergeStylesShadowRootContext: noop,
+    useMergeStylesRootStylesheets: noopRootStylesheets,
+    useWindow: noopUndefined,
+    useStyled: noopUndefined,
+  };
+};
+
+export type UseWindowHook = () => Window | undefined;
+
+export type MergeStylesDefaultContextValue = {
+  stylesheets: Map<string, ExtendedCSSStyleSheet>;
+  useAdoptedStylesheetEx: AdoptedStylesheetExHook;
+  useAdoptedStylesheet: AdoptedStylesheetHook;
+  useShadowConfig: ShadowConfigHook;
+  useMergeStylesShadowRootContext: MergeStylesShadowRootContetHook;
+  useHasMergeStylesShadowRootContext: HasMergeStylesShadowRootContextHook;
+  useMergeStylesRootStylesheets: MergeStylesRootStylesheetsHook;
+  useWindow: UseWindowHook;
+  useStyled: UseStyledHook;
+};
+
+export const MergeStylesDefaultContext = React.createContext<MergeStylesDefaultContextValue>(getNewContext());

--- a/packages/utilities/src/shadowDom/contexts/MergeStylesRootContext.tsx
+++ b/packages/utilities/src/shadowDom/contexts/MergeStylesRootContext.tsx
@@ -1,16 +1,12 @@
 import * as React from 'react';
-import {
-  GLOBAL_STYLESHEET_KEY,
-  ShadowDomStylesheet,
-  makeShadowConfig,
-  DEFAULT_SHADOW_CONFIG,
-} from '@fluentui/merge-styles';
+import { GLOBAL_STYLESHEET_KEY, ShadowDomStylesheet, makeShadowConfig } from '@fluentui/merge-styles';
 import { getWindow } from '../../dom';
-
+import { MergeStylesDefaultContext, getNewContext } from './MergeStylesDefaultContext';
 import {
   useAdoptedStylesheet as useAdoptedStylesheetDefault,
   useAdoptedStylesheetEx as useAdoptedStylesheetExDefault,
 } from '../hooks/useAdoptedStylesheet';
+
 import { useShadowConfig as useShadowConfigDefault } from '../hooks/useShadowConfig';
 import {
   useHasMergeStylesShadowRootContext as useHasMergeStylesShadowRootContextDefault,
@@ -29,6 +25,7 @@ import type {
 } from '../hooks/useMergeStylesShadowRoot';
 import type { MergeStylesRootStylesheetsHook } from '../hooks/useMergeStylesRootStylesheets';
 import type { UseStyledHook } from '../hooks/useStyled';
+import type { UseWindowHook } from './MergeStylesDefaultContext';
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -38,17 +35,7 @@ declare global {
   }
 }
 
-type UseWindowHook = () => Window | undefined;
-
-const noop = () => false;
-const noopShadow = () => DEFAULT_SHADOW_CONFIG;
-const noopRootStylesheets = () => new Map();
-const noopUndefined = () => undefined;
-
 export type MergeStylesRootContextValue = {
-  /**
-   * Map of stylesheets available in the context.
-   */
   stylesheets: Map<string, ExtendedCSSStyleSheet>;
   useAdoptedStylesheetEx: AdoptedStylesheetExHook;
   useAdoptedStylesheet: AdoptedStylesheetHook;
@@ -60,17 +47,7 @@ export type MergeStylesRootContextValue = {
   useStyled: UseStyledHook;
 };
 
-export const MergeStylesRootContext = React.createContext<MergeStylesRootContextValue>({
-  stylesheets: new Map(),
-  useAdoptedStylesheetEx: noop,
-  useAdoptedStylesheet: noop,
-  useShadowConfig: noopShadow,
-  useMergeStylesShadowRootContext: noopUndefined,
-  useHasMergeStylesShadowRootContext: noop,
-  useMergeStylesRootStylesheets: noopRootStylesheets,
-  useWindow: noopUndefined,
-  useStyled: noopUndefined,
-});
+export const MergeStylesRootContext = React.createContext<MergeStylesRootContextValue>(getNewContext());
 
 export type MergeStylesRootProviderProps = {
   /**
@@ -167,7 +144,7 @@ export const MergeStylesRootProvider: React.FC<MergeStylesRootProviderProps> = (
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const value = React.useMemo(() => {
+  const defaultValues = React.useMemo(() => {
     return {
       stylesheets,
       useAdoptedStylesheet: useAdoptedStylesheet || useAdoptedStylesheetDefault,
@@ -192,5 +169,9 @@ export const MergeStylesRootProvider: React.FC<MergeStylesRootProviderProps> = (
     useStyled,
   ]);
 
-  return <MergeStylesRootContext.Provider value={value} {...props} />;
+  return (
+    <MergeStylesDefaultContext.Provider value={defaultValues}>
+      <MergeStylesRootContext.Provider value={defaultValues} {...props} />
+    </MergeStylesDefaultContext.Provider>
+  );
 };

--- a/packages/utilities/src/shadowDom/hooks/useMergeStylesHooks.ts
+++ b/packages/utilities/src/shadowDom/hooks/useMergeStylesHooks.ts
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { MergeStylesRootContext } from '../contexts/MergeStylesRootContext';
+import { MergeStylesDefaultContext } from '../contexts/MergeStylesDefaultContext';
 
 export const useMergeStylesHooks = () => {
-  const ctx = React.useContext(MergeStylesRootContext);
+  const ctx = React.useContext(MergeStylesDefaultContext);
   return {
     useAdoptedStylesheet: ctx.useAdoptedStylesheet,
     useAdoptedStylesheetEx: ctx.useAdoptedStylesheetEx,

--- a/packages/utilities/src/shadowDom/hooks/useMergeStylesRootStylesheets.ts
+++ b/packages/utilities/src/shadowDom/hooks/useMergeStylesRootStylesheets.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { MergeStylesRootContext } from '../contexts/MergeStylesRootContext';
+import { MergeStylesDefaultContext } from '../contexts/MergeStylesDefaultContext';
 import type { ExtendedCSSStyleSheet } from '@fluentui/merge-styles';
 
 export type MergeStylesRootStylesheetsHook = () => Map<string, ExtendedCSSStyleSheet>;
@@ -8,5 +8,5 @@ export type MergeStylesRootStylesheetsHook = () => Map<string, ExtendedCSSStyleS
  * Get the map of stylesheets available in the context.
  */
 export const useMergeStylesRootStylesheets: MergeStylesRootStylesheetsHook = () => {
-  return React.useContext(MergeStylesRootContext).stylesheets;
+  return React.useContext(MergeStylesDefaultContext).stylesheets;
 };


### PR DESCRIPTION
## Previous Behavior

Apps using AMD might run into issues with circular dependencies.

## New Behavior

Circular deps are removed.

