### PR TITLE
fix: move proper menu positioning style for split button into the component css

### DIFF
--- a/change/@fluentui-web-components-42dee933-09cf-43d3-84d7-c9f946dfa0cb.json
+++ b/change/@fluentui-web-components-42dee933-09cf-43d3-84d7-c9f946dfa0cb.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: move proper menu positioning for split button into component css",
+  "packageName": "@fluentui/web-components",
+  "email": "machi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/menu/menu.styles.ts
+++ b/packages/web-components/src/menu/menu.styles.ts
@@ -22,6 +22,10 @@ export const styles = css`
     z-index: 1;
   }
 
+  :host([split]) ::slotted([popover]) {
+    position-area: block-end span-inline-start;
+  }
+
   ::slotted([popover]:popover-open) {
     inset: unset;
   }

--- a/packages/web-components/src/split-button/split-button.stories.ts
+++ b/packages/web-components/src/split-button/split-button.stories.ts
@@ -6,7 +6,7 @@ import type { Menu as FluentMenu } from '../menu/menu.js';
 type Story = StoryObj<FluentMenu>;
 
 const defaultSlottedContent = html`
-  <fluent-menu-list style="position-area: block-end span-inline-start;">
+  <fluent-menu-list>
     <fluent-menu-item>Menu item 1</fluent-menu-item>
     <fluent-menu-item>Menu item 2</fluent-menu-item>
     <fluent-menu-item>Menu item 3</fluent-menu-item>


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

When split button is used, without additional external styles, the menu list is positioned left aligned with the split menu button.

## New Behavior

The proper anchor positioning CSS is built-in in the component.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
