### PR TITLE
fix(react-file-type-icons): Map onepart extension to onenote icon

### DIFF
--- a/change/@fluentui-react-file-type-icons-d220b09a-74bc-4c36-a2b2-764d95a1ac82.json
+++ b/change/@fluentui-react-file-type-icons-d220b09a-74bc-4c36-a2b2-764d95a1ac82.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(react-file-type-icons): Map onepart extension to onenote icon",
+  "packageName": "@fluentui/react-file-type-icons",
+  "email": "125964455+cpalaparthi@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-file-type-icons-d220b09a-74bc-4c36-a2b2-764d95a1ac82.json
+++ b/change/@fluentui-react-file-type-icons-d220b09a-74bc-4c36-a2b2-764d95a1ac82.json
@@ -2,6 +2,6 @@
   "type": "patch",
   "comment": "fix(react-file-type-icons): Map onepart extension to onenote icon",
   "packageName": "@fluentui/react-file-type-icons",
-  "email": "125964455+cpalaparthi@users.noreply.github.com",
+  "email": "cpalaparthi@microsoft.com",
   "dependentChangeType": "patch"
 }

--- a/packages/react-file-type-icons/src/FileTypeIconMap.ts
+++ b/packages/react-file-type-icons/src/FileTypeIconMap.ts
@@ -355,7 +355,7 @@ export const FileTypeIconMap: { [key: string]: { extensions?: string[] } } = {
   multiple: {},
   one: {
     // This is a partial OneNote page or section export. Not whole notebooks, see "onetoc"
-    extensions: ['one'],
+    extensions: ['one', 'onepart'],
   },
   onetoc: {
     // This is an entire OneNote notebook.


### PR DESCRIPTION
## Previous Behavior

```onepart``` extension is mapped to ```genericfile``` (fallback) as it is not present in ```FileTypeIconMap```.

## New Behavior

```onepart``` extension is now mapped to ```one``` extension.

## Related Issue(s)

- Fixes # https://github.com/microsoft/fluentui/issues/33316