### PR TITLE
fix(TagPicker): add aria-disabled to expand button when disabled

### DIFF
--- a/change/@fluentui-react-tag-picker-81e8253d-652a-423d-bd38-2f4ee36719cb.json
+++ b/change/@fluentui-react-tag-picker-81e8253d-652a-423d-bd38-2f4ee36719cb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: add aria-disabled to expand button when disabled",
+  "packageName": "@fluentui/react-tag-picker",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tag-picker/library/src/components/TagPicker/TagPicker.test.tsx
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPicker/TagPicker.test.tsx
@@ -62,4 +62,18 @@ describe('TagPicker', () => {
     const expandButton = getByRole('button');
     expect(expandButton.getAttribute('aria-labelledby')).toContain('Selected Employees');
   });
+
+  it('sets expand button to disabled when TagPicker is disabled', () => {
+    const { getByRole } = render(
+      <TagPicker disabled>
+        <TagPickerControl>
+          <TagPickerInput />
+        </TagPickerControl>
+        <TagPickerList />
+      </TagPicker>,
+    );
+
+    const expandButton = getByRole('button');
+    expect(expandButton.getAttribute('aria-disabled')).toEqual('true');
+  });
 });

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerControl/useTagPickerControl.tsx
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerControl/useTagPickerControl.tsx
@@ -61,6 +61,7 @@ export const useTagPickerControl_unstable = (
     renderByDefault: !noPopover,
     defaultProps: {
       'aria-expanded': open,
+      'aria-disabled': disabled ? 'true' : undefined,
       children: <ChevronDownRegular />,
       role: 'button',
     },


### PR DESCRIPTION
## Previous Behavior

The expand button was the one holdout control that didn't get semantically disabled when the control is disabled

## New Behavior

Adds `aria-disabled`! (the functionality is already handled, only the semantics were missing)

## Related Issue(s)

- Fixes [ADO issue](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/24544)
