### PR TITLE
fix(Collapse): handle content padding by animating it to zero

### DIFF
--- a/change/@fluentui-react-motion-components-preview-b271a894-6660-439a-aef6-8f008b144e56.json
+++ b/change/@fluentui-react-motion-components-preview-b271a894-6660-439a-aef6-8f008b144e56.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: handle content padding in Collapse",
+  "packageName": "@fluentui/react-motion-components-preview",
+  "email": "robertpenner@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-motion-components-preview/library/src/components/Collapse/Collapse.ts
+++ b/packages/react-components/react-motion-components-preview/library/src/components/Collapse/Collapse.ts
@@ -43,7 +43,19 @@ export const createCollapsePresence: PresenceMotionFnCreator<CollapseVariantPara
     const sizeName = orientation === 'horizontal' ? 'maxWidth' : 'maxHeight';
     const overflowName = orientation === 'horizontal' ? 'overflowX' : 'overflowY';
 
-    // The enter transition is an array of up to 2 motion atoms: size and opacity.
+    // Because a height of zero does not eliminate padding,
+    // we will create keyframes to animate it to zero.
+    // TODO: consider collapsing margin, perhaps as an option.
+    const collapsedWhiteSpace = {} as { [key: string]: string };
+    if (orientation === 'horizontal') {
+      collapsedWhiteSpace.paddingLeft = '0';
+      collapsedWhiteSpace.paddingRight = '0';
+    } else {
+      collapsedWhiteSpace.paddingTop = '0';
+      collapsedWhiteSpace.paddingBottom = '0';
+    }
+
+    // The enter transition is an array of up to 3 motion atoms: size, whitespace and opacity.
     const enterAtoms: AtomMotion[] = [
       // Expand size (height or width)
       {
@@ -58,6 +70,13 @@ export const createCollapsePresence: PresenceMotionFnCreator<CollapseVariantPara
         duration: enterDuration,
         easing: enterEasing,
       },
+      // Expand whitespace (padding currently).
+      {
+        // Animate from zero values to the element's natural values (i.e. the missing other keyframe).
+        keyframes: [{ ...collapsedWhiteSpace, offset: 0 }],
+        duration: enterDuration,
+        easing: enterEasing,
+      },
     ];
     // Fade in only if animateOpacity is true. Otherwise, leave opacity unaffected.
     if (animateOpacity) {
@@ -69,7 +88,7 @@ export const createCollapsePresence: PresenceMotionFnCreator<CollapseVariantPara
       });
     }
 
-    // The exit transition is an array of up to 2 motion atoms: opacity and size.
+    // The exit transition is an array of up to 3 motion atoms: opacity, size and whitespace.
     const exitAtoms: AtomMotion[] = [];
     // Fade out only if animateOpacity is false. Otherwise, leave opacity unaffected.
     if (animateOpacity) {
@@ -89,6 +108,16 @@ export const createCollapsePresence: PresenceMotionFnCreator<CollapseVariantPara
         duration: exitDuration,
         easing: exitEasing,
         fill: 'both',
+      },
+    );
+    exitAtoms.push(
+      // Collapse whitespace (padding currently).
+      {
+        // Animate from the element's natural values (i.e. the missing other keyframe) to zero values.
+        keyframes: [{ ...collapsedWhiteSpace, offset: 1 }],
+        duration: exitDuration,
+        easing: exitEasing,
+        fill: 'forwards',
       },
     );
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

- In the web box model, by design, setting the height of an element to zero does not affect the padding.
- Consequently, when `Collapse` has animated the height of the content element to 0, the content's padding remains visible, if `animateOpacity` is `false`.
- Also, when `animateOpacity` is `true` but `unmountOnExit` is `true`, the size of the padding is removed abruptly, causing a visual jump on unmount.
  - The visual issue is visible in the [Collapse Customization story](https://react.fluentui.dev/?path=/docs/motion-components-preview-collapse--docs#customization):
![image](https://github.com/user-attachments/assets/3a6f057a-7dbc-452c-bd5e-255494ec03b9)
  

## New Behavior

- The content's padding is smoothly animated to zero automatically, using keyframes in the web animation.
  - The fix is visible in the [Collapse Customization story in the preview build](https://fluentuipr.z22.web.core.windows.net/pull/33063/public-docsite-v9/storybook/index.html?path=/docs/motion-components-preview-collapse--docs#customization).
- The padding animation produces a slight sliding effect, which varies according to the size of the padding. 
  - Motion Design team gave feedback that this effect is aesthetically pleasing, a happy accident.
  - If the end user doesn't want this effect, they can achieve a clean wipe by wrapping the content in an element with zero padding.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #32894 
