### PR TITLE
feat(motion): Collapse `orientation` param & horizontal implementation

### DIFF
--- a/change/@fluentui-react-motion-components-preview-e49e73e0-27c3-4285-baf8-2ca1d7fc8efd.json
+++ b/change/@fluentui-react-motion-components-preview-e49e73e0-27c3-4285-baf8-2ca1d7fc8efd.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add Collapse orientation parameter & horizontal implementation",
+  "packageName": "@fluentui/react-motion-components-preview",
+  "email": "robertpenner@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-motion-components-preview/stories/src/Collapse/CollapseDescription.md
+++ b/packages/react-components/react-motion-components-preview/stories/src/Collapse/CollapseDescription.md
@@ -1,4 +1,4 @@
-The `Collapse` component manages content presence, using a height expand/collapse motion.
+The `Collapse` component manages content presence, using a height or width expand/collapse motion.
 
 > **⚠️ Preview components are considered unstable**
 
@@ -8,7 +8,7 @@ import { Collapse } from '@fluentui/react-motion-components-preview';
 function Component({ visible }) {
   return (
     <Collapse visible={visible}>
-      <div style={{ background: 'lightblue' }}>Content</div>
+      <div>Content</div>
     </Collapse>
   );
 }

--- a/packages/react-components/react-motion-components-preview/stories/src/Collapse/CollapseHorizontal.stories.md
+++ b/packages/react-components/react-motion-components-preview/stories/src/Collapse/CollapseHorizontal.stories.md
@@ -1,0 +1,5 @@
+For a horizontal `Collapse`, set the `orientation` parameter:
+
+```tsx
+<Collapse orientation="horizontal" ...>
+```

--- a/packages/react-components/react-motion-components-preview/stories/src/Collapse/CollapseHorizontal.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Collapse/CollapseHorizontal.stories.tsx
@@ -1,0 +1,77 @@
+import { Field, makeStyles, tokens, Switch } from '@fluentui/react-components';
+import { Collapse } from '@fluentui/react-motion-components-preview';
+import * as React from 'react';
+
+import description from './CollapseHorizontal.stories.md';
+
+const useClasses = makeStyles({
+  container: {},
+  sideContent: {
+    background: 'lightgrey',
+    padding: '50px',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  card: {
+    gridArea: 'card',
+    padding: '20px',
+    width: '300px',
+  },
+  controls: {
+    display: 'grid',
+    gridTemplateColumns: '1fr 3fr',
+    justifyContent: 'start',
+    gridArea: 'controls',
+    border: `${tokens.strokeWidthThicker} solid ${tokens.colorNeutralForeground3}`,
+    borderRadius: tokens.borderRadiusMedium,
+    boxShadow: tokens.shadow16,
+    padding: '10px',
+  },
+  field: {
+    flex: 1,
+  },
+});
+
+const LoremIpsum = () => (
+  <>
+    {'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. '.repeat(
+      3,
+    )}
+  </>
+);
+
+export const Horizontal = () => {
+  const classes = useClasses();
+  const [visible, setVisible] = React.useState<boolean>(false);
+
+  return (
+    <div className={classes.container}>
+      <div className={classes.controls}>
+        <Field className={classes.field}>
+          <Switch label="Visible" checked={visible} onChange={() => setVisible(v => !v)} />
+        </Field>
+      </div>
+
+      <div style={{ display: 'flex' }}>
+        <Collapse visible={visible} orientation="horizontal">
+          {/* Wrapper div to make the collapse crop the card without reflowing the text. */}
+          <div>
+            <div className={classes.card}>
+              <LoremIpsum />
+            </div>
+          </div>
+        </Collapse>
+        <div className={classes.sideContent}>[side content]</div>
+      </div>
+    </div>
+  );
+};
+
+Horizontal.parameters = {
+  docs: {
+    description: {
+      story: description,
+    },
+  },
+};

--- a/packages/react-components/react-motion-components-preview/stories/src/Collapse/index.stories.ts
+++ b/packages/react-components/react-motion-components-preview/stories/src/Collapse/index.stories.ts
@@ -2,6 +2,7 @@ import { Collapse } from '@fluentui/react-motion-components-preview';
 import CollapseDescription from './CollapseDescription.md';
 
 export { Default } from './CollapseDefault.stories';
+export { Horizontal } from './CollapseHorizontal.stories';
 export { Snappy } from './CollapseSnappy.stories';
 export { Exaggerated } from './CollapseExaggerated.stories';
 export { Customization } from './CollapseCustomization.stories';


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

- `Collapse` only expands/collapses vertically, using height.
- Docs show only vertical collapse.

## New Behavior

- A new `orientation` runtime parameter can be set to `'horizontal'`, to expand/collapse the width.
- `Collapse` default behavior is still a vertical collapse.
- Implementation code is worded generically, using `size` to stand in for either width or height. 
- Docs have a [story for horizontal collapse](https://fluentuipr.z22.web.core.windows.net/pull/32998/public-docsite-v9/storybook/index.html?path=/docs/motion-components-preview-collapse--docs#horizontal): 

![image](https://github.com/user-attachments/assets/94133116-2be7-48b6-bdb9-04cdd1ba94e7)

## Related Issue(s)

- Fixes #32895

## Future Work

- PR https://github.com/microsoft/fluentui/pull/32999
