### PR TITLE
Partially revert changes in #32996

### DIFF
--- a/change/@fluentui-dom-utilities-ca7c88a2-3673-4cbe-97ce-12cfd661cebc.json
+++ b/change/@fluentui-dom-utilities-ca7c88a2-3673-4cbe-97ce-12cfd661cebc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix regression caused by #32996",
+  "packageName": "@fluentui/dom-utilities",
+  "email": "miclo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/dom-utilities/src/getParent.ts
+++ b/packages/dom-utilities/src/getParent.ts
@@ -17,18 +17,15 @@ export function getParent(child: HTMLElement, allowVirtualParents: boolean = tru
     return parent;
   }
 
-  let parentElement: Element | HTMLSlotElement | ParentNode | null;
   // Support looking for parents in shadow DOM
   if (typeof (child as HTMLSlotElement).assignedElements !== 'function' && child.assignedSlot?.parentNode) {
     // Element is slotted
-    parentElement = child.assignedSlot;
+    return child.assignedSlot as HTMLElement;
   } else if (child.parentNode?.nodeType === 11) {
     // nodeType 11 is DOCUMENT_FRAGMENT
     // Element is in shadow root
-    parentElement = (child.parentNode as ShadowRoot).host;
+    return (child.parentNode as ShadowRoot).host as HTMLElement;
   } else {
-    parentElement = child.parentNode;
+    return child.parentNode as HTMLElement;
   }
-
-  return !!parentElement && parentElement instanceof HTMLElement ? parentElement : null;
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

With the changes made in #32996, the `parentElement instanceof HTMLElement` was returning a false negative. I'm not sure if it's because it's a React node rather than a DOM element or what; regardless, it caused some behavior in Outlook to break.

## New Behavior

Given that #32996 had three separate changes to fix the underlying TypeError, I am reverting just this portion to fix this regression.
