### PR TITLE
chore: enable `@nx/workspace-no-missing-jsx-pragma` in whole monorepo

### DIFF
--- a/change/@fluentui-eslint-plugin-e633733d-0e64-45b7-a37a-eea61b3caa8a.json
+++ b/change/@fluentui-eslint-plugin-e633733d-0e64-45b7-a37a-eea61b3caa8a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: enable @nx/workspace-no-missing-jsx-pragma rule for react v9 projects",
+  "packageName": "@fluentui/eslint-plugin",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-aria-f6b92f50-19e6-4c66-beaf-bdeec75f87c5.json
+++ b/change/@fluentui-react-aria-f6b92f50-19e6-4c66-beaf-bdeec75f87c5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "style: resolve exposed jsx pragma lint issues within monorepo",
+  "packageName": "@fluentui/react-aria",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-carousel-bb8b8cfa-dbb7-4094-aa50-39701e30ef7b.json
+++ b/change/@fluentui-react-carousel-bb8b8cfa-dbb7-4094-aa50-39701e30ef7b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "style: resolve exposed jsx pragma lint issues within monorepo",
+  "packageName": "@fluentui/react-carousel",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-migration-v0-v9-f3f98053-be57-4569-9543-5160818b6385.json
+++ b/change/@fluentui-react-migration-v0-v9-f3f98053-be57-4569-9543-5160818b6385.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "style: resolve exposed jsx pragma lint issues within monorepo",
+  "packageName": "@fluentui/react-migration-v0-v9",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-nav-preview-bc353a18-51d4-4e8f-a44f-9be7cbe9d091.json
+++ b/change/@fluentui-react-nav-preview-bc353a18-51d4-4e8f-a44f-9be7cbe9d091.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "style: resolve exposed jsx pragma lint issues within monorepo",
+  "packageName": "@fluentui/react-nav-preview",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tag-picker-f9dff827-9ea3-4115-83e1-138279ba261d.json
+++ b/change/@fluentui-react-tag-picker-f9dff827-9ea3-4115-83e1-138279ba261d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "style: resolve exposed jsx pragma lint issues within monorepo",
+  "packageName": "@fluentui/react-tag-picker",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-teaching-popover-ee64a4be-b4cb-4d08-87f2-426507994031.json
+++ b/change/@fluentui-react-teaching-popover-ee64a4be-b4cb-4d08-87f2-426507994031.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "style: resolve exposed jsx pragma lint issues within monorepo",
+  "packageName": "@fluentui/react-teaching-popover",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/eslint-plugin/src/configs/react.js
+++ b/packages/eslint-plugin/src/configs/react.js
@@ -35,7 +35,6 @@ module.exports = {
       },
     ],
     'react-compiler/react-compiler': ['error'],
-    '@nx/workspace-no-missing-jsx-pragma': 'error',
   },
   overrides: [
     // Enable rules requiring type info only for appropriate files/circumstances

--- a/packages/eslint-plugin/src/configs/react.js
+++ b/packages/eslint-plugin/src/configs/react.js
@@ -35,6 +35,7 @@ module.exports = {
       },
     ],
     'react-compiler/react-compiler': ['error'],
+    '@nx/workspace-no-missing-jsx-pragma': 'error',
   },
   overrides: [
     // Enable rules requiring type info only for appropriate files/circumstances

--- a/packages/eslint-plugin/src/internal.js
+++ b/packages/eslint-plugin/src/internal.js
@@ -32,6 +32,7 @@ const __internal = {
           rules: {
             '@nx/workspace-consistent-callback-type': 'error',
             '@nx/workspace-no-restricted-globals': restrictedGlobals.react,
+            '@nx/workspace-no-missing-jsx-pragma': ['error', { runtime: 'automatic' }],
           },
         }
       : null,

--- a/packages/react-components/react-aria/library/src/AriaLiveAnnouncer/renderAriaLiveAnnouncer.tsx
+++ b/packages/react-components/react-aria/library/src/AriaLiveAnnouncer/renderAriaLiveAnnouncer.tsx
@@ -1,6 +1,4 @@
-/** @jsxRuntime automatic */
-/** @jsxImportSource @fluentui/react-jsx-runtime */
-
+import * as React from 'react';
 import { AnnounceProvider } from '@fluentui/react-shared-contexts';
 
 import type { AriaLiveAnnouncerContextValues, AriaLiveAnnouncerState } from './AriaLiveAnnouncer.types';

--- a/packages/react-components/react-carousel/library/src/components/CarouselAutoplayButton/renderCarouselAutoplayButton.tsx
+++ b/packages/react-components/react-carousel/library/src/components/CarouselAutoplayButton/renderCarouselAutoplayButton.tsx
@@ -1,6 +1,3 @@
-/** @jsxRuntime automatic */
-/** @jsxImportSource @fluentui/react-jsx-runtime */
-
 import { assertSlots } from '@fluentui/react-utilities';
 import type { CarouselAutoplayButtonState, CarouselAutoplayButtonSlots } from './CarouselAutoplayButton.types';
 import { renderToggleButton_unstable } from '@fluentui/react-button';

--- a/packages/react-components/react-carousel/library/src/components/CarouselButton/renderCarouselButton.tsx
+++ b/packages/react-components/react-carousel/library/src/components/CarouselButton/renderCarouselButton.tsx
@@ -1,6 +1,3 @@
-/** @jsxRuntime automatic */
-/** @jsxImportSource @fluentui/react-jsx-runtime */
-
 import { assertSlots } from '@fluentui/react-utilities';
 import type { CarouselButtonState, CarouselButtonSlots } from './CarouselButton.types';
 import { renderButton_unstable } from '@fluentui/react-button';

--- a/packages/react-components/react-jsx-runtime/.eslintrc.json
+++ b/packages/react-components/react-jsx-runtime/.eslintrc.json
@@ -1,4 +1,13 @@
 {
   "extends": ["plugin:@fluentui/eslint-plugin/react"],
-  "root": true
+  "root": true,
+  "overrides": [
+    {
+      "files": ["**/*.{test,spec}.tsx"],
+      "excludedFiles": ["jsx-runtime.test.tsx"],
+      "rules": {
+        "@nx/workspace-no-missing-jsx-pragma": ["error", { "runtime": "classic" }]
+      }
+    }
+  ]
 }

--- a/packages/react-components/react-migration-v0-v9/library/src/components/ItemLayout/ItemLayout.tsx
+++ b/packages/react-components/react-migration-v0-v9/library/src/components/ItemLayout/ItemLayout.tsx
@@ -1,7 +1,6 @@
-/** @jsxRuntime classic */
-/** @jsx createElement */
+/** @jsxRuntime automatic */
+/** @jsxImportSource @fluentui/react-jsx-runtime */
 
-import { createElement } from '@fluentui/react-jsx-runtime';
 import * as React from 'react';
 import { mergeClasses } from '@fluentui/react-components';
 import {

--- a/packages/react-components/react-nav-preview/library/src/components/NavCategory/renderNavCategory.tsx
+++ b/packages/react-components/react-nav-preview/library/src/components/NavCategory/renderNavCategory.tsx
@@ -1,6 +1,4 @@
-/** @jsxRuntime automatic */
-/** @jsxImportSource @fluentui/react-jsx-runtime */
-
+import * as React from 'react';
 import { NavCategoryContextValues, NavCategoryProvider } from '../NavCategoryContext';
 
 import type { NavCategoryState } from './NavCategory.types';

--- a/packages/react-components/react-nav-preview/library/src/components/NavCategoryItem/renderNavCategoryItem.tsx
+++ b/packages/react-components/react-nav-preview/library/src/components/NavCategoryItem/renderNavCategoryItem.tsx
@@ -1,7 +1,6 @@
-/** @jsxRuntime classic */
-/** @jsx createElement */
+/** @jsxRuntime automatic */
+/** @jsxImportSource @fluentui/react-jsx-runtime */
 
-import { createElement } from '@fluentui/react-jsx-runtime';
 import { assertSlots } from '@fluentui/react-utilities';
 import type { NavCategoryItemState, NavCategoryItemSlots, NavCategoryItemContextValues } from './NavCategoryItem.types';
 import { NavCategoryItemProvider } from '../NavCategoryItemContext';

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerOptionGroup/renderTagPickerOptionGroup.tsx
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerOptionGroup/renderTagPickerOptionGroup.tsx
@@ -1,6 +1,3 @@
-/** @jsxRuntime automatic */
-/** @jsxImportSource @fluentui/react-jsx-runtime */
-
 import type { TagPickerOptionGroupState } from './TagPickerOptionGroup.types';
 import { renderOptionGroup_unstable } from '@fluentui/react-combobox';
 

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverSurface/renderTeachingPopoverSurface.tsx
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverSurface/renderTeachingPopoverSurface.tsx
@@ -1,6 +1,3 @@
-/** @jsxRuntime classic */
-/** @jsx createElement */
-
 import type { TeachingPopoverSurfaceSlots, TeachingPopoverSurfaceState } from './TeachingPopoverSurface.types';
 import { assertSlots } from '@fluentui/react-utilities';
 import { renderPopoverSurface_unstable } from '@fluentui/react-popover';


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Pre-requirement

- [x] https://github.com/microsoft/fluentui/pull/32842

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

- see PR title
- updates affected projects including eslint-plugin react-config

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows https://github.com/microsoft/fluentui/pull/32838
