### PR TITLE
chore(`react-infolabel`): Adding `maxWidth` to `InfoButton`'s popover to match figma spec

### DIFF
--- a/change/@fluentui-react-infolabel-75e65619-149e-4b64-9ec9-06efe295fc27.json
+++ b/change/@fluentui-react-infolabel-75e65619-149e-4b64-9ec9-06efe295fc27.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "chore: Adding maxWidth to InfoButton's popover to match Tooltip.",
+  "comment": "chore: Adding maxWidth to InfoButton's popover to match figma spec.",
   "packageName": "@fluentui/react-infolabel",
   "email": "Humberto.Morimoto@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-infolabel-75e65619-149e-4b64-9ec9-06efe295fc27.json
+++ b/change/@fluentui-react-infolabel-75e65619-149e-4b64-9ec9-06efe295fc27.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Adding maxWidth to InfoButton's popover to match Tooltip.",
+  "packageName": "@fluentui/react-infolabel",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-infolabel/library/src/components/InfoButton/useInfoButtonStyles.styles.ts
+++ b/packages/react-components/react-infolabel/library/src/components/InfoButton/useInfoButtonStyles.styles.ts
@@ -96,7 +96,7 @@ const useButtonStyles = makeStyles({
 
 const usePopoverSurfaceStyles = makeStyles({
   base: {
-    maxWidth: '240px',
+    maxWidth: '264px',
   },
   smallMedium: typographyStyles.caption1,
   large: typographyStyles.body1,

--- a/packages/react-components/react-infolabel/library/src/components/InfoButton/useInfoButtonStyles.styles.ts
+++ b/packages/react-components/react-infolabel/library/src/components/InfoButton/useInfoButtonStyles.styles.ts
@@ -95,6 +95,9 @@ const useButtonStyles = makeStyles({
 });
 
 const usePopoverSurfaceStyles = makeStyles({
+  base: {
+    maxWidth: '240px',
+  },
   smallMedium: typographyStyles.caption1,
   large: typographyStyles.body1,
 });
@@ -112,6 +115,7 @@ export const useInfoButtonStyles_unstable = (state: InfoButtonState): InfoButton
 
   state.info.className = mergeClasses(
     infoButtonClassNames.info,
+    popoverSurfaceStyles.base,
     size === 'large' ? popoverSurfaceStyles.large : popoverSurfaceStyles.smallMedium,
     state.info.className,
   );


### PR DESCRIPTION
## Previous Behavior

The popover of `InfoButton` did not have a `maxWidth` constraint, which caused the popover to extend to the width of the viewport.

## New Behavior

The popover of `InfoButton` now has a `maxWidth` of `264px`, which matches the figma spec.

## Related Issue(s)

- Fixes #33245 
