### PR TITLE
fix: hovered menubutton icon does not disappear

### DIFF
--- a/change/@fluentui-react-button-87b1b58c-f4f5-4341-b7e9-348961287b4b.json
+++ b/change/@fluentui-react-button-87b1b58c-f4f5-4341-b7e9-348961287b4b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: hovered menubutton icon does not disappear",
+  "packageName": "@fluentui/react-button",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-button/library/src/components/MenuButton/useMenuButtonStyles.styles.ts
+++ b/packages/react-components/react-button/library/src/components/MenuButton/useMenuButtonStyles.styles.ts
@@ -66,7 +66,7 @@ const useIconExpandedStyles = makeStyles({
     // High contrast styles
     '@media (forced-colors: active)': {
       ':hover': {
-        color: 'Canvas',
+        color: 'Highlight',
       },
     },
   },


### PR DESCRIPTION
## Previous Behavior

We had a stray `:hover` style that made icons invisible on hover in expanded menubuttons:
<img width="218" alt="Screenshot of an expanded menubutton with menu in dark high contrast mode, and there is an empty dark space to the left of the light blue button text" src="https://github.com/user-attachments/assets/9c2318dc-6c8e-4441-8c8c-a9aa0f58cbc9">

## New Behavior

Uses the correct color token (Highlight) for the color, which matches the color/bg color pair used in Button's hover styles

## Related Issue(s)

Fixes an issue found while debugging icon high contrast color issues