### PR TITLE
fix(vr-tests): v8 VR tests are now wrapped with a ThemeProvider by default

### DIFF
--- a/apps/vr-tests/.storybook/preview.js
+++ b/apps/vr-tests/.storybook/preview.js
@@ -1,6 +1,7 @@
 // @ts-check
 
 import { setRTL } from '@fluentui/react/lib/Utilities';
+import { ThemeProviderDecorator } from '../src/utilities';
 
 /** @type {import('@storybook/react').Decorator[]} */
 export const decorators = [
@@ -9,6 +10,7 @@ export const decorators = [
 
     return storyFn(context);
   },
+  ThemeProviderDecorator,
 ];
 
 /** @type {import('@storybook/react').Parameters} */

--- a/apps/vr-tests/src/utilities/StoryVariantDecorator.tsx
+++ b/apps/vr-tests/src/utilities/StoryVariantDecorator.tsx
@@ -9,10 +9,12 @@ const StoryVariantDecorator: Decorator = (storyFn, context) => {
 
   setRTL(dir === 'rtl');
 
-  return (
+  return theme ? (
     <ThemeProvider applyTo="element" theme={theme}>
       {storyFn(context)}
     </ThemeProvider>
+  ) : (
+    storyFn(context)
   );
 };
 

--- a/apps/vr-tests/src/utilities/StoryVariantDecorator.tsx
+++ b/apps/vr-tests/src/utilities/StoryVariantDecorator.tsx
@@ -9,12 +9,10 @@ const StoryVariantDecorator: Decorator = (storyFn, context) => {
 
   setRTL(dir === 'rtl');
 
-  return theme ? (
+  return (
     <ThemeProvider applyTo="element" theme={theme}>
       {storyFn(context)}
     </ThemeProvider>
-  ) : (
-    <ThemeProvider>{storyFn(context)}</ThemeProvider>
   );
 };
 

--- a/apps/vr-tests/src/utilities/StoryVariantDecorator.tsx
+++ b/apps/vr-tests/src/utilities/StoryVariantDecorator.tsx
@@ -14,7 +14,7 @@ const StoryVariantDecorator: Decorator = (storyFn, context) => {
       {storyFn(context)}
     </ThemeProvider>
   ) : (
-    storyFn(context)
+    <ThemeProvider>{storyFn(context)}</ThemeProvider>
   );
 };
 

--- a/apps/vr-tests/src/utilities/ThemeProviderDecorator.tsx
+++ b/apps/vr-tests/src/utilities/ThemeProviderDecorator.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import type { Decorator } from '@storybook/react';
+import { ThemeProvider } from '@fluentui/react';
+
+/**
+ * A decorator that wraps the story in a v8 `ThemeProvider` component.
+ * @returns The decorator function.
+ */
+export const ThemeProviderDecorator: Decorator = (story, context) => (
+  <ThemeProvider> {story(context)} </ThemeProvider>
+);

--- a/apps/vr-tests/src/utilities/index.ts
+++ b/apps/vr-tests/src/utilities/index.ts
@@ -8,3 +8,4 @@ export * from './StoryVariantDecorator';
 export * from './StoryWrightDecorator';
 export * from './TestWrapperDecorator';
 export * from './DevOnlyStoryHeader';
+export * from './ThemeProviderDecorator';


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
- certain VR tests (see VR test diff in this PR) have broken baseline snapshots due to the component not being wrapped in a `ThemeProvider`
<!-- This is the behavior we have today -->

## New Behavior
- all v8 VR tests now have a `ThemeProvider` wrapper by default which fixes the existing broken tests

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #32946
