### PR TITLE
fix(react-search): Restore focus to `SearchBox` after clear button is clicked

### DIFF
--- a/change/@fluentui-react-search-ee89326e-8228-4cb3-911a-25ccd8ea4f8e.json
+++ b/change/@fluentui-react-search-ee89326e-8228-4cb3-911a-25ccd8ea4f8e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(react-search): restore focus to SearchBox after clear button is clicked",
+  "packageName": "@fluentui/react-search",
+  "email": "jiangemma@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-search/library/src/components/SearchBox/useSearchBox.tsx
+++ b/packages/react-components/react-search/library/src/components/SearchBox/useSearchBox.tsx
@@ -66,6 +66,8 @@ export const useSearchBox_unstable = (props: SearchBoxProps, ref: React.Ref<HTML
     const newValue = '';
     setInternalValue(newValue);
     props.onChange?.(event, { value: newValue });
+
+    searchBoxRef.current?.focus();
   });
 
   const inputState = useInput_unstable(


### PR DESCRIPTION
## Previous Behavior

<!-- This is the behavior we have today -->

When the clear button is pressed, the contents of the `SearchBox` is cleared but focus remains on the clear button.

## New Behavior

When the clear button is pressed, the contents of the `SearchBox` is cleared and focus is restored to the `SearchBox`, so users don't have to perform an extra action to begin typing in the `SearchBox` again.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

N/A
