### PR TITLE
ci:prevent running pipelines on forks

### DIFF
--- a/.github/workflows/azure-static-web-apps-deploy.yml
+++ b/.github/workflows/azure-static-web-apps-deploy.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   build_and_deploy:
+    if: ${{ github.repository_owner == 'microsoft' }}
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:

--- a/.github/workflows/bundle-size-base.yml
+++ b/.github/workflows/bundle-size-base.yml
@@ -18,6 +18,7 @@ env:
 
 jobs:
   bundle-size-base:
+    if: ${{ github.repository_owner == 'microsoft' }}
     # TODO: use macos-14-xlarge (arm) for faster builds once https://github.com/Azure/cli/issues/172 will be fixed
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/bundle-size-comment.yml
+++ b/.github/workflows/bundle-size-comment.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   comment:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.repository_owner == 'microsoft' }} && ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -16,6 +16,7 @@ env:
 
 jobs:
   bundle-size:
+    if: ${{ github.repository_owner == 'microsoft' }}
     runs-on: macos-14-xlarge
     permissions:
       contents: 'read'

--- a/.github/workflows/check-packages.yml
+++ b/.github/workflows/check-packages.yml
@@ -5,6 +5,7 @@ on:
 jobs:
   dependency-deduplication:
     runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'microsoft' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -37,6 +38,7 @@ jobs:
 
   dependency-mismatches:
     runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'microsoft' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -63,6 +65,7 @@ jobs:
 
   change-files:
     runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'microsoft' }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/check-tooling.yml
+++ b/.github/workflows/check-tooling.yml
@@ -14,6 +14,7 @@ env:
 
 jobs:
   check-tools:
+    if: ${{ github.repository_owner == 'microsoft' }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]

--- a/.github/workflows/create-milestone.yml
+++ b/.github/workflows/create-milestone.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   create-milestone:
+    if: ${{ github.repository_owner == 'microsoft' }}
     name: Create this month's milestone
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/docsite-publish-ghpages.yml
+++ b/.github/workflows/docsite-publish-ghpages.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
-    if: ${{ contains(github.event.head_commit.message, 'applying package updates') || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.repository_owner == 'microsoft' }} && ${{ contains(github.event.head_commit.message, 'applying package updates') || github.event_name == 'workflow_dispatch' }}
 
     outputs:
       status: ${{ steps.verify-react-components-changed.outputs.any_changed == 'true' || github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/pr-housekeeping.yml
+++ b/.github/workflows/pr-housekeeping.yml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   label:
+    if: ${{ github.repository_owner == 'microsoft' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@v5
@@ -18,6 +19,7 @@ jobs:
           configuration-path: .github/labeler.yml
 
   assign-to-current-milestone:
+    if: ${{ github.repository_owner == 'microsoft' }}
     runs-on: ubuntu-latest
     steps:
       - name: Assign to latest milestone

--- a/.github/workflows/pr-vrt-comment.yml
+++ b/.github/workflows/pr-vrt-comment.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   run_vr_diff:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.repository_owner == 'microsoft' }} && ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
     outputs:
       pr_number: ${{ steps.pr_number.outputs.result }}
     permissions:

--- a/.github/workflows/pr-vrt.yml
+++ b/.github/workflows/pr-vrt.yml
@@ -18,6 +18,7 @@ permissions:
 
 jobs:
   generate_vrt_screenshots:
+    if: ${{ github.repository_owner == 'microsoft' }}
     runs-on: macos-14-xlarge
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pr-website-deploy-comment.yml
+++ b/.github/workflows/pr-website-deploy-comment.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.repository_owner == 'microsoft' }} && ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
     outputs:
       pr_number: ${{ steps.pr_number.outputs.result }}
       website_url: ${{ steps.website_url.outputs.id }}

--- a/.github/workflows/pr-website-deploy.yml
+++ b/.github/workflows/pr-website-deploy.yml
@@ -16,6 +16,7 @@ env:
 
 jobs:
   bundle:
+    if: ${{ github.repository_owner == 'microsoft' }}
     runs-on: macos-14-xlarge
     permissions:
       contents: 'read'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,6 +23,7 @@ env:
 
 jobs:
   main:
+    if: ${{ github.repository_owner == 'microsoft' }}
     runs-on: macos-14-xlarge
     permissions:
       contents: 'read'
@@ -81,6 +82,7 @@ jobs:
           git diff-index --quiet HEAD -- || exit 1
 
   e2e:
+    if: ${{ github.repository_owner == 'microsoft' }}
     # TODO: switch to macos once problematic tests are fixed
     # https://github.com/microsoft/fluentui/issues/33173
     # https://github.com/microsoft/fluentui/issues/33172


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

our pipelines are triggered in forks which is unwanted behaviour

## New Behavior

CI pipelines run only on PR's against origin repo or workflows triggered within origin

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
