### PR TITLE
Virtualizer: Add gap property for calculation

### DIFF
--- a/change/@fluentui-react-virtualizer-9b989611-7a15-4cad-bb17-903e5e009e52.json
+++ b/change/@fluentui-react-virtualizer-9b989611-7a15-4cad-bb17-903e5e009e52.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: Add gap property to simplify gap css virtualization",
+  "packageName": "@fluentui/react-virtualizer",
+  "email": "mifraser@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-virtualizer/library/src/components/Virtualizer/Virtualizer.types.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/Virtualizer/Virtualizer.types.ts
@@ -204,7 +204,7 @@ export type VirtualizerConfigProps = {
   /**
    * Spacing between rendered children for calculation, should match the container's gap CSS value.
    */
-  gap: number;
+  gap?: number;
 };
 
 export type VirtualizerProps = ComponentProps<Partial<VirtualizerSlots>> & VirtualizerConfigProps;

--- a/packages/react-components/react-virtualizer/library/src/components/Virtualizer/Virtualizer.types.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/Virtualizer/Virtualizer.types.ts
@@ -200,6 +200,11 @@ export type VirtualizerConfigProps = {
    * this should be passed in from useDynamicVirtualizerMeasure
    */
   updateScrollPosition?: (position: number) => void;
+
+  /**
+   * Spacing between rendered children for calculation, should match the container's gap CSS value.
+   */
+  gap: number;
 };
 
 export type VirtualizerProps = ComponentProps<Partial<VirtualizerSlots>> & VirtualizerConfigProps;

--- a/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
@@ -27,6 +27,7 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
     scrollViewRef,
     enableScrollLoad,
     updateScrollPosition,
+    gap,
   } = props;
 
   /* The context is optional, it's useful for injecting additional index logic, or performing uniform state updates*/
@@ -87,7 +88,8 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
     }
 
     for (let index = 0; index < numItems; index++) {
-      childSizes.current[index] = getItemSize(index);
+      const _gap = index < numItems - 1 ? gap : 0;
+      childSizes.current[index] = getItemSize(index) + _gap;
       if (index === 0) {
         childProgressiveSizes.current[index] = childSizes.current[index];
       } else {
@@ -163,7 +165,8 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
 
       let didUpdate = false;
       for (let i = startIndex; i < endIndex; i++) {
-        const newSize = getItemSize(i);
+        const _gap = i < numItems - 1 ? gap : 0;
+        const newSize = getItemSize(i) + _gap;
         if (newSize !== childSizes.current[i]) {
           childSizes.current[i] = newSize;
           didUpdate = true;
@@ -178,7 +181,7 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
         }
       }
     },
-    [getItemSize, numItems, virtualizerLength],
+    [getItemSize, numItems, virtualizerLength, gap],
   );
 
   const batchUpdateNewIndex = useCallback(
@@ -244,12 +247,12 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
   const getIndexFromScrollPosition = useCallback(
     (scrollPos: number) => {
       if (!getItemSize) {
-        return Math.round(scrollPos / itemSize);
+        return Math.round(scrollPos / (itemSize + gap));
       }
 
       return getIndexFromSizeArray(scrollPos);
     },
-    [getIndexFromSizeArray, getItemSize, itemSize],
+    [getIndexFromSizeArray, getItemSize, itemSize, gap],
   );
 
   const calculateTotalSize = useCallback(() => {
@@ -533,7 +536,7 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
 
     // We only run this effect on getItemSize change (recalc dynamic sizes)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [getItemSize]);
+  }, [getItemSize, gap]);
 
   // Effect to check flag index on updates
   useEffect(() => {

--- a/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
@@ -27,7 +27,7 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
     scrollViewRef,
     enableScrollLoad,
     updateScrollPosition,
-    gap,
+    gap = 0,
   } = props;
 
   /* The context is optional, it's useful for injecting additional index logic, or performing uniform state updates*/
@@ -257,7 +257,7 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
 
   const calculateTotalSize = useCallback(() => {
     if (!getItemSize) {
-      return itemSize * numItems;
+      return (itemSize + gap) * numItems;
     }
 
     // Time for custom size calcs
@@ -269,7 +269,7 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
 
     if (!getItemSize) {
       // The missing items from before virtualization starts height
-      return currentIndex * itemSize;
+      return currentIndex * (itemSize + gap);
     }
 
     if (currentIndex <= 0) {
@@ -289,7 +289,7 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
     if (!getItemSize) {
       // The missing items from after virtualization ends height
       const remainingItems = numItems - lastItemIndex;
-      return remainingItems * itemSize;
+      return remainingItems * (itemSize + gap) - gap;
     }
 
     // Time for custom size calcs
@@ -399,9 +399,14 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
         // Get exact relative 'scrollTop' via IO values
         const measurementPos = calculateOverBuffer();
 
+        console.log('Measurementpos:', measurementPos);
+        console.log('Actual pos:', scrollViewRef?.current?.scrollTop);
+
         const maxIndex = Math.max(numItems - virtualizerLength, 0);
 
         const startIndex = getIndexFromScrollPosition(measurementPos) - bufferItems;
+
+        console.log('startIndex:', startIndex);
 
         // Safety limits
         const newStartIndex = Math.min(Math.max(startIndex, 0), maxIndex);

--- a/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
@@ -262,7 +262,7 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
 
     // Time for custom size calcs
     return childProgressiveSizes.current[numItems - 1];
-  }, [getItemSize, itemSize, numItems]);
+  }, [getItemSize, itemSize, numItems, gap]);
 
   const calculateBefore = useCallback(() => {
     const currentIndex = Math.min(actualIndex, numItems - 1);
@@ -278,7 +278,7 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
 
     // Time for custom size calcs
     return childProgressiveSizes.current[currentIndex - 1];
-  }, [actualIndex, getItemSize, itemSize, numItems]);
+  }, [actualIndex, getItemSize, itemSize, numItems, gap]);
 
   const calculateAfter = useCallback(() => {
     if (numItems === 0 || actualIndex + virtualizerLength >= numItems) {
@@ -294,7 +294,7 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
 
     // Time for custom size calcs
     return childProgressiveSizes.current[numItems - 1] - childProgressiveSizes.current[lastItemIndex - 1];
-  }, [actualIndex, getItemSize, itemSize, numItems, virtualizerLength]);
+  }, [actualIndex, getItemSize, itemSize, numItems, virtualizerLength, gap]);
 
   // Observe intersections of virtualized components
   const { setObserverList } = useIntersectionObserver(
@@ -399,14 +399,9 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
         // Get exact relative 'scrollTop' via IO values
         const measurementPos = calculateOverBuffer();
 
-        console.log('Measurementpos:', measurementPos);
-        console.log('Actual pos:', scrollViewRef?.current?.scrollTop);
-
         const maxIndex = Math.max(numItems - virtualizerLength, 0);
 
         const startIndex = getIndexFromScrollPosition(measurementPos) - bufferItems;
-
-        console.log('startIndex:', startIndex);
 
         // Safety limits
         const newStartIndex = Math.min(Math.max(startIndex, 0), maxIndex);

--- a/packages/react-components/react-virtualizer/stories/src/Virtualizer/Dynamic.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/Virtualizer/Dynamic.stories.tsx
@@ -14,6 +14,7 @@ const useStyles = makeStyles({
     width: '100%',
     height: '100%',
     maxHeight: '750px',
+    gap: '20px',
   },
   child: {
     height: `${smallSize}px`,
@@ -88,6 +89,7 @@ export const Dynamic = () => {
           containerSizeRef={containerSizeRef}
           virtualizerContext={contextState}
           updateScrollPosition={updateScrollPosition}
+          gap={20}
         >
           {useCallback(
             (index: number) => {

--- a/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollViewDynamic/AutoMeasure.stories.tsx
+++ b/packages/react-components/react-virtualizer/stories/src/VirtualizerScrollViewDynamic/AutoMeasure.stories.tsx
@@ -38,9 +38,10 @@ export const AutoMeasure = () => {
       numItems={childLength}
       // We can use itemSize to set average height and reduce unknown whitespace
       itemSize={minHeight + maxHeightIncrease / 2.0 + 100}
-      container={{ role: 'list', style: { maxHeight: '80vh' } }}
+      container={{ role: 'list', style: { maxHeight: '80vh', gap: '20px' } }}
       bufferItems={1}
       bufferSize={minHeight / 2.0}
+      gap={20}
     >
       {(index: number) => {
         const backgroundColor = index % 2 ? '#CCCCCC' : '#ABABAB';


### PR DESCRIPTION
## Previous Behavior
Consumers had to account for gap in itemSize

## New Behavior
Consumers can now use gap property to simplify calculations