### PR TITLE
fix(react-tabs): update tab border color to fix issues in high contrast mode

### DIFF
--- a/change/@fluentui-react-tabs-9ce35d6f-27b5-451e-aa6f-d2902a97787b.json
+++ b/change/@fluentui-react-tabs-9ce35d6f-27b5-451e-aa6f-d2902a97787b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: update tab border color for better visibility in high contrast mode",
+  "packageName": "@fluentui/react-tabs",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tabs/library/src/components/Tab/useTabStyles.styles.ts
+++ b/packages/react-components/react-tabs/library/src/components/Tab/useTabStyles.styles.ts
@@ -190,7 +190,7 @@ const useCircularAppearanceStyles = makeStyles({
   },
   subtle: {
     backgroundColor: tokens.colorSubtleBackground,
-    border: `solid ${tokens.strokeWidthThin} ${tokens.colorTransparentStroke}`,
+    border: `solid ${tokens.strokeWidthThin} transparent`,
     color: tokens.colorNeutralForeground2,
     ':enabled:hover': {
       backgroundColor: tokens.colorSubtleBackgroundHover,
@@ -221,7 +221,7 @@ const useCircularAppearanceStyles = makeStyles({
   subtleDisabled: {
     backgroundColor: tokens.colorSubtleBackground,
     color: tokens.colorNeutralForegroundDisabled,
-    border: `solid ${tokens.strokeWidthThin} ${tokens.colorTransparentStroke}`,
+    border: `solid ${tokens.strokeWidthThin} transparent`,
   },
   subtleDisabledSelected: {
     backgroundColor: tokens.colorNeutralBackgroundDisabled,
@@ -254,7 +254,7 @@ const useCircularAppearanceStyles = makeStyles({
   },
   filledDisabled: {
     backgroundColor: tokens.colorNeutralBackgroundDisabled,
-    border: `solid ${tokens.strokeWidthThin} ${tokens.colorTransparentStroke}`,
+    border: `solid ${tokens.strokeWidthThin} transparent`,
     color: tokens.colorNeutralForegroundDisabled,
   },
   filledDisabledSelected: {


### PR DESCRIPTION
## Previous Behavior

Tabs with `subtle-circular` and `filled-circular` appearance variants have a colored border in HC mode, making it difficult to distinguish between selected and unselected states.

![image](https://github.com/user-attachments/assets/67682185-523c-476b-8867-04cdfd7e1569)

This issue arises because the `tokens.colorTransparentStroke` value is not `transparent` in HC mode. 

## New Behavior

Tabs with `subtle-circular` and `filled-circular` appearance variants now have a transparent border for all themes including HC mode.

![image](https://github.com/user-attachments/assets/6270b076-0953-4bf2-99e2-c11b9819762d)

## Related Issue(s)

- Fixes #33516
