### PR TITLE
fix(react-toolbar): use contrasting token pairs for radio & toggle selected states

### DIFF
--- a/change/@fluentui-react-toolbar-8bb342b8-9cdc-4d1c-83e9-718c59bf4ef9.json
+++ b/change/@fluentui-react-toolbar-8bb342b8-9cdc-4d1c-83e9-718c59bf4ef9.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "fix: use contrasting token pairs for selected radio and toggle states",
+  "packageName": "@fluentui/react-toolbar",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarRadioButton/useToolbarRadioButtonStyles.styles.ts
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarRadioButton/useToolbarRadioButtonStyles.styles.ts
@@ -4,8 +4,14 @@ import { useToggleButtonStyles_unstable } from '@fluentui/react-button';
 import { ToolbarRadioButtonState } from './ToolbarRadioButton.types';
 
 const useBaseStyles = makeStyles({
+  /* use subtle ToggleButton selected styles for Toolbar Radio selected state */
   selected: {
-    color: tokens.colorBrandForeground1,
+    backgroundColor: tokens.colorSubtleBackgroundSelected,
+    color: tokens.colorNeutralForeground2Selected,
+  },
+
+  iconSelected: {
+    color: tokens.colorNeutralForeground2BrandSelected,
   },
 });
 
@@ -19,6 +25,10 @@ export const useToolbarRadioButtonStyles_unstable = (state: ToolbarRadioButtonSt
   const toggleButtonStyles = useBaseStyles();
 
   state.root.className = mergeClasses(state.root.className, state.checked && toggleButtonStyles.selected);
+
+  if (state.icon) {
+    state.icon.className = mergeClasses(state.icon.className, state.checked && toggleButtonStyles.iconSelected);
+  }
 
   return state;
 };

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarToggleButton/useToolbarToggleButtonStyles.styles.ts
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarToggleButton/useToolbarToggleButtonStyles.styles.ts
@@ -4,8 +4,14 @@ import { useToggleButtonStyles_unstable } from '@fluentui/react-button';
 import { ToolbarToggleButtonState } from './ToolbarToggleButton.types';
 
 const useBaseStyles = makeStyles({
+  /* use subtle ToggleButton selected styles for Toolbar Radio selected state */
   selected: {
-    color: tokens.colorBrandForeground1,
+    backgroundColor: tokens.colorSubtleBackgroundSelected,
+    color: tokens.colorNeutralForeground2Selected,
+  },
+
+  iconSelected: {
+    color: tokens.colorNeutralForeground2BrandSelected,
   },
 });
 
@@ -19,6 +25,10 @@ export const useToolbarToggleButtonStyles_unstable = (state: ToolbarToggleButton
   const toggleButtonStyles = useBaseStyles();
 
   state.root.className = mergeClasses(state.root.className, state.checked && toggleButtonStyles.selected);
+
+  if (state.icon) {
+    state.icon.className = mergeClasses(state.icon.className, state.checked && toggleButtonStyles.iconSelected);
+  }
 
   return state;
 };


### PR DESCRIPTION
## Previous Behavior

We overrode the color for the selected state for the Radio & ToggleButton Toolbar variants, otherwise using all styles from ToggleButton. Overriding just the selected color value meant that the color/background token pair was not a pair with guaranteed contrast, which caused the Teams high contrast theme to fail contrast checks in that state.

In Teams high contrast:
<img width="129" alt="Screenshot of the Teams high contrast theme showing a white icon on a light blue background" src="https://github.com/user-attachments/assets/e7ca8895-7674-4cf3-8b94-f3d56f9cf950" />

## New Behavior

After chatting with design, we decided to go with adopting the subtle variant of the ToggleButton's styles for the selected state for radio & toggle Toolbar buttons.

New colors in teams high contrast:
<img width="133" alt="Screenshot of the same button with a black icon on a light blue background" src="https://github.com/user-attachments/assets/67453a18-1c96-4ccc-ab63-04a9e9422cdf" />

The other themes end up with the same hex values, so there is no visible change.

## Related Issue(s)

- Fixes [ADO issue](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/24803)
