### PR TITLE
fix(Collapse): only affect opacity if `animateOpacity` is `true`

### DIFF
--- a/change/@fluentui-react-motion-components-preview-fe4b40ec-aa21-4a49-ad8a-b0eacc90a411.json
+++ b/change/@fluentui-react-motion-components-preview-fe4b40ec-aa21-4a49-ad8a-b0eacc90a411.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Collapse should only effect opacity when animateOpacity is true",
+  "packageName": "@fluentui/react-motion-components-preview",
+  "email": "robertpenner@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-motion-components-preview/library/src/components/Collapse/Collapse.test.ts
+++ b/packages/react-components/react-motion-components-preview/library/src/components/Collapse/Collapse.test.ts
@@ -1,4 +1,4 @@
-import { expectPresenceMotionFunction, expectPresenceMotionObject } from '../../testing/testUtils';
+import { expectPresenceMotionFunction, expectPresenceMotionArray } from '../../testing/testUtils';
 import { Collapse } from './Collapse';
 
 describe('Collapse', () => {
@@ -7,6 +7,6 @@ describe('Collapse', () => {
   });
 
   it('generates a motion definition from the static function', () => {
-    expectPresenceMotionObject(Collapse);
+    expectPresenceMotionArray(Collapse);
   });
 });

--- a/packages/react-components/react-motion-components-preview/library/src/testing/testUtils.ts
+++ b/packages/react-components/react-motion-components-preview/library/src/testing/testUtils.ts
@@ -36,6 +36,28 @@ export function expectPresenceMotionObject(component: PresenceComponent) {
   });
 }
 
+export function expectPresenceMotionArray(component: PresenceComponent) {
+  const presenceMotionFn = getMotionFunction(component);
+
+  // eslint-disable-next-line @nx/workspace-no-restricted-globals
+  expect(presenceMotionFn?.({ element: document.createElement('div') })).toMatchObject({
+    enter: expect.arrayContaining([
+      {
+        duration: expect.any(Number),
+        easing: expect.any(String),
+        keyframes: expect.any(Array),
+      },
+    ]),
+    exit: expect.arrayContaining([
+      {
+        duration: expect.any(Number),
+        easing: expect.any(String),
+        keyframes: expect.any(Array),
+      },
+    ]),
+  });
+}
+
 export function expectPresenceMotionFunction(PresenceComponent: PresenceComponent) {
   const presenceMotionFn = getMotionFunction(PresenceComponent);
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

- If `animateOpacity` is`false`, the content's opacity is still set to `1` by the motion component.
- Although we'd expect the opacity to be `1` most of the time, it could be a different value and we shouldn't overwrite it when `animateOpacity` is `false`.

## New Behavior

- If `animateOpacity` is`false`, the content's opacity is unaffected by the motion component.
- Implementation is refactored:
  - Keyframes that mixed opacity with size are now separated to motion atoms for opacity and size.
  - The opacity atoms are omitted from the generated motion when `animateOpacity` is `false`.
- Unit test for `Collapse` is updated to account for `enter` and `exit` being arrays of motion atoms.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #33016 
