### PR TITLE
feat(scripts-executors):  add inferred projects support to start experience

### DIFF
--- a/.github/workflows/check-tooling.yml
+++ b/.github/workflows/check-tooling.yml
@@ -35,6 +35,9 @@ jobs:
 
       - run: yarn nx list @fluentui/workspace-plugin
 
+      # pre-build react-jsx-runtime - as generate-api executor doesn't provide copy assets capability
+      - run: yarn nx run react-jsx-runtime:build
+
       - run: yarn nx g @fluentui/workspace-plugin:react-library --name hello-world --owner '@microsoft/fluentui-react-build' --kind standard --no-interactive
       - run: yarn nx g @fluentui/workspace-plugin:react-component --project hello-world-preview --name Aiur --no-interactive
       - run: yarn nx g @fluentui/workspace-plugin:cypress-component-configuration --project hello-world-preview --no-interactive

--- a/scripts/executors/src/start.ts
+++ b/scripts/executors/src/start.ts
@@ -210,8 +210,19 @@ async function getSelectedTarget(
     .filter(targetName => {
       return omitTargets.includes(targetName) ? false : true;
     })
+    .map(targetName => {
+      const targetConfigurations = Object.keys(projectTargets[targetName].configurations || {});
+
+      if (targetConfigurations) {
+        return [targetName, ...targetConfigurations.map(target => `${targetName}:${target}`)];
+      }
+
+      return targetName;
+    })
+    .flat()
     .sort()
     .concat('help');
+
   const preselectedTargetChoice =
     preselectedTarget && availableTargets.indexOf(preselectedTarget) !== -1
       ? availableTargets.indexOf(preselectedTarget)

--- a/scripts/executors/src/start.ts
+++ b/scripts/executors/src/start.ts
@@ -269,39 +269,43 @@ function createTargetDescription(
   targetName: string,
   targetsDescription: Record<string, string>,
 ) {
-  const description = targetsDescription[targetName];
+  const manualConfigDrivenDescription = targetsDescription[targetName];
   const nxTargetConfiguration = projectConfig.data.targets?.[targetName];
+  const nxMetadataDescription = nxTargetConfiguration?.metadata?.description;
+  const scriptContent: string | undefined = nxTargetConfiguration?.metadata?.scriptContent;
+  const command = scriptContent || nxTargetConfiguration?.options.command || nxTargetConfiguration?.command;
 
+  // special case for non existent targets that we add artificially like `help`
   if (!nxTargetConfiguration) {
-    return description;
+    return manualConfigDrivenDescription;
+  }
+
+  if (nxMetadataDescription) {
+    return nxMetadataDescription;
   }
 
   if (targetName === 'start') {
-    const scriptContent = nxTargetConfiguration.metadata?.scriptContent;
-    if (scriptContent.includes('storybook')) {
+    if (command && command.includes('storybook')) {
       return `Start the project (Alias of "storybook" target)`;
     }
-    return description;
+
+    return manualConfigDrivenDescription;
   }
 
   if (targetName === 'e2e') {
-    const scriptContent = nxTargetConfiguration.metadata?.scriptContent;
-    const runnerType = getRunnerType(scriptContent);
+    const runnerType = command && getRunnerType(command);
+    console.log({ runnerType, command });
 
-    if (!runnerType) {
-      return scriptContent;
-    }
-
-    return description + ` (using ${runnerType})`;
+    return runnerType ? manualConfigDrivenDescription + ` (using ${runnerType})` : manualConfigDrivenDescription;
   }
 
-  return description ?? nxTargetConfiguration.metadata?.scriptContent;
+  return manualConfigDrivenDescription ?? command;
 
-  function getRunnerType(scriptContent: string): 'cypress' | 'playwright' | null {
-    if (scriptContent.includes('cypress')) {
+  function getRunnerType(value: string): 'cypress' | 'playwright' | null {
+    if (value.includes('cypress')) {
       return 'cypress';
     }
-    if (scriptContent.includes('playwright')) {
+    if (value.includes('playwright')) {
       return 'playwright';
     }
 

--- a/tools/workspace-plugin/src/executors/generate-api/executor.ts
+++ b/tools/workspace-plugin/src/executors/generate-api/executor.ts
@@ -46,7 +46,8 @@ function normalizeOptions(schema: GenerateApiExecutorSchema, context: ExecutorCo
 
   const project = context.projectsConfigurations!.projects[context.projectName!];
 
-  const resolveLocalFlag = Boolean(process.env.__FORCE_API_MD_UPDATE__) || isCI() ? false : resolvedSchema.local;
+  const resolveLocalFlag = Boolean(process.env.__FORCE_API_MD_UPDATE__) || (isCI() ? false : resolvedSchema.local);
+
   const projectAbsolutePath = join(context.root, project.root);
   const resolveConfig = getApiExtractorConfigPath(resolvedSchema, projectAbsolutePath);
   const tsConfigPathForCompilation = getTsConfigPathUsedForProduction(projectAbsolutePath);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

- feat: adds support to inferred projects 
  - metadata retrieval for description
  - target configurations unwrap into separate commands
- fix: generate-api `local` flag resolution on CI

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows https://github.com/microsoft/fluentui/pull/33074
