### PR TITLE
feat(declarative-chart): Add default colorScale in heatmap chart

### DIFF
--- a/packages/charts/react-charting/src/components/DeclarativeChart/PlotlySchemaAdapter.ts
+++ b/packages/charts/react-charting/src/components/DeclarativeChart/PlotlySchemaAdapter.ts
@@ -586,21 +586,19 @@ export const transformPlotlyJsonToHeatmapProps = (input: PlotlySchema): IHeatMap
   };
 
   // Initialize domain and range to default values
-  const defaultDomain = [0.0, 0.1, 0.2];
+  const defaultDomain = [zMin, zMax];
   const defaultRange = [
     getColorFromToken(DataVizPalette.success),
     getColorFromToken(DataVizPalette.warning),
     getColorFromToken(DataVizPalette.error),
   ];
-  const domainValuesForColorScale: number[] =
-    firstData.colorscale && firstData.colorscale !== 'Viridis'
-      ? (firstData.colorscale as Array<[number, string]>).map(arr => arr[0] * (zMax - zMin) + zMin)
-      : defaultDomain;
+  const domainValuesForColorScale: number[] = Array.isArray(firstData.colorscale)
+    ? (firstData.colorscale as Array<[number, string]>).map(arr => arr[0] * (zMax - zMin) + zMin)
+    : defaultDomain;
 
-  const rangeValuesForColorScale: string[] =
-    firstData.colorscale && firstData.colorscale !== 'Viridis'
-      ? (firstData.colorscale as Array<[number, string]>).map(arr => arr[1])
-      : defaultRange;
+  const rangeValuesForColorScale: string[] = Array.isArray(firstData.colorscale)
+    ? (firstData.colorscale as Array<[number, string]>).map(arr => arr[1])
+    : defaultRange;
 
   const { chartTitle, xAxisTitle, yAxisTitle } = getTitles(input.layout);
 

--- a/packages/charts/react-charting/src/components/DeclarativeChart/PlotlySchemaAdapter.ts
+++ b/packages/charts/react-charting/src/components/DeclarativeChart/PlotlySchemaAdapter.ts
@@ -25,7 +25,7 @@ import { IHorizontalBarChartWithAxisProps } from '../HorizontalBarChartWithAxis/
 import { ILineChartProps } from '../LineChart/index';
 import { IAreaChartProps } from '../AreaChart/index';
 import { IHeatMapChartProps } from '../HeatMapChart/index';
-import { DataVizPalette, getNextColor } from '../../utilities/colors';
+import { DataVizPalette, getColorFromToken, getNextColor } from '../../utilities/colors';
 import { GaugeChartVariant, IGaugeChartProps, IGaugeChartSegment } from '../GaugeChart/index';
 import { IGroupedVerticalBarChartProps } from '../GroupedVerticalBarChart/index';
 import { IVerticalBarChartProps } from '../VerticalBarChart/index';
@@ -585,13 +585,23 @@ export const transformPlotlyJsonToHeatmapProps = (input: PlotlySchema): IHeatMap
     value: 0,
   };
 
-  // Convert normalized values to actual values
-  const domainValuesForColorScale: number[] = firstData.colorscale
-    ? (firstData.colorscale as Array<[number, string]>).map(arr => arr[0] * (zMax - zMin) + zMin)
-    : [];
-  const rangeValuesForColorScale: string[] = firstData.colorscale
-    ? (firstData.colorscale as Array<[number, string]>).map(arr => arr[1])
-    : [];
+  // Initialize domain and range to default values
+  const defaultDomain = [0.0, 0.1, 0.2];
+  const defaultRange = [
+    getColorFromToken(DataVizPalette.success),
+    getColorFromToken(DataVizPalette.warning),
+    getColorFromToken(DataVizPalette.error),
+  ];
+  const domainValuesForColorScale: number[] =
+    firstData.colorscale && firstData.colorscale !== 'Viridis'
+      ? (firstData.colorscale as Array<[number, string]>).map(arr => arr[0] * (zMax - zMin) + zMin)
+      : defaultDomain;
+
+  const rangeValuesForColorScale: string[] =
+    firstData.colorscale && firstData.colorscale !== 'Viridis'
+      ? (firstData.colorscale as Array<[number, string]>).map(arr => arr[1])
+      : defaultRange;
+
   const { chartTitle, xAxisTitle, yAxisTitle } = getTitles(input.layout);
 
   return {

--- a/packages/charts/react-charting/src/components/DeclarativeChart/PlotlySchemaAdapter.ts
+++ b/packages/charts/react-charting/src/components/DeclarativeChart/PlotlySchemaAdapter.ts
@@ -588,9 +588,9 @@ export const transformPlotlyJsonToHeatmapProps = (input: PlotlySchema): IHeatMap
   // Initialize domain and range to default values
   const defaultDomain = [zMin, zMax];
   const defaultRange = [
-    getColorFromToken(DataVizPalette.success),
-    getColorFromToken(DataVizPalette.warning),
-    getColorFromToken(DataVizPalette.error),
+    getColorFromToken(DataVizPalette.color1),
+    getColorFromToken(DataVizPalette.color2),
+    getColorFromToken(DataVizPalette.color3),
   ];
   const domainValuesForColorScale: number[] = Array.isArray(firstData.colorscale)
     ? (firstData.colorscale as Array<[number, string]>).map(arr => arr[0] * (zMax - zMin) + zMin)

--- a/packages/charts/react-charting/src/components/DeclarativeChart/__snapshots__/DeclarativeChartRTL.test.tsx.snap
+++ b/packages/charts/react-charting/src/components/DeclarativeChart/__snapshots__/DeclarativeChartRTL.test.tsx.snap
@@ -4142,7 +4142,7 @@ exports[`DeclarativeChart Should render gaugechart in DeclarativeChart 1`] = `
             transform="rotate(151.2, 0, 0)"
           >
             <path
-              aria-label="Current value: 84%"
+              aria-label="Current value: 420"
               class=
 
                   {
@@ -4180,7 +4180,7 @@ exports[`DeclarativeChart Should render gaugechart in DeclarativeChart 1`] = `
               x="0"
               y="0"
             >
-              84%
+              420
             </text>
           </g>
           <text

--- a/packages/charts/react-charting/src/components/DeclarativeChart/__snapshots__/PlotlySchemaAdapterUT.test.tsx.snap
+++ b/packages/charts/react-charting/src/components/DeclarativeChart/__snapshots__/PlotlySchemaAdapterUT.test.tsx.snap
@@ -368,6 +368,7 @@ exports[`transform Plotly Json To chart Props transformPlotlyJsonToGaugeProps - 
 Object {
   "chartTitle": "",
   "chartValue": 420,
+  "chartValueFormat": [Function],
   "height": 400,
   "maxValue": 500,
   "minValue": undefined,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
1. Heatmap chart with colorScale == 'Viridis' was crashing.
2. Heatmap chart with no colorscale defined was coming in black color.

## New Behavior

Defined a default colorScale for above cases.

Upcoming feature: Will add support for 'Viridis' colorscale.

![image](https://github.com/user-attachments/assets/fce9d946-769c-4d51-8201-44a4b12c88ed)

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
