### PR TITLE
Fixed SVG shape related bug for line chart 

### DIFF
--- a/packages/react-components/react-charts-preview/library/src/components/CommonComponents/Popover.styles.ts
+++ b/packages/react-components/react-charts-preview/library/src/components/CommonComponents/Popover.styles.ts
@@ -70,9 +70,7 @@ const useStyles = makeStyles({
     },
     paddingLeft: '8px',
   },
-  calloutBlockContainertoDrawShapetrue: {
-    display: 'flex',
-  },
+  calloutBlockContainertoDrawShapetrue: { display: 'inline-grid' },
   shapeStyles: {
     marginRight: '8px',
   },

--- a/packages/react-components/react-charts-preview/library/src/components/CommonComponents/Popover.tsx
+++ b/packages/react-components/react-charts-preview/library/src/components/CommonComponents/Popover.tsx
@@ -187,7 +187,7 @@ const PopoverComponent: React.FunctionComponent<IPopoverComponentProps> = React.
                 ? {
                     borderLeft: `4px solid ${xValue.color}`,
                   }
-                : { display: 'flex' }),
+                : {}),
             }}
           >
             {toDrawShape && (

--- a/packages/react-components/react-charts-preview/library/src/components/Legends/Legends.styles.ts
+++ b/packages/react-components/react-charts-preview/library/src/components/Legends/Legends.styles.ts
@@ -42,11 +42,7 @@ const useStyles = makeStyles({
     //   },
     // },
     width: '12px',
-    height: 'var(--rect-height)',
-    backgroundColor: 'var(--rect-backgroundColor)',
     border: '1px solid',
-    ...shorthands.borderColor('var(--rect-borderColor)'),
-    content: 'var(--rect-content)',
     marginRight: '8px',
   },
   shape: {

--- a/packages/react-components/react-charts-preview/library/src/components/Legends/Legends.tsx
+++ b/packages/react-components/react-charts-preview/library/src/components/Legends/Legends.tsx
@@ -296,18 +296,15 @@ export const Legends: React.FunctionComponent<ILegendsProps> = React.forwardRef<
           pathProps={svgChildProps}
           shape={legend.shape as LegendShape}
           classNameForNonSvg={classes.rect}
-          style={
-            {
-              // ToDo These styles are causing build breaks. Fix it and then uncomment
-              // '--rect-height': legend.isLineLegendInBarChart ? '4px' : '12px',
-              //'--rect-backgroundColor': legend.stripePattern ? '' : color,
-              //'--rect-borderColor': legend.color ? legend.color : tokens.colorNeutralStroke1,
-              //'--rect-content': legend.stripePattern
-              //  ? // eslint-disable-next-line @fluentui/max-len
-              //    `repeating-linear-gradient(135deg, transparent, transparent 3px, ${color} 1px, ${color} 4px)`
-              //  : '',
-            }
-          } /* eslint-enable react/jsx-no-bind */
+          style={{
+            height: legend.isLineLegendInBarChart ? '4px' : '12px',
+            backgroundColor: legend.stripePattern ? '' : color,
+            borderColor: legend.color ? legend.color : tokens.colorNeutralStroke1,
+            content: legend.stripePattern
+              ? // eslint-disable-next-line @fluentui/max-len
+                `repeating-linear-gradient(135deg, transparent, transparent 3px, ${color} 1px, ${color} 4px)`
+              : '',
+          }}
         />
       );
     }

--- a/packages/react-components/react-charts-preview/library/src/components/Legends/shape.tsx
+++ b/packages/react-components/react-charts-preview/library/src/components/Legends/shape.tsx
@@ -41,6 +41,10 @@ export const Shape: React.FunctionComponent<IShapeProps> = React.forwardRef<HTML
         transform={`rotate(${
           shape === Points[Points.diamond] ? 45 : shape === Points[Points.pyramid] ? 180 : 0
         }, 0, 0)`}
+        style={{
+          width: '14px',
+          height: '14px',
+        }}
       >
         <path d={pointPath[shape]} {...pathProps} />
       </svg>


### PR DESCRIPTION
Fixed the following bug: On selecting multiple shapes in line chart variant the legend shapes are coming very big