### PR TITLE
docs(MessageBar): Add reference to AriaLiveAnnouncer

### DIFF
--- a/packages/react-components/react-message-bar/stories/src/MessageBar/MessageBarDescription.md
+++ b/packages/react-components/react-message-bar/stories/src/MessageBar/MessageBarDescription.md
@@ -1,3 +1,6 @@
 Communicates important information about the state of the entire application or surface.
 For example, the status of a page, panel, dialog or card. The information shouldn't require someone
 to take immediate action, but should persist until the user performs one of the required actions.
+
+> ⚠️ For `aria-live` announcements to work correctly you should configure you application with a
+> <a href="https://react.fluentui.dev/?path=/docs/utilities-aria-live-arialiveannouncer--docs">AriaLiveAnnouncer</a>

--- a/packages/react-components/react-message-bar/stories/src/MessageBar/MessageBarDescription.md
+++ b/packages/react-components/react-message-bar/stories/src/MessageBar/MessageBarDescription.md
@@ -4,3 +4,4 @@ to take immediate action, but should persist until the user performs one of the 
 
 > ⚠️ For `aria-live` announcements to work correctly you should configure you application with a
 > <a href="https://react.fluentui.dev/?path=/docs/utilities-aria-live-arialiveannouncer--docs">AriaLiveAnnouncer</a>
+> towards the top of the React tree.


### PR DESCRIPTION
Adds a reference to the AriaLiveAnnouncer so users can know that it must be configured to announcements to function correctly