### PR TITLE
chore: replace deprecation eslint plugin in favor of ts-eslint/no-deprecated

### DIFF
--- a/apps/chart-docsite/.eslintrc.json
+++ b/apps/chart-docsite/.eslintrc.json
@@ -4,7 +4,7 @@
   "rules": {
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/jsx-no-bind": "off",
-    "deprecation/deprecation": "off",
+    "@typescript-eslint/no-deprecated": "off",
     "import/no-extraneous-dependencies": ["error", { "packageDir": [".", "../.."] }]
   }
 }

--- a/apps/public-docsite-resources/.eslintrc.json
+++ b/apps/public-docsite-resources/.eslintrc.json
@@ -5,7 +5,7 @@
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/explicit-member-accessibility": "off",
     "@typescript-eslint/member-ordering": "off",
-    "deprecation/deprecation": "off",
-    "no-restricted-globals": "off"
+    "no-restricted-globals": "off",
+    "@typescript-eslint/no-deprecated": "off"
   }
 }

--- a/apps/public-docsite-v9/.eslintrc.json
+++ b/apps/public-docsite-v9/.eslintrc.json
@@ -4,7 +4,7 @@
   "rules": {
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/jsx-no-bind": "off",
-    "deprecation/deprecation": "off",
-    "import/no-extraneous-dependencies": ["error", { "packageDir": [".", "../.."] }]
+    "import/no-extraneous-dependencies": ["error", { "packageDir": [".", "../.."] }],
+    "@typescript-eslint/no-deprecated": "off"
   }
 }

--- a/apps/public-docsite/.eslintrc.json
+++ b/apps/public-docsite/.eslintrc.json
@@ -3,10 +3,10 @@
   "root": true,
   "rules": {
     "@typescript-eslint/no-explicit-any": "off",
-    "deprecation/deprecation": "off",
     "import/no-webpack-loader-syntax": "off", // ok in this project
     "prefer-const": "off",
     "react/jsx-no-bind": "off",
-    "no-restricted-globals": "off"
+    "no-restricted-globals": "off",
+    "@typescript-eslint/no-deprecated": "off"
   }
 }

--- a/apps/theming-designer/.eslintrc.json
+++ b/apps/theming-designer/.eslintrc.json
@@ -3,8 +3,8 @@
   "root": true,
   "rules": {
     "@typescript-eslint/no-explicit-any": "off",
-    "deprecation/deprecation": "off",
     "prefer-const": "off",
-    "no-restricted-globals": "off"
+    "no-restricted-globals": "off",
+    "@typescript-eslint/no-deprecated": "off"
   }
 }

--- a/apps/vr-tests-react-components/.eslintrc.json
+++ b/apps/vr-tests-react-components/.eslintrc.json
@@ -7,8 +7,8 @@
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/naming-convention": "off",
     "@typescript-eslint/jsx-no-bind": "off",
-    "deprecation/deprecation": "off",
     "import/no-extraneous-dependencies": ["error", { "packageDir": [".", "../.."] }],
-    "@nx/workspace-no-restricted-globals": "off"
+    "@nx/workspace-no-restricted-globals": "off",
+    "@typescript-eslint/no-deprecated": "off"
   }
 }

--- a/apps/vr-tests/.eslintrc.json
+++ b/apps/vr-tests/.eslintrc.json
@@ -4,8 +4,8 @@
   "rules": {
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/jsx-no-bind": "off",
-    "deprecation/deprecation": "off",
     "import/no-extraneous-dependencies": ["error", { "packageDir": [".", "../.."] }],
-    "no-restricted-globals": "off"
+    "no-restricted-globals": "off",
+    "@typescript-eslint/no-deprecated": "off"
   }
 }

--- a/change/@fluentui-codemods-af108562-5adb-43f5-b0f2-06358f95ab65.json
+++ b/change/@fluentui-codemods-af108562-5adb-43f5-b0f2-06358f95ab65.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: migrate from deprecation plugin to ts-eslint/no-deprecated rule",
+  "packageName": "@fluentui/codemods",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-eslint-plugin-fa5bccc0-99d9-46ae-8cc6-5fbdd18360cb.json
+++ b/change/@fluentui-eslint-plugin-fa5bccc0-99d9-46ae-8cc6-5fbdd18360cb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: migrate from deprecation plugin to ts-eslint/no-deprecated rule",
+  "packageName": "@fluentui/eslint-plugin",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-font-icons-mdl2-db6b5e91-90e1-4d29-8a79-ac0f0c0ee232.json
+++ b/change/@fluentui-font-icons-mdl2-db6b5e91-90e1-4d29-8a79-ac0f0c0ee232.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: migrate from deprecation plugin to ts-eslint/no-deprecated rule",
+  "packageName": "@fluentui/font-icons-mdl2",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-foundation-legacy-05901292-a3b8-4d34-834a-8f5d74736e99.json
+++ b/change/@fluentui-foundation-legacy-05901292-a3b8-4d34-834a-8f5d74736e99.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: migrate from deprecation plugin to ts-eslint/no-deprecated rule",
+  "packageName": "@fluentui/foundation-legacy",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-keyboard-key-def9b0a9-f2af-4ae3-aaaf-210eb1cc7663.json
+++ b/change/@fluentui-keyboard-key-def9b0a9-f2af-4ae3-aaaf-210eb1cc7663.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: migrate from deprecation plugin to ts-eslint/no-deprecated rule",
+  "packageName": "@fluentui/keyboard-key",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-merge-styles-f28e7eb2-d3a4-4060-95af-0c74756f900d.json
+++ b/change/@fluentui-merge-styles-f28e7eb2-d3a4-4060-95af-0c74756f900d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: migrate from deprecation plugin to ts-eslint/no-deprecated rule",
+  "packageName": "@fluentui/merge-styles",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-8e31bacb-5949-4ddf-a561-b2e8eb9365b9.json
+++ b/change/@fluentui-react-8e31bacb-5949-4ddf-a561-b2e8eb9365b9.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: migrate from deprecation plugin to ts-eslint/no-deprecated rule",
+  "packageName": "@fluentui/react",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-accordion-b082df99-c014-4ba8-8523-fdc134b25bcb.json
+++ b/change/@fluentui-react-accordion-b082df99-c014-4ba8-8523-fdc134b25bcb.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: migrate from deprecation plugin to ts-eslint/no-deprecated rule",
+  "packageName": "@fluentui/react-accordion",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-aria-ece4e8b8-ef6f-487c-a209-1a55c9dc6bfb.json
+++ b/change/@fluentui-react-aria-ece4e8b8-ef6f-487c-a209-1a55c9dc6bfb.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: migrate from deprecation plugin to ts-eslint/no-deprecated rule",
+  "packageName": "@fluentui/react-aria",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-avatar-9cab8d3a-1bcd-4c03-8138-82520de36649.json
+++ b/change/@fluentui-react-avatar-9cab8d3a-1bcd-4c03-8138-82520de36649.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: migrate from deprecation plugin to ts-eslint/no-deprecated rule",
+  "packageName": "@fluentui/react-avatar",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-charting-aa5b0252-40de-497c-88f5-377ada948719.json
+++ b/change/@fluentui-react-charting-aa5b0252-40de-497c-88f5-377ada948719.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: migrate from deprecation plugin to ts-eslint/no-deprecated rule",
+  "packageName": "@fluentui/react-charting",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-color-picker-preview-1411f212-27ea-4335-bcd3-b210359b0bd1.json
+++ b/change/@fluentui-react-color-picker-preview-1411f212-27ea-4335-bcd3-b210359b0bd1.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: migrate from deprecation plugin to ts-eslint/no-deprecated rule",
+  "packageName": "@fluentui/react-color-picker-preview",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-combobox-6b28f16b-50a6-4ea3-8afc-d21e6b99bc5e.json
+++ b/change/@fluentui-react-combobox-6b28f16b-50a6-4ea3-8afc-d21e6b99bc5e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: migrate from deprecation plugin to ts-eslint/no-deprecated rule",
+  "packageName": "@fluentui/react-combobox",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-components-a1ed2f9c-dd8c-4d5c-82ae-295a90a26772.json
+++ b/change/@fluentui-react-components-a1ed2f9c-dd8c-4d5c-82ae-295a90a26772.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: migrate from deprecation plugin to ts-eslint/no-deprecated rule",
+  "packageName": "@fluentui/react-components",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-conformance-4944bee5-948a-4649-87a1-8362f68d4635.json
+++ b/change/@fluentui-react-conformance-4944bee5-948a-4649-87a1-8362f68d4635.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: migrate from deprecation plugin to ts-eslint/no-deprecated rule",
+  "packageName": "@fluentui/react-conformance",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-date-time-14e136f0-eeb5-4113-8921-e732772e0a04.json
+++ b/change/@fluentui-react-date-time-14e136f0-eeb5-4113-8921-e732772e0a04.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: migrate from deprecation plugin to ts-eslint/no-deprecated rule",
+  "packageName": "@fluentui/react-date-time",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-experiments-4f3c4b24-6a77-45ac-b7f8-fb04d982fd7b.json
+++ b/change/@fluentui-react-experiments-4f3c4b24-6a77-45ac-b7f8-fb04d982fd7b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: migrate from deprecation plugin to ts-eslint/no-deprecated rule",
+  "packageName": "@fluentui/react-experiments",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-focus-5e8ead15-c118-4dec-84e8-744d6bf63fcb.json
+++ b/change/@fluentui-react-focus-5e8ead15-c118-4dec-84e8-744d6bf63fcb.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: migrate from deprecation plugin to ts-eslint/no-deprecated rule",
+  "packageName": "@fluentui/react-focus",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-icons-compat-d79ea04c-0316-4c1e-9c1e-96710298947a.json
+++ b/change/@fluentui-react-icons-compat-d79ea04c-0316-4c1e-9c1e-96710298947a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: migrate from deprecation plugin to ts-eslint/no-deprecated rule",
+  "packageName": "@fluentui/react-icons-compat",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-menu-51e8bb80-2224-47a8-8a42-282214bcee42.json
+++ b/change/@fluentui-react-menu-51e8bb80-2224-47a8-8a42-282214bcee42.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: migrate from deprecation plugin to ts-eslint/no-deprecated rule",
+  "packageName": "@fluentui/react-menu",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-message-bar-045b67fd-ae48-4ed9-abbd-669235409ead.json
+++ b/change/@fluentui-react-message-bar-045b67fd-ae48-4ed9-abbd-669235409ead.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: migrate from deprecation plugin to ts-eslint/no-deprecated rule",
+  "packageName": "@fluentui/react-message-bar",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-monaco-editor-946876fa-b8f4-4e15-bf15-54f86a508654.json
+++ b/change/@fluentui-react-monaco-editor-946876fa-b8f4-4e15-bf15-54f86a508654.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: migrate from deprecation plugin to ts-eslint/no-deprecated rule",
+  "packageName": "@fluentui/react-monaco-editor",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-motion-32b72aa4-8d6a-42e7-8adc-3d0eb8162c7a.json
+++ b/change/@fluentui-react-motion-32b72aa4-8d6a-42e7-8adc-3d0eb8162c7a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: migrate from deprecation plugin to ts-eslint/no-deprecated rule",
+  "packageName": "@fluentui/react-motion",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-motion-components-preview-7795f18a-df86-480a-8546-efca47ef6069.json
+++ b/change/@fluentui-react-motion-components-preview-7795f18a-df86-480a-8546-efca47ef6069.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: migrate from deprecation plugin to ts-eslint/no-deprecated rule",
+  "packageName": "@fluentui/react-motion-components-preview",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-popover-02147114-2b1f-427d-a369-c495dcc060f7.json
+++ b/change/@fluentui-react-popover-02147114-2b1f-427d-a369-c495dcc060f7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: migrate from deprecation plugin to ts-eslint/no-deprecated rule",
+  "packageName": "@fluentui/react-popover",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-positioning-7ff1890e-77cb-4078-be01-2673bb29a80b.json
+++ b/change/@fluentui-react-positioning-7ff1890e-77cb-4078-be01-2673bb29a80b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: migrate from deprecation plugin to ts-eslint/no-deprecated rule",
+  "packageName": "@fluentui/react-positioning",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-radio-59106324-2e52-43e5-b407-87f41706faa5.json
+++ b/change/@fluentui-react-radio-59106324-2e52-43e5-b407-87f41706faa5.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: migrate from deprecation plugin to ts-eslint/no-deprecated rule",
+  "packageName": "@fluentui/react-radio",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-switch-eef105b5-30ee-4c92-bac3-3eb2f1db9980.json
+++ b/change/@fluentui-react-switch-eef105b5-30ee-4c92-bac3-3eb2f1db9980.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: migrate from deprecation plugin to ts-eslint/no-deprecated rule",
+  "packageName": "@fluentui/react-switch",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-table-041ffd34-f086-4af7-a72a-66dbbd56617b.json
+++ b/change/@fluentui-react-table-041ffd34-f086-4af7-a72a-66dbbd56617b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: migrate from deprecation plugin to ts-eslint/no-deprecated rule",
+  "packageName": "@fluentui/react-table",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tabs-c489edef-c7ee-4bf0-8f32-8565edccb381.json
+++ b/change/@fluentui-react-tabs-c489edef-c7ee-4bf0-8f32-8565edccb381.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: migrate from deprecation plugin to ts-eslint/no-deprecated rule",
+  "packageName": "@fluentui/react-tabs",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tabster-a4a177a3-0514-4657-9fdd-a0e90d44e813.json
+++ b/change/@fluentui-react-tabster-a4a177a3-0514-4657-9fdd-a0e90d44e813.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: migrate from deprecation plugin to ts-eslint/no-deprecated rule",
+  "packageName": "@fluentui/react-tabster",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tooltip-058754b5-d9ec-459a-acc5-ba9ff587c4e3.json
+++ b/change/@fluentui-react-tooltip-058754b5-d9ec-459a-acc5-ba9ff587c4e3.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: migrate from deprecation plugin to ts-eslint/no-deprecated rule",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tree-287da350-699b-410f-bd97-7cb590731302.json
+++ b/change/@fluentui-react-tree-287da350-699b-410f-bd97-7cb590731302.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: migrate from deprecation plugin to ts-eslint/no-deprecated rule",
+  "packageName": "@fluentui/react-tree",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-utilities-82544042-02b6-4262-91cd-e7f9fe24bad2.json
+++ b/change/@fluentui-react-utilities-82544042-02b6-4262-91cd-e7f9fe24bad2.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: migrate from deprecation plugin to ts-eslint/no-deprecated rule",
+  "packageName": "@fluentui/react-utilities",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-virtualizer-00dd23f0-89d0-486d-844f-30a880feb0f5.json
+++ b/change/@fluentui-react-virtualizer-00dd23f0-89d0-486d-844f-30a880feb0f5.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: migrate from deprecation plugin to ts-eslint/no-deprecated rule",
+  "packageName": "@fluentui/react-virtualizer",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-style-utilities-1e695416-a364-41c7-98b1-5cc336ce40ed.json
+++ b/change/@fluentui-style-utilities-1e695416-a364-41c7-98b1-5cc336ce40ed.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: migrate from deprecation plugin to ts-eslint/no-deprecated rule",
+  "packageName": "@fluentui/style-utilities",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-theme-9d03e3c6-0e57-491d-bbb2-ff84af746057.json
+++ b/change/@fluentui-theme-9d03e3c6-0e57-491d-bbb2-ff84af746057.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: migrate from deprecation plugin to ts-eslint/no-deprecated rule",
+  "packageName": "@fluentui/theme",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-utilities-e4d8572c-17af-41f6-8d5c-e84d6038d6bd.json
+++ b/change/@fluentui-utilities-e4d8572c-17af-41f6-8d5c-e84d6038d6bd.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: migrate from deprecation plugin to ts-eslint/no-deprecated rule",
+  "packageName": "@fluentui/utilities",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/package.json
+++ b/package.json
@@ -231,7 +231,6 @@
     "eslint-config-airbnb": "18.2.1",
     "eslint-config-prettier": "8.3.0",
     "eslint-import-resolver-typescript": "3.6.1",
-    "eslint-plugin-deprecation": "3.0.0",
     "eslint-plugin-es": "4.1.0",
     "eslint-plugin-import": "2.29.1",
     "eslint-plugin-jest": "28.8.0",

--- a/packages/charts/react-charting/src/Styling.ts
+++ b/packages/charts/react-charting/src/Styling.ts
@@ -6,7 +6,7 @@ export {
   DefaultEffects,
   DefaultFontStyles,
   DefaultPalette,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   EdgeChromiumHighContrastSelector,
   FontClassNames,
   FontSizes,
@@ -39,11 +39,11 @@ export {
   createTheme,
   focusClear,
   fontFace,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   getEdgeChromiumNoHighContrastAdjustSelector,
   getFadedOverflowStyle,
   getFocusOutlineStyle,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   getFocusStyle,
   getGlobalClassNames,
   getHighContrastNoAdjustStyle,

--- a/packages/charts/react-charting/src/Utilities.ts
+++ b/packages/charts/react-charting/src/Utilities.ts
@@ -1,10 +1,8 @@
 export {
   Async,
   AutoScroll,
-  // eslint-disable-next-line deprecation/deprecation
   BaseComponent,
   Customizations,
-  // eslint-disable-next-line deprecation/deprecation
   Customizer,
   CustomizerContext,
   DATA_IS_SCROLLABLE_ATTRIBUTE,
@@ -87,7 +85,6 @@ export {
   getRTL,
   getRTLSafeKeyCode,
   getRect,
-  // eslint-disable-next-line deprecation/deprecation
   getResourceUrl,
   getScrollbarWidth,
   getVirtualParent,
@@ -99,11 +96,9 @@ export {
   hoistStatics,
   htmlElementProperties,
   iframeProperties,
-  // eslint-disable-next-line deprecation/deprecation
   imageProperties,
   imgProperties,
   initializeComponentRef,
-  // eslint-disable-next-line deprecation/deprecation
   initializeFocusRects,
   inputProperties,
   isControlled,
@@ -135,7 +130,6 @@ export {
   optionProperties,
   portalContainsElement,
   precisionRound,
-  // eslint-disable-next-line deprecation/deprecation
   raiseClick,
   removeIndex,
   replaceElement,
@@ -145,15 +139,12 @@ export {
   safeRequestAnimationFrame,
   safeSetTimeout,
   selectProperties,
-  // eslint-disable-next-line deprecation/deprecation
   setBaseUrl,
   setFocusVisibility,
-  // eslint-disable-next-line deprecation/deprecation
   setLanguage,
   setMemoizeWeakMap,
   setPortalAttribute,
   setRTL,
-  // eslint-disable-next-line deprecation/deprecation
   setSSR,
   setVirtualParent,
   setWarningCallback,
@@ -184,7 +175,6 @@ export type {
   ICancelable,
   IChangeDescription,
   IChangeEventCallback,
-  // eslint-disable-next-line deprecation/deprecation
   IClassNames,
   IClassNamesFunctionOptions,
   IComponentAs,
@@ -207,7 +197,6 @@ export type {
   IPerfData,
   IPerfMeasurement,
   IPerfSummary,
-  // eslint-disable-next-line deprecation/deprecation
   IPoint,
   IPropsWithStyles,
   IRectangle,
@@ -226,13 +215,10 @@ export type {
   IStyleFunctionOrObject,
   IVirtualElement,
   IWarnControlledUsageParams,
-  // eslint-disable-next-line deprecation/deprecation
   Omit,
   Point,
   RefObject,
-  // eslint-disable-next-line deprecation/deprecation
   Settings,
-  // eslint-disable-next-line deprecation/deprecation
   SettingsFunction,
   StyleFunction,
 } from '@fluentui/react/lib/Utilities';

--- a/packages/charts/react-charting/src/components/DonutChart/DonutChart.base.tsx
+++ b/packages/charts/react-charting/src/components/DonutChart/DonutChart.base.tsx
@@ -178,6 +178,7 @@ export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChar
           hidden={!(!this.props.hideTooltip && this.state.showHover)}
           id={this._calloutId}
           onDismiss={this._closeCallout}
+          // eslint-disable-next-line @typescript-eslint/no-deprecated
           preventDismissOnLostFocus={true}
           /** Keep the callout updated with details of focused/hovered arc */
           shouldUpdateWhenHidden={true}

--- a/packages/charts/react-charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
+++ b/packages/charts/react-charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
@@ -163,6 +163,7 @@ export class HorizontalBarChartBase extends React.Component<IHorizontalBarChartP
           directionalHint={DirectionalHint.topAutoEdge}
           id={this._calloutId}
           onDismiss={this._closeCallout}
+          // eslint-disable-next-line @typescript-eslint/no-deprecated
           preventDismissOnLostFocus={true}
           {...this.props.calloutProps!}
           {...getAccessibleDataObject(this.state.callOutAccessibilityData)}

--- a/packages/charts/react-charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
+++ b/packages/charts/react-charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
@@ -148,6 +148,7 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
             directionalHint={DirectionalHint.topAutoEdge}
             id={this._calloutId}
             onDismiss={this._closeCallout}
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             preventDismissOnLostFocus={true}
             /** Keep the callout updated with details of focused/hovered bar */
             shouldUpdateWhenHidden={true}

--- a/packages/charts/react-charting/src/components/StackedBarChart/StackedBarChart.base.tsx
+++ b/packages/charts/react-charting/src/components/StackedBarChart/StackedBarChart.base.tsx
@@ -172,6 +172,7 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
                   directionalHint={DirectionalHint.topAutoEdge}
                   id={this._calloutId}
                   onDismiss={this._closeCallout}
+                  // eslint-disable-next-line @typescript-eslint/no-deprecated
                   preventDismissOnLostFocus={true}
                   /** Keep the callout updated with details of focused/hovered bar */
                   shouldUpdateWhenHidden={true}

--- a/packages/charts/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
+++ b/packages/charts/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
@@ -524,7 +524,7 @@ export class VerticalStackedBarChartBase
     this._barWidth = getBarWidth(this.props.barWidth, this.props.maxBarWidth);
     const { theme } = this.props;
     const { palette } = theme!;
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     this._colors = this.props.colors || [palette.blueLight, palette.blue, palette.blueMid, palette.red, palette.black];
     this._xAxisType = getTypeOfAxis(this.props.data[0].xAxisPoint, true) as XAxisTypes;
     this._lineObject = this._getFormattedLineData(this.props.data);

--- a/packages/charts/react-charting/src/utilities/SVGTooltipText.tsx
+++ b/packages/charts/react-charting/src/utilities/SVGTooltipText.tsx
@@ -252,7 +252,7 @@ export class SVGTooltipText
   };
 
   private _onTooltipKeyDown = (ev: React.KeyboardEvent<SVGElement>): void => {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     if ((ev.which === KeyCodes.escape || ev.ctrlKey) && this.state.isTooltipVisible) {
       this._hideTooltip();
       ev.stopPropagation();

--- a/packages/codemods/.eslintrc.json
+++ b/packages/codemods/.eslintrc.json
@@ -9,7 +9,7 @@
         "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/naming-convention": "off",
         "import/no-extraneous-dependencies": "off",
-        "deprecation/deprecation": "off"
+        "@typescript-eslint/no-deprecated": "off"
       }
     }
   ]

--- a/packages/codemods/src/codeMods/utilities/helpers/propHelpers.ts
+++ b/packages/codemods/src/codeMods/utilities/helpers/propHelpers.ts
@@ -255,7 +255,7 @@ function tryInsertExistingDecomposedProp(oldProp: string, statement: VariableSta
   const decompObject = statement.getFirstDescendantByKind(SyntaxKind.ObjectBindingPattern);
   if (decompObject) {
     let objectText = decompObject.getText();
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     objectText = objectText.substr(0, 1) + ` ${oldProp},` + objectText.substr(1);
     decompObject.replaceWithText(objectText);
     return true;

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -19,7 +19,6 @@
     "eslint-config-airbnb": "^18.2.1",
     "eslint-config-prettier": "^8.3.0",
     "eslint-import-resolver-typescript": "^3.6.1",
-    "eslint-plugin-deprecation": "^3.0.0",
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-jest": "^28.6.0",
     "eslint-plugin-jsdoc": "^48.7.0",

--- a/packages/eslint-plugin/src/configs/core.js
+++ b/packages/eslint-plugin/src/configs/core.js
@@ -14,16 +14,7 @@ const config = {
     'prettier',
   ],
   parser: '@typescript-eslint/parser',
-  plugins: [
-    'import',
-    '@fluentui',
-    '@rnx-kit',
-    '@typescript-eslint',
-    'deprecation',
-    'jest',
-    'jsdoc',
-    ...__internal.plugins,
-  ],
+  plugins: ['import', '@fluentui', '@rnx-kit', '@typescript-eslint', 'jest', 'jsdoc', ...__internal.plugins],
   settings: {
     'import/resolver': {
       // @see https://github.com/alexgorbatchev/eslint-import-resolver-typescript#configuration
@@ -245,10 +236,7 @@ const config = {
 
 /** @type {import("eslint").Linter.RulesRecord} */
 const typeAwareRules = {
-  /**
-   * plugin: https://github.com/gund/eslint-plugin-deprecation
-   */
-  'deprecation/deprecation': 'error',
+  '@typescript-eslint/no-deprecated': 'error',
 };
 
 /**
@@ -318,7 +306,7 @@ const getOverrides = () => [
   {
     files: 'src/**/*.deprecated.test.{ts,tsx}',
     rules: {
-      'deprecation/deprecation': 'off', // the purpose of these tests
+      '@typescript-eslint/no-deprecated ': 'off', // the purpose of these tests
     },
   },
   {

--- a/packages/eslint-plugin/src/configs/core.js
+++ b/packages/eslint-plugin/src/configs/core.js
@@ -236,6 +236,9 @@ const config = {
 
 /** @type {import("eslint").Linter.RulesRecord} */
 const typeAwareRules = {
+  /**
+   * plugin: https://github.com/gund/eslint-plugin-deprecation
+   */
   '@typescript-eslint/no-deprecated': 'error',
 };
 
@@ -306,7 +309,7 @@ const getOverrides = () => [
   {
     files: 'src/**/*.deprecated.test.{ts,tsx}',
     rules: {
-      '@typescript-eslint/no-deprecated ': 'off', // the purpose of these tests
+      '@typescript-eslint/no-deprecated': 'off',
     },
   },
   {

--- a/packages/font-icons-mdl2/src/IconNames.ts
+++ b/packages/font-icons-mdl2/src/IconNames.ts
@@ -1805,5 +1805,5 @@ export const enum IconNames {
   SizeLegacy = 'SizeLegacy',
 }
 
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 export type IconNamesInput = keyof typeof IconNames;

--- a/packages/font-icons-mdl2/src/iconNames.test.ts
+++ b/packages/font-icons-mdl2/src/iconNames.test.ts
@@ -1,6 +1,6 @@
 import { IconNames, IconNamesInput } from './IconNames';
 
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 declare const allIconNamesValues: IconNames;
 
 function validateIconNamesValues(allowedIconNamesValues: IconNamesInput): void {

--- a/packages/font-icons-mdl2/src/index.ts
+++ b/packages/font-icons-mdl2/src/index.ts
@@ -69,9 +69,9 @@ export function initializeIcons(
   registerIconAliases();
 }
 
-/* eslint-disable deprecation/deprecation */
+/* eslint-disable @typescript-eslint/no-deprecated */
 export type { IconNamesInput } from './IconNames';
 export { IconNames } from './IconNames';
-/* eslint-enable deprecation/deprecation */
+/* eslint-enable @typescript-eslint/no-deprecated */
 
 import './version';

--- a/packages/foundation-legacy/src/ThemeProvider.tsx
+++ b/packages/foundation-legacy/src/ThemeProvider.tsx
@@ -25,6 +25,6 @@ export const ThemeProvider: React.FunctionComponent<IThemeProviderProps> = (prop
     return getThemedContext(context, scheme, theme);
   };
 
-  // eslint-disable-next-line react/jsx-no-bind, deprecation/deprecation
+  // eslint-disable-next-line react/jsx-no-bind, @typescript-eslint/no-deprecated
   return <Customizer {...rest} contextTransform={contextTransform} />;
 };

--- a/packages/keyboard-key/src/index.ts
+++ b/packages/keyboard-key/src/index.ts
@@ -182,7 +182,7 @@ const isObject = (val: any): val is KeyboardEventLike => {
  */
 export function getCode(eventOrKey: Partial<KeyboardEventLike> | string): number | undefined {
   if (isObject(eventOrKey)) {
-    // eslint-disable-next-line deprecation/deprecation, @typescript-eslint/no-explicit-any
+    // eslint-disable-next-line @typescript-eslint/no-deprecated, @typescript-eslint/no-explicit-any
     return eventOrKey.keyCode || eventOrKey.which || (keyboardKey as any)[eventOrKey.key as string];
   }
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -204,7 +204,7 @@ export function getKey(eventOrCode: Partial<KeyboardEventLike> | number): string
     return event.key;
   }
 
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   let name = codes[(isEvent ? event.keyCode || event.which : eventOrCode) as number];
 
   if (Array.isArray(name)) {

--- a/packages/merge-styles/src/DeepPartial.ts
+++ b/packages/merge-styles/src/DeepPartial.ts
@@ -3,7 +3,7 @@
  * @deprecated - This type will hit infinite type instantiation recursion. Please use {@link DeepPartialV2}
  */
 export type DeepPartial<T> = {
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   [P in keyof T]?: T[P] extends Array<infer U> ? Array<DeepPartial<U>> : T[P] extends object ? DeepPartial<T[P]> : T[P];
 };
 

--- a/packages/merge-styles/src/IStyleSet.ts
+++ b/packages/merge-styles/src/IStyleSet.ts
@@ -12,9 +12,9 @@ export type Diff<T extends keyof any, U extends keyof any> = ({ [P in T]: P } & 
 /**
  * @deprecated Use the version provided by TypeScript instead.
  */
-// eslint-disable-next-line deprecation/deprecation, @typescript-eslint/naming-convention
+// eslint-disable-next-line @typescript-eslint/no-deprecated, @typescript-eslint/naming-convention
 type _Omit<U, K extends keyof U> = Pick<U, Diff<keyof U, K>>;
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 export type { _Omit as Omit };
 
 /**
@@ -40,7 +40,7 @@ export interface IStyleSetBase {
  * property.
  */
 export type IStyleSet<TStyleSet extends IStyleSetBase = { [key: string]: any }> = {
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   [P in keyof _Omit<TStyleSet, 'subComponentStyles'>]: IStyle;
 } & {
   subComponentStyles?: { [P in keyof TStyleSet['subComponentStyles']]: IStyleFunctionOrObject<any, any> };
@@ -50,7 +50,7 @@ export type IStyleSet<TStyleSet extends IStyleSetBase = { [key: string]: any }> 
  * A concatenated style set differs from `IStyleSet` in that subComponentStyles will always be a style function.
  */
 export type IConcatenatedStyleSet<TStyleSet extends IStyleSetBase> = {
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   [P in keyof _Omit<TStyleSet, 'subComponentStyles'>]: IStyle;
 } & {
   subComponentStyles?: { [P in keyof TStyleSet['subComponentStyles']]: IStyleFunction<any, any> };
@@ -61,7 +61,7 @@ export type IConcatenatedStyleSet<TStyleSet extends IStyleSetBase> = {
  * into a class name. Additionally, all subComponentStyles are style functions.
  */
 export type IProcessedStyleSet<TStyleSet extends IStyleSetBase> = {
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   [P in keyof _Omit<TStyleSet, 'subComponentStyles'>]: string;
 } & {
   subComponentStyles: {

--- a/packages/merge-styles/src/Stylesheet.ts
+++ b/packages/merge-styles/src/Stylesheet.ts
@@ -347,9 +347,9 @@ export class Stylesheet {
       this._rules.push(rule);
     }
 
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     if (this._config.onInsertRule) {
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       this._config.onInsertRule(rule);
     }
 

--- a/packages/merge-styles/src/index.ts
+++ b/packages/merge-styles/src/index.ts
@@ -6,10 +6,10 @@ export type { IKeyframes } from './IKeyframes';
 
 export type { IStyleFunction, IStyleFunctionOrObject } from './IStyleFunction';
 
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 export type { DeepPartial } from './DeepPartial';
 
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 export type { IConcatenatedStyleSet, IProcessedStyleSet, IStyleSet, IStyleSetBase, Omit } from './IStyleSet';
 
 export type {

--- a/packages/react-cards/.eslintrc.json
+++ b/packages/react-cards/.eslintrc.json
@@ -9,7 +9,7 @@
       "files": "**/*.{ts,tsx}",
       "rules": {
         // The components in this package are all deprecated
-        "deprecation/deprecation": "off"
+        "@typescript-eslint/no-deprecated": "off"
       }
     }
   ]

--- a/packages/react-components/react-accordion/library/src/components/Accordion/useAccordion.ts
+++ b/packages/react-components/react-accordion/library/src/components/Accordion/useAccordion.ts
@@ -20,7 +20,7 @@ export const useAccordion_unstable = <Value = AccordionItemValue>(
     multiple = false,
     collapsible = false,
     onToggle,
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     navigation,
   } = props;
   const [openItems, setOpenItems] = useControllableState({

--- a/packages/react-components/react-accordion/library/src/components/AccordionItem/useAccordionItemContextValues.ts
+++ b/packages/react-components/react-accordion/library/src/components/AccordionItem/useAccordionItemContextValues.ts
@@ -3,7 +3,7 @@ import type { AccordionItemContextValues, AccordionItemState } from './Accordion
 import { AccordionItemContextValue } from '../../contexts/accordionItem';
 
 export function useAccordionItemContextValues_unstable(state: AccordionItemState): AccordionItemContextValues {
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   const { disabled, open, value, onHeaderClick } = state;
   const accordionItem = React.useMemo<AccordionItemContextValue>(
     () => ({ disabled, open, value, onHeaderClick }),

--- a/packages/react-components/react-aria/library/src/activedescendant/useActivedescendant.test.tsx
+++ b/packages/react-components/react-aria/library/src/activedescendant/useActivedescendant.test.tsx
@@ -272,7 +272,7 @@ describe('useActivedescendant', () => {
       const { getByRole } = render(<Test imperativeRef={imperativeRef} />);
 
       // there should not be a last active descendant yet
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       expect(imperativeRef.current?.focusLastActive()).toBeFalsy();
 
       imperativeRef.current?.focus('option-3');
@@ -281,7 +281,7 @@ describe('useActivedescendant', () => {
       imperativeRef.current?.blur();
       expect(imperativeRef.current?.active()).toBeUndefined();
 
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       expect(imperativeRef.current?.focusLastActive()).toBeTruthy();
       expect(imperativeRef.current?.active()).toBe('option-3');
 

--- a/packages/react-components/react-aria/library/src/button/index.ts
+++ b/packages/react-components/react-aria/library/src/button/index.ts
@@ -1,5 +1,5 @@
 export { useARIAButtonProps } from './useARIAButtonProps';
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 export { useARIAButtonShorthand } from './useARIAButtonShorthand';
 export type {
   ARIAButtonAlteredProps,

--- a/packages/react-components/react-aria/library/src/button/useARIAButtonShorthand.test.tsx
+++ b/packages/react-components/react-aria/library/src/button/useARIAButtonShorthand.test.tsx
@@ -5,22 +5,22 @@ describe('useARIAButtonShorthands', () => {
   it('should return shorthands', () => {
     const {
       result: { current: buttonShorthand },
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
     } = renderHook(() => useARIAButtonShorthand({ as: 'button' }, { required: true }));
     expect(buttonShorthand.as).toBe('button');
     const {
       result: { current: buttonShorthand2 },
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
     } = renderHook(() => useARIAButtonShorthand({ as: undefined }, { required: true }));
     expect(buttonShorthand2.as).toBe(undefined);
     const {
       result: { current: anchorShorthand },
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
     } = renderHook(() => useARIAButtonShorthand({ as: 'a' }, { required: true }));
     expect(anchorShorthand.as).toBe('a');
     const {
       result: { current: divShorthand },
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
     } = renderHook(() => useARIAButtonShorthand({ as: 'div' }, { required: true }));
     expect(divShorthand.as).toBe('div');
   });

--- a/packages/react-components/react-aria/library/src/button/useARIAButtonShorthand.ts
+++ b/packages/react-components/react-aria/library/src/button/useARIAButtonShorthand.ts
@@ -14,9 +14,9 @@ import type { ARIAButtonProps, ARIAButtonSlotProps, ARIAButtonType } from './typ
  * for multiple scenarios of shorthand properties. Ensuring 1st rule of ARIA for cases
  * where no attribute addition is required.
  */
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 export const useARIAButtonShorthand: ResolveShorthandFunction<ARIAButtonSlotProps> = (value, options) => {
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   const shorthand = resolveShorthand(value, options);
   const shorthandARIAButton = useARIAButtonProps<ARIAButtonType, ARIAButtonProps>(shorthand?.as ?? 'button', shorthand);
   return shorthand && shorthandARIAButton;

--- a/packages/react-components/react-aria/library/src/index.ts
+++ b/packages/react-components/react-aria/library/src/index.ts
@@ -1,5 +1,5 @@
 export {
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   useARIAButtonShorthand,
   useARIAButtonProps,
 } from './button/index';

--- a/packages/react-components/react-avatar/library/src/Avatar.ts
+++ b/packages/react-components/react-avatar/library/src/Avatar.ts
@@ -3,7 +3,7 @@ export type {
   AvatarProps,
   AvatarShape,
   AvatarSize,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   AvatarSizes,
   AvatarSlots,
   AvatarState,

--- a/packages/react-components/react-avatar/library/src/components/Avatar/index.ts
+++ b/packages/react-components/react-avatar/library/src/components/Avatar/index.ts
@@ -3,7 +3,7 @@ export type {
   AvatarProps,
   AvatarShape,
   AvatarSize,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   AvatarSizes,
   AvatarSlots,
   AvatarState,

--- a/packages/react-components/react-avatar/library/src/index.ts
+++ b/packages/react-components/react-avatar/library/src/index.ts
@@ -11,7 +11,7 @@ export type {
   AvatarSlots,
   AvatarState,
   AvatarShape,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   AvatarSizes,
   AvatarSize,
 } from './Avatar';

--- a/packages/react-components/react-combobox/library/src/components/Combobox/renderCombobox.tsx
+++ b/packages/react-components/react-combobox/library/src/components/Combobox/renderCombobox.tsx
@@ -18,7 +18,7 @@ export const renderCombobox_unstable = (state: ComboboxState, contextValues: Com
     <state.root>
       <ActiveDescendantContextProvider value={contextValues.activeDescendant}>
         <ListboxProvider value={contextValues.listbox}>
-          {/*eslint-disable-next-line deprecation/deprecation*/}
+          {/*eslint-disable-next-line @typescript-eslint/no-deprecated*/}
           <ComboboxContext.Provider value={contextValues.combobox}>
             <state.input />
             {state.clearIcon && <state.clearIcon />}
@@ -31,7 +31,7 @@ export const renderCombobox_unstable = (state: ComboboxState, contextValues: Com
                   <state.listbox />
                 </Portal>
               ))}
-            {/*eslint-disable-next-line deprecation/deprecation*/}
+            {/*eslint-disable-next-line @typescript-eslint/no-deprecated*/}
           </ComboboxContext.Provider>
         </ListboxProvider>
       </ActiveDescendantContextProvider>

--- a/packages/react-components/react-combobox/library/src/components/Dropdown/renderDropdown.tsx
+++ b/packages/react-components/react-combobox/library/src/components/Dropdown/renderDropdown.tsx
@@ -19,7 +19,7 @@ export const renderDropdown_unstable = (state: DropdownState, contextValues: Dro
     <state.root>
       <ActiveDescendantContextProvider value={contextValues.activeDescendant}>
         <ListboxContext.Provider value={contextValues.listbox}>
-          {/*eslint-disable-next-line deprecation/deprecation*/}
+          {/*eslint-disable-next-line @typescript-eslint/no-deprecated*/}
           <ComboboxContext.Provider value={contextValues.combobox}>
             <state.button>
               {state.button.children}
@@ -34,7 +34,7 @@ export const renderDropdown_unstable = (state: DropdownState, contextValues: Dro
                   <state.listbox />
                 </Portal>
               ))}
-            {/*eslint-disable-next-line deprecation/deprecation*/}
+            {/*eslint-disable-next-line @typescript-eslint/no-deprecated*/}
           </ComboboxContext.Provider>
         </ListboxContext.Provider>
       </ActiveDescendantContextProvider>

--- a/packages/react-components/react-combobox/library/src/contexts/ComboboxContext.ts
+++ b/packages/react-components/react-combobox/library/src/contexts/ComboboxContext.ts
@@ -50,5 +50,5 @@ export const ComboboxContext = createContext<ComboboxContextValue>({
  * @see ListboxProvider
  * @see useListboxContext_unstable
  */
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 export const ComboboxProvider = ComboboxContext.Provider;

--- a/packages/react-components/react-combobox/library/src/index.ts
+++ b/packages/react-components/react-combobox/library/src/index.ts
@@ -1,4 +1,4 @@
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 export { ComboboxProvider } from './contexts/ComboboxContext';
 export type { ComboboxContextValue } from './contexts/ComboboxContext';
 export { ListboxProvider, useListboxContext_unstable } from './contexts/ListboxContext';

--- a/packages/react-components/react-components/src/index.ts
+++ b/packages/react-components/react-components/src/index.ts
@@ -103,19 +103,19 @@ export {
 export type { AnnounceContextValue } from '@fluentui/react-shared-contexts';
 export {
   // getNativeElementProps is deprecated but removing it would be a breaking change
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   getNativeElementProps,
   getIntrinsicElementProps,
   getPartitionedNativeProps,
   // getSlots is deprecated but removing it would be a breaking change
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   getSlots,
   slot,
   assertSlots,
   IdPrefixProvider,
   resetIdsForTests,
   // resolveShorthand is deprecated but removing it would be a breaking change
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   resolveShorthand,
   SSRProvider,
   useAnimationFrame,
@@ -134,10 +134,10 @@ export type {
   ComponentState,
   ForwardRefComponent,
   // ResolveShorthandFunction is deprecated but removing it would be a breaking change
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   ResolveShorthandFunction,
   // ResolveShorthandOptions is deprecated but removing it would be a breaking change
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   ResolveShorthandOptions,
   Slot,
   SlotOptions,
@@ -241,7 +241,7 @@ export type {
   AvatarNamedColor,
   AvatarProps,
   // AvatarSizes is deprecated but removing it would be a breaking change
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   AvatarSizes,
   AvatarSize,
   AvatarSlots,
@@ -374,7 +374,7 @@ export {
   optionGroupClassNames,
   useOptionGroupStyles_unstable,
   useOptionGroup_unstable,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   ComboboxProvider,
   useComboboxContextValues,
   ListboxProvider,
@@ -562,7 +562,7 @@ export type {
   MenuOpenChangeData,
   MenuOpenEvent,
   // MenuOpenEvents is deprecated but removing it would be a breaking change
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   MenuOpenEvents,
   MenuPopoverProps,
   MenuPopoverSlots,
@@ -578,7 +578,7 @@ export type {
   MenuTriggerState,
   SelectableHandler,
   // UninitializedMenuListState is deprecated but removing it would be a breaking change
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   UninitializedMenuListState,
 } from '@fluentui/react-menu';
 export {
@@ -630,7 +630,7 @@ export {
   renderRadio_unstable,
   renderRadioGroup_unstable,
   useRadio_unstable,
-  useRadioGroupContext_unstable, // eslint-disable-line deprecation/deprecation
+  useRadioGroupContext_unstable, // eslint-disable-line @typescript-eslint/no-deprecated
   useRadioGroupContextValue_unstable,
   useRadioGroupContextValues,
   useRadioGroup_unstable,

--- a/packages/react-components/react-components/src/unstable/index.ts
+++ b/packages/react-components/react-components/src/unstable/index.ts
@@ -7,7 +7,7 @@
 // - use/consume `*-preview` packages directly for preview/unstable Fluent UI core controls early access
 // =====================================================================================================
 
-/* eslint-disable deprecation/deprecation */
+/* eslint-disable @typescript-eslint/no-deprecated */
 export {
   Alert,
   alertClassNames,
@@ -37,7 +37,7 @@ export type {
   InfoLabelSlots,
   InfoLabelState,
 } from '@fluentui/react-infobutton';
-/* eslint-enable deprecation/deprecation */
+/* eslint-enable @typescript-eslint/no-deprecated */
 
 export {
   Virtualizer,

--- a/packages/react-components/react-icons-compat/library/src/icon.ts
+++ b/packages/react-components/react-icons-compat/library/src/icon.ts
@@ -171,7 +171,7 @@ export function getIcon(name?: string): IconRecord | undefined {
         }
       }
     } else {
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       if (!options.disableWarnings && options.warnOnMissingIcons) {
         // eslint-disable-next-line no-console
         console.warn(

--- a/packages/react-components/react-jsx-runtime/src/createElement.test.tsx
+++ b/packages/react-components/react-jsx-runtime/src/createElement.test.tsx
@@ -77,12 +77,12 @@ describe('createElement with getSlotsNext', () => {
         const state: TestComponentState = {
           components: { slot: 'div' },
 
-          // eslint-disable-next-line deprecation/deprecation
+          // eslint-disable-next-line @typescript-eslint/no-deprecated
           slot: resolveShorthand(props.slot, {
             defaultProps: { children: 'Default Children', id: 'slot' },
           }),
         };
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const { slots, slotProps } = getSlotsNext<TestComponentSlots>(state);
 
         return <slots.slot {...slotProps.slot} />;
@@ -120,12 +120,12 @@ describe('createElement with getSlotsNext', () => {
         const state: TestComponentState = {
           components: { inner: 'div', outer: 'div' },
 
-          // eslint-disable-next-line deprecation/deprecation
+          // eslint-disable-next-line @typescript-eslint/no-deprecated
           inner: resolveShorthand(props.inner, { defaultProps: { id: 'inner' } }),
-          // eslint-disable-next-line deprecation/deprecation
+          // eslint-disable-next-line @typescript-eslint/no-deprecated
           outer: resolveShorthand(props.outer, { defaultProps: { id: 'outer' } }),
         };
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const { slots, slotProps } = getSlotsNext<TestComponentSlots>(state);
 
         return (

--- a/packages/react-components/react-jsx-runtime/src/interop.test.tsx
+++ b/packages/react-components/react-jsx-runtime/src/interop.test.tsx
@@ -19,7 +19,7 @@ describe('resolveShorthand with assertSlots', () => {
       const TestComponent = (props: TestComponentProps) => {
         const state: TestComponentState = {
           components: { someSlot: 'div' },
-          // eslint-disable-next-line deprecation/deprecation
+          // eslint-disable-next-line @typescript-eslint/no-deprecated
           someSlot: resolveShorthand(props.someSlot, {
             required: true,
             defaultProps: { children: 'Default Children', id: 'slot' },
@@ -64,9 +64,9 @@ describe('resolveShorthand with assertSlots', () => {
       const TestComponent = (props: TestComponentProps) => {
         const state: TestComponentState = {
           components: { outer: 'div', inner: 'div' },
-          // eslint-disable-next-line deprecation/deprecation
+          // eslint-disable-next-line @typescript-eslint/no-deprecated
           inner: resolveShorthand(props.inner, { defaultProps: { id: 'inner' }, required: true }),
-          // eslint-disable-next-line deprecation/deprecation
+          // eslint-disable-next-line @typescript-eslint/no-deprecated
           outer: resolveShorthand(props.outer, { defaultProps: { id: 'outer' }, required: true }),
         };
         assertSlots<TestComponentSlots>(state);
@@ -125,7 +125,7 @@ describe('resolveShorthand with assertSlots', () => {
       const TestComponent = (props: TestComponentProps) => {
         const state: TestComponentState = {
           components: { slot: 'div' },
-          // eslint-disable-next-line deprecation/deprecation
+          // eslint-disable-next-line @typescript-eslint/no-deprecated
           slot: resolveShorthand(props.slot, { required: true }),
         };
         assertSlots<TestComponentSlots>(state);

--- a/packages/react-components/react-jsx-runtime/src/jsx-runtime.test.tsx
+++ b/packages/react-components/react-jsx-runtime/src/jsx-runtime.test.tsx
@@ -71,12 +71,12 @@ describe('createElement with getSlotsNext', () => {
         const state: TestComponentState = {
           components: { slot: 'div' },
 
-          // eslint-disable-next-line deprecation/deprecation
+          // eslint-disable-next-line @typescript-eslint/no-deprecated
           slot: resolveShorthand(props.slot, {
             defaultProps: { children: 'Default Children', id: 'slot' },
           }),
         };
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const { slots, slotProps } = getSlotsNext<TestComponentSlots>(state);
 
         return <slots.slot {...slotProps.slot} />;
@@ -114,12 +114,12 @@ describe('createElement with getSlotsNext', () => {
         const state: TestComponentState = {
           components: { inner: 'div', outer: 'div' },
 
-          // eslint-disable-next-line deprecation/deprecation
+          // eslint-disable-next-line @typescript-eslint/no-deprecated
           inner: resolveShorthand(props.inner, { defaultProps: { id: 'inner' } }),
-          // eslint-disable-next-line deprecation/deprecation
+          // eslint-disable-next-line @typescript-eslint/no-deprecated
           outer: resolveShorthand(props.outer, { defaultProps: { id: 'outer' } }),
         };
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const { slots, slotProps } = getSlotsNext<TestComponentSlots>(state);
 
         return (

--- a/packages/react-components/react-menu/library/src/Menu.ts
+++ b/packages/react-components/react-menu/library/src/Menu.ts
@@ -2,7 +2,7 @@ export type {
   MenuContextValues,
   MenuOpenChangeData,
   MenuOpenEvent,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   MenuOpenEvents,
   MenuProps,
   MenuSlots,

--- a/packages/react-components/react-menu/library/src/MenuList.ts
+++ b/packages/react-components/react-menu/library/src/MenuList.ts
@@ -5,7 +5,7 @@ export type {
   MenuListProps,
   MenuListSlots,
   MenuListState,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   UninitializedMenuListState,
 } from './components/MenuList/index';
 export {

--- a/packages/react-components/react-menu/library/src/components/Menu/index.ts
+++ b/packages/react-components/react-menu/library/src/components/Menu/index.ts
@@ -3,7 +3,7 @@ export type {
   MenuContextValues,
   MenuOpenChangeData,
   MenuOpenEvent,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   MenuOpenEvents,
   MenuProps,
   MenuSlots,

--- a/packages/react-components/react-menu/library/src/components/MenuList/index.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuList/index.ts
@@ -6,7 +6,7 @@ export type {
   MenuListProps,
   MenuListSlots,
   MenuListState,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   UninitializedMenuListState,
 } from './MenuList.types';
 export { renderMenuList_unstable } from './renderMenuList';

--- a/packages/react-components/react-menu/library/src/components/index.ts
+++ b/packages/react-components/react-menu/library/src/components/index.ts
@@ -13,7 +13,7 @@ export type {
   MenuListProps,
   MenuListSlots,
   MenuListState,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   UninitializedMenuListState,
 } from './MenuList/index';
 export {

--- a/packages/react-components/react-menu/library/src/index.ts
+++ b/packages/react-components/react-menu/library/src/index.ts
@@ -12,7 +12,7 @@ export type {
   MenuOpenChangeData,
   MenuOpenEvent,
   // MenuOpenEvents is deprecated but removing it would be a breaking change
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   MenuOpenEvents,
   MenuProps,
   MenuSlots,
@@ -83,7 +83,7 @@ export type {
   MenuListSlots,
   MenuListState,
   // UninitializedMenuListState is deprecated but removing it would be a breaking change
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   UninitializedMenuListState,
 } from './MenuList';
 export {

--- a/packages/react-components/react-message-bar/library/src/components/MessageBar/MessageBar.test.tsx
+++ b/packages/react-components/react-message-bar/library/src/components/MessageBar/MessageBar.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { render } from '@testing-library/react';
 import { isConformant } from '../../testing/isConformant';
 import { MessageBar } from './MessageBar';
-import { AnnounceProvider_unstable } from '@fluentui/react-shared-contexts';
+import { AnnounceProvider } from '@fluentui/react-shared-contexts';
 import { MessageBarBody } from '../MessageBarBody/MessageBarBody';
 import { MessageBarTitle } from '../MessageBarTitle/MessageBarTitle';
 import { MessageBarActions } from '../MessageBarActions/MessageBarActions';
@@ -67,13 +67,13 @@ describe('MessageBar', () => {
   ])('should announce %s with %s intent', (politeness, intent) => {
     const announce = jest.fn();
     render(
-      <AnnounceProvider_unstable value={{ announce }}>
+      <AnnounceProvider value={{ announce }}>
         <MessageBar intent={intent}>
           <MessageBarBody>
             <MessageBarTitle>Title</MessageBarTitle>Body
           </MessageBarBody>
         </MessageBar>
-      </AnnounceProvider_unstable>,
+      </AnnounceProvider>,
     );
 
     expect(announce).toHaveBeenCalledTimes(1);
@@ -86,7 +86,7 @@ describe('MessageBar', () => {
   it('should announce actions', () => {
     const announce = jest.fn();
     render(
-      <AnnounceProvider_unstable value={{ announce }}>
+      <AnnounceProvider value={{ announce }}>
         <MessageBar>
           <MessageBarBody>
             <MessageBarTitle>Title</MessageBarTitle>Body
@@ -96,7 +96,7 @@ describe('MessageBar', () => {
             <button>Action 2</button>
           </MessageBarActions>
         </MessageBar>
-      </AnnounceProvider_unstable>,
+      </AnnounceProvider>,
     );
 
     expect(announce).toHaveBeenCalledTimes(1);

--- a/packages/react-components/react-message-bar/library/src/components/MessageBar/useMessageBar.ts
+++ b/packages/react-components/react-message-bar/library/src/components/MessageBar/useMessageBar.ts
@@ -21,7 +21,7 @@ export const useMessageBar_unstable = (props: MessageBarProps, ref: React.Ref<HT
   const autoReflow = layout === 'auto';
   const { ref: reflowRef, reflowing } = useMessageBarReflow(autoReflow);
   const computedLayout = autoReflow ? (reflowing ? 'multiline' : 'singleline') : layout;
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   const { className: transitionClassName, nodeRef } = useMessageBarTransitionContext();
   const actionsRef = React.useRef<HTMLDivElement | null>(null);
   const bodyRef = React.useRef<HTMLDivElement | null>(null);

--- a/packages/react-components/react-motion/library/src/slots/presenceMotionSlot.tsx
+++ b/packages/react-components/react-motion/library/src/slots/presenceMotionSlot.tsx
@@ -42,7 +42,7 @@ export function presenceMotionSlot<MotionParams extends Record<string, MotionPar
     defaultProps: PresenceMotionSlotRenderProps & MotionParams;
   },
 ): SlotComponentType<PresenceMotionSlotRenderProps & MotionParams> {
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   const { as, children, ...rest } = motion ?? {};
 
   if (process.env.NODE_ENV !== 'production') {

--- a/packages/react-components/react-popover/library/src/components/Popover/usePopover.ts
+++ b/packages/react-components/react-popover/library/src/components/Popover/usePopover.ts
@@ -129,7 +129,7 @@ export const usePopover_unstable = (props: PopoverProps): PopoverState => {
   return {
     ...initialState,
     ...positioningRefs,
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     inertTrapFocus: props.inertTrapFocus ?? (props.legacyTrapFocus === undefined ? false : !props.legacyTrapFocus),
     popoverTrigger,
     popoverSurface,

--- a/packages/react-components/react-positioning/src/usePositioning.ts
+++ b/packages/react-components/react-positioning/src/usePositioning.ts
@@ -173,7 +173,7 @@ function usePositioningOptions(options: PositioningOptions) {
     pinned,
     position,
     unstable_disableTether: disableTether,
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     positionFixed,
     strategy,
     overflowBoundaryPadding,

--- a/packages/react-components/react-provider/library/src/components/FluentProvider/useFluentProviderThemeStyleTag.test.tsx
+++ b/packages/react-components/react-provider/library/src/components/FluentProvider/useFluentProviderThemeStyleTag.test.tsx
@@ -111,7 +111,7 @@ describe('useFluentProviderThemeStyleTag', () => {
 
     expect(targetDocument.body.querySelector('style')).toBeNull();
     expect(targetDocument.head.querySelectorAll('style').length).toBe(1);
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     expect(targetDocument.createElement).toHaveBeenCalledTimes(0);
   });
 });

--- a/packages/react-components/react-radio/library/src/contexts/index.ts
+++ b/packages/react-components/react-radio/library/src/contexts/index.ts
@@ -2,7 +2,7 @@ export {
   RadioGroupContext,
   RadioGroupProvider,
   useRadioGroupContextValue_unstable,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   useRadioGroupContext_unstable,
 } from './RadioGroupContext';
 export { useRadioGroupContextValues } from './useRadioGroupContextValues';

--- a/packages/react-components/react-radio/library/src/index.ts
+++ b/packages/react-components/react-radio/library/src/index.ts
@@ -18,6 +18,6 @@ export type { RadioProps, RadioSlots, RadioState, RadioOnChangeData } from './Ra
 export {
   RadioGroupProvider,
   useRadioGroupContextValues,
-  useRadioGroupContext_unstable, // eslint-disable-line deprecation/deprecation
+  useRadioGroupContext_unstable, // eslint-disable-line @typescript-eslint/no-deprecated
   useRadioGroupContextValue_unstable,
 } from './contexts/index';

--- a/packages/react-components/react-storybook-addon/src/preset/manager.ts
+++ b/packages/react-components/react-storybook-addon/src/preset/manager.ts
@@ -8,20 +8,20 @@ import { DirectionSwitch } from '../components/DirectionSwitch';
 addons.register(ADDON_ID, () => {
   addons.add(THEME_ID, {
     title: 'Fluent Theme Picker',
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     type: types.TOOL,
     match: ({ viewMode }) => !!(viewMode && viewMode.match(/^(story|docs)$/)),
     render: ThemePicker,
   });
   addons.add(DIR_ID, {
     title: 'Direction Switch',
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     type: types.TOOL,
     match: ({ viewMode }) => !!(viewMode && viewMode.match(/^(story|docs)$/)),
     render: DirectionSwitch,
   });
   addons.add(STRICT_MODE_ID, {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     type: types.TOOL,
     title: 'React Strict Mode',
     match: ({ viewMode }) => !!(viewMode && viewMode.match(/^(story|docs)$/)),

--- a/packages/react-components/react-switch/library/src/Switch.ts
+++ b/packages/react-components/react-switch/library/src/Switch.ts
@@ -2,7 +2,7 @@ export type { SwitchOnChangeData, SwitchProps, SwitchSlots, SwitchState } from '
 export {
   Switch,
   renderSwitch_unstable,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   switchClassName,
   switchClassNames,
   useSwitchStyles_unstable,

--- a/packages/react-components/react-switch/library/src/components/Switch/index.ts
+++ b/packages/react-components/react-switch/library/src/components/Switch/index.ts
@@ -3,7 +3,7 @@ export type { SwitchOnChangeData, SwitchProps, SwitchSlots, SwitchState } from '
 export { renderSwitch_unstable } from './renderSwitch';
 export { useSwitch_unstable } from './useSwitch';
 export {
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   switchClassName,
   switchClassNames,
   useSwitchStyles_unstable,

--- a/packages/react-components/react-switch/library/src/index.ts
+++ b/packages/react-components/react-switch/library/src/index.ts
@@ -1,7 +1,7 @@
 export {
   Switch,
   renderSwitch_unstable,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   switchClassName,
   switchClassNames,
   useSwitchStyles_unstable,

--- a/packages/react-components/react-table/library/src/components/DataGridHeaderCell/useDataGridHeaderCell.ts
+++ b/packages/react-components/react-table/library/src/components/DataGridHeaderCell/useDataGridHeaderCell.ts
@@ -42,7 +42,7 @@ export const useDataGridHeaderCell_unstable = (
     return ctx.columnSizing_unstable.getTableHeaderCellProps;
   });
 
-  // eslint-disable-next-line deprecation/deprecation -- prefer HTMLTableCellElement
+  // eslint-disable-next-line @typescript-eslint/no-deprecated -- prefer HTMLTableCellElement
   const onClick = useEventCallback((e: React.MouseEvent<HTMLTableHeaderCellElement>) => {
     if (sortable) {
       toggleColumnSort(e, columnId);

--- a/packages/react-components/react-table/library/src/components/TableSelectionCell/useTableSelectionCell.tsx
+++ b/packages/react-components/react-table/library/src/components/TableSelectionCell/useTableSelectionCell.tsx
@@ -26,7 +26,7 @@ export const useTableSelectionCell_unstable = (
     type = 'checkbox',
     checked = false,
     subtle = false,
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     hidden = false,
     invisible = false,
   } = props;

--- a/packages/react-components/react-tabs/library/src/components/Tab/useTabStyles.styles.ts
+++ b/packages/react-components/react-tabs/library/src/components/Tab/useTabStyles.styles.ts
@@ -717,7 +717,7 @@ export const useTabContentStyles_unstable = (state: TabState): TabState => {
     );
     // FIXME: this is a deprecated API
     // should be removed in the next major version
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     state.contentReservedSpaceClassName = state.contentReservedSpace.className;
   }
 

--- a/packages/react-components/react-tabster/src/index.ts
+++ b/packages/react-components/react-tabster/src/index.ts
@@ -64,10 +64,10 @@ export {
   /** @deprecated (Do not use! Exposed by mistake and will be removed in the next major version.)  */
   TabsterTypes6_0_1_DoNotUse as TabsterTypes,
   /** @deprecated Use element.dispatchEvent(new GroupperMoveFocusEvent({ action: GroupperMoveFocusActions.Escape })) */
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   dispatchGroupperMoveFocusEvent,
   /** @deprecated Use element.dispatchEvent(new MoverMoveFocusEvent({ key: MoverKeys.ArrowDown })) */
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   dispatchMoverMoveFocusEvent,
 };
 

--- a/packages/react-components/react-tree/library/src/components/TreeItem/useTreeItemContextValues.ts
+++ b/packages/react-components/react-tree/library/src/components/TreeItem/useTreeItemContextValues.ts
@@ -11,9 +11,9 @@ export function useTreeItemContextValues_unstable(state: TreeItemState): TreeIte
     expandIconRef,
     actionsRef,
     treeItemRef,
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     isActionsVisible,
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     isAsideVisible,
     selectionRef,
     checked,

--- a/packages/react-components/react-utilities/src/compose/deprecated/getSlots.test.tsx
+++ b/packages/react-components/react-utilities/src/compose/deprecated/getSlots.test.tsx
@@ -9,7 +9,7 @@ describe('getSlots', () => {
 
   it('returns provided component type for root if the as prop is not provided', () => {
     type Slots = { root: Slot<'div'> };
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     expect(getSlots<Slots>({ root: {}, components: { root: 'div' } })).toEqual({
       slots: { root: 'div' },
       slotProps: { root: {} },
@@ -18,7 +18,7 @@ describe('getSlots', () => {
 
   it('returns root slot as a span with no props', () => {
     type Slots = { root: Slot<'div', 'span'> };
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     expect(getSlots<Slots>({ root: { as: 'span' }, components: { root: 'div' } })).toEqual({
       slots: { root: 'span' },
       slotProps: { root: {} },
@@ -29,7 +29,7 @@ describe('getSlots', () => {
     type Slots = { root: Slot<'button'> };
     const invalidProp = { href: 'href' } as React.ButtonHTMLAttributes<HTMLButtonElement>;
     expect(
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       getSlots<Slots>({ root: { as: 'button', id: 'id', ...invalidProp }, components: { root: 'button' } }),
     ).toEqual({
       slots: { root: 'button' },
@@ -39,7 +39,7 @@ describe('getSlots', () => {
 
   it('returns root slot as an anchor, leaving the href intact', () => {
     type Slots = { root: Slot<'a'> };
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     expect(getSlots<Slots>({ root: { as: 'a', id: 'id', href: 'href' }, components: { root: 'a' } })).toEqual({
       slots: { root: 'a' },
       slotProps: { root: { id: 'id', href: 'href' } },
@@ -52,7 +52,7 @@ describe('getSlots', () => {
       icon: Slot<typeof Foo>;
     };
     expect(
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       getSlots<Slots>({
         icon: {},
         components: { root: 'div', icon: Foo },
@@ -70,7 +70,7 @@ describe('getSlots', () => {
       icon: Slot<'button'>;
     };
     expect(
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       getSlots<Slots>({
         components: { icon: 'button', root: 'div' },
         root: { as: 'span' },
@@ -88,7 +88,7 @@ describe('getSlots', () => {
       icon: Slot<'a'>;
     };
     expect(
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       getSlots<Slots>({
         root: { as: 'div' },
         components: { root: 'div', icon: 'a' },
@@ -106,7 +106,7 @@ describe('getSlots', () => {
       icon: Slot<'a'> | Slot<typeof Foo>;
     };
     expect(
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       getSlots<Slots>({
         components: { root: 'div', icon: Foo },
         root: { as: 'div' },
@@ -124,7 +124,7 @@ describe('getSlots', () => {
       icon: Slot<'a'>;
     };
     expect(
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       getSlots<Slots>({
         components: { root: 'div', icon: Foo },
         root: { as: 'div' },
@@ -143,12 +143,12 @@ describe('getSlots', () => {
     };
     const renderFunction = (C: React.ElementType, p: {}) => <C {...p} />;
     expect(
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       getSlots<Slots>({
         components: { root: 'div', icon: Foo },
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         root: resolveShorthand({ as: 'div' }, { required: true }),
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         icon: resolveShorthand({ id: 'bar', children: renderFunction }),
       }),
     ).toEqual({
@@ -164,7 +164,7 @@ describe('getSlots', () => {
       icon?: Slot<'a'>;
     };
     expect(
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       getSlots<Slots>({
         root: { as: 'div' },
         components: { root: 'div', input: 'input', icon: 'a' },

--- a/packages/react-components/react-utilities/src/compose/deprecated/getSlots.ts
+++ b/packages/react-components/react-utilities/src/compose/deprecated/getSlots.ts
@@ -59,23 +59,23 @@ export type ObjectSlotProps<S extends SlotPropsRecord> = {
 export function getSlots<R extends SlotPropsRecord>(
   state: ComponentState<R>,
 ): {
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   slots: Slots<R>;
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   slotProps: ObjectSlotProps<R>;
 } {
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   const slots = {} as Slots<R>;
   const slotProps = {} as R;
 
   const slotNames: (keyof R)[] = Object.keys(state.components);
   for (const slotName of slotNames) {
     const [slot, props] = getSlot(state, slotName);
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     slots[slotName] = slot as Slots<R>[typeof slotName];
     slotProps[slotName] = props;
   }
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   return { slots, slotProps: slotProps as unknown as ObjectSlotProps<R> };
 }
 

--- a/packages/react-components/react-utilities/src/compose/deprecated/getSlotsNext.test.tsx
+++ b/packages/react-components/react-utilities/src/compose/deprecated/getSlotsNext.test.tsx
@@ -16,7 +16,7 @@ describe('getSlotsNext', () => {
   it('returns provided component type for root if the as prop is not provided', () => {
     type Slots = { root: Slot<'div'> };
     expect(
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       getSlotsNext<Slots>({
         root: resolveShorthandMock<ExtractSlotProps<Slots['root']>>({}),
         components: { root: 'div' },
@@ -30,7 +30,7 @@ describe('getSlotsNext', () => {
   it('returns root slot as a span with no props', () => {
     type Slots = { root: Slot<'div', 'span'> };
     expect(
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       getSlotsNext<Slots>({
         root: resolveShorthandMock<ExtractSlotProps<Slots['root']>>({ as: 'span' }),
         components: { root: 'div' },
@@ -45,7 +45,7 @@ describe('getSlotsNext', () => {
     type Slots = { root: Slot<'button'> };
     const invalidProp = { href: 'href' } as React.ButtonHTMLAttributes<HTMLButtonElement>;
     expect(
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       getSlotsNext<Slots>({
         root: resolveShorthandMock<ExtractSlotProps<Slots['root']>>({ as: 'button', id: 'id', ...invalidProp }),
         components: { root: 'button' },
@@ -59,7 +59,7 @@ describe('getSlotsNext', () => {
   it('returns root slot as an anchor, leaving the href intact', () => {
     type Slots = { root: Slot<'a'> };
     expect(
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       getSlotsNext<Slots>({
         root: resolveShorthandMock<ExtractSlotProps<Slots['root']>>({ as: 'a', id: 'id', href: 'href' }),
         components: { root: 'a' },
@@ -76,7 +76,7 @@ describe('getSlotsNext', () => {
       icon: Slot<typeof Foo>;
     };
     expect(
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       getSlotsNext<Slots>({
         icon: resolveShorthandMock<ExtractSlotProps<Slots['icon']>>({}),
         components: { root: 'div', icon: Foo },
@@ -97,7 +97,7 @@ describe('getSlotsNext', () => {
       icon: Slot<'button'>;
     };
     expect(
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       getSlotsNext<Slots>({
         components: { icon: 'button', root: 'div' },
         root: resolveShorthandMock<ExtractSlotProps<Slots['root']>>({ as: 'span' }),
@@ -118,7 +118,7 @@ describe('getSlotsNext', () => {
       icon: Slot<'a'>;
     };
     expect(
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       getSlotsNext<Slots>({
         root: resolveShorthandMock<ExtractSlotProps<Slots['root']>>({ as: 'div' }),
         components: { root: 'div', icon: 'a' },
@@ -143,7 +143,7 @@ describe('getSlotsNext', () => {
       icon: Slot<'a'> | Slot<typeof Foo>;
     };
     expect(
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       getSlotsNext<Slots>({
         components: { root: 'div', icon: Foo },
         root: resolveShorthandMock<ExtractSlotProps<Slots['root']>>({ as: 'div' }),
@@ -169,7 +169,7 @@ describe('getSlotsNext', () => {
     };
     const renderIcon = (C: React.ElementType, p: {}) => <C {...p} />;
     expect(
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       getSlotsNext<Slots>({
         components: { root: 'div', icon: Foo },
         root: resolveShorthandMock<ExtractSlotProps<Slots['root']>>({ as: 'div' }),
@@ -191,12 +191,12 @@ describe('getSlotsNext', () => {
     };
     const renderFunction = (C: React.ElementType, p: {}) => <C {...p} />;
     expect(
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       getSlotsNext<Slots>({
         components: { root: 'div', icon: Foo },
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         root: resolveShorthand<ExtractSlotProps<Slots['root']>>({ as: 'div' }, { required: true }),
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         icon: resolveShorthand<ExtractSlotProps<Slots['icon']>>({ id: 'bar', children: renderFunction }),
       }),
     ).toEqual({
@@ -219,7 +219,7 @@ describe('getSlotsNext', () => {
       icon?: Slot<'a'>;
     };
     expect(
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       getSlotsNext<Slots>({
         root: resolveShorthandMock<ExtractSlotProps<Slots['root']>>({ as: 'div' }),
         components: { root: 'div', input: 'input', icon: 'a' },

--- a/packages/react-components/react-utilities/src/compose/deprecated/getSlotsNext.ts
+++ b/packages/react-components/react-utilities/src/compose/deprecated/getSlotsNext.ts
@@ -15,24 +15,24 @@ import { ObjectSlotProps, Slots } from './getSlots';
 export function getSlotsNext<R extends SlotPropsRecord>(
   state: ComponentState<R>,
 ): {
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   slots: Slots<R>;
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   slotProps: ObjectSlotProps<R>;
 } {
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   const slots = {} as Slots<R>;
   const slotProps = {} as R;
 
   const slotNames: (keyof R)[] = Object.keys(state.components);
   for (const slotName of slotNames) {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const [slot, props] = getSlotNext(state, slotName);
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     slots[slotName] = slot as Slots<R>[typeof slotName];
     slotProps[slotName] = props;
   }
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   return { slots, slotProps: slotProps as unknown as ObjectSlotProps<R> };
 }
 

--- a/packages/react-components/react-utilities/src/compose/deprecated/resolveShorthand.test.tsx
+++ b/packages/react-components/react-utilities/src/compose/deprecated/resolveShorthand.test.tsx
@@ -13,7 +13,7 @@ type TestProps = {
 describe('resolveShorthand', () => {
   it('resolves a string', () => {
     const props: TestProps = { slotA: 'hello' };
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const resolvedProps = resolveShorthand(props.slotA);
 
     expect(resolvedProps).toEqual({
@@ -23,7 +23,7 @@ describe('resolveShorthand', () => {
 
   it('resolves a JSX element', () => {
     const props: TestProps = { slotA: <div>hello</div> };
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const resolvedProps = resolveShorthand(props.slotA);
 
     expect(resolvedProps).toEqual({
@@ -33,7 +33,7 @@ describe('resolveShorthand', () => {
 
   it('resolves a number', () => {
     const props: TestProps = { slotA: 42 };
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const resolvedProps = resolveShorthand(props.slotA);
 
     expect(resolvedProps).toEqual({
@@ -44,7 +44,7 @@ describe('resolveShorthand', () => {
   it('resolves an object as its copy', () => {
     const slotA = {};
     const props: TestProps = { slotA };
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const resolvedProps = resolveShorthand(props.slotA);
 
     expect(resolvedProps).toEqual({});
@@ -54,15 +54,15 @@ describe('resolveShorthand', () => {
   it('resolves "null" without creating a child element', () => {
     const props: TestProps = { slotA: null, slotB: null };
 
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     expect(resolveShorthand(props.slotA)).toEqual(undefined);
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     expect(resolveShorthand(null, { required: true })).toEqual(undefined);
   });
 
   it('resolves undefined without creating a child element', () => {
     const props: TestProps = { slotA: undefined };
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const resolvedProps = resolveShorthand(props.slotA);
 
     expect(resolvedProps).toEqual(undefined);
@@ -70,7 +70,7 @@ describe('resolveShorthand', () => {
 
   it('resolves to empty object creating a child element', () => {
     const props: TestProps = { slotA: undefined };
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const resolvedProps = resolveShorthand(props.slotA, { required: true });
 
     expect(resolvedProps).toEqual({});

--- a/packages/react-components/react-utilities/src/compose/deprecated/resolveShorthand.ts
+++ b/packages/react-components/react-utilities/src/compose/deprecated/resolveShorthand.ts
@@ -12,9 +12,9 @@ export type ResolveShorthandOptions<Props, Required extends boolean = false> = R
  * @deprecated use slot.always or slot.optional combined with assertSlots instead
  */
 export type ResolveShorthandFunction<Props extends UnknownSlotProps = UnknownSlotProps> = {
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   <P extends Props>(value: P | SlotShorthandValue | undefined, options: ResolveShorthandOptions<P, true>): P;
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   <P extends Props>(value: P | SlotShorthandValue | null | undefined, options?: ResolveShorthandOptions<P, boolean>):
     | P
     | undefined;
@@ -29,7 +29,7 @@ export type ResolveShorthandFunction<Props extends UnknownSlotProps = UnknownSlo
  *
  * @deprecated use slot.always or slot.optional combined with assertSlots instead
  */
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 export const resolveShorthand: ResolveShorthandFunction<UnknownSlotProps> = (value, options) =>
   slot.optional<UnknownSlotProps>(value, {
     ...options,

--- a/packages/react-components/react-utilities/src/compose/getIntrinsicElementProps.ts
+++ b/packages/react-components/react-utilities/src/compose/getIntrinsicElementProps.ts
@@ -23,7 +23,7 @@ export const getIntrinsicElementProps = <
   /** List of native props to exclude from the returned value */
   excludedPropNames?: ExcludedPropKeys[],
 ) => {
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   return getNativeElementProps<
     DistributiveOmit<Props, Exclude<keyof Props, keyof HTMLAttributes | keyof UnknownSlotProps> | ExcludedPropKeys>
   >(props.as ?? tagName, props, excludedPropNames);

--- a/packages/react-components/react-utilities/src/compose/index.ts
+++ b/packages/react-components/react-utilities/src/compose/index.ts
@@ -26,15 +26,15 @@ export { isSlot } from './isSlot';
 export { assertSlots } from './assertSlots';
 export { getIntrinsicElementProps } from './getIntrinsicElementProps';
 
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 export type { ObjectSlotProps, Slots } from './deprecated/getSlots';
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 export { getSlots } from './deprecated/getSlots';
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 export type { ResolveShorthandFunction, ResolveShorthandOptions } from './deprecated/resolveShorthand';
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 export { resolveShorthand } from './deprecated/resolveShorthand';
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 export { getSlotsNext } from './deprecated/getSlotsNext';
 
 export { slot };

--- a/packages/react-components/react-utilities/src/hooks/useOnClickOutside.ts
+++ b/packages/react-components/react-utilities/src/hooks/useOnClickOutside.ts
@@ -121,11 +121,11 @@ export const useOnClickOutside = (options: UseOnClickOrScrollOutsideOptions) => 
 const getWindowEvent = (target: Node | Window | null | undefined): Event | undefined => {
   if (target) {
     if (typeof (target as Window).window === 'object' && (target as Window).window === target) {
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       return target.event;
     }
 
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return (target as Node).ownerDocument?.defaultView?.event ?? undefined;
   }
 

--- a/packages/react-components/react-utilities/src/index.ts
+++ b/packages/react-components/react-utilities/src/index.ts
@@ -1,12 +1,12 @@
 export {
   slot,
   isSlot,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   getSlots,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   getSlotsNext,
   assertSlots,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   resolveShorthand,
   isResolvedShorthand,
   getIntrinsicElementProps,
@@ -18,12 +18,12 @@ export type {
   ComponentProps,
   ComponentState,
   ForwardRefComponent,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   ResolveShorthandFunction,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   ResolveShorthandOptions,
   Slot,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   Slots,
   SlotClassNames,
   SlotPropsRecord,
@@ -60,7 +60,7 @@ export { canUseDOM, useIsSSR, SSRProvider } from './ssr/index';
 
 export {
   clamp,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   getNativeElementProps,
   getPartitionedNativeProps,
   getRTLSafeKey,

--- a/packages/react-components/react-utilities/src/ssr/canUseDOM.ts
+++ b/packages/react-components/react-utilities/src/ssr/canUseDOM.ts
@@ -7,7 +7,7 @@ export function canUseDOM(): boolean {
     typeof window !== 'undefined' &&
     !!(
       window.document &&
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       window.document.createElement
     )
     /* eslint-enable @nx/workspace-no-restricted-globals */

--- a/packages/react-components/react-utilities/src/utils/getNativeElementProps.test.ts
+++ b/packages/react-components/react-utilities/src/utils/getNativeElementProps.test.ts
@@ -2,21 +2,21 @@ import { getNativeElementProps } from './getNativeElementProps';
 
 describe('getNativeElementProps', () => {
   it('can filter native element properties', () => {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     expect(getNativeElementProps('div', { id: '123', checked: true })).toEqual({ id: '123' });
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     expect(getNativeElementProps('input', { id: '123', checked: true })).toEqual({ id: '123', checked: true });
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     expect(getNativeElementProps('input', { id: '123', checked: true }, ['id'])).toEqual({ checked: true });
   });
 
   it('includes `as` as a native prop', () => {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     expect(getNativeElementProps('div', { as: 'span' })).toEqual({ as: 'span' });
   });
 
   it('excludes props regardless of the allowed', () => {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     expect(getNativeElementProps('div', { as: 'span' }, ['as'])).toEqual({});
   });
 });

--- a/packages/react-components/react-utilities/src/utils/getNativeElementProps.ts
+++ b/packages/react-components/react-utilities/src/utils/getNativeElementProps.ts
@@ -101,7 +101,7 @@ export const getPartitionedNativeProps = <
 }) => {
   return {
     root: { style: props.style, className: props.className },
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     primary: getNativeElementProps<Omit<Props, ExcludedPropKeys>>(primarySlotTagName, props, [
       ...(excludedPropNames || []),
       'style',

--- a/packages/react-components/react-utilities/src/utils/index.ts
+++ b/packages/react-components/react-utilities/src/utils/index.ts
@@ -1,6 +1,6 @@
 export { clamp } from './clamp';
 export {
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   getNativeElementProps,
   getPartitionedNativeProps,
 } from './getNativeElementProps';

--- a/packages/react-conformance/src/isConformant.ts
+++ b/packages/react-conformance/src/isConformant.ts
@@ -15,7 +15,7 @@ export function isConformant<TProps = {}>(...testInfo: Partial<IsConformantOptio
     disabledTests = [],
     extraTests,
     tsConfig,
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     tsconfigDir,
     disableTypeTests,
   } = mergedOptions;

--- a/packages/react-date-time/src/Calendar.ts
+++ b/packages/react-date-time/src/Calendar.ts
@@ -6,7 +6,7 @@ export {
   FirstWeekOfYear,
   defaultCalendarNavigationIcons,
   defaultCalendarStrings,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   defaultDayPickerStrings,
 } from '@fluentui/react/lib/Calendar';
 export type {
@@ -19,9 +19,9 @@ export type {
   ICalendarDayProps,
   ICalendarDayStyleProps,
   ICalendarDayStyles,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   ICalendarFormatDateCallbacks,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   ICalendarIconStrings,
   ICalendarMonth,
   ICalendarMonthProps,

--- a/packages/react-date-time/src/DatePicker.ts
+++ b/packages/react-date-time/src/DatePicker.ts
@@ -6,9 +6,9 @@ export {
 } from '@fluentui/react/lib/DatePicker';
 export type {
   ICalendar,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   ICalendarFormatDateCallbacks,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   ICalendarIconStrings,
   ICalendarNavigationIcons,
   ICalendarProps,

--- a/packages/react-docsite-components/.eslintrc.json
+++ b/packages/react-docsite-components/.eslintrc.json
@@ -2,7 +2,15 @@
   "extends": ["plugin:@fluentui/eslint-plugin/react--legacy"],
   "root": true,
   "rules": {
-    "deprecation/deprecation": "off",
     "no-restricted-globals": "off"
-  }
+  },
+  "overrides": [
+    {
+      "files": "**/*.{ts,tsx}",
+      "rules": {
+        // The components in this package are all deprecated
+        "@typescript-eslint/no-deprecated": "off"
+      }
+    }
+  ]
 }

--- a/packages/react-examples/src/react-cards/Card/Card.Configure.Example.tsx
+++ b/packages/react-examples/src/react-cards/Card/Card.Configure.Example.tsx
@@ -20,7 +20,7 @@ import {
   ITextStyles,
 } from '@fluentui/react';
 
-/* eslint-disable deprecation/deprecation */
+/* eslint-disable @typescript-eslint/no-deprecated */
 
 export type FilledSectionKey = '0' | '1' | '2' | '3';
 

--- a/packages/react-examples/src/react-cards/Card/Card.Horizontal.Example.tsx
+++ b/packages/react-examples/src/react-cards/Card/Card.Horizontal.Example.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Card, ICardTokens, ICardSectionStyles, ICardSectionTokens } from '@fluentui/react-cards';
 import { FontWeights, Icon, IIconStyles, Image, Stack, IStackTokens, Text, ITextStyles } from '@fluentui/react';
 
-/* eslint-disable deprecation/deprecation */
+/* eslint-disable @typescript-eslint/no-deprecated */
 
 const alertClicked = (): void => {
   alert('Clicked');

--- a/packages/react-examples/src/react-cards/Card/Card.Vertical.Example.tsx
+++ b/packages/react-examples/src/react-cards/Card/Card.Vertical.Example.tsx
@@ -14,7 +14,7 @@ import {
   ITextStyles,
 } from '@fluentui/react';
 
-/* eslint-disable deprecation/deprecation */
+/* eslint-disable @typescript-eslint/no-deprecated */
 
 const alertClicked = (): void => {
   alert('Clicked');

--- a/packages/react-examples/src/react-experiments/Chiclet/Chiclet.Footer.Example.tsx
+++ b/packages/react-examples/src/react-experiments/Chiclet/Chiclet.Footer.Example.tsx
@@ -63,7 +63,7 @@ export const ChicletFooterExample: React.FunctionComponent<{}> = () => {
   );
 };
 
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 export interface IFooterComponent extends React.Props<FooterComponent> {
   buttonProps: IButtonProps[];
   activities: string;

--- a/packages/react-examples/src/react-experiments/Chiclet/Chiclet.Xsmall.Footer.Example.tsx
+++ b/packages/react-examples/src/react-experiments/Chiclet/Chiclet.Xsmall.Footer.Example.tsx
@@ -65,7 +65,7 @@ class FooterComponent extends React.Component<IFooterComponent, {}> {
   }
 }
 
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 interface IFooterComponent extends React.Props<FooterComponent> {
   buttonProps: IButtonProps[];
   attachProps: IIconProps;

--- a/packages/react-examples/src/react-experiments/CollapsibleSection/CollapsibleSection.Styled.Example.tsx
+++ b/packages/react-examples/src/react-experiments/CollapsibleSection/CollapsibleSection.Styled.Example.tsx
@@ -12,7 +12,7 @@ import {
 } from '@fluentui/react-experiments/lib/CollapsibleSection';
 
 // Workaround to prevent errors on usage of Customizer in this file, without disabling all deprecation checks
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 const Customizer = DeprecatedCustomizer;
 
 const getPropStyles: ICollapsibleSectionComponent['styles'] = (props, theme): ICollapsibleSectionStylesReturnType => ({

--- a/packages/react-examples/src/react-experiments/FloatingPeopleSuggestions/FloatingPeopleSuggestions.HeaderFooter.Example.tsx
+++ b/packages/react-examples/src/react-experiments/FloatingPeopleSuggestions/FloatingPeopleSuggestions.HeaderFooter.Example.tsx
@@ -186,7 +186,7 @@ export const FloatingPeopleSuggestionsHeaderFooterExample = (): JSX.Element => {
   };
 
   const _onInputKeyDown = (ev: React.KeyboardEvent<Autofill | HTMLElement>) => {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const keyCode = ev.which;
     switch (keyCode) {
       case KeyCodes.enter:

--- a/packages/react-examples/src/react-experiments/Slider/Slider.Example.tsx
+++ b/packages/react-examples/src/react-experiments/Slider/Slider.Example.tsx
@@ -3,7 +3,7 @@ import { Slider as DeprecatedSlider } from '@fluentui/react-experiments';
 import { IStackTokens, Stack } from '@fluentui/react';
 
 // Workaround to prevent errors on usage of Slider, without disabling all deprecation checks
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 const Slider = DeprecatedSlider;
 
 export interface ISliderBasicExampleState {

--- a/packages/react-examples/src/react-experiments/Slider/Slider.Vertical.Example.tsx
+++ b/packages/react-examples/src/react-experiments/Slider/Slider.Vertical.Example.tsx
@@ -3,7 +3,7 @@ import { Slider as DeprecatedSlider } from '@fluentui/react-experiments';
 import { IStackTokens, Stack } from '@fluentui/react/lib/Stack';
 
 // Workaround to prevent errors on usage of Slider, without disabling all deprecation checks
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 const Slider = DeprecatedSlider;
 
 export interface ISliderVerticalExampleState {

--- a/packages/react-examples/src/react-experiments/Theming/Theming.Schemes.Custom.Example.tsx
+++ b/packages/react-examples/src/react-experiments/Theming/Theming.Schemes.Custom.Example.tsx
@@ -26,7 +26,7 @@ import { CollapsibleSectionRecursiveExample } from '@fluentui/react-examples/lib
 import { ThemeProvider as DeprecatedThemeProvider } from '@fluentui/foundation-legacy';
 
 // Workaround to prevent errors on usage of ThemeProvider, without disabling all deprecation checks
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 const ThemeProvider = DeprecatedThemeProvider;
 
 const regionStyles: IStackComponent['styles'] = (props, theme): IStackStylesReturnType => ({
@@ -186,7 +186,7 @@ export class ThemingSchemesCustomExample extends React.Component<{}, IThemingExa
   };
 
   public render(): JSX.Element {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return <Customizer settings={{ theme: schemeThemeCustom }}>{this._renderSchemedComponents()}</Customizer>;
   }
 
@@ -270,7 +270,7 @@ export class ThemingSchemesCustomExample extends React.Component<{}, IThemingExa
   };
 }
 
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 const onCommandClick = (ev: any, item?: ICommandBarItemProps) => console.log(item && (item.text || item.name));
 const items: ICommandBarItemProps[] = [
   {

--- a/packages/react-examples/src/react-experiments/Theming/Theming.Schemes.Variant.Example.tsx
+++ b/packages/react-examples/src/react-experiments/Theming/Theming.Schemes.Variant.Example.tsx
@@ -25,7 +25,7 @@ import { CollapsibleSectionRecursiveExample } from '@fluentui/react-examples/lib
 import { ThemeProvider as DeprecatedThemeProvider } from '@fluentui/foundation-legacy';
 
 // Workaround to prevent errors on usage of ThemeProvider, without disabling all deprecation checks
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 const ThemeProvider = DeprecatedThemeProvider;
 
 const regionStyles: IStackComponent['styles'] = (props, theme): IStackStylesReturnType => ({
@@ -65,7 +65,7 @@ export class ThemingSchemesVariantExample extends React.Component<{}, IThemingEx
   };
 
   public render(): JSX.Element {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return <Customizer settings={{ theme: schemeThemeVariants }}>{this._renderSchemedComponents()}</Customizer>;
   }
 
@@ -149,7 +149,7 @@ export class ThemingSchemesVariantExample extends React.Component<{}, IThemingEx
   };
 }
 
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 const onCommandClick = (ev: any, item?: ICommandBarItemProps) => console.log(item && (item.text || item.name));
 const items: ICommandBarItemProps[] = [
   {

--- a/packages/react-examples/src/react-experiments/UnifiedPeoplePicker/UnifiedPeoplePicker.WithEdit.Example.tsx
+++ b/packages/react-examples/src/react-experiments/UnifiedPeoplePicker/UnifiedPeoplePicker.WithEdit.Example.tsx
@@ -339,7 +339,7 @@ export const UnifiedPeoplePickerWithEditExample = (): JSX.Element => {
 
   const _onKeyDown = React.useCallback(
     (ev: React.KeyboardEvent<HTMLDivElement>) => {
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       if (ev.ctrlKey && ev.which === KeyCodes.k) {
         ev.preventDefault();
         // If the input has text, resolve that

--- a/packages/react-examples/src/react-focus/FocusZone/FocusZone.List.Example.tsx
+++ b/packages/react-examples/src/react-focus/FocusZone/FocusZone.List.Example.tsx
@@ -75,6 +75,6 @@ export const FocusZoneListExample: React.FunctionComponent = () => {
 };
 
 function _shouldEnterInnerZone(ev: React.KeyboardEvent<HTMLElement>): boolean {
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   return ev.which === getRTLSafeKeyCode(KeyCodes.right);
 }

--- a/packages/react-examples/src/react/Layer/Layer.Customized.Example.tsx
+++ b/packages/react-examples/src/react/Layer/Layer.Customized.Example.tsx
@@ -25,7 +25,7 @@ export const LayerCustomizedExample: React.FunctionComponent = () => {
       </p>
       <Toggle label="Show panel" inlineLabel checked={isPanelOpen} onChange={isPanelOpen ? dismissPanel : showPanel} />
       <Toggle label="Trap panel" inlineLabel checked={trapPanel} onChange={toggleTrapPanel} />
-      {/* eslint-disable-next-line deprecation/deprecation */}
+      {/* eslint-disable-next-line @typescript-eslint/no-deprecated */}
       <Customizer scopedSettings={scopedSettings}>
         {isPanelOpen && (
           <Panel

--- a/packages/react-examples/src/react/Modal/Modal.Basic.Example.tsx
+++ b/packages/react-examples/src/react/Modal/Modal.Basic.Example.tsx
@@ -124,7 +124,7 @@ const contentStyles = mergeStyleSets({
     alignItems: 'stretch',
   },
   header: [
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     theme.fonts.xLargePlus,
     {
       flex: '1 1 auto',

--- a/packages/react-examples/src/react/Modal/Modal.Modeless.Example.tsx
+++ b/packages/react-examples/src/react/Modal/Modal.Modeless.Example.tsx
@@ -84,7 +84,7 @@ const contentStyles = mergeStyleSets({
     alignItems: 'stretch',
   },
   header: [
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     theme.fonts.xLargePlus,
     {
       flex: '1 1 auto',

--- a/packages/react-examples/src/react/Panel/Panel.HandleDismissTarget.Example.tsx
+++ b/packages/react-examples/src/react/Panel/Panel.HandleDismissTarget.Example.tsx
@@ -19,7 +19,7 @@ export const PanelHandleDismissTargetExample: React.FunctionComponent = () => {
 
       // Demonstrates how to do different things depending on how which element dismissed the panel
       console.log('Close button clicked or light dismissed.');
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       const srcElement = ev.nativeEvent.srcElement as Element | null;
       if (srcElement && srcElement.className.indexOf('ms-Button-icon') !== -1) {
         console.log('Close button clicked.');

--- a/packages/react-examples/src/react/PeoplePicker/examples/PeoplePickerExampleData.ts
+++ b/packages/react-examples/src/react/PeoplePicker/examples/PeoplePickerExampleData.ts
@@ -1,7 +1,7 @@
 import { IPersonaProps, PersonaPresence } from '@fluentui/react/lib/Persona';
 import { TestImages } from '@fluentui/example-data';
 
-/* eslint-disable deprecation/deprecation */
+/* eslint-disable @typescript-eslint/no-deprecated */
 
 /** @deprecated Use the version from `@fluentui/example-data` instead. */
 export const people: (IPersonaProps & { key: string | number })[] = [

--- a/packages/react-examples/src/react/Pivot/Pivot.OverflowMenu.Example.tsx
+++ b/packages/react-examples/src/react/Pivot/Pivot.OverflowMenu.Example.tsx
@@ -14,7 +14,7 @@ export const PivotOverflowMenuExample: React.FunctionComponent = () => {
         <Toggle label="linkFormat" offText="links" onText="tabs" checked={tabs} onChange={toggleTabs} />
         <Toggle label="direction" offText="ltr" onText="rtl" checked={rtl} onChange={toggleRtl} />
       </div>
-      {/* eslint-disable-next-line deprecation/deprecation */}
+      {/* eslint-disable-next-line @typescript-eslint/no-deprecated */}
       <Fabric dir={rtl ? 'rtl' : 'ltr'}>
         <Pivot
           aria-label="Pivot Overflow Menu Example"

--- a/packages/react-examples/src/react/ThemeGenerator/ThemeGenerator.doc.tsx
+++ b/packages/react-examples/src/react/ThemeGenerator/ThemeGenerator.doc.tsx
@@ -289,7 +289,7 @@ export class ThemeGeneratorPage extends React.Component<{}, IThemeGeneratorPageS
 
     const contrastRatio = getContrastRatio(bgc, fgc);
     let contrastRatioString = String(contrastRatio);
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     contrastRatioString = contrastRatioString.substr(0, contrastRatioString.indexOf('.') + 3);
     if (contrastRatio < 4.5) {
       contrastRatioString = '**' + contrastRatioString + '**';

--- a/packages/react-experiments/src/Foundation.ts
+++ b/packages/react-experiments/src/Foundation.ts
@@ -1,5 +1,5 @@
 export {
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   ThemeProvider,
   createComponent,
   createFactory,
@@ -22,7 +22,7 @@ export type {
   IHTMLElementSlot,
   IHTMLSlot,
   IProcessedSlotProps,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   IPropsWithChildren,
   ISlot,
   ISlotCreator,

--- a/packages/react-experiments/src/Styling.ts
+++ b/packages/react-experiments/src/Styling.ts
@@ -6,7 +6,7 @@ export {
   DefaultEffects,
   DefaultFontStyles,
   DefaultPalette,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   EdgeChromiumHighContrastSelector,
   FontClassNames,
   FontSizes,
@@ -39,11 +39,11 @@ export {
   createTheme,
   focusClear,
   fontFace,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   getEdgeChromiumNoHighContrastAdjustSelector,
   getFadedOverflowStyle,
   getFocusOutlineStyle,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   getFocusStyle,
   getGlobalClassNames,
   getHighContrastNoAdjustStyle,

--- a/packages/react-experiments/src/Utilities.ts
+++ b/packages/react-experiments/src/Utilities.ts
@@ -1,10 +1,8 @@
 export {
   Async,
   AutoScroll,
-  // eslint-disable-next-line deprecation/deprecation
   BaseComponent,
   Customizations,
-  // eslint-disable-next-line deprecation/deprecation
   Customizer,
   CustomizerContext,
   DATA_IS_SCROLLABLE_ATTRIBUTE,
@@ -87,7 +85,6 @@ export {
   getRTL,
   getRTLSafeKeyCode,
   getRect,
-  // eslint-disable-next-line deprecation/deprecation
   getResourceUrl,
   getScrollbarWidth,
   getVirtualParent,
@@ -99,11 +96,9 @@ export {
   hoistStatics,
   htmlElementProperties,
   iframeProperties,
-  // eslint-disable-next-line deprecation/deprecation
   imageProperties,
   imgProperties,
   initializeComponentRef,
-  // eslint-disable-next-line deprecation/deprecation
   initializeFocusRects,
   inputProperties,
   isControlled,
@@ -135,7 +130,6 @@ export {
   optionProperties,
   portalContainsElement,
   precisionRound,
-  // eslint-disable-next-line deprecation/deprecation
   raiseClick,
   removeIndex,
   replaceElement,
@@ -145,15 +139,12 @@ export {
   safeRequestAnimationFrame,
   safeSetTimeout,
   selectProperties,
-  // eslint-disable-next-line deprecation/deprecation
   setBaseUrl,
   setFocusVisibility,
-  // eslint-disable-next-line deprecation/deprecation
   setLanguage,
   setMemoizeWeakMap,
   setPortalAttribute,
   setRTL,
-  // eslint-disable-next-line deprecation/deprecation
   setSSR,
   setVirtualParent,
   setWarningCallback,
@@ -184,7 +175,6 @@ export type {
   ICancelable,
   IChangeDescription,
   IChangeEventCallback,
-  // eslint-disable-next-line deprecation/deprecation
   IClassNames,
   IClassNamesFunctionOptions,
   IComponentAs,
@@ -207,7 +197,6 @@ export type {
   IPerfData,
   IPerfMeasurement,
   IPerfSummary,
-  // eslint-disable-next-line deprecation/deprecation
   IPoint,
   IPropsWithStyles,
   IRectangle,
@@ -226,13 +215,10 @@ export type {
   IStyleFunctionOrObject,
   IVirtualElement,
   IWarnControlledUsageParams,
-  // eslint-disable-next-line deprecation/deprecation
   Omit,
   Point,
   RefObject,
-  // eslint-disable-next-line deprecation/deprecation
   Settings,
-  // eslint-disable-next-line deprecation/deprecation
   SettingsFunction,
   StyleFunction,
 } from '@fluentui/react/lib/Utilities';

--- a/packages/react-experiments/src/components/BAFAccordion/Accordion.tsx
+++ b/packages/react-experiments/src/components/BAFAccordion/Accordion.tsx
@@ -33,7 +33,7 @@ export class Accordion extends React.Component<IAccordionProps, IAccordionState>
   }
 
   public render(): JSX.Element {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const { onRenderMenu, className, buttonAs, onClick, ...other } = this.props;
     let { menuIconProps } = this.props;
 

--- a/packages/react-experiments/src/components/CollapsibleSection/CollapsibleSection.state.tsx
+++ b/packages/react-experiments/src/components/CollapsibleSection/CollapsibleSection.state.tsx
@@ -37,12 +37,12 @@ export const useCollapsibleSectionState: ICollapsibleSectionComponent['state'] =
       const collapseKey = getRTL() ? KeyCodes.right : KeyCodes.left;
       const expandKey = getRTL() ? KeyCodes.left : KeyCodes.right;
 
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       if (ev.which === collapseKey && !collapsed) {
         setCollapsed(true);
         ev.preventDefault();
         ev.stopPropagation();
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
       } else if (ev.which === expandKey && collapsed) {
         setCollapsed(false);
         ev.preventDefault();
@@ -58,7 +58,7 @@ export const useCollapsibleSectionState: ICollapsibleSectionComponent['state'] =
     // If left/right keypress originates from text input or text area inside collapsible section,
     // ignore the event.
     if (
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       ev.which === rootKey &&
       ev.target !== titleElementRef.current &&
       titleElementRef.current &&

--- a/packages/react-experiments/src/components/FloatingSuggestions/FloatingSuggestions.tsx
+++ b/packages/react-experiments/src/components/FloatingSuggestions/FloatingSuggestions.tsx
@@ -250,7 +250,7 @@ export class FloatingSuggestions<TItem extends {}>
     ) {
       return;
     }
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const keyCode = ev.which;
     switch (keyCode) {
       case KeyCodes.escape:

--- a/packages/react-experiments/src/components/FolderCover/FolderCover.types.ts
+++ b/packages/react-experiments/src/components/FolderCover/FolderCover.types.ts
@@ -38,6 +38,6 @@ export interface IFolderCoverProps extends IBaseProps, React.HTMLAttributes<HTML
   /**
    * The children to pass into the content area of the folder cover.
    */
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   children?: React.Props<{}>['children'] | ((childrenProps: IFolderCoverChildrenProps) => JSX.Element | null);
 }

--- a/packages/react-experiments/src/components/SelectedItemsList/Items/CopyableItem.tsx
+++ b/packages/react-experiments/src/components/SelectedItemsList/Items/CopyableItem.tsx
@@ -26,7 +26,7 @@ export const CopyableItem = <T extends any>(
           // Try to copy the text directly to the clipboard
           copyInput.value = copyText;
           copyInput.select();
-          // eslint-disable-next-line deprecation/deprecation
+          // eslint-disable-next-line @typescript-eslint/no-deprecated
           if (!document.execCommand('copy')) {
             // The command failed. Fallback to the method below.
             throw new Error();

--- a/packages/react-experiments/src/components/SelectedItemsList/Items/subcomponents/DefaultEditingItem.tsx
+++ b/packages/react-experiments/src/components/SelectedItemsList/Items/subcomponents/DefaultEditingItem.tsx
@@ -195,7 +195,7 @@ export const DefaultEditingItemInner = <TItem extends any>(
 
   const _onInputKeyDown = React.useCallback(
     (ev: React.KeyboardEvent<HTMLInputElement>): void => {
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       const keyCode = ev.which;
       switch (keyCode) {
         case KeyCodes.backspace:

--- a/packages/react-experiments/src/components/Sidebar/Sidebar.tsx
+++ b/packages/react-experiments/src/components/Sidebar/Sidebar.tsx
@@ -154,7 +154,7 @@ export class Sidebar extends React.Component<ISidebarProps, ISidebarState> imple
     }
 
     const ButtonAs = this._getButtonAs(item);
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const name = item.text || item.name;
 
     return (
@@ -204,7 +204,7 @@ export class Sidebar extends React.Component<ISidebarProps, ISidebarState> imple
     }
 
     const ButtonAs = this._getButtonAs(item);
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const name = item.text || item.name;
 
     return (
@@ -268,7 +268,7 @@ export class Sidebar extends React.Component<ISidebarProps, ISidebarState> imple
       return child;
     });
 
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const name = item.text || item.name;
 
     if (name) {

--- a/packages/react-experiments/src/components/Slider/Slider.base.tsx
+++ b/packages/react-experiments/src/components/Slider/Slider.base.tsx
@@ -15,7 +15,7 @@ import { DirectionalHint } from '@fluentui/react/lib/Callout';
 import { Async, EventGroup, FocusRects } from '@fluentui/utilities';
 import type { ISliderProps, ISlider, ISliderStyleProps, ISliderStyles, ISliderMarks } from './Slider.types';
 
-/* eslint-disable deprecation/deprecation */
+/* eslint-disable @typescript-eslint/no-deprecated */
 
 /** @deprecated */
 export interface ISliderState {

--- a/packages/react-experiments/src/components/Slider/Slider.styles.tsx
+++ b/packages/react-experiments/src/components/Slider/Slider.styles.tsx
@@ -3,7 +3,7 @@ import { getRTL } from '@fluentui/utilities';
 import type { ISliderStyleProps, ISliderStyles } from './Slider.types';
 import type { IRawStyle } from '../../Styling';
 
-/* eslint-disable deprecation/deprecation */
+/* eslint-disable @typescript-eslint/no-deprecated */
 
 const tickLabelSpacing = 13;
 

--- a/packages/react-experiments/src/components/Slider/Slider.test.tsx
+++ b/packages/react-experiments/src/components/Slider/Slider.test.tsx
@@ -9,7 +9,7 @@ import { ONKEYDOWN_TIMEOUT_DURATION } from './Slider.base';
 import { KeyCodes } from '../../Utilities';
 import type { ISlider } from './Slider.types';
 
-/* eslint-disable deprecation/deprecation */
+/* eslint-disable @typescript-eslint/no-deprecated */
 
 describe('Slider', () => {
   it('renders correctly', () => {

--- a/packages/react-experiments/src/components/Slider/Slider.tsx
+++ b/packages/react-experiments/src/components/Slider/Slider.tsx
@@ -4,7 +4,7 @@ import { SliderBase } from './Slider.base';
 import { getStyles } from './Slider.styles';
 import type { ISliderProps, ISliderStyleProps, ISliderStyles } from './Slider.types';
 
-/* eslint-disable deprecation/deprecation */
+/* eslint-disable @typescript-eslint/no-deprecated */
 
 /**
  * @deprecated This component was experimental and is not longer being developed on, nor will it be supported in the

--- a/packages/react-experiments/src/components/Slider/Slider.types.ts
+++ b/packages/react-experiments/src/components/Slider/Slider.types.ts
@@ -3,7 +3,7 @@ import { SliderBase } from './Slider.base';
 import type { IStyle, ITheme } from '../../Styling';
 import type { IStyleFunctionOrObject, IRefObject } from '../../Utilities';
 
-/* eslint-disable deprecation/deprecation */
+/* eslint-disable @typescript-eslint/no-deprecated */
 
 /**
  * @deprecated

--- a/packages/react-experiments/src/components/TilesList/TilesList.types.ts
+++ b/packages/react-experiments/src/components/TilesList/TilesList.types.ts
@@ -135,7 +135,7 @@ export interface ITilesGridSegment<TItem> {
 
 export interface ITilesListProps<TItem>
   extends IBaseProps,
-    React.Props<TilesList<TItem>>, // eslint-disable-line deprecation/deprecation
+    React.Props<TilesList<TItem>>, // eslint-disable-line @typescript-eslint/no-deprecated
     React.HTMLAttributes<HTMLDivElement> {
   /**
    * An array of items to assign to the list.

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -332,19 +332,19 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
       // Allow the caller to handle the key down
       onKeyDown?.(ev);
 
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       if (ev.ctrlKey && ev.which === KeyCodes.a) {
         selectAll();
       }
 
       // This is a temporary work around, it has localization issues
       // we plan on rewriting how this works in the future
-      /* eslint-disable deprecation/deprecation */
+      /* eslint-disable @typescript-eslint/no-deprecated */
       const isDel = ev.which === KeyCodes.del;
       const isCut = (ev.shiftKey && isDel) || (ev.ctrlKey && ev.which === KeyCodes.x);
       const isBackspace = ev.which === KeyCodes.backspace;
       const isCopy = ev.ctrlKey && ev.which === KeyCodes.c;
-      /* eslint-enable deprecation/deprecation */
+      /* eslint-enable @typescript-eslint/no-deprecated */
       const needToCopy = isCut || isCopy;
       const needToDelete =
         (isBackspace && selectedItems.length > 0) || ((isCut || isDel) && focusedItemIndices.length > 0);
@@ -421,7 +421,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
   const _onInputKeyDown = React.useCallback(
     (ev: React.KeyboardEvent<Autofill | HTMLElement>) => {
       if (isSuggestionsShown) {
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const keyCode = ev.which;
         switch (keyCode) {
           case KeyCodes.escape:

--- a/packages/react-focus/src/components/FocusZone/FocusZone.tsx
+++ b/packages/react-focus/src/components/FocusZone/FocusZone.tsx
@@ -62,7 +62,7 @@ function raiseClickFromKeyboardEvent(target: Element, ev?: React.KeyboardEvent<H
   } else {
     // eslint-disable-next-line no-restricted-globals
     event = document.createEvent('MouseEvents');
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     event.initMouseEvent(
       'click',
       ev ? ev.bubbles : false,
@@ -172,7 +172,7 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
    * for ref counting to work correctly!
    */
   private static _onKeyDownCapture(ev: KeyboardEvent): void {
-    // eslint-disable-next-line deprecation/deprecation, @fluentui/deprecated-keyboard-event-props
+    // eslint-disable-next-line @typescript-eslint/no-deprecated, @fluentui/deprecated-keyboard-event-props
     if (ev.which === KeyCodes.tab) {
       _outerZones.forEach((zone: FocusZone) => zone._updateTabIndexes());
     }
@@ -238,9 +238,9 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
 
       if (this.props.defaultTabbableElement && typeof this.props.defaultTabbableElement === 'string') {
         this._activeElement = this._getDocument().querySelector(this.props.defaultTabbableElement) as HTMLElement;
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
       } else if (this.props.defaultActiveElement) {
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         this._activeElement = this._getDocument().querySelector(this.props.defaultActiveElement) as HTMLElement;
       }
 
@@ -306,7 +306,7 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
   }
 
   public render(): React.ReactNode {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const { as: tag, elementType, rootProps, ariaDescribedBy, ariaLabelledBy, className } = this.props;
     const divProps = getNativeProps(this.props, htmlElementProperties);
 
@@ -338,7 +338,7 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
         // be replaced so that className is passed to getRootClass and is included there so
         // the class names will always be in the same order.
         className={css(getRootClass(), className)}
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         ref={this._mergedRef(this.props.elementRef, this._root)}
         data-focuszone-id={this._id}
         // eslint-disable-next-line react/jsx-no-bind
@@ -427,7 +427,7 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
    * @returns True if focus could be set to an active element, false if no operation was taken.
    */
   public focusElement(element: HTMLElement, forceAlignment?: boolean): boolean {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const { onBeforeFocus, shouldReceiveFocus } = this.props;
 
     if ((shouldReceiveFocus && !shouldReceiveFocus(element)) || (onBeforeFocus && !onBeforeFocus(element))) {
@@ -487,10 +487,10 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
 
     const {
       onActiveElementChanged,
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       doNotAllowFocusEventToPropagate,
       stopFocusPropagation,
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       onFocusNotification,
       onFocus,
       shouldFocusInnerElementWhenReceivedFocus,
@@ -671,7 +671,7 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
       return;
     }
 
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const { direction, disabled, isInnerZoneKeystroke, pagingSupportDisabled, shouldEnterInnerZone } = this.props;
 
     if (disabled) {
@@ -722,7 +722,7 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
     } else if (ev.altKey) {
       return;
     } else {
-      // eslint-disable-next-line @fluentui/deprecated-keyboard-event-props, deprecation/deprecation
+      // eslint-disable-next-line @fluentui/deprecated-keyboard-event-props, @typescript-eslint/no-deprecated
       switch (ev.which) {
         case KeyCodes.space:
           if (this._shouldRaiseClicksOnSpace && this._tryInvokeClickForFocusable(ev.target as HTMLElement, ev)) {
@@ -778,7 +778,7 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
 
         case KeyCodes.tab:
           if (
-            // eslint-disable-next-line deprecation/deprecation
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             this.props.allowTabKey ||
             this.props.handleTabKey === FocusZoneTabbableElements.all ||
             (this.props.handleTabKey === FocusZoneTabbableElements.inputOnly &&
@@ -924,7 +924,7 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
 
   private _moveFocus(
     isForward: boolean,
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     getDistanceFromCenter: (activeRect: ClientRect, targetRect: ClientRect) => number,
     ev?: Event,
     useDefaultWrap: boolean = true,
@@ -955,7 +955,7 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
       if (isBidirectional) {
         if (element) {
           const targetRect = element.getBoundingClientRect();
-          // eslint-disable-next-line deprecation/deprecation
+          // eslint-disable-next-line @typescript-eslint/no-deprecated
           const elementDistance = getDistanceFromCenter(activeRect as ClientRect, targetRect);
 
           if (elementDistance === -1 && candidateDistance === -1) {
@@ -1005,11 +1005,11 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
 
   private _moveFocusDown(): boolean {
     let targetTop = -1;
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const leftAlignment = this._focusAlignment.left || this._focusAlignment.x || 0;
 
     if (
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       this._moveFocus(true, (activeRect: ClientRect, targetRect: ClientRect) => {
         let distance = -1;
         // ClientRect values can be floats that differ by very small fractions of a decimal.
@@ -1048,11 +1048,11 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
 
   private _moveFocusUp(): boolean {
     let targetTop = -1;
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const leftAlignment = this._focusAlignment.left || this._focusAlignment.x || 0;
 
     if (
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       this._moveFocus(false, (activeRect: ClientRect, targetRect: ClientRect) => {
         let distance = -1;
         // ClientRect values can be floats that differ by very small fractions of a decimal.
@@ -1094,7 +1094,7 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
     if (
       this._moveFocus(
         getRTL(theme),
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         (activeRect: ClientRect, targetRect: ClientRect) => {
           let distance = -1;
           let topBottomComparison;
@@ -1137,7 +1137,7 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
     if (
       this._moveFocus(
         !getRTL(theme),
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         (activeRect: ClientRect, targetRect: ClientRect) => {
           let distance = -1;
           let topBottomComparison;
@@ -1177,12 +1177,12 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
 
   private _getHorizontalDistanceFromCenter = (
     isForward: boolean,
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     activeRect: ClientRect,
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     targetRect: ClientRect,
   ): number => {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const leftAlignment = this._focusAlignment.left || this._focusAlignment.x || 0;
     // ClientRect values can be floats that differ by very small fractions of a decimal.
     // If the difference between top and bottom are within a pixel then we should treat

--- a/packages/react-hooks/src/useConstCallback.test.tsx
+++ b/packages/react-hooks/src/useConstCallback.test.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable deprecation/deprecation */
+/* eslint-disable @typescript-eslint/no-deprecated */
 import * as React from 'react';
 import { mount } from 'enzyme';
 import { useConstCallback } from './useConstCallback';

--- a/packages/react-hooks/src/useMountSync.test.tsx
+++ b/packages/react-hooks/src/useMountSync.test.tsx
@@ -7,7 +7,7 @@ describe('useMountSync', () => {
     const onMount = jest.fn();
 
     const TestComponent: React.FunctionComponent = () => {
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       useMountSync(() => {
         onMount();
       });

--- a/packages/react-monaco-editor/src/utilities/getQueryParam.ts
+++ b/packages/react-monaco-editor/src/utilities/getQueryParam.ts
@@ -10,7 +10,7 @@ export function getQueryParam(name: string, url?: string): string | null {
   url = url || (win ? win.location.href : '');
   // Manually get the query string in case it's after the hash (possible with hash routing)
   const queryIndex = url.indexOf('?');
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   const query = queryIndex !== -1 ? url.substr(queryIndex) : '';
 
   const regex = new RegExp(`[?&]${name}(=([^&#]*)|&|#|$)`);

--- a/packages/react/src/Icons.ts
+++ b/packages/react/src/Icons.ts
@@ -1,6 +1,3 @@
 export { initializeIcons } from '@fluentui/font-icons-mdl2';
 
-export type {
-  // eslint-disable-next-line deprecation/deprecation
-  IconNames,
-} from '@fluentui/font-icons-mdl2';
+export type { IconNames } from '@fluentui/font-icons-mdl2';

--- a/packages/react/src/Styling.ts
+++ b/packages/react/src/Styling.ts
@@ -7,7 +7,6 @@ export {
   DefaultEffects,
   DefaultFontStyles,
   DefaultPalette,
-  // eslint-disable-next-line deprecation/deprecation
   EdgeChromiumHighContrastSelector,
   FontClassNames,
   FontSizes,
@@ -39,11 +38,9 @@ export {
   createFontStyles,
   focusClear,
   fontFace,
-  // eslint-disable-next-line deprecation/deprecation
   getEdgeChromiumNoHighContrastAdjustSelector,
   getFadedOverflowStyle,
   getFocusOutlineStyle,
-  // eslint-disable-next-line deprecation/deprecation
   getFocusStyle,
   getGlobalClassNames,
   getHighContrastNoAdjustStyle,

--- a/packages/react/src/Utilities.ts
+++ b/packages/react/src/Utilities.ts
@@ -2,10 +2,8 @@ import './version';
 export {
   Async,
   AutoScroll,
-  // eslint-disable-next-line deprecation/deprecation
   BaseComponent,
   Customizations,
-  // eslint-disable-next-line deprecation/deprecation
   Customizer,
   CustomizerContext,
   DATA_IS_SCROLLABLE_ATTRIBUTE,
@@ -92,7 +90,6 @@ export {
   getRTL,
   getRTLSafeKeyCode,
   getRect,
-  // eslint-disable-next-line deprecation/deprecation
   getResourceUrl,
   getScrollbarWidth,
   getVirtualParent,
@@ -104,11 +101,9 @@ export {
   hoistStatics,
   htmlElementProperties,
   iframeProperties,
-  // eslint-disable-next-line deprecation/deprecation
   imageProperties,
   imgProperties,
   initializeComponentRef,
-  // eslint-disable-next-line deprecation/deprecation
   initializeFocusRects,
   inputProperties,
   isControlled,
@@ -142,7 +137,6 @@ export {
   optionProperties,
   portalContainsElement,
   precisionRound,
-  // eslint-disable-next-line deprecation/deprecation
   raiseClick,
   removeDirectionalKeyCode,
   removeIndex,
@@ -153,15 +147,12 @@ export {
   safeRequestAnimationFrame,
   safeSetTimeout,
   selectProperties,
-  // eslint-disable-next-line deprecation/deprecation
   setBaseUrl,
   setFocusVisibility,
-  // eslint-disable-next-line deprecation/deprecation
   setLanguage,
   setMemoizeWeakMap,
   setPortalAttribute,
   setRTL,
-  // eslint-disable-next-line deprecation/deprecation
   setSSR,
   setVirtualParent,
   setWarningCallback,
@@ -203,7 +194,6 @@ export type {
   ICancelable,
   IChangeDescription,
   IChangeEventCallback,
-  // eslint-disable-next-line deprecation/deprecation
   IClassNames,
   IClassNamesFunctionOptions,
   IComponentAs,
@@ -227,7 +217,6 @@ export type {
   IPerfData,
   IPerfMeasurement,
   IPerfSummary,
-  // eslint-disable-next-line deprecation/deprecation
   IPoint,
   IPropsWithStyles,
   IReactProps,
@@ -247,13 +236,10 @@ export type {
   IStyleFunctionOrObject,
   IVirtualElement,
   IWarnControlledUsageParams,
-  // eslint-disable-next-line deprecation/deprecation
   Omit,
   Point,
   RefObject,
-  // eslint-disable-next-line deprecation/deprecation
   Settings,
-  // eslint-disable-next-line deprecation/deprecation
   SettingsFunction,
   ShadowConfigHook,
   StyleFunction,

--- a/packages/react/src/components/ActivityItem/ActivityItem.tsx
+++ b/packages/react/src/components/ActivityItem/ActivityItem.tsx
@@ -57,7 +57,7 @@ export class ActivityItem extends React.Component<IActivityItemProps, {}> {
   private _onRenderActivityDescription = (props: IActivityItemProps): JSX.Element | null => {
     const classNames = this._getClassNames(props);
 
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const activityDescription = props.activityDescription || props.activityDescriptionText;
 
     if (activityDescription) {
@@ -70,7 +70,7 @@ export class ActivityItem extends React.Component<IActivityItemProps, {}> {
   private _onRenderComments = (props: IActivityItemProps): JSX.Element | null => {
     const classNames = this._getClassNames(props);
 
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const comments = props.comments || props.commentText;
 
     if (!props.isCompact && comments) {
@@ -117,7 +117,7 @@ export class ActivityItem extends React.Component<IActivityItemProps, {}> {
               {...person}
               key={person.key || index}
               className={classNames.activityPersona}
-              // eslint-disable-next-line deprecation/deprecation
+              // eslint-disable-next-line @typescript-eslint/no-deprecated
               size={showSize16Personas ? PersonaSize.size16 : PersonaSize.size32}
               style={style}
             />,

--- a/packages/react/src/components/Autofill/Autofill.tsx
+++ b/packages/react/src/components/Autofill/Autofill.tsx
@@ -40,9 +40,9 @@ export class Autofill extends React.Component<IAutofillProps, IAutofillState> im
   private _async: Async;
 
   public static getDerivedStateFromProps(props: IAutofillProps, state: IAutofillState): IAutofillState | null {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     if (props.updateValueInWillReceiveProps) {
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       const updatedInputValue = props.updateValueInWillReceiveProps();
       // Don't update if we have a null value or the value isn't changing
       // the value should still update if an empty string is passed in
@@ -247,7 +247,7 @@ export class Autofill extends React.Component<IAutofillProps, IAutofillState> im
     // Right now typing does not have isComposing, once that has been fixed any should be removed.
 
     if (!(ev.nativeEvent as any).isComposing) {
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       switch (ev.which) {
         case KeyCodes.backspace:
           this._autoFillEnabled = false;
@@ -263,7 +263,7 @@ export class Autofill extends React.Component<IAutofillProps, IAutofillState> im
           break;
         default:
           if (!this._autoFillEnabled) {
-            // eslint-disable-next-line deprecation/deprecation
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             if (this.props.enableAutofillOnKeyPress!.indexOf(ev.which) !== -1) {
               this._autoFillEnabled = true;
             }
@@ -339,7 +339,7 @@ export class Autofill extends React.Component<IAutofillProps, IAutofillState> im
       return;
     }
 
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const { onInputChange, onInputValueChange } = this.props;
     if (onInputChange) {
       newValue = onInputChange?.(newValue, composing) || '';

--- a/packages/react/src/components/Button/BaseButton.tsx
+++ b/packages/react/src/components/Button/BaseButton.tsx
@@ -127,7 +127,7 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
       disabled,
       allowDisabledFocus,
       primaryDisabled,
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       secondaryText = this.props.description,
       href,
       iconProps,
@@ -181,7 +181,7 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
     const tag = renderAsAnchor ? 'a' : 'button';
 
     const nativeProps = getNativeProps(
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       assign(renderAsAnchor ? {} : { type: 'button' }, this.props.rootProps, this.props),
       renderAsAnchor ? anchorProperties : buttonProperties,
       [
@@ -230,7 +230,7 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
 
     const buttonProps = assign(nativeProps, {
       className: this._classNames.root,
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       ref: this._mergedRef(this.props.elementRef, this._buttonElement),
       disabled: isPrimaryButtonDisabled && !allowDisabledFocus,
       onKeyDown: this._onKeyDown,
@@ -320,7 +320,7 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
       onRenderIcon = this._onRenderIcon,
       onRenderAriaDescription = this._onRenderAriaDescription,
       onRenderChildren = this._onRenderChildren,
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       onRenderMenu = this._onRenderMenu,
       onRenderMenuIcon = this._onRenderMenuIcon,
       disabled,
@@ -385,7 +385,7 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
    */
   private _shouldRenderMenu() {
     const { menuHidden } = this.state;
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const { persistMenu, renderPersistedMenuHiddenOnMount } = this.props;
 
     if (!menuHidden) {
@@ -428,7 +428,7 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
     const {
       text,
       children,
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       secondaryText = this.props.description,
       onRenderText = this._onRenderText,
       onRenderDescription = this._onRenderDescription,
@@ -486,7 +486,7 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
   };
 
   private _onRenderDescription = (props: IButtonProps) => {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const { secondaryText = this.props.description } = props;
 
     // ms-Button-description is only shown when the button type is compound.
@@ -741,7 +741,7 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
 
   private _onKeyDown = (ev: React.KeyboardEvent<HTMLDivElement | HTMLAnchorElement | HTMLButtonElement>) => {
     // explicity cancelling event so click won't fire after this
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     if (this.props.disabled && (ev.which === KeyCodes.enter || ev.which === KeyCodes.space)) {
       ev.preventDefault();
       ev.stopPropagation();
@@ -765,9 +765,9 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
   private _onKeyPress = (
     ev: React.KeyboardEvent<HTMLDivElement | HTMLAnchorElement | HTMLButtonElement | HTMLSpanElement>,
   ) => {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     if (!this.props.disabled && this.props.onKeyPress !== undefined) {
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       this.props.onKeyPress(ev); // not cancelling event because it's not disabled
     }
   };
@@ -801,7 +801,7 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
   };
 
   private _onSplitButtonContainerKeyDown = (ev: React.KeyboardEvent<HTMLDivElement>) => {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     if (ev.which === KeyCodes.enter || ev.which === KeyCodes.space) {
       if (this._buttonElement.current) {
         this._buttonElement.current.click();
@@ -822,9 +822,9 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
       this.props.onKeyDown(ev);
     }
 
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const isUp = ev.which === KeyCodes.up;
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const isDown = ev.which === KeyCodes.down;
 
     if (!ev.defaultPrevented && this._isValidMenuOpenKey(ev)) {
@@ -838,7 +838,7 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
       ev.stopPropagation();
     }
 
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     if (ev.which === KeyCodes.enter || ev.which === KeyCodes.space) {
       // We manually set the focus visibility to true if opening via Enter or Space to account for the scenario where
       // a user clicks on the button, closes the menu and then opens it via keyboard. In this scenario our default logic
@@ -923,10 +923,10 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
     ev: React.KeyboardEvent<HTMLDivElement | HTMLAnchorElement | HTMLButtonElement>,
   ): boolean {
     if (this.props.menuTriggerKeyCode) {
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       return ev.which === this.props.menuTriggerKeyCode;
     } else if (this.props.menuProps) {
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       return ev.which === KeyCodes.down && (ev.altKey || ev.metaKey);
     }
 

--- a/packages/react/src/components/Button/Button.tsx
+++ b/packages/react/src/components/Button/Button.tsx
@@ -27,7 +27,7 @@ export class Button extends React.Component<IButtonProps, {}> {
   public render(): JSX.Element {
     const props = this.props;
 
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     switch (props.buttonType) {
       case ButtonType.command:
         return <ActionButton {...props} />;

--- a/packages/react/src/components/Button/Button.types.ts
+++ b/packages/react/src/components/Button/Button.types.ts
@@ -42,12 +42,12 @@ export interface IButton {
 /**
  * {@docCategory Button}
  */
-/* eslint-disable deprecation/deprecation */
+/* eslint-disable @typescript-eslint/no-deprecated */
 export interface IButtonProps
   extends React.AllHTMLAttributes<
     HTMLAnchorElement | HTMLButtonElement | HTMLDivElement | BaseButton | Button | HTMLSpanElement
   > {
-  /* eslint-enable deprecation/deprecation */
+  /* eslint-enable @typescript-eslint/no-deprecated */
   /**
    * Optional callback to access the `IButton` interface. Use this instead of `ref` for accessing
    * the public methods and properties of the component.

--- a/packages/react/src/components/Calendar/Calendar.base.tsx
+++ b/packages/react/src/components/Calendar/Calendar.base.tsx
@@ -228,7 +228,7 @@ export const CalendarBase: React.FunctionComponent<ICalendarProps> = React.forwa
 
     const onButtonKeyDown = (callback: () => void): ((ev: React.KeyboardEvent<HTMLButtonElement>) => void) => {
       return (ev: React.KeyboardEvent<HTMLButtonElement>) => {
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         switch (ev.which) {
           case KeyCodes.enter:
           case KeyCodes.space:
@@ -239,7 +239,7 @@ export const CalendarBase: React.FunctionComponent<ICalendarProps> = React.forwa
     };
 
     const onDatePickerPopupKeyDown = (ev: React.KeyboardEvent<HTMLElement>): void => {
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       switch (ev.which) {
         case KeyCodes.enter:
           ev.preventDefault();

--- a/packages/react/src/components/Calendar/CalendarDay/CalendarDay.base.tsx
+++ b/packages/react/src/components/Calendar/CalendarDay/CalendarDay.base.tsx
@@ -184,7 +184,7 @@ CalendarDayNavigationButtons.displayName = 'CalendarDayNavigationButtons';
 const onButtonKeyDown =
   (callback?: () => void): ((ev: React.KeyboardEvent<HTMLButtonElement | HTMLDivElement>) => void) =>
   (ev: React.KeyboardEvent<HTMLButtonElement>) => {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     switch (ev.which) {
       case KeyCodes.enter:
         callback?.();

--- a/packages/react/src/components/Calendar/CalendarMonth/CalendarMonth.base.tsx
+++ b/packages/react/src/components/Calendar/CalendarMonth/CalendarMonth.base.tsx
@@ -347,7 +347,7 @@ function isCurrentMonth(month: number, year: number, today: Date): boolean {
 
 function onButtonKeyDown(callback: () => void): (ev: React.KeyboardEvent<HTMLButtonElement>) => void {
   return (ev: React.KeyboardEvent<HTMLButtonElement>) => {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     switch (ev.which) {
       case KeyCodes.enter:
         callback();

--- a/packages/react/src/components/Calendar/CalendarYear/CalendarYear.base.tsx
+++ b/packages/react/src/components/Calendar/CalendarYear/CalendarYear.base.tsx
@@ -78,7 +78,7 @@ const CalendarYearGridCell: React.FunctionComponent<ICalendarYearGridCellProps> 
   };
 
   const onKeyDown = (ev: React.KeyboardEvent<HTMLElement>) => {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     if (ev.which === KeyCodes.enter) {
       onSelectYear?.(year);
     }
@@ -246,7 +246,7 @@ const CalendarYearNavArrow: React.FunctionComponent<ICalendarYearNavArrowProps> 
   };
 
   const onKeyDown = (ev: React.KeyboardEvent<HTMLElement>) => {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     if (ev.which === KeyCodes.enter) {
       onNavigate();
     }
@@ -308,7 +308,7 @@ const CalendarYearTitle: React.FunctionComponent<ICalendarYearHeaderProps> = pro
   };
 
   const onHeaderKeyDown = (ev: React.KeyboardEvent<HTMLElement>) => {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     if (ev.which === KeyCodes.enter || ev.which === KeyCodes.space) {
       onHeaderSelect();
     }

--- a/packages/react/src/components/CalendarDayGrid/CalendarGridDayCell.tsx
+++ b/packages/react/src/components/CalendarDayGrid/CalendarGridDayCell.tsx
@@ -44,18 +44,18 @@ export const CalendarGridDayCell: React.FunctionComponent<ICalendarGridDayCellPr
     let targetDate: Date | undefined = undefined;
     let direction = 1; // by default search forward
 
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     if (ev.which === KeyCodes.up) {
       targetDate = addWeeks(date, -1);
       direction = -1;
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
     } else if (ev.which === KeyCodes.down) {
       targetDate = addWeeks(date, 1);
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
     } else if (ev.which === getRTLSafeKeyCode(KeyCodes.left)) {
       targetDate = addDays(date, -1);
       direction = -1;
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
     } else if (ev.which === getRTLSafeKeyCode(KeyCodes.right)) {
       targetDate = addDays(date, 1);
     }
@@ -193,7 +193,7 @@ export const CalendarGridDayCell: React.FunctionComponent<ICalendarGridDayCellPr
   };
 
   const onDayKeyDown = (ev: React.KeyboardEvent<HTMLElement>): void => {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     if (ev.which === KeyCodes.enter) {
       onSelectDate?.(day.originalDate);
     } else {

--- a/packages/react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/react/src/components/Callout/CalloutContent.base.tsx
@@ -492,7 +492,7 @@ export const CalloutContentBase: React.FunctionComponent<ICalloutProps> = React.
       backgroundColor,
       calloutMaxHeight,
       onScroll,
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       shouldRestoreFocus = true,
       target,
       hidden,

--- a/packages/react/src/components/Check/Check.styles.ts
+++ b/packages/react/src/components/Check/Check.styles.ts
@@ -12,7 +12,7 @@ export const CheckGlobalClassNames = {
 };
 
 export const getStyles = (props: ICheckStyleProps): ICheckStyles => {
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   const { height = props.checkBoxHeight || '18px', checked, className, theme } = props;
 
   const { palette, semanticColors, fonts } = theme;

--- a/packages/react/src/components/Coachmark/Coachmark.base.tsx
+++ b/packages/react/src/components/Coachmark/Coachmark.base.tsx
@@ -215,9 +215,9 @@ function useListeners(
     (e: KeyboardEvent) => {
       // Open coachmark if user presses ALT + C (arbitrary keypress for now)
       if (
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         (e.altKey && e.which === KeyCodes.c) ||
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         (e.which === KeyCodes.enter && translateAnimationContainer.current?.contains?.(e.target as Node))
       ) {
         openCoachmark();
@@ -582,7 +582,7 @@ function getBounds(
 }
 
 function isInsideElement(
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   targetElementRect: ClientRect,
   mouseX: number,
   mouseY: number,

--- a/packages/react/src/components/ColorPicker/ColorPicker.base.tsx
+++ b/packages/react/src/components/ColorPicker/ColorPicker.base.tsx
@@ -120,7 +120,7 @@ export class ColorPickerBase extends React.Component<IColorPickerProps, IColorPi
       alphaSliderHidden: 'alphaType',
     });
 
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     if (strings.hue) {
       // warnDeprecations can't handle nested deprecated props
       warn("ColorPicker property 'strings.hue' was used but has been deprecated. Use 'strings.hueAriaLabel' instead.");
@@ -138,14 +138,14 @@ export class ColorPickerBase extends React.Component<IColorPickerProps, IColorPi
     const defaultStrings = ColorPickerBase.defaultProps.strings as Required<IColorPickerStrings>;
 
     this._textLabels = {
-      /* eslint-disable deprecation/deprecation */
+      /* eslint-disable @typescript-eslint/no-deprecated */
       r: props.redLabel || strings.red || defaultStrings.red,
       g: props.greenLabel || strings.green || defaultStrings.green,
       b: props.blueLabel || strings.blue || defaultStrings.blue,
       a: props.alphaLabel || strings.alpha || defaultStrings.alpha,
       hex: props.hexLabel || strings.hex || defaultStrings.hex,
       t: strings.transparency || defaultStrings.transparency,
-      /* eslint-enable deprecation/deprecation */
+      /* eslint-enable @typescript-eslint/no-deprecated */
     };
 
     this._strings = {
@@ -180,7 +180,7 @@ export class ColorPickerBase extends React.Component<IColorPickerProps, IColorPi
       className,
       styles,
       alphaType,
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       alphaSliderHidden = alphaType === 'none',
       tooltipProps,
     } = props;
@@ -218,7 +218,7 @@ export class ColorPickerBase extends React.Component<IColorPickerProps, IColorPi
               <ColorSlider
                 className="is-hue"
                 type="hue"
-                // eslint-disable-next-line deprecation/deprecation
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 ariaLabel={strings.hue || strings.hueAriaLabel}
                 value={color.h}
                 onChange={this._onHChanged}
@@ -347,7 +347,7 @@ export class ColorPickerBase extends React.Component<IColorPickerProps, IColorPi
     const isHex = component === 'hex';
     const isAlpha = component === 'a';
     const isTransparency = component === 't';
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     newValue = (newValue || '').substr(0, isHex ? MAX_HEX_LENGTH : MAX_RGBA_LENGTH);
 
     // Ignore what the user typed if it contains invalid characters

--- a/packages/react/src/components/ColorPicker/ColorRectangle/ColorRectangle.base.tsx
+++ b/packages/react/src/components/ColorPicker/ColorRectangle/ColorRectangle.base.tsx
@@ -135,7 +135,7 @@ export class ColorRectangleBase
 
     // Intentionally DO NOT flip the color picker in RTL: its orientation is not very meaningful,
     // and getting all the math and styles flipped correctly is tricky
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     switch (ev.which) {
       case KeyCodes.up: {
         this._isAdjustingSaturation = false;

--- a/packages/react/src/components/ColorPicker/ColorSlider/ColorSlider.base.tsx
+++ b/packages/react/src/components/ColorPicker/ColorSlider/ColorSlider.base.tsx
@@ -41,7 +41,7 @@ export class ColorSliderBase extends React.Component<IColorSliderProps, IColorSl
       maxValue: 'type',
       minValue: 'type',
     });
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     if (this._type !== 'hue' && !(props.overlayColor || props.overlayStyle)) {
       warn(`ColorSlider: 'overlayColor' is required when 'type' is "alpha" or "transparency"`);
     }
@@ -83,7 +83,7 @@ export class ColorSliderBase extends React.Component<IColorSliderProps, IColorSl
     const type = this._type;
     const maxValue = this._maxValue;
     const {
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       overlayStyle,
       overlayColor,
       theme,
@@ -139,7 +139,7 @@ export class ColorSliderBase extends React.Component<IColorSliderProps, IColorSl
   }
 
   private get _type(): IColorSliderProps['type'] {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const { isAlpha, type = isAlpha ? 'alpha' : 'hue' } = this.props;
     return type;
   }
@@ -155,7 +155,7 @@ export class ColorSliderBase extends React.Component<IColorSliderProps, IColorSl
 
     // Intentionally DO NOT flip the color picker in RTL: its orientation is not very meaningful,
     // and getting all the math and styles flipped correctly is tricky
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     switch (ev.which) {
       case KeyCodes.left: {
         currentValue -= increment;

--- a/packages/react/src/components/ColorPicker/ColorSlider/ColorSlider.styles.ts
+++ b/packages/react/src/components/ColorPicker/ColorSlider/ColorSlider.styles.ts
@@ -25,7 +25,7 @@ const alphaStyle = {
 };
 
 export const getStyles = (props: IColorSliderStyleProps): IColorSliderStyles => {
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   const { theme, className, type = 'hue', isAlpha: useAlphaBackground = type !== 'hue' } = props;
   const { palette, effects } = theme;
 

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -1233,7 +1233,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
    * OnBlur handler. Set the focused state to false
    * and submit any pending value
    */
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   private _onBlur = (event: React.FocusEvent<HTMLElement | Autofill | BaseButton | Button>): void => {
     const doc = getDocumentEx(this.context);
     // Do nothing if the blur is coming from something
@@ -2108,7 +2108,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
 
     let index = this._getPendingSelectedIndex(false /* includeCurrentPendingValue */);
 
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     switch (ev.which) {
       case KeyCodes.enter:
         if (this._autofill.current && this._autofill.current.inputElement) {
@@ -2231,7 +2231,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
 
         // If end, update the values to respond to END
         // which goes to the last selectable option
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         if (ev.which === KeyCodes.end) {
           index = currentOptions.length;
           directionToSearch = SearchDirection.backward;
@@ -2250,19 +2250,19 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
       default:
         /* eslint-enable no-fallthrough */
         // are we processing a function key? if so bail out
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         if (ev.which >= 112 /* F1 */ && ev.which <= 123 /* F12 */) {
           return;
         }
 
         // If we get here and we got either and ALT key
         // or meta key, let the event propagate
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         if (ev.keyCode === KeyCodes.alt || ev.key === 'Meta' /* && isOpen */) {
           return;
         }
 
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         if (allowParentArrowNavigation && (ev.keyCode === KeyCodes.left || ev.keyCode === KeyCodes.right)) {
           return;
         }
@@ -2306,7 +2306,7 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
       return;
     }
 
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     switch (ev.which) {
       case KeyCodes.space:
         // If we are not allowing freeform or free input, and autoComplete is off
@@ -2389,11 +2389,11 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
       // of the event unless we have a tab, escape, or function key
       if (
         ev !== null &&
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         ev.which !== KeyCodes.tab &&
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         ev.which !== KeyCodes.escape &&
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         (ev.which < 112 /* F1 */ || ev.which > 123) /* F12 */
       ) {
         ev.stopPropagation();
@@ -2618,6 +2618,6 @@ function getPreviewText(item: IComboBoxOption): string {
  * Returns true if the key for the event is alt (Mac option) or meta (Mac command).
  */
 function isAltOrMeta(ev: React.KeyboardEvent<HTMLElement | Autofill>): boolean {
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   return ev.which === KeyCodes.alt || ev.key === 'Meta';
 }

--- a/packages/react/src/components/CommandBar/CommandBar.base.tsx
+++ b/packages/react/src/components/CommandBar/CommandBar.base.tsx
@@ -166,7 +166,7 @@ export class CommandBarBase extends React.Component<ICommandBarProps, {}> implem
       return item.onRender(item, () => undefined);
     }
 
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const itemText = item.text || item.name;
     const commandButtonProps: ICommandBarItemProps = {
       allowDisabledFocus: true,
@@ -213,7 +213,7 @@ export class CommandBarBase extends React.Component<ICommandBarProps, {}> implem
   private _onButtonClick(item: ICommandBarItemProps): (ev: React.MouseEvent<HTMLButtonElement>) => void {
     return ev => {
       // inactive is deprecated. remove check in 7.0
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       if (item.inactive) {
         return;
       }

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -98,7 +98,7 @@ export function getSubmenuItems(
 ): IContextualMenuItem[] | undefined {
   const target = options?.target;
 
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   const items = item.subMenuProps ? item.subMenuProps.items : item.items;
 
   if (items) {
@@ -356,7 +356,7 @@ function useKeyHandlers(
   const shouldCloseSubMenu = (ev: React.KeyboardEvent<HTMLElement>): boolean => {
     const submenuCloseKey = getRTL(theme) ? KeyCodes.right : KeyCodes.left;
 
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     if (ev.which !== submenuCloseKey || !isSubMenu) {
       return false;
     }
@@ -369,10 +369,10 @@ function useKeyHandlers(
 
   const shouldHandleKeyDown = (ev: React.KeyboardEvent<HTMLElement>) => {
     return (
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       ev.which === KeyCodes.escape ||
       shouldCloseSubMenu(ev) ||
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       (ev.which === KeyCodes.up && (ev.altKey || ev.metaKey))
     );
   };
@@ -383,7 +383,7 @@ function useKeyHandlers(
     lastKeyDownWasAltOrMeta.current = isAltOrMeta(ev);
 
     // On Mac, pressing escape dismisses all levels of native context menus
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const dismissAllMenus = ev.which === KeyCodes.escape && (isMac() || isIOS());
 
     return keyHandler(ev, shouldHandleKeyDown, dismissAllMenus);
@@ -421,9 +421,9 @@ function useKeyHandlers(
     // If we have a modifier key being pressed, we do not want to move focus.
     // Otherwise, handle up and down keys.
     const hasModifier = !!(ev.altKey || ev.metaKey);
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const isUp = ev.which === KeyCodes.up;
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const isDown = ev.which === KeyCodes.down;
     if (!hasModifier && (isUp || isDown)) {
       const elementToFocus = isUp
@@ -443,7 +443,7 @@ function useKeyHandlers(
 
     if (
       !item.disabled &&
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       (ev.which === openKey || ev.which === KeyCodes.enter || (ev.which === KeyCodes.down && (ev.altKey || ev.metaKey)))
     ) {
       openSubMenu(item, ev.currentTarget as HTMLElement);
@@ -780,7 +780,7 @@ export const ContextualMenuBase: React.FunctionComponent<IContextualMenuProps> =
 
     const onDefaultRenderMenuList = (
       menuListProps: IContextualMenuListProps,
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       menuClassNames: IProcessedStyleSet<IContextualMenuStyles> | IContextualMenuClassNames,
       defaultRender?: IRenderFunction<IContextualMenuListProps>,
     ): JSX.Element => {
@@ -825,13 +825,13 @@ export const ContextualMenuBase: React.FunctionComponent<IContextualMenuProps> =
       totalItemCount: number,
       hasCheckmarks: boolean,
       hasIcons: boolean,
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       menuClassNames: IProcessedStyleSet<IContextualMenuStyles> | IContextualMenuClassNames,
     ): JSX.Element => {
       const renderedItems: React.ReactNode[] = [];
       const iconProps = item.iconProps || { iconName: 'None' };
       const {
-        getItemClassNames, // eslint-disable-line deprecation/deprecation
+        getItemClassNames, // eslint-disable-line @typescript-eslint/no-deprecated
         itemProps,
       } = item;
       const styles = itemProps ? itemProps.styles : undefined;
@@ -841,7 +841,7 @@ export const ContextualMenuBase: React.FunctionComponent<IContextualMenuProps> =
       const dividerClassName = item.itemType === ContextualMenuItemType.Divider ? item.className : undefined;
       const subMenuIconClassName = item.submenuIconProps ? item.submenuIconProps.className : '';
 
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       let itemClassNames: IMenuItemClassNames;
 
       // IContextualMenuItem#getItemClassNames for backwards compatibility
@@ -883,7 +883,7 @@ export const ContextualMenuBase: React.FunctionComponent<IContextualMenuProps> =
         );
       }
 
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       if (item.text === '-' || item.name === '-') {
         item.itemType = ContextualMenuItemType.Divider;
       }
@@ -925,7 +925,7 @@ export const ContextualMenuBase: React.FunctionComponent<IContextualMenuProps> =
 
     const defaultMenuItemRenderer = (
       item: IContextualMenuItemRenderProps,
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       menuClassNames: IProcessedStyleSet<IContextualMenuStyles> | IContextualMenuClassNames,
     ): React.ReactNode => {
       const { index, focusableElementIndex, totalItemCount, hasCheckmarks, hasIcons } = item;
@@ -942,9 +942,9 @@ export const ContextualMenuBase: React.FunctionComponent<IContextualMenuProps> =
 
     const renderSectionItem = (
       sectionItem: IContextualMenuItem,
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       itemClassNames: IMenuItemClassNames,
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       menuClassNames: IProcessedStyleSet<IContextualMenuStyles> | IContextualMenuClassNames,
       index: number,
       hasCheckmarks: boolean,
@@ -1033,7 +1033,7 @@ export const ContextualMenuBase: React.FunctionComponent<IContextualMenuProps> =
     const renderListItem = (
       content: React.ReactNode,
       key: string | number,
-      classNames: IMenuItemClassNames, // eslint-disable-line deprecation/deprecation
+      classNames: IMenuItemClassNames, // eslint-disable-line @typescript-eslint/no-deprecated
       title?: string,
     ) => {
       return (
@@ -1045,7 +1045,7 @@ export const ContextualMenuBase: React.FunctionComponent<IContextualMenuProps> =
 
     const renderSeparator = (
       index: number,
-      classNames: IMenuItemClassNames, // eslint-disable-line deprecation/deprecation
+      classNames: IMenuItemClassNames, // eslint-disable-line @typescript-eslint/no-deprecated
       top?: boolean,
       fromSection?: boolean,
     ): React.ReactNode => {
@@ -1064,7 +1064,7 @@ export const ContextualMenuBase: React.FunctionComponent<IContextualMenuProps> =
 
     const renderNormalItem = (
       item: IContextualMenuItem,
-      classNames: IMenuItemClassNames, // eslint-disable-line deprecation/deprecation
+      classNames: IMenuItemClassNames, // eslint-disable-line @typescript-eslint/no-deprecated
       index: number,
       focusableElementIndex: number,
       totalItemCount: number,
@@ -1142,9 +1142,9 @@ export const ContextualMenuBase: React.FunctionComponent<IContextualMenuProps> =
 
     const renderHeaderMenuItem = (
       item: IContextualMenuItem,
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       itemClassNames: IMenuItemClassNames,
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       menuClassNames: IProcessedStyleSet<IContextualMenuStyles> | IContextualMenuClassNames,
       index: number,
       hasCheckmarks: boolean,
@@ -1164,7 +1164,7 @@ export const ContextualMenuBase: React.FunctionComponent<IContextualMenuProps> =
       const divHtmlProperties =
         itemProps && getNativeProps<React.HTMLAttributes<HTMLDivElement>>(itemProps, divProperties);
       return (
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         <div id={id} className={menuClassNames.header} {...divHtmlProperties} style={item.style}>
           <ChildrenRenderer
             item={item}
@@ -1212,7 +1212,7 @@ export const ContextualMenuBase: React.FunctionComponent<IContextualMenuProps> =
         defaultRender?: IRenderFunction<IContextualMenuListProps>,
       ) => onDefaultRenderMenuList(menuListProps, classNames, defaultRender),
       focusZoneProps,
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       getMenuClassNames,
     } = props;
 
@@ -1374,7 +1374,7 @@ ContextualMenuBase.displayName = 'ContextualMenuBase';
  * Returns true if the key for the event is alt (Mac option) or meta (Mac command).
  */
 function isAltOrMeta(ev: React.KeyboardEvent<HTMLElement>): boolean {
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   return ev.which === KeyCodes.alt || ev.key === 'Meta';
 }
 

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.classNames.ts
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.classNames.ts
@@ -50,10 +50,10 @@ const CONTEXTUAL_SPLIT_MENU_MINWIDTH = '28px';
 const MediumScreenSelector = getScreenSelector(0, ScreenWidthMaxMedium);
 
 export const getSplitButtonVerticalDividerClassNames = memoizeFunction(
-  /* eslint-disable deprecation/deprecation */
+  /* eslint-disable @typescript-eslint/no-deprecated */
   (theme: ITheme): IVerticalDividerClassNames => {
     return mergeStyleSets(getDividerClassNames(theme), {
-      /* eslint-enable deprecation/deprecation */
+      /* eslint-enable @typescript-eslint/no-deprecated */
       wrapper: {
         position: 'absolute',
         right: 28, // width of the splitMenu based on the padding plus icon fontSize
@@ -267,7 +267,7 @@ export const getItemStyles = (props: IContextualMenuItemStyleProps): IContextual
     className,
   } = props;
 
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   return getItemClassNames(
     theme,
     disabled,

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -50,7 +50,7 @@ export interface IContextualMenu {}
 export interface IContextualMenuProps
   extends IBaseProps<IContextualMenu>,
     React.RefAttributes<HTMLDivElement>,
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     IWithResponsiveModeState {
   /**
    * Optional callback to access the IContextualMenu interface. Use this instead of ref for accessing
@@ -232,7 +232,7 @@ export interface IContextualMenuProps
    * Method to provide the classnames to style the contextual menu.
    * @deprecated Use `styles` instead to leverage mergeStyles API.
    */
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   getMenuClassNames?: (theme: ITheme, className?: string) => IContextualMenuClassNames;
 
   /** Custom render function for a submenu. */
@@ -466,7 +466,7 @@ export interface IContextualMenuItem {
     iconClassName?: string,
     subMenuClassName?: string,
     primaryDisabled?: boolean,
-  ) => // eslint-disable-next-line deprecation/deprecation
+  ) => // eslint-disable-next-line @typescript-eslint/no-deprecated
   IMenuItemClassNames;
 
   /**
@@ -479,7 +479,7 @@ export interface IContextualMenuItem {
    * Default value is the `getSplitButtonVerticalDividerClassNames` func defined in `ContextualMenu.classnames.ts`.
    * @defaultvalue getSplitButtonVerticalDividerClassNames
    */
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   getSplitButtonVerticalDividerClassNames?: (theme: ITheme) => IVerticalDividerClassNames;
 
   /**

--- a/packages/react/src/components/ContextualMenu/ContextualMenuItem.base.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenuItem.base.tsx
@@ -42,11 +42,11 @@ const renderCheckMarkIcon = ({ onCheckmarkClick, item, classNames }: IContextual
 };
 
 const renderItemName = ({ item, classNames }: IContextualMenuItemProps) => {
-  /* eslint-disable deprecation/deprecation */
+  /* eslint-disable @typescript-eslint/no-deprecated */
   if (item.text || item.name) {
     return <span className={classNames.label}>{item.text || item.name}</span>;
   }
-  /* eslint-enable deprecation/deprecation */
+  /* eslint-enable @typescript-eslint/no-deprecated */
   return null;
 };
 

--- a/packages/react/src/components/ContextualMenu/ContextualMenuItem.test.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenuItem.test.tsx
@@ -12,7 +12,7 @@ describe('ContextMenuItemChildren', () => {
   describe('when a checkmark icon', () => {
     let onCheckmarkClick: jest.Mock;
     let menuItem: IContextualMenuItem;
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     let menuClassNames: IMenuItemClassNames;
     let wrapper: ShallowWrapper<IContextualMenuItemProps, {}>;
 
@@ -52,7 +52,7 @@ describe('ContextMenuItemChildren', () => {
   describe('when hide checkmark icon for toggle command', () => {
     let onCheckmarkClick: jest.Mock;
     let menuItem: IContextualMenuItem;
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     let menuClassNames: IMenuItemClassNames;
     let wrapper: ShallowWrapper<IContextualMenuItemProps, {}>;
 
@@ -96,7 +96,7 @@ describe('ContextMenuItemChildren', () => {
   describe('when it has icons', () => {
     describe('when it has iconProps', () => {
       let menuItem: IContextualMenuItem;
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       let menuClassNames: IMenuItemClassNames;
       let wrapper: ShallowWrapper<IContextualMenuItemProps, {}>;
 
@@ -116,7 +116,7 @@ describe('ContextMenuItemChildren', () => {
 
     describe('when it doesnt have iconProps', () => {
       let menuItem: IContextualMenuItem;
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       let menuClassNames: IMenuItemClassNames;
       let wrapper: ShallowWrapper<IContextualMenuItemProps, {}>;
 
@@ -137,7 +137,7 @@ describe('ContextMenuItemChildren', () => {
 
   describe('when it has a sub menu', () => {
     let menuItem: IContextualMenuItem;
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     let menuClassNames: IMenuItemClassNames;
     let wrapper: ShallowWrapper<IContextualMenuItemProps, {}>;
 
@@ -157,7 +157,7 @@ describe('ContextMenuItemChildren', () => {
   });
 });
 
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 function getMenuItemClassNames(): IMenuItemClassNames {
   return {
     item: 'item',

--- a/packages/react/src/components/ContextualMenu/ContextualMenuItem.types.ts
+++ b/packages/react/src/components/ContextualMenu/ContextualMenuItem.types.ts
@@ -59,7 +59,7 @@ export interface IContextualMenuItemProps extends React.HTMLAttributes<IContextu
   /**
    * Classnames for different aspects of a menu item
    */
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   classNames: IMenuItemClassNames;
 
   /**

--- a/packages/react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuAnchor.test.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuAnchor.test.tsx
@@ -8,7 +8,7 @@ import type { IMenuItemClassNames } from '../ContextualMenu.classNames';
 describe('ContextualMenuButton', () => {
   describe('creates a normal button', () => {
     let menuItem: IContextualMenuItem;
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     let menuClassNames: IMenuItemClassNames;
 
     beforeEach(() => {
@@ -77,7 +77,7 @@ describe('ContextualMenuButton', () => {
   });
 });
 
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 function getMenuItemClassNames(): IMenuItemClassNames {
   return {
     item: 'item',

--- a/packages/react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuAnchor.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuAnchor.tsx
@@ -102,7 +102,7 @@ export class ContextualMenuAnchor extends ContextualMenuItemWrapper {
               aria-posinset={focusableElementIndex + 1}
               aria-setsize={totalItemCount}
               aria-disabled={isItemDisabled(item)}
-              // eslint-disable-next-line deprecation/deprecation
+              // eslint-disable-next-line @typescript-eslint/no-deprecated
               style={item.style}
               onClick={this._onItemClick}
               onMouseEnter={this._onItemMouseEnter}

--- a/packages/react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuButton.test.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuButton.test.tsx
@@ -8,7 +8,7 @@ import type { IMenuItemClassNames } from '../ContextualMenu.classNames';
 describe('ContextualMenuButton', () => {
   describe('creates a normal button', () => {
     let menuItem: IContextualMenuItem;
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     let menuClassNames: IMenuItemClassNames;
 
     beforeEach(() => {
@@ -108,7 +108,7 @@ describe('ContextualMenuButton', () => {
   });
 });
 
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 function getMenuItemClassNames(): IMenuItemClassNames {
   return {
     item: 'item',

--- a/packages/react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuButton.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuButton.tsx
@@ -103,7 +103,7 @@ export class ContextualMenuButton extends ContextualMenuItemWrapper {
         (itemRole === 'menuitemcheckbox' || itemRole === 'menuitemradio') && canCheck ? !!isChecked : undefined,
       'aria-selected': itemRole === 'menuitem' && canCheck ? !!isChecked : undefined,
       role: itemRole,
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       style: item.style,
     };
 

--- a/packages/react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuItemWrapper.types.ts
+++ b/packages/react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuItemWrapper.types.ts
@@ -19,7 +19,7 @@ export interface IContextualMenuItemWrapperProps extends React.ClassAttributes<I
   /**
    * CSS class to apply to the context menu.
    */
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   classNames: IMenuItemClassNames;
 
   /**

--- a/packages/react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuSplitButton.test.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuSplitButton.test.tsx
@@ -8,7 +8,7 @@ import type { IMenuItemClassNames } from '../ContextualMenu.classNames';
 describe('ContextualMenuSplitButton', () => {
   describe('creates a normal split button', () => {
     let menuItem: IContextualMenuItem;
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     let menuClassNames: IMenuItemClassNames;
 
     beforeEach(() => {
@@ -53,7 +53,7 @@ describe('ContextualMenuSplitButton', () => {
   });
 });
 
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 function getMenuItemClassNames(): IMenuItemClassNames {
   return {
     item: 'item',

--- a/packages/react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuSplitButton.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuSplitButton.tsx
@@ -136,7 +136,7 @@ export class ContextualMenuSplitButton extends ContextualMenuItemWrapper {
 
   protected _onItemKeyDown = (ev: React.KeyboardEvent<HTMLElement>): void => {
     const { item, onItemKeyDown } = this.props;
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     if (ev.which === KeyCodes.enter) {
       this._executeItemClick(ev);
       ev.preventDefault();
@@ -161,7 +161,7 @@ export class ContextualMenuSplitButton extends ContextualMenuItemWrapper {
 
   private _renderSplitPrimaryButton(
     item: IContextualMenuItem,
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     classNames: IMenuItemClassNames,
     index: number,
     hasCheckmarks: boolean,
@@ -172,11 +172,11 @@ export class ContextualMenuSplitButton extends ContextualMenuItemWrapper {
     const itemProps: IContextualMenuItem = {
       key: item.key,
       disabled: isItemDisabled(item) || item.primaryDisabled,
-      /* eslint-disable deprecation/deprecation */
+      /* eslint-disable @typescript-eslint/no-deprecated */
       name: item.name,
       text: item.text || item.name,
       secondaryText: item.secondaryText,
-      /* eslint-enable deprecation/deprecation */
+      /* eslint-enable @typescript-eslint/no-deprecated */
       className: classNames.splitPrimary,
       canCheck: item.canCheck,
       isChecked: item.isChecked,
@@ -214,7 +214,7 @@ export class ContextualMenuSplitButton extends ContextualMenuItemWrapper {
 
   private _renderSplitIconButton(
     item: IContextualMenuItem,
-    classNames: IMenuItemClassNames, // eslint-disable-line deprecation/deprecation
+    classNames: IMenuItemClassNames, // eslint-disable-line @typescript-eslint/no-deprecated
     index: number,
     keytipAttributes: any,
   ) {

--- a/packages/react/src/components/ContextualMenu/index.ts
+++ b/packages/react/src/components/ContextualMenu/index.ts
@@ -6,9 +6,8 @@ export * from './ContextualMenuItem.base';
 export * from './ContextualMenuItem.types';
 export { getMenuItemStyles } from './ContextualMenu.cnstyles';
 export {
-  // eslint-disable-next-line deprecation/deprecation
   getItemClassNames as getContextualMenuItemClassNames,
   getItemStyles as getContextualMenuItemStyles,
 } from './ContextualMenu.classNames';
-// eslint-disable-next-line deprecation/deprecation
+
 export type { IContextualMenuClassNames, IMenuItemClassNames } from './ContextualMenu.classNames';

--- a/packages/react/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.base.tsx
@@ -344,7 +344,7 @@ export const DatePickerBase: React.FunctionComponent<IDatePickerProps> = React.f
   };
 
   const onTextFieldKeyDown = (ev: React.KeyboardEvent<HTMLElement>): void => {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     switch (ev.which) {
       case KeyCodes.enter:
         ev.preventDefault();

--- a/packages/react/src/components/DetailsList/DetailsColumn.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsColumn.base.tsx
@@ -371,11 +371,11 @@ export class DetailsColumnBase extends React.Component<IDetailsColumnProps> {
   };
 
   private _updateHeaderDragInfo = (itemIndex: number, event?: MouseEvent) => {
-    /* eslint-disable deprecation/deprecation */
+    /* eslint-disable @typescript-eslint/no-deprecated */
     if (this.props.setDraggedItemIndex) {
       this.props.setDraggedItemIndex(itemIndex);
     }
-    /* eslint-enable deprecation/deprecation */
+    /* eslint-enable @typescript-eslint/no-deprecated */
     if (this.props.updateDragInfo) {
       this.props.updateDragInfo({ itemIndex }, event);
     }

--- a/packages/react/src/components/DetailsList/DetailsHeader.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsHeader.base.tsx
@@ -413,10 +413,10 @@ export class DetailsHeaderBase
             targetIndex,
           };
           columnReorderProps.onColumnDrop(dragDropDetails);
-          /* eslint-disable deprecation/deprecation */
+          /* eslint-disable @typescript-eslint/no-deprecated */
         } else if (columnReorderProps.handleColumnReorder) {
           columnReorderProps.handleColumnReorder(this._draggedColumnIndex, targetIndex);
-          /* eslint-enable deprecation/deprecation */
+          /* eslint-enable @typescript-eslint/no-deprecated */
         }
       }
     }
@@ -773,7 +773,7 @@ export class DetailsHeaderBase
     const columnIndex = Number(columnIndexAttr);
 
     if (!columnResizeDetails) {
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       if (ev.which === KeyCodes.enter) {
         this.setState({
           columnResizeDetails: {
@@ -788,7 +788,7 @@ export class DetailsHeaderBase
     } else {
       let increment: number | undefined;
 
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       if (ev.which === KeyCodes.enter) {
         this.setState({
           columnResizeDetails: undefined,
@@ -796,10 +796,10 @@ export class DetailsHeaderBase
 
         ev.preventDefault();
         ev.stopPropagation();
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
       } else if (ev.which === KeyCodes.left) {
         increment = getRTL(this.props.theme) ? 1 : -1;
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
       } else if (ev.which === KeyCodes.right) {
         increment = getRTL(this.props.theme) ? -1 : 1;
       }

--- a/packages/react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsList.base.tsx
@@ -141,11 +141,11 @@ const DetailsListInner: React.ComponentType<IDetailsListInnerProps> = (
     selectionMode = selection.mode,
     selectionPreservedOnEmptyClick,
     selectionZoneProps,
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     ariaLabel,
     ariaLabelForGrid,
     rowElementEventMap,
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     shouldApplyApplicationRole = false,
     getKey,
     listProps,
@@ -593,7 +593,7 @@ const DetailsListInner: React.ComponentType<IDetailsListInnerProps> = (
 
   const isRightArrow = React.useCallback(
     (event: React.KeyboardEvent<HTMLElement>) => {
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       return event.which === getRTLSafeKeyCode(KeyCodes.right, theme);
     },
     [theme],
@@ -657,7 +657,7 @@ const DetailsListInner: React.ComponentType<IDetailsListInnerProps> = (
 
   const onHeaderKeyDown = React.useCallback(
     (ev: React.KeyboardEvent<HTMLElement>): void => {
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       if (ev.which === KeyCodes.down) {
         if (focusZoneRef.current && focusZoneRef.current.focus()) {
           // select the first item in list after down arrow key event
@@ -676,7 +676,7 @@ const DetailsListInner: React.ComponentType<IDetailsListInnerProps> = (
 
   const onContentKeyDown = React.useCallback(
     (ev: React.KeyboardEvent<HTMLElement>): void => {
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       if (ev.which === KeyCodes.up && !ev.altKey) {
         if (headerRef.current && headerRef.current.focus()) {
           ev.preventDefault();
@@ -918,10 +918,10 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
             targetIndex,
           };
           columnReorderOptions.onColumnDrop(dragDropDetails);
-          /* eslint-disable deprecation/deprecation */
+          /* eslint-disable @typescript-eslint/no-deprecated */
         } else if (columnReorderOptions.handleColumnReorder) {
           columnReorderOptions.handleColumnReorder(draggedIndex, targetIndex);
-          /* eslint-enable deprecation/deprecation */
+          /* eslint-enable @typescript-eslint/no-deprecated */
         }
       }
     }
@@ -1345,7 +1345,7 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
         ...this._columnOverrides[column.key],
       };
 
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       if (!(baseColumn.isCollapsible || baseColumn.isCollapsable)) {
         minimumWidth += getPaddedWidth(baseColumn, props);
       }
@@ -1368,7 +1368,7 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
       const minWidth = column.minWidth || MIN_COLUMN_WIDTH;
       const overflowWidth = totalWidth - availableWidth;
 
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       if (column.calculatedWidth! - minWidth >= overflowWidth || !(column.isCollapsible || column.isCollapsable)) {
         const originalWidth = column.calculatedWidth!;
         if (minimumWidth < availableWidth) {

--- a/packages/react/src/components/DetailsList/DetailsRowCheck.tsx
+++ b/packages/react/src/components/DetailsList/DetailsRowCheck.tsx
@@ -60,7 +60,7 @@ const DetailsRowCheckBase: React.FunctionComponent<IDetailsRowCheckProps> = prop
     <div
       {...buttonProps}
       role={checkRole}
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       className={css(classNames.root, classNames.check)}
       aria-checked={selected}
       data-selection-toggle={true}
@@ -70,7 +70,7 @@ const DetailsRowCheckBase: React.FunctionComponent<IDetailsRowCheckProps> = prop
       {onRenderCheckbox(detailsCheckboxProps)}
     </div>
   ) : (
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     <div {...divProps} className={css(classNames.root, classNames.check)} />
   );
 };

--- a/packages/react/src/components/Dialog/Dialog.base.tsx
+++ b/packages/react/src/components/Dialog/Dialog.base.tsx
@@ -27,7 +27,7 @@ const DefaultDialogContentProps: IDialogContentProps = {
   topButtonsProps: [],
 };
 
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 @withResponsiveMode
 export class DialogBase extends React.Component<IDialogProps, {}> {
   public static defaultProps: IDialogProps = {
@@ -67,7 +67,7 @@ export class DialogBase extends React.Component<IDialogProps, {}> {
   public render(): JSX.Element {
     const props = this.props;
     const {
-      /* eslint-disable deprecation/deprecation */
+      /* eslint-disable @typescript-eslint/no-deprecated */
       className,
       containerClassName,
       contentClassName,
@@ -90,7 +90,7 @@ export class DialogBase extends React.Component<IDialogProps, {}> {
       title,
       topButtonsProps,
       type,
-      /* eslint-enable deprecation/deprecation */
+      /* eslint-enable @typescript-eslint/no-deprecated */
       minWidth,
       maxWidth,
       modalProps,
@@ -142,7 +142,7 @@ export class DialogBase extends React.Component<IDialogProps, {}> {
       ...props.dialogContentProps,
       draggableHeaderClassName: dialogDraggableClassName,
       titleProps: {
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         id: props.dialogContentProps?.titleId || this._defaultTitleTextId,
         ...props.dialogContentProps?.titleProps,
       },
@@ -179,7 +179,7 @@ export class DialogBase extends React.Component<IDialogProps, {}> {
   }
 
   private _getSubTextId = (): string | undefined => {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const { ariaDescribedById, modalProps, dialogContentProps, subText } = this.props;
     let id = (modalProps && modalProps.subtitleAriaId) || ariaDescribedById;
 
@@ -191,7 +191,7 @@ export class DialogBase extends React.Component<IDialogProps, {}> {
   };
 
   private _getTitleTextId = (): string | undefined => {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const { ariaLabelledById, modalProps, dialogContentProps, title } = this.props;
     let id = (modalProps && modalProps.titleAriaId) || ariaLabelledById;
 

--- a/packages/react/src/components/Dialog/Dialog.styles.ts
+++ b/packages/react/src/components/Dialog/Dialog.styles.ts
@@ -8,7 +8,7 @@ const GlobalClassNames = {
 export const getStyles = (props: IDialogStyleProps): IDialogStyles => {
   const {
     className,
-    containerClassName, // eslint-disable-line deprecation/deprecation
+    containerClassName, // eslint-disable-line @typescript-eslint/no-deprecated
     dialogDefaultMinWidth = '288px',
     dialogDefaultMaxWidth = '340px',
     hidden,

--- a/packages/react/src/components/Dialog/Dialog.types.ts
+++ b/packages/react/src/components/Dialog/Dialog.types.ts
@@ -20,7 +20,7 @@ export interface IDialog {}
  */
 export interface IDialogProps
   extends React.ClassAttributes<DialogBase>,
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     IWithResponsiveModeState,
     IAccessiblePopupProps {
   children?: React.ReactNode;

--- a/packages/react/src/components/Dialog/DialogContent.base.tsx
+++ b/packages/react/src/components/Dialog/DialogContent.base.tsx
@@ -13,7 +13,7 @@ const DialogFooterType = ((<DialogFooter />) as React.ReactElement<IDialogFooter
 
 const COMPONENT_NAME = 'DialogContent';
 
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 @withResponsiveMode
 export class DialogContentBase extends React.Component<IDialogContentProps, {}> {
   public static defaultProps: IDialogContentProps = {
@@ -41,7 +41,7 @@ export class DialogContentBase extends React.Component<IDialogContentProps, {}> 
       subTextId,
       subText,
       titleProps = {},
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       titleId,
       title,
       type,

--- a/packages/react/src/components/Divider/VerticalDivider.base.tsx
+++ b/packages/react/src/components/Divider/VerticalDivider.base.tsx
@@ -12,7 +12,7 @@ export const VerticalDividerBase: React.FunctionComponent<IVerticalDividerProps>
   HTMLDivElement,
   IVerticalDividerProps
 >((props, ref) => {
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   const { styles, theme, getClassNames: deprecatedGetClassNames, className } = props;
   const classNames = getClassNames(styles, { theme, getClassNames: deprecatedGetClassNames, className });
   return (

--- a/packages/react/src/components/Divider/VerticalDivider.classNames.ts
+++ b/packages/react/src/components/Divider/VerticalDivider.classNames.ts
@@ -7,7 +7,7 @@ import type { IVerticalDividerClassNames } from './VerticalDivider.types';
  * @deprecated use getStyles exported from VerticalDivider.styles.ts
  */
 export const getDividerClassNames = memoizeFunction(
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   (theme: ITheme): IVerticalDividerClassNames => {
     return mergeStyleSets({
       wrapper: {

--- a/packages/react/src/components/Divider/VerticalDivider.styles.ts
+++ b/packages/react/src/components/Divider/VerticalDivider.styles.ts
@@ -4,7 +4,7 @@ import type { IStyleFunction } from '../../Utilities';
 export const getStyles: IStyleFunction<IVerticalDividerPropsStyles, IVerticalDividerStyles> = (
   props: IVerticalDividerPropsStyles,
 ): IVerticalDividerStyles => {
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   const { theme, getClassNames, className } = props;
 
   if (!theme) {

--- a/packages/react/src/components/Divider/VerticalDivider.types.ts
+++ b/packages/react/src/components/Divider/VerticalDivider.types.ts
@@ -11,7 +11,7 @@ export interface IVerticalDividerProps extends React.HTMLAttributes<HTMLElement>
    * Optional function to generate the class names for the divider for custom styling
    * @deprecated Use `styles` instead.
    */
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   getClassNames?: (theme: ITheme) => IVerticalDividerClassNames;
   /**
    * The theme that should be used to render the vertical divider.

--- a/packages/react/src/components/DocumentCard/DocumentCard.base.tsx
+++ b/packages/react/src/components/DocumentCard/DocumentCard.base.tsx
@@ -48,7 +48,7 @@ export class DocumentCardBase extends React.Component<IDocumentCardProps, any> i
   }
 
   public render(): JSX.Element {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const { onClick, onClickHref, children, type, accentColor, styles, theme, className } = this.props;
     const nativeProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(this.props, divProperties, [
       'className',
@@ -104,7 +104,7 @@ export class DocumentCardBase extends React.Component<IDocumentCardProps, any> i
   };
 
   private _onKeyDown = (ev: React.KeyboardEvent<HTMLElement>): void => {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     if (ev.which === KeyCodes.enter || ev.which === KeyCodes.space) {
       this._onAction(ev);
     }

--- a/packages/react/src/components/DocumentCard/DocumentCardLogo.styles.ts
+++ b/packages/react/src/components/DocumentCard/DocumentCardLogo.styles.ts
@@ -15,7 +15,7 @@ export const getStyles = (props: IDocumentCardLogoStyleProps): IDocumentCardLogo
     root: [
       classNames.root,
       {
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         fontSize: fonts.xxLargePlus.fontSize,
         color: palette.themePrimary,
         display: 'block',

--- a/packages/react/src/components/DocumentCard/DocumentCardPreview.base.tsx
+++ b/packages/react/src/components/DocumentCard/DocumentCardPreview.base.tsx
@@ -46,13 +46,13 @@ export class DocumentCardPreviewBase extends React.Component<IDocumentCardPrevie
       preview = this._renderPreviewImage(previewImages[0]);
 
       // Override the border color if an accent color was provided
-      /* eslint-disable deprecation/deprecation */
+      /* eslint-disable @typescript-eslint/no-deprecated */
       if (previewImages[0].accentColor) {
         style = {
           borderBottomColor: previewImages[0].accentColor,
         };
       }
-      /* eslint-enable deprecation/deprecation */
+      /* eslint-enable @typescript-eslint/no-deprecated */
     }
 
     return (
@@ -127,7 +127,7 @@ export class DocumentCardPreviewBase extends React.Component<IDocumentCardPrevie
         />
         <Link
           className={this._classNames.fileListLink}
-          // eslint-disable-next-line deprecation/deprecation
+          // eslint-disable-next-line @typescript-eslint/no-deprecated
           href={file.url}
           {...file.linkProps}
         >

--- a/packages/react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.base.tsx
@@ -57,7 +57,7 @@ const COMPONENT_NAME = 'Dropdown';
 const getClassNames = classNamesFunction<IDropdownStyleProps, IDropdownStyles>();
 
 /** Internal only props interface to support mixing in responsive mode */
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 interface IDropdownInternalProps extends Omit<IDropdownProps, 'ref'>, IWithResponsiveModeState {
   hoisted: {
     rootRef: React.RefObject<HTMLDivElement>;
@@ -146,7 +146,7 @@ function useSelectedItemsState({
         if (searchKey != null) {
           return option.key === searchKey;
         } else {
-          // eslint-disable-next-line deprecation/deprecation
+          // eslint-disable-next-line @typescript-eslint/no-deprecated
           return !!option.selected || !!option.isSelected;
         }
       });
@@ -324,7 +324,7 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
       hoisted: { selectedIndices },
     } = props;
     const { isOpen, calloutRenderEdge, hasFocus } = this.state;
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const onRenderPlaceholder = props.onRenderPlaceholder || props.onRenderPlaceHolder || this._getPlaceholder;
 
     // If our cached options are out of date update our cache
@@ -492,7 +492,7 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
     checked?: boolean,
     multiSelect?: boolean,
   ) => {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const { onChange, onChanged } = this.props;
     if (onChange || onChanged) {
       // for single-select, option passed in will always be selected.
@@ -506,7 +506,7 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
 
   /** Get either props.placeholder (new name) or props.placeHolder (old name) */
   private _getPlaceholder = (): string | undefined => {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return this.props.placeholder || this.props.placeHolder;
   };
 
@@ -1048,7 +1048,7 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
     const containsExpandCollapseModifier = ev.altKey || ev.metaKey;
     const isOpen = this.state.isOpen;
 
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     switch (ev.which) {
       case KeyCodes.enter:
         this.setState({
@@ -1136,7 +1136,7 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
         return;
       }
     }
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     switch (ev.which) {
       case KeyCodes.space:
         this.setState({
@@ -1159,7 +1159,7 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
    * Returns true if the key for the event is alt (Mac option) or meta (Mac command).
    */
   private _isAltOrMeta(ev: React.KeyboardEvent<HTMLElement>): boolean {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return ev.which === KeyCodes.alt || ev.key === 'Meta';
   }
 
@@ -1187,7 +1187,7 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
     this._lastKeyDownWasAltOrMeta = this._isAltOrMeta(ev);
     const containsExpandCollapseModifier = ev.altKey || ev.metaKey;
 
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     switch (ev.which) {
       case KeyCodes.up:
         if (containsExpandCollapseModifier) {
@@ -1298,7 +1298,7 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
    */
   private _isDisabled: () => boolean | undefined = () => {
     let { disabled } = this.props;
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const { isDisabled } = this.props;
 
     // Remove this deprecation workaround at 1.0.0

--- a/packages/react/src/components/ExtendedPicker/BaseExtendedPicker.tsx
+++ b/packages/react/src/components/ExtendedPicker/BaseExtendedPicker.tsx
@@ -193,7 +193,7 @@ export class BaseExtendedPicker<T extends {}, P extends IBaseExtendedPickerProps
   // This is protected because we may expect the backspace key to work differently in a different kind of picker.
   // This lets the subclass override it and provide it's own onBackspace. For an example see the BasePickerListBelow
   protected onBackspace = (ev: React.KeyboardEvent<HTMLElement>): void => {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     if (ev.which !== KeyCodes.backspace) {
       return;
     }

--- a/packages/react/src/components/Fabric/Fabric.base.tsx
+++ b/packages/react/src/components/Fabric/Fabric.base.tsx
@@ -72,7 +72,7 @@ function useRenderedContent(
   if (needsTheme) {
     // Disabling ThemeProvider here because theme doesn't need to be re-provided by ThemeProvider if dir has changed.
     renderedContent = (
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       <Customizer settings={{ theme: getFabricTheme(theme, dir === 'rtl') }}>{renderedContent}</Customizer>
     );
   }

--- a/packages/react/src/components/Fabric/Fabric.test.tsx
+++ b/packages/react/src/components/Fabric/Fabric.test.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable deprecation/deprecation */
+/* eslint-disable @typescript-eslint/no-deprecated */
 import * as React from 'react';
 import { create } from '@fluentui/test-utilities';
 //import { Customizer } from '@fluentui/utilities';

--- a/packages/react/src/components/Facepile/Facepile.base.tsx
+++ b/packages/react/src/components/Facepile/Facepile.base.tsx
@@ -40,7 +40,7 @@ export class FacepileBase extends React.Component<IFacepileProps, {}> {
   public render(): JSX.Element {
     let { overflowButtonProps } = this.props;
     const {
-      chevronButtonProps, // eslint-disable-line deprecation/deprecation
+      chevronButtonProps, // eslint-disable-line @typescript-eslint/no-deprecated
       maxDisplayablePersonas,
       personas,
       overflowPersonas,

--- a/packages/react/src/components/FloatingPicker/BaseFloatingPicker.tsx
+++ b/packages/react/src/components/FloatingPicker/BaseFloatingPicker.tsx
@@ -253,7 +253,7 @@ export class BaseFloatingPicker<T extends {}, P extends IBaseFloatingPickerProps
     ) {
       return;
     }
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const keyCode = ev.which;
     switch (keyCode) {
       case KeyCodes.escape:

--- a/packages/react/src/components/FloatingPicker/PeoplePicker/PeoplePickerItems/SelectedItemDefault.tsx
+++ b/packages/react/src/components/FloatingPicker/PeoplePicker/PeoplePickerItems/SelectedItemDefault.tsx
@@ -39,7 +39,7 @@ export const SelectedItemDefault: (props: IPeoplePickerItemProps) => JSX.Element
         <Persona
           {...item}
           presence={item.presence !== undefined ? item.presence : PersonaPresence.none}
-          // eslint-disable-next-line deprecation/deprecation
+          // eslint-disable-next-line @typescript-eslint/no-deprecated
           size={PersonaSize.size28}
         />
       </div>

--- a/packages/react/src/components/FloatingPicker/Suggestions/SuggestionsStore.ts
+++ b/packages/react/src/components/FloatingPicker/Suggestions/SuggestionsStore.ts
@@ -54,7 +54,7 @@ export class SuggestionsStore<T> {
             ? this.getAriaLabel(suggestion)
             : (suggestion as any as ITag).name ||
               (<IPersonaProps>suggestion).text ||
-              // eslint-disable-next-line deprecation/deprecation
+              // eslint-disable-next-line @typescript-eslint/no-deprecated
               (<IPersonaProps>suggestion).primaryText,
       };
     }

--- a/packages/react/src/components/FocusTrapZone/FocusTrapZone.tsx
+++ b/packages/react/src/components/FocusTrapZone/FocusTrapZone.tsx
@@ -87,10 +87,10 @@ export const FocusTrapZone: React.FunctionComponent<IFocusTrapZoneProps> & {
     disableFirstFocus,
     forceFocusInsideTrap,
     focusPreviouslyFocusedInnerElement,
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     firstFocusableSelector,
     firstFocusableTarget,
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     disableRestoreFocus = props.ignoreExternalFocusing,
     isClickableOutsideFocusTrap,
     enableAriaHiddenSiblings,

--- a/packages/react/src/components/GroupedList/GroupHeader.base.tsx
+++ b/packages/react/src/components/GroupedList/GroupHeader.base.tsx
@@ -72,6 +72,7 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
       indentWidth,
       onRenderGroupHeaderCheckbox,
       isCollapsedGroupSelectVisible = true,
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       expandButtonProps,
       expandButtonIcon,
       selectAllButtonProps,

--- a/packages/react/src/components/GroupedList/GroupHeader.base.tsx
+++ b/packages/react/src/components/GroupedList/GroupHeader.base.tsx
@@ -66,7 +66,7 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
       viewport,
       selectionMode,
       loadingText,
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       isSelected = false,
       selected = false,
       indentWidth,
@@ -210,9 +210,9 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
     }
 
     if (!ev.defaultPrevented) {
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       const shouldOpen = this.state.isCollapsed && ev.which === getRTLSafeKeyCode(KeyCodes.right, this.props.theme);
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       const shouldClose = !this.state.isCollapsed && ev.which === getRTLSafeKeyCode(KeyCodes.left, this.props.theme);
       if (shouldClose || shouldOpen) {
         this._toggleCollapse();

--- a/packages/react/src/components/GroupedList/GroupSpacer.types.ts
+++ b/packages/react/src/components/GroupedList/GroupSpacer.types.ts
@@ -13,7 +13,7 @@ export interface IGroupSpacerProps {
   /**
    * @deprecated Unused. Will be removed in \>= 7.0
    */
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   styles?: IStyleFunctionOrObject<IGroupSpacerStyleProps, IGroupSpacerStyles>;
 
   /** Count of spacer(s) */

--- a/packages/react/src/components/GroupedList/GroupedList.base.tsx
+++ b/packages/react/src/components/GroupedList/GroupedList.base.tsx
@@ -356,7 +356,7 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
   };
 
   private _isInnerZoneKeystroke = (ev: React.KeyboardEvent<HTMLElement>): boolean => {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return ev.which === getRTLSafeKeyCode(KeyCodes.right);
   };
 

--- a/packages/react/src/components/GroupedList/GroupedListV2.base.tsx
+++ b/packages/react/src/components/GroupedList/GroupedListV2.base.tsx
@@ -199,7 +199,7 @@ const setGroupsCollapsedState = (groups: IGroup[] | undefined, isCollapsed: bool
 };
 
 const isInnerZoneKeystroke = (ev: React.KeyboardEvent<HTMLElement>): boolean => {
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   return ev.which === getRTLSafeKeyCode(KeyCodes.right);
 };
 
@@ -285,7 +285,6 @@ export const GroupedListV2FC: React.FC<IGroupedListV2Props> = props => {
   const [version, setVersion] = React.useState({});
   const [toggleVersion, setToggleVersion] = React.useState({});
 
-  // eslint-disable-next-line deprecation/deprecation
   const { shouldEnterInnerZone = isInnerZoneKeystroke } = focusZoneProps;
 
   const listView = React.useMemo(() => {

--- a/packages/react/src/components/HoverCard/ExpandingCard.base.tsx
+++ b/packages/react/src/components/HoverCard/ExpandingCard.base.tsx
@@ -70,7 +70,7 @@ export class ExpandingCardBase extends React.Component<IExpandingCardProps, IExp
   }
 
   private _onKeyDown = (ev: React.KeyboardEvent<HTMLElement>): void => {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     if (ev.which === KeyCodes.escape) {
       this.props.onLeave && this.props.onLeave(ev);
     }

--- a/packages/react/src/components/HoverCard/HoverCard.base.tsx
+++ b/packages/react/src/components/HoverCard/HoverCard.base.tsx
@@ -193,7 +193,7 @@ export class HoverCardBase extends React.Component<IHoverCardProps, IHoverCardSt
 
   // Show HoverCard
   private _cardOpen = (ev: MouseEvent): void => {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     if (this._shouldBlockHoverCard() || (ev.type === 'keydown' && !(ev.which === this.props.openHotKey))) {
       return;
     }
@@ -239,13 +239,13 @@ export class HoverCardBase extends React.Component<IHoverCardProps, IHoverCardSt
         return;
       }
 
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       if (ev.type === 'keydown' && ev.which !== KeyCodes.escape) {
         return;
       }
 
       // Dismiss if not sticky and currentTarget is the same element that mouse last entered
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       if (!this.props.sticky && (this._currentMouseTarget === ev.currentTarget || ev.which === KeyCodes.escape)) {
         this.dismiss(true);
       }

--- a/packages/react/src/components/HoverCard/PlainCard/PlainCard.base.tsx
+++ b/packages/react/src/components/HoverCard/PlainCard/PlainCard.base.tsx
@@ -33,7 +33,7 @@ export class PlainCardBase extends React.Component<IPlainCardProps, {}> {
   }
 
   private _onKeyDown = (ev: React.KeyboardEvent<HTMLElement>): void => {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     if (ev.which === KeyCodes.escape) {
       this.props.onLeave && this.props.onLeave(ev);
     }

--- a/packages/react/src/components/Icon/Icon.base.tsx
+++ b/packages/react/src/components/Icon/Icon.base.tsx
@@ -31,7 +31,7 @@ export class IconBase extends React.Component<IIconProps, IIconState> {
     const { children, className, styles, iconName, imageErrorAs, theme } = this.props;
     const isPlaceholder = typeof iconName === 'string' && iconName.length === 0;
     const isImage =
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       !!this.props.imageProps || this.props.iconType === IconType.image || this.props.iconType === IconType.Image;
     const iconContent = getIconContent(iconName) || {};
     const { iconClassName, children: iconContentChildren, mergeImageProps } = iconContent;
@@ -55,7 +55,7 @@ export class IconBase extends React.Component<IIconProps, IIconState> {
     };
     const ImageType = (imageLoadError && imageErrorAs) || Image;
 
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const ariaLabel = this.props['aria-label'] || this.props.ariaLabel;
     const accessibleName = imageProps.alt || ariaLabel || this.props.title;
     const hasName = !!(

--- a/packages/react/src/components/Icon/Icon.styles.ts
+++ b/packages/react/src/components/Icon/Icon.styles.ts
@@ -34,7 +34,7 @@ export const getStyles = (props: IIconStyleProps): IIconStyles => {
       iconClassName,
       className,
       styles && styles.root,
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       styles && styles.imageContainer,
     ],
   };

--- a/packages/react/src/components/Icon/Icon.types.ts
+++ b/packages/react/src/components/Icon/Icon.types.ts
@@ -51,7 +51,7 @@ export interface IIconProps extends IBaseProps, React.HTMLAttributes<HTMLElement
    * The type of icon to render (image or icon font).
    * @deprecated Inferred based on the presence of `imageProps`
    */
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   iconType?: IconType;
 
   /**

--- a/packages/react/src/components/Keytip/Keytip.styles.ts
+++ b/packages/react/src/components/Keytip/Keytip.styles.ts
@@ -69,9 +69,9 @@ export const getCalloutOffsetStyles = (
     return mergeStyleSets(getCalloutStyles(props), {
       root: [
         {
-          // eslint-disable-next-line deprecation/deprecation
+          // eslint-disable-next-line @typescript-eslint/no-deprecated
           marginLeft: offset.left || offset.x,
-          // eslint-disable-next-line deprecation/deprecation
+          // eslint-disable-next-line @typescript-eslint/no-deprecated
           marginTop: offset.top || offset.y,
         },
       ],

--- a/packages/react/src/components/Layer/Layer.base.tsx
+++ b/packages/react/src/components/Layer/Layer.base.tsx
@@ -79,7 +79,7 @@ export const LayerBase: React.FunctionComponent<ILayerProps> = React.forwardRef<
       hostId,
       insertFirst,
       onLayerDidMount = () => undefined,
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       onLayerMounted = () => undefined,
       onLayerWillUnmount,
       styles,
@@ -216,7 +216,7 @@ export const LayerBase: React.FunctionComponent<ILayerProps> = React.forwardRef<
         {layerRef.current &&
           ReactDOM.createPortal(
             <FocusRectsProvider layerRoot providerRef={fabricRef}>
-              {/* eslint-disable deprecation/deprecation */}
+              {/* eslint-disable @typescript-eslint/no-deprecated */}
               <Fabric
                 {...(!eventBubblingEnabled && getFilteredEvents())}
                 {...fabricProps}
@@ -225,7 +225,7 @@ export const LayerBase: React.FunctionComponent<ILayerProps> = React.forwardRef<
               >
                 {children}
               </Fabric>
-              {/* eslint-enable deprecation/deprecation */}
+              {/* eslint-enable @typescript-eslint/no-deprecated */}
             </FocusRectsProvider>,
             layerRef.current,
           )}

--- a/packages/react/src/components/Link/Link.test.tsx
+++ b/packages/react/src/components/Link/Link.test.tsx
@@ -96,7 +96,7 @@ describe('Link', () => {
     expect(
       /ms-Link($| )/.test(
         ReactDOM.renderToStaticMarkup(
-          // eslint-disable-next-line deprecation/deprecation
+          // eslint-disable-next-line @typescript-eslint/no-deprecated
           <Customizer settings={{ theme: NoClassNamesTheme }}>
             <Link href="helloworld.html">My Link</Link>
           </Customizer>,

--- a/packages/react/src/components/MessageBar/MessageBar.base.tsx
+++ b/packages/react/src/components/MessageBar/MessageBar.base.tsx
@@ -50,7 +50,7 @@ export const MessageBarBase: React.FunctionComponent<IMessageBarProps> = React.f
     actions,
     className,
     children,
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     overflowButtonAriaLabel,
     dismissIconProps,
     styles,

--- a/packages/react/src/components/MessageBar/MessageBar.types.ts
+++ b/packages/react/src/components/MessageBar/MessageBar.types.ts
@@ -41,7 +41,7 @@ export interface IMessageBarProps extends React.HTMLAttributes<HTMLElement>, Rea
    * If null, we don't show a dismiss button.
    * @defaultvalue null
    */
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   onDismiss?: (ev?: React.MouseEvent<HTMLElement | BaseButton | Button>) => any;
 
   /**

--- a/packages/react/src/components/Modal/Modal.base.tsx
+++ b/packages/react/src/components/Modal/Modal.base.tsx
@@ -105,7 +105,7 @@ export const ModalBase: React.FunctionComponent<IModalProps> = React.forwardRef<
       firstFocusableSelector,
       focusTrapZoneProps,
       forceFocusInsideTrap,
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       disableRestoreFocus = props.ignoreExternalFocusing,
       isBlocking,
       isAlert,
@@ -121,12 +121,12 @@ export const ModalBase: React.FunctionComponent<IModalProps> = React.forwardRef<
       theme,
       topOffsetFixed,
       responsiveMode,
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       onLayerDidMount,
       isModeless,
       dragOptions,
       onDismissed,
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       enableAriaHiddenSiblings,
       popupProps,
     } = props;
@@ -278,7 +278,7 @@ export const ModalBase: React.FunctionComponent<IModalProps> = React.forwardRef<
       // We need a global handleKeyDown event when we are in the move mode so that we can
       // handle the key presses and the components inside the modal do not get the events
       const handleKeyDown = (ev: React.KeyboardEvent<HTMLElement>): void => {
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         if (ev.altKey && ev.ctrlKey && ev.keyCode === KeyCodes.space) {
           // CTRL + ALT + SPACE is handled during keyUp
           ev.preventDefault();
@@ -286,13 +286,13 @@ export const ModalBase: React.FunctionComponent<IModalProps> = React.forwardRef<
           return;
         }
 
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const newLocal = ev.altKey || ev.keyCode === KeyCodes.escape;
         if (isModalMenuOpen && newLocal) {
           setModalMenuClose();
         }
 
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         if (internalState.isInKeyboardMoveMode && (ev.keyCode === KeyCodes.escape || ev.keyCode === KeyCodes.enter)) {
           internalState.isInKeyboardMoveMode = false;
           ev.preventDefault();
@@ -303,7 +303,7 @@ export const ModalBase: React.FunctionComponent<IModalProps> = React.forwardRef<
           let handledEvent = true;
           const delta = getMoveDelta(ev);
 
-          // eslint-disable-next-line deprecation/deprecation
+          // eslint-disable-next-line @typescript-eslint/no-deprecated
           switch (ev.keyCode) {
             /* eslint-disable no-fallthrough */
             case KeyCodes.escape:
@@ -364,7 +364,7 @@ export const ModalBase: React.FunctionComponent<IModalProps> = React.forwardRef<
       const handleKeyUp = (ev: React.KeyboardEvent<HTMLElement>): void => {
         // Needs to handle the CTRL + ALT + SPACE key during keyup due to FireFox bug:
         // https://bugzilla.mozilla.org/show_bug.cgi?id=1220143
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         if (ev.altKey && ev.ctrlKey && ev.keyCode === KeyCodes.space) {
           if (elementContains(internalState.scrollableContent, ev.target as HTMLElement)) {
             toggleModalMenuOpen();
@@ -433,7 +433,7 @@ export const ModalBase: React.FunctionComponent<IModalProps> = React.forwardRef<
         }
         disableRestoreFocus={focusTrapZoneProps?.disableRestoreFocus ?? disableRestoreFocus}
         forceFocusInsideTrap={(focusTrapZoneProps?.forceFocusInsideTrap ?? forceFocusInsideTrap) && !isModeless}
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         firstFocusableSelector={focusTrapZoneProps?.firstFocusableSelector || firstFocusableSelector}
         focusPreviouslyFocusedInnerElement={focusTrapZoneProps?.focusPreviouslyFocusedInnerElement ?? true}
         onBlur={internalState.isInKeyboardMoveMode ? handleExitKeyboardMoveMode : undefined}

--- a/packages/react/src/components/Modal/Modal.styles.ts
+++ b/packages/react/src/components/Modal/Modal.styles.ts
@@ -116,7 +116,7 @@ export const getStyles = (props: IModalStyleProps): IModalStyles => {
       padding: '3px 0px',
     },
     keyboardMoveIcon: {
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       fontSize: fonts.xLargePlus.fontSize,
       width: '24px',
     },

--- a/packages/react/src/components/Nav/Nav.base.tsx
+++ b/packages/react/src/components/Nav/Nav.base.tsx
@@ -148,7 +148,7 @@ export class NavBase extends React.Component<INavProps, INavState> implements IN
 
   private _renderCompositeLink(link: INavLink, linkIndex: number, nestingLevel: number): React.ReactElement<{}> {
     const divProps: React.HTMLProps<HTMLDivElement> = { ...getNativeProps(link, divProperties, ['onClick']) };
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const { expandButtonAriaLabel, styles, groups, theme } = this.props;
     const classNames = getClassNames(styles!, {
       theme: theme!,
@@ -254,7 +254,7 @@ export class NavBase extends React.Component<INavProps, INavState> implements IN
   };
 
   private _renderGroupHeader = (group: IRenderGroupHeaderProps): React.ReactElement<{}> => {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const { styles, groups, theme, expandButtonAriaLabel } = this.props;
 
     const { isExpanded } = group;
@@ -267,7 +267,7 @@ export class NavBase extends React.Component<INavProps, INavState> implements IN
     });
 
     // respect deprecated collapseAriaLabel, but default to expandAriaLabel for both states
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const collapseAriaLabel = group.collapseAriaLabel ?? group.expandAriaLabel;
     const label = (isExpanded ? collapseAriaLabel : group.expandAriaLabel) || expandButtonAriaLabel;
 

--- a/packages/react/src/components/Panel/Panel.base.tsx
+++ b/packages/react/src/components/Panel/Panel.base.tsx
@@ -157,7 +157,7 @@ export class PanelBase extends React.Component<IPanelProps, IPanelState> impleme
     const {
       className = '',
       elementToFocusOnDismiss,
-      /* eslint-disable deprecation/deprecation */
+      /* eslint-disable @typescript-eslint/no-deprecated */
       firstFocusableSelector,
       focusTrapZoneProps,
       forceFocusInsideTrap,

--- a/packages/react/src/components/Persona/Persona.base.tsx
+++ b/packages/react/src/components/Persona/Persona.base.tsx
@@ -44,7 +44,7 @@ export const PersonaBase: React.FunctionComponent<IPersonaProps> = React.forward
      * Deprecation helper for getting text.
      */
     const getText = (): string => {
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       return props.text || props.primaryText || '';
     };
 
@@ -130,7 +130,7 @@ export const PersonaBase: React.FunctionComponent<IPersonaProps> = React.forward
       initialsTextColor,
       isOutOfOffice,
       onPhotoLoadingStateChange,
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       onRenderCoin,
       onRenderInitials,
       presence,
@@ -192,14 +192,14 @@ export const PersonaBase: React.FunctionComponent<IPersonaProps> = React.forward
       >
         {onRenderPersonaCoin(personaCoinProps, onRenderPersonaCoin)}
         {
-          /* eslint-disable deprecation/deprecation */
+          /* eslint-disable @typescript-eslint/no-deprecated */
 
           (!hidePersonaDetails ||
             size === PersonaSize.size8 ||
             size === PersonaSize.size10 ||
             size === PersonaSize.tiny) &&
             personaDetails
-          /* eslint-enable deprecation/deprecation */
+          /* eslint-enable @typescript-eslint/no-deprecated */
         }
       </div>
     );

--- a/packages/react/src/components/Persona/PersonaCoin/PersonaCoin.base.tsx
+++ b/packages/react/src/components/Persona/PersonaCoin/PersonaCoin.base.tsx
@@ -106,15 +106,15 @@ export const PersonaCoinBase: React.FunctionComponent<IPersonaCoinProps> = React
     initialsColor,
     initialsTextColor,
     isOutOfOffice,
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     onRenderCoin = renderCoin,
-    // eslint-disable-next-line deprecation/deprecation
+
     onRenderPersonaCoin = onRenderCoin,
     onRenderInitials = renderPersonaCoinInitials,
     presence,
     presenceTitle,
     presenceColors,
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     primaryText,
     showInitialsUntilImageLoads,
     text,
@@ -155,7 +155,7 @@ export const PersonaCoinBase: React.FunctionComponent<IPersonaCoinProps> = React
     <div role="presentation" {...divProps} className={classNames.coin} ref={forwardedRef}>
       {
         // Render PersonaCoin if size is not size8. size10 and tiny need to removed after a deprecation cleanup.
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         size !== PersonaSize.size8 && size !== PersonaSize.size10 && size !== PersonaSize.tiny ? (
           <div role="presentation" {...divCoinProps} className={classNames.imageArea} style={coinSizeStyle}>
             {shouldRenderInitials && (
@@ -234,7 +234,7 @@ const renderPersonaCoinInitials = ({
   allowPhoneInitials,
   showUnknownPersonaCoin,
   text,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   primaryText,
   theme,
 }: IPersonaCoinProps): JSX.Element => {

--- a/packages/react/src/components/Persona/PersonaConsts.tsx
+++ b/packages/react/src/components/Persona/PersonaConsts.tsx
@@ -38,7 +38,7 @@ export namespace personaPresenceSize {
 // TODO: remove the deprecated parts in a future major release.
 export const sizeBoolean = (size: PersonaSize) => ({
   isSize8: size === PersonaSize.size8,
-  /* eslint-disable deprecation/deprecation */
+  /* eslint-disable @typescript-eslint/no-deprecated */
   isSize10: size === PersonaSize.size10 || size === PersonaSize.tiny,
   isSize16: size === PersonaSize.size16,
   isSize24: size === PersonaSize.size24 || size === PersonaSize.extraExtraSmall,
@@ -67,7 +67,7 @@ export const sizeToPixels: { [key: number]: number } = {
   [PersonaSize.size16]: 16, // TODO: deprecated (not in the design specs)
   [PersonaSize.size24]: 24,
   [PersonaSize.size28]: 28, // TODO: deprecated (not in the design specs)
-  /* eslint-enable deprecation/deprecation */
+  /* eslint-enable @typescript-eslint/no-deprecated */
   [PersonaSize.size32]: 32,
   [PersonaSize.size40]: 40,
   [PersonaSize.size48]: 48,

--- a/packages/react/src/components/Persona/PersonaInitialsColor.ts
+++ b/packages/react/src/components/Persona/PersonaInitialsColor.ts
@@ -77,7 +77,7 @@ function personaInitialsColorToHexCode(personaInitialsColor: PersonaInitialsColo
       return '#5C2E91';
     case PersonaInitialsColor.orange:
       return '#CA5010';
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     case PersonaInitialsColor.red:
       return '#EE1111';
     case PersonaInitialsColor.lightRed:
@@ -100,7 +100,7 @@ function personaInitialsColorToHexCode(personaInitialsColor: PersonaInitialsColo
       return '#8E562E';
     case PersonaInitialsColor.coolGray:
       return '#69797E';
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     case PersonaInitialsColor.black:
       return '#1D1D1D';
     case PersonaInitialsColor.gray:
@@ -120,7 +120,7 @@ export function initialsColorPropToColorCode(props: IPersonaProps): string {
  * @returns Hex color string prefixed with #
  */
 export function getPersonaInitialsColor(props: Pick<IPersonaProps, 'primaryText' | 'text' | 'initialsColor'>): string {
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   const { primaryText, text } = props;
   let { initialsColor } = props;
   let initialsColorCode: string;

--- a/packages/react/src/components/Pivot/Pivot.base.tsx
+++ b/packages/react/src/components/Pivot/Pivot.base.tsx
@@ -41,7 +41,7 @@ const getLinkItems = (props: IPivotProps, pivotId: string): PivotLinkCollection 
 
   React.Children.forEach(React.Children.toArray(props.children), (child: React.ReactNode, index: number) => {
     if (isPivotItem(child)) {
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       const { linkText, ...pivotItemProps } = child.props;
       const itemKey = child.props.itemKey || index.toString();
       result.links.push({
@@ -177,7 +177,7 @@ export const PivotBase: React.FunctionComponent<IPivotProps> = React.forwardRef<
     };
 
     const onKeyDown = (itemKey: string, ev: React.KeyboardEvent<HTMLElement>): void => {
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       if (ev.which === KeyCodes.enter) {
         ev.preventDefault();
         updateSelectedItem(itemKey);

--- a/packages/react/src/components/Popup/Popup.tsx
+++ b/packages/react/src/components/Popup/Popup.tsx
@@ -123,7 +123,7 @@ function useRestoreFocus(props: IPopupProps, root: React.RefObject<HTMLDivElemen
 }
 
 function useHideSiblingNodes(props: IPopupProps, root: React.RefObject<HTMLDivElement | undefined>) {
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   const shouldHideSiblings = String(props['aria-modal']).toLowerCase() === 'true' && props.enableAriaHiddenSiblings;
 
   React.useEffect(() => {
@@ -157,7 +157,7 @@ export const Popup: React.FunctionComponent<IPopupProps> = React.forwardRef<HTML
 
     const onKeyDown = React.useCallback(
       (ev: React.KeyboardEvent<HTMLElement> | KeyboardEvent): void => {
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         switch (ev.which) {
           case KeyCodes.escape:
             if (onDismiss) {

--- a/packages/react/src/components/ProgressIndicator/ProgressIndicator.base.tsx
+++ b/packages/react/src/components/ProgressIndicator/ProgressIndicator.base.tsx
@@ -38,7 +38,7 @@ export class ProgressIndicatorBase extends React.Component<IProgressIndicatorPro
     const {
       barHeight,
       className,
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       label = this.props.title, // Fall back to deprecated value.
       description,
       styles,
@@ -91,7 +91,7 @@ export class ProgressIndicatorBase extends React.Component<IProgressIndicatorPro
       barHeight,
       className,
       description,
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       label = this.props.title,
       styles,
       theme,

--- a/packages/react/src/components/Rating/Rating.base.tsx
+++ b/packages/react/src/components/Rating/Rating.base.tsx
@@ -92,7 +92,7 @@ export const RatingBase: React.FunctionComponent<IRatingProps> = React.forwardRe
       disabled,
       getAriaLabel,
       styles,
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       min: minFromProps = props.allowZeroStars ? 0 : 1,
       max = 5,
       readOnly,
@@ -146,7 +146,7 @@ export const RatingBase: React.FunctionComponent<IRatingProps> = React.forwardRe
       };
 
       const onStarKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const { which } = event;
         let newRating = starNum;
         switch (which) {

--- a/packages/react/src/components/SearchBox/SearchBox.base.tsx
+++ b/packages/react/src/components/SearchBox/SearchBox.base.tsx
@@ -41,9 +41,9 @@ export const SearchBoxBase: React.FunctionComponent<ISearchBoxProps> = React.for
     disabled,
     underlined,
     styles,
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     labelText,
-    // eslint-disable-next-line deprecation/deprecation
+
     placeholder = labelText,
     theme,
     clearButtonProps = defaultClearButtonProps,
@@ -57,7 +57,7 @@ export const SearchBoxBase: React.FunctionComponent<ISearchBoxProps> = React.for
     iconProps,
     role,
     onChange,
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     onChanged,
   } = props;
 
@@ -156,7 +156,7 @@ export const SearchBoxBase: React.FunctionComponent<ISearchBoxProps> = React.for
   };
 
   const onKeyDown = (ev: React.KeyboardEvent<HTMLInputElement>) => {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     switch (ev.which) {
       case KeyCodes.escape:
         customOnEscape?.(ev);

--- a/packages/react/src/components/SelectedItemsList/BaseSelectedItemsList.tsx
+++ b/packages/react/src/components/SelectedItemsList/BaseSelectedItemsList.tsx
@@ -225,7 +225,7 @@ export class BaseSelectedItemsList<T extends {}, P extends IBaseSelectedItemsLis
         // Try to copy the text directly to the clipboard
         copyInput.value = copyText;
         copyInput.select();
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         if (!doc.execCommand('copy')) {
           // The command failed. Fallback to the method below.
           throw new Error();

--- a/packages/react/src/components/SelectedItemsList/SelectedPeopleList/Items/EditingItem.tsx
+++ b/packages/react/src/components/SelectedItemsList/SelectedPeopleList/Items/EditingItem.tsx
@@ -116,7 +116,7 @@ export class EditingItem extends React.Component<IEditingSelectedPeopleItemProps
   };
 
   private _onInputKeyDown(ev: React.KeyboardEvent<HTMLInputElement>): void {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     if (ev.which === KeyCodes.backspace || ev.which === KeyCodes.del) {
       ev.stopPropagation();
     }

--- a/packages/react/src/components/Shimmer/ShimmerCircle/ShimmerCircle.base.tsx
+++ b/packages/react/src/components/Shimmer/ShimmerCircle/ShimmerCircle.base.tsx
@@ -5,7 +5,7 @@ import type { IShimmerCircleProps, IShimmerCircleStyleProps, IShimmerCircleStyle
 const getClassNames = classNamesFunction<IShimmerCircleStyleProps, IShimmerCircleStyles>();
 
 export const ShimmerCircleBase: React.FunctionComponent<IShimmerCircleProps> = props => {
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   const { height, styles, borderStyle, theme } = props;
   const classNames = getClassNames(styles!, {
     theme: theme!,

--- a/packages/react/src/components/Shimmer/ShimmerCircle/ShimmerCircle.styles.ts
+++ b/packages/react/src/components/Shimmer/ShimmerCircle/ShimmerCircle.styles.ts
@@ -8,7 +8,7 @@ const GlobalClassNames = {
 };
 
 export function getStyles(props: IShimmerCircleStyleProps): IShimmerCircleStyles {
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   const { height, borderStyle, theme } = props;
 
   const { semanticColors } = theme;

--- a/packages/react/src/components/Shimmer/ShimmerGap/ShimmerGap.base.tsx
+++ b/packages/react/src/components/Shimmer/ShimmerGap/ShimmerGap.base.tsx
@@ -8,7 +8,7 @@ const getClassNames = classNamesFunction<IShimmerGapStyleProps, IShimmerGapStyle
  * {@docCategory Shimmer}
  */
 export const ShimmerGapBase: React.FunctionComponent<IShimmerGapProps> = props => {
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   const { height, styles, width = '10px', borderStyle, theme } = props;
 
   const classNames = getClassNames(styles!, {

--- a/packages/react/src/components/Shimmer/ShimmerGap/ShimmerGap.styles.ts
+++ b/packages/react/src/components/Shimmer/ShimmerGap/ShimmerGap.styles.ts
@@ -7,7 +7,7 @@ const GlobalClassNames = {
 };
 
 export function getStyles(props: IShimmerGapStyleProps): IShimmerGapStyles {
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   const { height, borderStyle, theme } = props;
 
   const { semanticColors } = theme;

--- a/packages/react/src/components/Shimmer/ShimmerLine/ShimmerLine.base.tsx
+++ b/packages/react/src/components/Shimmer/ShimmerLine/ShimmerLine.base.tsx
@@ -8,7 +8,7 @@ const getClassNames = classNamesFunction<IShimmerLineStyleProps, IShimmerLineSty
  * {@docCategory Shimmer}
  */
 export const ShimmerLineBase: React.FunctionComponent<IShimmerLineProps> = props => {
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   const { height, styles, width = '100%', borderStyle, theme } = props;
 
   const classNames = getClassNames(styles!, {

--- a/packages/react/src/components/Shimmer/ShimmerLine/ShimmerLine.styles.ts
+++ b/packages/react/src/components/Shimmer/ShimmerLine/ShimmerLine.styles.ts
@@ -11,7 +11,7 @@ const GlobalClassNames = {
 };
 
 export function getStyles(props: IShimmerLineStyleProps): IShimmerLineStyles {
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   const { height, borderStyle, theme } = props;
 
   const { semanticColors } = theme;

--- a/packages/react/src/components/Slider/useSlider.ts
+++ b/packages/react/src/components/Slider/useSlider.ts
@@ -216,7 +216,7 @@ export const useSlider = (props: ISliderProps, ref: React.ForwardedRef<HTMLDivEl
       ? internalState.latestLowerValue
       : internalState.latestValue;
     let diff = 0;
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     switch (event.which) {
       case getRTLSafeKeyCode(KeyCodes.left, props.theme):
       case KeyCodes.down:
@@ -266,7 +266,7 @@ export const useSlider = (props: ISliderProps, ref: React.ForwardedRef<HTMLDivEl
   };
 
   const calculateCurrentSteps = (event: DragChangeEvent) => {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const sliderPositionRect: ClientRect = sliderLine.current!.getBoundingClientRect();
     const sliderLength: number = !props.vertical ? sliderPositionRect.width : sliderPositionRect.height;
     const stepLength: number = sliderLength / steps;

--- a/packages/react/src/components/SpinButton/SpinButton.base.tsx
+++ b/packages/react/src/components/SpinButton/SpinButton.base.tsx
@@ -345,7 +345,7 @@ export const SpinButtonBase: React.FunctionComponent<ISpinButtonProps> = React.f
   const handleKeyDown = (ev: React.KeyboardEvent<HTMLInputElement>): void => {
     // eat the up and down arrow keys to keep focus in the spinButton
     // (especially when a spinButton is inside of a FocusZone)
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     if (ev.which === KeyCodes.up || ev.which === KeyCodes.down || ev.which === KeyCodes.enter) {
       ev.preventDefault();
       ev.stopPropagation();
@@ -357,7 +357,7 @@ export const SpinButtonBase: React.FunctionComponent<ISpinButtonProps> = React.f
 
     let spinDirection = KeyboardSpinDirection.notSpinning;
 
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     switch (ev.which) {
       case KeyCodes.up:
         spinDirection = KeyboardSpinDirection.up;
@@ -386,7 +386,7 @@ export const SpinButtonBase: React.FunctionComponent<ISpinButtonProps> = React.f
   /** Stop spinning on keyUp if the up or down arrow key fired this event */
   const handleKeyUp = React.useCallback(
     (ev: React.KeyboardEvent<HTMLElement>): void => {
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       if (disabled || ev.which === KeyCodes.up || ev.which === KeyCodes.down) {
         stop();
         return;

--- a/packages/react/src/components/SpinButton/SpinButton.test.tsx
+++ b/packages/react/src/components/SpinButton/SpinButton.test.tsx
@@ -696,7 +696,7 @@ describe('SpinButton', () => {
       const onChange = jest.fn();
       let keyCode: number | undefined;
       const onValidate = jest.fn((value: string, event?: React.SyntheticEvent) => {
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         keyCode = (event as React.KeyboardEvent).which;
         return value;
       });

--- a/packages/react/src/components/Spinner/Spinner.base.tsx
+++ b/packages/react/src/components/Spinner/Spinner.base.tsx
@@ -13,7 +13,7 @@ export class SpinnerBase extends React.Component<ISpinnerProps, any> {
   };
 
   public render() {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const { type, size, ariaLabel, ariaLive, styles, label, theme, className, labelPosition } = this.props;
     const statusMessage = ariaLabel;
     const nativeProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(this.props, divProperties, ['size']);
@@ -23,7 +23,7 @@ export class SpinnerBase extends React.Component<ISpinnerProps, any> {
     // finally goes away we should delete this.
     let styleSize = size;
     if (styleSize === undefined && type !== undefined) {
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       styleSize = type === SpinnerType.large ? SpinnerSize.large : SpinnerSize.medium;
     }
 

--- a/packages/react/src/components/Spinner/Spinner.types.ts
+++ b/packages/react/src/components/Spinner/Spinner.types.ts
@@ -21,7 +21,7 @@ export interface ISpinnerProps extends React.HTMLAttributes<HTMLElement> {
   /**
    * @deprecated Use `size` instead. Will be removed at \>= 2.0.0.
    */
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   type?: SpinnerType;
 
   /**

--- a/packages/react/src/components/Stack/Stack.styles.ts
+++ b/packages/react/src/components/Stack/Stack.styles.ts
@@ -30,12 +30,12 @@ export const styles: IStackComponent['styles'] = (props, theme, tokens): IStackS
 
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
-  /* eslint-disable deprecation/deprecation */
+  /*  eslint-disable @typescript-eslint/no-deprecated */
   const childrenGap = tokens && tokens.childrenGap ? tokens.childrenGap : props.gap;
   const maxHeight = tokens && tokens.maxHeight ? tokens.maxHeight : props.maxHeight;
   const maxWidth = tokens && tokens.maxWidth ? tokens.maxWidth : props.maxWidth;
   const padding = tokens && tokens.padding ? tokens.padding : props.padding;
-  /* eslint-enable deprecation/deprecation */
+  /* eslint-enable @typescript-eslint/no-deprecated */
 
   const { rowGap, columnGap } = parseGap(childrenGap, theme);
 

--- a/packages/react/src/components/Stack/Stack.test.tsx
+++ b/packages/react/src/components/Stack/Stack.test.tsx
@@ -202,7 +202,7 @@ describe('Stack', () => {
 
   it('renders horizontal Stack with a gap in rtl context correctly', () => {
     const component = renderer.create(
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       <Fabric dir="rtl">
         <Stack horizontal tokens={{ childrenGap: 10 }}>
           <Stack.Item>Item 1</Stack.Item>

--- a/packages/react/src/components/Stack/Stack.tsx
+++ b/packages/react/src/components/Stack/Stack.tsx
@@ -13,7 +13,7 @@ const StackView: IStackComponent['view'] = props => {
   const {
     as: RootType = 'div',
     disableShrink = false,
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     doNotRenderFalsyValues = false,
     enableScopedSelectors = false,
     wrap,

--- a/packages/react/src/components/SwatchColorPicker/ColorPickerGridCell.base.tsx
+++ b/packages/react/src/components/SwatchColorPicker/ColorPickerGridCell.base.tsx
@@ -67,7 +67,7 @@ const getColorPickerGridCellButtonClassNames = memoizeFunction(
 export const ColorPickerGridCellBase: React.FunctionComponent<IColorPickerGridCellProps> = props => {
   const {
     item,
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     idPrefix = props.id,
     isRadio,
     selected = false,

--- a/packages/react/src/components/SwatchColorPicker/SwatchColorPicker.base.tsx
+++ b/packages/react/src/components/SwatchColorPicker/SwatchColorPicker.base.tsx
@@ -68,7 +68,7 @@ export const SwatchColorPickerBase: React.FunctionComponent<ISwatchColorPickerPr
     focusOnHover,
     mouseLeaveParentSelector,
     onChange,
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     onColorChanged,
     onCellHovered,
     onCellFocused,
@@ -285,13 +285,13 @@ export const SwatchColorPickerBase: React.FunctionComponent<ISwatchColorPickerPr
   const onKeyDown = React.useCallback(
     (ev: React.KeyboardEvent<HTMLButtonElement>): void => {
       if (
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         ev.which === KeyCodes.up ||
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         ev.which === KeyCodes.down ||
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         ev.which === KeyCodes.left ||
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         ev.which === KeyCodes.right
       ) {
         setNavigationTimeout();

--- a/packages/react/src/components/TeachingBubble/TeachingBubble.base.tsx
+++ b/packages/react/src/components/TeachingBubble/TeachingBubble.base.tsx
@@ -44,10 +44,10 @@ export const TeachingBubbleBase: React.FunctionComponent<ITeachingBubbleProps> =
   const mergedRootRef = useMergedRefs(rootElementRef, forwardedRef);
   const {
     calloutProps: setCalloutProps,
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     targetElement,
     onDismiss,
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     hasCloseButton = props.hasCloseIcon,
     isWide,
     styles,

--- a/packages/react/src/components/TeachingBubble/TeachingBubbleContent.base.tsx
+++ b/packages/react/src/components/TeachingBubble/TeachingBubbleContent.base.tsx
@@ -48,7 +48,7 @@ export const TeachingBubbleContentBase: React.FunctionComponent<ITeachingBubbleP
     secondaryButtonProps,
     headline,
     hasCondensedHeadline,
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     hasCloseButton = props.hasCloseIcon,
     onDismiss,
     closeButtonAriaLabel,
@@ -74,7 +74,7 @@ export const TeachingBubbleContentBase: React.FunctionComponent<ITeachingBubbleP
   const onKeyDown = React.useCallback(
     (ev: React.KeyboardEvent<HTMLElement> | KeyboardEvent): void => {
       if (onDismiss) {
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         if (ev.which === KeyCodes.escape) {
           onDismiss(ev);
         }

--- a/packages/react/src/components/TextField/MaskedTextField/MaskedTextField.tsx
+++ b/packages/react/src/components/TextField/MaskedTextField/MaskedTextField.tsx
@@ -221,7 +221,7 @@ export const MaskedTextField: React.FunctionComponent<IMaskedTextFieldProps> = R
         const charsSelected = selectionEnd - selectionStart;
         const charCount = inputValue.length + charsSelected - displayValue.length;
         const startPos = selectionStart;
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const pastedString = inputValue.substr(startPos, charCount);
 
         // Clear any selected characters
@@ -252,7 +252,7 @@ export const MaskedTextField: React.FunctionComponent<IMaskedTextFieldProps> = R
         // This case is if the user added characters
         const charCount = inputValue.length - displayValue.length;
         const startPos = selectionEnd - charCount;
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const enteredString = inputValue.substr(startPos, charCount);
 
         cursorPos = insertString(internalState.maskCharData, startPos, enteredString);
@@ -264,7 +264,7 @@ export const MaskedTextField: React.FunctionComponent<IMaskedTextFieldProps> = R
         const charCount = 1;
         const selectCount = displayValue.length + charCount - inputValue.length;
         const startPos = selectionEnd - charCount;
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const enteredString = inputValue.substr(startPos, charCount);
 
         // Clear the selected range
@@ -292,7 +292,7 @@ export const MaskedTextField: React.FunctionComponent<IMaskedTextFieldProps> = R
 
       internalState.changeSelectionData = null;
       if (textField.current && textField.current.value) {
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const { keyCode, ctrlKey, metaKey } = ev;
 
         // Ignore ctrl and meta keydown

--- a/packages/react/src/components/TextField/TextField.base.tsx
+++ b/packages/react/src/components/TextField/TextField.base.tsx
@@ -246,7 +246,7 @@ export class TextFieldBase
     }));
 
     return (
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       <div ref={this.props.elementRef} className={classNames.root}>
         <div className={classNames.wrapper}>
           {onRenderLabel(this.props, this._onRenderLabel)}

--- a/packages/react/src/components/TimePicker/TimePicker.tsx
+++ b/packages/react/src/components/TimePicker/TimePicker.tsx
@@ -191,7 +191,7 @@ export const TimePicker: React.FunctionComponent<ITimePickerProps> = ({
   );
 
   const evaluatePressedKey = (event: React.KeyboardEvent<IComboBox>) => {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const charCode = event.charCode;
     if (
       !onFormatDate &&

--- a/packages/react/src/components/Toggle/Toggle.base.tsx
+++ b/packages/react/src/components/Toggle/Toggle.base.tsx
@@ -19,13 +19,13 @@ export const ToggleBase: React.FunctionComponent<IToggleProps> = React.forwardRe
       disabled,
       inlineLabel,
       label,
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       offAriaLabel,
       offText,
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       onAriaLabel,
       onChange,
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       onChanged,
       onClick: onToggleClick,
       onText,

--- a/packages/react/src/components/Tooltip/TooltipHost.base.tsx
+++ b/packages/react/src/components/Tooltip/TooltipHost.base.tsx
@@ -67,7 +67,7 @@ export class TooltipHostBase extends React.Component<ITooltipHostProps, ITooltip
       directionalHintForRTL,
       hostClassName: className,
       id,
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       setAriaDescribedBy = true,
       tooltipProps,
       styles,
@@ -261,7 +261,7 @@ export class TooltipHostBase extends React.Component<ITooltipHostProps, ITooltip
   };
 
   private _onTooltipKeyDown = (ev: React.KeyboardEvent<HTMLElement>): void => {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     if ((ev.which === KeyCodes.escape || ev.ctrlKey) && this.state.isTooltipVisible) {
       this._hideTooltip();
       ev.stopPropagation();

--- a/packages/react/src/components/WeeklyDayPicker/WeeklyDayPicker.base.tsx
+++ b/packages/react/src/components/WeeklyDayPicker/WeeklyDayPicker.base.tsx
@@ -280,7 +280,7 @@ export class WeeklyDayPickerBase extends React.Component<IWeeklyDayPickerProps, 
   };
 
   private _onWrapperKeyDown = (ev: React.KeyboardEvent<HTMLElement>) => {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     switch (ev.which) {
       case KeyCodes.enter:
         ev.preventDefault();
@@ -297,7 +297,7 @@ export class WeeklyDayPickerBase extends React.Component<IWeeklyDayPickerProps, 
 
   private _onButtonKeyDown = (callback: () => void): ((ev: React.KeyboardEvent<HTMLButtonElement>) => void) => {
     return (ev: React.KeyboardEvent<HTMLButtonElement>) => {
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       switch (ev.which) {
         case KeyCodes.enter:
           callback();

--- a/packages/react/src/components/pickers/BasePicker.tsx
+++ b/packages/react/src/components/pickers/BasePicker.tsx
@@ -119,7 +119,7 @@ export class BasePicker<T extends {}, P extends IBasePickerProps<T>>
   protected SuggestionOfProperType = Suggestions as new (props: ISuggestionsProps<T>) => Suggestions<T>;
   protected currentPromise: PromiseLike<any> | undefined;
   protected _ariaMap: IPickerAriaIds;
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   private _styledSuggestions = getStyledSuggestions(this.SuggestionOfProperType);
   private _id: string;
   private _async: Async;
@@ -527,7 +527,7 @@ export class BasePicker<T extends {}, P extends IBasePickerProps<T>>
   protected onEmptyInputFocus() {
     const emptyResolveSuggestions = this.props.onEmptyResolveSuggestions
       ? this.props.onEmptyResolveSuggestions
-      : // eslint-disable-next-line deprecation/deprecation
+      : // eslint-disable-next-line @typescript-eslint/no-deprecated
         this.props.onEmptyInputFocus;
 
     // Only attempt to resolve suggestions if it exists
@@ -706,7 +706,7 @@ export class BasePicker<T extends {}, P extends IBasePickerProps<T>>
   };
 
   protected onKeyDown = (ev: React.KeyboardEvent<HTMLElement>): void => {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const keyCode = ev.which;
     switch (keyCode) {
       case KeyCodes.escape:
@@ -954,7 +954,7 @@ export class BasePicker<T extends {}, P extends IBasePickerProps<T>>
   protected _shouldFocusZoneEnterInnerZone = (ev: React.KeyboardEvent<HTMLElement>): boolean => {
     // If suggestions are shown const up/down keys control them, otherwise allow them through to control the focusZone.
     if (this.state.suggestionsVisible) {
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       switch (ev.which) {
         case KeyCodes.up:
         case KeyCodes.down:
@@ -962,7 +962,7 @@ export class BasePicker<T extends {}, P extends IBasePickerProps<T>>
       }
     }
 
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     if (ev.which === KeyCodes.enter) {
       return true;
     }
@@ -1023,7 +1023,7 @@ export class BasePicker<T extends {}, P extends IBasePickerProps<T>>
     return (
       <div className={alertClassName} id={this._ariaMap.selectedSuggestionAlert} aria-live="assertive">
         {
-          // eslint-disable-next-line deprecation/deprecation
+          // eslint-disable-next-line @typescript-eslint/no-deprecated
           this.getSuggestionsAlert(alertClassName)
         }
         {removedItemText}

--- a/packages/react/src/components/pickers/PeoplePicker/PeoplePickerItems/PeoplePickerItem.types.ts
+++ b/packages/react/src/components/pickers/PeoplePicker/PeoplePickerItems/PeoplePickerItem.types.ts
@@ -118,7 +118,7 @@ export interface IPeoplePickerItemSuggestionStyles {
  * PeoplePickerItemWithMenu props interface.
  * @deprecated Do not use. Will be removed in \>= 7.0
  */
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 export interface IPeoplePickerItemWithMenuProps extends IPickerItemProps<IPersonaWithMenu> {}
 
 /**

--- a/packages/react/src/components/pickers/PeoplePicker/PeoplePickerItems/SelectedItemDefault.tsx
+++ b/packages/react/src/components/pickers/PeoplePicker/PeoplePickerItems/SelectedItemDefault.tsx
@@ -45,7 +45,7 @@ export const SelectedItemDefault: (props: IPeoplePickerItemSelectedProps) => JSX
         <Persona
           {...item}
           presence={item.presence !== undefined ? item.presence : PersonaPresence.none}
-          size={PersonaSize.size28} // eslint-disable-line deprecation/deprecation
+          size={PersonaSize.size28} // eslint-disable-line @typescript-eslint/no-deprecated
         />
       </div>
       <IconButton

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -6,7 +6,6 @@ export { Announced, AnnouncedBase } from './Announced';
 export type { IAnnouncedProps, IAnnouncedStyleProps, IAnnouncedStyles } from './Announced';
 export { Breadcrumb, BreadcrumbBase } from './Breadcrumb';
 export type {
-  // eslint-disable-next-line deprecation/deprecation
   IBreadCrumbData,
   IBreadcrumb,
   IBreadcrumbData,
@@ -19,7 +18,6 @@ export type {
 export {
   ActionButton,
   BaseButton,
-  // eslint-disable-next-line deprecation/deprecation
   Button,
   ButtonGlobalClassNames,
   ButtonType,
@@ -58,7 +56,6 @@ export {
   FirstWeekOfYear,
   defaultCalendarNavigationIcons,
   defaultCalendarStrings,
-  // eslint-disable-next-line deprecation/deprecation
   defaultDayPickerStrings,
 } from './Calendar';
 export type {
@@ -71,9 +68,7 @@ export type {
   ICalendarDayProps,
   ICalendarDayStyleProps,
   ICalendarDayStyles,
-  // eslint-disable-next-line deprecation/deprecation
   ICalendarFormatDateCallbacks,
-  // eslint-disable-next-line deprecation/deprecation
   ICalendarIconStrings,
   ICalendarMonth,
   ICalendarMonthProps,
@@ -126,7 +121,6 @@ export type {
   ICoachmarkProps,
   ICoachmarkStyleProps,
   ICoachmarkStyles,
-  // eslint-disable-next-line deprecation/deprecation
   ICoachmarkTypes,
   IEntityRect,
 } from './Coachmark';
@@ -135,7 +129,6 @@ export {
   MAX_COLOR_ALPHA,
   MAX_COLOR_HUE,
   MAX_COLOR_RGB,
-  // eslint-disable-next-line deprecation/deprecation
   MAX_COLOR_RGBA,
   MAX_COLOR_SATURATION,
   MAX_COLOR_VALUE,
@@ -218,7 +211,6 @@ export {
   ContextualMenuItemBase,
   ContextualMenuItemType,
   canAnyMenuItemsCheck,
-  // eslint-disable-next-line deprecation/deprecation
   getContextualMenuItemClassNames,
   getContextualMenuItemStyles,
   getMenuItemStyles,
@@ -226,7 +218,6 @@ export {
 } from './ContextualMenu';
 export type {
   IContextualMenu,
-  // eslint-disable-next-line deprecation/deprecation
   IContextualMenuClassNames,
   IContextualMenuItem,
   IContextualMenuItemProps,
@@ -241,7 +232,6 @@ export type {
   IContextualMenuStyleProps,
   IContextualMenuStyles,
   IContextualMenuSubComponentStyles,
-  // eslint-disable-next-line deprecation/deprecation
   IMenuItemClassNames,
   IMenuItemStyles,
 } from './ContextualMenu';
@@ -401,7 +391,6 @@ export type {
 } from './Dialog';
 export { VerticalDivider } from './Divider';
 export type {
-  // eslint-disable-next-line deprecation/deprecation
   IVerticalDividerClassNames,
   IVerticalDividerProps,
   IVerticalDividerPropsStyles,
@@ -484,11 +473,7 @@ export type {
   IExtendedPeoplePickerProps,
   IPeoplePickerItemProps,
 } from './ExtendedPicker';
-export {
-  // eslint-disable-next-line deprecation/deprecation
-  Fabric,
-  FabricBase,
-} from './Fabric';
+export { Fabric, FabricBase } from './Fabric';
 export type { IFabricProps, IFabricStyleProps, IFabricStyles } from './Fabric';
 export { Facepile, FacepileBase, OverflowButtonType } from './Facepile';
 export type { IFacepile, IFacepilePersona, IFacepileProps, IFacepileStyleProps, IFacepileStyles } from './Facepile';
@@ -543,9 +528,7 @@ export type {
   IGroupShowAllStyleProps,
   IGroupShowAllStyles,
   IGroupSpacerProps,
-  // eslint-disable-next-line deprecation/deprecation
   IGroupSpacerStyleProps,
-  // eslint-disable-next-line deprecation/deprecation
   IGroupSpacerStyles,
   IGroupedListSectionProps,
   IGroupedListSectionState,
@@ -586,16 +569,7 @@ export type {
   IPlainCardStyleProps,
   IPlainCardStyles,
 } from './HoverCard';
-export {
-  FontIcon,
-  Icon,
-  IconBase,
-  // eslint-disable-next-line deprecation/deprecation
-  IconType,
-  ImageIcon,
-  getFontIcon,
-  getIconContent,
-} from './Icon';
+export { FontIcon, Icon, IconBase, IconType, ImageIcon, getFontIcon, getIconContent } from './Icon';
 export type {
   IFontIconProps,
   IIconContent,
@@ -606,10 +580,7 @@ export type {
   IImageIconProps,
 } from './Icon';
 export { initializeIcons } from './Icons';
-export type {
-  // eslint-disable-next-line deprecation/deprecation
-  IconNames,
-} from './Icons';
+export type { IconNames } from './Icons';
 export { Image, ImageBase, ImageCoverStyle, ImageFit, ImageLoadState } from './Image';
 export type { IImage, IImageProps, IImageState, IImageStyleProps, IImageStyles } from './Image';
 export {
@@ -677,14 +648,7 @@ export {
 } from './Layer';
 export type { ILayer, ILayerHost, ILayerHostProps, ILayerProps, ILayerStyleProps, ILayerStyles } from './Layer';
 export { Link, LinkBase } from './Link';
-export type {
-  ILink,
-  // eslint-disable-next-line deprecation/deprecation
-  ILinkHTMLAttributes,
-  ILinkProps,
-  ILinkStyleProps,
-  ILinkStyles,
-} from './Link';
+export type { ILink, ILinkHTMLAttributes, ILinkProps, ILinkStyleProps, ILinkStyles } from './Link';
 export { List, ScrollToMode } from './List';
 export type {
   IList,
@@ -818,10 +782,8 @@ export type {
   IPeoplePickerItemSuggestionProps,
   IPeoplePickerItemSuggestionStyleProps,
   IPeoplePickerItemSuggestionStyles,
-  // eslint-disable-next-line deprecation/deprecation
   IPeoplePickerItemWithMenuProps,
   IPeoplePickerProps,
-  // eslint-disable-next-line deprecation/deprecation
   IPersonaWithMenu,
   IPickerAriaIds,
   IPickerItem,
@@ -847,15 +809,7 @@ export type {
   ITagItemRemoveButtonProps,
   ITagPickerProps,
 } from './Pickers';
-export {
-  Pivot,
-  PivotBase,
-  PivotItem,
-  // eslint-disable-next-line deprecation/deprecation
-  PivotLinkFormat,
-  // eslint-disable-next-line deprecation/deprecation
-  PivotLinkSize,
-} from './Pivot';
+export { Pivot, PivotBase, PivotItem, PivotLinkFormat, PivotLinkSize } from './Pivot';
 export type {
   IPivot,
   IPivotItemProps,
@@ -883,7 +837,6 @@ export type {
   ICalloutPositionedInfo,
   IElementPosition,
   IElementPositionInfo,
-  // eslint-disable-next-line deprecation/deprecation
   IPoint,
   IPosition,
   IPositionDirectionalHintData,
@@ -897,7 +850,6 @@ export { PositioningContainer, useHeightOffset } from './PositioningContainer';
 export type {
   IPositioningContainer,
   IPositioningContainerProps,
-  // eslint-disable-next-line deprecation/deprecation
   IPositioningContainerTypes,
 } from './PositioningContainer';
 export { ProgressIndicator, ProgressIndicatorBase } from './ProgressIndicator';
@@ -930,13 +882,9 @@ export {
   initializeResponsiveMode,
   setResponsiveMode,
   useResponsiveMode,
-  // eslint-disable-next-line deprecation/deprecation
   withResponsiveMode,
 } from './ResponsiveMode';
-export type {
-  // eslint-disable-next-line deprecation/deprecation
-  IWithResponsiveModeState,
-} from './ResponsiveMode';
+export type { IWithResponsiveModeState } from './ResponsiveMode';
 export { ScrollablePane, ScrollablePaneBase, ScrollablePaneContext, ScrollbarVisibility } from './ScrollablePane';
 export type {
   IScrollablePane,
@@ -1021,13 +969,7 @@ export { Slider, SliderBase } from './Slider';
 export type { ISlider, ISliderProps, ISliderStyleProps, ISliderStyles } from './Slider';
 export { KeyboardSpinDirection, SpinButton } from './SpinButton';
 export type { ISpinButton, ISpinButtonProps, ISpinButtonStyleProps, ISpinButtonStyles } from './SpinButton';
-export {
-  Spinner,
-  SpinnerBase,
-  SpinnerSize,
-  // eslint-disable-next-line deprecation/deprecation
-  SpinnerType,
-} from './Spinner';
+export { Spinner, SpinnerBase, SpinnerSize, SpinnerType } from './Spinner';
 export type { ISpinner, ISpinnerProps, ISpinnerStyleProps, ISpinnerStyles, SpinnerLabelPosition } from './Spinner';
 export { Stack, StackItem } from './Stack';
 export type {
@@ -1059,7 +1001,6 @@ export {
   DefaultEffects,
   DefaultFontStyles,
   DefaultPalette,
-  // eslint-disable-next-line deprecation/deprecation
   EdgeChromiumHighContrastSelector,
   FontClassNames,
   FontSizes,
@@ -1092,11 +1033,9 @@ export {
   createTheme,
   focusClear,
   fontFace,
-  // eslint-disable-next-line deprecation/deprecation
   getEdgeChromiumNoHighContrastAdjustSelector,
   getFadedOverflowStyle,
   getFocusOutlineStyle,
-  // eslint-disable-next-line deprecation/deprecation
   getFocusStyle,
   getGlobalClassNames,
   getHighContrastNoAdjustStyle,
@@ -1224,10 +1163,8 @@ export type {
 export {
   Async,
   AutoScroll,
-  // eslint-disable-next-line deprecation/deprecation
   BaseComponent,
   Customizations,
-  // eslint-disable-next-line deprecation/deprecation
   Customizer,
   CustomizerContext,
   DATA_IS_SCROLLABLE_ATTRIBUTE,
@@ -1308,7 +1245,6 @@ export {
   getRTL,
   getRTLSafeKeyCode,
   getRect,
-  // eslint-disable-next-line deprecation/deprecation
   getResourceUrl,
   getScrollbarWidth,
   getVirtualParent,
@@ -1320,11 +1256,9 @@ export {
   hoistStatics,
   htmlElementProperties,
   iframeProperties,
-  // eslint-disable-next-line deprecation/deprecation
   imageProperties,
   imgProperties,
   initializeComponentRef,
-  // eslint-disable-next-line deprecation/deprecation
   initializeFocusRects,
   inputProperties,
   isControlled,
@@ -1358,7 +1292,6 @@ export {
   optionProperties,
   portalContainsElement,
   precisionRound,
-  // eslint-disable-next-line deprecation/deprecation
   raiseClick,
   removeDirectionalKeyCode,
   removeIndex,
@@ -1369,15 +1302,12 @@ export {
   safeRequestAnimationFrame,
   safeSetTimeout,
   selectProperties,
-  // eslint-disable-next-line deprecation/deprecation
   setBaseUrl,
   setFocusVisibility,
-  // eslint-disable-next-line deprecation/deprecation
   setLanguage,
   setMemoizeWeakMap,
   setPortalAttribute,
   setRTL,
-  // eslint-disable-next-line deprecation/deprecation
   setSSR,
   setVirtualParent,
   setWarningCallback,
@@ -1416,7 +1346,6 @@ export type {
   ICancelable,
   IChangeDescription,
   IChangeEventCallback,
-  // eslint-disable-next-line deprecation/deprecation
   IClassNames,
   IClassNamesFunctionOptions,
   IComponentAs,
@@ -1454,12 +1383,9 @@ export type {
   IStyleFunctionOrObject,
   IVirtualElement,
   IWarnControlledUsageParams,
-  // eslint-disable-next-line deprecation/deprecation
   Omit,
   RefObject,
-  // eslint-disable-next-line deprecation/deprecation
   Settings,
-  // eslint-disable-next-line deprecation/deprecation
   SettingsFunction,
   StyleFunction,
 } from './Utilities';
@@ -1485,19 +1411,8 @@ export type { WindowProviderProps } from './WindowProvider';
  * Styles and Theme both exported the same names which causes conflicting
  * star exports with webpack5. See here: https://github.com/microsoft/fluentui/issues/21601.
  */
-export {
-  ThemeContext,
-  ThemeProvider,
-  // eslint-disable-next-line deprecation/deprecation
-  makeStyles,
-  useTheme,
-} from './utilities/ThemeProvider/index';
-export type {
-  StylesClassMapping,
-  ThemeProviderProps,
-  // eslint-disable-next-line deprecation/deprecation
-  UseStylesOptions,
-} from './utilities/ThemeProvider/index';
+export { ThemeContext, ThemeProvider, makeStyles, useTheme } from './utilities/ThemeProvider/index';
+export type { StylesClassMapping, ThemeProviderProps, UseStylesOptions } from './utilities/ThemeProvider/index';
 export {
   CommunicationColors,
   DefaultSpacing,

--- a/packages/react/src/utilities/ButtonGrid/ButtonGrid.base.tsx
+++ b/packages/react/src/utilities/ButtonGrid/ButtonGrid.base.tsx
@@ -17,9 +17,9 @@ export const ButtonGridBase: React.FunctionComponent<IButtonGridProps> = React.f
     columnCount,
     onRenderItem,
     isSemanticRadio,
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     ariaPosInSet = props.positionInSet,
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     ariaSetSize = props.setSize,
     styles,
     doNotContainWithinFocusZone,

--- a/packages/react/src/utilities/DraggableZone/DraggableZone.tsx
+++ b/packages/react/src/utilities/DraggableZone/DraggableZone.tsx
@@ -269,7 +269,7 @@ export class DraggableZone extends React.Component<IDraggableZoneProps, IDraggab
     }
 
     const matchesSelectorFn: Function =
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       element.matches || element.webkitMatchesSelector || (element as any).msMatchesSelector; /* for IE */
 
     if (!matchesSelectorFn) {

--- a/packages/react/src/utilities/ThemeProvider/makeStyles.test.tsx
+++ b/packages/react/src/utilities/ThemeProvider/makeStyles.test.tsx
@@ -12,7 +12,7 @@ import { ThemeProvider } from './ThemeProvider';
 describe('makeStyles', () => {
   const stylesheet: Stylesheet = Stylesheet.getInstance();
 
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   const useThemedStyles = makeStyles(theme => ({
     root: {
       background: theme.palette.themePrimary,
@@ -27,7 +27,7 @@ describe('makeStyles', () => {
 
   const ThemeStyledComponent = () => <ThemeStyledComponentInner />;
 
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   const useStaticStyles = makeStyles({
     root: {
       background: 'yellow',
@@ -48,7 +48,7 @@ describe('makeStyles', () => {
   });
 
   it('can create basic styles as an object (no type errors)', () => {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     makeStyles({
       root: {
         alignItems: 'center',
@@ -57,7 +57,7 @@ describe('makeStyles', () => {
   });
 
   it('can create style functions (no type errors)', () => {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     makeStyles(() => ({
       root: {
         alignItems: 'center',
@@ -78,7 +78,7 @@ describe('makeStyles', () => {
     });
 
     safeMount(
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       <Customizer settings={{ theme: customTheme }}>
         <ThemeStyledComponent />
       </Customizer>,

--- a/packages/react/src/utilities/ThemeProvider/makeStyles.ts
+++ b/packages/react/src/utilities/ThemeProvider/makeStyles.ts
@@ -94,7 +94,7 @@ type WindowWithId = Window & {
  */
 export function makeStyles<TStyleSet extends { [key in keyof TStyleSet]: IStyle } = { [key: string]: IStyle }>(
   styleOrFunction: TStyleSet | ((theme: Theme) => TStyleSet),
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
 ): (options?: UseStylesOptions) => StylesClassMapping<TStyleSet> {
   // Create graph of inputs to map to output.
   const graph: Graph<TStyleSet> = new Map();
@@ -113,7 +113,7 @@ export function makeStyles<TStyleSet extends { [key in keyof TStyleSet]: IStyle 
     allWindows.delete(winId);
   };
 
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   return (options: UseStylesOptions = {}): StylesClassMapping<TStyleSet> => {
     let { theme } = options;
     let winId: string | undefined;

--- a/packages/react/src/utilities/ThemeProvider/useThemeProviderClasses.tsx
+++ b/packages/react/src/utilities/ThemeProvider/useThemeProviderClasses.tsx
@@ -5,7 +5,7 @@ import { makeStyles } from './makeStyles';
 import type { ThemeProviderState } from './ThemeProvider.types';
 import type { Theme } from '@fluentui/theme';
 
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 const useThemeProviderStyles = makeStyles((theme: Theme) => {
   const { semanticColors, fonts } = theme;
 

--- a/packages/react/src/utilities/contextualMenu/contextualMenuUtility.ts
+++ b/packages/react/src/utilities/contextualMenu/contextualMenuUtility.ts
@@ -26,7 +26,7 @@ export function getIsChecked(item: IContextualMenuItem): boolean | null {
 }
 
 export function hasSubmenu(item: IContextualMenuItem): boolean {
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   return !!(item.subMenuProps || item.items);
 }
 

--- a/packages/react/src/utilities/decorators/withResponsiveMode.test.tsx
+++ b/packages/react/src/utilities/decorators/withResponsiveMode.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as ReactTestUtils from 'react-dom/test-utils';
 import { setResponsiveMode, withResponsiveMode, ResponsiveMode } from './withResponsiveMode';
 
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 @withResponsiveMode
 class Example extends React.Component<any, any> {
   public render(): JSX.Element {

--- a/packages/react/src/utilities/decorators/withResponsiveMode.tsx
+++ b/packages/react/src/utilities/decorators/withResponsiveMode.tsx
@@ -74,7 +74,7 @@ export function getInitialResponsiveMode(): ResponsiveMode {
 export function withResponsiveMode<TProps extends { responsiveMode?: ResponsiveMode }, TState>(
   ComposedComponent: new (props: TProps, ...args: any[]) => React.Component<TProps, TState>,
 ): any {
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   const resultClass = class WithResponsiveMode extends BaseDecorator<TProps, IWithResponsiveModeState> {
     public static contextType = WindowContext;
     public context: React.ContextType<typeof WindowContext>;

--- a/packages/react/src/utilities/positioning/positioning.ts
+++ b/packages/react/src/utilities/positioning/positioning.ts
@@ -779,7 +779,7 @@ function _positionBeak(beakWidth: number, elementPosition: IElementPositionInfo)
 }
 
 function _getRectangleFromElement(element: Element): Rectangle {
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   const clientRect: ClientRect = element.getBoundingClientRect();
 
   return new Rectangle(clientRect.left, clientRect.right, clientRect.top, clientRect.bottom);
@@ -802,9 +802,9 @@ function _getTargetRect(bounds: Rectangle, target: Element | MouseEvent | Point 
       // HTMLImgElements can have x and y values. The check for it being a point must go last.
     } else {
       const rectOrPoint: Point & Rectangle = target as Point & Rectangle;
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       const left = rectOrPoint.left || rectOrPoint.x;
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       const top = rectOrPoint.top || rectOrPoint.y;
       const right = rectOrPoint.right || left;
       const bottom = rectOrPoint.bottom || top;
@@ -993,9 +993,9 @@ function _getRectangleFromTarget(target: Element | MouseEvent | Point | Rectangl
   const rectOrPointTarget: Point & Rectangle = target as Point & Rectangle;
   let targetRect: Rectangle;
 
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   const left = rectOrPointTarget.left ?? rectOrPointTarget.x;
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   const top = rectOrPointTarget.top ?? rectOrPointTarget.y;
   const right = rectOrPointTarget.right ?? left;
   const bottom = rectOrPointTarget.bottom ?? top;
@@ -1132,9 +1132,9 @@ function _getBoundsFromTargetWindow(
   }
   // If the target is not null get x-axis and y-axis coordinates directly.
   else if (target !== null) {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     x = (target as Point).left || (target as MouseEvent | Point).x;
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     y = (target as Point).top || (target as MouseEvent | Point).y;
   }
 

--- a/packages/react/src/utilities/positioning/positioning.types.ts
+++ b/packages/react/src/utilities/positioning/positioning.types.ts
@@ -123,5 +123,4 @@ export interface IRelativePositions {
   submenuDirection: DirectionalHint;
 }
 
-// eslint-disable-next-line deprecation/deprecation
 export type { Point, IPoint } from '../../Utilities';

--- a/packages/react/src/utilities/selection/SelectionZone.tsx
+++ b/packages/react/src/utilities/selection/SelectionZone.tsx
@@ -522,9 +522,9 @@ export class SelectionZone extends React.Component<ISelectionZoneProps, ISelecti
     const isSelectionDisabled = this._isSelectionDisabled(target);
 
     const { selection, selectionClearedOnEscapePress } = this.props;
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const isSelectAllKey = ev.which === KeyCodes.a && (this._isCtrlPressed || this._isMetaPressed);
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const isClearSelectionKey = ev.which === KeyCodes.escape;
 
     // Ignore key downs from input elements.
@@ -576,7 +576,7 @@ export class SelectionZone extends React.Component<ISelectionZoneProps, ISelecti
           }
           break;
         } else if (
-          // eslint-disable-next-line deprecation/deprecation
+          // eslint-disable-next-line @typescript-eslint/no-deprecated
           (ev.which === KeyCodes.enter || ev.which === KeyCodes.space) &&
           (target.tagName === 'BUTTON' ||
             target.tagName === 'A' ||
@@ -585,7 +585,7 @@ export class SelectionZone extends React.Component<ISelectionZoneProps, ISelecti
         ) {
           return false;
         } else if (target === itemRoot) {
-          // eslint-disable-next-line deprecation/deprecation
+          // eslint-disable-next-line @typescript-eslint/no-deprecated
           if (ev.which === KeyCodes.enter) {
             if (span === undefined) {
               // Items should be invokable even if selection is disabled.
@@ -593,7 +593,7 @@ export class SelectionZone extends React.Component<ISelectionZoneProps, ISelecti
               ev.preventDefault();
             }
             return;
-            // eslint-disable-next-line deprecation/deprecation
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
           } else if (ev.which === KeyCodes.space) {
             if (!isSelectionDisabled) {
               this._onToggleClick(ev, index, span);
@@ -794,7 +794,7 @@ export class SelectionZone extends React.Component<ISelectionZoneProps, ISelecti
     this._isCtrlPressed = ev.ctrlKey;
     this._isMetaPressed = ev.metaKey;
 
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const keyCode = (ev as React.KeyboardEvent<HTMLElement>).keyCode;
     this._isTabPressed = keyCode ? keyCode === KeyCodes.tab : false;
   }

--- a/packages/set-version/.eslintrc.json
+++ b/packages/set-version/.eslintrc.json
@@ -2,8 +2,15 @@
   "extends": ["plugin:@fluentui/eslint-plugin/react--legacy"],
   "root": true,
   "rules": {
-    "deprecation/deprecation": "off",
     "prefer-const": "off",
     "no-restricted-globals": "off"
-  }
+  },
+  "overrides": [
+    {
+      "files": ["**/*.{ts,tsx}"],
+      "rules": {
+        "@typescript-eslint/no-deprecated": "off"
+      }
+    }
+  ]
 }

--- a/packages/style-utilities/src/index.ts
+++ b/packages/style-utilities/src/index.ts
@@ -14,7 +14,7 @@ export {
   hiddenContentStyle,
   PulsingBeaconAnimationStyles,
   getGlobalClassNames,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   getFocusStyle,
   getFocusOutlineStyle,
   getInputFocusStyle,
@@ -29,7 +29,7 @@ export {
   HighContrastSelector,
   HighContrastSelectorWhite,
   HighContrastSelectorBlack,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   EdgeChromiumHighContrastSelector,
   ScreenWidthMinSmall,
   ScreenWidthMinMedium,
@@ -45,7 +45,7 @@ export {
   ScreenWidthMinUhfMobile,
   getScreenSelector,
   getHighContrastNoAdjustStyle,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   getEdgeChromiumNoHighContrastAdjustSelector,
   normalize,
   noWrap,

--- a/packages/style-utilities/src/styles/CommonStyles.ts
+++ b/packages/style-utilities/src/styles/CommonStyles.ts
@@ -47,10 +47,10 @@ export function getHighContrastNoAdjustStyle(): IRawStyle {
  * The style which turns off high contrast adjustment in (only) Edge Chromium browser.
  *  @deprecated Use `getHighContrastNoAdjustStyle`
  */
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 export function getEdgeChromiumNoHighContrastAdjustSelector(): { [EdgeChromiumHighContrastSelector]: IRawStyle } {
   return {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     [EdgeChromiumHighContrastSelector]: {
       forcedColorAdjust: 'none',
       MsHighContrastAdjust: 'none',

--- a/packages/style-utilities/src/utilities/icons.ts
+++ b/packages/style-utilities/src/utilities/icons.ts
@@ -194,7 +194,7 @@ export function getIcon(name?: string): IIconRecord | undefined {
         }
       }
     } else {
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       if (!options.disableWarnings && options.warnOnMissingIcons) {
         warn(
           `The icon "${name}" was used but not registered. See https://github.com/microsoft/fluentui/wiki/Using-icons for more information.`,

--- a/packages/theme/src/utilities/makeSemanticColors.ts
+++ b/packages/theme/src/utilities/makeSemanticColors.ts
@@ -132,7 +132,7 @@ export function getSemanticColors<TResult = Partial<ISemanticColors>>(
     result.listItemBackgroundChecked = neutralLight;
     result.listHeaderBackgroundPressed = neutralLight;
     result.menuItemBackgroundPressed = neutralLight;
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     result.menuItemBackgroundChecked = neutralLight;
   }
   if (neutralLighter) {
@@ -227,12 +227,12 @@ function _fixDeprecatedSlots(s: ISemanticColors, depComments: boolean): ISemanti
     dep = ' /* @deprecated */';
   }
 
-  /* eslint-disable deprecation/deprecation */
+  /*  eslint-disable @typescript-eslint/no-deprecated */
   s.listTextColor = s.listText + dep;
   s.menuItemBackgroundChecked += dep;
   s.warningHighlight += dep;
   s.warningText = s.messageText + dep;
   s.successText += dep;
-  /* eslint-enable deprecation/deprecation */
+  /* eslint-enable @typescript-eslint/no-deprecated */
   return s;
 }

--- a/packages/utilities/src/BaseComponent.test.tsx
+++ b/packages/utilities/src/BaseComponent.test.tsx
@@ -5,12 +5,12 @@ import { BaseComponent } from './BaseComponent';
 
 describe('BaseComponent', () => {
   it('can resolve refs', () => {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     class Foo extends BaseComponent<{}, {}> {
       public root!: HTMLElement;
 
       public render(): JSX.Element {
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return <div ref={this._resolveRef('root')} />;
       }
     }

--- a/packages/utilities/src/BaseComponent.ts
+++ b/packages/utilities/src/BaseComponent.ts
@@ -49,7 +49,7 @@ export class BaseComponent<TProps extends IBaseProps = {}, TState extends {} = {
   constructor(props: TProps, context?: any) {
     super(props, context);
 
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     _makeAllSafe(this, BaseComponent.prototype, [
       'componentDidMount',
       'shouldComponentUpdate',
@@ -235,14 +235,14 @@ export class BaseComponent<TProps extends IBaseProps = {}, TState extends {} = {
  * ensures that the BaseComponent's methods are called before the subclass's. This ensures that
  * componentWillUnmount in the base is called and that things in the _disposables array are disposed.
  */
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 function _makeAllSafe(obj: BaseComponent<{}, {}>, prototype: Object, methodNames: string[]): void {
   for (let i = 0, len = methodNames.length; i < len; i++) {
     _makeSafe(obj, prototype, methodNames[i]);
   }
 }
 
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 function _makeSafe(obj: BaseComponent<{}, {}>, prototype: Object, methodName: string): void {
   /* eslint-disable @typescript-eslint/no-explicit-any */
   let classMethod = (obj as any)[methodName];

--- a/packages/utilities/src/EventGroup.test.ts
+++ b/packages/utilities/src/EventGroup.test.ts
@@ -13,7 +13,7 @@ describe('EventGroup', () => {
     let ev = document.createEvent('HTMLEvents');
 
     eg.on(sourceButton, 'click', parent.cb);
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     ev.initEvent('click', true, true);
 
     sourceButton.dispatchEvent(ev);
@@ -150,7 +150,7 @@ describe('EventGroup', () => {
     try {
       let ev = document.createEvent('HTMLEvents');
 
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       ev.initEvent('click', true, true);
 
       grandChildButton.dispatchEvent(ev);

--- a/packages/utilities/src/EventGroup.ts
+++ b/packages/utilities/src/EventGroup.ts
@@ -76,7 +76,7 @@ export class EventGroup {
       if (typeof theDoc !== 'undefined' && theDoc.createEvent) {
         let ev = theDoc.createEvent('HTMLEvents');
 
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         ev.initEvent(eventName, bubbleEvent || false, true);
 
         assign(ev, eventArgs);

--- a/packages/utilities/src/customizations/Customizer.test.tsx
+++ b/packages/utilities/src/customizations/Customizer.test.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable deprecation/deprecation */
+/*  eslint-disable @typescript-eslint/no-deprecated */
 import * as React from 'react';
 import { customizable } from './customizable';
 import { Customizer } from './Customizer';

--- a/packages/utilities/src/customizations/customizable.test.tsx
+++ b/packages/utilities/src/customizations/customizable.test.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable deprecation/deprecation */
+/*  eslint-disable @typescript-eslint/no-deprecated */
 import * as React from 'react';
 import * as ReactDOM from 'react-dom/server';
 import { mount } from 'enzyme';

--- a/packages/utilities/src/dom.ts
+++ b/packages/utilities/src/dom.ts
@@ -15,7 +15,7 @@ export { isVirtualElement } from './dom/isVirtualElement';
 export { on } from './dom/on';
 export { portalContainsElement } from './dom/portalContainsElement';
 export {
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   raiseClick,
 } from './dom/raiseClick';
 export { DATA_PORTAL_ATTRIBUTE, setPortalAttribute } from './dom/setPortalAttribute';

--- a/packages/utilities/src/dom/canUseDOM.ts
+++ b/packages/utilities/src/dom/canUseDOM.ts
@@ -6,7 +6,7 @@ export function canUseDOM(): boolean {
     // eslint-disable-next-line no-restricted-globals
     typeof window !== 'undefined' &&
     !!(
-      // eslint-disable-next-line no-restricted-globals, deprecation/deprecation
+      // eslint-disable-next-line no-restricted-globals, @typescript-eslint/no-deprecated
       (window.document && window.document.createElement)
     )
   );

--- a/packages/utilities/src/dom/raiseClick.ts
+++ b/packages/utilities/src/dom/raiseClick.ts
@@ -6,7 +6,7 @@ import { getDocument } from './getDocument';
 export function raiseClick(target: Element, doc?: Document): void {
   const theDoc = doc ?? getDocument()!;
   const event = createNewEvent('MouseEvents', theDoc);
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   event.initEvent('click', true, true);
   target.dispatchEvent(event);
 }
@@ -19,7 +19,7 @@ function createNewEvent(eventName: string, doc: Document): Event {
   } else {
     // IE
     event = doc.createEvent('Event');
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     event.initEvent(eventName, true, true);
   }
   return event;

--- a/packages/utilities/src/index.ts
+++ b/packages/utilities/src/index.ts
@@ -2,7 +2,7 @@ export { Async } from './Async';
 export type { ICancelable } from './Async';
 export { AutoScroll } from './AutoScroll';
 export {
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   BaseComponent,
   nullRender,
 } from './BaseComponent';
@@ -17,13 +17,13 @@ export type { IPerfData, IPerfMeasurement, IPerfSummary } from './FabricPerforma
 export { GlobalSettings } from './GlobalSettings';
 export type { IChangeDescription, IChangeEventCallback } from './GlobalSettings';
 export type {
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   IClassNames,
 } from './IClassNames';
 export type { IComponentAs, IComponentAsProps } from './IComponentAs';
 export type { IDisposable } from './IDisposable';
 export type {
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   IPoint,
   Point,
 } from './Point';
@@ -62,13 +62,13 @@ export type {
   ICustomizations,
   ISettings,
   ISettingsFunction,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   Settings,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   SettingsFunction,
 } from './customizations/Customizations';
 export {
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   Customizer,
 } from './customizations/Customizer';
 export type { ICustomizerProps } from './customizations/Customizer.types';
@@ -95,7 +95,7 @@ export {
   isVirtualElement,
   on,
   portalContainsElement,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   raiseClick,
   setPortalAttribute,
   setVirtualParent,
@@ -127,7 +127,7 @@ export { hoistMethods, unhoistMethods } from './hoist';
 export { hoistStatics } from './hoistStatics';
 export { initializeComponentRef } from './initializeComponentRef';
 export {
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   initializeFocusRects,
 } from './initializeFocusRects';
 export { FocusRectsProvider } from './FocusRectsProvider';
@@ -138,7 +138,7 @@ export { getInitials } from './initials';
 export { addDirectionalKeyCode, isDirectionalKeyCode, removeDirectionalKeyCode } from './keyboard';
 export {
   getLanguage,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   setLanguage,
 } from './language';
 export { calculatePrecision, fitContentToBounds, getDistanceBetweenPoints, precisionRound } from './math';
@@ -163,7 +163,7 @@ export {
   getNativeProps,
   htmlElementProperties,
   iframeProperties,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   imageProperties,
   imgProperties,
   inputProperties,
@@ -181,9 +181,9 @@ export {
 } from './properties';
 export { composeRenderFunction } from './renderFunction/composeRenderFunction';
 export {
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   getResourceUrl,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   setBaseUrl,
 } from './resources';
 export { getRTL, getRTLSafeKeyCode, setRTL } from './rtl';
@@ -228,14 +228,14 @@ export { isIE11 } from './ie11Detector';
 export { getPropsWithDefaults } from './getPropsWithDefaults';
 export { setFocusVisibility, IsFocusVisibleClassName } from './setFocusVisibility';
 export { canUseDOM } from './dom/canUseDOM';
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 export { setSSR } from './dom/setSSR';
 export { createMergedRef } from './createMergedRef';
 export { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect';
 
 import './version';
 
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 export type { IStyleFunctionOrObject, Omit } from '@fluentui/merge-styles';
 
 export {

--- a/packages/utilities/src/initializeFocusRects.test.ts
+++ b/packages/utilities/src/initializeFocusRects.test.ts
@@ -38,7 +38,7 @@ describe('initializeFocusRects', () => {
 
   beforeEach(() => {
     classNames = [];
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     initializeFocusRects(mockWindow as Window);
   });
 

--- a/packages/utilities/src/initializeFocusRects.ts
+++ b/packages/utilities/src/initializeFocusRects.ts
@@ -50,6 +50,6 @@ function _onPointerDown(ev: PointerEvent): void {
 }
 
 function _onKeyDown(ev: KeyboardEvent): void {
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   isDirectionalKeyCode(ev.which) && setFocusVisibility(true, ev.target as Element);
 }

--- a/packages/utilities/src/math.ts
+++ b/packages/utilities/src/math.ts
@@ -6,13 +6,13 @@ import type { ISize } from './ISize';
  *
  * @public
  */
-/* eslint-disable deprecation/deprecation */
+/*  eslint-disable @typescript-eslint/no-deprecated */
 export function getDistanceBetweenPoints(point1: Point, point2: Point): number {
   const left1 = point1.left || point1.x || 0;
   const top1 = point1.top || point1.y || 0;
   const left2 = point2.left || point2.x || 0;
   const top2 = point2.top || point2.y || 0;
-  /* eslint-enable deprecation/deprecation */
+  /* eslint-enable @typescript-eslint/no-deprecated */
 
   let distance = Math.sqrt(Math.pow(left1 - left2, 2) + Math.pow(top1 - top2, 2));
 

--- a/packages/utilities/src/styled.test.tsx
+++ b/packages/utilities/src/styled.test.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable deprecation/deprecation */
+/*  eslint-disable @typescript-eslint/no-deprecated */
 import * as React from 'react';
 import * as ReactTestUtils from 'react-dom/test-utils';
 import { styled } from './styled';

--- a/packages/utilities/src/useFocusRects.ts
+++ b/packages/utilities/src/useFocusRects.ts
@@ -180,14 +180,14 @@ function _onPointerDown(ev: PointerEvent, registeredProviders?: React.RefObject<
 // This works because `classList.add` is smart and will not duplicate a classname that already exists on the classList
 // when focus visibility is turned on.
 function _onKeyDown(ev: KeyboardEvent, registeredProviders?: React.RefObject<HTMLElement>[]): void {
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   if (isDirectionalKeyCode(ev.which)) {
     setFocusVisibility(true, ev.target as Element, registeredProviders);
   }
 }
 
 function _onKeyUp(ev: KeyboardEvent, registeredProviders?: React.RefObject<HTMLElement>[]): void {
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   if (isDirectionalKeyCode(ev.which)) {
     setFocusVisibility(true, ev.target as Element, registeredProviders);
   }

--- a/packages/webpack-utilities/.eslintrc.json
+++ b/packages/webpack-utilities/.eslintrc.json
@@ -3,7 +3,14 @@
   "root": true,
   "rules": {
     "@typescript-eslint/no-explicit-any": "off",
-    "deprecation/deprecation": "off",
     "prefer-arrow-callback": "off"
-  }
+  },
+  "overrides": [
+    {
+      "files": ["**/*.{ts,tsx}"],
+      "rules": {
+        "@typescript-eslint/no-deprecated": "off"
+      }
+    }
+  ]
 }

--- a/scripts/executors/src/generate-ui.ts
+++ b/scripts/executors/src/generate-ui.ts
@@ -29,7 +29,7 @@ main()
 async function main() {
   const graph = await createProjectGraphAsync();
   const projects = readProjectsConfigurationFromProjectGraph(graph);
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   const nxJson = readNxJson();
   if (!nxJson) {
     throw new Error('nx.json not found');

--- a/scripts/tasks/src/index.ts
+++ b/scripts/tasks/src/index.ts
@@ -9,13 +9,11 @@ export {
   basicWebpackConfig,
   basicWebpackServeConfig,
   chain,
-  // eslint-disable-next-line deprecation/deprecation
   cleanTask,
   clearCache,
   condition,
   copyInstructions,
   copyInstructionsTask,
-  // eslint-disable-next-line deprecation/deprecation
   copyTask,
   createStylesOverlay,
   createTarTask,
@@ -36,11 +34,8 @@ export {
   prettierCheckTask,
   prettierTask,
   resetResolvePaths,
-  // eslint-disable-next-line deprecation/deprecation
   resolve,
-  // eslint-disable-next-line deprecation/deprecation
   resolveCwd,
-  // eslint-disable-next-line deprecation/deprecation
   sassTask,
   series,
   spawn,

--- a/syncpack.config.js
+++ b/syncpack.config.js
@@ -47,7 +47,6 @@ const config = {
         'eslint-config-airbnb',
         'eslint-config-prettier',
         'eslint-import-resolver-typescript',
-        'eslint-plugin-deprecation',
         'eslint-plugin-import',
         'eslint-plugin-jest',
         'eslint-plugin-jsx-a11y',

--- a/yarn.lock
+++ b/yarn.lock
@@ -6188,7 +6188,7 @@
     "@typescript-eslint/types" "8.8.1"
     "@typescript-eslint/typescript-estree" "8.8.1"
 
-"@typescript-eslint/utils@^7.0.0", "@typescript-eslint/utils@^7.9.0":
+"@typescript-eslint/utils@^7.9.0":
   version "7.18.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-7.18.0.tgz#bca01cde77f95fc6a8d5b0dbcbfb3d6ca4be451f"
   integrity sha512-kK0/rNa2j74XuHVcoCZxdFBMF+aq/vH83CXAOHieC+2Gis4mF8jJXT5eAfyD3K0sAxtPuwxaIOIOvhwzVDt/kw==
@@ -10885,15 +10885,6 @@ eslint-module-utils@^2.7.4, eslint-module-utils@^2.8.0:
   integrity sha512-rXDXR3h7cs7dy9RNpUlQf80nX31XWJEyGq1tRMo+6GsO5VmTe4UTwtmonAD4ZkAsrfMVDA2wlGJ3790Ys+D49Q==
   dependencies:
     debug "^3.2.7"
-
-eslint-plugin-deprecation@3.0.0, eslint-plugin-deprecation@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-deprecation/-/eslint-plugin-deprecation-3.0.0.tgz#c0b6bce543c2a01f231d39a1c54fdfebf3560d48"
-  integrity sha512-JuVLdNg/uf0Adjg2tpTyYoYaMbwQNn/c78P1HcccokvhtRphgnRjZDKmhlxbxYptppex03zO76f97DD/yQHv7A==
-  dependencies:
-    "@typescript-eslint/utils" "^7.0.0"
-    ts-api-utils "^1.3.0"
-    tslib "^2.3.1"
 
 eslint-plugin-es@4.1.0:
   version "4.1.0"


### PR DESCRIPTION
[eslint-plugin-deprecation](https://github.com/gund/eslint-plugin-deprecation) is archived and no longer maintained. It's recommended to migrate to [@typescript-eslint/no-deprecated before migrating to eslint v9.  ](https://github.com/gund/eslint-plugin-deprecation/issues/78#issuecomment-2416972936)

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

perf for rule tested locally (nx run react:lint --skip-nx-cache): 

| before       | after          |
| ---------- | ---------- |
|  5410 ms  | 4775 ms    |

~ 12% faster 🚀 


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->
Partially implements #30334
