### PR TITLE
chore: Fix doc-comment links that don't translate to storybook

### DIFF
--- a/packages/react-components/react-dialog/library/src/components/Dialog/Dialog.types.ts
+++ b/packages/react-components/react-dialog/library/src/components/Dialog/Dialog.types.ts
@@ -96,8 +96,8 @@ export type DialogProps = ComponentProps<Partial<DialogSlots>> & {
   // eslint-disable-next-line @nx/workspace-consistent-callback-type -- can't change type of existing callback
   onOpenChange?: DialogOpenChangeEventHandler;
   /**
-   * Can contain two children including {@link DialogTrigger} and {@link DialogSurface}.
-   * Alternatively can only contain {@link DialogSurface} if using trigger outside dialog, or controlling state.
+   * Can contain two children including DialogTrigger and DialogSurface.
+   * Alternatively can only contain DialogSurface if using trigger outside dialog, or controlling state.
    */
   children: [JSX.Element, JSX.Element] | JSX.Element;
   /**

--- a/packages/react-components/react-menu/library/src/components/Menu/Menu.types.ts
+++ b/packages/react-components/react-menu/library/src/components/Menu/Menu.types.ts
@@ -18,8 +18,8 @@ export type MenuProps = ComponentProps<MenuSlots> &
     'checkedValues' | 'defaultCheckedValues' | 'hasCheckmarks' | 'hasIcons' | 'onCheckedValueChange'
   > & {
     /**
-     * Can contain two children including {@link MenuTrigger} and {@link MenuPopover}.
-     * Alternatively can only contain {@link MenuPopover} if using a custom `target`.
+     * Can contain two children including MenuTrigger and MenuPopover.
+     * Alternatively can only contain MenuPopover if using a custom `target`.
      */
     children: [JSX.Element, JSX.Element] | JSX.Element;
 

--- a/packages/react-components/react-popover/library/src/components/Popover/Popover.types.ts
+++ b/packages/react-components/react-popover/library/src/components/Popover/Popover.types.ts
@@ -22,8 +22,8 @@ export type PopoverProps = Pick<PortalProps, 'mountNode'> & {
   appearance?: 'brand' | 'inverted';
 
   /**
-   * Can contain two children including {@link PopoverTrigger} and {@link PopoverSurface}.
-   * Alternatively can only contain {@link PopoverSurface} if using a custom `target`.
+   * Can contain two children including PopoverTrigger and PopoverSurface.
+   * Alternatively can only contain PopoverSurface if using a custom `target`.
    */
   children: [JSX.Element, JSX.Element] | JSX.Element;
 


### PR DESCRIPTION
## Previous Behavior

Broken doc-comment links did not translate to storybook:
![image](https://github.com/user-attachments/assets/4d62db6b-6525-4b93-bea8-498d277a5f35)

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes N/A
