### PR TITLE
Security: Ensure type safety of dependent fields

### DIFF
--- a/packages/charts/react-charting/src/components/DeclarativeChart/PlotlySchemaAdapter.ts
+++ b/packages/charts/react-charting/src/components/DeclarativeChart/PlotlySchemaAdapter.ts
@@ -65,11 +65,11 @@ export const transformPlotlyJsonToDonutProps = (
     };
   });
 
-  const width: number = layout?.width || 440;
-  const height: number = layout?.height || 220;
-  const hideLabels = firstData.textinfo ? !['value', 'percent'].includes(firstData.textinfo) : false;
-  const donutMarginHorizontal = hideLabels ? 0 : 80;
-  const donutMarginVertical = 40 + (hideLabels ? 0 : 40);
+  const width: number = typeof layout?.width === 'number' ? layout?.width : 440;
+  const height: number = typeof layout?.height === 'number' ? layout?.height : 220;
+  const hideLabels: boolean = firstData.textinfo ? !['value', 'percent'].includes(firstData.textinfo) : false;
+  const donutMarginHorizontal: number = hideLabels ? 0 : 80;
+  const donutMarginVertical: number = 40 + (hideLabels ? 0 : 40);
   const innerRadius: number = firstData.hole
     ? firstData.hole * (Math.min(width - donutMarginHorizontal, height - donutMarginVertical) / 2)
     : 0;
@@ -77,7 +77,7 @@ export const transformPlotlyJsonToDonutProps = (
   const styles: IDonutChartProps['styles'] = {
     root: {
       '[class^="arcLabel"]': {
-        fontSize: firstData.textfont?.size,
+        fontSize: typeof firstData.textfont?.size === 'number' ? firstData.textfont?.size : 0,
       },
     },
   };
@@ -222,8 +222,8 @@ export const transformPlotlyJsonToVBCProps = (
     const totalDataPoints = d3Merge(buckets).length;
 
     buckets.forEach(bucket => {
-      const legend = series.name || `Series ${index + 1}`;
-      const color = getColor(legend, colorMap, isDarkTheme);
+      const legend: string = series.name || `Series ${index + 1}`;
+      const color: string = getColor(legend, colorMap, isDarkTheme);
       let y = bucket.length;
 
       if (series.histnorm === 'percent') {
@@ -256,7 +256,7 @@ export const transformPlotlyJsonToVBCProps = (
 
   return {
     data: vbcData,
-    chartTitle: layout?.title,
+    chartTitle: typeof layout?.title === 'string' ? layout?.title : '',
     // width: layout?.width,
     // height: layout?.height,
     hideLegend: true,
@@ -278,7 +278,7 @@ export const transformPlotlyJsonToScatterChartProps = (
     const isString = typeof xValues[0] === 'string';
     const isXDate = isDateArray(xValues);
     const isXNumber = isNumberArray(xValues);
-    const legend = series.name || `Series ${index + 1}`;
+    const legend: string = series.name || `Series ${index + 1}`;
     const lineColor = getColor(legend, colorMap, isDarkTheme);
 
     return {
@@ -292,7 +292,7 @@ export const transformPlotlyJsonToScatterChartProps = (
   });
 
   const chartProps: IChartProps = {
-    chartTitle: layout.title || '',
+    chartTitle: typeof layout.title === 'string' ? layout.title : '',
     lineChartData: chartData,
   };
 
@@ -330,24 +330,24 @@ export const transformPlotlyJsonToHorizontalBarWithAxisProps = (
     })
     .flat();
 
-  const chartHeight = layout.height || 450;
-  const margin = layout.margin?.l || 0;
-  const padding = layout.margin?.pad || 0;
-  const availableHeight = chartHeight - margin - padding;
-  const numberOfBars = data[0].y.length;
+  const chartHeight: number = typeof layout.height === 'number' ? layout.height : 450;
+  const margin: number = typeof layout.margin?.l === 'number' ? layout.margin?.l : 0;
+  const padding: number = typeof layout.margin?.pad === 'number' ? layout.margin?.pad : 0;
+  const availableHeight: number = chartHeight - margin - padding;
+  const numberOfBars: number = typeof data[0].y.length === 'number' ? data[0].y.length : 0;
   const scalingFactor = 0.01;
   const gapFactor = 1 / (1 + scalingFactor * numberOfBars);
   const barHeight = availableHeight / (numberOfBars * (1 + gapFactor));
 
   return {
     data: chartData,
-    chartTitle: layout.title || '',
+    chartTitle: typeof layout.title === 'string' ? layout.title : '',
     barHeight,
     showYAxisLables: true,
     styles: {
       root: {
         height: chartHeight,
-        width: layout.width || 600,
+        width: typeof layout.width === 'number' ? layout.width : 600,
       },
     },
   };
@@ -375,7 +375,7 @@ export const transformPlotlyJsonToHeatmapProps = (jsonObj: any): IHeatMapChartPr
     });
   });
   const heatmapData: IHeatMapChartData = {
-    legend: firstData.name || '',
+    legend: typeof firstData.name === 'string' ? firstData.name : '',
     data: heatmapDataPoints,
     value: 0,
   };
@@ -429,17 +429,17 @@ export const transformPlotlyJsonToSankeyProps = (
     }),
   };
 
-  const width: number = layout?.width || 440;
-  const height: number = layout?.height || 220;
+  const width: number = typeof layout?.width === 'number' ? layout?.width : 440;
+  const height: number = typeof layout?.height === 'number' ? layout?.height : 220;
   const styles: ISankeyChartProps['styles'] = {
     root: {
-      fontSize: layout.font?.size,
+      fontSize: typeof layout.font?.size === 'number' ? layout.font?.size : 0,
     },
   };
   const shouldResize: number = width + height;
   return {
     data: {
-      chartTitle: layout?.title,
+      chartTitle: typeof layout?.title === 'string' ? layout?.title : '',
       SankeyChartData: sankeyChartData,
     },
     width,
@@ -491,15 +491,15 @@ export const transformPlotlyJsonToGaugeProps = (
 
   return {
     segments,
-    chartValue: firstData.value,
-    chartTitle: firstData.title?.text,
+    chartValue: typeof firstData.value === 'number' ? firstData.value : 0,
+    chartTitle: typeof firstData.title?.text === 'string' ? firstData.title?.text : '',
     sublabel,
     // range values can be null
-    minValue: firstData.gauge?.axis?.range?.[0] ?? undefined,
-    maxValue: firstData.gauge?.axis?.range?.[1] ?? undefined,
+    minValue: typeof firstData.gauge?.axis?.range?.[0] === 'number' ? firstData.gauge?.axis?.range?.[0] : undefined,
+    maxValue: typeof firstData.gauge?.axis?.range?.[1] === 'number' ? firstData.gauge?.axis?.range?.[1] : undefined,
     chartValueFormat: () => firstData.value,
-    width: layout?.width,
-    height: layout?.height,
+    width: typeof layout?.width === 'number' ? layout?.width : 0,
+    height: typeof layout?.height === 'number' ? layout?.height : 0,
     hideLegend: true,
     styles,
   };


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## New Behavior
Ensured type safety of these fields in plotly adapater

layout.width
layout.height
firstData.textfont?.size and other fields.

For eg: If the attacker can supply a payload which has a string value for firstData.textfont?.size property such as `14px; background-image: url(...)` I don't expect the style library to provide protection in this case.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
