### PR TITLE
feat(charts): Update V9 Charts to use DataVizGradientPalette

### DIFF
--- a/packages/charts/react-charts-preview/library/etc/react-charts-preview.api.md
+++ b/packages/charts/react-charts-preview/library/etc/react-charts-preview.api.md
@@ -164,8 +164,8 @@ export type ChartDataMode = 'default' | 'fraction' | 'percentage';
 // @public (undocumented)
 export interface ChartDataPoint {
     callOutAccessibilityData?: AccessibilityProps;
-    color?: string;
     data?: number;
+    gradient?: [string, string];
     horizontalBarChartdata?: HorizontalDataPoint;
     legend?: string;
     onClick?: VoidFunction;
@@ -305,6 +305,36 @@ export interface DataPoint {
 }
 
 // @public (undocumented)
+export const DataVizGradientPalette: {
+    gradient1: string;
+    gradient2: string;
+    gradient3: string;
+    gradient4: string;
+    gradient5: string;
+    gradient6: string;
+    gradient7: string;
+    gradient8: string;
+    gradient9: string;
+    gradient10: string;
+    gradient1Ext: string;
+    gradient2Ext: string;
+    gradient3Ext: string;
+    gradient4Ext: string;
+    gradient5Ext: string;
+    gradient6Ext: string;
+    gradient7Ext: string;
+    gradient8Ext: string;
+    gradient9Ext: string;
+    gradient10Ext: string;
+    success: string;
+    highSuccess: string;
+    warning: string;
+    error: string;
+    highError: string;
+    disabled: string;
+};
+
+// @public (undocumented)
 export const DataVizPalette: {
     color1: string;
     color2: string;
@@ -404,7 +434,13 @@ export interface EventsAnnotationProps {
 export const getColorFromToken: (token: string, isDarkTheme?: boolean) => string;
 
 // @public (undocumented)
+export const getGradientFromToken: (token: string, isDarkTheme?: boolean) => [string, string];
+
+// @public (undocumented)
 export const getNextColor: (index: number, offset?: number, isDarkTheme?: boolean) => string;
+
+// @public (undocumented)
+export const getNextGradient: (index: number, offset?: number, isDarkTheme?: boolean) => [string, string];
 
 // @public (undocumented)
 export interface GroupedVerticalBarChartData {

--- a/packages/charts/react-charts-preview/library/package.json
+++ b/packages/charts/react-charts-preview/library/package.json
@@ -24,6 +24,7 @@
     "start": "yarn storybook",
     "storybook": "yarn --cwd ../stories storybook",
     "test": "jest --passWithNoTests",
+    "update-snapshots": "jest -u",
     "type-check": "just-scripts type-check"
   },
   "syncpack": {

--- a/packages/charts/react-charts-preview/library/src/components/DonutChart/Arc/Arc.tsx
+++ b/packages/charts/react-charts-preview/library/src/components/DonutChart/Arc/Arc.tsx
@@ -5,6 +5,7 @@ import { ChartDataPoint } from '../index';
 import { ArcProps } from './index';
 import { format as d3Format } from 'd3-format';
 import { formatValueWithSIPrefix, useRtl } from '../../../utilities/index';
+import { useId } from '@fluentui/react-utilities';
 
 // Create a Arc within Donut Chart variant which uses these default styles and this styled subcomponent.
 /**
@@ -13,7 +14,7 @@ import { formatValueWithSIPrefix, useRtl } from '../../../utilities/index';
  */
 export const Arc: React.FunctionComponent<ArcProps> = React.forwardRef<HTMLDivElement, ArcProps>(
   (props, forwardedRef) => {
-    const arc = d3Arc();
+    const arc = d3Arc().cornerRadius(5);
     const currentRef = React.createRef<SVGPathElement>();
     const _isRTL: boolean = useRtl();
     const classes = useArcStyles_unstable(props);
@@ -90,33 +91,59 @@ export const Arc: React.FunctionComponent<ArcProps> = React.forwardRef<HTMLDivEl
     //TO DO 'replace' is throwing error
     const id = props.uniqText! + props.data!.data.legend!.replace(/\s+/, '') + props.data!.data.data;
     const opacity: number = props.activeArc === props.data!.data.legend || props.activeArc === '' ? 1 : 0.1;
+
+    const clipId = useId('Arc_clip') + `${props.gradient[0]}_${props.gradient[1]}`;
+    const gradientFill = `conic-gradient(
+      from ${props.data?.startAngle}rad,
+      ${props.gradient[0]},
+      ${props.gradient[1]} ${props.data?.endAngle}rad
+    )`;
+
+    const pathData = arc({ ...props.data!, innerRadius: props.innerRadius, outerRadius: props.outerRadius })!;
+    const focusPathData = arc({ ...props.focusData!, innerRadius: props.innerRadius, outerRadius: props.outerRadius })!;
+
     return (
       <g ref={currentRef}>
         {!!focusedArcId && focusedArcId === id && (
           // TODO innerradius and outerradius were absent
           <path
             id={id + 'focusRing'}
-            d={arc({ ...props.focusData!, innerRadius: props.innerRadius, outerRadius: props.outerRadius })!}
+            d={focusPathData}
             className={classes.focusRing}
           />
         )}
         <path
           // TODO innerradius and outerradius were absent
           id={id}
-          d={arc({ ...props.data!, innerRadius: props.innerRadius, outerRadius: props.outerRadius })!}
+          d={pathData}
           className={classes.root}
-          style={{ fill: props.color, cursor: href ? 'pointer' : 'default' }}
+          style={{ fill: 'transparent', cursor: href ? 'pointer' : 'default' }}
           onFocus={_onFocus.bind(this, props.data!.data, id)}
           data-is-focusable={props.activeArc === props.data!.data.legend || props.activeArc === ''}
           onMouseOver={_hoverOn.bind(this, props.data!.data)}
           onMouseMove={_hoverOn.bind(this, props.data!.data)}
           onMouseLeave={_hoverOff}
           onBlur={_onBlur}
-          opacity={opacity}
           onClick={props.data?.data.onClick}
           aria-label={_getAriaLabel()}
           role="img"
         />
+        {/* clipping mask  */}
+        <clipPath id={clipId}>
+          <path d={pathData} />
+        </clipPath>
+        {/* div to attach conic-gradient fill to */}
+        <foreignObject x="-50%" y="-50%" width="100%" height="100%" clipPath={`url(#${clipId})`}>
+          <div
+            className={classes.root}
+            style={{
+              width: '100%',
+              height: '100%',
+              background: gradientFill,
+              opacity,
+            }}
+          />
+        </foreignObject>
         {_renderArcLabel(classes.arcLabel)}
       </g>
     );

--- a/packages/charts/react-charts-preview/library/src/components/DonutChart/Arc/Arc.tsx
+++ b/packages/charts/react-charts-preview/library/src/components/DonutChart/Arc/Arc.tsx
@@ -116,7 +116,6 @@ export const Arc: React.FunctionComponent<ArcProps> = React.forwardRef<HTMLDivEl
           // TODO innerradius and outerradius were absent
           id={id}
           d={pathData}
-          className={classes.root}
           style={{ fill: 'transparent', cursor: href ? 'pointer' : 'default' }}
           onFocus={_onFocus.bind(this, props.data!.data, id)}
           data-is-focusable={props.activeArc === props.data!.data.legend || props.activeArc === ''}

--- a/packages/charts/react-charts-preview/library/src/components/DonutChart/Arc/Arc.types.ts
+++ b/packages/charts/react-charts-preview/library/src/components/DonutChart/Arc/Arc.types.ts
@@ -31,9 +31,9 @@ export interface ArcProps {
   outerRadius: number;
 
   /**
-   * Color for the Arc.
+   * Gradient for the legend in the chart. If not provided, it will fallback on the default color palette.
    */
-  color: string;
+  gradient: [string, string];
 
   /**
    * Defines the function that is executed upon hovering over the legend

--- a/packages/charts/react-charts-preview/library/src/components/DonutChart/DonutChart.test.tsx
+++ b/packages/charts/react-charts-preview/library/src/components/DonutChart/DonutChart.test.tsx
@@ -21,7 +21,6 @@ function sharedAfterEach() {
 
   // Do this after unmounting the wrapper to make sure if any timers cleaned up on unmount are
   // cleaned up in fake timers world
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   if ((global.setTimeout as any).mock) {
     jest.useRealTimers();
   }
@@ -56,8 +55,8 @@ describe('DonutChart snapShot testing', () => {
   });
 
   it('renders DonutChart correctly without color points', () => {
-    const chartPointColor = pointsDC[0].color;
-    delete pointsDC[0].color;
+    const chartPointColor = pointsDC[0].gradient;
+    delete pointsDC[0].gradient;
 
     let component: any;
     rendererAct(() => {
@@ -65,7 +64,7 @@ describe('DonutChart snapShot testing', () => {
     });
     const tree = component!.toJSON();
     expect(tree).toMatchSnapshot();
-    pointsDC[0].color = chartPointColor;
+    pointsDC[0].gradient = chartPointColor;
   });
 
   it('renders hideLegend correctly', () => {

--- a/packages/charts/react-charts-preview/library/src/components/DonutChart/DonutChart.tsx
+++ b/packages/charts/react-charts-preview/library/src/components/DonutChart/DonutChart.tsx
@@ -5,7 +5,7 @@ import { DonutChartProps } from './DonutChart.types';
 import { useDonutChartStyles_unstable } from './useDonutChartStyles.styles';
 import { ChartDataPoint } from '../../DonutChart';
 import { convertToLocaleString } from '../../utilities/locale-util';
-import { getColorFromToken, getNextColor } from '../../utilities/index';
+import { getNextGradient } from '../../utilities/index';
 import { Legend, Legends } from '../../index';
 import { useId } from '@fluentui/react-utilities';
 import { useFocusableGroup } from '@fluentui/react-tabster';
@@ -76,13 +76,13 @@ const DonutChartBase: React.FunctionComponent<DonutChartProps> = React.forwardRe
       });
       return elevatedData;
     }
+
     function _createLegends(chartData: ChartDataPoint[]): JSX.Element {
       const legendDataItems = chartData.map((point: ChartDataPoint, index: number) => {
-        const color: string = point.color!;
         // mapping data to the format Legends component needs
-        const legend: Legend = {
+        const pointLegend: Legend = {
           title: point.legend!,
-          color,
+          color: point.gradient![0],
           action: () => {
             if (selectedLegend === point.legend) {
               setSelectedLegend('');
@@ -98,7 +98,7 @@ const DonutChartBase: React.FunctionComponent<DonutChartProps> = React.forwardRe
             setActiveLegend('');
           },
         };
-        return legend;
+        return pointLegend;
       });
       const legends = (
         <Legends
@@ -115,7 +115,7 @@ const DonutChartBase: React.FunctionComponent<DonutChartProps> = React.forwardRe
       setPopoverOpen(selectedLegend === '' || selectedLegend === data.legend);
       setValue(data.data!.toString());
       setLegend(data.legend);
-      setColor(data.color!);
+      setColor(data.gradient![0]);
       setXCalloutValue(data.xAxisCalloutData!);
       setYCalloutValue(data.yAxisCalloutData!);
       setFocusedArcId(id);
@@ -128,7 +128,7 @@ const DonutChartBase: React.FunctionComponent<DonutChartProps> = React.forwardRe
         setPopoverOpen(selectedLegend === '' || selectedLegend === data.legend);
         setValue(data.data!.toString());
         setLegend(data.legend);
-        setColor(data.color!);
+        setColor(data.gradient![0]);
         setXCalloutValue(data.xAxisCalloutData!);
         setYCalloutValue(data.yAxisCalloutData!);
         setDataPointCalloutProps(data);
@@ -190,17 +190,11 @@ const DonutChartBase: React.FunctionComponent<DonutChartProps> = React.forwardRe
       );
     }
 
-    function _addDefaultColors(donutChartDataPoint?: ChartDataPoint[]): ChartDataPoint[] {
+    function _addDefaultGradients(donutChartDataPoint?: ChartDataPoint[]): ChartDataPoint[] {
       return donutChartDataPoint
         ? donutChartDataPoint.map((item, index) => {
-            let defaultColor: string;
-            if (typeof item.color === 'undefined') {
-              defaultColor = getNextColor(index, 0);
-            } else {
-              defaultColor = getColorFromToken(item.color);
-            }
-            return { ...item, defaultColor };
-          })
+          return { ...item, gradient: item.gradient ?? getNextGradient(index, 0) };
+        })
         : [];
     }
 
@@ -252,7 +246,7 @@ const DonutChartBase: React.FunctionComponent<DonutChartProps> = React.forwardRe
     }
 
     const { data, hideLegend = false } = props;
-    const points = _addDefaultColors(data?.chartData);
+    const points = _addDefaultGradients(data?.chartData);
 
     const classes = useDonutChartStyles_unstable(props);
 
@@ -263,6 +257,7 @@ const DonutChartBase: React.FunctionComponent<DonutChartProps> = React.forwardRe
     const chartData = _elevateToMinimums(points.filter((d: ChartDataPoint) => d.data! >= 0));
     const valueInsideDonut = _valueInsideDonut(props.valueInsideDonut!, chartData!);
     const focusAttributes = useFocusableGroup();
+
     return !_isChartEmpty() ? (
       <div
         className={classes.root}

--- a/packages/charts/react-charts-preview/library/src/components/DonutChart/DonutChartRTL.test.tsx
+++ b/packages/charts/react-charts-preview/library/src/components/DonutChart/DonutChartRTL.test.tsx
@@ -80,9 +80,9 @@ describe('Donut chart interactions', () => {
     fireEvent.mouseOver(legend!);
 
     // Assert
-    const getById = queryAllByAttribute.bind(null, 'id');
-    expect(getById(container, /Pie.*?second/i)[0]).toHaveAttribute('opacity', '0.1');
-    expect(getById(container, /Pie.*?third/i)[0]).toHaveAttribute('opacity', '0.1');
+    const getByClass = queryAllByAttribute.bind(null, 'class');
+    expect(getByClass(container, /fui-donut-arc__root/i)[1]).toHaveStyle('opacity: 0.1');
+    expect(getByClass(container, /fui-donut-arc__root/i)[2]).toHaveStyle('opacity: 0.1');
   });
 
   test('Should select legend on single mouse click on legends', () => {
@@ -95,8 +95,8 @@ describe('Donut chart interactions', () => {
     fireEvent.click(legend!);
 
     // Assert
-    const getById = queryAllByAttribute.bind(null, 'id');
-    expect(getById(container, /Pie.*?second/i)[0]).toHaveAttribute('opacity', '0.1');
+    const getByClass = queryAllByAttribute.bind(null, 'class');
+    expect(getByClass(container, /fui-donut-arc__root/i)[1]).toHaveStyle('opacity: 0.1');
     const firstLegend = screen.queryByText('first')?.closest('button');
     expect(firstLegend).toHaveAttribute('aria-selected', 'true');
     expect(firstLegend).toHaveAttribute(
@@ -115,8 +115,8 @@ describe('Donut chart interactions', () => {
 
     //single click on first legend
     fireEvent.click(legend!);
-    const getById = queryAllByAttribute.bind(null, 'id');
-    expect(getById(container, /Pie.*?second/i)[0]).toHaveAttribute('opacity', '0.1');
+    const getByClass = queryAllByAttribute.bind(null, 'class');
+    expect(getByClass(container, /fui-donut-arc__root/i)[1]).toHaveStyle('opacity: 0.1');
     const firstLegend = screen.queryByText('first')?.closest('button');
     expect(firstLegend).toHaveAttribute('aria-selected', 'true');
     expect(firstLegend).toHaveAttribute(
@@ -138,13 +138,13 @@ describe('Donut chart interactions', () => {
     const legend = screen.queryByText('first');
     expect(legend).toBeDefined();
     fireEvent.mouseOver(legend!);
-    const getById = queryAllByAttribute.bind(null, 'id');
-    expect(getById(container, /Pie.*?second/i)[0]).toHaveAttribute('opacity', '0.1');
+    const getByClass = queryAllByAttribute.bind(null, 'class');
+    expect(getByClass(container, /fui-donut-arc__root/i)[1]).toHaveStyle('opacity: 0.1');
     fireEvent.mouseOut(legend!);
 
     // Assert
-    expect(getById(container, /Pie.*?first/i)[0]).toHaveAttribute('opacity', '1');
-    expect(getById(container, /Pie.*?second/i)[0]).toHaveAttribute('opacity', '1');
+    expect(getByClass(container, /fui-donut-arc__root/i)[0]).toHaveStyle('opacity: 1');
+    expect(getByClass(container, /fui-donut-arc__root/i)[1]).toHaveStyle('opacity: 1');
   });
 
   test('Should display correct callout data on mouse move', async () => {

--- a/packages/charts/react-charts-preview/library/src/components/DonutChart/Pie/Pie.tsx
+++ b/packages/charts/react-charts-preview/library/src/components/DonutChart/Pie/Pie.tsx
@@ -2,12 +2,12 @@
 /* eslint-disable react/jsx-no-bind */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import * as React from 'react';
-import { pie as d3Pie } from 'd3-shape';
+import { pie as d3Pie, PieArcDatum } from 'd3-shape';
 import { PieProps } from './index';
 import { Arc } from '../Arc/index';
 import { ChartDataPoint } from '../index';
 import { usePieStyles_unstable } from './usePieStyles.styles';
-import { wrapTextInsideDonut } from '../../../utilities/index';
+import { getNextGradient, wrapTextInsideDonut } from '../../../utilities/index';
 const TEXT_PADDING: number = 5;
 
 // Create a Pie within Donut Chart variant which uses these default styles and this styled subcomponent.
@@ -25,7 +25,6 @@ export const Pie: React.FunctionComponent<PieProps> = React.forwardRef<HTMLDivEl
     const classes = usePieStyles_unstable(props);
     const pieForFocusRing = d3Pie()
       .sort(null)
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       .value((d: any) => d.data)
       .padAngle(0);
 
@@ -45,9 +44,8 @@ export const Pie: React.FunctionComponent<PieProps> = React.forwardRef<HTMLDivEl
       return totalValue;
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    function arcGenerator(d: any, i: number, focusData: any, href?: string): JSX.Element {
-      const color = d && d.data && d.data.color;
+    function arcGenerator(d: PieArcDatum<ChartDataPoint>, i: number, focusData: any, href?: string): JSX.Element {
+      const gradient = d.data.gradient ?? getNextGradient(i, 0);
       return (
         <Arc
           key={i}
@@ -55,7 +53,7 @@ export const Pie: React.FunctionComponent<PieProps> = React.forwardRef<HTMLDivEl
           focusData={focusData}
           innerRadius={props.innerRadius}
           outerRadius={props.outerRadius}
-          color={color!}
+          gradient={gradient}
           onFocusCallback={_focusCallback}
           hoverOnCallback={_hoverCallback}
           onBlurCallback={props.onBlurCallback}
@@ -78,7 +76,6 @@ export const Pie: React.FunctionComponent<PieProps> = React.forwardRef<HTMLDivEl
 
     const piechart = d3Pie<ChartDataPoint>()
       .sort(null)
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       .value((d: any) => d.data)
       .padAngle(0.02)(data);
     const translate = `translate(${props.width / 2}, ${props.height / 2})`;
@@ -87,7 +84,7 @@ export const Pie: React.FunctionComponent<PieProps> = React.forwardRef<HTMLDivEl
 
     return (
       <g transform={translate}>
-        {piechart.map((d: any, i: number) => arcGenerator(d, i, focusData[i], props.href))}
+        {piechart.map((d: PieArcDatum<ChartDataPoint>, i: number) => arcGenerator(d, i, focusData[i], props.href))}
         {props.valueInsideDonut && (
           <text y={5} textAnchor="middle" dominantBaseline="middle" className={classes.insideDonutString}>
             {props.valueInsideDonut}

--- a/packages/charts/react-charts-preview/library/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
+++ b/packages/charts/react-charts-preview/library/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
@@ -30,75 +30,159 @@ exports[`DonutChart - mouse events Should render callout correctly on mouseover 
           <g>
             <path
               aria-label="2020/04/30, 20000."
-              className="fui-donut-arc__root"
-              d="M0.55,-54.997A55,55,0,0,1,51.396,-19.582L0,0Z"
+              d="M0.497,-49.747A5,5,0,0,1,6.047,-54.667A55,55,0,0,1,49.18,-24.624A5,5,0,0,1,46.489,-17.713L0,0Z"
               data-is-focusable={true}
-              id="_Pie_42first20000"
+              id="_Pie_84first20000"
               onBlur={[Function]}
               onFocus={[Function]}
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
-              opacity={1}
               role="img"
               style={
                 Object {
                   "cursor": "default",
-                  "fill": "#E5E5E5",
+                  "fill": "transparent",
                 }
               }
             />
+            <clipPath
+              id="Arc_clip85#E5E5E5_"
+            >
+              <path
+                d="M0.497,-49.747A5,5,0,0,1,6.047,-54.667A55,55,0,0,1,49.18,-24.624A5,5,0,0,1,46.489,-17.713L0,0Z"
+              />
+            </clipPath>
+            <foreignObject
+              clipPath="url(#Arc_clip85#E5E5E5_)"
+              height="100%"
+              width="100%"
+              x="-50%"
+              y="-50%"
+            >
+              <div
+                className="fui-donut-arc__root"
+                style={
+                  Object {
+                    "background": "conic-gradient(
+      from 0rad,
+      #E5E5E5,
+       1.2167664052268437rad
+    )",
+                    "height": "100%",
+                    "opacity": 1,
+                    "width": "100%",
+                  }
+                }
+              />
+            </foreignObject>
           </g>
           <g>
             <path
               aria-label="2020/04/20, 39000."
-              className="fui-donut-arc__root"
-              d="M51.777,-18.551A55,55,0,0,1,-22.37,50.245L0,0Z"
+              d="M46.834,-16.78A5,5,0,0,1,53.373,-13.28A55,55,0,0,1,-17.233,52.23A5,5,0,0,1,-20.234,45.449L0,0Z"
               data-is-focusable={true}
-              id="_Pie_42second39000"
+              id="_Pie_84second39000"
               onBlur={[Function]}
               onFocus={[Function]}
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
-              opacity={1}
               role="img"
               style={
                 Object {
                   "cursor": "default",
-                  "fill": "#0078D4",
+                  "fill": "transparent",
                 }
               }
             />
+            <clipPath
+              id="Arc_clip86#0078D4_"
+            >
+              <path
+                d="M46.834,-16.78A5,5,0,0,1,53.373,-13.28A55,55,0,0,1,-17.233,52.23A5,5,0,0,1,-20.234,45.449L0,0Z"
+              />
+            </clipPath>
+            <foreignObject
+              clipPath="url(#Arc_clip86#0078D4_)"
+              height="100%"
+              width="100%"
+              x="-50%"
+              y="-50%"
+            >
+              <div
+                className="fui-donut-arc__root"
+                style={
+                  Object {
+                    "background": "conic-gradient(
+      from 1.2167664052268437rad,
+      #0078D4,
+       3.5704608954191888rad
+    )",
+                    "height": "100%",
+                    "opacity": 1,
+                    "width": "100%",
+                  }
+                }
+              />
+            </foreignObject>
           </g>
           <g>
             <path
               aria-label="2020/04/25, 45000."
-              className="fui-donut-arc__root"
-              d="M-23.37,49.788A55,55,0,0,1,-0.55,-54.997L0,0Z"
+              d="M-21.139,45.035A5,5,0,0,1,-28.232,47.201A55,55,0,0,1,-6.047,-54.667A5,5,0,0,1,-0.497,-49.747L0,0Z"
               data-is-focusable={true}
-              id="_Pie_42third45000"
+              id="_Pie_84third45000"
               onBlur={[Function]}
               onFocus={[Function]}
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
-              opacity={1}
               role="img"
               style={
                 Object {
                   "cursor": "default",
-                  "fill": "#DADADA",
+                  "fill": "transparent",
                 }
               }
             />
+            <clipPath
+              id="Arc_clip87#DADADA_"
+            >
+              <path
+                d="M-21.139,45.035A5,5,0,0,1,-28.232,47.201A55,55,0,0,1,-6.047,-54.667A5,5,0,0,1,-0.497,-49.747L0,0Z"
+              />
+            </clipPath>
+            <foreignObject
+              clipPath="url(#Arc_clip87#DADADA_)"
+              height="100%"
+              width="100%"
+              x="-50%"
+              y="-50%"
+            >
+              <div
+                className="fui-donut-arc__root"
+                style={
+                  Object {
+                    "background": "conic-gradient(
+      from 3.5704608954191888rad,
+      #DADADA,
+       6.283185307179586rad
+    )",
+                    "height": "100%",
+                    "opacity": 1,
+                    "width": "100%",
+                  }
+                }
+              />
+            </foreignObject>
           </g>
         </g>
       </svg>
     </div>
     <div
       className="fui-cart__calloutContainer"
-      id="callout43"
+      id="callout88"
     >
       <div
         className="fui-PopoverSurface"
@@ -338,75 +422,159 @@ exports[`DonutChart - mouse events Should render customized callout on mouseover
           <g>
             <path
               aria-label="2020/04/30, 20000."
-              className="fui-donut-arc__root"
-              d="M0.55,-54.997A55,55,0,0,1,51.396,-19.582L0,0Z"
+              d="M0.497,-49.747A5,5,0,0,1,6.047,-54.667A55,55,0,0,1,49.18,-24.624A5,5,0,0,1,46.489,-17.713L0,0Z"
               data-is-focusable={true}
-              id="_Pie_50first20000"
+              id="_Pie_98first20000"
               onBlur={[Function]}
               onFocus={[Function]}
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
-              opacity={1}
               role="img"
               style={
                 Object {
                   "cursor": "default",
-                  "fill": "#E5E5E5",
+                  "fill": "transparent",
                 }
               }
             />
+            <clipPath
+              id="Arc_clip99#E5E5E5_"
+            >
+              <path
+                d="M0.497,-49.747A5,5,0,0,1,6.047,-54.667A55,55,0,0,1,49.18,-24.624A5,5,0,0,1,46.489,-17.713L0,0Z"
+              />
+            </clipPath>
+            <foreignObject
+              clipPath="url(#Arc_clip99#E5E5E5_)"
+              height="100%"
+              width="100%"
+              x="-50%"
+              y="-50%"
+            >
+              <div
+                className="fui-donut-arc__root"
+                style={
+                  Object {
+                    "background": "conic-gradient(
+      from 0rad,
+      #E5E5E5,
+       1.2167664052268437rad
+    )",
+                    "height": "100%",
+                    "opacity": 1,
+                    "width": "100%",
+                  }
+                }
+              />
+            </foreignObject>
           </g>
           <g>
             <path
               aria-label="2020/04/20, 39000."
-              className="fui-donut-arc__root"
-              d="M51.777,-18.551A55,55,0,0,1,-22.37,50.245L0,0Z"
+              d="M46.834,-16.78A5,5,0,0,1,53.373,-13.28A55,55,0,0,1,-17.233,52.23A5,5,0,0,1,-20.234,45.449L0,0Z"
               data-is-focusable={true}
-              id="_Pie_50second39000"
+              id="_Pie_98second39000"
               onBlur={[Function]}
               onFocus={[Function]}
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
-              opacity={1}
               role="img"
               style={
                 Object {
                   "cursor": "default",
-                  "fill": "#0078D4",
+                  "fill": "transparent",
                 }
               }
             />
+            <clipPath
+              id="Arc_clip100#0078D4_"
+            >
+              <path
+                d="M46.834,-16.78A5,5,0,0,1,53.373,-13.28A55,55,0,0,1,-17.233,52.23A5,5,0,0,1,-20.234,45.449L0,0Z"
+              />
+            </clipPath>
+            <foreignObject
+              clipPath="url(#Arc_clip100#0078D4_)"
+              height="100%"
+              width="100%"
+              x="-50%"
+              y="-50%"
+            >
+              <div
+                className="fui-donut-arc__root"
+                style={
+                  Object {
+                    "background": "conic-gradient(
+      from 1.2167664052268437rad,
+      #0078D4,
+       3.5704608954191888rad
+    )",
+                    "height": "100%",
+                    "opacity": 1,
+                    "width": "100%",
+                  }
+                }
+              />
+            </foreignObject>
           </g>
           <g>
             <path
               aria-label="2020/04/25, 45000."
-              className="fui-donut-arc__root"
-              d="M-23.37,49.788A55,55,0,0,1,-0.55,-54.997L0,0Z"
+              d="M-21.139,45.035A5,5,0,0,1,-28.232,47.201A55,55,0,0,1,-6.047,-54.667A5,5,0,0,1,-0.497,-49.747L0,0Z"
               data-is-focusable={true}
-              id="_Pie_50third45000"
+              id="_Pie_98third45000"
               onBlur={[Function]}
               onFocus={[Function]}
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
-              opacity={1}
               role="img"
               style={
                 Object {
                   "cursor": "default",
-                  "fill": "#DADADA",
+                  "fill": "transparent",
                 }
               }
             />
+            <clipPath
+              id="Arc_clip101#DADADA_"
+            >
+              <path
+                d="M-21.139,45.035A5,5,0,0,1,-28.232,47.201A55,55,0,0,1,-6.047,-54.667A5,5,0,0,1,-0.497,-49.747L0,0Z"
+              />
+            </clipPath>
+            <foreignObject
+              clipPath="url(#Arc_clip101#DADADA_)"
+              height="100%"
+              width="100%"
+              x="-50%"
+              y="-50%"
+            >
+              <div
+                className="fui-donut-arc__root"
+                style={
+                  Object {
+                    "background": "conic-gradient(
+      from 3.5704608954191888rad,
+      #DADADA,
+       6.283185307179586rad
+    )",
+                    "height": "100%",
+                    "opacity": 1,
+                    "width": "100%",
+                  }
+                }
+              />
+            </foreignObject>
           </g>
         </g>
       </svg>
     </div>
     <div
       className="fui-cart__calloutContainer"
-      id="callout51"
+      id="callout102"
     >
       <div
         className="fui-PopoverSurface"
@@ -646,75 +814,159 @@ exports[`DonutChart snapShot testing Should elevate all smaller values to minimu
           <g>
             <path
               aria-label="2020/04/30, 20000."
-              className="fui-donut-arc__root"
-              d="M1,-99.995A100,100,0,0,1,93.447,-35.604L0,0Z"
+              d="M0.949,-94.864A5,5,0,0,1,6.261,-99.804A100,100,0,0,1,91.444,-40.473A5,5,0,0,1,88.652,-33.777L0,0Z"
               data-is-focusable={true}
-              id="_Pie_24first20000"
+              id="_Pie_48first20000"
               onBlur={[Function]}
               onFocus={[Function]}
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
-              opacity={1}
               role="img"
               style={
                 Object {
                   "cursor": "default",
-                  "fill": "#E5E5E5",
+                  "fill": "transparent",
                 }
               }
             />
+            <clipPath
+              id="Arc_clip49#E5E5E5_"
+            >
+              <path
+                d="M0.949,-94.864A5,5,0,0,1,6.261,-99.804A100,100,0,0,1,91.444,-40.473A5,5,0,0,1,88.652,-33.777L0,0Z"
+              />
+            </clipPath>
+            <foreignObject
+              clipPath="url(#Arc_clip49#E5E5E5_)"
+              height="100%"
+              width="100%"
+              x="-50%"
+              y="-50%"
+            >
+              <div
+                className="fui-donut-arc__root"
+                style={
+                  Object {
+                    "background": "conic-gradient(
+      from 0rad,
+      #E5E5E5,
+       1.2167664052268437rad
+    )",
+                    "height": "100%",
+                    "opacity": 1,
+                    "width": "100%",
+                  }
+                }
+              />
+            </foreignObject>
           </g>
           <g>
             <path
               aria-label="2020/04/20, 39000."
-              className="fui-donut-arc__root"
-              d="M94.14,-33.728A100,100,0,0,1,-40.673,91.355L0,0Z"
+              d="M89.309,-31.998A5,5,0,0,1,95.785,-28.727A100,100,0,0,1,-35.808,93.369A5,5,0,0,1,-38.585,86.667L0,0Z"
               data-is-focusable={true}
-              id="_Pie_24second39000"
+              id="_Pie_48second39000"
               onBlur={[Function]}
               onFocus={[Function]}
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
-              opacity={1}
               role="img"
               style={
                 Object {
                   "cursor": "default",
-                  "fill": "#0078D4",
+                  "fill": "transparent",
                 }
               }
             />
+            <clipPath
+              id="Arc_clip50#0078D4_"
+            >
+              <path
+                d="M89.309,-31.998A5,5,0,0,1,95.785,-28.727A100,100,0,0,1,-35.808,93.369A5,5,0,0,1,-38.585,86.667L0,0Z"
+              />
+            </clipPath>
+            <foreignObject
+              clipPath="url(#Arc_clip50#0078D4_)"
+              height="100%"
+              width="100%"
+              x="-50%"
+              y="-50%"
+            >
+              <div
+                className="fui-donut-arc__root"
+                style={
+                  Object {
+                    "background": "conic-gradient(
+      from 1.2167664052268437rad,
+      #0078D4,
+       3.5704608954191888rad
+    )",
+                    "height": "100%",
+                    "opacity": 1,
+                    "width": "100%",
+                  }
+                }
+              />
+            </foreignObject>
           </g>
           <g>
             <path
               aria-label="2020/04/25, 45000."
-              className="fui-donut-arc__root"
-              d="M-42.492,90.523A100,100,0,0,1,-1,-99.995L0,0Z"
+              d="M-40.311,85.878A5,5,0,0,1,-47.197,88.161A100,100,0,0,1,-6.261,-99.804A5,5,0,0,1,-0.949,-94.864L0,0Z"
               data-is-focusable={true}
-              id="_Pie_24third45000"
+              id="_Pie_48third45000"
               onBlur={[Function]}
               onFocus={[Function]}
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
-              opacity={1}
               role="img"
               style={
                 Object {
                   "cursor": "default",
-                  "fill": "#DADADA",
+                  "fill": "transparent",
                 }
               }
             />
+            <clipPath
+              id="Arc_clip51#DADADA_"
+            >
+              <path
+                d="M-40.311,85.878A5,5,0,0,1,-47.197,88.161A100,100,0,0,1,-6.261,-99.804A5,5,0,0,1,-0.949,-94.864L0,0Z"
+              />
+            </clipPath>
+            <foreignObject
+              clipPath="url(#Arc_clip51#DADADA_)"
+              height="100%"
+              width="100%"
+              x="-50%"
+              y="-50%"
+            >
+              <div
+                className="fui-donut-arc__root"
+                style={
+                  Object {
+                    "background": "conic-gradient(
+      from 3.5704608954191888rad,
+      #DADADA,
+       6.283185307179586rad
+    )",
+                    "height": "100%",
+                    "opacity": 1,
+                    "width": "100%",
+                  }
+                }
+              />
+            </foreignObject>
           </g>
         </g>
       </svg>
     </div>
     <div
       className="fui-cart__calloutContainer"
-      id="callout25"
+      id="callout52"
     />
     <div
       className="fui-donut__legendContainer"
@@ -903,24 +1155,52 @@ exports[`DonutChart snapShot testing Should render arc labels 1`] = `
           <g>
             <path
               aria-label="2020/04/30, 20000."
-              className="fui-donut-arc__root"
-              d="M0.6,-59.997A60,60,0,0,1,56.068,-21.363L0,0Z"
+              d="M0.548,-54.77A5,5,0,0,1,6.052,-59.694A60,60,0,0,1,53.894,-26.371A5,5,0,0,1,51.183,-19.501L0,0Z"
               data-is-focusable={true}
-              id="_Pie_18first20000"
+              id="_Pie_36first20000"
               onBlur={[Function]}
               onFocus={[Function]}
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
-              opacity={1}
               role="img"
               style={
                 Object {
                   "cursor": "default",
-                  "fill": "#E5E5E5",
+                  "fill": "transparent",
                 }
               }
             />
+            <clipPath
+              id="Arc_clip37#E5E5E5_"
+            >
+              <path
+                d="M0.548,-54.77A5,5,0,0,1,6.052,-59.694A60,60,0,0,1,53.894,-26.371A5,5,0,0,1,51.183,-19.501L0,0Z"
+              />
+            </clipPath>
+            <foreignObject
+              clipPath="url(#Arc_clip37#E5E5E5_)"
+              height="100%"
+              width="100%"
+              x="-50%"
+              y="-50%"
+            >
+              <div
+                className="fui-donut-arc__root"
+                style={
+                  Object {
+                    "background": "conic-gradient(
+      from 0rad,
+      #E5E5E5,
+       1.2167664052268437rad
+    )",
+                    "height": "100%",
+                    "opacity": 1,
+                    "width": "100%",
+                  }
+                }
+              />
+            </foreignObject>
             <text
               aria-hidden={true}
               className="fui-donut-arc__arcLabel"
@@ -935,24 +1215,52 @@ exports[`DonutChart snapShot testing Should render arc labels 1`] = `
           <g>
             <path
               aria-label="2020/04/20, 39000."
-              className="fui-donut-arc__root"
-              d="M56.484,-20.237A60,60,0,0,1,-24.404,54.813L0,0Z"
+              d="M51.563,-18.474A5,5,0,0,1,58.09,-15.018A60,60,0,0,1,-19.32,56.805A5,5,0,0,1,-22.277,50.037L0,0Z"
               data-is-focusable={true}
-              id="_Pie_18second39000"
+              id="_Pie_36second39000"
               onBlur={[Function]}
               onFocus={[Function]}
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
-              opacity={1}
               role="img"
               style={
                 Object {
                   "cursor": "default",
-                  "fill": "#0078D4",
+                  "fill": "transparent",
                 }
               }
             />
+            <clipPath
+              id="Arc_clip38#0078D4_"
+            >
+              <path
+                d="M51.563,-18.474A5,5,0,0,1,58.09,-15.018A60,60,0,0,1,-19.32,56.805A5,5,0,0,1,-22.277,50.037L0,0Z"
+              />
+            </clipPath>
+            <foreignObject
+              clipPath="url(#Arc_clip38#0078D4_)"
+              height="100%"
+              width="100%"
+              x="-50%"
+              y="-50%"
+            >
+              <div
+                className="fui-donut-arc__root"
+                style={
+                  Object {
+                    "background": "conic-gradient(
+      from 1.2167664052268437rad,
+      #0078D4,
+       3.5704608954191888rad
+    )",
+                    "height": "100%",
+                    "opacity": 1,
+                    "width": "100%",
+                  }
+                }
+              />
+            </foreignObject>
             <text
               aria-hidden={true}
               className="fui-donut-arc__arcLabel"
@@ -967,24 +1275,52 @@ exports[`DonutChart snapShot testing Should render arc labels 1`] = `
           <g>
             <path
               aria-label="2020/04/25, 45000."
-              className="fui-donut-arc__root"
-              d="M-25.495,54.314A60,60,0,0,1,-0.6,-59.997L0,0Z"
+              d="M-23.274,49.582A5,5,0,0,1,-30.327,51.771A60,60,0,0,1,-6.052,-59.694A5,5,0,0,1,-0.548,-54.77L0,0Z"
               data-is-focusable={true}
-              id="_Pie_18third45000"
+              id="_Pie_36third45000"
               onBlur={[Function]}
               onFocus={[Function]}
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
-              opacity={1}
               role="img"
               style={
                 Object {
                   "cursor": "default",
-                  "fill": "#DADADA",
+                  "fill": "transparent",
                 }
               }
             />
+            <clipPath
+              id="Arc_clip39#DADADA_"
+            >
+              <path
+                d="M-23.274,49.582A5,5,0,0,1,-30.327,51.771A60,60,0,0,1,-6.052,-59.694A5,5,0,0,1,-0.548,-54.77L0,0Z"
+              />
+            </clipPath>
+            <foreignObject
+              clipPath="url(#Arc_clip39#DADADA_)"
+              height="100%"
+              width="100%"
+              x="-50%"
+              y="-50%"
+            >
+              <div
+                className="fui-donut-arc__root"
+                style={
+                  Object {
+                    "background": "conic-gradient(
+      from 3.5704608954191888rad,
+      #DADADA,
+       6.283185307179586rad
+    )",
+                    "height": "100%",
+                    "opacity": 1,
+                    "width": "100%",
+                  }
+                }
+              />
+            </foreignObject>
             <text
               aria-hidden={true}
               className="fui-donut-arc__arcLabel"
@@ -1001,7 +1337,7 @@ exports[`DonutChart snapShot testing Should render arc labels 1`] = `
     </div>
     <div
       className="fui-cart__calloutContainer"
-      id="callout19"
+      id="callout40"
     />
     <div
       className="fui-donut__legendContainer"
@@ -1190,24 +1526,52 @@ exports[`DonutChart snapShot testing Should render arc labels in percentage form
           <g>
             <path
               aria-label="2020/04/30, 20000."
-              className="fui-donut-arc__root"
-              d="M0.6,-59.997A60,60,0,0,1,56.068,-21.363L0,0Z"
+              d="M0.548,-54.77A5,5,0,0,1,6.052,-59.694A60,60,0,0,1,53.894,-26.371A5,5,0,0,1,51.183,-19.501L0,0Z"
               data-is-focusable={true}
-              id="_Pie_21first20000"
+              id="_Pie_42first20000"
               onBlur={[Function]}
               onFocus={[Function]}
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
-              opacity={1}
               role="img"
               style={
                 Object {
                   "cursor": "default",
-                  "fill": "#E5E5E5",
+                  "fill": "transparent",
                 }
               }
             />
+            <clipPath
+              id="Arc_clip43#E5E5E5_"
+            >
+              <path
+                d="M0.548,-54.77A5,5,0,0,1,6.052,-59.694A60,60,0,0,1,53.894,-26.371A5,5,0,0,1,51.183,-19.501L0,0Z"
+              />
+            </clipPath>
+            <foreignObject
+              clipPath="url(#Arc_clip43#E5E5E5_)"
+              height="100%"
+              width="100%"
+              x="-50%"
+              y="-50%"
+            >
+              <div
+                className="fui-donut-arc__root"
+                style={
+                  Object {
+                    "background": "conic-gradient(
+      from 0rad,
+      #E5E5E5,
+       1.2167664052268437rad
+    )",
+                    "height": "100%",
+                    "opacity": 1,
+                    "width": "100%",
+                  }
+                }
+              />
+            </foreignObject>
             <text
               aria-hidden={true}
               className="fui-donut-arc__arcLabel"
@@ -1222,24 +1586,52 @@ exports[`DonutChart snapShot testing Should render arc labels in percentage form
           <g>
             <path
               aria-label="2020/04/20, 39000."
-              className="fui-donut-arc__root"
-              d="M56.484,-20.237A60,60,0,0,1,-24.404,54.813L0,0Z"
+              d="M51.563,-18.474A5,5,0,0,1,58.09,-15.018A60,60,0,0,1,-19.32,56.805A5,5,0,0,1,-22.277,50.037L0,0Z"
               data-is-focusable={true}
-              id="_Pie_21second39000"
+              id="_Pie_42second39000"
               onBlur={[Function]}
               onFocus={[Function]}
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
-              opacity={1}
               role="img"
               style={
                 Object {
                   "cursor": "default",
-                  "fill": "#0078D4",
+                  "fill": "transparent",
                 }
               }
             />
+            <clipPath
+              id="Arc_clip44#0078D4_"
+            >
+              <path
+                d="M51.563,-18.474A5,5,0,0,1,58.09,-15.018A60,60,0,0,1,-19.32,56.805A5,5,0,0,1,-22.277,50.037L0,0Z"
+              />
+            </clipPath>
+            <foreignObject
+              clipPath="url(#Arc_clip44#0078D4_)"
+              height="100%"
+              width="100%"
+              x="-50%"
+              y="-50%"
+            >
+              <div
+                className="fui-donut-arc__root"
+                style={
+                  Object {
+                    "background": "conic-gradient(
+      from 1.2167664052268437rad,
+      #0078D4,
+       3.5704608954191888rad
+    )",
+                    "height": "100%",
+                    "opacity": 1,
+                    "width": "100%",
+                  }
+                }
+              />
+            </foreignObject>
             <text
               aria-hidden={true}
               className="fui-donut-arc__arcLabel"
@@ -1254,24 +1646,52 @@ exports[`DonutChart snapShot testing Should render arc labels in percentage form
           <g>
             <path
               aria-label="2020/04/25, 45000."
-              className="fui-donut-arc__root"
-              d="M-25.495,54.314A60,60,0,0,1,-0.6,-59.997L0,0Z"
+              d="M-23.274,49.582A5,5,0,0,1,-30.327,51.771A60,60,0,0,1,-6.052,-59.694A5,5,0,0,1,-0.548,-54.77L0,0Z"
               data-is-focusable={true}
-              id="_Pie_21third45000"
+              id="_Pie_42third45000"
               onBlur={[Function]}
               onFocus={[Function]}
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
-              opacity={1}
               role="img"
               style={
                 Object {
                   "cursor": "default",
-                  "fill": "#DADADA",
+                  "fill": "transparent",
                 }
               }
             />
+            <clipPath
+              id="Arc_clip45#DADADA_"
+            >
+              <path
+                d="M-23.274,49.582A5,5,0,0,1,-30.327,51.771A60,60,0,0,1,-6.052,-59.694A5,5,0,0,1,-0.548,-54.77L0,0Z"
+              />
+            </clipPath>
+            <foreignObject
+              clipPath="url(#Arc_clip45#DADADA_)"
+              height="100%"
+              width="100%"
+              x="-50%"
+              y="-50%"
+            >
+              <div
+                className="fui-donut-arc__root"
+                style={
+                  Object {
+                    "background": "conic-gradient(
+      from 3.5704608954191888rad,
+      #DADADA,
+       6.283185307179586rad
+    )",
+                    "height": "100%",
+                    "opacity": 1,
+                    "width": "100%",
+                  }
+                }
+              />
+            </foreignObject>
             <text
               aria-hidden={true}
               className="fui-donut-arc__arcLabel"
@@ -1288,7 +1708,7 @@ exports[`DonutChart snapShot testing Should render arc labels in percentage form
     </div>
     <div
       className="fui-cart__calloutContainer"
-      id="callout22"
+      id="callout46"
     />
     <div
       className="fui-donut__legendContainer"
@@ -1477,8 +1897,7 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
           <g>
             <path
               aria-label="2020/04/30, 20000."
-              className="fui-donut-arc__root"
-              d="M1.141,-99.993A100,100,0,0,1,93.397,-35.736L51.182,-20.134A55,55,0,0,0,1.141,-54.988Z"
+              d="M1.141,-94.801A5,5,0,0,1,6.464,-99.791A100,100,0,0,1,91.361,-40.659A5,5,0,0,1,88.526,-33.936L55.588,-21.762A5,5,0,0,1,49.367,-24.248A55,55,0,0,0,5.629,-54.711A5,5,0,0,1,1.141,-59.685Z"
               data-is-focusable={true}
               id="_Pie_1first20000"
               onBlur={[Function]}
@@ -1486,21 +1905,49 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
-              opacity={1}
               role="img"
               style={
                 Object {
                   "cursor": "default",
-                  "fill": "#E5E5E5",
+                  "fill": "transparent",
                 }
               }
             />
+            <clipPath
+              id="Arc_clip2#E5E5E5_"
+            >
+              <path
+                d="M1.141,-94.801A5,5,0,0,1,6.464,-99.791A100,100,0,0,1,91.361,-40.659A5,5,0,0,1,88.526,-33.936L55.588,-21.762A5,5,0,0,1,49.367,-24.248A55,55,0,0,0,5.629,-54.711A5,5,0,0,1,1.141,-59.685Z"
+              />
+            </clipPath>
+            <foreignObject
+              clipPath="url(#Arc_clip2#E5E5E5_)"
+              height="100%"
+              width="100%"
+              x="-50%"
+              y="-50%"
+            >
+              <div
+                className="fui-donut-arc__root"
+                style={
+                  Object {
+                    "background": "conic-gradient(
+      from 0rad,
+      #E5E5E5,
+       1.2167664052268437rad
+    )",
+                    "height": "100%",
+                    "opacity": 1,
+                    "width": "100%",
+                  }
+                }
+              />
+            </foreignObject>
           </g>
           <g>
             <path
               aria-label="2020/04/20, 39000."
-              className="fui-donut-arc__root"
-              d="M94.188,-33.595A100,100,0,0,1,-40.544,91.412L-21.828,50.483A55,55,0,0,0,51.974,-17.993Z"
+              d="M89.318,-31.795A5,5,0,0,1,95.843,-28.532A100,100,0,0,1,-35.618,93.442A5,5,0,0,1,-38.384,86.69L-23.782,54.754A5,5,0,0,1,-17.632,52.097A55,55,0,0,0,53.27,-13.687A5,5,0,0,1,56.379,-19.621Z"
               data-is-focusable={true}
               id="_Pie_1second39000"
               onBlur={[Function]}
@@ -1508,21 +1955,49 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
-              opacity={1}
               role="img"
               style={
                 Object {
                   "cursor": "default",
-                  "fill": "#0078D4",
+                  "fill": "transparent",
                 }
               }
             />
+            <clipPath
+              id="Arc_clip3#0078D4_"
+            >
+              <path
+                d="M89.318,-31.795A5,5,0,0,1,95.843,-28.532A100,100,0,0,1,-35.618,93.442A5,5,0,0,1,-38.384,86.69L-23.782,54.754A5,5,0,0,1,-17.632,52.097A55,55,0,0,0,53.27,-13.687A5,5,0,0,1,56.379,-19.621Z"
+              />
+            </clipPath>
+            <foreignObject
+              clipPath="url(#Arc_clip3#0078D4_)"
+              height="100%"
+              width="100%"
+              x="-50%"
+              y="-50%"
+            >
+              <div
+                className="fui-donut-arc__root"
+                style={
+                  Object {
+                    "background": "conic-gradient(
+      from 1.2167664052268437rad,
+      #0078D4,
+       3.5704608954191888rad
+    )",
+                    "height": "100%",
+                    "opacity": 1,
+                    "width": "100%",
+                  }
+                }
+              />
+            </foreignObject>
           </g>
           <g>
             <path
               aria-label="2020/04/25, 45000."
-              className="fui-donut-arc__root"
-              d="M-42.619,90.463A100,100,0,0,1,-1.141,-99.993L-1.141,-54.988A55,55,0,0,0,-23.904,49.534Z"
+              d="M-40.46,85.741A5,5,0,0,1,-47.376,88.065A100,100,0,0,1,-6.464,-99.791A5,5,0,0,1,-1.141,-94.801L-1.141,-59.685A5,5,0,0,1,-5.629,-54.711A55,55,0,0,0,-27.871,47.415A5,5,0,0,1,-25.857,53.805Z"
               data-is-focusable={true}
               id="_Pie_1third45000"
               onBlur={[Function]}
@@ -1530,22 +2005,51 @@ exports[`DonutChart snapShot testing renders DonutChart correctly 1`] = `
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
-              opacity={1}
               role="img"
               style={
                 Object {
                   "cursor": "default",
-                  "fill": "#DADADA",
+                  "fill": "transparent",
                 }
               }
             />
+            <clipPath
+              id="Arc_clip4#DADADA_"
+            >
+              <path
+                d="M-40.46,85.741A5,5,0,0,1,-47.376,88.065A100,100,0,0,1,-6.464,-99.791A5,5,0,0,1,-1.141,-94.801L-1.141,-59.685A5,5,0,0,1,-5.629,-54.711A55,55,0,0,0,-27.871,47.415A5,5,0,0,1,-25.857,53.805Z"
+              />
+            </clipPath>
+            <foreignObject
+              clipPath="url(#Arc_clip4#DADADA_)"
+              height="100%"
+              width="100%"
+              x="-50%"
+              y="-50%"
+            >
+              <div
+                className="fui-donut-arc__root"
+                style={
+                  Object {
+                    "background": "conic-gradient(
+      from 3.5704608954191888rad,
+      #DADADA,
+       6.283185307179586rad
+    )",
+                    "height": "100%",
+                    "opacity": 1,
+                    "width": "100%",
+                  }
+                }
+              />
+            </foreignObject>
           </g>
         </g>
       </svg>
     </div>
     <div
       className="fui-cart__calloutContainer"
-      id="callout2"
+      id="callout5"
     />
     <div
       className="fui-donut__legendContainer"
@@ -1734,75 +2238,159 @@ exports[`DonutChart snapShot testing renders DonutChart correctly without color 
           <g>
             <path
               aria-label="2020/04/30, 20000."
-              className="fui-donut-arc__root"
-              d="M1,-99.995A100,100,0,0,1,93.447,-35.604L0,0Z"
+              d="M0.949,-94.864A5,5,0,0,1,6.261,-99.804A100,100,0,0,1,91.444,-40.473A5,5,0,0,1,88.652,-33.777L0,0Z"
               data-is-focusable={true}
-              id="_Pie_4first20000"
+              id="_Pie_7first20000"
               onBlur={[Function]}
               onFocus={[Function]}
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
-              opacity={1}
               role="img"
               style={
                 Object {
                   "cursor": "default",
-                  "fill": undefined,
+                  "fill": "transparent",
                 }
               }
             />
+            <clipPath
+              id="Arc_clip8#4760D5_#637CEF"
+            >
+              <path
+                d="M0.949,-94.864A5,5,0,0,1,6.261,-99.804A100,100,0,0,1,91.444,-40.473A5,5,0,0,1,88.652,-33.777L0,0Z"
+              />
+            </clipPath>
+            <foreignObject
+              clipPath="url(#Arc_clip8#4760D5_#637CEF)"
+              height="100%"
+              width="100%"
+              x="-50%"
+              y="-50%"
+            >
+              <div
+                className="fui-donut-arc__root"
+                style={
+                  Object {
+                    "background": "conic-gradient(
+      from 0rad,
+      #4760D5,
+      #637CEF 1.2167664052268437rad
+    )",
+                    "height": "100%",
+                    "opacity": 1,
+                    "width": "100%",
+                  }
+                }
+              />
+            </foreignObject>
           </g>
           <g>
             <path
               aria-label="2020/04/20, 39000."
-              className="fui-donut-arc__root"
-              d="M94.14,-33.728A100,100,0,0,1,-40.673,91.355L0,0Z"
+              d="M89.309,-31.998A5,5,0,0,1,95.785,-28.727A100,100,0,0,1,-35.808,93.369A5,5,0,0,1,-38.585,86.667L0,0Z"
               data-is-focusable={true}
-              id="_Pie_4second39000"
+              id="_Pie_7second39000"
               onBlur={[Function]}
               onFocus={[Function]}
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
-              opacity={1}
               role="img"
               style={
                 Object {
                   "cursor": "default",
-                  "fill": undefined,
+                  "fill": "transparent",
                 }
               }
             />
+            <clipPath
+              id="Arc_clip9#795AA6_#9373C0"
+            >
+              <path
+                d="M89.309,-31.998A5,5,0,0,1,95.785,-28.727A100,100,0,0,1,-35.808,93.369A5,5,0,0,1,-38.585,86.667L0,0Z"
+              />
+            </clipPath>
+            <foreignObject
+              clipPath="url(#Arc_clip9#795AA6_#9373C0)"
+              height="100%"
+              width="100%"
+              x="-50%"
+              y="-50%"
+            >
+              <div
+                className="fui-donut-arc__root"
+                style={
+                  Object {
+                    "background": "conic-gradient(
+      from 1.2167664052268437rad,
+      #795AA6,
+      #9373C0 3.5704608954191888rad
+    )",
+                    "height": "100%",
+                    "opacity": 1,
+                    "width": "100%",
+                  }
+                }
+              />
+            </foreignObject>
           </g>
           <g>
             <path
               aria-label="2020/04/25, 45000."
-              className="fui-donut-arc__root"
-              d="M-42.492,90.523A100,100,0,0,1,-1,-99.995L0,0Z"
+              d="M-40.311,85.878A5,5,0,0,1,-47.197,88.161A100,100,0,0,1,-6.261,-99.804A5,5,0,0,1,-0.949,-94.864L0,0Z"
               data-is-focusable={true}
-              id="_Pie_4third45000"
+              id="_Pie_7third45000"
               onBlur={[Function]}
               onFocus={[Function]}
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
-              opacity={1}
               role="img"
               style={
                 Object {
                   "cursor": "default",
-                  "fill": undefined,
+                  "fill": "transparent",
                 }
               }
             />
+            <clipPath
+              id="Arc_clip10#159195_#2AA0A4"
+            >
+              <path
+                d="M-40.311,85.878A5,5,0,0,1,-47.197,88.161A100,100,0,0,1,-6.261,-99.804A5,5,0,0,1,-0.949,-94.864L0,0Z"
+              />
+            </clipPath>
+            <foreignObject
+              clipPath="url(#Arc_clip10#159195_#2AA0A4)"
+              height="100%"
+              width="100%"
+              x="-50%"
+              y="-50%"
+            >
+              <div
+                className="fui-donut-arc__root"
+                style={
+                  Object {
+                    "background": "conic-gradient(
+      from 3.5704608954191888rad,
+      #159195,
+      #2AA0A4 6.283185307179586rad
+    )",
+                    "height": "100%",
+                    "opacity": 1,
+                    "width": "100%",
+                  }
+                }
+              />
+            </foreignObject>
           </g>
         </g>
       </svg>
     </div>
     <div
       className="fui-cart__calloutContainer"
-      id="callout5"
+      id="callout11"
     />
     <div
       className="fui-donut__legendContainer"
@@ -1834,8 +2422,8 @@ exports[`DonutChart snapShot testing renders DonutChart correctly without color 
             role="option"
             style={
               Object {
-                "--rect-backgroundColor": undefined,
-                "--rect-borderColor": "var(--colorNeutralStroke1)",
+                "--rect-backgroundColor": "#4760D5",
+                "--rect-borderColor": "#4760D5",
                 "--rect-content": "",
                 "--rect-height": "12px",
               }
@@ -1846,10 +2434,10 @@ exports[`DonutChart snapShot testing renders DonutChart correctly without color 
               className="fui-legend__rect"
               style={
                 Object {
-                  "--rect-content-high-contrast": "linear-gradient(to right, undefined, undefined)",
+                  "--rect-content-high-contrast": "linear-gradient(to right, #4760D5, #4760D5)",
                   "--rect-opacity-high-contrast": "",
-                  "backgroundColor": undefined,
-                  "borderColor": "var(--colorNeutralStroke1)",
+                  "backgroundColor": "#4760D5",
+                  "borderColor": "#4760D5",
                   "content": "",
                   "height": "12px",
                 }
@@ -1878,8 +2466,8 @@ exports[`DonutChart snapShot testing renders DonutChart correctly without color 
             role="option"
             style={
               Object {
-                "--rect-backgroundColor": undefined,
-                "--rect-borderColor": "var(--colorNeutralStroke1)",
+                "--rect-backgroundColor": "#795AA6",
+                "--rect-borderColor": "#795AA6",
                 "--rect-content": "",
                 "--rect-height": "12px",
               }
@@ -1890,10 +2478,10 @@ exports[`DonutChart snapShot testing renders DonutChart correctly without color 
               className="fui-legend__rect"
               style={
                 Object {
-                  "--rect-content-high-contrast": "linear-gradient(to right, undefined, undefined)",
+                  "--rect-content-high-contrast": "linear-gradient(to right, #795AA6, #795AA6)",
                   "--rect-opacity-high-contrast": "",
-                  "backgroundColor": undefined,
-                  "borderColor": "var(--colorNeutralStroke1)",
+                  "backgroundColor": "#795AA6",
+                  "borderColor": "#795AA6",
                   "content": "",
                   "height": "12px",
                 }
@@ -1922,8 +2510,8 @@ exports[`DonutChart snapShot testing renders DonutChart correctly without color 
             role="option"
             style={
               Object {
-                "--rect-backgroundColor": undefined,
-                "--rect-borderColor": "var(--colorNeutralStroke1)",
+                "--rect-backgroundColor": "#159195",
+                "--rect-borderColor": "#159195",
                 "--rect-content": "",
                 "--rect-height": "12px",
               }
@@ -1934,10 +2522,10 @@ exports[`DonutChart snapShot testing renders DonutChart correctly without color 
               className="fui-legend__rect"
               style={
                 Object {
-                  "--rect-content-high-contrast": "linear-gradient(to right, undefined, undefined)",
+                  "--rect-content-high-contrast": "linear-gradient(to right, #159195, #159195)",
                   "--rect-opacity-high-contrast": "",
-                  "backgroundColor": undefined,
-                  "borderColor": "var(--colorNeutralStroke1)",
+                  "backgroundColor": "#159195",
+                  "borderColor": "#159195",
                   "content": "",
                   "height": "12px",
                 }
@@ -1991,75 +2579,159 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
           <g>
             <path
               aria-label="2020/04/30, 20000."
-              className="fui-donut-arc__root"
-              d="M1,-99.995A100,100,0,0,1,93.447,-35.604L0,0Z"
+              d="M0.949,-94.864A5,5,0,0,1,6.261,-99.804A100,100,0,0,1,91.444,-40.473A5,5,0,0,1,88.652,-33.777L0,0Z"
               data-is-focusable={true}
-              id="_Pie_12first20000"
+              id="_Pie_24first20000"
               onBlur={[Function]}
               onFocus={[Function]}
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
-              opacity={1}
               role="img"
               style={
                 Object {
                   "cursor": "default",
-                  "fill": "#E5E5E5",
+                  "fill": "transparent",
                 }
               }
             />
+            <clipPath
+              id="Arc_clip25#E5E5E5_"
+            >
+              <path
+                d="M0.949,-94.864A5,5,0,0,1,6.261,-99.804A100,100,0,0,1,91.444,-40.473A5,5,0,0,1,88.652,-33.777L0,0Z"
+              />
+            </clipPath>
+            <foreignObject
+              clipPath="url(#Arc_clip25#E5E5E5_)"
+              height="100%"
+              width="100%"
+              x="-50%"
+              y="-50%"
+            >
+              <div
+                className="fui-donut-arc__root"
+                style={
+                  Object {
+                    "background": "conic-gradient(
+      from 0rad,
+      #E5E5E5,
+       1.2167664052268437rad
+    )",
+                    "height": "100%",
+                    "opacity": 1,
+                    "width": "100%",
+                  }
+                }
+              />
+            </foreignObject>
           </g>
           <g>
             <path
               aria-label="2020/04/20, 39000."
-              className="fui-donut-arc__root"
-              d="M94.14,-33.728A100,100,0,0,1,-40.673,91.355L0,0Z"
+              d="M89.309,-31.998A5,5,0,0,1,95.785,-28.727A100,100,0,0,1,-35.808,93.369A5,5,0,0,1,-38.585,86.667L0,0Z"
               data-is-focusable={true}
-              id="_Pie_12second39000"
+              id="_Pie_24second39000"
               onBlur={[Function]}
               onFocus={[Function]}
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
-              opacity={1}
               role="img"
               style={
                 Object {
                   "cursor": "default",
-                  "fill": "#0078D4",
+                  "fill": "transparent",
                 }
               }
             />
+            <clipPath
+              id="Arc_clip26#0078D4_"
+            >
+              <path
+                d="M89.309,-31.998A5,5,0,0,1,95.785,-28.727A100,100,0,0,1,-35.808,93.369A5,5,0,0,1,-38.585,86.667L0,0Z"
+              />
+            </clipPath>
+            <foreignObject
+              clipPath="url(#Arc_clip26#0078D4_)"
+              height="100%"
+              width="100%"
+              x="-50%"
+              y="-50%"
+            >
+              <div
+                className="fui-donut-arc__root"
+                style={
+                  Object {
+                    "background": "conic-gradient(
+      from 1.2167664052268437rad,
+      #0078D4,
+       3.5704608954191888rad
+    )",
+                    "height": "100%",
+                    "opacity": 1,
+                    "width": "100%",
+                  }
+                }
+              />
+            </foreignObject>
           </g>
           <g>
             <path
               aria-label="2020/04/25, 45000."
-              className="fui-donut-arc__root"
-              d="M-42.492,90.523A100,100,0,0,1,-1,-99.995L0,0Z"
+              d="M-40.311,85.878A5,5,0,0,1,-47.197,88.161A100,100,0,0,1,-6.261,-99.804A5,5,0,0,1,-0.949,-94.864L0,0Z"
               data-is-focusable={true}
-              id="_Pie_12third45000"
+              id="_Pie_24third45000"
               onBlur={[Function]}
               onFocus={[Function]}
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
-              opacity={1}
               role="img"
               style={
                 Object {
                   "cursor": "default",
-                  "fill": "#DADADA",
+                  "fill": "transparent",
                 }
               }
             />
+            <clipPath
+              id="Arc_clip27#DADADA_"
+            >
+              <path
+                d="M-40.311,85.878A5,5,0,0,1,-47.197,88.161A100,100,0,0,1,-6.261,-99.804A5,5,0,0,1,-0.949,-94.864L0,0Z"
+              />
+            </clipPath>
+            <foreignObject
+              clipPath="url(#Arc_clip27#DADADA_)"
+              height="100%"
+              width="100%"
+              x="-50%"
+              y="-50%"
+            >
+              <div
+                className="fui-donut-arc__root"
+                style={
+                  Object {
+                    "background": "conic-gradient(
+      from 3.5704608954191888rad,
+      #DADADA,
+       6.283185307179586rad
+    )",
+                    "height": "100%",
+                    "opacity": 1,
+                    "width": "100%",
+                  }
+                }
+              />
+            </foreignObject>
           </g>
         </g>
       </svg>
     </div>
     <div
       className="fui-cart__calloutContainer"
-      id="callout13"
+      id="callout28"
     />
     <div
       className="fui-donut__legendContainer"
@@ -2248,75 +2920,159 @@ exports[`DonutChart snapShot testing renders hideLegend correctly 1`] = `
           <g>
             <path
               aria-label="2020/04/30, 20000."
-              className="fui-donut-arc__root"
-              d="M1,-99.995A100,100,0,0,1,93.447,-35.604L0,0Z"
+              d="M0.949,-94.864A5,5,0,0,1,6.261,-99.804A100,100,0,0,1,91.444,-40.473A5,5,0,0,1,88.652,-33.777L0,0Z"
               data-is-focusable={true}
-              id="_Pie_7first20000"
+              id="_Pie_13first20000"
               onBlur={[Function]}
               onFocus={[Function]}
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
-              opacity={1}
               role="img"
               style={
                 Object {
                   "cursor": "default",
-                  "fill": "#E5E5E5",
+                  "fill": "transparent",
                 }
               }
             />
+            <clipPath
+              id="Arc_clip14#E5E5E5_"
+            >
+              <path
+                d="M0.949,-94.864A5,5,0,0,1,6.261,-99.804A100,100,0,0,1,91.444,-40.473A5,5,0,0,1,88.652,-33.777L0,0Z"
+              />
+            </clipPath>
+            <foreignObject
+              clipPath="url(#Arc_clip14#E5E5E5_)"
+              height="100%"
+              width="100%"
+              x="-50%"
+              y="-50%"
+            >
+              <div
+                className="fui-donut-arc__root"
+                style={
+                  Object {
+                    "background": "conic-gradient(
+      from 0rad,
+      #E5E5E5,
+       1.2167664052268437rad
+    )",
+                    "height": "100%",
+                    "opacity": 1,
+                    "width": "100%",
+                  }
+                }
+              />
+            </foreignObject>
           </g>
           <g>
             <path
               aria-label="2020/04/20, 39000."
-              className="fui-donut-arc__root"
-              d="M94.14,-33.728A100,100,0,0,1,-40.673,91.355L0,0Z"
+              d="M89.309,-31.998A5,5,0,0,1,95.785,-28.727A100,100,0,0,1,-35.808,93.369A5,5,0,0,1,-38.585,86.667L0,0Z"
               data-is-focusable={true}
-              id="_Pie_7second39000"
+              id="_Pie_13second39000"
               onBlur={[Function]}
               onFocus={[Function]}
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
-              opacity={1}
               role="img"
               style={
                 Object {
                   "cursor": "default",
-                  "fill": "#0078D4",
+                  "fill": "transparent",
                 }
               }
             />
+            <clipPath
+              id="Arc_clip15#0078D4_"
+            >
+              <path
+                d="M89.309,-31.998A5,5,0,0,1,95.785,-28.727A100,100,0,0,1,-35.808,93.369A5,5,0,0,1,-38.585,86.667L0,0Z"
+              />
+            </clipPath>
+            <foreignObject
+              clipPath="url(#Arc_clip15#0078D4_)"
+              height="100%"
+              width="100%"
+              x="-50%"
+              y="-50%"
+            >
+              <div
+                className="fui-donut-arc__root"
+                style={
+                  Object {
+                    "background": "conic-gradient(
+      from 1.2167664052268437rad,
+      #0078D4,
+       3.5704608954191888rad
+    )",
+                    "height": "100%",
+                    "opacity": 1,
+                    "width": "100%",
+                  }
+                }
+              />
+            </foreignObject>
           </g>
           <g>
             <path
               aria-label="2020/04/25, 45000."
-              className="fui-donut-arc__root"
-              d="M-42.492,90.523A100,100,0,0,1,-1,-99.995L0,0Z"
+              d="M-40.311,85.878A5,5,0,0,1,-47.197,88.161A100,100,0,0,1,-6.261,-99.804A5,5,0,0,1,-0.949,-94.864L0,0Z"
               data-is-focusable={true}
-              id="_Pie_7third45000"
+              id="_Pie_13third45000"
               onBlur={[Function]}
               onFocus={[Function]}
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
-              opacity={1}
               role="img"
               style={
                 Object {
                   "cursor": "default",
-                  "fill": "#DADADA",
+                  "fill": "transparent",
                 }
               }
             />
+            <clipPath
+              id="Arc_clip16#DADADA_"
+            >
+              <path
+                d="M-40.311,85.878A5,5,0,0,1,-47.197,88.161A100,100,0,0,1,-6.261,-99.804A5,5,0,0,1,-0.949,-94.864L0,0Z"
+              />
+            </clipPath>
+            <foreignObject
+              clipPath="url(#Arc_clip16#DADADA_)"
+              height="100%"
+              width="100%"
+              x="-50%"
+              y="-50%"
+            >
+              <div
+                className="fui-donut-arc__root"
+                style={
+                  Object {
+                    "background": "conic-gradient(
+      from 3.5704608954191888rad,
+      #DADADA,
+       6.283185307179586rad
+    )",
+                    "height": "100%",
+                    "opacity": 1,
+                    "width": "100%",
+                  }
+                }
+              />
+            </foreignObject>
           </g>
         </g>
       </svg>
     </div>
     <div
       className="fui-cart__calloutContainer"
-      id="callout8"
+      id="callout17"
     />
   </div>
 </div>
@@ -2352,75 +3108,159 @@ exports[`DonutChart snapShot testing renders hideTooltip correctly 1`] = `
           <g>
             <path
               aria-label="2020/04/30, 20000."
-              className="fui-donut-arc__root"
-              d="M1,-99.995A100,100,0,0,1,93.447,-35.604L0,0Z"
+              d="M0.949,-94.864A5,5,0,0,1,6.261,-99.804A100,100,0,0,1,91.444,-40.473A5,5,0,0,1,88.652,-33.777L0,0Z"
               data-is-focusable={true}
-              id="_Pie_9first20000"
+              id="_Pie_18first20000"
               onBlur={[Function]}
               onFocus={[Function]}
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
-              opacity={1}
               role="img"
               style={
                 Object {
                   "cursor": "default",
-                  "fill": "#E5E5E5",
+                  "fill": "transparent",
                 }
               }
             />
+            <clipPath
+              id="Arc_clip19#E5E5E5_"
+            >
+              <path
+                d="M0.949,-94.864A5,5,0,0,1,6.261,-99.804A100,100,0,0,1,91.444,-40.473A5,5,0,0,1,88.652,-33.777L0,0Z"
+              />
+            </clipPath>
+            <foreignObject
+              clipPath="url(#Arc_clip19#E5E5E5_)"
+              height="100%"
+              width="100%"
+              x="-50%"
+              y="-50%"
+            >
+              <div
+                className="fui-donut-arc__root"
+                style={
+                  Object {
+                    "background": "conic-gradient(
+      from 0rad,
+      #E5E5E5,
+       1.2167664052268437rad
+    )",
+                    "height": "100%",
+                    "opacity": 1,
+                    "width": "100%",
+                  }
+                }
+              />
+            </foreignObject>
           </g>
           <g>
             <path
               aria-label="2020/04/20, 39000."
-              className="fui-donut-arc__root"
-              d="M94.14,-33.728A100,100,0,0,1,-40.673,91.355L0,0Z"
+              d="M89.309,-31.998A5,5,0,0,1,95.785,-28.727A100,100,0,0,1,-35.808,93.369A5,5,0,0,1,-38.585,86.667L0,0Z"
               data-is-focusable={true}
-              id="_Pie_9second39000"
+              id="_Pie_18second39000"
               onBlur={[Function]}
               onFocus={[Function]}
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
-              opacity={1}
               role="img"
               style={
                 Object {
                   "cursor": "default",
-                  "fill": "#0078D4",
+                  "fill": "transparent",
                 }
               }
             />
+            <clipPath
+              id="Arc_clip20#0078D4_"
+            >
+              <path
+                d="M89.309,-31.998A5,5,0,0,1,95.785,-28.727A100,100,0,0,1,-35.808,93.369A5,5,0,0,1,-38.585,86.667L0,0Z"
+              />
+            </clipPath>
+            <foreignObject
+              clipPath="url(#Arc_clip20#0078D4_)"
+              height="100%"
+              width="100%"
+              x="-50%"
+              y="-50%"
+            >
+              <div
+                className="fui-donut-arc__root"
+                style={
+                  Object {
+                    "background": "conic-gradient(
+      from 1.2167664052268437rad,
+      #0078D4,
+       3.5704608954191888rad
+    )",
+                    "height": "100%",
+                    "opacity": 1,
+                    "width": "100%",
+                  }
+                }
+              />
+            </foreignObject>
           </g>
           <g>
             <path
               aria-label="2020/04/25, 45000."
-              className="fui-donut-arc__root"
-              d="M-42.492,90.523A100,100,0,0,1,-1,-99.995L0,0Z"
+              d="M-40.311,85.878A5,5,0,0,1,-47.197,88.161A100,100,0,0,1,-6.261,-99.804A5,5,0,0,1,-0.949,-94.864L0,0Z"
               data-is-focusable={true}
-              id="_Pie_9third45000"
+              id="_Pie_18third45000"
               onBlur={[Function]}
               onFocus={[Function]}
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
-              opacity={1}
               role="img"
               style={
                 Object {
                   "cursor": "default",
-                  "fill": "#DADADA",
+                  "fill": "transparent",
                 }
               }
             />
+            <clipPath
+              id="Arc_clip21#DADADA_"
+            >
+              <path
+                d="M-40.311,85.878A5,5,0,0,1,-47.197,88.161A100,100,0,0,1,-6.261,-99.804A5,5,0,0,1,-0.949,-94.864L0,0Z"
+              />
+            </clipPath>
+            <foreignObject
+              clipPath="url(#Arc_clip21#DADADA_)"
+              height="100%"
+              width="100%"
+              x="-50%"
+              y="-50%"
+            >
+              <div
+                className="fui-donut-arc__root"
+                style={
+                  Object {
+                    "background": "conic-gradient(
+      from 3.5704608954191888rad,
+      #DADADA,
+       6.283185307179586rad
+    )",
+                    "height": "100%",
+                    "opacity": 1,
+                    "width": "100%",
+                  }
+                }
+              />
+            </foreignObject>
           </g>
         </g>
       </svg>
     </div>
     <div
       className="fui-cart__calloutContainer"
-      id="callout10"
+      id="callout22"
     />
     <div
       className="fui-donut__legendContainer"
@@ -2609,68 +3449,152 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
           <g>
             <path
               aria-label="2020/04/30, 20000."
-              className="fui-donut-arc__root"
-              d="M1,-99.995A100,100,0,0,1,93.447,-35.604L0,0Z"
+              d="M0.949,-94.864A5,5,0,0,1,6.261,-99.804A100,100,0,0,1,91.444,-40.473A5,5,0,0,1,88.652,-33.777L0,0Z"
               data-is-focusable={true}
-              id="_Pie_15first20000"
+              id="_Pie_30first20000"
               onBlur={[Function]}
               onFocus={[Function]}
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
-              opacity={1}
               role="img"
               style={
                 Object {
                   "cursor": "default",
-                  "fill": "#E5E5E5",
+                  "fill": "transparent",
                 }
               }
             />
+            <clipPath
+              id="Arc_clip31#E5E5E5_"
+            >
+              <path
+                d="M0.949,-94.864A5,5,0,0,1,6.261,-99.804A100,100,0,0,1,91.444,-40.473A5,5,0,0,1,88.652,-33.777L0,0Z"
+              />
+            </clipPath>
+            <foreignObject
+              clipPath="url(#Arc_clip31#E5E5E5_)"
+              height="100%"
+              width="100%"
+              x="-50%"
+              y="-50%"
+            >
+              <div
+                className="fui-donut-arc__root"
+                style={
+                  Object {
+                    "background": "conic-gradient(
+      from 0rad,
+      #E5E5E5,
+       1.2167664052268437rad
+    )",
+                    "height": "100%",
+                    "opacity": 1,
+                    "width": "100%",
+                  }
+                }
+              />
+            </foreignObject>
           </g>
           <g>
             <path
               aria-label="2020/04/20, 39000."
-              className="fui-donut-arc__root"
-              d="M94.14,-33.728A100,100,0,0,1,-40.673,91.355L0,0Z"
+              d="M89.309,-31.998A5,5,0,0,1,95.785,-28.727A100,100,0,0,1,-35.808,93.369A5,5,0,0,1,-38.585,86.667L0,0Z"
               data-is-focusable={true}
-              id="_Pie_15second39000"
+              id="_Pie_30second39000"
               onBlur={[Function]}
               onFocus={[Function]}
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
-              opacity={1}
               role="img"
               style={
                 Object {
                   "cursor": "default",
-                  "fill": "#0078D4",
+                  "fill": "transparent",
                 }
               }
             />
+            <clipPath
+              id="Arc_clip32#0078D4_"
+            >
+              <path
+                d="M89.309,-31.998A5,5,0,0,1,95.785,-28.727A100,100,0,0,1,-35.808,93.369A5,5,0,0,1,-38.585,86.667L0,0Z"
+              />
+            </clipPath>
+            <foreignObject
+              clipPath="url(#Arc_clip32#0078D4_)"
+              height="100%"
+              width="100%"
+              x="-50%"
+              y="-50%"
+            >
+              <div
+                className="fui-donut-arc__root"
+                style={
+                  Object {
+                    "background": "conic-gradient(
+      from 1.2167664052268437rad,
+      #0078D4,
+       3.5704608954191888rad
+    )",
+                    "height": "100%",
+                    "opacity": 1,
+                    "width": "100%",
+                  }
+                }
+              />
+            </foreignObject>
           </g>
           <g>
             <path
               aria-label="2020/04/25, 45000."
-              className="fui-donut-arc__root"
-              d="M-42.492,90.523A100,100,0,0,1,-1,-99.995L0,0Z"
+              d="M-40.311,85.878A5,5,0,0,1,-47.197,88.161A100,100,0,0,1,-6.261,-99.804A5,5,0,0,1,-0.949,-94.864L0,0Z"
               data-is-focusable={true}
-              id="_Pie_15third45000"
+              id="_Pie_30third45000"
               onBlur={[Function]}
               onFocus={[Function]}
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onMouseOver={[Function]}
-              opacity={1}
               role="img"
               style={
                 Object {
                   "cursor": "default",
-                  "fill": "#DADADA",
+                  "fill": "transparent",
                 }
               }
             />
+            <clipPath
+              id="Arc_clip33#DADADA_"
+            >
+              <path
+                d="M-40.311,85.878A5,5,0,0,1,-47.197,88.161A100,100,0,0,1,-6.261,-99.804A5,5,0,0,1,-0.949,-94.864L0,0Z"
+              />
+            </clipPath>
+            <foreignObject
+              clipPath="url(#Arc_clip33#DADADA_)"
+              height="100%"
+              width="100%"
+              x="-50%"
+              y="-50%"
+            >
+              <div
+                className="fui-donut-arc__root"
+                style={
+                  Object {
+                    "background": "conic-gradient(
+      from 3.5704608954191888rad,
+      #DADADA,
+       6.283185307179586rad
+    )",
+                    "height": "100%",
+                    "opacity": 1,
+                    "width": "100%",
+                  }
+                }
+              />
+            </foreignObject>
           </g>
           <text
             className="fui-donut-pie__insideDonutString"
@@ -2685,7 +3609,7 @@ exports[`DonutChart snapShot testing renders value inside onf the pie 1`] = `
     </div>
     <div
       className="fui-cart__calloutContainer"
-      id="callout16"
+      id="callout34"
     />
     <div
       className="fui-donut__legendContainer"

--- a/packages/charts/react-charts-preview/library/src/components/DonutChart/__snapshots__/DonutChartRTL.test.tsx.snap
+++ b/packages/charts/react-charts-preview/library/src/components/DonutChart/__snapshots__/DonutChartRTL.test.tsx.snap
@@ -24,45 +24,96 @@ exports[`Donut chart interactions Should hide callout on mouse leave 1`] = `
             <g>
               <path
                 aria-label="2020/04/30, 20000."
-                class="fui-donut-arc__root"
-                d="M0.55,-54.997A55,55,0,0,1,51.396,-19.582L0,0Z"
+                d="M0.497,-49.747A5,5,0,0,1,6.047,-54.667A55,55,0,0,1,49.18,-24.624A5,5,0,0,1,46.489,-17.713L0,0Z"
                 data-is-focusable="true"
                 id="_Pie_1first20000"
-                opacity="1"
                 role="img"
-                style="fill: #E5E5E5; cursor: default;"
+                style="fill: transparent; cursor: default;"
               />
+              <clippath
+                id="Arc_clip2#E5E5E5_"
+              >
+                <path
+                  d="M0.497,-49.747A5,5,0,0,1,6.047,-54.667A55,55,0,0,1,49.18,-24.624A5,5,0,0,1,46.489,-17.713L0,0Z"
+                />
+              </clippath>
+              <foreignobject
+                clip-path="url(#Arc_clip2#E5E5E5_)"
+                height="100%"
+                width="100%"
+                x="-50%"
+                y="-50%"
+              >
+                <div
+                  class="fui-donut-arc__root"
+                  style="width: 100%; height: 100%; opacity: 1;"
+                />
+              </foreignobject>
             </g>
             <g>
               <path
                 aria-label="2020/04/20, 39000."
-                class="fui-donut-arc__root"
-                d="M51.777,-18.551A55,55,0,0,1,-22.37,50.245L0,0Z"
+                d="M46.834,-16.78A5,5,0,0,1,53.373,-13.28A55,55,0,0,1,-17.233,52.23A5,5,0,0,1,-20.234,45.449L0,0Z"
                 data-is-focusable="true"
                 id="_Pie_1second39000"
-                opacity="1"
                 role="img"
-                style="fill: #0078D4; cursor: default;"
+                style="fill: transparent; cursor: default;"
               />
+              <clippath
+                id="Arc_clip3#0078D4_"
+              >
+                <path
+                  d="M46.834,-16.78A5,5,0,0,1,53.373,-13.28A55,55,0,0,1,-17.233,52.23A5,5,0,0,1,-20.234,45.449L0,0Z"
+                />
+              </clippath>
+              <foreignobject
+                clip-path="url(#Arc_clip3#0078D4_)"
+                height="100%"
+                width="100%"
+                x="-50%"
+                y="-50%"
+              >
+                <div
+                  class="fui-donut-arc__root"
+                  style="width: 100%; height: 100%; opacity: 1;"
+                />
+              </foreignobject>
             </g>
             <g>
               <path
                 aria-label="2020/04/25, 45000."
-                class="fui-donut-arc__root"
-                d="M-23.37,49.788A55,55,0,0,1,-0.55,-54.997L0,0Z"
+                d="M-21.139,45.035A5,5,0,0,1,-28.232,47.201A55,55,0,0,1,-6.047,-54.667A5,5,0,0,1,-0.497,-49.747L0,0Z"
                 data-is-focusable="true"
                 id="_Pie_1third45000"
-                opacity="1"
                 role="img"
-                style="fill: #DADADA; cursor: default;"
+                style="fill: transparent; cursor: default;"
               />
+              <clippath
+                id="Arc_clip4#DADADA_"
+              >
+                <path
+                  d="M-21.139,45.035A5,5,0,0,1,-28.232,47.201A55,55,0,0,1,-6.047,-54.667A5,5,0,0,1,-0.497,-49.747L0,0Z"
+                />
+              </clippath>
+              <foreignobject
+                clip-path="url(#Arc_clip4#DADADA_)"
+                height="100%"
+                width="100%"
+                x="-50%"
+                y="-50%"
+              >
+                <div
+                  class="fui-donut-arc__root"
+                  style="width: 100%; height: 100%; opacity: 1;"
+                />
+              </foreignobject>
             </g>
           </g>
         </svg>
       </div>
       <div
         class="fui-cart__calloutContainer"
-        id="callout2"
+        id="callout5"
       />
       <div
         class="fui-donut__legendContainer"
@@ -146,7 +197,7 @@ exports[`Donut chart interactions Should hide callout on mouse leave 1`] = `
 exports[`Donut chart interactions Should reflect theme change 1`] = `
 <div>
   <div
-    class="fui-FluentProvider fui-FluentProvider32"
+    class="fui-FluentProvider fui-FluentProvider59"
     dir="ltr"
   >
     <div
@@ -171,45 +222,96 @@ exports[`Donut chart interactions Should reflect theme change 1`] = `
               <g>
                 <path
                   aria-label="2020/04/30, 20000."
-                  class="fui-donut-arc__root"
-                  d="M0.55,-54.997A55,55,0,0,1,51.396,-19.582L0,0Z"
+                  d="M0.497,-49.747A5,5,0,0,1,6.047,-54.667A55,55,0,0,1,49.18,-24.624A5,5,0,0,1,46.489,-17.713L0,0Z"
                   data-is-focusable="true"
-                  id="_Pie_33first20000"
-                  opacity="1"
+                  id="_Pie_60first20000"
                   role="img"
-                  style="fill: #E5E5E5; cursor: default;"
+                  style="fill: transparent; cursor: default;"
                 />
+                <clippath
+                  id="Arc_clip61#E5E5E5_"
+                >
+                  <path
+                    d="M0.497,-49.747A5,5,0,0,1,6.047,-54.667A55,55,0,0,1,49.18,-24.624A5,5,0,0,1,46.489,-17.713L0,0Z"
+                  />
+                </clippath>
+                <foreignobject
+                  clip-path="url(#Arc_clip61#E5E5E5_)"
+                  height="100%"
+                  width="100%"
+                  x="-50%"
+                  y="-50%"
+                >
+                  <div
+                    class="fui-donut-arc__root"
+                    style="width: 100%; height: 100%; opacity: 1;"
+                  />
+                </foreignobject>
               </g>
               <g>
                 <path
                   aria-label="2020/04/20, 39000."
-                  class="fui-donut-arc__root"
-                  d="M51.777,-18.551A55,55,0,0,1,-22.37,50.245L0,0Z"
+                  d="M46.834,-16.78A5,5,0,0,1,53.373,-13.28A55,55,0,0,1,-17.233,52.23A5,5,0,0,1,-20.234,45.449L0,0Z"
                   data-is-focusable="true"
-                  id="_Pie_33second39000"
-                  opacity="1"
+                  id="_Pie_60second39000"
                   role="img"
-                  style="fill: #0078D4; cursor: default;"
+                  style="fill: transparent; cursor: default;"
                 />
+                <clippath
+                  id="Arc_clip62#0078D4_"
+                >
+                  <path
+                    d="M46.834,-16.78A5,5,0,0,1,53.373,-13.28A55,55,0,0,1,-17.233,52.23A5,5,0,0,1,-20.234,45.449L0,0Z"
+                  />
+                </clippath>
+                <foreignobject
+                  clip-path="url(#Arc_clip62#0078D4_)"
+                  height="100%"
+                  width="100%"
+                  x="-50%"
+                  y="-50%"
+                >
+                  <div
+                    class="fui-donut-arc__root"
+                    style="width: 100%; height: 100%; opacity: 1;"
+                  />
+                </foreignobject>
               </g>
               <g>
                 <path
                   aria-label="2020/04/25, 45000."
-                  class="fui-donut-arc__root"
-                  d="M-23.37,49.788A55,55,0,0,1,-0.55,-54.997L0,0Z"
+                  d="M-21.139,45.035A5,5,0,0,1,-28.232,47.201A55,55,0,0,1,-6.047,-54.667A5,5,0,0,1,-0.497,-49.747L0,0Z"
                   data-is-focusable="true"
-                  id="_Pie_33third45000"
-                  opacity="1"
+                  id="_Pie_60third45000"
                   role="img"
-                  style="fill: #DADADA; cursor: default;"
+                  style="fill: transparent; cursor: default;"
                 />
+                <clippath
+                  id="Arc_clip63#DADADA_"
+                >
+                  <path
+                    d="M-21.139,45.035A5,5,0,0,1,-28.232,47.201A55,55,0,0,1,-6.047,-54.667A5,5,0,0,1,-0.497,-49.747L0,0Z"
+                  />
+                </clippath>
+                <foreignobject
+                  clip-path="url(#Arc_clip63#DADADA_)"
+                  height="100%"
+                  width="100%"
+                  x="-50%"
+                  y="-50%"
+                >
+                  <div
+                    class="fui-donut-arc__root"
+                    style="width: 100%; height: 100%; opacity: 1;"
+                  />
+                </foreignobject>
               </g>
             </g>
           </svg>
         </div>
         <div
           class="fui-cart__calloutContainer"
-          id="callout34"
+          id="callout64"
         />
         <div
           class="fui-donut__legendContainer"

--- a/packages/charts/react-charts-preview/library/src/components/HorizontalBarChart/HorizontalBarChart.test.tsx
+++ b/packages/charts/react-charts-preview/library/src/components/HorizontalBarChart/HorizontalBarChart.test.tsx
@@ -23,7 +23,7 @@ export const chartPoints: ChartProps[] = [
       {
         legend: 'one',
         horizontalBarChartdata: { x: 1543, y: 15000 },
-        color: '#004b50',
+        gradient: ['#004b50', ''],
         xAxisCalloutData: '2020/04/30',
         yAxisCalloutData: '94%',
       },
@@ -35,7 +35,7 @@ export const chartPoints: ChartProps[] = [
       {
         legend: 'two',
         horizontalBarChartdata: { x: 800, y: 15000 },
-        color: '#5c2d91',
+        gradient: ['#5c2d91', ''],
         xAxisCalloutData: '2020/04/30',
         yAxisCalloutData: '19%',
       },

--- a/packages/charts/react-charts-preview/library/src/components/HorizontalBarChart/HorizontalBarChart.tsx
+++ b/packages/charts/react-charts-preview/library/src/components/HorizontalBarChart/HorizontalBarChart.tsx
@@ -2,9 +2,15 @@ import * as React from 'react';
 import { useHorizontalBarChartStyles_unstable } from './useHorizontalBarChartStyles.styles';
 import { ChartProps, HorizontalBarChartProps, ChartDataPoint, RefArrayData, HorizontalBarChartVariant } from './index';
 import { convertToLocaleString } from '../../utilities/locale-util';
-import { formatValueWithSIPrefix, getAccessibleDataObject, useRtl } from '../../utilities/index';
+import {
+  DataVizGradientPalette,
+  formatValueWithSIPrefix,
+  getAccessibleDataObject,
+  getGradientFromToken,
+  getNextGradient,
+  useRtl,
+} from '../../utilities/index';
 import { useId } from '@fluentui/react-utilities';
-import { tokens } from '@fluentui/react-theme';
 import { useFocusableGroup } from '@fluentui/react-tabster';
 import { ChartPopover } from '../CommonComponents/ChartPopover';
 import { FocusableTooltipText } from '../../utilities/FocusableTooltipText';
@@ -27,6 +33,7 @@ export const HorizontalBarChart: React.FunctionComponent<HorizontalBarChartProps
   const _isRTL: boolean = useRtl();
   const barChartSvgRef: React.RefObject<SVGSVGElement> = React.createRef<SVGSVGElement>();
   const _emptyChartId: string = useId('_HBC_empty');
+  const _gradientId = useId('HBC_Gradient');
 
   const [hoverValue, setHoverValue] = React.useState<string | number | Date | null>('');
   const [lineColor, setLineColor] = React.useState<string>('');
@@ -51,7 +58,7 @@ export const HorizontalBarChart: React.FunctionComponent<HorizontalBarChartProps
       _calloutAnchorPoint = point;
       updatePosition(event.clientX, event.clientY);
       setHoverValue(hoverVal);
-      setLineColor(point.color!);
+      setLineColor(point.gradient![0]);
       setLegend(point.legend!);
       setXCalloutValue(point.xAxisCalloutData!);
       setYCalloutValue(point.yAxisCalloutData!);
@@ -141,18 +148,12 @@ export const HorizontalBarChart: React.FunctionComponent<HorizontalBarChartProps
    * Extra margin is also provided, in the x value to provide some spacing in between the bars
    */
 
-  function _createBars(data: ChartProps): JSX.Element[] {
+  function _createBars(data: ChartProps, dataPointIndex: number): JSX.Element[] {
     const noOfBars =
       data.chartData?.reduce((count: number, point: ChartDataPoint) => (count += (point.data || 0) > 0 ? 1 : 0), 0) ||
       1;
     const totalMarginPercent = barSpacingInPercent * (noOfBars - 1);
-    const defaultColors: string[] = [
-      tokens.colorPaletteBlueForeground2,
-      tokens.colorPaletteCornflowerForeground2,
-      tokens.colorPaletteDarkGreenForeground2,
-      tokens.colorPaletteNavyForeground2,
-      tokens.colorPaletteDarkOrangeForeground2,
-    ];
+
     // calculating starting point of each bar and it's range
     const startingPoint: number[] = [];
     const total = data.chartData!.reduce(
@@ -188,7 +189,6 @@ export const HorizontalBarChart: React.FunctionComponent<HorizontalBarChartProps
     const scalingRatio = sumOfPercent !== 0 ? (sumOfPercent - totalMarginPercent) / 100 : 1;
 
     const bars = data.chartData!.map((point: ChartDataPoint, index: number) => {
-      const color: string = point.color ? point.color : defaultColors[Math.floor(Math.random() * 4 + 1)];
       const pointData = point.horizontalBarChartdata!.x ? point.horizontalBarChartdata!.x : 0;
       if (index > 0) {
         prevPosition += value;
@@ -229,39 +229,58 @@ export const HorizontalBarChart: React.FunctionComponent<HorizontalBarChartProps
         );
       }
 
+      const gradientId = _gradientId + `_${dataPointIndex}_${index}`;
+
       return (
-        <rect
-          key={index}
-          x={`${
-            _isRTL
-              ? 100 - startingPoint[index] - value - index * barSpacingInPercent
-              : startingPoint[index] + index * barSpacingInPercent
-          }%`}
-          y={0}
-          data-is-focusable={point.legend !== '' ? true : false}
-          width={value + '%'}
-          height={_barHeight}
-          fill={color}
-          onMouseOver={point.legend !== '' ? event => _hoverOn(event, xValue, point) : undefined}
-          onFocus={point.legend !== '' ? event => _hoverOn.bind(event, xValue, point) : undefined}
-          role="img"
-          aria-label={_getAriaLabel(point)}
-          onBlur={_hoverOff}
-          onMouseLeave={_hoverOff}
-          className={classes.barWrapper}
-          tabIndex={point.legend !== '' ? 0 : undefined}
-        />
+        <>
+          <defs>
+            <linearGradient id={gradientId}>
+              <stop offset="0" stopColor={point.gradient?.[0]} />
+              <stop offset="100%" stopColor={point.gradient?.[1]} />
+            </linearGradient>
+          </defs>
+          <rect
+            key={index}
+            x={`${
+              _isRTL
+                ? 100 - startingPoint[index] - value - index * barSpacingInPercent
+                : startingPoint[index] + index * barSpacingInPercent
+            }%`}
+            y={0}
+            rx={4}
+            data-is-focusable={point.legend !== '' ? true : false}
+            width={value + '%'}
+            height={_barHeight}
+            fill={`url(#${gradientId})`}
+            onMouseOver={point.legend !== '' ? event => _hoverOn(event, xValue, point) : undefined}
+            onFocus={point.legend !== '' ? event => _hoverOn.bind(event, xValue, point) : undefined}
+            role="img"
+            aria-label={_getAriaLabel(point)}
+            onBlur={_hoverOff}
+            onMouseLeave={_hoverOff}
+            className={classes.barWrapper}
+            tabIndex={point.legend !== '' ? 0 : undefined}
+          />
+        </>
       );
     });
     return bars;
   }
 
+  function _addDefaultGradients(dataPoints: ChartDataPoint[], chartDataIndex: number): ChartDataPoint[] {
+    return dataPoints
+      ? dataPoints.map((item, index) => {
+          return { ...item, gradient: item.gradient ?? getNextGradient(chartDataIndex, 0) };
+        })
+      : [];
+  }
+
   const _getAriaLabel = (point: ChartDataPoint): string => {
-    const legend = point.xAxisCalloutData || point.legend;
+    const pointLegend = point.xAxisCalloutData || point.legend;
     const yValue =
       point.yAxisCalloutData ||
       (point.horizontalBarChartdata ? `${point.horizontalBarChartdata.x}/${point.horizontalBarChartdata.y}` : 0);
-    return point.callOutAccessibilityData?.ariaLabel || (legend ? `${legend}, ` : '') + `${yValue}.`;
+    return point.callOutAccessibilityData?.ariaLabel || (pointLegend ? `${pointLegend}, ` : '') + `${yValue}.`;
   };
 
   function _isChartEmpty(): boolean {
@@ -296,9 +315,13 @@ export const HorizontalBarChart: React.FunctionComponent<HorizontalBarChartProps
   const focusAttributes = useFocusableGroup();
 
   let datapoint: number | undefined = 0;
+
   return !_isChartEmpty() ? (
     <div className={classes.root} onMouseLeave={_handleChartMouseLeave}>
       {data!.map((points: ChartProps, index: number) => {
+        // Add default gradients if not present
+        points = { ...points, chartData: _addDefaultGradients(points.chartData!, index) };
+
         if (points.chartData && points.chartData![0] && points.chartData![0].horizontalBarChartdata!.x) {
           datapoint = points.chartData![0].horizontalBarChartdata!.x;
         } else {
@@ -310,13 +333,13 @@ export const HorizontalBarChart: React.FunctionComponent<HorizontalBarChartProps
             x: points.chartData![0].horizontalBarChartdata!.y - datapoint!,
             y: points.chartData![0].horizontalBarChartdata!.y,
           },
-          color: tokens.colorBackgroundOverlay,
+          gradient: getGradientFromToken(DataVizGradientPalette.disabled),
         };
 
         // Hide right side text of chart title for absolute-scale variant
         const chartDataText =
           props.variant === HorizontalBarChartVariant.AbsoluteScale ? null : _getChartDataText(points!);
-        const bars = _createBars(points!);
+        const bars = _createBars(points!, index);
         const keyVal = _uniqLineText + '_' + index;
         // ToDo - Showtriangle property is per data series. How to account for it in the new stylesheet
         /*         const classes = useHorizontalBarChartStyles_unstable(props.styles!, {

--- a/packages/charts/react-charts-preview/library/src/components/HorizontalBarChart/HorizontalBarChart.tsx
+++ b/packages/charts/react-charts-preview/library/src/components/HorizontalBarChart/HorizontalBarChart.tsx
@@ -232,9 +232,9 @@ export const HorizontalBarChart: React.FunctionComponent<HorizontalBarChartProps
       const gradientId = _gradientId + `_${dataPointIndex}_${index}`;
 
       return (
-        <>
+        <React.Fragment key={index}>
           <defs>
-            <linearGradient id={gradientId}>
+            <linearGradient id={gradientId} className='HBC_gradient'>
               <stop offset="0" stopColor={point.gradient?.[0]} />
               <stop offset="100%" stopColor={point.gradient?.[1]} />
             </linearGradient>
@@ -261,7 +261,7 @@ export const HorizontalBarChart: React.FunctionComponent<HorizontalBarChartProps
             className={classes.barWrapper}
             tabIndex={point.legend !== '' ? 0 : undefined}
           />
-        </>
+        </React.Fragment>
       );
     });
     return bars;

--- a/packages/charts/react-charts-preview/library/src/components/HorizontalBarChart/HorizontalBarChartRTL.test.tsx
+++ b/packages/charts/react-charts-preview/library/src/components/HorizontalBarChart/HorizontalBarChartRTL.test.tsx
@@ -5,6 +5,7 @@ import { HorizontalBarChart } from './HorizontalBarChart';
 import { getByClass, getById, testWithWait, testWithoutWait } from '../../utilities/TestUtility.test';
 import { HorizontalBarChartVariant, ChartProps } from './index';
 import { axe, toHaveNoViolations } from 'jest-axe';
+import { DataVizGradientPalette, getGradientFromToken } from '../../utilities/gradients';
 
 expect.extend(toHaveNoViolations);
 
@@ -88,14 +89,18 @@ describe('Horizontal bar chart - Subcomponent bar', () => {
     { data: chartPoints },
     container => {
       // colors mentioned in the data points itself
+
+      // find the gradients and check their stop color
+      const gradients = getByClass(container, /HBC_gradient/i);
+
+      const disabledColor = getGradientFromToken(DataVizGradientPalette.disabled)[0];
       // Assert
-      const bars = getByClass(container, /barWrapper/);
-      expect(bars[0].getAttribute('fill')).toEqual('#004b50');
-      expect(bars[1].getAttribute('fill')).toEqual('var(--colorBackgroundOverlay)');
-      expect(bars[2].getAttribute('fill')).toEqual('#5c2d91');
-      expect(bars[3].getAttribute('fill')).toEqual('var(--colorBackgroundOverlay)');
-      expect(bars[4].getAttribute('fill')).toEqual('#a4262c');
-      expect(bars[5].getAttribute('fill')).toEqual('var(--colorBackgroundOverlay)');
+      expect(gradients[0].querySelector('stop')?.getAttribute('stop-color')).toEqual('#004b50');
+      expect(gradients[1].querySelector('stop')?.getAttribute('stop-color')).toEqual(disabledColor);
+      expect(gradients[2].querySelector('stop')?.getAttribute('stop-color')).toEqual('#5c2d91');
+      expect(gradients[3].querySelector('stop')?.getAttribute('stop-color')).toEqual(disabledColor);
+      expect(gradients[4].querySelector('stop')?.getAttribute('stop-color')).toEqual('#a4262c');
+      expect(gradients[5].querySelector('stop')?.getAttribute('stop-color')).toEqual(disabledColor);
     },
   );
 

--- a/packages/charts/react-charts-preview/library/src/components/HorizontalBarChart/HorizontalBarChartRTL.test.tsx
+++ b/packages/charts/react-charts-preview/library/src/components/HorizontalBarChart/HorizontalBarChartRTL.test.tsx
@@ -15,7 +15,7 @@ const chartPoints: ChartProps[] = [
       {
         legend: 'one',
         horizontalBarChartdata: { x: 1543, y: 15000 },
-        color: '#004b50',
+        gradient: ['#004b50', ''],
         xAxisCalloutData: '2020/04/30',
         yAxisCalloutData: '10%',
       },
@@ -27,7 +27,7 @@ const chartPoints: ChartProps[] = [
       {
         legend: 'two',
         horizontalBarChartdata: { x: 800, y: 15000 },
-        color: '#5c2d91',
+        gradient: ['#5c2d91', ''],
         xAxisCalloutData: '2020/04/30',
         yAxisCalloutData: '5%',
       },
@@ -39,7 +39,7 @@ const chartPoints: ChartProps[] = [
       {
         legend: 'three',
         horizontalBarChartdata: { x: 8888, y: 15000 },
-        color: '#a4262c',
+        gradient: ['#a4262c', ''],
         xAxisCalloutData: '2020/04/30',
         yAxisCalloutData: '59%',
       },
@@ -50,15 +50,15 @@ const chartPoints: ChartProps[] = [
 const chartPointsWithBenchMark: ChartProps[] = [
   {
     chartTitle: 'one',
-    chartData: [{ legend: 'one', data: 50, horizontalBarChartdata: { x: 10, y: 100 }, color: '#004b50' }],
+    chartData: [{ legend: 'one', data: 50, horizontalBarChartdata: { x: 10, y: 100 }, gradient: ['#004b50', ''] }],
   },
   {
     chartTitle: 'two',
-    chartData: [{ legend: 'two', data: 30, horizontalBarChartdata: { x: 30, y: 200 }, color: '#5c2d91' }],
+    chartData: [{ legend: 'two', data: 30, horizontalBarChartdata: { x: 30, y: 200 }, gradient: ['#5c2d91', ''] }],
   },
   {
     chartTitle: 'three',
-    chartData: [{ legend: 'three', data: 5, horizontalBarChartdata: { x: 15, y: 50 }, color: '#a4262c' }],
+    chartData: [{ legend: 'three', data: 5, horizontalBarChartdata: { x: 15, y: 50 }, gradient: ['#a4262c', ''] }],
   },
 ];
 

--- a/packages/charts/react-charts-preview/library/src/components/HorizontalBarChart/__snapshots__/HorizontalBarChart.test.tsx.snap
+++ b/packages/charts/react-charts-preview/library/src/components/HorizontalBarChart/__snapshots__/HorizontalBarChart.test.tsx.snap
@@ -52,11 +52,25 @@ exports[`HorizontalBarChart - mouse events Should render callout correctly on mo
           key="_HorizontalLine_lllllm_0"
           onClick={[Function]}
         >
+          <defs>
+            <linearGradient
+              id="HBC_Gradient42_0_0"
+            >
+              <stop
+                offset="0"
+                stopColor="#004b50"
+              />
+              <stop
+                offset="100%"
+                stopColor=""
+              />
+            </linearGradient>
+          </defs>
           <rect
             aria-label="2020/04/30, 94%."
             className="fui-hbc__barWrapper"
             data-is-focusable={true}
-            fill="#004b50"
+            fill="url(#HBC_Gradient42_0_0)"
             height={12}
             key="0"
             onBlur={[Function]}
@@ -64,21 +78,37 @@ exports[`HorizontalBarChart - mouse events Should render callout correctly on mo
             onMouseLeave={[Function]}
             onMouseOver={[Function]}
             role="img"
+            rx={4}
             tabIndex={0}
             width="10.286666666666665%"
             x="0%"
             y={0}
           />
+          <defs>
+            <linearGradient
+              id="HBC_Gradient42_0_1"
+            >
+              <stop
+                offset="0"
+                stopColor="#E6E6E6"
+              />
+              <stop
+                offset="100%"
+                stopColor="#E6E6E6"
+              />
+            </linearGradient>
+          </defs>
           <rect
             aria-label="13457/15000."
             className="fui-hbc__barWrapper"
             data-is-focusable={false}
-            fill="var(--colorBackgroundOverlay)"
+            fill="url(#HBC_Gradient42_0_1)"
             height={12}
             key="1"
             onBlur={[Function]}
             onMouseLeave={[Function]}
             role="img"
+            rx={4}
             width="89.71333333333334%"
             x="10.286666666666665%"
             y={0}
@@ -134,11 +164,25 @@ exports[`HorizontalBarChart - mouse events Should render callout correctly on mo
           key="_HorizontalLine_lllllm_1"
           onClick={[Function]}
         >
+          <defs>
+            <linearGradient
+              id="HBC_Gradient42_1_0"
+            >
+              <stop
+                offset="0"
+                stopColor="#5c2d91"
+              />
+              <stop
+                offset="100%"
+                stopColor=""
+              />
+            </linearGradient>
+          </defs>
           <rect
             aria-label="2020/04/30, 19%."
             className="fui-hbc__barWrapper"
             data-is-focusable={true}
-            fill="#5c2d91"
+            fill="url(#HBC_Gradient42_1_0)"
             height={12}
             key="0"
             onBlur={[Function]}
@@ -146,21 +190,37 @@ exports[`HorizontalBarChart - mouse events Should render callout correctly on mo
             onMouseLeave={[Function]}
             onMouseOver={[Function]}
             role="img"
+            rx={4}
             tabIndex={0}
             width="5.333333333333334%"
             x="0%"
             y={0}
           />
+          <defs>
+            <linearGradient
+              id="HBC_Gradient42_1_1"
+            >
+              <stop
+                offset="0"
+                stopColor="#E6E6E6"
+              />
+              <stop
+                offset="100%"
+                stopColor="#E6E6E6"
+              />
+            </linearGradient>
+          </defs>
           <rect
             aria-label="14200/15000."
             className="fui-hbc__barWrapper"
             data-is-focusable={false}
-            fill="var(--colorBackgroundOverlay)"
+            fill="url(#HBC_Gradient42_1_1)"
             height={12}
             key="1"
             onBlur={[Function]}
             onMouseLeave={[Function]}
             role="img"
+            rx={4}
             width="94.66666666666667%"
             x="5.333333333333334%"
             y={0}
@@ -171,7 +231,7 @@ exports[`HorizontalBarChart - mouse events Should render callout correctly on mo
   </div>
   <div
     className="fui-cart__calloutContainer"
-    id="callout36"
+    id="callout45"
   />
 </div>
 `;
@@ -228,11 +288,25 @@ exports[`HorizontalBarChart - mouse events Should render customized callout on m
           key="_HorizontalLine_lllllm_0"
           onClick={[Function]}
         >
+          <defs>
+            <linearGradient
+              id="HBC_Gradient47_0_0"
+            >
+              <stop
+                offset="0"
+                stopColor="#004b50"
+              />
+              <stop
+                offset="100%"
+                stopColor=""
+              />
+            </linearGradient>
+          </defs>
           <rect
             aria-label="2020/04/30, 94%."
             className="fui-hbc__barWrapper"
             data-is-focusable={true}
-            fill="#004b50"
+            fill="url(#HBC_Gradient47_0_0)"
             height={12}
             key="0"
             onBlur={[Function]}
@@ -240,21 +314,37 @@ exports[`HorizontalBarChart - mouse events Should render customized callout on m
             onMouseLeave={[Function]}
             onMouseOver={[Function]}
             role="img"
+            rx={4}
             tabIndex={0}
             width="10.286666666666665%"
             x="0%"
             y={0}
           />
+          <defs>
+            <linearGradient
+              id="HBC_Gradient47_0_1"
+            >
+              <stop
+                offset="0"
+                stopColor="#E6E6E6"
+              />
+              <stop
+                offset="100%"
+                stopColor="#E6E6E6"
+              />
+            </linearGradient>
+          </defs>
           <rect
             aria-label="13457/15000."
             className="fui-hbc__barWrapper"
             data-is-focusable={false}
-            fill="var(--colorBackgroundOverlay)"
+            fill="url(#HBC_Gradient47_0_1)"
             height={12}
             key="1"
             onBlur={[Function]}
             onMouseLeave={[Function]}
             role="img"
+            rx={4}
             width="89.71333333333334%"
             x="10.286666666666665%"
             y={0}
@@ -310,11 +400,25 @@ exports[`HorizontalBarChart - mouse events Should render customized callout on m
           key="_HorizontalLine_lllllm_1"
           onClick={[Function]}
         >
+          <defs>
+            <linearGradient
+              id="HBC_Gradient47_1_0"
+            >
+              <stop
+                offset="0"
+                stopColor="#5c2d91"
+              />
+              <stop
+                offset="100%"
+                stopColor=""
+              />
+            </linearGradient>
+          </defs>
           <rect
             aria-label="2020/04/30, 19%."
             className="fui-hbc__barWrapper"
             data-is-focusable={true}
-            fill="#5c2d91"
+            fill="url(#HBC_Gradient47_1_0)"
             height={12}
             key="0"
             onBlur={[Function]}
@@ -322,21 +426,37 @@ exports[`HorizontalBarChart - mouse events Should render customized callout on m
             onMouseLeave={[Function]}
             onMouseOver={[Function]}
             role="img"
+            rx={4}
             tabIndex={0}
             width="5.333333333333334%"
             x="0%"
             y={0}
           />
+          <defs>
+            <linearGradient
+              id="HBC_Gradient47_1_1"
+            >
+              <stop
+                offset="0"
+                stopColor="#E6E6E6"
+              />
+              <stop
+                offset="100%"
+                stopColor="#E6E6E6"
+              />
+            </linearGradient>
+          </defs>
           <rect
             aria-label="14200/15000."
             className="fui-hbc__barWrapper"
             data-is-focusable={false}
-            fill="var(--colorBackgroundOverlay)"
+            fill="url(#HBC_Gradient47_1_1)"
             height={12}
             key="1"
             onBlur={[Function]}
             onMouseLeave={[Function]}
             role="img"
+            rx={4}
             width="94.66666666666667%"
             x="5.333333333333334%"
             y={0}
@@ -347,7 +467,7 @@ exports[`HorizontalBarChart - mouse events Should render customized callout on m
   </div>
   <div
     className="fui-cart__calloutContainer"
-    id="callout40"
+    id="callout50"
   />
 </div>
 `;
@@ -392,17 +512,32 @@ exports[`HorizontalBarChart snapShot testing Should not render bar labels in abs
           id="_HorizontalLine_lllllm_0"
           onClick={[Function]}
         >
+          <defs>
+            <linearGradient
+              id="HBC_Gradient7_0_0"
+            >
+              <stop
+                offset="0"
+                stopColor="#004b50"
+              />
+              <stop
+                offset="100%"
+                stopColor=""
+              />
+            </linearGradient>
+          </defs>
           <rect
             aria-label="2020/04/30, 94%."
             className="fui-hbc__barWrapper"
             data-is-focusable={true}
-            fill="#004b50"
+            fill="url(#HBC_Gradient7_0_0)"
             height={12}
             onBlur={[Function]}
             onFocus={[Function]}
             onMouseLeave={[Function]}
             onMouseOver={[Function]}
             role="img"
+            rx={4}
             tabIndex={0}
             width="10.286666666666665%"
             x="0%"
@@ -448,17 +583,32 @@ exports[`HorizontalBarChart snapShot testing Should not render bar labels in abs
           id="_HorizontalLine_lllllm_1"
           onClick={[Function]}
         >
+          <defs>
+            <linearGradient
+              id="HBC_Gradient7_1_0"
+            >
+              <stop
+                offset="0"
+                stopColor="#5c2d91"
+              />
+              <stop
+                offset="100%"
+                stopColor=""
+              />
+            </linearGradient>
+          </defs>
           <rect
             aria-label="2020/04/30, 19%."
             className="fui-hbc__barWrapper"
             data-is-focusable={true}
-            fill="#5c2d91"
+            fill="url(#HBC_Gradient7_1_0)"
             height={12}
             onBlur={[Function]}
             onFocus={[Function]}
             onMouseLeave={[Function]}
             onMouseOver={[Function]}
             role="img"
+            rx={4}
             tabIndex={0}
             width="5.333333333333334%"
             x="0%"
@@ -471,7 +621,7 @@ exports[`HorizontalBarChart snapShot testing Should not render bar labels in abs
   </div>
   <div
     className="fui-cart__calloutContainer"
-    id="callout8"
+    id="callout10"
   />
 </div>
 `;
@@ -516,17 +666,32 @@ exports[`HorizontalBarChart snapShot testing Should render absolute-scale varian
           id="_HorizontalLine_lllllm_0"
           onClick={[Function]}
         >
+          <defs>
+            <linearGradient
+              id="HBC_Gradient2_0_0"
+            >
+              <stop
+                offset="0"
+                stopColor="#004b50"
+              />
+              <stop
+                offset="100%"
+                stopColor=""
+              />
+            </linearGradient>
+          </defs>
           <rect
             aria-label="2020/04/30, 94%."
             className="fui-hbc__barWrapper"
             data-is-focusable={true}
-            fill="#004b50"
+            fill="url(#HBC_Gradient2_0_0)"
             height={12}
             onBlur={[Function]}
             onFocus={[Function]}
             onMouseLeave={[Function]}
             onMouseOver={[Function]}
             role="img"
+            rx={4}
             tabIndex={0}
             width="10.286666666666665%"
             x="0%"
@@ -581,17 +746,32 @@ exports[`HorizontalBarChart snapShot testing Should render absolute-scale varian
           id="_HorizontalLine_lllllm_1"
           onClick={[Function]}
         >
+          <defs>
+            <linearGradient
+              id="HBC_Gradient2_1_0"
+            >
+              <stop
+                offset="0"
+                stopColor="#5c2d91"
+              />
+              <stop
+                offset="100%"
+                stopColor=""
+              />
+            </linearGradient>
+          </defs>
           <rect
             aria-label="2020/04/30, 19%."
             className="fui-hbc__barWrapper"
             data-is-focusable={true}
-            fill="#5c2d91"
+            fill="url(#HBC_Gradient2_1_0)"
             height={12}
             onBlur={[Function]}
             onFocus={[Function]}
             onMouseLeave={[Function]}
             onMouseOver={[Function]}
             role="img"
+            rx={4}
             tabIndex={0}
             width="5.333333333333334%"
             x="0%"
@@ -613,7 +793,7 @@ exports[`HorizontalBarChart snapShot testing Should render absolute-scale varian
   </div>
   <div
     className="fui-cart__calloutContainer"
-    id="callout4"
+    id="callout5"
   />
 </div>
 `;

--- a/packages/charts/react-charts-preview/library/src/components/HorizontalBarChart/__snapshots__/HorizontalBarChartRTL.test.tsx.snap
+++ b/packages/charts/react-charts-preview/library/src/components/HorizontalBarChart/__snapshots__/HorizontalBarChartRTL.test.tsx.snap
@@ -42,25 +42,55 @@ exports[`Horizontal bar chart - Screen resolution Should remain unchanged on zoo
           <g
             id="_HorizontalLine_lllllm_0"
           >
+            <defs>
+              <lineargradient
+                id="HBC_Gradient80_0_0"
+              >
+                <stop
+                  offset="0"
+                  stop-color="#004b50"
+                />
+                <stop
+                  offset="100%"
+                  stop-color=""
+                />
+              </lineargradient>
+            </defs>
             <rect
               aria-label="2020/04/30, 10%."
               class="fui-hbc__barWrapper"
               data-is-focusable="true"
-              fill="#004b50"
+              fill="url(#HBC_Gradient80_0_0)"
               height="12"
               role="img"
+              rx="4"
               tabindex="0"
               width="10.286666666666665%"
               x="0%"
               y="0"
             />
+            <defs>
+              <lineargradient
+                id="HBC_Gradient80_0_1"
+              >
+                <stop
+                  offset="0"
+                  stop-color="#E6E6E6"
+                />
+                <stop
+                  offset="100%"
+                  stop-color="#E6E6E6"
+                />
+              </lineargradient>
+            </defs>
             <rect
               aria-label="13457/15000."
               class="fui-hbc__barWrapper"
               data-is-focusable="false"
-              fill="var(--colorBackgroundOverlay)"
+              fill="url(#HBC_Gradient80_0_1)"
               height="12"
               role="img"
+              rx="4"
               width="89.71333333333334%"
               x="10.286666666666665%"
               y="0"
@@ -106,25 +136,55 @@ exports[`Horizontal bar chart - Screen resolution Should remain unchanged on zoo
           <g
             id="_HorizontalLine_lllllm_1"
           >
+            <defs>
+              <lineargradient
+                id="HBC_Gradient80_1_0"
+              >
+                <stop
+                  offset="0"
+                  stop-color="#5c2d91"
+                />
+                <stop
+                  offset="100%"
+                  stop-color=""
+                />
+              </lineargradient>
+            </defs>
             <rect
               aria-label="2020/04/30, 5%."
               class="fui-hbc__barWrapper"
               data-is-focusable="true"
-              fill="#5c2d91"
+              fill="url(#HBC_Gradient80_1_0)"
               height="12"
               role="img"
+              rx="4"
               tabindex="0"
               width="5.333333333333334%"
               x="0%"
               y="0"
             />
+            <defs>
+              <lineargradient
+                id="HBC_Gradient80_1_1"
+              >
+                <stop
+                  offset="0"
+                  stop-color="#E6E6E6"
+                />
+                <stop
+                  offset="100%"
+                  stop-color="#E6E6E6"
+                />
+              </lineargradient>
+            </defs>
             <rect
               aria-label="14200/15000."
               class="fui-hbc__barWrapper"
               data-is-focusable="false"
-              fill="var(--colorBackgroundOverlay)"
+              fill="url(#HBC_Gradient80_1_1)"
               height="12"
               role="img"
+              rx="4"
               width="94.66666666666667%"
               x="5.333333333333334%"
               y="0"
@@ -170,25 +230,55 @@ exports[`Horizontal bar chart - Screen resolution Should remain unchanged on zoo
           <g
             id="_HorizontalLine_lllllm_2"
           >
+            <defs>
+              <lineargradient
+                id="HBC_Gradient80_2_0"
+              >
+                <stop
+                  offset="0"
+                  stop-color="#a4262c"
+                />
+                <stop
+                  offset="100%"
+                  stop-color=""
+                />
+              </lineargradient>
+            </defs>
             <rect
               aria-label="2020/04/30, 59%."
               class="fui-hbc__barWrapper"
               data-is-focusable="true"
-              fill="#a4262c"
+              fill="url(#HBC_Gradient80_2_0)"
               height="12"
               role="img"
+              rx="4"
               tabindex="0"
               width="59.25333333333334%"
               x="0%"
               y="0"
             />
+            <defs>
+              <lineargradient
+                id="HBC_Gradient80_2_1"
+              >
+                <stop
+                  offset="0"
+                  stop-color="#E6E6E6"
+                />
+                <stop
+                  offset="100%"
+                  stop-color="#E6E6E6"
+                />
+              </lineargradient>
+            </defs>
             <rect
               aria-label="6112/15000."
               class="fui-hbc__barWrapper"
               data-is-focusable="false"
-              fill="var(--colorBackgroundOverlay)"
+              fill="url(#HBC_Gradient80_2_1)"
               height="12"
               role="img"
+              rx="4"
               width="40.74666666666666%"
               x="59.25333333333334%"
               y="0"
@@ -199,7 +289,7 @@ exports[`Horizontal bar chart - Screen resolution Should remain unchanged on zoo
     </div>
     <div
       class="fui-cart__calloutContainer"
-      id="callout70"
+      id="callout84"
     />
   </div>
 </div>
@@ -247,25 +337,55 @@ exports[`Horizontal bar chart - Screen resolution Should remain unchanged on zoo
           <g
             id="_HorizontalLine_lllllm_0"
           >
+            <defs>
+              <lineargradient
+                id="HBC_Gradient86_0_0"
+              >
+                <stop
+                  offset="0"
+                  stop-color="#004b50"
+                />
+                <stop
+                  offset="100%"
+                  stop-color=""
+                />
+              </lineargradient>
+            </defs>
             <rect
               aria-label="2020/04/30, 10%."
               class="fui-hbc__barWrapper"
               data-is-focusable="true"
-              fill="#004b50"
+              fill="url(#HBC_Gradient86_0_0)"
               height="12"
               role="img"
+              rx="4"
               tabindex="0"
               width="10.286666666666665%"
               x="0%"
               y="0"
             />
+            <defs>
+              <lineargradient
+                id="HBC_Gradient86_0_1"
+              >
+                <stop
+                  offset="0"
+                  stop-color="#E6E6E6"
+                />
+                <stop
+                  offset="100%"
+                  stop-color="#E6E6E6"
+                />
+              </lineargradient>
+            </defs>
             <rect
               aria-label="13457/15000."
               class="fui-hbc__barWrapper"
               data-is-focusable="false"
-              fill="var(--colorBackgroundOverlay)"
+              fill="url(#HBC_Gradient86_0_1)"
               height="12"
               role="img"
+              rx="4"
               width="89.71333333333334%"
               x="10.286666666666665%"
               y="0"
@@ -311,25 +431,55 @@ exports[`Horizontal bar chart - Screen resolution Should remain unchanged on zoo
           <g
             id="_HorizontalLine_lllllm_1"
           >
+            <defs>
+              <lineargradient
+                id="HBC_Gradient86_1_0"
+              >
+                <stop
+                  offset="0"
+                  stop-color="#5c2d91"
+                />
+                <stop
+                  offset="100%"
+                  stop-color=""
+                />
+              </lineargradient>
+            </defs>
             <rect
               aria-label="2020/04/30, 5%."
               class="fui-hbc__barWrapper"
               data-is-focusable="true"
-              fill="#5c2d91"
+              fill="url(#HBC_Gradient86_1_0)"
               height="12"
               role="img"
+              rx="4"
               tabindex="0"
               width="5.333333333333334%"
               x="0%"
               y="0"
             />
+            <defs>
+              <lineargradient
+                id="HBC_Gradient86_1_1"
+              >
+                <stop
+                  offset="0"
+                  stop-color="#E6E6E6"
+                />
+                <stop
+                  offset="100%"
+                  stop-color="#E6E6E6"
+                />
+              </lineargradient>
+            </defs>
             <rect
               aria-label="14200/15000."
               class="fui-hbc__barWrapper"
               data-is-focusable="false"
-              fill="var(--colorBackgroundOverlay)"
+              fill="url(#HBC_Gradient86_1_1)"
               height="12"
               role="img"
+              rx="4"
               width="94.66666666666667%"
               x="5.333333333333334%"
               y="0"
@@ -375,25 +525,55 @@ exports[`Horizontal bar chart - Screen resolution Should remain unchanged on zoo
           <g
             id="_HorizontalLine_lllllm_2"
           >
+            <defs>
+              <lineargradient
+                id="HBC_Gradient86_2_0"
+              >
+                <stop
+                  offset="0"
+                  stop-color="#a4262c"
+                />
+                <stop
+                  offset="100%"
+                  stop-color=""
+                />
+              </lineargradient>
+            </defs>
             <rect
               aria-label="2020/04/30, 59%."
               class="fui-hbc__barWrapper"
               data-is-focusable="true"
-              fill="#a4262c"
+              fill="url(#HBC_Gradient86_2_0)"
               height="12"
               role="img"
+              rx="4"
               tabindex="0"
               width="59.25333333333334%"
               x="0%"
               y="0"
             />
+            <defs>
+              <lineargradient
+                id="HBC_Gradient86_2_1"
+              >
+                <stop
+                  offset="0"
+                  stop-color="#E6E6E6"
+                />
+                <stop
+                  offset="100%"
+                  stop-color="#E6E6E6"
+                />
+              </lineargradient>
+            </defs>
             <rect
               aria-label="6112/15000."
               class="fui-hbc__barWrapper"
               data-is-focusable="false"
-              fill="var(--colorBackgroundOverlay)"
+              fill="url(#HBC_Gradient86_2_1)"
               height="12"
               role="img"
+              rx="4"
               width="40.74666666666666%"
               x="59.25333333333334%"
               y="0"
@@ -404,7 +584,7 @@ exports[`Horizontal bar chart - Screen resolution Should remain unchanged on zoo
     </div>
     <div
       class="fui-cart__calloutContainer"
-      id="callout75"
+      id="callout90"
     />
   </div>
 </div>
@@ -413,7 +593,7 @@ exports[`Horizontal bar chart - Screen resolution Should remain unchanged on zoo
 exports[`Horizontal bar chart - Theme Should reflect theme change 1`] = `
 <div>
   <div
-    class="fui-FluentProvider fui-FluentProvider76"
+    class="fui-FluentProvider fui-FluentProvider91"
     dir="ltr"
   >
     <div
@@ -456,25 +636,55 @@ exports[`Horizontal bar chart - Theme Should reflect theme change 1`] = `
             <g
               id="_HorizontalLine_lllllm_0"
             >
+              <defs>
+                <lineargradient
+                  id="HBC_Gradient93_0_0"
+                >
+                  <stop
+                    offset="0"
+                    stop-color="#004b50"
+                  />
+                  <stop
+                    offset="100%"
+                    stop-color=""
+                  />
+                </lineargradient>
+              </defs>
               <rect
                 aria-label="2020/04/30, 10%."
                 class="fui-hbc__barWrapper"
                 data-is-focusable="true"
-                fill="#004b50"
+                fill="url(#HBC_Gradient93_0_0)"
                 height="12"
                 role="img"
+                rx="4"
                 tabindex="0"
                 width="10.286666666666665%"
                 x="0%"
                 y="0"
               />
+              <defs>
+                <lineargradient
+                  id="HBC_Gradient93_0_1"
+                >
+                  <stop
+                    offset="0"
+                    stop-color="#E6E6E6"
+                  />
+                  <stop
+                    offset="100%"
+                    stop-color="#E6E6E6"
+                  />
+                </lineargradient>
+              </defs>
               <rect
                 aria-label="13457/15000."
                 class="fui-hbc__barWrapper"
                 data-is-focusable="false"
-                fill="var(--colorBackgroundOverlay)"
+                fill="url(#HBC_Gradient93_0_1)"
                 height="12"
                 role="img"
+                rx="4"
                 width="89.71333333333334%"
                 x="10.286666666666665%"
                 y="0"
@@ -520,25 +730,55 @@ exports[`Horizontal bar chart - Theme Should reflect theme change 1`] = `
             <g
               id="_HorizontalLine_lllllm_1"
             >
+              <defs>
+                <lineargradient
+                  id="HBC_Gradient93_1_0"
+                >
+                  <stop
+                    offset="0"
+                    stop-color="#5c2d91"
+                  />
+                  <stop
+                    offset="100%"
+                    stop-color=""
+                  />
+                </lineargradient>
+              </defs>
               <rect
                 aria-label="2020/04/30, 5%."
                 class="fui-hbc__barWrapper"
                 data-is-focusable="true"
-                fill="#5c2d91"
+                fill="url(#HBC_Gradient93_1_0)"
                 height="12"
                 role="img"
+                rx="4"
                 tabindex="0"
                 width="5.333333333333334%"
                 x="0%"
                 y="0"
               />
+              <defs>
+                <lineargradient
+                  id="HBC_Gradient93_1_1"
+                >
+                  <stop
+                    offset="0"
+                    stop-color="#E6E6E6"
+                  />
+                  <stop
+                    offset="100%"
+                    stop-color="#E6E6E6"
+                  />
+                </lineargradient>
+              </defs>
               <rect
                 aria-label="14200/15000."
                 class="fui-hbc__barWrapper"
                 data-is-focusable="false"
-                fill="var(--colorBackgroundOverlay)"
+                fill="url(#HBC_Gradient93_1_1)"
                 height="12"
                 role="img"
+                rx="4"
                 width="94.66666666666667%"
                 x="5.333333333333334%"
                 y="0"
@@ -584,25 +824,55 @@ exports[`Horizontal bar chart - Theme Should reflect theme change 1`] = `
             <g
               id="_HorizontalLine_lllllm_2"
             >
+              <defs>
+                <lineargradient
+                  id="HBC_Gradient93_2_0"
+                >
+                  <stop
+                    offset="0"
+                    stop-color="#a4262c"
+                  />
+                  <stop
+                    offset="100%"
+                    stop-color=""
+                  />
+                </lineargradient>
+              </defs>
               <rect
                 aria-label="2020/04/30, 59%."
                 class="fui-hbc__barWrapper"
                 data-is-focusable="true"
-                fill="#a4262c"
+                fill="url(#HBC_Gradient93_2_0)"
                 height="12"
                 role="img"
+                rx="4"
                 tabindex="0"
                 width="59.25333333333334%"
                 x="0%"
                 y="0"
               />
+              <defs>
+                <lineargradient
+                  id="HBC_Gradient93_2_1"
+                >
+                  <stop
+                    offset="0"
+                    stop-color="#E6E6E6"
+                  />
+                  <stop
+                    offset="100%"
+                    stop-color="#E6E6E6"
+                  />
+                </lineargradient>
+              </defs>
               <rect
                 aria-label="6112/15000."
                 class="fui-hbc__barWrapper"
                 data-is-focusable="false"
-                fill="var(--colorBackgroundOverlay)"
+                fill="url(#HBC_Gradient93_2_1)"
                 height="12"
                 role="img"
+                rx="4"
                 width="40.74666666666666%"
                 x="59.25333333333334%"
                 y="0"
@@ -613,7 +883,7 @@ exports[`Horizontal bar chart - Theme Should reflect theme change 1`] = `
       </div>
       <div
         class="fui-cart__calloutContainer"
-        id="callout81"
+        id="callout97"
       />
     </div>
   </div>
@@ -624,7 +894,7 @@ exports[`Horizontal bar chart re-rendering Should re-render the Horizontal bar c
 <div>
   <div
     aria-label="Graph has no data to display"
-    id="_HBC_empty82"
+    id="_HBC_empty98"
     role="alert"
     style="opacity: 0;"
   />
@@ -674,25 +944,55 @@ exports[`Horizontal bar chart re-rendering Should re-render the Horizontal bar c
           <g
             id="_HorizontalLine_lllllm_0"
           >
+            <defs>
+              <lineargradient
+                id="HBC_Gradient99_0_0"
+              >
+                <stop
+                  offset="0"
+                  stop-color="#004b50"
+                />
+                <stop
+                  offset="100%"
+                  stop-color=""
+                />
+              </lineargradient>
+            </defs>
             <rect
               aria-label="2020/04/30, 10%."
               class="fui-hbc__barWrapper"
               data-is-focusable="true"
-              fill="#004b50"
+              fill="url(#HBC_Gradient99_0_0)"
               height="12"
               role="img"
+              rx="4"
               tabindex="0"
               width="10.286666666666665%"
               x="0%"
               y="0"
             />
+            <defs>
+              <lineargradient
+                id="HBC_Gradient99_0_1"
+              >
+                <stop
+                  offset="0"
+                  stop-color="#E6E6E6"
+                />
+                <stop
+                  offset="100%"
+                  stop-color="#E6E6E6"
+                />
+              </lineargradient>
+            </defs>
             <rect
               aria-label="13457/15000."
               class="fui-hbc__barWrapper"
               data-is-focusable="false"
-              fill="var(--colorBackgroundOverlay)"
+              fill="url(#HBC_Gradient99_0_1)"
               height="12"
               role="img"
+              rx="4"
               width="89.71333333333334%"
               x="10.286666666666665%"
               y="0"
@@ -738,25 +1038,55 @@ exports[`Horizontal bar chart re-rendering Should re-render the Horizontal bar c
           <g
             id="_HorizontalLine_lllllm_1"
           >
+            <defs>
+              <lineargradient
+                id="HBC_Gradient99_1_0"
+              >
+                <stop
+                  offset="0"
+                  stop-color="#5c2d91"
+                />
+                <stop
+                  offset="100%"
+                  stop-color=""
+                />
+              </lineargradient>
+            </defs>
             <rect
               aria-label="2020/04/30, 5%."
               class="fui-hbc__barWrapper"
               data-is-focusable="true"
-              fill="#5c2d91"
+              fill="url(#HBC_Gradient99_1_0)"
               height="12"
               role="img"
+              rx="4"
               tabindex="0"
               width="5.333333333333334%"
               x="0%"
               y="0"
             />
+            <defs>
+              <lineargradient
+                id="HBC_Gradient99_1_1"
+              >
+                <stop
+                  offset="0"
+                  stop-color="#E6E6E6"
+                />
+                <stop
+                  offset="100%"
+                  stop-color="#E6E6E6"
+                />
+              </lineargradient>
+            </defs>
             <rect
               aria-label="14200/15000."
               class="fui-hbc__barWrapper"
               data-is-focusable="false"
-              fill="var(--colorBackgroundOverlay)"
+              fill="url(#HBC_Gradient99_1_1)"
               height="12"
               role="img"
+              rx="4"
               width="94.66666666666667%"
               x="5.333333333333334%"
               y="0"
@@ -802,25 +1132,55 @@ exports[`Horizontal bar chart re-rendering Should re-render the Horizontal bar c
           <g
             id="_HorizontalLine_lllllm_2"
           >
+            <defs>
+              <lineargradient
+                id="HBC_Gradient99_2_0"
+              >
+                <stop
+                  offset="0"
+                  stop-color="#a4262c"
+                />
+                <stop
+                  offset="100%"
+                  stop-color=""
+                />
+              </lineargradient>
+            </defs>
             <rect
               aria-label="2020/04/30, 59%."
               class="fui-hbc__barWrapper"
               data-is-focusable="true"
-              fill="#a4262c"
+              fill="url(#HBC_Gradient99_2_0)"
               height="12"
               role="img"
+              rx="4"
               tabindex="0"
               width="59.25333333333334%"
               x="0%"
               y="0"
             />
+            <defs>
+              <lineargradient
+                id="HBC_Gradient99_2_1"
+              >
+                <stop
+                  offset="0"
+                  stop-color="#E6E6E6"
+                />
+                <stop
+                  offset="100%"
+                  stop-color="#E6E6E6"
+                />
+              </lineargradient>
+            </defs>
             <rect
               aria-label="6112/15000."
               class="fui-hbc__barWrapper"
               data-is-focusable="false"
-              fill="var(--colorBackgroundOverlay)"
+              fill="url(#HBC_Gradient99_2_1)"
               height="12"
               role="img"
+              rx="4"
               width="40.74666666666666%"
               x="59.25333333333334%"
               y="0"
@@ -831,7 +1191,7 @@ exports[`Horizontal bar chart re-rendering Should re-render the Horizontal bar c
     </div>
     <div
       class="fui-cart__calloutContainer"
-      id="callout86"
+      id="callout103"
     />
   </div>
 </div>
@@ -879,25 +1239,55 @@ exports[`Horizontal bar chart rendering Should render the Horizontal bar chart l
           <g
             id="_HorizontalLine_lllllm_0"
           >
+            <defs>
+              <lineargradient
+                id="HBC_Gradient2_0_0"
+              >
+                <stop
+                  offset="0"
+                  stop-color="#004b50"
+                />
+                <stop
+                  offset="100%"
+                  stop-color=""
+                />
+              </lineargradient>
+            </defs>
             <rect
               aria-label="2020/04/30, 10%."
               class="fui-hbc__barWrapper"
               data-is-focusable="true"
-              fill="#004b50"
+              fill="url(#HBC_Gradient2_0_0)"
               height="12"
               role="img"
+              rx="4"
               tabindex="0"
               width="10.286666666666665%"
               x="0%"
               y="0"
             />
+            <defs>
+              <lineargradient
+                id="HBC_Gradient2_0_1"
+              >
+                <stop
+                  offset="0"
+                  stop-color="#E6E6E6"
+                />
+                <stop
+                  offset="100%"
+                  stop-color="#E6E6E6"
+                />
+              </lineargradient>
+            </defs>
             <rect
               aria-label="13457/15000."
               class="fui-hbc__barWrapper"
               data-is-focusable="false"
-              fill="var(--colorBackgroundOverlay)"
+              fill="url(#HBC_Gradient2_0_1)"
               height="12"
               role="img"
+              rx="4"
               width="89.71333333333334%"
               x="10.286666666666665%"
               y="0"
@@ -943,25 +1333,55 @@ exports[`Horizontal bar chart rendering Should render the Horizontal bar chart l
           <g
             id="_HorizontalLine_lllllm_1"
           >
+            <defs>
+              <lineargradient
+                id="HBC_Gradient2_1_0"
+              >
+                <stop
+                  offset="0"
+                  stop-color="#5c2d91"
+                />
+                <stop
+                  offset="100%"
+                  stop-color=""
+                />
+              </lineargradient>
+            </defs>
             <rect
               aria-label="2020/04/30, 5%."
               class="fui-hbc__barWrapper"
               data-is-focusable="true"
-              fill="#5c2d91"
+              fill="url(#HBC_Gradient2_1_0)"
               height="12"
               role="img"
+              rx="4"
               tabindex="0"
               width="5.333333333333334%"
               x="0%"
               y="0"
             />
+            <defs>
+              <lineargradient
+                id="HBC_Gradient2_1_1"
+              >
+                <stop
+                  offset="0"
+                  stop-color="#E6E6E6"
+                />
+                <stop
+                  offset="100%"
+                  stop-color="#E6E6E6"
+                />
+              </lineargradient>
+            </defs>
             <rect
               aria-label="14200/15000."
               class="fui-hbc__barWrapper"
               data-is-focusable="false"
-              fill="var(--colorBackgroundOverlay)"
+              fill="url(#HBC_Gradient2_1_1)"
               height="12"
               role="img"
+              rx="4"
               width="94.66666666666667%"
               x="5.333333333333334%"
               y="0"
@@ -1007,25 +1427,55 @@ exports[`Horizontal bar chart rendering Should render the Horizontal bar chart l
           <g
             id="_HorizontalLine_lllllm_2"
           >
+            <defs>
+              <lineargradient
+                id="HBC_Gradient2_2_0"
+              >
+                <stop
+                  offset="0"
+                  stop-color="#a4262c"
+                />
+                <stop
+                  offset="100%"
+                  stop-color=""
+                />
+              </lineargradient>
+            </defs>
             <rect
               aria-label="2020/04/30, 59%."
               class="fui-hbc__barWrapper"
               data-is-focusable="true"
-              fill="#a4262c"
+              fill="url(#HBC_Gradient2_2_0)"
               height="12"
               role="img"
+              rx="4"
               tabindex="0"
               width="59.25333333333334%"
               x="0%"
               y="0"
             />
+            <defs>
+              <lineargradient
+                id="HBC_Gradient2_2_1"
+              >
+                <stop
+                  offset="0"
+                  stop-color="#E6E6E6"
+                />
+                <stop
+                  offset="100%"
+                  stop-color="#E6E6E6"
+                />
+              </lineargradient>
+            </defs>
             <rect
               aria-label="6112/15000."
               class="fui-hbc__barWrapper"
               data-is-focusable="false"
-              fill="var(--colorBackgroundOverlay)"
+              fill="url(#HBC_Gradient2_2_1)"
               height="12"
               role="img"
+              rx="4"
               width="40.74666666666666%"
               x="59.25333333333334%"
               y="0"
@@ -1036,7 +1486,7 @@ exports[`Horizontal bar chart rendering Should render the Horizontal bar chart l
     </div>
     <div
       class="fui-cart__calloutContainer"
-      id="callout5"
+      id="callout6"
     />
   </div>
 </div>

--- a/packages/charts/react-charts-preview/library/src/index.ts
+++ b/packages/charts/react-charts-preview/library/src/index.ts
@@ -7,4 +7,5 @@ export * from './CartesianChart';
 export * from './types/index';
 export * from './Sparkline';
 export * from './utilities/colors';
+export * from './utilities/gradients';
 export * from './Popover';

--- a/packages/charts/react-charts-preview/library/src/types/DataPoint.ts
+++ b/packages/charts/react-charts-preview/library/src/types/DataPoint.ts
@@ -129,9 +129,9 @@ export interface ChartDataPoint {
   onClick?: VoidFunction;
 
   /**
-   * Color for the legend in the chart. If not provided, it will fallback on the default color palette.
+   * Gradient for the legend in the chart. If not provided, it will fallback on the default gradient palette.
    */
-  color?: string;
+  gradient?: [string, string];
 
   /**
    * placeholder data point

--- a/packages/charts/react-charts-preview/library/src/utilities/UtilityUnitTests.test.ts
+++ b/packages/charts/react-charts-preview/library/src/utilities/UtilityUnitTests.test.ts
@@ -12,6 +12,7 @@ import { ScaleBand } from 'd3-scale';
 import { select as d3Select } from 'd3-selection';
 import { conditionalDescribe, isTimezoneSet } from './TestUtility.test';
 import * as vbcUtils from './vbc-utils';
+import { getGradientFromToken, getNextGradient } from './gradients';
 const { Timezone } = require('../../scripts/constants');
 const env = require('../../config/tests');
 
@@ -1352,5 +1353,72 @@ describe('getClosestPairDiffAndRange', () => {
     const data: Date[] = [new Date('2022-01-01'), new Date('2022-01-05'), new Date('2022-01-03')];
     const result = vbcUtils.getClosestPairDiffAndRange(data);
     expect(result).toEqual([2 * 24 * 60 * 60 * 1000, 4 * 24 * 60 * 60 * 1000]);
+  });
+});
+
+/** -------- dataviz gradient tests ------ */
+const mockGradients = {
+  // as per gradients.ts
+  default: [
+    [
+      ['#4760D5', '#637CEF'],
+      ['#4F6BED', '#637CEF'],
+    ],
+    [
+      ['#795AA6', '#9373C0'],
+      ['#8764B8', '#A083C9'],
+    ],
+    // Add more
+  ],
+  semantic: [
+    [
+      ['#0C5E0C', '#107C10'],
+      ['#218C21', '#359B35'],
+    ],
+    [
+      ['#107C10', '#359B35'],
+      ['#359B35', '#9FD89F'],
+    ],
+    // Add more
+  ],
+};
+
+describe('getNextGradient', () => {
+  it('should return the correct gradient based on index and offset in light theme', () => {
+    const result = getNextGradient(0, 0, false);
+    expect(result).toEqual(mockGradients.default[0][0]);
+  });
+
+  it('should return the correct gradient based on index and offset in dark theme', () => {
+    const result = getNextGradient(1, 0, true);
+    expect(result).toEqual(mockGradients.default[1][1]);
+  });
+
+  it('should wrap around when index + offset exceeds gradient length', () => {
+    const result = getNextGradient(10, 0, false); // 10 is outside the range of available gradients
+    expect(result).toEqual(mockGradients.default[0][0]);
+  });
+});
+
+describe('getGradientFromToken', () => {
+  it('should return the correct gradient for a valid token in light theme', () => {
+    const result = getGradientFromToken('default.1', false);
+    expect(result).toEqual(mockGradients.default[0][0]);
+  });
+
+  it('should return the correct gradient for a valid token in dark theme', () => {
+    const result = getGradientFromToken('semantic.success', true);
+    expect(result).toEqual(mockGradients.semantic[0][1]);
+  });
+
+  it('should return the token itself if the token does not match any gradient', () => {
+    const invalidToken = 'nonexistent.token';
+    const result = getGradientFromToken(invalidToken, false);
+    expect(result).toEqual([invalidToken, invalidToken]);
+  });
+
+  it('should handle invalid tokens with split error gracefully', () => {
+    const result = getGradientFromToken('invalidTokenWithoutDot', false);
+    expect(result).toEqual(['invalidTokenWithoutDot', 'invalidTokenWithoutDot']);
   });
 });

--- a/packages/charts/react-charts-preview/library/src/utilities/gradients.ts
+++ b/packages/charts/react-charts-preview/library/src/utilities/gradients.ts
@@ -1,0 +1,195 @@
+export const DataVizGradientPalette = {
+  gradient1: 'default.1',
+  gradient2: 'default.2',
+  gradient3: 'default.3',
+  gradient4: 'default.4',
+  gradient5: 'default.5',
+  gradient6: 'default.6',
+  gradient7: 'default.7',
+  gradient8: 'default.8',
+  gradient9: 'default.9',
+  gradient10: 'default.10',
+  // extended gradients
+  gradient1Ext: 'extended.1',
+  gradient2Ext: 'extended.2',
+  gradient3Ext: 'extended.3',
+  gradient4Ext: 'extended.4',
+  gradient5Ext: 'extended.5',
+  gradient6Ext: 'extended.6',
+  gradient7Ext: 'extended.7',
+  gradient8Ext: 'extended.8',
+  gradient9Ext: 'extended.9',
+  gradient10Ext: 'extended.10',
+  // status gradients
+  success: 'semantic.success',
+  highSuccess: 'semantic.highSuccess',
+  warning: 'semantic.warning',
+  error: 'semantic.error',
+  highError: 'semantic.highError',
+  disabled: 'semantic.disabled',
+};
+
+/**
+ * Key: Color code.
+ * Value:
+ *
+ * Index 0 - Default gradient for light theme
+ *      ├── Index 0 - start color of gradient
+ *      └── Index 1 - end color of gradient
+ *
+ * Index 1 - gradient for dark theme
+ *      ├── Index 0 - start color of gradient
+ *      └── Index 1 - end color of gradient
+ */
+type GradientPalette = { [key: string]: [string, string][] };
+
+const defaultGradientPalette: GradientPalette = {
+  '1': [
+    ['#4760D5', '#637CEF'], // [cornflower.shade10, cornflower.tint10],
+    ['#4F6BED', '#637CEF'], // [cornflower.shade10, cornflower.tint10],
+  ],
+  '2': [
+    ['#795AA6', '#9373C0'], // [orchid.shade20, orchid.tint10],
+    ['#8764B8', '#A083C9'], // [orchid.primary, orchid.tint20],
+  ],
+  '3': [
+    ['#159195', '#2AA0A4'], // [teal.tint10, teal.tint20],
+    ['#159195', '#2AA0A4'], // [teal.tint10, teal.tint20],
+  ],
+  '4': [
+    ['#B146C2', '#C36BD1'], // [lilac.primary, lilac.tint20],
+    ['#B146C2', '#C36BD1'], // [lilac.primary, lilac.tint20],
+  ],
+  '5': [
+    ['#3487C7', '#3A96DD'], // [lightBlue.shade10, lightBlue.primary],
+    ['#3487C7', '#3A96DD'], // [lightBlue.shade20, lightBlue.primary],
+  ],
+  '6': [
+    ['#0E7A0B', '#13A10E'], // [lightGreen.shade20, lightGreen.primary],
+    ['#11910D', '#27AC22'], // [lightGreen.shade10, lightGreen.tint10],
+  ],
+  '7': [
+    ['#E61C99', '#EE5FB7'], // [hotPink.tint10, hotPink.tint30],
+    ['#E61C99', '#EE5FB7'], // [hotPink.tint10, hotPink.tint30],
+  ],
+  '8': [
+    ['#CA5010', '#D77440'], // [pumpkin.primary, pumpkin.tint20],
+    ['#CA5010', '#D77440'], // [pumpkin.primary, pumpkin.tint10],
+  ],
+  '9': [
+    ['#57811B', '#689920'], // [lime.shade20, lime.shade10],
+    ['#57811B', '#689920'], // [lime.shade20, lime.shade10],
+  ],
+  '10': [
+    ['#937700', '#AE8C00'], // [gold.shade20, gold.shade10],
+    ['#937700', '#AE8C00'], // [gold.shade20, gold.shade10],
+  ],
+};
+
+const extendedGradientPalette: GradientPalette = {
+  '1': [
+    ['#2C3C85', '#3C51B4'], // [cornflower.shade30, cornflower.shade20],
+    ['#93A4F4', '#C8D1FA'], // [cornflower.tint30, cornflower.tint40],
+  ],
+  '2': [
+    ['#4C3867', '#674C8C'], // [orchid.shade30, orchid.shade20],
+    ['#A083C9', '#B29AD4'], // [orchid.tint20, orchid.tint30],
+  ],
+  '3': [
+    ['#02494C', '#038387'], // [teal.shade30, teal.primary],
+    ['#4CB4B7', '#9BD9DB'], // [teal.tint30, teal.tint40],
+  ],
+  '4': [
+    ['#63276D', '#863593'], // [lilac.shade30, lilac.shade20],
+    ['#C36BD1', '#CF87DA'], // [lilac.tint20, lilac.tint30],
+  ],
+  '5': [
+    ['#20547C', '#2C72A8'], // [lightBlue.shade30, lightBlue.shade20],
+    ['#4FA1E1', '#83BDEB'], // [lightBlue.tint10, lightBlue.tint30],
+  ],
+  '6': [
+    ['#0B5A08', '#0E7A0B'], // [lightGreen.shade30, lightGreen.shade20],
+    ['#27AC22', '#5EC75A'], // [lightGreen.tint10, lightGreen.tint30],
+  ],
+  '7': [
+    ['#AD006A', '#E3008C'], // [hotPink.shade20, hotPink.primary],
+    ['#EE5FB7', '#F7ADDA'], // [hotPink.tint30, hotPink.tint40],
+  ],
+  '8': [
+    ['#9A3D0C', '#CA5010'], // [pumpkin.shade20, pumpkin.primary],
+    ['#D77440', '#DF8E64'], // [pumpkin.tint20, pumpkin.tint30],
+  ],
+  '9': [
+    ['#405F14', '#57811B'], // [lime.shade30, lime.shade20],
+    ['#73AA24', '#A4CC6C'], // [lime.primary, lime.tint30],
+  ],
+  '10': [
+    ['#6D5700', '#937700'], // [gold.shade30, gold.shade20],
+    ['#D0B232', '#DAC157'], // [gold.tint20, gold.tint30],
+  ],
+};
+
+const semanticGradientPalette: GradientPalette = {
+  success: [
+    ['#0C5E0C', '#107C10'], // [green.shade20, green.primary],
+    ['#218C21', '#359B35'], // [green.tint10, green.tint20],
+  ],
+  highSuccess: [
+    ['#107C10', '#359B35'], // [green.primary, green.tint20],
+    ['#359B35', '#9FD89F'], // [green.tint20, green.tint40],
+  ],
+  warning: [
+    ['#DE590B', '#F7630C'], // [orange.shade10, orange.primary],
+    ['#DE590B', '#F87528'], // [orange.shade10, orange.tint10],
+  ],
+  error: [
+    ['#B10E1C', '#CC2635'], // [cranberry.shade10, cranberry.tint10],
+    ['#D33F4C', '#EEACB2'], // [cranberry.tint20, cranberry.tint40],
+  ],
+  highError: [
+    ['#6E0811', '#B10E1C'], // [cranberry.shade30, cranberry.shade10],
+    ['#D33F4C', '#DC626D'], // [cranberry.tint20, cranberry.tint30],
+  ],
+  disabled: [
+    ['#E6E6E6', '#E6E6E6'],
+    ['#E6E6E6', '#E6E6E6'],
+  ],
+};
+
+const Gradients: { [key: string]: GradientPalette } = {
+  default: defaultGradientPalette, // base gradients
+  semantic: semanticGradientPalette, // status gradients
+  extended: extendedGradientPalette, // extended gradients
+};
+
+const DEFAULT_COLORS = Object.values(defaultGradientPalette);
+const TOKENS = Object.values(DataVizGradientPalette);
+
+const getThemeSpecificGradient = (gradients: [string, string][], isDarkTheme: boolean): [string, string] => {
+  if (gradients.length === 0) {
+    return ['', ''];
+  }
+
+  const colorIdx = Number(isDarkTheme);
+
+  if (colorIdx < gradients.length) {
+    return gradients[colorIdx];
+  }
+
+  return gradients[0];
+};
+
+export const getNextGradient = (index: number, offset: number = 0, isDarkTheme: boolean = false): [string, string] => {
+  const gradients = DEFAULT_COLORS[(index + offset) % DEFAULT_COLORS.length];
+  return getThemeSpecificGradient(gradients, isDarkTheme);
+};
+
+export const getGradientFromToken = (token: string, isDarkTheme: boolean = false): [string, string] => {
+  if (TOKENS.indexOf(token) >= 0) {
+    const [paletteName, colorCode] = token.split('.');
+    const colors = Gradients[paletteName][colorCode];
+
+    return getThemeSpecificGradient(colors, isDarkTheme);
+  }
+  return [token, token];
+};

--- a/packages/charts/react-charts-preview/library/src/utilities/index.ts
+++ b/packages/charts/react-charts-preview/library/src/utilities/index.ts
@@ -1,3 +1,4 @@
 export * from './utilities';
 export * from './colors';
 export * from './vbc-utils';
+export * from './gradients';

--- a/packages/charts/react-charts-preview/library/src/utilities/test-data.ts
+++ b/packages/charts/react-charts-preview/library/src/utilities/test-data.ts
@@ -124,18 +124,18 @@ export const pointsHBCWA = [
 ];
 
 export const pointsDC: ChartDataPoint[] = [
-  { legend: 'first', data: 20000, color: '#E5E5E5', xAxisCalloutData: '2020/04/30' },
-  { legend: 'second', data: 39000, color: '#0078D4', xAxisCalloutData: '2020/04/20' },
-  { legend: 'third', data: 45000, color: '#DADADA', xAxisCalloutData: '2020/04/25' },
+  { legend: 'first', data: 20000, gradient: ['#E5E5E5', ''], xAxisCalloutData: '2020/04/30' },
+  { legend: 'second', data: 39000, gradient: ['#0078D4', ''], xAxisCalloutData: '2020/04/20' },
+  { legend: 'third', data: 45000, gradient: ['#DADADA', ''], xAxisCalloutData: '2020/04/25' },
 ];
 
 export const pointsDCElevateMinimumsExample: ChartDataPoint[] = [
-  { legend: 'first', data: 39000, color: '#E5E5E5', xAxisCalloutData: '2020/04/30' },
-  { legend: 'second', data: 20, color: '#0078D4', xAxisCalloutData: '2020/04/20' },
-  { legend: 'third', data: 20, color: '#DADADA', xAxisCalloutData: '2020/04/25' },
-  { legend: 'fourth', data: 20, color: '#DADADA', xAxisCalloutData: '2020/04/25' },
-  { legend: 'fifth', data: 20, color: '#DADADA', xAxisCalloutData: '2020/04/25' },
-  { legend: 'sixth', data: 20, color: '#DADADA', xAxisCalloutData: '2020/04/25' },
+  { legend: 'first', data: 39000, gradient: ['#E5E5E5', ''], xAxisCalloutData: '2020/04/30' },
+  { legend: 'second', data: 20, gradient: ['#0078D4', ''], xAxisCalloutData: '2020/04/20' },
+  { legend: 'third', data: 20, gradient: ['#DADADA', ''], xAxisCalloutData: '2020/04/25' },
+  { legend: 'fourth', data: 20, gradient: ['#DADADA', ''], xAxisCalloutData: '2020/04/25' },
+  { legend: 'fifth', data: 20, gradient: ['#DADADA', ''], xAxisCalloutData: '2020/04/25' },
+  { legend: 'sixth', data: 20, gradient: ['#DADADA', ''], xAxisCalloutData: '2020/04/25' },
 ];
 
 export const chartPointsDC: ChartProps = {

--- a/packages/charts/react-charts-preview/stories/src/DonutChart/DonutChartCustomAccessibility.stories.tsx
+++ b/packages/charts/react-charts-preview/stories/src/DonutChart/DonutChartCustomAccessibility.stories.tsx
@@ -3,8 +3,8 @@ import {
   DonutChart,
   ChartProps,
   ChartDataPoint,
-  DataVizPalette,
-  getColorFromToken,
+  getGradientFromToken,
+  DataVizGradientPalette,
 } from '@fluentui/react-charts-preview';
 
 export const DonutChartCustomAccessibility = () => {
@@ -12,14 +12,14 @@ export const DonutChartCustomAccessibility = () => {
     {
       legend: 'first',
       data: 20000,
-      color: getColorFromToken(DataVizPalette.color16),
+      gradient: getGradientFromToken(DataVizGradientPalette.gradient6Ext),
       xAxisCalloutData: '2020/04/30',
       callOutAccessibilityData: { ariaLabel: 'Pia chart 1 of 2 2020/04/30' },
     },
     {
       legend: 'second',
       data: 39000,
-      color: getColorFromToken(DataVizPalette.color3),
+      gradient: getGradientFromToken(DataVizGradientPalette.gradient3),
       xAxisCalloutData: '2020/04/20',
       callOutAccessibilityData: { ariaLabel: 'Pia chart 2 of 2 2020/04/20' },
     },

--- a/packages/charts/react-charts-preview/stories/src/DonutChart/DonutChartCustomCallout.stories.tsx
+++ b/packages/charts/react-charts-preview/stories/src/DonutChart/DonutChartCustomCallout.stories.tsx
@@ -6,6 +6,8 @@ import {
   DataVizPalette,
   getColorFromToken,
   ChartPopoverProps,
+  getGradientFromToken,
+  DataVizGradientPalette,
 } from '@fluentui/react-charts-preview';
 import { Switch, tokens } from '@fluentui/react-components';
 
@@ -16,14 +18,14 @@ export const DonutChartCustomCallout = () => {
     {
       legend: 'first',
       data: 20000,
-      color: getColorFromToken(DataVizPalette.color9),
+      gradient: getGradientFromToken(DataVizGradientPalette.gradient9),
       xAxisCalloutData: '2020/04/30',
       callOutAccessibilityData: { ariaLabel: 'Custom XVal Custom Legend 20000h' },
     },
     {
       legend: 'second',
       data: 39000,
-      color: getColorFromToken(DataVizPalette.color10),
+      gradient: getGradientFromToken(DataVizGradientPalette.gradient10),
       xAxisCalloutData: '2020/04/20',
       callOutAccessibilityData: { ariaLabel: 'Custom XVal Custom Legend 39000h' },
     },

--- a/packages/charts/react-charts-preview/stories/src/DonutChart/DonutChartDefault.stories.tsx
+++ b/packages/charts/react-charts-preview/stories/src/DonutChart/DonutChartDefault.stories.tsx
@@ -1,13 +1,24 @@
 import * as React from 'react';
-import { DonutChart, ChartProps, getColorFromToken, DataVizPalette } from '@fluentui/react-charts-preview';
+import {
+  DonutChart,
+  ChartProps,
+  ChartDataPoint,
+  DataVizGradientPalette,
+  getGradientFromToken,
+} from '@fluentui/react-charts-preview';
 
 export const DonutChartBasic = () => {
-  const points = [
-    { legend: 'first', data: 20000, color: getColorFromToken(DataVizPalette.color1), xAxisCalloutData: '2020/04/30' },
+  const points: ChartDataPoint[] = [
+    {
+      legend: 'first',
+      data: 20000,
+      gradient: getGradientFromToken(DataVizGradientPalette.gradient1),
+      xAxisCalloutData: '2020/04/30',
+    },
     {
       legend: 'second',
       data: 35000,
-      color: getColorFromToken(DataVizPalette.color2),
+      gradient: getGradientFromToken(DataVizGradientPalette.gradient2),
       xAxisCalloutData: '2020/04/20',
     },
   ];

--- a/packages/charts/react-charts-preview/stories/src/DonutChart/DonutChartDynamic.stories.tsx
+++ b/packages/charts/react-charts-preview/stories/src/DonutChart/DonutChartDynamic.stories.tsx
@@ -3,8 +3,8 @@ import {
   DonutChart,
   ChartProps,
   ChartDataPoint,
-  DataVizPalette,
-  getColorFromToken,
+  DataVizGradientPalette,
+  getGradientFromToken,
 } from '@fluentui/react-charts-preview';
 
 import { Button, Checkbox, CheckboxOnChangeData } from '@fluentui/react-components';
@@ -22,18 +22,26 @@ const screenReaderOnlyStyle: React.CSSProperties = {
 };
 
 export const DonutChartDynamic = () => {
-  const _colors = [
-    [DataVizPalette.color3, DataVizPalette.color4, DataVizPalette.color5, DataVizPalette.color6, DataVizPalette.color7],
-    [DataVizPalette.color8, DataVizPalette.color9, DataVizPalette.color10, DataVizPalette.color11],
-    [DataVizPalette.color12, DataVizPalette.color13, DataVizPalette.color14, DataVizPalette.color15],
-    [DataVizPalette.color16, DataVizPalette.color17, DataVizPalette.color18],
+  const _gradientColors = [
+    [
+      getGradientFromToken(DataVizGradientPalette.gradient1),
+      getGradientFromToken(DataVizGradientPalette.gradient3),
+      getGradientFromToken(DataVizGradientPalette.gradient9),
+    ],
+    [getGradientFromToken(DataVizGradientPalette.gradient2), getGradientFromToken(DataVizGradientPalette.gradient4)],
+    [
+      getGradientFromToken(DataVizGradientPalette.gradient5),
+      getGradientFromToken(DataVizGradientPalette.gradient6),
+      getGradientFromToken(DataVizGradientPalette.gradient10),
+    ],
+    [getGradientFromToken(DataVizGradientPalette.gradient7), getGradientFromToken(DataVizGradientPalette.gradient8)],
   ];
 
   const [dynamicData, setDynamicData] = React.useState<ChartDataPoint[]>([
-    { legend: 'first', data: 40, color: getColorFromToken(DataVizPalette.color1) },
-    { legend: 'second', data: 20, color: getColorFromToken(DataVizPalette.color2) },
-    { legend: 'third', data: 30, color: getColorFromToken(DataVizPalette.color3) },
-    { legend: 'fourth', data: 10, color: getColorFromToken(DataVizPalette.color4) },
+    { legend: 'first', data: 40, gradient: getGradientFromToken(DataVizGradientPalette.gradient1) },
+    { legend: 'second', data: 20, gradient: getGradientFromToken(DataVizGradientPalette.gradient2) },
+    { legend: 'third', data: 30, gradient: getGradientFromToken(DataVizGradientPalette.gradient3) },
+    { legend: 'fourth', data: 10, gradient: getGradientFromToken(DataVizGradientPalette.gradient4) },
   ]);
   const [hideLabels, setHideLabels] = React.useState<boolean>(false);
   const [showLabelsInPercent, setShowLabelsInPercent] = React.useState<boolean>(false);
@@ -43,10 +51,10 @@ export const DonutChartDynamic = () => {
 
   const _changeData = (): void => {
     setDynamicData([
-      { legend: 'first', data: _randomY(), color: getColorFromToken(DataVizPalette.color1) },
-      { legend: 'second', data: _randomY(), color: getColorFromToken(DataVizPalette.color2) },
-      { legend: 'third', data: _randomY(), color: getColorFromToken(DataVizPalette.color3) },
-      { legend: 'fourth', data: _randomY(), color: getColorFromToken(DataVizPalette.color4) },
+      { legend: 'first', data: _randomY(), gradient: getGradientFromToken(DataVizGradientPalette.gradient1) },
+      { legend: 'second', data: _randomY(), gradient: getGradientFromToken(DataVizGradientPalette.gradient2) },
+      { legend: 'third', data: _randomY(), gradient: getGradientFromToken(DataVizGradientPalette.gradient3) },
+      { legend: 'fourth', data: _randomY(), gradient: getGradientFromToken(DataVizGradientPalette.gradient4) },
     ]);
     setStatusKey(statusKey + 1);
     setStatusMessage('Donut chart data changed');
@@ -54,10 +62,10 @@ export const DonutChartDynamic = () => {
 
   const _changeColors = (): void => {
     setDynamicData([
-      { legend: 'first', data: 40, color: _randomColor(0) },
-      { legend: 'second', data: 20, color: _randomColor(1) },
-      { legend: 'third', data: 30, color: _randomColor(2) },
-      { legend: 'fourth', data: 10, color: _randomColor(3) },
+      { legend: 'first', data: 40, gradient: _randomGradient(0) },
+      { legend: 'second', data: 20, gradient: _randomGradient(1) },
+      { legend: 'third', data: 30, gradient: _randomGradient(2) },
+      { legend: 'fourth', data: 10, gradient: _randomGradient(3) },
     ]);
     setStatusKey(statusKey + 1);
     setStatusMessage('Donut chart colors changed');
@@ -67,8 +75,8 @@ export const DonutChartDynamic = () => {
     return Math.floor(Math.random() * max + 5);
   };
 
-  const _randomColor = (index: number): string => {
-    return getColorFromToken(_colors[index][Math.floor(Math.random() * _colors[index].length)]);
+  const _randomGradient = (index: number): [string, string] => {
+    return _gradientColors[index][Math.floor(Math.random() * _gradientColors[index].length)];
   };
 
   const _onHideLabelsCheckChange = (ev: React.ChangeEvent<HTMLInputElement>, checked: CheckboxOnChangeData) => {

--- a/packages/charts/react-charts-preview/stories/src/DonutChart/DonutChartStyled.stories.tsx
+++ b/packages/charts/react-charts-preview/stories/src/DonutChart/DonutChartStyled.stories.tsx
@@ -1,5 +1,13 @@
 import * as React from 'react';
-import { DonutChart, ChartProps, getColorFromToken, DataVizPalette } from '@fluentui/react-charts-preview';
+import {
+  DonutChart,
+  ChartProps,
+  getColorFromToken,
+  DataVizPalette,
+  ChartDataPoint,
+  DataVizGradientPalette,
+  getGradientFromToken,
+} from '@fluentui/react-charts-preview';
 import { makeStyles, mergeClasses } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
@@ -14,12 +22,17 @@ const useStyles = makeStyles({
 export const DonutChartStyled = () => {
   const classes = useStyles();
 
-  const points = [
-    { legend: 'first', data: 20000, color: getColorFromToken(DataVizPalette.color1), xAxisCalloutData: '2020/04/30' },
+  const points: ChartDataPoint[] = [
+    {
+      legend: 'first',
+      data: 20000,
+      gradient: getGradientFromToken(DataVizGradientPalette.gradient1),
+      xAxisCalloutData: '2020/04/30',
+    },
     {
       legend: 'second',
       data: 39000,
-      color: getColorFromToken(DataVizPalette.color2),
+      gradient: getGradientFromToken(DataVizGradientPalette.gradient2),
       xAxisCalloutData: '2020/04/20',
     },
   ];

--- a/packages/charts/react-charts-preview/stories/src/HorizontalBarChart/HorizontalBarChartBenchmark.stories.tsx
+++ b/packages/charts/react-charts-preview/stories/src/HorizontalBarChart/HorizontalBarChartBenchmark.stories.tsx
@@ -1,5 +1,10 @@
 import * as React from 'react';
-import { HorizontalBarChart, ChartProps, DataVizPalette, getColorFromToken } from '@fluentui/react-charts-preview';
+import {
+  HorizontalBarChart,
+  ChartProps,
+  DataVizGradientPalette,
+  getGradientFromToken,
+} from '@fluentui/react-charts-preview';
 
 export const HorizontalBarBenchmark = () => {
   const hideRatio: boolean[] = [true, false];
@@ -11,7 +16,7 @@ export const HorizontalBarBenchmark = () => {
           legend: 'one',
           data: 50,
           horizontalBarChartdata: { x: 10, y: 100 },
-          color: getColorFromToken(DataVizPalette.color25),
+          gradient: getGradientFromToken(DataVizGradientPalette.gradient8Ext),
         },
       ],
     },
@@ -22,7 +27,7 @@ export const HorizontalBarBenchmark = () => {
           legend: 'two',
           data: 30,
           horizontalBarChartdata: { x: 30, y: 200 },
-          color: getColorFromToken(DataVizPalette.color26),
+          gradient: getGradientFromToken(DataVizGradientPalette.gradient9Ext),
         },
       ],
     },
@@ -33,7 +38,7 @@ export const HorizontalBarBenchmark = () => {
           legend: 'three',
           data: 5,
           horizontalBarChartdata: { x: 15, y: 50 },
-          color: getColorFromToken(DataVizPalette.color27),
+          gradient: getGradientFromToken(DataVizGradientPalette.gradient10Ext),
         },
       ],
     },

--- a/packages/charts/react-charts-preview/stories/src/HorizontalBarChart/HorizontalBarChartCustomAccessibility.stories.tsx
+++ b/packages/charts/react-charts-preview/stories/src/HorizontalBarChart/HorizontalBarChartCustomAccessibility.stories.tsx
@@ -1,5 +1,10 @@
 import * as React from 'react';
-import { HorizontalBarChart, ChartProps, DataVizPalette, getColorFromToken } from '@fluentui/react-charts-preview';
+import {
+  HorizontalBarChart,
+  ChartProps,
+  DataVizGradientPalette,
+  getGradientFromToken,
+} from '@fluentui/react-charts-preview';
 
 export const HorizontalBarCustomAccessibility = () => {
   const data: ChartProps[] = [
@@ -11,7 +16,7 @@ export const HorizontalBarCustomAccessibility = () => {
         {
           legend: 'one',
           horizontalBarChartdata: { x: 1543, y: 15000 },
-          color: getColorFromToken(DataVizPalette.color9),
+          gradient: getGradientFromToken(DataVizGradientPalette.gradient1Ext),
           xAxisCalloutData: '2021/06/10',
           yAxisCalloutData: '10%',
           callOutAccessibilityData: { ariaLabel: 'Bar series 1 of chart one 2021/06/10 10%' },
@@ -26,7 +31,7 @@ export const HorizontalBarCustomAccessibility = () => {
         {
           legend: 'two',
           horizontalBarChartdata: { x: 800, y: 15000 },
-          color: getColorFromToken(DataVizPalette.color10),
+          gradient: getGradientFromToken(DataVizGradientPalette.gradient2Ext),
           xAxisCalloutData: '2021/06/11',
           yAxisCalloutData: '5%',
           callOutAccessibilityData: { ariaLabel: 'Bar series 1 of chart two 2021/06/11 5%' },
@@ -41,7 +46,7 @@ export const HorizontalBarCustomAccessibility = () => {
         {
           legend: 'three',
           horizontalBarChartdata: { x: 8888, y: 15000 },
-          color: getColorFromToken(DataVizPalette.color11),
+          gradient: getGradientFromToken(DataVizGradientPalette.gradient3Ext),
           xAxisCalloutData: '2021/06/12',
           yAxisCalloutData: '59%',
           callOutAccessibilityData: { ariaLabel: 'Bar series 1 of chart three 2021/06/12 59%' },
@@ -56,7 +61,7 @@ export const HorizontalBarCustomAccessibility = () => {
         {
           legend: 'four',
           horizontalBarChartdata: { x: 15888, y: 15000 },
-          color: getColorFromToken(DataVizPalette.color12),
+          gradient: getGradientFromToken(DataVizGradientPalette.gradient4Ext),
           xAxisCalloutData: '2021/06/13',
           yAxisCalloutData: '105%',
           callOutAccessibilityData: { ariaLabel: 'Bar series 1 of chart four 2021/06/13 105%' },
@@ -71,7 +76,7 @@ export const HorizontalBarCustomAccessibility = () => {
         {
           legend: 'five',
           horizontalBarChartdata: { x: 11444, y: 15000 },
-          color: getColorFromToken(DataVizPalette.color13),
+          gradient: getGradientFromToken(DataVizGradientPalette.gradient5Ext),
           xAxisCalloutData: '2021/06/14',
           yAxisCalloutData: '76%',
           callOutAccessibilityData: { ariaLabel: 'Bar series 1 of chart five 2021/06/14 76%' },
@@ -86,7 +91,7 @@ export const HorizontalBarCustomAccessibility = () => {
         {
           legend: 'six',
           horizontalBarChartdata: { x: 14000, y: 15000 },
-          color: getColorFromToken(DataVizPalette.color14),
+          gradient: getGradientFromToken(DataVizGradientPalette.gradient6Ext),
           xAxisCalloutData: '2021/06/15',
           yAxisCalloutData: '93%',
           callOutAccessibilityData: { ariaLabel: 'Bar series 1 of chart six 2021/06/15 93%' },
@@ -101,7 +106,7 @@ export const HorizontalBarCustomAccessibility = () => {
         {
           legend: 'seven',
           horizontalBarChartdata: { x: 9855, y: 15000 },
-          color: getColorFromToken(DataVizPalette.color15),
+          gradient: getGradientFromToken(DataVizGradientPalette.gradient7Ext),
           xAxisCalloutData: '2021/06/16',
           yAxisCalloutData: '65%',
           callOutAccessibilityData: { ariaLabel: 'Bar series 1 of chart seven 2021/06/16 65%' },
@@ -116,7 +121,7 @@ export const HorizontalBarCustomAccessibility = () => {
         {
           legend: 'eight',
           horizontalBarChartdata: { x: 4250, y: 15000 },
-          color: getColorFromToken(DataVizPalette.color16),
+          gradient: getGradientFromToken(DataVizGradientPalette.gradient8Ext),
           xAxisCalloutData: '2021/06/17',
           yAxisCalloutData: '28%',
           callOutAccessibilityData: { ariaLabel: 'Bar series 1 of chart eight 2021/06/17 28%' },

--- a/packages/charts/react-charts-preview/stories/src/HorizontalBarChart/HorizontalBarChartCustomCallout.stories.tsx
+++ b/packages/charts/react-charts-preview/stories/src/HorizontalBarChart/HorizontalBarChartCustomCallout.stories.tsx
@@ -6,6 +6,8 @@ import {
   DataVizPalette,
   getColorFromToken,
   ChartPopoverProps,
+  DataVizGradientPalette,
+  getGradientFromToken,
 } from '@fluentui/react-charts-preview';
 // import * as d3 from 'd3-format';
 import { Switch, tokens } from '@fluentui/react-components';
@@ -21,7 +23,7 @@ export const HorizontalBarCustomCallout = () => {
         {
           legend: 'one',
           horizontalBarChartdata: { x: 1543, y: 15000 },
-          color: getColorFromToken(DataVizPalette.color28),
+          gradient: getGradientFromToken(DataVizGradientPalette.gradient1Ext),
           xAxisCalloutData: '2020/04/30',
           yAxisCalloutData: '1.5K',
         },
@@ -33,7 +35,7 @@ export const HorizontalBarCustomCallout = () => {
         {
           legend: 'two',
           horizontalBarChartdata: { x: 800, y: 15000 },
-          color: getColorFromToken(DataVizPalette.color29),
+          gradient: getGradientFromToken(DataVizGradientPalette.gradient2Ext),
           xAxisCalloutData: '2020/04/30',
           yAxisCalloutData: '800',
         },
@@ -45,7 +47,7 @@ export const HorizontalBarCustomCallout = () => {
         {
           legend: 'three',
           horizontalBarChartdata: { x: 8888, y: 15000 },
-          color: getColorFromToken(DataVizPalette.color30),
+          gradient: getGradientFromToken(DataVizGradientPalette.gradient3Ext),
           xAxisCalloutData: '2020/04/30',
           yAxisCalloutData: '8.8K',
         },
@@ -57,7 +59,7 @@ export const HorizontalBarCustomCallout = () => {
         {
           legend: 'four',
           horizontalBarChartdata: { x: 15888, y: 15000 },
-          color: getColorFromToken(DataVizPalette.color31),
+          gradient: getGradientFromToken(DataVizGradientPalette.gradient4Ext),
           xAxisCalloutData: '2020/04/30',
           yAxisCalloutData: '16K',
         },
@@ -69,7 +71,7 @@ export const HorizontalBarCustomCallout = () => {
         {
           legend: 'five',
           horizontalBarChartdata: { x: 11444, y: 15000 },
-          color: getColorFromToken(DataVizPalette.color32),
+          gradient: getGradientFromToken(DataVizGradientPalette.gradient5Ext),
           xAxisCalloutData: '2020/04/30',
           yAxisCalloutData: '11K',
         },
@@ -81,7 +83,7 @@ export const HorizontalBarCustomCallout = () => {
         {
           legend: 'six',
           horizontalBarChartdata: { x: 14000, y: 15000 },
-          color: getColorFromToken(DataVizPalette.color33),
+          gradient: getGradientFromToken(DataVizGradientPalette.gradient6Ext),
           xAxisCalloutData: '2020/04/30',
           yAxisCalloutData: '14K',
         },
@@ -93,7 +95,7 @@ export const HorizontalBarCustomCallout = () => {
         {
           legend: 'seven',
           horizontalBarChartdata: { x: 9855, y: 15000 },
-          color: getColorFromToken(DataVizPalette.color34),
+          gradient: getGradientFromToken(DataVizGradientPalette.gradient7Ext),
           xAxisCalloutData: '2020/04/30',
           yAxisCalloutData: '9.9K',
         },
@@ -105,16 +107,17 @@ export const HorizontalBarCustomCallout = () => {
         {
           legend: 'eight',
           horizontalBarChartdata: { x: 4250, y: 15000 },
-          color: getColorFromToken(DataVizPalette.color35),
+          gradient: getGradientFromToken(DataVizGradientPalette.gradient8Ext),
           xAxisCalloutData: '2020/04/30',
           yAxisCalloutData: '4.3K',
         },
       ],
     },
   ];
+
   const customPopoverProps = (props: ChartDataPoint): ChartPopoverProps => {
     const yValue = props ? `${props.yAxisCalloutData! || props.data} h` : '';
-    const color = props ? props.color : getColorFromToken(DataVizPalette.color28);
+    const color = props ? props.gradient?.[0] : getColorFromToken(DataVizPalette.color28);
     return {
       XValue: 'Custom XVal',
       legend: 'Custom Legend',

--- a/packages/charts/react-charts-preview/stories/src/HorizontalBarChart/HorizontalBarChartDefault.stories.tsx
+++ b/packages/charts/react-charts-preview/stories/src/HorizontalBarChart/HorizontalBarChartDefault.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { HorizontalBarChart, getColorFromToken, DataVizPalette } from '@fluentui/react-charts-preview';
+import { HorizontalBarChart, DataVizGradientPalette, getGradientFromToken } from '@fluentui/react-charts-preview';
 
 export const HorizontalBarBasic = () => {
   const data = [
@@ -9,7 +9,7 @@ export const HorizontalBarBasic = () => {
         {
           legend: 'one',
           horizontalBarChartdata: { x: 1543, y: 15000 },
-          color: getColorFromToken(DataVizPalette.color1),
+          gradient: getGradientFromToken(DataVizGradientPalette.gradient1),
           xAxisCalloutData: '2020/04/30',
           yAxisCalloutData: '10%',
         },
@@ -21,7 +21,7 @@ export const HorizontalBarBasic = () => {
         {
           legend: 'two',
           horizontalBarChartdata: { x: 800, y: 15000 },
-          color: getColorFromToken(DataVizPalette.color2),
+          gradient: getGradientFromToken(DataVizGradientPalette.gradient2),
           xAxisCalloutData: '2020/04/30',
           yAxisCalloutData: '5%',
         },
@@ -33,7 +33,7 @@ export const HorizontalBarBasic = () => {
         {
           legend: 'three',
           horizontalBarChartdata: { x: 8888, y: 15000 },
-          color: getColorFromToken(DataVizPalette.color3),
+          gradient: getGradientFromToken(DataVizGradientPalette.gradient3),
           xAxisCalloutData: '2020/04/30',
           yAxisCalloutData: '59%',
         },
@@ -45,7 +45,7 @@ export const HorizontalBarBasic = () => {
         {
           legend: 'four',
           horizontalBarChartdata: { x: 15888, y: 15000 },
-          color: getColorFromToken(DataVizPalette.color4),
+          gradient: getGradientFromToken(DataVizGradientPalette.gradient4),
           xAxisCalloutData: '2020/04/30',
           yAxisCalloutData: '106%',
         },
@@ -57,7 +57,7 @@ export const HorizontalBarBasic = () => {
         {
           legend: 'five',
           horizontalBarChartdata: { x: 11444, y: 15000 },
-          color: getColorFromToken(DataVizPalette.color5),
+          gradient: getGradientFromToken(DataVizGradientPalette.gradient5),
           xAxisCalloutData: '2020/04/30',
           yAxisCalloutData: '76%',
         },
@@ -69,7 +69,7 @@ export const HorizontalBarBasic = () => {
         {
           legend: 'six',
           horizontalBarChartdata: { x: 14000, y: 15000 },
-          color: getColorFromToken(DataVizPalette.color6),
+          gradient: getGradientFromToken(DataVizGradientPalette.gradient6),
           xAxisCalloutData: '2020/04/30',
           yAxisCalloutData: '93%',
         },
@@ -81,7 +81,7 @@ export const HorizontalBarBasic = () => {
         {
           legend: 'seven',
           horizontalBarChartdata: { x: 9855, y: 15000 },
-          color: getColorFromToken(DataVizPalette.color7),
+          gradient: getGradientFromToken(DataVizGradientPalette.gradient7),
           xAxisCalloutData: '2020/04/30',
           yAxisCalloutData: '66%',
         },
@@ -93,7 +93,7 @@ export const HorizontalBarBasic = () => {
         {
           legend: 'eight',
           horizontalBarChartdata: { x: 4250, y: 15000 },
-          color: getColorFromToken(DataVizPalette.color8),
+          gradient: getGradientFromToken(DataVizGradientPalette.gradient8),
           xAxisCalloutData: '2020/04/30',
           yAxisCalloutData: '28%',
         },

--- a/packages/charts/react-charts-preview/stories/src/HorizontalBarChart/HorizontalBarChartVariant.stories.tsx
+++ b/packages/charts/react-charts-preview/stories/src/HorizontalBarChart/HorizontalBarChartVariant.stories.tsx
@@ -3,8 +3,8 @@ import {
   HorizontalBarChart,
   HorizontalBarChartVariant,
   ChartProps,
-  DataVizPalette,
-  getColorFromToken,
+  DataVizGradientPalette,
+  getGradientFromToken,
 } from '@fluentui/react-charts-preview';
 import { Checkbox, CheckboxOnChangeData } from '@fluentui/react-components';
 
@@ -20,7 +20,7 @@ export const HorizontalBarAbsoluteScale = () => {
         {
           legend: 'one',
           horizontalBarChartdata: { x: 1543, y: 15000 },
-          color: getColorFromToken(DataVizPalette.color17),
+          gradient: getGradientFromToken(DataVizGradientPalette.gradient1),
         },
       ],
     },
@@ -30,7 +30,7 @@ export const HorizontalBarAbsoluteScale = () => {
         {
           legend: 'two',
           horizontalBarChartdata: { x: 800, y: 15000 },
-          color: getColorFromToken(DataVizPalette.color18),
+          gradient: getGradientFromToken(DataVizGradientPalette.gradient2),
         },
       ],
     },
@@ -40,7 +40,7 @@ export const HorizontalBarAbsoluteScale = () => {
         {
           legend: 'three',
           horizontalBarChartdata: { x: 8888, y: 15000 },
-          color: getColorFromToken(DataVizPalette.color19),
+          gradient: getGradientFromToken(DataVizGradientPalette.gradient3),
         },
       ],
     },
@@ -50,7 +50,7 @@ export const HorizontalBarAbsoluteScale = () => {
         {
           legend: 'four',
           horizontalBarChartdata: { x: 15888, y: 15000 },
-          color: getColorFromToken(DataVizPalette.color20),
+          gradient: getGradientFromToken(DataVizGradientPalette.gradient4),
         },
       ],
     },
@@ -60,7 +60,7 @@ export const HorizontalBarAbsoluteScale = () => {
         {
           legend: 'five',
           horizontalBarChartdata: { x: 11444, y: 15000 },
-          color: getColorFromToken(DataVizPalette.color21),
+          gradient: getGradientFromToken(DataVizGradientPalette.gradient5),
         },
       ],
     },
@@ -70,7 +70,7 @@ export const HorizontalBarAbsoluteScale = () => {
         {
           legend: 'six',
           horizontalBarChartdata: { x: 14000, y: 15000 },
-          color: getColorFromToken(DataVizPalette.color22),
+          gradient: getGradientFromToken(DataVizGradientPalette.gradient6),
         },
       ],
     },
@@ -80,7 +80,7 @@ export const HorizontalBarAbsoluteScale = () => {
         {
           legend: 'seven',
           horizontalBarChartdata: { x: 9855, y: 15000 },
-          color: getColorFromToken(DataVizPalette.color23),
+          gradient: getGradientFromToken(DataVizGradientPalette.gradient7),
         },
       ],
     },
@@ -90,11 +90,12 @@ export const HorizontalBarAbsoluteScale = () => {
         {
           legend: 'eight',
           horizontalBarChartdata: { x: 4250, y: 15000 },
-          color: getColorFromToken(DataVizPalette.color24),
+          gradient: getGradientFromToken(DataVizGradientPalette.gradient8),
         },
       ],
     },
   ];
+
   return (
     <>
       <div style={{ marginBottom: '20px' }}>


### PR DESCRIPTION
Implement DataVizGradientPalette and rounded corners to v9 charts

## Modified
- DonutChart
- HorizontalBarChart

## New Behavior (UI)
![image](https://github.com/user-attachments/assets/881780f3-c528-4db3-9b7a-0425107d4a43)
![image](https://github.com/user-attachments/assets/43f8444d-39c2-4439-8596-102994bb6b6d)

### Notable Changes:
- Added DataVizGradientPalette in `utilities/gradients.ts`
- Replaced `color` properties with `gradient` in `types/DataPoint.ts`

### New Usage
```jsx
const data: ChartProps = {
  chartData: [
    {
      legend: 'first',
      data: 20000,
      // new `gradient` prop
      gradient: getGradientFromToken(DataVizGradientPalette.gradient1),
    },
    {
      legend: 'second',
      data: 39000,
      // custom gradient
      gradient: [ '#ff88cc', '#db3794' ],
    },
  ],
};
```

## TODO
- VerticalBarChart