### PR TITLE
chore(web-components): build tokens package before running e2e tests

### DIFF
--- a/change/@fluentui-web-components-674e26a9-57d5-4147-bda1-e4a467529eaf.json
+++ b/change/@fluentui-web-components-674e26a9-57d5-4147-bda1-e4a467529eaf.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "build tokens package before running e2e tests",
+  "packageName": "@fluentui/web-components",
+  "email": "863023+radium-v@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/project.json
+++ b/packages/web-components/project.json
@@ -3,5 +3,10 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],
+  "targets": {
+    "e2e": {
+      "dependsOn": [{ "target": "build", "projects": "dependencies" }]
+    }
+  },
   "tags": ["platform:web", "web-components"]
 }

--- a/packages/web-components/project.json
+++ b/packages/web-components/project.json
@@ -3,10 +3,5 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],
-  "targets": {
-    "e2e": {
-      "dependsOn": [{ "target": "build", "projects": "dependencies" }]
-    }
-  },
   "tags": ["platform:web", "web-components"]
 }

--- a/packages/web-components/test/harness/vite.config.ts
+++ b/packages/web-components/test/harness/vite.config.ts
@@ -1,4 +1,8 @@
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
 import type { UserConfig } from 'vite';
+
+const { resolve } = createRequire(import.meta.url);
 
 export default {
   clearScreen: false,
@@ -19,5 +23,10 @@ export default {
     port: 5173,
     strictPort: true,
     open: false,
+  },
+  resolve: {
+    alias: {
+      '@fluentui/tokens': join(dirname(resolve('@fluentui/tokens/package.json')), 'src'),
+    },
   },
 } as UserConfig;


### PR DESCRIPTION
The `@fluentui/tokens` package is a dependency of the `@fluentui/web-components` package.

## Previous Behavior

The `tokens` package was not being built before the `e2e` task ran, which caused errors on CI (https://github.com/microsoft/fluentui/actions/runs/12755006210/job/35551157062?pr=33637)

## New Behavior

The `project.json` configuration for the `web-components` package specifies that dependencies need to be built before the `e2e` task runs.
