### PR TITLE
fix(`react`): Adding high contrast selector to `SplitButton`'s menu button styles so that the styles do not bleed when high contrast mode is not active

### DIFF
--- a/change/@fluentui-react-d4200381-5290-4a0b-806c-c5642cee70ea.json
+++ b/change/@fluentui-react-d4200381-5290-4a0b-806c-c5642cee70ea.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Adding high contrast selector to SplitButton's menu button styles so that the styles do not bleed when high contrast mode is not active.",
+  "packageName": "@fluentui/react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Button/SplitButton/SplitButton.styles.ts
+++ b/packages/react/src/components/Button/SplitButton/SplitButton.styles.ts
@@ -110,12 +110,14 @@ export const getStyles = memoizeFunction((theme: ITheme, customStyles?: IButtonS
           },
         },
         '.ms-Button--primary + .ms-Button[aria-expanded="true"]': {
-          backgroundColor: 'Highlight',
-          borderColor: 'Highlight',
-          color: 'HighlightText',
-          ...getHighContrastNoAdjustStyle(),
-          '.ms-Button-menuIcon': {
+          [HighContrastSelector]: {
+            backgroundColor: 'Highlight',
+            borderColor: 'Highlight',
             color: 'HighlightText',
+            ...getHighContrastNoAdjustStyle(),
+            '.ms-Button-menuIcon': {
+              color: 'HighlightText',
+            },
           },
         },
         '.ms-Button.is-disabled': {


### PR DESCRIPTION
_**Note:** Color changed in screenshots to accentuate difference._

## Previous Behavior

High contrast mode styles were bleeding in the `SplitButton`'s menu button styles when high contrast mode was not active because the high contrast selector was not being applied. This means that, in most case, the styles are lost.

![image](https://github.com/user-attachments/assets/f418a8c8-0352-4bf5-8bec-2fa3aed2f522)

## New Behavior

This PR adds the high contrast selector to these styles so that they do not bleed anymore when high contrast mode is not active.

![image](https://github.com/user-attachments/assets/1876dd8d-5096-4050-ba0c-4d6060e31bfe)

## Related Issue(s)

- Fixes #33061
