### PR TITLE
ci(gha): limit privileged vrt workflow trigger branch base

### DIFF
--- a/.github/workflows/pr-vrt-comment.yml
+++ b/.github/workflows/pr-vrt-comment.yml
@@ -4,6 +4,10 @@ on:
     workflows: ['VRT CI']
     types:
       - completed
+    branches:
+      - master
+      # remove following once CRT testing is done
+      - vrt-gha-testing
 
 concurrency:
   # see https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

restrict commenting workflow to be run only if event is registered against master or temporary vrt-testing branch.

✅ this will completely avoid spamming our master commit history with testing commits for vrt-commenting workflow.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows https://github.com/microsoft/fluentui/pull/33606
