### PR TITLE
feat(Collapse): create CollapseDelayed variant

### DIFF
--- a/change/@fluentui-react-motion-components-preview-5ac64407-160d-4ad2-aaf7-e8923c092373.json
+++ b/change/@fluentui-react-motion-components-preview-5ac64407-160d-4ad2-aaf7-e8923c092373.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add CollapseDelayed motion component variant",
+  "packageName": "@fluentui/react-motion-components-preview",
+  "email": "robertpenner@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-motion-components-preview/library/etc/react-motion-components-preview.api.md
+++ b/packages/react-components/react-motion-components-preview/library/etc/react-motion-components-preview.api.md
@@ -12,10 +12,16 @@ import type { PresenceMotionFn } from '@fluentui/react-motion';
 export const Collapse: PresenceComponent<CollapseRuntimeParams>;
 
 // @public (undocumented)
+export const CollapseDelayed: PresenceComponent<CollapseRuntimeParams>;
+
+// @public (undocumented)
 export const CollapseExaggerated: PresenceComponent<CollapseRuntimeParams>;
 
 // @public (undocumented)
 export const CollapseSnappy: PresenceComponent<CollapseRuntimeParams>;
+
+// @public
+export const createCollapseDelayedPresence: PresenceMotionFnCreator<CollapseDelayedVariantParams, CollapseRuntimeParams>;
 
 // @public
 export const createCollapsePresence: PresenceMotionFnCreator<CollapseVariantParams, CollapseRuntimeParams>;

--- a/packages/react-components/react-motion-components-preview/library/src/components/Collapse/Collapse.ts
+++ b/packages/react-components/react-motion-components-preview/library/src/components/Collapse/Collapse.ts
@@ -127,6 +127,151 @@ export const createCollapsePresence: PresenceMotionFnCreator<CollapseVariantPara
     };
   };
 
+type CollapseDelayedVariantParams = {
+  /** Time (ms) for the size expand. Defaults to the durationNormal value (200 ms). */
+  enterSizeDuration?: number;
+
+  /** Time (ms) for the fade-in. Defaults to the enterSizeDuration param, to sync fade-in with expand. */
+  enterOpacityDuration?: number;
+
+  /** Time (ms) for the size collapse. Defaults to the enterSizeDuration param, for temporal symmetry.. */
+  exitSizeDuration?: number;
+
+  /** Defaults to the exitSizeDuration param, to sync the fade-out with the collapse. */
+  exitOpacityDuration?: number;
+
+  /** Time (ms) between the size expand start and the fade-in start. Defaults to `0`.  */
+  enterDelay?: number;
+
+  /** Time (ms) between the fade-out start and the size collapse start. Defaults to `0`.  */
+  exitDelay?: number;
+
+  /** Easing curve for the enter transition, shared by size and opacity. Defaults to the easeEaseMax value.  */
+  enterEasing?: string;
+
+  /** Easing curve for the exit transition, shared by size and opacity. Defaults to the enterEasing param. */
+  exitEasing?: string;
+};
+
+/** Define a presence motion for collapse/expand */
+export const createCollapseDelayedPresence: PresenceMotionFnCreator<
+  CollapseDelayedVariantParams,
+  CollapseRuntimeParams
+> =
+  ({
+    // enter
+    enterSizeDuration = motionTokens.durationNormal,
+    enterOpacityDuration = enterSizeDuration,
+    enterEasing = motionTokens.curveEasyEaseMax,
+    enterDelay = 0,
+
+    // exit
+    exitSizeDuration = enterSizeDuration,
+    exitOpacityDuration = enterOpacityDuration,
+    // exitOpacityDuration = exitSizeDuration,
+    exitEasing = enterEasing,
+    exitDelay = 0,
+  } = {}) =>
+  ({ element, animateOpacity = true, orientation = 'vertical' }) => {
+    const fromOpacity = 0;
+    const toOpacity = 1;
+    const fromSize = '0'; // Could be a custom param in the future to start with partially expanded width or height
+    const measuredSize = orientation === 'horizontal' ? element.scrollWidth : element.scrollHeight;
+    const toSize = `${measuredSize}px`;
+    // use generic names for size and overflow, handling vertical or horizontal orientation
+    const sizeName = orientation === 'horizontal' ? 'maxWidth' : 'maxHeight';
+    const overflowName = orientation === 'horizontal' ? 'overflowX' : 'overflowY';
+
+    // Because a height of zero does not eliminate padding,
+    // we will create keyframes to animate it to zero.
+    // TODO: consider collapsing margin, perhaps as an option.
+    const collapsedWhiteSpace = {} as { [key: string]: string };
+    if (orientation === 'horizontal') {
+      collapsedWhiteSpace.paddingLeft = '0';
+      collapsedWhiteSpace.paddingRight = '0';
+    } else {
+      collapsedWhiteSpace.paddingTop = '0';
+      collapsedWhiteSpace.paddingBottom = '0';
+    }
+
+    // The enter transition is an array of up to 3 motion atoms: size, whitespace and opacity.
+    const enterAtoms: AtomMotion[] = [
+      // Expand size (height or width)
+      {
+        keyframes: [
+          {
+            [sizeName]: fromSize,
+            [overflowName]: 'hidden',
+          },
+          { [sizeName]: toSize, offset: 0.9999, [overflowName]: 'hidden' },
+          { [sizeName]: 'unset', [overflowName]: 'unset' },
+        ],
+        duration: enterSizeDuration,
+        easing: enterEasing,
+      },
+      // Expand whitespace (padding currently).
+      {
+        // Animate from zero values to the element's natural values (i.e. the missing other keyframe).
+        keyframes: [{ ...collapsedWhiteSpace, offset: 0 }],
+        duration: enterSizeDuration,
+        easing: enterEasing,
+      },
+    ];
+    // Fade in only if animateOpacity is true. Otherwise, leave opacity unaffected.
+    if (animateOpacity) {
+      enterAtoms.push({
+        // If enterDelay > 0, the fade-in will start after the size expand.
+        delay: enterDelay,
+        keyframes: [{ opacity: fromOpacity }, { opacity: toOpacity }],
+        duration: enterOpacityDuration,
+        easing: enterEasing,
+        fill: 'both',
+      });
+    }
+
+    // The exit transition is an array of up to 3 motion atoms: opacity, size and whitespace.
+    const exitAtoms: AtomMotion[] = [];
+    // Fade out only if animateOpacity is false. Otherwise, leave opacity unaffected.
+    if (animateOpacity) {
+      exitAtoms.push({
+        keyframes: [{ opacity: toOpacity }, { opacity: fromOpacity }],
+        duration: exitOpacityDuration,
+        easing: exitEasing,
+      });
+    }
+    exitAtoms.push(
+      // Collapse size (height or width)
+      {
+        // If exitDelay > 0, the size collapse will start after the fade-out.
+        delay: exitDelay,
+        keyframes: [
+          { [sizeName]: toSize, [overflowName]: 'hidden' },
+          { [sizeName]: fromSize, [overflowName]: 'hidden' },
+        ],
+        duration: exitSizeDuration,
+        easing: exitEasing,
+        fill: 'both',
+      },
+    );
+    exitAtoms.push(
+      // Collapse whitespace (padding currently).
+      {
+        // If exitDelay > 0, the whitespace collapse will start after the fade-out.
+        delay: exitDelay,
+        // Animate from the element's natural values (i.e. the missing other keyframe) to zero values.
+        keyframes: [{ ...collapsedWhiteSpace, offset: 1 }],
+        duration: exitSizeDuration,
+        easing: exitEasing,
+        fill: 'forwards',
+      },
+    );
+
+    return {
+      enter: enterAtoms,
+      exit: exitAtoms,
+    };
+  };
+
 /** A React component that applies collapse/expand transitions to its children. */
 export const Collapse = createPresenceComponent(createCollapsePresence());
 
@@ -136,4 +281,14 @@ export const CollapseSnappy = createPresenceComponent(
 
 export const CollapseExaggerated = createPresenceComponent(
   createCollapsePresence({ enterDuration: motionTokens.durationSlower }),
+);
+
+export const CollapseDelayed = createPresenceComponent(
+  createCollapseDelayedPresence({
+    enterSizeDuration: motionTokens.durationNormal,
+    enterOpacityDuration: motionTokens.durationSlower,
+    enterDelay: motionTokens.durationNormal,
+    exitDelay: motionTokens.durationSlower,
+    enterEasing: motionTokens.curveEasyEase,
+  }),
 );

--- a/packages/react-components/react-motion-components-preview/library/src/components/Collapse/Collapse.ts
+++ b/packages/react-components/react-motion-components-preview/library/src/components/Collapse/Collapse.ts
@@ -3,156 +3,6 @@ import type { PresenceMotionFnCreator } from '../../types';
 
 type CollapseOrientation = 'horizontal' | 'vertical';
 
-type CollapseVariantParams = {
-  /** Time (ms) for the enter transition (expand). Defaults to the `durationNormal` value (200 ms). */
-  enterDuration?: number;
-
-  /** Easing curve for the enter transition (expand). Defaults to the `easeEaseMax` value.  */
-  enterEasing?: string;
-
-  /** Time (ms) for the exit transition (collapse). Defaults to the `enterDuration` param for symmetry. */
-  exitDuration?: number;
-
-  /** Easing curve for the exit transition (collapse). Defaults to the `enterEasing` param for symmetry.  */
-  exitEasing?: string;
-};
-
-type CollapseRuntimeParams = {
-  /** Whether to animate the opacity. Defaults to `true`. */
-  animateOpacity?: boolean;
-
-  /** The orientation of the size animation. Defaults to `'vertical'` to expand/collapse the height. */
-  orientation?: CollapseOrientation;
-};
-
-/** Define a presence motion for collapse/expand */
-export const createCollapsePresence: PresenceMotionFnCreator<CollapseVariantParams, CollapseRuntimeParams> =
-  ({
-    enterDuration = motionTokens.durationNormal,
-    enterEasing = motionTokens.curveEasyEaseMax,
-    exitDuration = enterDuration,
-    exitEasing = enterEasing,
-  } = {}) =>
-  ({ element, animateOpacity = true, orientation = 'vertical' }) => {
-    const fromOpacity = 0;
-    const toOpacity = 1;
-    const fromSize = '0'; // Could be a custom param in the future to start with partially expanded width or height
-    const measuredSize = orientation === 'horizontal' ? element.scrollWidth : element.scrollHeight;
-    const toSize = `${measuredSize}px`;
-    // use generic names for size and overflow, handling vertical or horizontal orientation
-    const sizeName = orientation === 'horizontal' ? 'maxWidth' : 'maxHeight';
-    const overflowName = orientation === 'horizontal' ? 'overflowX' : 'overflowY';
-
-    // Because a height of zero does not eliminate padding,
-    // we will create keyframes to animate it to zero.
-    // TODO: consider collapsing margin, perhaps as an option.
-    const collapsedWhiteSpace = {} as { [key: string]: string };
-    if (orientation === 'horizontal') {
-      collapsedWhiteSpace.paddingLeft = '0';
-      collapsedWhiteSpace.paddingRight = '0';
-    } else {
-      collapsedWhiteSpace.paddingTop = '0';
-      collapsedWhiteSpace.paddingBottom = '0';
-    }
-
-    // The enter transition is an array of up to 3 motion atoms: size, whitespace and opacity.
-    const enterAtoms: AtomMotion[] = [
-      // Expand size (height or width)
-      {
-        keyframes: [
-          {
-            [sizeName]: fromSize,
-            [overflowName]: 'hidden',
-          },
-          { [sizeName]: toSize, offset: 0.9999, [overflowName]: 'hidden' },
-          { [sizeName]: 'unset', [overflowName]: 'unset' },
-        ],
-        duration: enterDuration,
-        easing: enterEasing,
-      },
-      // Expand whitespace (padding currently).
-      {
-        // Animate from zero values to the element's natural values (i.e. the missing other keyframe).
-        keyframes: [{ ...collapsedWhiteSpace, offset: 0 }],
-        duration: enterDuration,
-        easing: enterEasing,
-      },
-    ];
-    // Fade in only if animateOpacity is true. Otherwise, leave opacity unaffected.
-    if (animateOpacity) {
-      enterAtoms.push({
-        keyframes: [{ opacity: fromOpacity }, { opacity: toOpacity }],
-        duration: enterDuration,
-        easing: enterEasing,
-        fill: 'both',
-      });
-    }
-
-    // The exit transition is an array of up to 3 motion atoms: opacity, size and whitespace.
-    const exitAtoms: AtomMotion[] = [];
-    // Fade out only if animateOpacity is false. Otherwise, leave opacity unaffected.
-    if (animateOpacity) {
-      exitAtoms.push({
-        keyframes: [{ opacity: toOpacity }, { opacity: fromOpacity }],
-        duration: exitDuration,
-        easing: exitEasing,
-      });
-    }
-    exitAtoms.push(
-      // Collapse size (height or width)
-      {
-        keyframes: [
-          { [sizeName]: toSize, [overflowName]: 'hidden' },
-          { [sizeName]: fromSize, [overflowName]: 'hidden' },
-        ],
-        duration: exitDuration,
-        easing: exitEasing,
-        fill: 'both',
-      },
-    );
-    exitAtoms.push(
-      // Collapse whitespace (padding currently).
-      {
-        // Animate from the element's natural values (i.e. the missing other keyframe) to zero values.
-        keyframes: [{ ...collapsedWhiteSpace, offset: 1 }],
-        duration: exitDuration,
-        easing: exitEasing,
-        fill: 'forwards',
-      },
-    );
-
-    return {
-      enter: enterAtoms,
-      exit: exitAtoms,
-    };
-  };
-
-type CollapseDelayedVariantParams = {
-  /** Time (ms) for the size expand. Defaults to the durationNormal value (200 ms). */
-  enterSizeDuration?: number;
-
-  /** Time (ms) for the fade-in. Defaults to the enterSizeDuration param, to sync fade-in with expand. */
-  enterOpacityDuration?: number;
-
-  /** Time (ms) for the size collapse. Defaults to the enterSizeDuration param, for temporal symmetry.. */
-  exitSizeDuration?: number;
-
-  /** Defaults to the exitSizeDuration param, to sync the fade-out with the collapse. */
-  exitOpacityDuration?: number;
-
-  /** Time (ms) between the size expand start and the fade-in start. Defaults to `0`.  */
-  enterDelay?: number;
-
-  /** Time (ms) between the fade-out start and the size collapse start. Defaults to `0`.  */
-  exitDelay?: number;
-
-  /** Easing curve for the enter transition, shared by size and opacity. Defaults to the easeEaseMax value.  */
-  enterEasing?: string;
-
-  /** Easing curve for the exit transition, shared by size and opacity. Defaults to the enterEasing param. */
-  exitEasing?: string;
-};
-
 const sizeEnterAtom = ({
   fromSize,
   toSize,
@@ -288,6 +138,41 @@ const opacityExitAtom = ({
   easing,
 });
 
+// TODO: reduce duplication between CollapseDelayedVariantParams and CollapseVariantParams
+type CollapseDelayedVariantParams = {
+  /** Time (ms) for the size expand. Defaults to the durationNormal value (200 ms). */
+  enterSizeDuration?: number;
+
+  /** Time (ms) for the fade-in. Defaults to the enterSizeDuration param, to sync fade-in with expand. */
+  enterOpacityDuration?: number;
+
+  /** Time (ms) for the size collapse. Defaults to the enterSizeDuration param, for temporal symmetry.. */
+  exitSizeDuration?: number;
+
+  /** Defaults to the exitSizeDuration param, to sync the fade-out with the collapse. */
+  exitOpacityDuration?: number;
+
+  /** Time (ms) between the size expand start and the fade-in start. Defaults to `0`.  */
+  enterDelay?: number;
+
+  /** Time (ms) between the fade-out start and the size collapse start. Defaults to `0`.  */
+  exitDelay?: number;
+
+  /** Easing curve for the enter transition, shared by size and opacity. Defaults to the easeEaseMax value.  */
+  enterEasing?: string;
+
+  /** Easing curve for the exit transition, shared by size and opacity. Defaults to the enterEasing param. */
+  exitEasing?: string;
+};
+
+type CollapseRuntimeParams = {
+  /** Whether to animate the opacity. Defaults to `true`. */
+  animateOpacity?: boolean;
+
+  /** The orientation of the size animation. Defaults to `'vertical'` to expand/collapse the height. */
+  orientation?: CollapseOrientation;
+};
+
 /** Define a presence motion for collapse/expand */
 export const createCollapseDelayedPresence: PresenceMotionFnCreator<
   CollapseDelayedVariantParams,
@@ -378,6 +263,36 @@ export const createCollapseDelayedPresence: PresenceMotionFnCreator<
       exit: exitAtoms,
     };
   };
+
+type CollapseVariantParams = {
+  /** Time (ms) for the enter transition (expand). Defaults to the `durationNormal` value (200 ms). */
+  enterDuration?: number;
+
+  /** Easing curve for the enter transition (expand). Defaults to the `easeEaseMax` value.  */
+  enterEasing?: string;
+
+  /** Time (ms) for the exit transition (collapse). Defaults to the `enterDuration` param for symmetry. */
+  exitDuration?: number;
+
+  /** Easing curve for the exit transition (collapse). Defaults to the `enterEasing` param for symmetry.  */
+  exitEasing?: string;
+};
+
+/** Define a presence motion for collapse/expand */
+export const createCollapsePresence: PresenceMotionFnCreator<CollapseVariantParams, CollapseRuntimeParams> = ({
+  enterDuration = motionTokens.durationNormal,
+  enterEasing = motionTokens.curveEasyEaseMax,
+  exitDuration = enterDuration,
+  exitEasing = enterEasing,
+} = {}) =>
+  // Implement a regular collapse as a special case of the delayed collapse,
+  // where the delays are zero, and the size and opacity durations are equal.
+  createCollapseDelayedPresence({
+    enterSizeDuration: enterDuration,
+    enterEasing,
+    exitSizeDuration: exitDuration,
+    exitEasing,
+  });
 
 /** A React component that applies collapse/expand transitions to its children. */
 export const Collapse = createPresenceComponent(createCollapsePresence());

--- a/packages/react-components/react-motion-components-preview/library/src/components/Collapse/Collapse.ts
+++ b/packages/react-components/react-motion-components-preview/library/src/components/Collapse/Collapse.ts
@@ -1,189 +1,14 @@
 import { motionTokens, createPresenceComponent, AtomMotion } from '@fluentui/react-motion';
 import type { PresenceMotionFnCreator } from '../../types';
-
-type CollapseOrientation = 'horizontal' | 'vertical';
-
-const sizeValuesForOrientation = (orientation: CollapseOrientation, element: Element) => {
-  const sizeName = orientation === 'horizontal' ? 'maxWidth' : 'maxHeight';
-  const overflowName = orientation === 'horizontal' ? 'overflowX' : 'overflowY';
-  const measuredSize = orientation === 'horizontal' ? element.scrollWidth : element.scrollHeight;
-  const toSize = `${measuredSize}px`;
-  return { sizeName, overflowName, toSize };
-};
-
-const sizeEnterAtom = ({
-  orientation,
-  duration,
-  easing,
-  element,
-  fromSize = '0',
-}: {
-  orientation: CollapseOrientation;
-  duration: number;
-  easing: string;
-  element: HTMLElement;
-  fromSize?: string;
-}): AtomMotion => {
-  const { sizeName, overflowName, toSize } = sizeValuesForOrientation(orientation, element);
-
-  return {
-    keyframes: [
-      { [sizeName]: fromSize, [overflowName]: 'hidden' },
-      { [sizeName]: toSize, offset: 0.9999, [overflowName]: 'hidden' },
-      { [sizeName]: 'unset', [overflowName]: 'unset' },
-    ],
-    duration,
-    easing,
-  };
-};
-
-const sizeExitAtom = ({
-  orientation,
-  duration,
-  easing,
-  element,
-  delay = 0,
-  fromSize = '0',
-}: {
-  orientation: CollapseOrientation;
-  duration: number;
-  easing: string;
-  element: HTMLElement;
-  delay?: number;
-  fromSize?: string;
-}): AtomMotion => {
-  const { sizeName, overflowName, toSize } = sizeValuesForOrientation(orientation, element);
-
-  return {
-    keyframes: [
-      { [sizeName]: toSize, [overflowName]: 'hidden' },
-      { [sizeName]: fromSize, [overflowName]: 'hidden' },
-    ],
-    duration,
-    easing,
-    fill: 'both',
-    delay,
-  };
-};
-
-const whitespaceValuesForOrientation = (orientation: CollapseOrientation) => {
-  const paddingStart = orientation === 'horizontal' ? 'paddingLeft' : 'paddingTop';
-  const paddingEnd = orientation === 'horizontal' ? 'paddingRight' : 'paddingBottom';
-  return { paddingStart, paddingEnd };
-};
-
-// Because a height of zero does not eliminate padding,
-// we will create keyframes to animate it to zero.
-// TODO: consider collapsing margin, perhaps as an option.
-
-const whitespaceEnterAtom = ({
-  orientation,
-  duration,
-  easing,
-}: {
-  orientation: CollapseOrientation;
-  duration: number;
-  easing: string;
-}): AtomMotion => {
-  const { paddingStart, paddingEnd } = whitespaceValuesForOrientation(orientation);
-  return {
-    keyframes: [{ [paddingStart]: '0', [paddingEnd]: '0', offset: 0 }],
-    duration,
-    easing,
-  };
-};
-
-const whitespaceExitAtom = ({
-  orientation,
-  duration,
-  easing,
-  delay = 0,
-}: {
-  orientation: CollapseOrientation;
-  duration: number;
-  easing: string;
-  delay?: number;
-}): AtomMotion => {
-  const { paddingStart, paddingEnd } = whitespaceValuesForOrientation(orientation);
-  return {
-    keyframes: [{ [paddingStart]: '0', [paddingEnd]: '0', offset: 1 }],
-    duration,
-    easing,
-    fill: 'forwards',
-    delay,
-  };
-};
-
-const opacityEnterAtom = ({
-  duration,
-  easing,
-  delay = 0,
-  fromOpacity = 0,
-  toOpacity = 1,
-}: {
-  duration: number;
-  easing: string;
-  delay?: number;
-  fromOpacity?: number;
-  toOpacity?: number;
-}): AtomMotion => ({
-  keyframes: [{ opacity: fromOpacity }, { opacity: toOpacity }],
-  duration,
-  easing,
-  delay,
-  fill: 'both',
-});
-
-const opacityExitAtom = ({
-  duration,
-  easing,
-  fromOpacity = 0,
-  toOpacity = 1,
-}: {
-  duration: number;
-  easing: string;
-  fromOpacity?: number;
-  toOpacity?: number;
-}): AtomMotion => ({
-  keyframes: [{ opacity: toOpacity }, { opacity: fromOpacity }],
-  duration,
-  easing,
-});
-
-// TODO: reduce duplication between CollapseDelayedVariantParams and CollapseVariantParams
-type CollapseDelayedVariantParams = {
-  /** Time (ms) for the size expand. Defaults to the durationNormal value (200 ms). */
-  enterSizeDuration?: number;
-
-  /** Time (ms) for the fade-in. Defaults to the enterSizeDuration param, to sync fade-in with expand. */
-  enterOpacityDuration?: number;
-
-  /** Time (ms) for the size collapse. Defaults to the enterSizeDuration param, for temporal symmetry.. */
-  exitSizeDuration?: number;
-
-  /** Defaults to the exitSizeDuration param, to sync the fade-out with the collapse. */
-  exitOpacityDuration?: number;
-
-  /** Time (ms) between the size expand start and the fade-in start. Defaults to `0`.  */
-  enterDelay?: number;
-
-  /** Time (ms) between the fade-out start and the size collapse start. Defaults to `0`.  */
-  exitDelay?: number;
-
-  /** Easing curve for the enter transition, shared by size and opacity. Defaults to the easeEaseMax value.  */
-  enterEasing?: string;
-
-  /** Easing curve for the exit transition, shared by size and opacity. Defaults to the enterEasing param. */
-  exitEasing?: string;
-};
-
-type CollapseRuntimeParams = {
-  /** Whether to animate the opacity. Defaults to `true`. */
-  animateOpacity?: boolean;
-
-  /** The orientation of the size animation. Defaults to `'vertical'` to expand/collapse the height. */
-  orientation?: CollapseOrientation;
-};
+import type { CollapseDelayedVariantParams, CollapseRuntimeParams, CollapseVariantParams } from './collapse-types';
+import {
+  sizeEnterAtom,
+  whitespaceEnterAtom,
+  opacityEnterAtom,
+  opacityExitAtom,
+  sizeExitAtom,
+  whitespaceExitAtom,
+} from './collapse-atoms';
 
 /** Define a presence motion for collapse/expand that can stagger the size and opacity motions by a given delay. */
 export const createCollapseDelayedPresence: PresenceMotionFnCreator<
@@ -204,6 +29,7 @@ export const createCollapseDelayedPresence: PresenceMotionFnCreator<
     exitDelay = 0,
   } = {}) =>
   ({ element, animateOpacity = true, orientation = 'vertical' }) => {
+    // ----- ENTER -----
     // The enter transition is an array of up to 3 motion atoms: size, whitespace and opacity.
     const enterAtoms: AtomMotion[] = [
       sizeEnterAtom({
@@ -229,6 +55,7 @@ export const createCollapseDelayedPresence: PresenceMotionFnCreator<
       );
     }
 
+    // ----- EXIT -----
     // The exit transition is an array of up to 3 motion atoms: opacity, size and whitespace.
     const exitAtoms: AtomMotion[] = [];
     // Fade out only if animateOpacity is true. Otherwise, leave opacity unaffected.
@@ -264,21 +91,7 @@ export const createCollapseDelayedPresence: PresenceMotionFnCreator<
     };
   };
 
-type CollapseVariantParams = {
-  /** Time (ms) for the enter transition (expand). Defaults to the `durationNormal` value (200 ms). */
-  enterDuration?: number;
-
-  /** Easing curve for the enter transition (expand). Defaults to the `easeEaseMax` value.  */
-  enterEasing?: string;
-
-  /** Time (ms) for the exit transition (collapse). Defaults to the `enterDuration` param for symmetry. */
-  exitDuration?: number;
-
-  /** Easing curve for the exit transition (collapse). Defaults to the `enterEasing` param for symmetry.  */
-  exitEasing?: string;
-};
-
-/** Define a presence motion for collapse/expand */
+/** Defines a presence motion for collapse/expand. */
 export const createCollapsePresence: PresenceMotionFnCreator<CollapseVariantParams, CollapseRuntimeParams> = ({
   enterDuration = motionTokens.durationNormal,
   enterEasing = motionTokens.curveEasyEaseMax,

--- a/packages/react-components/react-motion-components-preview/library/src/components/Collapse/Collapse.ts
+++ b/packages/react-components/react-motion-components-preview/library/src/components/Collapse/Collapse.ts
@@ -3,22 +3,28 @@ import type { PresenceMotionFnCreator } from '../../types';
 
 type CollapseOrientation = 'horizontal' | 'vertical';
 
+const sizeValuesForOrientation = (orientation: CollapseOrientation, element: Element) => {
+  const sizeName = orientation === 'horizontal' ? 'maxWidth' : 'maxHeight';
+  const overflowName = orientation === 'horizontal' ? 'overflowX' : 'overflowY';
+  const measuredSize = orientation === 'horizontal' ? element.scrollWidth : element.scrollHeight;
+  const toSize = `${measuredSize}px`;
+  return { sizeName, overflowName, toSize };
+};
+
 const sizeEnterAtom = ({
   orientation,
   duration,
   easing,
   element,
+  fromSize = '0',
 }: {
   orientation: CollapseOrientation;
   duration: number;
   easing: string;
   element: HTMLElement;
+  fromSize?: string;
 }): AtomMotion => {
-  const fromSize = '0'; // Could be a custom param in the future to start with partially expanded width or height
-  const sizeName = orientation === 'horizontal' ? 'maxWidth' : 'maxHeight';
-  const overflowName = orientation === 'horizontal' ? 'overflowX' : 'overflowY';
-  const measuredSize = orientation === 'horizontal' ? element.scrollWidth : element.scrollHeight;
-  const toSize = `${measuredSize}px`;
+  const { sizeName, overflowName, toSize } = sizeValuesForOrientation(orientation, element);
 
   return {
     keyframes: [
@@ -37,18 +43,16 @@ const sizeExitAtom = ({
   easing,
   element,
   delay = 0,
+  fromSize = '0',
 }: {
   orientation: CollapseOrientation;
   duration: number;
   easing: string;
   element: HTMLElement;
   delay?: number;
+  fromSize?: string;
 }): AtomMotion => {
-  const fromSize = '0'; // Could be a custom param in the future to start with partially expanded width or height
-  const sizeName = orientation === 'horizontal' ? 'maxWidth' : 'maxHeight';
-  const overflowName = orientation === 'horizontal' ? 'overflowX' : 'overflowY';
-  const measuredSize = orientation === 'horizontal' ? element.scrollWidth : element.scrollHeight;
-  const toSize = `${measuredSize}px`;
+  const { sizeName, overflowName, toSize } = sizeValuesForOrientation(orientation, element);
 
   return {
     keyframes: [
@@ -60,6 +64,12 @@ const sizeExitAtom = ({
     fill: 'both',
     delay,
   };
+};
+
+const whitespaceValuesForOrientation = (orientation: CollapseOrientation) => {
+  const paddingStart = orientation === 'horizontal' ? 'paddingLeft' : 'paddingTop';
+  const paddingEnd = orientation === 'horizontal' ? 'paddingRight' : 'paddingBottom';
+  return { paddingStart, paddingEnd };
 };
 
 // Because a height of zero does not eliminate padding,
@@ -75,8 +85,7 @@ const whitespaceEnterAtom = ({
   duration: number;
   easing: string;
 }): AtomMotion => {
-  const paddingStart = orientation === 'horizontal' ? 'paddingLeft' : 'paddingTop';
-  const paddingEnd = orientation === 'horizontal' ? 'paddingRight' : 'paddingBottom';
+  const { paddingStart, paddingEnd } = whitespaceValuesForOrientation(orientation);
   return {
     keyframes: [{ [paddingStart]: '0', [paddingEnd]: '0', offset: 0 }],
     duration,
@@ -95,8 +104,7 @@ const whitespaceExitAtom = ({
   easing: string;
   delay?: number;
 }): AtomMotion => {
-  const paddingStart = orientation === 'horizontal' ? 'paddingLeft' : 'paddingTop';
-  const paddingEnd = orientation === 'horizontal' ? 'paddingRight' : 'paddingBottom';
+  const { paddingStart, paddingEnd } = whitespaceValuesForOrientation(orientation);
   return {
     keyframes: [{ [paddingStart]: '0', [paddingEnd]: '0', offset: 1 }],
     duration,
@@ -177,7 +185,7 @@ type CollapseRuntimeParams = {
   orientation?: CollapseOrientation;
 };
 
-/** Define a presence motion for collapse/expand */
+/** Define a presence motion for collapse/expand that can stagger the size and opacity motions by a given delay. */
 export const createCollapseDelayedPresence: PresenceMotionFnCreator<
   CollapseDelayedVariantParams,
   CollapseRuntimeParams

--- a/packages/react-components/react-motion-components-preview/library/src/components/Collapse/collapse-atoms.ts
+++ b/packages/react-components/react-motion-components-preview/library/src/components/Collapse/collapse-atoms.ts
@@ -1,0 +1,155 @@
+import { AtomMotion } from '@fluentui/react-motion/src/types';
+import type { CollapseOrientation } from './collapse-types';
+
+// ----- SIZE -----
+
+const sizeValuesForOrientation = (orientation: CollapseOrientation, element: Element) => {
+  const sizeName = orientation === 'horizontal' ? 'maxWidth' : 'maxHeight';
+  const overflowName = orientation === 'horizontal' ? 'overflowX' : 'overflowY';
+  const measuredSize = orientation === 'horizontal' ? element.scrollWidth : element.scrollHeight;
+  const toSize = `${measuredSize}px`;
+  return { sizeName, overflowName, toSize };
+};
+
+export const sizeEnterAtom = ({
+  orientation,
+  duration,
+  easing,
+  element,
+  fromSize = '0',
+}: {
+  orientation: CollapseOrientation;
+  duration: number;
+  easing: string;
+  element: HTMLElement;
+  fromSize?: string;
+}): AtomMotion => {
+  const { sizeName, overflowName, toSize } = sizeValuesForOrientation(orientation, element);
+
+  return {
+    keyframes: [
+      { [sizeName]: fromSize, [overflowName]: 'hidden' },
+      { [sizeName]: toSize, offset: 0.9999, [overflowName]: 'hidden' },
+      { [sizeName]: 'unset', [overflowName]: 'unset' },
+    ],
+    duration,
+    easing,
+  };
+};
+
+export const sizeExitAtom = ({
+  orientation,
+  duration,
+  easing,
+  element,
+  delay = 0,
+  fromSize = '0',
+}: {
+  orientation: CollapseOrientation;
+  duration: number;
+  easing: string;
+  element: HTMLElement;
+  delay?: number;
+  fromSize?: string;
+}): AtomMotion => {
+  const { sizeName, overflowName, toSize } = sizeValuesForOrientation(orientation, element);
+
+  return {
+    keyframes: [
+      { [sizeName]: toSize, [overflowName]: 'hidden' },
+      { [sizeName]: fromSize, [overflowName]: 'hidden' },
+    ],
+    duration,
+    easing,
+    fill: 'both',
+    delay,
+  };
+};
+
+// ----- WHITESPACE -----
+
+// Whitespace animation currently includes padding, but could be extended to handle margin.
+const whitespaceValuesForOrientation = (orientation: CollapseOrientation) => {
+  const paddingStart = orientation === 'horizontal' ? 'paddingLeft' : 'paddingTop';
+  const paddingEnd = orientation === 'horizontal' ? 'paddingRight' : 'paddingBottom';
+  return { paddingStart, paddingEnd };
+};
+
+// Because a height of zero does not eliminate padding,
+// we will create keyframes to animate it to zero.
+// TODO: consider collapsing margin, perhaps as an option.
+export const whitespaceEnterAtom = ({
+  orientation,
+  duration,
+  easing,
+}: {
+  orientation: CollapseOrientation;
+  duration: number;
+  easing: string;
+}): AtomMotion => {
+  const { paddingStart, paddingEnd } = whitespaceValuesForOrientation(orientation);
+  return {
+    keyframes: [{ [paddingStart]: '0', [paddingEnd]: '0', offset: 0 }],
+    duration,
+    easing,
+  };
+};
+
+export const whitespaceExitAtom = ({
+  orientation,
+  duration,
+  easing,
+  delay = 0,
+}: {
+  orientation: CollapseOrientation;
+  duration: number;
+  easing: string;
+  delay?: number;
+}): AtomMotion => {
+  const { paddingStart, paddingEnd } = whitespaceValuesForOrientation(orientation);
+  return {
+    keyframes: [{ [paddingStart]: '0', [paddingEnd]: '0', offset: 1 }],
+    duration,
+    easing,
+    fill: 'forwards',
+    delay,
+  };
+};
+
+// ----- OPACITY -----
+
+export const opacityEnterAtom = ({
+  duration,
+  easing,
+  delay = 0,
+  fromOpacity = 0,
+  toOpacity = 1,
+}: {
+  duration: number;
+  easing: string;
+  delay?: number;
+  fromOpacity?: number;
+  toOpacity?: number;
+}): AtomMotion => ({
+  keyframes: [{ opacity: fromOpacity }, { opacity: toOpacity }],
+  duration,
+  easing,
+  delay,
+  fill: 'both',
+});
+
+export const opacityExitAtom = ({
+  duration,
+  easing,
+  fromOpacity = 0,
+  toOpacity = 1,
+}: {
+  duration: number;
+  easing: string;
+  fromOpacity?: number;
+  toOpacity?: number;
+}): AtomMotion => ({
+  keyframes: [{ opacity: toOpacity }, { opacity: fromOpacity }],
+  duration,
+  easing,
+});

--- a/packages/react-components/react-motion-components-preview/library/src/components/Collapse/collapse-types.ts
+++ b/packages/react-components/react-motion-components-preview/library/src/components/Collapse/collapse-types.ts
@@ -1,0 +1,50 @@
+export type CollapseOrientation = 'horizontal' | 'vertical';
+
+// TODO: reduce duplication between CollapseDelayedVariantParams and CollapseVariantParams
+export type CollapseDelayedVariantParams = {
+  /** Time (ms) for the size expand. Defaults to the durationNormal value (200 ms). */
+  enterSizeDuration?: number;
+
+  /** Time (ms) for the fade-in. Defaults to the enterSizeDuration param, to sync fade-in with expand. */
+  enterOpacityDuration?: number;
+
+  /** Time (ms) for the size collapse. Defaults to the enterSizeDuration param, for temporal symmetry.. */
+  exitSizeDuration?: number;
+
+  /** Defaults to the exitSizeDuration param, to sync the fade-out with the collapse. */
+  exitOpacityDuration?: number;
+
+  /** Time (ms) between the size expand start and the fade-in start. Defaults to `0`.  */
+  enterDelay?: number;
+
+  /** Time (ms) between the fade-out start and the size collapse start. Defaults to `0`.  */
+  exitDelay?: number;
+
+  /** Easing curve for the enter transition, shared by size and opacity. Defaults to the easeEaseMax value.  */
+  enterEasing?: string;
+
+  /** Easing curve for the exit transition, shared by size and opacity. Defaults to the enterEasing param. */
+  exitEasing?: string;
+};
+
+export type CollapseRuntimeParams = {
+  /** Whether to animate the opacity. Defaults to `true`. */
+  animateOpacity?: boolean;
+
+  /** The orientation of the size animation. Defaults to `'vertical'` to expand/collapse the height. */
+  orientation?: CollapseOrientation;
+};
+
+export type CollapseVariantParams = {
+  /** Time (ms) for the enter transition (expand). Defaults to the `durationNormal` value (200 ms). */
+  enterDuration?: number;
+
+  /** Easing curve for the enter transition (expand). Defaults to the `easeEaseMax` value.  */
+  enterEasing?: string;
+
+  /** Time (ms) for the exit transition (collapse). Defaults to the `enterDuration` param for symmetry. */
+  exitDuration?: number;
+
+  /** Easing curve for the exit transition (collapse). Defaults to the `enterEasing` param for symmetry.  */
+  exitEasing?: string;
+};

--- a/packages/react-components/react-motion-components-preview/library/src/index.ts
+++ b/packages/react-components/react-motion-components-preview/library/src/index.ts
@@ -1,3 +1,10 @@
-export { Collapse, CollapseSnappy, CollapseExaggerated, createCollapsePresence } from './components/Collapse';
+export {
+  Collapse,
+  CollapseSnappy,
+  CollapseExaggerated,
+  CollapseDelayed,
+  createCollapsePresence,
+  createCollapseDelayedPresence,
+} from './components/Collapse';
 export { Fade, FadeSnappy, FadeExaggerated } from './components/Fade';
 export { Scale, ScaleSnappy, ScaleExaggerated } from './components/Scale';

--- a/packages/react-components/react-motion-components-preview/stories/src/Collapse/CollapseDelayed.stories.md
+++ b/packages/react-components/react-motion-components-preview/stories/src/Collapse/CollapseDelayed.stories.md
@@ -1,0 +1,1 @@
+The `CollapseDelayed` variant has a delay between the size and opacity animations.

--- a/packages/react-components/react-motion-components-preview/stories/src/Collapse/CollapseDelayed.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Collapse/CollapseDelayed.stories.tsx
@@ -1,0 +1,67 @@
+import { Field, makeStyles, tokens, Switch } from '@fluentui/react-components';
+import { CollapseDelayed } from '@fluentui/react-motion-components-preview';
+import * as React from 'react';
+
+import description from './CollapseDelayed.stories.md';
+
+const useClasses = makeStyles({
+  container: {
+    display: 'grid',
+    gridTemplate: `"controls ." "card card" / 1fr 1fr`,
+    gap: '20px 10px',
+  },
+  card: {
+    gridArea: 'card',
+    padding: '10px',
+  },
+  controls: {
+    display: 'flex',
+    flexDirection: 'column',
+    gridArea: 'controls',
+
+    border: `${tokens.strokeWidthThicker} solid ${tokens.colorNeutralForeground3}`,
+    borderRadius: tokens.borderRadiusMedium,
+    boxShadow: tokens.shadow16,
+    padding: '10px',
+  },
+  field: {
+    flex: 1,
+  },
+});
+
+const LoremIpsum = () => (
+  <>
+    {'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. '.repeat(
+      10,
+    )}
+  </>
+);
+
+export const Delayed = () => {
+  const classes = useClasses();
+  const [visible, setVisible] = React.useState<boolean>(false);
+
+  return (
+    <div className={classes.container}>
+      <div className={classes.controls}>
+        <Field className={classes.field}>
+          <Switch label="Visible" checked={visible} onChange={() => setVisible(v => !v)} />
+        </Field>
+      </div>
+
+      <CollapseDelayed visible={visible}>
+        <div className={classes.card}>
+          <LoremIpsum />
+        </div>
+      </CollapseDelayed>
+    </div>
+  );
+};
+
+Delayed.parameters = {
+  docs: {
+    description: {
+      story: description,
+    },
+  },
+};

--- a/packages/react-components/react-motion-components-preview/stories/src/Collapse/index.stories.ts
+++ b/packages/react-components/react-motion-components-preview/stories/src/Collapse/index.stories.ts
@@ -6,6 +6,7 @@ export { Horizontal } from './CollapseHorizontal.stories';
 export { Snappy } from './CollapseSnappy.stories';
 export { Exaggerated } from './CollapseExaggerated.stories';
 export { Customization } from './CollapseCustomization.stories';
+export { Delayed } from './CollapseDelayed.stories';
 
 export default {
   title: 'Motion/Components (preview)/Collapse',


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

- `Collapse` animates size (height or width) and opacity in sync: they start together and have the same duration.

## New Behavior

- `CollapseDelayed` is a new variant that animates size and opacity separately: 
  - Enter: size expands immediately, while the fade-in starts after a delay. 
  - Exit: fade-out first, then size collapses after a delay.
 
##  Documentation
- Added a `CollapseDelayed` example in Storybook.

## Refactoring
- Extracted `Collapse` motion atom objects to reusable factory functions and moved them to a separate file.
- Moved `Collapse` types to a separate file as well.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #33068 
