### PR TITLE
fix(react-utilities): add autoCorrect and minLength input properties support to getNativeProps utility

### DIFF
--- a/change/@fluentui-react-utilities-0b333279-3531-4fce-a0ee-8e9c05d6f830.json
+++ b/change/@fluentui-react-utilities-0b333279-3531-4fce-a0ee-8e9c05d6f830.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: add autoCorrect and minLength input properties support to getNativeProps utility",
+  "packageName": "@fluentui/react-utilities",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-utilities/src/utils/properties.test.ts
+++ b/packages/react-components/react-utilities/src/utils/properties.test.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeProps, divProperties } from './properties';
+import { getNativeProps, divProperties, inputProperties } from './properties';
 
 describe('getNativeProps', () => {
   it('can pass through data tags', () => {
@@ -41,6 +41,32 @@ describe('getNativeProps', () => {
     expect(result.className).toEqual('foo');
     expect(typeof result.onClick).toEqual('function');
     expect(typeof result.onClickCapture).toEqual('function');
+  });
+
+  it('can pass through input props', () => {
+    const result = getNativeProps<React.InputHTMLAttributes<HTMLInputElement>>(
+      {
+        autoCapitalize: 'off',
+        autoCorrect: 'on',
+        maxLength: 10,
+        minLength: 1,
+        value: '123',
+        // Non-input property
+        foobar: 1,
+      },
+      inputProperties,
+    );
+
+    expect(result).toMatchObject({
+      autoCapitalize: 'off',
+      autoCorrect: 'on',
+      maxLength: 10,
+      minLength: 1,
+      value: '123',
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((result as any).foobar).toBeUndefined();
   });
 
   it('can remove unexpected properties', () => {

--- a/packages/react-components/react-utilities/src/utils/properties.ts
+++ b/packages/react-components/react-utilities/src/utils/properties.ts
@@ -248,6 +248,7 @@ export const buttonProperties = toObjectMap(htmlElementProperties, [
 export const inputProperties = toObjectMap(buttonProperties, [
   'accept', // input
   'alt', // area, img, input
+  'autoCorrect', // input, textarea
   'autoCapitalize', // input, textarea
   'autoComplete', // form, input
   'checked', // input
@@ -259,6 +260,7 @@ export const inputProperties = toObjectMap(buttonProperties, [
   'max', // input, meter
   'maxLength', // input, textarea
   'min', // input, meter
+  'minLength', // input, textarea
   'multiple', // input, select
   'pattern', // input
   'placeholder', // input, textarea


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

`autoCorrect` and `minLength` prop were not considered as input props by `getNativeProps` utility and as a result were not forwarded to the native input/textarea elements by default.

## New Behavior

Added `autoCorrect` and `minLength` props to `getNativeProps` utility configuration to make them available as input props.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #33614
