### PR TITLE
fix(v8 ColorSwatchPicker): Add border to white color in high contrast mode

### DIFF
--- a/change/@fluentui-react-e3da4668-61a1-4a12-a488-fd618c230554.json
+++ b/change/@fluentui-react-e3da4668-61a1-4a12-a488-fd618c230554.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(v8 ColorSwatchPicker): Add border to white color in high contrast mode",
+  "packageName": "@fluentui/react",
+  "email": "jiangemma@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/SwatchColorPicker/ColorPickerGridCell.styles.ts
+++ b/packages/react/src/components/SwatchColorPicker/ColorPickerGridCell.styles.ts
@@ -134,6 +134,11 @@ export const getStyles = (props: IColorPickerGridCellStyleProps): IColorPickerGr
           // fake a border for white
           backgroundColor: buttonBorderIsWhite,
           padding: 1,
+          selectors: {
+            [HighContrastSelector]: {
+              outline: `1px solid ButtonText`,
+            },
+          },
         },
     ],
     // the <svg> that holds the color

--- a/packages/react/src/components/SwatchColorPicker/__snapshots__/SwatchColorPicker.test.tsx.snap
+++ b/packages/react/src/components/SwatchColorPicker/__snapshots__/SwatchColorPicker.test.tsx.snap
@@ -2226,6 +2226,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                 }
                 @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                   border-color: Window;
+                  outline: 1px solid ButtonText;
                 }
                 .ms-Fabric--isFocusVisible &:focus::after {
                   border-color: #605e5c;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

In high contrast mode, there was not enough contrast between the white color and the background.
<img width="510" alt="image" src="https://github.com/user-attachments/assets/46f93487-2e03-4a78-bf76-c488bb3be16b">

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

There is now a border around the white color in high contrast mode.
<img width="510" alt="image" src="https://github.com/user-attachments/assets/590d43d4-ddb7-4dca-aad8-b31e230e474a">

Confirmation that it works on Windows:
![image](https://github.com/user-attachments/assets/8d27de75-24d5-48ac-82c0-817a89cbd15b)


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes [ADO bug](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/18609)
