### PR TITLE
bugfix: secondaryContent not displaying properly

### DIFF
--- a/change/@fluentui-react-tag-picker-f788c84a-933e-4291-9111-2a6187517663.json
+++ b/change/@fluentui-react-tag-picker-f788c84a-933e-4291-9111-2a6187517663.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: secondaryContent not displaying properly",
+  "packageName": "@fluentui/react-tag-picker",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerOption/__snapshots__/TagPickerOption.test.tsx.snap
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerOption/__snapshots__/TagPickerOption.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`TagPickerOption renders a default state 1`] = `
 <div>
   <div
     aria-selected="false"
-    class="fui-TagPickerOption fui-Option"
+    class="fui-Option fui-TagPickerOption"
     id="fluent-option8"
     role="option"
   >

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerOption/useTagPickerOptionStyles.styles.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerOption/useTagPickerOptionStyles.styles.ts
@@ -2,6 +2,7 @@ import { makeStyles, mergeClasses } from '@griffel/react';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import type { TagPickerOptionSlots, TagPickerOptionState } from './TagPickerOption.types';
 import { useOptionStyles_unstable } from '@fluentui/react-combobox';
+import { typographyStyles } from '@fluentui/react-theme';
 
 export const tagPickerOptionClassNames: SlotClassNames<TagPickerOptionSlots> = {
   root: 'fui-TagPickerOption',
@@ -22,6 +23,7 @@ const useStyles = makeStyles({
   secondaryContent: {
     gridColumnStart: 2,
     gridRowStart: 2,
+    ...typographyStyles.caption1,
   },
 
   media: {
@@ -35,6 +37,9 @@ const useStyles = makeStyles({
 export const useTagPickerOptionStyles_unstable = (state: TagPickerOptionState): TagPickerOptionState => {
   'use no memo';
 
+  const styles = useStyles();
+
+  state.root.className = mergeClasses(tagPickerOptionClassNames.root, styles.root, state.root.className);
   useOptionStyles_unstable({
     ...state,
     active: false,
@@ -43,9 +48,6 @@ export const useTagPickerOptionStyles_unstable = (state: TagPickerOptionState): 
     checkIcon: undefined,
     selected: false,
   });
-  const styles = useStyles();
-
-  state.root.className = mergeClasses(tagPickerOptionClassNames.root, styles.root, state.root.className);
   if (state.media) {
     state.media.className = mergeClasses(tagPickerOptionClassNames.media, styles.media, state.media.className);
   }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

`secondaryContent` (in this example the text `Microsoft FTE`) is not properly positioned, according to design spec it should be on it's own separate line and with `caption1` style by default

![image](https://github.com/user-attachments/assets/4b8e9210-4fa3-46c1-8768-f4735b352b64)

<!-- This is the behavior we have today -->

## New Behavior

![image](https://github.com/user-attachments/assets/0aa4647b-9321-4b99-afb0-926c6583dc79)

1. move `useOptionStyles` hook to lose priority over `useTagPickerOptionStyles` internal styles
2. properly add `caption1` typography styles which were missing

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/33683
