### PR TITLE
fix(web-components): eslint config for json files

### DIFF
--- a/packages/web-components/.eslintrc.json
+++ b/packages/web-components/.eslintrc.json
@@ -70,5 +70,14 @@
         // TODO: I think we can come up with a regex that ignores variables with __ in them
       }
     ]
-  }
+  },
+  "overrides": [
+    {
+      "files": ["**/*.json"],
+      "rules": {
+        "@typescript-eslint/naming-convention": "off",
+        "@typescript-eslint/no-unused-expressions": "off"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
## Previous Behavior

Warnings are displayed when viewing `packages/web-components/package.json` in VS Code.

## New Behavior

This eslint override for JSON files stops these warnings from being displayed.