### PR TITLE
feat(eslint-rules): implement `no-missing-jsx-pragma`  in order to automate and unify slot API usage

### DIFF
--- a/tools/eslint-rules/index.ts
+++ b/tools/eslint-rules/index.ts
@@ -1,4 +1,5 @@
 import { RULE_NAME as noRestrictedGlobalsName, rule as noRestrictedGlobals } from './rules/no-restricted-globals';
+import { RULE_NAME as noMissingJsxPragmaName, rule as noMissingJsxPragma } from './rules/no-missing-jsx-pragma';
 import {
   RULE_NAME as consistentCallbackTypeName,
   rule as consistentCallbackType,
@@ -28,5 +29,9 @@ module.exports = {
    *  [myCustomRuleName]: myCustomRule
    * }
    */
-  rules: { [consistentCallbackTypeName]: consistentCallbackType, [noRestrictedGlobalsName]: noRestrictedGlobals },
+  rules: {
+    [consistentCallbackTypeName]: consistentCallbackType,
+    [noRestrictedGlobalsName]: noRestrictedGlobals,
+    [noMissingJsxPragmaName]: noMissingJsxPragma,
+  },
 };

--- a/tools/eslint-rules/project.json
+++ b/tools/eslint-rules/project.json
@@ -4,5 +4,9 @@
   "sourceRoot": "tools/eslint-rules",
   "projectType": "library",
   "tags": ["platform:node", "tools"],
-  "targets": {}
+  "targets": {
+    "type-check": {
+      "executor": "@fluentui/workspace-plugin:type-check"
+    }
+  }
 }

--- a/tools/eslint-rules/rules/no-missing-jsx-pragma.spec.ts
+++ b/tools/eslint-rules/rules/no-missing-jsx-pragma.spec.ts
@@ -98,22 +98,6 @@ ruleTester.run(RULE_NAME, rule, {
     };
     `,
     },
-    // =====================================================================================
-    // using slot.* apis via direct JSX rendering - anti-pattern in v9 framework composition
-    // =====================================================================================
-    {
-      options: [{ runtime: 'automatic' }],
-      code: `
-    import { slot, getIntrinsicElementProps } from '@fluentui/react-utilities';
-
-    export const factory = (props: {}) => {
-      const SlotComponent = slot.always(getIntrinsicElementProps('span', {}),{ elementType: 'span' })
-      const InlineCmp = () => <div>inline</div>
-
-      return {SlotComponent,InlineCmp}
-    };
-    `,
-    },
     {
       options: [{ runtime: 'automatic' }],
       code: `
@@ -164,6 +148,21 @@ ruleTester.run(RULE_NAME, rule, {
             <SlotOptionalComponent/>
           </div>
       );
+    };
+    `,
+    },
+
+    // using slot.* apis return value without direct JSX rendering - anti-pattern in v9 framework composition
+    {
+      options: [{ runtime: 'automatic' }],
+      code: `
+    import { slot, getIntrinsicElementProps } from '@fluentui/react-utilities';
+
+    export const factory = (props: {}) => {
+      const SlotComponent = slot.always(getIntrinsicElementProps('span', {}),{ elementType: 'span' })
+      const InlineCmp = () => <div>inline</div>
+
+      return {SlotComponent,InlineCmp}
     };
     `,
     },
@@ -293,9 +292,8 @@ ruleTester.run(RULE_NAME, rule, {
       `,
       errors: [{ messageId: 'redundantPragma' }],
     },
-    // =====================================================================================
-    // using slot.* apis via direct JSX rendering - anti-pattern in v9 framework composition
-    // =====================================================================================
+
+    // using slot.* apis return value to render JSX directly - anti-pattern in v9 framework composition
     {
       options: [{ runtime: 'automatic' }],
       code: `
@@ -313,6 +311,8 @@ ruleTester.run(RULE_NAME, rule, {
     `,
       errors: [{ messageId: 'missingJsxImportSource' }],
     },
+
+    // using slot.* apis return value to render JSX directly - anti-pattern in v9 framework composition
     {
       options: [{ runtime: 'automatic' }],
       code: `
@@ -330,6 +330,8 @@ ruleTester.run(RULE_NAME, rule, {
     `,
       errors: [{ messageId: 'missingJsxImportSource' }],
     },
+
+    // using slot.* apis return value to render JSX directly - anti-pattern in v9 framework composition
     {
       options: [{ runtime: 'automatic' }],
       code: `

--- a/tools/eslint-rules/rules/no-missing-jsx-pragma.spec.ts
+++ b/tools/eslint-rules/rules/no-missing-jsx-pragma.spec.ts
@@ -1,0 +1,130 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { rule, RULE_NAME } from './no-missing-jsx-pragma';
+
+const ruleTester = new RuleTester({
+  parser: '@typescript-eslint/parser',
+  parserOptions: { ecmaFeatures: { jsx: true } },
+});
+
+ruleTester.run(RULE_NAME, rule, {
+  valid: [
+    {
+      code: `
+    export const renderFoo = () => {
+      return (
+          <div>
+            hello
+          </div>
+        );
+    }
+  `,
+    },
+    {
+      code: `
+    /** @jsx createElement */
+    import { createElement } from '@fluentui/react-jsx-runtime';
+    import { assertSlots } from '@fluentui/react-utilities';
+
+    import type { FooState, FooContextValues, FooSlots  } from './Foo.types';
+
+    export const renderFoo_unstable = (state: FooState, contextValues: FooContextValues) => {
+      assertSlots<FooSlots>(state);
+
+      return (
+          <state.root>
+            <state.button>
+              hello
+            </state.button>
+          </state.root>
+      );
+    };
+    `,
+    },
+    {
+      code: `
+    /** @jsx createElement */
+    import { createElement } from './some/local/factory';
+    import { assertSlots } from '@fluentui/react-utilities';
+
+    import type { FooState, FooContextValues, FooSlots  } from './Foo.types';
+
+    export const renderFoo_unstable = (state: FooState, contextValues: FooContextValues) => {
+      assertSlots<FooSlots>(state);
+
+      return (
+          <state.root>
+            <state.button>
+              hello
+            </state.button>
+          </state.root>
+      );
+    };
+    `,
+    },
+    {
+      code: `
+  /** @jsxImportSource @fluentui/react-jsx-runtime */
+
+  import { assertSlots } from '@fluentui/react-utilities';
+
+  import type { FooState, FooContextValues, FooSlots  } from './Foo.types';
+
+  export const renderFoo_unstable = (state: FooState, contextValues: FooContextValues) => {
+    assertSlots<FooSlots>(state);
+
+    return (
+        <state.root>
+          <state.button>
+            hello
+          </state.button>
+        </state.root>
+    );
+  };
+  `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+  import { assertSlots } from '@fluentui/react-utilities';
+
+  import type { FooState, FooContextValues, FooSlots  } from './Foo.types';
+
+  export const renderFoo_unstable = (state: FooState, contextValues: FooContextValues) => {
+    assertSlots<FooSlots>(state);
+
+    return (
+        <state.root>
+          <state.button>
+            hello
+          </state.button>
+        </state.root>
+    );
+  };
+  `,
+
+      errors: [{ messageId: 'missingPragma' }],
+    },
+    {
+      code: `
+    /** @jsx createElement */
+    import { assertSlots } from '@fluentui/react-utilities';
+
+    import type { FooState, FooContextValues, FooSlots  } from './Foo.types';
+
+    export const renderFoo_unstable = (state: FooState, contextValues: FooContextValues) => {
+      assertSlots<FooSlots>(state);
+
+      return (
+          <state.root>
+            <state.button>
+              hello
+            </state.button>
+          </state.root>
+      );
+    };
+    `,
+      errors: [{ messageId: 'missingCreateElementFactoryImport' }],
+    },
+  ],
+});

--- a/tools/eslint-rules/rules/no-missing-jsx-pragma.spec.ts
+++ b/tools/eslint-rules/rules/no-missing-jsx-pragma.spec.ts
@@ -98,6 +98,75 @@ ruleTester.run(RULE_NAME, rule, {
     };
     `,
     },
+    // =====================================================================================
+    // using slot.* apis via direct JSX rendering - anti-pattern in v9 framework composition
+    // =====================================================================================
+    {
+      options: [{ runtime: 'automatic' }],
+      code: `
+    import { slot, getIntrinsicElementProps } from '@fluentui/react-utilities';
+
+    export const factory = (props: {}) => {
+      const SlotComponent = slot.always(getIntrinsicElementProps('span', {}),{ elementType: 'span' })
+      const InlineCmp = () => <div>inline</div>
+
+      return {SlotComponent,InlineCmp}
+    };
+    `,
+    },
+    {
+      options: [{ runtime: 'automatic' }],
+      code: `
+    /** @jsxImportSource @fluentui/react-jsx-runtime */
+    import { slot, getIntrinsicElementProps } from '@fluentui/react-utilities';
+
+    export const Test = (props: {}) => {
+      const SlotComponent = slot.always(getIntrinsicElementProps('span', {}),{ elementType: 'span' })
+
+      return (
+          <div>
+            <SlotComponent/>
+          </div>
+      );
+    };
+    `,
+    },
+    {
+      options: [{ runtime: 'automatic' }],
+      code: `
+    /** @jsxImportSource @fluentui/react-jsx-runtime */
+    import { slot, getIntrinsicElementProps } from '@fluentui/react-utilities';
+
+    export const Test = (props: {}) => {
+      const SlotComponent = slot.optional(getIntrinsicElementProps('span', {}),{ elementType: 'span' })
+
+      return (
+          <div>
+            <SlotComponent/>
+          </div>
+      );
+    };
+    `,
+    },
+    {
+      options: [{ runtime: 'automatic' }],
+      code: `
+    /** @jsxImportSource @fluentui/react-jsx-runtime */
+    import { slot, getIntrinsicElementProps } from '@fluentui/react-utilities';
+
+    export const Test = (props: {}) => {
+      const SlotComponent = slot.always(getIntrinsicElementProps('span', {}),{ elementType: 'span' })
+      const SlotOptionalComponent = slot.optional(getIntrinsicElementProps('span', {}),{ elementType: 'span' })
+
+      return (
+          <div>
+            <SlotComponent/>
+            <SlotOptionalComponent/>
+          </div>
+      );
+    };
+    `,
+    },
   ],
   invalid: [
     {
@@ -223,6 +292,62 @@ ruleTester.run(RULE_NAME, rule, {
       };
       `,
       errors: [{ messageId: 'redundantPragma' }],
+    },
+    // =====================================================================================
+    // using slot.* apis via direct JSX rendering - anti-pattern in v9 framework composition
+    // =====================================================================================
+    {
+      options: [{ runtime: 'automatic' }],
+      code: `
+    import { slot, getIntrinsicElementProps } from '@fluentui/react-utilities';
+
+    export const Test = (props: {}) => {
+      const SlotComponent = slot.always(getIntrinsicElementProps('span', {}),{ elementType: 'span' })
+
+      return (
+          <div>
+            <SlotComponent/>
+          </div>
+      );
+    };
+    `,
+      errors: [{ messageId: 'missingJsxImportSource' }],
+    },
+    {
+      options: [{ runtime: 'automatic' }],
+      code: `
+    import { slot, getIntrinsicElementProps } from '@fluentui/react-utilities';
+
+    export const Test = (props: {}) => {
+      const SlotComponent = slot.optional(getIntrinsicElementProps('span', {}),{ elementType: 'span' })
+
+      return (
+          <div>
+            <SlotComponent/>
+          </div>
+      );
+    };
+    `,
+      errors: [{ messageId: 'missingJsxImportSource' }],
+    },
+    {
+      options: [{ runtime: 'automatic' }],
+      code: `
+    import { slot, getIntrinsicElementProps } from '@fluentui/react-utilities';
+
+    export const Test = (props: {}) => {
+      const SlotComponent = slot.always(getIntrinsicElementProps('span', {}),{ elementType: 'span' })
+      const SlotOptionalComponent = slot.optional(getIntrinsicElementProps('span', {}),{ elementType: 'span' })
+
+      return (
+          <div>
+            <SlotComponent/>
+            <SlotOptionalComponent/>
+          </div>
+      );
+    };
+    `,
+      errors: [{ messageId: 'missingJsxImportSource' }],
     },
   ],
 });

--- a/tools/eslint-rules/rules/no-missing-jsx-pragma.spec.ts
+++ b/tools/eslint-rules/rules/no-missing-jsx-pragma.spec.ts
@@ -8,6 +8,7 @@ const ruleTester = new RuleTester({
 
 ruleTester.run(RULE_NAME, rule, {
   valid: [
+    // no slot api used case
     {
       options: [{ runtime: 'automatic' }],
       code: `
@@ -20,6 +21,8 @@ ruleTester.run(RULE_NAME, rule, {
     }
   `,
     },
+
+    // no slot api used case
     {
       options: [{ runtime: 'classic' }],
       code: `
@@ -32,6 +35,8 @@ ruleTester.run(RULE_NAME, rule, {
     }
   `,
     },
+
+    // slot api used + valid pragma exist case
     {
       options: [{ runtime: 'automatic' }],
       code: `
@@ -54,6 +59,8 @@ ruleTester.run(RULE_NAME, rule, {
   };
   `,
     },
+
+    // slot api used + valid pragma exist case
     {
       options: [{ runtime: 'classic' }],
       code: `
@@ -76,28 +83,8 @@ ruleTester.run(RULE_NAME, rule, {
     };
     `,
     },
-    {
-      options: [{ runtime: 'classic' }],
-      code: `
-    /** @jsx createElement */
-    import { createElement } from './some/local/factory';
-    import { assertSlots } from '@fluentui/react-utilities';
 
-    import type { FooState, FooContextValues, FooSlots  } from './Foo.types';
-
-    export const renderFoo_unstable = (state: FooState, contextValues: FooContextValues) => {
-      assertSlots<FooSlots>(state);
-
-      return (
-          <state.root>
-            <state.button>
-              hello
-            </state.button>
-          </state.root>
-      );
-    };
-    `,
-    },
+    // slot api (.always) used in a non conformant way + valid pragma exist case
     {
       options: [{ runtime: 'automatic' }],
       code: `
@@ -115,6 +102,8 @@ ruleTester.run(RULE_NAME, rule, {
     };
     `,
     },
+
+    // slot api (.optional) used in a non conformant way + valid pragma exist case
     {
       options: [{ runtime: 'automatic' }],
       code: `
@@ -132,6 +121,8 @@ ruleTester.run(RULE_NAME, rule, {
     };
     `,
     },
+
+    // slot api (both .optional,.always) used in a non conformant way + valid pragma exist case
     {
       options: [{ runtime: 'automatic' }],
       code: `
@@ -152,7 +143,7 @@ ruleTester.run(RULE_NAME, rule, {
     `,
     },
 
-    // using slot.* apis return value without direct JSX rendering - anti-pattern in v9 framework composition
+    // slot api (.always) used in a non conformant way + no direct JSX rendering + no pragma required case
     {
       options: [{ runtime: 'automatic' }],
       code: `
@@ -162,12 +153,13 @@ ruleTester.run(RULE_NAME, rule, {
       const SlotComponent = slot.always(getIntrinsicElementProps('span', {}),{ elementType: 'span' })
       const InlineCmp = () => <div>inline</div>
 
-      return {SlotComponent,InlineCmp}
+      return { SlotComponent, InlineCmp };
     };
     `,
     },
   ],
   invalid: [
+    // slot api used + missing pragma
     {
       options: [{ runtime: 'automatic' }],
       code: `
@@ -186,6 +178,8 @@ ruleTester.run(RULE_NAME, rule, {
     `,
       errors: [{ messageId: 'missingJsxImportSource' }],
     },
+
+    // slot api used + missing pragma
     {
       options: [{ runtime: 'classic' }],
       code: `
@@ -204,6 +198,8 @@ ruleTester.run(RULE_NAME, rule, {
     `,
       errors: [{ messageId: 'missingJsxPragma' }],
     },
+
+    // slot api used + pragma present + factory import missing
     {
       options: [{ runtime: 'classic' }],
       code: `
@@ -223,6 +219,8 @@ ruleTester.run(RULE_NAME, rule, {
       `,
       errors: [{ messageId: 'missingCreateElementFactoryImport' }],
     },
+
+    // slot api used + pragma present + invalid pragma for automatic mode
     {
       options: [{ runtime: 'automatic' }],
       code: `
@@ -243,6 +241,8 @@ ruleTester.run(RULE_NAME, rule, {
       `,
       errors: [{ messageId: 'invalidJSXPragmaForAutomatic' }],
     },
+
+    // slot api used + pragma present + invalid pragma for classic mode
     {
       options: [{ runtime: 'classic' }],
       code: `
@@ -262,6 +262,8 @@ ruleTester.run(RULE_NAME, rule, {
       `,
       errors: [{ messageId: 'invalidJSXPragmaForClassic' }],
     },
+
+    // no slot api used for JSX rendering + pragma present + pragma should not be specified
     {
       options: [{ runtime: 'automatic' }],
       code: `
@@ -277,6 +279,8 @@ ruleTester.run(RULE_NAME, rule, {
       `,
       errors: [{ messageId: 'redundantPragma' }],
     },
+
+    // no slot api used for JSX rendering + pragma present + pragma should not be specified
     {
       options: [{ runtime: 'classic' }],
       code: `
@@ -293,7 +297,7 @@ ruleTester.run(RULE_NAME, rule, {
       errors: [{ messageId: 'redundantPragma' }],
     },
 
-    // using slot.* apis return value to render JSX directly - anti-pattern in v9 framework composition
+    // slot api (.always) used in a non conformant way +  direct JSX rendering + pragma is missing
     {
       options: [{ runtime: 'automatic' }],
       code: `
@@ -312,7 +316,7 @@ ruleTester.run(RULE_NAME, rule, {
       errors: [{ messageId: 'missingJsxImportSource' }],
     },
 
-    // using slot.* apis return value to render JSX directly - anti-pattern in v9 framework composition
+    // slot api (.optional) used in a non conformant way +  direct JSX rendering + pragma is missing
     {
       options: [{ runtime: 'automatic' }],
       code: `
@@ -331,7 +335,7 @@ ruleTester.run(RULE_NAME, rule, {
       errors: [{ messageId: 'missingJsxImportSource' }],
     },
 
-    // using slot.* apis return value to render JSX directly - anti-pattern in v9 framework composition
+    // slot api (.optional,.always) used in a non conformant way +  direct JSX rendering + pragma is missing
     {
       options: [{ runtime: 'automatic' }],
       code: `

--- a/tools/eslint-rules/rules/no-missing-jsx-pragma.spec.ts
+++ b/tools/eslint-rules/rules/no-missing-jsx-pragma.spec.ts
@@ -9,6 +9,7 @@ const ruleTester = new RuleTester({
 ruleTester.run(RULE_NAME, rule, {
   valid: [
     {
+      options: [{ runtime: 'automatic' }],
       code: `
     export const renderFoo = () => {
       return (
@@ -20,6 +21,41 @@ ruleTester.run(RULE_NAME, rule, {
   `,
     },
     {
+      options: [{ runtime: 'classic' }],
+      code: `
+    export const renderFoo = () => {
+      return (
+          <div>
+            hello
+          </div>
+        );
+    }
+  `,
+    },
+    {
+      options: [{ runtime: 'automatic' }],
+      code: `
+  /** @jsxImportSource @fluentui/react-jsx-runtime */
+
+  import { assertSlots } from '@fluentui/react-utilities';
+
+  import type { FooState, FooContextValues, FooSlots  } from './Foo.types';
+
+  export const renderFoo_unstable = (state: FooState, contextValues: FooContextValues) => {
+    assertSlots<FooSlots>(state);
+
+    return (
+        <state.root>
+          <state.button>
+            hello
+          </state.button>
+        </state.root>
+    );
+  };
+  `,
+    },
+    {
+      options: [{ runtime: 'classic' }],
       code: `
     /** @jsx createElement */
     import { createElement } from '@fluentui/react-jsx-runtime';
@@ -41,6 +77,7 @@ ruleTester.run(RULE_NAME, rule, {
     `,
     },
     {
+      options: [{ runtime: 'classic' }],
       code: `
     /** @jsx createElement */
     import { createElement } from './some/local/factory';
@@ -61,60 +98,15 @@ ruleTester.run(RULE_NAME, rule, {
     };
     `,
     },
-    {
-      code: `
-  /** @jsxImportSource @fluentui/react-jsx-runtime */
-
-  import { assertSlots } from '@fluentui/react-utilities';
-
-  import type { FooState, FooContextValues, FooSlots  } from './Foo.types';
-
-  export const renderFoo_unstable = (state: FooState, contextValues: FooContextValues) => {
-    assertSlots<FooSlots>(state);
-
-    return (
-        <state.root>
-          <state.button>
-            hello
-          </state.button>
-        </state.root>
-    );
-  };
-  `,
-    },
   ],
   invalid: [
     {
+      options: [{ runtime: 'automatic' }],
       code: `
-  import { assertSlots } from '@fluentui/react-utilities';
-
-  import type { FooState, FooContextValues, FooSlots  } from './Foo.types';
-
-  export const renderFoo_unstable = (state: FooState, contextValues: FooContextValues) => {
-    assertSlots<FooSlots>(state);
-
-    return (
-        <state.root>
-          <state.button>
-            hello
-          </state.button>
-        </state.root>
-    );
-  };
-  `,
-
-      errors: [{ messageId: 'missingPragma' }],
-    },
-    {
-      code: `
-    /** @jsx createElement */
     import { assertSlots } from '@fluentui/react-utilities';
-
     import type { FooState, FooContextValues, FooSlots  } from './Foo.types';
-
     export const renderFoo_unstable = (state: FooState, contextValues: FooContextValues) => {
       assertSlots<FooSlots>(state);
-
       return (
           <state.root>
             <state.button>
@@ -124,7 +116,113 @@ ruleTester.run(RULE_NAME, rule, {
       );
     };
     `,
+      errors: [{ messageId: 'missingJsxImportSource' }],
+    },
+    {
+      options: [{ runtime: 'classic' }],
+      code: `
+    import { assertSlots } from '@fluentui/react-utilities';
+    import type { FooState, FooContextValues, FooSlots  } from './Foo.types';
+    export const renderFoo_unstable = (state: FooState, contextValues: FooContextValues) => {
+      assertSlots<FooSlots>(state);
+      return (
+          <state.root>
+            <state.button>
+              hello
+            </state.button>
+          </state.root>
+      );
+    };
+    `,
+      errors: [{ messageId: 'missingJsxPragma' }],
+    },
+    {
+      options: [{ runtime: 'classic' }],
+      code: `
+      /** @jsx createElement */
+      import { assertSlots } from '@fluentui/react-utilities';
+      import type { FooState, FooContextValues, FooSlots  } from './Foo.types';
+      export const renderFoo_unstable = (state: FooState, contextValues: FooContextValues) => {
+        assertSlots<FooSlots>(state);
+        return (
+            <state.root>
+              <state.button>
+                hello
+              </state.button>
+            </state.root>
+        );
+      };
+      `,
       errors: [{ messageId: 'missingCreateElementFactoryImport' }],
+    },
+    {
+      options: [{ runtime: 'automatic' }],
+      code: `
+      /** @jsx createElement */
+      import { assertSlots } from '@fluentui/react-utilities';
+      import { createElement } from '@fluentui/react-jsx-runtime';
+      import type { FooState, FooContextValues, FooSlots  } from './Foo.types';
+      export const renderFoo_unstable = (state: FooState, contextValues: FooContextValues) => {
+        assertSlots<FooSlots>(state);
+        return (
+            <state.root>
+              <state.button>
+                hello
+              </state.button>
+            </state.root>
+        );
+      };
+      `,
+      errors: [{ messageId: 'invalidJSXPragmaForAutomatic' }],
+    },
+    {
+      options: [{ runtime: 'classic' }],
+      code: `
+      /** @jsxImportSource @fluentui/react-jsx-runtime */
+      import { assertSlots } from '@fluentui/react-utilities';
+      import type { FooState, FooContextValues, FooSlots  } from './Foo.types';
+      export const renderFoo_unstable = (state: FooState, contextValues: FooContextValues) => {
+        assertSlots<FooSlots>(state);
+        return (
+            <state.root>
+              <state.button>
+                hello
+              </state.button>
+            </state.root>
+        );
+      };
+      `,
+      errors: [{ messageId: 'invalidJSXPragmaForClassic' }],
+    },
+    {
+      options: [{ runtime: 'automatic' }],
+      code: `
+      /** @jsxImportSource @fluentui/react-jsx-runtime */
+      import { assertSlots } from '@fluentui/react-utilities';
+      import type { FooState, FooContextValues, FooSlots  } from './Foo.types';
+      export const renderFoo_unstable = (state: FooState, contextValues: FooContextValues) => {
+        assertSlots<FooSlots>(state);
+        return (
+            <div>hello</div>
+        );
+      };
+      `,
+      errors: [{ messageId: 'redundantPragma' }],
+    },
+    {
+      options: [{ runtime: 'classic' }],
+      code: `
+      /** @jsxImportSource @fluentui/react-jsx-runtime */
+      import { assertSlots } from '@fluentui/react-utilities';
+      import type { FooState, FooContextValues, FooSlots  } from './Foo.types';
+      export const renderFoo_unstable = (state: FooState, contextValues: FooContextValues) => {
+        assertSlots<FooSlots>(state);
+        return (
+            <div>hello</div>
+        );
+      };
+      `,
+      errors: [{ messageId: 'redundantPragma' }],
     },
   ],
 });

--- a/tools/eslint-rules/rules/no-missing-jsx-pragma.ts
+++ b/tools/eslint-rules/rules/no-missing-jsx-pragma.ts
@@ -29,8 +29,8 @@ export const rule = ESLintUtils.RuleCreator(() => __filename)({
     },
     schema: [],
     messages: {
-      missingPragma: `File uses JSX slots API but doesn't specify custom jsx transforms`,
-      missingCreateElementFactoryImport: `File uses JSX slots API, has defined /** jsx createElement */ pragma  /**, but is missing 'createElement' factory function import`,
+      missingPragma: `File uses JSX slots API but doesn't specify custom jsx transforms. To fix this add /** @jsxImportSource @fluentui/react-jsx-runtime */`,
+      missingCreateElementFactoryImport: `File uses JSX slots API, has defined /** jsx createElement */ pragma, but is missing 'createElement' factory function import. To fix this add "import {createElement} from '@fluentui/react-jsx-runtime'"`,
     },
   },
   defaultOptions: [],

--- a/tools/eslint-rules/rules/no-missing-jsx-pragma.ts
+++ b/tools/eslint-rules/rules/no-missing-jsx-pragma.ts
@@ -1,0 +1,113 @@
+/**
+ * This file sets you up with structure needed for an ESLint rule.
+ *
+ * It leverages utilities from @typescript-eslint to allow TypeScript to
+ * provide autocompletions etc for the configuration.
+ *
+ * Your rule's custom logic will live within the create() method below
+ * and you can learn more about writing ESLint rules on the official guide:
+ *
+ * https://eslint.org/docs/developer-guide/working-with-rules
+ *
+ * You can also view many examples of existing rules here:
+ *
+ * https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/eslint-plugin/src/rules
+ */
+
+import { ESLintUtils, AST_NODE_TYPES, AST_TOKEN_TYPES, ASTUtils, TSESTree } from '@typescript-eslint/utils';
+
+// NOTE: The rule will be available in ESLint configs as "@nx/workspace-no-missing-jsx-pragma"
+export const RULE_NAME = 'no-missing-jsx-pragma';
+
+export const rule = ESLintUtils.RuleCreator(() => __filename)({
+  name: RULE_NAME,
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Enforce properly configured of @jsx or @jsxImportSource pragma for files using Fluent slot API',
+      recommended: 'recommended',
+    },
+    schema: [],
+    messages: {
+      missingPragma: `File uses JSX slots API but doesn't specify custom jsx transforms`,
+      missingCreateElementFactoryImport: `File uses JSX slots API, has defined /** jsx createElement */ pragma  /**, but is missing 'createElement' factory function import`,
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    let hasCreateElementImport = false;
+    let hasAssertSlots = false;
+    let hasSlotJsxExpression = false;
+    let hasJsxImportSourcePragma = false;
+    let hasJsxPragma = false;
+    let specifiedJsxRuntimePragma: 'automatic' | 'classic' | null = null;
+
+    return {
+      Program(node) {
+        if (!node.comments) {
+          return;
+        }
+
+        // Check comments in the program
+        node.comments.forEach(checkJsxPragmas);
+      },
+      'ImportDeclaration ImportSpecifier[local.name=createElement]'(node: TSESTree.ImportSpecifier) {
+        hasCreateElementImport = true;
+      },
+      'JSXElement JSXMemberExpression[object.name=state]'(node: TSESTree.JSXMemberExpression) {
+        hasSlotJsxExpression = true;
+      },
+      CallExpression(node) {
+        if (node.callee.type === AST_NODE_TYPES.Identifier && node.callee.name === 'assertSlots') {
+          hasAssertSlots = true;
+        }
+      },
+      'Program:exit'() {
+        if (!(hasSlotJsxExpression && hasAssertSlots)) {
+          return;
+        }
+
+        const hasRequiredPragma = hasJsxImportSourcePragma || hasJsxPragma;
+
+        if (!hasRequiredPragma) {
+          context.report({
+            messageId: 'missingPragma',
+            // Adjust location if needed
+            loc: { line: 1, column: 1 },
+          });
+
+          return;
+        }
+
+        if (hasJsxPragma && !hasCreateElementImport) {
+          context.report({
+            messageId: 'missingCreateElementFactoryImport',
+            // Adjust location if needed
+            loc: { line: 1, column: 1 },
+          });
+          return;
+        }
+      },
+    };
+
+    function checkJsxPragmas(node: TSESTree.Comment) {
+      if (node.type !== AST_TOKEN_TYPES.Block) {
+        return;
+      }
+
+      if (node.value.includes('@jsxImportSource @fluentui/react-jsx-runtime')) {
+        hasJsxImportSourcePragma = true;
+      }
+      if (node.value.includes('@jsx createElement')) {
+        hasJsxPragma = true;
+      }
+
+      const runtimeRegex = /jsxRuntime\s+(classic|automatic)\s+/;
+      const parsedRuntimeDefinition = runtimeRegex.exec(node.value);
+
+      if (parsedRuntimeDefinition) {
+        specifiedJsxRuntimePragma = parsedRuntimeDefinition[1] as 'automatic' | 'classic';
+      }
+    }
+  },
+});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

no enforcement how to use custom jsx pragma for v9 Slot API within component implementation

## New Behavior

- enforced usage of jsx pragma for v9 Slot API, driven by new `no-missing-jsx-pragma` workspace lint rule
- we use `runtime: 'automatic'` for lint configuration which enforces to use `@jsxImportSource` 

Rule covers various use-cases driven by `runtime: <type>` configuration. For v9 we use `automatic` which produces following lint capabilities:

> see [spec file fore thorough use cases](https://github.com/microsoft/fluentui/pull/32842/files#diff-160c8e689c6e93f923ae593f7a57f99b7ba47dd7f959734b1b793b870fe47a92) 

**❌ Examples of Incorrect code:**

1. using pragma that works with runtime classic

```tsx
/** @jsxRuntime classic */
/** @jsx createElement */
// ~~~~~~~~~~~~~~~~~ 🚨

import { createElement } from '@fluentui/react-jsx-runtime';
// ~~~~~~~~~~~~~~~~~ 🚨

const renderFoo_unstable = (state: FooState) => {
    assertSlots<FooSlots>(state);

    return (
        <state.root>
          <state.button>
            hello
          </state.button>
        </state.root>
    );
  };
```

_missing pragma when slot api is used_

```tsx
// ~~~~~~~~~~~~~~~~~ 🚨

const renderFoo_unstable = (state: FooState) => {
    assertSlots<FooSlots>(state);

    return (
        <state.root>
          <state.button>
            hello
          </state.button>
        </state.root>
    );
  };
```

_present pragma when NO slot api is used_

```tsx
/** @jsxRuntime automatic */
/** @jsxImportSource @fluentui/react-jsx-runtime */
// ~~~~~~~~~~~~~~~~~ 🚨

const renderFoo_unstable = (state: FooState) => {
    return (
       <div>
            hello
        </div>
    );
  };
```

**✅ Examples of Correct Code:**

_present pragma when slot api is used_

```tsx
/** @jsxRuntime automatic */
/** @jsxImportSource @fluentui/react-jsx-runtime */

const renderFoo_unstable = (state: FooState) => {
    assertSlots<FooSlots>(state);

    return (
        <state.root>
          <state.button>
            hello
          </state.button>
        </state.root>
    );
  };
```

_no pragma when no slots API is used_

```tsx
const renderFoo_unstable = (state: FooState) => {
    return (
        <div>hello</div>
    );
  };
```

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows https://github.com/microsoft/fluentui/pull/32838
