### PR TITLE
fix(react-infolabel): dismiss correctly after clicking on the infoButton in Safari

### DIFF
--- a/change/@fluentui-react-infolabel-3073ec02-8c14-4fef-976d-39ee32603aa0.json
+++ b/change/@fluentui-react-infolabel-3073ec02-8c14-4fef-976d-39ee32603aa0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: popover not dismissing in Safari after clicking on infoButton",
+  "packageName": "@fluentui/react-infolabel",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-infolabel/library/src/components/InfoButton/useInfoButton.tsx
+++ b/packages/react-components/react-infolabel/library/src/components/InfoButton/useInfoButton.tsx
@@ -92,13 +92,13 @@ export const useInfoButton_unstable = (props: InfoButtonProps, ref: React.Ref<HT
   // Hide the popover when focus moves out of the button and popover
   const onBlurButtonOrInfo = (e: React.FocusEvent) => {
     const nextFocused = e.relatedTarget;
-    if (rootRef.current !== nextFocused && !elementContains(infoRef.current, nextFocused)) {
+
+    if (nextFocused && rootRef.current !== nextFocused && !elementContains(infoRef.current, nextFocused)) {
       setPopoverOpen(false);
     }
   };
 
   state.root.onBlur = useEventCallback(mergeCallbacks(state.root.onBlur, onBlurButtonOrInfo));
   state.info.onBlurCapture = useEventCallback(mergeCallbacks(state.info.onBlurCapture, onBlurButtonOrInfo));
-
   return state;
 };


### PR DESCRIPTION
`e.relatedTarget` is null in Safari leading to incorrect dismissing behavior

## Previous Behavior

https://github.com/user-attachments/assets/668815e3-b985-452b-85eb-6f27f8bb3c8b

## New Behavior

https://github.com/user-attachments/assets/cd668f62-8d19-4f91-9e5e-62c40e6b3dae

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #31067 


