### PR TITLE
feat(react-overflow) Allow Overflow children to be render function

### DIFF
--- a/change/@fluentui-react-overflow-a2d80786-56a5-418d-8c9e-b6cbb8916016.json
+++ b/change/@fluentui-react-overflow-a2d80786-56a5-418d-8c9e-b6cbb8916016.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Allow Overflow children to be a render function",
+  "packageName": "@fluentui/react-overflow",
+  "email": "miroslav.stastny@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-overflow/library/etc/react-overflow.api.md
+++ b/packages/react-components/react-overflow/library/etc/react-overflow.api.md
@@ -26,7 +26,7 @@ export const DATA_OVERFLOWING = "data-overflowing";
 
 // @public
 export const Overflow: React_2.ForwardRefExoticComponent<Partial<Pick<ObserveOptions, "padding" | "overflowDirection" | "overflowAxis" | "minimumVisible">> & {
-    children: React_2.ReactElement;
+    children: React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | ((props: React_2.ComponentPropsWithRef<React_2.ElementType>) => React_2.ReactElement);
 } & React_2.RefAttributes<unknown>>;
 
 // @public
@@ -45,7 +45,7 @@ export type OverflowItemProps = {
 
 // @public
 export type OverflowProps = Partial<Pick<ObserveOptions, 'overflowAxis' | 'overflowDirection' | 'padding' | 'minimumVisible'>> & {
-    children: React_2.ReactElement;
+    children: React_2.ReactElement | ((props: React_2.ComponentPropsWithRef<React_2.ElementType>) => React_2.ReactElement);
 };
 
 // @public (undocumented)

--- a/packages/react-components/react-overflow/library/src/components/Overflow.test.tsx
+++ b/packages/react-components/react-overflow/library/src/components/Overflow.test.tsx
@@ -48,6 +48,26 @@ describe('Overflow', () => {
     );
   });
 
+  it('accepts render function', () => {
+    const { getAllByRole } = render(
+      <Overflow>
+        {props => (
+          <div {...props}>
+            <OverflowItem id="1">
+              <button>foo</button>
+            </OverflowItem>
+            <OverflowItem id="2">
+              <button>foo</button>
+            </OverflowItem>
+          </div>
+        )}
+      </Overflow>,
+    );
+
+    const buttons = getAllByRole('button');
+    expect(buttons).toHaveLength(2);
+  });
+
   describe('ref', () => {
     it('handles ref propagation', () => {
       const itemRef = jest.fn();

--- a/packages/react-components/react-overflow/library/src/components/Overflow.tsx
+++ b/packages/react-components/react-overflow/library/src/components/Overflow.tsx
@@ -19,7 +19,7 @@ interface OverflowState {
 export type OverflowProps = Partial<
   Pick<ObserveOptions, 'overflowAxis' | 'overflowDirection' | 'padding' | 'minimumVisible'>
 > & {
-  children: React.ReactElement;
+  children: React.ReactElement | ((props: React.ComponentPropsWithRef<React.ElementType>) => React.ReactElement);
 };
 
 /**
@@ -69,7 +69,12 @@ export const Overflow = React.forwardRef((props: OverflowProps, ref) => {
   const child = getTriggerChild(children);
   const clonedChild = applyTriggerPropsToChildren(children, {
     ref: useMergedRefs(containerRef, ref, child?.ref),
-    className: mergeClasses('fui-Overflow', styles.overflowMenu, styles.overflowingItems, children.props.className),
+    className: mergeClasses(
+      'fui-Overflow',
+      styles.overflowMenu,
+      styles.overflowingItems,
+      React.isValidElement(children) && (children as React.ReactElement).props.className,
+    ),
   });
 
   return (


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Overflow only accepts `ReactElement` as children.

## New Behavior

Overflow now also accepts a render function as children. This is useful when you need to render another component inside the overflow context besides the overflow container itself.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
