### PR TITLE
fix: [BUG 12159] default legend selection for Horizontal Bar Chart

### DIFF
--- a/packages/charts/react-charting/src/components/HorizontalBarChartWithAxis/HorizontalBarChartWithAxis.base.tsx
+++ b/packages/charts/react-charting/src/components/HorizontalBarChartWithAxis/HorizontalBarChartWithAxis.base.tsx
@@ -91,7 +91,9 @@ export class HorizontalBarChartWithAxisBase
       color: '',
       dataForHoverCard: 0,
       isCalloutVisible: false,
-      isLegendSelected: props.legendProps?.selectedLegend !== undefined,
+      isLegendSelected:
+        (props.legendProps?.selectedLegends && props.legendProps.selectedLegends.length > 0) ||
+        props.legendProps?.selectedLegend !== undefined,
       isLegendHovered: false,
       refSelected: null,
       selectedLegendTitle: props.legendProps?.selectedLegend ?? '',


### PR DESCRIPTION
fix: default legend selection for Horizontal Bar Chart for declarative charts

https://uifabric.visualstudio.com/iss/_workitems/edit/12159