### PR TITLE
ci(ado): dont run bundle-size on PR which is covered by GHA

### DIFF
--- a/azure-pipelines.bundlesize.yml
+++ b/azure-pipelines.bundlesize.yml
@@ -1,6 +1,4 @@
-pr:
-  - master
-
+pr: none
 trigger:
   - master
 
@@ -24,25 +22,25 @@ jobs:
           filePath: yarn-ci.sh
         displayName: yarn
 
-      - script: |
-          yarn nx affected -t bundle-size --nxBail $(sinceArg)
-        displayName: build packages & create reports
-        condition: eq(variables.isPR, true)
+      # - script: |
+      #     yarn nx affected -t bundle-size --nxBail $(sinceArg)
+      #   displayName: build packages & create reports
+      #   condition: eq(variables.isPR, true)
 
-      - script: |
-          npx monosize compare-reports --branch=$(System.PullRequest.TargetBranch) --output=markdown --quiet > ./monosize-report.md
-        displayName: compare bundle size with base (PR only)
-        condition: eq(variables.isPR, true)
+      # - script: |
+      #     npx monosize compare-reports --branch=$(System.PullRequest.TargetBranch) --output=markdown --quiet > ./monosize-report.md
+      #   displayName: compare bundle size with base (PR only)
+      #   condition: eq(variables.isPR, true)
 
-      - task: GithubPRComment@0
-        displayName: Post results to PR (PR only)
-        condition: eq(variables.isPR, true)
-        inputs:
-          githubOwner: microsoft
-          githubRepo: 'fluentui'
-          blobFilePath: 'monosize-report.md'
-          status: 'success'
-          uniqueId: 'bundleSizeComment9423'
+      # - task: GithubPRComment@0
+      #   displayName: Post results to PR (PR only)
+      #   condition: eq(variables.isPR, true)
+      #   inputs:
+      #     githubOwner: microsoft
+      #     githubRepo: 'fluentui'
+      #     blobFilePath: 'monosize-report.md'
+      #     status: 'success'
+      #     uniqueId: 'bundleSizeComment9423'
 
       - script: |
           yarn nx run-many -t bundle-size --nxBail


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

- bundle-size base upload from master branch ( NO FORKS ) doesn't work via GHA yet, thus ADO will be necessary to keep for master runs only to update bundle diff base within azure storage. 

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Relates to https://github.com/microsoft/monosize/pull/87 and https://github.com/Azure/cli/issues/174
