### PR TITLE
[web-components] fix: disabled switch state in high-contrast mode

### DIFF
--- a/change/@fluentui-web-components-a03312db-25ed-42ac-8259-b9754b5afdd9.json
+++ b/change/@fluentui-web-components-a03312db-25ed-42ac-8259-b9754b5afdd9.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: update disabled switch styles to GrayText for high-contrast mode",
+  "packageName": "@fluentui/web-components",
+  "email": "rupertdavid@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/switch/switch.styles.ts
+++ b/packages/web-components/src/switch/switch.styles.ts
@@ -141,5 +141,9 @@ export const styles = css`
     :host(${checkedState}:active) .checked-indicator {
       background-color: ButtonFace;
     }
+    :host(:disabled) .checked-indicator,
+    :host(${checkedState}:disabled) .checked-indicator {
+      background-color: GrayText;
+    }
   `),
 );


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

A disabled Switch in high-contrast mode had no visual checked indicator.

![image](https://github.com/user-attachments/assets/75d2de95-d61a-4435-a239-c2c44c1730b0)


## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

A disabled Switch in high-contrast mode now has a `GrayText` checked indicator

![image](https://github.com/user-attachments/assets/5324f6a5-5021-44ae-bad7-d7d95a52db76)


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #33506
