### PR TITLE
ci(.github): decouple bundle-size base CI in order to provide token-id permissions

### DIFF
--- a/.github/workflows/bundle-size-base.yml
+++ b/.github/workflows/bundle-size-base.yml
@@ -1,6 +1,8 @@
-name: Bundle size
+name: Bundle size Base
 on:
-  pull_request:
+  push:
+    branches:
+      - master
 
 concurrency:
   # see https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow
@@ -15,11 +17,12 @@ env:
   BROWSERSLIST_IGNORE_OLD_DATA: true
 
 jobs:
-  bundle-size:
+  bundle-size-base:
     runs-on: macos-14-xlarge
     permissions:
       contents: 'read'
       actions: 'read'
+      id-token: 'write'
 
     steps:
       - uses: actions/checkout@v4
@@ -36,23 +39,25 @@ jobs:
           cache: 'yarn'
           node-version: '20'
 
-      - run: echo number of CPUs "$(getconf _NPROCESSORS_ONLN)"
-
       - run: yarn install --frozen-lockfile
 
-      - name: Build packages & create reports
-        run: yarn nx affected -t bundle-size --nxBail
+      - name: Build all packages & create reports (non-PR)
+        run: yarn nx run-many -t bundle-size --nxBail
 
-      - name: Compare bundle size with base
-        run: npx monosize compare-reports --branch=${{ github.event.pull_request.base.ref }} --output=markdown --quiet > ./monosize-report.md
-
-      - name: Save PR number
-        run: echo ${{ github.event.number }} > pr.txt
-
-      - uses: actions/upload-artifact@v4
+      - name: Login via Azure CLI
+        uses: azure/login@v2
         with:
-          name: monosize-report
-          if-no-files-found: error
-          path: |
-            monosize-report.md
-            pr.txt
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Upload report
+        uses: azure/cli@v2
+        with:
+          azcliversion: latest
+          inlineScript: |
+            yarn monosize upload-report --branch=${{ github.ref }} --commit-sha ${{ github.sha }}
+        env:
+          AZCOPY_AUTO_LOGIN_TYPE: 'AZCLI'
+          SYSTEM_ACCESSTOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUNDLESIZE_ACCOUNT_NAME: ${{ secrets.BUNDLESIZE_ACCOUNT_NAME }}

--- a/.github/workflows/pr-website-deploy-comment.yml
+++ b/.github/workflows/pr-website-deploy-comment.yml
@@ -21,6 +21,9 @@ jobs:
     outputs:
       pr_number: ${{ steps.pr_number.outputs.id }}
       website_url: ${{ steps.website_url.outputs.id }}
+    permissions:
+      id-token: write
+
     steps:
       - name: Download WebSite artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

- az login needs token-id access https://github.com/microsoft/fluentui/actions/runs/11629896665/job/32387736735#step:6:18
- we grant permission and decouple bundle-size pipelines to separate "base" pipeline in order to safely grant permission to token-id

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows https://github.com/microsoft/fluentui/pull/33185
