### PR TITLE
fix(react-charting): ensure text elements use the correct font-family in SVG export

### DIFF
--- a/change/@fluentui-react-charting-ef56337f-c8bb-48ee-94f5-75abe0aa1d3b.json
+++ b/change/@fluentui-react-charting-ef56337f-c8bb-48ee-94f5-75abe0aa1d3b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: ensure text elements use the correct font-family in SVG export",
+  "packageName": "@fluentui/react-charting",
+  "email": "110246001+krkshitij@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charts/react-charting/src/components/DeclarativeChart/imageExporter.ts
+++ b/packages/charts/react-charting/src/components/DeclarativeChart/imageExporter.ts
@@ -52,7 +52,9 @@ function toSVG(chartContainer: HTMLElement, background: string) {
     .attr('width', null)
     .attr('height', null)
     .attr('viewBox', null);
+  const { fontFamily } = getComputedStyle(chartContainer);
 
+  clonedSvg.selectAll('text').style('font-family', fontFamily);
   if (legendGroup.node) {
     clonedSvg.append(() => legendGroup.node);
   }


### PR DESCRIPTION
## Previous Behavior

![converted-image (5)](https://github.com/user-attachments/assets/26cc77d1-7f19-4e8b-b8ab-667fef454980)

## New Behavior

![converted-image (6)](https://github.com/user-attachments/assets/5a837bfb-6a4b-4fd4-aa21-e377d2a3fc10)