### PR TITLE
Add strokeDasharray property when optimizeLargeData is true

### DIFF
--- a/change/@fluentui-react-charting-fbf8562f-4d14-45f5-b74e-75304b828612.json
+++ b/change/@fluentui-react-charting-fbf8562f-4d14-45f5-b74e-75304b828612.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add strokeDasharray for line charts with large datasets",
+  "packageName": "@fluentui/react-charting",
+  "email": "kaelens@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-charting/src/components/LineChart/LineChart.base.tsx
+++ b/packages/react-charting/src/components/LineChart/LineChart.base.tsx
@@ -709,6 +709,7 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
               stroke={lineColor}
               strokeWidth={strokeWidth}
               strokeLinecap={this._points[i].lineOptions?.strokeLinecap ?? 'round'}
+              strokeDasharray={this._points[i].lineOptions?.strokeDasharray}
               onMouseMove={this._onMouseOverLargeDataset.bind(this, i, verticaLineHeight)}
               onMouseOver={this._onMouseOverLargeDataset.bind(this, i, verticaLineHeight)}
               onMouseOut={this._handleMouseOut}
@@ -727,6 +728,7 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
               stroke={lineColor}
               strokeWidth={strokeWidth}
               strokeLinecap={this._points[i].lineOptions?.strokeLinecap ?? 'round'}
+              strokeDasharray={this._points[i].lineOptions?.strokeDasharray}
               opacity={0.1}
             />,
           );


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

When optimizeLargeData is true, the line chart cannot have dashed lines

## New Behavior

When optimizeLargeData is true, the line chart can have dashed lines


Created for this discussion: https://github.com/microsoft/fluentui/discussions/32449