### PR TITLE
[Fix](react-nav-preview): Changing nav item hover animation curves.

### DIFF
--- a/change/@fluentui-react-nav-preview-f1f67efd-37ec-4bf3-a0b8-470029586904.json
+++ b/change/@fluentui-react-nav-preview-f1f67efd-37ec-4bf3-a0b8-470029586904.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix - changing hover animation curve to linear.",
+  "packageName": "@fluentui/react-nav-preview",
+  "email": "matejera@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-nav-preview/library/src/components/sharedNavStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/library/src/components/sharedNavStyles.styles.ts
@@ -15,11 +15,11 @@ export const navItemTokens = {
   animationTokens: {
     animationDuration: tokens.durationFaster,
     animationFillMode: 'both',
-    animationTimingFunction: tokens.curveAccelerateMid,
+    animationTimingFunction: tokens.curveLinear,
   },
   transitionTokens: {
     transitionDuration: tokens.durationFaster,
-    transitionTimingFunction: tokens.curveAccelerateMid,
+    transitionTimingFunction: tokens.curveLinear,
     transitionProperty: 'background',
   },
 };


### PR DESCRIPTION
Had an over the shoulder conversation with an animation SME and he suggested linear curves as the standard for hover over.