### PR TITLE
fix(react-tag-picker): Change "No options available" from text to `TagPickerOption`

### DIFF
--- a/packages/react-components/react-tag-picker/stories/src/TagPicker/TagPickerAppearance.stories.tsx
+++ b/packages/react-components/react-tag-picker/stories/src/TagPicker/TagPickerAppearance.stories.tsx
@@ -24,6 +24,9 @@ const options = [
 const Example = ({ appearance }: Pick<TagPickerProps, 'appearance'>) => {
   const [selectedOptions, setSelectedOptions] = React.useState<string[]>([options[0]]);
   const onOptionSelect: TagPickerProps['onOptionSelect'] = (e, data) => {
+    if (data.value === 'no-options') {
+      return;
+    }
     setSelectedOptions(data.selectedOptions);
   };
   const tagPickerOptions = options.filter(option => !selectedOptions.includes(option));
@@ -54,18 +57,20 @@ const Example = ({ appearance }: Pick<TagPickerProps, 'appearance'>) => {
           <TagPickerInput aria-label="Select Employees" />
         </TagPickerControl>
         <TagPickerList>
-          {tagPickerOptions.length > 0
-            ? tagPickerOptions.map(option => (
-                <TagPickerOption
-                  secondaryContent="Microsoft FTE"
-                  media={<Avatar shape="square" aria-hidden name={option} color="colorful" />}
-                  value={option}
-                  key={option}
-                >
-                  {option}
-                </TagPickerOption>
-              ))
-            : 'No options available'}
+          {tagPickerOptions.length > 0 ? (
+            tagPickerOptions.map(option => (
+              <TagPickerOption
+                secondaryContent="Microsoft FTE"
+                media={<Avatar shape="square" aria-hidden name={option} color="colorful" />}
+                value={option}
+                key={option}
+              >
+                {option}
+              </TagPickerOption>
+            ))
+          ) : (
+            <TagPickerOption value="no-options">No options available</TagPickerOption>
+          )}
         </TagPickerList>
       </TagPicker>
     </Field>

--- a/packages/react-components/react-tag-picker/stories/src/TagPicker/TagPickerButton.stories.tsx
+++ b/packages/react-components/react-tag-picker/stories/src/TagPicker/TagPickerButton.stories.tsx
@@ -24,6 +24,9 @@ const options = [
 export const Button = () => {
   const [selectedOptions, setSelectedOptions] = React.useState<string[]>([]);
   const onOptionSelect: TagPickerProps['onOptionSelect'] = (e, data) => {
+    if (data.value === 'no-options') {
+      return;
+    }
     setSelectedOptions(data.selectedOptions);
   };
   const tagPickerOptions = options.filter(option => !selectedOptions.includes(option));
@@ -48,18 +51,20 @@ export const Button = () => {
         </TagPickerControl>
 
         <TagPickerList>
-          {tagPickerOptions.length > 0
-            ? tagPickerOptions.map(option => (
-                <TagPickerOption
-                  secondaryContent="Microsoft FTE"
-                  media={<Avatar shape="square" aria-hidden name={option} color="colorful" />}
-                  value={option}
-                  key={option}
-                >
-                  {option}
-                </TagPickerOption>
-              ))
-            : 'No options available'}
+          {tagPickerOptions.length > 0 ? (
+            tagPickerOptions.map(option => (
+              <TagPickerOption
+                secondaryContent="Microsoft FTE"
+                media={<Avatar shape="square" aria-hidden name={option} color="colorful" />}
+                value={option}
+                key={option}
+              >
+                {option}
+              </TagPickerOption>
+            ))
+          ) : (
+            <TagPickerOption value="no-options">No options available</TagPickerOption>
+          )}
         </TagPickerList>
       </TagPicker>
     </Field>

--- a/packages/react-components/react-tag-picker/stories/src/TagPicker/TagPickerDefault.stories.tsx
+++ b/packages/react-components/react-tag-picker/stories/src/TagPicker/TagPickerDefault.stories.tsx
@@ -24,6 +24,9 @@ const options = [
 export const Default = () => {
   const [selectedOptions, setSelectedOptions] = React.useState<string[]>([]);
   const onOptionSelect: TagPickerProps['onOptionSelect'] = (e, data) => {
+    if (data.value === 'no-options') {
+      return;
+    }
     setSelectedOptions(data.selectedOptions);
   };
   const tagPickerOptions = options.filter(option => !selectedOptions.includes(option));
@@ -47,18 +50,20 @@ export const Default = () => {
           <TagPickerInput aria-label="Select Employees" />
         </TagPickerControl>
         <TagPickerList>
-          {tagPickerOptions.length > 0
-            ? tagPickerOptions.map(option => (
-                <TagPickerOption
-                  secondaryContent="Microsoft FTE"
-                  media={<Avatar shape="square" aria-hidden name={option} color="colorful" />}
-                  value={option}
-                  key={option}
-                >
-                  {option}
-                </TagPickerOption>
-              ))
-            : 'No options available'}
+          {tagPickerOptions.length > 0 ? (
+            tagPickerOptions.map(option => (
+              <TagPickerOption
+                secondaryContent="Microsoft FTE"
+                media={<Avatar shape="square" aria-hidden name={option} color="colorful" />}
+                value={option}
+                key={option}
+              >
+                {option}
+              </TagPickerOption>
+            ))
+          ) : (
+            <TagPickerOption value="no-options">No options available</TagPickerOption>
+          )}
         </TagPickerList>
       </TagPicker>
     </Field>

--- a/packages/react-components/react-tag-picker/stories/src/TagPicker/TagPickerDisabled.stories.tsx
+++ b/packages/react-components/react-tag-picker/stories/src/TagPicker/TagPickerDisabled.stories.tsx
@@ -24,6 +24,9 @@ const options = [
 export const Disabled = () => {
   const [selectedOptions, setSelectedOptions] = React.useState<string[]>(options.slice(0, 4));
   const onOptionSelect: TagPickerProps['onOptionSelect'] = (e, data) => {
+    if (data.value === 'no-options') {
+      return;
+    }
     setSelectedOptions(data.selectedOptions);
   };
   const tagPickerOptions = options.filter(option => !selectedOptions.includes(option));
@@ -47,18 +50,20 @@ export const Disabled = () => {
           <TagPickerInput aria-label="Select Employees" />
         </TagPickerControl>
         <TagPickerList>
-          {tagPickerOptions.length > 0
-            ? tagPickerOptions.map(option => (
-                <TagPickerOption
-                  secondaryContent="Microsoft FTE"
-                  media={<Avatar shape="square" aria-hidden name={option} color="colorful" />}
-                  value={option}
-                  key={option}
-                >
-                  {option}
-                </TagPickerOption>
-              ))
-            : 'No options available'}
+          {tagPickerOptions.length > 0 ? (
+            tagPickerOptions.map(option => (
+              <TagPickerOption
+                secondaryContent="Microsoft FTE"
+                media={<Avatar shape="square" aria-hidden name={option} color="colorful" />}
+                value={option}
+                key={option}
+              >
+                {option}
+              </TagPickerOption>
+            ))
+          ) : (
+            <TagPickerOption value="no-options">No options available</TagPickerOption>
+          )}
         </TagPickerList>
       </TagPicker>
     </Field>

--- a/packages/react-components/react-tag-picker/stories/src/TagPicker/TagPickerExpandIcon.stories.tsx
+++ b/packages/react-components/react-tag-picker/stories/src/TagPicker/TagPickerExpandIcon.stories.tsx
@@ -25,6 +25,9 @@ const options = [
 export const ExpandIcon = () => {
   const [selectedOptions, setSelectedOptions] = React.useState<string[]>([options[0]]);
   const onOptionSelect: TagPickerProps['onOptionSelect'] = (event, data) => {
+    if (data.value === 'no-options') {
+      return;
+    }
     setSelectedOptions(data.selectedOptions);
   };
   const tagPickerOptions = options.filter(option => !selectedOptions.includes(option));
@@ -48,18 +51,20 @@ export const ExpandIcon = () => {
           <TagPickerInput aria-label="Select Employees" />
         </TagPickerControl>
         <TagPickerList>
-          {tagPickerOptions.length > 0
-            ? tagPickerOptions.map(option => (
-                <TagPickerOption
-                  secondaryContent="Microsoft FTE"
-                  media={<Avatar shape="square" aria-hidden name={option} color="colorful" />}
-                  value={option}
-                  key={option}
-                >
-                  {option}
-                </TagPickerOption>
-              ))
-            : 'No options available'}
+          {tagPickerOptions.length > 0 ? (
+            tagPickerOptions.map(option => (
+              <TagPickerOption
+                secondaryContent="Microsoft FTE"
+                media={<Avatar shape="square" aria-hidden name={option} color="colorful" />}
+                value={option}
+                key={option}
+              >
+                {option}
+              </TagPickerOption>
+            ))
+          ) : (
+            <TagPickerOption value="no-options">No options available</TagPickerOption>
+          )}
         </TagPickerList>
       </TagPicker>
     </Field>

--- a/packages/react-components/react-tag-picker/stories/src/TagPicker/TagPickerGrouped.stories.tsx
+++ b/packages/react-components/react-tag-picker/stories/src/TagPicker/TagPickerGrouped.stories.tsx
@@ -17,6 +17,9 @@ const devs = ['Pierre Dupont', 'Amelie Dupont', 'Mario Rossi', 'Maria Rossi'];
 export const Grouped = () => {
   const [selectedOptions, setSelectedOptions] = React.useState<string[]>([]);
   const onOptionSelect: TagPickerProps['onOptionSelect'] = (e, data) => {
+    if (data.value === 'no-options') {
+      return;
+    }
     setSelectedOptions(data.selectedOptions);
   };
   const unSelectedManagers = managers.filter(option => !selectedOptions.includes(option));
@@ -41,7 +44,9 @@ export const Grouped = () => {
           <TagPickerInput aria-label="Select Employees" />
         </TagPickerControl>
         <TagPickerList>
-          {unSelectedManagers.length === 0 && unSelectedDevs.length === 0 && 'No options available'}
+          {unSelectedManagers.length === 0 && unSelectedDevs.length === 0 && (
+            <TagPickerOption value="no-options">No options available</TagPickerOption>
+          )}
           {unSelectedManagers.length > 0 && (
             <TagPickerOptionGroup label="Managers">
               {unSelectedManagers.map(option => (

--- a/packages/react-components/react-tag-picker/stories/src/TagPicker/TagPickerSecondaryAction.stories.tsx
+++ b/packages/react-components/react-tag-picker/stories/src/TagPicker/TagPickerSecondaryAction.stories.tsx
@@ -24,6 +24,9 @@ const options = [
 export const SecondaryAction = () => {
   const [selectedOptions, setSelectedOptions] = React.useState<string[]>([options[0]]);
   const onOptionSelect: TagPickerProps['onOptionSelect'] = (event, data) => {
+    if (data.value === 'no-options') {
+      return;
+    }
     setSelectedOptions(data.selectedOptions);
   };
   const handleAllClear: React.MouseEventHandler = event => {
@@ -56,18 +59,20 @@ export const SecondaryAction = () => {
           <TagPickerInput aria-label="Select Employees" />
         </TagPickerControl>
         <TagPickerList>
-          {tagPickerOptions.length > 0
-            ? tagPickerOptions.map(option => (
-                <TagPickerOption
-                  secondaryContent="Microsoft FTE"
-                  media={<Avatar shape="square" aria-hidden name={option} color="colorful" />}
-                  value={option}
-                  key={option}
-                >
-                  {option}
-                </TagPickerOption>
-              ))
-            : 'No options available'}
+          {tagPickerOptions.length > 0 ? (
+            tagPickerOptions.map(option => (
+              <TagPickerOption
+                secondaryContent="Microsoft FTE"
+                media={<Avatar shape="square" aria-hidden name={option} color="colorful" />}
+                value={option}
+                key={option}
+              >
+                {option}
+              </TagPickerOption>
+            ))
+          ) : (
+            <TagPickerOption value="no-options">No options available</TagPickerOption>
+          )}
         </TagPickerList>
       </TagPicker>
     </Field>

--- a/packages/react-components/react-tag-picker/stories/src/TagPicker/TagPickerSize.stories.tsx
+++ b/packages/react-components/react-tag-picker/stories/src/TagPicker/TagPickerSize.stories.tsx
@@ -24,6 +24,9 @@ const options = [
 const Example = ({ size }: Pick<TagPickerProps, 'size'>) => {
   const [selectedOptions, setSelectedOptions] = React.useState<string[]>([options[0]]);
   const onOptionSelect: TagPickerProps['onOptionSelect'] = (e, data) => {
+    if (data.value === 'no-options') {
+      return;
+    }
     setSelectedOptions(data.selectedOptions);
   };
   const tagPickerOptions = options.filter(option => !selectedOptions.includes(option));
@@ -47,18 +50,20 @@ const Example = ({ size }: Pick<TagPickerProps, 'size'>) => {
           <TagPickerInput aria-label="Select Employees" />
         </TagPickerControl>
         <TagPickerList>
-          {tagPickerOptions.length > 0
-            ? tagPickerOptions.map(option => (
-                <TagPickerOption
-                  secondaryContent="Microsoft FTE"
-                  media={<Avatar shape="square" aria-hidden name={option} color="colorful" />}
-                  value={option}
-                  key={option}
-                >
-                  {option}
-                </TagPickerOption>
-              ))
-            : 'No options available'}
+          {tagPickerOptions.length > 0 ? (
+            tagPickerOptions.map(option => (
+              <TagPickerOption
+                secondaryContent="Microsoft FTE"
+                media={<Avatar shape="square" aria-hidden name={option} color="colorful" />}
+                value={option}
+                key={option}
+              >
+                {option}
+              </TagPickerOption>
+            ))
+          ) : (
+            <TagPickerOption value="no-options">No options available</TagPickerOption>
+          )}
         </TagPickerList>
       </TagPicker>
     </Field>

--- a/packages/react-components/react-tag-picker/stories/src/TagPicker/TagPickerTruncatedText.stories.tsx
+++ b/packages/react-components/react-tag-picker/stories/src/TagPicker/TagPickerTruncatedText.stories.tsx
@@ -51,6 +51,9 @@ const useStyles = makeStyles({
 export const TruncatedText = () => {
   const [selectedOptions, setSelectedOptions] = React.useState<Option[]>(options);
   const onOptionSelect: TagPickerProps['onOptionSelect'] = (e, data) => {
+    if (data.value === 'no-options') {
+      return;
+    }
     setSelectedOptions(data.selectedOptions.map(option => options.find(o => o.value === option)!));
   };
   const tagPickerOptions = options.filter(option => !selectedOptions.includes(option));
@@ -82,20 +85,22 @@ export const TruncatedText = () => {
           <TagPickerInput aria-label="Select Employees" />
         </TagPickerControl>
         <TagPickerList>
-          {tagPickerOptions.length > 0
-            ? tagPickerOptions.map(option => (
-                <TagPickerOption
-                  secondaryContent={{ children: 'Microsoft FTE', className: styles.optionSecondaryContent }}
-                  media={<Avatar shape="square" aria-hidden name={option.value} color="colorful" />}
-                  value={option.value}
-                  key={option.value}
-                  title={option.value}
-                  text={option.value}
-                >
-                  <div className={styles.optionContent}>{option.value}</div>
-                </TagPickerOption>
-              ))
-            : 'No options available'}
+          {tagPickerOptions.length > 0 ? (
+            tagPickerOptions.map(option => (
+              <TagPickerOption
+                secondaryContent={{ children: 'Microsoft FTE', className: styles.optionSecondaryContent }}
+                media={<Avatar shape="square" aria-hidden name={option.value} color="colorful" />}
+                value={option.value}
+                key={option.value}
+                title={option.value}
+                text={option.value}
+              >
+                <div className={styles.optionContent}>{option.value}</div>
+              </TagPickerOption>
+            ))
+          ) : (
+            <TagPickerOption value="no-options">No options available</TagPickerOption>
+          )}
         </TagPickerList>
       </TagPicker>
     </Field>


### PR DESCRIPTION
## Previous Behavior

The "No options available" option in `TagPicker` used to be just a text node, which meant it wasn't announced for screenreaders.

<img width="428" alt="image" src="https://github.com/user-attachments/assets/87e5bfbb-02b9-4c82-8643-8d4a7c055140">


## New Behavior

Using a `TagPickerOption` that cannot be selected allows for the message to be announced by screenreaders.
<img width="429" alt="image" src="https://github.com/user-attachments/assets/f19055f4-78bf-43c1-b959-f0ae0fae9cdc">


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes [ADO Bug](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/22228)
