### PR TITLE
fix(react-color-picker): focus shifts to inputY when user clicks `tab`

### DIFF
--- a/change/@fluentui-react-color-picker-preview-c30cb79c-aed3-4e9b-ad55-b1f946c8c691.json
+++ b/change/@fluentui-react-color-picker-preview-c30cb79c-aed3-4e9b-ad55-b1f946c8c691.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: focus jumps to inputY instead of next element",
+  "packageName": "@fluentui/react-color-picker-preview",
+  "email": "vkozlova@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-color-picker-preview/library/src/components/ColorArea/useColorArea.ts
+++ b/packages/react-components/react-color-picker-preview/library/src/components/ColorArea/useColorArea.ts
@@ -175,7 +175,7 @@ export const useColorArea_unstable = (props: ColorAreaProps, ref: React.Ref<HTML
       defaultProps: {
         id: useId('sliderX-'),
         type: 'range',
-        ...(activeAxis === 'x' && { tabIndex: 0 }),
+        ...(activeAxis && { tabIndex: activeAxis === 'x' ? 0 : -1 }),
       },
       elementType: 'input',
     }),
@@ -183,7 +183,7 @@ export const useColorArea_unstable = (props: ColorAreaProps, ref: React.Ref<HTML
       defaultProps: {
         id: useId('sliderY-'),
         type: 'range',
-        ...(activeAxis === 'y' && { tabIndex: 0 }),
+        ...(activeAxis && { tabIndex: activeAxis === 'y' ? 0 : -1 }),
       },
       elementType: 'input',
     }),

--- a/packages/react-components/react-color-picker-preview/stories/src/ColorPicker/AlphaSliderDefault.stories.tsx
+++ b/packages/react-components/react-color-picker-preview/stories/src/ColorPicker/AlphaSliderDefault.stories.tsx
@@ -20,8 +20,7 @@ const useStyles = makeStyles({
     },
   },
 });
-
-const COLOR = tinycolor('#5be600').toHsv();
+const COLOR = { h: 96, s: 1, v: 0.9, a: 1 };
 
 export const AlphaSliderExample = (props: Partial<AlphaSliderProps>) => {
   const styles = useStyles();

--- a/packages/react-components/react-color-picker-preview/stories/src/ColorPicker/ColorAndSwatchPicker.stories.tsx
+++ b/packages/react-components/react-color-picker-preview/stories/src/ColorPicker/ColorAndSwatchPicker.stories.tsx
@@ -48,8 +48,9 @@ const useStyles = makeStyles({
 
 const ITEMS_LIMIT = 8;
 const DEFAULT_SELECTED_VALUE = '2be700';
-const DEFAULT_SELECTED_COLOR = '#2be700';
-const DEFAULT_COLOR_HSV = tinycolor(DEFAULT_SELECTED_COLOR).toHsv();
+
+const DEFAULT_COLOR_HSV = { h: 109, s: 1, v: 0.9, a: 1 };
+const DEFAULT_SELECTED_COLOR = tinycolor(DEFAULT_COLOR_HSV).toHex();
 
 export const ColorAndSwatchPickerExample = () => {
   const styles = useStyles();
@@ -110,6 +111,7 @@ export const ColorAndSwatchPickerExample = () => {
         aria-label="SwatchPicker with empty swatches"
         selectedValue={selectedValue}
         onSelectionChange={handleSelect}
+        shape="rounded"
       >
         {items.map(item => (
           <ColorSwatch key={item.value} ref={item.value === colorFocusTarget ? colorFocusTargetRef : null} {...item} />

--- a/packages/react-components/react-color-picker-preview/stories/src/ColorPicker/ColorAreaDefault.stories.tsx
+++ b/packages/react-components/react-color-picker-preview/stories/src/ColorPicker/ColorAreaDefault.stories.tsx
@@ -21,7 +21,7 @@ const useStyles = makeStyles({
   },
 });
 
-const DEFAULT_COLOR_HSV = tinycolor('#804066').toHsv();
+const DEFAULT_COLOR_HSV = { h: 324, s: 0.5, v: 0.5, a: 1 };
 
 export const ColorAreaExample = () => {
   const styles = useStyles();

--- a/packages/react-components/react-color-picker-preview/stories/src/ColorPicker/ColorPickerDefault.stories.tsx
+++ b/packages/react-components/react-color-picker-preview/stories/src/ColorPicker/ColorPickerDefault.stories.tsx
@@ -56,7 +56,7 @@ const useStyles = makeStyles({
 
 const HEX_COLOR_REGEX = /^#?([0-9A-Fa-f]{0,6})$/;
 const NUMBER_REGEX = /^\d+$/;
-const DEFAULT_COLOR_HSV = tinycolor('#2be700').toHsv();
+const DEFAULT_COLOR_HSV = { h: 109, s: 1, v: 0.9, a: 1 };
 
 type RgbKey = 'r' | 'g' | 'b';
 

--- a/packages/react-components/react-color-picker-preview/stories/src/ColorPicker/ColorPickerPopup.stories.tsx
+++ b/packages/react-components/react-color-picker-preview/stories/src/ColorPicker/ColorPickerPopup.stories.tsx
@@ -36,7 +36,7 @@ const useStyles = makeStyles({
   },
 });
 
-const DEFAULT_COLOR_HSV = tinycolor('#2be700').toHsv();
+const DEFAULT_COLOR_HSV = { h: 109, s: 1, v: 0.9, a: 1 };
 
 export const ColorPickerPopup = () => {
   const styles = useStyles();

--- a/packages/react-components/react-color-picker-preview/stories/src/ColorPicker/ColorPickerShape.stories.tsx
+++ b/packages/react-components/react-color-picker-preview/stories/src/ColorPicker/ColorPickerShape.stories.tsx
@@ -27,7 +27,7 @@ const useStyles = makeStyles({
   },
 });
 
-const DEFAULT_COLOR_HSV = tinycolor('#2be700').toHsv();
+const DEFAULT_COLOR_HSV = { h: 109, s: 1, v: 0.91, a: 1 };
 
 export const ColorPickerShape = () => {
   const styles = useStyles();
@@ -39,15 +39,15 @@ export const ColorPickerShape = () => {
     <div className={styles.example}>
       <h3>Rounded (default)</h3>
       <ColorPicker color={color} onColorChange={handleChange}>
+        <ColorArea />
         <ColorSlider />
         <AlphaSlider />
-        <ColorArea />
       </ColorPicker>
       <h3>Square (default)</h3>
       <ColorPicker shape="square" color={color} onColorChange={handleChange}>
+        <ColorArea />
         <ColorSlider />
         <AlphaSlider />
-        <ColorArea />
       </ColorPicker>
       <div className={styles.previewColor} style={{ backgroundColor: tinycolor(color).toRgbString() }} />
     </div>

--- a/packages/react-components/react-color-picker-preview/stories/src/ColorPicker/ColorSliderDefault.stories.tsx
+++ b/packages/react-components/react-color-picker-preview/stories/src/ColorPicker/ColorSliderDefault.stories.tsx
@@ -20,8 +20,7 @@ const useStyles = makeStyles({
     },
   },
 });
-
-const DEFAULT_COLOR_HSV = tinycolor('#2be700').toHsv();
+const DEFAULT_COLOR_HSV = { h: 109, s: 1, v: 0.9, a: 1 };
 
 export const ColorSliderExample = (props: Partial<ColorSliderProps>) => {
   const styles = useStyles();


### PR DESCRIPTION
## Previous Behavior
- When the user clicks on the `tab` key, the focus goes to the `inputY` instead of the next element.
- Color in stories in hex format

## New Behavior
- When the user clicks on the `tab` key, the focus goes to the next element.
- Moved color in stories in one HSV format