### PR TITLE
Carousel Storybook: Add navigation guidance aria-label example

### DIFF
--- a/packages/react-components/react-carousel/stories/src/Carousel/CarouselActionCards.stories.tsx
+++ b/packages/react-components/react-carousel/stories/src/Carousel/CarouselActionCards.stories.tsx
@@ -201,7 +201,7 @@ export const AlignmentAndWhitespace = () => {
       <div className={classes.card}>
         <Carousel align={alignment} className={classes.carousel} whitespace={whitespace} announcement={getAnnouncement}>
           <CarouselViewport>
-            <CarouselSlider cardFocus>
+            <CarouselSlider cardFocus aria-label="Use the left and right arrow keys to navigate focused carousel card">
               {POSTS.map((post, index) => (
                 <ActionCard {...post} key={post.name} index={index} />
               ))}


### PR DESCRIPTION
## Previous Behavior
Consumers mentioned that an aria-label to explain custom left/right navigation controls was required
This is possible with current implementation but not shown in storybook demo.

## New Behavior
Updated cardFocus example with aria-label to narrate navigation controls
