### PR TITLE
ci: separate VRT pipelines in GHA compliant pattern for future enablement

### DIFF
--- a/.github/actions/run-publish-vr-screenshot/action.yml
+++ b/.github/actions/run-publish-vr-screenshot/action.yml
@@ -86,7 +86,6 @@ runs:
     # ==========================================================
     # STEPS BELOW WILL FAIL TO RUN ON GITHUB ACTIONS - see TODOs
     # ==========================================================
-
     # TODO: will need Federated Identity to be added to tool similarly like we have for monosize azure plugin https://github.com/microsoft/monosize/blob/main/packages/monosize-storage-azure/src/createTableClient.mts#L27
     - name: VR App - Create Policy
       if: ${{ env.isPR == 'true' }}
@@ -94,12 +93,12 @@ runs:
       run: |
         set -exuo pipefail
         npx vr-approval-cli@0.4.11 create-policy --nonBlockingPipelines '{"${{ env.pipelineId }}":{"pipelineStatus": "PENDING","pipelineName": "${{ env.pipelineName }}"}}' --clientType 'FLUENTUI'
-      env:
-        VR_APP_API_URL: ${{ secrets.VR_APP_API_URL }}
-        TENANT_ID: ${{ secrets.TenantId }}
-        PRINCIPAL_CLIENT_ID: ${{ secrets.PrincipalClientId }}
-        SERVICE_CONNECTION_ID: ${{ secrets.ServiceConnectionId }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # env:
+      # VR_APP_API_URL: ${{ secrets.VR_APP_API_URL }}
+      # TENANT_ID: ${{ secrets.TenantId }}
+      # PRINCIPAL_CLIENT_ID: ${{ secrets.PrincipalClientId }}
+      # SERVICE_CONNECTION_ID: ${{ secrets.ServiceConnectionId }}
+      # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     # TODO: will need azure/login@v2 to be added to the workflow {@ling file://./../../workflows/pr-website-deploy-comment.yml#49}
     - name: Run screenshotdiff
@@ -109,14 +108,14 @@ runs:
         # ciDefinitionId is set to 205 because that is the ID of the baseline pipeline (https://uifabric.visualstudio.com/fabricpublic/_build?definitionId=205) used by the master branch
         # TODO: not sure how this will be used on GHA cc @evancharlton @TristanWatanabe
         CI_DEFINITION_ID: 205
-        API_TOKEN: ${{ secrets.fabric-public-pipeline-access-PAT }}
-        GITHUB_API_TOKEN: ${{ secrets.githubRepoStatusPAT }}
-        VR_APP_API_URL: ${{ secrets.VR_APP_API_URL }}
-        STORAGE_ACCOUNT_ID: ${{ secrets.StorageAccountId }}
-        TENANT_ID: ${{ secrets.TenantId }}
-        PRINCIPAL_CLIENT_ID: ${{ secrets.PrincipalClientId }}
-        SERVICE_CONNECTION_ID: ${{ secrets.ServiceConnectionId }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # API_TOKEN: ${{ secrets.fabric-public-pipeline-access-PAT }}
+        # GITHUB_API_TOKEN: ${{ secrets.githubRepoStatusPAT }}
+        # VR_APP_API_URL: ${{ secrets.VR_APP_API_URL }}
+        # STORAGE_ACCOUNT_ID: ${{ secrets.StorageAccountId }}
+        # TENANT_ID: ${{ secrets.TenantId }}
+        # PRINCIPAL_CLIENT_ID: ${{ secrets.PrincipalClientId }}
+        # SERVICE_CONNECTION_ID: ${{ secrets.ServiceConnectionId }}
+        # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         azcliversion: latest
         inlineScript: |
@@ -126,15 +125,15 @@ runs:
     - name: Run screenshotdiff - update baseline (non PR)
       if: ${{ github.event_name != 'pull_request' }}
       uses: azure/cli@v2
-      env:
-        API_TOKEN: ${{ secrets.fabric-public-pipeline-access-PAT }}
-        GITHUB_API_TOKEN: ${{ secrets.githubRepoStatusPAT }}
-        VR_APP_API_URL: ${{ secrets.VR_APP_API_URL }}
-        STORAGE_ACCOUNT_ID: ${{ secrets.StorageAccountId }}
-        TENANT_ID: ${{ secrets.TenantId }}
-        PRINCIPAL_CLIENT_ID: ${{ secrets.PrincipalClientId }}
-        SERVICE_CONNECTION_ID: ${{ secrets.ServiceConnectionId }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # env:
+      # API_TOKEN: ${{ secrets.fabric-public-pipeline-access-PAT }}
+      # GITHUB_API_TOKEN: ${{ secrets.githubRepoStatusPAT }}
+      # VR_APP_API_URL: ${{ secrets.VR_APP_API_URL }}
+      # STORAGE_ACCOUNT_ID: ${{ secrets.StorageAccountId }}
+      # TENANT_ID: ${{ secrets.TenantId }}
+      # PRINCIPAL_CLIENT_ID: ${{ secrets.PrincipalClientId }}
+      # SERVICE_CONNECTION_ID: ${{ secrets.ServiceConnectionId }}
+      # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         azcliversion: latest
         inlineScript: |

--- a/.github/actions/run-publish-vr-screenshot/action.yml
+++ b/.github/actions/run-publish-vr-screenshot/action.yml
@@ -84,48 +84,51 @@ runs:
         path: screenshots
 
     # ==========================================================
-    # STEPS BELOW WILL FAIL TO RUN ON GITHUB ACTIONS - see TODOs
+    # STEPS BELOW WILL FAIL TO RUN ON GITHUB ACTIONS - see @TODOs
     # ==========================================================
-    # TODO: will need Federated Identity to be added to tool similarly like we have for monosize azure plugin https://github.com/microsoft/monosize/blob/main/packages/monosize-storage-azure/src/createTableClient.mts#L27
-    - name: VR App - Create Policy
-      if: ${{ env.isPR == 'true' && env.vrTestSkip == 'no' }}
-      shell: bash
-      run: |
-        set -exuo pipefail
-        npx vr-approval-cli@0.4.11 create-policy --nonBlockingPipelines '{"${{ env.pipelineId }}":{"pipelineStatus": "PENDING","pipelineName": "${{ env.pipelineName }}"}}' --clientType 'FLUENTUI'
-      # env:
-      # VR_APP_API_URL: ${{ secrets.VR_APP_API_URL }}
-      # TENANT_ID: ${{ secrets.TenantId }}
-      # PRINCIPAL_CLIENT_ID: ${{ secrets.PrincipalClientId }}
-      # SERVICE_CONNECTION_ID: ${{ secrets.ServiceConnectionId }}
-      # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    #
+    # @TODO: will need Federated Identity to be added to tool similarly like we have for monosize azure plugin https://github.com/microsoft/monosize/blob/main/packages/monosize-storage-azure/src/createTableClient.mts#L27
+    # - name: VR App - Create Policy
+    #   if: ${{ env.isPR == 'true' && env.vrTestSkip == 'no' }}
+    #   shell: bash
+    #   run: |
+    #     set -exuo pipefail
+    #     npx vr-approval-cli@0.4.11 create-policy --nonBlockingPipelines '{"${{ env.pipelineId }}":{"pipelineStatus": "PENDING","pipelineName": "${{ env.pipelineName }}"}}' --clientType 'FLUENTUI'
+    # env:
+    # VR_APP_API_URL: ${{ secrets.VR_APP_API_URL }}
+    # TENANT_ID: ${{ secrets.TenantId }}
+    # PRINCIPAL_CLIENT_ID: ${{ secrets.PrincipalClientId }}
+    # SERVICE_CONNECTION_ID: ${{ secrets.ServiceConnectionId }}
+    # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    # TODO: will need azure/login@v2 to be added to the workflow {@link file://./../../workflows/pr-website-deploy-comment.yml#49}
-    - name: Run screenshotdiff
-      if: ${{ env.isPR == 'true' && env.vrTestSkip == 'no' }}
-      uses: azure/cli@v2
-      env:
-        # ciDefinitionId is set to 205 because that is the ID of the baseline pipeline (https://uifabric.visualstudio.com/fabricpublic/_build?definitionId=205) used by the master branch
-        # TODO: not sure how this will be used on GHA cc @evancharlton @TristanWatanabe
-        CI_DEFINITION_ID: 205
-        # API_TOKEN: ${{ secrets.fabric-public-pipeline-access-PAT }}
-        # GITHUB_API_TOKEN: ${{ secrets.githubRepoStatusPAT }}
-        # VR_APP_API_URL: ${{ secrets.VR_APP_API_URL }}
-        # STORAGE_ACCOUNT_ID: ${{ secrets.StorageAccountId }}
-        # TENANT_ID: ${{ secrets.TenantId }}
-        # PRINCIPAL_CLIENT_ID: ${{ secrets.PrincipalClientId }}
-        # SERVICE_CONNECTION_ID: ${{ secrets.ServiceConnectionId }}
-        # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        azcliversion: latest
-        inlineScript: |
-          npx vr-approval-cli@0.4.11 run-diff --screenshotsDirectory ./screenshots --buildType pr --clientType "FLUENTUI" --ciDefinitionId ${{ env.CI_DEFINITION_ID }} --groupName ${{ env.pipelineName }} --locationPrefix ${{ inputs.locationPrefix }} --locationPostfix ${{ inputs.locationPostfix }} --pipelineId ${{ env.pipelineId }} --clientName ${{ inputs.clientName }} --threshold '0.04' --cumThreshold '1'
+    # @TODO: will need azure/login@v2 to be added to the workflow {@link file://./../../workflows/pr-website-deploy-comment.yml#49}
+    # - name: Run screenshotdiff
+    #   if: ${{ env.isPR == 'true' && env.vrTestSkip == 'no' }}
+    #   uses: azure/cli@v2
+    #   env:
+    # ciDefinitionId is set to 205 because that is the ID of the baseline pipeline (https://uifabric.visualstudio.com/fabricpublic/_build?definitionId=205) used by the master branch
+    # TODO: not sure how this will be used on GHA cc @evancharlton @TristanWatanabe
+    # CI_DEFINITION_ID: 205
+    # API_TOKEN: ${{ secrets.fabric-public-pipeline-access-PAT }}
+    # GITHUB_API_TOKEN: ${{ secrets.githubRepoStatusPAT }}
+    # VR_APP_API_URL: ${{ secrets.VR_APP_API_URL }}
+    # STORAGE_ACCOUNT_ID: ${{ secrets.StorageAccountId }}
+    # TENANT_ID: ${{ secrets.TenantId }}
+    # PRINCIPAL_CLIENT_ID: ${{ secrets.PrincipalClientId }}
+    # SERVICE_CONNECTION_ID: ${{ secrets.ServiceConnectionId }}
+    # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    # with:
+    #   azcliversion: latest
+    #   inlineScript: |
+    #     npx vr-approval-cli@0.4.11 run-diff --screenshotsDirectory ./screenshots --buildType pr --clientType "FLUENTUI" --ciDefinitionId ${{ env.CI_DEFINITION_ID }} --groupName ${{ env.pipelineName }} --locationPrefix ${{ inputs.locationPrefix }} --locationPostfix ${{ inputs.locationPostfix }} --pipelineId ${{ env.pipelineId }} --clientName ${{ inputs.clientName }} --threshold '0.04' --cumThreshold '1'
 
+    # ============
     # NON PR STEPS
+    # ============
 
-    # NOTE: this step runs via ADO from master branch only for now {@link file://./../../../azure-pipelines.vrt-baseline.yml }
+    # @NOTE: this step runs via ADO from master branch only for now {@link file://./../../../azure-pipelines.vrt-baseline.yml }
 
-    # TODO: will need azure/login@v2 to be added to the workflow {@link file://./../../workflows/pr-website-deploy-comment.yml#49}
+    # @TODO: will need azure/login@v2 to be added to the workflow {@link file://./../../workflows/pr-website-deploy-comment.yml#49}
     # - name: Run screenshotdiff - update baseline (non PR)
     # if: ${{ github.event_name != 'pull_request' }}
     # uses: azure/cli@v2

--- a/.github/actions/run-publish-vr-screenshot/action.yml
+++ b/.github/actions/run-publish-vr-screenshot/action.yml
@@ -88,7 +88,7 @@ runs:
     # ==========================================================
     # TODO: will need Federated Identity to be added to tool similarly like we have for monosize azure plugin https://github.com/microsoft/monosize/blob/main/packages/monosize-storage-azure/src/createTableClient.mts#L27
     - name: VR App - Create Policy
-      if: ${{ env.isPR == 'true' }}
+      if: ${{ env.isPR == 'true' && env.vrTestSkip == 'no' }}
       shell: bash
       run: |
         set -exuo pipefail
@@ -100,7 +100,7 @@ runs:
       # SERVICE_CONNECTION_ID: ${{ secrets.ServiceConnectionId }}
       # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    # TODO: will need azure/login@v2 to be added to the workflow {@ling file://./../../workflows/pr-website-deploy-comment.yml#49}
+    # TODO: will need azure/login@v2 to be added to the workflow {@link file://./../../workflows/pr-website-deploy-comment.yml#49}
     - name: Run screenshotdiff
       if: ${{ env.isPR == 'true' && env.vrTestSkip == 'no' }}
       uses: azure/cli@v2
@@ -121,20 +121,24 @@ runs:
         inlineScript: |
           npx vr-approval-cli@0.4.11 run-diff --screenshotsDirectory ./screenshots --buildType pr --clientType "FLUENTUI" --ciDefinitionId ${{ env.CI_DEFINITION_ID }} --groupName ${{ env.pipelineName }} --locationPrefix ${{ inputs.locationPrefix }} --locationPostfix ${{ inputs.locationPostfix }} --pipelineId ${{ env.pipelineId }} --clientName ${{ inputs.clientName }} --threshold '0.04' --cumThreshold '1'
 
-    # TODO: will need azure/login@v2 to be added to the workflow {@ling file://./../../workflows/pr-website-deploy-comment.yml#49}
-    - name: Run screenshotdiff - update baseline (non PR)
-      if: ${{ github.event_name != 'pull_request' }}
-      uses: azure/cli@v2
-      # env:
-      # API_TOKEN: ${{ secrets.fabric-public-pipeline-access-PAT }}
-      # GITHUB_API_TOKEN: ${{ secrets.githubRepoStatusPAT }}
-      # VR_APP_API_URL: ${{ secrets.VR_APP_API_URL }}
-      # STORAGE_ACCOUNT_ID: ${{ secrets.StorageAccountId }}
-      # TENANT_ID: ${{ secrets.TenantId }}
-      # PRINCIPAL_CLIENT_ID: ${{ secrets.PrincipalClientId }}
-      # SERVICE_CONNECTION_ID: ${{ secrets.ServiceConnectionId }}
-      # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        azcliversion: latest
-        inlineScript: |
-          npx vr-approval-cli@0.4.11 run-diff --buildType release --screenshotsDirectory ./screenshots --clientType "FLUENTUI" --locationPrefix ${{ inputs.locationPrefix }} --locationPostfix ${{ inputs.locationPostfix }} --pipelineId ${{ env.pipelineId }}
+    # NON PR STEPS
+
+    # NOTE: this step runs via ADO from master branch only for now {@link file://./../../../azure-pipelines.vrt-baseline.yml }
+
+    # TODO: will need azure/login@v2 to be added to the workflow {@link file://./../../workflows/pr-website-deploy-comment.yml#49}
+    # - name: Run screenshotdiff - update baseline (non PR)
+    # if: ${{ github.event_name != 'pull_request' }}
+    # uses: azure/cli@v2
+    # env:
+    # API_TOKEN: ${{ secrets.fabric-public-pipeline-access-PAT }}
+    # GITHUB_API_TOKEN: ${{ secrets.githubRepoStatusPAT }}
+    # VR_APP_API_URL: ${{ secrets.VR_APP_API_URL }}
+    # STORAGE_ACCOUNT_ID: ${{ secrets.StorageAccountId }}
+    # TENANT_ID: ${{ secrets.TenantId }}
+    # PRINCIPAL_CLIENT_ID: ${{ secrets.PrincipalClientId }}
+    # SERVICE_CONNECTION_ID: ${{ secrets.ServiceConnectionId }}
+    # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    # with:
+    #   azcliversion: latest
+    #   inlineScript: |
+    #     npx vr-approval-cli@0.4.11 run-diff --buildType release --screenshotsDirectory ./screenshots --clientType "FLUENTUI" --locationPrefix ${{ inputs.locationPrefix }} --locationPostfix ${{ inputs.locationPostfix }} --pipelineId ${{ env.pipelineId }}

--- a/.github/scripts/prepare-vr-screenshots-for-upload.js
+++ b/.github/scripts/prepare-vr-screenshots-for-upload.js
@@ -1,0 +1,36 @@
+// @ts-check
+
+const { join } = require('node:path');
+const { existsSync, cpSync, mkdirSync } = require('node:fs');
+const { createProjectGraphAsync } = require('@nx/devkit');
+
+module.exports = main;
+
+/**
+ *
+ * @param {import('../../scripts/triage-bot/src/types.ts').GithubScriptsParams & {config:{projects:string[]}} } options
+ * @returns
+ */
+async function main(options) {
+  const rootDir = 'screenshots';
+  const graph = await createProjectGraphAsync();
+
+  options.config.projects.forEach(project => {
+    const projectConfig = graph.nodes[project];
+    const screenshotsPath = join(projectConfig.data.root, 'dist/screenshots');
+
+    if (!existsSync(screenshotsPath)) {
+      return;
+    }
+
+    const destinationFolder = join(rootDir, project);
+
+    mkdirSync(destinationFolder, { recursive: true });
+
+    cpSync(screenshotsPath, destinationFolder, {
+      recursive: true,
+    });
+
+    console.info(`✅ ${screenshotsPath} contents copied to ${destinationFolder}`);
+  });
+}

--- a/.github/scripts/prepare-vr-screenshots-for-upload.js
+++ b/.github/scripts/prepare-vr-screenshots-for-upload.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 const { join } = require('node:path');
-const { existsSync, cpSync, mkdirSync } = require('node:fs');
+const { existsSync, cpSync, mkdirSync, writeFileSync } = require('node:fs');
 const { createProjectGraphAsync } = require('@nx/devkit');
 
 module.exports = main;
@@ -14,6 +14,11 @@ module.exports = main;
 async function main(options) {
   const rootDir = 'screenshots';
   const graph = await createProjectGraphAsync();
+
+  /**
+   * @type {{[project_name:string]:{path:string}}}
+   */
+  const report = {};
 
   options.config.projects.forEach(project => {
     const projectConfig = graph.nodes[project];
@@ -32,5 +37,10 @@ async function main(options) {
     });
 
     console.info(`✅ ${screenshotsPath} contents copied to ${destinationFolder}`);
+    report[project] = { path: project };
   });
+
+  writeFileSync(join(rootDir, 'screenshots-report.json'), JSON.stringify(report, null, 2));
+
+  return rootDir;
 }

--- a/.github/workflows/pr-vrt-comment.yml
+++ b/.github/workflows/pr-vrt-comment.yml
@@ -15,22 +15,24 @@ env:
   NX_PREFER_TS_NODE: true
   NX_VERBOSE_LOGGING: true
 
-permissions:
-  contents: 'read'
-  actions: 'read'
-
 jobs:
   run_vr_diff:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
     outputs:
       pr_number: ${{ steps.pr_number.outputs.result }}
+    permissions:
+      # necessary to write comments to the PR from the vr-approval-cli
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:
           sparse-checkout: |
             .github
 
+      # downloaded artifacts will contain screenshots from affected project including 'screenshots-report.json' which contains proper image mappings for affected project
+      # - see @{link file://./../scripts/prepare-vr-screenshots-for-upload.js#43}
+      # - see @{link file://./pr-vrt.yml#56}
       - uses: actions/download-artifact@v4
         with:
           name: vrscreenshot

--- a/.github/workflows/pr-vrt-comment.yml
+++ b/.github/workflows/pr-vrt-comment.yml
@@ -1,0 +1,145 @@
+name: VRT CI | Comment on PR
+on:
+  workflow_run:
+    workflows: ['VRT CI']
+    types:
+      - completed
+
+concurrency:
+  # see https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  NX_PARALLEL: 4 # ubuntu-latest = 4-core CPU / 16 GB of RAM | macos-14-xlarge (arm) = 6-core CPU / 14 GB of RAM
+  NX_PREFER_TS_NODE: true
+  NX_VERBOSE_LOGGING: true
+
+permissions:
+  contents: 'read'
+  actions: 'read'
+
+jobs:
+  run_vr_diff:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
+    outputs:
+      pr_number: ${{ steps.pr_number.outputs.result }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: vrscreenshot
+          path: ./screenshots
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: pr-number
+          path: ./results
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Load PR number
+        uses: actions/github-script@v7
+        id: pr_number
+        with:
+          script: |
+            const run = require('./.github/scripts/validate-pr-number');
+            const result = run({filePath:'results/pr.txt'});
+            return result;
+          result-encoding: string
+
+      - name: VR App - Create Policy
+        run: |
+          echo "MAKE THIS WORK"
+
+      - name: Run screenshotdiff
+        run: |
+          echo "MAKE THIS WORK"
+          npx vr-approval-cli@0.4.11 run-diff --screenshotsDirectory ./screenshots --buildType pr --clientType "FLUENTUI" --threshold '0.04' --cumThreshold '1'
+
+# 💡 NOTE:
+#   - following is manually provided setup used in previous ADO pipeline {@link file://./../../azure-pipelines.vrt-baseline.yml }
+#   - keeping for future reference
+
+# web_components:
+#   runs-on: ubuntu-latest
+#   env:
+#     pipelineId: '315'
+#     pipelineName: 'fluent-ui_VRT_Pipeline_web-components'
+#   steps:
+#     - uses: actions/checkout@v4
+#       with:
+#         fetch-depth: 0
+#     - name: Run and publish VR screenshot
+#       uses: ./.github/actions/run-publish-vr-screenshot
+#       with:
+#         fluentVersion: webcomponents
+#         vrTestPackageName: 'vr-tests-web-components'
+#         vrTestPackagePath: 'apps/vr-tests-web-components'
+#         locationPrefix: 'FluentUI-web-components'
+#         locationPostfix: 'vrscreenshotwebcomponents'
+#         clientName: 'fluentui-web-components-v3'
+
+# react_components:
+#   runs-on: ubuntu-latest
+#   env:
+#     pipelineId: '311'
+#     pipelineName: 'fluent-ui_VRT_Pipeline_v9'
+#   steps:
+#     - uses: actions/checkout@v4
+#       with:
+#         fetch-depth: 0
+#     - name: Run and publish VR screenshot
+#       uses: ./.github/actions/run-publish-vr-screenshot
+#       with:
+#         fluentVersion: v9
+#         vrTestPackageName: 'vr-tests-react-components'
+#         vrTestPackagePath: 'apps/vr-tests-react-components'
+#         locationPrefix: 'fluentuiv9'
+#         locationPostfix: 'vrscreenshotv9'
+#         clientName: 'fluentuiv9'
+
+# react:
+#   runs-on: ubuntu-latest
+#   env:
+#     pipelineId: '312'
+#     pipelineName: 'fluent-ui_VRT_Pipeline_v8'
+#   steps:
+#     - uses: actions/checkout@v4
+#       with:
+#         fetch-depth: 0
+#     - name: Run and publish VR screenshot
+#       uses: ./.github/actions/run-publish-vr-screenshot
+#       with:
+#         fluentVersion: v8
+#         vrTestPackageName: 'vr-tests'
+#         vrTestPackagePath: 'apps/vr-tests'
+#         locationPrefix: 'fluentuiv8'
+#         locationPostfix: 'vrscreenshotv8'
+#         clientName: 'fluentuiv8'
+
+# react_northstar:
+#   runs-on: ubuntu-latest
+#   env:
+#     pipelineId: '313'
+#     pipelineName: 'fluent-ui_VRT_Pipeline_v0'
+#   steps:
+#     - uses: actions/checkout@v4
+#       with:
+#         fetch-depth: 0
+#     - name: Run and publish VR screenshot
+#       uses: ./.github/actions/run-publish-vr-screenshot
+#       with:
+#         fluentVersion: v0
+#         vrTestPackageName: 'docs'
+#         vrTestPackagePath: 'packages/fluentui/docs'
+#         locationPrefix: 'FluentUI-v0'
+#         locationPostfix: 'vrscreenshotv0'
+#         clientName: 'FluentUIV0'

--- a/.github/workflows/pr-vrt.yml
+++ b/.github/workflows/pr-vrt.yml
@@ -1,9 +1,5 @@
 name: VRT CI
-
 on:
-  push:
-    branches:
-      - master
   pull_request:
 
 concurrency:
@@ -21,78 +17,52 @@ permissions:
   actions: 'read'
 
 jobs:
-  web_components:
+  generate_vrt_screenshots:
     runs-on: ubuntu-latest
-    env:
-      pipelineId: '315'
-      pipelineName: 'fluent-ui_VRT_Pipeline_web-components'
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Run and publish VR screenshot
-        uses: ./.github/actions/run-publish-vr-screenshot
-        with:
-          fluentVersion: webcomponents
-          vrTestPackageName: 'vr-tests-web-components'
-          vrTestPackagePath: 'apps/vr-tests-web-components'
-          locationPrefix: 'FluentUI-web-components'
-          locationPostfix: 'vrscreenshotwebcomponents'
-          clientName: 'fluentui-web-components-v3'
 
-  react_components:
-    runs-on: ubuntu-latest
-    env:
-      pipelineId: '311'
-      pipelineName: 'fluent-ui_VRT_Pipeline_v9'
-    steps:
-      - uses: actions/checkout@v4
+      - name: Derive appropriate SHAs for base and head for `nx affected` commands
+        uses: nrwl/nx-set-shas@v4
         with:
-          fetch-depth: 0
-      - name: Run and publish VR screenshot
-        uses: ./.github/actions/run-publish-vr-screenshot
-        with:
-          fluentVersion: v9
-          vrTestPackageName: 'vr-tests-react-components'
-          vrTestPackagePath: 'apps/vr-tests-react-components'
-          locationPrefix: 'fluentuiv9'
-          locationPostfix: 'vrscreenshotv9'
-          clientName: 'fluentuiv9'
+          main-branch-name: 'master'
 
-  react:
-    runs-on: ubuntu-latest
-    env:
-      pipelineId: '312'
-      pipelineName: 'fluent-ui_VRT_Pipeline_v8'
-    steps:
-      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          fetch-depth: 0
-      - name: Run and publish VR screenshot
-        uses: ./.github/actions/run-publish-vr-screenshot
-        with:
-          fluentVersion: v8
-          vrTestPackageName: 'vr-tests'
-          vrTestPackagePath: 'apps/vr-tests'
-          locationPrefix: 'fluentuiv8'
-          locationPostfix: 'vrscreenshotv8'
-          clientName: 'fluentuiv8'
+          cache: 'yarn'
+          node-version: '20'
 
-  react_northstar:
-    runs-on: ubuntu-latest
-    env:
-      pipelineId: '313'
-      pipelineName: 'fluent-ui_VRT_Pipeline_v0'
-    steps:
-      - uses: actions/checkout@v4
+      - run: yarn install --frozen-lockfile
+      - run: yarn playwright install --with-deps
+
+      - name: Run VR tests (generate screenshots)
+        run: yarn nx affected -t test-vr --nxBail
+
+      - name: Prepare VR screenshots
+        uses: actions/github-script@v7
         with:
-          fetch-depth: 0
-      - name: Run and publish VR screenshot
-        uses: ./.github/actions/run-publish-vr-screenshot
+          script: |
+            const run = require('./.github/scripts/prepare-vr-screenshots-for-upload');
+            const config = {
+              projects: ["vr-tests-web-components", "vr-tests-react-components", "vr-tests", "docs"]
+            };
+            await run({github,context,core,config});
+
+      - name: Upload VR screenshots
+        uses: actions/upload-artifact@v4
         with:
-          fluentVersion: v0
-          vrTestPackageName: 'docs'
-          vrTestPackagePath: 'packages/fluentui/docs'
-          locationPrefix: 'FluentUI-v0'
-          locationPostfix: 'vrscreenshotv0'
-          clientName: 'FluentUIV0'
+          name: vrscreenshot
+          retention-days: 1
+          path: screenshots
+
+      - name: Save PR number
+        run: echo ${{ github.event.number }} > pr.txt
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pr-number
+          retention-days: 1
+          if-no-files-found: error
+          path: |
+            pr.txt

--- a/.github/workflows/pr-vrt.yml
+++ b/.github/workflows/pr-vrt.yml
@@ -8,7 +8,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  NX_PARALLEL: 4 # ubuntu-latest = 4-core CPU / 16 GB of RAM | macos-14-xlarge (arm) = 6-core CPU / 14 GB of RAM
+  NX_PARALLEL: 6 # ubuntu-latest = 4-core CPU / 16 GB of RAM | macos-14-xlarge (arm) = 6-core CPU / 14 GB of RAM
   NX_PREFER_TS_NODE: true
   NX_VERBOSE_LOGGING: true
 
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   generate_vrt_screenshots:
-    runs-on: ubuntu-latest
+    runs-on: macos-14-xlarge
     steps:
       - uses: actions/checkout@v4
         with:
@@ -40,22 +40,25 @@ jobs:
       - name: Run VR tests (generate screenshots)
         run: yarn nx affected -t test-vr --nxBail
 
-      - name: Prepare VR screenshots
+      - name: Prepare VR screenshots for upload
         uses: actions/github-script@v7
+        id: screenshots_root
         with:
           script: |
             const run = require('./.github/scripts/prepare-vr-screenshots-for-upload');
             const config = {
-              projects: ["vr-tests-web-components", "vr-tests-react-components", "vr-tests", "docs"]
+              projects: ['vr-tests-web-components', 'vr-tests-react-components', 'vr-tests', 'docs']
             };
-            await run({github,context,core,config});
+            const result = await run({github,context,core,config});
+            return result;
+          result-encoding: string
 
       - name: Upload VR screenshots
         uses: actions/upload-artifact@v4
         with:
           name: vrscreenshot
           retention-days: 1
-          path: screenshots
+          path: ${{steps.screenshots_root.outputs.result}}
 
       - name: Save PR number
         run: echo ${{ github.event.number }} > pr.txt


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

> **💡 NOTE:** both of these pipelines will be disabled until we have compliant vrt tooling 

Splits/Implements VRT pipelines in 2 to follow GHA pattern on forks for future enablement.

1. generating screenshots on affected projects on Forks (works after merge)

<img width="815" alt="image" src="https://github.com/user-attachments/assets/858a241c-f5e8-46f6-8e99-75a8abe6bcac" />

2. running vrt diffing and commenting  from master branch (doesn't work untill we have new vrt diff tool)

**Out of scope:**

- updating baseline screenshot diffs 
  - we can/will use ADO pipeline for now from master (no Forks)

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows https://github.com/microsoft/fluentui/pull/33070
