### PR TITLE
docs(v8 Picker): Add wrapped text example and information about truncation in the docs

### DIFF
--- a/packages/react-examples/src/react/Pickers/TagPicker.Wrapped.Example.tsx
+++ b/packages/react-examples/src/react/Pickers/TagPicker.Wrapped.Example.tsx
@@ -1,0 +1,75 @@
+import * as React from 'react';
+
+import {
+  TagPicker,
+  IBasePicker,
+  ITag,
+  IInputProps,
+  IBasePickerSuggestionsProps,
+  TagItemSuggestion,
+  ITagItemSuggestionStyles,
+} from '@fluentui/react/lib/Pickers';
+import { mergeStyles } from '@fluentui/react/lib/Styling';
+import { useId } from '@fluentui/react-hooks';
+
+const rootClass = mergeStyles({
+  maxWidth: 500,
+});
+
+const inputProps: IInputProps = {
+  onBlur: (ev: React.FocusEvent<HTMLInputElement>) => console.log('onBlur called'),
+  onFocus: (ev: React.FocusEvent<HTMLInputElement>) => console.log('onFocus called'),
+};
+
+const pickerSuggestionsProps: IBasePickerSuggestionsProps = {
+  suggestionsHeaderText: 'Suggested tags',
+  noResultsFoundText: 'No tags found',
+};
+
+const testTags: ITag[] = [
+  'A short tag',
+  'A very long tag that spans more than the entire width of the picker',
+  'A second very long tag that spans more than the entire width of the picker',
+  'A third very long tag that spans more than the entire width of the picker',
+].map(item => ({ key: item, name: item }));
+
+const filterSelectedTags = (filterText: string, tagList: ITag[]): ITag[] => {
+  return filterText ? testTags.filter(tag => tag.name.toLowerCase().indexOf(filterText.toLowerCase()) === 0) : [];
+};
+
+const getTextFromItem = (item: ITag) => item.name;
+
+const tagStyles: Partial<ITagItemSuggestionStyles> = {
+  suggestionTextOverflow: {
+    height: 'auto',
+    whiteSpace: 'normal',
+  },
+};
+
+const onRenderSuggestionItem = (props: ITag) => {
+  return <TagItemSuggestion styles={tagStyles}>{props.name}</TagItemSuggestion>;
+};
+
+export const TagPickerWrappedExample: React.FunctionComponent = () => {
+  const pickerId = useId('wrapped-picker');
+  const picker = React.useRef<IBasePicker<ITag>>(null);
+
+  return (
+    <div className={rootClass}>
+      <label htmlFor={pickerId}>Choose a tag</label>
+      <TagPicker
+        onRenderSuggestionsItem={onRenderSuggestionItem}
+        removeButtonAriaLabel="Remove"
+        selectionAriaLabel="Selected tags"
+        componentRef={picker}
+        onResolveSuggestions={filterSelectedTags}
+        getTextFromItem={getTextFromItem}
+        pickerSuggestionsProps={pickerSuggestionsProps}
+        inputProps={{
+          ...inputProps,
+          id: pickerId,
+        }}
+      />
+    </div>
+  );
+};

--- a/packages/react-examples/src/react/Pickers/docs/PickersBestPractices.md
+++ b/packages/react-examples/src/react/Pickers/docs/PickersBestPractices.md
@@ -10,3 +10,9 @@ Picker dropdowns render in their own layer by default to ensure they are not cli
 ```js
 pickerCalloutProps={{ doNotLayer: true }}
 ```
+
+#### Truncation
+
+By default, the Picker truncates item text in the dropdown instead of wrapping to a new line. To avoid losing meaningful information, adjusting styles to wrap the text is recommended. Tooltips are not shown for truncated text within the dropdown to avoid nested popups and the usability and accessibility issues they cause.
+
+The Wrapped Picker example demonstrates how to override truncation styles to support wrapping. The default style will continue to truncate to support existing implementations.

--- a/packages/react-examples/src/react/Pickers/index.stories.tsx
+++ b/packages/react-examples/src/react/Pickers/index.stories.tsx
@@ -6,6 +6,8 @@ export { TagPickerCustomRemoveIconExample as TagPickerCustomRemoveIcon } from '.
 
 export { TagPickerInlineExample as TagPickerInline } from './TagPicker.Inline.Example';
 
+export { TagPickerWrappedExample as TagPickerWrapped } from './TagPicker.Wrapped.Example';
+
 export default {
   title: 'Components/Pickers',
 };


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

There was no example for wrapped text in Picker, only truncated text.

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

This PR adds an example of wrapped text in the Picker example and adds a note in the docs about how to handle truncation.
<img width="537" alt="image" src="https://github.com/user-attachments/assets/b62e4f0b-6643-48b3-bc40-c2a33df6eaf7">


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes [ADO Bug](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/22434)