### PR TITLE
feat: add explicit `.js` file extensions to all relative import/export statement within built output to support native ESM within browser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,8 @@ screenshots
 !tools/**/lib
 tools/**/__fixtures__/**/lib
 tools/**/__fixtures__/**/lib-commonjs
+# Playwright
+test-results/
 
 *.tar.gz
 

--- a/change/@fluentui-tokens-7b6f098e-f611-4292-adb9-4c0351d335cb.json
+++ b/change/@fluentui-tokens-7b6f098e-f611-4292-adb9-4c0351d335cb.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: add explicit .js file extensions to all relative import/export statement within built output to support native ESM within browser",
+  "packageName": "@fluentui/tokens",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/tokens/.swcrc
+++ b/packages/tokens/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/tokens/.swcrc
+++ b/packages/tokens/.swcrc
@@ -4,6 +4,7 @@
     "/testing",
     "/**/*.cy.ts",
     "/**/*.cy.tsx",
+    "/**/*.spec-e2e.ts",
     "/**/*.spec.ts",
     "/**/*.spec.tsx",
     "/**/*.test.ts",

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -20,7 +20,8 @@
     "test": "jest --passWithNoTests",
     "token-pipeline": "node -r ../../scripts/ts-node/src/register ../../scripts/generators/src/token-pipeline.ts",
     "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api"
+    "generate-api": "just-scripts generate-api",
+    "e2e": "playwright test"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",

--- a/packages/tokens/playwright.config.ts
+++ b/packages/tokens/playwright.config.ts
@@ -1,0 +1,41 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import type { PlaywrightTestConfig } from '@playwright/test';
+import { devices } from '@playwright/test';
+
+const config: PlaywrightTestConfig = {
+  reporter: 'list',
+  retries: 3,
+  fullyParallel: process.env.CI ? false : true,
+  timeout: process.env.CI ? 10000 : 30000,
+  use: {
+    baseURL: 'http://localhost:6006',
+    viewport: {
+      height: 720,
+      width: 1280,
+    },
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+      testMatch: /.*\.spec-e2e\.ts$/,
+    },
+    // {
+    //   name: 'firefox',
+    //   use: { ...devices['Desktop Firefox'] },
+    //   testMatch: [/set-theme\.spec\.ts$/],
+    // },
+    // {
+    //   name: 'webkit',
+    //   use: { ...devices['Desktop Safari'] },
+    //   testMatch: [/set-theme\.spec\.ts$/],
+    // },
+  ],
+  webServer: {
+    command: `node scripts/server.js --port 6006`,
+    port: 6006,
+    reuseExistingServer: process.env.CI ? false : true,
+  },
+};
+
+export default config;

--- a/packages/tokens/project.json
+++ b/packages/tokens/project.json
@@ -4,5 +4,10 @@
   "projectType": "library",
   "implicitDependencies": [],
   "sourceRoot": "packages/tokens/src",
-  "tags": ["vNext", "platform:web"]
+  "tags": ["vNext", "platform:web"],
+  "targets": {
+    "e2e": {
+      "dependsOn": ["build"]
+    }
+  }
 }

--- a/packages/tokens/scripts/server.js
+++ b/packages/tokens/scripts/server.js
@@ -1,0 +1,34 @@
+// @ts-check
+
+const { parseArgs } = require('node:util');
+const path = require('node:path');
+const express = require('express');
+
+main();
+
+function main() {
+  const argv = processArgs();
+
+  const app = express();
+  const port = argv.port;
+
+  app.use(express.static(path.join(__dirname)));
+  app.use('/lib', express.static(path.join(__dirname, '../lib')));
+
+  app.listen(port, () => {
+    console.log(`Example app listening on port ${port}`);
+  });
+}
+
+function processArgs() {
+  const options = /** @type {const} */ ({
+    port: {
+      type: 'string',
+      default: '6006',
+    },
+  });
+
+  const { values } = parseArgs({ options, allowPositionals: false });
+
+  return values;
+}

--- a/packages/tokens/scripts/test-esm.html
+++ b/packages/tokens/scripts/test-esm.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>native ESM for @fluentui/tokens</title>
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      .root {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        width: 50%;
+        margin: auto;
+      }
+      .color-ramp {
+        display: flex;
+      }
+      .color-ramp > div {
+        flex: 1;
+        padding: 0.5em;
+      }
+    </style>
+    <script type="importmap">
+      {
+        "imports": {
+          "@fluentui/tokens": "../lib/index.js"
+        }
+      }
+    </script>
+    <script type="module">
+      import * as tokens from '@fluentui/tokens';
+
+      bootstrap(App());
+
+      function App() {
+        const Root = document.createElement('section');
+        Root.classList.add('root');
+
+        const Colors = Object.entries(tokens.webLightTheme)
+          .map(([key, value]) => {
+            if (key.startsWith('color')) {
+              return `<div class="color-ramp" data-id="${key}">
+                      <div>${key}</div>
+                      <div style="background-color:${value}"></div>
+                    </div>`;
+            }
+
+            return;
+          })
+          .filter(Boolean)
+          .join('\n');
+
+        Root.innerHTML = Colors;
+
+        return Root;
+      }
+
+      function bootstrap(App) {
+        const mountRoot = document.querySelector('#app');
+        mountRoot.appendChild(App);
+      }
+    </script>
+  </head>
+  <body>
+    <h1>Native ESM / <code>@fluentui/tokens</code></h1>
+    <div id="app"></div>
+  </body>
+</html>

--- a/packages/tokens/src/native-esm.spec-e2e.ts
+++ b/packages/tokens/src/native-esm.spec-e2e.ts
@@ -1,0 +1,15 @@
+import { expect, test } from '@playwright/test';
+
+import { webLightTheme } from './index';
+
+test.describe('Native ESM', () => {
+  test('should render UI divs including all webLightTheme colors', async ({ page }) => {
+    await page.goto('test-esm.html');
+
+    await expect(page).toHaveTitle('native ESM for @fluentui/tokens');
+    await expect(page.locator('.root')).not.toBeEmpty();
+    await expect(page.locator('.color-ramp')).toHaveCount(
+      Object.keys(webLightTheme).filter(value => value.startsWith('color')).length,
+    );
+  });
+});

--- a/packages/tokens/tsconfig.e2e.json
+++ b/packages/tokens/tsconfig.e2e.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "include": ["playwright.config.ts", "**/*.spec-e2e.ts"]
+}

--- a/packages/tokens/tsconfig.json
+++ b/packages/tokens/tsconfig.json
@@ -16,6 +16,9 @@
     },
     {
       "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./tsconfig.e2e.json"
     }
   ]
 }

--- a/packages/tokens/tsconfig.lib.json
+++ b/packages/tokens/tsconfig.lib.json
@@ -9,6 +9,6 @@
     "inlineSources": true,
     "types": ["static-assets", "environment"]
   },
-  "exclude": ["**/*.spec.ts", "**/*.test.ts"],
+  "exclude": ["**/*.spec.ts", "**/*.test.ts", "**/*.spec-e2e.ts"],
   "include": ["./src/**/*.ts"]
 }

--- a/scripts/tasks/src/swc/index.ts
+++ b/scripts/tasks/src/swc/index.ts
@@ -1,0 +1,1 @@
+export { swc } from './swc';

--- a/scripts/tasks/src/swc/swc.ts
+++ b/scripts/tasks/src/swc/swc.ts
@@ -2,15 +2,15 @@ import fs from 'fs';
 import path from 'path';
 
 import { transform } from '@swc/core';
-import type { Options as SwcOptions } from '@swc/core';
 import glob from 'glob';
-import * as match from 'micromatch';
+import * as micromatch from 'micromatch';
 
-type Options = SwcOptions & { module: { type: 'es6' | 'commonjs' | 'amd' }; outputPath: string };
+import { Options } from './types';
+import { addJsExtensionToImports } from './utils';
 
 async function swcTransform(options: Options) {
-  const { outputPath, module } = options;
-  const packageRoot = process.cwd();
+  const { outputPath, module, root: packageRoot = process.cwd() } = options;
+
   const sourceRootDirName = module.type === 'es6' ? 'src' : 'lib';
 
   let sourceFiles: string[] = [];
@@ -24,11 +24,12 @@ async function swcTransform(options: Options) {
   }
 
   const swcConfig = JSON.parse(fs.readFileSync(path.resolve(packageRoot, '.swcrc'), 'utf-8'));
+  const enableResolveFully = Boolean(swcConfig.jsc.baseUrl);
   const tsFileExtensionRegex = /\.(tsx|ts)$/;
 
   for (const fileName of sourceFiles) {
     const srcFilePath = path.resolve(packageRoot, fileName);
-    const isFileExcluded = match.isMatch(srcFilePath, swcConfig.exclude, { contains: true });
+    const isFileExcluded = micromatch.isMatch(srcFilePath, swcConfig.exclude, { contains: true });
 
     if (isFileExcluded) {
       continue;
@@ -38,15 +39,18 @@ async function swcTransform(options: Options) {
 
     const result = await transform(sourceCode, {
       filename: fileName,
-      module: { type: module.type },
+      module: { type: module.type, resolveFully: enableResolveFully },
       sourceFileName: path.basename(fileName),
       outputPath,
     });
 
     // Strip @jsx comments, see https://github.com/microsoft/fluentui/issues/29126
-    const resultCode = result.code
+    let resultCode = result.code
       .replace('/** @jsxRuntime automatic */', '')
       .replace('/** @jsxImportSource @fluentui/react-jsx-runtime */', '');
+
+    // Remove after swc implement proper js extension addition https://github.com/microsoft/fluentui/issues/30634
+    resultCode = enableResolveFully ? addJsExtensionToImports(resultCode, module.type) : resultCode;
 
     const compiledFilePath = path.resolve(packageRoot, fileName.replace(`${sourceRootDirName}`, outputPath));
 

--- a/scripts/tasks/src/swc/swc.ts
+++ b/scripts/tasks/src/swc/swc.ts
@@ -45,10 +45,7 @@ async function swcTransform(options: Options) {
       outputPath,
     });
 
-    const resultCode = postprocessOutput(result.code, {
-      addExplicitJsExtensionToImports: enableResolveFully,
-      moduleType,
-    });
+    const resultCode = postprocessOutput(result.code);
 
     const compiledFilePath = path.resolve(packageRoot, fileName.replace(`${sourceRootDirName}`, outputPath));
 

--- a/scripts/tasks/src/swc/types.ts
+++ b/scripts/tasks/src/swc/types.ts
@@ -1,0 +1,10 @@
+import { type Options as SwcOptions } from '@swc/core';
+
+declare module '@swc/core' {
+  interface BaseModuleConfig {
+    resolveFully?: boolean;
+  }
+}
+
+export type Options = Omit<SwcOptions, 'module' | 'outputPath'> &
+  Required<Pick<SwcOptions, 'module' | 'outputPath'>> & { root?: string };

--- a/scripts/tasks/src/swc/types.ts
+++ b/scripts/tasks/src/swc/types.ts
@@ -6,5 +6,4 @@ declare module '@swc/core' {
   }
 }
 
-export type Options = Omit<SwcOptions, 'module' | 'outputPath'> &
-  Required<Pick<SwcOptions, 'module' | 'outputPath'>> & { root?: string };
+export type Options = SwcOptions & Required<Pick<SwcOptions, 'module' | 'outputPath'>> & { root?: string };

--- a/scripts/tasks/src/swc/utils.spec.ts
+++ b/scripts/tasks/src/swc/utils.spec.ts
@@ -1,0 +1,59 @@
+import { stripIndents } from '@nx/devkit';
+
+import { addJsExtensionToImports } from './utils';
+
+describe(`utils`, () => {
+  describe(`#addJsExtensionToImports`, () => {
+    it(`should not transform anything if non supported module type is specified`, () => {
+      const code = stripIndents`
+        export { themeToTokensObject } from './themeToTokensObject';
+      `;
+
+      let actual = addJsExtensionToImports(code, 'umd');
+
+      expect(actual).toEqual(code);
+
+      actual = addJsExtensionToImports(code, 'amd');
+
+      expect(actual).toEqual(code);
+
+      actual = addJsExtensionToImports(code, 'systemjs');
+
+      expect(actual).toEqual(code);
+    });
+
+    it(`should add .js extensions for esm`, () => {
+      const code = stripIndents`
+        export { themeToTokensObject } from './themeToTokensObject';
+        export { tokens } from './tokens';
+        export { typographyStyles } from './global/index.js';
+      `;
+
+      const actual = addJsExtensionToImports(code, 'es6');
+      const expected = stripIndents`
+        export { themeToTokensObject } from './themeToTokensObject.js';
+        export { tokens } from './tokens.js';
+        export { typographyStyles } from './global/index.js';
+    `;
+
+      expect(actual).toEqual(expected);
+    });
+
+    it(`should add .js extensions for commonjs`, () => {
+      const code = stripIndents`
+        const _themeToTokensObject = require("./themeToTokensObject");
+        const _tokens = require("./tokens");
+        const _index2 = require("./global/index.js");
+      `;
+
+      const actual = addJsExtensionToImports(code, 'commonjs');
+      const expected = stripIndents`
+        const _themeToTokensObject = require("./themeToTokensObject.js");
+        const _tokens = require("./tokens.js");
+        const _index2 = require("./global/index.js");
+    `;
+
+      expect(actual).toEqual(expected);
+    });
+  });
+});

--- a/scripts/tasks/src/swc/utils.ts
+++ b/scripts/tasks/src/swc/utils.ts
@@ -1,0 +1,20 @@
+import { type Options } from './types';
+
+const importPaths = {
+  es6: /from\s+["']([^"']+)["']/g,
+  commonjs: /require\(["']([^"']+)["']\)/g,
+};
+export function addJsExtensionToImports(code: string, type: Options['module']['type'] = 'es6') {
+  if (!(type === 'es6' || type === 'commonjs')) {
+    return code;
+  }
+
+  const regex = importPaths[type];
+
+  return code.replace(regex, (match, importPath) => {
+    if (importPath.endsWith('.js')) {
+      return match;
+    }
+    return match.replace(importPath, importPath + '.js');
+  });
+}

--- a/scripts/tasks/src/swc/utils.ts
+++ b/scripts/tasks/src/swc/utils.ts
@@ -18,3 +18,20 @@ export function addJsExtensionToImports(code: string, type: Options['module']['t
     return match.replace(importPath, importPath + '.js');
   });
 }
+
+export function postprocessOutput(
+  code: string,
+  options: { moduleType: Options['module']['type']; addExplicitJsExtensionToImports: boolean },
+) {
+  // Strip @jsx comments, see https://github.com/microsoft/fluentui/issues/29126
+  let resultCode = code
+    .replace('/** @jsxRuntime automatic */', '')
+    .replace('/** @jsxImportSource @fluentui/react-jsx-runtime */', '');
+
+  // TODO: Remove after swc implement proper js extension addition https://github.com/microsoft/fluentui/issues/30634
+  resultCode = options.addExplicitJsExtensionToImports
+    ? addJsExtensionToImports(resultCode, options.moduleType)
+    : resultCode;
+
+  return resultCode;
+}

--- a/scripts/tasks/src/swc/utils.ts
+++ b/scripts/tasks/src/swc/utils.ts
@@ -19,19 +19,11 @@ export function addJsExtensionToImports(code: string, type: Options['module']['t
   });
 }
 
-export function postprocessOutput(
-  code: string,
-  options: { moduleType: Options['module']['type']; addExplicitJsExtensionToImports: boolean },
-) {
+export function postprocessOutput(code: string) {
   // Strip @jsx comments, see https://github.com/microsoft/fluentui/issues/29126
-  let resultCode = code
+  const resultCode = code
     .replace('/** @jsxRuntime automatic */', '')
     .replace('/** @jsxImportSource @fluentui/react-jsx-runtime */', '');
-
-  // TODO: Remove after swc implement proper js extension addition https://github.com/microsoft/fluentui/issues/30634
-  resultCode = options.addExplicitJsExtensionToImports
-    ? addJsExtensionToImports(resultCode, options.moduleType)
-    : resultCode;
 
   return resultCode;
 }

--- a/scripts/tasks/src/swc/utils.ts
+++ b/scripts/tasks/src/swc/utils.ts
@@ -1,9 +1,15 @@
 import { type Options } from './types';
 
 const importPaths = {
+  // TODO - cover dynamic imports eg `import("file.js")`
   es6: /from\s+["']([^"']+)["']/g,
   commonjs: /require\(["']([^"']+)["']\)/g,
 };
+
+/**
+ *
+ * NOTE: this is not used ATM as swc implemented changes we needed. keeping for future reference if we might need to do some extra transforms on our side
+ */
 export function addJsExtensionToImports(code: string, type: Options['module']['type'] = 'es6') {
   if (!(type === 'es6' || type === 'commonjs')) {
     return code;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

**`@fluentui/tokens`**

- enables full path resolution when compiling with `swc`(https://github.com/swc-project/swc/issues/8742) which add `.js` extension explicitly to all imports/exports for esm and commonjs module output
  - **NOTE:** this behaviour is enabled IFF `jsc.baseUrl` is present within projects `.swcrc` configuration
- implements e2e with playwright that tests native ESM in real browser
- mitigates issues (https://github.com/microsoft/fluentui/issues/30795, https://github.com/microsoft/fluentui/issues/30802) where the issue was that we transformed 3rd party exports which led to creating invalid path according to map export ( `@swc/helpers` )

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Implements https://github.com/microsoft/fluentui/issues/30634
- Replaces https://github.com/microsoft/fluentui/pull/30770
- Resolves https://github.com/microsoft/fluentui/issues/30795, https://github.com/microsoft/fluentui/issues/30802
