### PR TITLE
[react-nav-preview](feat): Allowing Nav to be navigable by tabbing

### DIFF
--- a/change/@fluentui-react-nav-preview-bbaa31db-f4ef-4bdb-95f0-f3f749a409c9.json
+++ b/change/@fluentui-react-nav-preview-bbaa31db-f4ef-4bdb-95f0-f3f749a409c9.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "feat: Exposing tabster dom attributes so consumers can disagree with the default behavior.",
+  "comment": "feat: Exposed 'tabbable' prop on NavDrawer to let consumers disagree with default arrowing opinion.",
   "packageName": "@fluentui/react-nav-preview",
   "email": "matejera@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-nav-preview-bbaa31db-f4ef-4bdb-95f0-f3f749a409c9.json
+++ b/change/@fluentui-react-nav-preview-bbaa31db-f4ef-4bdb-95f0-f3f749a409c9.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: Exposing tabster dom attributes so consumers can disagree with the default behavior.",
+  "packageName": "@fluentui/react-nav-preview",
+  "email": "matejera@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-nav-preview/library/etc/react-nav-preview.api.md
+++ b/packages/react-components/react-nav-preview/library/etc/react-nav-preview.api.md
@@ -35,7 +35,6 @@ import { MenuButtonProps } from '@fluentui/react-button';
 import * as React_2 from 'react';
 import type { Slot } from '@fluentui/react-utilities';
 import { SlotClassNames } from '@fluentui/react-utilities';
-import { TabsterDOMAttribute } from '@fluentui/react-tabster/src/index';
 import { ToggleButtonProps } from '@fluentui/react-button';
 import type { TooltipProps } from '@fluentui/react-tooltip';
 
@@ -219,7 +218,7 @@ export type NavDrawerHeaderState = DrawerHeaderState;
 
 // @public
 export type NavDrawerProps = ComponentProps<NavDrawerSlots> & DrawerProps & NavProps & {
-    tabsterDomAttribute?: TabsterDOMAttribute;
+    tabbable?: boolean;
 };
 
 // @public

--- a/packages/react-components/react-nav-preview/library/etc/react-nav-preview.api.md
+++ b/packages/react-components/react-nav-preview/library/etc/react-nav-preview.api.md
@@ -35,6 +35,7 @@ import { MenuButtonProps } from '@fluentui/react-button';
 import * as React_2 from 'react';
 import type { Slot } from '@fluentui/react-utilities';
 import { SlotClassNames } from '@fluentui/react-utilities';
+import { TabsterDOMAttribute } from '@fluentui/react-tabster/src/index';
 import { ToggleButtonProps } from '@fluentui/react-button';
 import type { TooltipProps } from '@fluentui/react-tooltip';
 
@@ -217,7 +218,9 @@ export type NavDrawerHeaderSlots = DrawerHeaderSlots;
 export type NavDrawerHeaderState = DrawerHeaderState;
 
 // @public
-export type NavDrawerProps = ComponentProps<NavDrawerSlots> & DrawerProps & NavProps;
+export type NavDrawerProps = ComponentProps<NavDrawerSlots> & DrawerProps & NavProps & {
+    tabsterDomAttribute?: TabsterDOMAttribute;
+};
 
 // @public
 export type NavDrawerSlots = DrawerSlots;

--- a/packages/react-components/react-nav-preview/library/src/components/NavDrawer/NavDrawer.types.ts
+++ b/packages/react-components/react-nav-preview/library/src/components/NavDrawer/NavDrawer.types.ts
@@ -2,7 +2,6 @@ import { DrawerProps, DrawerSlots, DrawerState } from '@fluentui/react-drawer';
 import { ComponentProps } from '@fluentui/react-utilities';
 import { NavProps } from '../Nav/Nav.types';
 import { NavContextValue } from '../NavContext.types';
-import { TabsterDOMAttribute } from '@fluentui/react-tabster/src/index';
 
 /**
  * NavDrawer slots
@@ -16,10 +15,11 @@ export type NavDrawerProps = ComponentProps<NavDrawerSlots> &
   DrawerProps &
   NavProps & {
     /**
-     * An optional tabster attribute to let consumers override keyboard navigation behavior.
-     * @default axis: 'vertical', circular: true
+     * The component uses arrow navigation by default.
+     * Setting this to true enables tab AND arrow navigation.
+     * @default false
      */
-    tabsterDomAttribute?: TabsterDOMAttribute;
+    tabbable?: boolean;
   };
 
 /**

--- a/packages/react-components/react-nav-preview/library/src/components/NavDrawer/NavDrawer.types.ts
+++ b/packages/react-components/react-nav-preview/library/src/components/NavDrawer/NavDrawer.types.ts
@@ -17,7 +17,6 @@ export type NavDrawerProps = ComponentProps<NavDrawerSlots> &
   NavProps & {
     /**
      * An optional tabster attribute to let consumers override keyboard navigation behavior.
-     * Note that passing this in will override the default behavior of the component.
      * @default axis: 'vertical', circular: true
      */
     tabsterDomAttribute?: TabsterDOMAttribute;

--- a/packages/react-components/react-nav-preview/library/src/components/NavDrawer/NavDrawer.types.ts
+++ b/packages/react-components/react-nav-preview/library/src/components/NavDrawer/NavDrawer.types.ts
@@ -2,6 +2,7 @@ import { DrawerProps, DrawerSlots, DrawerState } from '@fluentui/react-drawer';
 import { ComponentProps } from '@fluentui/react-utilities';
 import { NavProps } from '../Nav/Nav.types';
 import { NavContextValue } from '../NavContext.types';
+import { TabsterDOMAttribute } from '@fluentui/react-tabster/src/index';
 
 /**
  * NavDrawer slots
@@ -11,7 +12,16 @@ export type NavDrawerSlots = DrawerSlots;
 /**
  * NavDrawer Props
  */
-export type NavDrawerProps = ComponentProps<NavDrawerSlots> & DrawerProps & NavProps;
+export type NavDrawerProps = ComponentProps<NavDrawerSlots> &
+  DrawerProps &
+  NavProps & {
+    /**
+     * An optional tabster attribute to let consumers override keyboard navigation behavior.
+     * Note that passing this in will override the default behavior of the component.
+     * @default axis: 'vertical', circular: true
+     */
+    tabsterDomAttribute?: TabsterDOMAttribute;
+  };
 
 /**
  * State used in rendering NavDrawer

--- a/packages/react-components/react-nav-preview/library/src/components/NavDrawer/useNavDrawer.ts
+++ b/packages/react-components/react-nav-preview/library/src/components/NavDrawer/useNavDrawer.ts
@@ -16,11 +16,12 @@ import type { NavDrawerProps, NavDrawerState } from './NavDrawer.types';
  * @param ref - reference to root HTMLDivElement of NavDrawer
  */
 export const useNavDrawer_unstable = (props: NavDrawerProps, ref: React.Ref<HTMLDivElement>): NavDrawerState => {
-  const { tabsterDomAttribute: tabsterDomAttributeFromProps } = props;
+  const { tabbable = false } = props;
 
   const defaultFocusAttributes = useArrowNavigationGroup({
     axis: 'vertical',
     circular: true,
+    tabbable,
   });
 
   const navState = useNav_unstable(
@@ -42,7 +43,7 @@ export const useNavDrawer_unstable = (props: NavDrawerProps, ref: React.Ref<HTML
     },
 
     root: slot.always(
-      { ref, ...props, ...{ ...defaultFocusAttributes, ...tabsterDomAttributeFromProps } },
+      { ref, ...props, ...{ ...defaultFocusAttributes } },
       {
         // TODO: remove once React v18 slot API is modified
         // this is a problem with the lack of support for union types on React v18

--- a/packages/react-components/react-nav-preview/library/src/components/NavDrawer/useNavDrawer.ts
+++ b/packages/react-components/react-nav-preview/library/src/components/NavDrawer/useNavDrawer.ts
@@ -42,7 +42,7 @@ export const useNavDrawer_unstable = (props: NavDrawerProps, ref: React.Ref<HTML
     },
 
     root: slot.always(
-      { ref, ...props, ...(tabsterDomAttributeFromProps ?? defaultFocusAttributes) },
+      { ref, ...props, ...{ ...defaultFocusAttributes, ...tabsterDomAttributeFromProps } },
       {
         // TODO: remove once React v18 slot API is modified
         // this is a problem with the lack of support for union types on React v18

--- a/packages/react-components/react-nav-preview/library/src/components/NavDrawer/useNavDrawer.ts
+++ b/packages/react-components/react-nav-preview/library/src/components/NavDrawer/useNavDrawer.ts
@@ -16,7 +16,9 @@ import type { NavDrawerProps, NavDrawerState } from './NavDrawer.types';
  * @param ref - reference to root HTMLDivElement of NavDrawer
  */
 export const useNavDrawer_unstable = (props: NavDrawerProps, ref: React.Ref<HTMLDivElement>): NavDrawerState => {
-  const focusAttributes = useArrowNavigationGroup({
+  const { tabsterDomAttribute: tabsterDomAttributeFromProps } = props;
+
+  const defaultFocusAttributes = useArrowNavigationGroup({
     axis: 'vertical',
     circular: true,
   });
@@ -40,7 +42,7 @@ export const useNavDrawer_unstable = (props: NavDrawerProps, ref: React.Ref<HTML
     },
 
     root: slot.always(
-      { ref, ...props, ...focusAttributes },
+      { ref, ...props, ...(tabsterDomAttributeFromProps ?? defaultFocusAttributes) },
       {
         // TODO: remove once React v18 slot API is modified
         // this is a problem with the lack of support for union types on React v18

--- a/packages/react-components/react-nav-preview/library/src/components/NavDrawer/useNavDrawer.ts
+++ b/packages/react-components/react-nav-preview/library/src/components/NavDrawer/useNavDrawer.ts
@@ -18,7 +18,7 @@ import type { NavDrawerProps, NavDrawerState } from './NavDrawer.types';
 export const useNavDrawer_unstable = (props: NavDrawerProps, ref: React.Ref<HTMLDivElement>): NavDrawerState => {
   const { tabbable = false } = props;
 
-  const defaultFocusAttributes = useArrowNavigationGroup({
+  const focusAttributes = useArrowNavigationGroup({
     axis: 'vertical',
     circular: true,
     tabbable,
@@ -43,7 +43,7 @@ export const useNavDrawer_unstable = (props: NavDrawerProps, ref: React.Ref<HTML
     },
 
     root: slot.always(
-      { ref, ...props, ...{ ...defaultFocusAttributes } },
+      { ref, ...props, ...focusAttributes },
       {
         // TODO: remove once React v18 slot API is modified
         // this is a problem with the lack of support for union types on React v18

--- a/packages/react-components/react-nav-preview/stories/src/NavDrawer/Controlled.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/src/NavDrawer/Controlled.stories.tsx
@@ -16,7 +16,16 @@ import {
   NavSubItemGroup,
   OnNavItemSelectData,
 } from '@fluentui/react-nav-preview';
-import { Button, Label, Switch, Tooltip, makeStyles, tokens, useId } from '@fluentui/react-components';
+import {
+  Button,
+  Label,
+  Switch,
+  Tooltip,
+  makeStyles,
+  tokens,
+  useArrowNavigationGroup,
+  useId,
+} from '@fluentui/react-components';
 import {
   Board20Filled,
   Board20Regular,
@@ -193,6 +202,13 @@ export const Controlled = (props: Partial<NavDrawerProps>) => {
     }
   };
 
+  // you can override the default keyboard behavior this way:
+  const tabsterDomAttribute = useArrowNavigationGroup({
+    axis: 'vertical', // default
+    circular: true, // default
+    tabbable: true, // new value
+  });
+
   return (
     <div className={styles.root}>
       <NavDrawer
@@ -204,6 +220,7 @@ export const Controlled = (props: Partial<NavDrawerProps>) => {
         // multiple={isMultiple}
         onNavCategoryItemToggle={handleCategoryToggle}
         onNavItemSelect={handleItemSelect}
+        tabsterDomAttribute={tabsterDomAttribute}
         openCategories={openCategories}
         selectedValue={selectedValue}
         selectedCategoryValue={selectedCategoryValue}

--- a/packages/react-components/react-nav-preview/stories/src/NavDrawer/Controlled.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/src/NavDrawer/Controlled.stories.tsx
@@ -16,16 +16,7 @@ import {
   NavSubItemGroup,
   OnNavItemSelectData,
 } from '@fluentui/react-nav-preview';
-import {
-  Button,
-  Label,
-  Switch,
-  Tooltip,
-  makeStyles,
-  tokens,
-  useArrowNavigationGroup,
-  useId,
-} from '@fluentui/react-components';
+import { Button, Label, Switch, Tooltip, makeStyles, tokens, useId } from '@fluentui/react-components';
 import {
   Board20Filled,
   Board20Regular,

--- a/packages/react-components/react-nav-preview/stories/src/NavDrawer/Controlled.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/src/NavDrawer/Controlled.stories.tsx
@@ -202,11 +202,6 @@ export const Controlled = (props: Partial<NavDrawerProps>) => {
     }
   };
 
-  // you can override the default keyboard behavior this way:
-  const tabsterDomAttribute = useArrowNavigationGroup({
-    tabbable: true, // new value
-  });
-
   return (
     <div className={styles.root}>
       <NavDrawer
@@ -218,7 +213,7 @@ export const Controlled = (props: Partial<NavDrawerProps>) => {
         // multiple={isMultiple}
         onNavCategoryItemToggle={handleCategoryToggle}
         onNavItemSelect={handleItemSelect}
-        tabsterDomAttribute={tabsterDomAttribute}
+        tabbable={true} // enables keyboard tabbing
         openCategories={openCategories}
         selectedValue={selectedValue}
         selectedCategoryValue={selectedCategoryValue}

--- a/packages/react-components/react-nav-preview/stories/src/NavDrawer/Controlled.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/src/NavDrawer/Controlled.stories.tsx
@@ -204,8 +204,6 @@ export const Controlled = (props: Partial<NavDrawerProps>) => {
 
   // you can override the default keyboard behavior this way:
   const tabsterDomAttribute = useArrowNavigationGroup({
-    axis: 'vertical', // default
-    circular: true, // default
     tabbable: true, // new value
   });
 


### PR DESCRIPTION
This pull request introduces a new feature to the `NavDrawer` component by exposing a `tabbable` prop, allowing consumers to enable both tab and arrow navigation. Additionally, it includes some import adjustments to accommodate this new feature.

### New Feature:

* Added `tabbable` prop to `NavDrawer` to enable both tab and arrow navigation. (`packages/react-components/react-nav-preview/library/src/components/NavDrawer/NavDrawer.types.ts`)
* Updated `useNavDrawer_unstable` hook to utilize the `tabbable` prop for navigation. (`packages/react-components/react-nav-preview/library/src/components/NavDrawer/useNavDrawer.ts`)
* Modified `Controlled` story to demonstrate the use of the `tabbable` prop. (`packages/react-components/react-nav-preview/stories/src/NavDrawer/Controlled.stories.tsx`)

### Import Adjustments:

* Added `TabsterDOMAttribute` import to support the new `tabbable` prop. (`packages/react-components/react-nav-preview/library/etc/react-nav-preview.api.md`)
* Updated `NavDrawerProps` type to include `tabsterDomAttribute`. (`packages/react-components/react-nav-preview/library/etc/react-nav-preview.api.md`)