### PR TITLE
ci(.github): prepare new pipelines for migration from ADO

### DIFF
--- a/.github/actions/run-publish-vr-screenshot/action.yml
+++ b/.github/actions/run-publish-vr-screenshot/action.yml
@@ -80,6 +80,7 @@ runs:
       uses: actions/upload-artifact@v4
       with:
         name: vrscreenshot${{ inputs.fluentVersion }}
+        retention-days: 1
         path: screenshots
 
     # ==========================================================

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,1 +1,29 @@
-'Type: RFC': 'rfcs/**/*.md'
+'Type: RFC':
+  - changed-files:
+      - any-glob-to-any-file: 'docs/react-v9/contributing/rfcs/**'
+
+'CI':
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/**'
+          - '.devops/**'
+          - 'azure-pipelines*.yml'
+
+'NX: core':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'tools/workspace-plugin/**'
+          - 'nx.json'
+          - '**/project.json'
+
+'NX: workspace generators':
+  - changed-files:
+      - any-glob-to-any-file: 'tools/workspace-plugin/src/generators/*'
+
+'NX: workspace executors':
+  - changed-files:
+      - any-glob-to-any-file: 'tools/workspace-plugin/src/executors/*'
+
+'NX: workspace eslint-rules':
+  - changed-files:
+      - any-glob-to-any-file: 'tools/eslint-rules/*'

--- a/.github/workflows/bundle-size-base.yml
+++ b/.github/workflows/bundle-size-base.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  NX_PARALLEL: 6 # ubuntu-latest = 4-core CPU / 16 GB of RAM | macos-14-xlarge (arm) = 6-core CPU / 14 GB of RAM
+  NX_PARALLEL: 4 # ubuntu-latest = 4-core CPU / 16 GB of RAM | macos-14-xlarge (arm) = 6-core CPU / 14 GB of RAM
   NX_PREFER_TS_NODE: true
   NX_VERBOSE_LOGGING: true
 
@@ -18,7 +18,8 @@ env:
 
 jobs:
   bundle-size-base:
-    runs-on: macos-14-xlarge
+    # TODO: use macos-14-xlarge (arm) for faster builds once https://github.com/Azure/cli/issues/172 will be fixed
+    runs-on: ubuntu-latest
     permissions:
       contents: 'read'
       actions: 'read'

--- a/.github/workflows/bundle-size-base.yml
+++ b/.github/workflows/bundle-size-base.yml
@@ -21,19 +21,10 @@ jobs:
     # TODO: use macos-14-xlarge (arm) for faster builds once https://github.com/Azure/cli/issues/172 will be fixed
     runs-on: ubuntu-latest
     permissions:
-      contents: 'read'
-      actions: 'read'
       id-token: 'write'
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        uses: nrwl/nx-set-shas@v4
-        with:
-          main-branch-name: 'master'
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -52,6 +52,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: monosize-report
+          retention-days: 1
           if-no-files-found: error
           path: |
             monosize-report.md

--- a/.github/workflows/check-packages.yml
+++ b/.github/workflows/check-packages.yml
@@ -6,11 +6,11 @@ jobs:
   dependency-deduplication:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 20.x
           cache: 'yarn'
@@ -38,15 +38,15 @@ jobs:
   dependency-mismatches:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 20.x
 
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v7
         with:
           script: |
             const syncpackVersion = require('./package.json').devDependencies.syncpack;
@@ -64,15 +64,15 @@ jobs:
   change-files:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 20.x
 
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v7
         with:
           script: |
             const beachballVersion = require('./package.json').devDependencies.beachball;

--- a/.github/workflows/docsite-publish-ghpages.yml
+++ b/.github/workflows/docsite-publish-ghpages.yml
@@ -16,7 +16,7 @@ jobs:
       status: ${{ steps.verify-react-components-changed.outputs.any_changed == 'true' || github.event_name == 'workflow_dispatch' }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout [master]
 
       - name: Verify react-compoenents has changed
@@ -31,11 +31,11 @@ jobs:
     if: needs.check.outputs.status == 'true'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 20.x
           cache: 'yarn'

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -12,8 +12,8 @@ jobs:
       issues: write
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/github-script@v6
+      - uses: actions/checkout@v4
+      - uses: actions/github-script@v7
         with:
           script: |
             const config = require('./.github/triage-bot.config.json');

--- a/.github/workflows/pr-housekeeping.yml
+++ b/.github/workflows/pr-housekeeping.yml
@@ -11,9 +11,12 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v3
+      - uses: actions/labeler@v5
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
+          sync-labels: true
+          configuration-path: .github/labeler.yml
+
   assign-to-current-milestone:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-website-deploy-comment.yml
+++ b/.github/workflows/pr-website-deploy-comment.yml
@@ -77,6 +77,7 @@ jobs:
     if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
     permissions:
       pull-requests: write
+      statuses: write
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/pr-website-deploy.yml
+++ b/.github/workflows/pr-website-deploy.yml
@@ -14,21 +14,6 @@ env:
 
   BROWSERSLIST_IGNORE_OLD_DATA: true
 
-  # Deploy host and URL
-  # DEPLOY_BASE_PATH: ''
-  DEPLOY_HOST: fluentuipr.z22.web.core.windows.net
-  DEPLOY_URL: https://fluentuipr.z22.web.core.windows.net/${{ github.event.pull_request.number || github.ref_name }}
-  # DEPLOY_BASE_PATH: pull/${{github.event.pull_request.number}}
-  DEPLOY_BASE_PATH: ${{ github.event.pull_request.number != '' && format('pull/{0}', github.event.pull_request.number) || format('heads/{0}', github.ref_name) }}
-
-  IS_PR: ${{ github.event_name == 'pull_request' }}
-  TARGET_BRANCH: ${{ github.event.pull_request.base.ref || '' }}
-
-  # GitHub Secrets for Azure access
-  # This service principal ("subscription" is a misleading name) only has access to the fluentuipr storage account
-  AZURE_SUBSCRIPTION: Azure PR deploy - NEW
-  AZURE_STORAGE: fluentuipr
-
 jobs:
   bundle:
     runs-on: macos-14-xlarge

--- a/.github/workflows/pr-website-deploy.yml
+++ b/.github/workflows/pr-website-deploy.yml
@@ -51,6 +51,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: pr-website-artifacts
+          retention-days: 1
           if-no-files-found: error
           path: |
             apps/pr-deploy-site/dist/
@@ -60,6 +61,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: pr-number
+          retention-days: 1
           if-no-files-found: error
           path: |
             pr.txt

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,6 @@ env:
 
   DEPLOY_HOST: fluentuipr.z22.web.core.windows.net
   DEPLOY_URL: https://fluentuipr.z22.web.core.windows.net/${{ github.event.pull_request.number || github.ref_name }}
-  # DEPLOY_BASE_PATH: pull/${{github.event.pull_request.number}}
   DEPLOY_BASE_PATH: ${{ github.event.pull_request.number != '' && format('pull/{0}', github.event.pull_request.number) || format('heads/{0}', github.ref_name) }}
 
 jobs:
@@ -116,9 +115,4 @@ jobs:
         run: yarn cypress verify
 
       - name: Cypress/Playwright E2E tests
-        if: github.event_name == 'pull_request'
         run: yarn nx affected -t e2e --nxBail --parallel 1
-
-      - name: Cypress/Playwright E2E tests (non-PR)
-        if: github.event_name != 'pull_request'
-        run: yarn nx run-many -t e2e --nxBail --parallel 1

--- a/change/@fluentui-web-components-9ecadf3f-3fd0-44c1-9abd-20a3456d8738.json
+++ b/change/@fluentui-web-components-9ecadf3f-3fd0-44c1-9abd-20a3456d8738.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: resolve TS errors within web-components build",
+  "packageName": "@fluentui/web-components",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/src/tooltip/tooltip.ts
+++ b/packages/web-components/src/tooltip/tooltip.ts
@@ -170,7 +170,7 @@ export class Tooltip extends FASTElement {
   public showTooltip(delay: number = this.defaultDelay): void {
     setTimeout(() => {
       this.setAttribute('aria-hidden', 'false');
-      // @ts-expect-error - Baseline 2024
+      //// @ts-expect-error - Baseline 2024
       this.showPopover();
     }, delay);
   }
@@ -189,7 +189,7 @@ export class Tooltip extends FASTElement {
       }
 
       this.setAttribute('aria-hidden', 'true');
-      // @ts-expect-error - Baseline 2024
+      //// @ts-expect-error - Baseline 2024
       this.hidePopover();
     }, delay);
   }

--- a/scripts/triage-bot/README.md
+++ b/scripts/triage-bot/README.md
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v7
         with:
           script: |
             const config = require('./.github/triage-bot.config.json');


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

- use ubuntu-latest runner to make azure cli  work for bundle-size-comment 
  - https://github.com/Azure/cli/issues/172
  - **NOTE: this degrades CI (bundles size base) performance by 90% 🐌**
-  adds proper permission to update status with web site deployment
- sets retention day to for uploaded assets to minimum (1 day)
- migrates to latest core actions we use in pipelines (aligning with node v20 usage)
  - [labeler](https://github.com/actions/labeler) will work again going forward 
- improves **performance of master pipelines**
  -  going forward instead running all task on whole monorepo on every merge, we will run only affected projects since last succesfull merge commit passed - this should improve master runs perf **by 30%+**

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows https://github.com/microsoft/fluentui/pull/33191
