### PR TITLE
fix: remove forced synchronous layout in Drawer

### DIFF
--- a/change/@fluentui-react-drawer-592aa752-5056-4be4-bf91-b47f98cea7d4.json
+++ b/change/@fluentui-react-drawer-592aa752-5056-4be4-bf91-b47f98cea7d4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove forced synchronous layout in Drawer",
+  "packageName": "@fluentui/react-drawer",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-drawer/library/src/components/DrawerBody/useDrawerBody.ts
+++ b/packages/react-components/react-drawer/library/src/components/DrawerBody/useDrawerBody.ts
@@ -65,12 +65,14 @@ export const useDrawerBody_unstable = (props: DrawerBodyProps, ref: React.Ref<HT
   }, [cancelAnimationFrame, setAnimationFrame, updateScrollState]);
 
   useIsomorphicLayoutEffect(() => {
+    cancelAnimationFrame();
     setAnimationFrame(() => updateScrollState());
     /* update scroll state when children changes */
     return () => cancelAnimationFrame();
   }, [props.children, cancelAnimationFrame, updateScrollState, setAnimationFrame]);
 
   useIsomorphicLayoutEffect(() => {
+    cancelAnimationFrame();
     setAnimationFrame(() => updateScrollState());
 
     return () => cancelAnimationFrame();

--- a/packages/react-components/react-drawer/library/src/components/DrawerBody/useDrawerBody.ts
+++ b/packages/react-components/react-drawer/library/src/components/DrawerBody/useDrawerBody.ts
@@ -65,15 +65,16 @@ export const useDrawerBody_unstable = (props: DrawerBodyProps, ref: React.Ref<HT
   }, [cancelAnimationFrame, setAnimationFrame, updateScrollState]);
 
   useIsomorphicLayoutEffect(() => {
-    updateScrollState();
+    setAnimationFrame(() => updateScrollState());
     /* update scroll state when children changes */
-  }, [props.children, updateScrollState]);
+    return () => cancelAnimationFrame();
+  }, [props.children, cancelAnimationFrame, updateScrollState, setAnimationFrame]);
 
   useIsomorphicLayoutEffect(() => {
-    updateScrollState();
+    setAnimationFrame(() => updateScrollState());
 
     return () => cancelAnimationFrame();
-  }, [cancelAnimationFrame, updateScrollState]);
+  }, [cancelAnimationFrame, updateScrollState, setAnimationFrame]);
 
   return {
     components: {


### PR DESCRIPTION
## Previous Behavior

Drawer was [forcing synchronous layout](https://web.dev/articles/avoid-large-complex-layouts-and-layout-thrashing#avoid_forced_synchronous_layouts) by reading [scrollTop, scrollHeight and clientHeight in its getScrollState() function](https://github.com/microsoft/fluentui/blob/00458f3bbe3f12c0cef556f8d8fd564ffa66983c/packages/react-components/react-drawer/library/src/components/DrawerBody/useDrawerBody.ts#L23).

This change defers the read with a `requestAnimationFrame()` so the browser can read the values from the previous frame, removing the forced synchronous layout.

## New Behavior

No forced synchronous layout

## Related Issue(s)

- Fixes #33655

## References

### Before profile

![Chrome DevTools showing the forced style recalc and layout](https://github.com/user-attachments/assets/0045840d-c568-4eda-8a7d-a36bf9987314)

### After profile

![Chrome DevTools showing no forced style recalc and layout](https://github.com/user-attachments/assets/6dca3f52-324e-4c0b-a7fa-edf72a9809be)



