### PR TITLE
bugfix(react-tree): ensure that onActionVisibilityChange is properly invoked

### DIFF
--- a/change/@fluentui-react-tree-42fe21a3-4b97-431e-b2b6-ed5e0bc00663.json
+++ b/change/@fluentui-react-tree-42fe21a3-4b97-431e-b2b6-ed5e0bc00663.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: ensure that onActionVisibilityChange is properly invoked",
+  "packageName": "@fluentui/react-tree",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tree/library/src/components/TreeItemLayout/useTreeItemLayout.tsx
+++ b/packages/react-components/react-tree/library/src/components/TreeItemLayout/useTreeItemLayout.tsx
@@ -78,6 +78,9 @@ export const useTreeItemLayout_unstable = (
           event,
           type: event.type,
         } as Extract<TreeItemLayoutActionVisibilityChangeData, { event: typeof event }>);
+        if (event.defaultPrevented) {
+          return;
+        }
         setIsActionsVisible(true);
       }
     },
@@ -97,6 +100,9 @@ export const useTreeItemLayout_unstable = (
           event,
           type: event.type,
         } as Extract<TreeItemLayoutActionVisibilityChangeData, { event: typeof event }>);
+        if (event.defaultPrevented) {
+          return;
+        }
         setIsActionsVisible(true);
         return;
       }
@@ -108,6 +114,9 @@ export const useTreeItemLayout_unstable = (
         event,
         type: event.type,
       } as Extract<TreeItemLayoutActionVisibilityChangeData, { event: typeof event }>);
+      if (event.defaultPrevented) {
+        return;
+      }
       setIsActionsVisible(false);
     },
     [setIsActionsVisible, onActionVisibilityChange, treeItemRef],
@@ -155,7 +164,7 @@ export const useTreeItemLayout_unstable = (
   const hasActions = Boolean(props.actions);
 
   React.useEffect(() => {
-    if (treeItemRef.current && hasActions && isActionsVisibleFromProps === undefined) {
+    if (treeItemRef.current && hasActions) {
       const treeItemElement = treeItemRef.current;
 
       const handleMouseOver = setActionsVisibleIfNotFromSubtree;
@@ -175,13 +184,7 @@ export const useTreeItemLayout_unstable = (
         treeItemElement.removeEventListener('blur', handleBlur);
       };
     }
-  }, [
-    hasActions,
-    treeItemRef,
-    isActionsVisibleFromProps,
-    setActionsVisibleIfNotFromSubtree,
-    setActionsInvisibleIfNotFromSubtree,
-  ]);
+  }, [hasActions, treeItemRef, setActionsVisibleIfNotFromSubtree, setActionsInvisibleIfNotFromSubtree]);
 
   return {
     components: {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Event listeners that ensured `actions` visibility were only being added if `actions` visibility state was uncontrolled, causing `onActionsVisibilityChange` callback to not being properly called

## New Behavior

1. Always adds event listeners, even if `actions` visibility state is controlled, ensuring the `onActionsVisibilityChange` callback will be properly called.
2. Adds conditionals to ensure opt-out behaviour in case user prevents event

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/33319
