### PR TITLE
fix(v8 SwatchColorPicker): Add forced-color-adjust to gradients

### DIFF
--- a/change/@fluentui-react-4726e359-06af-4ddf-baa2-635fc6b47b59.json
+++ b/change/@fluentui-react-4726e359-06af-4ddf-baa2-635fc6b47b59.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(v8 SwatchColorPicker): Add forced-color-adjust to gradients",
+  "packageName": "@fluentui/react",
+  "email": "jiangemma@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/SwatchColorPicker/ColorPickerGridCell.styles.ts
+++ b/packages/react/src/components/SwatchColorPicker/ColorPickerGridCell.styles.ts
@@ -60,6 +60,7 @@ export const getStyles = (props: IColorPickerGridCellStyleProps): IColorPickerGr
         height,
         width,
         verticalAlign: 'top',
+        'forced-color-adjust': 'none',
       },
       !circle && {
         selectors: {

--- a/packages/react/src/components/SwatchColorPicker/__snapshots__/SwatchColorPicker.test.tsx.snap
+++ b/packages/react/src/components/SwatchColorPicker/__snapshots__/SwatchColorPicker.test.tsx.snap
@@ -76,6 +76,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
+                  forced-color-adjust: none;
                   height: 20px;
                   justify-content: center;
                   outline: transparent;
@@ -284,6 +285,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
+                  forced-color-adjust: none;
                   height: 20px;
                   justify-content: center;
                   outline: transparent;
@@ -492,6 +494,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
+                  forced-color-adjust: none;
                   height: 20px;
                   justify-content: center;
                   outline: transparent;
@@ -700,6 +703,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
+                  forced-color-adjust: none;
                   height: 20px;
                   justify-content: center;
                   outline: transparent;
@@ -912,6 +916,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
+                  forced-color-adjust: none;
                   height: 20px;
                   justify-content: center;
                   outline: transparent;
@@ -1120,6 +1125,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
+                  forced-color-adjust: none;
                   height: 20px;
                   justify-content: center;
                   outline: transparent;
@@ -1328,6 +1334,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
+                  forced-color-adjust: none;
                   height: 20px;
                   justify-content: center;
                   outline: transparent;
@@ -1536,6 +1543,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
+                  forced-color-adjust: none;
                   height: 20px;
                   justify-content: center;
                   outline: transparent;
@@ -1748,6 +1756,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
+                  forced-color-adjust: none;
                   height: 20px;
                   justify-content: center;
                   outline: transparent;
@@ -1956,6 +1965,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
+                  forced-color-adjust: none;
                   height: 20px;
                   justify-content: center;
                   outline: transparent;
@@ -2164,6 +2174,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
+                  forced-color-adjust: none;
                   height: 20px;
                   justify-content: center;
                   outline: transparent;
@@ -2373,6 +2384,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
+                  forced-color-adjust: none;
                   height: 20px;
                   justify-content: center;
                   outline: transparent;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

With `forced-colors: active`:
<img width="455" alt="image" src="https://github.com/user-attachments/assets/1edb4e26-d7fd-4744-a65a-96363ddab02d">


## New Behavior

With `forced-colors: active`:
<img width="455" alt="image" src="https://github.com/user-attachments/assets/1a87c414-8bf7-4627-9a4c-4dc5c00b44a2">


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes [ADO Bug](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/18609)
