### PR TITLE
fix: Menu gets a scrollbar when it does not fit in the viewport

### DIFF
--- a/change/@fluentui-react-menu-03eacec4-8929-4be4-8813-62c6cc3ea21e.json
+++ b/change/@fluentui-react-menu-03eacec4-8929-4be4-8813-62c6cc3ea21e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Menu gets a scrollbar when it does not fit in the viewport",
+  "packageName": "@fluentui/react-menu",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-menu/library/src/components/Menu/useMenu.tsx
+++ b/packages/react-components/react-menu/library/src/components/Menu/useMenu.tsx
@@ -63,6 +63,7 @@ export const useMenu_unstable = (props: MenuProps): MenuState => {
     align: isSubmenu ? 'top' : 'start',
     target: props.openOnContext ? contextTarget : undefined,
     fallbackPositions: isSubmenu ? submenuFallbackPositions : undefined,
+    autoSize: true,
     ...resolvePositioningShorthand(props.positioning),
   } as const;
 


### PR DESCRIPTION
## Previous Behavior

When the Menu popup could not fit within the viewport using any allowed positioning fallback, it would pick the best fit and get clipped by the viewport. This could theoretically be fine if the page can scroll, but when a Menu is too close to the top or left of the page, it can be clipped by the page bounds and fully inaccessible.

This particularly affects zooming & small screen scenarios (and specifically the Reflow WCAG criterion), since it's more likely to happen at smaller viewport sizes.

Even when page scroll could give access to the menu, it's probably more ergonomic to allow the menu itself to scroll without moving the page & trigger out of view.

<img width="387" alt="Screenshot of an open menu showing the top header clipped by the top of the viewport" src="https://github.com/user-attachments/assets/fab80369-1bed-46cf-81cf-e06ec71471db">
(here the top of the menu is clipped out of view)

## New Behavior

Adds `autoSize: true` to the default Positioning options, so the menu has scroll overflow by default if it doesn't fit in the viewport.

https://github.com/user-attachments/assets/88bf81aa-8d60-4650-b410-2e3b6431e3a9

## Related Issue(s)

- Fixes [ADO issue](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/18533)
