### PR TITLE
Breaking: Render List/ListItem as "div" when in composite nav mode

### DIFF
--- a/packages/react-components/react-list-preview/library/src/components/List/useList.ts
+++ b/packages/react-components/react-list-preview/library/src/components/List/useList.ts
@@ -32,14 +32,9 @@ export const useList_unstable = (
   props: ListProps,
   ref: React.Ref<HTMLDivElement | HTMLUListElement | HTMLOListElement>,
 ): ListState => {
-  const {
-    navigationMode,
-    selectionMode,
-    selectedItems,
-    defaultSelectedItems,
-    as = DEFAULT_ROOT_EL_TYPE,
-    onSelectionChange,
-  } = props;
+  const { navigationMode, selectionMode, selectedItems, defaultSelectedItems, onSelectionChange } = props;
+
+  const as = props.as || navigationMode === 'composite' ? 'div' : DEFAULT_ROOT_EL_TYPE;
 
   const arrowNavigationAttributes = useArrowNavigationGroup({
     axis: 'vertical',
@@ -82,10 +77,10 @@ export const useList_unstable = (
 
   return {
     components: {
-      root: DEFAULT_ROOT_EL_TYPE,
+      root: as,
     },
     root: slot.always(
-      getIntrinsicElementProps(DEFAULT_ROOT_EL_TYPE, {
+      getIntrinsicElementProps(as, {
         ref,
         role: listRole,
         ...(selectionMode && {
@@ -94,7 +89,7 @@ export const useList_unstable = (
         ...arrowNavigationAttributes,
         ...props,
       }),
-      { elementType: DEFAULT_ROOT_EL_TYPE },
+      { elementType: as },
     ),
     listItemRole,
     validateListItem,

--- a/packages/react-components/react-list-preview/library/src/components/ListItem/useListItem.tsx
+++ b/packages/react-components/react-list-preview/library/src/components/ListItem/useListItem.tsx
@@ -52,6 +52,8 @@ export const useListItem_unstable = (
   const listItemRole = useListContext_unstable(ctx => ctx.listItemRole);
   const validateListItem = useListContext_unstable(ctx => ctx.validateListItem);
 
+  const as = props.as || navigationMode === 'composite' ? 'div' : DEFAULT_ROOT_EL_TYPE;
+
   const finalListItemRole = role || listItemRole;
 
   const focusableItems = Boolean(isSelectionEnabled || navigationMode || tabIndex === 0);
@@ -180,7 +182,7 @@ export const useListItem_unstable = (
   );
 
   const root = slot.always(
-    getIntrinsicElementProps(DEFAULT_ROOT_EL_TYPE, {
+    getIntrinsicElementProps(as, {
       ref: useMergedRefs(rootRef, ref) as React.Ref<HTMLLIElement & HTMLDivElement>,
       tabIndex: focusableItems ? 0 : undefined,
       role: finalListItemRole,
@@ -193,7 +195,7 @@ export const useListItem_unstable = (
       onKeyDown: handleKeyDown,
       onClick: isSelectionEnabled || onClick || onAction ? handleClick : undefined,
     }),
-    { elementType: DEFAULT_ROOT_EL_TYPE },
+    { elementType: as },
   );
 
   const checkmark = slot.optional(props.checkmark, {
@@ -213,7 +215,7 @@ export const useListItem_unstable = (
 
   const state: ListItemState = {
     components: {
-      root: DEFAULT_ROOT_EL_TYPE,
+      root: as,
       checkmark: Checkbox,
     },
     root,

--- a/packages/react-components/react-list-preview/stories/src/List/ListActiveElement.stories.tsx
+++ b/packages/react-components/react-list-preview/stories/src/List/ListActiveElement.stories.tsx
@@ -62,7 +62,6 @@ export const ListActiveElement = () => {
   return (
     <div>
       <List
-        as="div"
         selectionMode="single"
         navigationMode="composite"
         selectedItems={selectedItems}
@@ -70,7 +69,6 @@ export const ListActiveElement = () => {
       >
         {items.map(({ name, avatar }) => (
           <ListItem
-            as="div"
             key={name}
             value={name}
             className={mergeClasses(classes.item, selectedItems.includes(name) && classes.itemSelected)}

--- a/packages/react-components/react-list-preview/stories/src/List/MultipleActionsDifferentPrimary.stories.tsx
+++ b/packages/react-components/react-list-preview/stories/src/List/MultipleActionsDifferentPrimary.stories.tsx
@@ -80,7 +80,6 @@ const CustomListItem = (props: { title: string; value: string }) => {
 
   return (
     <ListItem
-      as="div"
       value={props.value}
       className={mergeClasses(listItemStyles, styles.listItem)}
       checkmark={{ root: { role: 'gridcell' }, className: styles.checkmark, 'aria-label': value }}
@@ -165,7 +164,6 @@ export const MultipleActionsDifferentPrimary = () => {
 
   return (
     <List
-      as="div"
       className={classes.list}
       navigationMode="composite"
       selectionMode="multiselect"

--- a/packages/react-components/react-list-preview/stories/src/List/MultipleActionsSelection.stories.tsx
+++ b/packages/react-components/react-list-preview/stories/src/List/MultipleActionsSelection.stories.tsx
@@ -73,7 +73,6 @@ const CustomListItem = (props: { title: string; value: string }) => {
 
   return (
     <ListItem
-      as="div"
       value={value}
       className={mergeClasses(listItemStyles, styles.listItem)}
       checkmark={{ root: { role: 'gridcell' }, className: styles.checkmark, 'aria-label': value }}
@@ -157,7 +156,6 @@ export const MultipleActionsSelection = () => {
 
   return (
     <List
-      as="div"
       className={classes.list}
       navigationMode="composite"
       selectionMode="multiselect"

--- a/packages/react-components/react-list-preview/stories/src/List/MultipleActionsWithPrimary.stories.tsx
+++ b/packages/react-components/react-list-preview/stories/src/List/MultipleActionsWithPrimary.stories.tsx
@@ -74,7 +74,6 @@ const CustomListItem = (props: { title: string; value: string }) => {
 
   return (
     <ListItem
-      as="div"
       value={props.value}
       className={mergeClasses(listItemStyles, styles.listItem)}
       aria-label={value}
@@ -153,7 +152,7 @@ export const MultipleActionsWithPrimary = () => {
   const classes = useStyles();
 
   return (
-    <List navigationMode="composite" className={classes.list} as="div">
+    <List navigationMode="composite" className={classes.list}>
       <CustomListItem title="Example List Item" value="card-1" />
       <CustomListItem title="Example List Item" value="card-2" />
       <CustomListItem title="Example List Item" value="card-3" />


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Previously the `List` and `ListItem` would always be rendered as `ul` and `li` respectively. This, when combined with the `navigationMode="composite"` would result in a markup of `<ul role="grid">` and `<li role="gridcell">` which is invalid.

## New Behavior

When the `navigationMode` is set to `"composite"`, the default element for both `List` and `ListItem` is now `div`. It is still possible to pass `as` prop to change this.