### PR TITLE
ci(.github): migrate from deprecated usage of set-output syntax and fix invalid deploy URL

### DIFF
--- a/.github/workflows/bundle-size-comment.yml
+++ b/.github/workflows/bundle-size-comment.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Load PR number
         id: pr_number
-        run: echo "::set-output name=id::$(cat pr.txt)"
+        run: echo "id=$(cat pr.txt)" >> $GITHUB_OUTPUT
         working-directory: ./results
 
       - name: 'Comment on PR'

--- a/.github/workflows/pr-website-deploy-comment.yml
+++ b/.github/workflows/pr-website-deploy-comment.yml
@@ -42,12 +42,12 @@ jobs:
 
       - name: Load PR number
         id: pr_number
-        run: echo "::set-output name=id::$(cat pr.txt)"
+        run: echo "id=$(cat pr.txt)" >> $GITHUB_OUTPUT
         working-directory: ./results
 
       - name: Load WEBSITE URL
         id: website_url
-        run: echo "::set-output name=id::${{env.DEPLOY_HOST_URL}}pull/${{steps.pr_number.outputs.id}}"
+        run: echo "id=${{env.DEPLOY_HOST_URL}}pull/${{steps.pr_number.outputs.id}}"
 
       - name: Login via Azure CLI
         uses: azure/login@v2
@@ -86,7 +86,6 @@ jobs:
             Pull request demo site: [URL](${{needs.deploy.outputs.website_url}})
 
       - name: Update PR deploy site GitHub status
-        if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/pr-website-deploy-comment.yml
+++ b/.github/workflows/pr-website-deploy-comment.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Load WEBSITE URL
         id: website_url
-        run: echo "id=${{env.DEPLOY_HOST_URL}}pull/${{steps.pr_number.outputs.id}}"
+        run: echo "id=${{env.DEPLOY_HOST_URL}}pull/${{steps.pr_number.outputs.id}}/"
 
       - name: Login via Azure CLI
         uses: azure/login@v2


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

- we don't use deprecated syntax for dynamically set job outputs (https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
- web url properly points to azure website 

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows https://github.com/microsoft/fluentui/pull/33187
