### PR TITLE
chore(web-components): use predicate function instead of instanceof in Accordion

### DIFF
--- a/apps/vr-tests-web-components/src/stories/accordion/accordion.stories.tsx
+++ b/apps/vr-tests-web-components/src/stories/accordion/accordion.stories.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react';
 import { default as parse } from 'html-react-parser';
 import { Steps, StoryWright } from 'storywright';
-import { accordionDefinition, accordionItemDefinition, FluentDesignSystem } from '@fluentui/web-components';
 import { DARK_MODE, getStoryVariant, RTL } from '../../utilities/WCThemeDecorator.js';
 
-accordionDefinition.define(FluentDesignSystem.registry);
-accordionItemDefinition.define(FluentDesignSystem.registry);
+import '@fluentui/web-components/accordion.js';
+import '@fluentui/web-components/accordion-item.js';
 
 export default {
   title: 'Accordion',

--- a/change/@fluentui-web-components-bdb28bcb-73de-4a25-bd52-f8f5ebad565a.json
+++ b/change/@fluentui-web-components-bdb28bcb-73de-4a25-bd52-f8f5ebad565a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "use isAccordionItem predicate function instead of instanceof in Accordion",
+  "packageName": "@fluentui/web-components",
+  "email": "863023+radium-v@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/docs/api-report.md
+++ b/packages/web-components/docs/api-report.md
@@ -21,7 +21,7 @@ import { ViewTemplate } from '@microsoft/fast-element';
 // @public
 export class Accordion extends FASTElement {
     // @internal (undocumented)
-    protected accordionItems: Element[];
+    protected accordionItems: BaseAccordionItem[];
     expandmode: AccordionExpandMode;
     // (undocumented)
     expandmodeChanged(prev: AccordionExpandMode, next: AccordionExpandMode): void;
@@ -33,8 +33,8 @@ export class Accordion extends FASTElement {
     slottedAccordionItemsChanged(oldValue: HTMLElement[], newValue: HTMLElement[]): void;
 }
 
-// @public (undocumented)
-export const accordionDefinition: FASTElementDefinition<typeof Accordion>;
+// @public
+export const AccordionBaseName = "accordion";
 
 // @public
 export const AccordionExpandMode: {
@@ -64,8 +64,8 @@ export class AccordionItem extends BaseAccordionItem {
 export interface AccordionItem extends StartEnd {
 }
 
-// @public (undocumented)
-export const accordionItemDefinition: FASTElementDefinition<typeof AccordionItem>;
+// @public
+export const AccordionItemBaseName = "accordion-item";
 
 // Warning: (ae-missing-release-tag) "AccordionItemMarkerPosition" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -2197,6 +2197,16 @@ export const curveLinear = "var(--curveLinear)";
 export const darkModeStylesheetBehavior: (styles: ElementStyles) => MatchMediaStyleSheetBehavior;
 
 // @public
+const definition: FASTElementDefinition<typeof AccordionItem>;
+export { definition as AccordionItemDefinition }
+export { definition as accordionItemDefinition }
+
+// @public
+const definition_2: FASTElementDefinition<typeof Accordion>;
+export { definition_2 as AccordionDefinition }
+export { definition_2 as accordionDefinition }
+
+// @public
 export class Dialog extends FASTElement {
     ariaDescribedby?: string;
     ariaLabelledby?: string;
@@ -2451,9 +2461,7 @@ export const FieldStyles: ElementStyles;
 // @public
 export const FieldTemplate: ElementViewTemplate;
 
-// Warning: (ae-missing-release-tag) "FluentDesignSystem" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export const FluentDesignSystem: Readonly<{
     prefix: "fluent";
     shadowRootMode: "open";
@@ -2515,6 +2523,9 @@ export const fontWeightSemibold = "var(--fontWeightSemibold)";
 export const forcedColorsStylesheetBehavior: (styles: ElementStyles) => MatchMediaStyleSheetBehavior;
 
 // @public
+export function generateElementName(baseName: string): string;
+
+// @public
 export const getDirection: (rootNode: HTMLElement) => Direction;
 
 // @public
@@ -2565,6 +2576,12 @@ export const ImageStyles: ElementStyles;
 
 // @public
 export const ImageTemplate: ElementViewTemplate<Image_2>;
+
+// @public
+export function isAccordion(element: Element): element is Accordion;
+
+// @public
+export function isAccordionItem(element: Element): element is BaseAccordionItem;
 
 // @public
 export class Label extends FASTElement {
@@ -3500,6 +3517,9 @@ export type StartOptions<TSource = any, TParent = any> = {
 export function startSlotTemplate<TSource extends StartEnd = StartEnd, TParent = any>(options: StartOptions<TSource, TParent>): CaptureType<TSource, TParent>;
 
 // @public
+export type StaticallyComposableHTML<TSource = any, TParent = any> = string | HTMLDirective | SyntheticViewTemplate<TSource, TParent> | undefined;
+
+// @public
 export const strokeWidthThick = "var(--strokeWidthThick)";
 
 // @public
@@ -3802,9 +3822,7 @@ export const TextAreaAppearance: {
 // @public (undocumented)
 export type TextAreaAppearance = ValuesOf<typeof TextAreaAppearance>;
 
-// Warning: (ae-missing-release-tag) "TextAreaAppearancesForDisplayShadow" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export const TextAreaAppearancesForDisplayShadow: Partial<TextAreaAppearance[]>;
 
 // Warning: (ae-missing-release-tag) "TextAreaAutocomplete" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -4133,10 +4151,6 @@ export const ValidationFlags: {
 
 // @public (undocumented)
 export type ValidationFlags = ValuesOf<typeof ValidationFlags>;
-
-// Warnings were encountered during analysis:
-//
-// dist/dts/accordion-item/accordion-item.d.ts:11:5 - (ae-forgotten-export) The symbol "StaticallyComposableHTML" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/web-components/docs/api-report.md
+++ b/packages/web-components/docs/api-report.md
@@ -37,6 +37,9 @@ export class Accordion extends FASTElement {
 export const AccordionBaseName = "accordion";
 
 // @public
+export const AccordionDefinition: FASTElementDefinition<typeof Accordion>;
+
+// @public
 export const AccordionExpandMode: {
     readonly single: "single";
     readonly multi: "multi";
@@ -66,6 +69,9 @@ export interface AccordionItem extends StartEnd {
 
 // @public
 export const AccordionItemBaseName = "accordion-item";
+
+// @public
+export const AccordionItemDefinition: FASTElementDefinition<typeof AccordionItem>;
 
 // Warning: (ae-missing-release-tag) "AccordionItemMarkerPosition" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -2195,16 +2201,6 @@ export const curveLinear = "var(--curveLinear)";
 
 // @public
 export const darkModeStylesheetBehavior: (styles: ElementStyles) => MatchMediaStyleSheetBehavior;
-
-// @public
-const definition: FASTElementDefinition<typeof AccordionItem>;
-export { definition as AccordionItemDefinition }
-export { definition as accordionItemDefinition }
-
-// @public
-const definition_2: FASTElementDefinition<typeof Accordion>;
-export { definition_2 as AccordionDefinition }
-export { definition_2 as accordionDefinition }
 
 // @public
 export class Dialog extends FASTElement {

--- a/packages/web-components/src/accordion-item/accordion-item.definition.ts
+++ b/packages/web-components/src/accordion-item/accordion-item.definition.ts
@@ -1,16 +1,36 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
-import { AccordionItem } from './accordion-item.js';
+import { generateElementName } from '../fluent-design-system.js';
+import { AccordionItem, type BaseAccordionItem } from './accordion-item.js';
 import { styles } from './accordion-item.styles.js';
 import { template } from './accordion-item.template.js';
 
 /**
+ * The base name of the {@link BaseAccordionItem | AccordionItem} element.
+ *
+ * @public
+ */
+export const baseName = 'accordion-item';
+
+/**
+ * The {@link BaseAccordionItem | AccordionItem} custom element definition.
  *
  * @public
  * @remarks
- * HTML Element: \<fluent-accordion-item\>
+ * HTML Element: `<fluent-accordion-item>`
  */
 export const definition = AccordionItem.compose({
-  name: `${FluentDesignSystem.prefix}-accordion-item`,
+  name: generateElementName(baseName),
   template,
   styles,
 });
+
+/**
+ * Checks if an element is an {@link BaseAccordionItem | AccordionItem}.
+ *
+ * @param element - The element to check
+ * @returns - The element is an AccordionItem
+ *
+ * @public
+ */
+export function isAccordionItem(element: Element): element is BaseAccordionItem {
+  return element.tagName.toLowerCase().endsWith(baseName);
+}

--- a/packages/web-components/src/accordion-item/accordion-item.options.ts
+++ b/packages/web-components/src/accordion-item/accordion-item.options.ts
@@ -1,4 +1,16 @@
-import type { ValuesOf } from '../utils/index.js';
+import type { StartEndOptions } from '../patterns/start-end.js';
+import type { StaticallyComposableHTML } from '../utils/template-helpers.js';
+import type { ValuesOf } from '../utils/typings.js';
+import type { AccordionItem } from './accordion-item.js';
+
+/**
+ * Accordion Item configuration options
+ * @public
+ */
+export type AccordionItemOptions = StartEndOptions<AccordionItem> & {
+  expandedIcon?: StaticallyComposableHTML<AccordionItem>;
+  collapsedIcon?: StaticallyComposableHTML<AccordionItem>;
+};
 
 /**
  * An Accordion Item header font size can be small, medium, large, and extra-large

--- a/packages/web-components/src/accordion-item/accordion-item.template.ts
+++ b/packages/web-components/src/accordion-item/accordion-item.template.ts
@@ -1,7 +1,8 @@
 import { ElementViewTemplate, html, ref } from '@microsoft/fast-element';
 import { endSlotTemplate, startSlotTemplate } from '../patterns/index.js';
 import { staticallyCompose } from '../utils/index.js';
-import type { AccordionItem, AccordionItemOptions } from './accordion-item.js';
+import type { AccordionItem } from './accordion-item.js';
+import type { AccordionItemOptions } from './accordion-item.options.js';
 
 const chevronRight20Filled = html.partial(`<svg
   width="20"
@@ -50,8 +51,8 @@ export function accordionItemTemplate<T extends AccordionItem>(
         <slot name="heading"></slot>
       </button>
       ${startSlotTemplate(options)}
-      <slot name="marker-expanded"> ${staticallyCompose(options.expandedIcon)} </slot>
-      <slot name="marker-collapsed"> ${staticallyCompose(options.collapsedIcon)} </slot>
+      <slot name="marker-expanded">${staticallyCompose(options.expandedIcon)}</slot>
+      <slot name="marker-collapsed">${staticallyCompose(options.collapsedIcon)}</slot>
     </div>
     <div class="content" part="content" id="${x => x.id}-panel" role="region" aria-labelledby="${x => x.id}">
       <slot></slot>

--- a/packages/web-components/src/accordion-item/accordion-item.ts
+++ b/packages/web-components/src/accordion-item/accordion-item.ts
@@ -1,20 +1,9 @@
 import { attr, FASTElement, nullableNumberConverter } from '@microsoft/fast-element';
 import { uniqueId } from '@microsoft/fast-web-utilities';
-import type { StaticallyComposableHTML } from '../utils/index.js';
-import { StartEnd } from '../patterns/index.js';
-import type { StartEndOptions } from '../patterns/index.js';
+import { StartEnd } from '../patterns/start-end.js';
 import { applyMixins } from '../utils/apply-mixins.js';
 import { toggleState } from '../utils/element-internals.js';
-import { AccordionItemMarkerPosition, AccordionItemSize } from './accordion-item.options.js';
-
-/**
- * Accordion Item configuration options
- * @public
- */
-export type AccordionItemOptions = StartEndOptions<AccordionItem> & {
-  expandedIcon?: StaticallyComposableHTML<AccordionItem>;
-  collapsedIcon?: StaticallyComposableHTML<AccordionItem>;
-};
+import type { AccordionItemMarkerPosition, AccordionItemSize } from './accordion-item.options.js';
 
 /**
  *

--- a/packages/web-components/src/accordion-item/index.ts
+++ b/packages/web-components/src/accordion-item/index.ts
@@ -1,6 +1,9 @@
+export {
+  baseName as AccordionItemBaseName,
+  definition as AccordionItemDefinition,
+  isAccordionItem,
+} from './accordion-item.definition.js';
 export { AccordionItem, BaseAccordionItem } from './accordion-item.js';
-export type { AccordionItemOptions } from './accordion-item.js';
-export { AccordionItemSize, AccordionItemMarkerPosition } from './accordion-item.options.js';
+export { AccordionItemMarkerPosition, AccordionItemSize, type AccordionItemOptions } from './accordion-item.options.js';
 export { styles as accordionItemStyles } from './accordion-item.styles.js';
-export { definition as accordionItemDefinition } from './accordion-item.definition.js';
 export { template as accordionItemTemplate } from './accordion-item.template.js';

--- a/packages/web-components/src/accordion/accordion.definition.ts
+++ b/packages/web-components/src/accordion/accordion.definition.ts
@@ -1,15 +1,36 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
+import { generateElementName } from '../fluent-design-system.js';
 import { Accordion } from './accordion.js';
 import { styles } from './accordion.styles.js';
 import { template } from './accordion.template.js';
 
 /**
+ * The base name of the {@link Accordion}.
+ *
+ * @public
+ */
+export const baseName = 'accordion';
+
+/**
+ * The {@link Accordion} custom element definition.
+ *
  * @public
  * @remarks
- * HTML Element: \<fluent-accordion\>
+ * HTML Element: `<fluent-accordion>`
  */
 export const definition = Accordion.compose({
-  name: `${FluentDesignSystem.prefix}-accordion`,
+  name: generateElementName(baseName),
   template,
   styles,
 });
+
+/**
+ * Checks if an element is an {@link Accordion}.
+ *
+ * @param element - The element to check
+ * @returns - The element is an Accordion
+ *
+ * @public
+ */
+export function isAccordion(element: Element): element is Accordion {
+  return element.tagName.toLowerCase().endsWith(baseName);
+}

--- a/packages/web-components/src/accordion/accordion.ts
+++ b/packages/web-components/src/accordion/accordion.ts
@@ -82,8 +82,9 @@ export class Accordion extends FASTElement {
   private activeItemIndex: number = 0;
 
   /**
-   * Find the first expanded item in the accordion
-   * @returns {void}
+   * Find the first expanded item in the accordion.
+   *
+   * @internal
    */
   private findExpandedItem(): BaseAccordionItem | Element | null {
     if (this.accordionItems.length === 0) {
@@ -98,9 +99,9 @@ export class Accordion extends FASTElement {
   }
 
   /**
-   * Resets event listeners and sets the `accordionItems` property
-   * then rebinds event listeners to each non-disabled item
-   * @returns {void}
+   * Resets event listeners and sets the `accordionItems` property, then rebinds event listeners to each enabled item.
+   *
+   * @internal
    */
   private setItems = (): void => {
     if (this.slottedAccordionItems.length === 0) {
@@ -131,17 +132,20 @@ export class Accordion extends FASTElement {
   };
 
   /**
-   * Checks if the accordion is in single expand mode
-   * @returns {boolean}
+   * Checks if the accordion is in single expand mode.
+   *
+   * @internal
    */
   private isSingleExpandMode(): boolean {
     return this.expandmode === AccordionExpandMode.single;
   }
 
   /**
-   * Controls the behavior of the accordion in single expand mode
-   * @param expandedItem The item to expand in single expand mode
-   * @returns {void}
+   * Controls the behavior of the accordion in single expand mode.
+   *
+   * @param expandedItem - The item to expand in single expand mode
+   *
+   * @internal
    */
   private setSingleExpandMode(expandedItem: Element): void {
     if (this.accordionItems.length === 0) {
@@ -167,8 +171,10 @@ export class Accordion extends FASTElement {
   }
 
   /**
-   * Removes event listeners from the previous accordion items
-   * @param oldValue An array of the previous accordion items
+   * Removes event listeners from the previous accordion items.
+   *
+   * @param oldValue - An array of the previous accordion items
+   * @internal
    */
   private removeItemListeners = (oldValue: any): void => {
     oldValue.forEach((item: HTMLElement, index: number) => {
@@ -179,9 +185,10 @@ export class Accordion extends FASTElement {
   };
 
   /**
-   * Changes the expanded state of the accordion item
-   * @param evt Click event
-   * @returns
+   * Changes the expanded state of the accordion item.
+   *
+   * @param evt - The click event
+   * @internal
    */
   private expandedChangedHandler: EventListener = (evt: Event): void => {
     const item = evt.target as HTMLElement;

--- a/packages/web-components/src/accordion/accordion.ts
+++ b/packages/web-components/src/accordion/accordion.ts
@@ -1,6 +1,6 @@
-import { Observable } from '@microsoft/fast-element';
-import { attr, FASTElement, observable } from '@microsoft/fast-element';
-import { BaseAccordionItem } from '../accordion-item/accordion-item.js';
+import { attr, FASTElement, Observable, observable } from '@microsoft/fast-element';
+import { isAccordionItem } from '../accordion-item/accordion-item.definition.js';
+import type { BaseAccordionItem } from '../accordion-item/accordion-item.js';
 import { AccordionExpandMode } from './accordion.options.js';
 
 /**

--- a/packages/web-components/src/accordion/index.ts
+++ b/packages/web-components/src/accordion/index.ts
@@ -1,5 +1,9 @@
+export {
+  baseName as AccordionBaseName,
+  definition as AccordionDefinition,
+  isAccordion,
+} from './accordion.definition.js';
 export { Accordion } from './accordion.js';
 export { AccordionExpandMode } from './accordion.options.js';
-export { template as accordionTemplate } from './accordion.template.js';
 export { styles as accordionStyles } from './accordion.styles.js';
-export { definition as accordionDefinition } from './accordion.definition.js';
+export { template as accordionTemplate } from './accordion.template.js';

--- a/packages/web-components/src/fluent-design-system.ts
+++ b/packages/web-components/src/fluent-design-system.ts
@@ -1,5 +1,21 @@
+/**
+ * Design system configuration for the Fluent Web Components library.
+ *
+ * @public
+ */
 export const FluentDesignSystem = Object.freeze({
   prefix: 'fluent',
   shadowRootMode: 'open',
   registry: customElements,
 });
+
+/**
+ * Generates an element name based on the base name and the design system prefix.
+ * @param baseName - The base name of the element
+ * @returns The generated element name
+ *
+ * @public
+ */
+export function generateElementName(baseName: string): string {
+  return `${FluentDesignSystem.prefix}-${baseName}`;
+}

--- a/packages/web-components/src/index.ts
+++ b/packages/web-components/src/index.ts
@@ -1,11 +1,14 @@
 export {
   AccordionItem,
-  accordionItemDefinition,
+  AccordionItemBaseName,
+  AccordionItemDefinition,
+  AccordionItemDefinition as accordionItemDefinition, // deprecated, use AccordionItemDefinition
   AccordionItemMarkerPosition,
   AccordionItemSize,
   accordionItemStyles,
   accordionItemTemplate,
   BaseAccordionItem,
+  isAccordionItem,
 } from './accordion-item/index.js';
 export type { AccordionItemOptions } from './accordion-item/index.js';
 export {

--- a/packages/web-components/src/index.ts
+++ b/packages/web-components/src/index.ts
@@ -114,7 +114,7 @@ export {
   FieldTemplate,
 } from './field/index.js';
 export type { SlottableInput } from './field/index.js';
-export { FluentDesignSystem } from './fluent-design-system.js';
+export { FluentDesignSystem, generateElementName } from './fluent-design-system.js';
 export { Image, ImageDefinition, ImageFit, ImageShape, ImageStyles, ImageTemplate } from './image/index.js';
 export { Label, LabelDefinition, LabelSize, LabelStyles, LabelTemplate, LabelWeight } from './label/index.js';
 export {

--- a/packages/web-components/src/index.ts
+++ b/packages/web-components/src/index.ts
@@ -2,7 +2,6 @@ export {
   AccordionItem,
   AccordionItemBaseName,
   AccordionItemDefinition,
-  AccordionItemDefinition as accordionItemDefinition, // deprecated, use AccordionItemDefinition
   AccordionItemMarkerPosition,
   AccordionItemSize,
   accordionItemStyles,
@@ -15,7 +14,6 @@ export {
   Accordion,
   AccordionBaseName,
   AccordionDefinition,
-  AccordionDefinition as accordionDefinition, // deprecated, use AccordionDefinition
   AccordionExpandMode,
   accordionStyles,
   accordionTemplate,

--- a/packages/web-components/src/index.ts
+++ b/packages/web-components/src/index.ts
@@ -13,10 +13,13 @@ export {
 export type { AccordionItemOptions } from './accordion-item/index.js';
 export {
   Accordion,
-  accordionDefinition,
+  AccordionBaseName,
+  AccordionDefinition,
+  AccordionDefinition as accordionDefinition, // deprecated, use AccordionDefinition
   AccordionExpandMode,
   accordionStyles,
   accordionTemplate,
+  isAccordion,
 } from './accordion/index.js';
 export { Link, LinkAppearance, LinkDefinition, LinkTemplate, LinkStyles, LinkTarget } from './link/index.js';
 export {

--- a/packages/web-components/src/index.ts
+++ b/packages/web-components/src/index.ts
@@ -311,3 +311,4 @@ export {
 export type { MediaQueryListListener } from './utils/behaviors/match-media-stylesheet-behavior.js';
 export { getDirection } from './utils/direction.js';
 export { display } from './utils/display.js';
+export type { StaticallyComposableHTML } from './utils/template-helpers.js';


### PR DESCRIPTION
## Previous Behavior

In systems which bundle components individually, we noticed that by using `instanceof` in the `Accordion` class, we're pulling the `BaseAccordion` class into our bundles.

## New Behavior

This PR introduces type predicate functions, `isAccordionItem` and `isAccordion`, to cheaply determine if a child component is one which is expected. These functions do this by checking if the `tagName` ends with a `baseName` value, so `isAccordionItem(element)` will return true if `element.tagName` ends with "accordion-item".

Some other changes:
* The top-level `index.ts` exports `accordionDefinition` and `accordionItemDefinition`. These should be deprecated and removed in favor of the more consistent PascalCased `AccordionDefinition` and `AccordionItemDefinition`.
* The `Accordion.accordionItems` property was typed as `Element[]`, which required a lot of checking to confirm if the collection actually contains `AccordionItem[]`. This PR fixes the property's type to make it easier to work with.

This PR also fixes some minor API Extractor warnings generated by the `Accordion` and `AccordionItem` modules.
