### PR TITLE
docs: stop click propagation on cell focusable example

### DIFF
--- a/packages/react-components/react-table/stories/src/DataGrid/FocusableElementsInCells.stories.tsx
+++ b/packages/react-components/react-table/stories/src/DataGrid/FocusableElementsInCells.stories.tsx
@@ -108,7 +108,11 @@ const columns: TableColumnDefinition<Item>[] = [
       return 'Single action';
     },
     renderCell: () => {
-      return <Button icon={<OpenRegular />}>Open</Button>;
+      return (
+        <Button onClick={e => e.stopPropagation()} icon={<OpenRegular />}>
+          Open
+        </Button>
+      );
     },
   }),
   createTableColumn<Item>({
@@ -118,10 +122,10 @@ const columns: TableColumnDefinition<Item>[] = [
     },
     renderCell: () => {
       return (
-        <>
+        <span onClick={e => e.stopPropagation()}>
           <Button aria-label="Edit" icon={<EditRegular />} />
           <Button aria-label="Delete" icon={<DeleteRegular />} />
-        </>
+        </span>
       );
     },
   }),


### PR DESCRIPTION
Adds stopPropagation to button and button groups in cells to avoid triggering row selection.

Fixes #33262

