### PR TITLE
fix: Button with as=a and href should present as a semantic link

### DIFF
--- a/change/@fluentui-react-aria-a057ce6a-2aa9-4d0d-afa3-90191feb8fd4.json
+++ b/change/@fluentui-react-aria-a057ce6a-2aa9-4d0d-afa3-90191feb8fd4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: correct expectations for Button rendered as a link with an href",
+  "packageName": "@fluentui/react-aria",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-button-cb3c039e-aafb-48df-8759-04567fadb59c.json
+++ b/change/@fluentui-react-button-cb3c039e-aafb-48df-8759-04567fadb59c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Button with as=a should present as a semantic link",
+  "packageName": "@fluentui/react-button",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/a11y-testing/src/definitions/Link/linkBehaviorDefinition.ts
+++ b/packages/a11y-testing/src/definitions/Link/linkBehaviorDefinition.ts
@@ -5,8 +5,8 @@ export const linkBehaviorDefinition: Rule[] = [
   BehaviorRule.root()
     .forProps({ href: '#' })
     .doesNotHaveAttribute('role')
+    .doesNotHaveAttribute('tabindex')
     .hasAttribute('href', '#')
-    .hasAttribute('tabindex', '0')
     .description(`if element has href and is rendered as an 'anchor'.`),
   BehaviorRule.root()
     .doesNotHaveAttribute('tabindex')
@@ -19,7 +19,7 @@ export const linkBehaviorDefinition: Rule[] = [
     .description(`if element is forced to render as a 'button' even if it was passed an href.`),
   BehaviorRule.root()
     .forProps({ as: 'a' })
-    .doesNotHaveAttribute('role')
+    .hasAttribute('role', 'link')
     .hasAttribute('tabindex', '0')
     .description(`if element is forced to render as an 'anchor' event if it does not have an href.`),
   BehaviorRule.root()

--- a/packages/a11y-testing/src/definitions/react-button/buttonAccessibilityBehaviorDefinition.ts
+++ b/packages/a11y-testing/src/definitions/react-button/buttonAccessibilityBehaviorDefinition.ts
@@ -8,8 +8,9 @@ export const buttonAccessibilityBehaviorDefinition: Rule[] = [
     .description(`if element is rendered as a default 'button'.`),
   BehaviorRule.root()
     .forProps({ as: 'a', href: '#' })
-    .hasAttribute('role', 'button')
-    .hasAttribute('tabindex', '0')
+    .doesNotHaveAttribute('role')
+    .doesNotHaveAttribute('tabindex')
+    .doesNotHaveAttribute('type')
     .description(`if element has href and is rendered as an 'anchor'.`),
   BehaviorRule.root()
     .forProps({ disabled: true })
@@ -18,6 +19,8 @@ export const buttonAccessibilityBehaviorDefinition: Rule[] = [
   BehaviorRule.root()
     .forProps({ as: 'a', disabled: true, href: '#' })
     .doesNotHaveAttribute('disabled')
+    .doesNotHaveAttribute('href')
+    .hasAttribute('role', 'link')
     .description(`if element has href and is rendered as an 'anchor' and is disabled.`),
   BehaviorRule.root()
     .forProps({ disabledFocusable: true })
@@ -27,6 +30,7 @@ export const buttonAccessibilityBehaviorDefinition: Rule[] = [
   BehaviorRule.root()
     .forProps({ as: 'a', disabledFocusable: true, href: '#' })
     .doesNotHaveAttribute('disabled')
+    .doesNotHaveAttribute('href')
     .hasAttribute('aria-disabled', 'true')
     .hasAttribute('tabindex', '0')
     .description(`if element has href and is rendered as an 'anchor' and is disabled but focusable.`),

--- a/packages/react-components/react-aria/library/src/button/useARIAButtonProps.ts
+++ b/packages/react-components/react-aria/library/src/button/useARIAButtonProps.ts
@@ -122,9 +122,17 @@ export function useARIAButtonProps<Type extends ARIAButtonType, Props extends AR
   // If an <a> or <div> tag is to be rendered we have to remove disabled and type,
   // and set aria-disabled, role and tabIndex.
   else {
+    // the role needs to be explicitly set if the href is undefined
+    const isLink = !!(rest as ARIAButtonResultProps<'a', Props>).href;
+    let roleOverride = isLink ? undefined : 'button';
+    if (!roleOverride && isDisabled) {
+      // need to set role=link explicitly for disabled links
+      roleOverride = 'link';
+    }
+
     const resultProps = {
-      role: 'button',
-      tabIndex: disabled && !disabledFocusable ? undefined : 0,
+      role: roleOverride,
+      tabIndex: disabledFocusable || (!isLink && !disabled) ? 0 : undefined,
       ...rest,
       // If it's not a <button> than listeners are required even with disabledFocusable
       // Since you cannot assure the default behavior of the element
@@ -132,7 +140,7 @@ export function useARIAButtonProps<Type extends ARIAButtonType, Props extends AR
       onClick: handleClick,
       onKeyUp: handleKeyUp,
       onKeyDown: handleKeyDown,
-      'aria-disabled': disabled || disabledFocusable || normalizedARIADisabled,
+      'aria-disabled': isDisabled,
     } as ARIAButtonResultProps<Type, Props>;
 
     if (type === 'a' && isDisabled) {

--- a/packages/react-components/react-button/library/src/components/Button/Button.test.tsx
+++ b/packages/react-components/react-button/library/src/components/Button/Button.test.tsx
@@ -107,9 +107,19 @@ describe('Button', () => {
           This is a button
         </Button>,
       );
+      const anchor = getByRole('link');
+
+      expect(anchor.tagName).toBe('A');
+      expect(anchor.getAttribute('role')).toBeFalsy();
+    });
+
+    it('applies role and tabindex with no href', () => {
+      const { getByRole } = render(<Button as="a">This is a button</Button>);
       const anchor = getByRole('button');
 
       expect(anchor.tagName).toBe('A');
+      expect(anchor.getAttribute('role')).toEqual('button');
+      expect(anchor.tabIndex).toEqual(0);
     });
 
     it('can be focused', () => {
@@ -118,7 +128,7 @@ describe('Button', () => {
           This is a button
         </Button>,
       );
-      const anchor = getByRole('button');
+      const anchor = getByRole('link');
 
       expect(document.activeElement).not.toEqual(anchor);
       userEvent.tab();
@@ -131,7 +141,7 @@ describe('Button', () => {
           This is a button
         </Button>,
       );
-      const anchor = getByRole('button');
+      const anchor = getByRole('link');
 
       expect(document.activeElement).not.toEqual(anchor);
       userEvent.tab();
@@ -144,7 +154,7 @@ describe('Button', () => {
           This is a button
         </Button>,
       );
-      const anchor = getByRole('button');
+      const anchor = getByRole('link');
 
       expect(document.activeElement).not.toEqual(anchor);
       userEvent.tab();

--- a/packages/react-components/react-button/library/src/components/Button/useButton.ts
+++ b/packages/react-components/react-button/library/src/components/Button/useButton.ts
@@ -39,7 +39,7 @@ export const useButton_unstable = (
       elementType: 'button',
       defaultProps: {
         ref: ref as React.Ref<HTMLButtonElement & HTMLAnchorElement>,
-        type: 'button',
+        type: as === 'button' ? 'button' : undefined,
       },
     }),
     icon: iconShorthand,

--- a/packages/react-components/react-button/library/src/components/CompoundButton/CompoundButton.test.tsx
+++ b/packages/react-components/react-button/library/src/components/CompoundButton/CompoundButton.test.tsx
@@ -103,7 +103,7 @@ describe('CompoundButton', () => {
           This is a button
         </CompoundButton>,
       );
-      const anchor = getByRole('button');
+      const anchor = getByRole('link');
 
       expect(anchor.tagName).toBe('A');
     });
@@ -114,7 +114,7 @@ describe('CompoundButton', () => {
           This is a button
         </CompoundButton>,
       );
-      const anchor = getByRole('button');
+      const anchor = getByRole('link');
 
       expect(document.activeElement).not.toEqual(anchor);
       anchor.focus();
@@ -127,7 +127,7 @@ describe('CompoundButton', () => {
           This is a button
         </CompoundButton>,
       );
-      const anchor = getByRole('button');
+      const anchor = getByRole('link');
 
       expect(document.activeElement).not.toEqual(anchor);
       anchor.focus();
@@ -140,7 +140,7 @@ describe('CompoundButton', () => {
           This is a button
         </CompoundButton>,
       );
-      const anchor = getByRole('button');
+      const anchor = getByRole('link');
 
       expect(document.activeElement).not.toEqual(anchor);
       anchor.focus();

--- a/packages/react-components/react-button/library/src/components/MenuButton/MenuButton.test.tsx
+++ b/packages/react-components/react-button/library/src/components/MenuButton/MenuButton.test.tsx
@@ -110,7 +110,7 @@ describe('MenuButton', () => {
           This is a button
         </MenuButton>,
       );
-      const anchor = getByRole('button');
+      const anchor = getByRole('link');
 
       expect(anchor.tagName).toBe('A');
     });
@@ -121,7 +121,7 @@ describe('MenuButton', () => {
           This is a button
         </MenuButton>,
       );
-      const anchor = getByRole('button');
+      const anchor = getByRole('link');
 
       expect(document.activeElement).not.toEqual(anchor);
       anchor.focus();
@@ -134,7 +134,7 @@ describe('MenuButton', () => {
           This is a button
         </MenuButton>,
       );
-      const anchor = getByRole('button');
+      const anchor = getByRole('link');
 
       expect(document.activeElement).not.toEqual(anchor);
       anchor.focus();
@@ -147,7 +147,7 @@ describe('MenuButton', () => {
           This is a button
         </MenuButton>,
       );
-      const anchor = getByRole('button');
+      const anchor = getByRole('link');
 
       expect(document.activeElement).not.toEqual(anchor);
       anchor.focus();

--- a/packages/react-components/react-button/library/src/components/ToggleButton/ToggleButton.test.tsx
+++ b/packages/react-components/react-button/library/src/components/ToggleButton/ToggleButton.test.tsx
@@ -107,7 +107,7 @@ describe('ToggleButton', () => {
           This is a button
         </ToggleButton>,
       );
-      const anchor = getByRole('button');
+      const anchor = getByRole('link');
 
       expect(anchor.tagName).toBe('A');
     });
@@ -118,7 +118,7 @@ describe('ToggleButton', () => {
           This is a button
         </ToggleButton>,
       );
-      const anchor = getByRole('button');
+      const anchor = getByRole('link');
 
       expect(document.activeElement).not.toEqual(anchor);
       anchor.focus();
@@ -131,7 +131,7 @@ describe('ToggleButton', () => {
           This is a button
         </ToggleButton>,
       );
-      const anchor = getByRole('button');
+      const anchor = getByRole('link');
 
       expect(document.activeElement).not.toEqual(anchor);
       anchor.focus();
@@ -144,7 +144,7 @@ describe('ToggleButton', () => {
           This is a button
         </ToggleButton>,
       );
-      const anchor = getByRole('button');
+      const anchor = getByRole('link');
 
       expect(document.activeElement).not.toEqual(anchor);
       anchor.focus();


### PR DESCRIPTION
## Previous Behavior

We've had this incorrect behavior in v9 for a while, but `<Button as="a" href={href}>` has been rendering as:

```html
<a href={href} type="button" role="button">
```

It's harmful to override the `role` of semantic links with `href` attributes for a number of reasons, primarily around screen readers no longer presenting link-specific built-in features when the role is overridden. Additionally, `type` is not a valid prop on `<a>` elements.

Also we'd been adding `tabindex` to link elements with `href` attributes, which is unnecessary.

## New Behavior

When authors use `<Button as="a" href={href}>`, it now renders as a semantic link. The following edge cases are also handled:

- Button with `as=a` but no `href`: uses `role="button"` + `tabIndex`
- Button with `as=a`, `href`, and `disabled` or `disabledFocusable`: uses `role=link`, no `href` and `tabIndex` if focusable (matching the Link behavior)

Also updates the a11y tests to match the desired semantics.

## Related Issue(s)

- Fixes [ADO issue](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/19975)
