### PR TITLE
chore(web-components): identify type-only imports and exports

### DIFF
--- a/change/@fluentui-web-components-ee3cdda9-b12f-45d0-aede-ede164c72ea4.json
+++ b/change/@fluentui-web-components-ee3cdda9-b12f-45d0-aede-ede164c72ea4.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "identify type-only imports and exports",
+  "packageName": "@fluentui/web-components",
+  "email": "863023+radium-v@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/docs/api-report.md
+++ b/packages/web-components/docs/api-report.md
@@ -15,7 +15,7 @@ import type { HostBehavior } from '@microsoft/fast-element';
 import type { HostController } from '@microsoft/fast-element';
 import { HTMLDirective } from '@microsoft/fast-element';
 import { Orientation } from '@microsoft/fast-web-utilities';
-import type { SyntheticViewTemplate } from '@microsoft/fast-element';
+import { SyntheticViewTemplate } from '@microsoft/fast-element';
 import { ViewTemplate } from '@microsoft/fast-element';
 
 // @public
@@ -187,7 +187,7 @@ export class Avatar extends BaseAvatar {
     appearance?: AvatarAppearance | undefined;
     color?: AvatarColor | undefined;
     colorId?: AvatarNamedColor | undefined;
-    static colors: ("anchor" | "dark-red" | "cranberry" | "red" | "pumpkin" | "peach" | "marigold" | "gold" | "brass" | "brown" | "forest" | "seafoam" | "dark-green" | "light-teal" | "teal" | "steel" | "blue" | "royal-blue" | "cornflower" | "navy" | "lavender" | "purple" | "grape" | "lilac" | "pink" | "magenta" | "plum" | "beige" | "mink" | "platinum")[];
+    static colors: ("anchor" | "beige" | "blue" | "brass" | "brown" | "cornflower" | "cranberry" | "dark-green" | "dark-red" | "forest" | "gold" | "grape" | "lavender" | "light-teal" | "lilac" | "magenta" | "marigold" | "mink" | "navy" | "peach" | "pink" | "platinum" | "plum" | "pumpkin" | "purple" | "red" | "royal-blue" | "seafoam" | "steel" | "teal")[];
     // (undocumented)
     connectedCallback(): void;
     // (undocumented)

--- a/packages/web-components/src/accordion-item/accordion-item.template.ts
+++ b/packages/web-components/src/accordion-item/accordion-item.template.ts
@@ -1,5 +1,5 @@
-import { ElementViewTemplate, html, ref } from '@microsoft/fast-element';
-import { endSlotTemplate, startSlotTemplate } from '../patterns/index.js';
+import { type ElementViewTemplate, html, ref } from '@microsoft/fast-element';
+import { startSlotTemplate } from '../patterns/index.js';
 import { staticallyCompose } from '../utils/index.js';
 import type { AccordionItem, AccordionItemOptions } from './accordion-item.js';
 

--- a/packages/web-components/src/accordion-item/accordion-item.ts
+++ b/packages/web-components/src/accordion-item/accordion-item.ts
@@ -5,7 +5,7 @@ import { StartEnd } from '../patterns/index.js';
 import type { StartEndOptions } from '../patterns/index.js';
 import { applyMixins } from '../utils/apply-mixins.js';
 import { toggleState } from '../utils/element-internals.js';
-import { AccordionItemMarkerPosition, AccordionItemSize } from './accordion-item.options.js';
+import type { AccordionItemMarkerPosition, AccordionItemSize } from './accordion-item.options.js';
 
 /**
  * Accordion Item configuration options

--- a/packages/web-components/src/accordion/accordion.template.ts
+++ b/packages/web-components/src/accordion/accordion.template.ts
@@ -1,4 +1,4 @@
-import { elements, ElementViewTemplate, html, slotted } from '@microsoft/fast-element';
+import { elements, type ElementViewTemplate, html, slotted } from '@microsoft/fast-element';
 import type { Accordion } from './accordion.js';
 
 /**

--- a/packages/web-components/src/anchor-button/anchor-button.options.ts
+++ b/packages/web-components/src/anchor-button/anchor-button.options.ts
@@ -38,7 +38,7 @@ export const AnchorButtonSize = ButtonSize;
  */
 export type AnchorButtonSize = ValuesOf<typeof AnchorButtonSize>;
 
-export { AnchorOptions as AnchorButtonOptions };
+export type { AnchorOptions as AnchorButtonOptions };
 
 /**
  * Anchor target values.

--- a/packages/web-components/src/anchor-button/anchor-button.template.ts
+++ b/packages/web-components/src/anchor-button/anchor-button.template.ts
@@ -1,4 +1,4 @@
-import { ElementViewTemplate, html, ViewTemplate } from '@microsoft/fast-element';
+import { type ElementViewTemplate, html, type ViewTemplate } from '@microsoft/fast-element';
 import { endSlotTemplate, startSlotTemplate } from '../patterns/index.js';
 import type { AnchorButton, AnchorOptions } from './anchor-button.js';
 

--- a/packages/web-components/src/avatar/avatar.spec.ts
+++ b/packages/web-components/src/avatar/avatar.spec.ts
@@ -1,7 +1,7 @@
 import { test } from '@playwright/test';
 import { expect, fixtureURL } from '../helpers.tests.js';
 import type { Avatar } from './avatar.js';
-import { AvatarAppearance, AvatarColor, AvatarSize } from './avatar.options.js';
+import type { AvatarAppearance, AvatarColor, AvatarSize } from './avatar.options.js';
 
 test.describe('Avatar Component', () => {
   test.beforeEach(async ({ page }) => {

--- a/packages/web-components/src/avatar/avatar.template.ts
+++ b/packages/web-components/src/avatar/avatar.template.ts
@@ -1,4 +1,4 @@
-import { ElementViewTemplate, html } from '@microsoft/fast-element';
+import { type ElementViewTemplate, html } from '@microsoft/fast-element';
 import type { Avatar } from './avatar.js';
 
 const defaultIconTemplate = html`<svg

--- a/packages/web-components/src/avatar/avatar.ts
+++ b/packages/web-components/src/avatar/avatar.ts
@@ -1,13 +1,13 @@
-import { attr, FASTElement, nullableNumberConverter, observable, Observable, Updates } from '@microsoft/fast-element';
+import { attr, FASTElement, nullableNumberConverter, Observable } from '@microsoft/fast-element';
 import { getInitials } from '../utils/get-initials.js';
 import { toggleState } from '../utils/element-internals.js';
 import {
-  AvatarActive,
-  AvatarAppearance,
+  type AvatarActive,
+  type AvatarAppearance,
   AvatarColor,
   AvatarNamedColor,
-  AvatarShape,
-  AvatarSize,
+  type AvatarShape,
+  type AvatarSize,
 } from './avatar.options.js';
 
 /**

--- a/packages/web-components/src/badge/badge.options.ts
+++ b/packages/web-components/src/badge/badge.options.ts
@@ -1,4 +1,4 @@
-import { StartEndOptions } from '../patterns/index.js';
+import type { StartEndOptions } from '../patterns/index.js';
 import type { StaticallyComposableHTML, ValuesOf } from '../utils/index.js';
 import type { Badge } from './badge.js';
 

--- a/packages/web-components/src/badge/badge.template.ts
+++ b/packages/web-components/src/badge/badge.template.ts
@@ -1,4 +1,4 @@
-import { ElementViewTemplate, html } from '@microsoft/fast-element';
+import { type ElementViewTemplate, html } from '@microsoft/fast-element';
 import { endSlotTemplate, startSlotTemplate } from '../patterns/index.js';
 import { staticallyCompose } from '../utils/template-helpers.js';
 import type { Badge } from './badge.js';

--- a/packages/web-components/src/badge/badge.ts
+++ b/packages/web-components/src/badge/badge.ts
@@ -3,7 +3,7 @@ import { attr, FASTElement } from '@microsoft/fast-element';
 import { applyMixins } from '../utils/apply-mixins.js';
 import { StartEnd } from '../patterns/index.js';
 import { toggleState } from '../utils/element-internals.js';
-import { BadgeAppearance, BadgeColor, BadgeShape, BadgeSize } from './badge.options.js';
+import { BadgeAppearance, BadgeColor, type BadgeShape, type BadgeSize } from './badge.options.js';
 
 /**
  * The base class used for constructing a fluent-badge custom element

--- a/packages/web-components/src/button/button.options.ts
+++ b/packages/web-components/src/button/button.options.ts
@@ -1,4 +1,4 @@
-import { StartEndOptions } from '../patterns/index.js';
+import type { StartEndOptions } from '../patterns/index.js';
 import type { ValuesOf } from '../utils/index.js';
 import type { Button } from './button.js';
 

--- a/packages/web-components/src/button/button.template.ts
+++ b/packages/web-components/src/button/button.template.ts
@@ -1,7 +1,7 @@
-import { ElementViewTemplate, html, slotted } from '@microsoft/fast-element';
+import { type ElementViewTemplate, html, slotted } from '@microsoft/fast-element';
 import { endSlotTemplate, startSlotTemplate } from '../patterns/index.js';
 import type { Button } from './button.js';
-import { ButtonOptions } from './button.options.js';
+import type { ButtonOptions } from './button.options.js';
 
 /**
  * Generates a template for the Button component.

--- a/packages/web-components/src/checkbox/checkbox.stories.ts
+++ b/packages/web-components/src/checkbox/checkbox.stories.ts
@@ -2,7 +2,7 @@ import { html, repeat } from '@microsoft/fast-element';
 import { uniqueId } from '@microsoft/fast-web-utilities';
 import { LabelPosition, ValidationFlags } from '../field/field.options.js';
 import { type Meta, renderComponent, type StoryArgs, type StoryObj } from '../helpers.stories.js';
-import { Checkbox as FluentCheckbox } from './checkbox.js';
+import type { Checkbox as FluentCheckbox } from './checkbox.js';
 import { CheckboxShape, CheckboxSize } from './checkbox.options.js';
 
 type Story = StoryObj<FluentCheckbox>;

--- a/packages/web-components/src/checkbox/checkbox.ts
+++ b/packages/web-components/src/checkbox/checkbox.ts
@@ -1,6 +1,6 @@
 import { attr, FASTElement, Observable, observable } from '@microsoft/fast-element';
 import { toggleState } from '../utils/element-internals.js';
-import { CheckboxShape, CheckboxSize } from './checkbox.options.js';
+import type { CheckboxShape, CheckboxSize } from './checkbox.options.js';
 
 /**
  * The base class for a component with a toggleable checked state.

--- a/packages/web-components/src/compound-button/compound-button.options.ts
+++ b/packages/web-components/src/compound-button/compound-button.options.ts
@@ -38,4 +38,4 @@ export const CompoundButtonSize = ButtonSize;
  */
 export type CompoundButtonSize = ValuesOf<typeof CompoundButtonSize>;
 
-export { ButtonOptions as CompoundButtonOptions };
+export type { ButtonOptions as CompoundButtonOptions };

--- a/packages/web-components/src/compound-button/compound-button.template.ts
+++ b/packages/web-components/src/compound-button/compound-button.template.ts
@@ -1,4 +1,4 @@
-import { ElementViewTemplate, html, slotted } from '@microsoft/fast-element';
+import { type ElementViewTemplate, html, slotted } from '@microsoft/fast-element';
 import { endSlotTemplate, startSlotTemplate } from '../patterns/index.js';
 import type { CompoundButton } from './compound-button.js';
 import type { CompoundButtonOptions } from './compound-button.options.js';

--- a/packages/web-components/src/counter-badge/counter-badge.options.ts
+++ b/packages/web-components/src/counter-badge/counter-badge.options.ts
@@ -1,4 +1,4 @@
-import { BadgeOptions } from '../badge/badge.options.js';
+import type { BadgeOptions } from '../badge/badge.options.js';
 import type { ValuesOf } from '../utils/index.js';
 
 /**

--- a/packages/web-components/src/counter-badge/counter-badge.template.ts
+++ b/packages/web-components/src/counter-badge/counter-badge.template.ts
@@ -1,8 +1,8 @@
-import { ElementViewTemplate, html } from '@microsoft/fast-element';
+import { type ElementViewTemplate, html } from '@microsoft/fast-element';
 import { badgeTemplate } from '../badge/badge.template.js';
-import { Badge } from '../badge/badge.js';
-import { CounterBadge } from './counter-badge.js';
-import { CounterBadgeOptions } from './counter-badge.options.js';
+import type { Badge } from '../badge/badge.js';
+import type { CounterBadge } from './counter-badge.js';
+import type { CounterBadgeOptions } from './counter-badge.options.js';
 
 function composeTemplate<T extends CounterBadge & Badge>(options: CounterBadgeOptions = {}): ElementViewTemplate<T> {
   return badgeTemplate<T>({

--- a/packages/web-components/src/counter-badge/counter-badge.ts
+++ b/packages/web-components/src/counter-badge/counter-badge.ts
@@ -3,7 +3,7 @@ import { attr, FASTElement, nullableNumberConverter } from '@microsoft/fast-elem
 import { applyMixins } from '../utils/apply-mixins.js';
 import { StartEnd } from '../patterns/index.js';
 import { toggleState } from '../utils/element-internals.js';
-import {
+import type {
   CounterBadgeAppearance,
   CounterBadgeColor,
   CounterBadgeShape,

--- a/packages/web-components/src/dialog-body/dialog-body.template.ts
+++ b/packages/web-components/src/dialog-body/dialog-body.template.ts
@@ -1,4 +1,4 @@
-import { ElementViewTemplate, html, ref } from '@microsoft/fast-element';
+import { type ElementViewTemplate, html, ref } from '@microsoft/fast-element';
 import { DialogType } from '../dialog/dialog.options.js';
 
 const dismissed16Regular = html.partial(`

--- a/packages/web-components/src/dialog/dialog.spec.ts
+++ b/packages/web-components/src/dialog/dialog.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 import type { Locator } from '@playwright/test';
 import { fixtureURL } from '../helpers.tests.js';
-import { Dialog } from './dialog.js';
+import type { Dialog } from './dialog.js';
 
 async function getPointOutside(element: Locator) {
   // Get the bounding box of the element

--- a/packages/web-components/src/dialog/dialog.stories.ts
+++ b/packages/web-components/src/dialog/dialog.stories.ts
@@ -1,6 +1,6 @@
 import { css, html, ref } from '@microsoft/fast-element';
 import type { DialogBody as FluentDialogBody } from '../dialog-body/dialog-body.js';
-import { generateImage, Meta, renderComponent, type StoryArgs, type StoryObj } from '../helpers.stories.js';
+import { generateImage, type Meta, renderComponent, type StoryArgs, type StoryObj } from '../helpers.stories.js';
 import { definition } from './dialog.definition.js';
 import type { Dialog as FluentDialog } from './dialog.js';
 import { DialogType } from './dialog.options.js';

--- a/packages/web-components/src/dialog/dialog.template.ts
+++ b/packages/web-components/src/dialog/dialog.template.ts
@@ -1,4 +1,4 @@
-import { ElementViewTemplate, html, ref } from '@microsoft/fast-element';
+import { type ElementViewTemplate, html, ref } from '@microsoft/fast-element';
 import type { Dialog } from './dialog.js';
 import { DialogType } from './dialog.options.js';
 

--- a/packages/web-components/src/divider/divider.spec.ts
+++ b/packages/web-components/src/divider/divider.spec.ts
@@ -1,6 +1,6 @@
 import { test } from '@playwright/test';
 import { expect, fixtureURL } from '../helpers.tests.js';
-import { Divider } from './divider.js';
+import type { Divider } from './divider.js';
 
 test.describe('Divider', () => {
   test.beforeEach(async ({ page }) => {

--- a/packages/web-components/src/divider/divider.template.ts
+++ b/packages/web-components/src/divider/divider.template.ts
@@ -1,4 +1,4 @@
-import { ElementViewTemplate, html } from '@microsoft/fast-element';
+import { type ElementViewTemplate, html } from '@microsoft/fast-element';
 import type { Divider } from './divider.js';
 
 export function dividerTemplate<T extends Divider>(): ElementViewTemplate<T> {

--- a/packages/web-components/src/drawer-body/drawer-body.template.ts
+++ b/packages/web-components/src/drawer-body/drawer-body.template.ts
@@ -1,4 +1,4 @@
-import { ElementViewTemplate, html } from '@microsoft/fast-element';
+import { type ElementViewTemplate, html } from '@microsoft/fast-element';
 import type { DrawerBody } from './drawer-body.js';
 
 /**

--- a/packages/web-components/src/drawer/drawer.template.ts
+++ b/packages/web-components/src/drawer/drawer.template.ts
@@ -1,4 +1,4 @@
-import { ElementViewTemplate, html, ref } from '@microsoft/fast-element';
+import { type ElementViewTemplate, html, ref } from '@microsoft/fast-element';
 import type { Drawer } from './drawer.js';
 
 /**

--- a/packages/web-components/src/field/field.spec.ts
+++ b/packages/web-components/src/field/field.spec.ts
@@ -1,6 +1,6 @@
 import { test } from '@playwright/test';
 import { expect, fixtureURL } from '../helpers.tests.js';
-import { TextInput } from '../index.js';
+import type { TextInput } from '../index.js';
 import type { Field } from './field.js';
 
 test.describe('Field', () => {

--- a/packages/web-components/src/field/field.template.ts
+++ b/packages/web-components/src/field/field.template.ts
@@ -1,4 +1,4 @@
-import { children, elements, ElementViewTemplate, html, slotted } from '@microsoft/fast-element';
+import { children, elements, type ElementViewTemplate, html, slotted } from '@microsoft/fast-element';
 import type { Field } from './field.js';
 
 /**

--- a/packages/web-components/src/field/field.ts
+++ b/packages/web-components/src/field/field.ts
@@ -1,7 +1,7 @@
 import { attr, FASTElement, observable } from '@microsoft/fast-element';
 import { uniqueId } from '@microsoft/fast-web-utilities';
 import { toggleState } from '../utils/element-internals.js';
-import { LabelPosition, SlottableInput, ValidationFlags } from './field.options.js';
+import { LabelPosition, type SlottableInput, ValidationFlags } from './field.options.js';
 
 /**
  * A Field Custom HTML Element.

--- a/packages/web-components/src/image/image.template.ts
+++ b/packages/web-components/src/image/image.template.ts
@@ -1,4 +1,4 @@
-import { ElementViewTemplate, html } from '@microsoft/fast-element';
+import { type ElementViewTemplate, html } from '@microsoft/fast-element';
 import type { Image } from './image.js';
 
 /**

--- a/packages/web-components/src/image/image.ts
+++ b/packages/web-components/src/image/image.ts
@@ -1,6 +1,6 @@
 import { attr, FASTElement } from '@microsoft/fast-element';
 import { toggleState } from '../utils/element-internals.js';
-import { ImageFit, ImageShape } from './image.options.js';
+import type { ImageFit, ImageShape } from './image.options.js';
 
 /**
  * The base class used for constucting a fluent image custom element

--- a/packages/web-components/src/label/label.template.ts
+++ b/packages/web-components/src/label/label.template.ts
@@ -1,5 +1,5 @@
-import { ElementViewTemplate, html } from '@microsoft/fast-element';
-import { Label } from './label.js';
+import { type ElementViewTemplate, html } from '@microsoft/fast-element';
+import type { Label } from './label.js';
 
 /**
  * The template for the Fluent label web-component.

--- a/packages/web-components/src/label/label.ts
+++ b/packages/web-components/src/label/label.ts
@@ -1,6 +1,6 @@
 import { attr, FASTElement } from '@microsoft/fast-element';
 import { toggleState } from '../utils/element-internals.js';
-import { LabelSize, LabelWeight } from './label.options.js';
+import type { LabelSize, LabelWeight } from './label.options.js';
 
 /**
  * The base class used for constructing a fluent-label custom element

--- a/packages/web-components/src/link/link.spec.ts
+++ b/packages/web-components/src/link/link.spec.ts
@@ -1,7 +1,7 @@
 import { spinalCase } from '@microsoft/fast-web-utilities';
 import { test } from '@playwright/test';
 import { expect, fixtureURL } from '../helpers.tests.js';
-import { Link } from './link.js';
+import type { Link } from './link.js';
 
 const proxyAttributes = {
   href: 'href',

--- a/packages/web-components/src/link/link.template.ts
+++ b/packages/web-components/src/link/link.template.ts
@@ -1,4 +1,4 @@
-import { ElementViewTemplate, html, ViewTemplate } from '@microsoft/fast-element';
+import { type ElementViewTemplate, html, ViewTemplate } from '@microsoft/fast-element';
 import type { Link } from './link.js';
 
 /**

--- a/packages/web-components/src/link/link.ts
+++ b/packages/web-components/src/link/link.ts
@@ -1,7 +1,7 @@
 import { attr } from '@microsoft/fast-element';
 import { BaseAnchor } from '../anchor-button/anchor-button.js';
 import { toggleState } from '../utils/element-internals.js';
-import { type LinkAppearance } from './link.options.js';
+import type { LinkAppearance } from './link.options.js';
 
 /**
  * An Anchor Custom HTML Element.

--- a/packages/web-components/src/menu-button/menu-button.template.ts
+++ b/packages/web-components/src/menu-button/menu-button.template.ts
@@ -1,4 +1,4 @@
-import { ElementViewTemplate, html } from '@microsoft/fast-element';
+import { type ElementViewTemplate, html } from '@microsoft/fast-element';
 import { buttonTemplate } from '../button/button.template.js';
 import type { MenuButton } from './menu-button.js';
 

--- a/packages/web-components/src/menu-item/menu-item.ts
+++ b/packages/web-components/src/menu-item/menu-item.ts
@@ -1,6 +1,6 @@
-import { attr, ElementsFilter, FASTElement, observable } from '@microsoft/fast-element';
+import { attr, type ElementsFilter, FASTElement, observable } from '@microsoft/fast-element';
 import { keyArrowLeft, keyArrowRight, keyEnter, keySpace } from '@microsoft/fast-web-utilities';
-import { MenuList } from '../menu-list/menu-list.js';
+import type { MenuList } from '../menu-list/menu-list.js';
 import type { StartEndOptions } from '../patterns/start-end.js';
 import { StartEnd } from '../patterns/start-end.js';
 import { applyMixins } from '../utils/apply-mixins.js';

--- a/packages/web-components/src/menu-list/menu-list.spec.ts
+++ b/packages/web-components/src/menu-list/menu-list.spec.ts
@@ -1,8 +1,7 @@
-import { once } from 'events';
 import { test } from '@playwright/test';
 import { expect, fixtureURL } from '../helpers.tests.js';
+import type { MenuItem } from '../menu-item/menu-item.js';
 import { MenuItemRole } from '../menu-item/menu-item.options.js';
-import { MenuItem } from '../menu-item/menu-item.js';
 
 test.describe('Menu', () => {
   test.beforeEach(async ({ page }) => {

--- a/packages/web-components/src/menu-list/menu-list.template.ts
+++ b/packages/web-components/src/menu-list/menu-list.template.ts
@@ -1,4 +1,4 @@
-import { ElementViewTemplate, html, slotted } from '@microsoft/fast-element';
+import { type ElementViewTemplate, html, slotted } from '@microsoft/fast-element';
 import type { MenuList } from './menu-list.js';
 
 export function menuTemplate<T extends MenuList>(): ElementViewTemplate<T> {

--- a/packages/web-components/src/menu/menu.template.ts
+++ b/packages/web-components/src/menu/menu.template.ts
@@ -1,4 +1,4 @@
-import { elements, ElementViewTemplate, html, ref, slotted } from '@microsoft/fast-element';
+import { elements, type ElementViewTemplate, html, ref, slotted } from '@microsoft/fast-element';
 import type { Menu } from './menu.js';
 
 export function menuTemplate<T extends Menu>(): ElementViewTemplate<T> {

--- a/packages/web-components/src/menu/menu.ts
+++ b/packages/web-components/src/menu/menu.ts
@@ -1,6 +1,6 @@
 import { attr, FASTElement, observable, Updates } from '@microsoft/fast-element';
 import { keyEnter, keyEscape, keySpace, keyTab } from '@microsoft/fast-web-utilities';
-import { MenuList } from '../menu-list/menu-list.js';
+import type { MenuList } from '../menu-list/menu-list.js';
 import { MenuItem } from '../menu-item/menu-item.js';
 import { MenuItemRole } from '../menu-item/menu-item.options.js';
 

--- a/packages/web-components/src/message-bar/message-bar.stories.ts
+++ b/packages/web-components/src/message-bar/message-bar.stories.ts
@@ -1,8 +1,7 @@
 import { html, repeat } from '@microsoft/fast-element';
 import { type Meta, renderComponent, type StoryArgs, type StoryObj } from '../helpers.stories.js';
-import { MessageBar as FluentMessageBar } from './message-bar.js';
+import type { MessageBar as FluentMessageBar } from './message-bar.js';
 import { MessageBarIntent, MessageBarLayout, MessageBarShape } from './message-bar.options.js';
-import './define';
 
 type Story = StoryObj<FluentMessageBar>;
 

--- a/packages/web-components/src/message-bar/message-bar.template.ts
+++ b/packages/web-components/src/message-bar/message-bar.template.ts
@@ -1,4 +1,4 @@
-import { ElementViewTemplate, html } from '@microsoft/fast-element';
+import { type ElementViewTemplate, html } from '@microsoft/fast-element';
 import type { MessageBar } from './message-bar.js';
 
 /**

--- a/packages/web-components/src/message-bar/message-bar.ts
+++ b/packages/web-components/src/message-bar/message-bar.ts
@@ -1,6 +1,6 @@
 import { attr, FASTElement } from '@microsoft/fast-element';
 import { toggleState } from '../utils/element-internals.js';
-import { MessageBarIntent, MessageBarLayout, MessageBarShape } from './message-bar.options.js';
+import type { MessageBarIntent, MessageBarLayout, MessageBarShape } from './message-bar.options.js';
 
 /**
  * A Message Bar Custom HTML Element.

--- a/packages/web-components/src/patterns/start-end.ts
+++ b/packages/web-components/src/patterns/start-end.ts
@@ -1,6 +1,6 @@
 //Copied from @microsoft/fast-foundation
 
-import { CaptureType, html, ref } from '@microsoft/fast-element';
+import { type CaptureType, html, ref } from '@microsoft/fast-element';
 import type { StaticallyComposableHTML } from '../utils/index.js';
 import { staticallyCompose } from '../utils/index.js';
 

--- a/packages/web-components/src/progress-bar/progress-bar.options.ts
+++ b/packages/web-components/src/progress-bar/progress-bar.options.ts
@@ -1,5 +1,4 @@
-import type { StaticallyComposableHTML, ValuesOf } from '../utils/index.js';
-import { ProgressBar } from './progress-bar.js';
+import type { ValuesOf } from '../utils/index.js';
 
 /**
  * ProgressBarThickness Constants

--- a/packages/web-components/src/progress-bar/progress-bar.ts
+++ b/packages/web-components/src/progress-bar/progress-bar.ts
@@ -1,6 +1,6 @@
 import { attr, FASTElement, nullableNumberConverter, volatile } from '@microsoft/fast-element';
 import { toggleState } from '../utils/element-internals.js';
-import { ProgressBarShape, ProgressBarThickness, ProgressBarValidationState } from './progress-bar.options.js';
+import type { ProgressBarShape, ProgressBarThickness, ProgressBarValidationState } from './progress-bar.options.js';
 
 /**
  * A Progress HTML Element.

--- a/packages/web-components/src/radio-group/radio-group.template.ts
+++ b/packages/web-components/src/radio-group/radio-group.template.ts
@@ -1,4 +1,4 @@
-import { ElementViewTemplate, html } from '@microsoft/fast-element';
+import { type ElementViewTemplate, html } from '@microsoft/fast-element';
 import type { RadioGroup } from './radio-group.js';
 
 export function radioGroupTemplate<T extends RadioGroup>(): ElementViewTemplate<T> {

--- a/packages/web-components/src/radio/radio.template.ts
+++ b/packages/web-components/src/radio/radio.template.ts
@@ -1,4 +1,4 @@
-import { ElementViewTemplate, html } from '@microsoft/fast-element';
+import { type ElementViewTemplate, html } from '@microsoft/fast-element';
 import { staticallyCompose } from '../utils/index.js';
 import type { Radio } from './radio.js';
 import type { RadioOptions } from './radio.options.js';

--- a/packages/web-components/src/rating-display/rating-display.spec.ts
+++ b/packages/web-components/src/rating-display/rating-display.spec.ts
@@ -1,7 +1,7 @@
-import { Locator, test } from '@playwright/test';
+import { type Locator, test } from '@playwright/test';
 import { expect, fixtureURL } from '../helpers.tests.js';
 import { RatingDisplaySize } from './rating-display.options.js';
-import { RatingDisplay } from './rating-display.js';
+import type { RatingDisplay } from './rating-display.js';
 
 test.describe('Rating Display', () => {
   let element: Locator;

--- a/packages/web-components/src/rating-display/rating-display.template.ts
+++ b/packages/web-components/src/rating-display/rating-display.template.ts
@@ -1,4 +1,4 @@
-import { elements, ElementViewTemplate, html, slotted } from '@microsoft/fast-element';
+import { elements, type ElementViewTemplate, html, slotted } from '@microsoft/fast-element';
 import { staticallyCompose } from '../utils/template-helpers.js';
 import type { RatingDisplay } from './rating-display.js';
 

--- a/packages/web-components/src/rating-display/rating-display.ts
+++ b/packages/web-components/src/rating-display/rating-display.ts
@@ -1,6 +1,6 @@
 import { attr, FASTElement, nullableNumberConverter, observable } from '@microsoft/fast-element';
 import { toggleState } from '../utils/element-internals.js';
-import { RatingDisplayColor, RatingDisplaySize } from './rating-display.options.js';
+import type { RatingDisplayColor, RatingDisplaySize } from './rating-display.options.js';
 
 /**
  * The base class used for constructing a fluent-rating-display custom element

--- a/packages/web-components/src/slider/slider.ts
+++ b/packages/web-components/src/slider/slider.ts
@@ -14,7 +14,7 @@ import {
 import { numberLikeStringConverter } from '../utils/converters.js';
 import { getDirection } from '../utils/direction.js';
 import { toggleState } from '../utils/element-internals.js';
-import { SliderConfiguration, SliderMode, SliderOrientation, SliderSize } from './slider.options.js';
+import { type SliderConfiguration, SliderMode, SliderOrientation, SliderSize } from './slider.options.js';
 import { convertPixelToPercent } from './slider-utilities.js';
 
 /**

--- a/packages/web-components/src/spinner/spinner.stories.ts
+++ b/packages/web-components/src/spinner/spinner.stories.ts
@@ -1,7 +1,7 @@
 import { html, repeat } from '@microsoft/fast-element';
 import { type Meta, renderComponent, type StoryArgs, type StoryObj } from '../helpers.stories.js';
 import { SpinnerAppearance, SpinnerSize } from './spinner.options.js';
-import { Spinner as FluentSpinner } from './spinner.js';
+import type { Spinner as FluentSpinner } from './spinner.js';
 
 type Story = StoryObj<FluentSpinner>;
 

--- a/packages/web-components/src/spinner/spinner.template.ts
+++ b/packages/web-components/src/spinner/spinner.template.ts
@@ -1,5 +1,5 @@
 import { html } from '@microsoft/fast-element';
-import { Spinner } from './spinner.js';
+import type { Spinner } from './spinner.js';
 
 export const template = html<Spinner>`
   <slot name="indicator">

--- a/packages/web-components/src/switch/switch.template.ts
+++ b/packages/web-components/src/switch/switch.template.ts
@@ -1,6 +1,6 @@
-import { ElementViewTemplate, html } from '@microsoft/fast-element';
+import { type ElementViewTemplate, html } from '@microsoft/fast-element';
 import { staticallyCompose } from '../utils/index.js';
-import { Switch, SwitchOptions } from './switch.js';
+import type { Switch, SwitchOptions } from './switch.js';
 
 export function switchTemplate<T extends Switch>(options: SwitchOptions = {}): ElementViewTemplate<T> {
   return html<T>`

--- a/packages/web-components/src/tab-panel/tab-panel.template.ts
+++ b/packages/web-components/src/tab-panel/tab-panel.template.ts
@@ -1,5 +1,5 @@
-import { ElementViewTemplate, html } from '@microsoft/fast-element';
-import { TabPanel } from './tab-panel.js';
+import { type ElementViewTemplate, html } from '@microsoft/fast-element';
+import type { TabPanel } from './tab-panel.js';
 
 export function tabPanelTemplate<T extends TabPanel>(): ElementViewTemplate<T> {
   return html<T>`

--- a/packages/web-components/src/tab/tab.template.ts
+++ b/packages/web-components/src/tab/tab.template.ts
@@ -1,4 +1,4 @@
-import { ElementViewTemplate, html } from '@microsoft/fast-element';
+import { type ElementViewTemplate, html } from '@microsoft/fast-element';
 import { endSlotTemplate, startSlotTemplate } from '../patterns/index.js';
 import type { Tab, TabOptions } from './tab.js';
 

--- a/packages/web-components/src/tab/tab.ts
+++ b/packages/web-components/src/tab/tab.ts
@@ -1,5 +1,6 @@
-import { attr, css, ElementStyles, FASTElement } from '@microsoft/fast-element';
-import { StartEnd, StartEndOptions } from '../patterns/index.js';
+import { attr, css, type ElementStyles, FASTElement } from '@microsoft/fast-element';
+import type { StartEndOptions } from '../patterns/start-end.js';
+import { StartEnd } from '../patterns/start-end.js';
 import { applyMixins } from '../utils/apply-mixins.js';
 
 /**

--- a/packages/web-components/src/tablist/tablist.template.ts
+++ b/packages/web-components/src/tablist/tablist.template.ts
@@ -1,5 +1,5 @@
 import { html, slotted } from '@microsoft/fast-element';
-import { Tablist } from './tablist.js';
+import type { Tablist } from './tablist.js';
 
 /**
  * @public

--- a/packages/web-components/src/tablist/tablist.ts
+++ b/packages/web-components/src/tablist/tablist.ts
@@ -1,5 +1,4 @@
 import { attr, FASTElement, observable } from '@microsoft/fast-element';
-import { wrapInBounds } from '@microsoft/fast-web-utilities';
 import {
   keyArrowDown,
   keyArrowLeft,
@@ -8,12 +7,13 @@ import {
   keyEnd,
   keyHome,
   uniqueId,
+  wrapInBounds,
 } from '@microsoft/fast-web-utilities';
 import { getDirection } from '../utils/index.js';
 import { toggleState } from '../utils/element-internals.js';
 import { isFocusableElement } from '../utils/focusable-element.js';
-import { Tab } from '../index.js';
-import { TablistAppearance, TablistOrientation, TablistSize } from './tablist.options.js';
+import type { Tab } from '../tab/tab.js';
+import { TablistAppearance, TablistOrientation, type TablistSize } from './tablist.options.js';
 
 type TabData = Omit<DOMRect, 'top' | 'bottom' | 'left' | 'right' | 'toJSON'>;
 

--- a/packages/web-components/src/tabs/tabs.options.ts
+++ b/packages/web-components/src/tabs/tabs.options.ts
@@ -1,7 +1,7 @@
 import { Orientation } from '@microsoft/fast-web-utilities';
-import { StartEndOptions } from '../patterns/index.js';
+import type { StartEndOptions } from '../patterns/start-end.js';
 import type { ValuesOf } from '../utils/index.js';
-import { Tabs } from './tabs.js';
+import type { Tabs } from './tabs.js';
 
 export const TabsAppearance = {
   subtle: 'subtle',

--- a/packages/web-components/src/tabs/tabs.template.ts
+++ b/packages/web-components/src/tabs/tabs.template.ts
@@ -1,7 +1,7 @@
-import { ElementViewTemplate, html, slotted } from '@microsoft/fast-element';
+import { type ElementViewTemplate, html, slotted } from '@microsoft/fast-element';
 import { endSlotTemplate, startSlotTemplate } from '../patterns/index.js';
-import { Tabs } from './tabs.js';
-import { TabsOptions } from './tabs.options.js';
+import type { Tabs } from './tabs.js';
+import type { TabsOptions } from './tabs.options.js';
 
 export function tabsTemplate<T extends Tabs>(options: TabsOptions = {}): ElementViewTemplate<T> {
   return html<T>`

--- a/packages/web-components/src/tabs/tabs.ts
+++ b/packages/web-components/src/tabs/tabs.ts
@@ -1,4 +1,4 @@
-import { attr, css, ElementStyles, FASTElement, observable } from '@microsoft/fast-element';
+import { attr, css, type ElementStyles, FASTElement, observable } from '@microsoft/fast-element';
 import {
   keyArrowDown,
   keyArrowLeft,
@@ -9,10 +9,10 @@ import {
   limit,
   uniqueId,
 } from '@microsoft/fast-web-utilities';
-import { Tab } from '../index.js';
+import type { Tab } from '../tab/tab.js';
 import { applyMixins } from '../utils/apply-mixins.js';
 import { StartEnd } from '../patterns/index.js';
-import { TabsAppearance, TabsOrientation, TabsSize } from './tabs.options.js';
+import { TabsAppearance, TabsOrientation, type TabsSize } from './tabs.options.js';
 
 type TabData = Omit<DOMRect, 'top' | 'bottom' | 'left' | 'right' | 'toJSON'>;
 

--- a/packages/web-components/src/text/text.template.ts
+++ b/packages/web-components/src/text/text.template.ts
@@ -1,4 +1,4 @@
-import { ElementViewTemplate, html } from '@microsoft/fast-element';
+import { type ElementViewTemplate, html } from '@microsoft/fast-element';
 import type { Text } from './text.js';
 
 /**

--- a/packages/web-components/src/textarea/textarea.stories.ts
+++ b/packages/web-components/src/textarea/textarea.stories.ts
@@ -1,7 +1,7 @@
-import { html, when } from '@microsoft/fast-element';
+import { html } from '@microsoft/fast-element';
 import { type Meta, renderComponent, type StoryArgs, type StoryObj } from '../helpers.stories.js';
 import { colorNeutralBackground1, colorNeutralBackground3 } from '../theme/design-tokens.js';
-import { TextArea as FluentTextArea } from './textarea.js';
+import type { TextArea as FluentTextArea } from './textarea.js';
 import { TextAreaAppearance, TextAreaResize, TextAreaSize } from './textarea.options.js';
 
 type Story = StoryObj<FluentTextArea>;

--- a/packages/web-components/src/textarea/textarea.template.ts
+++ b/packages/web-components/src/textarea/textarea.template.ts
@@ -1,4 +1,4 @@
-import { ElementViewTemplate, html, ref, slotted } from '@microsoft/fast-element';
+import { type ElementViewTemplate, html, ref, slotted } from '@microsoft/fast-element';
 import { whitespaceFilter } from '../utils/index.js';
 import type { TextArea } from './textarea.js';
 

--- a/packages/web-components/src/toggle-button/toggle-button.template.ts
+++ b/packages/web-components/src/toggle-button/toggle-button.template.ts
@@ -1,4 +1,4 @@
-import { ElementViewTemplate } from '@microsoft/fast-element';
+import type { ElementViewTemplate } from '@microsoft/fast-element';
 import { buttonTemplate } from '../button/button.template.js';
 import type { ToggleButton } from './toggle-button.js';
 

--- a/packages/web-components/src/utils/template-helpers.ts
+++ b/packages/web-components/src/utils/template-helpers.ts
@@ -1,7 +1,11 @@
 //Copied from @microsoft/fast-foundation
 
-import { CaptureType, HTMLDirective, InlineTemplateDirective } from '@microsoft/fast-element';
-import type { SyntheticViewTemplate } from '@microsoft/fast-element';
+import {
+  type CaptureType,
+  type HTMLDirective,
+  InlineTemplateDirective,
+  type SyntheticViewTemplate,
+} from '@microsoft/fast-element';
 
 /**
  * A value that can be statically composed into a


### PR DESCRIPTION
## Previous Behavior

Type-only imports and exports are referenced as values.

## New Behavior

All type-only imports and exports are identified as types.

## Related Issue(s)
