### PR TITLE
fix: table selection checkbox or radio should be rendered even if invisible

### DIFF
--- a/change/@fluentui-react-table-a47e4abb-986f-4876-8f3b-1d94487949f6.json
+++ b/change/@fluentui-react-table-a47e4abb-986f-4876-8f3b-1d94487949f6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: table selection checkbox or radio should be rendered even if invisible",
+  "packageName": "@fluentui/react-table",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-slider/stories/src/Slider/SliderControlled.stories.tsx
+++ b/packages/react-components/react-slider/stories/src/Slider/SliderControlled.stories.tsx
@@ -18,7 +18,9 @@ export const Controlled = () => {
         onChange={onSliderChange}
         id={id}
       />
-      <Button onClick={resetSlider}>Reset</Button>
+      <Button onClick={resetSlider} disabledFocusable={sliderValue === 0}>
+        Reset
+      </Button>
     </>
   );
 };

--- a/packages/react-components/react-slider/stories/src/Slider/SliderControlled.stories.tsx
+++ b/packages/react-components/react-slider/stories/src/Slider/SliderControlled.stories.tsx
@@ -18,9 +18,7 @@ export const Controlled = () => {
         onChange={onSliderChange}
         id={id}
       />
-      <Button onClick={resetSlider} disabledFocusable={sliderValue === 0}>
-        Reset
-      </Button>
+      <Button onClick={resetSlider}>Reset</Button>
     </>
   );
 };

--- a/packages/react-components/react-table/library/src/components/TableSelectionCell/useTableSelectionCell.tsx
+++ b/packages/react-components/react-table/library/src/components/TableSelectionCell/useTableSelectionCell.tsx
@@ -38,12 +38,12 @@ export const useTableSelectionCell_unstable = (
       radioIndicator: Radio,
     },
     checkboxIndicator: slot.optional(props.checkboxIndicator, {
-      renderByDefault: type === 'checkbox' && !invisible,
+      renderByDefault: type === 'checkbox',
       defaultProps: { checked: props.checked },
       elementType: Checkbox,
     }),
     radioIndicator: slot.optional(props.radioIndicator, {
-      renderByDefault: type === 'radio' && !invisible,
+      renderByDefault: type === 'radio',
       defaultProps: { checked: !!checked, input: { name: useId('table-selection-radio') } },
       elementType: Radio,
     }),


### PR DESCRIPTION
## Previous Behavior

If authors set `selectionCell: {{ invisible: true }}` without passing any data to the `radioIndicator` or `checkboxIndicator` slots, the radio/checkbox input would not be rendered in the DOM. For some (e.g. touch) screen reader and voice control users, this means that they would not be able to select rows.

Our examples do pass in data (an `aria-label`) to the indicator slot, so the issue does not show up in our docs site. While authors _should_ always pass in an accessible name to the indicator slot they're using, it's still better to have an unnamed radio or checkbox than to have none at all.

## New Behavior

The `radioIndicator` and `checkboxIndicator` slots render by default even with `invisible: true`. The visuals don't change (`invisible` will cause the `opacity: 0` style to be added), just the DOM.

This also means that the lack of an accessible name for the radio/checkbox inputs should be able to be caught in automated tests.

## Related Issue(s)

Not a github issue, but this came up in a Teams question from a partner team who got an a11y issue about the selection cells being empty.
