### PR TITLE
chore(charts): fix import

### DIFF
--- a/change/@fluentui-react-charts-preview-803c5a15-3686-44e2-827f-e70720369036.json
+++ b/change/@fluentui-react-charts-preview-803c5a15-3686-44e2-827f-e70720369036.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: fix import of makeStyles()",
+  "packageName": "@fluentui/react-charts-preview",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charts/react-charts-preview/library/src/components/HorizontalBarChart/useHorizontalBarChartStyles.styles.ts
+++ b/packages/charts/react-charts-preview/library/src/components/HorizontalBarChart/useHorizontalBarChartStyles.styles.ts
@@ -1,4 +1,4 @@
-import { makeStyles, mergeClasses, shorthands } from '@fluentui/react-components';
+import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
 import { tokens, typographyStyles } from '@fluentui/react-theme';
 import { HorizontalBarChartProps, HorizontalBarChartStyles, HorizontalBarChartVariant } from './index';
 import type { SlotClassNames } from '@fluentui/react-utilities';


### PR DESCRIPTION
## Previous Behavior

`makeStyles()` is imported from `@fluentui/react-components`:

Build is broken:

<img width="2128" alt="image" src="https://github.com/user-attachments/assets/904a1ee8-bd8e-4bd9-a83a-206903468956">

There is also no dependency declared:

https://github.com/microsoft/fluentui/blob/99e5e6a9d394d6be64a58ac4ffb38b11023bcb72/packages/charts/react-charts-preview/library/package.json#L40-L49

## New Behavior

`makeStyles()` is imported from `@griffel/react`.

## Related Issue(s)

Breaks my PR #33380 😭 
