### PR TITLE
chore: remove usage of "export *" [part 2]

### DIFF
--- a/change/@fluentui-react-accordion-67d8888d-52d6-4a95-9b3c-9cd76aa70488.json
+++ b/change/@fluentui-react-accordion-67d8888d-52d6-4a95-9b3c-9cd76aa70488.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: remove usage of \"export *\"",
+  "packageName": "@fluentui/react-accordion",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-aria-be61f4a4-b090-4e41-874e-dec6e4e5e80a.json
+++ b/change/@fluentui-react-aria-be61f4a4-b090-4e41-874e-dec6e4e5e80a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: remove usage of \"export *\"",
+  "packageName": "@fluentui/react-aria",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-avatar-cd15db31-19ac-40b6-a12a-4a87f173abab.json
+++ b/change/@fluentui-react-avatar-cd15db31-19ac-40b6-a12a-4a87f173abab.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: remove usage of \"export *\"",
+  "packageName": "@fluentui/react-avatar",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-badge-4435d094-4941-462f-8ada-601bfe6c0b16.json
+++ b/change/@fluentui-react-badge-4435d094-4941-462f-8ada-601bfe6c0b16.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: remove usage of \"export *\"",
+  "packageName": "@fluentui/react-badge",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-breadcrumb-3dc0d3db-4959-4b49-a734-f01e8478469a.json
+++ b/change/@fluentui-react-breadcrumb-3dc0d3db-4959-4b49-a734-f01e8478469a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: remove usage of \"export *\"",
+  "packageName": "@fluentui/react-breadcrumb",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-calendar-compat-7c848d2d-dee4-47d0-9222-aa943df20c31.json
+++ b/change/@fluentui-react-calendar-compat-7c848d2d-dee4-47d0-9222-aa943df20c31.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: remove usage of \"export *\"",
+  "packageName": "@fluentui/react-calendar-compat",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-card-6af2a477-71cd-43e6-98f1-363b044791e0.json
+++ b/change/@fluentui-react-card-6af2a477-71cd-43e6-98f1-363b044791e0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: remove usage of \"export *\"",
+  "packageName": "@fluentui/react-card",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-checkbox-fcd798f7-bd3b-4715-80e5-899e7e74a342.json
+++ b/change/@fluentui-react-checkbox-fcd798f7-bd3b-4715-80e5-899e7e74a342.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: remove usage of \"export *\"",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-color-picker-preview-e116e813-2541-47e1-be7b-159d9a76a189.json
+++ b/change/@fluentui-react-color-picker-preview-e116e813-2541-47e1-be7b-159d9a76a189.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: remove usage of \"export *\"",
+  "packageName": "@fluentui/react-color-picker-preview",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-combobox-2035e929-0975-4951-b5aa-783722bc75d3.json
+++ b/change/@fluentui-react-combobox-2035e929-0975-4951-b5aa-783722bc75d3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: remove usage of \"export *\"",
+  "packageName": "@fluentui/react-combobox",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-datepicker-compat-b124d14b-ca68-4da9-bbab-8120060f4829.json
+++ b/change/@fluentui-react-datepicker-compat-b124d14b-ca68-4da9-bbab-8120060f4829.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: remove usage of \"export *\"",
+  "packageName": "@fluentui/react-datepicker-compat",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-divider-5b8aa37c-f51b-4523-ba58-c2aecc330556.json
+++ b/change/@fluentui-react-divider-5b8aa37c-f51b-4523-ba58-c2aecc330556.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: remove usage of \"export *\"",
+  "packageName": "@fluentui/react-divider",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-drawer-99e3c276-f97a-4036-aad4-6090803928d8.json
+++ b/change/@fluentui-react-drawer-99e3c276-f97a-4036-aad4-6090803928d8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: remove usage of \"export *\"",
+  "packageName": "@fluentui/react-drawer",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-field-da9428b9-b3fd-4a51-8456-8a9780a98f71.json
+++ b/change/@fluentui-react-field-da9428b9-b3fd-4a51-8456-8a9780a98f71.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: remove usage of \"export *\"",
+  "packageName": "@fluentui/react-field",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-image-7c13b585-9592-4836-b750-799941546c9c.json
+++ b/change/@fluentui-react-image-7c13b585-9592-4836-b750-799941546c9c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: remove usage of \"export *\"",
+  "packageName": "@fluentui/react-image",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-infolabel-f4568ea4-e41d-40e8-8776-64d488fd2054.json
+++ b/change/@fluentui-react-infolabel-f4568ea4-e41d-40e8-8776-64d488fd2054.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: remove usage of \"export *\"",
+  "packageName": "@fluentui/react-infolabel",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-input-48b32bab-e915-4423-ae9f-43740b87e482.json
+++ b/change/@fluentui-react-input-48b32bab-e915-4423-ae9f-43740b87e482.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: remove usage of \"export *\"",
+  "packageName": "@fluentui/react-input",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-label-6a0a1548-e58d-483b-bb1d-3fb9233067e3.json
+++ b/change/@fluentui-react-label-6a0a1548-e58d-483b-bb1d-3fb9233067e3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: remove usage of \"export *\"",
+  "packageName": "@fluentui/react-label",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-link-6310b24c-98ad-439f-a015-35580eee2eb9.json
+++ b/change/@fluentui-react-link-6310b24c-98ad-439f-a015-35580eee2eb9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: remove usage of \"export *\"",
+  "packageName": "@fluentui/react-link",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-migration-v8-v9-7a1fd34b-d85c-42f6-91aa-28ff58cc656a.json
+++ b/change/@fluentui-react-migration-v8-v9-7a1fd34b-d85c-42f6-91aa-28ff58cc656a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: remove usage of \"export *\"",
+  "packageName": "@fluentui/react-migration-v8-v9",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-persona-dc541129-36ea-44ef-baa2-09cef638e24f.json
+++ b/change/@fluentui-react-persona-dc541129-36ea-44ef-baa2-09cef638e24f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: remove usage of \"export *\"",
+  "packageName": "@fluentui/react-persona",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-progress-449f13de-c420-4d5c-8bcf-0b8d22ff0c55.json
+++ b/change/@fluentui-react-progress-449f13de-c420-4d5c-8bcf-0b8d22ff0c55.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: remove usage of \"export *\"",
+  "packageName": "@fluentui/react-progress",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-rating-b95a04b0-0189-4820-b684-652dd06ee28c.json
+++ b/change/@fluentui-react-rating-b95a04b0-0189-4820-b684-652dd06ee28c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: remove usage of \"export *\"",
+  "packageName": "@fluentui/react-rating",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-search-e79be79d-d859-408c-af56-43f586ff24b0.json
+++ b/change/@fluentui-react-search-e79be79d-d859-408c-af56-43f586ff24b0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: remove usage of \"export *\"",
+  "packageName": "@fluentui/react-search",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-select-2f9f2a2f-8583-4d5e-9d6f-76b7f77c0ea7.json
+++ b/change/@fluentui-react-select-2f9f2a2f-8583-4d5e-9d6f-76b7f77c0ea7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: remove usage of \"export *\"",
+  "packageName": "@fluentui/react-select",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-skeleton-32700cae-41eb-4ff2-9de4-d4695070b8cd.json
+++ b/change/@fluentui-react-skeleton-32700cae-41eb-4ff2-9de4-d4695070b8cd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: remove usage of \"export *\"",
+  "packageName": "@fluentui/react-skeleton",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-slider-db962bf1-6829-47fb-ac22-900dcc23d320.json
+++ b/change/@fluentui-react-slider-db962bf1-6829-47fb-ac22-900dcc23d320.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: remove usage of \"export *\"",
+  "packageName": "@fluentui/react-slider",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-spinbutton-0d660341-38dc-452b-87f5-ef25c14af242.json
+++ b/change/@fluentui-react-spinbutton-0d660341-38dc-452b-87f5-ef25c14af242.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: remove usage of \"export *\"",
+  "packageName": "@fluentui/react-spinbutton",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-spinner-c2f9c1dd-b25d-4800-b16b-d4110c46bb1e.json
+++ b/change/@fluentui-react-spinner-c2f9c1dd-b25d-4800-b16b-d4110c46bb1e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: remove usage of \"export *\"",
+  "packageName": "@fluentui/react-spinner",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-swatch-picker-360eae03-48bb-44f9-a29e-28d4ab4a40a0.json
+++ b/change/@fluentui-react-swatch-picker-360eae03-48bb-44f9-a29e-28d4ab4a40a0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: remove usage of \"export *\"",
+  "packageName": "@fluentui/react-swatch-picker",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-switch-a23f21b5-5604-42f3-934e-08ff109cf5a8.json
+++ b/change/@fluentui-react-switch-a23f21b5-5604-42f3-934e-08ff109cf5a8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: remove usage of \"export *\"",
+  "packageName": "@fluentui/react-switch",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tabs-9f0a77cb-8dce-4688-afcb-312ba202efbd.json
+++ b/change/@fluentui-react-tabs-9f0a77cb-8dce-4688-afcb-312ba202efbd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: remove usage of \"export *\"",
+  "packageName": "@fluentui/react-tabs",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-text-e62c51c3-2caf-43b7-9795-40e654e84749.json
+++ b/change/@fluentui-react-text-e62c51c3-2caf-43b7-9795-40e654e84749.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: remove usage of \"export *\"",
+  "packageName": "@fluentui/react-text",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-textarea-8a238d88-54be-4e3a-8b16-d73630085feb.json
+++ b/change/@fluentui-react-textarea-8a238d88-54be-4e3a-8b16-d73630085feb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: remove usage of \"export *\"",
+  "packageName": "@fluentui/react-textarea",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tooltip-df57a98c-410b-4a79-ae53-87a1abfe0795.json
+++ b/change/@fluentui-react-tooltip-df57a98c-410b-4a79-ae53-87a1abfe0795.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: remove usage of \"export *\"",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-accordion/library/src/Accordion.ts
+++ b/packages/react-components/react-accordion/library/src/Accordion.ts
@@ -1,1 +1,18 @@
-export * from './components/Accordion/index';
+export type {
+  AccordionContextValues,
+  AccordionIndex,
+  AccordionProps,
+  AccordionSlots,
+  AccordionState,
+  AccordionToggleData,
+  AccordionToggleEvent,
+  AccordionToggleEventHandler,
+} from './components/Accordion/index';
+export {
+  Accordion,
+  accordionClassNames,
+  renderAccordion_unstable,
+  useAccordionContextValues_unstable,
+  useAccordionStyles_unstable,
+  useAccordion_unstable,
+} from './components/Accordion/index';

--- a/packages/react-components/react-accordion/library/src/AccordionHeader.ts
+++ b/packages/react-components/react-accordion/library/src/AccordionHeader.ts
@@ -1,1 +1,16 @@
-export * from './components/AccordionHeader/index';
+export type {
+  AccordionHeaderContextValues,
+  AccordionHeaderExpandIconPosition,
+  AccordionHeaderProps,
+  AccordionHeaderSize,
+  AccordionHeaderSlots,
+  AccordionHeaderState,
+} from './components/AccordionHeader/index';
+export {
+  AccordionHeader,
+  accordionHeaderClassNames,
+  renderAccordionHeader_unstable,
+  useAccordionHeaderContextValues_unstable,
+  useAccordionHeaderStyles_unstable,
+  useAccordionHeader_unstable,
+} from './components/AccordionHeader/index';

--- a/packages/react-components/react-accordion/library/src/AccordionItem.ts
+++ b/packages/react-components/react-accordion/library/src/AccordionItem.ts
@@ -1,1 +1,15 @@
-export * from './components/AccordionItem/index';
+export type {
+  AccordionItemContextValues,
+  AccordionItemProps,
+  AccordionItemSlots,
+  AccordionItemState,
+  AccordionItemValue,
+} from './components/AccordionItem/index';
+export {
+  AccordionItem,
+  accordionItemClassNames,
+  renderAccordionItem_unstable,
+  useAccordionItemContextValues_unstable,
+  useAccordionItemStyles_unstable,
+  useAccordionItem_unstable,
+} from './components/AccordionItem/index';

--- a/packages/react-components/react-accordion/library/src/AccordionPanel.ts
+++ b/packages/react-components/react-accordion/library/src/AccordionPanel.ts
@@ -1,1 +1,8 @@
-export * from './components/AccordionPanel/index';
+export type { AccordionPanelProps, AccordionPanelSlots, AccordionPanelState } from './components/AccordionPanel/index';
+export {
+  AccordionPanel,
+  accordionPanelClassNames,
+  renderAccordionPanel_unstable,
+  useAccordionPanelStyles_unstable,
+  useAccordionPanel_unstable,
+} from './components/AccordionPanel/index';

--- a/packages/react-components/react-accordion/library/src/components/Accordion/index.ts
+++ b/packages/react-components/react-accordion/library/src/components/Accordion/index.ts
@@ -1,6 +1,15 @@
-export * from './Accordion';
-export * from './Accordion.types';
-export * from './renderAccordion';
-export * from './useAccordion';
-export * from './useAccordionStyles.styles';
-export * from './useAccordionContextValues';
+export { Accordion } from './Accordion';
+export type {
+  AccordionContextValues,
+  AccordionIndex,
+  AccordionProps,
+  AccordionSlots,
+  AccordionState,
+  AccordionToggleData,
+  AccordionToggleEvent,
+  AccordionToggleEventHandler,
+} from './Accordion.types';
+export { renderAccordion_unstable } from './renderAccordion';
+export { useAccordion_unstable } from './useAccordion';
+export { accordionClassNames, useAccordionStyles_unstable } from './useAccordionStyles.styles';
+export { useAccordionContextValues_unstable } from './useAccordionContextValues';

--- a/packages/react-components/react-accordion/library/src/components/Accordion/useAccordion.ts
+++ b/packages/react-components/react-accordion/library/src/components/Accordion/useAccordion.ts
@@ -53,7 +53,7 @@ export const useAccordion_unstable = <Value = AccordionItemValue>(
     root: slot.always(
       getIntrinsicElementProps('div', {
         ...props,
-        // eslint-disable-next-line deprecation/deprecation
+
         ...(navigation ? arrowNavigationProps : undefined),
         // FIXME:
         // `ref` is wrongly assigned to be `HTMLElement` instead of `HTMLDivElement`

--- a/packages/react-components/react-accordion/library/src/components/AccordionHeader/index.ts
+++ b/packages/react-components/react-accordion/library/src/components/AccordionHeader/index.ts
@@ -1,6 +1,13 @@
-export * from './AccordionHeader';
-export * from './AccordionHeader.types';
-export * from './renderAccordionHeader';
-export * from './useAccordionHeader';
-export * from './useAccordionHeaderContextValues';
-export * from './useAccordionHeaderStyles.styles';
+export { AccordionHeader } from './AccordionHeader';
+export type {
+  AccordionHeaderContextValues,
+  AccordionHeaderExpandIconPosition,
+  AccordionHeaderProps,
+  AccordionHeaderSize,
+  AccordionHeaderSlots,
+  AccordionHeaderState,
+} from './AccordionHeader.types';
+export { renderAccordionHeader_unstable } from './renderAccordionHeader';
+export { useAccordionHeader_unstable } from './useAccordionHeader';
+export { useAccordionHeaderContextValues_unstable } from './useAccordionHeaderContextValues';
+export { accordionHeaderClassNames, useAccordionHeaderStyles_unstable } from './useAccordionHeaderStyles.styles';

--- a/packages/react-components/react-accordion/library/src/components/AccordionItem/index.ts
+++ b/packages/react-components/react-accordion/library/src/components/AccordionItem/index.ts
@@ -1,6 +1,12 @@
-export * from './AccordionItem';
-export * from './AccordionItem.types';
-export * from './renderAccordionItem';
-export * from './useAccordionItem';
-export * from './useAccordionItemContextValues';
-export * from './useAccordionItemStyles.styles';
+export { AccordionItem } from './AccordionItem';
+export type {
+  AccordionItemContextValues,
+  AccordionItemProps,
+  AccordionItemSlots,
+  AccordionItemState,
+  AccordionItemValue,
+} from './AccordionItem.types';
+export { renderAccordionItem_unstable } from './renderAccordionItem';
+export { useAccordionItem_unstable } from './useAccordionItem';
+export { useAccordionItemContextValues_unstable } from './useAccordionItemContextValues';
+export { accordionItemClassNames, useAccordionItemStyles_unstable } from './useAccordionItemStyles.styles';

--- a/packages/react-components/react-accordion/library/src/components/AccordionPanel/index.ts
+++ b/packages/react-components/react-accordion/library/src/components/AccordionPanel/index.ts
@@ -1,5 +1,5 @@
-export * from './AccordionPanel';
-export * from './AccordionPanel.types';
-export * from './renderAccordionPanel';
-export * from './useAccordionPanel';
-export * from './useAccordionPanelStyles.styles';
+export { AccordionPanel } from './AccordionPanel';
+export type { AccordionPanelProps, AccordionPanelSlots, AccordionPanelState } from './AccordionPanel.types';
+export { renderAccordionPanel_unstable } from './renderAccordionPanel';
+export { useAccordionPanel_unstable } from './useAccordionPanel';
+export { accordionPanelClassNames, useAccordionPanelStyles_unstable } from './useAccordionPanelStyles.styles';

--- a/packages/react-components/react-aria/library/src/activedescendant/index.ts
+++ b/packages/react-components/react-aria/library/src/activedescendant/index.ts
@@ -1,4 +1,16 @@
-export * from './ActiveDescendantContext';
-export * from './useActiveDescendant';
-export * from './constants';
-export * from './types';
+export type { ActiveDescendantContextValue } from './ActiveDescendantContext';
+export {
+  ActiveDescendantContextProvider,
+  useActiveDescendantContext,
+  useHasParentActiveDescendantContext,
+} from './ActiveDescendantContext';
+export type { ActiveDescendantChangeEvent } from './useActiveDescendant';
+export { createActiveDescendantChangeEvent, useActiveDescendant } from './useActiveDescendant';
+export { ACTIVEDESCENDANT_ATTRIBUTE, ACTIVEDESCENDANT_FOCUSVISIBLE_ATTRIBUTE } from './constants';
+export type {
+  ActiveDescendantImperativeRef,
+  ActiveDescendantOptions,
+  FindOptions,
+  IteratorOptions,
+  UseActiveDescendantReturn,
+} from './types';

--- a/packages/react-components/react-aria/library/src/button/index.ts
+++ b/packages/react-components/react-aria/library/src/button/index.ts
@@ -1,3 +1,12 @@
-export * from './useARIAButtonProps';
-export * from './useARIAButtonShorthand';
-export * from './types';
+export { useARIAButtonProps } from './useARIAButtonProps';
+// eslint-disable-next-line deprecation/deprecation
+export { useARIAButtonShorthand } from './useARIAButtonShorthand';
+export type {
+  ARIAButtonAlteredProps,
+  ARIAButtonElement,
+  ARIAButtonElementIntersection,
+  ARIAButtonProps,
+  ARIAButtonResultProps,
+  ARIAButtonSlotProps,
+  ARIAButtonType,
+} from './types';

--- a/packages/react-components/react-avatar/library/src/Avatar.ts
+++ b/packages/react-components/react-avatar/library/src/Avatar.ts
@@ -1,1 +1,19 @@
-export * from './components/Avatar/index';
+export type {
+  AvatarNamedColor,
+  AvatarProps,
+  AvatarShape,
+  AvatarSize,
+  // eslint-disable-next-line deprecation/deprecation
+  AvatarSizes,
+  AvatarSlots,
+  AvatarState,
+} from './components/Avatar/index';
+export {
+  Avatar,
+  DEFAULT_STRINGS,
+  avatarClassNames,
+  renderAvatar_unstable,
+  useAvatarStyles_unstable,
+  useAvatar_unstable,
+  useSizeStyles,
+} from './components/Avatar/index';

--- a/packages/react-components/react-avatar/library/src/AvatarGroup.ts
+++ b/packages/react-components/react-avatar/library/src/AvatarGroup.ts
@@ -1,1 +1,16 @@
-export * from './components/AvatarGroup/index';
+export type {
+  AvatarGroupContextValue,
+  AvatarGroupContextValues,
+  AvatarGroupProps,
+  AvatarGroupSlots,
+  AvatarGroupState,
+} from './components/AvatarGroup/index';
+export {
+  AvatarGroup,
+  avatarGroupClassNames,
+  defaultAvatarGroupSize,
+  renderAvatarGroup_unstable,
+  useAvatarGroupContextValues,
+  useAvatarGroupStyles_unstable,
+  useAvatarGroup_unstable,
+} from './components/AvatarGroup/index';

--- a/packages/react-components/react-avatar/library/src/AvatarGroupItem.ts
+++ b/packages/react-components/react-avatar/library/src/AvatarGroupItem.ts
@@ -1,1 +1,13 @@
-export * from './components/AvatarGroupItem/index';
+export type {
+  AvatarGroupItemProps,
+  AvatarGroupItemSlots,
+  AvatarGroupItemState,
+} from './components/AvatarGroupItem/index';
+export {
+  AvatarGroupItem,
+  avatarGroupItemClassNames,
+  renderAvatarGroupItem_unstable,
+  useAvatarGroupItemStyles_unstable,
+  useAvatarGroupItem_unstable,
+  useGroupChildClassName,
+} from './components/AvatarGroupItem/index';

--- a/packages/react-components/react-avatar/library/src/AvatarGroupPopover.ts
+++ b/packages/react-components/react-avatar/library/src/AvatarGroupPopover.ts
@@ -1,1 +1,13 @@
-export * from './components/AvatarGroupPopover/index';
+export type {
+  AvatarGroupPopoverProps,
+  AvatarGroupPopoverSlots,
+  AvatarGroupPopoverState,
+} from './components/AvatarGroupPopover/index';
+export {
+  AvatarGroupPopover,
+  avatarGroupPopoverClassNames,
+  renderAvatarGroupPopover_unstable,
+  useAvatarGroupPopoverContextValues_unstable,
+  useAvatarGroupPopoverStyles_unstable,
+  useAvatarGroupPopover_unstable,
+} from './components/AvatarGroupPopover/index';

--- a/packages/react-components/react-avatar/library/src/components/Avatar/index.ts
+++ b/packages/react-components/react-avatar/library/src/components/Avatar/index.ts
@@ -1,5 +1,14 @@
-export * from './Avatar.types';
-export * from './Avatar';
-export * from './renderAvatar';
-export * from './useAvatar';
-export * from './useAvatarStyles.styles';
+export type {
+  AvatarNamedColor,
+  AvatarProps,
+  AvatarShape,
+  AvatarSize,
+  // eslint-disable-next-line deprecation/deprecation
+  AvatarSizes,
+  AvatarSlots,
+  AvatarState,
+} from './Avatar.types';
+export { Avatar } from './Avatar';
+export { renderAvatar_unstable } from './renderAvatar';
+export { DEFAULT_STRINGS, useAvatar_unstable } from './useAvatar';
+export { avatarClassNames, useAvatarStyles_unstable, useSizeStyles } from './useAvatarStyles.styles';

--- a/packages/react-components/react-avatar/library/src/components/AvatarGroup/index.ts
+++ b/packages/react-components/react-avatar/library/src/components/AvatarGroup/index.ts
@@ -1,6 +1,12 @@
-export * from './AvatarGroup';
-export * from './AvatarGroup.types';
-export * from './renderAvatarGroup';
-export * from './useAvatarGroup';
-export * from './useAvatarGroupStyles.styles';
-export * from './useAvatarGroupContextValues';
+export { AvatarGroup } from './AvatarGroup';
+export type {
+  AvatarGroupContextValue,
+  AvatarGroupContextValues,
+  AvatarGroupProps,
+  AvatarGroupSlots,
+  AvatarGroupState,
+} from './AvatarGroup.types';
+export { renderAvatarGroup_unstable } from './renderAvatarGroup';
+export { defaultAvatarGroupSize, useAvatarGroup_unstable } from './useAvatarGroup';
+export { avatarGroupClassNames, useAvatarGroupStyles_unstable } from './useAvatarGroupStyles.styles';
+export { useAvatarGroupContextValues } from './useAvatarGroupContextValues';

--- a/packages/react-components/react-avatar/library/src/components/AvatarGroupItem/index.ts
+++ b/packages/react-components/react-avatar/library/src/components/AvatarGroupItem/index.ts
@@ -1,5 +1,9 @@
-export * from './AvatarGroupItem';
-export * from './AvatarGroupItem.types';
-export * from './renderAvatarGroupItem';
-export * from './useAvatarGroupItem';
-export * from './useAvatarGroupItemStyles.styles';
+export { AvatarGroupItem } from './AvatarGroupItem';
+export type { AvatarGroupItemProps, AvatarGroupItemSlots, AvatarGroupItemState } from './AvatarGroupItem.types';
+export { renderAvatarGroupItem_unstable } from './renderAvatarGroupItem';
+export { useAvatarGroupItem_unstable } from './useAvatarGroupItem';
+export {
+  avatarGroupItemClassNames,
+  useAvatarGroupItemStyles_unstable,
+  useGroupChildClassName,
+} from './useAvatarGroupItemStyles.styles';

--- a/packages/react-components/react-avatar/library/src/components/AvatarGroupPopover/index.ts
+++ b/packages/react-components/react-avatar/library/src/components/AvatarGroupPopover/index.ts
@@ -1,6 +1,13 @@
-export * from './AvatarGroupPopover';
-export * from './AvatarGroupPopover.types';
-export * from './renderAvatarGroupPopover';
-export * from './useAvatarGroupPopover';
-export * from './useAvatarGroupPopoverStyles.styles';
-export * from './useAvatarGroupPopoverContextValues';
+export { AvatarGroupPopover } from './AvatarGroupPopover';
+export type {
+  AvatarGroupPopoverProps,
+  AvatarGroupPopoverSlots,
+  AvatarGroupPopoverState,
+} from './AvatarGroupPopover.types';
+export { renderAvatarGroupPopover_unstable } from './renderAvatarGroupPopover';
+export { useAvatarGroupPopover_unstable } from './useAvatarGroupPopover';
+export {
+  avatarGroupPopoverClassNames,
+  useAvatarGroupPopoverStyles_unstable,
+} from './useAvatarGroupPopoverStyles.styles';
+export { useAvatarGroupPopoverContextValues_unstable } from './useAvatarGroupPopoverContextValues';

--- a/packages/react-components/react-avatar/library/src/contexts/index.ts
+++ b/packages/react-components/react-avatar/library/src/contexts/index.ts
@@ -1,2 +1,3 @@
-export * from './AvatarGroupContext';
-export * from './AvatarContext';
+export { AvatarGroupContext, AvatarGroupProvider, useAvatarGroupContext_unstable } from './AvatarGroupContext';
+export type { AvatarContextValue } from './AvatarContext';
+export { AvatarContextProvider, useAvatarContext } from './AvatarContext';

--- a/packages/react-components/react-badge/library/src/Badge.ts
+++ b/packages/react-components/react-badge/library/src/Badge.ts
@@ -1,1 +1,8 @@
-export * from './components/Badge/index';
+export type { BadgeProps, BadgeSlots, BadgeState } from './components/Badge/index';
+export {
+  Badge,
+  badgeClassNames,
+  renderBadge_unstable,
+  useBadgeStyles_unstable,
+  useBadge_unstable,
+} from './components/Badge/index';

--- a/packages/react-components/react-badge/library/src/CounterBadge.ts
+++ b/packages/react-components/react-badge/library/src/CounterBadge.ts
@@ -1,1 +1,7 @@
-export * from './components/CounterBadge/index';
+export type { CounterBadgeProps, CounterBadgeState } from './components/CounterBadge/index';
+export {
+  CounterBadge,
+  counterBadgeClassNames,
+  useCounterBadgeStyles_unstable,
+  useCounterBadge_unstable,
+} from './components/CounterBadge/index';

--- a/packages/react-components/react-badge/library/src/PresenceBadge.ts
+++ b/packages/react-components/react-badge/library/src/PresenceBadge.ts
@@ -1,1 +1,18 @@
-export * from './components/PresenceBadge/index';
+export type { PresenceBadgeProps, PresenceBadgeState, PresenceBadgeStatus } from './components/PresenceBadge/index';
+export {
+  PresenceBadge,
+  presenceAvailableFilled,
+  presenceAvailableRegular,
+  presenceAwayFilled,
+  presenceAwayRegular,
+  presenceBadgeClassNames,
+  presenceBlockedRegular,
+  presenceBusyFilled,
+  presenceDndFilled,
+  presenceDndRegular,
+  presenceOfflineRegular,
+  presenceOofRegular,
+  presenceUnknownRegular,
+  usePresenceBadgeStyles_unstable,
+  usePresenceBadge_unstable,
+} from './components/PresenceBadge/index';

--- a/packages/react-components/react-badge/library/src/components/Badge/index.ts
+++ b/packages/react-components/react-badge/library/src/components/Badge/index.ts
@@ -1,6 +1,6 @@
-export * from './Badge';
+export { Badge } from './Badge';
 // Explicit exports to omit BadgeCommons
 export type { BadgeProps, BadgeSlots, BadgeState } from './Badge.types';
-export * from './renderBadge';
-export * from './useBadge';
-export * from './useBadgeStyles.styles';
+export { renderBadge_unstable } from './renderBadge';
+export { useBadge_unstable } from './useBadge';
+export { badgeClassNames, useBadgeStyles_unstable } from './useBadgeStyles.styles';

--- a/packages/react-components/react-badge/library/src/components/CounterBadge/index.ts
+++ b/packages/react-components/react-badge/library/src/components/CounterBadge/index.ts
@@ -1,4 +1,4 @@
-export * from './CounterBadge';
-export * from './CounterBadge.types';
-export * from './useCounterBadge';
-export * from './useCounterBadgeStyles.styles';
+export { CounterBadge } from './CounterBadge';
+export type { CounterBadgeProps, CounterBadgeState } from './CounterBadge.types';
+export { useCounterBadge_unstable } from './useCounterBadge';
+export { counterBadgeClassNames, useCounterBadgeStyles_unstable } from './useCounterBadgeStyles.styles';

--- a/packages/react-components/react-badge/library/src/components/PresenceBadge/index.ts
+++ b/packages/react-components/react-badge/library/src/components/PresenceBadge/index.ts
@@ -1,5 +1,17 @@
-export * from './PresenceBadge';
-export * from './PresenceBadge.types';
-export * from './usePresenceBadge';
-export * from './usePresenceBadgeStyles.styles';
-export * from './presenceIcons';
+export { PresenceBadge } from './PresenceBadge';
+export type { PresenceBadgeProps, PresenceBadgeState, PresenceBadgeStatus } from './PresenceBadge.types';
+export { usePresenceBadge_unstable } from './usePresenceBadge';
+export { presenceBadgeClassNames, usePresenceBadgeStyles_unstable } from './usePresenceBadgeStyles.styles';
+export {
+  presenceAvailableFilled,
+  presenceAvailableRegular,
+  presenceAwayFilled,
+  presenceAwayRegular,
+  presenceBlockedRegular,
+  presenceBusyFilled,
+  presenceDndFilled,
+  presenceDndRegular,
+  presenceOfflineRegular,
+  presenceOofRegular,
+  presenceUnknownRegular,
+} from './presenceIcons';

--- a/packages/react-components/react-breadcrumb/library/src/Breadcrumb.ts
+++ b/packages/react-components/react-breadcrumb/library/src/Breadcrumb.ts
@@ -1,1 +1,16 @@
-export * from './components/Breadcrumb/index';
+export type {
+  BreadcrumbContextValues,
+  BreadcrumbProps,
+  BreadcrumbSlots,
+  BreadcrumbState,
+} from './components/Breadcrumb/index';
+export {
+  Breadcrumb,
+  BreadcrumbProvider,
+  breadcrumbClassNames,
+  breadcrumbDefaultValue,
+  renderBreadcrumb_unstable,
+  useBreadcrumbContext_unstable,
+  useBreadcrumbStyles_unstable,
+  useBreadcrumb_unstable,
+} from './components/Breadcrumb/index';

--- a/packages/react-components/react-breadcrumb/library/src/BreadcrumbButton.ts
+++ b/packages/react-components/react-breadcrumb/library/src/BreadcrumbButton.ts
@@ -1,1 +1,12 @@
-export * from './components/BreadcrumbButton/index';
+export type {
+  BreadcrumbButtonProps,
+  BreadcrumbButtonSlots,
+  BreadcrumbButtonState,
+} from './components/BreadcrumbButton/index';
+export {
+  BreadcrumbButton,
+  breadcrumbButtonClassNames,
+  renderBreadcrumbButton_unstable,
+  useBreadcrumbButtonStyles_unstable,
+  useBreadcrumbButton_unstable,
+} from './components/BreadcrumbButton/index';

--- a/packages/react-components/react-breadcrumb/library/src/BreadcrumbDivider.ts
+++ b/packages/react-components/react-breadcrumb/library/src/BreadcrumbDivider.ts
@@ -1,1 +1,12 @@
-export * from './components/BreadcrumbDivider/index';
+export type {
+  BreadcrumbDividerProps,
+  BreadcrumbDividerSlots,
+  BreadcrumbDividerState,
+} from './components/BreadcrumbDivider/index';
+export {
+  BreadcrumbDivider,
+  breadcrumbDividerClassNames,
+  renderBreadcrumbDivider_unstable,
+  useBreadcrumbDividerStyles_unstable,
+  useBreadcrumbDivider_unstable,
+} from './components/BreadcrumbDivider/index';

--- a/packages/react-components/react-breadcrumb/library/src/BreadcrumbItem.ts
+++ b/packages/react-components/react-breadcrumb/library/src/BreadcrumbItem.ts
@@ -1,1 +1,8 @@
-export * from './components/BreadcrumbItem/index';
+export type { BreadcrumbItemProps, BreadcrumbItemSlots, BreadcrumbItemState } from './components/BreadcrumbItem/index';
+export {
+  BreadcrumbItem,
+  breadcrumbItemClassNames,
+  renderBreadcrumbItem_unstable,
+  useBreadcrumbItemStyles_unstable,
+  useBreadcrumbItem_unstable,
+} from './components/BreadcrumbItem/index';

--- a/packages/react-components/react-breadcrumb/library/src/components/Breadcrumb/index.ts
+++ b/packages/react-components/react-breadcrumb/library/src/components/Breadcrumb/index.ts
@@ -1,6 +1,6 @@
-export * from './Breadcrumb';
-export * from './Breadcrumb.types';
-export * from './BreadcrumbContext';
-export * from './renderBreadcrumb';
-export * from './useBreadcrumb';
-export * from './useBreadcrumbStyles.styles';
+export { Breadcrumb } from './Breadcrumb';
+export type { BreadcrumbContextValues, BreadcrumbProps, BreadcrumbSlots, BreadcrumbState } from './Breadcrumb.types';
+export { BreadcrumbProvider, breadcrumbDefaultValue, useBreadcrumbContext_unstable } from './BreadcrumbContext';
+export { renderBreadcrumb_unstable } from './renderBreadcrumb';
+export { useBreadcrumb_unstable } from './useBreadcrumb';
+export { breadcrumbClassNames, useBreadcrumbStyles_unstable } from './useBreadcrumbStyles.styles';

--- a/packages/react-components/react-breadcrumb/library/src/components/BreadcrumbButton/index.ts
+++ b/packages/react-components/react-breadcrumb/library/src/components/BreadcrumbButton/index.ts
@@ -1,5 +1,5 @@
-export * from './BreadcrumbButton';
-export * from './BreadcrumbButton.types';
-export * from './renderBreadcrumbButton';
-export * from './useBreadcrumbButton';
-export * from './useBreadcrumbButtonStyles.styles';
+export { BreadcrumbButton } from './BreadcrumbButton';
+export type { BreadcrumbButtonProps, BreadcrumbButtonSlots, BreadcrumbButtonState } from './BreadcrumbButton.types';
+export { renderBreadcrumbButton_unstable } from './renderBreadcrumbButton';
+export { useBreadcrumbButton_unstable } from './useBreadcrumbButton';
+export { breadcrumbButtonClassNames, useBreadcrumbButtonStyles_unstable } from './useBreadcrumbButtonStyles.styles';

--- a/packages/react-components/react-breadcrumb/library/src/components/BreadcrumbDivider/index.ts
+++ b/packages/react-components/react-breadcrumb/library/src/components/BreadcrumbDivider/index.ts
@@ -1,5 +1,5 @@
-export * from './BreadcrumbDivider';
-export * from './BreadcrumbDivider.types';
-export * from './renderBreadcrumbDivider';
-export * from './useBreadcrumbDivider';
-export * from './useBreadcrumbDividerStyles.styles';
+export { BreadcrumbDivider } from './BreadcrumbDivider';
+export type { BreadcrumbDividerProps, BreadcrumbDividerSlots, BreadcrumbDividerState } from './BreadcrumbDivider.types';
+export { renderBreadcrumbDivider_unstable } from './renderBreadcrumbDivider';
+export { useBreadcrumbDivider_unstable } from './useBreadcrumbDivider';
+export { breadcrumbDividerClassNames, useBreadcrumbDividerStyles_unstable } from './useBreadcrumbDividerStyles.styles';

--- a/packages/react-components/react-breadcrumb/library/src/components/BreadcrumbItem/index.ts
+++ b/packages/react-components/react-breadcrumb/library/src/components/BreadcrumbItem/index.ts
@@ -1,5 +1,5 @@
-export * from './BreadcrumbItem';
-export * from './BreadcrumbItem.types';
-export * from './renderBreadcrumbItem';
-export * from './useBreadcrumbItem';
-export * from './useBreadcrumbItemStyles.styles';
+export { BreadcrumbItem } from './BreadcrumbItem';
+export type { BreadcrumbItemProps, BreadcrumbItemSlots, BreadcrumbItemState } from './BreadcrumbItem.types';
+export { renderBreadcrumbItem_unstable } from './renderBreadcrumbItem';
+export { useBreadcrumbItem_unstable } from './useBreadcrumbItem';
+export { breadcrumbItemClassNames, useBreadcrumbItemStyles_unstable } from './useBreadcrumbItemStyles.styles';

--- a/packages/react-components/react-calendar-compat/library/src/Calendar.ts
+++ b/packages/react-components/react-calendar-compat/library/src/Calendar.ts
@@ -1,1 +1,8 @@
-export * from './components/Calendar/index';
+export type { CalendarProps, CalendarStyleProps, CalendarStyles, ICalendar } from './components/Calendar/index';
+export {
+  AnimationDirection,
+  Calendar,
+  calendarClassNames,
+  defaultCalendarStrings,
+  useCalendarStyles_unstable,
+} from './components/Calendar/index';

--- a/packages/react-components/react-calendar-compat/library/src/CalendarDay.ts
+++ b/packages/react-components/react-calendar-compat/library/src/CalendarDay.ts
@@ -1,1 +1,7 @@
-export * from './components/CalendarDay/index';
+export type {
+  CalendarDayProps,
+  CalendarDayStyleProps,
+  CalendarDayStyles,
+  ICalendarDay,
+} from './components/CalendarDay/index';
+export { CalendarDay, calendarDayClassNames, useCalendarDayStyles_unstable } from './components/CalendarDay/index';

--- a/packages/react-components/react-calendar-compat/library/src/CalendarDayGrid.ts
+++ b/packages/react-components/react-calendar-compat/library/src/CalendarDayGrid.ts
@@ -1,1 +1,14 @@
-export * from './components/CalendarDayGrid/index';
+export type {
+  CalendarDayGridProps,
+  CalendarDayGridStyleProps,
+  CalendarDayGridStyles,
+  DayInfo,
+  ICalendarDayGrid,
+  WeekCorners,
+} from './components/CalendarDayGrid/index';
+export {
+  CalendarDayGrid,
+  calendarDayGridClassNames,
+  extraCalendarDayGridClassNames,
+  useCalendarDayGridStyles_unstable,
+} from './components/CalendarDayGrid/index';

--- a/packages/react-components/react-calendar-compat/library/src/CalendarMonth.ts
+++ b/packages/react-components/react-calendar-compat/library/src/CalendarMonth.ts
@@ -1,1 +1,7 @@
-export * from './components/CalendarMonth/index';
+export type {
+  CalendarMonthProps,
+  CalendarMonthStyleProps,
+  CalendarMonthStyles,
+  ICalendarMonth,
+} from './components/CalendarMonth/index';
+export { CalendarMonth, useCalendarMonthStyles_unstable } from './components/CalendarMonth/index';

--- a/packages/react-components/react-calendar-compat/library/src/CalendarPicker.ts
+++ b/packages/react-components/react-calendar-compat/library/src/CalendarPicker.ts
@@ -1,1 +1,2 @@
-export * from './components/CalendarPicker/index';
+export type { CalendarPickerStyleProps, CalendarPickerStyles } from './components/CalendarPicker/index';
+export { calendarPickerClassNames, useCalendarPickerStyles_unstable } from './components/CalendarPicker/index';

--- a/packages/react-components/react-calendar-compat/library/src/CalendarYear.ts
+++ b/packages/react-components/react-calendar-compat/library/src/CalendarYear.ts
@@ -1,1 +1,11 @@
-export * from './components/CalendarYear/index';
+export type {
+  CalendarYearHeaderProps,
+  CalendarYearProps,
+  CalendarYearRange,
+  CalendarYearRangeToString,
+  CalendarYearStrings,
+  CalendarYearStyleProps,
+  CalendarYearStyles,
+  ICalendarYear,
+} from './components/CalendarYear/index';
+export { CalendarYear, useCalendarYearStyles_unstable } from './components/CalendarYear/index';

--- a/packages/react-components/react-calendar-compat/library/src/components/Calendar/index.ts
+++ b/packages/react-components/react-calendar-compat/library/src/components/Calendar/index.ts
@@ -1,4 +1,5 @@
-export * from './Calendar';
-export * from './Calendar.types';
-export * from './useCalendarStyles.styles';
+export { Calendar } from './Calendar';
+export type { CalendarProps, CalendarStyleProps, CalendarStyles, ICalendar } from './Calendar.types';
+export { AnimationDirection } from './Calendar.types';
+export { calendarClassNames, useCalendarStyles_unstable } from './useCalendarStyles.styles';
 export { defaultCalendarStrings } from './defaults';

--- a/packages/react-components/react-calendar-compat/library/src/components/CalendarDay/index.ts
+++ b/packages/react-components/react-calendar-compat/library/src/components/CalendarDay/index.ts
@@ -1,3 +1,3 @@
-export * from './CalendarDay';
-export * from './CalendarDay.types';
-export * from './useCalendarDayStyles.styles';
+export { CalendarDay } from './CalendarDay';
+export type { CalendarDayProps, CalendarDayStyleProps, CalendarDayStyles, ICalendarDay } from './CalendarDay.types';
+export { calendarDayClassNames, useCalendarDayStyles_unstable } from './useCalendarDayStyles.styles';

--- a/packages/react-components/react-calendar-compat/library/src/components/CalendarDayGrid/index.ts
+++ b/packages/react-components/react-calendar-compat/library/src/components/CalendarDayGrid/index.ts
@@ -1,5 +1,14 @@
-export * from './CalendarDayGrid';
-export * from './CalendarDayGrid.types';
-export * from './useCalendarDayGridStyles.styles';
-export { calendarDayGridClassNames, extraCalendarDayGridClassNames } from './useCalendarDayGridStyles.styles';
+export type { DayInfo } from './CalendarDayGrid';
+export { CalendarDayGrid } from './CalendarDayGrid';
+export type {
+  CalendarDayGridProps,
+  CalendarDayGridStyleProps,
+  CalendarDayGridStyles,
+  ICalendarDayGrid,
+} from './CalendarDayGrid.types';
+export {
+  calendarDayGridClassNames,
+  extraCalendarDayGridClassNames,
+  useCalendarDayGridStyles_unstable,
+} from './useCalendarDayGridStyles.styles';
 export type { WeekCorners } from './useWeekCornerStyles.styles';

--- a/packages/react-components/react-calendar-compat/library/src/components/CalendarMonth/index.ts
+++ b/packages/react-components/react-calendar-compat/library/src/components/CalendarMonth/index.ts
@@ -1,3 +1,8 @@
-export * from './CalendarMonth';
-export * from './CalendarMonth.types';
-export * from './useCalendarMonthStyles.styles';
+export { CalendarMonth } from './CalendarMonth';
+export type {
+  CalendarMonthProps,
+  CalendarMonthStyleProps,
+  CalendarMonthStyles,
+  ICalendarMonth,
+} from './CalendarMonth.types';
+export { useCalendarMonthStyles_unstable } from './useCalendarMonthStyles.styles';

--- a/packages/react-components/react-calendar-compat/library/src/components/CalendarPicker/index.ts
+++ b/packages/react-components/react-calendar-compat/library/src/components/CalendarPicker/index.ts
@@ -1,2 +1,2 @@
-export * from './CalendarPicker.types';
-export * from './useCalendarPickerStyles.styles';
+export type { CalendarPickerStyleProps, CalendarPickerStyles } from './CalendarPicker.types';
+export { calendarPickerClassNames, useCalendarPickerStyles_unstable } from './useCalendarPickerStyles.styles';

--- a/packages/react-components/react-calendar-compat/library/src/components/CalendarYear/index.ts
+++ b/packages/react-components/react-calendar-compat/library/src/components/CalendarYear/index.ts
@@ -1,3 +1,12 @@
-export * from './CalendarYear';
-export * from './CalendarYear.types';
-export * from './useCalendarYearStyles.styles';
+export { CalendarYear } from './CalendarYear';
+export type {
+  CalendarYearHeaderProps,
+  CalendarYearProps,
+  CalendarYearRange,
+  CalendarYearRangeToString,
+  CalendarYearStrings,
+  CalendarYearStyleProps,
+  CalendarYearStyles,
+  ICalendarYear,
+} from './CalendarYear.types';
+export { useCalendarYearStyles_unstable } from './useCalendarYearStyles.styles';

--- a/packages/react-components/react-calendar-compat/library/src/utils/dateFormatting/index.ts
+++ b/packages/react-components/react-calendar-compat/library/src/utils/dateFormatting/index.ts
@@ -1,2 +1,11 @@
-export * from './dateFormatting.defaults';
-export * from './dateFormatting.types';
+export {
+  DEFAULT_CALENDAR_STRINGS,
+  DEFAULT_DATE_FORMATTING,
+  DEFAULT_DATE_GRID_STRINGS,
+  formatDay,
+  formatMonth,
+  formatMonthDayYear,
+  formatMonthYear,
+  formatYear,
+} from './dateFormatting.defaults';
+export type { CalendarStrings, DateFormatting, DateGridStrings } from './dateFormatting.types';

--- a/packages/react-components/react-calendar-compat/library/src/utils/dateGrid/index.ts
+++ b/packages/react-components/react-calendar-compat/library/src/utils/dateGrid/index.ts
@@ -1,5 +1,5 @@
-export * from './dateGrid.types';
-export * from './findAvailableDate';
-export * from './getBoundedDateRange';
-export * from './getDayGrid';
-export * from './isRestrictedDate';
+export type { AvailableDateOptions, Day, DayGridOptions, RestrictedDatesOptions } from './dateGrid.types';
+export { findAvailableDate } from './findAvailableDate';
+export { getBoundedDateRange } from './getBoundedDateRange';
+export { getDayGrid } from './getDayGrid';
+export { isRestrictedDate } from './isRestrictedDate';

--- a/packages/react-components/react-calendar-compat/library/src/utils/dateMath/index.ts
+++ b/packages/react-components/react-calendar-compat/library/src/utils/dateMath/index.ts
@@ -1,1 +1,20 @@
-export * from './dateMath';
+export {
+  addDays,
+  addMonths,
+  addWeeks,
+  addYears,
+  compareDatePart,
+  compareDates,
+  getDatePartHashValue,
+  getDateRangeArray,
+  getEndDateOfWeek,
+  getMonthEnd,
+  getMonthStart,
+  getStartDateOfWeek,
+  getWeekNumber,
+  getWeekNumbersInMonth,
+  getYearEnd,
+  getYearStart,
+  isInDateRangeArray,
+  setMonth,
+} from './dateMath';

--- a/packages/react-components/react-calendar-compat/library/src/utils/index.ts
+++ b/packages/react-components/react-calendar-compat/library/src/utils/index.ts
@@ -1,6 +1,52 @@
-export * from './animations';
-export * from './constants';
-export * from './dateFormatting';
-export * from './dateGrid';
-export * from './dateMath';
-export * from './focus';
+export {
+  DURATION_1,
+  DURATION_2,
+  DURATION_3,
+  DURATION_4,
+  EASING_FUNCTION_1,
+  EASING_FUNCTION_2,
+  FADE_IN,
+  FADE_OUT,
+  SLIDE_DOWN_IN20,
+  SLIDE_DOWN_OUT20,
+  SLIDE_LEFT_IN20,
+  SLIDE_RIGHT_IN20,
+  SLIDE_UP_IN20,
+  SLIDE_UP_OUT20,
+  TRANSITION_ROW_DISAPPEARANCE,
+} from './animations';
+export { DAYS_IN_WEEK, DateRangeType, DayOfWeek, FirstWeekOfYear, MonthOfYear, TimeConstants } from './constants';
+export type { CalendarStrings, DateFormatting, DateGridStrings } from './dateFormatting';
+export {
+  DEFAULT_CALENDAR_STRINGS,
+  DEFAULT_DATE_FORMATTING,
+  DEFAULT_DATE_GRID_STRINGS,
+  formatDay,
+  formatMonth,
+  formatMonthDayYear,
+  formatMonthYear,
+  formatYear,
+} from './dateFormatting';
+export type { AvailableDateOptions, Day, DayGridOptions, RestrictedDatesOptions } from './dateGrid';
+export { findAvailableDate, getBoundedDateRange, getDayGrid, isRestrictedDate } from './dateGrid';
+export {
+  addDays,
+  addMonths,
+  addWeeks,
+  addYears,
+  compareDatePart,
+  compareDates,
+  getDatePartHashValue,
+  getDateRangeArray,
+  getEndDateOfWeek,
+  getMonthEnd,
+  getMonthStart,
+  getStartDateOfWeek,
+  getWeekNumber,
+  getWeekNumbersInMonth,
+  getYearEnd,
+  getYearStart,
+  isInDateRangeArray,
+  setMonth,
+} from './dateMath';
+export { focusAsync } from './focus';

--- a/packages/react-components/react-card/library/src/Card.ts
+++ b/packages/react-components/react-card/library/src/Card.ts
@@ -1,1 +1,19 @@
-export * from './components/Card/index';
+export type {
+  CardContextValue,
+  CardOnSelectData,
+  CardOnSelectionChangeEvent,
+  CardProps,
+  CardSlots,
+  CardState,
+} from './components/Card/index';
+export {
+  Card,
+  CardProvider,
+  cardCSSVars,
+  cardClassNames,
+  cardContextDefaultValue,
+  renderCard_unstable,
+  useCardContext_unstable,
+  useCardStyles_unstable,
+  useCard_unstable,
+} from './components/Card/index';

--- a/packages/react-components/react-card/library/src/CardFooter.ts
+++ b/packages/react-components/react-card/library/src/CardFooter.ts
@@ -1,1 +1,8 @@
-export * from './components/CardFooter/index';
+export type { CardFooterProps, CardFooterSlots, CardFooterState } from './components/CardFooter/index';
+export {
+  CardFooter,
+  cardFooterClassNames,
+  renderCardFooter_unstable,
+  useCardFooterStyles_unstable,
+  useCardFooter_unstable,
+} from './components/CardFooter/index';

--- a/packages/react-components/react-card/library/src/CardHeader.ts
+++ b/packages/react-components/react-card/library/src/CardHeader.ts
@@ -1,1 +1,9 @@
-export * from './components/CardHeader/index';
+export type { CardHeaderProps, CardHeaderSlots, CardHeaderState } from './components/CardHeader/index';
+export {
+  CardHeader,
+  cardHeaderCSSVars,
+  cardHeaderClassNames,
+  renderCardHeader_unstable,
+  useCardHeaderStyles_unstable,
+  useCardHeader_unstable,
+} from './components/CardHeader/index';

--- a/packages/react-components/react-card/library/src/CardPreview.ts
+++ b/packages/react-components/react-card/library/src/CardPreview.ts
@@ -1,1 +1,8 @@
-export * from './components/CardPreview/index';
+export type { CardPreviewProps, CardPreviewSlots, CardPreviewState } from './components/CardPreview/index';
+export {
+  CardPreview,
+  cardPreviewClassNames,
+  renderCardPreview_unstable,
+  useCardPreviewStyles_unstable,
+  useCardPreview_unstable,
+} from './components/CardPreview/index';

--- a/packages/react-components/react-card/library/src/components/Card/index.ts
+++ b/packages/react-components/react-card/library/src/components/Card/index.ts
@@ -1,6 +1,13 @@
-export * from './Card';
-export * from './Card.types';
-export * from './CardContext';
-export * from './renderCard';
-export * from './useCard';
-export * from './useCardStyles.styles';
+export { Card } from './Card';
+export type {
+  CardContextValue,
+  CardOnSelectData,
+  CardOnSelectionChangeEvent,
+  CardProps,
+  CardSlots,
+  CardState,
+} from './Card.types';
+export { CardProvider, cardContextDefaultValue, useCardContext_unstable } from './CardContext';
+export { renderCard_unstable } from './renderCard';
+export { useCard_unstable } from './useCard';
+export { cardCSSVars, cardClassNames, useCardStyles_unstable } from './useCardStyles.styles';

--- a/packages/react-components/react-card/library/src/components/CardFooter/index.ts
+++ b/packages/react-components/react-card/library/src/components/CardFooter/index.ts
@@ -1,5 +1,5 @@
-export * from './CardFooter';
-export * from './CardFooter.types';
-export * from './renderCardFooter';
-export * from './useCardFooter';
-export * from './useCardFooterStyles.styles';
+export { CardFooter } from './CardFooter';
+export type { CardFooterProps, CardFooterSlots, CardFooterState } from './CardFooter.types';
+export { renderCardFooter_unstable } from './renderCardFooter';
+export { useCardFooter_unstable } from './useCardFooter';
+export { cardFooterClassNames, useCardFooterStyles_unstable } from './useCardFooterStyles.styles';

--- a/packages/react-components/react-card/library/src/components/CardHeader/index.ts
+++ b/packages/react-components/react-card/library/src/components/CardHeader/index.ts
@@ -1,5 +1,5 @@
-export * from './CardHeader';
-export * from './CardHeader.types';
-export * from './renderCardHeader';
-export * from './useCardHeader';
-export * from './useCardHeaderStyles.styles';
+export { CardHeader } from './CardHeader';
+export type { CardHeaderProps, CardHeaderSlots, CardHeaderState } from './CardHeader.types';
+export { renderCardHeader_unstable } from './renderCardHeader';
+export { useCardHeader_unstable } from './useCardHeader';
+export { cardHeaderCSSVars, cardHeaderClassNames, useCardHeaderStyles_unstable } from './useCardHeaderStyles.styles';

--- a/packages/react-components/react-card/library/src/components/CardPreview/index.ts
+++ b/packages/react-components/react-card/library/src/components/CardPreview/index.ts
@@ -1,5 +1,5 @@
-export * from './CardPreview';
-export * from './CardPreview.types';
-export * from './renderCardPreview';
-export * from './useCardPreview';
-export * from './useCardPreviewStyles.styles';
+export { CardPreview } from './CardPreview';
+export type { CardPreviewProps, CardPreviewSlots, CardPreviewState } from './CardPreview.types';
+export { renderCardPreview_unstable } from './renderCardPreview';
+export { useCardPreview_unstable } from './useCardPreview';
+export { cardPreviewClassNames, useCardPreviewStyles_unstable } from './useCardPreviewStyles.styles';

--- a/packages/react-components/react-checkbox/library/src/Checkbox.ts
+++ b/packages/react-components/react-checkbox/library/src/Checkbox.ts
@@ -1,1 +1,8 @@
-export * from './components/Checkbox/index';
+export type { CheckboxOnChangeData, CheckboxProps, CheckboxSlots, CheckboxState } from './components/Checkbox/index';
+export {
+  Checkbox,
+  checkboxClassNames,
+  renderCheckbox_unstable,
+  useCheckboxStyles_unstable,
+  useCheckbox_unstable,
+} from './components/Checkbox/index';

--- a/packages/react-components/react-checkbox/library/src/components/Checkbox/index.ts
+++ b/packages/react-components/react-checkbox/library/src/components/Checkbox/index.ts
@@ -1,5 +1,5 @@
-export * from './Checkbox';
-export * from './Checkbox.types';
-export * from './renderCheckbox';
-export * from './useCheckbox';
-export * from './useCheckboxStyles.styles';
+export { Checkbox } from './Checkbox';
+export type { CheckboxOnChangeData, CheckboxProps, CheckboxSlots, CheckboxState } from './Checkbox.types';
+export { renderCheckbox_unstable } from './renderCheckbox';
+export { useCheckbox_unstable } from './useCheckbox';
+export { checkboxClassNames, useCheckboxStyles_unstable } from './useCheckboxStyles.styles';

--- a/packages/react-components/react-color-picker-preview/library/src/AlphaSlider.ts
+++ b/packages/react-components/react-color-picker-preview/library/src/AlphaSlider.ts
@@ -1,1 +1,9 @@
-export * from './components/AlphaSlider/index';
+export type { AlphaSliderProps, AlphaSliderSlots, AlphaSliderState } from './components/AlphaSlider/index';
+export {
+  AlphaSlider,
+  alphaSliderCSSVars,
+  alphaSliderClassNames,
+  renderAlphaSlider_unstable,
+  useAlphaSliderStyles_unstable,
+  useAlphaSlider_unstable,
+} from './components/AlphaSlider/index';

--- a/packages/react-components/react-color-picker-preview/library/src/ColorArea.ts
+++ b/packages/react-components/react-color-picker-preview/library/src/ColorArea.ts
@@ -1,1 +1,14 @@
-export * from './components/ColorArea/index';
+export type {
+  ColorAreaOnColorChangeData,
+  ColorAreaProps,
+  ColorAreaSlots,
+  ColorAreaState,
+} from './components/ColorArea/index';
+export {
+  ColorArea,
+  colorAreaCSSVars,
+  colorAreaClassNames,
+  renderColorArea_unstable,
+  useColorAreaStyles_unstable,
+  useColorArea_unstable,
+} from './components/ColorArea/index';

--- a/packages/react-components/react-color-picker-preview/library/src/ColorPicker.ts
+++ b/packages/react-components/react-color-picker-preview/library/src/ColorPicker.ts
@@ -1,1 +1,13 @@
-export * from './components/ColorPicker/index';
+export type {
+  ColorPickerOnChangeData,
+  ColorPickerProps,
+  ColorPickerSlots,
+  ColorPickerState,
+} from './components/ColorPicker/index';
+export {
+  ColorPicker,
+  colorPickerClassNames,
+  renderColorPicker_unstable,
+  useColorPickerStyles_unstable,
+  useColorPicker_unstable,
+} from './components/ColorPicker/index';

--- a/packages/react-components/react-color-picker-preview/library/src/ColorSlider.ts
+++ b/packages/react-components/react-color-picker-preview/library/src/ColorSlider.ts
@@ -1,1 +1,14 @@
-export * from './components/ColorSlider/index';
+export type {
+  ColorSliderProps,
+  ColorSliderSlots,
+  ColorSliderState,
+  SliderOnChangeData,
+} from './components/ColorSlider/index';
+export {
+  ColorSlider,
+  colorSliderCSSVars,
+  colorSliderClassNames,
+  renderColorSlider_unstable,
+  useColorSliderStyles_unstable,
+  useColorSlider_unstable,
+} from './components/ColorSlider/index';

--- a/packages/react-components/react-color-picker-preview/library/src/components/AlphaSlider/index.ts
+++ b/packages/react-components/react-color-picker-preview/library/src/components/AlphaSlider/index.ts
@@ -1,5 +1,9 @@
-export * from './AlphaSlider';
-export * from './AlphaSlider.types';
-export * from './renderAlphaSlider';
-export * from './useAlphaSlider';
-export * from './useAlphaSliderStyles.styles';
+export { AlphaSlider } from './AlphaSlider';
+export type { AlphaSliderProps, AlphaSliderSlots, AlphaSliderState } from './AlphaSlider.types';
+export { renderAlphaSlider_unstable } from './renderAlphaSlider';
+export { useAlphaSlider_unstable } from './useAlphaSlider';
+export {
+  alphaSliderCSSVars,
+  alphaSliderClassNames,
+  useAlphaSliderStyles_unstable,
+} from './useAlphaSliderStyles.styles';

--- a/packages/react-components/react-color-picker-preview/library/src/components/ColorArea/index.ts
+++ b/packages/react-components/react-color-picker-preview/library/src/components/ColorArea/index.ts
@@ -1,5 +1,5 @@
-export * from './ColorArea';
-export * from './ColorArea.types';
-export * from './renderColorArea';
-export * from './useColorArea';
-export * from './useColorAreaStyles.styles';
+export { ColorArea } from './ColorArea';
+export type { ColorAreaOnColorChangeData, ColorAreaProps, ColorAreaSlots, ColorAreaState } from './ColorArea.types';
+export { renderColorArea_unstable } from './renderColorArea';
+export { useColorArea_unstable } from './useColorArea';
+export { colorAreaCSSVars, colorAreaClassNames, useColorAreaStyles_unstable } from './useColorAreaStyles.styles';

--- a/packages/react-components/react-color-picker-preview/library/src/components/ColorPicker/index.ts
+++ b/packages/react-components/react-color-picker-preview/library/src/components/ColorPicker/index.ts
@@ -1,5 +1,10 @@
-export * from './ColorPicker';
-export * from './ColorPicker.types';
-export * from './renderColorPicker';
-export * from './useColorPicker';
-export * from './useColorPickerStyles.styles';
+export { ColorPicker } from './ColorPicker';
+export type {
+  ColorPickerOnChangeData,
+  ColorPickerProps,
+  ColorPickerSlots,
+  ColorPickerState,
+} from './ColorPicker.types';
+export { renderColorPicker_unstable } from './renderColorPicker';
+export { useColorPicker_unstable } from './useColorPicker';
+export { colorPickerClassNames, useColorPickerStyles_unstable } from './useColorPickerStyles.styles';

--- a/packages/react-components/react-color-picker-preview/library/src/components/ColorSlider/index.ts
+++ b/packages/react-components/react-color-picker-preview/library/src/components/ColorSlider/index.ts
@@ -1,5 +1,9 @@
-export * from './ColorSlider';
-export * from './ColorSlider.types';
-export * from './renderColorSlider';
-export * from './useColorSlider';
-export * from './useColorSliderStyles.styles';
+export { ColorSlider } from './ColorSlider';
+export type { ColorSliderProps, ColorSliderSlots, ColorSliderState, SliderOnChangeData } from './ColorSlider.types';
+export { renderColorSlider_unstable } from './renderColorSlider';
+export { useColorSlider_unstable } from './useColorSlider';
+export {
+  colorSliderCSSVars,
+  colorSliderClassNames,
+  useColorSliderStyles_unstable,
+} from './useColorSliderStyles.styles';

--- a/packages/react-components/react-combobox/library/src/Combobox.ts
+++ b/packages/react-components/react-combobox/library/src/Combobox.ts
@@ -1,1 +1,16 @@
-export * from './components/Combobox/index';
+export type {
+  ActiveOptionChangeData,
+  ComboboxContextValues,
+  ComboboxOpenChangeData,
+  ComboboxOpenEvents,
+  ComboboxProps,
+  ComboboxSlots,
+  ComboboxState,
+} from './components/Combobox/index';
+export {
+  Combobox,
+  comboboxClassNames,
+  renderCombobox_unstable,
+  useComboboxStyles_unstable,
+  useCombobox_unstable,
+} from './components/Combobox/index';

--- a/packages/react-components/react-combobox/library/src/Dropdown.ts
+++ b/packages/react-components/react-combobox/library/src/Dropdown.ts
@@ -1,1 +1,16 @@
-export * from './components/Dropdown/index';
+export type {
+  ActiveOptionChangeData,
+  DropdownContextValues,
+  DropdownOpenChangeData,
+  DropdownOpenEvents,
+  DropdownProps,
+  DropdownSlots,
+  DropdownState,
+} from './components/Dropdown/index';
+export {
+  Dropdown,
+  dropdownClassNames,
+  renderDropdown_unstable,
+  useDropdownStyles_unstable,
+  useDropdown_unstable,
+} from './components/Dropdown/index';

--- a/packages/react-components/react-combobox/library/src/Listbox.ts
+++ b/packages/react-components/react-combobox/library/src/Listbox.ts
@@ -1,1 +1,8 @@
-export * from './components/Listbox/index';
+export type { ListboxContextValues, ListboxProps, ListboxSlots, ListboxState } from './components/Listbox/index';
+export {
+  Listbox,
+  listboxClassNames,
+  renderListbox_unstable,
+  useListboxStyles_unstable,
+  useListbox_unstable,
+} from './components/Listbox/index';

--- a/packages/react-components/react-combobox/library/src/Option.ts
+++ b/packages/react-components/react-combobox/library/src/Option.ts
@@ -1,1 +1,8 @@
-export * from './components/Option/index';
+export type { OptionProps, OptionSlots, OptionState } from './components/Option/index';
+export {
+  Option,
+  optionClassNames,
+  renderOption_unstable,
+  useOptionStyles_unstable,
+  useOption_unstable,
+} from './components/Option/index';

--- a/packages/react-components/react-combobox/library/src/OptionGroup.ts
+++ b/packages/react-components/react-combobox/library/src/OptionGroup.ts
@@ -1,1 +1,8 @@
-export * from './components/OptionGroup/index';
+export type { OptionGroupProps, OptionGroupSlots, OptionGroupState } from './components/OptionGroup/index';
+export {
+  OptionGroup,
+  optionGroupClassNames,
+  renderOptionGroup_unstable,
+  useOptionGroupStyles_unstable,
+  useOptionGroup_unstable,
+} from './components/OptionGroup/index';

--- a/packages/react-components/react-combobox/library/src/Selection.ts
+++ b/packages/react-components/react-combobox/library/src/Selection.ts
@@ -1,1 +1,1 @@
-export * from './utils/Selection.types';
+export type { OptionOnSelectData, SelectionEvents, SelectionProps, SelectionState } from './utils/Selection.types';

--- a/packages/react-components/react-combobox/library/src/components/Combobox/index.ts
+++ b/packages/react-components/react-combobox/library/src/components/Combobox/index.ts
@@ -1,5 +1,13 @@
-export * from './Combobox';
-export * from './Combobox.types';
-export * from './renderCombobox';
-export * from './useCombobox';
-export * from './useComboboxStyles.styles';
+export { Combobox } from './Combobox';
+export type {
+  ActiveOptionChangeData,
+  ComboboxContextValues,
+  ComboboxOpenChangeData,
+  ComboboxOpenEvents,
+  ComboboxProps,
+  ComboboxSlots,
+  ComboboxState,
+} from './Combobox.types';
+export { renderCombobox_unstable } from './renderCombobox';
+export { useCombobox_unstable } from './useCombobox';
+export { comboboxClassNames, useComboboxStyles_unstable } from './useComboboxStyles.styles';

--- a/packages/react-components/react-combobox/library/src/components/Dropdown/index.ts
+++ b/packages/react-components/react-combobox/library/src/components/Dropdown/index.ts
@@ -1,5 +1,13 @@
-export * from './Dropdown';
-export * from './Dropdown.types';
-export * from './renderDropdown';
-export * from './useDropdown';
-export * from './useDropdownStyles.styles';
+export { Dropdown } from './Dropdown';
+export type {
+  ActiveOptionChangeData,
+  DropdownContextValues,
+  DropdownOpenChangeData,
+  DropdownOpenEvents,
+  DropdownProps,
+  DropdownSlots,
+  DropdownState,
+} from './Dropdown.types';
+export { renderDropdown_unstable } from './renderDropdown';
+export { useDropdown_unstable } from './useDropdown';
+export { dropdownClassNames, useDropdownStyles_unstable } from './useDropdownStyles.styles';

--- a/packages/react-components/react-combobox/library/src/components/Listbox/index.ts
+++ b/packages/react-components/react-combobox/library/src/components/Listbox/index.ts
@@ -1,5 +1,5 @@
-export * from './Listbox';
-export * from './Listbox.types';
-export * from './renderListbox';
-export * from './useListbox';
-export * from './useListboxStyles.styles';
+export { Listbox } from './Listbox';
+export type { ListboxContextValues, ListboxProps, ListboxSlots, ListboxState } from './Listbox.types';
+export { renderListbox_unstable } from './renderListbox';
+export { useListbox_unstable } from './useListbox';
+export { listboxClassNames, useListboxStyles_unstable } from './useListboxStyles.styles';

--- a/packages/react-components/react-combobox/library/src/components/Option/index.ts
+++ b/packages/react-components/react-combobox/library/src/components/Option/index.ts
@@ -1,5 +1,5 @@
-export * from './Option';
-export * from './Option.types';
-export * from './renderOption';
-export * from './useOption';
-export * from './useOptionStyles.styles';
+export { Option } from './Option';
+export type { OptionProps, OptionSlots, OptionState } from './Option.types';
+export { renderOption_unstable } from './renderOption';
+export { useOption_unstable } from './useOption';
+export { optionClassNames, useOptionStyles_unstable } from './useOptionStyles.styles';

--- a/packages/react-components/react-combobox/library/src/components/OptionGroup/index.ts
+++ b/packages/react-components/react-combobox/library/src/components/OptionGroup/index.ts
@@ -1,5 +1,5 @@
-export * from './OptionGroup';
-export * from './OptionGroup.types';
-export * from './renderOptionGroup';
-export * from './useOptionGroup';
-export * from './useOptionGroupStyles.styles';
+export { OptionGroup } from './OptionGroup';
+export type { OptionGroupProps, OptionGroupSlots, OptionGroupState } from './OptionGroup.types';
+export { renderOptionGroup_unstable } from './renderOptionGroup';
+export { useOptionGroup_unstable } from './useOptionGroup';
+export { optionGroupClassNames, useOptionGroupStyles_unstable } from './useOptionGroupStyles.styles';

--- a/packages/react-components/react-datepicker-compat/library/src/DatePicker.ts
+++ b/packages/react-components/react-datepicker-compat/library/src/DatePicker.ts
@@ -1,1 +1,16 @@
-export * from './components/DatePicker/index';
+export type {
+  DatePickerErrorType,
+  DatePickerProps,
+  DatePickerSlots,
+  DatePickerState,
+  DatePickerValidationResultData,
+} from './components/DatePicker/index';
+export {
+  DatePicker,
+  datePickerClassNames,
+  defaultDatePickerErrorStrings,
+  defaultDatePickerStrings,
+  renderDatePicker_unstable,
+  useDatePickerStyles_unstable,
+  useDatePicker_unstable,
+} from './components/DatePicker/index';

--- a/packages/react-components/react-datepicker-compat/library/src/components/DatePicker/index.ts
+++ b/packages/react-components/react-datepicker-compat/library/src/components/DatePicker/index.ts
@@ -1,6 +1,12 @@
-export * from './defaults';
-export * from './DatePicker';
-export * from './DatePicker.types';
-export * from './renderDatePicker';
-export * from './useDatePicker';
-export * from './useDatePickerStyles.styles';
+export { defaultDatePickerErrorStrings, defaultDatePickerStrings } from './defaults';
+export { DatePicker } from './DatePicker';
+export type {
+  DatePickerErrorType,
+  DatePickerProps,
+  DatePickerSlots,
+  DatePickerState,
+  DatePickerValidationResultData,
+} from './DatePicker.types';
+export { renderDatePicker_unstable } from './renderDatePicker';
+export { useDatePicker_unstable } from './useDatePicker';
+export { datePickerClassNames, useDatePickerStyles_unstable } from './useDatePickerStyles.styles';

--- a/packages/react-components/react-divider/library/src/Divider.ts
+++ b/packages/react-components/react-divider/library/src/Divider.ts
@@ -1,1 +1,8 @@
-export * from './components/Divider/index';
+export type { DividerProps, DividerSlots, DividerState } from './components/Divider/index';
+export {
+  Divider,
+  dividerClassNames,
+  renderDivider_unstable,
+  useDividerStyles_unstable,
+  useDivider_unstable,
+} from './components/Divider/index';

--- a/packages/react-components/react-divider/library/src/components/Divider/index.ts
+++ b/packages/react-components/react-divider/library/src/components/Divider/index.ts
@@ -1,5 +1,5 @@
-export * from './Divider';
-export * from './Divider.types';
-export * from './renderDivider';
-export * from './useDivider';
-export * from './useDividerStyles.styles';
+export { Divider } from './Divider';
+export type { DividerProps, DividerSlots, DividerState } from './Divider.types';
+export { renderDivider_unstable } from './renderDivider';
+export { useDivider_unstable } from './useDivider';
+export { dividerClassNames, useDividerStyles_unstable } from './useDividerStyles.styles';

--- a/packages/react-components/react-drawer/library/src/Drawer.ts
+++ b/packages/react-components/react-drawer/library/src/Drawer.ts
@@ -1,1 +1,8 @@
-export * from './components/Drawer/index';
+export type { DrawerProps, DrawerSlots, DrawerState } from './components/Drawer/index';
+export {
+  Drawer,
+  drawerClassNames,
+  renderDrawer_unstable,
+  useDrawerStyles_unstable,
+  useDrawer_unstable,
+} from './components/Drawer/index';

--- a/packages/react-components/react-drawer/library/src/DrawerBody.ts
+++ b/packages/react-components/react-drawer/library/src/DrawerBody.ts
@@ -1,1 +1,8 @@
-export * from './components/DrawerBody/index';
+export type { DrawerBodyProps, DrawerBodySlots, DrawerBodyState } from './components/DrawerBody/index';
+export {
+  DrawerBody,
+  drawerBodyClassNames,
+  renderDrawerBody_unstable,
+  useDrawerBodyStyles_unstable,
+  useDrawerBody_unstable,
+} from './components/DrawerBody/index';

--- a/packages/react-components/react-drawer/library/src/DrawerFooter.ts
+++ b/packages/react-components/react-drawer/library/src/DrawerFooter.ts
@@ -1,1 +1,8 @@
-export * from './components/DrawerFooter/index';
+export type { DrawerFooterProps, DrawerFooterSlots, DrawerFooterState } from './components/DrawerFooter/index';
+export {
+  DrawerFooter,
+  drawerFooterClassNames,
+  renderDrawerFooter_unstable,
+  useDrawerFooterStyles_unstable,
+  useDrawerFooter_unstable,
+} from './components/DrawerFooter/index';

--- a/packages/react-components/react-drawer/library/src/DrawerHeader.ts
+++ b/packages/react-components/react-drawer/library/src/DrawerHeader.ts
@@ -1,1 +1,8 @@
-export * from './components/DrawerHeader/index';
+export type { DrawerHeaderProps, DrawerHeaderSlots, DrawerHeaderState } from './components/DrawerHeader/index';
+export {
+  DrawerHeader,
+  drawerHeaderClassNames,
+  renderDrawerHeader_unstable,
+  useDrawerHeaderStyles_unstable,
+  useDrawerHeader_unstable,
+} from './components/DrawerHeader/index';

--- a/packages/react-components/react-drawer/library/src/DrawerHeaderNavigation.ts
+++ b/packages/react-components/react-drawer/library/src/DrawerHeaderNavigation.ts
@@ -1,1 +1,12 @@
-export * from './components/DrawerHeaderNavigation/index';
+export type {
+  DrawerHeaderNavigationProps,
+  DrawerHeaderNavigationSlots,
+  DrawerHeaderNavigationState,
+} from './components/DrawerHeaderNavigation/index';
+export {
+  DrawerHeaderNavigation,
+  drawerHeaderNavigationClassNames,
+  renderDrawerHeaderNavigation_unstable,
+  useDrawerHeaderNavigationStyles_unstable,
+  useDrawerHeaderNavigation_unstable,
+} from './components/DrawerHeaderNavigation/index';

--- a/packages/react-components/react-drawer/library/src/DrawerHeaderTitle.ts
+++ b/packages/react-components/react-drawer/library/src/DrawerHeaderTitle.ts
@@ -1,1 +1,12 @@
-export * from './components/DrawerHeaderTitle/index';
+export type {
+  DrawerHeaderTitleProps,
+  DrawerHeaderTitleSlots,
+  DrawerHeaderTitleState,
+} from './components/DrawerHeaderTitle/index';
+export {
+  DrawerHeaderTitle,
+  drawerHeaderTitleClassNames,
+  renderDrawerHeaderTitle_unstable,
+  useDrawerHeaderTitleStyles_unstable,
+  useDrawerHeaderTitle_unstable,
+} from './components/DrawerHeaderTitle/index';

--- a/packages/react-components/react-drawer/library/src/InlineDrawer.ts
+++ b/packages/react-components/react-drawer/library/src/InlineDrawer.ts
@@ -1,1 +1,13 @@
-export * from './components/InlineDrawer/index';
+export type {
+  InlineDrawerProps,
+  InlineDrawerSlots,
+  InlineDrawerState,
+  SurfaceMotionSlotProps,
+} from './components/InlineDrawer/index';
+export {
+  InlineDrawer,
+  inlineDrawerClassNames,
+  renderInlineDrawer_unstable,
+  useInlineDrawerStyles_unstable,
+  useInlineDrawer_unstable,
+} from './components/InlineDrawer/index';

--- a/packages/react-components/react-drawer/library/src/OverlayDrawer.ts
+++ b/packages/react-components/react-drawer/library/src/OverlayDrawer.ts
@@ -1,1 +1,13 @@
-export * from './components/OverlayDrawer/index';
+export type {
+  OverlayDrawerInternalSlots,
+  OverlayDrawerProps,
+  OverlayDrawerSlots,
+  OverlayDrawerState,
+} from './components/OverlayDrawer/index';
+export {
+  OverlayDrawer,
+  overlayDrawerClassNames,
+  renderOverlayDrawer_unstable,
+  useOverlayDrawerStyles_unstable,
+  useOverlayDrawer_unstable,
+} from './components/OverlayDrawer/index';

--- a/packages/react-components/react-drawer/library/src/components/Drawer/index.ts
+++ b/packages/react-components/react-drawer/library/src/components/Drawer/index.ts
@@ -1,5 +1,5 @@
-export * from './Drawer';
-export * from './Drawer.types';
-export * from './renderDrawer';
-export * from './useDrawer';
-export * from './useDrawerStyles.styles';
+export { Drawer } from './Drawer';
+export type { DrawerProps, DrawerSlots, DrawerState } from './Drawer.types';
+export { renderDrawer_unstable } from './renderDrawer';
+export { useDrawer_unstable } from './useDrawer';
+export { drawerClassNames, useDrawerStyles_unstable } from './useDrawerStyles.styles';

--- a/packages/react-components/react-drawer/library/src/components/DrawerBody/index.ts
+++ b/packages/react-components/react-drawer/library/src/components/DrawerBody/index.ts
@@ -1,5 +1,5 @@
-export * from './DrawerBody';
-export * from './DrawerBody.types';
-export * from './renderDrawerBody';
-export * from './useDrawerBody';
-export * from './useDrawerBodyStyles.styles';
+export { DrawerBody } from './DrawerBody';
+export type { DrawerBodyProps, DrawerBodySlots, DrawerBodyState } from './DrawerBody.types';
+export { renderDrawerBody_unstable } from './renderDrawerBody';
+export { useDrawerBody_unstable } from './useDrawerBody';
+export { drawerBodyClassNames, useDrawerBodyStyles_unstable } from './useDrawerBodyStyles.styles';

--- a/packages/react-components/react-drawer/library/src/components/DrawerFooter/index.ts
+++ b/packages/react-components/react-drawer/library/src/components/DrawerFooter/index.ts
@@ -1,5 +1,5 @@
-export * from './DrawerFooter';
-export * from './DrawerFooter.types';
-export * from './renderDrawerFooter';
-export * from './useDrawerFooter';
-export * from './useDrawerFooterStyles.styles';
+export { DrawerFooter } from './DrawerFooter';
+export type { DrawerFooterProps, DrawerFooterSlots, DrawerFooterState } from './DrawerFooter.types';
+export { renderDrawerFooter_unstable } from './renderDrawerFooter';
+export { useDrawerFooter_unstable } from './useDrawerFooter';
+export { drawerFooterClassNames, useDrawerFooterStyles_unstable } from './useDrawerFooterStyles.styles';

--- a/packages/react-components/react-drawer/library/src/components/DrawerHeader/index.ts
+++ b/packages/react-components/react-drawer/library/src/components/DrawerHeader/index.ts
@@ -1,5 +1,5 @@
-export * from './DrawerHeader';
-export * from './DrawerHeader.types';
-export * from './renderDrawerHeader';
-export * from './useDrawerHeader';
-export * from './useDrawerHeaderStyles.styles';
+export { DrawerHeader } from './DrawerHeader';
+export type { DrawerHeaderProps, DrawerHeaderSlots, DrawerHeaderState } from './DrawerHeader.types';
+export { renderDrawerHeader_unstable } from './renderDrawerHeader';
+export { useDrawerHeader_unstable } from './useDrawerHeader';
+export { drawerHeaderClassNames, useDrawerHeaderStyles_unstable } from './useDrawerHeaderStyles.styles';

--- a/packages/react-components/react-drawer/library/src/components/DrawerHeaderNavigation/index.ts
+++ b/packages/react-components/react-drawer/library/src/components/DrawerHeaderNavigation/index.ts
@@ -1,5 +1,12 @@
-export * from './DrawerHeaderNavigation';
-export * from './DrawerHeaderNavigation.types';
-export * from './renderDrawerHeaderNavigation';
-export * from './useDrawerHeaderNavigation';
-export * from './useDrawerHeaderNavigationStyles.styles';
+export { DrawerHeaderNavigation } from './DrawerHeaderNavigation';
+export type {
+  DrawerHeaderNavigationProps,
+  DrawerHeaderNavigationSlots,
+  DrawerHeaderNavigationState,
+} from './DrawerHeaderNavigation.types';
+export { renderDrawerHeaderNavigation_unstable } from './renderDrawerHeaderNavigation';
+export { useDrawerHeaderNavigation_unstable } from './useDrawerHeaderNavigation';
+export {
+  drawerHeaderNavigationClassNames,
+  useDrawerHeaderNavigationStyles_unstable,
+} from './useDrawerHeaderNavigationStyles.styles';

--- a/packages/react-components/react-drawer/library/src/components/DrawerHeaderTitle/index.ts
+++ b/packages/react-components/react-drawer/library/src/components/DrawerHeaderTitle/index.ts
@@ -1,5 +1,5 @@
-export * from './DrawerHeaderTitle';
-export * from './DrawerHeaderTitle.types';
-export * from './renderDrawerHeaderTitle';
-export * from './useDrawerHeaderTitle';
-export * from './useDrawerHeaderTitleStyles.styles';
+export { DrawerHeaderTitle } from './DrawerHeaderTitle';
+export type { DrawerHeaderTitleProps, DrawerHeaderTitleSlots, DrawerHeaderTitleState } from './DrawerHeaderTitle.types';
+export { renderDrawerHeaderTitle_unstable } from './renderDrawerHeaderTitle';
+export { useDrawerHeaderTitle_unstable } from './useDrawerHeaderTitle';
+export { drawerHeaderTitleClassNames, useDrawerHeaderTitleStyles_unstable } from './useDrawerHeaderTitleStyles.styles';

--- a/packages/react-components/react-drawer/library/src/components/InlineDrawer/index.ts
+++ b/packages/react-components/react-drawer/library/src/components/InlineDrawer/index.ts
@@ -1,5 +1,10 @@
-export * from './InlineDrawer';
-export * from './InlineDrawer.types';
-export * from './renderInlineDrawer';
-export * from './useInlineDrawer';
-export * from './useInlineDrawerStyles.styles';
+export { InlineDrawer } from './InlineDrawer';
+export type {
+  InlineDrawerProps,
+  InlineDrawerSlots,
+  InlineDrawerState,
+  SurfaceMotionSlotProps,
+} from './InlineDrawer.types';
+export { renderInlineDrawer_unstable } from './renderInlineDrawer';
+export { useInlineDrawer_unstable } from './useInlineDrawer';
+export { inlineDrawerClassNames, useInlineDrawerStyles_unstable } from './useInlineDrawerStyles.styles';

--- a/packages/react-components/react-drawer/library/src/components/OverlayDrawer/OverlayDrawerSurface/index.ts
+++ b/packages/react-components/react-drawer/library/src/components/OverlayDrawer/OverlayDrawerSurface/index.ts
@@ -1,2 +1,2 @@
-export * from './OverlayDrawerSurface';
-export * from './OverlayDrawerSurface.types';
+export { OverlayDrawerSurface } from './OverlayDrawerSurface';
+export type { OverlayDrawerSurfaceProps, OverlayDrawerSurfaceSlots } from './OverlayDrawerSurface.types';

--- a/packages/react-components/react-drawer/library/src/components/OverlayDrawer/index.ts
+++ b/packages/react-components/react-drawer/library/src/components/OverlayDrawer/index.ts
@@ -1,5 +1,10 @@
-export * from './OverlayDrawer';
-export * from './OverlayDrawer.types';
-export * from './renderOverlayDrawer';
-export * from './useOverlayDrawer';
-export * from './useOverlayDrawerStyles.styles';
+export { OverlayDrawer } from './OverlayDrawer';
+export type {
+  OverlayDrawerInternalSlots,
+  OverlayDrawerProps,
+  OverlayDrawerSlots,
+  OverlayDrawerState,
+} from './OverlayDrawer.types';
+export { renderOverlayDrawer_unstable } from './renderOverlayDrawer';
+export { useOverlayDrawer_unstable } from './useOverlayDrawer';
+export { overlayDrawerClassNames, useOverlayDrawerStyles_unstable } from './useOverlayDrawerStyles.styles';

--- a/packages/react-components/react-drawer/library/src/contexts/index.ts
+++ b/packages/react-components/react-drawer/library/src/contexts/index.ts
@@ -1,1 +1,2 @@
-export * from './drawerContext';
+export type { DrawerContextValue } from './drawerContext';
+export { DrawerProvider, drawerContext, useDrawerContextValue, useDrawerContext_unstable } from './drawerContext';

--- a/packages/react-components/react-drawer/stories/src/Drawer/DrawerMultipleLevels.stories.tsx
+++ b/packages/react-components/react-drawer/stories/src/Drawer/DrawerMultipleLevels.stories.tsx
@@ -59,7 +59,7 @@ const BodyPresenceMotion = createPresenceComponent<{ level: 1 | 2 }>(({ level })
 
   return {
     enter: {
-      keyframes: keyframes,
+      keyframes,
       duration,
       easing,
     },
@@ -78,7 +78,7 @@ const IconPresenceMotion = createPresenceComponent(() => {
 
   return {
     enter: {
-      keyframes: keyframes,
+      keyframes,
       duration: motionTokens.durationNormal,
       easing: motionTokens.curveEasyEase,
     },

--- a/packages/react-components/react-field/library/src/Field.ts
+++ b/packages/react-components/react-field/library/src/Field.ts
@@ -1,1 +1,15 @@
-export * from './components/Field/index';
+export type {
+  FieldContextValue,
+  FieldContextValues,
+  FieldControlProps,
+  FieldProps,
+  FieldSlots,
+  FieldState,
+} from './components/Field/index';
+export {
+  Field,
+  fieldClassNames,
+  renderField_unstable,
+  useFieldStyles_unstable,
+  useField_unstable,
+} from './components/Field/index';

--- a/packages/react-components/react-field/library/src/components/Field/index.ts
+++ b/packages/react-components/react-field/library/src/components/Field/index.ts
@@ -1,5 +1,12 @@
-export * from './Field.types';
-export * from './Field';
-export * from './renderField';
-export * from './useField';
-export * from './useFieldStyles.styles';
+export type {
+  FieldContextValue,
+  FieldContextValues,
+  FieldControlProps,
+  FieldProps,
+  FieldSlots,
+  FieldState,
+} from './Field.types';
+export { Field } from './Field';
+export { renderField_unstable } from './renderField';
+export { useField_unstable } from './useField';
+export { fieldClassNames, useFieldStyles_unstable } from './useFieldStyles.styles';

--- a/packages/react-components/react-field/library/src/contexts/index.ts
+++ b/packages/react-components/react-field/library/src/contexts/index.ts
@@ -1,3 +1,4 @@
-export * from './FieldContext';
-export * from './useFieldContextValues';
-export * from './useFieldControlProps';
+export { FieldContextProvider, useFieldContext_unstable } from './FieldContext';
+export { useFieldContextValues_unstable } from './useFieldContextValues';
+export type { FieldControlPropsOptions } from './useFieldControlProps';
+export { getFieldControlProps, useFieldControlProps_unstable } from './useFieldControlProps';

--- a/packages/react-components/react-image/library/src/Image.ts
+++ b/packages/react-components/react-image/library/src/Image.ts
@@ -1,1 +1,8 @@
-export * from './components/Image/index';
+export type { ImageProps, ImageSlots, ImageState } from './components/Image/index';
+export {
+  Image,
+  imageClassNames,
+  renderImage_unstable,
+  useImageStyles_unstable,
+  useImage_unstable,
+} from './components/Image/index';

--- a/packages/react-components/react-image/library/src/components/Image/index.ts
+++ b/packages/react-components/react-image/library/src/components/Image/index.ts
@@ -1,5 +1,5 @@
-export * from './Image.types';
-export * from './Image';
-export * from './renderImage';
-export * from './useImage';
-export * from './useImageStyles.styles';
+export type { ImageProps, ImageSlots, ImageState } from './Image.types';
+export { Image } from './Image';
+export { renderImage_unstable } from './renderImage';
+export { useImage_unstable } from './useImage';
+export { imageClassNames, useImageStyles_unstable } from './useImageStyles.styles';

--- a/packages/react-components/react-infolabel/library/src/InfoButton.ts
+++ b/packages/react-components/react-infolabel/library/src/InfoButton.ts
@@ -1,1 +1,8 @@
-export * from './components/InfoButton/index';
+export type { InfoButtonProps, InfoButtonSlots, InfoButtonState } from './components/InfoButton/index';
+export {
+  InfoButton,
+  infoButtonClassNames,
+  renderInfoButton_unstable,
+  useInfoButtonStyles_unstable,
+  useInfoButton_unstable,
+} from './components/InfoButton/index';

--- a/packages/react-components/react-infolabel/library/src/InfoLabel.ts
+++ b/packages/react-components/react-infolabel/library/src/InfoLabel.ts
@@ -1,1 +1,8 @@
-export * from './components/InfoLabel/index';
+export type { InfoLabelProps, InfoLabelSlots, InfoLabelState } from './components/InfoLabel/index';
+export {
+  InfoLabel,
+  infoLabelClassNames,
+  renderInfoLabel_unstable,
+  useInfoLabelStyles_unstable,
+  useInfoLabel_unstable,
+} from './components/InfoLabel/index';

--- a/packages/react-components/react-infolabel/library/src/components/InfoButton/index.ts
+++ b/packages/react-components/react-infolabel/library/src/components/InfoButton/index.ts
@@ -1,5 +1,5 @@
-export * from './InfoButton';
-export * from './InfoButton.types';
-export * from './renderInfoButton';
-export * from './useInfoButton';
-export * from './useInfoButtonStyles.styles';
+export { InfoButton } from './InfoButton';
+export type { InfoButtonProps, InfoButtonSlots, InfoButtonState } from './InfoButton.types';
+export { renderInfoButton_unstable } from './renderInfoButton';
+export { useInfoButton_unstable } from './useInfoButton';
+export { infoButtonClassNames, useInfoButtonStyles_unstable } from './useInfoButtonStyles.styles';

--- a/packages/react-components/react-infolabel/library/src/components/InfoLabel/index.ts
+++ b/packages/react-components/react-infolabel/library/src/components/InfoLabel/index.ts
@@ -1,5 +1,5 @@
-export * from './InfoLabel';
-export * from './InfoLabel.types';
-export * from './renderInfoLabel';
-export * from './useInfoLabel';
-export * from './useInfoLabelStyles.styles';
+export { InfoLabel } from './InfoLabel';
+export type { InfoLabelProps, InfoLabelSlots, InfoLabelState } from './InfoLabel.types';
+export { renderInfoLabel_unstable } from './renderInfoLabel';
+export { useInfoLabel_unstable } from './useInfoLabel';
+export { infoLabelClassNames, useInfoLabelStyles_unstable } from './useInfoLabelStyles.styles';

--- a/packages/react-components/react-input/library/src/Input.ts
+++ b/packages/react-components/react-input/library/src/Input.ts
@@ -1,1 +1,8 @@
-export * from './components/Input/index';
+export type { InputOnChangeData, InputProps, InputSlots, InputState } from './components/Input/index';
+export {
+  Input,
+  inputClassNames,
+  renderInput_unstable,
+  useInputStyles_unstable,
+  useInput_unstable,
+} from './components/Input/index';

--- a/packages/react-components/react-input/library/src/components/Input/index.ts
+++ b/packages/react-components/react-input/library/src/components/Input/index.ts
@@ -1,5 +1,5 @@
-export * from './Input';
-export * from './Input.types';
-export * from './renderInput';
-export * from './useInput';
-export * from './useInputStyles.styles';
+export { Input } from './Input';
+export type { InputOnChangeData, InputProps, InputSlots, InputState } from './Input.types';
+export { renderInput_unstable } from './renderInput';
+export { useInput_unstable } from './useInput';
+export { inputClassNames, useInputStyles_unstable } from './useInputStyles.styles';

--- a/packages/react-components/react-label/library/src/Label.ts
+++ b/packages/react-components/react-label/library/src/Label.ts
@@ -1,1 +1,8 @@
-export * from './components/Label/index';
+export type { LabelProps, LabelSlots, LabelState } from './components/Label/index';
+export {
+  Label,
+  labelClassNames,
+  renderLabel_unstable,
+  useLabelStyles_unstable,
+  useLabel_unstable,
+} from './components/Label/index';

--- a/packages/react-components/react-label/library/src/components/Label/index.ts
+++ b/packages/react-components/react-label/library/src/components/Label/index.ts
@@ -1,5 +1,5 @@
-export * from './Label';
-export * from './Label.types';
-export * from './renderLabel';
-export * from './useLabel';
-export * from './useLabelStyles.styles';
+export { Label } from './Label';
+export type { LabelProps, LabelSlots, LabelState } from './Label.types';
+export { renderLabel_unstable } from './renderLabel';
+export { useLabel_unstable } from './useLabel';
+export { labelClassNames, useLabelStyles_unstable } from './useLabelStyles.styles';

--- a/packages/react-components/react-link/library/src/Link.ts
+++ b/packages/react-components/react-link/library/src/Link.ts
@@ -1,2 +1,11 @@
-export * from './components/Link/index';
-export * from './contexts';
+export type { LinkProps, LinkSlots, LinkState } from './components/Link/index';
+export {
+  Link,
+  linkClassNames,
+  renderLink_unstable,
+  useLinkState_unstable,
+  useLinkStyles_unstable,
+  useLink_unstable,
+} from './components/Link/index';
+export type { LinkContextValue } from './contexts';
+export { LinkContextProvider, linkContextDefaultValue, useLinkContext } from './contexts';

--- a/packages/react-components/react-link/library/src/components/Link/index.ts
+++ b/packages/react-components/react-link/library/src/components/Link/index.ts
@@ -1,6 +1,6 @@
-export * from './Link';
-export * from './Link.types';
-export * from './renderLink';
-export * from './useLink';
-export * from './useLinkState';
-export * from './useLinkStyles.styles';
+export { Link } from './Link';
+export type { LinkProps, LinkSlots, LinkState } from './Link.types';
+export { renderLink_unstable } from './renderLink';
+export { useLink_unstable } from './useLink';
+export { useLinkState_unstable } from './useLinkState';
+export { linkClassNames, useLinkStyles_unstable } from './useLinkStyles.styles';

--- a/packages/react-components/react-link/library/src/contexts/index.ts
+++ b/packages/react-components/react-link/library/src/contexts/index.ts
@@ -1,1 +1,2 @@
-export * from './linkContext';
+export type { LinkContextValue } from './linkContext';
+export { LinkContextProvider, linkContextDefaultValue, useLinkContext } from './linkContext';

--- a/packages/react-components/react-migration-v8-v9/library/src/components/Button/index.ts
+++ b/packages/react-components/react-migration-v8-v9/library/src/components/Button/index.ts
@@ -1,9 +1,9 @@
-export * from './ActionButtonShim';
-export * from './ButtonShim';
-export * from './CommandButtonShim';
-export * from './CompoundButtonShim';
-export * from './DefaultButtonShim';
-export * from './MenuButtonShim';
-export * from './PrimaryButtonShim';
-export * from './shimButtonProps';
-export * from './ToggleButtonShim';
+export { ActionButtonShim } from './ActionButtonShim';
+export { ButtonShim } from './ButtonShim';
+export { CommandButtonShim } from './CommandButtonShim';
+export { CompoundButtonShim } from './CompoundButtonShim';
+export { DefaultButtonShim } from './DefaultButtonShim';
+export { MenuButtonShim } from './MenuButtonShim';
+export { PrimaryButtonShim } from './PrimaryButtonShim';
+export { shimButtonProps } from './shimButtonProps';
+export { ToggleButtonShim } from './ToggleButtonShim';

--- a/packages/react-components/react-migration-v8-v9/library/src/components/Checkbox/index.ts
+++ b/packages/react-components/react-migration-v8-v9/library/src/components/Checkbox/index.ts
@@ -1,1 +1,1 @@
-export * from './CheckboxShim';
+export { CheckboxShim } from './CheckboxShim';

--- a/packages/react-components/react-migration-v8-v9/library/src/components/Menu/index.ts
+++ b/packages/react-components/react-migration-v8-v9/library/src/components/Menu/index.ts
@@ -1,2 +1,2 @@
-export * from './MenuShim';
-export * from './shimMenuProps';
+export { MenuItemShim } from './MenuShim';
+export { shimMenuHeaderProps, shimMenuItemCheckboxProps, shimMenuItemProps, shimMenuProps } from './shimMenuProps';

--- a/packages/react-components/react-migration-v8-v9/library/src/components/Stack/index.ts
+++ b/packages/react-components/react-migration-v8-v9/library/src/components/Stack/index.ts
@@ -1,2 +1,2 @@
-export * from './StackItemShim';
-export * from './StackShim';
+export { StackItemShim } from './StackItemShim';
+export { StackShim } from './StackShim';

--- a/packages/react-components/react-migration-v8-v9/library/src/components/Theme/index.ts
+++ b/packages/react-components/react-migration-v8-v9/library/src/components/Theme/index.ts
@@ -1,4 +1,31 @@
-export * from './themeDuplicates';
-export * from './v8ThemeShim';
-export * from './v9BrandVariantsShim';
-export * from './v9ThemeShim';
+export type {
+  AlphaColors,
+  ColorVariants,
+  GlobalSharedColors,
+  Greys,
+  TextAlignment,
+  TextAlignments,
+} from './themeDuplicates';
+export {
+  black,
+  blackAlpha,
+  brandWeb,
+  grey,
+  grey10Alpha,
+  grey12Alpha,
+  grey14Alpha,
+  hcButtonFace,
+  hcButtonText,
+  hcCanvas,
+  hcCanvasText,
+  hcDisabled,
+  hcHighlight,
+  hcHighlightText,
+  hcHyperlink,
+  sharedColors,
+  white,
+  whiteAlpha,
+} from './themeDuplicates';
+export { createV8Theme } from './v8ThemeShim';
+export { createBrandVariants } from './v9BrandVariantsShim';
+export { createV9Theme } from './v9ThemeShim';

--- a/packages/react-components/react-migration-v8-v9/stories/src/ThemeShim/ThemePreviewV8.stories.tsx
+++ b/packages/react-components/react-migration-v8-v9/stories/src/ThemeShim/ThemePreviewV8.stories.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 /* eslint-disable @typescript-eslint/naming-convention */
 import * as React from 'react';
 import { Checkbox } from '@fluentui/react/lib/Checkbox';

--- a/packages/react-components/react-persona/library/src/Persona.ts
+++ b/packages/react-components/react-persona/library/src/Persona.ts
@@ -1,1 +1,8 @@
-export * from './components/Persona/index';
+export type { PersonaProps, PersonaSlots, PersonaState } from './components/Persona/index';
+export {
+  Persona,
+  personaClassNames,
+  renderPersona_unstable,
+  usePersonaStyles_unstable,
+  usePersona_unstable,
+} from './components/Persona/index';

--- a/packages/react-components/react-persona/library/src/components/Persona/index.ts
+++ b/packages/react-components/react-persona/library/src/components/Persona/index.ts
@@ -1,5 +1,5 @@
-export * from './Persona';
-export * from './Persona.types';
-export * from './renderPersona';
-export * from './usePersona';
-export * from './usePersonaStyles.styles';
+export { Persona } from './Persona';
+export type { PersonaProps, PersonaSlots, PersonaState } from './Persona.types';
+export { renderPersona_unstable } from './renderPersona';
+export { usePersona_unstable } from './usePersona';
+export { personaClassNames, usePersonaStyles_unstable } from './usePersonaStyles.styles';

--- a/packages/react-components/react-progress/library/src/ProgressBar.ts
+++ b/packages/react-components/react-progress/library/src/ProgressBar.ts
@@ -1,1 +1,8 @@
-export * from './components/ProgressBar/index';
+export type { ProgressBarProps, ProgressBarSlots, ProgressBarState } from './components/ProgressBar/index';
+export {
+  ProgressBar,
+  progressBarClassNames,
+  renderProgressBar_unstable,
+  useProgressBarStyles_unstable,
+  useProgressBar_unstable,
+} from './components/ProgressBar/index';

--- a/packages/react-components/react-progress/library/src/components/ProgressBar/index.ts
+++ b/packages/react-components/react-progress/library/src/components/ProgressBar/index.ts
@@ -1,5 +1,5 @@
-export * from './ProgressBar';
-export * from './ProgressBar.types';
-export * from './renderProgressBar';
-export * from './useProgressBar';
-export * from './useProgressBarStyles.styles';
+export { ProgressBar } from './ProgressBar';
+export type { ProgressBarProps, ProgressBarSlots, ProgressBarState } from './ProgressBar.types';
+export { renderProgressBar_unstable } from './renderProgressBar';
+export { useProgressBar_unstable } from './useProgressBar';
+export { progressBarClassNames, useProgressBarStyles_unstable } from './useProgressBarStyles.styles';

--- a/packages/react-components/react-progress/library/src/utils/index.ts
+++ b/packages/react-components/react-progress/library/src/utils/index.ts
@@ -1,2 +1,2 @@
-export * from './clampMax';
-export * from './clampValue';
+export { clampMax } from './clampMax';
+export { clampValue } from './clampValue';

--- a/packages/react-components/react-rating/library/src/Rating.ts
+++ b/packages/react-components/react-rating/library/src/Rating.ts
@@ -1,1 +1,15 @@
-export * from './components/Rating/index';
+export type {
+  RatingContextValues,
+  RatingOnChangeEventData,
+  RatingProps,
+  RatingSlots,
+  RatingState,
+} from './components/Rating/index';
+export {
+  Rating,
+  ratingClassNames,
+  renderRating_unstable,
+  useRatingContextValues,
+  useRatingStyles_unstable,
+  useRating_unstable,
+} from './components/Rating/index';

--- a/packages/react-components/react-rating/library/src/RatingDisplay.ts
+++ b/packages/react-components/react-rating/library/src/RatingDisplay.ts
@@ -1,1 +1,14 @@
-export * from './components/RatingDisplay/index';
+export type {
+  RatingDisplayContextValues,
+  RatingDisplayProps,
+  RatingDisplaySlots,
+  RatingDisplayState,
+} from './components/RatingDisplay/index';
+export {
+  RatingDisplay,
+  ratingDisplayClassNames,
+  renderRatingDisplay_unstable,
+  useRatingDisplayContextValues,
+  useRatingDisplayStyles_unstable,
+  useRatingDisplay_unstable,
+} from './components/RatingDisplay/index';

--- a/packages/react-components/react-rating/library/src/RatingItem.ts
+++ b/packages/react-components/react-rating/library/src/RatingItem.ts
@@ -1,1 +1,13 @@
-export * from './components/RatingItem/index';
+export type {
+  RatingItemContextValue,
+  RatingItemProps,
+  RatingItemSlots,
+  RatingItemState,
+} from './components/RatingItem/index';
+export {
+  RatingItem,
+  ratingItemClassNames,
+  renderRatingItem_unstable,
+  useRatingItemStyles_unstable,
+  useRatingItem_unstable,
+} from './components/RatingItem/index';

--- a/packages/react-components/react-rating/library/src/components/Rating/index.ts
+++ b/packages/react-components/react-rating/library/src/components/Rating/index.ts
@@ -1,6 +1,12 @@
-export * from './Rating';
-export * from './Rating.types';
-export * from './renderRating';
-export * from './useRating';
-export * from './useRatingStyles.styles';
-export * from './useRatingContextValues';
+export { Rating } from './Rating';
+export type {
+  RatingContextValues,
+  RatingOnChangeEventData,
+  RatingProps,
+  RatingSlots,
+  RatingState,
+} from './Rating.types';
+export { renderRating_unstable } from './renderRating';
+export { useRating_unstable } from './useRating';
+export { ratingClassNames, useRatingStyles_unstable } from './useRatingStyles.styles';
+export { useRatingContextValues } from './useRatingContextValues';

--- a/packages/react-components/react-rating/library/src/components/RatingDisplay/index.ts
+++ b/packages/react-components/react-rating/library/src/components/RatingDisplay/index.ts
@@ -1,6 +1,11 @@
-export * from './RatingDisplay';
-export * from './RatingDisplay.types';
-export * from './renderRatingDisplay';
-export * from './useRatingDisplay';
-export * from './useRatingDisplayStyles.styles';
-export * from './useRatingDisplayContextValues';
+export { RatingDisplay } from './RatingDisplay';
+export type {
+  RatingDisplayContextValues,
+  RatingDisplayProps,
+  RatingDisplaySlots,
+  RatingDisplayState,
+} from './RatingDisplay.types';
+export { renderRatingDisplay_unstable } from './renderRatingDisplay';
+export { useRatingDisplay_unstable } from './useRatingDisplay';
+export { ratingDisplayClassNames, useRatingDisplayStyles_unstable } from './useRatingDisplayStyles.styles';
+export { useRatingDisplayContextValues } from './useRatingDisplayContextValues';

--- a/packages/react-components/react-rating/library/src/components/RatingItem/index.ts
+++ b/packages/react-components/react-rating/library/src/components/RatingItem/index.ts
@@ -1,5 +1,5 @@
-export * from './RatingItem';
-export * from './RatingItem.types';
-export * from './renderRatingItem';
-export * from './useRatingItem';
-export * from './useRatingItemStyles.styles';
+export { RatingItem } from './RatingItem';
+export type { RatingItemContextValue, RatingItemProps, RatingItemSlots, RatingItemState } from './RatingItem.types';
+export { renderRatingItem_unstable } from './renderRatingItem';
+export { useRatingItem_unstable } from './useRatingItem';
+export { ratingItemClassNames, useRatingItemStyles_unstable } from './useRatingItemStyles.styles';

--- a/packages/react-components/react-rating/library/src/contexts/index.ts
+++ b/packages/react-components/react-rating/library/src/contexts/index.ts
@@ -1,1 +1,1 @@
-export * from './RatingItemContext';
+export { RatingItemContext, RatingItemProvider, useRatingItemContextValue_unstable } from './RatingItemContext';

--- a/packages/react-components/react-search/library/src/SearchBox.ts
+++ b/packages/react-components/react-search/library/src/SearchBox.ts
@@ -1,1 +1,13 @@
-export * from './components/SearchBox/index';
+export type {
+  SearchBoxChangeEvent,
+  SearchBoxProps,
+  SearchBoxSlots,
+  SearchBoxState,
+} from './components/SearchBox/index';
+export {
+  SearchBox,
+  renderSearchBox_unstable,
+  searchBoxClassNames,
+  useSearchBoxStyles_unstable,
+  useSearchBox_unstable,
+} from './components/SearchBox/index';

--- a/packages/react-components/react-search/library/src/components/SearchBox/index.ts
+++ b/packages/react-components/react-search/library/src/components/SearchBox/index.ts
@@ -1,5 +1,5 @@
-export * from './SearchBox';
-export * from './SearchBox.types';
-export * from './renderSearchBox';
-export * from './useSearchBox';
-export * from './useSearchBoxStyles.styles';
+export { SearchBox } from './SearchBox';
+export type { SearchBoxChangeEvent, SearchBoxProps, SearchBoxSlots, SearchBoxState } from './SearchBox.types';
+export { renderSearchBox_unstable } from './renderSearchBox';
+export { useSearchBox_unstable } from './useSearchBox';
+export { searchBoxClassNames, useSearchBoxStyles_unstable } from './useSearchBoxStyles.styles';

--- a/packages/react-components/react-select/library/src/Select.ts
+++ b/packages/react-components/react-select/library/src/Select.ts
@@ -1,1 +1,8 @@
-export * from './components/Select/index';
+export type { SelectOnChangeData, SelectProps, SelectSlots, SelectState } from './components/Select/index';
+export {
+  Select,
+  renderSelect_unstable,
+  selectClassNames,
+  useSelectStyles_unstable,
+  useSelect_unstable,
+} from './components/Select/index';

--- a/packages/react-components/react-select/library/src/components/Select/index.ts
+++ b/packages/react-components/react-select/library/src/components/Select/index.ts
@@ -1,5 +1,5 @@
-export * from './Select';
-export * from './Select.types';
-export * from './renderSelect';
-export * from './useSelect';
-export * from './useSelectStyles.styles';
+export { Select } from './Select';
+export type { SelectOnChangeData, SelectProps, SelectSlots, SelectState } from './Select.types';
+export { renderSelect_unstable } from './renderSelect';
+export { useSelect_unstable } from './useSelect';
+export { selectClassNames, useSelectStyles_unstable } from './useSelectStyles.styles';

--- a/packages/react-components/react-skeleton/library/src/Skeleton.ts
+++ b/packages/react-components/react-skeleton/library/src/Skeleton.ts
@@ -1,1 +1,9 @@
-export * from './components/Skeleton/index';
+export type { SkeletonContextValues, SkeletonProps, SkeletonSlots, SkeletonState } from './components/Skeleton/index';
+export {
+  Skeleton,
+  renderSkeleton_unstable,
+  skeletonClassNames,
+  useSkeletonContextValues,
+  useSkeletonStyles_unstable,
+  useSkeleton_unstable,
+} from './components/Skeleton/index';

--- a/packages/react-components/react-skeleton/library/src/SkeletonItem.ts
+++ b/packages/react-components/react-skeleton/library/src/SkeletonItem.ts
@@ -1,1 +1,13 @@
-export * from './components/SkeletonItem/index';
+export type {
+  SkeletonItemProps,
+  SkeletonItemSize,
+  SkeletonItemSlots,
+  SkeletonItemState,
+} from './components/SkeletonItem/index';
+export {
+  SkeletonItem,
+  renderSkeletonItem_unstable,
+  skeletonItemClassNames,
+  useSkeletonItemStyles_unstable,
+  useSkeletonItem_unstable,
+} from './components/SkeletonItem/index';

--- a/packages/react-components/react-skeleton/library/src/components/Skeleton/index.ts
+++ b/packages/react-components/react-skeleton/library/src/components/Skeleton/index.ts
@@ -1,6 +1,6 @@
-export * from './Skeleton';
-export * from './Skeleton.types';
-export * from './renderSkeleton';
-export * from './useSkeleton';
-export * from './useSkeletonContextValues';
-export * from './useSkeletonStyles.styles';
+export { Skeleton } from './Skeleton';
+export type { SkeletonContextValues, SkeletonProps, SkeletonSlots, SkeletonState } from './Skeleton.types';
+export { renderSkeleton_unstable } from './renderSkeleton';
+export { useSkeleton_unstable } from './useSkeleton';
+export { useSkeletonContextValues } from './useSkeletonContextValues';
+export { skeletonClassNames, useSkeletonStyles_unstable } from './useSkeletonStyles.styles';

--- a/packages/react-components/react-skeleton/library/src/components/SkeletonItem/index.ts
+++ b/packages/react-components/react-skeleton/library/src/components/SkeletonItem/index.ts
@@ -1,5 +1,5 @@
-export * from './SkeletonItem';
-export * from './SkeletonItem.types';
-export * from './renderSkeletonItem';
-export * from './useSkeletonItem';
-export * from './useSkeletonItemStyles.styles';
+export { SkeletonItem } from './SkeletonItem';
+export type { SkeletonItemProps, SkeletonItemSize, SkeletonItemSlots, SkeletonItemState } from './SkeletonItem.types';
+export { renderSkeletonItem_unstable } from './renderSkeletonItem';
+export { useSkeletonItem_unstable } from './useSkeletonItem';
+export { skeletonItemClassNames, useSkeletonItemStyles_unstable } from './useSkeletonItemStyles.styles';

--- a/packages/react-components/react-skeleton/library/src/contexts/index.ts
+++ b/packages/react-components/react-skeleton/library/src/contexts/index.ts
@@ -1,1 +1,2 @@
-export * from './SkeletonContext';
+export type { SkeletonContextValue } from './SkeletonContext';
+export { SkeletonContextProvider, useSkeletonContext } from './SkeletonContext';

--- a/packages/react-components/react-slider/library/src/Slider.ts
+++ b/packages/react-components/react-slider/library/src/Slider.ts
@@ -1,1 +1,10 @@
-export * from './components/Slider/index';
+export type { SliderOnChangeData, SliderProps, SliderSlots, SliderState } from './components/Slider/index';
+export {
+  Slider,
+  renderSlider_unstable,
+  sliderCSSVars,
+  sliderClassNames,
+  useSliderState_unstable,
+  useSliderStyles_unstable,
+  useSlider_unstable,
+} from './components/Slider/index';

--- a/packages/react-components/react-slider/library/src/components/Slider/index.ts
+++ b/packages/react-components/react-slider/library/src/components/Slider/index.ts
@@ -1,6 +1,6 @@
-export * from './Slider';
-export * from './Slider.types';
-export * from './renderSlider';
-export * from './useSlider';
+export { Slider } from './Slider';
+export type { SliderOnChangeData, SliderProps, SliderSlots, SliderState } from './Slider.types';
+export { renderSlider_unstable } from './renderSlider';
+export { useSlider_unstable } from './useSlider';
 export { useSliderState_unstable } from './useSliderState';
 export { sliderClassNames, sliderCSSVars, useSliderStyles_unstable } from './useSliderStyles.styles';

--- a/packages/react-components/react-spinbutton/library/src/SpinButton.ts
+++ b/packages/react-components/react-spinbutton/library/src/SpinButton.ts
@@ -1,1 +1,16 @@
-export * from './components/SpinButton/index';
+export type {
+  SpinButtonBounds,
+  SpinButtonChangeEvent,
+  SpinButtonOnChangeData,
+  SpinButtonProps,
+  SpinButtonSlots,
+  SpinButtonSpinState,
+  SpinButtonState,
+} from './components/SpinButton/index';
+export {
+  SpinButton,
+  renderSpinButton_unstable,
+  spinButtonClassNames,
+  useSpinButtonStyles_unstable,
+  useSpinButton_unstable,
+} from './components/SpinButton/index';

--- a/packages/react-components/react-spinbutton/library/src/components/SpinButton/index.ts
+++ b/packages/react-components/react-spinbutton/library/src/components/SpinButton/index.ts
@@ -1,5 +1,13 @@
-export * from './SpinButton';
-export * from './SpinButton.types';
-export * from './renderSpinButton';
-export * from './useSpinButton';
-export * from './useSpinButtonStyles.styles';
+export { SpinButton } from './SpinButton';
+export type {
+  SpinButtonBounds,
+  SpinButtonChangeEvent,
+  SpinButtonOnChangeData,
+  SpinButtonProps,
+  SpinButtonSlots,
+  SpinButtonSpinState,
+  SpinButtonState,
+} from './SpinButton.types';
+export { renderSpinButton_unstable } from './renderSpinButton';
+export { useSpinButton_unstable } from './useSpinButton';
+export { spinButtonClassNames, useSpinButtonStyles_unstable } from './useSpinButtonStyles.styles';

--- a/packages/react-components/react-spinbutton/library/src/utils/index.ts
+++ b/packages/react-components/react-spinbutton/library/src/utils/index.ts
@@ -1,3 +1,3 @@
-export * from './clamp';
-export * from './getBound';
-export * from './precision';
+export { clamp } from './clamp';
+export { getBound } from './getBound';
+export { calculatePrecision, precisionRound } from './precision';

--- a/packages/react-components/react-spinner/library/src/Spinner.ts
+++ b/packages/react-components/react-spinner/library/src/Spinner.ts
@@ -1,1 +1,8 @@
-export * from './components/Spinner/index';
+export type { SpinnerProps, SpinnerSlots, SpinnerState } from './components/Spinner/index';
+export {
+  Spinner,
+  renderSpinner_unstable,
+  spinnerClassNames,
+  useSpinnerStyles_unstable,
+  useSpinner_unstable,
+} from './components/Spinner/index';

--- a/packages/react-components/react-spinner/library/src/components/Spinner/index.ts
+++ b/packages/react-components/react-spinner/library/src/components/Spinner/index.ts
@@ -1,5 +1,5 @@
-export * from './Spinner';
-export * from './Spinner.types';
-export * from './renderSpinner';
-export * from './useSpinner';
-export * from './useSpinnerStyles.styles';
+export { Spinner } from './Spinner';
+export type { SpinnerProps, SpinnerSlots, SpinnerState } from './Spinner.types';
+export { renderSpinner_unstable } from './renderSpinner';
+export { useSpinner_unstable } from './useSpinner';
+export { spinnerClassNames, useSpinnerStyles_unstable } from './useSpinnerStyles.styles';

--- a/packages/react-components/react-spinner/library/src/contexts/index.ts
+++ b/packages/react-components/react-spinner/library/src/contexts/index.ts
@@ -1,1 +1,2 @@
-export * from './SpinnerContext';
+export type { SpinnerContextValue } from './SpinnerContext';
+export { SpinnerContextProvider, useSpinnerContext } from './SpinnerContext';

--- a/packages/react-components/react-swatch-picker/library/src/ColorSwatch.ts
+++ b/packages/react-components/react-swatch-picker/library/src/ColorSwatch.ts
@@ -1,1 +1,9 @@
-export * from './components/ColorSwatch/index';
+export type { ColorSwatchProps, ColorSwatchSlots, ColorSwatchState } from './components/ColorSwatch/index';
+export {
+  ColorSwatch,
+  colorSwatchClassNames,
+  renderColorSwatch_unstable,
+  swatchCSSVars,
+  useColorSwatchStyles_unstable,
+  useColorSwatch_unstable,
+} from './components/ColorSwatch/index';

--- a/packages/react-components/react-swatch-picker/library/src/EmptySwatch.ts
+++ b/packages/react-components/react-swatch-picker/library/src/EmptySwatch.ts
@@ -1,1 +1,8 @@
-export * from './components/EmptySwatch/index';
+export type { EmptySwatchProps, EmptySwatchSlots, EmptySwatchState } from './components/EmptySwatch/index';
+export {
+  EmptySwatch,
+  emptySwatchClassNames,
+  renderEmptySwatch_unstable,
+  useEmptySwatchStyles_unstable,
+  useEmptySwatch_unstable,
+} from './components/EmptySwatch/index';

--- a/packages/react-components/react-swatch-picker/library/src/ImageSwatch.ts
+++ b/packages/react-components/react-swatch-picker/library/src/ImageSwatch.ts
@@ -1,1 +1,8 @@
-export * from './components/ImageSwatch/index';
+export type { ImageSwatchProps, ImageSwatchSlots, ImageSwatchState } from './components/ImageSwatch/index';
+export {
+  ImageSwatch,
+  imageSwatchClassNames,
+  renderImageSwatch_unstable,
+  useImageSwatchStyles_unstable,
+  useImageSwatch_unstable,
+} from './components/ImageSwatch/index';

--- a/packages/react-components/react-swatch-picker/library/src/SwatchPicker.ts
+++ b/packages/react-components/react-swatch-picker/library/src/SwatchPicker.ts
@@ -1,1 +1,14 @@
-export * from './components/SwatchPicker/index';
+export type {
+  SwatchPickerOnSelectEventHandler,
+  SwatchPickerOnSelectionChangeData,
+  SwatchPickerProps,
+  SwatchPickerSlots,
+  SwatchPickerState,
+} from './components/SwatchPicker/index';
+export {
+  SwatchPicker,
+  renderSwatchPicker_unstable,
+  swatchPickerClassNames,
+  useSwatchPickerStyles_unstable,
+  useSwatchPicker_unstable,
+} from './components/SwatchPicker/index';

--- a/packages/react-components/react-swatch-picker/library/src/SwatchPickerRow.ts
+++ b/packages/react-components/react-swatch-picker/library/src/SwatchPickerRow.ts
@@ -1,1 +1,12 @@
-export * from './components/SwatchPickerRow/index';
+export type {
+  SwatchPickerRowProps,
+  SwatchPickerRowSlots,
+  SwatchPickerRowState,
+} from './components/SwatchPickerRow/index';
+export {
+  SwatchPickerRow,
+  renderSwatchPickerRow_unstable,
+  swatchPickerRowClassNames,
+  useSwatchPickerRowStyles_unstable,
+  useSwatchPickerRow_unstable,
+} from './components/SwatchPickerRow/index';

--- a/packages/react-components/react-swatch-picker/library/src/components/ColorSwatch/index.ts
+++ b/packages/react-components/react-swatch-picker/library/src/components/ColorSwatch/index.ts
@@ -1,5 +1,5 @@
-export * from './ColorSwatch';
-export * from './ColorSwatch.types';
-export * from './renderColorSwatch';
-export * from './useColorSwatch';
-export * from './useColorSwatchStyles.styles';
+export { ColorSwatch } from './ColorSwatch';
+export type { ColorSwatchProps, ColorSwatchSlots, ColorSwatchState } from './ColorSwatch.types';
+export { renderColorSwatch_unstable } from './renderColorSwatch';
+export { useColorSwatch_unstable } from './useColorSwatch';
+export { colorSwatchClassNames, swatchCSSVars, useColorSwatchStyles_unstable } from './useColorSwatchStyles.styles';

--- a/packages/react-components/react-swatch-picker/library/src/components/EmptySwatch/index.ts
+++ b/packages/react-components/react-swatch-picker/library/src/components/EmptySwatch/index.ts
@@ -1,5 +1,5 @@
-export * from './EmptySwatch';
-export * from './EmptySwatch.types';
-export * from './renderEmptySwatch';
-export * from './useEmptySwatch';
-export * from './useEmptySwatchStyles.styles';
+export { EmptySwatch } from './EmptySwatch';
+export type { EmptySwatchProps, EmptySwatchSlots, EmptySwatchState } from './EmptySwatch.types';
+export { renderEmptySwatch_unstable } from './renderEmptySwatch';
+export { useEmptySwatch_unstable } from './useEmptySwatch';
+export { emptySwatchClassNames, useEmptySwatchStyles_unstable } from './useEmptySwatchStyles.styles';

--- a/packages/react-components/react-swatch-picker/library/src/components/ImageSwatch/index.ts
+++ b/packages/react-components/react-swatch-picker/library/src/components/ImageSwatch/index.ts
@@ -1,5 +1,5 @@
-export * from './ImageSwatch';
-export * from './ImageSwatch.types';
-export * from './renderImageSwatch';
-export * from './useImageSwatch';
-export * from './useImageSwatchStyles.styles';
+export { ImageSwatch } from './ImageSwatch';
+export type { ImageSwatchProps, ImageSwatchSlots, ImageSwatchState } from './ImageSwatch.types';
+export { renderImageSwatch_unstable } from './renderImageSwatch';
+export { useImageSwatch_unstable } from './useImageSwatch';
+export { imageSwatchClassNames, useImageSwatchStyles_unstable } from './useImageSwatchStyles.styles';

--- a/packages/react-components/react-swatch-picker/library/src/components/SwatchPicker/index.ts
+++ b/packages/react-components/react-swatch-picker/library/src/components/SwatchPicker/index.ts
@@ -1,5 +1,11 @@
-export * from './SwatchPicker';
-export * from './SwatchPicker.types';
-export * from './renderSwatchPicker';
-export * from './useSwatchPicker';
-export * from './useSwatchPickerStyles.styles';
+export { SwatchPicker } from './SwatchPicker';
+export type {
+  SwatchPickerOnSelectEventHandler,
+  SwatchPickerOnSelectionChangeData,
+  SwatchPickerProps,
+  SwatchPickerSlots,
+  SwatchPickerState,
+} from './SwatchPicker.types';
+export { renderSwatchPicker_unstable } from './renderSwatchPicker';
+export { useSwatchPicker_unstable } from './useSwatchPicker';
+export { swatchPickerClassNames, useSwatchPickerStyles_unstable } from './useSwatchPickerStyles.styles';

--- a/packages/react-components/react-swatch-picker/library/src/components/SwatchPickerRow/index.ts
+++ b/packages/react-components/react-swatch-picker/library/src/components/SwatchPickerRow/index.ts
@@ -1,5 +1,5 @@
-export * from './SwatchPickerRow';
-export * from './SwatchPickerRow.types';
-export * from './renderSwatchPickerRow';
-export * from './useSwatchPickerRow';
-export * from './useSwatchPickerRowStyles.styles';
+export { SwatchPickerRow } from './SwatchPickerRow';
+export type { SwatchPickerRowProps, SwatchPickerRowSlots, SwatchPickerRowState } from './SwatchPickerRow.types';
+export { renderSwatchPickerRow_unstable } from './renderSwatchPickerRow';
+export { useSwatchPickerRow_unstable } from './useSwatchPickerRow';
+export { swatchPickerRowClassNames, useSwatchPickerRowStyles_unstable } from './useSwatchPickerRowStyles.styles';

--- a/packages/react-components/react-swatch-picker/library/src/contexts/index.ts
+++ b/packages/react-components/react-swatch-picker/library/src/contexts/index.ts
@@ -1,1 +1,7 @@
-export * from './swatchPicker';
+export type { SwatchPickerContextValue, SwatchPickerContextValues } from './swatchPicker';
+export {
+  SwatchPickerProvider,
+  swatchPickerContextDefaultValue,
+  useSwatchPickerContextValue_unstable,
+  useSwatchPickerContextValues,
+} from './swatchPicker';

--- a/packages/react-components/react-switch/library/src/Switch.ts
+++ b/packages/react-components/react-switch/library/src/Switch.ts
@@ -1,1 +1,10 @@
-export * from './components/Switch/index';
+export type { SwitchOnChangeData, SwitchProps, SwitchSlots, SwitchState } from './components/Switch/index';
+export {
+  Switch,
+  renderSwitch_unstable,
+  // eslint-disable-next-line deprecation/deprecation
+  switchClassName,
+  switchClassNames,
+  useSwitchStyles_unstable,
+  useSwitch_unstable,
+} from './components/Switch/index';

--- a/packages/react-components/react-switch/library/src/components/Switch/index.ts
+++ b/packages/react-components/react-switch/library/src/components/Switch/index.ts
@@ -1,5 +1,10 @@
-export * from './Switch';
-export * from './Switch.types';
-export * from './renderSwitch';
-export * from './useSwitch';
-export * from './useSwitchStyles.styles';
+export { Switch } from './Switch';
+export type { SwitchOnChangeData, SwitchProps, SwitchSlots, SwitchState } from './Switch.types';
+export { renderSwitch_unstable } from './renderSwitch';
+export { useSwitch_unstable } from './useSwitch';
+export {
+  // eslint-disable-next-line deprecation/deprecation
+  switchClassName,
+  switchClassNames,
+  useSwitchStyles_unstable,
+} from './useSwitchStyles.styles';

--- a/packages/react-components/react-tabs/library/src/Tab.ts
+++ b/packages/react-components/react-tabs/library/src/Tab.ts
@@ -1,1 +1,12 @@
-export * from './components/Tab/index';
+export type { TabInternalSlots, TabProps, TabSlots, TabState, TabValue } from './components/Tab/index';
+export {
+  Tab,
+  renderTab_unstable,
+  tabClassNames,
+  useTabAnimatedIndicatorStyles_unstable,
+  useTabButtonStyles_unstable,
+  useTabContentStyles_unstable,
+  useTabIndicatorStyles_unstable,
+  useTabStyles_unstable,
+  useTab_unstable,
+} from './components/Tab/index';

--- a/packages/react-components/react-tabs/library/src/TabList.ts
+++ b/packages/react-components/react-tabs/library/src/TabList.ts
@@ -1,1 +1,23 @@
-export * from './components/TabList/index';
+export type {
+  RegisterTabEventHandler,
+  SelectTabData,
+  SelectTabEvent,
+  SelectTabEventHandler,
+  TabListContextValue,
+  TabListContextValues,
+  TabListProps,
+  TabListSlots,
+  TabListState,
+  TabRegisterData,
+} from './components/TabList/index';
+export {
+  TabList,
+  TabListContext,
+  TabListProvider,
+  renderTabList_unstable,
+  tabListClassNames,
+  useTabListContextValues_unstable,
+  useTabListContext_unstable,
+  useTabListStyles_unstable,
+  useTabList_unstable,
+} from './components/TabList/index';

--- a/packages/react-components/react-tabs/library/src/components/Tab/index.ts
+++ b/packages/react-components/react-tabs/library/src/components/Tab/index.ts
@@ -1,6 +1,12 @@
-export * from './Tab';
-export * from './Tab.types';
-export * from './renderTab';
-export * from './useTab';
-export * from './useTabStyles.styles';
-export * from './useTabAnimatedIndicator.styles';
+export { Tab } from './Tab';
+export type { TabInternalSlots, TabProps, TabSlots, TabState, TabValue } from './Tab.types';
+export { renderTab_unstable } from './renderTab';
+export { useTab_unstable } from './useTab';
+export {
+  tabClassNames,
+  useTabButtonStyles_unstable,
+  useTabContentStyles_unstable,
+  useTabIndicatorStyles_unstable,
+  useTabStyles_unstable,
+} from './useTabStyles.styles';
+export { useTabAnimatedIndicatorStyles_unstable } from './useTabAnimatedIndicator.styles';

--- a/packages/react-components/react-tabs/library/src/components/TabList/index.ts
+++ b/packages/react-components/react-tabs/library/src/components/TabList/index.ts
@@ -1,7 +1,18 @@
-export * from './TabList';
-export * from './TabList.types';
-export * from './TabListContext';
-export * from './renderTabList';
-export * from './useTabList';
-export * from './useTabListContextValues';
-export * from './useTabListStyles.styles';
+export { TabList } from './TabList';
+export type {
+  RegisterTabEventHandler,
+  SelectTabData,
+  SelectTabEvent,
+  SelectTabEventHandler,
+  TabListContextValue,
+  TabListContextValues,
+  TabListProps,
+  TabListSlots,
+  TabListState,
+  TabRegisterData,
+} from './TabList.types';
+export { TabListContext, TabListProvider, useTabListContext_unstable } from './TabListContext';
+export { renderTabList_unstable } from './renderTabList';
+export { useTabList_unstable } from './useTabList';
+export { useTabListContextValues_unstable } from './useTabListContextValues';
+export { tabListClassNames, useTabListStyles_unstable } from './useTabListStyles.styles';

--- a/packages/react-components/react-tabs/stories/src/Tabs/TabListWithOverflow.stories.tsx
+++ b/packages/react-components/react-tabs/stories/src/Tabs/TabListWithOverflow.stories.tsx
@@ -112,7 +112,7 @@ const tabs: ExampleTab[] = [
 
 type OverflowMenuItemProps = {
   tab: ExampleTab;
-  // eslint-disable-next-line @nx/workspace-consistent-callback-type
+
   onClick: MenuItemProps['onClick'];
 };
 
@@ -146,7 +146,6 @@ const useOverflowMenuStyles = makeStyles({
 });
 
 type OverflowMenuProps = {
-  // eslint-disable-next-line @nx/workspace-consistent-callback-type
   onTabSelect?: (tabId: string) => void;
 };
 

--- a/packages/react-components/react-text/library/src/Body1.ts
+++ b/packages/react-components/react-text/library/src/Body1.ts
@@ -1,1 +1,1 @@
-export * from './components/presets/Body1/index';
+export { Body1, body1ClassNames } from './components/presets/Body1/index';

--- a/packages/react-components/react-text/library/src/Body1Strong.ts
+++ b/packages/react-components/react-text/library/src/Body1Strong.ts
@@ -1,1 +1,1 @@
-export * from './components/presets/Body1Strong/index';
+export { Body1Strong, body1StrongClassNames } from './components/presets/Body1Strong/index';

--- a/packages/react-components/react-text/library/src/Body1Stronger.ts
+++ b/packages/react-components/react-text/library/src/Body1Stronger.ts
@@ -1,1 +1,1 @@
-export * from './components/presets/Body1Stronger/index';
+export { Body1Stronger, body1StrongerClassNames } from './components/presets/Body1Stronger/index';

--- a/packages/react-components/react-text/library/src/Body2.ts
+++ b/packages/react-components/react-text/library/src/Body2.ts
@@ -1,1 +1,1 @@
-export * from './components/presets/Body2/index';
+export { Body2, body2ClassNames } from './components/presets/Body2/index';

--- a/packages/react-components/react-text/library/src/Caption1.ts
+++ b/packages/react-components/react-text/library/src/Caption1.ts
@@ -1,1 +1,1 @@
-export * from './components/presets/Caption1/index';
+export { Caption1, caption1ClassNames } from './components/presets/Caption1/index';

--- a/packages/react-components/react-text/library/src/Caption1Strong.ts
+++ b/packages/react-components/react-text/library/src/Caption1Strong.ts
@@ -1,1 +1,1 @@
-export * from './components/presets/Caption1Strong/index';
+export { Caption1Strong, caption1StrongClassNames } from './components/presets/Caption1Strong/index';

--- a/packages/react-components/react-text/library/src/Caption1Stronger.ts
+++ b/packages/react-components/react-text/library/src/Caption1Stronger.ts
@@ -1,1 +1,1 @@
-export * from './components/presets/Caption1Stronger/index';
+export { Caption1Stronger, caption1StrongerClassNames } from './components/presets/Caption1Stronger/index';

--- a/packages/react-components/react-text/library/src/Caption2.ts
+++ b/packages/react-components/react-text/library/src/Caption2.ts
@@ -1,1 +1,1 @@
-export * from './components/presets/Caption2/index';
+export { Caption2, caption2ClassNames } from './components/presets/Caption2/index';

--- a/packages/react-components/react-text/library/src/Caption2Strong.ts
+++ b/packages/react-components/react-text/library/src/Caption2Strong.ts
@@ -1,1 +1,1 @@
-export * from './components/presets/Caption2Strong/index';
+export { Caption2Strong, caption2StrongClassNames } from './components/presets/Caption2Strong/index';

--- a/packages/react-components/react-text/library/src/Display.ts
+++ b/packages/react-components/react-text/library/src/Display.ts
@@ -1,1 +1,1 @@
-export * from './components/presets/Display/index';
+export { Display, displayClassNames } from './components/presets/Display/index';

--- a/packages/react-components/react-text/library/src/LargeTitle.ts
+++ b/packages/react-components/react-text/library/src/LargeTitle.ts
@@ -1,1 +1,1 @@
-export * from './components/presets/LargeTitle/index';
+export { LargeTitle, largeTitleClassNames } from './components/presets/LargeTitle/index';

--- a/packages/react-components/react-text/library/src/Subtitle1.ts
+++ b/packages/react-components/react-text/library/src/Subtitle1.ts
@@ -1,1 +1,1 @@
-export * from './components/presets/Subtitle1/index';
+export { Subtitle1, subtitle1ClassNames } from './components/presets/Subtitle1/index';

--- a/packages/react-components/react-text/library/src/Subtitle2.ts
+++ b/packages/react-components/react-text/library/src/Subtitle2.ts
@@ -1,1 +1,1 @@
-export * from './components/presets/Subtitle2/index';
+export { Subtitle2, subtitle2ClassNames } from './components/presets/Subtitle2/index';

--- a/packages/react-components/react-text/library/src/Subtitle2Stronger.ts
+++ b/packages/react-components/react-text/library/src/Subtitle2Stronger.ts
@@ -1,1 +1,1 @@
-export * from './components/presets/Subtitle2Stronger/index';
+export { Subtitle2Stronger, subtitle2StrongerClassNames } from './components/presets/Subtitle2Stronger/index';

--- a/packages/react-components/react-text/library/src/Text.ts
+++ b/packages/react-components/react-text/library/src/Text.ts
@@ -1,1 +1,8 @@
-export * from './components/Text/index';
+export type { TextPresetProps, TextProps, TextSlots, TextState } from './components/Text/index';
+export {
+  Text,
+  renderText_unstable,
+  textClassNames,
+  useTextStyles_unstable,
+  useText_unstable,
+} from './components/Text/index';

--- a/packages/react-components/react-text/library/src/Title1.ts
+++ b/packages/react-components/react-text/library/src/Title1.ts
@@ -1,1 +1,1 @@
-export * from './components/presets/Title1/index';
+export { Title1, title1ClassNames } from './components/presets/Title1/index';

--- a/packages/react-components/react-text/library/src/Title2.ts
+++ b/packages/react-components/react-text/library/src/Title2.ts
@@ -1,1 +1,1 @@
-export * from './components/presets/Title2/index';
+export { Title2, title2ClassNames } from './components/presets/Title2/index';

--- a/packages/react-components/react-text/library/src/Title3.ts
+++ b/packages/react-components/react-text/library/src/Title3.ts
@@ -1,1 +1,1 @@
-export * from './components/presets/Title3/index';
+export { Title3, title3ClassNames } from './components/presets/Title3/index';

--- a/packages/react-components/react-text/library/src/components/Text/index.ts
+++ b/packages/react-components/react-text/library/src/components/Text/index.ts
@@ -1,5 +1,5 @@
-export * from './Text';
-export * from './Text.types';
-export * from './renderText';
-export * from './useText';
-export * from './useTextStyles.styles';
+export { Text } from './Text';
+export type { TextPresetProps, TextProps, TextSlots, TextState } from './Text.types';
+export { renderText_unstable } from './renderText';
+export { useText_unstable } from './useText';
+export { textClassNames, useTextStyles_unstable } from './useTextStyles.styles';

--- a/packages/react-components/react-text/library/src/components/presets/Body1/index.ts
+++ b/packages/react-components/react-text/library/src/components/presets/Body1/index.ts
@@ -1,2 +1,2 @@
-export * from './Body1';
+export { Body1 } from './Body1';
 export { body1ClassNames } from './useBody1Styles.styles';

--- a/packages/react-components/react-text/library/src/components/presets/Body1Strong/index.ts
+++ b/packages/react-components/react-text/library/src/components/presets/Body1Strong/index.ts
@@ -1,2 +1,2 @@
-export * from './Body1Strong';
+export { Body1Strong } from './Body1Strong';
 export { body1StrongClassNames } from './useBody1StrongStyles.styles';

--- a/packages/react-components/react-text/library/src/components/presets/Body1Stronger/index.ts
+++ b/packages/react-components/react-text/library/src/components/presets/Body1Stronger/index.ts
@@ -1,2 +1,2 @@
-export * from './Body1Stronger';
+export { Body1Stronger } from './Body1Stronger';
 export { body1StrongerClassNames } from './useBody1StrongerStyles.styles';

--- a/packages/react-components/react-text/library/src/components/presets/Body2/index.ts
+++ b/packages/react-components/react-text/library/src/components/presets/Body2/index.ts
@@ -1,2 +1,2 @@
-export * from './Body2';
+export { Body2 } from './Body2';
 export { body2ClassNames } from './useBody2Styles.styles';

--- a/packages/react-components/react-text/library/src/components/presets/Caption1/index.ts
+++ b/packages/react-components/react-text/library/src/components/presets/Caption1/index.ts
@@ -1,2 +1,2 @@
-export * from './Caption1';
+export { Caption1 } from './Caption1';
 export { caption1ClassNames } from './useCaption1Styles.styles';

--- a/packages/react-components/react-text/library/src/components/presets/Caption1Strong/index.ts
+++ b/packages/react-components/react-text/library/src/components/presets/Caption1Strong/index.ts
@@ -1,2 +1,2 @@
-export * from './Caption1Strong';
+export { Caption1Strong } from './Caption1Strong';
 export { caption1StrongClassNames } from './useCaption1StrongStyles.styles';

--- a/packages/react-components/react-text/library/src/components/presets/Caption1Stronger/index.ts
+++ b/packages/react-components/react-text/library/src/components/presets/Caption1Stronger/index.ts
@@ -1,2 +1,2 @@
-export * from './Caption1Stronger';
+export { Caption1Stronger } from './Caption1Stronger';
 export { caption1StrongerClassNames } from './useCaption1Stronger.styles';

--- a/packages/react-components/react-text/library/src/components/presets/Caption2/index.ts
+++ b/packages/react-components/react-text/library/src/components/presets/Caption2/index.ts
@@ -1,2 +1,2 @@
-export * from './Caption2';
+export { Caption2 } from './Caption2';
 export { caption2ClassNames } from './useCaption2Styles.styles';

--- a/packages/react-components/react-text/library/src/components/presets/Caption2Strong/index.ts
+++ b/packages/react-components/react-text/library/src/components/presets/Caption2Strong/index.ts
@@ -1,2 +1,2 @@
-export * from './Caption2Strong';
+export { Caption2Strong } from './Caption2Strong';
 export { caption2StrongClassNames } from './useCaption2StrongStyles.styles';

--- a/packages/react-components/react-text/library/src/components/presets/Display/index.ts
+++ b/packages/react-components/react-text/library/src/components/presets/Display/index.ts
@@ -1,2 +1,2 @@
-export * from './Display';
+export { Display } from './Display';
 export { displayClassNames } from './useDisplayStyles.styles';

--- a/packages/react-components/react-text/library/src/components/presets/LargeTitle/index.ts
+++ b/packages/react-components/react-text/library/src/components/presets/LargeTitle/index.ts
@@ -1,2 +1,2 @@
-export * from './LargeTitle';
+export { LargeTitle } from './LargeTitle';
 export { largeTitleClassNames } from './useLargeTitleStyles.styles';

--- a/packages/react-components/react-text/library/src/components/presets/Subtitle1/index.ts
+++ b/packages/react-components/react-text/library/src/components/presets/Subtitle1/index.ts
@@ -1,2 +1,2 @@
-export * from './Subtitle1';
+export { Subtitle1 } from './Subtitle1';
 export { subtitle1ClassNames } from './useSubtitle1Styles.styles';

--- a/packages/react-components/react-text/library/src/components/presets/Subtitle2/index.ts
+++ b/packages/react-components/react-text/library/src/components/presets/Subtitle2/index.ts
@@ -1,2 +1,2 @@
-export * from './Subtitle2';
+export { Subtitle2 } from './Subtitle2';
 export { subtitle2ClassNames } from './useSubtitle2Styles.styles';

--- a/packages/react-components/react-text/library/src/components/presets/Subtitle2Stronger/index.ts
+++ b/packages/react-components/react-text/library/src/components/presets/Subtitle2Stronger/index.ts
@@ -1,2 +1,2 @@
-export * from './Subtitle2Stronger';
+export { Subtitle2Stronger } from './Subtitle2Stronger';
 export { subtitle2StrongerClassNames } from './useSubtitle2Stronger.styles';

--- a/packages/react-components/react-text/library/src/components/presets/Title1/index.ts
+++ b/packages/react-components/react-text/library/src/components/presets/Title1/index.ts
@@ -1,2 +1,2 @@
-export * from './Title1';
+export { Title1 } from './Title1';
 export { title1ClassNames } from './useTitle1Styles.styles';

--- a/packages/react-components/react-text/library/src/components/presets/Title2/index.ts
+++ b/packages/react-components/react-text/library/src/components/presets/Title2/index.ts
@@ -1,2 +1,2 @@
-export * from './Title2';
+export { Title2 } from './Title2';
 export { title2ClassNames } from './useTitle2Styles.styles';

--- a/packages/react-components/react-text/library/src/components/presets/Title3/index.ts
+++ b/packages/react-components/react-text/library/src/components/presets/Title3/index.ts
@@ -1,2 +1,2 @@
-export * from './Title3';
+export { Title3 } from './Title3';
 export { title3ClassNames } from './useTitle3Styles.styles';

--- a/packages/react-components/react-textarea/library/src/Textarea.ts
+++ b/packages/react-components/react-textarea/library/src/Textarea.ts
@@ -1,1 +1,8 @@
-export * from './components/Textarea/index';
+export type { TextareaOnChangeData, TextareaProps, TextareaSlots, TextareaState } from './components/Textarea/index';
+export {
+  Textarea,
+  renderTextarea_unstable,
+  textareaClassNames,
+  useTextareaStyles_unstable,
+  useTextarea_unstable,
+} from './components/Textarea/index';

--- a/packages/react-components/react-textarea/library/src/components/Textarea/index.ts
+++ b/packages/react-components/react-textarea/library/src/components/Textarea/index.ts
@@ -1,5 +1,5 @@
-export * from './Textarea';
-export * from './Textarea.types';
-export * from './renderTextarea';
-export * from './useTextarea';
-export * from './useTextareaStyles.styles';
+export { Textarea } from './Textarea';
+export type { TextareaOnChangeData, TextareaProps, TextareaSlots, TextareaState } from './Textarea.types';
+export { renderTextarea_unstable } from './renderTextarea';
+export { useTextarea_unstable } from './useTextarea';
+export { textareaClassNames, useTextareaStyles_unstable } from './useTextareaStyles.styles';

--- a/packages/react-components/react-tooltip/library/src/Tooltip.ts
+++ b/packages/react-components/react-tooltip/library/src/Tooltip.ts
@@ -1,1 +1,14 @@
-export * from './components/Tooltip/index';
+export type {
+  OnVisibleChangeData,
+  TooltipChildProps,
+  TooltipProps,
+  TooltipSlots,
+  TooltipState,
+} from './components/Tooltip/index';
+export {
+  Tooltip,
+  renderTooltip_unstable,
+  tooltipClassNames,
+  useTooltipStyles_unstable,
+  useTooltip_unstable,
+} from './components/Tooltip/index';

--- a/packages/react-components/react-tooltip/library/src/components/Tooltip/index.ts
+++ b/packages/react-components/react-tooltip/library/src/components/Tooltip/index.ts
@@ -1,5 +1,5 @@
-export * from './Tooltip';
-export * from './Tooltip.types';
-export * from './renderTooltip';
-export * from './useTooltip';
-export * from './useTooltipStyles.styles';
+export { Tooltip } from './Tooltip';
+export type { OnVisibleChangeData, TooltipChildProps, TooltipProps, TooltipSlots, TooltipState } from './Tooltip.types';
+export { renderTooltip_unstable } from './renderTooltip';
+export { useTooltip_unstable } from './useTooltip';
+export { tooltipClassNames, useTooltipStyles_unstable } from './useTooltipStyles.styles';

--- a/packages/react-components/recipes/src/recipes/media-object/code-snippets/index.ts
+++ b/packages/react-components/recipes/src/recipes/media-object/code-snippets/index.ts
@@ -1,1 +1,1 @@
-export * from './MediaObject';
+export { FlexSkeleton, IconMediaObject, TextAlignmentVariations, TextPositionVariations } from './MediaObject';

--- a/packages/react-components/recipes/src/templates/index.ts
+++ b/packages/react-components/recipes/src/templates/index.ts
@@ -1,1 +1,1 @@
-export * from './Example';
+export { TemplateExample } from './Example';


### PR DESCRIPTION
## Previous Behavior

`export *` is used in a lot of files.

## New Behavior

**No API changes**

`export *` is replaced with exact exports. This will improve performance of current compiler in Griffel and will unblock the future one, see https://github.com/microsoft/griffel/pull/621.

Note: I used autofix via `--fix` on ESLint, so some other things _were_ fixed (unused ESLint supressions, etc.).