### PR TITLE
Fixed popover related bugs for Donut, HBC and VBC

### DIFF
--- a/packages/react-components/react-charts-preview/library/src/components/CommonComponents/CartesianChart.tsx
+++ b/packages/react-components/react-charts-preview/library/src/components/CommonComponents/CartesianChart.tsx
@@ -158,12 +158,7 @@ const CartesianChartBase: React.FunctionComponent<IModifiedCartesianChartProps> 
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   function _generateCallout(calloutProps: any): JSX.Element {
-    const popoverProps = {
-      ...calloutProps,
-      customizedCallout: props.customizedCallout,
-      isCalloutForStack: props.isCalloutForStack,
-    };
-    return <PopoverComponent {...popoverProps} />;
+    return <PopoverComponent {...calloutProps} />;
   }
 
   const {

--- a/packages/react-components/react-charts-preview/library/src/components/CommonComponents/CartesianChart.types.ts
+++ b/packages/react-components/react-charts-preview/library/src/components/CommonComponents/CartesianChart.types.ts
@@ -425,6 +425,12 @@ export interface ICartesianChartProps {
    * @param {number} height - The new height of the chart.
    */
   onResize?: (width: number, height: number) => void;
+
+  /**
+   * Define a custom callout props override
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  customProps?: (dataPointCalloutProps: any) => IPopoverComponentProps;
 }
 
 export interface IYValueHover {
@@ -534,21 +540,10 @@ export interface IModifiedCartesianChartProps extends ICartesianChartProps {
    */
   children(props: IChildProps): React.ReactNode;
 
-  /**
-   * To enable callout for individualbar or complete stack. Using for only Vertical stacked bar chart.
-   * @default false
-   * @type \{boolean \}
-   */
-  isCalloutForStack?: boolean;
-
   /** dataset values to find out domain of the String axis
    * Present using for only vertical stacked bar chart and grouped vertical bar chart
    */
   datasetForXAxisDomain?: string[];
-
-  /** Own callout design */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  customizedCallout?: any;
 
   /**
    * if the data points for the y-axis is of type string, then we need to give this

--- a/packages/react-components/react-charts-preview/library/src/components/CommonComponents/Popover.styles.ts
+++ b/packages/react-components/react-charts-preview/library/src/components/CommonComponents/Popover.styles.ts
@@ -11,12 +11,14 @@ export const popoverClassNames: SlotClassNames<IPopoverComponentStyles> = {
   calloutContentRoot: 'fui-cart__calloutContentRoot',
   calloutDateTimeContainer: 'fui-cart__calloutDateTimeContainer',
   calloutContentX: 'fui-cart__calloutContentX',
-  calloutBlockContainer: 'fui-cart__calloutBlockContainer',
+  calloutBlockContainerCartesian: 'fui-cart__calloutBlockContainerCartesian',
+  calloutBlockContainerNonCartesian: 'fui-cart__calloutBlockContainerNonCartesian',
   calloutBlockContainertoDrawShapefalse: 'fui-cart__calloutBlockContainertoDrawShapefalse',
   calloutBlockContainertoDrawShapetrue: 'fui-cart__calloutBlockContainertoDrawShapetrue',
   shapeStyles: 'fui-cart__shapeStyles',
   calloutlegendText: 'fui-cart__calloutlegendText',
-  calloutContentY: 'fui-cart__calloutContentY',
+  calloutContentYCartesian: 'fui-cart__calloutContentYCartesian',
+  calloutContentYNonCartesian: 'fui-cart__calloutContentYNonCartesian',
   descriptionMessage: 'fui-cart__descriptionMessage',
   ratio: 'fui-cart__ratio',
   numerator: 'fui-cart__numerator',
@@ -45,11 +47,21 @@ const useStyles = makeStyles({
     opacity: '0.8',
     color: tokens.colorNeutralForeground2,
   },
-  calloutBlockContainer: {
+  calloutBlockContainerCartesian: {
     fontSize: tokens.fontSizeBase200,
     marginTop: '13px',
     color: tokens.colorNeutralForeground2,
+  },
+  calloutBlockContainerNonCartesian: {
+    fontSize: tokens.fontSizeHero700,
+    color: tokens.colorNeutralForeground2,
     paddingLeft: '8px',
+    lineHeight: '22px',
+    '& selectors': {
+      [HighContrastSelector]: {
+        forcedColorAdjust: 'none',
+      },
+    },
   },
   calloutBlockContainertoDrawShapefalse: {
     '& selectors': {
@@ -75,7 +87,17 @@ const useStyles = makeStyles({
       },
     },
   },
-  calloutContentY: {
+  calloutContentYCartesian: {
+    fontSize: tokens.fontSizeBase400,
+    fontWeight: 'bold',
+    lineHeight: '22px',
+    '& selectors': {
+      [HighContrastSelectorBlack]: {
+        color: 'rgb(255, 255, 255)',
+      },
+    },
+  },
+  calloutContentYNonCartesian: {
     fontSize: tokens.fontSizeHero700,
     fontWeight: 'bold',
     lineHeight: '36px',
@@ -122,9 +144,13 @@ export const usePopoverStyles_unstable = (props: IPopoverComponentProps): IPopov
       popoverClassNames.calloutContentX,
       baseStyles.calloutContentX /*props.styles?.calloutContentX*/,
     ),
-    calloutBlockContainer: mergeClasses(
-      popoverClassNames.calloutBlockContainer,
-      baseStyles.calloutBlockContainer /*props.styles?.calloutBlockContainer*/,
+    calloutBlockContainerCartesian: mergeClasses(
+      popoverClassNames.calloutBlockContainerCartesian,
+      baseStyles.calloutBlockContainerCartesian /*props.styles?.calloutBlockContainerCartesian*/,
+    ),
+    calloutBlockContainerNonCartesian: mergeClasses(
+      popoverClassNames.calloutBlockContainerNonCartesian,
+      baseStyles.calloutBlockContainerNonCartesian /*props.styles?.calloutBlockContainerNonCartesian*/,
     ),
     calloutBlockContainertoDrawShapefalse: mergeClasses(
       popoverClassNames.calloutBlockContainertoDrawShapefalse,
@@ -139,9 +165,13 @@ export const usePopoverStyles_unstable = (props: IPopoverComponentProps): IPopov
       popoverClassNames.calloutlegendText,
       baseStyles.calloutLegendText /*props.styles?.calloutlegendText*/,
     ),
-    calloutContentY: mergeClasses(
-      popoverClassNames.calloutContentY,
-      baseStyles.calloutContentY /*props.styles?.calloutContentY*/,
+    calloutContentYCartesian: mergeClasses(
+      popoverClassNames.calloutContentYCartesian,
+      baseStyles.calloutContentYCartesian /*props.styles?.calloutContentYCartesian*/,
+    ),
+    calloutContentYNonCartesian: mergeClasses(
+      popoverClassNames.calloutContentYNonCartesian,
+      baseStyles.calloutContentYNonCartesian /*props.styles?.calloutContentYNonCartesian*/,
     ),
     descriptionMessage: mergeClasses(
       popoverClassNames.descriptionMessage,

--- a/packages/react-components/react-charts-preview/library/src/components/CommonComponents/Popover.styles.ts
+++ b/packages/react-components/react-charts-preview/library/src/components/CommonComponents/Popover.styles.ts
@@ -23,6 +23,7 @@ export const popoverClassNames: SlotClassNames<IPopoverComponentStyles> = {
   ratio: 'fui-cart__ratio',
   numerator: 'fui-cart__numerator',
   denominator: 'fui-cart__denominator',
+  calloutInfoContainer: 'fui-cart__calloutInfoContainer',
 };
 
 /**
@@ -125,6 +126,9 @@ const useStyles = makeStyles({
   denominator: {
     fontWeight: tokens.fontWeightSemibold,
   },
+  calloutInfoContainer: {
+    paddingLeft: '8px',
+  },
 });
 /**
  * Apply styling to the Carousel slots based on the state
@@ -180,5 +184,6 @@ export const usePopoverStyles_unstable = (props: IPopoverComponentProps): IPopov
     ratio: mergeClasses(popoverClassNames.ratio, baseStyles.ratio /*props.styles?.ratio*/),
     numerator: mergeClasses(popoverClassNames.numerator, baseStyles.numerator /*props.styles?.numerator*/),
     denominator: mergeClasses(popoverClassNames.denominator, baseStyles.denominator /*props.styles?.denominator*/),
+    calloutInfoContainer: mergeClasses(popoverClassNames.calloutInfoContainer, baseStyles.calloutInfoContainer),
   };
 };

--- a/packages/react-components/react-charts-preview/library/src/components/CommonComponents/Popover.styles.ts
+++ b/packages/react-components/react-charts-preview/library/src/components/CommonComponents/Popover.styles.ts
@@ -40,7 +40,7 @@ const useStyles = makeStyles({
     justifyContent: 'space-between',
   },
   calloutContentX: {
-    fontSize: tokens.fontSizeBase100,
+    fontSize: tokens.fontSizeBase200,
     lineHeight: '16px',
     opacity: '0.8',
     color: tokens.colorNeutralForeground2,

--- a/packages/react-components/react-charts-preview/library/src/components/CommonComponents/Popover.styles.ts
+++ b/packages/react-components/react-charts-preview/library/src/components/CommonComponents/Popover.styles.ts
@@ -11,14 +11,12 @@ export const popoverClassNames: SlotClassNames<IPopoverComponentStyles> = {
   calloutContentRoot: 'fui-cart__calloutContentRoot',
   calloutDateTimeContainer: 'fui-cart__calloutDateTimeContainer',
   calloutContentX: 'fui-cart__calloutContentX',
-  calloutBlockContainerCartesian: 'fui-cart__calloutBlockContainerCartesian',
-  calloutBlockContainerNonCartesian: 'fui-cart__calloutBlockContainerNonCartesian',
+  calloutBlockContainer: 'fui-cart__calloutBlockContainer',
   calloutBlockContainertoDrawShapefalse: 'fui-cart__calloutBlockContainertoDrawShapefalse',
   calloutBlockContainertoDrawShapetrue: 'fui-cart__calloutBlockContainertoDrawShapetrue',
   shapeStyles: 'fui-cart__shapeStyles',
   calloutlegendText: 'fui-cart__calloutlegendText',
-  calloutContentYCartesian: 'fui-cart__calloutContentYCartesian',
-  calloutContentYNonCartesian: 'fui-cart__calloutContentYNonCartesian',
+  calloutContentY: 'fui-cart__calloutContentY',
   descriptionMessage: 'fui-cart__descriptionMessage',
   ratio: 'fui-cart__ratio',
   numerator: 'fui-cart__numerator',
@@ -48,15 +46,15 @@ const useStyles = makeStyles({
     opacity: '0.8',
     color: tokens.colorNeutralForeground2,
   },
+  calloutBlockContainer: {
+    color: tokens.colorNeutralForeground2,
+  },
   calloutBlockContainerCartesian: {
     fontSize: tokens.fontSizeBase200,
     marginTop: '13px',
-    color: tokens.colorNeutralForeground2,
   },
   calloutBlockContainerNonCartesian: {
     fontSize: tokens.fontSizeHero700,
-    color: tokens.colorNeutralForeground2,
-    paddingLeft: '8px',
     lineHeight: '22px',
     '& selectors': {
       [HighContrastSelector]: {
@@ -88,25 +86,21 @@ const useStyles = makeStyles({
       },
     },
   },
-  calloutContentYCartesian: {
-    fontSize: tokens.fontSizeBase400,
+  calloutContentY: {
     fontWeight: 'bold',
-    lineHeight: '22px',
     '& selectors': {
       [HighContrastSelectorBlack]: {
         color: 'rgb(255, 255, 255)',
       },
     },
   },
+  calloutContentYCartesian: {
+    fontSize: tokens.fontSizeBase400,
+    lineHeight: '22px',
+  },
   calloutContentYNonCartesian: {
     fontSize: tokens.fontSizeHero700,
-    fontWeight: 'bold',
     lineHeight: '36px',
-    '& selectors': {
-      [HighContrastSelectorBlack]: {
-        color: 'rgb(255, 255, 255)',
-      },
-    },
   },
   descriptionMessage: {
     fontSize: tokens.fontSizeBase200,
@@ -134,6 +128,7 @@ const useStyles = makeStyles({
  * Apply styling to the Carousel slots based on the state
  */
 export const usePopoverStyles_unstable = (props: IPopoverComponentProps): IPopoverComponentStyles => {
+  const { isCartesian } = props;
   const baseStyles = useStyles();
   return {
     calloutContentRoot: mergeClasses(
@@ -148,13 +143,10 @@ export const usePopoverStyles_unstable = (props: IPopoverComponentProps): IPopov
       popoverClassNames.calloutContentX,
       baseStyles.calloutContentX /*props.styles?.calloutContentX*/,
     ),
-    calloutBlockContainerCartesian: mergeClasses(
-      popoverClassNames.calloutBlockContainerCartesian,
-      baseStyles.calloutBlockContainerCartesian /*props.styles?.calloutBlockContainerCartesian*/,
-    ),
-    calloutBlockContainerNonCartesian: mergeClasses(
-      popoverClassNames.calloutBlockContainerNonCartesian,
-      baseStyles.calloutBlockContainerNonCartesian /*props.styles?.calloutBlockContainerNonCartesian*/,
+    calloutBlockContainer: mergeClasses(
+      popoverClassNames.calloutBlockContainer,
+      baseStyles.calloutBlockContainer /*props.styles?.calloutBlockContainerCartesian*/,
+      isCartesian ? baseStyles.calloutBlockContainerCartesian : baseStyles.calloutBlockContainerNonCartesian,
     ),
     calloutBlockContainertoDrawShapefalse: mergeClasses(
       popoverClassNames.calloutBlockContainertoDrawShapefalse,
@@ -169,13 +161,10 @@ export const usePopoverStyles_unstable = (props: IPopoverComponentProps): IPopov
       popoverClassNames.calloutlegendText,
       baseStyles.calloutLegendText /*props.styles?.calloutlegendText*/,
     ),
-    calloutContentYCartesian: mergeClasses(
-      popoverClassNames.calloutContentYCartesian,
-      baseStyles.calloutContentYCartesian /*props.styles?.calloutContentYCartesian*/,
-    ),
-    calloutContentYNonCartesian: mergeClasses(
-      popoverClassNames.calloutContentYNonCartesian,
-      baseStyles.calloutContentYNonCartesian /*props.styles?.calloutContentYNonCartesian*/,
+    calloutContentY: mergeClasses(
+      popoverClassNames.calloutContentY,
+      baseStyles.calloutContentY /*props.styles?.calloutContentYNonCartesian*/,
+      isCartesian ? baseStyles.calloutContentYCartesian : baseStyles.calloutContentYNonCartesian,
     ),
     descriptionMessage: mergeClasses(
       popoverClassNames.descriptionMessage,

--- a/packages/react-components/react-charts-preview/library/src/components/CommonComponents/Popover.styles.ts
+++ b/packages/react-components/react-charts-preview/library/src/components/CommonComponents/Popover.styles.ts
@@ -46,9 +46,10 @@ const useStyles = makeStyles({
     color: tokens.colorNeutralForeground2,
   },
   calloutBlockContainer: {
-    fontSize: 'fontSizeBase200',
+    fontSize: tokens.fontSizeBase200,
     marginTop: '13px',
     color: tokens.colorNeutralForeground2,
+    paddingLeft: '8px',
   },
   calloutBlockContainertoDrawShapefalse: {
     '& selectors': {
@@ -56,7 +57,6 @@ const useStyles = makeStyles({
         forcedColorAdjust: 'none',
       },
     },
-    ...shorthands.borderLeft('4px solid'),
     paddingLeft: '8px',
   },
   calloutBlockContainertoDrawShapetrue: {
@@ -66,7 +66,7 @@ const useStyles = makeStyles({
     marginRight: '8px',
   },
   calloutLegendText: {
-    fontSize: 'fontSizeBase200',
+    fontSize: tokens.fontSizeBase200,
     lineHeight: '16px',
     color: tokens.colorNeutralForeground2,
     '& selectors': {
@@ -76,7 +76,7 @@ const useStyles = makeStyles({
     },
   },
   calloutContentY: {
-    fontSize: tokens.fontSizeBase400,
+    fontSize: tokens.fontSizeHero700,
     fontWeight: 'bold',
     lineHeight: '36px',
     '& selectors': {

--- a/packages/react-components/react-charts-preview/library/src/components/CommonComponents/Popover.tsx
+++ b/packages/react-components/react-charts-preview/library/src/components/CommonComponents/Popover.tsx
@@ -54,12 +54,13 @@ const PopoverComponent: React.FunctionComponent<IPopoverComponentProps> = React.
                 {/* <div className={classNames.calloutContentX}>07:00am</div> */}
               </div>
               <div
-                style={
-                  props.ratio && {
+                style={{
+                  ...(props.ratio && {
                     display: 'flex',
                     alignItems: 'flex-end',
-                  }
-                }
+                  }),
+                  borderLeft: `4px solid ${props.color}`,
+                }}
               >
                 <div className={classes.calloutBlockContainer}>
                   <div className={classes.calloutlegendText}>{convertToLocaleString(Legend, props.culture)}</div>

--- a/packages/react-components/react-charts-preview/library/src/components/CommonComponents/Popover.tsx
+++ b/packages/react-components/react-charts-preview/library/src/components/CommonComponents/Popover.tsx
@@ -47,11 +47,13 @@ const PopoverComponent: React.FunctionComponent<IPopoverComponentProps> = React.
       >
         <PopoverSurface>
           {/** Given custom callout, then it will render */}
-          {props.customizedCallout && props.customizedCallout}
+          {props.customProps && props.customProps.customizedCallout && props.customProps.customizedCallout}
           {/** single x point its corresponding y points of all the bars/lines in chart will render in callout */}
-          {!props.customizedCallout && props.isCalloutForStack && _multiValueCallout()}
+          {(!props.customProps || !props.customProps.customizedCallout) &&
+            props.isCalloutForStack &&
+            _multiValueCallout()}
           {/** single x point its corresponding y point of single line/bar in the chart will render in callout */}
-          {!props.customizedCallout && !props.isCalloutForStack && (
+          {(!props.customProps || !props.customProps.customizedCallout) && !props.isCalloutForStack && (
             <div className={classes.calloutContentRoot}>
               <div className={classes.calloutDateTimeContainer}>
                 <div className={classes.calloutContentX}>{props.XValue} </div>
@@ -59,6 +61,7 @@ const PopoverComponent: React.FunctionComponent<IPopoverComponentProps> = React.
                 {/* <div className={classNames.calloutContentX}>07:00am</div> */}
               </div>
               <div
+                className={classes.calloutInfoContainer}
                 style={{
                   ...(props.ratio && {
                     display: 'flex',
@@ -230,7 +233,7 @@ const PopoverComponent: React.FunctionComponent<IPopoverComponentProps> = React.
           </div>
           {Object.keys(subcounts).map((subcountName: string) => {
             return (
-              <div key={subcountName} className={classes.calloutBlockContainer}>
+              <div key={subcountName} className={calloutBlockContainerStyle}>
                 <div className={classes.calloutlegendText}> {convertToLocaleString(subcountName, culture)}</div>
                 <div
                   className={calloutContentYStyle}

--- a/packages/react-components/react-charts-preview/library/src/components/CommonComponents/Popover.tsx
+++ b/packages/react-components/react-charts-preview/library/src/components/CommonComponents/Popover.tsx
@@ -32,12 +32,6 @@ const PopoverComponent: React.FunctionComponent<IPopoverComponentProps> = React.
   const classes = usePopoverStyles_unstable(props);
   const Legend = props.xCalloutValue ? props.xCalloutValue : props.legend;
   const YValue = props.yCalloutValue ? props.yCalloutValue : props.YValue;
-  const calloutBlockContainerStyle = props.isCartesian
-    ? classes.calloutBlockContainerCartesian
-    : classes.calloutBlockContainerNonCartesian;
-  const calloutContentYStyle = props.isCartesian
-    ? classes.calloutContentYCartesian
-    : classes.calloutContentYNonCartesian;
   return (
     <div id={useId('callout')}>
       <Popover
@@ -70,10 +64,10 @@ const PopoverComponent: React.FunctionComponent<IPopoverComponentProps> = React.
                   borderLeft: `4px solid ${props.color}`,
                 }}
               >
-                <div className={calloutBlockContainerStyle}>
+                <div className={classes.calloutBlockContainer}>
                   <div className={classes.calloutlegendText}>{convertToLocaleString(Legend, props.culture)}</div>
                   <div
-                    className={calloutContentYStyle}
+                    className={classes.calloutContentY}
                     style={{ color: props.color ? props.color : tokens.colorNeutralForeground1 }}
                   >
                     {convertToLocaleString(YValue, props.culture)}
@@ -186,7 +180,7 @@ const PopoverComponent: React.FunctionComponent<IPopoverComponentProps> = React.
           )}
           <div
             id={`${index}_${xValue.y}`}
-            className={calloutBlockContainerStyle}
+            className={classes.calloutBlockContainer}
             style={{
               marginTop: props.XValue ? '13px' : 'unset',
               ...(!toDrawShape
@@ -207,14 +201,14 @@ const PopoverComponent: React.FunctionComponent<IPopoverComponentProps> = React.
             )}
             <div
               className={mergeClasses(
-                calloutBlockContainerStyle,
+                classes.calloutBlockContainer,
                 toDrawShape
                   ? classes.calloutBlockContainertoDrawShapetrue
                   : classes.calloutBlockContainertoDrawShapefalse,
               )}
             >
               <div className={classes.calloutlegendText}> {xValue.legend}</div>
-              <div className={calloutContentYStyle}>
+              <div className={classes.calloutContentY}>
                 {convertToLocaleString(
                   xValue.yAxisCalloutData ? xValue.yAxisCalloutData : xValue.y ?? xValue.data,
                   culture,
@@ -233,10 +227,10 @@ const PopoverComponent: React.FunctionComponent<IPopoverComponentProps> = React.
           </div>
           {Object.keys(subcounts).map((subcountName: string) => {
             return (
-              <div key={subcountName} className={calloutBlockContainerStyle}>
+              <div key={subcountName} className={classes.calloutBlockContainer}>
                 <div className={classes.calloutlegendText}> {convertToLocaleString(subcountName, culture)}</div>
                 <div
-                  className={calloutContentYStyle}
+                  className={classes.calloutContentY}
                   style={{ color: props.color ? props.color : tokens.colorNeutralForeground1 }}
                 >
                   {convertToLocaleString(subcounts[subcountName], culture)}

--- a/packages/react-components/react-charts-preview/library/src/components/CommonComponents/Popover.tsx
+++ b/packages/react-components/react-charts-preview/library/src/components/CommonComponents/Popover.tsx
@@ -32,7 +32,12 @@ const PopoverComponent: React.FunctionComponent<IPopoverComponentProps> = React.
   const classes = usePopoverStyles_unstable(props);
   const Legend = props.xCalloutValue ? props.xCalloutValue : props.legend;
   const YValue = props.yCalloutValue ? props.yCalloutValue : props.YValue;
-
+  const calloutBlockContainerStyle = props.isCartesian
+    ? classes.calloutBlockContainerCartesian
+    : classes.calloutBlockContainerNonCartesian;
+  const calloutContentYStyle = props.isCartesian
+    ? classes.calloutContentYCartesian
+    : classes.calloutContentYNonCartesian;
   return (
     <div id={useId('callout')}>
       <Popover
@@ -62,10 +67,10 @@ const PopoverComponent: React.FunctionComponent<IPopoverComponentProps> = React.
                   borderLeft: `4px solid ${props.color}`,
                 }}
               >
-                <div className={classes.calloutBlockContainer}>
+                <div className={calloutBlockContainerStyle}>
                   <div className={classes.calloutlegendText}>{convertToLocaleString(Legend, props.culture)}</div>
                   <div
-                    className={classes.calloutContentY}
+                    className={calloutContentYStyle}
                     style={{ color: props.color ? props.color : tokens.colorNeutralForeground1 }}
                   >
                     {convertToLocaleString(YValue, props.culture)}
@@ -178,7 +183,7 @@ const PopoverComponent: React.FunctionComponent<IPopoverComponentProps> = React.
           )}
           <div
             id={`${index}_${xValue.y}`}
-            className={classes.calloutBlockContainer}
+            className={calloutBlockContainerStyle}
             style={{
               marginTop: props.XValue ? '13px' : 'unset',
               ...(!toDrawShape
@@ -199,14 +204,14 @@ const PopoverComponent: React.FunctionComponent<IPopoverComponentProps> = React.
             )}
             <div
               className={mergeClasses(
-                classes.calloutBlockContainer,
+                calloutBlockContainerStyle,
                 toDrawShape
                   ? classes.calloutBlockContainertoDrawShapetrue
                   : classes.calloutBlockContainertoDrawShapefalse,
               )}
             >
               <div className={classes.calloutlegendText}> {xValue.legend}</div>
-              <div className={classes.calloutContentY}>
+              <div className={calloutContentYStyle}>
                 {convertToLocaleString(
                   xValue.yAxisCalloutData ? xValue.yAxisCalloutData : xValue.y ?? xValue.data,
                   culture,
@@ -228,7 +233,7 @@ const PopoverComponent: React.FunctionComponent<IPopoverComponentProps> = React.
               <div key={subcountName} className={classes.calloutBlockContainer}>
                 <div className={classes.calloutlegendText}> {convertToLocaleString(subcountName, culture)}</div>
                 <div
-                  className={classes.calloutContentY}
+                  className={calloutContentYStyle}
                   style={{ color: props.color ? props.color : tokens.colorNeutralForeground1 }}
                 >
                   {convertToLocaleString(subcounts[subcountName], culture)}

--- a/packages/react-components/react-charts-preview/library/src/components/CommonComponents/Popover.types.ts
+++ b/packages/react-components/react-charts-preview/library/src/components/CommonComponents/Popover.types.ts
@@ -29,14 +29,12 @@ export interface IPopoverComponentStyles {
   calloutContentRoot: string;
   calloutDateTimeContainer: string;
   calloutContentX: string;
-  calloutBlockContainerCartesian: string;
-  calloutBlockContainerNonCartesian: string;
+  calloutBlockContainer: string;
   calloutBlockContainertoDrawShapefalse: string;
   calloutBlockContainertoDrawShapetrue: string;
   shapeStyles: string;
   calloutlegendText: string;
-  calloutContentYCartesian: string;
-  calloutContentYNonCartesian: string;
+  calloutContentY: string;
   descriptionMessage: string;
   ratio: string;
   numerator: string;

--- a/packages/react-components/react-charts-preview/library/src/components/CommonComponents/Popover.types.ts
+++ b/packages/react-components/react-charts-preview/library/src/components/CommonComponents/Popover.types.ts
@@ -12,9 +12,11 @@ export interface IPopoverComponentProps {
   XValue?: string;
   color?: string;
   culture?: string;
-  customProps?: IPopoverComponentProps;
+  customProps?: {
+    customizedCallout?: JSX.Element;
+    customCalloutProps?: IPopoverComponentProps;
+  };
   isCalloutForStack?: boolean;
-  customizedCallout?: JSX.Element;
   xAxisCalloutAccessibilityData?: { ariaLabel?: string; data?: string };
   hoverXValue?: string | number;
   YValueHover?: IYValueHover[];
@@ -39,4 +41,5 @@ export interface IPopoverComponentStyles {
   ratio: string;
   numerator: string;
   denominator: string;
+  calloutInfoContainer: string;
 }

--- a/packages/react-components/react-charts-preview/library/src/components/CommonComponents/Popover.types.ts
+++ b/packages/react-components/react-charts-preview/library/src/components/CommonComponents/Popover.types.ts
@@ -20,18 +20,21 @@ export interface IPopoverComponentProps {
   YValueHover?: IYValueHover[];
   descriptionMessage?: string;
   ratio?: [number, number];
+  isCartesian?: boolean;
 }
 
 export interface IPopoverComponentStyles {
   calloutContentRoot: string;
   calloutDateTimeContainer: string;
   calloutContentX: string;
-  calloutBlockContainer: string;
+  calloutBlockContainerCartesian: string;
+  calloutBlockContainerNonCartesian: string;
   calloutBlockContainertoDrawShapefalse: string;
   calloutBlockContainertoDrawShapetrue: string;
   shapeStyles: string;
   calloutlegendText: string;
-  calloutContentY: string;
+  calloutContentYCartesian: string;
+  calloutContentYNonCartesian: string;
   descriptionMessage: string;
   ratio: string;
   numerator: string;

--- a/packages/react-components/react-charts-preview/library/src/components/DonutChart/DonutChart.tsx
+++ b/packages/react-components/react-charts-preview/library/src/components/DonutChart/DonutChart.tsx
@@ -319,6 +319,7 @@ const DonutChartBase: React.FunctionComponent<IDonutChartProps> = React.forwardR
             props.onRenderCalloutPerDataPoint ? props.onRenderCalloutPerDataPoint(dataPointCalloutProps!) : undefined
           }
           customProps={props.customProps ? props.customProps(dataPointCalloutProps!) : undefined}
+          isCartesian={false}
         />
         {!hideLegend && (
           <div ref={(e: HTMLDivElement) => (legendContainer.current = e)} className={classes.legendContainer}>

--- a/packages/react-components/react-charts-preview/library/src/components/DonutChart/DonutChart.tsx
+++ b/packages/react-components/react-charts-preview/library/src/components/DonutChart/DonutChart.tsx
@@ -315,10 +315,12 @@ const DonutChartBase: React.FunctionComponent<IDonutChartProps> = React.forwardR
           YValue={value!}
           color={color}
           isCalloutForStack={false}
-          customizedCallout={
-            props.onRenderCalloutPerDataPoint ? props.onRenderCalloutPerDataPoint(dataPointCalloutProps!) : undefined
-          }
-          customProps={props.customProps ? props.customProps(dataPointCalloutProps!) : undefined}
+          customProps={{
+            customizedCallout: props.onRenderCalloutPerDataPoint
+              ? props.onRenderCalloutPerDataPoint(dataPointCalloutProps!)
+              : undefined,
+            customCalloutProps: props.customProps ? props.customProps(dataPointCalloutProps!) : undefined,
+          }}
           isCartesian={false}
         />
         {!hideLegend && (

--- a/packages/react-components/react-charts-preview/library/src/components/HorizontalBarChart/HorizontalBarChart.tsx
+++ b/packages/react-components/react-charts-preview/library/src/components/HorizontalBarChart/HorizontalBarChart.tsx
@@ -388,10 +388,12 @@ export const HorizontalBarChart: React.FunctionComponent<IHorizontalBarChartProp
         YValue={hoverValue!}
         color={lineColor}
         isCalloutForStack={false}
-        customizedCallout={
-          props.onRenderCalloutPerHorizontalBar ? props.onRenderCalloutPerHorizontalBar(barCalloutProps!) : undefined
-        }
-        customProps={props.customProps ? props.customProps(barCalloutProps!) : undefined}
+        customProps={{
+          customizedCallout: props.onRenderCalloutPerHorizontalBar
+            ? props.onRenderCalloutPerHorizontalBar(barCalloutProps!)
+            : undefined,
+          customCalloutProps: props.customProps ? props.customProps(barCalloutProps!) : undefined,
+        }}
         isCartesian={false}
       />
     </div>

--- a/packages/react-components/react-charts-preview/library/src/components/HorizontalBarChart/HorizontalBarChart.tsx
+++ b/packages/react-components/react-charts-preview/library/src/components/HorizontalBarChart/HorizontalBarChart.tsx
@@ -392,6 +392,7 @@ export const HorizontalBarChart: React.FunctionComponent<IHorizontalBarChartProp
           props.onRenderCalloutPerHorizontalBar ? props.onRenderCalloutPerHorizontalBar(barCalloutProps!) : undefined
         }
         customProps={props.customProps ? props.customProps(barCalloutProps!) : undefined}
+        isCartesian={false}
       />
     </div>
   ) : (

--- a/packages/react-components/react-charts-preview/library/src/components/LineChart/LineChart.tsx
+++ b/packages/react-components/react-charts-preview/library/src/components/LineChart/LineChart.tsx
@@ -1280,6 +1280,10 @@ export const LineChart: React.FunctionComponent<ILineChartProps> = React.forward
       isCalloutForStack: true,
       culture: props.culture ?? 'en-us',
       isCartesian: true,
+      customProps: {
+        customizedCallout: _getCustomizedCallout(),
+        customCalloutProps: props.customProps ? props.customProps(dataPointCalloutProps!) : undefined,
+      },
     };
     const tickParams = {
       tickValues,
@@ -1292,14 +1296,12 @@ export const LineChart: React.FunctionComponent<ILineChartProps> = React.forward
         chartTitle={props.data.chartTitle}
         points={points}
         chartType={ChartTypes.LineChart}
-        isCalloutForStack
         calloutProps={calloutProps}
         tickParams={tickParams}
         legendBars={legendBars}
         getmargins={_getMargins}
         getGraphData={_initializeLineChartData}
         xAxisType={isXAxisDateType ? XAxisTypes.DateAxis : XAxisTypes.NumericAxis}
-        customizedCallout={_getCustomizedCallout()}
         onChartMouseLeave={_handleChartMouseLeave}
         enableFirstRenderOptimization={props.enablePerfOptimization && _firstRenderOptimization}
         /* eslint-disable react/jsx-no-bind */

--- a/packages/react-components/react-charts-preview/library/src/components/LineChart/LineChart.tsx
+++ b/packages/react-components/react-charts-preview/library/src/components/LineChart/LineChart.tsx
@@ -1281,7 +1281,7 @@ export const LineChart: React.FunctionComponent<ILineChartProps> = React.forward
       culture: props.culture ?? 'en-us',
       isCartesian: true,
       customProps: {
-        customizedCallout: _getCustomizedCallout(),
+        customizedCallout: _getCustomizedCallout() !== null ? _getCustomizedCallout() : undefined,
         customCalloutProps: props.customProps ? props.customProps(dataPointCalloutProps!) : undefined,
       },
     };

--- a/packages/react-components/react-charts-preview/library/src/components/LineChart/LineChart.tsx
+++ b/packages/react-components/react-charts-preview/library/src/components/LineChart/LineChart.tsx
@@ -1279,6 +1279,7 @@ export const LineChart: React.FunctionComponent<ILineChartProps> = React.forward
       isPopoverOpen: isPopoverOpen,
       isCalloutForStack: true,
       culture: props.culture ?? 'en-us',
+      isCartesian: true,
     };
     const tickParams = {
       tickValues,

--- a/packages/react-components/react-charts-preview/library/src/components/VerticalBarChart/VerticalBarChart.tsx
+++ b/packages/react-components/react-charts-preview/library/src/components/VerticalBarChart/VerticalBarChart.tsx
@@ -955,6 +955,7 @@ export const VerticalBarChart: React.FunctionComponent<IVerticalBarChartProps> =
     }),
     color: color,
     legend: calloutLegend,
+    XValue: xCalloutValue,
     YValue: yCalloutValue ? yCalloutValue : dataForHoverCard,
     ...props.calloutProps,
     ...getAccessibleDataObject(callOutAccessibilityData),

--- a/packages/react-components/react-charts-preview/library/src/components/VerticalBarChart/VerticalBarChart.tsx
+++ b/packages/react-components/react-charts-preview/library/src/components/VerticalBarChart/VerticalBarChart.tsx
@@ -961,9 +961,13 @@ export const VerticalBarChart: React.FunctionComponent<IVerticalBarChartProps> =
     ...getAccessibleDataObject(callOutAccessibilityData),
     clickPosition: clickPosition,
     isPopoverOpen: isPopoverOpen,
-    isCalloutForStack: true,
+    isCalloutForStack: _isHavingLine && _noLegendHighlighted(),
     culture: props.culture ?? 'en-us',
     isCartesian: true,
+    customProps: {
+      customizedCallout: _getCustomizedCallout() != null ? _getCustomizedCallout() : undefined,
+      customCalloutProps: props.customProps ? props.customProps(dataPointCalloutProps!) : undefined,
+    },
   };
 
   const tickParams = {
@@ -982,7 +986,6 @@ export const VerticalBarChart: React.FunctionComponent<IVerticalBarChartProps> =
       legendBars={legendBars}
       datasetForXAxisDomain={_xAxisLabels}
       barwidth={_barWidth}
-      customizedCallout={_getCustomizedCallout()}
       getmargins={_getMargins}
       getGraphData={_getGraphData}
       getAxisData={_getAxisData}

--- a/packages/react-components/react-charts-preview/library/src/components/VerticalBarChart/VerticalBarChart.tsx
+++ b/packages/react-components/react-charts-preview/library/src/components/VerticalBarChart/VerticalBarChart.tsx
@@ -963,6 +963,7 @@ export const VerticalBarChart: React.FunctionComponent<IVerticalBarChartProps> =
     isPopoverOpen: isPopoverOpen,
     isCalloutForStack: true,
     culture: props.culture ?? 'en-us',
+    isCartesian: true,
   };
 
   const tickParams = {


### PR DESCRIPTION
Fixed the following bugs:
1. Fixed Callout for donut and horizontal bar dont have legend vertical line. The font size and popover size are not matching v8 callout equivalent.
2. Fixed Vertical Bar all examples - x value is not showing on the callout
3. Consolidating custom popover props
4. Fixing styles for Vertical bar chart especially isCalloutForStack prop