### PR TITLE
Fix TypeError in portalContainsElement when element is Document or similar

### DIFF
--- a/change/@fluentui-dom-utilities-7d7b79ff-8120-4958-a7f8-6215d2d843eb.json
+++ b/change/@fluentui-dom-utilities-7d7b79ff-8120-4958-a7f8-6215d2d843eb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix TypeError in portalContainsElement when element is Document or similar",
+  "packageName": "@fluentui/dom-utilities",
+  "email": "miclo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/dom-utilities/src/findElementRecursive.ts
+++ b/packages/dom-utilities/src/findElementRecursive.ts
@@ -12,7 +12,7 @@ export function findElementRecursive(
 ): HTMLElement | null {
   // eslint-disable-next-line no-restricted-globals
   doc ??= document;
-  if (!element || element === doc.body) {
+  if (!element || element === doc.body || element instanceof Document) {
     return null;
   }
   return matchFunction(element) ? element : findElementRecursive(getParent(element), matchFunction);

--- a/packages/dom-utilities/src/getParent.ts
+++ b/packages/dom-utilities/src/getParent.ts
@@ -17,15 +17,18 @@ export function getParent(child: HTMLElement, allowVirtualParents: boolean = tru
     return parent;
   }
 
+  let parentElement: Element | HTMLSlotElement | ParentNode | null;
   // Support looking for parents in shadow DOM
   if (typeof (child as HTMLSlotElement).assignedElements !== 'function' && child.assignedSlot?.parentNode) {
     // Element is slotted
-    return child.assignedSlot as HTMLElement;
+    parentElement = child.assignedSlot;
   } else if (child.parentNode?.nodeType === 11) {
     // nodeType 11 is DOCUMENT_FRAGMENT
     // Element is in shadow root
-    return (child.parentNode as ShadowRoot).host as HTMLElement;
+    parentElement = (child.parentNode as ShadowRoot).host;
   } else {
-    return child.parentNode as HTMLElement;
+    parentElement = child.parentNode;
   }
+
+  return !!parentElement && parentElement instanceof HTMLElement ? parentElement : null;
 }

--- a/packages/dom-utilities/src/portalContainsElement.ts
+++ b/packages/dom-utilities/src/portalContainsElement.ts
@@ -12,8 +12,8 @@ import { DATA_PORTAL_ATTRIBUTE } from './setPortalAttribute';
 export function portalContainsElement(target: HTMLElement, parent?: HTMLElement, doc?: Document): boolean {
   const elementMatch = findElementRecursive(
     target,
-    (testElement: HTMLElement) => parent === testElement || testElement.hasAttribute(DATA_PORTAL_ATTRIBUTE),
+    (testElement: HTMLElement) => parent === testElement || !!testElement.hasAttribute?.(DATA_PORTAL_ATTRIBUTE),
     doc,
   );
-  return elementMatch !== null && elementMatch.hasAttribute(DATA_PORTAL_ATTRIBUTE);
+  return elementMatch !== null && !!elementMatch.hasAttribute?.(DATA_PORTAL_ATTRIBUTE);
 }


### PR DESCRIPTION
## Previous Behavior

Error telemetry in Outlook showed this error:

```
Error
-------------------
Uncaught TypeError: e.hasAttribute is not a function
 
Callstack
-------------------
webpack://owa/node_modules/@fluentui/dom-utilities/src/portalContainsElement.ts:15
webpack://owa/node_modules/@fluentui/dom-utilities/src/findElementRecursive.ts:18
webpack://owa/node_modules/@fluentui/dom-utilities/src/findElementRecursive.ts:18
webpack://owa/node_modules/@fluentui/dom-utilities/src/findElementRecursive.ts:18
webpack://owa/node_modules/@fluentui/dom-utilities/src/findElementRecursive.ts:18
webpack://owa/node_modules/@fluentui/dom-utilities/src/findElementRecursive.ts:18
webpack://owa/node_modules/@fluentui/dom-utilities/src/findElementRecursive.ts:18
webpack://owa/node_modules/@fluentui/dom-utilities/src/findElementRecursive.ts:18
webpack://owa/node_modules/@fluentui/dom-utilities/src/findElementRecursive.ts:18
webpack://owa/node_modules/@fluentui/dom-utilities/src/findElementRecursive.ts:18
webpack://owa/node_modules/@fluentui/dom-utilities/src/findElementRecursive.ts:18
webpack://owa/node_modules/@fluentui/dom-utilities/src/findElementRecursive.ts:18
webpack://owa/node_modules/@fluentui/dom-utilities/src/portalContainsElement.ts:14
webpack://owa/node_modules/@fluentui/react-focus/lib/components/src/components/FocusZone/FocusZone.tsx:1464
webpack://owa/node_modules/@fluentui/react-focus/lib/components/src/components/FocusZone/FocusZone.tsx:483
webpack://owa/node_modules/react-dom/cjs/react-dom.production.min.js:54
webpack://owa/node_modules/react-dom/cjs/react-dom.production.min.js:54
undefined:undefined
 
Original Callstack
-------------------
TypeError: e.hasAttribute is not a function
    at https://res.public.onecdn.static.microsoft/owamail/hashed-v1/scripts/owa.61781.m.819a64d6.js:1:646938
    at e (https://res.public.onecdn.static.microsoft/owamail/hashed-v1/scripts/owa.61781.m.819a64d6.js:1:646281)
    at e (https://res.public.onecdn.static.microsoft/owamail/hashed-v1/scripts/owa.61781.m.819a64d6.js:1:646288)
    at e (https://res.public.onecdn.static.microsoft/owamail/hashed-v1/scripts/owa.61781.m.819a64d6.js:1:646288)
    at e (https://res.public.onecdn.static.microsoft/owamail/hashed-v1/scripts/owa.61781.m.819a64d6.js:1:646288)
    at e (https://res.public.onecdn.static.microsoft/owamail/hashed-v1/scripts/owa.61781.m.819a64d6.js:1:646288)
    at e (https://res.public.onecdn.static.microsoft/owamail/hashed-v1/scripts/owa.61781.m.819a64d6.js:1:646288)
    at e (https://res.public.onecdn.static.microsoft/owamail/hashed-v1/scripts/owa.61781.m.819a64d6.js:1:646288)
    at e (https://res.public.onecdn.static.microsoft/owamail/hashed-v1/scripts/owa.61781.m.819a64d6.js:1:646288)
    at e (https://res.public.onecdn.static.microsoft/owamail/hashed-v1/scripts/owa.61781.m.819a64d6.js:1:646288)
    at e (https://res.public.onecdn.static.microsoft/owamail/hashed-v1/scripts/owa.61781.m.819a64d6.js:1:646288)
    at e (https://res.public.onecdn.static.microsoft/owamail/hashed-v1/scripts/owa.61781.m.819a64d6.js:1:646288)
    at i (https://res.public.onecdn.static.microsoft/owamail/hashed-v1/scripts/owa.61781.m.819a64d6.js:1:646907)
    at t._portalContainsElement (https://res.public.onecdn.static.microsoft/owamail/hashed-v1/scripts/owa.61781.m.819a64d6.js:1:807724)
    at v._onFocus (https://res.public.onecdn.static.microsoft/owamail/hashed-v1/scripts/owa.61781.m.819a64d6.js:1:790928)
    at Object.eL (https://res.public.onecdn.static.microsoft/owamail/hashed-v1/scripts/owa.61781.m.819a64d6.js:31:826869)
    at eU (https://res.public.onecdn.static.microsoft/owamail/hashed-v1/scripts/owa.61781.m.819a64d6.js:31:827023)
    at https://res.public.onecdn.static.micr/
```

## New Behavior

This change adds three distinctive fixes to prevent this issue where a defined object without the `hasAttribute` function is referenced in `portalContainsElement()`

#### The call to `.hasAttribute()` uses the optional chaining operator `?.`, and the possibly undefined value is forced to a `boolean`

```ts
!!elementMatch.hasAttribute?.(DATA_PORTAL_ATTRIBUTE);
```

#### The short-circuit check in `findElementRecursive()` also checks for a `Document`
```ts
 if (!element || element === doc.body || element instanceof Document) 
```

#### `getParent()` checks if a potential return value is an `HTMLElement`, rather than blindly casting it as such
```ts
return !!parentElement && parentElement instanceof HTMLElement ? parentElement : null;
```