### PR TITLE
fix(`react`): Left-aligning menu items in `Pivot`'s overflow menu

### DIFF
--- a/change/@fluentui-react-61cfae8a-355e-4814-bf2d-073d07f4d67e.json
+++ b/change/@fluentui-react-61cfae8a-355e-4814-bf2d-073d07f4d67e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Left-aligning menu items in Pivot's overflow menu.",
+  "packageName": "@fluentui/react",
+  "email": "makotom@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Pivot/Pivot.styles.ts
+++ b/packages/react/src/components/Pivot/Pivot.styles.ts
@@ -224,10 +224,10 @@ export const getStyles = (props: IPivotStyleProps): IPivotStyles => {
       classNames.linkInMenu,
       ...getLinkStyles(props, classNames, true),
       {
-        textAlign: 'left',
-        width: '100%',
+        justifyContent: 'start',
         height: 36,
         lineHeight: 36,
+        width: '100%',
       },
     ],
     linkIsSelected: [


### PR DESCRIPTION
## Previous Behavior

After #32380 merged, there were a number of unintended consequences, one of them making overflow menu items in `Pivot` be centered instead of left-aligned.

![Before](https://github.com/user-attachments/assets/aee10be7-61be-438c-ac56-34ec10a1ba06)

## New Behavior

This PR fixes this issue by left-aligning the items within `Pivot`'s overflow menu.

![After](https://github.com/user-attachments/assets/e5eb2093-b4c8-4a74-adf5-59d957e90911)

## Related Issue(s)

- Fixes #33312
