### PR TITLE
fix(TagItemSuggestion v8): pass rest of the props to the underlying component

### DIFF
--- a/change/@fluentui-react-04cc1ab9-345e-4196-a9fd-d0ad829eec9b.json
+++ b/change/@fluentui-react-04cc1ab9-345e-4196-a9fd-d0ad829eec9b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "pass rest of ITagItemSuggestionProps to the underlying component",
+  "packageName": "@fluentui/react",
+  "email": "kmatejka@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-04cc1ab9-345e-4196-a9fd-d0ad829eec9b.json
+++ b/change/@fluentui-react-04cc1ab9-345e-4196-a9fd-d0ad829eec9b.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "pass rest of ITagItemSuggestionProps to the underlying component",
+  "comment": "fix: Passing rest of ITagItemSuggestionProps to the underlying component.",
   "packageName": "@fluentui/react",
   "email": "kmatejka@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/react/src/components/pickers/TagPicker/TagItemSuggestion.tsx
+++ b/packages/react/src/components/pickers/TagPicker/TagItemSuggestion.tsx
@@ -14,13 +14,18 @@ const getClassNames = classNamesFunction<ITagItemSuggestionStyleProps, ITagItemS
  * {@docCategory TagPicker}
  */
 export const TagItemSuggestionBase = (props: ITagItemSuggestionProps) => {
-  const { styles, theme, children } = props;
+  const { styles, theme, children, ...rest } = props;
 
   const classNames = getClassNames(styles, {
     theme: theme!,
   });
 
-  return <div className={classNames.suggestionTextOverflow}> {children} </div>;
+  return (
+    <div className={classNames.suggestionTextOverflow} {...rest}>
+      {' '}
+      {children}{' '}
+    </div>
+  );
 };
 
 export const TagItemSuggestion = styled<


### PR DESCRIPTION
## Previous Behavior

`ITagItemSuggestionProps` extends `React.AllHTMLAttributes<HTMLElement>` which allows to put any HTMLElement props on `TagItemSuggestion`

**For example**
```
    onRenderSuggestionsItem: (props: ITag) => (
      <TagItemSuggestion onClick={() => console.log('click')}>{props.name}</TagItemSuggestion>
    ),
```

But only `styles, theme, children` were used

## New Behavior

All HTMLElement props are passed to the div component.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
