### PR TITLE
Use css system colors for high contrast mode

### DIFF
--- a/packages/charts/chart-web-components/src/donut-chart/donut-chart.styles.ts
+++ b/packages/charts/chart-web-components/src/donut-chart/donut-chart.styles.ts
@@ -142,7 +142,7 @@ export const styles = css`
 `.withBehaviors(
   forcedColorsStylesheetBehavior(css`
     .text-inside-donut {
-      fill: rgb(179, 179, 179);
+      fill: CanvasText;
     }
 
     .legend-rect,
@@ -153,7 +153,7 @@ export const styles = css`
     .tooltip-legend-text,
     .tooltip-content-y {
       forced-color-adjust: auto;
-      color: rgb(255, 255, 255);
+      color: CanvasText;
     }
   `),
 );

--- a/packages/charts/chart-web-components/src/horizontal-bar-chart/horizontal-bar-chart.styles.ts
+++ b/packages/charts/chart-web-components/src/horizontal-bar-chart/horizontal-bar-chart.styles.ts
@@ -181,10 +181,10 @@ export const styles: ElementStyles = css`
     .tooltip-legend-text,
     .tooltip-content-y {
       forced-color-adjust: auto;
-      color: rgb(255, 255, 255);
+      color: CanvasText;
     }
     .bar-label {
-      fill: white !important;
+      fill: CanvasText !important;
     }
   `),
 );


### PR DESCRIPTION
This PR addresses the following comment:
> Typically we use [CSS System Colors](https://developer.mozilla.org/en-US/docs/Web/CSS/system-color) for forced colors over RGB values so that we're compatible with light and dark modes.
-- https://github.com/microsoft/fluentui/pull/33084#discussion_r1909631808

## Previous Behavior
### High contrast mode
![Screenshot 2025-01-13 152208](https://github.com/user-attachments/assets/e919d921-b642-4fde-a0b7-b028d79bc71a)
![Screenshot 2025-01-13 152227](https://github.com/user-attachments/assets/45fa5b0a-223d-4c15-90a7-6fa199d0d610)

## New Behavior
### High contrast mode
![Screenshot 2025-01-13 151259](https://github.com/user-attachments/assets/4d4297a1-bd95-422f-82a4-0592b7823d44)
![Screenshot 2025-01-13 151237](https://github.com/user-attachments/assets/c3976ed6-e904-4f27-8aca-ceee5da32f40)
