### PR TITLE
fix(Panel): Add event listener to Panel in order to update the footer's sticky property correctly when content changes dynamically

### DIFF
--- a/change/@fluentui-react-da358841-feeb-4166-a7d8-e955d9e51ad7.json
+++ b/change/@fluentui-react-da358841-feeb-4166-a7d8-e955d9e51ad7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Add event listener to Panel in order to update the footer's sticky property correctly when content changes dynamically.",
+  "packageName": "@fluentui/react",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Panel/Panel.base.tsx
+++ b/packages/react/src/components/Panel/Panel.base.tsx
@@ -124,8 +124,6 @@ export class PanelBase extends React.Component<IPanelProps, IPanelState> impleme
     if (this.props.isOpen) {
       this.setState({ visibility: PanelVisibilityState.animatingOpen });
     }
-
-    this._resizeObserver?.disconnect();
   }
 
   public componentDidUpdate(previousProps: IPanelProps, previousState: IPanelState): void {
@@ -152,6 +150,7 @@ export class PanelBase extends React.Component<IPanelProps, IPanelState> impleme
   public componentWillUnmount(): void {
     this._async.dispose();
     this._events.dispose();
+    this._resizeObserver?.disconnect();
   }
 
   public render(): JSX.Element | null {


### PR DESCRIPTION
This pull request includes changes to the `Panel` component in the `@fluentui/react` package to fix the footer's sticky property when content changes dynamically. The most important changes include adding a `ResizeObserver` to monitor content changes and updating the footer position accordingly.

Enhancements to `Panel` component:

* Added a new event listener to the `Panel` component to update the footer's sticky property when content changes dynamically. (`change/@fluentui-react-da358841-feeb-4166-a7d8-e955d9e51ad7.json`)

Codebase improvements:

* Introduced a `_resizeObserver` property in the `PanelBase` class to observe content size changes. (`packages/react/src/components/Panel/Panel.base.tsx`)
* Ensured the `ResizeObserver` is disconnected when the component unmounts to prevent memory leaks. (`packages/react/src/components/Panel/Panel.base.tsx`)
* Added a private method `_createResizeObserver` to create and return a `ResizeObserver` instance. (`packages/react/src/components/Panel/Panel.base.tsx`)
* Updated the `_allowScrollOnPanel` method to initialize and observe the `ResizeObserver`, and update the footer position when content changes. (`packages/react/src/components/Panel/Panel.base.tsx`)


Fixes #33508