### PR TITLE
Virtualizer: Reduce state updates and fix intersection ratio detection

### DIFF
--- a/change/@fluentui-react-virtualizer-701a2cd4-bd8c-48af-a2d4-753903d62124.json
+++ b/change/@fluentui-react-virtualizer-701a2cd4-bd8c-48af-a2d4-753903d62124.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: Enable virtualizer to fall back to most recent IO event if none intersecting",
+  "packageName": "@fluentui/react-virtualizer",
+  "email": "mifraser@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-virtualizer/library/etc/react-virtualizer.api.md
+++ b/packages/react-components/react-virtualizer/library/etc/react-virtualizer.api.md
@@ -81,6 +81,7 @@ export const useDynamicVirtualizerMeasure: <TElement extends HTMLElement>(virtua
     bufferSize: number;
     scrollRef: (instance: TElement | null) => void;
     containerSizeRef: React_2.RefObject<number>;
+    updateScrollPosition: (scrollPosition: number) => void;
 };
 
 // @public
@@ -145,8 +146,6 @@ export const virtualizerClassNames: SlotClassNames<VirtualizerSlots>;
 export type VirtualizerContextProps = {
     contextIndex: number;
     setContextIndex: (index: number) => void;
-    contextPosition?: number;
-    setContextPosition?: (index: number) => void;
     childProgressiveSizes?: React_2.MutableRefObject<number[]>;
 };
 

--- a/packages/react-components/react-virtualizer/library/src/components/Virtualizer/Virtualizer.types.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/Virtualizer/Virtualizer.types.ts
@@ -140,8 +140,7 @@ export type VirtualizerConfigProps = {
 
   /**
    * Enables users to override the intersectionObserverRoot.
-   * RECOMMEND: DO NOT PASS THIS IN, as it can cause side effects
-   * when overlapping with other scroll views
+   * We recommend passing this in for accurate distance assessment in IO
    */
   scrollViewRef?: React.MutableRefObject<HTMLElement | null>;
 

--- a/packages/react-components/react-virtualizer/library/src/components/Virtualizer/Virtualizer.types.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/Virtualizer/Virtualizer.types.ts
@@ -195,6 +195,12 @@ export type VirtualizerConfigProps = {
    * Virtualizer Measure hooks provide a suitable reference.
    */
   containerSizeRef: RefObject<number>;
+
+  /**
+   * A callback that enables updating scroll position for calculating required dynamic lengths,
+   * this should be passed in from useDynamicVirtualizerMeasure
+   */
+  updateScrollPosition?: (position: number) => void;
 };
 
 export type VirtualizerProps = ComponentProps<Partial<VirtualizerSlots>> & VirtualizerConfigProps;

--- a/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
@@ -422,7 +422,6 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
         numItems,
         bufferSize,
         bufferItems,
-        scrollViewRef,
         containerSizeRef,
         updateScrollPosition,
         batchUpdateNewIndex,

--- a/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
@@ -428,6 +428,12 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
         bufferSize,
         bufferItems,
         scrollViewRef,
+        batchUpdateNewIndex,
+        calculateAfter,
+        calculateBefore,
+        calculateTotalSize,
+        getIndexFromScrollPosition,
+        updateCurrentItemSizes,
       ],
     ),
     {

--- a/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
@@ -366,10 +366,6 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
             // Get before buffers position
             measurementPos = calculateBefore();
 
-            // No IO Root - Account for offset of top of virtualizer
-            if (!scrollViewRef?.current) {
-              measurementPos += beforeElementRef?.current?.offsetTop;
-            }
             // Get exact intersection position based on overflow size (how far into window did we scroll IO?)
             const overflowAmount =
               axis === 'vertical' ? latestEntry.intersectionRect.height : latestEntry.intersectionRect.width;

--- a/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
@@ -419,7 +419,6 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
         });
       },
       [
-        updateScrollPosition,
         actualIndex,
         virtualizerLength,
         axis,
@@ -428,6 +427,8 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
         bufferSize,
         bufferItems,
         scrollViewRef,
+        containerSizeRef,
+        updateScrollPosition,
         batchUpdateNewIndex,
         calculateAfter,
         calculateBefore,

--- a/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollViewDynamic/useVirtualizerScrollViewDynamic.tsx
+++ b/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollViewDynamic/useVirtualizerScrollViewDynamic.tsx
@@ -49,15 +49,16 @@ export function useVirtualizerScrollViewDynamic_unstable(
     [sizeTrackingArray, props.itemSize, sizeUpdateCount],
   );
 
-  const { virtualizerLength, bufferItems, bufferSize, scrollRef, containerSizeRef } = useDynamicVirtualizerMeasure({
-    defaultItemSize: props.itemSize,
-    direction: props.axis ?? 'vertical',
-    getItemSize: props.getItemSize ?? getChildSizeAuto,
-    virtualizerContext: contextState,
-    numItems: props.numItems,
-    bufferItems: _bufferItems,
-    bufferSize: _bufferSize,
-  });
+  const { virtualizerLength, bufferItems, bufferSize, scrollRef, containerSizeRef, updateScrollPosition } =
+    useDynamicVirtualizerMeasure({
+      defaultItemSize: props.itemSize,
+      direction: props.axis ?? 'vertical',
+      getItemSize: props.getItemSize ?? getChildSizeAuto,
+      virtualizerContext: contextState,
+      numItems: props.numItems,
+      bufferItems: _bufferItems,
+      bufferSize: _bufferSize,
+    });
 
   const _imperativeVirtualizerRef = useMergedRefs(React.useRef<VirtualizerDataRef>(null), imperativeVirtualizerRef);
 
@@ -76,7 +77,7 @@ export function useVirtualizerScrollViewDynamic_unstable(
   if (virtualizerLengthRef.current !== virtualizerLength) {
     virtualizerLengthRef.current = virtualizerLength;
   }
-  const scrollViewRef = useMergedRefs(props.scrollViewRef, scrollRef, paginationRef) as React.RefObject<HTMLDivElement>;
+  const scrollViewRef = useMergedRefs(props.scrollViewRef, scrollRef, paginationRef);
   const scrollCallbackRef = React.useRef<null | ((index: number) => void)>(null);
 
   useImperativeHandle(
@@ -97,7 +98,7 @@ export function useVirtualizerScrollViewDynamic_unstable(
               index,
               itemSizes: _imperativeVirtualizerRef.current?.nodeSizes,
               totalSize,
-              scrollViewRef,
+              scrollViewRef: scrollViewRef as React.RefObject<HTMLDivElement>,
               axis,
               reversed,
               behavior,
@@ -127,6 +128,8 @@ export function useVirtualizerScrollViewDynamic_unstable(
     imperativeVirtualizerRef: _imperativeVirtualizerRef,
     onRenderedFlaggedIndex: handleRenderedIndex,
     containerSizeRef,
+    scrollViewRef,
+    updateScrollPosition,
   });
 
   const measureObject = useMeasureList(

--- a/packages/react-components/react-virtualizer/library/src/utilities/VirtualizerContext/VirtualizerContext.ts
+++ b/packages/react-components/react-virtualizer/library/src/utilities/VirtualizerContext/VirtualizerContext.ts
@@ -17,7 +17,6 @@ export const useVirtualizerContextState_unstable = (
 ): DynamicVirtualizerContextProps => {
   const virtualizerContext = useVirtualizerContext_unstable();
   const [_contextIndex, _setContextIndex] = useState<number>(-1);
-  const [_contextPosition, _setContextPosition] = useState<number>(0);
   const childProgressiveSizes = useRef<number[]>([]);
 
   /* We respect any wrapped providers while also ensuring defaults or passed through
@@ -27,12 +26,9 @@ export const useVirtualizerContextState_unstable = (
     () => ({
       contextIndex: passedContext?.contextIndex ?? virtualizerContext?.contextIndex ?? _contextIndex,
       setContextIndex: passedContext?.setContextIndex ?? virtualizerContext?.setContextIndex ?? _setContextIndex,
-      contextPosition: passedContext?.contextPosition ?? virtualizerContext?.contextPosition ?? _contextPosition,
-      setContextPosition:
-        passedContext?.setContextPosition ?? virtualizerContext?.setContextPosition ?? _setContextPosition,
       childProgressiveSizes,
     }),
-    [_contextIndex, _contextPosition, passedContext, virtualizerContext],
+    [_contextIndex, passedContext, virtualizerContext],
   );
 
   return context;

--- a/packages/react-components/react-virtualizer/library/src/utilities/VirtualizerContext/types.ts
+++ b/packages/react-components/react-virtualizer/library/src/utilities/VirtualizerContext/types.ts
@@ -8,8 +8,6 @@ export type VirtualizerContextProps = {
   /*
    * These option props are used in dynamic virtualizer
    */
-  contextPosition?: number;
-  setContextPosition?: (index: number) => void;
   childProgressiveSizes?: React.MutableRefObject<number[]>;
 };
 

--- a/packages/react-components/react-virtualizer/library/src/utilities/VirtualizerContext/types.ts
+++ b/packages/react-components/react-virtualizer/library/src/utilities/VirtualizerContext/types.ts
@@ -6,7 +6,7 @@ export type VirtualizerContextProps = {
   contextIndex: number;
   setContextIndex: (index: number) => void;
   /*
-   * These option props are used in dynamic virtualizer
+   * These optional props are used in dynamic virtualizer
    */
   childProgressiveSizes?: React.MutableRefObject<number[]>;
 };

--- a/packages/react-components/react-virtualizer/stories/src/Virtualizer/Dynamic.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/Virtualizer/Dynamic.stories.tsx
@@ -31,7 +31,6 @@ const useStyles = makeStyles({
 
 export const Dynamic = () => {
   const [currentIndex, setCurrentIndex] = React.useState(-1);
-  const [currentPosition, setCurrentPosition] = React.useState(0);
   const childProgressiveSizes = React.useRef<number[]>([]);
   const [flag, toggleFlag] = React.useState(false);
   const styles = useStyles();
@@ -65,17 +64,16 @@ export const Dynamic = () => {
   const contextState: DynamicVirtualizerContextProps = {
     contextIndex: currentIndex,
     setContextIndex: setCurrentIndex,
-    contextPosition: currentPosition,
-    setContextPosition: setCurrentPosition,
     childProgressiveSizes,
   };
 
-  const { virtualizerLength, bufferItems, bufferSize, scrollRef, containerSizeRef } = useDynamicVirtualizerMeasure({
-    defaultItemSize: 100,
-    getItemSize: getSizeForIndex,
-    numItems: childLength,
-    virtualizerContext: contextState,
-  });
+  const { virtualizerLength, bufferItems, bufferSize, scrollRef, containerSizeRef, updateScrollPosition } =
+    useDynamicVirtualizerMeasure({
+      defaultItemSize: 100,
+      getItemSize: getSizeForIndex,
+      numItems: childLength,
+      virtualizerContext: contextState,
+    });
 
   return (
     <VirtualizerContextProvider value={contextState}>
@@ -89,6 +87,7 @@ export const Dynamic = () => {
           itemSize={100}
           containerSizeRef={containerSizeRef}
           virtualizerContext={contextState}
+          updateScrollPosition={updateScrollPosition}
         >
           {useCallback(
             (index: number) => {

--- a/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollViewDynamic/AutoMeasure.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollViewDynamic/AutoMeasure.stories.tsx
@@ -43,7 +43,7 @@ export const AutoMeasure = () => {
       bufferSize={minHeight / 2.0}
     >
       {(index: number) => {
-        const backgroundColor = index % 2 ? '#FFFFFF' : '#ABABAB';
+        const backgroundColor = index % 2 ? '#CCCCCC' : '#ABABAB';
         return (
           <div
             role={'listitem'}


### PR DESCRIPTION
## Previous Behavior
Virtualizer used state to store the current scroll position in dynamically sized items to trigger a recalc of virtualizer length
Virtualizer depended on intersectionRect ratio being above zero

## New Behavior
Virtualizer now uses a callback with new scroll position to calculate if a state update (virtualization length) update is nessecary
Virtualizer now uses isIntersecting to account for when intersectionRect may be rounded down to zero.
