### PR TITLE
chore: ensure TreeItem role can be overridden by props

### DIFF
--- a/change/@fluentui-react-tree-a886fa7c-b0f9-4646-8bd7-e9be02201229.json
+++ b/change/@fluentui-react-tree-a886fa7c-b0f9-4646-8bd7-e9be02201229.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: ensure TreeItem role can be overridden by props",
+  "packageName": "@fluentui/react-tree",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tree/library/src/components/TreeItem/useTreeItem.tsx
+++ b/packages/react-components/react-tree/library/src/components/TreeItem/useTreeItem.tsx
@@ -288,12 +288,11 @@ export function useTreeItem_unstable(props: TreeItemProps, ref: React.Ref<HTMLDi
       getIntrinsicElementProps(as, {
         tabIndex: -1,
         [dataTreeItemValueAttrName]: value,
+        role: 'treeitem',
         ...rest,
         ref: useMergedRefs(ref, treeItemRef),
-        role: 'treeitem',
         'aria-level': level,
         'aria-checked': selectionMode === 'multiselect' ? checked : undefined,
-        // Casting: when selectionMode is 'single', checked is a boolean
         'aria-selected': ariaSelected !== undefined ? ariaSelected : selectionMode === 'single' ? !!checked : undefined,
         'aria-expanded': ariaExpanded !== undefined ? ariaExpanded : itemType === 'branch' ? open : undefined,
         onClick: handleClick,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

Currently there's no way to make a `TreeItem` unfocusable.

## New Behavior

Ensure that the `role` attribute of the `TreeItem` root can be overridden by `props`. Now it's possible to make a `TreeItem` become unfocusable by just ensuring that it does not have the role `treeitem` (which is what is used internally by the `Tree` navigation)

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
