### PR TITLE
Fix typo in ToolbarSmall story

### DIFF
--- a/packages/react-components/react-toolbar/stories/src/Toolbar/ToolbarSmall.stories.tsx
+++ b/packages/react-components/react-toolbar/stories/src/Toolbar/ToolbarSmall.stories.tsx
@@ -24,7 +24,7 @@ Small.parameters = {
     description: {
       story: [
         'The size determines the spacing around the toolbar controls.',
-        'A small sized toolbar has no vertical padding and uses 20px for horizontal padding.',
+        'A small sized toolbar has no vertical padding and uses 4px for horizontal padding.',
       ].join('\n'),
     },
   },


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->


## Previous Behavior

<!-- This is the behavior we have today -->

![image](https://github.com/user-attachments/assets/7f5b975e-ec67-4cc2-8393-92dcb5149709)

Docs mention the wrong padding for small size toolbar: 20px

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
Docs mention the correct padding applied: 4px

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #33574 
