### PR TITLE
fix(react-button): make SplitButton divider match Figma spec

### DIFF
--- a/change/@fluentui-react-button-82ba9b76-3c25-43aa-a6d1-32edfcf774ae.json
+++ b/change/@fluentui-react-button-82ba9b76-3c25-43aa-a6d1-32edfcf774ae.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: make SplitButton divider transparent for subtle and transparent variants",
+  "packageName": "@fluentui/react-button",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-button/library/src/components/SplitButton/useSplitButtonStyles.styles.ts
+++ b/packages/react-components/react-button/library/src/components/SplitButton/useSplitButtonStyles.styles.ts
@@ -92,35 +92,35 @@ const useRootStyles = makeStyles({
   },
   subtle: {
     [`& .${splitButtonClassNames.primaryActionButton}`]: {
-      borderRightColor: tokens.colorNeutralStroke1,
+      borderRightColor: tokens.colorTransparentBackground,
     },
 
     ':hover': {
       [`& .${splitButtonClassNames.primaryActionButton}`]: {
-        borderRightColor: tokens.colorNeutralStroke1Hover,
+        borderRightColor: tokens.colorTransparentBackgroundHover,
       },
     },
 
     ':hover:active': {
       [`& .${splitButtonClassNames.primaryActionButton}`]: {
-        borderRightColor: tokens.colorNeutralStroke1Pressed,
+        borderRightColor: tokens.colorTransparentBackgroundPressed,
       },
     },
   },
   transparent: {
     [`& .${splitButtonClassNames.primaryActionButton}`]: {
-      borderRightColor: tokens.colorNeutralStroke1,
+      borderRightColor: tokens.colorTransparentBackground,
     },
 
     ':hover': {
       [`& .${splitButtonClassNames.primaryActionButton}`]: {
-        borderRightColor: tokens.colorNeutralStroke1Hover,
+        borderRightColor: tokens.colorTransparentBackgroundHover,
       },
     },
 
     ':hover:active': {
       [`& .${splitButtonClassNames.primaryActionButton}`]: {
-        borderRightColor: tokens.colorNeutralStroke1Pressed,
+        borderRightColor: tokens.colorTransparentBackgroundPressed,
       },
     },
   },


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

Current SplitButton subtle and transparent variants have a divider that does not match Figma specification.

![Screenshot 2025-01-24 at 20 46 06](https://github.com/user-attachments/assets/850cf360-624a-4c59-a060-42b432949c32)

## Previous Behavior

![Screenshot 2025-01-24 at 20 44 07](https://github.com/user-attachments/assets/07f229da-d7a5-4346-b687-0318ac0f074d)

## New Behavior

![Screenshot 2025-01-24 at 20 44 28](https://github.com/user-attachments/assets/b85a025e-0ec5-4456-ae88-30cd375ef2c7)

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #33721 
