### PR TITLE
[fix](motion-comopnents): Updates API.md

### DIFF
--- a/change/@fluentui-react-motion-components-preview-18de7e14-2257-4cec-b90a-4b68c838c706.json
+++ b/change/@fluentui-react-motion-components-preview-18de7e14-2257-4cec-b90a-4b68c838c706.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Api.md update only",
+  "packageName": "@fluentui/react-motion-components-preview",
+  "email": "matejera@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-motion-components-preview/library/etc/react-motion-components-preview.api.md
+++ b/packages/react-components/react-motion-components-preview/library/etc/react-motion-components-preview.api.md
@@ -37,6 +37,9 @@ export const createCollapsePresence: PresenceMotionFnCreator<CollapseVariantPara
 export const createFadePresence: PresenceMotionCreator<FadeVariantParams>;
 
 // @public
+export const createScalePresence: PresenceMotionFnCreator<ScaleVariantParams_unstable, ScaleRuntimeParams_unstable>;
+
+// @public
 export const Fade: PresenceComponent<    {}>;
 
 // @public (undocumented)
@@ -46,19 +49,13 @@ export const FadeRelaxed: PresenceComponent<    {}>;
 export const FadeSnappy: PresenceComponent<    {}>;
 
 // @public
-export const Scale: PresenceComponent<    {
-animateOpacity?: boolean | undefined;
-}>;
+export const Scale: PresenceComponent<ScaleRuntimeParams_unstable>;
 
 // @public (undocumented)
-export const ScaleRelaxed: PresenceComponent<    {
-animateOpacity?: boolean | undefined;
-}>;
+export const ScaleRelaxed: PresenceComponent<ScaleRuntimeParams_unstable>;
 
 // @public (undocumented)
-export const ScaleSnappy: PresenceComponent<    {
-animateOpacity?: boolean | undefined;
-}>;
+export const ScaleSnappy: PresenceComponent<ScaleRuntimeParams_unstable>;
 
 // (No @packageDocumentation comment for this package)
 


### PR DESCRIPTION
It looks like [this PR](https://github.com/microsoft/fluentui/commit/80f2ce07be06e66b369bd18e4484d8faf6b493c7) did not include an API.md file despite changing the type definition.

This means someone making new changes and generating API.md files for their changes will also get this file.

This PR isolates it to a dedicated PR without cluttering other's environments.