### PR TITLE
chore(web-components): update tensile to run headless

### DIFF
--- a/change/@fluentui-web-components-8e02b581-6c01-41bb-a0c1-bc480f986dc0.json
+++ b/change/@fluentui-web-components-8e02b581-6c01-41bb-a0c1-bc480f986dc0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: update tensile to run in headless mode",
+  "packageName": "@fluentui/web-components",
+  "email": "13071055+chrisdholt@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/tensile.config.js
+++ b/packages/web-components/tensile.config.js
@@ -1,7 +1,7 @@
 const config = {
   // Browsers to test against
   browsers: ['chrome'],
-
+  headless: true,
   // Importmaps for your test.
   // See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap
   imports: {


### PR DESCRIPTION
## Previous Behavior
Tensile did not run in headless mode.

## New Behavior
Tensile runs in headless mode.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
