### PR TITLE
fix(SpinButton): up/down buttons were not semantically disabled when unclickable

### DIFF
--- a/change/@fluentui-react-spinbutton-43864ed0-359e-407e-8250-36a85a8ba6b4.json
+++ b/change/@fluentui-react-spinbutton-43864ed0-359e-407e-8250-36a85a8ba6b4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: up/down buttons were not semantically disabled when unclickable",
+  "packageName": "@fluentui/react-spinbutton",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-spinbutton/library/src/components/SpinButton/SpinButton.test.tsx
+++ b/packages/react-components/react-spinbutton/library/src/components/SpinButton/SpinButton.test.tsx
@@ -126,6 +126,31 @@ describe('SpinButton', () => {
       expect(spinButton.getAttribute('aria-valuemax')).toBeNull();
     });
 
+    it('disables increment and decrement buttons and the min and max values', () => {
+      const { getByLabelText } = render(
+        <SpinButton
+          defaultValue={1}
+          min={0}
+          max={10}
+          incrementButton={{ 'aria-label': 'increment' }}
+          decrementButton={{ 'aria-label': 'decrement' }}
+        />,
+      );
+
+      const decrementBtn = getByLabelText('decrement') as HTMLButtonElement;
+      const incrementBtn = getByLabelText('increment') as HTMLButtonElement;
+
+      expect(decrementBtn.disabled).toBeFalsy();
+      expect(incrementBtn.disabled).toBeFalsy();
+
+      userEvent.click(decrementBtn);
+      expect(decrementBtn.disabled).toBeTruthy();
+
+      fireEvent.keyDown(getSpinButtonInput(), { key: End });
+      expect(decrementBtn.disabled).toBeFalsy();
+      expect(incrementBtn.disabled).toBeTruthy();
+    });
+
     it('clamps value at min when uncontrolled', () => {
       const onChange = jest.fn();
       const { getAllByRole } = render(<SpinButton defaultValue={-100} min={-100} onChange={onChange} />);

--- a/packages/react-components/react-spinbutton/library/src/components/SpinButton/useSpinButton.tsx
+++ b/packages/react-components/react-spinbutton/library/src/components/SpinButton/useSpinButton.tsx
@@ -294,7 +294,10 @@ export const useSpinButton_unstable = (props: SpinButtonProps, ref: React.Ref<HT
       defaultProps: {
         tabIndex: -1,
         children: <ChevronUp16Regular />,
-        disabled: nativeProps.primary.disabled,
+        disabled:
+          nativeProps.primary.disabled ||
+          internalState.current.atBound === 'max' ||
+          internalState.current.atBound === 'both',
         'aria-label': 'Increment value',
         type: 'button',
       },
@@ -304,7 +307,10 @@ export const useSpinButton_unstable = (props: SpinButtonProps, ref: React.Ref<HT
       defaultProps: {
         tabIndex: -1,
         children: <ChevronDown16Regular />,
-        disabled: nativeProps.primary.disabled,
+        disabled:
+          nativeProps.primary.disabled ||
+          internalState.current.atBound === 'min' ||
+          internalState.current.atBound === 'both',
         'aria-label': 'Decrement value',
         type: 'button',
       },

--- a/packages/react-components/react-spinbutton/library/src/components/SpinButton/useSpinButtonStyles.styles.ts
+++ b/packages/react-components/react-spinbutton/library/src/components/SpinButton/useSpinButtonStyles.styles.ts
@@ -387,104 +387,19 @@ const useButtonStyles = makeStyles({
   },
 });
 
-// Cannot just disable button as they need to remain
-// exposed to ATs like screen readers.
-const useButtonDisabledStyles = makeStyles({
-  base: {
-    cursor: 'not-allowed',
-
-    ':hover': {
-      cursor: 'not-allowed',
-    },
-  },
-
-  outline: {
-    color: tokens.colorNeutralForegroundDisabled,
-    ':enabled': {
-      ':hover': {
-        color: tokens.colorNeutralForegroundDisabled,
-        backgroundColor: 'transparent',
-      },
-      ':active': {
-        color: tokens.colorNeutralForegroundDisabled,
-        backgroundColor: 'transparent',
-      },
-      [`&.${spinButtonExtraClassNames.buttonActive}`]: {
-        color: tokens.colorNeutralForegroundDisabled,
-        backgroundColor: 'transparent',
-      },
-    },
-  },
-
-  underline: {
-    color: tokens.colorNeutralForegroundDisabled,
-    ':enabled': {
-      ':hover': {
-        color: tokens.colorNeutralForegroundDisabled,
-        backgroundColor: 'transparent',
-      },
-      ':active': {
-        color: tokens.colorNeutralForegroundDisabled,
-        backgroundColor: 'transparent',
-      },
-      [`&.${spinButtonExtraClassNames.buttonActive}`]: {
-        color: tokens.colorNeutralForegroundDisabled,
-        backgroundColor: 'transparent',
-      },
-    },
-  },
-
-  'filled-darker': {
-    color: tokens.colorNeutralForegroundDisabled,
-    ':enabled': {
-      ':hover': {
-        color: tokens.colorNeutralForegroundDisabled,
-        backgroundColor: 'transparent',
-      },
-      ':active': {
-        color: tokens.colorNeutralForegroundDisabled,
-        backgroundColor: 'transparent',
-      },
-      [`&.${spinButtonExtraClassNames.buttonActive}`]: {
-        color: tokens.colorNeutralForegroundDisabled,
-        backgroundColor: 'transparent',
-      },
-    },
-  },
-
-  'filled-lighter': {
-    color: tokens.colorNeutralForegroundDisabled,
-    ':enabled': {
-      ':hover': {
-        color: tokens.colorNeutralForegroundDisabled,
-        backgroundColor: 'transparent',
-      },
-      ':active': {
-        color: tokens.colorNeutralForegroundDisabled,
-        backgroundColor: 'transparent',
-      },
-      [`&.${spinButtonExtraClassNames.buttonActive}`]: {
-        color: tokens.colorNeutralForegroundDisabled,
-        backgroundColor: 'transparent',
-      },
-    },
-  },
-});
-
 /**
  * Apply styling to the SpinButton slots based on the state
  */
 export const useSpinButtonStyles_unstable = (state: SpinButtonState): SpinButtonState => {
   'use no memo';
 
-  const { appearance, atBound, spinState, size } = state;
+  const { appearance, spinState, size } = state;
   const disabled = state.input.disabled;
   const invalid = `${state.input['aria-invalid']}` === 'true';
   const filled = appearance.startsWith('filled');
 
   const rootStyles = useRootStyles();
   const buttonStyles = useButtonStyles();
-  const buttonDisabledStyles = useButtonDisabledStyles();
   const inputStyles = useInputStyles();
 
   state.root.className = mergeClasses(
@@ -508,8 +423,6 @@ export const useSpinButtonStyles_unstable = (state: SpinButtonState): SpinButton
     buttonStyles.increment,
     buttonStyles[appearance],
     size === 'small' && buttonStyles.incrementButtonSmall,
-    (atBound === 'max' || atBound === 'both') && buttonDisabledStyles.base,
-    (atBound === 'max' || atBound === 'both') && buttonDisabledStyles[appearance],
     state.incrementButton.className,
   );
   state.decrementButton.className = mergeClasses(
@@ -519,8 +432,6 @@ export const useSpinButtonStyles_unstable = (state: SpinButtonState): SpinButton
     buttonStyles.decrement,
     buttonStyles[appearance],
     size === 'small' && buttonStyles.decrementButtonSmall,
-    (atBound === 'min' || atBound === 'both') && buttonDisabledStyles.base,
-    (atBound === 'min' || atBound === 'both') && buttonDisabledStyles[appearance],
     state.decrementButton.className,
   );
 


### PR DESCRIPTION
## Previous Behavior

When the value hits a min or max bound, the up or down arrow gets visually disabled and doesn't respond to interaction. It was previously not semantically disabled, so screen reader users had no indication that the buttons were disabled.
<img width="860" alt="screenshot of the spinbutton with the value at 0, and the down arrow button greyed out. The image is marked up to call attention to that button." src="https://github.com/user-attachments/assets/4e947328-dafb-4183-be07-6ce70e919e95">


## New Behavior

The button gets semantically disabled, which also means the extra disabled-appearance styles could be removed from `useSpinButtonStyles`, since they're covered by the Button disabled styles.

## Related Issue(s)

- Fixes [ADO issue](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/22192)
