### PR TITLE
(fix)[react-nav-preview): Updating Nav animation speeds

### DIFF
--- a/change/@fluentui-react-nav-preview-b0930295-331e-4b55-96fc-c17b84ce854b.json
+++ b/change/@fluentui-react-nav-preview-b0930295-331e-4b55-96fc-c17b84ce854b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[fix] - Speeding up animations in Nav.",
+  "packageName": "@fluentui/react-nav-preview",
+  "email": "matejera@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-nav-preview-b0930295-331e-4b55-96fc-c17b84ce854b.json
+++ b/change/@fluentui-react-nav-preview-b0930295-331e-4b55-96fc-c17b84ce854b.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "[fix] - Speeding up animations in Nav.",
+  "comment": "fix: Speeding up animations in Nav.",
   "packageName": "@fluentui/react-nav-preview",
   "email": "matejera@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/react-components/react-nav-preview/library/src/components/sharedNavStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/library/src/components/sharedNavStyles.styles.ts
@@ -13,12 +13,12 @@ export const navItemTokens = {
   backgroundColorHover: tokens.colorNeutralBackground4Hover,
   backgroundColorPressed: tokens.colorNeutralBackground4Pressed,
   animationTokens: {
-    animationDuration: tokens.durationFast,
+    animationDuration: tokens.durationFaster,
     animationFillMode: 'both',
     animationTimingFunction: tokens.curveAccelerateMid,
   },
   transitionTokens: {
-    transitionDuration: tokens.durationFast,
+    transitionDuration: tokens.durationFaster,
     transitionTimingFunction: tokens.curveAccelerateMid,
     transitionProperty: 'background',
   },


### PR DESCRIPTION
Speeding up the default motion for Nav item hovers and indicators after getting customer feedback and consulting with animation SMEs.

Takes speed from 150ms -> 100ms.