### PR TITLE
[NO-MERGE]: Disable tabster for SwatchPicker

### DIFF
--- a/packages/react-components/react-swatch-picker/library/src/components/SwatchPicker/useSwatchPicker.ts
+++ b/packages/react-components/react-swatch-picker/library/src/components/SwatchPicker/useSwatchPicker.ts
@@ -1,7 +1,6 @@
 import * as React from 'react';
 
 import { useFieldControlProps_unstable } from '@fluentui/react-field';
-import { useArrowNavigationGroup } from '@fluentui/react-tabster';
 import { getIntrinsicElementProps, useControllableState, useEventCallback, slot } from '@fluentui/react-utilities';
 
 import type { SwatchPickerProps, SwatchPickerState } from './SwatchPicker.types';
@@ -25,12 +24,6 @@ export const useSwatchPicker_unstable = (
   const { layout, onSelectionChange, size = 'medium', shape, spacing = 'medium', style, ...rest } = props;
 
   const isGrid = layout === 'grid';
-  const focusAttributes = useArrowNavigationGroup({
-    circular: true,
-    axis: isGrid ? 'grid-linear' : 'both',
-    memorizeCurrent: true,
-  });
-
   const role = isGrid ? 'grid' : 'radiogroup';
 
   const [selectedValue, setSelectedValue] = useControllableState({
@@ -57,7 +50,6 @@ export const useSwatchPicker_unstable = (
       getIntrinsicElementProps('div', {
         ref,
         role,
-        ...focusAttributes,
         ...rest,
       }),
       { elementType: 'div' },

--- a/packages/react-components/react-tooltip/library/etc/react-tooltip.api.md
+++ b/packages/react-components/react-tooltip/library/etc/react-tooltip.api.md
@@ -56,7 +56,7 @@ export type TooltipState = ComponentState<TooltipSlots> & Pick<TooltipProps, 'mo
 // @public
 export type TooltipTriggerProps = {
     ref?: React_2.Ref<unknown>;
-} & Pick<React_2.HTMLAttributes<HTMLElement>, 'aria-describedby' | 'aria-label' | 'aria-labelledby' | 'onBlur' | 'onFocus' | 'onPointerEnter' | 'onPointerLeave'>;
+} & Pick<React_2.HTMLAttributes<HTMLElement>, 'aria-describedby' | 'aria-label' | 'aria-labelledby' | 'onBlur' | 'onFocus' | 'onPointerEnter' | 'onPointerLeave' | 'aria-haspopup' | 'aria-expanded'>;
 
 // @public
 export const useTooltip_unstable: (props: TooltipProps) => TooltipState;


### PR DESCRIPTION
This is PR to help partners to find an issue with tooltips