### PR TITLE
fix: clear Modal timer on component unmount

### DIFF
--- a/change/@fluentui-react-cee72ab8-f9ab-4400-949b-d38ee4fabdc6.json
+++ b/change/@fluentui-react-cee72ab8-f9ab-4400-949b-d38ee4fabdc6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: clear Modal timer on component unmount",
+  "packageName": "@fluentui/react",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Modal/Modal.base.tsx
+++ b/packages/react/src/components/Modal/Modal.base.tsx
@@ -411,6 +411,10 @@ export const ModalBase: React.FunctionComponent<IModalProps> = React.forwardRef<
 
     useUnmount(() => {
       internalState.events.dispose();
+      if (internalState.onModalCloseTimer) {
+        clearTimeout(internalState.onModalCloseTimer);
+        internalState.onModalCloseTimer = 0;
+      }
     });
 
     useComponentRef(props, focusTrapZone);


### PR DESCRIPTION
## Previous Behavior

`Modal` animation timer was not cleared on unmount.

## New Behavior

`Modal` animation timer is cleared on unmount.

## Related Issue(s)

We don't have a repro case so it's not possible to be certain this fixes the issue but it is potentially a problem regardless.

- Fixes #32965
