### PR TITLE
fix: radio-group emit change with keyboard and disabled radio unchecks

### DIFF
--- a/change/@fluentui-web-components-fc912571-691c-494a-b4de-9a632a76a26c.json
+++ b/change/@fluentui-web-components-fc912571-691c-494a-b4de-9a632a76a26c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: radio-group emit change with keyboard and disabled radio unchecks",
+  "packageName": "@fluentui/web-components",
+  "email": "jes@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/docs/api-report.md
+++ b/packages/web-components/docs/api-report.md
@@ -4194,6 +4194,30 @@ export const ValidationFlags: {
 // @public (undocumented)
 export type ValidationFlags = ValuesOf<typeof ValidationFlags>;
 
+// @public
+export const zIndexBackground = "var(--zIndexBackground)";
+
+// @public
+export const zIndexContent = "var(--zIndexContent)";
+
+// @public
+export const zIndexDebug = "var(--zIndexDebug)";
+
+// @public
+export const zIndexFloating = "var(--zIndexFloating)";
+
+// @public
+export const zIndexMessages = "var(--zIndexMessages)";
+
+// @public
+export const zIndexOverlay = "var(--zIndexOverlay)";
+
+// @public
+export const zIndexPopup = "var(--zIndexPopup)";
+
+// @public
+export const zIndexPriority = "var(--zIndexPriority)";
+
 // Warnings were encountered during analysis:
 //
 // dist/dts/accordion-item/accordion-item.d.ts:11:5 - (ae-forgotten-export) The symbol "StaticallyComposableHTML" needs to be exported by the entry point index.d.ts

--- a/packages/web-components/docs/api-report.md
+++ b/packages/web-components/docs/api-report.md
@@ -3045,7 +3045,7 @@ export class RadioGroup extends FASTElement {
     // @internal
     protected checkedIndexChanged(prev: number | undefined, next: number): void;
     // @internal
-    checkRadio(index?: number): void;
+    checkRadio(index?: number, shouldEmit?: boolean): void;
     checkValidity(): boolean;
     // @internal
     clickHandler(e: MouseEvent): boolean | void;
@@ -4193,30 +4193,6 @@ export const ValidationFlags: {
 
 // @public (undocumented)
 export type ValidationFlags = ValuesOf<typeof ValidationFlags>;
-
-// @public
-export const zIndexBackground = "var(--zIndexBackground)";
-
-// @public
-export const zIndexContent = "var(--zIndexContent)";
-
-// @public
-export const zIndexDebug = "var(--zIndexDebug)";
-
-// @public
-export const zIndexFloating = "var(--zIndexFloating)";
-
-// @public
-export const zIndexMessages = "var(--zIndexMessages)";
-
-// @public
-export const zIndexOverlay = "var(--zIndexOverlay)";
-
-// @public
-export const zIndexPopup = "var(--zIndexPopup)";
-
-// @public
-export const zIndexPriority = "var(--zIndexPriority)";
 
 // Warnings were encountered during analysis:
 //

--- a/packages/web-components/src/radio-group/radio-group.spec.ts
+++ b/packages/web-components/src/radio-group/radio-group.spec.ts
@@ -249,9 +249,6 @@ test.describe('RadioGroup', () => {
 
     await radios.nth(0).evaluate((node: Radio) => {
       node.checked = true;
-    });
-
-    await radios.nth(0).evaluate((node: Radio) => {
       node.disabled = true;
     });
 

--- a/packages/web-components/src/radio-group/radio-group.spec.ts
+++ b/packages/web-components/src/radio-group/radio-group.spec.ts
@@ -233,7 +233,9 @@ test.describe('RadioGroup', () => {
     await expect(radios.nth(2)).toHaveJSProperty('checked', false);
   });
 
-  test('radio should remain checked after it is set to disabled and uncheck when a new radio is checked', async ({ page }) => {
+  test('radio should remain checked after it is set to disabled and uncheck when a new radio is checked', async ({
+    page,
+  }) => {
     const element = page.locator('fluent-radio-group');
     const radios = element.locator('fluent-radio');
 
@@ -278,18 +280,17 @@ test.describe('RadioGroup', () => {
       </fluent-radio-group>
     `);
 
-      const wasChanged = element.evaluate((node: RadioGroup) => {
-        return new Promise(resolve => {
-          node.addEventListener('change', () => resolve(true), { once: true })
-        });
+    const wasChanged = element.evaluate((node: RadioGroup) => {
+      return new Promise(resolve => {
+        node.addEventListener('change', () => resolve(true), { once: true });
       });
-
-      await radios.nth(1).click();
-      await page.keyboard.press('Tab');
-      await page.keyboard.press('ArrowRight');
-      await expect(wasChanged).resolves.toBeTruthy();
     });
 
+    await radios.nth(1).click();
+    await page.keyboard.press('Tab');
+    await page.keyboard.press('ArrowRight');
+    await expect(wasChanged).resolves.toBeTruthy();
+  });
 
   // @FIXME: This test is failing on OSX - https://github.com/microsoft/fluentui/issues/33172
   test.skip('should set a child radio with a matching `value` to `checked` when value changes', async ({ page }) => {

--- a/packages/web-components/src/radio-group/radio-group.spec.ts
+++ b/packages/web-components/src/radio-group/radio-group.spec.ts
@@ -233,6 +233,64 @@ test.describe('RadioGroup', () => {
     await expect(radios.nth(2)).toHaveJSProperty('checked', false);
   });
 
+  test('radio should remain checked after it is set to disabled and uncheck when a new radio is checked', async ({ page }) => {
+    const element = page.locator('fluent-radio-group');
+    const radios = element.locator('fluent-radio');
+
+    await page.setContent(/* html */ `
+      <fluent-radio-group>
+        <fluent-radio id="radio-1" name="radio" value="foo"></fluent-radio>
+        <fluent-radio id="radio-2" name="radio" value="bar"></fluent-radio>
+        <fluent-radio id="radio-3" name="radio" value="baz"></fluent-radio>
+      </fluent-radio-group>
+    `);
+
+    await radios.nth(0).evaluate((node: Radio) => {
+      node.checked = true;
+    });
+
+    await radios.nth(0).evaluate((node: Radio) => {
+      node.disabled = true;
+    });
+
+    await expect(radios.nth(0)).toHaveJSProperty('checked', true);
+
+    await radios.nth(1).click();
+
+    await expect(radios.nth(1)).toBeFocused();
+
+    await page.keyboard.press('ArrowRight');
+
+    await expect(radios.nth(0)).toHaveJSProperty('checked', false);
+    await expect(radios.nth(1)).toHaveJSProperty('checked', false);
+    await expect(radios.nth(2)).toHaveJSProperty('checked', true);
+  });
+
+  test('should emit `change` event when using keyboard', async ({ page }) => {
+    const element = page.locator('fluent-radio-group');
+    const radios = element.locator('fluent-radio');
+
+    await page.setContent(/* html */ `
+      <fluent-radio-group>
+        <fluent-radio id="radio-1" name="radio" value="foo"></fluent-radio>
+        <fluent-radio id="radio-2" name="radio" value="bar"></fluent-radio>
+        <fluent-radio id="radio-3" name="radio" value="baz"></fluent-radio>
+      </fluent-radio-group>
+    `);
+
+      const wasChanged = element.evaluate((node: RadioGroup) => {
+        return new Promise(resolve => {
+          node.addEventListener('change', () => resolve(true), { once: true })
+        });
+      });
+
+      await radios.nth(1).click();
+      await page.keyboard.press('Tab');
+      await page.keyboard.press('ArrowRight');
+      await expect(wasChanged).resolves.toBeTruthy();
+    });
+
+
   // @FIXME: This test is failing on OSX - https://github.com/microsoft/fluentui/issues/33172
   test.skip('should set a child radio with a matching `value` to `checked` when value changes', async ({ page }) => {
     const element = page.locator('fluent-radio-group');

--- a/packages/web-components/src/radio-group/radio-group.stories.ts
+++ b/packages/web-components/src/radio-group/radio-group.stories.ts
@@ -204,7 +204,7 @@ export const DisabledItems: Story = {
   },
 };
 
-export const DisabledAndChheckedItem: Story = {
+export const DisabledAndCheckedItem: Story = {
   args: {
     orientation: RadioGroupOrientation.vertical,
     id: 'radio-group-disabled-and-checked-item',

--- a/packages/web-components/src/radio-group/radio-group.stories.ts
+++ b/packages/web-components/src/radio-group/radio-group.stories.ts
@@ -204,6 +204,49 @@ export const DisabledItems: Story = {
   },
 };
 
+export const DisabledAndChheckedItem: Story = {
+  args: {
+    orientation: RadioGroupOrientation.vertical,
+    id: 'radio-group-disabled-and-checked-item',
+    value: 'pear',
+    defaultSlotContent: () => html`
+      ${repeat(
+        [
+          {
+            labelSlottedContent: () => html`<label slot="label">Apple</label>`,
+            value: 'apple',
+            disabled: true,
+          },
+          {
+            labelSlottedContent: () => html`<label slot="label">Pear</label>`,
+            value: 'pear',
+            disabled: true,
+          },
+          {
+            labelSlottedContent: () => html`<label slot="label">Banana</label>`,
+            value: 'banana',
+            disabled: true,
+          },
+          {
+            labelSlottedContent: () => html`<label slot="label">Orange</label>`,
+            value: 'orange',
+          },
+          {
+            labelSlottedContent: () => html`<label slot="label">Grape</label>`,
+            value: 'grape',
+          },
+          {
+            labelSlottedContent: () => html`<label slot="label">Kiwi</label>`,
+            value: 'kiwi',
+            disabled: true,
+          },
+        ],
+        radioFieldTemplate,
+      )}
+    `,
+  },
+};
+
 export const Required: Story = {
   render: renderComponent(html<StoryArgs<FluentRadioGroup>>`
     <form

--- a/packages/web-components/src/radio-group/radio-group.ts
+++ b/packages/web-components/src/radio-group/radio-group.ts
@@ -321,6 +321,9 @@ export class RadioGroup extends FASTElement {
     this.dirtyState = true;
     const radioIndex = this.enabledRadios.indexOf(e.target as Radio);
     this.checkRadio(radioIndex);
+    this.radios?.filter(x => x.disabled)?.forEach((item) => {
+      item.checked = false;
+    })
     return true;
   }
 
@@ -330,7 +333,7 @@ export class RadioGroup extends FASTElement {
    * @param index - the index of the radio to check
    * @internal
    */
-  public checkRadio(index: number = this.checkedIndex): void {
+  public checkRadio(index: number = this.checkedIndex, shouldEmit: boolean = false): void {
     let checkedIndex = this.checkedIndex;
 
     this.enabledRadios.forEach((item, i) => {
@@ -338,6 +341,9 @@ export class RadioGroup extends FASTElement {
       item.checked = shouldCheck;
       if (shouldCheck) {
         checkedIndex = i;
+        if(shouldEmit) {
+          item.$emit("change");
+        }
       }
     });
 
@@ -480,7 +486,7 @@ export class RadioGroup extends FASTElement {
     }
 
     const nextIndex = checkedIndex + increment;
-    this.checkedIndex = this.getEnabledIndexInBounds(nextIndex);
+    this.checkRadio(this.getEnabledIndexInBounds(nextIndex), true);
     this.enabledRadios[this.checkedIndex]?.focus();
   }
 

--- a/packages/web-components/src/radio-group/radio-group.ts
+++ b/packages/web-components/src/radio-group/radio-group.ts
@@ -321,9 +321,11 @@ export class RadioGroup extends FASTElement {
     this.dirtyState = true;
     const radioIndex = this.enabledRadios.indexOf(e.target as Radio);
     this.checkRadio(radioIndex);
-    this.radios?.filter(x => x.disabled)?.forEach((item) => {
-      item.checked = false;
-    })
+    this.radios
+      ?.filter(x => x.disabled)
+      ?.forEach(item => {
+        item.checked = false;
+      });
     return true;
   }
 
@@ -341,8 +343,8 @@ export class RadioGroup extends FASTElement {
       item.checked = shouldCheck;
       if (shouldCheck) {
         checkedIndex = i;
-        if(shouldEmit) {
-          item.$emit("change");
+        if (shouldEmit) {
+          item.$emit('change');
         }
       }
     });

--- a/packages/web-components/src/radio/radio.ts
+++ b/packages/web-components/src/radio/radio.ts
@@ -33,7 +33,6 @@ export class Radio extends BaseCheckbox {
   protected disabledChanged(prev: boolean | undefined, next: boolean | undefined): void {
     super.disabledChanged(prev, next);
     if (next) {
-      this.checked = false;
       this.tabIndex = -1;
     }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

When setting `radio` to disabled the radio would set checked to false. This does not behave how native radios work. However the reason we were doing this is because is the radio was checked and disabled there was no way to tab into the radio-group (this bug is also present in native radio-groups).

When navigating within `radio-group` via keyboard the change event was not being emitted

## New Behavior

Setting disabled to a checked radio no longer unchecks the radio. However, when a user tabs into the radio-group the first nondisabled radio will get focus. This is a best of both worlds' scenario, allowing the checked and disabled state but also not breaking keyboard navigation.

Also the change event is now emitting from radio-group when you select a new radio via keyboard.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #33523 and #33546 
