### PR TITLE
docs(`react-table`): Adding stop propagation to focusable elements in `DataGrid` so that clicking on them does not toggle cell selection

### DIFF
--- a/packages/react-components/react-table/stories/src/DataGrid/FocusableElementsInCells.stories.tsx
+++ b/packages/react-components/react-table/stories/src/DataGrid/FocusableElementsInCells.stories.tsx
@@ -23,6 +23,7 @@ import {
   Button,
   TableColumnId,
   DataGridCellFocusMode,
+  ButtonProps,
 } from '@fluentui/react-components';
 
 type FileCell = {
@@ -69,6 +70,10 @@ const items: Item[] = [
   },
 ];
 
+const onButtonClick = (ev: React.MouseEvent<HTMLButtonElement>) => {
+  ev.stopPropagation();
+};
+
 const columns: TableColumnDefinition<Item>[] = [
   createTableColumn<Item>({
     columnId: 'file',
@@ -108,7 +113,11 @@ const columns: TableColumnDefinition<Item>[] = [
       return 'Single action';
     },
     renderCell: () => {
-      return <Button icon={<OpenRegular />}>Open</Button>;
+      return (
+        <Button icon={<OpenRegular />} onClick={onButtonClick}>
+          Open
+        </Button>
+      );
     },
   }),
   createTableColumn<Item>({
@@ -119,8 +128,8 @@ const columns: TableColumnDefinition<Item>[] = [
     renderCell: () => {
       return (
         <>
-          <Button aria-label="Edit" icon={<EditRegular />} />
-          <Button aria-label="Delete" icon={<DeleteRegular />} />
+          <Button aria-label="Edit" icon={<EditRegular />} onClick={onButtonClick} />
+          <Button aria-label="Delete" icon={<DeleteRegular />} onClick={onButtonClick} />
         </>
       );
     },

--- a/packages/react-components/react-table/stories/src/DataGrid/FocusableElementsInCells.stories.tsx
+++ b/packages/react-components/react-table/stories/src/DataGrid/FocusableElementsInCells.stories.tsx
@@ -190,6 +190,8 @@ FocusableElementsInCells.parameters = {
         '',
         'Use `none` when there is one single focusable element in cell,',
         '`none` will make the cell non-focusable',
+        '',
+        'Stop propagation of events on focusable elements to prevent cell selection from changing.',
       ].join('\n'),
     },
   },

--- a/packages/react-components/react-table/stories/src/DataGrid/FocusableElementsInCells.stories.tsx
+++ b/packages/react-components/react-table/stories/src/DataGrid/FocusableElementsInCells.stories.tsx
@@ -23,7 +23,6 @@ import {
   Button,
   TableColumnId,
   DataGridCellFocusMode,
-  ButtonProps,
 } from '@fluentui/react-components';
 
 type FileCell = {


### PR DESCRIPTION
## Previous Behavior

Buttons in the `DataGrid` focusable elements example were toggling cell selection. The correct thing to show in our docs is probably to have them not toggle this selection.

![Before](https://github.com/user-attachments/assets/f9e2deeb-f9c6-4c88-9d01-d6deade604e7)

## New Behavior

Buttons in the `DataGrid` focusable elements example now stop propagation to avoid toggling cell selection and a mention of this has been made in the example description.

![After](https://github.com/user-attachments/assets/84aa8452-1c24-4960-a495-93d0049cc4f3)

## Related Issue(s)

- Fixes #33249
