### PR TITLE
Stable Release Tool: Ignore -preview in project search and package update

### DIFF
--- a/tools/workspace-plugin/src/generators/prepare-initial-release/index.ts
+++ b/tools/workspace-plugin/src/generators/prepare-initial-release/index.ts
@@ -242,6 +242,7 @@ async function stableRelease(tree: Tree, options: NormalizedSchema & { isSplitPr
   );
 
   unknownProjectsToBeUpdated?.forEach(projectName => {
+    projectName = projectName.replace('-preview', '');
     const projectConfig = getProjectConfig(tree, {
       packageName: projectName,
     });

--- a/tools/workspace-plugin/src/utils.ts
+++ b/tools/workspace-plugin/src/utils.ts
@@ -193,7 +193,7 @@ export const workspacePaths = {
     codeowners: joinPathFragments('/.github', 'CODEOWNERS'),
   },
   storybook: {
-    root: '/.storyboook',
+    root: '/.storybook',
   },
 };
 


### PR DESCRIPTION
NOTE: This will resolve the stable script issues, however it requires further investigation and testing, it could be possible that the script structure can be changed to retain the -preview tag here when appropriate, currently this will not rename all -preview strings within the library files automatically, but it does work on files and namespaces.

## Previous Behavior
- Unknown projects was retrieving project names with the -preview tag attached, however when it cycles to stories, -preview has already been removed from the package name as part of the initial modifications.
- Incorrect 'storyboook' name error

## New Behavior
- Packages are found in project tree without considering '-preview', this should include packages that match the provided package name, but have already been package parsed and require updating.
- Fixed incorrect 'storyboook' to 'storybook'

## Related Issue(s)
- Fixes #32878 
