### PR TITLE
fix: Align menu item long content with icon slots

### DIFF
--- a/apps/vr-tests-react-components/src/stories/Menu/MenuItemSelectableWIthLongText.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Menu/MenuItemSelectableWIthLongText.stories.tsx
@@ -1,22 +1,20 @@
 import * as React from 'react';
-
-import {
-  Button,
-  Menu,
-  MenuTrigger,
-  MenuList,
-  MenuItem,
-  MenuItemCheckbox,
-  MenuPopover,
-} from '@fluentui/react-components';
+import type { Meta } from '@storybook/react';
+import { Menu, MenuTrigger, MenuPopover, MenuList, MenuItemCheckbox, MenuItem } from '@fluentui/react-menu';
+import { StoryWright } from 'storywright';
 import { CutRegular, CutFilled, bundleIcon } from '@fluentui/react-icons';
 
 const CutIcon = bundleIcon(CutFilled, CutRegular);
 
-export const AligningWithSelectableItems = () => (
+export default {
+  title: 'Menu Converged - selection',
+  decorators: [story => <StoryWright>{story()}</StoryWright>],
+} satisfies Meta<typeof Menu>;
+
+export const SelectableWithLongText = () => (
   <Menu hasIcons hasCheckmarks open>
     <MenuTrigger disableButtonEnhancement>
-      <Button>Toggle menu</Button>
+      <button>Toggle menu</button>
     </MenuTrigger>
     <MenuPopover>
       <MenuList>
@@ -30,12 +28,4 @@ export const AligningWithSelectableItems = () => (
   </Menu>
 );
 
-AligningWithSelectableItems.parameters = {
-  docs: {
-    description: {
-      story: ['The `hasCheckmarks` prop will align menu items if only a subset of menu items are selectable.'].join(
-        '\n',
-      ),
-    },
-  },
-};
+SelectableWithLongText.storyName = 'selectable with long text';

--- a/change/@fluentui-react-menu-738a350f-94f7-49f4-a55a-6f5f807cf659.json
+++ b/change/@fluentui-react-menu-738a350f-94f7-49f4-a55a-6f5f807cf659.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Align menu item long content with icon slots",
+  "packageName": "@fluentui/react-menu",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-menu/library/src/components/MenuItem/useMenuItemStyles.styles.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuItem/useMenuItemStyles.styles.ts
@@ -98,6 +98,7 @@ const useIconBaseStyles = makeResetStyles({
   alignItems: 'center',
   display: 'inline-flex',
   justifyContent: 'center',
+  flexShrink: 0,
 });
 
 const useSubmenuIndicatorBaseStyles = makeResetStyles({

--- a/packages/react-components/react-menu/library/src/selectable/useCheckmarkStyles.styles.ts
+++ b/packages/react-components/react-menu/library/src/selectable/useCheckmarkStyles.styles.ts
@@ -7,9 +7,11 @@ const useStyles = makeStyles({
     width: '16px',
     height: '16px',
     visibility: 'hidden',
+    flexShrink: 0,
   },
   rootChecked: {
     visibility: 'visible',
+    flexShrink: 0,
   },
 });
 

--- a/packages/react-components/react-menu/stories/src/Menu/MenuAligningWithSelectableItems.stories.tsx
+++ b/packages/react-components/react-menu/stories/src/Menu/MenuAligningWithSelectableItems.stories.tsx
@@ -14,7 +14,7 @@ import { CutRegular, CutFilled, bundleIcon } from '@fluentui/react-icons';
 const CutIcon = bundleIcon(CutFilled, CutRegular);
 
 export const AligningWithSelectableItems = () => (
-  <Menu hasIcons hasCheckmarks open>
+  <Menu hasIcons hasCheckmarks>
     <MenuTrigger disableButtonEnhancement>
       <Button>Toggle menu</Button>
     </MenuTrigger>
@@ -23,7 +23,7 @@ export const AligningWithSelectableItems = () => (
         <MenuItemCheckbox icon={<CutIcon />} name="edit" value="cut">
           Checkbox item
         </MenuItemCheckbox>
-        <MenuItem>Menu item with really long text, this is really really long text</MenuItem>
+        <MenuItem>Menu item</MenuItem>
         <MenuItem>Menu item</MenuItem>
       </MenuList>
     </MenuPopover>


### PR DESCRIPTION
Sets `flex-shrink: 0` on icon and checkmark slots

Fixes #32979

