### PR TITLE
docs: Fixing virtualized list example being skipped when tabbing forward

### DIFF
--- a/packages/react-components/react-list-preview/stories/src/List/VirtualizedList.stories.tsx
+++ b/packages/react-components/react-list-preview/stories/src/List/VirtualizedList.stories.tsx
@@ -207,7 +207,7 @@ const useTextStyle = makeResetStyles({
 });
 
 const CountriesList = React.forwardRef<HTMLUListElement>((props: React.ComponentProps<typeof List>, ref) => (
-  <List aria-label="Countries" tabIndex={0} {...props} ref={ref} />
+  <List aria-label="Countries" data-tabster={undefined} tabIndex={0} {...props} ref={ref} />
 ));
 
 export const VirtualizedList = () => {
@@ -241,7 +241,12 @@ VirtualizedList.parameters = {
         'by using the `tabIndex={0}` property on the List.',
         '',
         '> ⚠️ _It is important to manually set `aria-setsize` and `aria-posinset` attributes on the list items, since_',
-        '_the virualization will only render the visible items. Relying on the DOM state for these attributes will not work._',
+        '_the virtualization will only render the visible items. Relying on the DOM state for these attributes will not work._',
+        '',
+        '> ⚠️ _There is a weird issue when using `react-window` with `tabster` where adding `tab-index={0}` to the `List` while',
+        'having a mover for arrow navigation causes the tab key to skip the list when moving forward, but not backwards.',
+        'Since we do not need to support arrow navigation with non-interactive list items, we can set `data-tabster={undefined}`',
+        'to prevent this issue._',
       ].join('\n'),
     },
   },


### PR DESCRIPTION
## Previous Behavior

When tabbing forward on the `List` example page, focus would skip over the `Virtualized List` example, but it would not be skipped over when tabbing backwards. This happens because of a weird interaction between `react-window` and `tabster`'s mover.

## New Behavior

This PR disables `tabster`'s mover logic from the `Virtualized List` example, since it is not needed due to the list having non-interactive elements only. This PR also calls out this behavior in the example's description.

## Related Issue(s)

- Fixes #33255
