### PR TITLE
docs(react-carousel): add accNames to FRE dialog and autoplay button

### DIFF
--- a/packages/react-components/react-carousel/stories/src/Carousel/CarouselControlled.stories.tsx
+++ b/packages/react-components/react-carousel/stories/src/Carousel/CarouselControlled.stories.tsx
@@ -162,7 +162,7 @@ export const Controlled = () => {
         </div>
 
         <div className={classes.footer}>
-          <CarouselAutoplayButton />
+          <CarouselAutoplayButton aria-label="Enable autoplay" />
           <Divider vertical />
           <code className={classes.code}>{JSON.stringify({ activeIndex }, null, 2)}</code>
           <Divider vertical />

--- a/packages/react-components/react-carousel/stories/src/Carousel/CarouselFirstRunExperience.stories.tsx
+++ b/packages/react-components/react-carousel/stories/src/Carousel/CarouselFirstRunExperience.stories.tsx
@@ -93,7 +93,7 @@ export const FirstRunExperience = () => {
       <DialogTrigger>
         <Button>Open Dialog</Button>
       </DialogTrigger>
-      <DialogSurface className={styles.surface}>
+      <DialogSurface className={styles.surface} aria-label="Discover Copilot">
         <Carousel
           className={styles.carousel}
           groupSize={1}


### PR DESCRIPTION
## Previous Behavior

A couple missing `aria-labels` in two stories

## New Behavior

Moar `aria-label`s

## Related Issue(s)

- Fixes [ADO issue 1](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/24618) and [ADO issue 2](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/24615)
