### PR TITLE
chore: remove unnecessary cleanup step for deprecate-package pipeline

### DIFF
--- a/azure-pipelines.deprecate-package.yml
+++ b/azure-pipelines.deprecate-package.yml
@@ -38,5 +38,3 @@ jobs:
           npm deprecate $(packageSpec) "$(message)" --registry https://registry.npmjs.org/ --//registry.npmjs.org/:_authToken=$(npmToken)
 
         displayName: 'Deprecate package'
-
-      - template: .devops/templates/cleanup.yml@self


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

The `cleanup` step in the `deprecate-package` Azure Pipeline is failing due to the absence of `node_modules`. 
(https://uifabric.visualstudio.com/UI%20Fabric/_build/results?buildId=363904&view=logs&j=eeaaeaf0-3b6a-54a9-34ad-31cbae258819&t=9002a20b-4045-5185-cf9c-b98fb0442721&l=45)

## New Behavior

`node_modules` are not required for the pipeline's operation since it only runs the `npm deprecate` command using environmental variables and pipeline parameters, without producing any artifacts. So the solution is to remove the unnecessary `cleanup` step. 
