### PR TITLE
[fix][menu-item]: Emit current state when checked change event fires

### DIFF
--- a/change/@fluentui-web-components-32b505fd-a856-47b9-9639-f9ce57af0ce4.json
+++ b/change/@fluentui-web-components-32b505fd-a856-47b9-9639-f9ce57af0ce4.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix: menu-item emit current state when checked change event fires",
+  "packageName": "@fluentui/web-components",
+  "email": "jes@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/menu-item/menu-item.ts
+++ b/packages/web-components/src/menu-item/menu-item.ts
@@ -111,7 +111,7 @@ export class MenuItem extends FASTElement {
     toggleState(this.elementInternals, 'checked', checkableMenuItem ? next : false);
 
     if (this.$fastController.isConnected) {
-      this.$emit('change');
+      this.$emit('change', next, { bubbles: true });
     }
   }
 

--- a/packages/web-components/src/menu-list/menu-list.spec.ts
+++ b/packages/web-components/src/menu-list/menu-list.spec.ts
@@ -539,9 +539,11 @@ test.describe('Menu', () => {
       `);
 
       const [wasChanged] = await Promise.all([
-        menuItems.nth(0).evaluate(
-          node => new Promise(resolve => node.addEventListener('change', () => resolve(true), { once: true })),
-        ),
+        menuItems
+          .nth(0)
+          .evaluate(
+            node => new Promise(resolve => node.addEventListener('change', () => resolve(true), { once: true })),
+          ),
         menuItems.nth(0).evaluate((node: MenuItem) => {
           node.checked = true;
         }),
@@ -564,26 +566,26 @@ test.describe('Menu', () => {
       `);
 
       let wasChanged = menuItems.nth(0).evaluate((node: MenuItem) => {
-          return new Promise(resolve => {
-              node.addEventListener('change', (evt) => {
-                resolve((evt as any).detail)
-              });
+        return new Promise(resolve => {
+          node.addEventListener('change', evt => {
+            resolve((evt as any).detail);
           });
+        });
       });
 
-        await menuItems.nth(0).click();
-        await expect(wasChanged).resolves.toBeTruthy();
+      await menuItems.nth(0).click();
+      await expect(wasChanged).resolves.toBeTruthy();
 
-        wasChanged = menuItems.nth(0).evaluate((node: MenuItem) => {
-          return new Promise(resolve => {
-              node.addEventListener('change', (evt) => {
-                resolve((evt as any).detail)
-              });
+      wasChanged = menuItems.nth(0).evaluate((node: MenuItem) => {
+        return new Promise(resolve => {
+          node.addEventListener('change', evt => {
+            resolve((evt as any).detail);
           });
+        });
       });
 
       await menuItems.nth(1).click();
       await expect(wasChanged).resolves.toBeFalsy();
     });
-    });
+  });
 });


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
`change` custom event fires when `menu-item` becomes checked and unchecked. When role is set to `menuitemradio` and another menu-item is checked it's difficult to decern between the menu-item being checked and the menu-item being unchecked.

## New Behavior
This change emits the current state of the checked property so a developer can properly listen for the item being checked.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
