### PR TITLE
chore: Update BASEURL to new CDN

### DIFF
--- a/packages/icons/src/index.ts
+++ b/packages/icons/src/index.ts
@@ -21,7 +21,7 @@ import { initializeIcons as i17 } from './fabric-icons-17';
 import { IIconOptions } from '@uifabric/styling';
 import { registerIconAliases } from './iconAliases';
 import { getWindow } from '@uifabric/utilities';
-const DEFAULT_BASE_URL = 'https://spoppe-b.azureedge.net/files/fabric-cdn-prod_20210407.001/assets/icons/';
+const DEFAULT_BASE_URL = 'https://res.cdn.office.net/files/fabric-cdn-prod_20241209.001/assets/icons/';
 
 /*
  * The Window variable has the iconBaseUrl prop in order to allow for users to redirect icon font downloads to a new


### PR DESCRIPTION
The CDN that hosts the font icon assets will be deleted on 1/15/2025. This PR changes the base URL to point to a new CDN.