### PR TITLE
feat(web-components): added support for custom progress bar indicator color

### DIFF
--- a/change/@fluentui-web-components-0be12bb0-8a61-4863-b045-d39adb9983d5.json
+++ b/change/@fluentui-web-components-0be12bb0-8a61-4863-b045-d39adb9983d5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Added support for custom indicator colors to progress-bar",
+  "packageName": "@fluentui/web-components",
+  "email": "mlijanto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/docs/api-report.md
+++ b/packages/web-components/docs/api-report.md
@@ -2287,10 +2287,7 @@ export const DividerDefinition: FASTElementDefinition<typeof Divider>;
 
 // @public
 export const DividerOrientation: {
-    readonly horizontal: "horizontal"; /**
-    * Divider roles
-    * @public
-    */
+    readonly horizontal: "horizontal";
     readonly vertical: "vertical";
 };
 
@@ -3598,10 +3595,7 @@ export const TablistDefinition: FASTElementDefinition<typeof Tablist>;
 
 // @public
 export const TablistOrientation: {
-    readonly horizontal: "horizontal"; /**
-    * The appearance of the component
-    * @public
-    */
+    readonly horizontal: "horizontal";
     readonly vertical: "vertical";
 };
 
@@ -4131,6 +4125,30 @@ export const ValidationFlags: {
 
 // @public (undocumented)
 export type ValidationFlags = ValuesOf<typeof ValidationFlags>;
+
+// @public
+export const zIndexBackground = "var(--zIndexBackground)";
+
+// @public
+export const zIndexContent = "var(--zIndexContent)";
+
+// @public
+export const zIndexDebug = "var(--zIndexDebug)";
+
+// @public
+export const zIndexFloating = "var(--zIndexFloating)";
+
+// @public
+export const zIndexMessages = "var(--zIndexMessages)";
+
+// @public
+export const zIndexOverlay = "var(--zIndexOverlay)";
+
+// @public
+export const zIndexPopup = "var(--zIndexPopup)";
+
+// @public
+export const zIndexPriority = "var(--zIndexPriority)";
 
 // Warnings were encountered during analysis:
 //

--- a/packages/web-components/src/progress-bar/progress-bar.styles.ts
+++ b/packages/web-components/src/progress-bar/progress-bar.styles.ts
@@ -19,6 +19,7 @@ export const styles = css`
   ${display('block')}
 
   :host {
+    --indicator-color: ${colorCompoundBrandBackground};
     width: 100%;
     height: 2px;
     overflow-x: hidden;
@@ -36,7 +37,7 @@ export const styles = css`
   }
 
   .indicator {
-    background-color: ${colorCompoundBrandBackground};
+    background-color: var(--indicator-color);
     border-radius: inherit;
     height: 100%;
   }
@@ -61,15 +62,15 @@ export const styles = css`
   }
 
   :host(${errorState}) .indicator {
-    background-color: ${colorPaletteRedBackground3};
+    --indicator-color: ${colorPaletteRedBackground3};
   }
 
   :host(${warningState}) .indicator {
-    background-color: ${colorPaletteDarkOrangeBackground3};
+    --indicator-color: ${colorPaletteDarkOrangeBackground3};
   }
 
   :host(${successState}) .indicator {
-    background-color: ${colorPaletteGreenBackground3};
+    --indicator-color: ${colorPaletteGreenBackground3};
   }
 
   @layer animations {

--- a/packages/web-components/src/theme/design-tokens.ts
+++ b/packages/web-components/src/theme/design-tokens.ts
@@ -2615,3 +2615,51 @@ export const curveEasyEase = 'var(--curveEasyEase)';
  * @public
  */
 export const curveLinear = 'var(--curveLinear)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#zIndexBackground | `zIndexBackground`} design token.
+ * @public
+ */
+export const zIndexBackground = 'var(--zIndexBackground)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#zIndexContent | `zIndexContent`} design token.
+ * @public
+ */
+export const zIndexContent = 'var(--zIndexContent)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#zIndexOverlay | `zIndexOverlay`} design token.
+ * @public
+ */
+export const zIndexOverlay = 'var(--zIndexOverlay)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#zIndexPopup | `zIndexPopup`} design token.
+ * @public
+ */
+export const zIndexPopup = 'var(--zIndexPopup)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#zIndexMessages | `zIndexMessages`} design token.
+ * @public
+ */
+export const zIndexMessages = 'var(--zIndexMessages)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#zIndexFloating | `zIndexFloating`} design token.
+ * @public
+ */
+export const zIndexFloating = 'var(--zIndexFloating)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#zIndexPriority | `zIndexPriority`} design token.
+ * @public
+ */
+export const zIndexPriority = 'var(--zIndexPriority)';
+
+/**
+ * CSS custom property value for the {@link @fluentui/tokens#zIndexDebug | `zIndexDebug`} design token.
+ * @public
+ */
+export const zIndexDebug = 'var(--zIndexDebug)';


### PR DESCRIPTION
## Previous Behavior
No support for custom indicator colors.

## New Behavior
This PR adds a new CSS variable that will enable the use of custom progress-bar indicator colors.