### PR TITLE
Carousel: Ensure autoplay is reset on interactions and correctly stops on slider focus/mouseover

### DIFF
--- a/change/@fluentui-react-carousel-preview-96e37f6f-4669-4470-b6a7-3c06903806f9.json
+++ b/change/@fluentui-react-carousel-preview-96e37f6f-4669-4470-b6a7-3c06903806f9.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: Add resetAutoplay feature to reset index change timer",
+  "packageName": "@fluentui/react-carousel-preview",
+  "email": "mifraser@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-carousel-preview/library/etc/react-carousel-preview.api.md
+++ b/packages/react-components/react-carousel-preview/library/etc/react-carousel-preview.api.md
@@ -125,6 +125,7 @@ export type CarouselContextValue = {
     selectPageByIndex: (event: React_2.MouseEvent<HTMLButtonElement | HTMLAnchorElement>, value: number, jump?: boolean) => void;
     subscribeForValues: (listener: (data: CarouselUpdateData) => void) => () => void;
     enableAutoplay: (autoplay: boolean) => void;
+    resetAutoplay: () => void;
     containerRef?: React_2.RefObject<HTMLDivElement>;
 };
 

--- a/packages/react-components/react-carousel-preview/library/src/components/Carousel/useCarousel.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/Carousel/useCarousel.ts
@@ -28,16 +28,17 @@ export function useCarousel_unstable(props: CarouselProps, ref: React.Ref<HTMLDi
   } = props;
 
   const { dir } = useFluent();
-  const { activeIndex, carouselApi, containerRef, subscribeForValues, enableAutoplay } = useEmblaCarousel({
-    align,
-    direction: dir,
-    loop: circular,
-    slidesToScroll: groupSize,
-    defaultActiveIndex: props.defaultActiveIndex,
-    activeIndex: props.activeIndex,
-    watchDrag: draggable,
-    containScroll: whitespace ? false : 'keepSnaps',
-  });
+  const { activeIndex, carouselApi, containerRef, subscribeForValues, enableAutoplay, resetAutoplay } =
+    useEmblaCarousel({
+      align,
+      direction: dir,
+      loop: circular,
+      slidesToScroll: groupSize,
+      defaultActiveIndex: props.defaultActiveIndex,
+      activeIndex: props.activeIndex,
+      watchDrag: draggable,
+      containScroll: whitespace ? false : 'keepSnaps',
+    });
 
   const selectPageByElement: CarouselContextValue['selectPageByElement'] = useEventCallback((event, element, jump) => {
     const foundIndex = carouselApi.scrollToElement(element, jump);
@@ -82,5 +83,6 @@ export function useCarousel_unstable(props: CarouselProps, ref: React.Ref<HTMLDi
     selectPageByIndex,
     subscribeForValues,
     enableAutoplay,
+    resetAutoplay,
   };
 }

--- a/packages/react-components/react-carousel-preview/library/src/components/Carousel/useCarouselContextValues.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/Carousel/useCarouselContextValues.ts
@@ -11,6 +11,7 @@ export function useCarouselContextValues_unstable(state: CarouselState): Carouse
     selectPageByIndex,
     subscribeForValues,
     enableAutoplay,
+    resetAutoplay,
     circular,
     containerRef,
   } = state;
@@ -23,6 +24,7 @@ export function useCarouselContextValues_unstable(state: CarouselState): Carouse
       selectPageByIndex,
       subscribeForValues,
       enableAutoplay,
+      resetAutoplay,
       circular,
       containerRef,
     }),
@@ -33,6 +35,7 @@ export function useCarouselContextValues_unstable(state: CarouselState): Carouse
       selectPageByIndex,
       subscribeForValues,
       enableAutoplay,
+      resetAutoplay,
       circular,
       containerRef,
     ],

--- a/packages/react-components/react-carousel-preview/library/src/components/CarouselButton/useCarouselButton.tsx
+++ b/packages/react-components/react-carousel-preview/library/src/components/CarouselButton/useCarouselButton.tsx
@@ -39,6 +39,7 @@ export const useCarouselButton_unstable = (
   const containerRef = useCarouselContext(ctx => ctx.containerRef);
   const selectPageByDirection = useCarouselContext(ctx => ctx.selectPageByDirection);
   const subscribeForValues = useCarouselContext(ctx => ctx.subscribeForValues);
+  const resetAutoplay = useCarouselContext(ctx => ctx.resetAutoplay);
 
   const isTrailing = useCarouselContext(ctx => {
     if (circular) {
@@ -77,6 +78,8 @@ export const useCarouselButton_unstable = (
         }
       });
     }
+
+    resetAutoplay();
   };
 
   useIsomorphicLayoutEffect(() => {

--- a/packages/react-components/react-carousel-preview/library/src/components/CarouselContext.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/CarouselContext.ts
@@ -18,6 +18,9 @@ export const carouselContextDefaultValue: CarouselContextValue = {
   enableAutoplay: () => {
     /** noop */
   },
+  resetAutoplay: () => {
+    /** noop */
+  },
   circular: false,
   containerRef: undefined,
 };

--- a/packages/react-components/react-carousel-preview/library/src/components/CarouselContext.types.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/CarouselContext.types.ts
@@ -28,6 +28,7 @@ export type CarouselContextValue = {
   ) => void;
   subscribeForValues: (listener: (data: CarouselUpdateData) => void) => () => void;
   enableAutoplay: (autoplay: boolean) => void;
+  resetAutoplay: () => void;
   containerRef?: React.RefObject<HTMLDivElement>;
 };
 

--- a/packages/react-components/react-carousel-preview/library/src/components/CarouselNavButton/useCarouselNavButton.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/CarouselNavButton/useCarouselNavButton.ts
@@ -36,6 +36,7 @@ export const useCarouselNavButton_unstable = (
   const selectPageByIndex = useCarouselContext(ctx => ctx.selectPageByIndex);
   const selected = useCarouselContext(ctx => ctx.activeIndex === index);
   const subscribeForValues = useCarouselContext(ctx => ctx.subscribeForValues);
+  const resetAutoplay = useCarouselContext(ctx => ctx.resetAutoplay);
 
   const handleClick: ARIAButtonSlotProps['onClick'] = useEventCallback(event => {
     onClick?.(event);
@@ -43,6 +44,9 @@ export const useCarouselNavButton_unstable = (
     if (!event.defaultPrevented && isHTMLElement(event.target)) {
       selectPageByIndex(event, index);
     }
+
+    // Ensure any autoplay timers are extended/reset
+    resetAutoplay();
   });
 
   const defaultTabProps = useTabsterAttributes({

--- a/packages/react-components/react-carousel-preview/library/src/components/useEmblaCarousel.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/useEmblaCarousel.ts
@@ -7,13 +7,15 @@ import { carouselSliderClassNames } from './CarouselSlider/useCarouselSliderStyl
 import { CarouselUpdateData, CarouselVisibilityEventDetail } from '../Carousel';
 import Autoplay from 'embla-carousel-autoplay';
 
+const sliderClassname = `.${carouselSliderClassNames.root}`;
+
 const DEFAULT_EMBLA_OPTIONS: EmblaOptionsType = {
   containScroll: 'trimSnaps',
   inViewThreshold: 0.99,
   watchDrag: false,
   skipSnaps: true,
 
-  container: `.${carouselSliderClassNames.root}`,
+  container: sliderClassname,
   slides: `.${carouselCardClassNames.root}`,
 };
 
@@ -57,19 +59,20 @@ export function useEmblaCarousel(
 
   const emblaApi = React.useRef<EmblaCarouselType | null>(null);
 
+  const resetAutoplay = React.useCallback(() => {
+    emblaApi.current?.plugins().autoplay.reset();
+  }, []);
+
   const autoplayRef = React.useRef<boolean>(false);
   /* Our autoplay button, which is required by standards for autoplay to be enabled, will handle controlled state */
   const enableAutoplay = React.useCallback((autoplay: boolean) => {
     autoplayRef.current = autoplay;
     if (autoplay) {
-      console.log('Playing autoplay:', autoplay);
       emblaApi.current?.plugins().autoplay.play();
-      console.log('Is autoplay:', emblaApi.current?.plugins().autoplay.isPlaying());
-      emblaApi.current?.plugins().autoplay.reset();
-      console.log('Is autoplay:', emblaApi.current?.plugins().autoplay.isPlaying());
+      // Reset after play to ensure timing and any focus/mouse pause state is reset.
+      resetAutoplay();
     } else {
-      console.log('Stop autoplay:', autoplay);
-      // emblaApi.current?.plugins().autoplay.stop();
+      emblaApi.current?.plugins().autoplay.stop();
     }
   }, []);
 
@@ -137,7 +140,6 @@ export function useEmblaCarousel(
 
         if (newElement) {
           currentElement = newElement;
-          console.log('New element: ', autoplayRef.current);
           emblaApi.current = EmblaCarousel(
             newElement,
             {
@@ -147,9 +149,12 @@ export function useEmblaCarousel(
             [
               Autoplay({
                 playOnInit: autoplayRef.current,
-                // stopOnInteraction: !autoplayRef.current,
-                stopOnMouseEnter: false,
-                stopOnFocusIn: false,
+                stopOnInteraction: !autoplayRef.current,
+                stopOnMouseEnter: true,
+                stopOnFocusIn: true,
+                rootNode: (emblaRoot: HTMLElement) => {
+                  return emblaRoot.querySelector(sliderClassname) ?? emblaRoot;
+                },
               }),
             ],
           );
@@ -213,6 +218,9 @@ export function useEmblaCarousel(
           stopOnInteraction: !autoplayRef.current,
           stopOnMouseEnter: true,
           stopOnFocusIn: true,
+          rootNode: (emblaRoot: HTMLElement) => {
+            return emblaRoot.querySelector(sliderClassname) ?? emblaRoot;
+          },
         }),
       ],
     );
@@ -224,5 +232,6 @@ export function useEmblaCarousel(
     containerRef,
     subscribeForValues,
     enableAutoplay,
+    resetAutoplay,
   };
 }

--- a/packages/react-components/react-carousel-preview/library/src/components/useEmblaCarousel.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/useEmblaCarousel.ts
@@ -59,10 +59,6 @@ export function useEmblaCarousel(
 
   const emblaApi = React.useRef<EmblaCarouselType | null>(null);
 
-  const resetAutoplay = React.useCallback(() => {
-    emblaApi.current?.plugins().autoplay.reset();
-  }, []);
-
   const autoplayRef = React.useRef<boolean>(false);
   /* Our autoplay button, which is required by standards for autoplay to be enabled, will handle controlled state */
   const enableAutoplay = React.useCallback((autoplay: boolean) => {
@@ -74,6 +70,10 @@ export function useEmblaCarousel(
     } else {
       emblaApi.current?.plugins().autoplay.stop();
     }
+  }, []);
+
+  const resetAutoplay = React.useCallback(() => {
+    emblaApi.current?.plugins().autoplay.reset();
   }, []);
 
   // Listeners contains callbacks for UI elements that may require state update based on embla changes

--- a/packages/react-components/react-carousel-preview/library/src/components/useEmblaCarousel.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/useEmblaCarousel.ts
@@ -62,9 +62,14 @@ export function useEmblaCarousel(
   const enableAutoplay = React.useCallback((autoplay: boolean) => {
     autoplayRef.current = autoplay;
     if (autoplay) {
+      console.log('Playing autoplay:', autoplay);
       emblaApi.current?.plugins().autoplay.play();
+      console.log('Is autoplay:', emblaApi.current?.plugins().autoplay.isPlaying());
+      emblaApi.current?.plugins().autoplay.reset();
+      console.log('Is autoplay:', emblaApi.current?.plugins().autoplay.isPlaying());
     } else {
-      emblaApi.current?.plugins().autoplay.stop();
+      console.log('Stop autoplay:', autoplay);
+      // emblaApi.current?.plugins().autoplay.stop();
     }
   }, []);
 
@@ -132,6 +137,7 @@ export function useEmblaCarousel(
 
         if (newElement) {
           currentElement = newElement;
+          console.log('New element: ', autoplayRef.current);
           emblaApi.current = EmblaCarousel(
             newElement,
             {
@@ -141,9 +147,9 @@ export function useEmblaCarousel(
             [
               Autoplay({
                 playOnInit: autoplayRef.current,
-                stopOnInteraction: !autoplayRef.current,
-                stopOnMouseEnter: true,
-                stopOnFocusIn: true,
+                // stopOnInteraction: !autoplayRef.current,
+                stopOnMouseEnter: false,
+                stopOnFocusIn: false,
               }),
             ],
           );

--- a/packages/react-components/react-carousel-preview/library/src/components/useEmblaCarousel.ts
+++ b/packages/react-components/react-carousel-preview/library/src/components/useEmblaCarousel.ts
@@ -58,23 +58,26 @@ export function useEmblaCarousel(
   });
 
   const emblaApi = React.useRef<EmblaCarouselType | null>(null);
-
   const autoplayRef = React.useRef<boolean>(false);
-  /* Our autoplay button, which is required by standards for autoplay to be enabled, will handle controlled state */
-  const enableAutoplay = React.useCallback((autoplay: boolean) => {
-    autoplayRef.current = autoplay;
-    if (autoplay) {
-      emblaApi.current?.plugins().autoplay.play();
-      // Reset after play to ensure timing and any focus/mouse pause state is reset.
-      resetAutoplay();
-    } else {
-      emblaApi.current?.plugins().autoplay.stop();
-    }
-  }, []);
 
   const resetAutoplay = React.useCallback(() => {
     emblaApi.current?.plugins().autoplay.reset();
   }, []);
+
+  /* Our autoplay button, which is required by standards for autoplay to be enabled, will handle controlled state */
+  const enableAutoplay = React.useCallback(
+    (autoplay: boolean) => {
+      autoplayRef.current = autoplay;
+      if (autoplay) {
+        emblaApi.current?.plugins().autoplay.play();
+        // Reset after play to ensure timing and any focus/mouse pause state is reset.
+        resetAutoplay();
+      } else {
+        emblaApi.current?.plugins().autoplay.stop();
+      }
+    },
+    [resetAutoplay],
+  );
 
   // Listeners contains callbacks for UI elements that may require state update based on embla changes
   const listeners = React.useRef(new Set<(data: CarouselUpdateData) => void>());


### PR DESCRIPTION
## Previous Behavior
- Carousel autoplay timer would not restart on nav, causing quick page changes sometimes.
- Carousel autoplay was stopping autoplay on any control mouseover/focus (incl. accessibility software).

## New Behavior
- Carousel autoplay timer restarts on any nav changes.
- Carousel autoplay now only stops on any control mouseover/focus of carousel cards & slider itself (not including controls).

