### PR TITLE
fix(scripts/monorepo): silent nx verbose messages when invoking getAffectedPackages to emit valid JSON

### DIFF
--- a/scripts/monorepo/src/getAffectedPackages.js
+++ b/scripts/monorepo/src/getAffectedPackages.js
@@ -10,14 +10,23 @@ const { workspaceRoot } = require('./utils');
  * @returns {Set<string>} - Set of packages that are affected by in the current branch
  */
 function getAffectedPackages(base = 'origin/master') {
-  const res = spawnSync('nx', ['show', 'projects', '--affected', `--base=${base}`, '--json'], {
+  const cmdArgs = [
+    'show',
+    'projects',
+    '--affected',
+    `--base=${base}`,
+    '--json',
+    // override NX_VERBOSE_LOGGING in order to emit valid JSON
+    `--verbose=false`,
+  ];
+  const res = spawnSync('nx', cmdArgs, {
     cwd: workspaceRoot,
     shell: true,
   });
 
   if (res.status !== 0) {
     console.error(res.stderr);
-    throw new Error(`'nx show projects --affected --base ${base} --json' failed with status ${res.status}`);
+    throw new Error(`'nx ${cmdArgs.join(' ')}' failed with status ${res.status}`);
   }
 
   const output = res.stdout.toString();


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

- see PR title
- once https://github.com/microsoft/fluentui/pull/33098 lands and we will enable the plugin it will log measurements on CI, which would create invalid json output for `getAffectedPackages`. This PR always forces non verbose mode on our API

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows https://github.com/microsoft/fluentui/pull/33098
