### PR TITLE
Carousel: High contrast Windows

### DIFF
--- a/change/@fluentui-react-carousel-d45f8c82-f098-4820-9e34-31862a08f3d3.json
+++ b/change/@fluentui-react-carousel-d45f8c82-f098-4820-9e34-31862a08f3d3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Ensure a viable background color for nav items in high contrast windows",
+  "packageName": "@fluentui/react-carousel",
+  "email": "mifraser@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-carousel/library/src/components/CarouselNavButton/useCarouselNavButtonStyles.styles.ts
+++ b/packages/react-components/react-carousel/library/src/components/CarouselNavButton/useCarouselNavButtonStyles.styles.ts
@@ -31,6 +31,12 @@ const useStyles = makeStyles({
       width: tokens.spacingHorizontalS,
       backgroundColor: tokens.colorNeutralForeground1,
       color: tokens.colorNeutralForeground1,
+      '@media (forced-colors: active)': {
+        // Bypass OS high contrast with inverted blend mode (otherwise icon is invisible)
+        forcedColorAdjust: 'none',
+        backgroundColor: 'white',
+        mixBlendMode: 'difference',
+      },
     },
   },
   rootUnselected: {


### PR DESCRIPTION
## Previous Behavior
High contrast mode in windows overrides all background colors, causing our nav icons to be invisible

## New Behavior
When forced colors is active, we will contrast the nav icons against the background color via blend mode and a white default color.

Default: Unaffected
![image](https://github.com/user-attachments/assets/9902aa95-c8e7-4572-8ab3-4782e6945467)

Desert HC (Light HC):
![image](https://github.com/user-attachments/assets/44fc5e86-6d14-4525-9b64-ced9e74442f5)

Night Sky HC (Dark HC):
![image](https://github.com/user-attachments/assets/e6bb384e-8128-4d6e-af5c-dc36ef290187)


