### PR TITLE
chore: make cxe-red the owner of react-experiments

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -430,6 +430,7 @@ packages/react/src/components/WeeklyDayPicker @microsoft/cxe-red
 packages/react/src/utilities/ThemeProvider @microsoft/cxe-red @dzearing
 packages/fluent2-theme @microsoft/cxe-red @geoffcoxmsft
 ## Experiments
+packages/react-experiments @microsoft/cxe-red
 packages/react-experiments/src/components/Signals @ThomasMichon
 packages/react-experiments/src/components/Tile @ThomasMichon
 packages/react-experiments/src/components/TileList @ThomasMichon


### PR DESCRIPTION
Right now, we have no owner for `@fluentui/react-experiments`, and changes to `@fluentui/react` semi-regularly cause snapshot updates in that package, which then requires a review from fluentui-admins. It seems to make sense to put this under `cxe-red` along with react and react-examples.

Chatted about this briefly in Teams chat as well.