### PR TITLE
fix: MenuItem is only focused when mouse cursor is moved

### DIFF
--- a/change/@fluentui-react-menu-820da09f-c52a-4751-a749-7f8ca4387d65.json
+++ b/change/@fluentui-react-menu-820da09f-c52a-4751-a749-7f8ca4387d65.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: MenuItem is only focused when mouse cursor is moved",
+  "packageName": "@fluentui/react-menu",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-menu/library/src/components/MenuItem/MenuItem.test.tsx
+++ b/packages/react-components/react-menu/library/src/components/MenuItem/MenuItem.test.tsx
@@ -40,13 +40,13 @@ describe('MenuItem', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it('should focus the item on mouseenter', () => {
+  it('should focus the item on mousemove', () => {
     // Arrange
     const { getByRole } = render(<MenuItem>Item</MenuItem>);
 
     // Act
     const menuitem = getByRole('menuitem');
-    fireEvent.mouseEnter(menuitem);
+    fireEvent.mouseMove(menuitem);
 
     // Assert
     expect(document.activeElement).toBe(menuitem);

--- a/packages/react-components/react-menu/library/src/components/MenuItem/__snapshots__/MenuItem.test.tsx.snap
+++ b/packages/react-components/react-menu/library/src/components/MenuItem/__snapshots__/MenuItem.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`MenuItem renders a default state 1`] = `
   onClick={[Function]}
   onKeyDown={[Function]}
   onKeyUp={[Function]}
-  onMouseEnter={[Function]}
+  onMouseMove={[Function]}
   role="menuitem"
   tabIndex={0}
 >

--- a/packages/react-components/react-menu/library/src/components/MenuItem/useMenuItem.tsx
+++ b/packages/react-components/react-menu/library/src/components/MenuItem/useMenuItem.tsx
@@ -74,10 +74,12 @@ export const useMenuItem_unstable = (props: MenuItemProps, ref: React.Ref<ARIABu
               dismissedWithKeyboardRef.current = true;
             }
           }),
-          onMouseEnter: useEventCallback(event => {
-            innerRef.current?.focus();
+          onMouseMove: useEventCallback(event => {
+            if (event.currentTarget.ownerDocument.activeElement !== event.currentTarget) {
+              innerRef.current?.focus();
+            }
 
-            props.onMouseEnter?.(event);
+            props.onMouseMove?.(event);
           }),
           onClick: useEventCallback(event => {
             if (!hasSubmenu && !persistOnClick) {

--- a/packages/react-components/react-menu/library/src/components/MenuItemCheckbox/__snapshots__/MenuItemCheckbox.test.tsx.snap
+++ b/packages/react-components/react-menu/library/src/components/MenuItemCheckbox/__snapshots__/MenuItemCheckbox.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`MenuItemCheckbox conformance renders a default state 1`] = `
   onClick={[Function]}
   onKeyDown={[Function]}
   onKeyUp={[Function]}
-  onMouseEnter={[Function]}
+  onMouseMove={[Function]}
   role="menuitemcheckbox"
   tabIndex={0}
 >

--- a/packages/react-components/react-menu/library/src/components/MenuItemRadio/__snapshots__/MenuItemRadio.test.tsx.snap
+++ b/packages/react-components/react-menu/library/src/components/MenuItemRadio/__snapshots__/MenuItemRadio.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`MenuItemRadio renders a default state 1`] = `
   onClick={[Function]}
   onKeyDown={[Function]}
   onKeyUp={[Function]}
-  onMouseEnter={[Function]}
+  onMouseMove={[Function]}
   role="menuitemradio"
   tabIndex={0}
 >

--- a/packages/react-components/react-menu/library/src/components/MenuList/MenuList.cy.tsx
+++ b/packages/react-components/react-menu/library/src/components/MenuList/MenuList.cy.tsx
@@ -22,7 +22,7 @@ describe('MenuList', () => {
       </div>,
     );
     cy.get(menuItemSelector).each(el => {
-      cy.wrap(el).trigger('mouseover').should('be.focused');
+      cy.wrap(el).trigger('mousemove').should('be.focused');
     });
   });
 


### PR DESCRIPTION
Currently the MenuItem uses `onMouseEnter` to focus - this causes a nasty side effect where the menu item is focused if the menu opens and hte cursor just happens to be on top of a menuitem.

This PR changes the logic to use `onMouseMove` which requires the user to explicitly move the cursor inside the menu item

## Previous Behavior
![menu hover bad](https://github.com/user-attachments/assets/1c774134-dff7-4cb9-b4a0-e96a9b59dd3b)


## New Behavior
![menu hover good](https://github.com/user-attachments/assets/309ff961-7017-44ef-92fa-d78760fb2357)


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
