### PR TITLE
feat(eslint-plugin-react-components): add prefer-fluentui-v9 rule

### DIFF
--- a/change/@fluentui-eslint-plugin-react-components-1c2bc691-c857-43cf-9806-ffe8d0d058c0.json
+++ b/change/@fluentui-eslint-plugin-react-components-1c2bc691-c857-43cf-9806-ffe8d0d058c0.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add prefer-fluentui-v9 rule",
+  "packageName": "@fluentui/eslint-plugin-react-components",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-eslint-plugin-react-components-1c2bc691-c857-43cf-9806-ffe8d0d058c0.json
+++ b/change/@fluentui-eslint-plugin-react-components-1c2bc691-c857-43cf-9806-ffe8d0d058c0.json
@@ -1,7 +1,7 @@
 {
-  "type": "minor",
+  "type": "patch",
   "comment": "feat: add prefer-fluentui-v9 rule",
   "packageName": "@fluentui/eslint-plugin-react-components",
   "email": "dmytrokirpa@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "none"
 }

--- a/packages/react-components/eslint-plugin-react-components/.eslintrc.json
+++ b/packages/react-components/eslint-plugin-react-components/.eslintrc.json
@@ -1,5 +1,13 @@
 {
   "extends": ["plugin:@fluentui/eslint-plugin/node", "plugin:eslint-plugin/recommended"],
   "plugins": ["eslint-plugin"],
-  "root": true
+  "root": true,
+  "overrides": [
+    {
+      "files": ["src/rules/*.ts"],
+      "rules": {
+        "@typescript-eslint/naming-convention": "off"
+      }
+    }
+  ]
 }

--- a/packages/react-components/eslint-plugin-react-components/README.md
+++ b/packages/react-components/eslint-plugin-react-components/README.md
@@ -40,21 +40,46 @@ module.exports = {
 };
 ```
 
-1. Or configure individual rules manually:
+2. Or configure individual rules manually:
 
 ```js
 module.exports = {
   plugins: ['@fluentui/react-components'],
   rules: {
-    '@fluentui/react-components/rule-name-1': 'error',
-    '@fluentui/react-components/rule-name-2': 'warn',
+    '@fluentui/react-components/prefer-fluentui-v9': 'warn',
   },
 };
 ```
 
 ## Available Rules
 
-TBD
+### prefer-fluentui-v9
+
+This rule ensures the use of Fluent UI v9 counterparts for Fluent UI v8 components.
+
+#### Options
+
+- `unstable` (boolean): Whether to enforce Fluent UI v9 preview component migrations.
+
+#### Examples
+
+**✅ Do**
+
+```js
+// Import and use components that have been already migrated to Fluent UI v9
+import { Button } from '@fluentui/react-components';
+
+const Component = () => <Button>...</Button>;
+```
+
+**❌ Don't**
+
+```js
+// Avoid importing and using Fluent UI V8 components that have already been migrated to Fluent UI V9.
+import { DefaultButton } from '@fluentui/react';
+
+const Component = () => <DefaultButton>...</DefaultButton>;
+```
 
 ## License
 

--- a/packages/react-components/eslint-plugin-react-components/README.md
+++ b/packages/react-components/eslint-plugin-react-components/README.md
@@ -57,10 +57,6 @@ module.exports = {
 
 This rule ensures the use of Fluent UI v9 counterparts for Fluent UI v8 components.
 
-#### Options
-
-- `unstable` (boolean): Whether to enforce Fluent UI v9 preview component migrations.
-
 #### Examples
 
 **✅ Do**

--- a/packages/react-components/eslint-plugin-react-components/etc/eslint-plugin-react-components.api.md
+++ b/packages/react-components/eslint-plugin-react-components/etc/eslint-plugin-react-components.api.md
@@ -4,8 +4,11 @@
 
 ```ts
 
+import { RuleListener } from '@typescript-eslint/utils/dist/ts-eslint';
+import { RuleModule } from '@typescript-eslint/utils/dist/ts-eslint';
+
 // @public (undocumented)
-const plugin: {
+export const plugin: {
     meta: {
         name: string;
         version: string;
@@ -13,12 +16,17 @@ const plugin: {
     configs: {
         recommended: {
             plugins: string[];
-            rules: {};
+            rules: {
+                "@fluentui/react-components/prefer-fluentui-v9": string;
+            };
         };
     };
-    rules: {};
+    rules: {
+        "prefer-fluentui-v9": RuleModule<"replaceFluent8With9" | "replaceFluent8With9Unstable" | "replaceIconWithJsx" | "replaceStackWithFlex", {
+        unstable?: boolean | undefined;
+        }[], unknown, RuleListener>;
+    };
 };
-export default plugin;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react-components/eslint-plugin-react-components/etc/eslint-plugin-react-components.api.md
+++ b/packages/react-components/eslint-plugin-react-components/etc/eslint-plugin-react-components.api.md
@@ -22,9 +22,7 @@ export const plugin: {
         };
     };
     rules: {
-        "prefer-fluentui-v9": RuleModule<"replaceFluent8With9" | "replaceIconWithJsx" | "replaceStackWithFlex" | "replaceFocusZoneWithTabster", {
-        preview?: boolean | undefined;
-        }[], unknown, RuleListener>;
+        "prefer-fluentui-v9": RuleModule<"replaceFluent8With9" | "replaceIconWithJsx" | "replaceStackWithFlex" | "replaceFocusZoneWithTabster", {}[], unknown, RuleListener>;
     };
 };
 

--- a/packages/react-components/eslint-plugin-react-components/etc/eslint-plugin-react-components.api.md
+++ b/packages/react-components/eslint-plugin-react-components/etc/eslint-plugin-react-components.api.md
@@ -16,9 +16,7 @@ export const plugin: {
     configs: {
         recommended: {
             plugins: string[];
-            rules: {
-                "@fluentui/react-components/prefer-fluentui-v9": string;
-            };
+            rules: {};
         };
     };
     rules: {

--- a/packages/react-components/eslint-plugin-react-components/etc/eslint-plugin-react-components.api.md
+++ b/packages/react-components/eslint-plugin-react-components/etc/eslint-plugin-react-components.api.md
@@ -22,8 +22,8 @@ export const plugin: {
         };
     };
     rules: {
-        "prefer-fluentui-v9": RuleModule<"replaceFluent8With9" | "replaceFluent8With9Unstable" | "replaceIconWithJsx" | "replaceStackWithFlex", {
-        unstable?: boolean | undefined;
+        "prefer-fluentui-v9": RuleModule<"replaceFluent8With9" | "replaceIconWithJsx" | "replaceStackWithFlex" | "replaceFocusZoneWithTabster", {
+        preview?: boolean | undefined;
         }[], unknown, RuleListener>;
     };
 };

--- a/packages/react-components/eslint-plugin-react-components/src/index.ts
+++ b/packages/react-components/eslint-plugin-react-components/src/index.ts
@@ -1,20 +1,21 @@
 import { name, version } from '../package.json';
+import { RULE_NAME as preferFluentUIV9Name, rule as preferFluentUIV9 } from './rules/prefer-fluentui-v9';
 
 const allRules = {
-  // add all rules here
+  [preferFluentUIV9Name]: preferFluentUIV9,
 };
 
 const configs = {
   recommended: {
     plugins: [name],
     rules: {
-      // add all recommended rules here
+      [`@fluentui/react-components/${preferFluentUIV9Name}`]: 'warn',
     },
   },
 };
 
 // Plugin definition
-const plugin = {
+export const plugin = {
   meta: {
     name,
     version,
@@ -33,4 +34,4 @@ Object.assign(configs, {
   },
 });
 
-export default plugin;
+module.exports = plugin;

--- a/packages/react-components/eslint-plugin-react-components/src/index.ts
+++ b/packages/react-components/eslint-plugin-react-components/src/index.ts
@@ -9,7 +9,7 @@ const configs = {
   recommended: {
     plugins: [name],
     rules: {
-      [`@fluentui/react-components/${preferFluentUIV9Name}`]: 'warn',
+      // add all recommended rules here
     },
   },
 };

--- a/packages/react-components/eslint-plugin-react-components/src/rules/prefer-fluentui-v9.spec.ts
+++ b/packages/react-components/eslint-plugin-react-components/src/rules/prefer-fluentui-v9.spec.ts
@@ -18,8 +18,8 @@ ruleTester.run(RULE_NAME, rule, {
       code: `import { Button } from '@fluentui/react-components';`,
     },
     {
-      code: `import { Rating } from '@fluentui/react';`,
-      options: [{ unstable: false }],
+      code: `import { ColorPicker } from '@fluentui/react';`,
+      options: [{ preview: false }],
     },
   ],
   invalid: [
@@ -33,12 +33,22 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `import { DatePicker } from '@fluentui/react';`,
-      errors: [{ messageId: 'replaceFluent8With9Unstable' }],
+      errors: [
+        {
+          messageId: 'replaceFluent8With9',
+          data: { fluent8: 'DatePicker', fluent9: 'DatePicker', package: '@fluentui/react-datepicker-compat' },
+        },
+      ],
     },
     {
-      code: `import { Rating } from '@fluentui/react';`,
-      options: [{ unstable: true }],
-      errors: [{ messageId: 'replaceFluent8With9Unstable' }],
+      code: `import { List } from '@fluentui/react';`,
+      options: [{ preview: true }],
+      errors: [
+        {
+          messageId: 'replaceFluent8With9',
+          data: { fluent8: 'List', fluent9: 'List', package: '@fluentui/react-list-preview' },
+        },
+      ],
     },
   ],
 });

--- a/packages/react-components/eslint-plugin-react-components/src/rules/prefer-fluentui-v9.spec.ts
+++ b/packages/react-components/eslint-plugin-react-components/src/rules/prefer-fluentui-v9.spec.ts
@@ -17,10 +17,6 @@ ruleTester.run(RULE_NAME, rule, {
     {
       code: `import { Button } from '@fluentui/react-components';`,
     },
-    {
-      code: `import { ColorPicker } from '@fluentui/react';`,
-      options: [{ preview: false }],
-    },
   ],
   invalid: [
     {
@@ -37,16 +33,6 @@ ruleTester.run(RULE_NAME, rule, {
         {
           messageId: 'replaceFluent8With9',
           data: { fluent8: 'DatePicker', fluent9: 'DatePicker', package: '@fluentui/react-datepicker-compat' },
-        },
-      ],
-    },
-    {
-      code: `import { List } from '@fluentui/react';`,
-      options: [{ preview: true }],
-      errors: [
-        {
-          messageId: 'replaceFluent8With9',
-          data: { fluent8: 'List', fluent9: 'List', package: '@fluentui/react-list-preview' },
         },
       ],
     },

--- a/packages/react-components/eslint-plugin-react-components/src/rules/prefer-fluentui-v9.spec.ts
+++ b/packages/react-components/eslint-plugin-react-components/src/rules/prefer-fluentui-v9.spec.ts
@@ -1,0 +1,44 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { RULE_NAME, rule } from './prefer-fluentui-v9';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run(RULE_NAME, rule, {
+  valid: [
+    {
+      code: `import type { IDropdownOption } from '@fluentui/react';`,
+    },
+    {
+      code: `import type { ITheme } from '@fluentui/react';`,
+    },
+    {
+      code: `import { ThemeProvider } from '@fluentui/react';`,
+    },
+    {
+      code: `import { Button } from '@fluentui/react-components';`,
+    },
+    {
+      code: `import { Rating } from '@fluentui/react';`,
+      options: [{ unstable: false }],
+    },
+  ],
+  invalid: [
+    {
+      code: `import { Dropdown, Icon } from '@fluentui/react';`,
+      errors: [{ messageId: 'replaceFluent8With9' }, { messageId: 'replaceIconWithJsx' }],
+    },
+    {
+      code: `import { Stack } from '@fluentui/react';`,
+      errors: [{ messageId: 'replaceStackWithFlex' }],
+    },
+    {
+      code: `import { DatePicker } from '@fluentui/react';`,
+      errors: [{ messageId: 'replaceFluent8With9Unstable' }],
+    },
+    {
+      code: `import { Rating } from '@fluentui/react';`,
+      options: [{ unstable: true }],
+      errors: [{ messageId: 'replaceFluent8With9Unstable' }],
+    },
+  ],
+});

--- a/packages/react-components/eslint-plugin-react-components/src/rules/prefer-fluentui-v9.ts
+++ b/packages/react-components/eslint-plugin-react-components/src/rules/prefer-fluentui-v9.ts
@@ -13,12 +13,7 @@ export const rule = createRule<Options, MessageIds>({
     docs: {
       description: 'This rule ensures the use of Fluent UI v9 counterparts for Fluent UI v8 components.',
     },
-    schema: [
-      {
-        type: 'object',
-        properties: {},
-      },
-    ],
+    schema: [],
     messages: {
       replaceFluent8With9: `Avoid importing {{ fluent8 }} from '@fluentui/react', as this package has started migration to Fluent UI 9. Import {{ fluent9 }} from '{{ package }}' instead.`,
       replaceIconWithJsx: `Avoid using Icon from '@fluentui/react', as this package has already migrated to Fluent UI 9. Use a JSX SVG icon from '@fluentui/react-icons' instead.`,

--- a/packages/react-components/eslint-plugin-react-components/src/rules/prefer-fluentui-v9.ts
+++ b/packages/react-components/eslint-plugin-react-components/src/rules/prefer-fluentui-v9.ts
@@ -1,0 +1,192 @@
+import { createRule } from './utils/create-rule';
+
+export const RULE_NAME = 'prefer-fluentui-v9';
+
+type Options = Array<{
+  /** Whether to enforce Fluent UI v9 preview component migrations. */
+  unstable?: boolean;
+}>;
+
+type MessageIds = 'replaceFluent8With9' | 'replaceFluent8With9Unstable' | 'replaceIconWithJsx' | 'replaceStackWithFlex';
+
+export const rule = createRule<Options, MessageIds>({
+  name: RULE_NAME,
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'This rule ensures the use of Fluent UI v9 counterparts for Fluent UI v8 components.',
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          unstable: { type: 'boolean' },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      replaceFluent8With9: `Avoid importing {{ fluent8 }} from '@fluentui/react', as this package has already migrated to Fluent UI 9. Import {{ fluent9 }} from '@fluentui/react-components' instead.`,
+      replaceFluent8With9Unstable: `Avoid importing {{ fluent8 }} from '@fluentui/react', as this package has started migration to Fluent UI 9. Import {{ fluent9 }} from '{{ package }}' instead.`,
+      replaceIconWithJsx: `Avoid using Icon from '@fluentui/react', as this package has already migrated to Fluent UI 9. Use a JSX SVG icon from '@fluentui/react-icons' instead.`,
+      replaceStackWithFlex: `Avoid using Stack from '@fluentui/react', as this package has already migrated to Fluent UI 9. Use native CSS flexbox instead.`,
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    const { unstable = false } = context.options[0] ?? {};
+
+    return {
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      ImportDeclaration(node) {
+        if (node.source.value !== '@fluentui/react') {
+          return;
+        }
+
+        for (const specifier of node.specifiers) {
+          if (specifier.type === 'ImportSpecifier' && specifier.imported.type === 'Identifier') {
+            const name = specifier.imported.name;
+
+            switch (name) {
+              case 'Icon':
+                context.report({ node, messageId: 'replaceIconWithJsx' });
+                break;
+              case 'Stack':
+                context.report({ node, messageId: 'replaceStackWithFlex' });
+                break;
+              default:
+                if (isMigration(name)) {
+                  context.report({
+                    node,
+                    messageId: 'replaceFluent8With9',
+                    data: {
+                      fluent8: name,
+                      fluent9: MIGRATIONS[name],
+                    },
+                  });
+                } else if (isCompatMigration(name)) {
+                  context.report({
+                    node,
+                    messageId: 'replaceFluent8With9Unstable',
+                    data: {
+                      fluent8: name,
+                      fluent9: COMPAT_MIGRATIONS[name].component,
+                      package: COMPAT_MIGRATIONS[name].package,
+                    },
+                  });
+                } else if (isPreviewMigration(name) && unstable) {
+                  context.report({
+                    node,
+                    messageId: 'replaceFluent8With9Unstable',
+                    data: {
+                      fluent8: name,
+                      fluent9: PREVIEW_MIGRATIONS[name].component,
+                      package: PREVIEW_MIGRATIONS[name].package,
+                    },
+                  });
+                }
+                break;
+            }
+          }
+        }
+      },
+    };
+  },
+});
+
+type Migration = string | { component: string; package: string };
+
+/**
+ * Migrations from Fluent 8 components to Fluent 9 components as of Fluent UI 9.46.3
+ * @see https://react.fluentui.dev/?path=/docs/concepts-migration-from-v8-component-mapping--page
+ */
+const MIGRATIONS = {
+  mergeStyles: 'makeStyles',
+  ActionButton: 'Button',
+  Announced: 'useAnnounce',
+  Breadcrumb: 'Breadcrumb',
+  CommandBar: 'Toolbar',
+  CommandBarButton: 'ToolbarButton',
+  CommandButton: 'MenuButton',
+  CompoundButton: 'CompoundButton',
+  Callout: 'Popover',
+  Checkbox: 'Checkbox',
+  ChoiceGroup: 'Radio',
+  ComboBox: 'Dropdown',
+  ContextualMenu: 'Menu',
+  DefaultButton: 'Button',
+  DetailsList: 'DataGrid',
+  Dialog: 'Dialog',
+  DocumentCard: 'Card',
+  Dropdown: 'Dropdown',
+  Facepile: 'AvatarGroup',
+  GroupedList: 'Tree',
+  IconButton: 'Button',
+  Image: 'Image',
+  Label: 'Label',
+  Layer: 'Portal',
+  Link: 'Link',
+  MessageBar: 'MessageBar',
+  Modal: 'Dialog',
+  OverflowSet: 'Overflow',
+  Overlay: 'Portal',
+  Panel: 'Drawer',
+  Popup: 'Dialog',
+  PrimaryButton: 'Button',
+  Persona: 'Avatar',
+  Pivot: 'TabList',
+  PivotItem: 'Tab',
+  ProgressIndicator: 'ProgressBar',
+  Separator: 'Divider',
+  Shimmer: 'Skeleton',
+  Slider: 'Slider',
+  SplitButton: 'SplitButton',
+  SpinButton: 'SpinButton',
+  Spinner: 'Spinner',
+  Text: 'Text',
+  TextField: 'Input',
+  ToggleButton: 'ToggleButton',
+  Toggle: 'Switch',
+  Tooltip: 'Tooltip',
+  TooltipHost: 'Tooltip',
+  VerticalDivider: 'Divider',
+} satisfies Record<string, Migration>;
+
+/**
+ * Compatibility migrations for certain components.
+ * @see https://react.fluentui.dev/?path=/docs/concepts-migration-from-v8-component-mapping--page
+ */
+const COMPAT_MIGRATIONS = {
+  DatePicker: { component: 'DatePicker', package: '@fluentui/react-datepicker-compat' },
+  TimePicker: { component: 'TeachingPopover', package: '@fluentui/react-timepicker-compat' },
+} satisfies Record<string, Migration>;
+
+/**
+ * Preview migrations for certain components.
+ * @see https://react.fluentui.dev/?path=/docs/concepts-migration-from-v8-component-mapping--page
+ */
+const PREVIEW_MIGRATIONS = {
+  Rating: { component: 'Rating', package: '@fluentui/react-rating-preview' },
+  TeachingBubble: { component: 'TeachingPopover', package: '@fluentui/react-teaching-popover-preview' },
+} satisfies Record<string, Migration>;
+
+/**
+ * Checks if a component name is in the MIGRATIONS list.
+ * @param name - The name of the component.
+ * @returns True if the component is in the MIGRATIONS list, false otherwise.
+ */
+const isMigration = (name: string): name is keyof typeof MIGRATIONS => name in MIGRATIONS;
+
+/**
+ * Checks if a component name is in the COMPAT_MIGRATIONS list.
+ * @param name - The name of the component.
+ * @returns True if the component is in the COMPAT_MIGRATIONS list, false otherwise.
+ */
+const isCompatMigration = (name: string): name is keyof typeof COMPAT_MIGRATIONS => name in COMPAT_MIGRATIONS;
+
+/**
+ * Checks if a component name is in the PREVIEW_MIGRATIONS list.
+ * @param name - The name of the component.
+ * @returns True if the component is in the PREVIEW_MIGRATIONS list, false otherwise.
+ */
+const isPreviewMigration = (name: string): name is keyof typeof PREVIEW_MIGRATIONS => name in PREVIEW_MIGRATIONS;

--- a/packages/react-components/eslint-plugin-react-components/src/rules/prefer-fluentui-v9.ts
+++ b/packages/react-components/eslint-plugin-react-components/src/rules/prefer-fluentui-v9.ts
@@ -26,7 +26,6 @@ export const rule = createRule<Options, MessageIds>({
   defaultOptions: [],
   create(context) {
     return {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       ImportDeclaration(node) {
         if (node.source.value !== '@fluentui/react') {
           return;
@@ -52,14 +51,14 @@ export const rule = createRule<Options, MessageIds>({
                 break;
               default:
                 if (isMigration(name)) {
-                  const migration = getMigrationDetails(MIGRATIONS[name]);
+                  const migration = MIGRATIONS[name];
 
                   context.report({
                     node,
                     messageId: 'replaceFluent8With9',
                     data: {
                       fluent8: name,
-                      fluent9: migration.component,
+                      fluent9: migration.import,
                       package: migration.package,
                     },
                   });
@@ -72,76 +71,74 @@ export const rule = createRule<Options, MessageIds>({
   },
 });
 
-type Migration = string | { component: string; package: string };
-
 /**
  * Migrations from Fluent 8 components to Fluent 9 components.
  * @see https://react.fluentui.dev/?path=/docs/concepts-migration-from-v8-component-mapping--docs
  */
 const MIGRATIONS = {
-  makeStyles: 'makeStyles',
-  ActionButton: 'Button',
-  Announced: 'useAnnounce',
-  Breadcrumb: 'Breadcrumb',
-  Button: 'Button',
-  Callout: 'Popover',
-  Calendar: { component: 'Calendar', package: '@fluentui/react-calendar-compat' },
-  CommandBar: 'Toolbar',
-  CommandBarButton: 'Toolbar',
-  CommandButton: 'MenuButton',
-  CompoundButton: 'CompoundButton',
-  Checkbox: 'Checkbox',
-  ChoiceGroup: 'RadioGroup',
-  Coachmark: 'TeachingPopover',
-  ComboBox: 'Combobox',
-  ContextualMenu: 'Menu',
-  DefaultButton: 'Button',
-  DatePicker: { component: 'DatePicker', package: '@fluentui/react-datepicker-compat' },
-  DetailsList: 'DataGrid',
-  Dialog: 'Dialog',
-  DocumentCard: 'Card',
-  Dropdown: 'Dropdown',
-  Fabric: 'FluentProvider',
-  Facepile: 'AvatarGroup',
-  FocusTrapZone: 'Tabster',
-  FocusZone: 'Tabster',
-  GroupedList: 'Tree',
-  HoverCard: 'Popover', // Not a direct equivalent; but could be used with custom behavior.
-  IconButton: 'Button',
-  Image: 'Image',
-  Keytips: { component: 'Keytips', package: '@fluentui-contrib/react-keytips' },
-  Label: 'Label',
-  Layer: 'Portal',
-  Link: 'Link',
-  MessageBar: 'MessageBar',
-  Modal: 'Dialog',
-  OverflowSet: 'Overflow',
-  Overlay: 'Portal',
-  Panel: 'Drawer',
-  PeoplePicker: 'TagPicker',
-  Persona: 'Persona',
-  Pivot: 'TabList',
-  PivotItem: 'Tab',
-  ProgressIndicator: 'ProgressBar',
-  Rating: 'Rating',
-  SearchBox: 'SearchBox',
-  Separator: 'Divider',
-  Shimmer: 'Skeleton',
-  Slider: 'Slider',
-  SplitButton: 'SplitButton',
-  SpinButton: 'SpinButton',
-  Spinner: 'Spinner',
-  Stack: 'StackShim',
-  SwatchColorPicker: 'SwatchPicker',
-  TagPicker: 'TagPicker',
-  TeachingBubble: 'TeachingPopover',
-  Text: 'Text',
-  TextField: 'Input',
-  TimePicker: { component: 'TimePicker', package: '@fluentui/react-timepicker-compat' },
-  ToggleButton: 'ToggleButton',
-  Toggle: 'Switch',
-  Tooltip: 'Tooltip',
-} satisfies Record<string, Migration>;
+  makeStyles: { import: 'makeStyles', package: '@fluentui/react-components' },
+  ActionButton: { import: 'Button', package: '@fluentui/react-components' },
+  Announced: { import: 'useAnnounce', package: '@fluentui/react-components' },
+  Breadcrumb: { import: 'Breadcrumb', package: '@fluentui/react-components' },
+  Button: { import: 'Button', package: '@fluentui/react-components' },
+  Callout: { import: 'Popover', package: '@fluentui/react-components' },
+  Calendar: { import: 'Calendar', package: '@fluentui/react-calendar-compat' },
+  CommandBar: { import: 'Toolbar', package: '@fluentui/react-components' },
+  CommandBarButton: { import: 'Toolbar', package: '@fluentui/react-components' },
+  CommandButton: { import: 'MenuButton', package: '@fluentui/react-components' },
+  CompoundButton: { import: 'CompoundButton', package: '@fluentui/react-components' },
+  Checkbox: { import: 'Checkbox', package: '@fluentui/react-components' },
+  ChoiceGroup: { import: 'RadioGroup', package: '@fluentui/react-components' },
+  Coachmark: { import: 'TeachingPopover', package: '@fluentui/react-components' },
+  ComboBox: { import: 'Combobox', package: '@fluentui/react-components' },
+  ContextualMenu: { import: 'Menu', package: '@fluentui/react-components' },
+  DefaultButton: { import: 'Button', package: '@fluentui/react-components' },
+  DatePicker: { import: 'DatePicker', package: '@fluentui/react-datepicker-compat' },
+  DetailsList: { import: 'DataGrid', package: '@fluentui/react-components' },
+  Dialog: { import: 'Dialog', package: '@fluentui/react-components' },
+  DocumentCard: { import: 'Card', package: '@fluentui/react-components' },
+  Dropdown: { import: 'Dropdown', package: '@fluentui/react-components' },
+  Fabric: { import: 'FluentProvider', package: '@fluentui/react-components' },
+  Facepile: { import: 'AvatarGroup', package: '@fluentui/react-components' },
+  FocusTrapZone: { import: 'Tabster', package: '@fluentui/react-components' },
+  FocusZone: { import: 'Tabster', package: '@fluentui/react-components' },
+  GroupedList: { import: 'Tree', package: '@fluentui/react-components' },
+  HoverCard: { import: 'Popover', package: '@fluentui/react-components' }, // Not a direct equivalent; but could be used with custom behavior.
+  IconButton: { import: 'Button', package: '@fluentui/react-components' },
+  Image: { import: 'Image', package: '@fluentui/react-components' },
+  Keytips: { import: 'Keytips', package: '@fluentui-contrib/react-keytips' },
+  Label: { import: 'Label', package: '@fluentui/react-components' },
+  Layer: { import: 'Portal', package: '@fluentui/react-components' },
+  Link: { import: 'Link', package: '@fluentui/react-components' },
+  MessageBar: { import: 'MessageBar', package: '@fluentui/react-components' },
+  Modal: { import: 'Dialog', package: '@fluentui/react-components' },
+  OverflowSet: { import: 'Overflow', package: '@fluentui/react-components' },
+  Overlay: { import: 'Portal', package: '@fluentui/react-components' },
+  Panel: { import: 'Drawer', package: '@fluentui/react-components' },
+  PeoplePicker: { import: 'TagPicker', package: '@fluentui/react-components' },
+  Persona: { import: 'Persona', package: '@fluentui/react-components' },
+  Pivot: { import: 'TabList', package: '@fluentui/react-components' },
+  PivotItem: { import: 'Tab', package: '@fluentui/react-components' },
+  ProgressIndicator: { import: 'ProgressBar', package: '@fluentui/react-components' },
+  Rating: { import: 'Rating', package: '@fluentui/react-components' },
+  SearchBox: { import: 'SearchBox', package: '@fluentui/react-components' },
+  Separator: { import: 'Divider', package: '@fluentui/react-components' },
+  Shimmer: { import: 'Skeleton', package: '@fluentui/react-components' },
+  Slider: { import: 'Slider', package: '@fluentui/react-components' },
+  SplitButton: { import: 'SplitButton', package: '@fluentui/react-components' },
+  SpinButton: { import: 'SpinButton', package: '@fluentui/react-components' },
+  Spinner: { import: 'Spinner', package: '@fluentui/react-components' },
+  Stack: { import: 'StackShim', package: '@fluentui/react-components' },
+  SwatchColorPicker: { import: 'SwatchPicker', package: '@fluentui/react-components' },
+  TagPicker: { import: 'TagPicker', package: '@fluentui/react-components' },
+  TeachingBubble: { import: 'TeachingPopover', package: '@fluentui/react-components' },
+  Text: { import: 'Text', package: '@fluentui/react-components' },
+  TextField: { import: 'Input', package: '@fluentui/react-components' },
+  TimePicker: { import: 'TimePicker', package: '@fluentui/react-timepicker-compat' },
+  ToggleButton: { import: 'ToggleButton', package: '@fluentui/react-components' },
+  Toggle: { import: 'Switch', package: '@fluentui/react-components' },
+  Tooltip: { import: 'Tooltip', package: '@fluentui/react-components' },
+};
 
 /**
  * Checks if a component name is in the MIGRATIONS list.
@@ -149,14 +146,3 @@ const MIGRATIONS = {
  * @returns True if the component is in the MIGRATIONS list, false otherwise.
  */
 const isMigration = (name: string): name is keyof typeof MIGRATIONS => name in MIGRATIONS;
-
-/**
- * Get the component and package name to use for a migration.
- */
-const getMigrationDetails = (migration: Migration) => {
-  if (typeof migration === 'string') {
-    return { component: migration, package: '@fluentui/react-components' };
-  }
-
-  return migration;
-};

--- a/packages/react-components/eslint-plugin-react-components/src/rules/prefer-fluentui-v9.ts
+++ b/packages/react-components/eslint-plugin-react-components/src/rules/prefer-fluentui-v9.ts
@@ -4,10 +4,10 @@ export const RULE_NAME = 'prefer-fluentui-v9';
 
 type Options = Array<{
   /** Whether to enforce Fluent UI v9 preview component migrations. */
-  unstable?: boolean;
+  preview?: boolean;
 }>;
 
-type MessageIds = 'replaceFluent8With9' | 'replaceFluent8With9Unstable' | 'replaceIconWithJsx' | 'replaceStackWithFlex';
+type MessageIds = 'replaceFluent8With9' | 'replaceIconWithJsx' | 'replaceStackWithFlex' | 'replaceFocusZoneWithTabster';
 
 export const rule = createRule<Options, MessageIds>({
   name: RULE_NAME,
@@ -20,21 +20,21 @@ export const rule = createRule<Options, MessageIds>({
       {
         type: 'object',
         properties: {
-          unstable: { type: 'boolean' },
+          preview: { type: 'boolean' },
         },
         additionalProperties: false,
       },
     ],
     messages: {
-      replaceFluent8With9: `Avoid importing {{ fluent8 }} from '@fluentui/react', as this package has already migrated to Fluent UI 9. Import {{ fluent9 }} from '@fluentui/react-components' instead.`,
-      replaceFluent8With9Unstable: `Avoid importing {{ fluent8 }} from '@fluentui/react', as this package has started migration to Fluent UI 9. Import {{ fluent9 }} from '{{ package }}' instead.`,
+      replaceFluent8With9: `Avoid importing {{ fluent8 }} from '@fluentui/react', as this package has started migration to Fluent UI 9. Import {{ fluent9 }} from '{{ package }}' instead.`,
       replaceIconWithJsx: `Avoid using Icon from '@fluentui/react', as this package has already migrated to Fluent UI 9. Use a JSX SVG icon from '@fluentui/react-icons' instead.`,
-      replaceStackWithFlex: `Avoid using Stack from '@fluentui/react', as this package has already migrated to Fluent UI 9. Use native CSS flexbox instead.`,
+      replaceStackWithFlex: `Avoid using Stack from '@fluentui/react', as this package has already migrated to Fluent UI 9. Use native CSS flexbox instead. More details are available at https://react.fluentui.dev/?path=/docs/concepts-migration-from-v8-components-flex-stack--docs`,
+      replaceFocusZoneWithTabster: `Avoid using {{ fluent8 }} from '@fluentui/react', as this package has already migrated to Fluent UI 9. Use the equivalent [Tabster](https://tabster.io/) hook instead.`,
     },
   },
   defaultOptions: [],
   create(context) {
-    const { unstable = false } = context.options[0] ?? {};
+    const { preview = false } = context.options[0] ?? {};
 
     return {
       // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -54,30 +54,27 @@ export const rule = createRule<Options, MessageIds>({
               case 'Stack':
                 context.report({ node, messageId: 'replaceStackWithFlex' });
                 break;
+              case 'FocusTrapZone':
+              case 'FocusZone':
+                context.report({ node, messageId: 'replaceFocusZoneWithTabster', data: { fluent8: name } });
+                break;
               default:
                 if (isMigration(name)) {
+                  const migration = getMigrationData(MIGRATIONS[name]);
+
                   context.report({
                     node,
                     messageId: 'replaceFluent8With9',
                     data: {
                       fluent8: name,
-                      fluent9: MIGRATIONS[name],
+                      fluent9: migration.component,
+                      package: migration.package,
                     },
                   });
-                } else if (isCompatMigration(name)) {
+                } else if (isPreviewMigration(name) && preview) {
                   context.report({
                     node,
-                    messageId: 'replaceFluent8With9Unstable',
-                    data: {
-                      fluent8: name,
-                      fluent9: COMPAT_MIGRATIONS[name].component,
-                      package: COMPAT_MIGRATIONS[name].package,
-                    },
-                  });
-                } else if (isPreviewMigration(name) && unstable) {
-                  context.report({
-                    node,
-                    messageId: 'replaceFluent8With9Unstable',
+                    messageId: 'replaceFluent8With9',
                     data: {
                       fluent8: name,
                       fluent9: PREVIEW_MIGRATIONS[name].component,
@@ -97,32 +94,41 @@ export const rule = createRule<Options, MessageIds>({
 type Migration = string | { component: string; package: string };
 
 /**
- * Migrations from Fluent 8 components to Fluent 9 components as of Fluent UI 9.46.3
- * @see https://react.fluentui.dev/?path=/docs/concepts-migration-from-v8-component-mapping--page
+ * Migrations from Fluent 8 components to Fluent 9 components.
+ * @see https://react.fluentui.dev/?path=/docs/concepts-migration-from-v8-component-mapping--docs
  */
 const MIGRATIONS = {
-  mergeStyles: 'makeStyles',
+  makeStyles: 'makeStyles',
   ActionButton: 'Button',
   Announced: 'useAnnounce',
   Breadcrumb: 'Breadcrumb',
+  Button: 'Button',
+  Callout: 'Popover',
+  Calendar: { component: 'Calendar', package: '@fluentui/react-calendar-compat' },
   CommandBar: 'Toolbar',
-  CommandBarButton: 'ToolbarButton',
+  CommandBarButton: 'Toolbar',
   CommandButton: 'MenuButton',
   CompoundButton: 'CompoundButton',
-  Callout: 'Popover',
   Checkbox: 'Checkbox',
-  ChoiceGroup: 'Radio',
-  ComboBox: 'Dropdown',
+  ChoiceGroup: 'RadioGroup',
+  Coachmark: 'TeachingPopover',
+  ComboBox: 'Combobox',
   ContextualMenu: 'Menu',
   DefaultButton: 'Button',
+  DatePicker: { component: 'DatePicker', package: '@fluentui/react-datepicker-compat' },
   DetailsList: 'DataGrid',
   Dialog: 'Dialog',
   DocumentCard: 'Card',
   Dropdown: 'Dropdown',
+  Fabric: 'FluentProvider',
   Facepile: 'AvatarGroup',
+  FocusTrapZone: 'Tabster',
+  FocusZone: 'Tabster',
   GroupedList: 'Tree',
+  HoverCard: 'Popover', // Not a direct equivalent; but could be used with custom behavior.
   IconButton: 'Button',
   Image: 'Image',
+  Keytips: { component: 'Keytips', package: '@fluentui-contrib/react-keytips' },
   Label: 'Label',
   Layer: 'Portal',
   Link: 'Link',
@@ -131,43 +137,39 @@ const MIGRATIONS = {
   OverflowSet: 'Overflow',
   Overlay: 'Portal',
   Panel: 'Drawer',
-  Popup: 'Dialog',
-  PrimaryButton: 'Button',
-  Persona: 'Avatar',
+  PeoplePicker: 'TagPicker',
+  Persona: 'Persona',
   Pivot: 'TabList',
   PivotItem: 'Tab',
   ProgressIndicator: 'ProgressBar',
+  Rating: 'Rating',
+  SearchBox: 'SearchBox',
   Separator: 'Divider',
   Shimmer: 'Skeleton',
   Slider: 'Slider',
   SplitButton: 'SplitButton',
   SpinButton: 'SpinButton',
   Spinner: 'Spinner',
+  Stack: 'StackShim',
+  SwatchColorPicker: 'SwatchPicker',
+  TagPicker: 'TagPicker',
+  TeachingBubble: 'TeachingPopover',
   Text: 'Text',
   TextField: 'Input',
+  TimePicker: { component: 'TimePicker', package: '@fluentui/react-timepicker-compat' },
   ToggleButton: 'ToggleButton',
   Toggle: 'Switch',
   Tooltip: 'Tooltip',
-  TooltipHost: 'Tooltip',
-  VerticalDivider: 'Divider',
-} satisfies Record<string, Migration>;
-
-/**
- * Compatibility migrations for certain components.
- * @see https://react.fluentui.dev/?path=/docs/concepts-migration-from-v8-component-mapping--page
- */
-const COMPAT_MIGRATIONS = {
-  DatePicker: { component: 'DatePicker', package: '@fluentui/react-datepicker-compat' },
-  TimePicker: { component: 'TeachingPopover', package: '@fluentui/react-timepicker-compat' },
 } satisfies Record<string, Migration>;
 
 /**
  * Preview migrations for certain components.
- * @see https://react.fluentui.dev/?path=/docs/concepts-migration-from-v8-component-mapping--page
+ * @see https://react.fluentui.dev/?path=/docs/concepts-migration-from-v8-component-mapping--docs
  */
 const PREVIEW_MIGRATIONS = {
-  Rating: { component: 'Rating', package: '@fluentui/react-rating-preview' },
-  TeachingBubble: { component: 'TeachingPopover', package: '@fluentui/react-teaching-popover-preview' },
+  ColorPicker: { component: 'ColorPicker', package: '@fluentui/react-color-picker-preview' },
+  List: { component: 'List', package: '@fluentui/react-list-preview' },
+  Virtualizer: { component: 'Virtualizer', package: '@fluentui/react-virtualizer-preview' },
 } satisfies Record<string, Migration>;
 
 /**
@@ -178,15 +180,15 @@ const PREVIEW_MIGRATIONS = {
 const isMigration = (name: string): name is keyof typeof MIGRATIONS => name in MIGRATIONS;
 
 /**
- * Checks if a component name is in the COMPAT_MIGRATIONS list.
- * @param name - The name of the component.
- * @returns True if the component is in the COMPAT_MIGRATIONS list, false otherwise.
- */
-const isCompatMigration = (name: string): name is keyof typeof COMPAT_MIGRATIONS => name in COMPAT_MIGRATIONS;
-
-/**
  * Checks if a component name is in the PREVIEW_MIGRATIONS list.
  * @param name - The name of the component.
  * @returns True if the component is in the PREVIEW_MIGRATIONS list, false otherwise.
  */
 const isPreviewMigration = (name: string): name is keyof typeof PREVIEW_MIGRATIONS => name in PREVIEW_MIGRATIONS;
+
+/**
+ * Get the component and package name to use for a migration.
+ */
+const getMigrationData = (migration: Migration) => {
+  return typeof migration === 'string' ? { component: migration, package: '@fluentui/react-components' } : migration;
+};

--- a/packages/react-components/eslint-plugin-react-components/src/rules/prefer-fluentui-v9.ts
+++ b/packages/react-components/eslint-plugin-react-components/src/rules/prefer-fluentui-v9.ts
@@ -1,3 +1,5 @@
+import { AST_NODE_TYPES } from '@typescript-eslint/utils';
+
 import { createRule } from './utils/create-rule';
 
 export const RULE_NAME = 'prefer-fluentui-v9';
@@ -31,7 +33,10 @@ export const rule = createRule<Options, MessageIds>({
         }
 
         for (const specifier of node.specifiers) {
-          if (specifier.type === 'ImportSpecifier' && specifier.imported.type === 'Identifier') {
+          if (
+            specifier.type === AST_NODE_TYPES.ImportSpecifier &&
+            specifier.imported.type === AST_NODE_TYPES.Identifier
+          ) {
             const name = specifier.imported.name;
 
             switch (name) {

--- a/packages/react-components/eslint-plugin-react-components/src/rules/prefer-fluentui-v9.ts
+++ b/packages/react-components/eslint-plugin-react-components/src/rules/prefer-fluentui-v9.ts
@@ -47,7 +47,7 @@ export const rule = createRule<Options, MessageIds>({
                 break;
               default:
                 if (isMigration(name)) {
-                  const migration = getMigrationData(MIGRATIONS[name]);
+                  const migration = getMigrationDetails(MIGRATIONS[name]);
 
                   context.report({
                     node,
@@ -148,6 +148,10 @@ const isMigration = (name: string): name is keyof typeof MIGRATIONS => name in M
 /**
  * Get the component and package name to use for a migration.
  */
-const getMigrationData = (migration: Migration) => {
-  return typeof migration === 'string' ? { component: migration, package: '@fluentui/react-components' } : migration;
+const getMigrationDetails = (migration: Migration) => {
+  if (typeof migration === 'string') {
+    return { component: migration, package: '@fluentui/react-components' };
+  }
+
+  return migration;
 };

--- a/packages/react-components/eslint-plugin-react-components/src/rules/prefer-fluentui-v9.ts
+++ b/packages/react-components/eslint-plugin-react-components/src/rules/prefer-fluentui-v9.ts
@@ -2,10 +2,7 @@ import { createRule } from './utils/create-rule';
 
 export const RULE_NAME = 'prefer-fluentui-v9';
 
-type Options = Array<{
-  /** Whether to enforce Fluent UI v9 preview component migrations. */
-  preview?: boolean;
-}>;
+type Options = Array<{}>;
 
 type MessageIds = 'replaceFluent8With9' | 'replaceIconWithJsx' | 'replaceStackWithFlex' | 'replaceFocusZoneWithTabster';
 
@@ -19,10 +16,7 @@ export const rule = createRule<Options, MessageIds>({
     schema: [
       {
         type: 'object',
-        properties: {
-          preview: { type: 'boolean' },
-        },
-        additionalProperties: false,
+        properties: {},
       },
     ],
     messages: {
@@ -34,8 +28,6 @@ export const rule = createRule<Options, MessageIds>({
   },
   defaultOptions: [],
   create(context) {
-    const { preview = false } = context.options[0] ?? {};
-
     return {
       // eslint-disable-next-line @typescript-eslint/naming-convention
       ImportDeclaration(node) {
@@ -71,18 +63,7 @@ export const rule = createRule<Options, MessageIds>({
                       package: migration.package,
                     },
                   });
-                } else if (isPreviewMigration(name) && preview) {
-                  context.report({
-                    node,
-                    messageId: 'replaceFluent8With9',
-                    data: {
-                      fluent8: name,
-                      fluent9: PREVIEW_MIGRATIONS[name].component,
-                      package: PREVIEW_MIGRATIONS[name].package,
-                    },
-                  });
                 }
-                break;
             }
           }
         }
@@ -163,28 +144,11 @@ const MIGRATIONS = {
 } satisfies Record<string, Migration>;
 
 /**
- * Preview migrations for certain components.
- * @see https://react.fluentui.dev/?path=/docs/concepts-migration-from-v8-component-mapping--docs
- */
-const PREVIEW_MIGRATIONS = {
-  ColorPicker: { component: 'ColorPicker', package: '@fluentui/react-color-picker-preview' },
-  List: { component: 'List', package: '@fluentui/react-list-preview' },
-  Virtualizer: { component: 'Virtualizer', package: '@fluentui/react-virtualizer-preview' },
-} satisfies Record<string, Migration>;
-
-/**
  * Checks if a component name is in the MIGRATIONS list.
  * @param name - The name of the component.
  * @returns True if the component is in the MIGRATIONS list, false otherwise.
  */
 const isMigration = (name: string): name is keyof typeof MIGRATIONS => name in MIGRATIONS;
-
-/**
- * Checks if a component name is in the PREVIEW_MIGRATIONS list.
- * @param name - The name of the component.
- * @returns True if the component is in the PREVIEW_MIGRATIONS list, false otherwise.
- */
-const isPreviewMigration = (name: string): name is keyof typeof PREVIEW_MIGRATIONS => name in PREVIEW_MIGRATIONS;
 
 /**
  * Get the component and package name to use for a migration.

--- a/packages/react-components/eslint-plugin-react-components/src/rules/utils/create-rule.ts
+++ b/packages/react-components/eslint-plugin-react-components/src/rules/utils/create-rule.ts
@@ -1,0 +1,9 @@
+import { ESLintUtils } from '@typescript-eslint/utils';
+
+/**
+ * Creates an ESLint rule with a pre-configured URL pointing to the rule's documentation.
+ */
+export const createRule = ESLintUtils.RuleCreator(
+  name =>
+    `https://github.com/microsoft/fluentui/blob/master/packages/react-components/eslint-plugin-react-components/README.md#${name}`,
+);

--- a/packages/react-components/eslint-plugin-react-components/tsconfig.spec.json
+++ b/packages/react-components/eslint-plugin-react-components/tsconfig.spec.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "CommonJS",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "outDir": "dist",
     "types": ["jest", "node"]
   },


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

--

## New Behavior

- Added new rule `prefer-fluentui-v9` to `eslint-plugin-react-components` to enforce the use of Fluent UI v9 equivalent for Fluent UI v8 components. 
- Added it to the `recommended` config.
- Updated docs

Example of output:

```
fluentui/apps/vr-tests/src/stories/Toggle.stories.tsx
  4:1  warning  Avoid importing Toggle from '@fluentui/react', as this package has already migrated to Fluent UI 9. Import Switch from '@fluentui/react-components' instead  @fluentui/react-components/prefer-fluentui-v9

fluentui/apps/vr-tests/src/stories/Tooltip/Tooltip.stories.tsx
  4:1  warning  Avoid importing TooltipHost from '@fluentui/react', as this package has already migrated to Fluent UI 9. Import Tooltip from '@fluentui/react-components' instead  @fluentui/react-components/prefer-fluentui-v9
```

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Partially implements #32183
