### PR TITLE
Add top:0 to hiddenContentStyles

### DIFF
--- a/packages/style-utilities/src/styles/hiddenContentStyle.ts
+++ b/packages/style-utilities/src/styles/hiddenContentStyle.ts
@@ -2,6 +2,7 @@ import type { IRawStyle } from '@fluentui/merge-styles';
 
 export const hiddenContentStyle: IRawStyle = {
   position: 'absolute',
+  top: 0;
   width: 1,
   height: 1,
   margin: -1,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

`hiddenContentStyles` sets `position: absolute` but does not specify `top` or any other positioning property.  In this case, the element gets positioned [wherever it would fall in the static flow](https://www.w3.org/TR/CSS21/visudet.html#abs-non-replaced-height).  This can, in some cases cause the scroll height of the container to get inflated.  E.g. consider the following pseudocode:

```
<container style="position:relative; height: 100px">
    <content-wrapper style="max-height:100px">
        <content style="height:200px" />
        <hidden-div class="hiddenContentStyles" />
    </content-wrapper>
</container>
```

You would expect `container` not to scroll, because its height (100px) matches its content (`max-height: 100px`).  But `hidden-div` gets defaulted to a position of `top: 200px`, meaning `container` has 200px of scrollable range (and the bottom 100px of it are empty space!)

## New Behavior

By specifying `top: 0` the hidden div is guarantee to be positioned at the top of the container and won't affect the scroll height.