### PR TITLE
Carousel: Set CarouselNav totalSlides to controlled

### DIFF
--- a/change/@fluentui-react-carousel-6c54eead-adb1-472f-9bdd-51f424e2c9db.json
+++ b/change/@fluentui-react-carousel-6c54eead-adb1-472f-9bdd-51f424e2c9db.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Set totalSlides on CarouselNav to controlled state",
+  "packageName": "@fluentui/react-carousel",
+  "email": "mifraser@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-carousel/library/src/components/CarouselNav/useCarouselNav.ts
+++ b/packages/react-components/react-carousel/library/src/components/CarouselNav/useCarouselNav.ts
@@ -38,7 +38,7 @@ export const useCarouselNav_unstable = (props: CarouselNavProps, ref: React.Ref<
     return subscribeForValues(data => {
       setTotalSlides(data.navItemsCount);
     });
-  }, [subscribeForValues]);
+  }, [subscribeForValues, setTotalSlides]);
 
   return {
     totalSlides,

--- a/packages/react-components/react-carousel/library/src/components/CarouselNav/useCarouselNav.ts
+++ b/packages/react-components/react-carousel/library/src/components/CarouselNav/useCarouselNav.ts
@@ -26,8 +26,8 @@ export const useCarouselNav_unstable = (props: CarouselNavProps, ref: React.Ref<
     unstable_hasDefault: true,
   });
 
+  // Users can choose controlled or uncontrolled, if uncontrolled, the default is initialized by carousel context
   const [totalSlides, setTotalSlides] = useControllableState({
-    defaultState: props.totalSlides,
     state: props.totalSlides,
     initialState: 0,
   });

--- a/packages/react-components/react-carousel/library/src/components/CarouselNav/useCarouselNav.ts
+++ b/packages/react-components/react-carousel/library/src/components/CarouselNav/useCarouselNav.ts
@@ -4,6 +4,7 @@ import * as React from 'react';
 
 import { useCarouselContext_unstable as useCarouselContext } from '../CarouselContext';
 import type { CarouselNavProps, CarouselNavState } from './CarouselNav.types';
+import { useControllableState } from '@fluentui/react-utilities';
 
 /**
  * Create the state required to render CarouselNav.
@@ -25,7 +26,12 @@ export const useCarouselNav_unstable = (props: CarouselNavProps, ref: React.Ref<
     unstable_hasDefault: true,
   });
 
-  const [totalSlides, setTotalSlides] = React.useState(props.totalSlides ?? 0);
+  const [totalSlides, setTotalSlides] = useControllableState({
+    defaultState: props.totalSlides,
+    state: props.totalSlides,
+    initialState: 0,
+  });
+
   const subscribeForValues = useCarouselContext(ctx => ctx.subscribeForValues);
 
   useIsomorphicLayoutEffect(() => {


### PR DESCRIPTION
## Previous Behavior
CarouselNav totalSlides prop was only used to initialize state

## New Behavior
totalSlides prop now controls state without preventing undefined default behaviour

## Related Issue(s)
- Fixes #33442
