### PR TITLE
feat(workspace-plugin): implement simple node measure execution utils

### DIFF
--- a/tools/workspace-plugin/src/executors/clean/executor.ts
+++ b/tools/workspace-plugin/src/executors/clean/executor.ts
@@ -4,10 +4,16 @@ import { join } from 'node:path';
 import { rm } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 
+import { measureEnd, measureStart } from '../../utils';
+
 const runExecutor: PromiseExecutor<CleanExecutorSchema> = async (schema, context) => {
+  measureStart('CleanExecutor');
+
   const options = normalizeOptions(schema, context);
 
   const success = await runClean(options, context);
+
+  measureEnd('CleanExecutor');
 
   return { success };
 };

--- a/tools/workspace-plugin/src/executors/generate-api/executor.ts
+++ b/tools/workspace-plugin/src/executors/generate-api/executor.ts
@@ -7,11 +7,16 @@ import { Extractor, ExtractorConfig, type IConfigFile } from '@microsoft/api-ext
 
 import type { GenerateApiExecutorSchema } from './schema';
 import type { PackageJson, TsConfig } from '../../types';
+import { measureEnd, measureStart } from '../../utils';
 
 const runExecutor: PromiseExecutor<GenerateApiExecutorSchema> = async (schema, context) => {
+  measureStart('GenerateApiExecutor');
+
   const options = normalizeOptions(schema, context);
 
   const success = await runGenerateApi(options, context);
+
+  measureEnd('GenerateApiExecutor');
 
   return { success };
 };

--- a/tools/workspace-plugin/src/executors/type-check/executor.ts
+++ b/tools/workspace-plugin/src/executors/type-check/executor.ts
@@ -1,18 +1,24 @@
 import { PromiseExecutor, joinPathFragments, readJsonFile, logger, ExecutorContext } from '@nx/devkit';
 
-import { TypeCheckExecutorSchema } from './schema';
 import { existsSync } from 'node:fs';
 import { promisify } from 'node:util';
 import { exec } from 'node:child_process';
+
+import { type TypeCheckExecutorSchema } from './schema';
+import { measureEnd, measureStart } from '../../utils';
 
 const asyncExec = promisify(exec);
 
 interface NormalizedOptions extends ReturnType<typeof normalizeOptions> {}
 
 const runExecutor: PromiseExecutor<TypeCheckExecutorSchema> = async (schema, context) => {
+  measureStart('TypeCheckExecutor');
+
   const options = normalizeOptions(schema, context);
 
   const success = await runTypeCheck(options, context);
+
+  measureEnd('TypeCheckExecutor');
 
   return { success };
 };

--- a/tools/workspace-plugin/src/executors/verify-packaging/executor.ts
+++ b/tools/workspace-plugin/src/executors/verify-packaging/executor.ts
@@ -5,11 +5,16 @@ import micromatch from 'micromatch';
 
 import { type VerifyPackagingExecutorSchema } from './schema';
 import { join } from 'node:path';
+import { measureEnd, measureStart } from '../../utils';
 
 const runExecutor: PromiseExecutor<VerifyPackagingExecutorSchema> = async (schema, context) => {
+  measureStart('VerifyTargetExecutor');
+
   const options = normalizeOptions(schema, context);
 
   const success = await runVerifyPackaging(options, context);
+
+  measureEnd('VerifyTargetExecutor');
 
   return { success };
 };

--- a/tools/workspace-plugin/src/utils.ts
+++ b/tools/workspace-plugin/src/utils.ts
@@ -1,3 +1,4 @@
+import { performance } from 'node:perf_hooks';
 import yargsParser from 'yargs-parser';
 import type * as Enquirer from 'enquirer';
 import {
@@ -266,4 +267,18 @@ export function isV8Package(tree: Tree, project: ProjectConfiguration) {
 
 export function packageJsonHasBeachballConfig(packageJson: PackageJson): packageJson is PackageJsonWithBeachball {
   return !!(packageJson as PackageJsonWithBeachball).beachball;
+}
+
+// ==========================
+// Execution time measurement
+// ==========================
+
+export function measureStart(key: string) {
+  performance.mark(`${key}:start`);
+}
+export function measureEnd(key: string) {
+  performance.mark(`${key}:end`);
+  const measure = performance.measure(key, `${key}:start`, `${key}:end`);
+
+  logger.verbose(`Execution Timings: ${key} (${(measure.duration / 1000).toFixed(2)} s)`);
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

No logs in verbose mode on CI, how long did a task execution take

## New Behavior

This PR implements time measurement utils and integrates them with our custom executors

- when using our executors we will get measurement data on CI runs
- this output will be present only in verbose mode: (`--verbose` or `NX_VERBOSE_LOGGING=true`)

**Demo:**

<img width="1334" alt="image" src="https://github.com/user-attachments/assets/e8be6e47-f7da-44cb-9881-7223cb53d721">


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Temporary workaround for https://github.com/nrwl/nx/discussions/27712
- Implements partially #30267 
