### PR TITLE
fix(docs): Correct link in v8-v9 theme migration docs

### DIFF
--- a/apps/public-docsite-v9/src/Concepts/Migration/FromV8/Components/Theme.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/Migration/FromV8/Components/Theme.stories.mdx
@@ -21,7 +21,7 @@ Beyond consistency with the latest Fluent Design system, this change provides si
 
 #### Portals
 
-To be use v9 components inside v8 components like `Panel` & `Callout`, please enable [portal compatibility](?path=/docs/concepts-migration-from-v8-troubleshooting--page).
+To be use v9 components inside v8 components like `Panel` & `Callout`, please enable [portal compatibility](?path=/docs/concepts-migration-from-v8-troubleshooting--docs#portal-compatibility).
 
 ### Theme (v8) => Theme (v9)
 

--- a/apps/public-docsite-v9/src/Concepts/Migration/FromV8/Troubleshooting.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/Migration/FromV8/Troubleshooting.stories.mdx
@@ -43,7 +43,7 @@ function App() {
 }
 ```
 
-## "I tried uing a layered v8 component like Callout in a layered v9 component like Dialog and my Callout appears beneath my Dialog. What's going on?"
+## <a id="portal-compatibility"></a> "I tried using a layered v8 component like Callout in a layered v9 component like Dialog and my Callout appears beneath my Dialog. What's going on?"
 
 Both v9 and v8 layers set the same `z-index` value by default, which means the document order will resolve their z-positioning.
 This can lead to inconsistent behavior because z-positioning depends on the order in which elements appear in the DOM.


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

There is a broken link in the v8-v9 theme migration docs that should point to the troubleshooting page.

## New Behavior

Update the broken link. Fix a typo on the target page, and add a named anchor to make a friendlier link URL.
