### PR TITLE
chore(react-tag-picker): ensure no toggle behaviour when re-selecting already selected data

### DIFF
--- a/change/@fluentui-react-tag-picker-7980ff9b-a205-4ac9-a45d-b3043836e532.json
+++ b/change/@fluentui-react-tag-picker-7980ff9b-a205-4ac9-a45d-b3043836e532.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore(react-tag-picker): ensure no toggle behaviour when re-selecting already selected data",
+  "packageName": "@fluentui/react-tag-picker",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tag-picker/library/src/components/TagPicker/useTagPicker.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPicker/useTagPicker.ts
@@ -70,7 +70,6 @@ export const useTagPicker_unstable = (props: TagPickerProps): TagPickerState => 
   });
 
   const { trigger, popover } = childrenToTriggerAndPopover(props.children, noPopover);
-
   return {
     activeDescendantController,
     components: {},
@@ -98,7 +97,20 @@ export const useTagPicker_unstable = (props: TagPickerProps): TagPickerState => 
     getOptionsMatchingValue: comboboxState.getOptionsMatchingValue,
     registerOption: comboboxState.registerOption,
     selectedOptions: comboboxState.selectedOptions,
-    selectOption: comboboxState.selectOption,
+    selectOption: useEventCallback((event, data) => {
+      // if the option is already selected, invoke onOptionSelect callback with current selected values
+      // the combobox state would unselect the option, which is not the behavior expected
+      if (comboboxState.selectedOptions.includes(data.value)) {
+        props.onOptionSelect?.(event, {
+          selectedOptions: comboboxState.selectedOptions,
+          value: data.value,
+          type: event.type,
+          event,
+        } as TagPickerOnOptionSelectData);
+        return;
+      }
+      comboboxState.selectOption(event, data);
+    }),
     setHasFocus: comboboxState.setHasFocus,
     setOpen: comboboxState.setOpen,
     setValue: comboboxState.setValue,

--- a/packages/react-components/react-tag-picker/library/src/components/TagPicker/useTagPicker.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPicker/useTagPicker.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useEventCallback, useId, useMergedRefs } from '@fluentui/react-utilities';
+import { elementContains, useEventCallback, useId, useMergedRefs } from '@fluentui/react-utilities';
 import type {
   TagPickerOnOpenChangeData,
   TagPickerOnOptionSelectData,
@@ -100,7 +100,10 @@ export const useTagPicker_unstable = (props: TagPickerProps): TagPickerState => 
     selectOption: useEventCallback((event, data) => {
       // if the option is already selected, invoke onOptionSelect callback with current selected values
       // the combobox state would unselect the option, which is not the behavior expected
-      if (comboboxState.selectedOptions.includes(data.value)) {
+      if (
+        comboboxState.selectedOptions.includes(data.value) &&
+        !elementContains(tagPickerGroupRef.current, event.target as Node)
+      ) {
         props.onOptionSelect?.(event, {
           selectedOptions: comboboxState.selectedOptions,
           value: data.value,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

At the moment whenever the user tries to re-select the same option, the option is unselected. This happens because we're using `Combobox` logic internally to implement `TagPicker` logic, but this is a bit problematic in this scenario as `Combobox` supports toggling the selected data on the "option select event", meanwhile `TagPicker` only allows selection on the "option select event", to unselect a tag should be clicked manually, it does not involve the combobox logic

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

1. adds conditional logic to ensure internal combobox state will not be updated in this scenario. Instead, `onOptionsSelect` should be invoked with the current `selectedOptions` with no modifications

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/33305
