### PR TITLE
docs(v8 coachmark): Add a11y documentation

### DIFF
--- a/packages/react-examples/src/react/Coachmark/docs/CoachmarkBestPractices.md
+++ b/packages/react-examples/src/react/Coachmark/docs/CoachmarkBestPractices.md
@@ -4,3 +4,8 @@
 - Coach marks can be standalone or sequential. Sequential coach marks should be used sparingly to walk through complex multistep interactions. It’s recommended that a sequence of coach marks doesn’t exceed three steps.
 - Coach marks are designed to only hold teaching bubbles.
 - Coach mark size, color, and animation shouldn’t be altered.
+
+### Accessibility
+
+- Coach marks are difficult to access for screenreaders and keyboard users. Consider providing an alternative display of the information in the coach mark through text documentation or a video walkthrough.
+- Keyboard users can press Alt+C to open the coach mark.


### PR DESCRIPTION
## Previous Behavior

The coach mark is not a very accessible component. There was an ADO bug filed that made us consider adding more documentation for it from an accessibility standpoint.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes [ADO Bug](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/22590)
