### PR TITLE
ci(gha): enable manual trigger for VRT and disable automatic PR trigger for testing purposes

### DIFF
--- a/.github/workflows/pr-vrt.yml
+++ b/.github/workflows/pr-vrt.yml
@@ -1,6 +1,8 @@
 name: VRT CI
 on:
-  pull_request:
+  # TODO: once testing is done enable pull_request trigger again
+  # pull_request:
+  workflow_dispatch:
 
 concurrency:
   # see https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow


### PR DESCRIPTION


<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

see title 

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
