### PR TITLE
feat(animation): add option to disable motion on motion component level

### DIFF
--- a/change/@fluentui-react-motion-798078cf-4718-44f2-8477-3b5d8540ee6b.json
+++ b/change/@fluentui-react-motion-798078cf-4718-44f2-8477-3b5d8540ee6b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Introduced a new skip prop for createPresenceComponent to disable animations on a per-instance basis",
+  "packageName": "@fluentui/react-motion",
+  "email": "olkatruk@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-motion-components-preview/stories/src/Collapse/CollapseDisableMotion.md
+++ b/packages/react-components/react-motion-components-preview/stories/src/Collapse/CollapseDisableMotion.md
@@ -1,0 +1,1 @@
+Use the `skip` property to prevent animations from playing while keeping all functionality, such as callbacks (e.g., `onMotionFinished`), intact. This is especially useful for improving accessibility by offering a non-animated experience while ensuring the component logic remains unaffected.

--- a/packages/react-components/react-motion-components-preview/stories/src/Collapse/CollapseDisableMotion.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Collapse/CollapseDisableMotion.stories.tsx
@@ -1,0 +1,71 @@
+import { Field, makeStyles, tokens, Switch } from '@fluentui/react-components';
+import { CollapseExaggerated } from '@fluentui/react-motion-components-preview';
+import * as React from 'react';
+
+import description from './CollapseDisableMotion.md';
+
+const useClasses = makeStyles({
+  container: {
+    display: 'grid',
+    gridTemplate: `"controls ." "card card" / 1fr 1fr`,
+    gap: '20px 10px',
+  },
+  card: {
+    gridArea: 'card',
+    padding: '10px',
+  },
+  controls: {
+    display: 'flex',
+    flexDirection: 'column',
+    gridArea: 'controls',
+
+    border: `${tokens.strokeWidthThicker} solid ${tokens.colorNeutralForeground3}`,
+    borderRadius: tokens.borderRadiusMedium,
+    boxShadow: tokens.shadow16,
+    padding: '10px',
+  },
+  field: {
+    display: 'flex',
+    flex: 1,
+    gao: '20px',
+  },
+});
+
+const LoremIpsum = () => (
+  <>
+    {'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. '.repeat(
+      10,
+    )}
+  </>
+);
+
+export const DisableMotion = () => {
+  const classes = useClasses();
+  const [visible, setVisible] = React.useState<boolean>(false);
+  const [disableMotion, setDisableMotion] = React.useState<boolean>(false);
+
+  return (
+    <div className={classes.container}>
+      <div className={classes.controls}>
+        <Field className={classes.field}>
+          <Switch label="Visible" checked={visible} onChange={() => setVisible(v => !v)} />
+          <Switch label="Disable collapse animaiton" checked={disableMotion} onChange={() => setDisableMotion(v => !v)} />
+        </Field>
+      </div>
+
+      <CollapseExaggerated visible={visible} skip={disableMotion}>
+        <div className={classes.card}>
+          <LoremIpsum />
+        </div>
+      </CollapseExaggerated>
+    </div>
+  );
+};
+
+DisableMotion.parameters = {
+  docs: {
+    description: {
+      story: description,
+    },
+  },
+};

--- a/packages/react-components/react-motion-components-preview/stories/src/Collapse/index.stories.ts
+++ b/packages/react-components/react-motion-components-preview/stories/src/Collapse/index.stories.ts
@@ -6,6 +6,7 @@ export { Horizontal } from './CollapseHorizontal.stories';
 export { Snappy } from './CollapseSnappy.stories';
 export { Exaggerated } from './CollapseExaggerated.stories';
 export { Customization } from './CollapseCustomization.stories';
+export { DisableMotion } from './CollapseDisableMotion.stories'
 
 export default {
   title: 'Motion/Components (preview)/Collapse',

--- a/packages/react-components/react-motion/library/src/factories/createPresenceComponent.ts
+++ b/packages/react-components/react-motion/library/src/factories/createPresenceComponent.ts
@@ -60,6 +60,9 @@ export type PresenceComponentProps = {
   /** Defines whether a component is visible; triggers the "enter" or "exit" motions. */
   visible?: boolean;
 
+  /** Determines whether the component should skip all animations */
+  skip?: boolean;
+
   /**
    * By default, the child component remains mounted after it reaches the "finished" state. Set "unmountOnExit" if
    * you prefer to unmount the component after it finishes exiting.
@@ -96,6 +99,7 @@ export function createPresenceComponent<MotionParams extends Record<string, Moti
         onMotionStart,
         onMotionCancel,
         visible,
+        skip,
         unmountOnExit,
         ..._rest
       } = merged;
@@ -159,7 +163,7 @@ export function createPresenceComponent<MotionParams extends Record<string, Moti
             handleMotionStart(direction);
           }
 
-          const handle = animateAtoms(element, atoms, { isReducedMotion: isReducedMotion() });
+          const handle = animateAtoms(element, atoms, { isReducedMotion: isReducedMotion() || !!skip });
 
           if (applyInitialStyles) {
             // Heads up!


### PR DESCRIPTION
## Previous Behavior
- Disabling animations globally was only possible through `MotionBehaviorProvider`.
- No built-in way to selectively disable animations for individual motion component instances while preserving callbacks and behavior logic.

## New Behavior
- Introduced a new `skip` prop for `createPresenceComponent` to disable animations on a per-instance basis.
- When `skip` is set to `true`, the animation will not play, but all associated callbacks (like `onMotionFinished`) will still be invoked.
- This feature allows developers to override global settings and manage animation behavior at the component level, ensuring better alignment with accessibility requirements.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #33090
