### PR TITLE
fix(react-tooltip): wrong call of useIsNavigatingWithKeyboard

### DIFF
--- a/change/@fluentui-react-tooltip-4088de96-b20d-4c18-9567-9987be622dbf.json
+++ b/change/@fluentui-react-tooltip-4088de96-b20d-4c18-9567-9987be622dbf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: wrong call of useIsNavigatingWithKeyboard",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "viktorgenaev@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tooltip/library/src/components/Tooltip/useTooltip.tsx
+++ b/packages/react-components/react-tooltip/library/src/components/Tooltip/useTooltip.tsx
@@ -177,7 +177,7 @@ export const useTooltip_unstable = (props: TooltipProps): TooltipState => {
     [setDelayTimeout, setVisible, state.showDelay, context],
   );
 
-  const isNavigatingWithKeyboard = useIsNavigatingWithKeyboard()();
+  const isNavigatingWithKeyboard = useIsNavigatingWithKeyboard();
 
   // Callback ref that attaches a keyborg:focusin event listener.
   const [keyborgListenerCallbackRef] = React.useState(() => {
@@ -186,7 +186,7 @@ export const useTooltip_unstable = (props: TooltipProps): TooltipState => {
       // For example, we don't want to show the tooltip when a dialog is closed
       // and Tabster programmatically restores focus to the trigger button.
       // See https://github.com/microsoft/fluentui/issues/27576
-      if (ev.detail?.isFocusedProgrammatically && !isNavigatingWithKeyboard) {
+      if (ev.detail?.isFocusedProgrammatically && !isNavigatingWithKeyboard()) {
         ignoreNextFocusEventRef.current = true;
       }
     }) as EventListener;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

https://github.com/user-attachments/assets/7e357c00-3f3a-48b1-acc1-5e624d22cb08

## New Behavior

https://github.com/user-attachments/assets/7e7b43ae-99ee-4144-93cc-9ce305e0c758

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #33646 
