### PR TITLE
chore: migrate v9 and tools to nx inferred tasks

### DIFF
--- a/change/@fluentui-babel-preset-global-context-be7bd550-e553-4a5f-9aa9-50399a752c06.json
+++ b/change/@fluentui-babel-preset-global-context-be7bd550-e553-4a5f-9aa9-50399a752c06.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/babel-preset-global-context",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-eslint-plugin-4ae85fd9-5899-48d8-8e78-f34c47eb28fd.json
+++ b/change/@fluentui-eslint-plugin-4ae85fd9-5899-48d8-8e78-f34c47eb28fd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/eslint-plugin",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-global-context-3e3d8e33-972f-4ccf-84de-ecaf80d8735b.json
+++ b/change/@fluentui-global-context-3e3d8e33-972f-4ccf-84de-ecaf80d8735b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/global-context",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-keyboard-keys-bdbb54d9-c744-48a1-bee2-8e2aa70fe7cb.json
+++ b/change/@fluentui-keyboard-keys-bdbb54d9-c744-48a1-bee2-8e2aa70fe7cb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/keyboard-keys",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-priority-overflow-220fbe91-1e4c-493f-a757-e37bf5635a92.json
+++ b/change/@fluentui-priority-overflow-220fbe91-1e4c-493f-a757-e37bf5635a92.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/priority-overflow",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-accordion-2ebfffa9-907d-4853-9437-570030b2fc04.json
+++ b/change/@fluentui-react-accordion-2ebfffa9-907d-4853-9437-570030b2fc04.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-accordion",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-aria-4e0b8fc2-56a2-4358-bbf2-e72924f237be.json
+++ b/change/@fluentui-react-aria-4e0b8fc2-56a2-4358-bbf2-e72924f237be.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-aria",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-avatar-00c1eac8-3841-4672-b186-42526685bfc6.json
+++ b/change/@fluentui-react-avatar-00c1eac8-3841-4672-b186-42526685bfc6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-avatar",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-badge-9df42d69-c96e-47ca-9cfd-21b0b73921ba.json
+++ b/change/@fluentui-react-badge-9df42d69-c96e-47ca-9cfd-21b0b73921ba.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-badge",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-breadcrumb-81a620ea-ef5d-4a3f-a651-a55f6a71cb9c.json
+++ b/change/@fluentui-react-breadcrumb-81a620ea-ef5d-4a3f-a651-a55f6a71cb9c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-breadcrumb",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-button-8d341ad0-18b5-408d-b618-5a8ed35eee0f.json
+++ b/change/@fluentui-react-button-8d341ad0-18b5-408d-b618-5a8ed35eee0f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-button",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-calendar-compat-2f6062c2-2b44-4aef-a03c-8bab115c183b.json
+++ b/change/@fluentui-react-calendar-compat-2f6062c2-2b44-4aef-a03c-8bab115c183b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-calendar-compat",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-card-09b69e5e-21be-4879-8499-ed6d60c41f21.json
+++ b/change/@fluentui-react-card-09b69e5e-21be-4879-8499-ed6d60c41f21.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-card",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-carousel-a84c4a01-f21a-41db-9d31-2d60928bf31e.json
+++ b/change/@fluentui-react-carousel-a84c4a01-f21a-41db-9d31-2d60928bf31e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-carousel",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-carousel-preview-23a76a75-878c-485b-89c5-0677ca5831c3.json
+++ b/change/@fluentui-react-carousel-preview-23a76a75-878c-485b-89c5-0677ca5831c3.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "fix: Handle LTR for CarouselButton icons",
-  "packageName": "@fluentui/react-carousel-preview",
-  "email": "mifraser@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@fluentui-react-carousel-preview-e1d97696-5a68-4c35-ada2-ab65c5deedb5.json
+++ b/change/@fluentui-react-carousel-preview-e1d97696-5a68-4c35-ada2-ab65c5deedb5.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Breaking Preview Change: Set Announcer to drive inner text directly from event, remove state causing unnecessary updates",
-  "packageName": "@fluentui/react-carousel-preview",
-  "email": "mifraser@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@fluentui-react-checkbox-bc2386ad-3009-4fda-a185-aa64cf180a25.json
+++ b/change/@fluentui-react-checkbox-bc2386ad-3009-4fda-a185-aa64cf180a25.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-combobox-e22e370e-8cca-4cf5-9bc0-bbc06388b470.json
+++ b/change/@fluentui-react-combobox-e22e370e-8cca-4cf5-9bc0-bbc06388b470.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-combobox",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-components-43eb1e2e-455d-4c1e-93b1-24dee5ebfd6f.json
+++ b/change/@fluentui-react-components-43eb1e2e-455d-4c1e-93b1-24dee5ebfd6f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-components",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-conformance-75f77571-9f00-43cf-97d1-0961c05e730a.json
+++ b/change/@fluentui-react-conformance-75f77571-9f00-43cf-97d1-0961c05e730a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-conformance",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-conformance-griffel-4018b4df-8a8f-4d1d-aca6-f4e6bbf4c18e.json
+++ b/change/@fluentui-react-conformance-griffel-4018b4df-8a8f-4d1d-aca6-f4e6bbf4c18e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-conformance-griffel",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-context-selector-3dc99098-a9e9-4e40-9678-c6084dff86d9.json
+++ b/change/@fluentui-react-context-selector-3dc99098-a9e9-4e40-9678-c6084dff86d9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-context-selector",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-datepicker-compat-142f79a8-47c9-4faa-bb69-efdc8bf9bcfc.json
+++ b/change/@fluentui-react-datepicker-compat-142f79a8-47c9-4faa-bb69-efdc8bf9bcfc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-datepicker-compat",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-dialog-b9081838-9f31-4f02-9334-9b87e7d804d4.json
+++ b/change/@fluentui-react-dialog-b9081838-9f31-4f02-9334-9b87e7d804d4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-dialog",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-divider-e7e0b812-b3cf-4662-a004-b81a0527fd84.json
+++ b/change/@fluentui-react-divider-e7e0b812-b3cf-4662-a004-b81a0527fd84.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-divider",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-drawer-fac2422d-3e65-444e-9353-2a9ef60fca54.json
+++ b/change/@fluentui-react-drawer-fac2422d-3e65-444e-9353-2a9ef60fca54.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-drawer",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-field-bc502849-66b3-4308-a29c-c0eaf5cd0282.json
+++ b/change/@fluentui-react-field-bc502849-66b3-4308-a29c-c0eaf5cd0282.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-field",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-icons-compat-3eedbc41-5d0e-435e-966f-02b216faabf8.json
+++ b/change/@fluentui-react-icons-compat-3eedbc41-5d0e-435e-966f-02b216faabf8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-icons-compat",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-image-ceaa6d3b-c5db-43a8-8269-0f72444791a3.json
+++ b/change/@fluentui-react-image-ceaa6d3b-c5db-43a8-8269-0f72444791a3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-image",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-infolabel-f97a60ac-1548-4c50-9ead-83697782a60b.json
+++ b/change/@fluentui-react-infolabel-f97a60ac-1548-4c50-9ead-83697782a60b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-infolabel",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-input-2c3b763e-6c50-467c-829e-5c12f383dfe3.json
+++ b/change/@fluentui-react-input-2c3b763e-6c50-467c-829e-5c12f383dfe3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-input",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-jsx-runtime-bb038512-ff6c-48bf-a52d-68ecff992f7f.json
+++ b/change/@fluentui-react-jsx-runtime-bb038512-ff6c-48bf-a52d-68ecff992f7f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-jsx-runtime",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-label-26142382-0b85-40f2-ab28-5e1d7162e7fb.json
+++ b/change/@fluentui-react-label-26142382-0b85-40f2-ab28-5e1d7162e7fb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-label",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-link-a8217c08-3399-4794-bc4b-6e753077338d.json
+++ b/change/@fluentui-react-link-a8217c08-3399-4794-bc4b-6e753077338d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-link",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-list-preview-f41467fe-7846-4f38-9713-f9ed2935b95f.json
+++ b/change/@fluentui-react-list-preview-f41467fe-7846-4f38-9713-f9ed2935b95f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-list-preview",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-menu-fba974c4-d16d-49cc-ae16-963e8dfcef62.json
+++ b/change/@fluentui-react-menu-fba974c4-d16d-49cc-ae16-963e8dfcef62.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-menu",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-message-bar-f318ef3f-94c3-4c92-a824-1c74e5a49b0d.json
+++ b/change/@fluentui-react-message-bar-f318ef3f-94c3-4c92-a824-1c74e5a49b0d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-message-bar",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-migration-v0-v9-daa93382-ed02-435b-93fb-853a9785eb22.json
+++ b/change/@fluentui-react-migration-v0-v9-daa93382-ed02-435b-93fb-853a9785eb22.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-migration-v0-v9",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-migration-v8-v9-20b47d45-1e86-4519-8cd2-79188d333096.json
+++ b/change/@fluentui-react-migration-v8-v9-20b47d45-1e86-4519-8cd2-79188d333096.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-migration-v8-v9",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-motion-31c5a63f-5ae7-4822-be57-2da9d757f29b.json
+++ b/change/@fluentui-react-motion-31c5a63f-5ae7-4822-be57-2da9d757f29b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-motion",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-motion-components-preview-dd70ef3c-9f5d-4704-863d-0e3a69d051f2.json
+++ b/change/@fluentui-react-motion-components-preview-dd70ef3c-9f5d-4704-863d-0e3a69d051f2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-motion-components-preview",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-nav-preview-736525ef-84b6-4aa8-9487-222ce778c09a.json
+++ b/change/@fluentui-react-nav-preview-736525ef-84b6-4aa8-9487-222ce778c09a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-nav-preview",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-overflow-5da3fc0b-4e0e-47f6-a763-6931f309420c.json
+++ b/change/@fluentui-react-overflow-5da3fc0b-4e0e-47f6-a763-6931f309420c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-overflow",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-persona-e6ac8ca4-de62-40c1-bc0c-c84fb7af49ca.json
+++ b/change/@fluentui-react-persona-e6ac8ca4-de62-40c1-bc0c-c84fb7af49ca.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-persona",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-popover-3b74e9c5-3229-4c1e-ab68-2c520020b4ef.json
+++ b/change/@fluentui-react-popover-3b74e9c5-3229-4c1e-ab68-2c520020b4ef.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-popover",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-portal-2440644b-5b8f-46aa-b132-544118efc361.json
+++ b/change/@fluentui-react-portal-2440644b-5b8f-46aa-b132-544118efc361.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-portal",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-portal-compat-4e4ef06e-be85-40f0-8c8b-682c286f642f.json
+++ b/change/@fluentui-react-portal-compat-4e4ef06e-be85-40f0-8c8b-682c286f642f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-portal-compat",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-portal-compat-context-50128cbf-48de-448e-b3e7-c5a5f7da3a29.json
+++ b/change/@fluentui-react-portal-compat-context-50128cbf-48de-448e-b3e7-c5a5f7da3a29.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-portal-compat-context",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-positioning-d3827f64-1a29-463a-92cd-71ae211b4d3a.json
+++ b/change/@fluentui-react-positioning-d3827f64-1a29-463a-92cd-71ae211b4d3a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-positioning",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-progress-a6da0ff6-ea7f-4c24-9a81-46b9fe4fb396.json
+++ b/change/@fluentui-react-progress-a6da0ff6-ea7f-4c24-9a81-46b9fe4fb396.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-progress",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-provider-da364738-f300-4aaa-8db0-cf9bfc536de9.json
+++ b/change/@fluentui-react-provider-da364738-f300-4aaa-8db0-cf9bfc536de9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-provider",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-radio-476e9978-e0cf-4dd6-b019-133d26bdc90b.json
+++ b/change/@fluentui-react-radio-476e9978-e0cf-4dd6-b019-133d26bdc90b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-radio",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-rating-02e1508a-b053-4b1a-b91e-388ff3b0a174.json
+++ b/change/@fluentui-react-rating-02e1508a-b053-4b1a-b91e-388ff3b0a174.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-rating",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-search-f596067c-1848-4b54-838d-bfd75fc0895a.json
+++ b/change/@fluentui-react-search-f596067c-1848-4b54-838d-bfd75fc0895a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-search",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-select-fe513681-4eab-4e83-921e-9484ed87538c.json
+++ b/change/@fluentui-react-select-fe513681-4eab-4e83-921e-9484ed87538c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-select",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-shared-contexts-b5e90940-d204-4e52-af41-7a09bb9d628a.json
+++ b/change/@fluentui-react-shared-contexts-b5e90940-d204-4e52-af41-7a09bb9d628a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-shared-contexts",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-skeleton-94d5644a-448a-48ac-84e9-0499321e1eee.json
+++ b/change/@fluentui-react-skeleton-94d5644a-448a-48ac-84e9-0499321e1eee.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-skeleton",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-slider-8d5bd435-8282-4c16-90f6-0ab83f76863e.json
+++ b/change/@fluentui-react-slider-8d5bd435-8282-4c16-90f6-0ab83f76863e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-slider",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-spinbutton-3f0cd67d-a4f4-448f-b6a1-04026fbab9af.json
+++ b/change/@fluentui-react-spinbutton-3f0cd67d-a4f4-448f-b6a1-04026fbab9af.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-spinbutton",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-spinner-ed594ded-e941-49b9-9e3b-c0e7f2be0a2e.json
+++ b/change/@fluentui-react-spinner-ed594ded-e941-49b9-9e3b-c0e7f2be0a2e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-spinner",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-swatch-picker-61cf349a-6a9e-4474-9908-ec9e524af775.json
+++ b/change/@fluentui-react-swatch-picker-61cf349a-6a9e-4474-9908-ec9e524af775.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-swatch-picker",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-switch-bb616a2f-5ebb-41c1-bf54-4646455a7c2f.json
+++ b/change/@fluentui-react-switch-bb616a2f-5ebb-41c1-bf54-4646455a7c2f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-switch",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-table-5c4b17c7-922d-4f1f-b053-e4b72119aff8.json
+++ b/change/@fluentui-react-table-5c4b17c7-922d-4f1f-b053-e4b72119aff8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-table",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tabs-d482dbb7-5a04-4639-8d12-47bbbc26ef9e.json
+++ b/change/@fluentui-react-tabs-d482dbb7-5a04-4639-8d12-47bbbc26ef9e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-tabs",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tabster-bc1b5f9c-28cb-48e9-9ae0-8ef0c8f7b322.json
+++ b/change/@fluentui-react-tabster-bc1b5f9c-28cb-48e9-9ae0-8ef0c8f7b322.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-tabster",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tag-picker-847fc350-7b82-462f-8704-aa548e9dc430.json
+++ b/change/@fluentui-react-tag-picker-847fc350-7b82-462f-8704-aa548e9dc430.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-tag-picker",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tags-e1088f4c-87b2-4288-a6c9-efbffcecb2a8.json
+++ b/change/@fluentui-react-tags-e1088f4c-87b2-4288-a6c9-efbffcecb2a8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-tags",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-teaching-popover-9c0cab0e-4f75-466d-ac43-267283505e17.json
+++ b/change/@fluentui-react-teaching-popover-9c0cab0e-4f75-466d-ac43-267283505e17.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-teaching-popover",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-text-6d0f7a2c-4d6a-4e64-82a6-ecb24b9bb88c.json
+++ b/change/@fluentui-react-text-6d0f7a2c-4d6a-4e64-82a6-ecb24b9bb88c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-text",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-textarea-46bd0926-fd92-41c9-bddf-64c6ca0010dc.json
+++ b/change/@fluentui-react-textarea-46bd0926-fd92-41c9-bddf-64c6ca0010dc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-textarea",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-theme-abea04fe-59c3-4cfa-8acb-dd12f811980e.json
+++ b/change/@fluentui-react-theme-abea04fe-59c3-4cfa-8acb-dd12f811980e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-theme",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-theme-sass-2751df59-7de3-4ada-839a-627244282e79.json
+++ b/change/@fluentui-react-theme-sass-2751df59-7de3-4ada-839a-627244282e79.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-theme-sass",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-timepicker-compat-2614113e-4c65-4294-874e-ab825c0b779c.json
+++ b/change/@fluentui-react-timepicker-compat-2614113e-4c65-4294-874e-ab825c0b779c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-timepicker-compat",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-toast-aa30b909-34e6-4a31-aea0-ce257ce9ae36.json
+++ b/change/@fluentui-react-toast-aa30b909-34e6-4a31-aea0-ce257ce9ae36.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-toast",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-toolbar-dafb90bd-b539-444e-beaa-d2a509e0c8b8.json
+++ b/change/@fluentui-react-toolbar-dafb90bd-b539-444e-beaa-d2a509e0c8b8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-toolbar",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tooltip-79a824fe-88e5-49ea-8fe8-76993486cb6b.json
+++ b/change/@fluentui-react-tooltip-79a824fe-88e5-49ea-8fe8-76993486cb6b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tree-0df7aa66-4a4c-4123-af39-ed3dba0fbaa1.json
+++ b/change/@fluentui-react-tree-0df7aa66-4a4c-4123-af39-ed3dba0fbaa1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-tree",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-utilities-c1fc3524-20f5-4ab5-9b7c-43776cc179dd.json
+++ b/change/@fluentui-react-utilities-c1fc3524-20f5-4ab5-9b7c-43776cc179dd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-utilities",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-virtualizer-bb9b8d66-d28d-4bab-a972-f102ef38085f.json
+++ b/change/@fluentui-react-virtualizer-bb9b8d66-d28d-4bab-a972-f102ef38085f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/react-virtualizer",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-tokens-dd714959-9f38-408a-84df-1a078a3ad75a.json
+++ b/change/@fluentui-tokens-dd714959-9f38-408a-84df-1a078a3ad75a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: replace npm-scripts and just-scrtips with nx inferred tasks",
+  "packageName": "@fluentui/tokens",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/nx.json
+++ b/nx.json
@@ -138,7 +138,14 @@
   "plugins": [
     {
       "plugin": "./tools/workspace-plugin/src/plugins/workspace-plugin.ts",
-      "options": {},
+      "options": {
+        "testSSR": {
+          "exclude": ["react-theme-stories", "react-migration-v8-v9-stories", "react-migration-v0-v9-stories"]
+        },
+        "verifyPackaging": {
+          "include": ["react-text", "react-components"]
+        }
+      },
       "include": [
         "tools/**/*",
         "scripts/**/*",

--- a/nx.json
+++ b/nx.json
@@ -137,18 +137,16 @@
   "defaultBase": "master",
   "plugins": [
     {
-      "plugin": "@nx/jest/plugin",
-      "options": {
-        "targetName": "test"
-      },
-      "include": ["tools/**/*", "scripts/**/*"]
-    },
-    {
-      "plugin": "@nx/eslint/plugin",
-      "options": {
-        "targetName": "lint"
-      },
-      "include": ["tools/**/*", "scripts/**/*"]
+      "plugin": "./tools/workspace-plugin/src/plugins/workspace-plugin.ts",
+      "options": {},
+      "include": [
+        "tools/**/*",
+        "scripts/**/*",
+        "packages/eslint-plugin/**",
+        "packages/tokens/**",
+        "packages/react-conformance/**",
+        "packages/react-components/**/*"
+      ]
     }
   ]
 }

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -8,11 +8,6 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "type-check": "tsc --noEmit",
-    "lint": "eslint --ext .js,.ts --cache ./src",
-    "test": "yarn jest --passWithNoTests"
-  },
   "dependencies": {
     "@griffel/eslint-plugin": "^1.6.4",
     "@rnx-kit/eslint-plugin": "^0.8.2",

--- a/packages/react-components/babel-preset-global-context/just.config.ts
+++ b/packages/react-components/babel-preset-global-context/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/babel-preset-global-context/package.json
+++ b/packages/react-components/babel-preset-global-context/package.json
@@ -9,24 +9,10 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build --module cjs",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "e2e": "cypress run --component",
-    "e2e:local": "cypress open --component",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "test": "jest --passWithNoTests",
-    "type-check": "tsc -b tsconfig.json",
-    "generate-api": "just-scripts generate-api",
-    "test-ssr": "test-ssr \"./stories/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-cypress": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-cypress": "*"
   },
   "dependencies": {
     "@babel/core": "^7.10.4",

--- a/packages/react-components/babel-preset-storybook-full-source/just.config.ts
+++ b/packages/react-components/babel-preset-storybook-full-source/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/babel-preset-storybook-full-source/package.json
+++ b/packages/react-components/babel-preset-storybook-full-source/package.json
@@ -10,20 +10,9 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build --module cjs",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "test": "jest --passWithNoTests",
-    "type-check": "tsc -b tsconfig.json",
-    "generate-api": "just-scripts generate-api"
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@babel/core": "^7.10.4",

--- a/packages/react-components/global-context/just.config.ts
+++ b/packages/react-components/global-context/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/global-context/package.json
+++ b/packages/react-components/global-context/package.json
@@ -11,25 +11,10 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "bundle-size": "monosize measure",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "e2e": "cypress run --component",
-    "e2e:local": "cypress open --component",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "test": "jest --passWithNoTests",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api",
-    "test-ssr": "test-ssr \"./stories/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-cypress": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-cypress": "*"
   },
   "dependencies": {
     "@fluentui/react-context-selector": "^9.1.68",

--- a/packages/react-components/keyboard-keys/just.config.ts
+++ b/packages/react-components/keyboard-keys/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/keyboard-keys/package.json
+++ b/packages/react-components/keyboard-keys/package.json
@@ -11,21 +11,9 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "test": "jest --passWithNoTests",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api",
-    "test-ssr": "test-ssr \"./stories/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@swc/helpers": "^0.5.1"

--- a/packages/react-components/priority-overflow/just.config.ts
+++ b/packages/react-components/priority-overflow/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/priority-overflow/package.json
+++ b/packages/react-components/priority-overflow/package.json
@@ -11,22 +11,9 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "bundle-size": "monosize measure",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "test": "jest --passWithNoTests",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api",
-    "test-ssr": "test-ssr \"./stories/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@swc/helpers": "^0.5.1"

--- a/packages/react-components/react-accordion/library/just.config.ts
+++ b/packages/react-components/react-accordion/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-accordion/library/package.json
+++ b/packages/react-components/react-accordion/library/package.json
@@ -11,25 +11,11 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "bundle-size": "monosize measure",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "start": "yarn storybook",
-    "test": "jest --passWithNoTests",
-    "storybook": "yarn --cwd ../stories storybook",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api"
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@fluentui/react-aria": "^9.13.8",

--- a/packages/react-components/react-accordion/stories/just.config.ts
+++ b/packages/react-components/react-accordion/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-accordion/stories/package.json
+++ b/packages/react-components/react-accordion/stories/package.json
@@ -2,20 +2,11 @@
   "name": "@fluentui/react-accordion-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-aria/library/just.config.ts
+++ b/packages/react-components/react-aria/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-aria/library/package.json
+++ b/packages/react-components/react-aria/library/package.json
@@ -11,25 +11,10 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "e2e": "cypress run --component",
-    "e2e:local": "cypress open --component",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "start": "yarn storybook",
-    "test": "jest --passWithNoTests",
-    "storybook": "yarn --cwd ../stories storybook",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api"
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*",
     "@fluentui/scripts-cypress": "*"
   },
   "dependencies": {

--- a/packages/react-components/react-aria/stories/just.config.ts
+++ b/packages/react-components/react-aria/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-aria/stories/package.json
+++ b/packages/react-components/react-aria/stories/package.json
@@ -2,20 +2,11 @@
   "name": "@fluentui/react-aria-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-avatar/library/just.config.ts
+++ b/packages/react-components/react-avatar/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-avatar/library/package.json
+++ b/packages/react-components/react-avatar/library/package.json
@@ -11,21 +11,6 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "bundle-size": "monosize measure",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "start": "yarn storybook",
-    "e2e": "cypress run --component",
-    "e2e:local": "cypress open --component",
-    "test": "jest --passWithNoTests",
-    "storybook": "yarn --cwd ../stories storybook",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api"
-  },
   "devDependencies": {
     "@fluentui/react-provider": "*",
     "@fluentui/eslint-plugin": "*",
@@ -33,8 +18,7 @@
     "@fluentui/react-conformance-griffel": "*",
     "es6-weak-map": "^2.0.2",
     "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-cypress": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-cypress": "*"
   },
   "dependencies": {
     "@fluentui/react-badge": "^9.2.44",

--- a/packages/react-components/react-avatar/stories/just.config.ts
+++ b/packages/react-components/react-avatar/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-avatar/stories/package.json
+++ b/packages/react-components/react-avatar/stories/package.json
@@ -2,20 +2,11 @@
   "name": "@fluentui/react-avatar-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-badge/library/just.config.ts
+++ b/packages/react-components/react-badge/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-badge/library/package.json
+++ b/packages/react-components/react-badge/library/package.json
@@ -11,25 +11,11 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "bundle-size": "monosize measure",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "start": "yarn storybook",
-    "test": "jest --passWithNoTests",
-    "storybook": "yarn --cwd ../stories storybook",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api"
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@fluentui/react-icons": "^2.0.245",

--- a/packages/react-components/react-badge/stories/just.config.ts
+++ b/packages/react-components/react-badge/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-badge/stories/package.json
+++ b/packages/react-components/react-badge/stories/package.json
@@ -2,20 +2,11 @@
   "name": "@fluentui/react-badge-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-breadcrumb/library/just.config.ts
+++ b/packages/react-components/react-breadcrumb/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-breadcrumb/library/package.json
+++ b/packages/react-components/react-breadcrumb/library/package.json
@@ -11,21 +11,6 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "e2e": "cypress run --component",
-    "e2e:local": "cypress open --component",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "test": "jest --passWithNoTests",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api",
-    "storybook": "yarn --cwd ../stories storybook",
-    "start": "yarn storybook",
-    "bundle-size": "monosize measure"
-  },
   "devDependencies": {
     "@fluentui/react-provider": "*",
     "@fluentui/react-menu": "*",
@@ -34,8 +19,7 @@
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
     "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-cypress": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-cypress": "*"
   },
   "dependencies": {
     "@fluentui/react-aria": "^9.13.8",

--- a/packages/react-components/react-breadcrumb/stories/just.config.ts
+++ b/packages/react-components/react-breadcrumb/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-breadcrumb/stories/package.json
+++ b/packages/react-components/react-breadcrumb/stories/package.json
@@ -2,20 +2,11 @@
   "name": "@fluentui/react-breadcrumb-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-button/library/just.config.ts
+++ b/packages/react-components/react-button/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-button/library/package.json
+++ b/packages/react-components/react-button/library/package.json
@@ -11,26 +11,12 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "bundle-size": "monosize measure",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "start": "yarn storybook",
-    "test": "jest --passWithNoTests",
-    "storybook": "yarn --cwd ../stories storybook",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api"
-  },
   "devDependencies": {
     "@fluentui/a11y-testing": "*",
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@fluentui/keyboard-keys": "^9.0.7",

--- a/packages/react-components/react-button/stories/just.config.ts
+++ b/packages/react-components/react-button/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-button/stories/package.json
+++ b/packages/react-components/react-button/stories/package.json
@@ -2,21 +2,12 @@
   "name": "@fluentui/react-button-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-utilities": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-calendar-compat/library/just.config.ts
+++ b/packages/react-components/react-calendar-compat/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-calendar-compat/library/package.json
+++ b/packages/react-components/react-calendar-compat/library/package.json
@@ -11,23 +11,11 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "bundle-size": "monosize measure",
-    "clean": "just-scripts clean",
-    "generate-api": "just-scripts generate-api",
-    "lint": "just-scripts lint",
-    "start": "yarn storybook",
-    "storybook": "yarn --cwd ../stories storybook",
-    "test": "jest --passWithNoTests",
-    "type-check": "just-scripts type-check"
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@fluentui/keyboard-keys": "^9.0.7",

--- a/packages/react-components/react-calendar-compat/stories/just.config.ts
+++ b/packages/react-components/react-calendar-compat/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-calendar-compat/stories/package.json
+++ b/packages/react-components/react-calendar-compat/stories/package.json
@@ -2,21 +2,12 @@
   "name": "@fluentui/react-calendar-compat-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-calendar-compat": "*",
     "@fluentui/react-components": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-card/library/just.config.ts
+++ b/packages/react-components/react-card/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-card/library/package.json
+++ b/packages/react-components/react-card/library/package.json
@@ -12,21 +12,6 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "bundle-size": "monosize measure",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "e2e": "cypress run --component",
-    "e2e:local": "cypress open --component",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "start": "yarn storybook",
-    "test": "jest --passWithNoTests",
-    "storybook": "yarn --cwd ../stories storybook",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api"
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-button": "*",
@@ -34,8 +19,7 @@
     "@fluentui/react-conformance": "*",
     "@fluentui/react-provider": "*",
     "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-cypress": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-cypress": "*"
   },
   "dependencies": {
     "@fluentui/keyboard-keys": "^9.0.7",

--- a/packages/react-components/react-card/stories/just.config.ts
+++ b/packages/react-components/react-card/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-card/stories/package.json
+++ b/packages/react-components/react-card/stories/package.json
@@ -2,20 +2,11 @@
   "name": "@fluentui/react-card-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-carousel/library/just.config.ts
+++ b/packages/react-components/react-carousel/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-carousel/library/package.json
+++ b/packages/react-components/react-carousel/library/package.json
@@ -17,22 +17,11 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "clean": "just-scripts clean",
-    "generate-api": "just-scripts generate-api",
-    "lint": "just-scripts lint",
-    "start": "yarn storybook",
-    "storybook": "yarn --cwd ../stories storybook",
-    "test": "jest --passWithNoTests",
-    "type-check": "just-scripts type-check"
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@fluentui/react-aria": "^9.13.8",

--- a/packages/react-components/react-carousel/stories/just.config.ts
+++ b/packages/react-components/react-carousel/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-carousel/stories/package.json
+++ b/packages/react-components/react-carousel/stories/package.json
@@ -2,20 +2,11 @@
   "name": "@fluentui/react-carousel-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-checkbox/library/just.config.ts
+++ b/packages/react-components/react-checkbox/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-checkbox/library/package.json
+++ b/packages/react-components/react-checkbox/library/package.json
@@ -11,25 +11,11 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "bundle-size": "monosize measure",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "start": "yarn storybook",
-    "test": "jest --passWithNoTests",
-    "storybook": "yarn --cwd ../stories storybook",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api"
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@fluentui/react-field": "^9.1.78",

--- a/packages/react-components/react-checkbox/stories/just.config.ts
+++ b/packages/react-components/react-checkbox/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-checkbox/stories/package.json
+++ b/packages/react-components/react-checkbox/stories/package.json
@@ -2,20 +2,11 @@
   "name": "@fluentui/react-checkbox-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-color-picker-preview/library/just.config.ts
+++ b/packages/react-components/react-color-picker-preview/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-color-picker-preview/library/package.json
+++ b/packages/react-components/react-color-picker-preview/library/package.json
@@ -18,22 +18,11 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "clean": "just-scripts clean",
-    "generate-api": "just-scripts generate-api",
-    "lint": "just-scripts lint",
-    "start": "yarn storybook",
-    "storybook": "yarn --cwd ../stories storybook",
-    "test": "jest --passWithNoTests",
-    "type-check": "just-scripts type-check"
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@ctrl/tinycolor": "3.3.4",

--- a/packages/react-components/react-color-picker-preview/stories/just.config.ts
+++ b/packages/react-components/react-color-picker-preview/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-color-picker-preview/stories/package.json
+++ b/packages/react-components/react-color-picker-preview/stories/package.json
@@ -2,21 +2,12 @@
   "name": "@fluentui/react-color-picker-preview-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-color-picker-preview": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-colorpicker-compat/just.config.ts
+++ b/packages/react-components/react-colorpicker-compat/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-colorpicker-compat/package.json
+++ b/packages/react-components/react-colorpicker-compat/package.json
@@ -12,23 +12,11 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "test": "jest --passWithNoTests",
-    "test-ssr": "test-ssr \"./stories/**/*.stories.tsx\"",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api"
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@fluentui/react-jsx-runtime": "^9.0.45",

--- a/packages/react-components/react-combobox/library/just.config.ts
+++ b/packages/react-components/react-combobox/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-combobox/library/package.json
+++ b/packages/react-components/react-combobox/library/package.json
@@ -11,27 +11,11 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "bundle-size": "monosize measure",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "start": "yarn storybook",
-    "test": "jest --passWithNoTests",
-    "storybook": "yarn --cwd ../stories storybook",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api",
-    "e2e": "cypress run --component",
-    "e2e:local": "cypress open --component"
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
     "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*",
     "@fluentui/scripts-cypress": "*"
   },
   "dependencies": {

--- a/packages/react-components/react-combobox/stories/just.config.ts
+++ b/packages/react-components/react-combobox/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-combobox/stories/package.json
+++ b/packages/react-components/react-combobox/stories/package.json
@@ -2,20 +2,11 @@
   "name": "@fluentui/react-combobox-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-components/config/pre-copy.json
+++ b/packages/react-components/react-components/config/pre-copy.json
@@ -1,5 +1,0 @@
-{
-  "copyTo": {
-    "unstable/package.json": "./src/unstable/package.json__tmpl__"
-  }
-}

--- a/packages/react-components/react-components/just.config.ts
+++ b/packages/react-components/react-components/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-components/package.json
+++ b/packages/react-components/react-components/package.json
@@ -11,23 +11,9 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "bundle-size": "monosize measure",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "start": "echo 'This doesn't do anything. Run `yarn workspace @fluentui/public-docsite-v9 storybook` instead.'",
-    "test": "jest --passWithNoTests",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api",
-    "verify-packaging": "just-scripts verify-packaging"
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@fluentui/react-accordion": "^9.5.7",

--- a/packages/react-components/react-components/project.json
+++ b/packages/react-components/react-components/project.json
@@ -4,5 +4,21 @@
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-components/src",
   "tags": ["vNext", "platform:web"],
-  "implicitDependencies": []
+  "implicitDependencies": [],
+  "targets": {
+    "build": {
+      "options": {
+        "assets": [
+          {
+            "input": "{projectRoot}/src/unstable",
+            "output": "unstable",
+            "glob": "*.json__tmpl__",
+            "substitutions": {
+              "__tmpl__": ""
+            }
+          }
+        ]
+      }
+    }
+  }
 }

--- a/packages/react-components/react-components/project.json
+++ b/packages/react-components/react-components/project.json
@@ -16,6 +16,14 @@
             "substitutions": {
               "__tmpl__": ""
             }
+          },
+          {
+            "input": "{projectRoot}/src/unstable",
+            "output": "dist",
+            "glob": "*.d.ts__tmpl__",
+            "substitutions": {
+              "__tmpl__": ""
+            }
           }
         ]
       }

--- a/packages/react-components/react-components/src/unstable/unstable.d.ts__tmpl__
+++ b/packages/react-components/react-components/src/unstable/unstable.d.ts__tmpl__
@@ -1,0 +1,561 @@
+import { Alert } from '@fluentui/react-alert';
+import { alertClassNames } from '@fluentui/react-alert';
+import { AlertProps } from '@fluentui/react-alert';
+import { AlertSlots } from '@fluentui/react-alert';
+import { AlertState } from '@fluentui/react-alert';
+import { Drawer } from '@fluentui/react-drawer';
+import { DrawerBody } from '@fluentui/react-drawer';
+import { drawerBodyClassNames } from '@fluentui/react-drawer';
+import { DrawerBodySlots } from '@fluentui/react-drawer';
+import { DrawerBodyState } from '@fluentui/react-drawer';
+import { DrawerFooter } from '@fluentui/react-drawer';
+import { drawerFooterClassNames } from '@fluentui/react-drawer';
+import { DrawerFooterSlots } from '@fluentui/react-drawer';
+import { DrawerFooterState } from '@fluentui/react-drawer';
+import { DrawerHeader } from '@fluentui/react-drawer';
+import { drawerHeaderClassNames } from '@fluentui/react-drawer';
+import { DrawerHeaderNavigation } from '@fluentui/react-drawer';
+import { drawerHeaderNavigationClassNames } from '@fluentui/react-drawer';
+import { DrawerHeaderNavigationProps } from '@fluentui/react-drawer';
+import { DrawerHeaderNavigationSlots } from '@fluentui/react-drawer';
+import { DrawerHeaderNavigationState } from '@fluentui/react-drawer';
+import { DrawerHeaderSlots } from '@fluentui/react-drawer';
+import { DrawerHeaderState } from '@fluentui/react-drawer';
+import { DrawerHeaderTitle } from '@fluentui/react-drawer';
+import { drawerHeaderTitleClassNames } from '@fluentui/react-drawer';
+import { DrawerHeaderTitleSlots } from '@fluentui/react-drawer';
+import { DrawerHeaderTitleState } from '@fluentui/react-drawer';
+import { DrawerProps } from '@fluentui/react-drawer';
+import { DrawerSlots } from '@fluentui/react-drawer';
+import { DrawerState } from '@fluentui/react-drawer';
+import { flattenTree_unstable } from '@fluentui/react-tree';
+import { FlatTree } from '@fluentui/react-tree';
+import { flatTreeClassNames } from '@fluentui/react-tree';
+import { FlatTreeProps } from '@fluentui/react-tree';
+import { FlatTreeSlots } from '@fluentui/react-tree';
+import { FlatTreeState } from '@fluentui/react-tree';
+import { HeadlessFlatTree } from '@fluentui/react-tree';
+import { HeadlessFlatTreeItem } from '@fluentui/react-tree';
+import { HeadlessFlatTreeItemProps } from '@fluentui/react-tree';
+import { HeadlessFlatTreeOptions } from '@fluentui/react-tree';
+import { InfoButton } from '@fluentui/react-infobutton';
+import { infoButtonClassNames } from '@fluentui/react-infobutton';
+import { InfoButtonProps } from '@fluentui/react-infobutton';
+import { InfoButtonSlots } from '@fluentui/react-infobutton';
+import { InfoButtonState } from '@fluentui/react-infobutton';
+import { InfoLabel } from '@fluentui/react-infobutton';
+import { infoLabelClassNames } from '@fluentui/react-infobutton';
+import { InfoLabelProps } from '@fluentui/react-infobutton';
+import { InfoLabelSlots } from '@fluentui/react-infobutton';
+import { InfoLabelState } from '@fluentui/react-infobutton';
+import { InlineDrawer } from '@fluentui/react-drawer';
+import { inlineDrawerClassNames } from '@fluentui/react-drawer';
+import { InlineDrawerProps } from '@fluentui/react-drawer';
+import { InlineDrawerSlots } from '@fluentui/react-drawer';
+import { InlineDrawerState } from '@fluentui/react-drawer';
+import { OverlayDrawer } from '@fluentui/react-drawer';
+import { overlayDrawerClassNames } from '@fluentui/react-drawer';
+import { OverlayDrawerProps } from '@fluentui/react-drawer';
+import { OverlayDrawerSlots } from '@fluentui/react-drawer';
+import { OverlayDrawerState } from '@fluentui/react-drawer';
+import { renderAlert_unstable } from '@fluentui/react-alert';
+import { renderDrawer_unstable } from '@fluentui/react-drawer';
+import { renderDrawerBody_unstable } from '@fluentui/react-drawer';
+import { renderDrawerFooter_unstable } from '@fluentui/react-drawer';
+import { renderDrawerHeader_unstable } from '@fluentui/react-drawer';
+import { renderDrawerHeaderNavigation_unstable } from '@fluentui/react-drawer';
+import { renderDrawerHeaderTitle_unstable } from '@fluentui/react-drawer';
+import { renderFlatTree_unstable } from '@fluentui/react-tree';
+import { renderInfoButton_unstable } from '@fluentui/react-infobutton';
+import { renderInfoLabel_unstable } from '@fluentui/react-infobutton';
+import { renderInlineDrawer_unstable } from '@fluentui/react-drawer';
+import { renderOverlayDrawer_unstable } from '@fluentui/react-drawer';
+import { renderTree_unstable } from '@fluentui/react-tree';
+import { renderTreeItem_unstable } from '@fluentui/react-tree';
+import { renderTreeItemLayout_unstable } from '@fluentui/react-tree';
+import { renderTreeItemPersonaLayout_unstable } from '@fluentui/react-tree';
+import { renderVirtualizer_unstable } from '@fluentui/react-virtualizer';
+import { renderVirtualizerScrollView_unstable } from '@fluentui/react-virtualizer';
+import { renderVirtualizerScrollViewDynamic_unstable } from '@fluentui/react-virtualizer';
+import { ResizeCallbackWithRef } from '@fluentui/react-virtualizer';
+import { ScrollToInterface } from '@fluentui/react-virtualizer';
+import { scrollToItemDynamic } from '@fluentui/react-virtualizer';
+import { ScrollToItemDynamicParams } from '@fluentui/react-virtualizer';
+import { scrollToItemStatic } from '@fluentui/react-virtualizer';
+import { ScrollToItemStaticParams } from '@fluentui/react-virtualizer';
+import { Tree } from '@fluentui/react-tree';
+import { treeClassNames } from '@fluentui/react-tree';
+import { TreeContextValue } from '@fluentui/react-tree';
+import { TreeItem } from '@fluentui/react-tree';
+import { treeItemClassNames } from '@fluentui/react-tree';
+import { TreeItemLayout } from '@fluentui/react-tree';
+import { treeItemLayoutClassNames } from '@fluentui/react-tree';
+import { TreeItemLayoutProps } from '@fluentui/react-tree';
+import { TreeItemLayoutSlots } from '@fluentui/react-tree';
+import { TreeItemLayoutState } from '@fluentui/react-tree';
+import { treeItemLevelToken } from '@fluentui/react-tree';
+import { TreeItemPersonaLayout } from '@fluentui/react-tree';
+import { treeItemPersonaLayoutClassNames } from '@fluentui/react-tree';
+import { TreeItemPersonaLayoutProps } from '@fluentui/react-tree';
+import { TreeItemPersonaLayoutSlots } from '@fluentui/react-tree';
+import { TreeItemPersonaLayoutState } from '@fluentui/react-tree';
+import { TreeItemProps } from '@fluentui/react-tree';
+import { TreeItemProvider } from '@fluentui/react-tree';
+import { TreeItemSlots } from '@fluentui/react-tree';
+import { TreeItemState } from '@fluentui/react-tree';
+import { TreeNavigationData_unstable } from '@fluentui/react-tree';
+import { TreeNavigationEvent_unstable } from '@fluentui/react-tree';
+import { TreeOpenChangeData } from '@fluentui/react-tree';
+import { TreeOpenChangeEvent } from '@fluentui/react-tree';
+import { TreeProps } from '@fluentui/react-tree';
+import { TreeProvider } from '@fluentui/react-tree';
+import { TreeSlots } from '@fluentui/react-tree';
+import { TreeState } from '@fluentui/react-tree';
+import { useAlert_unstable } from '@fluentui/react-alert';
+import { useAlertStyles_unstable } from '@fluentui/react-alert';
+import { useDrawer_unstable } from '@fluentui/react-drawer';
+import { useDrawerBody_unstable } from '@fluentui/react-drawer';
+import { useDrawerBodyStyles_unstable } from '@fluentui/react-drawer';
+import { useDrawerFooter_unstable } from '@fluentui/react-drawer';
+import { useDrawerFooterStyles_unstable } from '@fluentui/react-drawer';
+import { useDrawerHeader_unstable } from '@fluentui/react-drawer';
+import { useDrawerHeaderNavigation_unstable } from '@fluentui/react-drawer';
+import { useDrawerHeaderNavigationStyles_unstable } from '@fluentui/react-drawer';
+import { useDrawerHeaderStyles_unstable } from '@fluentui/react-drawer';
+import { useDrawerHeaderTitle_unstable } from '@fluentui/react-drawer';
+import { useDrawerHeaderTitleStyles_unstable } from '@fluentui/react-drawer';
+import { useDynamicVirtualizerMeasure } from '@fluentui/react-virtualizer';
+import { useFlatTree_unstable } from '@fluentui/react-tree';
+import { useFlatTreeContextValues_unstable } from '@fluentui/react-tree';
+import { useFlatTreeStyles_unstable } from '@fluentui/react-tree';
+import { useHeadlessFlatTree_unstable } from '@fluentui/react-tree';
+import { useInfoButton_unstable } from '@fluentui/react-infobutton';
+import { useInfoButtonStyles_unstable } from '@fluentui/react-infobutton';
+import { useInfoLabel_unstable } from '@fluentui/react-infobutton';
+import { useInfoLabelStyles_unstable } from '@fluentui/react-infobutton';
+import { useInlineDrawer_unstable } from '@fluentui/react-drawer';
+import { useInlineDrawerStyles_unstable } from '@fluentui/react-drawer';
+import { useIntersectionObserver } from '@fluentui/react-virtualizer';
+import { useOverlayDrawer_unstable } from '@fluentui/react-drawer';
+import { useOverlayDrawerStyles_unstable } from '@fluentui/react-drawer';
+import { useResizeObserverRef_unstable } from '@fluentui/react-virtualizer';
+import { useStaticVirtualizerMeasure } from '@fluentui/react-virtualizer';
+import { useTree_unstable } from '@fluentui/react-tree';
+import { useTreeContext_unstable } from '@fluentui/react-tree';
+import { useTreeContextValues_unstable } from '@fluentui/react-tree';
+import { useTreeItem_unstable } from '@fluentui/react-tree';
+import { useTreeItemContext_unstable } from '@fluentui/react-tree';
+import { useTreeItemContextValues_unstable } from '@fluentui/react-tree';
+import { useTreeItemLayout_unstable } from '@fluentui/react-tree';
+import { useTreeItemLayoutStyles_unstable } from '@fluentui/react-tree';
+import { useTreeItemPersonaLayout_unstable } from '@fluentui/react-tree';
+import { useTreeItemPersonaLayoutStyles_unstable } from '@fluentui/react-tree';
+import { useTreeItemStyles_unstable } from '@fluentui/react-tree';
+import { useTreeStyles_unstable } from '@fluentui/react-tree';
+import { useVirtualizer_unstable } from '@fluentui/react-virtualizer';
+import { useVirtualizerContext_unstable } from '@fluentui/react-virtualizer';
+import { useVirtualizerScrollView_unstable } from '@fluentui/react-virtualizer';
+import { useVirtualizerScrollViewDynamic_unstable } from '@fluentui/react-virtualizer';
+import { useVirtualizerScrollViewDynamicStyles_unstable } from '@fluentui/react-virtualizer';
+import { useVirtualizerScrollViewStyles_unstable } from '@fluentui/react-virtualizer';
+import { useVirtualizerStyles_unstable } from '@fluentui/react-virtualizer';
+import { Virtualizer } from '@fluentui/react-virtualizer';
+import { VirtualizerChildRenderFunction } from '@fluentui/react-virtualizer';
+import { virtualizerClassNames } from '@fluentui/react-virtualizer';
+import { VirtualizerContextProps } from '@fluentui/react-virtualizer';
+import { VirtualizerContextProvider } from '@fluentui/react-virtualizer';
+import { VirtualizerMeasureDynamicProps } from '@fluentui/react-virtualizer';
+import { VirtualizerMeasureProps } from '@fluentui/react-virtualizer';
+import { VirtualizerProps } from '@fluentui/react-virtualizer';
+import { VirtualizerScrollView } from '@fluentui/react-virtualizer';
+import { virtualizerScrollViewClassNames } from '@fluentui/react-virtualizer';
+import { VirtualizerScrollViewDynamic } from '@fluentui/react-virtualizer';
+import { virtualizerScrollViewDynamicClassNames } from '@fluentui/react-virtualizer';
+import { VirtualizerScrollViewDynamicProps } from '@fluentui/react-virtualizer';
+import { VirtualizerScrollViewDynamicSlots } from '@fluentui/react-virtualizer';
+import { VirtualizerScrollViewDynamicState } from '@fluentui/react-virtualizer';
+import { VirtualizerScrollViewProps } from '@fluentui/react-virtualizer';
+import { VirtualizerScrollViewSlots } from '@fluentui/react-virtualizer';
+import { VirtualizerScrollViewState } from '@fluentui/react-virtualizer';
+import { VirtualizerSlots } from '@fluentui/react-virtualizer';
+import { VirtualizerState } from '@fluentui/react-virtualizer';
+
+export { Alert }
+
+export { alertClassNames }
+
+export { AlertProps }
+
+export { AlertSlots }
+
+export { AlertState }
+
+export { Drawer }
+
+export { DrawerBody }
+
+export { drawerBodyClassNames }
+
+export { DrawerBodySlots }
+
+export { DrawerBodyState }
+
+export { DrawerFooter }
+
+export { drawerFooterClassNames }
+
+export { DrawerFooterSlots }
+
+export { DrawerFooterState }
+
+export { DrawerHeader }
+
+export { drawerHeaderClassNames }
+
+export { DrawerHeaderNavigation }
+
+export { drawerHeaderNavigationClassNames }
+
+export { DrawerHeaderNavigationProps }
+
+export { DrawerHeaderNavigationSlots }
+
+export { DrawerHeaderNavigationState }
+
+export { DrawerHeaderSlots }
+
+export { DrawerHeaderState }
+
+export { DrawerHeaderTitle }
+
+export { drawerHeaderTitleClassNames }
+
+export { DrawerHeaderTitleSlots }
+
+export { DrawerHeaderTitleState }
+
+export { DrawerProps }
+
+export { DrawerSlots }
+
+export { DrawerState }
+
+export { flattenTree_unstable }
+
+export { FlatTree }
+
+export { flatTreeClassNames }
+
+export { FlatTreeProps }
+
+export { FlatTreeSlots }
+
+export { FlatTreeState }
+
+export { HeadlessFlatTree }
+
+export { HeadlessFlatTreeItem }
+
+export { HeadlessFlatTreeItemProps }
+
+export { HeadlessFlatTreeOptions }
+
+export { InfoButton }
+
+export { infoButtonClassNames }
+
+export { InfoButtonProps }
+
+export { InfoButtonSlots }
+
+export { InfoButtonState }
+
+export { InfoLabel }
+
+export { infoLabelClassNames }
+
+export { InfoLabelProps }
+
+export { InfoLabelSlots }
+
+export { InfoLabelState }
+
+export { InlineDrawer as DrawerInline }
+export { InlineDrawer }
+
+export { inlineDrawerClassNames as DrawerInlineClassNames }
+export { inlineDrawerClassNames }
+
+export { InlineDrawerProps as DrawerInlineProps }
+export { InlineDrawerProps }
+
+export { InlineDrawerSlots as DrawerInlineSlots }
+export { InlineDrawerSlots }
+
+export { InlineDrawerState as DrawerInlineState }
+export { InlineDrawerState }
+
+export { OverlayDrawer as DrawerOverlay }
+export { OverlayDrawer }
+
+export { overlayDrawerClassNames as DrawerOverlayClassNames }
+export { overlayDrawerClassNames }
+
+export { OverlayDrawerProps as DrawerOverlayProps }
+export { OverlayDrawerProps }
+
+export { OverlayDrawerSlots as DrawerOverlaySlots }
+export { OverlayDrawerSlots }
+
+export { OverlayDrawerState as DrawerOverlayState }
+export { OverlayDrawerState }
+
+export { renderAlert_unstable }
+
+export { renderDrawer_unstable }
+
+export { renderDrawerBody_unstable }
+
+export { renderDrawerFooter_unstable }
+
+export { renderDrawerHeader_unstable }
+
+export { renderDrawerHeaderNavigation_unstable }
+
+export { renderDrawerHeaderTitle_unstable }
+
+export { renderFlatTree_unstable }
+
+export { renderInfoButton_unstable }
+
+export { renderInfoLabel_unstable }
+
+export { renderInlineDrawer_unstable as renderDrawerInline_unstable }
+export { renderInlineDrawer_unstable }
+
+export { renderOverlayDrawer_unstable as renderDrawerOverlay_unstable }
+export { renderOverlayDrawer_unstable }
+
+export { renderTree_unstable }
+
+export { renderTreeItem_unstable }
+
+export { renderTreeItemLayout_unstable }
+
+export { renderTreeItemPersonaLayout_unstable }
+
+export { renderVirtualizer_unstable }
+
+export { renderVirtualizerScrollView_unstable }
+
+export { renderVirtualizerScrollViewDynamic_unstable }
+
+export { ResizeCallbackWithRef }
+
+export { ScrollToInterface }
+
+export { scrollToItemDynamic }
+
+export { ScrollToItemDynamicParams }
+
+export { scrollToItemStatic }
+
+export { ScrollToItemStaticParams }
+
+export { Tree }
+
+export { treeClassNames }
+
+export { TreeContextValue }
+
+export { TreeItem }
+
+export { treeItemClassNames }
+
+export { TreeItemLayout }
+
+export { treeItemLayoutClassNames }
+
+export { TreeItemLayoutProps }
+
+export { TreeItemLayoutSlots }
+
+export { TreeItemLayoutState }
+
+export { treeItemLevelToken }
+
+export { TreeItemPersonaLayout }
+
+export { treeItemPersonaLayoutClassNames }
+
+export { TreeItemPersonaLayoutProps }
+
+export { TreeItemPersonaLayoutSlots }
+
+export { TreeItemPersonaLayoutState }
+
+export { TreeItemProps }
+
+export { TreeItemProvider }
+
+export { TreeItemSlots }
+
+export { TreeItemState }
+
+export { TreeNavigationData_unstable }
+
+export { TreeNavigationEvent_unstable }
+
+export { TreeOpenChangeData }
+
+export { TreeOpenChangeEvent }
+
+export { TreeProps }
+
+export { TreeProvider }
+
+export { TreeSlots }
+
+export { TreeState }
+
+export { useAlert_unstable }
+
+export { useAlertStyles_unstable }
+
+export { useDrawer_unstable }
+
+export { useDrawerBody_unstable }
+
+export { useDrawerBodyStyles_unstable }
+
+export { useDrawerFooter_unstable }
+
+export { useDrawerFooterStyles_unstable }
+
+export { useDrawerHeader_unstable }
+
+export { useDrawerHeaderNavigation_unstable }
+
+export { useDrawerHeaderNavigationStyles_unstable }
+
+export { useDrawerHeaderStyles_unstable }
+
+export { useDrawerHeaderTitle_unstable }
+
+export { useDrawerHeaderTitleStyles_unstable }
+
+export { useDynamicVirtualizerMeasure }
+
+export { useFlatTree_unstable }
+
+export { useFlatTreeContextValues_unstable }
+
+export { useFlatTreeStyles_unstable }
+
+export { useHeadlessFlatTree_unstable }
+
+export { useInfoButton_unstable }
+
+export { useInfoButtonStyles_unstable }
+
+export { useInfoLabel_unstable }
+
+export { useInfoLabelStyles_unstable }
+
+export { useInlineDrawer_unstable as useDrawerInline_unstable }
+export { useInlineDrawer_unstable }
+
+export { useInlineDrawerStyles_unstable as useDrawerInlineStyles_unstable }
+export { useInlineDrawerStyles_unstable }
+
+export { useIntersectionObserver }
+
+export { useOverlayDrawer_unstable as useDrawerOverlay_unstable }
+export { useOverlayDrawer_unstable }
+
+export { useOverlayDrawerStyles_unstable as useDrawerOverlayStyles_unstable }
+export { useOverlayDrawerStyles_unstable }
+
+export { useResizeObserverRef_unstable }
+
+export { useStaticVirtualizerMeasure }
+
+export { useTree_unstable }
+
+export { useTreeContext_unstable }
+
+export { useTreeContextValues_unstable }
+
+export { useTreeItem_unstable }
+
+export { useTreeItemContext_unstable }
+
+export { useTreeItemContextValues_unstable }
+
+export { useTreeItemLayout_unstable }
+
+export { useTreeItemLayoutStyles_unstable }
+
+export { useTreeItemPersonaLayout_unstable }
+
+export { useTreeItemPersonaLayoutStyles_unstable }
+
+export { useTreeItemStyles_unstable }
+
+export { useTreeStyles_unstable }
+
+export { useVirtualizer_unstable }
+
+export { useVirtualizerContext_unstable }
+
+export { useVirtualizerScrollView_unstable }
+
+export { useVirtualizerScrollViewDynamic_unstable }
+
+export { useVirtualizerScrollViewDynamicStyles_unstable }
+
+export { useVirtualizerScrollViewStyles_unstable }
+
+export { useVirtualizerStyles_unstable }
+
+export { Virtualizer }
+
+export { VirtualizerChildRenderFunction }
+
+export { virtualizerClassNames }
+
+export { VirtualizerContextProps }
+
+export { VirtualizerContextProvider }
+
+export { VirtualizerMeasureDynamicProps }
+
+export { VirtualizerMeasureProps }
+
+export { VirtualizerProps }
+
+export { VirtualizerScrollView }
+
+export { virtualizerScrollViewClassNames }
+
+export { VirtualizerScrollViewDynamic }
+
+export { virtualizerScrollViewDynamicClassNames }
+
+export { VirtualizerScrollViewDynamicProps }
+
+export { VirtualizerScrollViewDynamicSlots }
+
+export { VirtualizerScrollViewDynamicState }
+
+export { VirtualizerScrollViewProps }
+
+export { VirtualizerScrollViewSlots }
+
+export { VirtualizerScrollViewState }
+
+export { VirtualizerSlots }
+
+export { VirtualizerState }
+
+export { }

--- a/packages/react-components/react-conformance-griffel/just.config.ts
+++ b/packages/react-components/react-conformance-griffel/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-conformance-griffel/package.json
+++ b/packages/react-components/react-conformance-griffel/package.json
@@ -9,21 +9,10 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "test": "jest --passWithNoTests",
-    "type-check": "tsc -b tsconfig.json",
-    "generate-api": "just-scripts generate-api"
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <19.0.0",

--- a/packages/react-components/react-context-selector/just.config.ts
+++ b/packages/react-components/react-context-selector/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-context-selector/package.json
+++ b/packages/react-components/react-context-selector/package.json
@@ -11,21 +11,9 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "test": "jest --passWithNoTests",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api",
-    "test-ssr": "test-ssr \"./stories/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@fluentui/react-utilities": "^9.18.16",

--- a/packages/react-components/react-datepicker-compat/library/just.config.ts
+++ b/packages/react-components/react-datepicker-compat/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-datepicker-compat/library/package.json
+++ b/packages/react-components/react-datepicker-compat/library/package.json
@@ -11,28 +11,12 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "bundle-size": "monosize measure",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "e2e": "cypress run --component",
-    "e2e:local": "cypress open --component",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "test": "jest --passWithNoTests",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api",
-    "storybook": "yarn --cwd ../stories storybook",
-    "start": "yarn storybook"
-  },
   "devDependencies": {
     "@fluentui/react-provider": "*",
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
     "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*",
     "@fluentui/scripts-cypress": "*"
   },
   "dependencies": {

--- a/packages/react-components/react-datepicker-compat/stories/just.config.ts
+++ b/packages/react-components/react-datepicker-compat/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-datepicker-compat/stories/package.json
+++ b/packages/react-components/react-datepicker-compat/stories/package.json
@@ -2,14 +2,6 @@
   "name": "@fluentui/react-datepicker-compat-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-calendar-compat": "*",
     "@fluentui/react-datepicker-compat": "*",
@@ -17,7 +9,6 @@
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-dialog/library/just.config.ts
+++ b/packages/react-components/react-dialog/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-dialog/library/package.json
+++ b/packages/react-components/react-dialog/library/package.json
@@ -11,21 +11,6 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "bundle-size": "monosize measure",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "start": "yarn storybook",
-    "test": "jest --passWithNoTests",
-    "e2e": "cypress run --component",
-    "e2e:local": "cypress open --component",
-    "storybook": "yarn --cwd ../stories storybook",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api"
-  },
   "devDependencies": {
     "@fluentui/react-provider": "*",
     "@fluentui/react-popover": "*",
@@ -36,8 +21,7 @@
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
     "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-cypress": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-cypress": "*"
   },
   "dependencies": {
     "@fluentui/react-utilities": "^9.18.16",

--- a/packages/react-components/react-dialog/stories/just.config.ts
+++ b/packages/react-components/react-dialog/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-dialog/stories/package.json
+++ b/packages/react-components/react-dialog/stories/package.json
@@ -2,20 +2,11 @@
   "name": "@fluentui/react-dialog-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-divider/library/just.config.ts
+++ b/packages/react-components/react-divider/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-divider/library/package.json
+++ b/packages/react-components/react-divider/library/package.json
@@ -11,25 +11,11 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "bundle-size": "monosize measure",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "start": "yarn storybook",
-    "test": "jest --passWithNoTests",
-    "storybook": "yarn --cwd ../stories storybook",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api"
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@fluentui/react-jsx-runtime": "^9.0.45",

--- a/packages/react-components/react-divider/stories/just.config.ts
+++ b/packages/react-components/react-divider/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-divider/stories/package.json
+++ b/packages/react-components/react-divider/stories/package.json
@@ -2,20 +2,11 @@
   "name": "@fluentui/react-divider-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-drawer/library/just.config.ts
+++ b/packages/react-components/react-drawer/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-drawer/library/package.json
+++ b/packages/react-components/react-drawer/library/package.json
@@ -11,27 +11,12 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "e2e": "cypress run --component",
-    "e2e:local": "cypress open --component",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "test": "jest --passWithNoTests",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api",
-    "storybook": "yarn --cwd ../stories storybook",
-    "start": "yarn storybook"
-  },
   "devDependencies": {
     "@fluentui/react-provider": "*",
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
     "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*",
     "@fluentui/scripts-cypress": "*"
   },
   "dependencies": {

--- a/packages/react-components/react-drawer/stories/just.config.ts
+++ b/packages/react-components/react-drawer/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-drawer/stories/package.json
+++ b/packages/react-components/react-drawer/stories/package.json
@@ -2,21 +2,12 @@
   "name": "@fluentui/react-drawer-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-drawer": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-field/library/just.config.ts
+++ b/packages/react-components/react-field/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-field/library/package.json
+++ b/packages/react-components/react-field/library/package.json
@@ -11,26 +11,12 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "bundle-size": "monosize measure",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "start": "yarn storybook",
-    "storybook": "yarn --cwd ../stories storybook",
-    "test": "jest --passWithNoTests",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api"
-  },
   "devDependencies": {
     "@fluentui/react-tooltip": "*",
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@fluentui/react-context-selector": "^9.1.68",

--- a/packages/react-components/react-field/stories/just.config.ts
+++ b/packages/react-components/react-field/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-field/stories/package.json
+++ b/packages/react-components/react-field/stories/package.json
@@ -2,20 +2,11 @@
   "name": "@fluentui/react-field-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-icons-compat/library/just.config.ts
+++ b/packages/react-components/react-icons-compat/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-icons-compat/library/package.json
+++ b/packages/react-components/react-icons-compat/library/package.json
@@ -17,22 +17,11 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "clean": "just-scripts clean",
-    "generate-api": "just-scripts generate-api",
-    "lint": "just-scripts lint",
-    "start": "yarn storybook",
-    "storybook": "yarn --cwd ../stories storybook",
-    "test": "jest --passWithNoTests",
-    "type-check": "just-scripts type-check"
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@fluentui/react-jsx-runtime": "^9.0.45",

--- a/packages/react-components/react-icons-compat/stories/just.config.ts
+++ b/packages/react-components/react-icons-compat/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-icons-compat/stories/package.json
+++ b/packages/react-components/react-icons-compat/stories/package.json
@@ -2,19 +2,10 @@
   "name": "@fluentui/react-icons-compat-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-image/library/just.config.ts
+++ b/packages/react-components/react-image/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-image/library/package.json
+++ b/packages/react-components/react-image/library/package.json
@@ -11,25 +11,11 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "bundle-size": "monosize measure",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "start": "yarn storybook",
-    "test": "jest --passWithNoTests",
-    "storybook": "yarn --cwd ../stories storybook",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api"
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@fluentui/react-shared-contexts": "^9.20.2",

--- a/packages/react-components/react-image/stories/just.config.ts
+++ b/packages/react-components/react-image/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-image/stories/package.json
+++ b/packages/react-components/react-image/stories/package.json
@@ -2,20 +2,11 @@
   "name": "@fluentui/react-image-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-infolabel/library/just.config.ts
+++ b/packages/react-components/react-infolabel/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-infolabel/library/package.json
+++ b/packages/react-components/react-infolabel/library/package.json
@@ -11,25 +11,12 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "clean": "just-scripts clean",
-    "e2e": "cypress run --component",
-    "e2e:local": "cypress open --component",
-    "generate-api": "just-scripts generate-api",
-    "lint": "just-scripts lint",
-    "start": "yarn storybook",
-    "storybook": "yarn --cwd ../stories storybook",
-    "test": "jest --passWithNoTests",
-    "type-check": "just-scripts type-check"
-  },
   "devDependencies": {
     "@fluentui/react-provider": "*",
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
     "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*",
     "@fluentui/scripts-cypress": "*"
   },
   "dependencies": {

--- a/packages/react-components/react-infolabel/stories/just.config.ts
+++ b/packages/react-components/react-infolabel/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-infolabel/stories/package.json
+++ b/packages/react-components/react-infolabel/stories/package.json
@@ -2,20 +2,11 @@
   "name": "@fluentui/react-infolabel-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-input/library/just.config.ts
+++ b/packages/react-components/react-input/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-input/library/package.json
+++ b/packages/react-components/react-input/library/package.json
@@ -11,26 +11,12 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "bundle-size": "monosize measure",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "start": "yarn storybook",
-    "test": "jest --passWithNoTests",
-    "storybook": "yarn --cwd ../stories storybook",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api"
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
     "@fluentui/react-text": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@fluentui/react-field": "^9.1.78",

--- a/packages/react-components/react-input/stories/just.config.ts
+++ b/packages/react-components/react-input/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-input/stories/package.json
+++ b/packages/react-components/react-input/stories/package.json
@@ -2,20 +2,11 @@
   "name": "@fluentui/react-input-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-jsx-runtime/config/pre-copy.json
+++ b/packages/react-components/react-jsx-runtime/config/pre-copy.json
@@ -1,8 +1,0 @@
-{
-  "copyTo": {
-    "jsx-runtime/package.json": "./src/jsx-runtime/package.json__tmpl__",
-    "jsx-dev-runtime/package.json": "./src/jsx-dev-runtime/package.json__tmpl__",
-    "dist/jsx-runtime.d.ts": "./src/jsx-runtime/index.d.ts__tmpl__",
-    "dist/jsx-dev-runtime.d.ts": "./src/jsx-dev-runtime/index.d.ts__tmpl__"
-  }
-}

--- a/packages/react-components/react-jsx-runtime/just.config.ts
+++ b/packages/react-components/react-jsx-runtime/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task, series } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', series('build:react-components', 'copy')).cached?.();

--- a/packages/react-components/react-jsx-runtime/package.json
+++ b/packages/react-components/react-jsx-runtime/package.json
@@ -11,24 +11,11 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "test": "jest --passWithNoTests",
-    "type-check": "tsc -b tsconfig.json",
-    "generate-api": "just-scripts copy && just-scripts generate-api",
-    "test-ssr": "test-ssr \"./stories/**/*.stories.tsx\"",
-    "bundle-size": "monosize measure"
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@fluentui/react-utilities": "^9.18.16",

--- a/packages/react-components/react-jsx-runtime/project.json
+++ b/packages/react-components/react-jsx-runtime/project.json
@@ -4,5 +4,47 @@
   "projectType": "library",
   "implicitDependencies": [],
   "sourceRoot": "packages/react-components/react-jsx-runtime/src",
-  "tags": ["vNext", "platform:any"]
+  "tags": ["vNext", "platform:any"],
+  "targets": {
+    "build": {
+      "options": {
+        "assets": [
+          {
+            "input": "{projectRoot}/src/jsx-runtime",
+            "output": "jsx-runtime",
+            "glob": "*.json__tmpl__",
+            "substitutions": {
+              "__tmpl__": ""
+            }
+          },
+          {
+            "input": "{projectRoot}/src/jsx-runtime",
+            "output": "dist",
+            "glob": "*.d.ts__tmpl__",
+            "substitutions": {
+              "__tmpl__": "",
+              "index": "jsx-runtime"
+            }
+          },
+          {
+            "input": "{projectRoot}/src/jsx-dev-runtime",
+            "output": "jsx-dev-runtime",
+            "glob": "*.json__tmpl__",
+            "substitutions": {
+              "__tmpl__": ""
+            }
+          },
+          {
+            "input": "{projectRoot}/src/jsx-dev-runtime",
+            "output": "dist",
+            "glob": "*.d.ts__tmpl__",
+            "substitutions": {
+              "__tmpl__": "",
+              "index": "jsx-dev-runtime"
+            }
+          }
+        ]
+      }
+    }
+  }
 }

--- a/packages/react-components/react-label/library/just.config.ts
+++ b/packages/react-components/react-label/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-label/library/package.json
+++ b/packages/react-components/react-label/library/package.json
@@ -11,25 +11,11 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "bundle-size": "monosize measure",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "start": "yarn storybook",
-    "test": "jest --passWithNoTests",
-    "storybook": "yarn --cwd ../stories storybook",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api"
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@fluentui/react-shared-contexts": "^9.20.2",

--- a/packages/react-components/react-label/stories/just.config.ts
+++ b/packages/react-components/react-label/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-label/stories/package.json
+++ b/packages/react-components/react-label/stories/package.json
@@ -2,20 +2,11 @@
   "name": "@fluentui/react-label-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-link/library/just.config.ts
+++ b/packages/react-components/react-link/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-link/library/package.json
+++ b/packages/react-components/react-link/library/package.json
@@ -11,26 +11,12 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "bundle-size": "monosize measure",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "start": "yarn storybook",
-    "test": "jest --passWithNoTests",
-    "storybook": "yarn --cwd ../stories storybook",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api"
-  },
   "devDependencies": {
     "@fluentui/a11y-testing": "*",
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@fluentui/keyboard-keys": "^9.0.7",

--- a/packages/react-components/react-link/stories/just.config.ts
+++ b/packages/react-components/react-link/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-link/stories/package.json
+++ b/packages/react-components/react-link/stories/package.json
@@ -2,20 +2,11 @@
   "name": "@fluentui/react-link-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-list-preview/library/just.config.ts
+++ b/packages/react-components/react-list-preview/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-list-preview/library/package.json
+++ b/packages/react-components/react-list-preview/library/package.json
@@ -17,26 +17,12 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "bundle-size": "monosize measure",
-    "clean": "just-scripts clean",
-    "generate-api": "just-scripts generate-api",
-    "lint": "just-scripts lint",
-    "start": "yarn storybook",
-    "storybook": "yarn --cwd ../stories storybook",
-    "test": "jest --passWithNoTests",
-    "type-check": "just-scripts type-check",
-    "e2e": "cypress run --component",
-    "e2e:local": "cypress open --component"
-  },
   "devDependencies": {
     "@fluentui/react-provider": "*",
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
     "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*",
     "@fluentui/scripts-cypress": "*"
   },
   "dependencies": {

--- a/packages/react-components/react-list-preview/stories/just.config.ts
+++ b/packages/react-components/react-list-preview/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-list-preview/stories/package.json
+++ b/packages/react-components/react-list-preview/stories/package.json
@@ -2,21 +2,12 @@
   "name": "@fluentui/react-list-preview-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-list-preview": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-menu/library/just.config.ts
+++ b/packages/react-components/react-menu/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-menu/library/package.json
+++ b/packages/react-components/react-menu/library/package.json
@@ -11,29 +11,13 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "bundle-size": "monosize measure",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "e2e": "cypress run --component",
-    "e2e:local": "cypress open --component",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "start": "yarn storybook",
-    "storybook": "yarn --cwd ../stories storybook",
-    "test": "jest --passWithNoTests",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api"
-  },
   "devDependencies": {
     "@fluentui/react-provider": "*",
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
     "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-cypress": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-cypress": "*"
   },
   "dependencies": {
     "@fluentui/keyboard-keys": "^9.0.7",

--- a/packages/react-components/react-menu/stories/just.config.ts
+++ b/packages/react-components/react-menu/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-menu/stories/package.json
+++ b/packages/react-components/react-menu/stories/package.json
@@ -2,20 +2,11 @@
   "name": "@fluentui/react-menu-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-message-bar/library/just.config.ts
+++ b/packages/react-components/react-message-bar/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-message-bar/library/package.json
+++ b/packages/react-components/react-message-bar/library/package.json
@@ -11,23 +11,11 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "bundle-size": "monosize measure",
-    "clean": "just-scripts clean",
-    "generate-api": "just-scripts generate-api",
-    "lint": "just-scripts lint",
-    "start": "yarn storybook",
-    "storybook": "yarn --cwd ../stories storybook",
-    "test": "jest --passWithNoTests",
-    "type-check": "just-scripts type-check"
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@fluentui/react-button": "^9.3.94",

--- a/packages/react-components/react-message-bar/stories/just.config.ts
+++ b/packages/react-components/react-message-bar/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-message-bar/stories/package.json
+++ b/packages/react-components/react-message-bar/stories/package.json
@@ -2,20 +2,11 @@
   "name": "@fluentui/react-message-bar-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-migration-v0-v9/library/just.config.ts
+++ b/packages/react-components/react-migration-v0-v9/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-migration-v0-v9/library/package.json
+++ b/packages/react-components/react-migration-v0-v9/library/package.json
@@ -11,25 +11,12 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "test": "jest --passWithNoTests",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api",
-    "storybook": "yarn --cwd ../stories storybook",
-    "start": "yarn storybook"
-  },
   "devDependencies": {
     "@fluentui/react-conformance": "*",
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-northstar": "*",
     "@fluentui/react-conformance-griffel": "*",
     "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*",
     "@fluentui/scripts-storybook": "*"
   },
   "dependencies": {

--- a/packages/react-components/react-migration-v0-v9/stories/just.config.ts
+++ b/packages/react-components/react-migration-v0-v9/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-migration-v0-v9/stories/package.json
+++ b/packages/react-components/react-migration-v0-v9/stories/package.json
@@ -2,13 +2,6 @@
   "name": "@fluentui/react-migration-v0-v9-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "start-storybook",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier"
-  },
   "devDependencies": {
     "@fluentui/react-migration-v0-v9": "*",
     "@fluentui/react-northstar": "*",
@@ -17,7 +10,6 @@
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-migration-v8-v9/library/just.config.ts
+++ b/packages/react-components/react-migration-v8-v9/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-migration-v8-v9/library/package.json
+++ b/packages/react-components/react-migration-v8-v9/library/package.json
@@ -11,24 +11,11 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "test": "jest --passWithNoTests",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api",
-    "storybook": "yarn --cwd ../stories storybook",
-    "start": "yarn storybook"
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@ctrl/tinycolor": "3.3.4",

--- a/packages/react-components/react-migration-v8-v9/stories/just.config.ts
+++ b/packages/react-components/react-migration-v8-v9/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-migration-v8-v9/stories/package.json
+++ b/packages/react-components/react-migration-v8-v9/stories/package.json
@@ -2,13 +2,6 @@
   "name": "@fluentui/react-migration-v8-v9-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "start-storybook",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier"
-  },
   "devDependencies": {
     "@fluentui/react": "*",
     "@fluentui/react-components": "*",
@@ -16,7 +9,6 @@
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-motion-components-preview/library/just.config.ts
+++ b/packages/react-components/react-motion-components-preview/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-motion-components-preview/library/package.json
+++ b/packages/react-components/react-motion-components-preview/library/package.json
@@ -17,22 +17,11 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "clean": "just-scripts clean",
-    "generate-api": "just-scripts generate-api",
-    "lint": "just-scripts lint",
-    "start": "yarn storybook",
-    "storybook": "yarn --cwd ../stories storybook",
-    "test": "jest --passWithNoTests",
-    "type-check": "just-scripts type-check"
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@fluentui/react-motion": "*",

--- a/packages/react-components/react-motion-components-preview/stories/just.config.ts
+++ b/packages/react-components/react-motion-components-preview/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-motion-components-preview/stories/package.json
+++ b/packages/react-components/react-motion-components-preview/stories/package.json
@@ -2,21 +2,12 @@
   "name": "@fluentui/react-motion-components-preview-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-motion-components-preview": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-motion/library/just.config.ts
+++ b/packages/react-components/react-motion/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-motion/library/package.json
+++ b/packages/react-components/react-motion/library/package.json
@@ -17,25 +17,11 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "clean": "just-scripts clean",
-    "generate-api": "just-scripts generate-api",
-    "lint": "just-scripts lint",
-    "start": "yarn storybook",
-    "storybook": "yarn --cwd ../stories storybook",
-    "test": "jest --passWithNoTests",
-    "type-check": "just-scripts type-check",
-    "e2e": "cypress run --component",
-    "e2e:local": "cypress open --component",
-    "bundle-size": "monosize measure"
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
     "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*",
     "@fluentui/scripts-cypress": "*"
   },
   "dependencies": {

--- a/packages/react-components/react-motion/stories/just.config.ts
+++ b/packages/react-components/react-motion/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-motion/stories/package.json
+++ b/packages/react-components/react-motion/stories/package.json
@@ -2,21 +2,12 @@
   "name": "@fluentui/react-motion-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-motion": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-nav-preview/library/just.config.ts
+++ b/packages/react-components/react-nav-preview/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-nav-preview/library/package.json
+++ b/packages/react-components/react-nav-preview/library/package.json
@@ -11,22 +11,11 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "clean": "just-scripts clean",
-    "generate-api": "just-scripts generate-api",
-    "lint": "just-scripts lint",
-    "start": "yarn storybook",
-    "storybook": "yarn --cwd ../stories storybook",
-    "test": "jest --passWithNoTests",
-    "type-check": "just-scripts type-check"
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@fluentui/react-aria": "^9.13.8",

--- a/packages/react-components/react-nav-preview/stories/just.config.ts
+++ b/packages/react-components/react-nav-preview/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-nav-preview/stories/package.json
+++ b/packages/react-components/react-nav-preview/stories/package.json
@@ -2,14 +2,6 @@
   "name": "@fluentui/react-nav-preview-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-nav-preview": "*",
     "@fluentui/react-drawer": "*",
@@ -17,7 +9,6 @@
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-overflow/library/just.config.ts
+++ b/packages/react-components/react-overflow/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-overflow/library/package.json
+++ b/packages/react-components/react-overflow/library/package.json
@@ -11,28 +11,12 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "bundle-size": "monosize measure",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "e2e": "cypress run --component",
-    "e2e:local": "cypress open --component",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "start": "yarn storybook",
-    "test": "jest --passWithNoTests",
-    "storybook": "yarn --cwd ../stories storybook",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api"
-  },
   "devDependencies": {
     "@fluentui/react-portal": "*",
     "@fluentui/react-menu": "*",
     "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-cypress": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-cypress": "*"
   },
   "dependencies": {
     "@fluentui/priority-overflow": "^9.1.13",

--- a/packages/react-components/react-overflow/stories/just.config.ts
+++ b/packages/react-components/react-overflow/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-overflow/stories/package.json
+++ b/packages/react-components/react-overflow/stories/package.json
@@ -2,20 +2,11 @@
   "name": "@fluentui/react-overflow-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-persona/library/just.config.ts
+++ b/packages/react-components/react-persona/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-persona/library/package.json
+++ b/packages/react-components/react-persona/library/package.json
@@ -11,25 +11,11 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "bundle-size": "monosize measure",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "test": "jest --passWithNoTests",
-    "type-check": "just-scripts type-check",
-    "storybook": "yarn --cwd ../stories storybook",
-    "start": "yarn storybook",
-    "generate-api": "just-scripts generate-api"
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@fluentui/react-avatar": "^9.6.41",

--- a/packages/react-components/react-persona/stories/just.config.ts
+++ b/packages/react-components/react-persona/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-persona/stories/package.json
+++ b/packages/react-components/react-persona/stories/package.json
@@ -2,20 +2,11 @@
   "name": "@fluentui/react-persona-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-popover/library/just.config.ts
+++ b/packages/react-components/react-popover/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-popover/library/package.json
+++ b/packages/react-components/react-popover/library/package.json
@@ -11,21 +11,6 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "bundle-size": "monosize measure",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "start": "yarn storybook",
-    "e2e": "cypress run --component",
-    "e2e:local": "cypress open --component",
-    "storybook": "yarn --cwd ../stories storybook",
-    "test": "jest --passWithNoTests",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api"
-  },
   "devDependencies": {
     "@fluentui/react-provider": "*",
     "@fluentui/react-menu": "*",
@@ -33,8 +18,7 @@
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
     "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-cypress": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-cypress": "*"
   },
   "dependencies": {
     "@fluentui/keyboard-keys": "^9.0.7",

--- a/packages/react-components/react-popover/stories/just.config.ts
+++ b/packages/react-components/react-popover/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-popover/stories/package.json
+++ b/packages/react-components/react-popover/stories/package.json
@@ -2,20 +2,11 @@
   "name": "@fluentui/react-popover-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-portal-compat-context/just.config.ts
+++ b/packages/react-components/react-portal-compat-context/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-portal-compat-context/package.json
+++ b/packages/react-components/react-portal-compat-context/package.json
@@ -11,21 +11,9 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build --module esm,cjs,amd",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "test": "jest --passWithNoTests",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api",
-    "test-ssr": "test-ssr \"./stories/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@swc/helpers": "^0.5.1"

--- a/packages/react-components/react-portal-compat/just.config.ts
+++ b/packages/react-components/react-portal-compat/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-portal-compat/package.json
+++ b/packages/react-components/react-portal-compat/package.json
@@ -11,20 +11,6 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build --module esm,cjs,amd",
-    "bundle-size": "monosize measure",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "e2e": "cypress run --component",
-    "e2e:local": "cypress open --component",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "test": "jest --passWithNoTests",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api",
-    "test-ssr": "test-ssr \"./stories/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-provider": "*",
     "@fluentui/react-theme": "*",
@@ -33,8 +19,7 @@
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-components": "*",
     "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-cypress": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-cypress": "*"
   },
   "dependencies": {
     "@fluentui/react-portal-compat-context": "^9.0.12",

--- a/packages/react-components/react-portal/library/just.config.ts
+++ b/packages/react-components/react-portal/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-portal/library/package.json
+++ b/packages/react-components/react-portal/library/package.json
@@ -11,25 +11,11 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "bundle-size": "monosize measure",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "start": "yarn storybook",
-    "test": "jest --passWithNoTests",
-    "storybook": "yarn --cwd ../stories storybook",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api"
-  },
   "devDependencies": {
     "@fluentui/react-provider": "*",
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@fluentui/react-shared-contexts": "^9.20.2",

--- a/packages/react-components/react-portal/stories/just.config.ts
+++ b/packages/react-components/react-portal/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-portal/stories/package.json
+++ b/packages/react-components/react-portal/stories/package.json
@@ -2,20 +2,11 @@
   "name": "@fluentui/react-portal-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-positioning/just.config.ts
+++ b/packages/react-components/react-positioning/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-positioning/package.json
+++ b/packages/react-components/react-positioning/package.json
@@ -11,22 +11,9 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "bundle-size": "monosize measure",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "test": "jest --passWithNoTests",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api",
-    "test-ssr": "test-ssr \"./stories/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@floating-ui/dom": "^1.2.0",

--- a/packages/react-components/react-progress/library/just.config.ts
+++ b/packages/react-components/react-progress/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-progress/library/package.json
+++ b/packages/react-components/react-progress/library/package.json
@@ -11,25 +11,11 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "bundle-size": "monosize measure",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "test": "jest --passWithNoTests",
-    "type-check": "just-scripts type-check",
-    "storybook": "yarn --cwd ../stories storybook",
-    "start": "yarn storybook",
-    "generate-api": "just-scripts generate-api"
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@fluentui/react-field": "^9.1.78",

--- a/packages/react-components/react-progress/stories/just.config.ts
+++ b/packages/react-components/react-progress/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-progress/stories/package.json
+++ b/packages/react-components/react-progress/stories/package.json
@@ -2,20 +2,11 @@
   "name": "@fluentui/react-progress-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-provider/library/just.config.ts
+++ b/packages/react-components/react-provider/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-provider/library/package.json
+++ b/packages/react-components/react-provider/library/package.json
@@ -11,25 +11,11 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "bundle-size": "monosize measure",
-    "test": "jest --passWithNoTests",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "storybook": "yarn --cwd ../stories storybook",
-    "start": "yarn storybook",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api"
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@fluentui/react-icons": "^2.0.245",

--- a/packages/react-components/react-provider/stories/just.config.ts
+++ b/packages/react-components/react-provider/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-provider/stories/package.json
+++ b/packages/react-components/react-provider/stories/package.json
@@ -2,20 +2,11 @@
   "name": "@fluentui/react-provider-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-radio/library/just.config.ts
+++ b/packages/react-components/react-radio/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-radio/library/package.json
+++ b/packages/react-components/react-radio/library/package.json
@@ -11,25 +11,11 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "bundle-size": "monosize measure",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "start": "yarn storybook",
-    "test": "jest --passWithNoTests",
-    "storybook": "yarn --cwd ../stories storybook",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api"
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@fluentui/react-field": "^9.1.78",

--- a/packages/react-components/react-radio/stories/just.config.ts
+++ b/packages/react-components/react-radio/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-radio/stories/package.json
+++ b/packages/react-components/react-radio/stories/package.json
@@ -2,20 +2,11 @@
   "name": "@fluentui/react-radio-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-rating/library/just.config.ts
+++ b/packages/react-components/react-rating/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-rating/library/package.json
+++ b/packages/react-components/react-rating/library/package.json
@@ -11,22 +11,11 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "clean": "just-scripts clean",
-    "generate-api": "just-scripts generate-api",
-    "lint": "just-scripts lint",
-    "start": "yarn storybook",
-    "storybook": "yarn --cwd ../stories storybook",
-    "test": "jest --passWithNoTests",
-    "type-check": "just-scripts type-check"
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@fluentui/react-jsx-runtime": "^9.0.45",

--- a/packages/react-components/react-rating/stories/just.config.ts
+++ b/packages/react-components/react-rating/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-rating/stories/package.json
+++ b/packages/react-components/react-rating/stories/package.json
@@ -2,20 +2,11 @@
   "name": "@fluentui/react-rating-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-search/library/just.config.ts
+++ b/packages/react-components/react-search/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-search/library/package.json
+++ b/packages/react-components/react-search/library/package.json
@@ -11,24 +11,11 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "test": "jest --passWithNoTests",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api",
-    "storybook": "yarn --cwd ../stories storybook",
-    "start": "yarn storybook"
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@fluentui/react-icons": "^2.0.245",

--- a/packages/react-components/react-search/stories/just.config.ts
+++ b/packages/react-components/react-search/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-search/stories/package.json
+++ b/packages/react-components/react-search/stories/package.json
@@ -2,20 +2,11 @@
   "name": "@fluentui/react-search-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-select/library/just.config.ts
+++ b/packages/react-components/react-select/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-select/library/package.json
+++ b/packages/react-components/react-select/library/package.json
@@ -11,25 +11,11 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "bundle-size": "monosize measure",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "start": "yarn storybook",
-    "test": "jest --passWithNoTests",
-    "storybook": "yarn --cwd ../stories storybook",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api"
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@fluentui/react-field": "^9.1.78",

--- a/packages/react-components/react-select/stories/just.config.ts
+++ b/packages/react-components/react-select/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-select/stories/package.json
+++ b/packages/react-components/react-select/stories/package.json
@@ -2,20 +2,11 @@
   "name": "@fluentui/react-select-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-shared-contexts/library/just.config.ts
+++ b/packages/react-components/react-shared-contexts/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-shared-contexts/library/package.json
+++ b/packages/react-components/react-shared-contexts/library/package.json
@@ -11,22 +11,9 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "test": "jest --passWithNoTests",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api",
-    "storybook": "yarn --cwd ../stories storybook",
-    "start": "yarn storybook"
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@fluentui/react-theme": "^9.1.21",

--- a/packages/react-components/react-shared-contexts/stories/just.config.ts
+++ b/packages/react-components/react-shared-contexts/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-shared-contexts/stories/package.json
+++ b/packages/react-components/react-shared-contexts/stories/package.json
@@ -2,20 +2,11 @@
   "name": "@fluentui/react-shared-contexts-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-skeleton/library/just.config.ts
+++ b/packages/react-components/react-skeleton/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-skeleton/library/package.json
+++ b/packages/react-components/react-skeleton/library/package.json
@@ -11,24 +11,11 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "test": "jest --passWithNoTests",
-    "generate-api": "just-scripts generate-api",
-    "type-check": "just-scripts type-check",
-    "storybook": "yarn --cwd ../stories storybook",
-    "start": "yarn storybook"
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@fluentui/react-field": "^9.1.78",

--- a/packages/react-components/react-skeleton/stories/just.config.ts
+++ b/packages/react-components/react-skeleton/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-skeleton/stories/package.json
+++ b/packages/react-components/react-skeleton/stories/package.json
@@ -2,20 +2,11 @@
   "name": "@fluentui/react-skeleton-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-slider/library/just.config.ts
+++ b/packages/react-components/react-slider/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-slider/library/package.json
+++ b/packages/react-components/react-slider/library/package.json
@@ -11,26 +11,12 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "bundle-size": "monosize measure",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "start": "yarn storybook",
-    "test": "jest --passWithNoTests",
-    "storybook": "yarn --cwd ../stories storybook",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api"
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
     "@fluentui/react-label": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@fluentui/react-field": "^9.1.78",

--- a/packages/react-components/react-slider/stories/just.config.ts
+++ b/packages/react-components/react-slider/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-slider/stories/package.json
+++ b/packages/react-components/react-slider/stories/package.json
@@ -2,20 +2,11 @@
   "name": "@fluentui/react-slider-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-spinbutton/library/just.config.ts
+++ b/packages/react-components/react-spinbutton/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-spinbutton/library/package.json
+++ b/packages/react-components/react-spinbutton/library/package.json
@@ -11,26 +11,12 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "bundle-size": "monosize measure",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "start": "yarn storybook",
-    "test": "jest --passWithNoTests",
-    "storybook": "yarn --cwd ../stories storybook",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api"
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
     "@fluentui/react-label": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@fluentui/keyboard-keys": "^9.0.7",

--- a/packages/react-components/react-spinbutton/stories/just.config.ts
+++ b/packages/react-components/react-spinbutton/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-spinbutton/stories/package.json
+++ b/packages/react-components/react-spinbutton/stories/package.json
@@ -2,20 +2,11 @@
   "name": "@fluentui/react-spinbutton-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-spinner/library/just.config.ts
+++ b/packages/react-components/react-spinner/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-spinner/library/package.json
+++ b/packages/react-components/react-spinner/library/package.json
@@ -11,25 +11,11 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "bundle-size": "monosize measure",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "start": "yarn storybook",
-    "test": "jest --passWithNoTests",
-    "storybook": "yarn --cwd ../stories storybook",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api"
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@fluentui/react-jsx-runtime": "^9.0.45",

--- a/packages/react-components/react-spinner/stories/just.config.ts
+++ b/packages/react-components/react-spinner/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-spinner/stories/package.json
+++ b/packages/react-components/react-spinner/stories/package.json
@@ -2,20 +2,11 @@
   "name": "@fluentui/react-spinner-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-storybook-addon-export-to-sandbox/just.config.ts
+++ b/packages/react-components/react-storybook-addon-export-to-sandbox/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-storybook-addon-export-to-sandbox/package.json
+++ b/packages/react-components/react-storybook-addon-export-to-sandbox/package.json
@@ -11,20 +11,9 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "test": "jest --passWithNoTests",
-    "type-check": "tsc -b tsconfig.json",
-    "generate-api": "just-scripts generate-api"
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@swc/helpers": "^0.5.1",

--- a/packages/react-components/react-storybook-addon/just.config.ts
+++ b/packages/react-components/react-storybook-addon/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-storybook-addon/package.json
+++ b/packages/react-components/react-storybook-addon/package.json
@@ -12,22 +12,9 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "start": "yarn storybook",
-    "test": "jest --passWithNoTests",
-    "storybook": "storybook dev",
-    "type-check": "tsc -b tsconfig.json",
-    "generate-api": "just-scripts generate-api"
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@fluentui/react-aria": "^9.13.8",

--- a/packages/react-components/react-swatch-picker/library/just.config.ts
+++ b/packages/react-components/react-swatch-picker/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-swatch-picker/library/package.json
+++ b/packages/react-components/react-swatch-picker/library/package.json
@@ -11,27 +11,13 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "clean": "just-scripts clean",
-    "e2e": "cypress run --component",
-    "e2e:local": "cypress open --component",
-    "generate-api": "just-scripts generate-api",
-    "lint": "just-scripts lint",
-    "start": "yarn storybook",
-    "storybook": "yarn --cwd ../stories storybook",
-    "test": "jest --passWithNoTests",
-    "type-check": "just-scripts type-check",
-    "bundle-size": "monosize measure"
-  },
   "devDependencies": {
     "@fluentui/react-provider": "*",
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
     "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-cypress": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-cypress": "*"
   },
   "dependencies": {
     "@fluentui/react-context-selector": "^9.1.68",

--- a/packages/react-components/react-swatch-picker/stories/just.config.ts
+++ b/packages/react-components/react-swatch-picker/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-swatch-picker/stories/package.json
+++ b/packages/react-components/react-swatch-picker/stories/package.json
@@ -2,20 +2,11 @@
   "name": "@fluentui/react-swatch-picker-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-switch/library/just.config.ts
+++ b/packages/react-components/react-switch/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-switch/library/package.json
+++ b/packages/react-components/react-switch/library/package.json
@@ -11,25 +11,11 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "bundle-size": "monosize measure",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "start": "yarn storybook",
-    "test": "jest --passWithNoTests",
-    "storybook": "yarn --cwd ../stories storybook",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api"
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@fluentui/react-field": "^9.1.78",

--- a/packages/react-components/react-switch/stories/just.config.ts
+++ b/packages/react-components/react-switch/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-switch/stories/package.json
+++ b/packages/react-components/react-switch/stories/package.json
@@ -2,20 +2,11 @@
   "name": "@fluentui/react-switch-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-table/library/just.config.ts
+++ b/packages/react-components/react-table/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-table/library/package.json
+++ b/packages/react-components/react-table/library/package.json
@@ -11,28 +11,12 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "bundle-size": "monosize measure",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "e2e": "cypress run --component",
-    "e2e:local": "cypress open --component",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "test": "jest --passWithNoTests",
-    "type-check": "just-scripts type-check",
-    "storybook": "yarn --cwd ../stories storybook",
-    "start": "yarn storybook",
-    "generate-api": "just-scripts generate-api"
-  },
   "devDependencies": {
     "@fluentui/react-provider": "*",
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
     "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*",
     "@fluentui/scripts-cypress": "*"
   },
   "dependencies": {

--- a/packages/react-components/react-table/stories/just.config.ts
+++ b/packages/react-components/react-table/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-table/stories/package.json
+++ b/packages/react-components/react-table/stories/package.json
@@ -2,20 +2,11 @@
   "name": "@fluentui/react-table-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-tabs/library/just.config.ts
+++ b/packages/react-components/react-tabs/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-tabs/library/package.json
+++ b/packages/react-components/react-tabs/library/package.json
@@ -11,24 +11,11 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "start": "yarn storybook",
-    "test": "jest --passWithNoTests",
-    "storybook": "yarn --cwd ../stories storybook",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api"
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@fluentui/react-context-selector": "^9.1.68",

--- a/packages/react-components/react-tabs/stories/just.config.ts
+++ b/packages/react-components/react-tabs/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-tabs/stories/package.json
+++ b/packages/react-components/react-tabs/stories/package.json
@@ -2,20 +2,11 @@
   "name": "@fluentui/react-tabs-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-tabster/just.config.ts
+++ b/packages/react-components/react-tabster/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-tabster/package.json
+++ b/packages/react-components/react-tabster/package.json
@@ -11,24 +11,10 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "e2e": "cypress run --component",
-    "e2e:local": "cypress open --component",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "test": "jest --passWithNoTests",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api",
-    "test-ssr": "test-ssr \"./stories/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-cypress": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-cypress": "*"
   },
   "dependencies": {
     "@fluentui/react-shared-contexts": "^9.20.2",

--- a/packages/react-components/react-tag-picker/library/just.config.ts
+++ b/packages/react-components/react-tag-picker/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-tag-picker/library/package.json
+++ b/packages/react-components/react-tag-picker/library/package.json
@@ -17,19 +17,6 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "clean": "just-scripts clean",
-    "generate-api": "just-scripts generate-api",
-    "lint": "just-scripts lint",
-    "start": "yarn storybook",
-    "storybook": "yarn --cwd ../stories storybook",
-    "test": "jest --passWithNoTests",
-    "type-check": "just-scripts type-check",
-    "e2e": "cypress run --component",
-    "e2e:local": "cypress open --component",
-    "bundle-size": "monosize measure"
-  },
   "devDependencies": {
     "@fluentui/react-provider": "*",
     "@fluentui/react-avatar": "*",
@@ -38,7 +25,6 @@
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
     "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*",
     "@fluentui/scripts-cypress": "*"
   },
   "dependencies": {

--- a/packages/react-components/react-tag-picker/stories/just.config.ts
+++ b/packages/react-components/react-tag-picker/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-tag-picker/stories/package.json
+++ b/packages/react-components/react-tag-picker/stories/package.json
@@ -2,20 +2,11 @@
   "name": "@fluentui/react-tag-picker-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-tags/library/just.config.ts
+++ b/packages/react-components/react-tags/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-tags/library/package.json
+++ b/packages/react-components/react-tags/library/package.json
@@ -11,29 +11,13 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "bundle-size": "monosize measure",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "test": "jest --passWithNoTests",
-    "e2e": "cypress run --component",
-    "e2e:local": "cypress open --component",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api",
-    "storybook": "yarn --cwd ../stories storybook",
-    "start": "yarn storybook"
-  },
   "devDependencies": {
     "@fluentui/react-provider": "*",
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
     "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-cypress": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-cypress": "*"
   },
   "dependencies": {
     "@fluentui/keyboard-keys": "^9.0.7",

--- a/packages/react-components/react-tags/stories/just.config.ts
+++ b/packages/react-components/react-tags/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-tags/stories/package.json
+++ b/packages/react-components/react-tags/stories/package.json
@@ -2,20 +2,11 @@
   "name": "@fluentui/react-tags-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-teaching-popover/library/just.config.ts
+++ b/packages/react-components/react-teaching-popover/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-teaching-popover/library/package.json
+++ b/packages/react-components/react-teaching-popover/library/package.json
@@ -17,22 +17,11 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "clean": "just-scripts clean",
-    "generate-api": "just-scripts generate-api",
-    "lint": "just-scripts lint",
-    "start": "yarn storybook",
-    "storybook": "yarn --cwd ../stories storybook",
-    "test": "jest --passWithNoTests",
-    "type-check": "just-scripts type-check"
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@fluentui/react-jsx-runtime": "^9.0.45",

--- a/packages/react-components/react-teaching-popover/stories/just.config.ts
+++ b/packages/react-components/react-teaching-popover/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-teaching-popover/stories/package.json
+++ b/packages/react-components/react-teaching-popover/stories/package.json
@@ -2,20 +2,11 @@
   "name": "@fluentui/react-teaching-popover-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-text/library/just.config.ts
+++ b/packages/react-components/react-text/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-text/library/package.json
+++ b/packages/react-components/react-text/library/package.json
@@ -11,26 +11,11 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "bundle-size": "monosize measure",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "start": "yarn storybook",
-    "test": "jest --passWithNoTests",
-    "storybook": "yarn --cwd ../stories storybook",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api",
-    "verify-packaging": "just-scripts verify-packaging"
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@fluentui/react-shared-contexts": "^9.20.2",

--- a/packages/react-components/react-text/stories/just.config.ts
+++ b/packages/react-components/react-text/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-text/stories/package.json
+++ b/packages/react-components/react-text/stories/package.json
@@ -2,20 +2,11 @@
   "name": "@fluentui/react-text-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-textarea/library/just.config.ts
+++ b/packages/react-components/react-textarea/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-textarea/library/package.json
+++ b/packages/react-components/react-textarea/library/package.json
@@ -11,25 +11,11 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "bundle-size": "monosize measure",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "start": "yarn storybook",
-    "test": "jest --passWithNoTests",
-    "storybook": "yarn --cwd ../stories storybook",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api"
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@fluentui/react-field": "^9.1.78",

--- a/packages/react-components/react-textarea/stories/just.config.ts
+++ b/packages/react-components/react-textarea/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-textarea/stories/package.json
+++ b/packages/react-components/react-textarea/stories/package.json
@@ -2,20 +2,11 @@
   "name": "@fluentui/react-textarea-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-theme-sass/just.config.ts
+++ b/packages/react-components/react-theme-sass/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-theme-sass/package.json
+++ b/packages/react-components/react-theme-sass/package.json
@@ -12,22 +12,10 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "test": "jest --passWithNoTests",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api",
-    "test-ssr": "test-ssr \"./stories/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-theme": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-theme/library/just.config.ts
+++ b/packages/react-components/react-theme/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-theme/library/package.json
+++ b/packages/react-components/react-theme/library/package.json
@@ -11,23 +11,9 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "bundle-size": "monosize measure",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "start": "yarn storybook",
-    "storybook": "yarn --cwd ../stories storybook",
-    "test": "jest --passWithNoTests",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api"
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@fluentui/tokens": "1.0.0-alpha.18",

--- a/packages/react-components/react-theme/stories/just.config.ts
+++ b/packages/react-components/react-theme/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-theme/stories/package.json
+++ b/packages/react-components/react-theme/stories/package.json
@@ -2,19 +2,11 @@
   "name": "@fluentui/react-theme-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier"
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-timepicker-compat/library/just.config.ts
+++ b/packages/react-components/react-timepicker-compat/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-timepicker-compat/library/package.json
+++ b/packages/react-components/react-timepicker-compat/library/package.json
@@ -17,19 +17,6 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "bundle-size": "monosize measure",
-    "clean": "just-scripts clean",
-    "e2e": "cypress run --component",
-    "e2e:local": "cypress open --component",
-    "generate-api": "just-scripts generate-api",
-    "lint": "just-scripts lint",
-    "start": "yarn storybook",
-    "storybook": "yarn --cwd ../stories storybook",
-    "test": "jest --passWithNoTests",
-    "type-check": "just-scripts type-check"
-  },
   "devDependencies": {
     "@fluentui/react-provider": "*",
     "@fluentui/react-components": "*",
@@ -37,7 +24,6 @@
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
     "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*",
     "@fluentui/scripts-cypress": "*"
   },
   "dependencies": {

--- a/packages/react-components/react-timepicker-compat/stories/just.config.ts
+++ b/packages/react-components/react-timepicker-compat/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-timepicker-compat/stories/package.json
+++ b/packages/react-components/react-timepicker-compat/stories/package.json
@@ -2,14 +2,6 @@
   "name": "@fluentui/react-timepicker-compat-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-timepicker-compat": "*",
@@ -17,7 +9,6 @@
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-toast/library/just.config.ts
+++ b/packages/react-components/react-toast/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-toast/library/package.json
+++ b/packages/react-components/react-toast/library/package.json
@@ -11,28 +11,12 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "bundle-size": "monosize measure",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "test": "jest --passWithNoTests",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api",
-    "storybook": "yarn --cwd ../stories storybook",
-    "start": "yarn storybook",
-    "e2e": "cypress run --component",
-    "e2e:local": "cypress open --component"
-  },
   "devDependencies": {
     "@fluentui/react-provider": "*",
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
     "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*",
     "@fluentui/scripts-cypress": "*"
   },
   "dependencies": {

--- a/packages/react-components/react-toast/stories/just.config.ts
+++ b/packages/react-components/react-toast/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-toast/stories/package.json
+++ b/packages/react-components/react-toast/stories/package.json
@@ -2,20 +2,11 @@
   "name": "@fluentui/react-toast-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-toolbar/library/just.config.ts
+++ b/packages/react-components/react-toolbar/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-toolbar/library/package.json
+++ b/packages/react-components/react-toolbar/library/package.json
@@ -11,28 +11,13 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "e2e": "cypress run --component",
-    "e2e:local": "cypress open --component",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "start": "yarn storybook",
-    "test": "jest --passWithNoTests",
-    "storybook": "yarn --cwd ../stories storybook",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api"
-  },
   "devDependencies": {
     "@fluentui/react-provider": "*",
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
     "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-cypress": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-cypress": "*"
   },
   "dependencies": {
     "@fluentui/react-button": "^9.3.94",

--- a/packages/react-components/react-toolbar/stories/just.config.ts
+++ b/packages/react-components/react-toolbar/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-toolbar/stories/package.json
+++ b/packages/react-components/react-toolbar/stories/package.json
@@ -2,20 +2,11 @@
   "name": "@fluentui/react-toolbar-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-tooltip/library/just.config.ts
+++ b/packages/react-components/react-tooltip/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-tooltip/library/package.json
+++ b/packages/react-components/react-tooltip/library/package.json
@@ -11,25 +11,11 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "bundle-size": "monosize measure",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "start": "yarn storybook",
-    "test": "jest --passWithNoTests",
-    "storybook": "yarn --cwd ../stories storybook",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api"
-  },
   "devDependencies": {
     "@fluentui/react-conformance": "*",
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance-griffel": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@fluentui/keyboard-keys": "^9.0.7",

--- a/packages/react-components/react-tooltip/stories/just.config.ts
+++ b/packages/react-components/react-tooltip/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-tooltip/stories/package.json
+++ b/packages/react-components/react-tooltip/stories/package.json
@@ -2,20 +2,11 @@
   "name": "@fluentui/react-tooltip-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-tree/library/just.config.ts
+++ b/packages/react-components/react-tree/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-tree/library/package.json
+++ b/packages/react-components/react-tree/library/package.json
@@ -11,25 +11,12 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "clean": "just-scripts clean",
-    "generate-api": "just-scripts generate-api",
-    "lint": "just-scripts lint",
-    "start": "yarn storybook",
-    "storybook": "yarn --cwd ../stories storybook",
-    "test": "jest --passWithNoTests",
-    "type-check": "just-scripts type-check",
-    "e2e": "cypress run --component",
-    "e2e:local": "cypress open --component"
-  },
   "devDependencies": {
     "@fluentui/react-provider": "*",
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
     "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*",
     "@fluentui/scripts-cypress": "*"
   },
   "dependencies": {

--- a/packages/react-components/react-tree/stories/just.config.ts
+++ b/packages/react-components/react-tree/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-tree/stories/package.json
+++ b/packages/react-components/react-tree/stories/package.json
@@ -2,20 +2,11 @@
   "name": "@fluentui/react-tree-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-utilities-compat/library/just.config.ts
+++ b/packages/react-components/react-utilities-compat/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-utilities-compat/library/package.json
+++ b/packages/react-components/react-utilities-compat/library/package.json
@@ -18,22 +18,11 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "clean": "just-scripts clean",
-    "generate-api": "just-scripts generate-api",
-    "lint": "just-scripts lint",
-    "start": "yarn storybook",
-    "storybook": "yarn --cwd ../stories storybook",
-    "test": "jest --passWithNoTests",
-    "type-check": "just-scripts type-check"
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@fluentui/react-jsx-runtime": "^9.0.45",

--- a/packages/react-components/react-utilities-compat/stories/just.config.ts
+++ b/packages/react-components/react-utilities-compat/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-utilities-compat/stories/package.json
+++ b/packages/react-components/react-utilities-compat/stories/package.json
@@ -2,19 +2,10 @@
   "name": "@fluentui/react-utilities-compat-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/react-utilities/just.config.ts
+++ b/packages/react-components/react-utilities/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-utilities/package.json
+++ b/packages/react-components/react-utilities/package.json
@@ -11,24 +11,9 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "bundle-size": "monosize measure",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "test": "jest --passWithNoTests",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api",
-    "test-ssr": "test-ssr \"./stories/**/*.stories.tsx\"",
-    "e2e": "cypress run --component",
-    "e2e:local": "cypress open --component"
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*",
     "@fluentui/scripts-cypress": "*"
   },
   "dependencies": {

--- a/packages/react-components/react-virtualizer/library/just.config.ts
+++ b/packages/react-components/react-virtualizer/library/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/react-virtualizer/library/package.json
+++ b/packages/react-components/react-virtualizer/library/package.json
@@ -11,24 +11,11 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "test": "jest --passWithNoTests",
-    "storybook": "yarn --cwd ../stories storybook",
-    "start": "yarn storybook",
-    "generate-api": "just-scripts generate-api",
-    "type-check": "just-scripts type-check"
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@fluentui/react-jsx-runtime": "^9.0.45",

--- a/packages/react-components/react-virtualizer/stories/just.config.ts
+++ b/packages/react-components/react-virtualizer/stories/just.config.ts
@@ -1,3 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();

--- a/packages/react-components/react-virtualizer/stories/package.json
+++ b/packages/react-components/react-virtualizer/stories/package.json
@@ -2,21 +2,12 @@
   "name": "@fluentui/react-virtualizer-stories",
   "version": "0.0.0",
   "private": true,
-  "scripts": {
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "lint": "eslint src/",
-    "format": "just-scripts prettier",
-    "test-ssr": "test-ssr \"./src/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-virtualizer": ">=9.0.0-alpha",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/scripts-storybook": "*",
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   }
 }

--- a/packages/react-components/recipes/just.config.ts
+++ b/packages/react-components/recipes/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/recipes/package.json
+++ b/packages/react-components/recipes/package.json
@@ -18,20 +18,11 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "clean": "just-scripts clean",
-    "generate-api": "just-scripts generate-api",
-    "lint": "just-scripts lint",
-    "test": "jest --passWithNoTests",
-    "type-check": "just-scripts type-check"
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
     "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*",
     "@fluentui/react-storybook-addon": "*",
     "@fluentui/react-storybook-addon-export-to-sandbox": "*"
   },

--- a/packages/react-components/theme-designer/just.config.ts
+++ b/packages/react-components/theme-designer/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-components/theme-designer/package.json
+++ b/packages/react-components/theme-designer/package.json
@@ -12,24 +12,9 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "build-storybook": "storybook build -o ./dist/storybook",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "start": "yarn storybook",
-    "test": "jest --passWithNoTests",
-    "storybook": "storybook dev",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api",
-    "test-ssr": "test-ssr \"./stories/**/*.stories.tsx\""
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@fluentui/react-components": "^9.55.1",

--- a/packages/react-conformance/just.config.ts
+++ b/packages/react-conformance/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/react-conformance/package.json
+++ b/packages/react-conformance/package.json
@@ -9,16 +9,6 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "test": "just-scripts test",
-    "lint": "just-scripts lint",
-    "generate-api": "just-scripts generate-api",
-    "type-check": "just-scripts type-check"
-  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",
@@ -26,8 +16,7 @@
     ]
   },
   "devDependencies": {
-    "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/eslint-plugin": "*"
   },
   "dependencies": {
     "lodash": "^4.17.15",

--- a/packages/tokens/just.config.ts
+++ b/packages/tokens/just.config.ts
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -11,22 +11,9 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "just": "just-scripts",
-    "lint": "just-scripts lint",
-    "test": "jest --passWithNoTests",
-    "token-pipeline": "node -r ../../scripts/ts-node/src/register ../../scripts/generators/src/token-pipeline.ts",
-    "type-check": "just-scripts type-check",
-    "generate-api": "just-scripts generate-api",
-    "e2e": "playwright test"
-  },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
-    "@fluentui/scripts-api-extractor": "*",
-    "@fluentui/scripts-tasks": "*"
+    "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@swc/helpers": "^0.5.1"

--- a/packages/tokens/project.json
+++ b/packages/tokens/project.json
@@ -8,6 +8,12 @@
   "targets": {
     "e2e": {
       "dependsOn": ["build"]
+    },
+    "token-pipeline": {
+      "command": "node -r ../../scripts/ts-node/src/register ../../scripts/generators/src/token-pipeline.ts",
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     }
   }
 }

--- a/scripts/api-extractor/package.json
+++ b/scripts/api-extractor/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.1",
   "private": true,
   "main": "index.js",
-  "scripts": {},
   "dependencies": {},
   "devDependencies": {}
 }

--- a/scripts/api-extractor/project.json
+++ b/scripts/api-extractor/project.json
@@ -3,11 +3,5 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/api-extractor",
   "projectType": "library",
-  "tags": ["tools"],
-  "targets": {
-    "type-check": {
-      "executor": "@fluentui/workspace-plugin:type-check"
-    },
-    "format": {}
-  }
+  "tags": ["tools"]
 }

--- a/scripts/babel/package.json
+++ b/scripts/babel/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.1",
   "private": true,
   "main": "src/index.js",
-  "scripts": {},
   "dependencies": {},
   "devDependencies": {},
   "exports": {

--- a/scripts/babel/project.json
+++ b/scripts/babel/project.json
@@ -3,11 +3,5 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/babel/src",
   "projectType": "library",
-  "tags": ["tools"],
-  "targets": {
-    "type-check": {
-      "executor": "@fluentui/workspace-plugin:type-check"
-    },
-    "format": {}
-  }
+  "tags": ["tools"]
 }

--- a/scripts/beachball/package.json
+++ b/scripts/beachball/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.1",
   "private": true,
   "main": "src/index.js",
-  "scripts": {},
   "dependencies": {
     "@fluentui/scripts-github": "*",
     "@fluentui/scripts-monorepo": "*",

--- a/scripts/beachball/project.json
+++ b/scripts/beachball/project.json
@@ -3,11 +3,5 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/beachball/src",
   "projectType": "library",
-  "tags": ["tools"],
-  "targets": {
-    "type-check": {
-      "executor": "@fluentui/workspace-plugin:type-check"
-    },
-    "format": {}
-  }
+  "tags": ["tools"]
 }

--- a/scripts/cypress/package.json
+++ b/scripts/cypress/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.1",
   "private": true,
   "main": "src/index.ts",
-  "scripts": {},
   "dependencies": {},
   "devDependencies": {}
 }

--- a/scripts/cypress/project.json
+++ b/scripts/cypress/project.json
@@ -3,11 +3,5 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/cypress/src",
   "projectType": "library",
-  "tags": ["tools"],
-  "targets": {
-    "type-check": {
-      "executor": "@fluentui/workspace-plugin:type-check"
-    },
-    "format": {}
-  }
+  "tags": ["tools"]
 }

--- a/scripts/dangerjs/package.json
+++ b/scripts/dangerjs/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.1",
   "private": true,
   "main": "src/index.js",
-  "scripts": {},
   "dependencies": {
     "@fluentui/scripts-monorepo": "*",
     "@fluentui/scripts-utils": "*"

--- a/scripts/dangerjs/project.json
+++ b/scripts/dangerjs/project.json
@@ -3,11 +3,5 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/dangerjs/src",
   "projectType": "library",
-  "tags": ["tools"],
-  "targets": {
-    "type-check": {
-      "executor": "@fluentui/workspace-plugin:type-check"
-    },
-    "format": {}
-  }
+  "tags": ["tools"]
 }

--- a/scripts/executors/package.json
+++ b/scripts/executors/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.1",
   "private": true,
   "main": "index.js",
-  "scripts": {},
   "dependencies": {
     "@fluentui/scripts-utils": "*",
     "@fluentui/scripts-monorepo": "*",

--- a/scripts/executors/project.json
+++ b/scripts/executors/project.json
@@ -3,11 +3,5 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/executors/src",
   "projectType": "library",
-  "tags": ["tools"],
-  "targets": {
-    "type-check": {
-      "executor": "@fluentui/workspace-plugin:type-check"
-    },
-    "format": {}
-  }
+  "tags": ["tools"]
 }

--- a/scripts/fluentui-publish/package.json
+++ b/scripts/fluentui-publish/package.json
@@ -5,10 +5,6 @@
   "bin": {
     "northstar-release": "./bin/northstar-release.js"
   },
-  "scripts": {
-    "lint": "eslint --ext .ts,.js ./src ./bin",
-    "test": "jest --passWithNoTests"
-  },
   "dependencies": {
     "@fluentui/scripts-monorepo": "*"
   },

--- a/scripts/fluentui-publish/project.json
+++ b/scripts/fluentui-publish/project.json
@@ -3,19 +3,5 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/fluentui-publish/src",
   "projectType": "library",
-  "tags": ["tools"],
-  "targets": {
-    "test": {
-      "inputs": [
-        "default",
-        "^production",
-        "{workspaceRoot}/jest.preset.js",
-        "{workspaceRoot}/packages/fluentui/*/project.json"
-      ]
-    },
-    "type-check": {
-      "executor": "@fluentui/workspace-plugin:type-check"
-    },
-    "format": {}
-  }
+  "tags": ["tools"]
 }

--- a/scripts/generators/package.json
+++ b/scripts/generators/package.json
@@ -3,10 +3,6 @@
   "version": "0.0.1",
   "private": true,
   "main": "index.js",
-  "scripts": {
-    "lint": "eslint --ext .ts,.js ./src",
-    "test": "jest --passWithNoTests"
-  },
   "dependencies": {
     "@fluentui/scripts-monorepo": "*",
     "@fluentui/scripts-projects-test": "*"

--- a/scripts/generators/project.json
+++ b/scripts/generators/project.json
@@ -3,11 +3,5 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/generators/src",
   "projectType": "library",
-  "tags": ["tools"],
-  "targets": {
-    "type-check": {
-      "executor": "@fluentui/workspace-plugin:type-check"
-    },
-    "format": {}
-  }
+  "tags": ["tools"]
 }

--- a/scripts/github/package.json
+++ b/scripts/github/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.1",
   "private": true,
   "main": "src/index.ts",
-  "scripts": {},
   "dependencies": {},
   "devDependencies": {}
 }

--- a/scripts/github/project.json
+++ b/scripts/github/project.json
@@ -3,11 +3,5 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/github/src",
   "projectType": "library",
-  "tags": ["tools"],
-  "targets": {
-    "type-check": {
-      "executor": "@fluentui/workspace-plugin:type-check"
-    },
-    "format": {}
-  }
+  "tags": ["tools"]
 }

--- a/scripts/gulp/package.json
+++ b/scripts/gulp/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.1",
   "private": true,
   "main": "src/index.ts",
-  "scripts": {},
   "dependencies": {
     "@fluentui/scripts-monorepo": "*",
     "@fluentui/scripts-utils": "*",

--- a/scripts/gulp/project.json
+++ b/scripts/gulp/project.json
@@ -3,11 +3,5 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/gulp/src",
   "projectType": "library",
-  "tags": ["tools"],
-  "targets": {
-    "type-check": {
-      "executor": "@fluentui/workspace-plugin:type-check"
-    },
-    "format": {}
-  }
+  "tags": ["tools"]
 }

--- a/scripts/jest/package.json
+++ b/scripts/jest/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.1",
   "private": true,
   "main": "src/index.js",
-  "scripts": {},
   "dependencies": {
     "@fluentui/scripts-monorepo": "*",
     "@fluentui/scripts-utils": "*"

--- a/scripts/jest/project.json
+++ b/scripts/jest/project.json
@@ -3,11 +3,5 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/jest/src",
   "projectType": "library",
-  "tags": ["tools"],
-  "targets": {
-    "type-check": {
-      "executor": "@fluentui/workspace-plugin:type-check"
-    },
-    "format": {}
-  }
+  "tags": ["tools"]
 }

--- a/scripts/lint-staged/package.json
+++ b/scripts/lint-staged/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.1",
   "private": true,
   "main": "index.js",
-  "scripts": {},
   "dependencies": {
     "@fluentui/scripts-monorepo": "*",
     "@fluentui/scripts-utils": "*"

--- a/scripts/lint-staged/project.json
+++ b/scripts/lint-staged/project.json
@@ -3,11 +3,5 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/lint-staged/src",
   "projectType": "library",
-  "tags": ["tools"],
-  "targets": {
-    "type-check": {
-      "executor": "@fluentui/workspace-plugin:type-check"
-    },
-    "format": {}
-  }
+  "tags": ["tools"]
 }

--- a/scripts/monorepo/package.json
+++ b/scripts/monorepo/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.1",
   "private": true,
   "main": "src/index.js",
-  "scripts": {},
   "dependencies": {
     "@fluentui/scripts-utils": "*"
   },

--- a/scripts/monorepo/project.json
+++ b/scripts/monorepo/project.json
@@ -3,11 +3,5 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/monorepo/src",
   "projectType": "library",
-  "tags": ["tools"],
-  "targets": {
-    "type-check": {
-      "executor": "@fluentui/workspace-plugin:type-check"
-    },
-    "format": {}
-  }
+  "tags": ["tools"]
 }

--- a/scripts/monorepo/src/getDependencies.spec.js
+++ b/scripts/monorepo/src/getDependencies.spec.js
@@ -50,11 +50,6 @@ describe(`#getDependencies`, () => {
         Object {
           "dependencyType": "devDependencies",
           "isTopLevel": true,
-          "name": "scripts-tasks",
-        },
-        Object {
-          "dependencyType": "devDependencies",
-          "isTopLevel": true,
           "name": "eslint-plugin",
         },
         Object {
@@ -71,21 +66,6 @@ describe(`#getDependencies`, () => {
           "dependencyType": "devDependencies",
           "isTopLevel": true,
           "name": "scripts-api-extractor",
-        },
-        Object {
-          "dependencyType": "dependencies",
-          "isTopLevel": false,
-          "name": "scripts-monorepo",
-        },
-        Object {
-          "dependencyType": "dependencies",
-          "isTopLevel": false,
-          "name": "scripts-utils",
-        },
-        Object {
-          "dependencyType": "dependencies",
-          "isTopLevel": false,
-          "name": "scripts-prettier",
         },
         Object {
           "dependencyType": "devDependencies",

--- a/scripts/package-manager/package.json
+++ b/scripts/package-manager/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.1",
   "private": true,
   "main": "index.js",
-  "scripts": {},
   "dependencies": {},
   "devDependencies": {}
 }

--- a/scripts/package-manager/project.json
+++ b/scripts/package-manager/project.json
@@ -3,11 +3,5 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/package-manager/src",
   "projectType": "library",
-  "tags": ["tools"],
-  "targets": {
-    "type-check": {
-      "executor": "@fluentui/workspace-plugin:type-check"
-    },
-    "format": {}
-  }
+  "tags": ["tools"]
 }

--- a/scripts/perf-test-flamegrill/package.json
+++ b/scripts/perf-test-flamegrill/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.1",
   "private": true,
   "main": "src/index.ts",
-  "scripts": {},
   "peerDependencies": {
     "@types/react": ">=16.8.0 <19.0.0",
     "@types/react-dom": ">=16.8.0 <19.0.0",

--- a/scripts/perf-test-flamegrill/project.json
+++ b/scripts/perf-test-flamegrill/project.json
@@ -3,11 +3,5 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/perf-test-flamegrill/src",
   "projectType": "library",
-  "tags": ["tools", "platform:any"],
-  "targets": {
-    "type-check": {
-      "executor": "@fluentui/workspace-plugin:type-check"
-    },
-    "format": {}
-  }
+  "tags": ["tools", "platform:any"]
 }

--- a/scripts/prettier/package.json
+++ b/scripts/prettier/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.1",
   "private": true,
   "main": "src/index.js",
-  "scripts": {},
   "dependencies": {
     "@fluentui/scripts-monorepo": "*"
   },

--- a/scripts/prettier/project.json
+++ b/scripts/prettier/project.json
@@ -3,11 +3,5 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/prettier/src",
   "projectType": "library",
-  "tags": ["tools"],
-  "targets": {
-    "type-check": {
-      "executor": "@fluentui/workspace-plugin:type-check"
-    },
-    "format": {}
-  }
+  "tags": ["tools"]
 }

--- a/scripts/projects-test/package.json
+++ b/scripts/projects-test/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.1",
   "private": true,
   "main": "src/index.ts",
-  "scripts": {},
   "dependencies": {
     "@fluentui/scripts-utils": "*",
     "@fluentui/scripts-puppeteer": "*",

--- a/scripts/projects-test/project.json
+++ b/scripts/projects-test/project.json
@@ -3,11 +3,5 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/projects-test/src",
   "projectType": "library",
-  "tags": ["tools"],
-  "targets": {
-    "type-check": {
-      "executor": "@fluentui/workspace-plugin:type-check"
-    },
-    "format": {}
-  }
+  "tags": ["tools"]
 }

--- a/scripts/puppeteer/package.json
+++ b/scripts/puppeteer/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.1",
   "private": true,
   "main": "src/index.ts",
-  "scripts": {},
   "dependencies": {},
   "devDependencies": {}
 }

--- a/scripts/puppeteer/project.json
+++ b/scripts/puppeteer/project.json
@@ -3,11 +3,5 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/puppeteer/src",
   "projectType": "library",
-  "tags": ["tools"],
-  "targets": {
-    "type-check": {
-      "executor": "@fluentui/workspace-plugin:type-check"
-    },
-    "format": {}
-  }
+  "tags": ["tools"]
 }

--- a/scripts/storybook/package.json
+++ b/scripts/storybook/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.1",
   "private": true,
   "main": "src/index.js",
-  "scripts": {},
   "dependencies": {
     "@fluentui/scripts-monorepo": "*"
   },

--- a/scripts/storybook/project.json
+++ b/scripts/storybook/project.json
@@ -3,11 +3,5 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/storybook/src",
   "projectType": "library",
-  "tags": ["tools"],
-  "targets": {
-    "type-check": {
-      "executor": "@fluentui/workspace-plugin:type-check"
-    },
-    "format": {}
-  }
+  "tags": ["tools"]
 }

--- a/scripts/tasks/package.json
+++ b/scripts/tasks/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.1",
   "private": true,
   "main": "src/index.ts",
-  "scripts": {},
   "dependencies": {
     "@fluentui/scripts-monorepo": "*",
     "@fluentui/scripts-utils": "*",

--- a/scripts/tasks/project.json
+++ b/scripts/tasks/project.json
@@ -3,11 +3,5 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/tasks/src",
   "projectType": "library",
-  "tags": ["tools"],
-  "targets": {
-    "type-check": {
-      "executor": "@fluentui/workspace-plugin:type-check"
-    },
-    "format": {}
-  }
+  "tags": ["tools"]
 }

--- a/scripts/test-ssr/package.json
+++ b/scripts/test-ssr/package.json
@@ -5,10 +5,6 @@
   "bin": {
     "test-ssr": "./bin/test-ssr.js"
   },
-  "scripts": {
-    "lint": "eslint --ext .ts,.js ./src ./bin",
-    "test": "jest --passWithNoTests"
-  },
   "dependencies": {
     "@fluentui/scripts-puppeteer": "*",
     "@fluentui/scripts-ts-node": "*"

--- a/scripts/test-ssr/project.json
+++ b/scripts/test-ssr/project.json
@@ -3,11 +3,5 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/test-ssr/src",
   "projectType": "library",
-  "tags": ["tools"],
-  "targets": {
-    "type-check": {
-      "executor": "@fluentui/workspace-plugin:type-check"
-    },
-    "format": {}
-  }
+  "tags": ["tools"]
 }

--- a/scripts/triage-bot/package.json
+++ b/scripts/triage-bot/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.1",
   "private": true,
   "main": "src/index.js",
-  "scripts": {},
   "dependencies": {},
   "devDependencies": {}
 }

--- a/scripts/triage-bot/project.json
+++ b/scripts/triage-bot/project.json
@@ -3,11 +3,5 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/triage-bot/src",
   "projectType": "library",
-  "tags": ["tools"],
-  "targets": {
-    "type-check": {
-      "executor": "@fluentui/workspace-plugin:type-check"
-    },
-    "format": {}
-  }
+  "tags": ["tools"]
 }

--- a/scripts/ts-node/package.json
+++ b/scripts/ts-node/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.1",
   "private": true,
   "main": "index.js",
-  "scripts": {},
   "dependencies": {},
   "devDependencies": {}
 }

--- a/scripts/ts-node/project.json
+++ b/scripts/ts-node/project.json
@@ -3,11 +3,5 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/ts-node/src",
   "projectType": "library",
-  "tags": ["tools"],
-  "targets": {
-    "type-check": {
-      "executor": "@fluentui/workspace-plugin:type-check"
-    },
-    "format": {}
-  }
+  "tags": ["tools"]
 }

--- a/scripts/update-release-notes/package.json
+++ b/scripts/update-release-notes/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.1",
   "private": true,
   "main": "index.js",
-  "scripts": {},
   "dependencies": {
     "@fluentui/scripts-github": "*",
     "@fluentui/scripts-monorepo": "*"

--- a/scripts/update-release-notes/project.json
+++ b/scripts/update-release-notes/project.json
@@ -3,11 +3,5 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/update-release-notes/src",
   "projectType": "library",
-  "tags": ["tools"],
-  "targets": {
-    "type-check": {
-      "executor": "@fluentui/workspace-plugin:type-check"
-    },
-    "format": {}
-  }
+  "tags": ["tools"]
 }

--- a/scripts/utils/package.json
+++ b/scripts/utils/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.1",
   "private": true,
   "main": "src/index.js",
-  "scripts": {},
   "dependencies": {},
   "devDependencies": {}
 }

--- a/scripts/utils/project.json
+++ b/scripts/utils/project.json
@@ -3,11 +3,5 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/utils/src",
   "projectType": "library",
-  "tags": ["tools"],
-  "targets": {
-    "type-check": {
-      "executor": "@fluentui/workspace-plugin:type-check"
-    },
-    "format": {}
-  }
+  "tags": ["tools"]
 }

--- a/scripts/webpack/package.json
+++ b/scripts/webpack/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.1",
   "private": true,
   "main": "src/index.js",
-  "scripts": {},
   "dependencies": {
     "@fluentui/scripts-monorepo": "*",
     "@fluentui/scripts-utils": "*"

--- a/scripts/webpack/project.json
+++ b/scripts/webpack/project.json
@@ -3,11 +3,5 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "scripts/webpack/src",
   "projectType": "library",
-  "tags": ["tools"],
-  "targets": {
-    "type-check": {
-      "executor": "@fluentui/workspace-plugin:type-check"
-    },
-    "format": {}
-  }
+  "tags": ["tools"]
 }

--- a/tools/eslint-rules/project.json
+++ b/tools/eslint-rules/project.json
@@ -3,10 +3,5 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "tools/eslint-rules",
   "projectType": "library",
-  "tags": ["platform:node", "tools"],
-  "targets": {
-    "type-check": {
-      "executor": "@fluentui/workspace-plugin:type-check"
-    }
-  }
+  "tags": ["platform:node", "tools"]
 }

--- a/tools/workspace-plugin/package.json
+++ b/tools/workspace-plugin/package.json
@@ -5,9 +5,6 @@
   "type": "commonjs",
   "generators": "./generators.json",
   "executors": "./executors.json",
-  "scripts": {
-    "check-graph": "node ./scripts/check-dep-graph.js"
-  },
   "dependencies": {
     "@nx/devkit": "~19.5.7"
   },

--- a/tools/workspace-plugin/project.json
+++ b/tools/workspace-plugin/project.json
@@ -36,8 +36,11 @@
         ]
       }
     },
-    "type-check": {
-      "executor": "@fluentui/workspace-plugin:type-check"
+    "check-graph": {
+      "command": "node ./scripts/check-dep-graph.js",
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     }
   }
 }

--- a/tools/workspace-plugin/src/generators/bundle-size-configuration/generator.spec.ts
+++ b/tools/workspace-plugin/src/generators/bundle-size-configuration/generator.spec.ts
@@ -30,7 +30,7 @@ describe('bundle-size-configuration generator', () => {
 
     expect(tree.exists(joinPathFragments(config.root, 'monosize.config.mjs'))).toEqual(false);
 
-    expect(packageJson.scripts['bundle-size']).toEqual('monosize measure');
+    expect(packageJson.scripts).toEqual(undefined);
 
     expect(tree.read(joinPathFragments(config.root, 'bundle-size/index.fixture.js'), 'utf-8')).toMatchInlineSnapshot(`
       "import * as p from '@proj/react-continental';
@@ -97,7 +97,6 @@ function createLibrary(tree: Tree, name: string) {
   writeJson(tree, joinPathFragments(root, 'package.json'), {
     name: npmProjectName,
     version: '9.0.0',
-    scripts: {},
   });
 
   return tree;

--- a/tools/workspace-plugin/src/generators/bundle-size-configuration/generator.ts
+++ b/tools/workspace-plugin/src/generators/bundle-size-configuration/generator.ts
@@ -6,13 +6,11 @@ import {
   ProjectConfiguration,
   readProjectConfiguration,
   Tree,
-  updateJson,
   visitNotIgnoredFiles,
 } from '@nx/devkit';
 
 import * as path from 'path';
 
-import { PackageJson } from '../../types';
 import { getNpmScope } from '../../utils';
 import { assertStoriesProject, isSplitProject } from '../split-library-in-two/shared';
 
@@ -50,12 +48,6 @@ export async function bundleSizeConfigurationGenerator(tree: Tree, schema: Bundl
   if (options.overrideBaseConfig === false) {
     tree.delete(configPaths.bundleSizeConfig);
   }
-
-  updateJson(tree, joinPathFragments(project.root, 'package.json'), (json: PackageJson) => {
-    json.scripts = json.scripts ?? {};
-    json.scripts['bundle-size'] = 'monosize measure';
-    return json;
-  });
 
   await formatFiles(tree);
 }

--- a/tools/workspace-plugin/src/generators/cypress-component-configuration/index.spec.ts
+++ b/tools/workspace-plugin/src/generators/cypress-component-configuration/index.spec.ts
@@ -72,12 +72,7 @@ describe(`cypress-component-configuration`, () => {
 
     const pkgJson = readJson(tree, 'packages/one/package.json');
 
-    expect(pkgJson.scripts).toEqual(
-      expect.objectContaining({
-        e2e: 'cypress run --component',
-        'e2e:local': 'cypress open --component',
-      }),
-    );
+    expect(pkgJson.scripts).toEqual(undefined);
     expect(pkgJson.devDependencies).toEqual(
       expect.objectContaining({
         '@fluentui/scripts-cypress': '*',
@@ -100,7 +95,6 @@ function setupDummyPackage(tree: Tree, options: { name: string; projectType?: 'a
       version: '0.0.1',
       typings: 'lib/index.d.ts',
       main: 'lib-commonjs/index.js',
-      scripts: {},
       dependencies: {},
       devDependencies: {},
     },

--- a/tools/workspace-plugin/src/generators/cypress-component-configuration/lib/add-files.ts
+++ b/tools/workspace-plugin/src/generators/cypress-component-configuration/lib/add-files.ts
@@ -28,10 +28,6 @@ export function addFiles(tree: Tree, options: Options) {
   });
 
   updateJson(tree, options.paths.packageJson, (json: PackageJson) => {
-    json.scripts = json.scripts ?? {};
-    json.scripts.e2e = 'cypress run --component';
-    json.scripts['e2e:local'] = 'cypress open --component';
-
     json.devDependencies = json.devDependencies ?? {};
     json.devDependencies['@fluentui/scripts-cypress'] = '*';
 

--- a/tools/workspace-plugin/src/generators/migrate-converged-pkg/index.spec.ts
+++ b/tools/workspace-plugin/src/generators/migrate-converged-pkg/index.spec.ts
@@ -786,12 +786,6 @@ describe('migrate-converged-pkg generator', () => {
       });
       expect(mainTsConfig.references).toEqual(expect.arrayContaining([{ path: './tsconfig.cy.json' }]));
       expect(libTsConfig.exclude).toEqual(expect.arrayContaining(['**/*.cy.ts', '**/*.cy.tsx']));
-
-      // package.json updates
-      const packageJson: PackageJson = readJson(tree, paths.packageJson);
-      expect(packageJson.scripts).toEqual(
-        expect.objectContaining({ e2e: 'cypress run --component', 'e2e:local': 'cypress open --component' }),
-      );
     });
   });
 

--- a/tools/workspace-plugin/src/generators/react-component/index.ts
+++ b/tools/workspace-plugin/src/generators/react-component/index.ts
@@ -22,7 +22,7 @@ export default async function (tree: Tree, schema: ReactComponentGeneratorSchema
 
   return () => {
     const root = workspaceRoot;
-    const { npmPackageName, project, componentName } = options;
+    const { project, componentName } = options;
 
     execSync(`yarn nx run ${project}:generate-api`, {
       cwd: root,
@@ -31,14 +31,14 @@ export default async function (tree: Tree, schema: ReactComponentGeneratorSchema
 
     // This is used only for integration testing purposes on CI as jest disables snapshot updates by default
     const forceSnapshotUpdate = Boolean(process.env.__FORCE_SNAPSHOT_UPDATE__);
-    const testCmd = `yarn workspace ${npmPackageName} test -t ${componentName}` + (forceSnapshotUpdate ? ' -u' : '');
+    const testCmd = `yarn nx run ${project}:test -t ${componentName}` + (forceSnapshotUpdate ? ' -u' : '');
 
     execSync(testCmd, {
       cwd: root,
       stdio: 'inherit',
     });
 
-    execSync(`yarn workspace ${npmPackageName} lint --fix`, {
+    execSync(`yarn nx run ${project}:lint --fix`, {
       cwd: root,
       stdio: 'inherit',
     });

--- a/tools/workspace-plugin/src/generators/react-library/files/just.config.ts__tmpl__
+++ b/tools/workspace-plugin/src/generators/react-library/files/just.config.ts__tmpl__
@@ -1,5 +1,0 @@
-import { preset, task } from '@fluentui/scripts-tasks';
-
-preset();
-
-task('build', 'build:react-components').cached?.();

--- a/tools/workspace-plugin/src/generators/react-library/files/package.json__tmpl__
+++ b/tools/workspace-plugin/src/generators/react-library/files/package.json__tmpl__
@@ -18,23 +18,11 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
-  "scripts": {
-    "build": "just-scripts build",
-    "clean": "just-scripts clean",
-    "generate-api": "just-scripts generate-api",
-    "lint": "just-scripts lint",
-    "start": "yarn storybook",
-    "storybook": "storybook dev",
-    "test": "jest --passWithNoTests",
-    "test-ssr": "test-ssr \"./stories/**/*.stories.tsx\"",
-    "type-check": "tsc -b tsconfig.json"
-  },
   "devDependencies": {
     "@<%= npmScope %>/eslint-plugin": "*",
     "@<%= npmScope %>/react-conformance": "*",
     "@<%= npmScope %>/react-conformance-griffel": "*",
-    "@<%= npmScope %>/scripts-api-extractor": "*",
-    "@<%= npmScope %>/scripts-tasks": "*"
+    "@<%= npmScope %>/scripts-api-extractor": "*"
   },
   "dependencies": {
     "@<%= npmScope %>/react-jsx-runtime": "",

--- a/tools/workspace-plugin/src/generators/react-library/index.spec.ts
+++ b/tools/workspace-plugin/src/generators/react-library/index.spec.ts
@@ -63,7 +63,6 @@ describe('react-library generator', () => {
         "docs",
         "etc",
         "jest.config.js",
-        "just.config.ts",
         "package.json",
         "src",
         "tsconfig.json",
@@ -99,7 +98,7 @@ describe('react-library generator', () => {
         '<projectRoot>/../../../../../../dist/out-tsc/types/packages/react-components/<unscopedPackageName>/library/src/index.d.ts',
     });
     const libPackageJson = readJson(tree, `${library.root}/package.json`);
-    expect(libPackageJson.scripts['test-ssr']).toEqual(undefined);
+    expect(libPackageJson.scripts).toEqual(undefined);
     expect(libPackageJson).toEqual(
       expect.objectContaining({
         name: '@proj/react-one-preview',
@@ -174,7 +173,6 @@ describe('react-library generator', () => {
         "src",
         ".storybook",
         "README.md",
-        "just.config.ts",
         ".eslintrc.json",
         "tsconfig.json",
         "tsconfig.lib.json",
@@ -192,15 +190,6 @@ describe('react-library generator', () => {
         '@proj/react-storybook-addon': '*',
         '@proj/react-storybook-addon-export-to-sandbox': '*',
         '@proj/scripts-storybook': '*',
-        '@proj/scripts-tasks': '*',
-      },
-      scripts: {
-        format: 'just-scripts prettier',
-        lint: 'eslint src/',
-        start: 'yarn storybook',
-        storybook: 'storybook dev',
-        'type-check': 'just-scripts type-check',
-        'test-ssr': 'test-ssr "./src/**/*.stories.tsx"',
       },
     });
 
@@ -284,7 +273,6 @@ describe('react-library generator', () => {
         "docs",
         "etc",
         "jest.config.js",
-        "just.config.ts",
         "package.json",
         "src",
         "tsconfig.json",
@@ -307,7 +295,6 @@ describe('react-library generator', () => {
         "src",
         ".storybook",
         "README.md",
-        "just.config.ts",
         ".eslintrc.json",
         "tsconfig.json",
         "tsconfig.lib.json",

--- a/tools/workspace-plugin/src/generators/split-library-in-two/generator.spec.ts
+++ b/tools/workspace-plugin/src/generators/split-library-in-two/generator.spec.ts
@@ -120,14 +120,10 @@ describe('split-library-in-two generator', () => {
     );
 
     const newConfigPackageJSON = readJson(tree, `${newConfig.root}/package.json`);
-    expect(newConfigPackageJSON.scripts['test-ssr']).toEqual(undefined);
+    expect(newConfigPackageJSON.scripts).toEqual(undefined);
     expect(newConfigPackageJSON).toEqual(
       expect.objectContaining({
         name: '@proj/react-hello',
-        scripts: expect.objectContaining({
-          'type-check': 'just-scripts type-check',
-          storybook: 'yarn --cwd ../stories storybook',
-        }),
         devDependencies: {
           '@proj/react-one-for-test': '*',
           '@proj/react-provider': '*',
@@ -184,18 +180,9 @@ describe('split-library-in-two generator', () => {
           "@proj/react-storybook-addon-export-to-sandbox": "*",
           "@proj/react-two-preview": "*",
           "@proj/scripts-storybook": "*",
-          "@proj/scripts-tasks": "*",
         },
         "name": "@proj/react-hello-stories",
         "private": true,
-        "scripts": Object {
-          "format": "just-scripts prettier",
-          "lint": "eslint src/",
-          "start": "yarn storybook",
-          "storybook": "storybook dev",
-          "test-ssr": "test-ssr \\"./src/**/*.stories.tsx\\"",
-          "type-check": "just-scripts type-check",
-        },
         "version": "0.0.0",
       }
     `);
@@ -372,21 +359,6 @@ function setupDummyPackage(tree: Tree, options: { projectName: string }) {
       version: '9.0.0',
       typings: 'lib/index.d.ts',
       main: 'lib-commonjs/index.js',
-      scripts: {
-        build: 'just-scripts build',
-        'bundle-size': 'monosize measure',
-        clean: 'just-scripts clean',
-        'code-style': 'just-scripts code-style',
-        just: 'just-scripts',
-        lint: 'just-scripts lint',
-        start: 'yarn storybook',
-        test: 'jest --passWithNoTests',
-        storybook: 'storybook dev',
-        'type-check': 'tsc -b tsconfig.json',
-        'generate-api': 'just-scripts generate-api',
-        'test-ssr': 'test-ssr "./stories/**/*.stories.tsx"',
-        'verify-packaging': 'just-scripts verify-packaging',
-      },
       dependencies: {},
     },
     tsConfig: {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

Migrates v9 and tools packages to use [project crystal ( inferred tasks )](https://nx.dev/concepts/inferred-tasks)

### additional changes

**🔐 security**

- v9 won't ship `package.json#scripts` anymore, mitigating exposure of tools used that could be possibly compromised  to run malicious code in user land

**👨‍🔧 less boilerplate**

_git diff stats (excluding change files):_
- 827 insertions(+), 
- **2897 deletions(-)**


**🧹 task cleanup/normalization**

> 📊 comparison data (before/after) [npm-scripts-to-nx-project-crystal.json](https://github.com/user-attachments/files/17509644/scripts-to-nx-migration.json)

- unified task names across all projects ( example of v9 library/ project ):
  - `storybook`
  - `test`
  - `test-ssr`
  - `lint`
  - `format` and `format:check`
  - `type-check`
  - `build`
  - `bundle-size`
  - `generate-api` 
  - `e2e` and `e2e:local`
  - `verify-packaging`

- ghost configurations that were not properly executed are now ran ( because project crystall properly defines them based on context )
  - we have new `bundle-size` entries for packages
  - some projects that defined `e2e` task, but had no e2e setup/tests are no longer present
  - some projects that defined `test-ssr` task, but had no supporting stories to run actual test are no longer present

**🧹 project cleanup**

- `just-scripts` are gonne

**🎬 react-components project**

- generation of `unstable.d.ts` is not using api-extractor anymore rather switches to template 
  - `/unstable` api is deprecated and cannot be tweaked by anyone
  - switching to template explicitly sets the contract while improving performance of 1 less api-extractor invocation


### 🚨 Breaking changes:

_1. using `yarn workspace` won't work anymore (for packages using project crystal)_
- v9 (libraries for now)
- tooling related

> - 💡 following wont work anymore: `yarn workspace @fluentui/<project-name> <task-name>`
> - 💡 if package.json doesn't have `scripts`  === migrated to project crystal

**how to run tasks going forward?**
- use `yarn nx run <project>:<task-name>` 
- use `yarn start` from monorepo root

_2. `package.json#scripts` are gone and forbidden to use going forward_

how can I determine what tasks are available per project ?:
- `yarn nx show project <project-name>`
- `yarn start`
-  Nx Console 
  - <img width="254" alt="image" src="https://github.com/user-attachments/assets/1193f83c-424f-4a70-b699-486cf486e3a6">
  - <img width="674" alt="image" src="https://github.com/user-attachments/assets/7864b63a-b93c-4387-acb9-71a32a8677e6">

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Implements partially #30267 
- Replaces https://github.com/microsoft/fluentui/pull/33019 
