### PR TITLE
Carousel: Set controlled index to newly added cards

### DIFF
--- a/change/@fluentui-react-carousel-dd4976ee-6c52-4282-a43d-55367389b1c5.json
+++ b/change/@fluentui-react-carousel-dd4976ee-6c52-4282-a43d-55367389b1c5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Enable controlled index to be set to a new card when added",
+  "packageName": "@fluentui/react-carousel",
+  "email": "mifraser@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-carousel/library/src/components/useEmblaCarousel.ts
+++ b/packages/react-components/react-carousel/library/src/components/useEmblaCarousel.ts
@@ -124,6 +124,25 @@ export function useEmblaCarousel(
     };
   }, []);
 
+  const handleReinit = useEventCallback(() => {
+    const nodes: HTMLElement[] = emblaApi.current?.slideNodes() ?? [];
+    const groupIndexList: number[][] = emblaApi.current?.internalEngine().slideRegistry ?? [];
+    const navItemsCount = groupIndexList.length > 0 ? groupIndexList.length : nodes.length;
+
+    const data: CarouselUpdateData = {
+      navItemsCount,
+      activeIndex: emblaApi.current?.selectedScrollSnap() ?? 0,
+      groupIndexList,
+      slideNodes: nodes,
+    };
+
+    console.log('activeIndex:', activeIndex);
+    emblaApi.current?.scrollTo(activeIndex, false);
+    for (const listener of listeners.current) {
+      listener(data);
+    }
+  });
+
   const viewportRef: React.RefObject<HTMLDivElement> = React.useRef(null);
   const containerRef: React.RefObject<HTMLDivElement> = React.useMemo(() => {
     let currentElement: HTMLDivElement | null = null;
@@ -139,22 +158,7 @@ export function useEmblaCarousel(
       });
       setActiveIndex(newIndex);
     };
-    const handleReinit = () => {
-      const nodes: HTMLElement[] = emblaApi.current?.slideNodes() ?? [];
-      const groupIndexList: number[][] = emblaApi.current?.internalEngine().slideRegistry ?? [];
-      const navItemsCount = groupIndexList.length > 0 ? groupIndexList.length : nodes.length;
 
-      const data: CarouselUpdateData = {
-        navItemsCount,
-        activeIndex: emblaApi.current?.selectedScrollSnap() ?? 0,
-        groupIndexList,
-        slideNodes: nodes,
-      };
-
-      for (const listener of listeners.current) {
-        listener(data);
-      }
-    };
     const handleVisibilityChange = () => {
       const cardElements = emblaApi.current?.slideNodes();
       const visibleIndexes = emblaApi.current?.slidesInView() ?? [];
@@ -233,9 +237,11 @@ export function useEmblaCarousel(
 
   React.useEffect(() => {
     // Scroll to controlled values on update
+    // If active index is out of bounds, re-init will handle instead
     const currentActiveIndex = emblaApi.current?.selectedScrollSnap() ?? 0;
+    const slideLength = emblaApi.current?.slideNodes().length ?? 0;
     emblaOptions.current.startIndex = activeIndex;
-    if (activeIndex !== currentActiveIndex) {
+    if (activeIndex < slideLength && activeIndex !== currentActiveIndex) {
       emblaApi.current?.scrollTo(activeIndex);
     }
   }, [activeIndex]);

--- a/packages/react-components/react-carousel/library/src/components/useEmblaCarousel.ts
+++ b/packages/react-components/react-carousel/library/src/components/useEmblaCarousel.ts
@@ -136,7 +136,6 @@ export function useEmblaCarousel(
       slideNodes: nodes,
     };
 
-    console.log('activeIndex:', activeIndex);
     emblaApi.current?.scrollTo(activeIndex, false);
     for (const listener of listeners.current) {
       listener(data);
@@ -203,7 +202,7 @@ export function useEmblaCarousel(
         }
       },
     };
-  }, [getPlugins, setActiveIndex]);
+  }, [getPlugins, setActiveIndex, handleReinit]);
 
   const carouselApi = React.useMemo(
     () => ({

--- a/packages/react-components/react-carousel/library/src/components/useEmblaCarousel.ts
+++ b/packages/react-components/react-carousel/library/src/components/useEmblaCarousel.ts
@@ -239,7 +239,7 @@ export function useEmblaCarousel(
     // Scroll to controlled values on update
     // If active index is out of bounds, re-init will handle instead
     const currentActiveIndex = emblaApi.current?.selectedScrollSnap() ?? 0;
-    const slideLength = emblaApi.current?.slideNodes().length ?? 0;
+    const slideLength = emblaApi.current?.slideNodes()?.length ?? 0;
     emblaOptions.current.startIndex = activeIndex;
     if (activeIndex < slideLength && activeIndex !== currentActiveIndex) {
       emblaApi.current?.scrollTo(activeIndex);


### PR DESCRIPTION
## Previous Behavior
Controlled index implementation, user adds a CarouselCard and sets index to index of newly added card (simultaneous state update).
As index is not registered at time of state change, state is not updated.

## New Behavior
Controlled index implementation, user adds a CarouselCard and sets index to index of newly added card (simultaneous state update).
Engine will update to new card in this scenario only.