### PR TITLE
fix(react-drawer): reversed animations

### DIFF
--- a/change/@fluentui-react-drawer-ffcd33f0-21e3-4ccc-af34-d63229d2adf8.json
+++ b/change/@fluentui-react-drawer-ffcd33f0-21e3-4ccc-af34-d63229d2adf8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: reversed animations",
+  "packageName": "@fluentui/react-drawer",
+  "email": "marcosvmmoura@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-drawer/library/src/shared/drawerMotions.test.ts
+++ b/packages/react-components/react-drawer/library/src/shared/drawerMotions.test.ts
@@ -1,15 +1,28 @@
 import { getPositionTransform } from './drawerMotions';
 
 describe('getPositionTransform', () => {
-  it('should return the correct transform', () => {
-    expect(getPositionTransform('start', 'medium', 'ltr')).toBe('translate3d(var(medium), 0, 0)');
-    expect(getPositionTransform('start', 'medium', 'rtl')).toBe('translate3d(calc(var(medium) * -1), 0, 0)');
-    expect(getPositionTransform('end', 'medium', 'ltr')).toBe('translate3d(calc(var(medium) * -1), 0, 0)');
-    expect(getPositionTransform('end', 'medium', 'rtl')).toBe('translate3d(var(medium), 0, 0)');
-    expect(getPositionTransform('bottom', 'medium', 'ltr')).toBe('translate3d(0, var(medium), 0)');
-    expect(getPositionTransform('bottom', 'medium', 'rtl')).toBe('translate3d(0, var(medium), 0)');
+  it('should return the correct transform for start position', () => {
+    expect(getPositionTransform('start', 'medium', 'rtl')).toBe('translate3d(var(medium), 0, 0)');
+    expect(getPositionTransform('start', 'medium', 'ltr')).toBe('translate3d(calc(var(medium) * -1), 0, 0)');
+  });
 
-    // In case of undefined or unknown position
+  it('should return the correct transform for end position', () => {
+    expect(getPositionTransform('end', 'medium', 'rtl')).toBe('translate3d(calc(var(medium) * -1), 0, 0)');
+    expect(getPositionTransform('end', 'medium', 'ltr')).toBe('translate3d(var(medium), 0, 0)');
+  });
+
+  it('should return the correct transform for bottom position', () => {
+    expect(getPositionTransform('bottom', 'medium', 'rtl')).toBe('translate3d(0, var(medium), 0)');
+    expect(getPositionTransform('bottom', 'medium', 'ltr')).toBe('translate3d(0, var(medium), 0)');
+  });
+
+  it('should return the default transform for undefined or unknown position', () => {
     expect(getPositionTransform('top' as unknown as undefined, 'medium', 'ltr')).toBe('translate3d(0, 0, 0)');
+  });
+
+  it('should handle different sizes correctly', () => {
+    expect(getPositionTransform('start', 'small', 'ltr')).toBe('translate3d(calc(var(small) * -1), 0, 0)');
+    expect(getPositionTransform('end', 'large', 'rtl')).toBe('translate3d(calc(var(large) * -1), 0, 0)');
+    expect(getPositionTransform('bottom', 'full', 'ltr')).toBe('translate3d(0, var(full), 0)');
   });
 });

--- a/packages/react-components/react-drawer/library/src/shared/drawerMotions.ts
+++ b/packages/react-components/react-drawer/library/src/shared/drawerMotions.ts
@@ -30,11 +30,11 @@ export function getPositionTransform(
   const bottomToTopTransform = `translate3d(0, var(${sizeVar}), 0)`;
 
   if (position === 'start') {
-    return dir === 'rtl' ? rightToLeftTransform : leftToRightTransform;
+    return dir === 'ltr' ? rightToLeftTransform : leftToRightTransform;
   }
 
   if (position === 'end') {
-    return dir === 'rtl' ? leftToRightTransform : rightToLeftTransform;
+    return dir === 'ltr' ? leftToRightTransform : rightToLeftTransform;
   }
 
   if (position === 'bottom') {


### PR DESCRIPTION
## Previous Behavior
Animations were coming from the wrong direction

## New Behavior
Animations now play from the correct direction

## Related Issue(s)
- Fixes #32916
