### PR TITLE
Fixed High contrast bugs for multiple charts

### DIFF
--- a/packages/charts/react-charts-preview/library/src/components/CommonComponents/ChartPopover.tsx
+++ b/packages/charts/react-charts-preview/library/src/components/CommonComponents/ChartPopover.tsx
@@ -35,7 +35,7 @@ export const ChartPopover: React.FunctionComponent<ChartPopoverProps> = React.fo
   const legend = props.xCalloutValue ? props.xCalloutValue : props.legend;
   const YValue = props.yCalloutValue ? props.yCalloutValue : props.YValue;
   return (
-    <div id={useId('callout')} ref={forwardedRef}>
+    <div id={useId('callout')} ref={forwardedRef} className={classes.calloutContainer}>
       <Popover
         positioning={{ target: virtualElement, autoSize: 'always', offset: 20, coverTarget: false }}
         open={props.isPopoverOpen}

--- a/packages/charts/react-charts-preview/library/src/components/CommonComponents/ChartPopover.types.ts
+++ b/packages/charts/react-charts-preview/library/src/components/CommonComponents/ChartPopover.types.ts
@@ -38,4 +38,5 @@ export interface PopoverComponentStyles {
   numerator: string;
   denominator: string;
   calloutInfoContainer: string;
+  calloutContainer: string;
 }

--- a/packages/charts/react-charts-preview/library/src/components/CommonComponents/useCartesianChartStyles.styles.ts
+++ b/packages/charts/react-charts-preview/library/src/components/CommonComponents/useCartesianChartStyles.styles.ts
@@ -58,7 +58,7 @@ const useStyles = makeStyles({
     '& text': {
       fill: tokens.colorNeutralForeground1,
       ...typographyStyles.caption2Strong,
-      '@media (forced-colors: active)': {
+      [HighContrastSelectorBlack]: {
         fill: 'rgb(179, 179, 179)',
         forcedColorAdjust: 'none',
       },
@@ -67,7 +67,7 @@ const useStyles = makeStyles({
       opacity: 0.2,
       stroke: tokens.colorNeutralForeground1,
       width: '1px',
-      '@media (forced-colors: active)': {
+      [HighContrastSelectorBlack]: {
         opacity: 0.1,
         stroke: 'rgb(179, 179, 179)',
         forcedColorAdjust: 'none',
@@ -81,7 +81,7 @@ const useStyles = makeStyles({
     '& text': {
       ...typographyStyles.caption2Strong,
       fill: tokens.colorNeutralForeground1,
-      '@media (forced-colors: active)': {
+      [HighContrastSelectorBlack]: {
         fill: 'rgb(179, 179, 179)',
         forcedColorAdjust: 'none',
       },
@@ -89,7 +89,7 @@ const useStyles = makeStyles({
     '& line': {
       opacity: 0.2,
       stroke: tokens.colorNeutralForeground1,
-      '@media (forced-colors: active)': {
+      [HighContrastSelectorBlack]: {
         opacity: 0.1,
         stroke: 'rgb(179, 179, 179)',
         forcedColorAdjust: 'none',
@@ -136,7 +136,7 @@ const useStyles = makeStyles({
     color: tokens.colorNeutralForeground2,
   },
   calloutBlockContainertoDrawShapefalse: {
-    '@media (forced-colors: active)': {
+    [HighContrastSelector]: {
       forcedColorAdjust: 'none',
     },
     ...shorthands.borderLeft('4px solid'),
@@ -151,14 +151,14 @@ const useStyles = makeStyles({
   calloutLegendText: {
     ...typographyStyles.caption1,
     color: tokens.colorNeutralForeground2,
-    '@media (forced-colors: active)': {
+    [HighContrastSelectorBlack]: {
       color: 'rgb(255, 255, 255)',
       forcedColorAdjust: 'none',
     },
   },
   calloutContentY: {
     ...typographyStyles.subtitle2Stronger,
-    '@media (forced-colors: active)': {
+    [HighContrastSelectorBlack]: {
       color: 'rgb(255, 255, 255)',
       forcedColorAdjust: 'none',
     },

--- a/packages/charts/react-charts-preview/library/src/components/CommonComponents/useCartesianChartStyles.styles.ts
+++ b/packages/charts/react-charts-preview/library/src/components/CommonComponents/useCartesianChartStyles.styles.ts
@@ -58,21 +58,19 @@ const useStyles = makeStyles({
     '& text': {
       fill: tokens.colorNeutralForeground1,
       ...typographyStyles.caption2Strong,
-      '& selectors': {
-        [HighContrastSelectorBlack]: {
-          fill: 'rgb(179, 179, 179)',
-        },
+      '@media (forced-colors: active)': {
+        fill: 'rgb(179, 179, 179)',
+        forcedColorAdjust: 'none',
       },
     },
     '& line': {
       opacity: 0.2,
       stroke: tokens.colorNeutralForeground1,
       width: '1px',
-      '& selectors': {
-        [HighContrastSelectorBlack]: {
-          opacity: 0.1,
-          stroke: 'rgb(179, 179, 179)',
-        },
+      '@media (forced-colors: active)': {
+        opacity: 0.1,
+        stroke: 'rgb(179, 179, 179)',
+        forcedColorAdjust: 'none',
       },
     },
     '& path': {
@@ -83,20 +81,18 @@ const useStyles = makeStyles({
     '& text': {
       ...typographyStyles.caption2Strong,
       fill: tokens.colorNeutralForeground1,
-      '& selectors': {
-        [HighContrastSelectorBlack]: {
-          fill: 'rgb(179, 179, 179)',
-        },
+      '@media (forced-colors: active)': {
+        fill: 'rgb(179, 179, 179)',
+        forcedColorAdjust: 'none',
       },
     },
     '& line': {
       opacity: 0.2,
       stroke: tokens.colorNeutralForeground1,
-      '& selectors': {
-        [HighContrastSelectorBlack]: {
-          opacity: 0.1,
-          stroke: 'rgb(179, 179, 179)',
-        },
+      '@media (forced-colors: active)': {
+        opacity: 0.1,
+        stroke: 'rgb(179, 179, 179)',
+        forcedColorAdjust: 'none',
       },
     },
     '& path': {
@@ -140,10 +136,8 @@ const useStyles = makeStyles({
     color: tokens.colorNeutralForeground2,
   },
   calloutBlockContainertoDrawShapefalse: {
-    '& selectors': {
-      [HighContrastSelector]: {
-        forcedColorAdjust: 'none',
-      },
+    '@media (forced-colors: active)': {
+      forcedColorAdjust: 'none',
     },
     ...shorthands.borderLeft('4px solid'),
     paddingLeft: tokens.spacingHorizontalS,
@@ -157,18 +151,16 @@ const useStyles = makeStyles({
   calloutLegendText: {
     ...typographyStyles.caption1,
     color: tokens.colorNeutralForeground2,
-    '& selectors': {
-      [HighContrastSelectorBlack]: {
-        color: 'rgb(255, 255, 255)',
-      },
+    '@media (forced-colors: active)': {
+      color: 'rgb(255, 255, 255)',
+      forcedColorAdjust: 'none',
     },
   },
   calloutContentY: {
     ...typographyStyles.subtitle2Stronger,
-    '& selectors': {
-      [HighContrastSelectorBlack]: {
-        color: 'rgb(255, 255, 255)',
-      },
+    '@media (forced-colors: active)': {
+      color: 'rgb(255, 255, 255)',
+      forcedColorAdjust: 'none',
     },
   },
   descriptionMessage: {

--- a/packages/charts/react-charts-preview/library/src/components/CommonComponents/useChartPopoverStyles.styles.ts
+++ b/packages/charts/react-charts-preview/library/src/components/CommonComponents/useChartPopoverStyles.styles.ts
@@ -22,6 +22,7 @@ export const popoverClassNames: SlotClassNames<PopoverComponentStyles> = {
   numerator: 'fui-cart__numerator',
   denominator: 'fui-cart__denominator',
   calloutInfoContainer: 'fui-cart__calloutInfoContainer',
+  calloutContainer: 'fui-cart__calloutContainer',
 };
 
 /**
@@ -116,6 +117,12 @@ const useStyles = makeStyles({
   calloutInfoContainer: {
     paddingLeft: tokens.spacingHorizontalS,
   },
+  calloutContainer: {
+    '@media (forced-colors: active)': {
+      fill: 'WindowText', // Ensure visibility in high contrast mode
+      forcedColorAdjust: 'none',
+    },
+  },
 });
 /**
  * Apply styling to the Carousel slots based on the state
@@ -167,5 +174,6 @@ export const usePopoverStyles_unstable = (props: ChartPopoverProps): PopoverComp
     numerator: mergeClasses(popoverClassNames.numerator, baseStyles.numerator /*props.styles?.numerator*/),
     denominator: mergeClasses(popoverClassNames.denominator, baseStyles.denominator /*props.styles?.denominator*/),
     calloutInfoContainer: mergeClasses(popoverClassNames.calloutInfoContainer, baseStyles.calloutInfoContainer),
+    calloutContainer: mergeClasses(popoverClassNames.calloutContainer, baseStyles.calloutContainer),
   };
 };

--- a/packages/charts/react-charts-preview/library/src/components/CommonComponents/useChartPopoverStyles.styles.ts
+++ b/packages/charts/react-charts-preview/library/src/components/CommonComponents/useChartPopoverStyles.styles.ts
@@ -118,7 +118,7 @@ const useStyles = makeStyles({
     paddingLeft: tokens.spacingHorizontalS,
   },
   calloutContainer: {
-    '@media (forced-colors: active)': {
+    [HighContrastSelector]: {
       fill: 'WindowText', // Ensure visibility in high contrast mode
       forcedColorAdjust: 'none',
     },

--- a/packages/charts/react-charts-preview/library/src/components/HorizontalBarChart/useHorizontalBarChartStyles.styles.ts
+++ b/packages/charts/react-charts-preview/library/src/components/HorizontalBarChart/useHorizontalBarChartStyles.styles.ts
@@ -2,6 +2,7 @@ import { makeStyles, mergeClasses, shorthands } from '@fluentui/react-components
 import { tokens, typographyStyles } from '@fluentui/react-theme';
 import { HorizontalBarChartProps, HorizontalBarChartStyles, HorizontalBarChartVariant } from './index';
 import type { SlotClassNames } from '@fluentui/react-utilities';
+import { HighContrastSelector } from '../../utilities/index';
 
 /**
  * @internal
@@ -88,7 +89,7 @@ const useStyles = makeStyles({
   barLabel: {
     ...typographyStyles.caption1Strong,
     fill: tokens.colorNeutralForeground1,
-    '@media (forced-colors: active)': {
+    [HighContrastSelector]: {
       fill: 'WindowText', // Ensure visibility in high contrast mode
       forcedColorAdjust: 'none',
     },

--- a/packages/charts/react-charts-preview/library/src/components/HorizontalBarChart/useHorizontalBarChartStyles.styles.ts
+++ b/packages/charts/react-charts-preview/library/src/components/HorizontalBarChart/useHorizontalBarChartStyles.styles.ts
@@ -88,6 +88,10 @@ const useStyles = makeStyles({
   barLabel: {
     ...typographyStyles.caption1Strong,
     fill: tokens.colorNeutralForeground1,
+    '@media (forced-colors: active)': {
+      fill: 'WindowText', // Ensure visibility in high contrast mode
+      forcedColorAdjust: 'none',
+    },
   },
   chartWrapper40ppadding: {
     paddingRight: '40p',

--- a/packages/charts/react-charts-preview/library/src/components/Legends/Legends.tsx
+++ b/packages/charts/react-charts-preview/library/src/components/Legends/Legends.tsx
@@ -79,11 +79,10 @@ export const Legends: React.FunctionComponent<LegendsProps> = React.forwardRef<H
             'aria-label': 'Legends',
             'aria-multiselectable': canSelectMultipleLegends,
           })}
-          style={{ justifyContent: props.centerLegends ? 'center' : 'unset', flexWrap: 'wrap', ...overflowStyles }}
           className={classes.root}
         >
           <Overflow>
-            <div className={classes.resizableArea}>
+            <div className={classes.resizableArea} style={{ textAlign: props.centerLegends ? 'center' : 'unset' }}>
               {dataToRender.map((item, id) => (
                 <OverflowItem key={id} id={id.toString()}>
                   {_renderButton(item)}

--- a/packages/charts/react-charts-preview/library/src/components/Legends/useLegendsStyles.styles.ts
+++ b/packages/charts/react-charts-preview/library/src/components/Legends/useLegendsStyles.styles.ts
@@ -34,12 +34,12 @@ const useStyles = makeStyles({
     ...shorthands.border('none'),
     ...shorthands.padding(tokens.spacingHorizontalS),
     textTransform: 'capitalize',
-    '@media (forced-colors: active)': {
+    [HighContrastSelector]: {
       color: 'WindowText',
       forcedColorAdjust: 'none',
     },
     '&:hover': {
-      '@media (forced-colors: active)': {
+      [HighContrastSelector]: {
         color: 'HighlightText',
         forcedColorAdjust: 'none',
       },
@@ -70,7 +70,7 @@ const useStyles = makeStyles({
   text: {
     ...typographyStyles.caption1,
     color: tokens.colorNeutralForeground1,
-    '@media (forced-colors: active)': {
+    [HighContrastSelector]: {
       color: 'WindowText',
       forcedColorAdjust: 'none',
     },

--- a/packages/charts/react-charts-preview/library/src/components/Legends/useLegendsStyles.styles.ts
+++ b/packages/charts/react-charts-preview/library/src/components/Legends/useLegendsStyles.styles.ts
@@ -34,6 +34,16 @@ const useStyles = makeStyles({
     ...shorthands.border('none'),
     ...shorthands.padding(tokens.spacingHorizontalS),
     textTransform: 'capitalize',
+    '@media (forced-colors: active)': {
+      color: 'WindowText',
+      forcedColorAdjust: 'none',
+    },
+    '&:hover': {
+      '@media (forced-colors: active)': {
+        color: 'HighlightText',
+        forcedColorAdjust: 'none',
+      },
+    },
   },
   rect: {
     [HighContrastSelector]: {
@@ -60,6 +70,10 @@ const useStyles = makeStyles({
   text: {
     ...typographyStyles.caption1,
     color: tokens.colorNeutralForeground1,
+    '@media (forced-colors: active)': {
+      color: 'WindowText',
+      forcedColorAdjust: 'none',
+    },
   },
   // TO DO Add props when these styles are used in the component
   hoverChange: {

--- a/packages/charts/react-charts-preview/library/src/components/Sparkline/useSparklineStyles.styles.ts
+++ b/packages/charts/react-charts-preview/library/src/components/Sparkline/useSparklineStyles.styles.ts
@@ -2,6 +2,7 @@ import { makeStyles, mergeClasses } from '@griffel/react';
 import { SparklineProps, SparklineStyles } from './Sparkline.types';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import { tokens, typographyStyles } from '@fluentui/react-theme';
+import { HighContrastSelector } from '../../utilities/index';
 
 /**
  * @internal
@@ -21,9 +22,9 @@ const useStyles = makeStyles({
   valueText: {
     ...typographyStyles.caption1,
     fill: tokens.colorNeutralForeground1,
-    '@media (forced-colors: active)': {
+    [HighContrastSelector]: {
       opacity: 0.1,
-      stroke: 'rgb(179, 179, 179)', 
+      stroke: 'rgb(179, 179, 179)',
       forcedColorAdjust: 'none',
     },
   },

--- a/packages/charts/react-charts-preview/library/src/components/Sparkline/useSparklineStyles.styles.ts
+++ b/packages/charts/react-charts-preview/library/src/components/Sparkline/useSparklineStyles.styles.ts
@@ -21,6 +21,11 @@ const useStyles = makeStyles({
   valueText: {
     ...typographyStyles.caption1,
     fill: tokens.colorNeutralForeground1,
+    '@media (forced-colors: active)': {
+      opacity: 0.1,
+      stroke: 'rgb(179, 179, 179)', 
+      forcedColorAdjust: 'none',
+    },
   },
 });
 


### PR DESCRIPTION
Fixed the following high contrast bugs for multiple charts:

1. [Bug 11575 [V9] [Doc site][High contrast] Horizontal Bar Absolute Scale data is not present on the bars.](https://uifabric.visualstudio.com/iss/_workitems/edit/11575)

2. [Bug 11579 [V9] [Doc site][High contrast] line and vertical bar charts x and y axis chart data and titles are not present](https://uifabric.visualstudio.com/iss/_workitems/edit/11579)

3. [Bug 11578 [V9] [Doc site][High contrast] sparkline row data is not present.](https://uifabric.visualstudio.com/iss/_workitems/edit/11578)

4. [Bug 11576 [V9] [Doc site][High contrast]when we toggle on User Popover Override the text is visible in white color only for all the charts...](https://uifabric.visualstudio.com/iss/_workitems/edit/11576/) 

5. [Bug 11574 [V9] [Doc site][High contrast] legend representation line color is missing on the mouse over chart data for all the charts.](https://uifabric.visualstudio.com/iss/_workitems/edit/11574/)

6. [[V9] [Doc site][High contrast]After selecting the legend selected legend text is not visible properly for all the charts.](https://uifabric.visualstudio.com/iss/_workitems/recentlyupdated/)