### PR TITLE
fix: [fluent-text] removes display inheritance so all html elements can render

### DIFF
--- a/change/@fluentui-web-components-0ad28ef7-3eb4-49da-a2ea-31e53af4e811.json
+++ b/change/@fluentui-web-components-0ad28ef7-3eb4-49da-a2ea-31e53af4e811.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: removes display inheritance so all html elements can render",
+  "packageName": "@fluentui/web-components",
+  "email": "jes@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/text/text.styles.ts
+++ b/packages/web-components/src/text/text.styles.ts
@@ -155,7 +155,6 @@ export const styles = css`
   }
 
   ::slotted(*) {
-    display: inherit;
     font: inherit;
     line-height: inherit;
     text-decoration-line: inherit;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
the catch all slotted selector was setting `display: inherit`, if the host has `display: contents` set it causes some html elements (SVG) to not render. 

https://drafts.csswg.org/css-display/#unbox-svg

## New Behavior
Removes the inheritance of the `display`

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
