### PR TITLE
chore: Updating `dependabot.yml` to allow only minor and patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,6 @@ updates:
       - dependency-type: 'development'
     open-pull-requests-limit: 6
     versioning-strategy: increase
+    update-types:
+      - "minor"
+      - "patch"


### PR DESCRIPTION
This PR updates `dependabot.yml` to allow only minor and patch updates