### PR TITLE
Adding secondary y axis for declarative charts

### DIFF
--- a/packages/charts/react-charting/src/components/DeclarativeChart/PlotlySchemaAdapter.ts
+++ b/packages/charts/react-charting/src/components/DeclarativeChart/PlotlySchemaAdapter.ts
@@ -32,6 +32,11 @@ import { IVerticalBarChartProps } from '../VerticalBarChart/index';
 import { Layout, PlotlySchema, PieData, PlotData, SankeyData } from './PlotlySchema';
 import type { Datum, TypedArray } from './PlotlySchema';
 
+interface ISecondaryYAxisValues {
+  secondaryYAxistitle?: string;
+  secondaryYScaleOptions?: { yMinValue?: number; yMaxValue?: number };
+}
+
 const isDate = (value: any): boolean => !isNaN(Date.parse(value));
 const isNumber = (value: any): boolean => !isNaN(parseFloat(value)) && isFinite(value);
 
@@ -139,10 +144,7 @@ export const getColor = (
 };
 
 const getSecondaryYAxisValues = (series: PlotData, layout: Partial<Layout> | undefined) => {
-  const secondaryYAxisValues: {
-    secondaryYAxistitle?: string | undefined;
-    secondaryYScaleOptions?: { yMinValue?: number; yMaxValue?: number } | undefined;
-  } = {};
+  const secondaryYAxisValues: ISecondaryYAxisValues = {};
   if (layout && layout.yaxis2 && series.yaxis === 'y2') {
     secondaryYAxisValues.secondaryYAxistitle =
       typeof layout.yaxis2.title === 'string'
@@ -233,10 +235,7 @@ export const transformPlotlyJsonToVSBCProps = (
 ): IVerticalStackedBarChartProps => {
   const mapXToDataPoints: { [key: string]: IVerticalStackedChartProps } = {};
   let yMaxValue = 0;
-  let secondaryYAxisValues: {
-    secondaryYAxistitle?: string;
-    secondaryYScaleOptions?: { yMinValue?: number; yMaxValue?: number };
-  } = {};
+  let secondaryYAxisValues: ISecondaryYAxisValues = {};
   input.data.forEach((series: PlotData, index1: number) => {
     if (series.x?.length > 0 && Array.isArray(series.x[0])) {
       throw new Error('transform to VSBC:: 2D x array not supported');
@@ -298,10 +297,7 @@ export const transformPlotlyJsonToGVBCProps = (
   isDarkTheme?: boolean,
 ): IGroupedVerticalBarChartProps => {
   const mapXToDataPoints: Record<string, IGroupedVerticalBarChartData> = {};
-  let secondaryYAxisValues: {
-    secondaryYAxistitle?: string;
-    secondaryYScaleOptions?: { yMinValue?: number; yMaxValue?: number };
-  } = {};
+  let secondaryYAxisValues: ISecondaryYAxisValues = {};
   input.data.forEach((series: PlotData, index1: number) => {
     if (series.x?.length > 0 && Array.isArray(series.x[0])) {
       throw new Error('transform to GVBC:: 2D x array not supported');
@@ -448,10 +444,7 @@ export const transformPlotlyJsonToScatterChartProps = (
   colorMap: React.MutableRefObject<Map<string, string>>,
   isDarkTheme?: boolean,
 ): ILineChartProps | IAreaChartProps => {
-  let secondaryYAxisValues: {
-    secondaryYAxistitle?: string;
-    secondaryYScaleOptions?: { yMinValue?: number; yMaxValue?: number };
-  } = {};
+  let secondaryYAxisValues: ISecondaryYAxisValues = {};
   const chartData: ILineChartPoints[] = input.data.map((series: PlotData, index: number) => {
     if (series.x?.length > 0 && Array.isArray(series.x[0])) {
       throw new Error('transform to Scatter:: 2D x array not supported');

--- a/packages/charts/react-charting/src/components/DeclarativeChart/PlotlySchemaAdapter.ts
+++ b/packages/charts/react-charting/src/components/DeclarativeChart/PlotlySchemaAdapter.ts
@@ -138,20 +138,25 @@ export const getColor = (
   return colorMap.current.get(legendLabel) as string;
 };
 
-const getSecondaryYAxisValues = (series: any, layout: any) => {
+const getSecondaryYAxisValues = (series: PlotData, layout: Partial<Layout> | undefined) => {
   const secondaryYAxisValues: {
     secondaryYAxistitle?: string | undefined;
     secondaryYScaleOptions?: { yMinValue?: number; yMaxValue?: number } | undefined;
   } = {};
-  if (layout.yaxis2 && series.yaxis === 'y2') {
-    secondaryYAxisValues.secondaryYAxistitle = layout.yaxis2.title;
+  if (layout && layout.yaxis2 && series.yaxis === 'y2') {
+    secondaryYAxisValues.secondaryYAxistitle =
+      typeof layout.yaxis2.title === 'string'
+        ? layout.yaxis2.title
+        : typeof layout.yaxis2.title?.text === 'string'
+        ? layout.yaxis2.title.text
+        : '';
     if (layout.yaxis2.range) {
       secondaryYAxisValues.secondaryYScaleOptions = {
         yMinValue: layout.yaxis2.range[0],
         yMaxValue: layout.yaxis2.range[1],
       };
     } else {
-      const yValues = series.y;
+      const yValues = series.y as number[];
       if (yValues) {
         secondaryYAxisValues.secondaryYScaleOptions = {
           yMinValue: Math.min(...yValues),
@@ -160,10 +165,12 @@ const getSecondaryYAxisValues = (series: any, layout: any) => {
       }
     }
   }
-  secondaryYAxisValues.secondaryYAxistitle !== '' ? secondaryYAxisValues.secondaryYAxistitle : undefined;
-  secondaryYAxisValues.secondaryYScaleOptions && Object.keys(secondaryYAxisValues.secondaryYScaleOptions).length !== 0
-    ? secondaryYAxisValues.secondaryYScaleOptions
-    : undefined;
+  secondaryYAxisValues.secondaryYAxistitle =
+    secondaryYAxisValues.secondaryYAxistitle !== '' ? secondaryYAxisValues.secondaryYAxistitle : undefined;
+  secondaryYAxisValues.secondaryYScaleOptions =
+    secondaryYAxisValues.secondaryYScaleOptions && Object.keys(secondaryYAxisValues.secondaryYScaleOptions).length !== 0
+      ? secondaryYAxisValues.secondaryYScaleOptions
+      : undefined;
   return secondaryYAxisValues;
 };
 


### PR DESCRIPTION
From PR https://github.com/microsoft/fluentui/pull/33594
Adding secondary y axis for declarative charts.

Area chart:

![image](https://github.com/user-attachments/assets/b56b70b4-e383-4934-8377-00330643771b)

Line chart:

![image](https://github.com/user-attachments/assets/11512448-ae4e-4961-9c77-10a8cf9f4107)

Grouped Vertical bar chart:

![image](https://github.com/user-attachments/assets/dbe36d08-b503-4b05-9c4a-fae3ad306819)

Vertical Stacked bar chart:

![image](https://github.com/user-attachments/assets/b21d1181-bef8-47da-a9e6-452ffa2ae2be)
