### PR TITLE
Adding support for custom Popover

### DIFF
--- a/packages/react-components/react-charts-preview/library/src/components/CommonComponents/Popover.tsx
+++ b/packages/react-components/react-charts-preview/library/src/components/CommonComponents/Popover.tsx
@@ -18,20 +18,21 @@ const PopoverComponent: React.FunctionComponent<IPopoverComponentProps> = React.
 >((props, forwardedRef) => {
   const virtualElement: PositioningVirtualElement = {
     getBoundingClientRect: () => ({
-      top: props.clickPosition.y,
-      left: props.clickPosition.x,
-      right: props.clickPosition.x,
-      bottom: props.clickPosition.y,
-      x: props.clickPosition.x,
-      y: props.clickPosition.y,
+      top: props.clickPosition!.y,
+      left: props.clickPosition!.x,
+      right: props.clickPosition!.x,
+      bottom: props.clickPosition!.y,
+      x: props.clickPosition!.x,
+      y: props.clickPosition!.y,
       width: 0,
       height: 0,
     }),
   };
-
+  props = { ...props, ...props.customProps };
   const classes = usePopoverStyles_unstable(props);
   const Legend = props.xCalloutValue ? props.xCalloutValue : props.legend;
   const YValue = props.yCalloutValue ? props.yCalloutValue : props.YValue;
+
   return (
     <div id={useId('callout')}>
       <Popover
@@ -230,7 +231,6 @@ const PopoverComponent: React.FunctionComponent<IPopoverComponentProps> = React.
                   style={{ color: props.color ? props.color : tokens.colorNeutralForeground1 }}
                 >
                   {convertToLocaleString(subcounts[subcountName], culture)}
-                  style={{ color: props.color ? props.color : tokens.colorNeutralForeground1 }}
                 </div>
               </div>
             );

--- a/packages/react-components/react-charts-preview/library/src/components/CommonComponents/Popover.types.ts
+++ b/packages/react-components/react-charts-preview/library/src/components/CommonComponents/Popover.types.ts
@@ -1,22 +1,24 @@
+import * as React from 'react';
 import { IChartDataPoint, IYValueHover } from '../../index';
+import { PopoverSurfaceSlots } from '@fluentui/react-popover';
 
 export interface IPopoverComponentProps {
-  clickPosition: { x: number; y: number };
-  isPopoverOpen: boolean;
+  clickPosition?: { x: number; y: number };
+  isPopoverOpen?: boolean;
   xCalloutValue?: string;
-  legend?: string;
+  legend?: string | number | Date;
   yCalloutValue?: string;
   YValue?: string | number | Date;
   XValue?: string;
   color?: string;
-  culture: string;
-  isCalloutForStack: boolean;
+  culture?: string;
+  customProps?: IPopoverComponentProps;
+  isCalloutForStack?: boolean;
   customizedCallout?: JSX.Element;
   xAxisCalloutAccessibilityData?: { ariaLabel?: string; data?: string };
   hoverXValue?: string | number;
   YValueHover?: IYValueHover[];
   descriptionMessage?: string;
-  Legend?: string | number | Date;
   ratio?: [number, number];
 }
 

--- a/packages/react-components/react-charts-preview/library/src/components/DonutChart/DonutChart.tsx
+++ b/packages/react-components/react-charts-preview/library/src/components/DonutChart/DonutChart.tsx
@@ -313,6 +313,7 @@ export const DonutChart: React.FunctionComponent<IDonutChartProps> = React.forwa
           customizedCallout={
             props.onRenderCalloutPerDataPoint ? props.onRenderCalloutPerDataPoint(dataPointCalloutProps!) : undefined
           }
+          customProps={props.customProps ? props.customProps(dataPointCalloutProps!) : undefined}
         />
         {!hideLegend && <div className={classes.legendContainer}>{legendBars}</div>}
       </div>

--- a/packages/react-components/react-charts-preview/library/src/components/DonutChart/DonutChart.types.ts
+++ b/packages/react-components/react-charts-preview/library/src/components/DonutChart/DonutChart.types.ts
@@ -32,7 +32,12 @@ export interface IDonutChartProps extends ICartesianChartProps {
   /**
    * Define a custom callout renderer for a data point
    */
-  onRenderCalloutPerDataPoint?: (dataPointCalloutProps: IChartDataPoint) => JSX.Element;
+  onRenderCalloutPerDataPoint?: (dataPointCalloutProps: IChartDataPoint) => JSX.Element | undefined;
+
+  /**
+   * Define a custom callout props override
+   */
+  customProps?: (dataPointCalloutProps: IChartDataPoint) => IPopoverComponentProps;
 
   /**
    * props for the callout in the chart

--- a/packages/react-components/react-charts-preview/library/src/components/HorizontalBarChart/HorizontalBarChart.tsx
+++ b/packages/react-components/react-charts-preview/library/src/components/HorizontalBarChart/HorizontalBarChart.tsx
@@ -391,6 +391,7 @@ export const HorizontalBarChart: React.FunctionComponent<IHorizontalBarChartProp
         customizedCallout={
           props.onRenderCalloutPerHorizontalBar ? props.onRenderCalloutPerHorizontalBar(barCalloutProps!) : undefined
         }
+        customProps={props.customProps ? props.customProps(barCalloutProps!) : undefined}
       />
     </div>
   ) : (

--- a/packages/react-components/react-charts-preview/library/src/components/HorizontalBarChart/HorizontalBarChart.types.ts
+++ b/packages/react-components/react-charts-preview/library/src/components/HorizontalBarChart/HorizontalBarChart.types.ts
@@ -99,7 +99,12 @@ export interface IHorizontalBarChartProps extends React.RefAttributes<HTMLDivEle
   /**
    * prop to render the custom callout
    */
-  onRenderCalloutPerHorizontalBar?: (props: IChartDataPoint) => JSX.Element;
+  onRenderCalloutPerHorizontalBar?: (props: IChartDataPoint) => JSX.Element | undefined;
+
+  /**
+   * Define a custom callout props override
+   */
+  customProps?: (dataPointCalloutProps: IChartDataPoint) => IPopoverComponentProps;
 }
 
 /**

--- a/packages/react-components/react-charts-preview/stories/src/DonutChart/DonutChartCustomCallout.stories.tsx
+++ b/packages/react-components/react-charts-preview/stories/src/DonutChart/DonutChartCustomCallout.stories.tsx
@@ -5,10 +5,13 @@ import {
   IChartDataPoint,
   DataVizPalette,
   getColorFromToken,
-  PopoverComponent,
+  IPopoverComponentProps,
 } from '@fluentui/react-charts-preview';
+import { Switch } from '../../../../react-switch/library/src/Switch';
 
 export const DonutCustomCallout = () => {
+  const [useCustomPopover, setUseCustomPopover] = React.useState(false);
+
   const points: IChartDataPoint[] = [
     {
       legend: 'first',
@@ -26,13 +29,41 @@ export const DonutCustomCallout = () => {
     },
   ];
 
+  const _onTogglePopoverCheckChange = React.useCallback(ev => {
+    setUseCustomPopover(ev.currentTarget.checked);
+  }, []);
+
   const data: IChartProps = {
     chartTitle: 'Donut chart custom callout example',
     chartData: points,
   };
 
+  const customPopoverProps = (props: IChartDataPoint): IPopoverComponentProps => {
+    const yValue = props ? `${props.yAxisCalloutData! || props.data} h` : '';
+    return {
+      XValue: 'Custom XVal',
+      legend: 'Custom Legend',
+      YValue: yValue,
+      color: getColorFromToken(DataVizPalette.warning),
+    };
+  };
+
+  const customPopover = (props: IChartDataPoint): JSX.Element | undefined => {
+    const yValue = props ? `${props.yAxisCalloutData! || props.data} h` : 'Y Value';
+    const xValue = props ? props.xAxisCalloutData! : 'X Value';
+    const legend = props ? props.legend : 'Legend';
+    return useCustomPopover ? (
+      <div>
+        <div>{xValue}</div>
+        <div>{legend}</div>
+        <div>{yValue}</div>
+      </div>
+    ) : undefined;
+  };
+
   return (
     <>
+      <Switch label={'Custom Popover Override'} checked={useCustomPopover} onChange={_onTogglePopoverCheckChange} />
       <DonutChart
         data={data}
         innerRadius={55}
@@ -42,21 +73,13 @@ export const DonutCustomCallout = () => {
         height={220}
         width={176}
         valueInsideDonut={39000}
-        // eslint-disable-next-line react/jsx-no-bind
-        onRenderCalloutPerDataPoint={(props: IChartDataPoint) =>
-          props ? (
-            <PopoverComponent
-              XValue={'Custom XVal'}
-              Legend={'Custom Legend'}
-              YValue={`${props.yAxisCalloutData || props.data} h`}
-              color={getColorFromToken(DataVizPalette.warning)}
-            />
-          ) : null
-        }
+        customProps={(props: IChartDataPoint) => customPopoverProps(props)}
+        onRenderCalloutPerDataPoint={(props: IChartDataPoint) => customPopover(props)}
       />
     </>
   );
 };
+
 DonutCustomCallout.parameters = {
   docs: {
     description: {

--- a/packages/react-components/react-charts-preview/stories/src/HorizontalBarChart/HorizontalBarChartCustomCallout.stories.tsx
+++ b/packages/react-components/react-charts-preview/stories/src/HorizontalBarChart/HorizontalBarChartCustomCallout.stories.tsx
@@ -6,11 +6,14 @@ import {
   DataVizPalette,
   getColorFromToken,
   PopoverComponent,
+  IPopoverComponentProps,
 } from '@fluentui/react-charts-preview';
 import * as d3 from 'd3-format';
+import { Switch } from '../../../../react-switch/library/src/Switch';
 
 export const HBCCustomCallout = () => {
   const hideRatio: boolean[] = [true, false];
+  const [useCustomPopover, setUseCustomPopover] = React.useState(false);
 
   const data: IChartProps[] = [
     {
@@ -110,8 +113,37 @@ export const HBCCustomCallout = () => {
       ],
     },
   ];
+  const customPopoverProps = (props: IChartDataPoint): IPopoverComponentProps => {
+    const yValue = props ? `${props.yAxisCalloutData! || props.data} h` : '';
+    const color = props ? props.color : getColorFromToken(DataVizPalette.color28);
+    return {
+      XValue: 'Custom XVal',
+      legend: 'Custom Legend',
+      YValue: yValue,
+      color: color,
+      isCalloutForStack: false,
+    };
+  };
+
+  const _onTogglePopoverCheckChange = React.useCallback(ev => {
+    setUseCustomPopover(ev.currentTarget.checked);
+  }, []);
+
+  const customPopover = (props: IChartDataPoint): JSX.Element | undefined => {
+    const yValue = props ? `${props.yAxisCalloutData! || props.data} h` : 'Y Value';
+    const xValue = props ? props.xAxisCalloutData! : 'X Value';
+    const legend = props ? props.legend : 'Legend';
+    return useCustomPopover ? (
+      <div>
+        <div>{xValue}</div>
+        <div>{legend}</div>
+        <div>{yValue}</div>
+      </div>
+    ) : undefined;
+  };
   return (
     <div style={{ maxWidth: 600 }}>
+      <Switch label={'Custom Popover Override'} checked={useCustomPopover} onChange={_onTogglePopoverCheckChange} />
       <HorizontalBarChart
         data={data}
         hideRatio={hideRatio}
@@ -127,18 +159,8 @@ export const HBCCustomCallout = () => {
             </div>
           );
         }}
-        // eslint-disable-next-line react/jsx-no-bind
-        onRenderCalloutPerHorizontalBar={(props: IChartDataPoint) =>
-          props ? (
-            <PopoverComponent
-              xCalloutValue={props.xAxisCalloutData}
-              yCalloutValue={`${props.yAxisCalloutData || props.horizontalBarChartdata?.y} h`}
-              legend={props.legend}
-              color={props.color}
-              isCalloutForStack={false}
-            />
-          ) : null
-        }
+        customProps={(props: IChartDataPoint) => customPopoverProps(props)}
+        onRenderCalloutPerHorizontalBar={(props: IChartDataPoint) => customPopover(props)}
       />
     </div>
   );


### PR DESCRIPTION
Custom Popover element or custom popover props can be set using props.
Fixes custom popover issues for both Donut and Horizontal bar charts.