### PR TITLE
Combobox: Update Virtualizer buffer sizing to accommodate page up/down

### DIFF
--- a/packages/react-components/react-combobox/stories/src/Combobox/ComboboxVirtualizer.stories.tsx
+++ b/packages/react-components/react-combobox/stories/src/Combobox/ComboboxVirtualizer.stories.tsx
@@ -21,9 +21,15 @@ export const ComboboxVirtualizer = (props: Partial<ComboboxProps>) => {
   const itemHeight = 34;
   const numberOfItems = 10000;
 
+  const [open, setOpen] = React.useState(false);
+
   const { virtualizerLength, bufferItems, bufferSize, scrollRef, containerSizeRef } = useStaticVirtualizerMeasure({
     defaultItemSize: itemHeight,
     direction: 'vertical',
+    // We want at least 10 additional items on each side of visible items for page up/down (+ 1 buffer)
+    bufferItems: 11,
+    // We need to recalculate index when at least 10 items (+1px) from the bottom or top for page up/down
+    bufferSize: itemHeight * 10 + 1,
   });
 
   const styles = useStyles();
@@ -37,6 +43,10 @@ export const ComboboxVirtualizer = (props: Partial<ComboboxProps>) => {
           placeholder="Select a number"
           positioning={{ autoSize: 'width' }}
           listbox={{ ref: scrollRef, className: styles.listbox }}
+          open={open}
+          onOpenChange={(e, data) => {
+            setOpen(data.open);
+          }}
         >
           <Virtualizer
             numItems={numberOfItems}

--- a/packages/react-components/react-combobox/stories/src/Combobox/ComboboxVirtualizer.stories.tsx
+++ b/packages/react-components/react-combobox/stories/src/Combobox/ComboboxVirtualizer.stories.tsx
@@ -21,8 +21,6 @@ export const ComboboxVirtualizer = (props: Partial<ComboboxProps>) => {
   const itemHeight = 34;
   const numberOfItems = 10000;
 
-  const [open, setOpen] = React.useState(false);
-
   const { virtualizerLength, bufferItems, bufferSize, scrollRef, containerSizeRef } = useStaticVirtualizerMeasure({
     defaultItemSize: itemHeight,
     direction: 'vertical',
@@ -43,10 +41,6 @@ export const ComboboxVirtualizer = (props: Partial<ComboboxProps>) => {
           placeholder="Select a number"
           positioning={{ autoSize: 'width' }}
           listbox={{ ref: scrollRef, className: styles.listbox }}
-          open={open}
-          onOpenChange={(e, data) => {
-            setOpen(data.open);
-          }}
         >
           <Virtualizer
             numItems={numberOfItems}


### PR DESCRIPTION
## Previous Behavior
Virtualized combobox optimized virtualization which prevented page up/down from having the DOM nodes nessecary for a full and consistent pagination.

## New Behavior
We now render an additional ~10 items on each side of the buffer with appropriate buffer sizing for consistent re-rendering to enable standard pagination.

## Related Issue(s)
- Fixes #32220 
