### PR TITLE
feat(motion): add extended support for reduced motion

### DIFF
--- a/change/@fluentui-react-motion-f4c1433b-f36e-4b2c-a9bd-9b16f37489fc.json
+++ b/change/@fluentui-react-motion-f4c1433b-f36e-4b2c-a9bd-9b16f37489fc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: add extended support for reduced motion",
+  "packageName": "@fluentui/react-motion",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-motion/library/etc/react-motion.api.md
+++ b/packages/react-components/react-motion/library/etc/react-motion.api.md
@@ -9,9 +9,9 @@ import { SlotComponentType } from '@fluentui/react-utilities';
 import { SlotRenderFunction } from '@fluentui/react-utilities';
 
 // @public (undocumented)
-export type AtomMotion = {
-    keyframes: Keyframe[];
-} & KeyframeEffectOptions;
+export type AtomMotion = AtomCore & {
+    reducedMotion?: Partial<AtomCore>;
+};
 
 // @public (undocumented)
 export type AtomMotionFn<MotionParams extends Record<string, MotionParam> = {}> = (params: {

--- a/packages/react-components/react-motion/library/src/hooks/useAnimateAtoms.test.tsx
+++ b/packages/react-components/react-motion/library/src/hooks/useAnimateAtoms.test.tsx
@@ -1,0 +1,88 @@
+import { renderHook } from '@testing-library/react-hooks';
+
+import type { AtomMotion } from '../types';
+import { DEFAULT_ANIMATION_OPTIONS, useAnimateAtoms } from './useAnimateAtoms';
+
+function createElementMock() {
+  const animate = jest.fn().mockReturnValue({
+    persist: jest.fn(),
+  });
+
+  return [{ animate } as unknown as HTMLElement, animate] as const;
+}
+
+const DEFAULT_KEYFRAMES = [{ transform: 'rotate(0)' }, { transform: 'rotate(180deg)' }];
+const REDUCED_MOTION_KEYFRAMES = [{ opacity: 0 }, { opacity: 1 }];
+
+describe('useAnimateAtoms', () => {
+  beforeEach(() => {
+    // We set production environment to avoid testing the mock implementation
+    process.env.NODE_ENV = 'production';
+  });
+
+  it('should return a function', () => {
+    const { result } = renderHook(() => useAnimateAtoms());
+
+    expect(result.current).toBeInstanceOf(Function);
+  });
+
+  describe('reduce motion', () => {
+    it('calls ".animate()" with regular motion', () => {
+      const { result } = renderHook(() => useAnimateAtoms());
+
+      const [element, animateMock] = createElementMock();
+      const motion: AtomMotion = { keyframes: DEFAULT_KEYFRAMES };
+
+      result.current(element, motion, { isReducedMotion: false });
+
+      expect(animateMock).toHaveBeenCalledTimes(1);
+      expect(animateMock).toHaveBeenCalledWith(DEFAULT_KEYFRAMES, { ...DEFAULT_ANIMATION_OPTIONS });
+    });
+
+    it('calls ".animate()" with shortened duration (1ms) when reduced motion is enabled', () => {
+      const { result } = renderHook(() => useAnimateAtoms());
+
+      const [element, animateMock] = createElementMock();
+      const motion: AtomMotion = { keyframes: DEFAULT_KEYFRAMES };
+
+      result.current(element, motion, { isReducedMotion: true });
+
+      expect(animateMock).toHaveBeenCalledTimes(1);
+      expect(animateMock).toHaveBeenCalledWith(DEFAULT_KEYFRAMES, { ...DEFAULT_ANIMATION_OPTIONS, duration: 1 });
+    });
+
+    it('calls ".animate()" with specified reduced motion keyframes when reduced motion is enabled', () => {
+      const { result } = renderHook(() => useAnimateAtoms());
+
+      const [element, animateMock] = createElementMock();
+      const motion: AtomMotion = {
+        keyframes: DEFAULT_KEYFRAMES,
+        reducedMotion: { keyframes: REDUCED_MOTION_KEYFRAMES },
+      };
+
+      result.current(element, motion, { isReducedMotion: true });
+
+      expect(animateMock).toHaveBeenCalledTimes(1);
+      expect(animateMock).toHaveBeenCalledWith(REDUCED_MOTION_KEYFRAMES, { ...DEFAULT_ANIMATION_OPTIONS });
+    });
+
+    it('calls ".animate()" with specified reduced motion params when reduced motion is enabled', () => {
+      const { result } = renderHook(() => useAnimateAtoms());
+
+      const [element, animateMock] = createElementMock();
+      const motion: AtomMotion = {
+        keyframes: DEFAULT_KEYFRAMES,
+        reducedMotion: { duration: 100, easing: 'linear' },
+      };
+
+      result.current(element, motion, { isReducedMotion: true });
+
+      expect(animateMock).toHaveBeenCalledTimes(1);
+      expect(animateMock).toHaveBeenCalledWith(DEFAULT_KEYFRAMES, {
+        ...DEFAULT_ANIMATION_OPTIONS,
+        easing: 'linear',
+        duration: 100,
+      });
+    });
+  });
+});

--- a/packages/react-components/react-motion/library/src/hooks/useAnimateAtoms.ts
+++ b/packages/react-components/react-motion/library/src/hooks/useAnimateAtoms.ts
@@ -1,6 +1,10 @@
 import * as React from 'react';
 import type { AnimationHandle, AtomMotion } from '../types';
 
+export const DEFAULT_ANIMATION_OPTIONS: KeyframeEffectOptions = {
+  fill: 'forwards',
+};
+
 function useAnimateAtomsInSupportedEnvironment() {
   // eslint-disable-next-line @nx/workspace-no-restricted-globals
   const SUPPORTS_PERSIST = typeof window !== 'undefined' && typeof window.Animation?.prototype.persist === 'function';
@@ -17,13 +21,20 @@ function useAnimateAtomsInSupportedEnvironment() {
       const { isReducedMotion } = options;
 
       const animations = atoms.map(motion => {
-        const { keyframes, ...params } = motion;
-        const animation = element.animate(keyframes, {
-          fill: 'forwards',
+        const { keyframes, reducedMotion, ...params } = motion;
+        const { keyframes: reducedMotionKeyframes = keyframes, ...reducedMotionParams } = reducedMotion ?? {
+          duration: 1,
+        };
 
+        const animationKeyframes: Keyframe[] = isReducedMotion ? reducedMotionKeyframes : keyframes;
+        const animationParams: KeyframeEffectOptions = {
+          ...DEFAULT_ANIMATION_OPTIONS,
           ...params,
-          ...(isReducedMotion && { duration: 1 }),
-        });
+
+          ...(isReducedMotion && reducedMotionParams),
+        };
+
+        const animation = element.animate(animationKeyframes, animationParams);
 
         if (SUPPORTS_PERSIST) {
           animation.persist();

--- a/packages/react-components/react-motion/library/src/types.ts
+++ b/packages/react-components/react-motion/library/src/types.ts
@@ -1,15 +1,15 @@
-export type AtomMotion = { keyframes: Keyframe[] } & KeyframeEffectOptions & {
-    /**
-     * Allows to specify a reduced motion version of the animation. If provided, the settings will be used when the
-     * user has enabled the reduced motion setting in the operating system. If not provided, the duration of the
-     * animation will be overridden to be 1ms.
-     *
-     * Note, if keyframes are provided, they will be used instead of the regular keyframes.
-     *
-     * @see https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion
-     */
-    reducedMotion?: { keyframes?: Keyframe[] } & KeyframeEffectOptions;
-  };
+type AtomCore = { keyframes: Keyframe[] } & KeyframeEffectOptions;
+
+export type AtomMotion = AtomCore & {
+  /**
+   * Allows to specify a reduced motion version of the animation. If provided, the settings will be used when the
+   * user has enabled the reduced motion setting in the operating system (i.e `prefers-reduced-motion` media query is
+   * active). If not provided, the duration of the animation will be overridden to be 1ms.
+   *
+   * Note, if `keyframes` are provided, they will be used instead of the regular `keyframes`.
+   */
+  reducedMotion?: Partial<AtomCore>;
+};
 
 export type PresenceDirection = 'enter' | 'exit';
 

--- a/packages/react-components/react-motion/library/src/types.ts
+++ b/packages/react-components/react-motion/library/src/types.ts
@@ -1,4 +1,15 @@
-export type AtomMotion = { keyframes: Keyframe[] } & KeyframeEffectOptions;
+export type AtomMotion = { keyframes: Keyframe[] } & KeyframeEffectOptions & {
+    /**
+     * Allows to specify a reduced motion version of the animation. If provided, the settings will be used when the
+     * user has enabled the reduced motion setting in the operating system. If not provided, the duration of the
+     * animation will be overridden to be 1ms.
+     *
+     * Note, if keyframes are provided, they will be used instead of the regular keyframes.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion
+     */
+    reducedMotion?: { keyframes?: Keyframe[] } & KeyframeEffectOptions;
+  };
 
 export type PresenceDirection = 'enter' | 'exit';
 

--- a/packages/react-components/react-motion/stories/src/CreateMotionComponent/CreateMotionComponentDefault.stories.tsx
+++ b/packages/react-components/react-motion/stories/src/CreateMotionComponent/CreateMotionComponentDefault.stories.tsx
@@ -41,6 +41,10 @@ const FadeEnter = createMotionComponent({
   keyframes: [{ opacity: 0 }, { opacity: 1 }],
   duration: motionTokens.durationSlow,
   iterations: Infinity,
+
+  reducedMotion: {
+    iterations: 1,
+  },
 });
 
 export const CreateMotionComponentDefault = (props: MotionComponentProps) => {

--- a/packages/react-components/react-motion/stories/src/CreateMotionComponent/CreateMotionComponentFactory.stories.tsx
+++ b/packages/react-components/react-motion/stories/src/CreateMotionComponent/CreateMotionComponentFactory.stories.tsx
@@ -45,6 +45,10 @@ const DropIn = createMotionComponent({
   ],
   duration: 4000,
   iterations: Infinity,
+
+  reducedMotion: {
+    iterations: 1,
+  },
 });
 
 export const CreateMotionComponentFactory = () => {

--- a/packages/react-components/react-motion/stories/src/CreateMotionComponent/CreateMotionComponentFunctionParams.stories.tsx
+++ b/packages/react-components/react-motion/stories/src/CreateMotionComponent/CreateMotionComponentFunctionParams.stories.tsx
@@ -81,6 +81,10 @@ const Scale = createMotionComponent<{ startFrom?: number }>(({ startFrom = 0.5 }
     ],
     duration: motionTokens.durationUltraSlow,
     iterations: Infinity,
+
+    reducedMotion: {
+      iterations: 1,
+    },
   };
 });
 

--- a/packages/react-components/react-motion/stories/src/CreateMotionComponent/CreateMotionComponentImperativeRefPlayState.stories.tsx
+++ b/packages/react-components/react-motion/stories/src/CreateMotionComponent/CreateMotionComponentImperativeRefPlayState.stories.tsx
@@ -66,6 +66,10 @@ const FadeEnter = createMotionComponent({
   keyframes: [{ opacity: 0 }, { opacity: 1 }],
   duration: motionTokens.durationSlow,
   iterations: Infinity,
+
+  reducedMotion: {
+    iterations: 1,
+  },
 });
 
 export const CreateMotionComponentImperativeRefPlayState = () => {

--- a/packages/react-components/react-motion/stories/src/CreateMotionComponent/CreateMotionComponentTokensUsage.stories.tsx
+++ b/packages/react-components/react-motion/stories/src/CreateMotionComponent/CreateMotionComponentTokensUsage.stories.tsx
@@ -45,6 +45,10 @@ const BackgroundChange = createMotionComponent({
   ],
   duration: 3000,
   iterations: Infinity,
+
+  reducedMotion: {
+    iterations: 1,
+  },
 });
 
 export const CreateMotionComponentTokensUsage = () => {

--- a/packages/react-components/react-motion/stories/src/CreatePresenceComponent/CreatePresenceComponentReducedMotion.stories.md
+++ b/packages/react-components/react-motion/stories/src/CreatePresenceComponent/CreatePresenceComponentReducedMotion.stories.md
@@ -1,0 +1,24 @@
+By default, when [reduced motion](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion) is enabled the duration of the animation is set to `1ms`. `reducedMotion` allows to customize a reduced motion version of the animation:
+
+```ts
+const Motion = createPresenceComponent({
+  enter: {
+    keyframes: [
+      { opacity: 0, transform: 'scale(0)' },
+      { opacity: 1, transform: 'scale(1)' },
+    ],
+    duration: 300,
+
+    /* 💡reduced motion will not have scale animation */
+    reducedMotion: {
+      keyframes: [{ opacity: 0 }, { opacity: 1 }],
+      duration: 1000,
+    },
+  },
+  exit: {
+    /* ... */
+  },
+});
+```
+
+> 💡Note, if `keyframes` are provided, they will be used instead of the regular keyframes.

--- a/packages/react-components/react-motion/stories/src/CreatePresenceComponent/CreatePresenceComponentReducedMotion.stories.tsx
+++ b/packages/react-components/react-motion/stories/src/CreatePresenceComponent/CreatePresenceComponentReducedMotion.stories.tsx
@@ -1,16 +1,17 @@
 import {
-  createMotionComponent,
+  createPresenceComponent,
   Field,
   makeStyles,
   mergeClasses,
   type MotionImperativeRef,
   motionTokens,
   Slider,
+  Switch,
   tokens,
 } from '@fluentui/react-components';
 import * as React from 'react';
 
-import description from './CreateMotionComponentFunctions.stories.md';
+import description from './CreatePresenceComponentReducedMotion.stories.md';
 
 const useClasses = makeStyles({
   container: {
@@ -29,7 +30,6 @@ const useClasses = makeStyles({
     borderRadius: tokens.borderRadiusMedium,
     boxShadow: tokens.shadow16,
     padding: '10px',
-    minHeight: '180px',
   },
   controls: {
     display: 'flex',
@@ -52,53 +52,68 @@ const useClasses = makeStyles({
   },
 
   item: {
-    border: `${tokens.strokeWidthThicker} solid ${tokens.colorBrandBackground}`,
-    padding: '8px',
-    width: '300px',
-    overflow: 'hidden',
+    backgroundColor: tokens.colorBrandBackground,
+    border: `${tokens.strokeWidthThicker} solid ${tokens.colorTransparentStroke}`,
+
+    width: '100px',
+    height: '100px',
   },
-  description: { margin: '5px' },
 });
 
-const Grow = createMotionComponent(({ element }) => ({
-  duration: motionTokens.durationUltraSlow,
-  keyframes: [
-    { opacity: 0, maxHeight: `${element.scrollHeight / 2}px` },
-    { opacity: 1, maxHeight: `${element.scrollHeight}px` },
-    { opacity: 0, maxHeight: `${element.scrollHeight / 2}px` },
-  ],
-  iterations: Infinity,
+const FadeAndScale = createPresenceComponent({
+  enter: {
+    keyframes: [
+      { opacity: 0, transform: 'rotate(0)' },
+      { transform: 'rotate(90deg) scale(1.5)' },
+      { opacity: 1, transform: 'rotate(0)' },
+    ],
+    duration: motionTokens.durationGentle,
 
-  reducedMotion: {
-    iterations: 1,
+    reducedMotion: {
+      keyframes: [{ opacity: 0 }, { opacity: 1 }],
+      duration: motionTokens.durationUltraSlow,
+    },
   },
-}));
+  exit: {
+    keyframes: [
+      { opacity: 1, transform: 'rotate(0)' },
+      { transform: 'rotate(-90deg) scale(1.5)' },
+      { opacity: 0, transform: 'rotate(0)' },
+    ],
+    duration: motionTokens.durationGentle,
 
-export const CreateMotionComponentFunctions = () => {
+    reducedMotion: {
+      keyframes: [{ opacity: 1 }, { opacity: 0 }],
+      duration: motionTokens.durationUltraSlow,
+    },
+  },
+});
+
+export const CreatePresenceComponentReducedMotion = () => {
   const classes = useClasses();
-
   const motionRef = React.useRef<MotionImperativeRef>();
-  const [playbackRate, setPlaybackRate] = React.useState<number>(20);
+
+  const [playbackRate, setPlaybackRate] = React.useState<number>(30);
+  const [visible, setVisible] = React.useState<boolean>(true);
 
   // Heads up!
   // This is optional and is intended solely to slow down the animations, making motions more visible in the examples.
   React.useEffect(() => {
     motionRef.current?.setPlaybackRate(playbackRate / 100);
-  }, [playbackRate]);
+  }, [playbackRate, visible]);
 
   return (
     <div className={classes.container}>
       <div className={classes.card}>
-        <Grow imperativeRef={motionRef}>
-          <div className={classes.item}>
-            Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Sed vel lectus. Donec odio tempus molestie,
-            porttitor ut, iaculis quis, sem. Integer vulputate sem a nibh rutrum consequat. Etiam quis quam. Curabitur
-            sagittis hendrerit ante. Duis ante orci, molestie vitae vehicula venenatis, tincidunt ac pede.
-          </div>
-        </Grow>
+        <FadeAndScale imperativeRef={motionRef} visible={visible}>
+          <div className={classes.item} />
+        </FadeAndScale>
       </div>
 
       <div className={classes.controls}>
+        <Field className={classes.field}>
+          <Switch label="Visible" checked={visible} onChange={() => setVisible(v => !v)} />
+        </Field>
         <Field
           className={mergeClasses(classes.field, classes.sliderField)}
           label={{
@@ -126,7 +141,7 @@ export const CreateMotionComponentFunctions = () => {
   );
 };
 
-CreateMotionComponentFunctions.parameters = {
+CreatePresenceComponentReducedMotion.parameters = {
   docs: {
     description: {
       story: description,

--- a/packages/react-components/react-motion/stories/src/CreatePresenceComponent/index.stories.ts
+++ b/packages/react-components/react-motion/stories/src/CreatePresenceComponent/index.stories.ts
@@ -8,6 +8,7 @@ export { CreatePresenceComponentDefault as Default } from './CreatePresenceCompo
 export { CreatePresenceComponentFactory as createPresenceComponent } from './CreatePresenceComponentFactory.stories';
 
 export { CreatePresenceComponentAppear as appear } from './CreatePresenceComponentAppear.stories';
+export { CreatePresenceComponentReducedMotion as reducedMotion } from './CreatePresenceComponentReducedMotion.stories';
 export { CreatePresenceComponentUnmountOnExit as unmountOnExit } from './CreatePresenceComponentUnmountOnExit.stories';
 export { CreatePresenceComponentLifecycleCallbacks as LifecycleCallbacks } from './CreatePresenceComponentLifecycleCallbacks.stories';
 


### PR DESCRIPTION
## Previous Behavior

No way to customize motions' behavior when reduced motion is enabled.

## New Behavior

- Adds `reducedMotion` option to `AtomMotion` type.
- Tests added
- Story added

By default, when [reduced motion](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion) is enabled the duration of the animation is set to `1ms` (current behavior).

`reducedMotion` allows to customize a reduced motion version of the animation:

```ts
const Motion = createPresenceComponent({
  enter: {
    keyframes: [
      { opacity: 0, transform: 'scale(0)' },
      { opacity: 1, transform: 'scale(1)' },
    ],
    duration: 300,

    /** 💡reduced motion will not have scale animation with a different duration */
    reducedMotion: {
      keyframes: [{ opacity: 0 }, { opacity: 1 }],
      duration: 1000,
    },
  },
  exit: {
    /* ... */
  },
});
```

> 💡Note, if `keyframes` are provided, they will be used instead of the regular keyframes.

This will also works with arrays of atoms as `reducedMotion` definitions are collocated to its atoms:

```ts
const Motion = createPresenceComponent({
  enter: [
    /** Atom A
        Has a definition for "reducedMotion" */
    {
      keyframes: [
        /* ... */
      ],
      reducedMotion: {
        /* some options or keyframes*/
      },
    },
    /** Atom B
        This atom _may_ declare "reducedMotion" (it's optional) */
    {
      keyframes: [
        /* ... */
      ],
    },
  ],
  exit: [
    /* ... */
  ],
});
```

## Rejected options

### Second argument to `createMotionComponent()` & `createPresenceComponent()`

> Note: examples are based on `createPresenceComponent()` as its syntax is more verbose and highlights challenges better.

We have already an array syntax for multiple atoms (see [createPresenceComponent() and arrays](https://react.fluentui.dev/?path=/docs/motion-apis-createpresencecomponent--docs#arrays)):

```js
// 💡 We already have this API implemented
createPresenceComponent({
  enter: [
    { keyframes: [] /* Atom A: enter */},
    { keyframes: [] /* Atom B: enter */},
  ],
  exit: [/* ... */],
});
```

The proposal is two have a second argument:

```js
// ⚠️ Proposed API (rejected option)
createPresenceComponent([
  {
    enter: [
      { keyframes: [] /* Atom A: enter */ },
      { keyframes: [] /* Atom B: enter */ },
    ],
    exit: [/* ... */],
  },
  {
    enter: [
      { keyframes: [] /* Atom A: enter & reduced motion */ },
      { keyframes: [] /* Atom B: enter & reduced motion */ },
    ],
    exit: [/* ... */],
  },
]);
```

However, it will be _hard_ to distinguish between atoms and reduced motion declarations - you have to know the order of arguments in the functions to understand it.

This implementation also brings a challenge of collocation: reduced options should be optional, however we will need to maintain the order to make it work. The example below shows the requirement:

```js
// ⚠️ Proposed API (rejected option)
createPresenceComponent([
  {
    enter: [
      { keyframes: [] /* Atom A: enter */ },
      { keyframes: [] /* Atom B: enter */ },
    ],
    exit: [/* ... */],
  },
  {
    enter: [
      { keyframes: [] /* Atom B: enter & reduced motion */ },
      // 💥 💥 💥 
      // There are two atoms in the motion declaration, however only one in reduced options
      // The order will break and options will be wrongly applied
    ],
    exit: [/* ... */],
  },
]);
```

Consumers will be forced to pass `null` (_or something else?_) in this case:

```js
// ⚠️ Proposed API (rejected option)
createPresenceComponent([
  {
    enter: [
      { keyframes: [] /* Atom A: enter */ },
      { keyframes: [] /* Atom B: enter */ },
    ],
    exit: [
      { keyframes: [] /* Atom A: exit */ },
      { keyframes: [] /* Atom B: enter */ },
    ],
  },
  {
    enter: [
      null, /* Atom A: enter & reduced motion */,
      { keyframes: [] /* Atom B: enter & reduced motion */ },
    ],
    exit: [/* ... */],
  },
]);
```

### Nest atoms

That's very similar to previous option, but instead we will have syntax similar to [fallback values in Griffel](https://griffel.js.org/react/api/make-styles#css-fallback-properties).

```js
// ⚠️ Proposed API (rejected option)
createPresenceComponent([
  {
    enter: [
      [
        { keyframes: [], duration: 1000 /* Atom A: enter */ },
        { keyframes: [], duration: 300 /* Atom A: enter, reduced options */ },
        // 👆 reduced options are collocated there
      ],
      [{ keyframes: [] /* Atom B: enter */ }],
    ],
    exit: [/* ... */],
  },
]);
```

In this case we collocate reduced options with the atom they are related to, so we don't need to maintain the order like in the previous option 👍

However, this option has the same issue with being implicit and hard to understand: _which array stands for atoms and which for reduced options?_

## Related issues

Fixes #33358.