### PR TITLE
fix(docs): Misdirected link fix, docs spelling fixes

### DIFF
--- a/packages/react-components/react-table/stories/src/DataGrid/ResizableColumnsDisableAutoFit.stories.tsx
+++ b/packages/react-components/react-table/stories/src/DataGrid/ResizableColumnsDisableAutoFit.stories.tsx
@@ -232,10 +232,10 @@ ResizableColumns.parameters = {
   docs: {
     description: {
       story: [
-        'In previous example, the columns are automatically fitted to the container. This means that the columns are',
+        'In the previous example, the columns are automatically fitted to the container. This means that the columns are',
         'squeezed when the container is narrowed, until the',
-        'minimum width is reached, and also the last column is extended past its optimal width to fill teh available',
-        'space. This also efectively prevents the user from making the columns wider than the total width of the ',
+        'minimum width is reached, and the last column is extended past its optimal width to fill the available',
+        'space. This also effectively prevents the user from making the columns wider than the total width of the ',
         'container, as the columns are automatically resized to fit the container.',
         '',
         'This behavior can be disabled by passing `resizableColumnsOptions` prop to Datagrid,',

--- a/packages/react-components/react-theme/stories/src/Theme/typography/index.stories.mdx
+++ b/packages/react-components/react-theme/stories/src/Theme/typography/index.stories.mdx
@@ -12,7 +12,7 @@ import { MixedStyles } from './MixedStyles.stories';
 Typography style is represented by a set of tokens instead of an individual token. The tokens are used to create and share a consistent look and feel.
 
 > **ℹ️ &nbsp;This page guides you on how to fully leverage the tokens to create a consistent typography system.<br />
-> To take full advantage of the typography system, you should also read the [Text component documentation](./?path=/docs/components-text--default).**
+> To take full advantage of the typography system, you should also read the [Text component documentation](./?path=/docs/components-text--docs).**
 
 <Canvas withSource="none">
   <Story name="Page" component={Typography} />


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

Fix link to redirect to the correct place (--docs instead of --default)
<img width="209" alt="image" src="https://github.com/user-attachments/assets/049ab5be-594f-4781-ac3c-eb60230a3fd1">


Fixed spelling for DataGrid w/ resizable columns
<img width="1018" alt="image" src="https://github.com/user-attachments/assets/b788b799-c464-4810-aa03-502cc74a684a">


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes N/A
