### PR TITLE
fix(workspace-plugin): properly resolve isCi on ADO

### DIFF
--- a/tools/workspace-plugin/src/executors/generate-api/executor.spec.ts
+++ b/tools/workspace-plugin/src/executors/generate-api/executor.spec.ts
@@ -12,6 +12,7 @@ import { type TsConfig } from '../../types';
 
 import { type GenerateApiExecutorSchema } from './schema';
 import executor from './executor';
+import { isCI } from './lib/shared';
 
 // =========== mocks START
 import { execSync } from 'node:child_process';
@@ -169,8 +170,11 @@ describe('GenerateApi Executor', () => {
       skipLibCheck: false,
     });
     expect(extractorConfig.skipLibCheck).toBe(false);
+
+    const actualLocalBuildValue = isCI() ? false : true;
+
     expect(extractorArgs).toEqual({
-      localBuild: true,
+      localBuild: actualLocalBuildValue,
       showDiagnostics: false,
       showVerboseMessages: true,
     });

--- a/tools/workspace-plugin/src/executors/generate-api/executor.ts
+++ b/tools/workspace-plugin/src/executors/generate-api/executor.ts
@@ -8,6 +8,7 @@ import { Extractor, ExtractorConfig, type IConfigFile } from '@microsoft/api-ext
 import type { GenerateApiExecutorSchema } from './schema';
 import type { PackageJson, TsConfig } from '../../types';
 import { measureEnd, measureStart } from '../../utils';
+import { isCI } from './lib/shared';
 
 const runExecutor: PromiseExecutor<GenerateApiExecutorSchema> = async (schema, context) => {
   measureStart('GenerateApiExecutor');
@@ -67,14 +68,6 @@ function normalizeOptions(schema: GenerateApiExecutorSchema, context: ExecutorCo
     tsConfigPathForCompilation: tsConfigPathForCompilation.result!,
     packageJsonPath,
   };
-
-  function isCI() {
-    return (
-      (process.env.CI && process.env.CI !== 'false') ||
-      process.env.TF_BUILD === 'true' ||
-      process.env.GITHUB_ACTIONS === 'true'
-    );
-  }
 }
 
 function generateTypeDeclarations(options: NormalizedOptions) {

--- a/tools/workspace-plugin/src/executors/generate-api/lib/shared.ts
+++ b/tools/workspace-plugin/src/executors/generate-api/lib/shared.ts
@@ -1,0 +1,7 @@
+export function isCI() {
+  return (
+    (process.env.CI && process.env.CI !== 'false') ||
+    (process.env.TF_BUILD && process.env.TF_BUILD.toLowerCase() === 'true') ||
+    process.env.GITHUB_ACTIONS === 'true'
+  );
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

on ADO `process.env.TF_BUILD` was never `true` rather `True` 🫡. 

This PR fixes this inconsistency that was affecting generate-api executor functionality on CI environment.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows #30267 
