### PR TITLE
fix(Autofill): Only apply selection logic if the current value does not match the previous value to avoid using the value before state is set and handle del key as delete in the keydown event

### DIFF
--- a/change/@fluentui-react-681d58c2-312a-4905-9e8c-c6446e14a971.json
+++ b/change/@fluentui-react-681d58c2-312a-4905-9e8c-c6446e14a971.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(Autofill): Set selection to the end when suggested value is an empty string and the component has updated.",
+  "packageName": "@fluentui/react",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-681d58c2-312a-4905-9e8c-c6446e14a971.json
+++ b/change/@fluentui-react-681d58c2-312a-4905-9e8c-c6446e14a971.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "fix(Autofill): Set selection to the end when suggested value is an empty string and the component has updated.",
+  "comment": "fix(Autofill): Only apply selection logic if the current value does not match the previous value to avoid using the value before state is set and handle del key as delete in the keydown event.",
   "packageName": "@fluentui/react",
   "email": "estebanmu@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -477,7 +477,7 @@ export class Autofill extends React_2.Component<IAutofillProps, IAutofillState> 
     // Warning: (ae-forgotten-export) The symbol "ICursorLocation" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    componentDidUpdate(_: any, _1: any, cursor: ICursorLocation | null): void;
+    componentDidUpdate(_: any, previousState: IAutofillState, cursor: ICursorLocation | null): void;
     // (undocumented)
     componentWillUnmount(): void;
     // (undocumented)

--- a/packages/react/src/components/Autofill/Autofill.tsx
+++ b/packages/react/src/components/Autofill/Autofill.tsx
@@ -98,7 +98,7 @@ export class Autofill extends React.Component<IAutofillProps, IAutofillState> im
     return this._inputElement.current;
   }
 
-  public componentDidUpdate(_: any, _1: any, cursor: ICursorLocation | null) {
+  public componentDidUpdate(_: any, previousState: IAutofillState, cursor: ICursorLocation | null) {
     const { suggestedDisplayValue, shouldSelectFullInputValueInComponentDidUpdate, preventValueSelection } = this.props;
     let differenceIndex = 0;
 
@@ -109,11 +109,8 @@ export class Autofill extends React.Component<IAutofillProps, IAutofillState> im
     const document = this.context?.window.document || getDocument(this._inputElement.current);
     const isFocused = this._inputElement.current && this._inputElement.current === document?.activeElement;
 
-    if (isFocused && this._autoFillEnabled && this.value) {
-      // when there's no suggestedDisplayValue, set the selection to the end of the input value
-      if (suggestedDisplayValue === '') {
-        this._inputElement.current!.setSelectionRange(this.value.length, this.value.length, SELECTION_BACKWARD);
-      } else if (suggestedDisplayValue && _doesTextStartWith(suggestedDisplayValue, this.value)) {
+    if (isFocused && this._autoFillEnabled && this.value && previousState.inputValue !== this.value) {
+      if (suggestedDisplayValue && _doesTextStartWith(suggestedDisplayValue, this.value)) {
         let shouldSelectFullRange = false;
 
         if (shouldSelectFullInputValueInComponentDidUpdate) {

--- a/packages/react/src/components/Autofill/Autofill.tsx
+++ b/packages/react/src/components/Autofill/Autofill.tsx
@@ -109,34 +109,34 @@ export class Autofill extends React.Component<IAutofillProps, IAutofillState> im
     const document = this.context?.window.document || getDocument(this._inputElement.current);
     const isFocused = this._inputElement.current && this._inputElement.current === document?.activeElement;
 
-    if (
-      isFocused &&
-      this._autoFillEnabled &&
-      this.value &&
-      suggestedDisplayValue &&
-      _doesTextStartWith(suggestedDisplayValue, this.value)
-    ) {
-      let shouldSelectFullRange = false;
+    if (isFocused && this._autoFillEnabled && this.value) {
+      // when there's no suggestedDisplayValue, set the selection to the end of the input value
+      if (suggestedDisplayValue === '') {
+        this._inputElement.current!.setSelectionRange(this.value.length, this.value.length, SELECTION_BACKWARD);
+      } else if (suggestedDisplayValue && _doesTextStartWith(suggestedDisplayValue, this.value)) {
+        let shouldSelectFullRange = false;
 
-      if (shouldSelectFullInputValueInComponentDidUpdate) {
-        shouldSelectFullRange = shouldSelectFullInputValueInComponentDidUpdate();
-      }
-
-      if (shouldSelectFullRange) {
-        this._inputElement.current!.setSelectionRange(0, suggestedDisplayValue.length, SELECTION_BACKWARD);
-      } else {
-        while (
-          differenceIndex < this.value.length &&
-          this.value[differenceIndex].toLocaleLowerCase() === suggestedDisplayValue[differenceIndex].toLocaleLowerCase()
-        ) {
-          differenceIndex++;
+        if (shouldSelectFullInputValueInComponentDidUpdate) {
+          shouldSelectFullRange = shouldSelectFullInputValueInComponentDidUpdate();
         }
-        if (differenceIndex > 0) {
-          this._inputElement.current!.setSelectionRange(
-            differenceIndex,
-            suggestedDisplayValue.length,
-            SELECTION_BACKWARD,
-          );
+
+        if (shouldSelectFullRange) {
+          this._inputElement.current!.setSelectionRange(0, suggestedDisplayValue.length, SELECTION_BACKWARD);
+        } else {
+          while (
+            differenceIndex < this.value.length &&
+            this.value[differenceIndex].toLocaleLowerCase() ===
+              suggestedDisplayValue[differenceIndex].toLocaleLowerCase()
+          ) {
+            differenceIndex++;
+          }
+          if (differenceIndex > 0) {
+            this._inputElement.current!.setSelectionRange(
+              differenceIndex,
+              suggestedDisplayValue.length,
+              SELECTION_BACKWARD,
+            );
+          }
         }
       }
     } else if (this._inputElement.current) {
@@ -249,6 +249,7 @@ export class Autofill extends React.Component<IAutofillProps, IAutofillState> im
     if (!(ev.nativeEvent as any).isComposing) {
       // eslint-disable-next-line @typescript-eslint/no-deprecated
       switch (ev.which) {
+        case KeyCodes.del:
         case KeyCodes.backspace:
           this._autoFillEnabled = false;
           break;

--- a/packages/react/src/components/Autofill/Autofill.tsx
+++ b/packages/react/src/components/Autofill/Autofill.tsx
@@ -109,31 +109,35 @@ export class Autofill extends React.Component<IAutofillProps, IAutofillState> im
     const document = this.context?.window.document || getDocument(this._inputElement.current);
     const isFocused = this._inputElement.current && this._inputElement.current === document?.activeElement;
 
-    if (isFocused && this._autoFillEnabled && this.value && previousState.inputValue !== this.value) {
-      if (suggestedDisplayValue && _doesTextStartWith(suggestedDisplayValue, this.value)) {
-        let shouldSelectFullRange = false;
+    if (
+      isFocused &&
+      this._autoFillEnabled &&
+      this.value &&
+      suggestedDisplayValue &&
+      _doesTextStartWith(suggestedDisplayValue, this.value) &&
+      previousState.inputValue !== this.value
+    ) {
+      let shouldSelectFullRange = false;
 
-        if (shouldSelectFullInputValueInComponentDidUpdate) {
-          shouldSelectFullRange = shouldSelectFullInputValueInComponentDidUpdate();
+      if (shouldSelectFullInputValueInComponentDidUpdate) {
+        shouldSelectFullRange = shouldSelectFullInputValueInComponentDidUpdate();
+      }
+
+      if (shouldSelectFullRange) {
+        this._inputElement.current!.setSelectionRange(0, suggestedDisplayValue.length, SELECTION_BACKWARD);
+      } else {
+        while (
+          differenceIndex < this.value.length &&
+          this.value[differenceIndex].toLocaleLowerCase() === suggestedDisplayValue[differenceIndex].toLocaleLowerCase()
+        ) {
+          differenceIndex++;
         }
-
-        if (shouldSelectFullRange) {
-          this._inputElement.current!.setSelectionRange(0, suggestedDisplayValue.length, SELECTION_BACKWARD);
-        } else {
-          while (
-            differenceIndex < this.value.length &&
-            this.value[differenceIndex].toLocaleLowerCase() ===
-              suggestedDisplayValue[differenceIndex].toLocaleLowerCase()
-          ) {
-            differenceIndex++;
-          }
-          if (differenceIndex > 0) {
-            this._inputElement.current!.setSelectionRange(
-              differenceIndex,
-              suggestedDisplayValue.length,
-              SELECTION_BACKWARD,
-            );
-          }
+        if (differenceIndex > 0) {
+          this._inputElement.current!.setSelectionRange(
+            differenceIndex,
+            suggestedDisplayValue.length,
+            SELECTION_BACKWARD,
+          );
         }
       }
     } else if (this._inputElement.current) {


### PR DESCRIPTION
Currently the selection logic runs twice, once when the input is updated via keypress and then another time when the inputValue state is set. This causes issues with autofill since currently we apply the selection logic even if the previous value matches the current one (this can happen due to re-renders or in our case what I explained before). To avoid this and checking the actual new value of the input, we should only apply the selection logic when the previous state does not match the current state.

For example if we have Blac with a suggested value of Black (k being highlighted) and we press k, there will be two checks:
1. before "Black" is set to the input value where the selection logic is being run with "Blac", therefore we keep the current selection and suggested value.
2. after "Black" is set to the input value where suggested value is an empty string now therefore the selection logic does not run and leaves us with k highlighted and k is not registered in the input. But we want the selection logic to run with the previous suggested value.

In addition to this, I've added handling the del key to the onkeydown event since this blocks deleting characters through the delete key.

- Fixes #31051 