### PR TITLE
chore: Migrate to @1js/vr-approval-cli package

### DIFF
--- a/.devops/templates/runpublishvrscreenshot.yml
+++ b/.devops/templates/runpublishvrscreenshot.yml
@@ -67,7 +67,7 @@ steps:
 
   - bash: |
       set -exuo pipefail
-      npx vr-approval-cli@0.4.5 create-policy --nonBlockingPipelines '{"$(pipelineId)":{"pipelineStatus": "PENDING","pipelineName": "$(pipelineName)"}}' --clientType 'FLUENTUI'
+      npx @1js/vr-approval-cli@^1.1.6 create-policy --nonBlockingPipelines '{"$(pipelineId)":{"pipelineStatus": "PENDING","pipelineName": "$(pipelineName)"}}' --clientType 'FLUENTUI'
     displayName: VR App - Create Policy
     env:
       VR_APP_API_URL: $(VR_APP_API_URL)
@@ -94,5 +94,5 @@ steps:
       scriptLocation: 'inlineScript'
       # ciDefinitionId is set to 205 because that is the ID of the baseline pipeline (https://uifabric.visualstudio.com/fabricpublic/_build?definitionId=205) used by the master branch
       inlineScript: |
-        npx vr-approval-cli@0.4.5 run-diff --screenshotsDirectory ./screenshots  --buildType pr --clientType "FLUENTUI" --ciDefinitionId 205 --groupName $(pipelineName) --locationPrefix ${{ parameters.locationPrefix }} --locationPostfix ${{ parameters.locationPostfix }} --pipelineId $(pipelineId)  --clientName ${{ parameters.clientName }} --threshold '0.04' --cumThreshold '1'
+        npx @1js/vr-approval-cli@^1.1.6 run-diff --screenshotsDirectory ./screenshots  --buildType pr --clientType "FLUENTUI" --ciDefinitionId 205 --groupName $(pipelineName) --locationPrefix ${{ parameters.locationPrefix }} --locationPostfix ${{ parameters.locationPostfix }} --pipelineId $(pipelineId)  --clientName ${{ parameters.clientName }} --threshold '0.04' --cumThreshold '1'
     condition: and(eq(variables.isPR, true), eq(variables['vrTestSkip'], 'no'))

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,8 @@
 registry=https://registry.npmjs.org/
 package-lock=false
 save-exact=true
+
+# The @1js/ scope is used for internal Microsoft packages. These need to be fetched
+# from the internal registry, rather than the public NPM registry.
+@1js:registry=https://pkgs.dev.azure.com/uifabric/_packaging/uifabric/npm/registry/
+//pkgs.dev.azure.com/uifabric/_packaging/uifabric/npm/registry/:always-auth=true

--- a/apps/vr-tests-react-components/src/stories/Button/Button.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Button/Button.stories.tsx
@@ -26,6 +26,7 @@ export const AsAnAnchor = () => (
 );
 
 AsAnAnchor.storyName = 'As an anchor';
+console.log(AsAnAnchor.storyName);
 
 export const Circular = () => (
   <Button id={buttonId} shape="circular">

--- a/azure-pipelines.vrt-baseline.yml
+++ b/azure-pipelines.vrt-baseline.yml
@@ -44,7 +44,7 @@ jobs:
           scriptType: bash
           scriptLocation: 'inlineScript'
           inlineScript: |
-            npx vr-approval-cli@0.4.5 run-diff --buildType release --screenshotsDirectory ./screenshots --clientType "FLUENTUI" --locationPrefix 'FluentUI-web-components' --locationPostfix 'vrscreenshotwebcomponents' --pipelineId $(pipelineId)
+            npx @1js/vr-approval-cli@^1.1.6 run-diff --buildType release --screenshotsDirectory ./screenshots --clientType "FLUENTUI" --locationPrefix 'FluentUI-web-components' --locationPostfix 'vrscreenshotwebcomponents' --pipelineId $(pipelineId)
 
   - job: VRToolUpdateBaseline_V9
     variables:
@@ -75,7 +75,7 @@ jobs:
           scriptType: bash
           scriptLocation: 'inlineScript'
           inlineScript: |
-            npx vr-approval-cli@0.4.5 run-diff --buildType release --screenshotsDirectory ./screenshots --clientType "FLUENTUI" --locationPrefix 'fluentuiv9' --locationPostfix 'vrscreenshotv9' --pipelineId $(pipelineId)
+            npx @1js/vr-approval-cli@^1.1.6 run-diff --buildType release --screenshotsDirectory ./screenshots --clientType "FLUENTUI" --locationPrefix 'fluentuiv9' --locationPostfix 'vrscreenshotv9' --pipelineId $(pipelineId)
 
   - job: VRToolUpdateBaseline_V8
     variables:
@@ -106,7 +106,7 @@ jobs:
           scriptType: bash
           scriptLocation: 'inlineScript'
           inlineScript: |
-            npx vr-approval-cli@0.4.5 run-diff --screenshotsDirectory ./screenshots --buildType release --clientType "FLUENTUI" --locationPrefix 'fluentuiv8' --locationPostfix 'vrscreenshotv8' --pipelineId $(pipelineId)
+            npx @1js/vr-approval-cli@^1.1.6 run-diff --screenshotsDirectory ./screenshots --buildType release --clientType "FLUENTUI" --locationPrefix 'fluentuiv8' --locationPostfix 'vrscreenshotv8' --pipelineId $(pipelineId)
 
   - job: VRToolUpdateBaseline_V0
     variables:
@@ -137,4 +137,4 @@ jobs:
           scriptType: bash
           scriptLocation: 'inlineScript'
           inlineScript: |
-            npx vr-approval-cli@0.4.5 run-diff --buildType release --screenshotsDirectory ./screenshots --clientType "FLUENTUI" --locationPrefix 'FluentUI-v0' --locationPostfix 'vrscreenshotv0' --pipelineId $(pipelineId)
+            npx @1js/vr-approval-cli@^1.1.6 run-diff --buildType release --screenshotsDirectory ./screenshots --clientType "FLUENTUI" --locationPrefix 'FluentUI-v0' --locationPostfix 'vrscreenshotv0' --pipelineId $(pipelineId)


### PR DESCRIPTION
 ## Previous Behavior

The Azure pipelines are using the `vr-approval-cli` package, which is deprecated and no longer maintained.

 ## New Behavior

This change migrates the pipelines to use the modernized (& migrated) package: `@1js/vr-approval-cli`