### PR TITLE
fix: searchbox dismiss span control not accessible via keyboard

### DIFF
--- a/change/@fluentui-react-search-c8601c24-3de4-405d-8af5-d32f1a6f65c8.json
+++ b/change/@fluentui-react-search-c8601c24-3de4-405d-8af5-d32f1a6f65c8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: searchbox dismiss span control not accessible via keyboard",
+  "packageName": "@fluentui/react-search",
+  "email": "mateus.sle.per@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-search/library/etc/react-search.api.md
+++ b/packages/react-components/react-search/library/etc/react-search.api.md
@@ -24,7 +24,7 @@ export const renderSearchBox_unstable: (state: SearchBoxState) => JSX.Element;
 export const SearchBox: ForwardRefComponent<SearchBoxProps>;
 
 // @public
-export type SearchBoxChangeEvent = React_2.ChangeEvent<HTMLInputElement> | React_2.MouseEvent<HTMLSpanElement>;
+export type SearchBoxChangeEvent = React_2.ChangeEvent<HTMLInputElement> | React_2.MouseEvent<HTMLSpanElement> | React_2.KeyboardEvent<HTMLSpanElement>;
 
 // @public (undocumented)
 export const searchBoxClassNames: SlotClassNames<SearchBoxSlots>;

--- a/packages/react-components/react-search/library/src/components/SearchBox/SearchBox.test.tsx
+++ b/packages/react-components/react-search/library/src/components/SearchBox/SearchBox.test.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import userEvent from '@testing-library/user-event';
-import { render, RenderResult, fireEvent, screen } from '@testing-library/react';
+import { fireEvent, render, RenderResult, screen } from '@testing-library/react';
 import { SearchBox } from './SearchBox';
 import { isConformant } from '../../testing/isConformant';
 import { resetIdsForTests } from '@fluentui/react-utilities';
-import { searchBoxClassNames } from './useSearchBoxStyles.styles';
+import { searchBoxClassNames } from '@fluentui/react-search';
 
 function getSearchBox(): HTMLInputElement {
   return screen.getByRole('searchbox') as HTMLInputElement;
@@ -120,6 +120,18 @@ describe('SearchBox', () => {
     userEvent.click(renderedComponent.getByRole('button'));
     expect(getSearchBox().value).toBe('');
     expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears value after pressing Tab + Enter if focused', () => {
+    renderedComponent = render(<SearchBox defaultValue="hello" />);
+    const searchBox = getSearchBox();
+    searchBox.focus();
+
+    const dismissButton = renderedComponent.getByRole('button');
+    fireEvent.keyDown(searchBox, { key: 'Tab' });
+    fireEvent.keyDown(dismissButton, { key: 'Enter' });
+
+    expect(searchBox.value).toBe('');
   });
 
   it('invokes `onChange` when the dismiss button is clicked', () => {

--- a/packages/react-components/react-search/library/src/components/SearchBox/SearchBox.types.ts
+++ b/packages/react-components/react-search/library/src/components/SearchBox/SearchBox.types.ts
@@ -3,19 +3,19 @@ import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utili
 import type { InputOnChangeData, InputProps, InputSlots, InputState } from '@fluentui/react-input';
 
 export type SearchBoxSlots = InputSlots & {
-    /** Last element in the input, within the input border */
-    dismiss?: Slot<'span'>;
+  /** Last element in the input, within the input border */
+  dismiss?: Slot<'span'>;
 };
 
 /**
  * SearchBox Props
  */
 export type SearchBoxProps = Omit<
-    ComponentProps<Partial<SearchBoxSlots>, 'input'>,
-    // `children` is unsupported. The rest of these native props have customized definitions.
-    'children' | 'defaultValue' | 'onChange' | 'size' | 'type' | 'value'
+  ComponentProps<Partial<SearchBoxSlots>, 'input'>,
+  // `children` is unsupported. The rest of these native props have customized definitions.
+  'children' | 'defaultValue' | 'onChange' | 'size' | 'type' | 'value'
 > &
-    Omit<InputProps, 'onChange'> & {
+  Omit<InputProps, 'onChange'> & {
     /**
      * Custom onChange callback.
      * Will be traditionally supplied with a React.ChangeEvent<HTMLInputElement> for usual character entry.
@@ -24,17 +24,20 @@ export type SearchBoxProps = Omit<
      */
     // eslint-disable-next-line @nx/workspace-consistent-callback-type -- can't change type of existing callback
     onChange?: (event: SearchBoxChangeEvent, data: InputOnChangeData) => void;
-};
+  };
 
 /**
  * State used in rendering SearchBox
  */
 export type SearchBoxState = ComponentState<SearchBoxSlots> &
-    InputState &
-    Required<Pick<InputState, 'size'>> &
-    Required<Pick<SearchBoxProps, 'disabled'>> & {
+  InputState &
+  Required<Pick<InputState, 'size'>> &
+  Required<Pick<SearchBoxProps, 'disabled'>> & {
     focused: boolean;
-};
+  };
 
 /** Overloaded onChange event type, used to merge functionality of regular text entry and the dismiss button */
-export type SearchBoxChangeEvent = React.ChangeEvent<HTMLInputElement> | React.MouseEvent<HTMLSpanElement> | React.KeyboardEvent<HTMLSpanElement>;
+export type SearchBoxChangeEvent =
+  | React.ChangeEvent<HTMLInputElement>
+  | React.MouseEvent<HTMLSpanElement>
+  | React.KeyboardEvent<HTMLSpanElement>;

--- a/packages/react-components/react-search/library/src/components/SearchBox/SearchBox.types.ts
+++ b/packages/react-components/react-search/library/src/components/SearchBox/SearchBox.types.ts
@@ -3,19 +3,19 @@ import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utili
 import type { InputOnChangeData, InputProps, InputSlots, InputState } from '@fluentui/react-input';
 
 export type SearchBoxSlots = InputSlots & {
-  /** Last element in the input, within the input border */
-  dismiss?: Slot<'span'>;
+    /** Last element in the input, within the input border */
+    dismiss?: Slot<'span'>;
 };
 
 /**
  * SearchBox Props
  */
 export type SearchBoxProps = Omit<
-  ComponentProps<Partial<SearchBoxSlots>, 'input'>,
-  // `children` is unsupported. The rest of these native props have customized definitions.
-  'children' | 'defaultValue' | 'onChange' | 'size' | 'type' | 'value'
+    ComponentProps<Partial<SearchBoxSlots>, 'input'>,
+    // `children` is unsupported. The rest of these native props have customized definitions.
+    'children' | 'defaultValue' | 'onChange' | 'size' | 'type' | 'value'
 > &
-  Omit<InputProps, 'onChange'> & {
+    Omit<InputProps, 'onChange'> & {
     /**
      * Custom onChange callback.
      * Will be traditionally supplied with a React.ChangeEvent<HTMLInputElement> for usual character entry.
@@ -24,17 +24,17 @@ export type SearchBoxProps = Omit<
      */
     // eslint-disable-next-line @nx/workspace-consistent-callback-type -- can't change type of existing callback
     onChange?: (event: SearchBoxChangeEvent, data: InputOnChangeData) => void;
-  };
+};
 
 /**
  * State used in rendering SearchBox
  */
 export type SearchBoxState = ComponentState<SearchBoxSlots> &
-  InputState &
-  Required<Pick<InputState, 'size'>> &
-  Required<Pick<SearchBoxProps, 'disabled'>> & {
+    InputState &
+    Required<Pick<InputState, 'size'>> &
+    Required<Pick<SearchBoxProps, 'disabled'>> & {
     focused: boolean;
-  };
+};
 
 /** Overloaded onChange event type, used to merge functionality of regular text entry and the dismiss button */
-export type SearchBoxChangeEvent = React.ChangeEvent<HTMLInputElement> | React.MouseEvent<HTMLSpanElement>;
+export type SearchBoxChangeEvent = React.ChangeEvent<HTMLInputElement> | React.MouseEvent<HTMLSpanElement> | React.KeyboardEvent<HTMLSpanElement>;

--- a/packages/react-components/react-search/library/src/components/SearchBox/__snapshots__/SearchBox.test.tsx.snap
+++ b/packages/react-components/react-search/library/src/components/SearchBox/__snapshots__/SearchBox.test.tsx.snap
@@ -35,7 +35,7 @@ exports[`SearchBox renders a default state 1`] = `
         aria-label="clear"
         class="fui-SearchBox__dismiss"
         role="button"
-        tabindex="-1"
+        tabindex="0"
       >
         <svg
           aria-hidden="true"

--- a/packages/react-components/react-search/library/src/components/SearchBox/useSearchBox.tsx
+++ b/packages/react-components/react-search/library/src/components/SearchBox/useSearchBox.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import type {ExtractSlotProps} from '@fluentui/react-utilities';
+import type { ExtractSlotProps } from '@fluentui/react-utilities';
 import {
   isResolvedShorthand,
   mergeCallbacks,
@@ -8,10 +8,9 @@ import {
   useEventCallback,
   useMergedRefs,
 } from '@fluentui/react-utilities';
-import {useInput_unstable} from '@fluentui/react-input';
-import {DismissRegular, SearchRegular} from '@fluentui/react-icons';
-import {SearchBoxProps, SearchBoxSlots, SearchBoxState} from './SearchBox.types';
-
+import { useInput_unstable } from '@fluentui/react-input';
+import { DismissRegular, SearchRegular } from '@fluentui/react-icons';
+import { SearchBoxProps, SearchBoxSlots, SearchBoxState } from './SearchBox.types';
 
 /**
  * Create the state required to render SearchBox.
@@ -52,59 +51,61 @@ export const useSearchBox_unstable = (props: SearchBoxProps, ref: React.Ref<HTML
   }, [setFocused]);
 
   const onBlur: React.FocusEventHandler<HTMLSpanElement> = React.useCallback(
-      ev => {
-        setFocused(!!searchBoxRootRef.current?.contains(ev.relatedTarget));
-      },
-      [setFocused],
+    ev => {
+      setFocused(!!searchBoxRootRef.current?.contains(ev.relatedTarget));
+    },
+    [setFocused],
   );
 
   const rootProps = slot.resolveShorthand(root);
 
-  const handleDismissClick = useEventCallback((event: React.MouseEvent<HTMLSpanElement> | React.KeyboardEvent<HTMLSpanElement>) => {
-    if (isResolvedShorthand(dismiss) && event.type === 'click') {
-      dismiss.onClick?.(event as React.MouseEvent<HTMLSpanElement>);
-    }
-    const newValue = '';
-    setInternalValue(newValue);
-    props.onChange?.(event, { value: newValue });
-  });
+  const handleDismissClick = useEventCallback(
+    (event: React.MouseEvent<HTMLSpanElement> | React.KeyboardEvent<HTMLSpanElement>) => {
+      if (isResolvedShorthand(dismiss) && event.type === 'click') {
+        dismiss.onClick?.(event as React.MouseEvent<HTMLSpanElement>);
+      }
+      const newValue = '';
+      setInternalValue(newValue);
+      props.onChange?.(event, { value: newValue });
+    },
+  );
 
   const inputState = useInput_unstable(
-      {
-        type: 'search',
-        disabled,
-        size,
-        value: internalValue,
-        root: slot.always<ExtractSlotProps<SearchBoxSlots['root']>>(
-            {
-              ...rootProps,
-              ref: useMergedRefs(rootProps?.ref, searchBoxRootRef),
-              onFocus: mergeCallbacks(rootProps?.onFocus, onFocus),
-              onBlur: mergeCallbacks(rootProps?.onBlur, onBlur),
-            },
-            {
-              elementType: 'span',
-            },
-        ),
-        contentBefore: slot.optional(contentBefore, {
-          renderByDefault: true,
-          defaultProps: {
-            children: <SearchRegular />,
-          },
+    {
+      type: 'search',
+      disabled,
+      size,
+      value: internalValue,
+      root: slot.always<ExtractSlotProps<SearchBoxSlots['root']>>(
+        {
+          ...rootProps,
+          ref: useMergedRefs(rootProps?.ref, searchBoxRootRef),
+          onFocus: mergeCallbacks(rootProps?.onFocus, onFocus),
+          onBlur: mergeCallbacks(rootProps?.onBlur, onBlur),
+        },
+        {
           elementType: 'span',
-        }),
-        contentAfter: slot.optional(contentAfter, {
-          renderByDefault: true,
-          elementType: 'span',
-        }),
-        ...inputProps,
-        onChange: useEventCallback(ev => {
-          const newValue = ev.target.value;
-          props.onChange?.(ev, { value: newValue });
-          setInternalValue(newValue);
-        }),
-      },
-      useMergedRefs(searchBoxRef, ref),
+        },
+      ),
+      contentBefore: slot.optional(contentBefore, {
+        renderByDefault: true,
+        defaultProps: {
+          children: <SearchRegular />,
+        },
+        elementType: 'span',
+      }),
+      contentAfter: slot.optional(contentAfter, {
+        renderByDefault: true,
+        elementType: 'span',
+      }),
+      ...inputProps,
+      onChange: useEventCallback(ev => {
+        const newValue = ev.target.value;
+        props.onChange?.(ev, { value: newValue });
+        setInternalValue(newValue);
+      }),
+    },
+    useMergedRefs(searchBoxRef, ref),
   );
 
   const state: SearchBoxState = {

--- a/packages/react-components/react-search/library/src/components/SearchBox/useSearchBox.tsx
+++ b/packages/react-components/react-search/library/src/components/SearchBox/useSearchBox.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import type {ExtractSlotProps} from '@fluentui/react-utilities';
 import {
   isResolvedShorthand,
   mergeCallbacks,
@@ -7,10 +8,10 @@ import {
   useEventCallback,
   useMergedRefs,
 } from '@fluentui/react-utilities';
-import { useInput_unstable } from '@fluentui/react-input';
-import { DismissRegular, SearchRegular } from '@fluentui/react-icons';
-import type { ExtractSlotProps } from '@fluentui/react-utilities';
-import type { SearchBoxSlots, SearchBoxProps, SearchBoxState } from './SearchBox.types';
+import {useInput_unstable} from '@fluentui/react-input';
+import {DismissRegular, SearchRegular} from '@fluentui/react-icons';
+import {SearchBoxProps, SearchBoxSlots, SearchBoxState} from './SearchBox.types';
+
 
 /**
  * Create the state required to render SearchBox.
@@ -51,17 +52,17 @@ export const useSearchBox_unstable = (props: SearchBoxProps, ref: React.Ref<HTML
   }, [setFocused]);
 
   const onBlur: React.FocusEventHandler<HTMLSpanElement> = React.useCallback(
-    ev => {
-      setFocused(!!searchBoxRootRef.current?.contains(ev.relatedTarget));
-    },
-    [setFocused],
+      ev => {
+        setFocused(!!searchBoxRootRef.current?.contains(ev.relatedTarget));
+      },
+      [setFocused],
   );
 
   const rootProps = slot.resolveShorthand(root);
 
-  const handleDismissClick = useEventCallback((event: React.MouseEvent<HTMLSpanElement>) => {
-    if (isResolvedShorthand(dismiss)) {
-      dismiss.onClick?.(event);
+  const handleDismissClick = useEventCallback((event: React.MouseEvent<HTMLSpanElement> | React.KeyboardEvent<HTMLSpanElement>) => {
+    if (isResolvedShorthand(dismiss) && event.type === 'click') {
+      dismiss.onClick?.(event as React.MouseEvent<HTMLSpanElement>);
     }
     const newValue = '';
     setInternalValue(newValue);
@@ -69,41 +70,41 @@ export const useSearchBox_unstable = (props: SearchBoxProps, ref: React.Ref<HTML
   });
 
   const inputState = useInput_unstable(
-    {
-      type: 'search',
-      disabled,
-      size,
-      value: internalValue,
-      root: slot.always<ExtractSlotProps<SearchBoxSlots['root']>>(
-        {
-          ...rootProps,
-          ref: useMergedRefs(rootProps?.ref, searchBoxRootRef),
-          onFocus: mergeCallbacks(rootProps?.onFocus, onFocus),
-          onBlur: mergeCallbacks(rootProps?.onBlur, onBlur),
-        },
-        {
+      {
+        type: 'search',
+        disabled,
+        size,
+        value: internalValue,
+        root: slot.always<ExtractSlotProps<SearchBoxSlots['root']>>(
+            {
+              ...rootProps,
+              ref: useMergedRefs(rootProps?.ref, searchBoxRootRef),
+              onFocus: mergeCallbacks(rootProps?.onFocus, onFocus),
+              onBlur: mergeCallbacks(rootProps?.onBlur, onBlur),
+            },
+            {
+              elementType: 'span',
+            },
+        ),
+        contentBefore: slot.optional(contentBefore, {
+          renderByDefault: true,
+          defaultProps: {
+            children: <SearchRegular />,
+          },
           elementType: 'span',
-        },
-      ),
-      contentBefore: slot.optional(contentBefore, {
-        renderByDefault: true,
-        defaultProps: {
-          children: <SearchRegular />,
-        },
-        elementType: 'span',
-      }),
-      contentAfter: slot.optional(contentAfter, {
-        renderByDefault: true,
-        elementType: 'span',
-      }),
-      ...inputProps,
-      onChange: useEventCallback(ev => {
-        const newValue = ev.target.value;
-        props.onChange?.(ev, { value: newValue });
-        setInternalValue(newValue);
-      }),
-    },
-    useMergedRefs(searchBoxRef, ref),
+        }),
+        contentAfter: slot.optional(contentAfter, {
+          renderByDefault: true,
+          elementType: 'span',
+        }),
+        ...inputProps,
+        onChange: useEventCallback(ev => {
+          const newValue = ev.target.value;
+          props.onChange?.(ev, { value: newValue });
+          setInternalValue(newValue);
+        }),
+      },
+      useMergedRefs(searchBoxRef, ref),
   );
 
   const state: SearchBoxState = {
@@ -117,7 +118,12 @@ export const useSearchBox_unstable = (props: SearchBoxProps, ref: React.Ref<HTML
         children: <DismissRegular />,
         role: 'button',
         'aria-label': 'clear',
-        tabIndex: -1,
+        tabIndex: 0,
+        onKeyDown: useEventCallback(ev => {
+          if (ev.key === 'Enter') {
+            handleDismissClick(ev);
+          }
+        }),
       },
       renderByDefault: true,
       elementType: 'span',


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [X] Code is up-to-date with the `master` branch
* [X] Your changes are covered by tests (if possible)
* [X] You've run `yarn change` locally


PR flow tips:
* [X] Try to start with a Draft PR
* [X] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
[current_behavior.webm](https://github.com/user-attachments/assets/9f166695-8978-4dd3-b226-54fc17bff202)

<!-- This is the behavior we have today -->

## New Behavior
[new_behavior.webm](https://github.com/user-attachments/assets/ca4f8740-787b-4199-9bf4-cef81420a06c)

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #33324 
