### PR TITLE
fix: change to new css anchor positioning properties

### DIFF
--- a/change/@fluentui-web-components-cb8c9815-f5ec-4855-b020-72aec63d5760.json
+++ b/change/@fluentui-web-components-cb8c9815-f5ec-4855-b020-72aec63d5760.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: change to new css anchor positioning properties",
+  "packageName": "@fluentui/web-components",
+  "email": "machi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/menu-item/menu-item.styles.ts
+++ b/packages/web-components/src/menu-item/menu-item.styles.ts
@@ -151,12 +151,12 @@ export const styles = css`
     }
 
     ::slotted([popover]) {
-      inset-area: inline-end span-block-end;
       margin: 0;
       max-height: var(--menu-max-height, auto);
       position: absolute;
       position-anchor: --menu-trigger;
-      position-try-options: flip-inline, inset-area(block-start);
+      position-area: inline-end span-block-end;
+      position-try-fallbacks: flip-inline;
       z-index: 1;
     }
 

--- a/packages/web-components/src/menu/menu.styles.ts
+++ b/packages/web-components/src/menu/menu.styles.ts
@@ -13,11 +13,11 @@ export const styles = css`
   }
 
   ::slotted([popover]) {
-    inset-area: block-end span-inline-end;
     margin: 0;
     max-height: var(--menu-max-height, auto);
     position-anchor: --menu-trigger;
-    position-try-options: flip-block;
+    position-area: block-end span-inline-end;
+    position-try-fallbacks: flip-block;
     position: absolute;
     z-index: 1;
   }

--- a/packages/web-components/src/split-button/split-button.stories.ts
+++ b/packages/web-components/src/split-button/split-button.stories.ts
@@ -6,7 +6,7 @@ import type { Menu as FluentMenu } from '../menu/menu.js';
 type Story = StoryObj<FluentMenu>;
 
 const defaultSlottedContent = html`
-  <fluent-menu-list style="inset-area: block-end span-inline-start;">
+  <fluent-menu-list style="position-area: block-end span-inline-start;">
     <fluent-menu-item>Menu item 1</fluent-menu-item>
     <fluent-menu-item>Menu item 2</fluent-menu-item>
     <fluent-menu-item>Menu item 3</fluent-menu-item>


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Using the old/deprecated CSS Anchor Positioning property names. (See details: https://github.com/microsoft/fluentui/pull/32987)

## New Behavior

Update to the new ones.

Tested in Edge Canary:

<img width="601" alt="image" src="https://github.com/user-attachments/assets/0a8db20d-2cad-40b4-9824-485b99b87770">

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
