### PR TITLE
bugfix(react-dialog): ensures dialog surface style without surfaceMotion

### DIFF
--- a/change/@fluentui-react-dialog-5f8bb155-a039-460c-8314-c8d28bfe9cfa.json
+++ b/change/@fluentui-react-dialog-5f8bb155-a039-460c-8314-c8d28bfe9cfa.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: ensures dialog surface style without surfaceMotion",
+  "packageName": "@fluentui/react-dialog",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-dialog/library/src/components/DialogSurface/useDialogSurfaceStyles.styles.ts
+++ b/packages/react-components/react-dialog/library/src/components/DialogSurface/useDialogSurfaceStyles.styles.ts
@@ -42,8 +42,6 @@ const useRootBaseStyle = makeResetStyles({
   // Same styles as DialogSurfaceMotion last keyframe,
   // to ensure dialog will be properly styled when surfaceMotion is opted-out
   boxShadow: tokens.shadow64,
-  transform: 'scale(1) translateZ(0)',
-  opacity: 1,
 
   [MEDIA_QUERY_BREAKPOINT_SELECTOR]: {
     maxWidth: '100vw',

--- a/packages/react-components/react-dialog/library/src/components/DialogSurface/useDialogSurfaceStyles.styles.ts
+++ b/packages/react-components/react-dialog/library/src/components/DialogSurface/useDialogSurfaceStyles.styles.ts
@@ -39,6 +39,11 @@ const useRootBaseStyle = makeResetStyles({
   boxSizing: 'border-box',
   backgroundColor: tokens.colorNeutralBackground1,
   color: tokens.colorNeutralForeground1,
+  // Same styles as DialogSurfaceMotion last keyframe,
+  // to ensure dialog will be properly styled when surfaceMotion is opted-out
+  boxShadow: tokens.shadow64,
+  transform: 'scale(1) translateZ(0)',
+  opacity: 1,
 
   [MEDIA_QUERY_BREAKPOINT_SELECTOR]: {
     maxWidth: '100vw',


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

Dialog is showing up with no proper style when opting-out of `surfaceMotion`

![image](https://github.com/user-attachments/assets/91536dd3-fad8-45df-b5be-f749438bc140)

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

Ensures `DialogSurface` will maintain its style even when opting out of `surfaceMotion`

![image](https://github.com/user-attachments/assets/9a160a2e-99f4-44de-a166-57d426435d48)


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/32433
