### PR TITLE
Carousel: Set initial focus target on init

### DIFF
--- a/change/@fluentui-react-carousel-b0491798-cc10-487f-a3c0-98bcd6016f7f.json
+++ b/change/@fluentui-react-carousel-b0491798-cc10-487f-a3c0-98bcd6016f7f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Set tabster default on carousel initialization",
+  "packageName": "@fluentui/react-carousel",
+  "email": "mifraser@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-carousel/library/src/components/useEmblaCarousel.ts
+++ b/packages/react-components/react-carousel/library/src/components/useEmblaCarousel.ts
@@ -147,11 +147,21 @@ export function useEmblaCarousel(
     };
   }, []);
 
+  const updateIndex = () => {
+    const newIndex = emblaApi.current?.selectedScrollSnap() ?? 0;
+    const slides = emblaApi.current?.slideNodes();
+    const actualIndex = emblaApi.current?.internalEngine().slideRegistry[newIndex][0] ?? 0;
+    // We set the active or first index of group on-screen as the selected tabster index
+    slides?.forEach((slide, slideIndex) => {
+      setTabsterDefault(slide, slideIndex === actualIndex);
+    });
+    setActiveIndex(newIndex);
+  };
+
   const handleReinit = useEventCallback(() => {
     const nodes: HTMLElement[] = emblaApi.current?.slideNodes() ?? [];
     const groupIndexList: number[][] = emblaApi.current?.internalEngine().slideRegistry ?? [];
     const navItemsCount = groupIndexList.length > 0 ? groupIndexList.length : nodes.length;
-
     const data: CarouselUpdateData = {
       navItemsCount,
       activeIndex: emblaApi.current?.selectedScrollSnap() ?? 0,
@@ -159,6 +169,7 @@ export function useEmblaCarousel(
       slideNodes: nodes,
     };
 
+    updateIndex();
     emblaApi.current?.scrollTo(activeIndex, false);
     for (const listener of listeners.current) {
       listener(data);
@@ -167,15 +178,8 @@ export function useEmblaCarousel(
 
   const handleIndexChange: EmblaEventHandler = useEventCallback((_, eventType) => {
     const newIndex = emblaApi.current?.selectedScrollSnap() ?? 0;
-    const slides = emblaApi.current?.slideNodes();
-    const actualIndex = emblaApi.current?.internalEngine().slideRegistry[newIndex][0] ?? 0;
 
-    // We set the active or first index of group on-screen as the selected tabster index
-    slides?.forEach((slide, slideIndex) => {
-      setTabsterDefault(slide, slideIndex === actualIndex);
-    });
-    setActiveIndex(newIndex);
-
+    updateIndex();
     if (eventType === 'autoplay:select') {
       const noopEvent = new Event('autoplay');
       onAutoplayIndexChange?.(noopEvent, { event: noopEvent, type: 'autoplay', index: newIndex });

--- a/packages/react-components/react-carousel/library/src/components/useEmblaCarousel.ts
+++ b/packages/react-components/react-carousel/library/src/components/useEmblaCarousel.ts
@@ -151,7 +151,7 @@ export function useEmblaCarousel(
     const newIndex = emblaApi.current?.selectedScrollSnap() ?? 0;
     const slides = emblaApi.current?.slideNodes();
     const actualIndex = emblaApi.current?.internalEngine().slideRegistry[newIndex][0] ?? 0;
-    // We set the active or first index of group on-screen as the selected tabster index
+    // We set the first card in the current group as the default tabster index for focus capture
     slides?.forEach((slide, slideIndex) => {
       setTabsterDefault(slide, slideIndex === actualIndex);
     });
@@ -178,7 +178,6 @@ export function useEmblaCarousel(
 
   const handleIndexChange: EmblaEventHandler = useEventCallback((_, eventType) => {
     const newIndex = emblaApi.current?.selectedScrollSnap() ?? 0;
-
     updateIndex();
     if (eventType === 'autoplay:select') {
       const noopEvent = new Event('autoplay');


### PR DESCRIPTION
## Previous Behavior
Default tabster element was set on index change, causing it to be missed on initial render, if the user shift-tabbed into the carousel it would go to the last card.

## New Behavior
Carousel now sets default tab to the first card in current group on init, including controlled or alternate default start indexes.
