### PR TITLE
fix typo in slot docs

### DIFF
--- a/apps/public-docsite-v9/src/Concepts/Slots/Slots.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/Slots/Slots.stories.mdx
@@ -174,7 +174,7 @@ If you need to replace the slot's entire content, including the containing eleme
 pass a render function as the children.
 
 This is an escape hatch in the slots API, so prefer the other techniques whenever possible.
-If you replace the entire slot, very accessibility, layout, and styling still work properly.
+If you replace the entire slot, verify accessibility, layout, and styling still work properly.
 
 By passing `renderBigLetterIcon` as the `children`, the `span` that normally contains the icon is replaced with an `b` (bold).
 


### PR DESCRIPTION
## Previous Behavior

There was a typo in the Slot docs.

## New Behavior

There is not a typo in the Slot docs. Well maybe there still is, but this one is fixed.

