### PR TITLE
chore(react-components): Export useListboxContext_unstable

### DIFF
--- a/change/@fluentui-react-components-1c2b6bfb-1ab8-4b00-9a20-3ccff0c4cfc8.json
+++ b/change/@fluentui-react-components-1c2b6bfb-1ab8-4b00-9a20-3ccff0c4cfc8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: Export useListboxContext_unstable.",
+  "packageName": "@fluentui/react-components",
+  "email": "owcampbe@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-components/etc/react-components.api.md
+++ b/packages/react-components/react-components/etc/react-components.api.md
@@ -1553,6 +1553,7 @@ import { useLink_unstable } from '@fluentui/react-link';
 import { useLinkState_unstable } from '@fluentui/react-link';
 import { useLinkStyles_unstable } from '@fluentui/react-link';
 import { useListbox_unstable } from '@fluentui/react-combobox';
+import { useListboxContext_unstable } from '@fluentui/react-combobox';
 import { useListboxContextValues } from '@fluentui/react-combobox';
 import { useListboxStyles_unstable } from '@fluentui/react-combobox';
 import { useMenu_unstable } from '@fluentui/react-menu';
@@ -4904,6 +4905,8 @@ export { useLinkState_unstable }
 export { useLinkStyles_unstable }
 
 export { useListbox_unstable }
+
+export { useListboxContext_unstable }
 
 export { useListboxContextValues }
 

--- a/packages/react-components/react-components/src/index.ts
+++ b/packages/react-components/react-components/src/index.ts
@@ -378,6 +378,7 @@ export {
   ComboboxProvider,
   useComboboxContextValues,
   ListboxProvider,
+  useListboxContext_unstable,
   useListboxContextValues,
   useComboboxFilter,
 } from '@fluentui/react-combobox';


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->
`useListboxContext_unstable` is exported from `@fluentui/react-combobox`, but not `@fluentui/react-components`
## New Behavior
Export from `@fluentui/react-components`
<!-- This is the behavior we should expect with the changes in this PR -->