### PR TITLE
Carousel: Enable circular card focus and animation on focus index change

### DIFF
--- a/change/@fluentui-react-carousel-a4f2fe14-2f61-4182-81d9-df0672b90ed5.json
+++ b/change/@fluentui-react-carousel-a4f2fe14-2f61-4182-81d9-df0672b90ed5.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: Enable circular focus if circular, and enable animations on focus index change",
+  "packageName": "@fluentui/react-carousel",
+  "email": "mifraser@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-carousel/library/etc/react-carousel.api.md
+++ b/packages/react-components/react-carousel/library/etc/react-carousel.api.md
@@ -235,7 +235,7 @@ export type CarouselSliderSlots = {
 };
 
 // @public
-export type CarouselSliderState = ComponentState<CarouselSliderSlots> & Pick<CarouselSliderProps, 'cardFocus'>;
+export type CarouselSliderState = ComponentState<CarouselSliderSlots> & CarouselSliderContextValue;
 
 // @public (undocumented)
 export type CarouselSlots = {

--- a/packages/react-components/react-carousel/library/src/components/CarouselCard/useCarouselCard.ts
+++ b/packages/react-components/react-carousel/library/src/components/CarouselCard/useCarouselCard.ts
@@ -33,6 +33,7 @@ export const useCarouselCard_unstable = (
   const elementRef = React.useRef<HTMLDivElement>(null);
   const isMouseEvent = React.useRef<boolean>(false);
   const selectPageByElement = useCarouselContext(ctx => ctx.selectPageByElement);
+  const containerRef = useCarouselContext(ctx => ctx.containerRef);
   const { cardFocus } = useCarouselSliderContext();
 
   const focusAttr = useFocusableGroup({
@@ -68,10 +69,15 @@ export const useCarouselCard_unstable = (
   const handleFocusCapture = React.useCallback(
     (e: React.FocusEvent) => {
       if (!e.defaultPrevented && isHTMLElement(e.currentTarget) && !isMouseEvent.current) {
-        selectPageByElement(e, e.currentTarget, true);
+        e.preventDefault();
+
+        // We want to prevent any browser scroll intervention for 'offscreen' focus
+        containerRef?.current?.scrollTo(0, 0);
+
+        selectPageByElement(e, e.currentTarget, false);
       }
     },
-    [selectPageByElement],
+    [selectPageByElement, containerRef],
   );
 
   const handleMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {

--- a/packages/react-components/react-carousel/library/src/components/CarouselCard/useCarouselCard.ts
+++ b/packages/react-components/react-carousel/library/src/components/CarouselCard/useCarouselCard.ts
@@ -69,11 +69,8 @@ export const useCarouselCard_unstable = (
   const handleFocusCapture = React.useCallback(
     (e: React.FocusEvent) => {
       if (!e.defaultPrevented && isHTMLElement(e.currentTarget) && !isMouseEvent.current) {
-        e.preventDefault();
-
         // We want to prevent any browser scroll intervention for 'offscreen' focus
         containerRef?.current?.scrollTo(0, 0);
-
         selectPageByElement(e, e.currentTarget, false);
       }
     },

--- a/packages/react-components/react-carousel/library/src/components/CarouselSlider/CarouselSlider.types.ts
+++ b/packages/react-components/react-carousel/library/src/components/CarouselSlider/CarouselSlider.types.ts
@@ -22,9 +22,8 @@ export type CarouselSliderProps = Partial<ComponentProps<CarouselSliderSlots>> &
   cardFocus?: boolean;
 };
 
+export type CarouselSliderContextValue = Pick<CarouselSliderProps, 'cardFocus'>;
 /**
  * State used in rendering CarouselSlider
  */
-export type CarouselSliderState = ComponentState<CarouselSliderSlots> & Pick<CarouselSliderProps, 'cardFocus'>;
-
-export type CarouselSliderContextValue = Pick<CarouselSliderProps, 'cardFocus'>;
+export type CarouselSliderState = ComponentState<CarouselSliderSlots> & CarouselSliderContextValue;

--- a/packages/react-components/react-carousel/library/src/components/CarouselSlider/CarouselSliderContext.ts
+++ b/packages/react-components/react-carousel/library/src/components/CarouselSlider/CarouselSliderContext.ts
@@ -21,7 +21,6 @@ export type CarouselSliderContextValues = {
 
 export function useCarouselSliderContextValues_unstable(state: CarouselSliderState): CarouselSliderContextValues {
   const { cardFocus } = state;
-
   const carouselSlider = React.useMemo(
     () => ({
       cardFocus,

--- a/packages/react-components/react-carousel/library/src/components/CarouselSlider/useCarouselSlider.ts
+++ b/packages/react-components/react-carousel/library/src/components/CarouselSlider/useCarouselSlider.ts
@@ -3,6 +3,7 @@ import * as React from 'react';
 
 import type { CarouselSliderProps, CarouselSliderState } from './CarouselSlider.types';
 import { useArrowNavigationGroup } from '@fluentui/react-tabster';
+import { useCarouselContext_unstable as useCarouselContext } from '../CarouselContext';
 
 /**
  * Create the state required to render CarouselSlider.
@@ -18,8 +19,9 @@ export const useCarouselSlider_unstable = (
   ref: React.Ref<HTMLDivElement>,
 ): CarouselSliderState => {
   const { cardFocus = false } = props;
+  const circular = useCarouselContext(ctx => ctx.circular);
   const focusableGroupAttr = useArrowNavigationGroup({
-    circular: false, // We don't want circular focus here, it's confusing in carousel.
+    circular,
     axis: 'horizontal',
     memorizeCurrent: false,
     // eslint-disable-next-line @typescript-eslint/naming-convention


### PR DESCRIPTION
## Previous Behavior
Cards could only be navigated to the first/last card then stopped, despite visual order.
Card focus set animation to jump (to prevent auto-scroll issues in browser)

## New Behavior
Card focus can now be navigated circular (to match circular prop)
Card focus will now animate, we may add a reduced motion option in the future which will set jump to true if desired.