### PR TITLE
ci(.github): make custom gha script accessible to workflow and don't override comments on PRs

### DIFF
--- a/.github/workflows/bundle-size-comment.yml
+++ b/.github/workflows/bundle-size-comment.yml
@@ -28,5 +28,6 @@ jobs:
       - name: 'Comment on PR'
         uses: marocchino/sticky-pull-request-comment@v2
         with:
+          header: bundle-size-report
           number: ${{ steps.pr_number.outputs.id }}
           path: ./results/monosize-report.md

--- a/.github/workflows/pr-website-deploy-comment.yml
+++ b/.github/workflows/pr-website-deploy-comment.yml
@@ -83,6 +83,7 @@ jobs:
       - name: 'Comment on PR'
         uses: marocchino/sticky-pull-request-comment@v2
         with:
+          header: deploy-pr-site
           number: ${{ needs.deploy.outputs.pr_number }}
           message: |
             Pull request demo site: [URL](${{needs.deploy.outputs.website_url}})

--- a/.github/workflows/pr-website-deploy-comment.yml
+++ b/.github/workflows/pr-website-deploy-comment.yml
@@ -78,6 +78,8 @@ jobs:
     permissions:
       pull-requests: write
     steps:
+      - uses: actions/checkout@v4
+
       - name: 'Comment on PR'
         uses: marocchino/sticky-pull-request-comment@v2
         with:


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

- resolves PR comments override each other from 2 different workflows
- resolves issues with loading custom script from file-system for comment job https://github.com/microsoft/fluentui/actions/runs/11632798450

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows https://github.com/microsoft/fluentui/pull/33190
