### PR TITLE
fix(`react-combobox`): Clearable `Dropdowns` and `Comboboxes` do not show clear button if they are disabled

### DIFF
--- a/change/@fluentui-react-combobox-cd58fbb4-facf-4aa2-8116-88f7d8f05ee9.json
+++ b/change/@fluentui-react-combobox-cd58fbb4-facf-4aa2-8116-88f7d8f05ee9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Clearable Dropdowns and Comboboxes do not show clear button if they are disabled.",
+  "packageName": "@fluentui/react-combobox",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/library/src/components/Combobox/Combobox.test.tsx
+++ b/packages/react-components/react-combobox/library/src/components/Combobox/Combobox.test.tsx
@@ -1046,6 +1046,26 @@ describe('Combobox', () => {
       expect(clearButton).toHaveStyle({ display: 'none' });
       expect(clearButton).toHaveAttribute('aria-hidden', 'true');
     });
+
+    it('is not visible when the component is disabled', () => {
+      const { getByText } = render(
+        <Combobox
+          clearable
+          clearIcon={{ children: 'CLEAR BUTTON' }}
+          defaultSelectedOptions={['Red']}
+          defaultValue="Red"
+          disabled
+        >
+          <Option>Red</Option>
+          <Option>Green</Option>
+          <Option>Blue</Option>
+        </Combobox>,
+      );
+      const clearButton = getByText('CLEAR BUTTON');
+
+      expect(clearButton).toHaveStyle({ display: 'none' });
+      expect(clearButton).toHaveAttribute('aria-hidden', 'true');
+    });
   });
 
   describe('Active item change', () => {

--- a/packages/react-components/react-combobox/library/src/components/Combobox/useCombobox.tsx
+++ b/packages/react-components/react-combobox/library/src/components/Combobox/useCombobox.tsx
@@ -87,7 +87,7 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLIn
   });
   rootSlot.ref = useMergedRefs(rootSlot.ref, comboboxTargetRef);
 
-  const showClearIcon = selectedOptions.length > 0 && clearable && !multiselect;
+  const showClearIcon = selectedOptions.length > 0 && !disabled && clearable && !multiselect;
   const state: ComboboxState = {
     components: { root: 'div', input: 'input', expandIcon: 'span', listbox: Listbox, clearIcon: 'span' },
     root: rootSlot,

--- a/packages/react-components/react-combobox/library/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/react-components/react-combobox/library/src/components/Dropdown/Dropdown.test.tsx
@@ -747,6 +747,20 @@ describe('Dropdown', () => {
 
       expect(clearButton).toHaveStyle({ display: 'none' });
     });
+
+    it('is not visible when the component is disabled', () => {
+      const { getByLabelText } = render(
+        <Dropdown clearable defaultSelectedOptions={['Red']} defaultValue="Red" disabled>
+          <Option>Red</Option>
+          <Option>Green</Option>
+          <Option>Blue</Option>
+        </Dropdown>,
+      );
+
+      const clearButton = getByLabelText('Clear selection');
+
+      expect(clearButton).toHaveStyle({ display: 'none' });
+    });
   });
   describe('Active item change', () => {
     it('should call onActiveOptionChange with arrow down', () => {

--- a/packages/react-components/react-combobox/library/src/components/Dropdown/useDropdown.tsx
+++ b/packages/react-components/react-combobox/library/src/components/Dropdown/useDropdown.tsx
@@ -43,7 +43,7 @@ export const useDropdown_unstable = (props: DropdownProps, ref: React.Ref<HTMLBu
   });
 
   const baseState = useComboboxBaseState({ ...props, activeDescendantController, freeform: false });
-  const { clearable, clearSelection, hasFocus, multiselect, open, selectedOptions, setOpen } = baseState;
+  const { clearable, clearSelection, disabled, hasFocus, multiselect, open, selectedOptions, setOpen } = baseState;
 
   const { primary: triggerNativeProps, root: rootNativeProps } = getPartitionedNativeProps({
     props,
@@ -94,7 +94,7 @@ export const useDropdown_unstable = (props: DropdownProps, ref: React.Ref<HTMLBu
   });
   rootSlot.ref = useMergedRefs(rootSlot.ref, comboboxTargetRef);
 
-  const showClearButton = selectedOptions.length > 0 && clearable && !multiselect;
+  const showClearButton = selectedOptions.length > 0 && !disabled && clearable && !multiselect;
   const state: DropdownState = {
     components: { root: 'div', button: 'button', clearButton: 'button', expandIcon: 'span', listbox: Listbox },
     root: rootSlot,


### PR DESCRIPTION
## Previous Behavior

When the `Dropdown` and `Combobox` components were `clearable` and `disabled`, the clear button was still visible and interactive even though the components themselves were disabled.

## New Behavior

When the `Dropdown` and `Combobox` components are `clearable`, if they are `disabled`, then the clear button is not visible anymore.

## Related Issue(s)

- Fixes #33240
