### PR TITLE
Fixed chart crashing bug on enabling multiple shapes with multiple legends selected

### DIFF
--- a/packages/charts/react-charts-preview/library/src/components/LineChart/LineChart.tsx
+++ b/packages/charts/react-charts-preview/library/src/components/LineChart/LineChart.tsx
@@ -184,7 +184,6 @@ export const LineChart: React.FunctionComponent<LineChartProps> = React.forwardR
     }, [props.height, props.width, props.data]);
 
     function _injectIndexPropertyInLineChartData(lineChartData?: LineChartPoints[]): LineChartDataWithIndex[] | [] {
-      const { allowMultipleShapesForPoints = false } = props;
       return lineChartData
         ? lineChartData.map((item: LineChartPoints, index: number) => {
             let color: string;
@@ -195,7 +194,7 @@ export const LineChart: React.FunctionComponent<LineChartProps> = React.forwardR
             }
             return {
               ...item,
-              index: allowMultipleShapesForPoints ? index : -1,
+              index: index,
               color,
             };
           })


### PR DESCRIPTION
Fixed chart crashing bug on enabling multiple shapes with multiple legends selected
[[V9] [Doc site] when we select more than 3 legends and enable on multiple shapes getting an error as Cannot read properties of undefined.](https://uifabric.visualstudio.com/iss/_workitems/edit/11333/)