### PR TITLE
chore(react-message-bar): Use `useAnnounce()` instead of the deprecated `useAnnounce_unstable()`

### DIFF
--- a/change/@fluentui-react-message-bar-dcc6ade3-1e4b-44ab-b29b-14b1cafc1320.json
+++ b/change/@fluentui-react-message-bar-dcc6ade3-1e4b-44ab-b29b-14b1cafc1320.json
@@ -1,6 +1,6 @@
 {
   "type": "none",
-  "comment": "fix(react-message-bar): Use useAnnounce() instead of the deprecated useAnnounce_unstable()",
+  "comment": "chore(react-message-bar): Use useAnnounce() instead of the deprecated useAnnounce_unstable()",
   "packageName": "@fluentui/react-message-bar",
   "email": "jiangemma@microsoft.com",
   "dependentChangeType": "none"

--- a/change/@fluentui-react-message-bar-dcc6ade3-1e4b-44ab-b29b-14b1cafc1320.json
+++ b/change/@fluentui-react-message-bar-dcc6ade3-1e4b-44ab-b29b-14b1cafc1320.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "fix(react-message-bar): Use useAnnounce() instead of the deprecated useAnnounce_unstable()",
+  "packageName": "@fluentui/react-message-bar",
+  "email": "jiangemma@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-message-bar/library/src/components/MessageBar/useMessageBar.ts
+++ b/packages/react-components/react-message-bar/library/src/components/MessageBar/useMessageBar.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { getIntrinsicElementProps, slot, useId, useMergedRefs } from '@fluentui/react-utilities';
-import { useAnnounce_unstable } from '@fluentui/react-shared-contexts';
+import { useAnnounce } from '@fluentui/react-shared-contexts';
 import type { MessageBarProps, MessageBarState } from './MessageBar.types';
 import { getIntentIcon } from './getIntentIcon';
 import { useMessageBarReflow } from './useMessageBarReflow';
@@ -24,7 +24,7 @@ export const useMessageBar_unstable = (props: MessageBarProps, ref: React.Ref<HT
   const { className: transitionClassName, nodeRef } = useMessageBarTransitionContext();
   const actionsRef = React.useRef<HTMLDivElement | null>(null);
   const bodyRef = React.useRef<HTMLDivElement | null>(null);
-  const { announce } = useAnnounce_unstable();
+  const { announce } = useAnnounce();
   const titleId = useId();
 
   React.useEffect(() => {


### PR DESCRIPTION
## Previous Behavior

I found this while investigating another bug and decided to put in a PR -- feel free to close if this is an unnecessary change.

We currently use `useAnnounce_unstable`, which is deprecated, instead of `useAnnounce`. The hooks are functionally the same. The change comes from #30328.

## New Behavior

Use `useAnnounce`, the stable version of the old hook `useAnnounce_unstable`

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

N/A
