### PR TITLE
bugfix(tokens): ensure teams tokens follow teams overrides for fonts

### DIFF
--- a/change/@fluentui-tokens-a1396b99-e2b7-4ab3-8c89-7d58c5b4ba8b.json
+++ b/change/@fluentui-tokens-a1396b99-e2b7-4ab3-8c89-7d58c5b4ba8b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "bugfix: ensure teams tokens follow teams overrides for fonts",
+  "packageName": "@fluentui/tokens",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/tokens/src/alias/teamsFontFamilies.ts
+++ b/packages/tokens/src/alias/teamsFontFamilies.ts
@@ -1,0 +1,7 @@
+import { fontFamilies as globalFontFamilies } from '../global/fonts';
+
+export const fontFamilies = {
+  ...globalFontFamilies,
+  fontFamilyBase:
+    '-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, "Apple Color Emoji", "Segoe UI Emoji", sans-serif',
+};

--- a/packages/tokens/src/themes/teams/darkTheme.ts
+++ b/packages/tokens/src/themes/teams/darkTheme.ts
@@ -1,5 +1,9 @@
 import { createTeamsDarkTheme } from '../../utils/createTeamsDarkTheme';
 import { brandTeams } from '../../global/brandColors';
 import type { Theme } from '../../types';
+import { fontFamilies } from '../../alias/teamsFontFamilies';
 
-export const teamsDarkTheme: Theme = createTeamsDarkTheme(brandTeams);
+export const teamsDarkTheme: Theme = {
+  ...createTeamsDarkTheme(brandTeams),
+  ...fontFamilies,
+};

--- a/packages/tokens/src/themes/teams/highContrastTheme.ts
+++ b/packages/tokens/src/themes/teams/highContrastTheme.ts
@@ -1,4 +1,8 @@
 import { createHighContrastTheme } from '../../utils/createHighContrastTheme';
 import type { Theme } from '../../types';
+import { fontFamilies } from '../../alias/teamsFontFamilies';
 
-export const teamsHighContrastTheme: Theme = createHighContrastTheme();
+export const teamsHighContrastTheme: Theme = {
+  ...createHighContrastTheme(),
+  ...fontFamilies,
+};

--- a/packages/tokens/src/themes/teams/lightTheme.ts
+++ b/packages/tokens/src/themes/teams/lightTheme.ts
@@ -1,5 +1,9 @@
 import { createLightTheme } from '../../utils/createLightTheme';
 import { brandTeams } from '../../global/brandColors';
 import type { Theme } from '../../types';
+import { fontFamilies } from '../../alias/teamsFontFamilies';
 
-export const teamsLightTheme: Theme = createLightTheme(brandTeams);
+export const teamsLightTheme: Theme = {
+  ...createLightTheme(brandTeams),
+  ...fontFamilies,
+};


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Fluent Teams tokens gives preference for `Segoe UI` font family instead of local system font `-apple-system, BlinkMacSystemFont`. This is causing inconsistencies between Teams and Teams embedded applications, as they consume those token from different sources.

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

Updates the `fontFamilyBase` token to give preference for `-apple-system, BlinkMacSystemFont` as that is the default fonts being used on Teams

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/33392
