### PR TITLE
fix(web-components): prefers-reduced-motion media query in button

### DIFF
--- a/change/@fluentui-web-components-941a8116-c21a-4ade-b542-db2e8a43500b.json
+++ b/change/@fluentui-web-components-941a8116-c21a-4ade-b542-db2e8a43500b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix prefers-reduced-motion media query in button",
+  "packageName": "@fluentui/web-components",
+  "email": "863023+radium-v@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/button/button.styles.ts
+++ b/packages/web-components/src/button/button.styles.ts
@@ -128,7 +128,9 @@ export const baseButtonStyles = css`
   }
 
   @media screen and (prefers-reduced-motion: reduce) {
-    transition-duration: 0.01ms;
+    :host {
+      transition-duration: 0.01ms;
+    }
   }
 
   ::slotted(svg) {


### PR DESCRIPTION
## Previous Behavior

The media query for buttons was incorrectly formatted.

## New Behavior

The `transition-duration` property should apply to the `:host` selector when the media query matches `prefers-reduced-motion: reduce`.
