### PR TITLE
chore: fix N* tests

### DIFF
--- a/packages/fluentui/projects-test/assets/cra/src/index.tsx
+++ b/packages/fluentui/projects-test/assets/cra/src/index.tsx
@@ -1,0 +1,7 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import App from './App';
+
+const root = document.getElementById('root') as HTMLElement;
+
+ReactDOM.render(<App />, root);

--- a/packages/fluentui/projects-test/src/createReactApp.ts
+++ b/packages/fluentui/projects-test/src/createReactApp.ts
@@ -37,6 +37,11 @@ export async function createReactApp() {
   await addResolutionPathsForProjectPackages(testAppPathRoot);
 
   await shEcho(`yarn add ${packedPackages['@fluentui/react-northstar']}`, testAppPathRoot);
+
+  // Enforce React 17
+  const dependencies = ['@types/react@17', '@types/react-dom@17', 'react@17', 'react-dom@17'].join(' ');
+  await shEcho(`yarn add ${dependencies}`, tempPaths.testApp);
+
   logger(`✔️ Fluent UI packages were added to dependencies`);
 
   logger("STEP 3. Reference Fluent UI components in test project's App.tsx");

--- a/packages/fluentui/react-northstar/jest.config.js
+++ b/packages/fluentui/react-northstar/jest.config.js
@@ -10,6 +10,9 @@ const config = commonConfig({
     // Legacy aliases, they should not be used in new tests
     ...getAliases(),
   },
+  // Keeps Jest from using too much memory as GC gets invokes more often, makes tests slower
+  // https://stackoverflow.com/a/75857711
+  workerIdleMemoryLimit: '1024MB',
 });
 config.setupFilesAfterEnv = [...config.setupFilesAfterEnv, './jest-setup.js'];
 


### PR DESCRIPTION
## Fix in `jest.config.js`

Currently tests on CI are failing with OOM:

<img width="1533" alt="image" src="https://github.com/user-attachments/assets/8b823dc9-8ade-4dfb-9d7a-303c9800219f" />

It looks that GC is not triggered on time for workers. This could be observed even locally:

#### Before

```
PASS react-northstar test/specs/components/Box/Box-test.tsx (3686 MB heap size)
PASS react-northstar test/specs/components/Skeleton/Skeleton-test.tsx (8.947 s, 3685 MB heap size)
PASS react-northstar test/specs/components/Status/Status-test.tsx (6.757 s, 3717 MB heap size)
PASS react-northstar test/specs/components/Video/Video-test.tsx (5.27 s, 3614 MB heap size)
```

#### After

```
PASS react-northstar test/specs/components/Card/CardFooter-test.tsx (11.592 s, 703 MB heap size)
PASS react-northstar test/specs/components/Box/Box-test.tsx (911 MB heap size)
PASS react-northstar test/specs/components/Reaction/Reaction-test.tsx (11.723 s, 943 MB heap size)
PASS react-northstar test/specs/components/Divider/Divider-test.tsx (10.926 s, 590 MB heap size)
PASS react-northstar test/specs/components/Status/Status-test.tsx (10.6 s, 699 MB heap size)
```

I don't think that it's a good solution for everything, but it unblocks pipelines. In the long run this code will be discontinued anyway.

## Fix in project-tests

React 19 was released, `findDOMNode()` is removed from typings & breaks the project tests as React version is now 19.

N* never supported even 18, so I pinned versions to be 17.