### PR TITLE
feat(`react-swatch-picker`): Correctly integrating `SwatchPicker` with `Field` component

### DIFF
--- a/change/@fluentui-react-swatch-picker-e5e27fd6-7f1e-444e-b5bf-146b6cc0e925.json
+++ b/change/@fluentui-react-swatch-picker-e5e27fd6-7f1e-444e-b5bf-146b6cc0e925.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: Correctly integrating SwatchPicker with Field component.",
+  "packageName": "@fluentui/react-swatch-picker",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-swatch-picker/library/package.json
+++ b/packages/react-components/react-swatch-picker/library/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@fluentui/react-context-selector": "^9.1.69",
+    "@fluentui/react-field": "^9.1.79",
     "@fluentui/react-icons": "^2.0.245",
     "@fluentui/react-jsx-runtime": "^9.0.46",
     "@fluentui/react-shared-contexts": "^9.21.0",

--- a/packages/react-components/react-swatch-picker/library/src/components/SwatchPicker/useSwatchPicker.ts
+++ b/packages/react-components/react-swatch-picker/library/src/components/SwatchPicker/useSwatchPicker.ts
@@ -1,7 +1,10 @@
 import * as React from 'react';
-import { getIntrinsicElementProps, useControllableState, useEventCallback, slot } from '@fluentui/react-utilities';
-import type { SwatchPickerProps, SwatchPickerState } from './SwatchPicker.types';
+
+import { useFieldControlProps_unstable } from '@fluentui/react-field';
 import { useArrowNavigationGroup } from '@fluentui/react-tabster';
+import { getIntrinsicElementProps, useControllableState, useEventCallback, slot } from '@fluentui/react-utilities';
+
+import type { SwatchPickerProps, SwatchPickerState } from './SwatchPicker.types';
 
 /**
  * Create the state required to render SwatchPicker.
@@ -16,6 +19,9 @@ export const useSwatchPicker_unstable = (
   props: SwatchPickerProps,
   ref: React.Ref<HTMLDivElement>,
 ): SwatchPickerState => {
+  // Merge props from surrounding <Field>, if any
+  props = useFieldControlProps_unstable(props);
+
   const { layout, onSelectionChange, size = 'medium', shape, spacing = 'medium', style, ...rest } = props;
 
   const isGrid = layout === 'grid';


### PR DESCRIPTION
## Previous Behavior

`SwatchPicker` had no integration with the `Field` component. So when they were used together, all the expectations of correctly labeling things for accessibility were not being meant.

## New Behavior

We have integrated the `Field`'s context with `SwatchPicker` so that when they are used together, `SwatchPicker` will be correctly labelled for accessibility.

## Related Issue(s)

- Fixes #33269
