### PR TITLE
fix: make type-check target use targetDefault dependsOn definition for all monorepo projects

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -34,8 +34,7 @@
     },
     "type-check": {
       "dependsOn": ["^build"],
-      "cache": true,
-      "executor": "@fluentui/workspace-plugin:type-check"
+      "cache": true
     },
     "prepare": {
       "dependsOn": ["^prepare"],

--- a/scripts/api-extractor/project.json
+++ b/scripts/api-extractor/project.json
@@ -5,7 +5,9 @@
   "projectType": "library",
   "tags": ["tools"],
   "targets": {
-    "type-check": {},
+    "type-check": {
+      "executor": "@fluentui/workspace-plugin:type-check"
+    },
     "format": {}
   }
 }

--- a/scripts/babel/project.json
+++ b/scripts/babel/project.json
@@ -5,7 +5,9 @@
   "projectType": "library",
   "tags": ["tools"],
   "targets": {
-    "type-check": {},
+    "type-check": {
+      "executor": "@fluentui/workspace-plugin:type-check"
+    },
     "format": {}
   }
 }

--- a/scripts/beachball/project.json
+++ b/scripts/beachball/project.json
@@ -5,7 +5,9 @@
   "projectType": "library",
   "tags": ["tools"],
   "targets": {
-    "type-check": {},
+    "type-check": {
+      "executor": "@fluentui/workspace-plugin:type-check"
+    },
     "format": {}
   }
 }

--- a/scripts/cypress/project.json
+++ b/scripts/cypress/project.json
@@ -5,7 +5,9 @@
   "projectType": "library",
   "tags": ["tools"],
   "targets": {
-    "type-check": {},
+    "type-check": {
+      "executor": "@fluentui/workspace-plugin:type-check"
+    },
     "format": {}
   }
 }

--- a/scripts/dangerjs/project.json
+++ b/scripts/dangerjs/project.json
@@ -5,7 +5,9 @@
   "projectType": "library",
   "tags": ["tools"],
   "targets": {
-    "type-check": {},
+    "type-check": {
+      "executor": "@fluentui/workspace-plugin:type-check"
+    },
     "format": {}
   }
 }

--- a/scripts/executors/project.json
+++ b/scripts/executors/project.json
@@ -5,7 +5,9 @@
   "projectType": "library",
   "tags": ["tools"],
   "targets": {
-    "type-check": {},
+    "type-check": {
+      "executor": "@fluentui/workspace-plugin:type-check"
+    },
     "format": {}
   }
 }

--- a/scripts/fluentui-publish/project.json
+++ b/scripts/fluentui-publish/project.json
@@ -13,7 +13,9 @@
         "{workspaceRoot}/packages/fluentui/*/project.json"
       ]
     },
-    "type-check": {},
+    "type-check": {
+      "executor": "@fluentui/workspace-plugin:type-check"
+    },
     "format": {}
   }
 }

--- a/scripts/generators/project.json
+++ b/scripts/generators/project.json
@@ -5,7 +5,9 @@
   "projectType": "library",
   "tags": ["tools"],
   "targets": {
-    "type-check": {},
+    "type-check": {
+      "executor": "@fluentui/workspace-plugin:type-check"
+    },
     "format": {}
   }
 }

--- a/scripts/github/project.json
+++ b/scripts/github/project.json
@@ -5,7 +5,9 @@
   "projectType": "library",
   "tags": ["tools"],
   "targets": {
-    "type-check": {},
+    "type-check": {
+      "executor": "@fluentui/workspace-plugin:type-check"
+    },
     "format": {}
   }
 }

--- a/scripts/gulp/project.json
+++ b/scripts/gulp/project.json
@@ -5,7 +5,9 @@
   "projectType": "library",
   "tags": ["tools"],
   "targets": {
-    "type-check": {},
+    "type-check": {
+      "executor": "@fluentui/workspace-plugin:type-check"
+    },
     "format": {}
   }
 }

--- a/scripts/jest/project.json
+++ b/scripts/jest/project.json
@@ -5,7 +5,9 @@
   "projectType": "library",
   "tags": ["tools"],
   "targets": {
-    "type-check": {},
+    "type-check": {
+      "executor": "@fluentui/workspace-plugin:type-check"
+    },
     "format": {}
   }
 }

--- a/scripts/lint-staged/project.json
+++ b/scripts/lint-staged/project.json
@@ -5,7 +5,9 @@
   "projectType": "library",
   "tags": ["tools"],
   "targets": {
-    "type-check": {},
+    "type-check": {
+      "executor": "@fluentui/workspace-plugin:type-check"
+    },
     "format": {}
   }
 }

--- a/scripts/monorepo/project.json
+++ b/scripts/monorepo/project.json
@@ -5,7 +5,9 @@
   "projectType": "library",
   "tags": ["tools"],
   "targets": {
-    "type-check": {},
+    "type-check": {
+      "executor": "@fluentui/workspace-plugin:type-check"
+    },
     "format": {}
   }
 }

--- a/scripts/package-manager/project.json
+++ b/scripts/package-manager/project.json
@@ -5,7 +5,9 @@
   "projectType": "library",
   "tags": ["tools"],
   "targets": {
-    "type-check": {},
+    "type-check": {
+      "executor": "@fluentui/workspace-plugin:type-check"
+    },
     "format": {}
   }
 }

--- a/scripts/perf-test-flamegrill/project.json
+++ b/scripts/perf-test-flamegrill/project.json
@@ -5,7 +5,9 @@
   "projectType": "library",
   "tags": ["tools", "platform:any"],
   "targets": {
-    "type-check": {},
+    "type-check": {
+      "executor": "@fluentui/workspace-plugin:type-check"
+    },
     "format": {}
   }
 }

--- a/scripts/prettier/project.json
+++ b/scripts/prettier/project.json
@@ -5,7 +5,9 @@
   "projectType": "library",
   "tags": ["tools"],
   "targets": {
-    "type-check": {},
+    "type-check": {
+      "executor": "@fluentui/workspace-plugin:type-check"
+    },
     "format": {}
   }
 }

--- a/scripts/projects-test/project.json
+++ b/scripts/projects-test/project.json
@@ -5,7 +5,9 @@
   "projectType": "library",
   "tags": ["tools"],
   "targets": {
-    "type-check": {},
+    "type-check": {
+      "executor": "@fluentui/workspace-plugin:type-check"
+    },
     "format": {}
   }
 }

--- a/scripts/puppeteer/project.json
+++ b/scripts/puppeteer/project.json
@@ -5,7 +5,9 @@
   "projectType": "library",
   "tags": ["tools"],
   "targets": {
-    "type-check": {},
+    "type-check": {
+      "executor": "@fluentui/workspace-plugin:type-check"
+    },
     "format": {}
   }
 }

--- a/scripts/storybook/project.json
+++ b/scripts/storybook/project.json
@@ -5,7 +5,9 @@
   "projectType": "library",
   "tags": ["tools"],
   "targets": {
-    "type-check": {},
+    "type-check": {
+      "executor": "@fluentui/workspace-plugin:type-check"
+    },
     "format": {}
   }
 }

--- a/scripts/tasks/project.json
+++ b/scripts/tasks/project.json
@@ -5,7 +5,9 @@
   "projectType": "library",
   "tags": ["tools"],
   "targets": {
-    "type-check": {},
+    "type-check": {
+      "executor": "@fluentui/workspace-plugin:type-check"
+    },
     "format": {}
   }
 }

--- a/scripts/test-ssr/project.json
+++ b/scripts/test-ssr/project.json
@@ -5,7 +5,9 @@
   "projectType": "library",
   "tags": ["tools"],
   "targets": {
-    "type-check": {},
+    "type-check": {
+      "executor": "@fluentui/workspace-plugin:type-check"
+    },
     "format": {}
   }
 }

--- a/scripts/triage-bot/project.json
+++ b/scripts/triage-bot/project.json
@@ -5,7 +5,9 @@
   "projectType": "library",
   "tags": ["tools"],
   "targets": {
-    "type-check": {},
+    "type-check": {
+      "executor": "@fluentui/workspace-plugin:type-check"
+    },
     "format": {}
   }
 }

--- a/scripts/ts-node/project.json
+++ b/scripts/ts-node/project.json
@@ -5,7 +5,9 @@
   "projectType": "library",
   "tags": ["tools"],
   "targets": {
-    "type-check": {},
+    "type-check": {
+      "executor": "@fluentui/workspace-plugin:type-check"
+    },
     "format": {}
   }
 }

--- a/scripts/update-release-notes/project.json
+++ b/scripts/update-release-notes/project.json
@@ -5,7 +5,9 @@
   "projectType": "library",
   "tags": ["tools"],
   "targets": {
-    "type-check": {},
+    "type-check": {
+      "executor": "@fluentui/workspace-plugin:type-check"
+    },
     "format": {}
   }
 }

--- a/scripts/utils/project.json
+++ b/scripts/utils/project.json
@@ -5,7 +5,9 @@
   "projectType": "library",
   "tags": ["tools"],
   "targets": {
-    "type-check": {},
+    "type-check": {
+      "executor": "@fluentui/workspace-plugin:type-check"
+    },
     "format": {}
   }
 }

--- a/scripts/webpack/project.json
+++ b/scripts/webpack/project.json
@@ -5,7 +5,9 @@
   "projectType": "library",
   "tags": ["tools"],
   "targets": {
-    "type-check": {},
+    "type-check": {
+      "executor": "@fluentui/workspace-plugin:type-check"
+    },
     "format": {}
   }
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

`dependsOn` for `type-check` doesn't work for projects using npm-scripts

> **Note:**  🚨 this is affecting all v9 projects

<img width="1425" alt="image" src="https://github.com/user-attachments/assets/9f85fe08-ac0d-4412-ad56-4920edc0b735">


## New Behavior

`dependsOn` works as before

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes regression introduced in https://github.com/microsoft/fluentui/pull/32371/files#diff-15552e50b1b7c05b05b7ffe08ee47b5ed62b8d2039229c58972a42fd22a7381cR38
