### PR TITLE
List: Fix HC theme in storybook

### DIFF
--- a/packages/react-components/react-list-preview/stories/src/List/ListActiveElement.stories.tsx
+++ b/packages/react-components/react-list-preview/stories/src/List/ListActiveElement.stories.tsx
@@ -39,6 +39,15 @@ const useStyles = makeStyles({
   },
   itemSelected: {
     backgroundColor: tokens.colorSubtleBackgroundSelected,
+    '@media (forced-colors:active)': {
+      background: 'Highlight',
+    },
+  },
+  personaSelected: {
+    '@media (forced-colors:active)': {
+      'forced-color-adjust': 'none',
+      color: 'HighlightText',
+    },
   },
 });
 
@@ -82,6 +91,7 @@ export const ListActiveElement = () => {
               role="gridcell"
               secondaryText="Available"
               presence={{ status: 'available' }}
+              className={mergeClasses(selectedItems.includes(name) && classes.personaSelected)}
               avatar={{
                 image: {
                   src: avatar,

--- a/packages/react-components/react-list-preview/stories/src/List/ListActiveElement.stories.tsx
+++ b/packages/react-components/react-list-preview/stories/src/List/ListActiveElement.stories.tsx
@@ -45,7 +45,7 @@ const useStyles = makeStyles({
   },
   personaSelected: {
     '@media (forced-colors:active)': {
-      'forced-color-adjust': 'none',
+      forcedColorAdjust: 'none',
       color: 'HighlightText',
     },
   },


### PR DESCRIPTION
Fixes HC theme in one List example, where previously the background for active element wasn't visible.

![image](https://github.com/user-attachments/assets/bcc9040c-5ff5-45dd-94b3-ce407f64dfc1)
