### PR TITLE
Carousel: Ensure safe indexing of carousel on resize edge case

### DIFF
--- a/change/@fluentui-react-carousel-6f17b80c-0ebc-4bca-969c-2776de76fc80.json
+++ b/change/@fluentui-react-carousel-6f17b80c-0ebc-4bca-969c-2776de76fc80.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Ensure carousel handles indexing when window size is larger then combined card size",
+  "packageName": "@fluentui/react-carousel",
+  "email": "mifraser@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-carousel/library/src/components/CarouselNavButton/useCarouselNavButton.ts
+++ b/packages/react-components/react-carousel/library/src/components/CarouselNavButton/useCarouselNavButton.ts
@@ -70,6 +70,9 @@ export const useCarouselNavButton_unstable = (
 
   useIsomorphicLayoutEffect(() => {
     return subscribeForValues(data => {
+      if (index < 0 || index >= data.groupIndexList.length) {
+        return;
+      }
       const controlList = data.groupIndexList[index];
       const _controlledSlideIds = controlList
         .map((slideIndex: number) => {

--- a/packages/react-components/react-carousel/library/src/components/CarouselNavButton/useCarouselNavButton.ts
+++ b/packages/react-components/react-carousel/library/src/components/CarouselNavButton/useCarouselNavButton.ts
@@ -70,7 +70,7 @@ export const useCarouselNavButton_unstable = (
 
   useIsomorphicLayoutEffect(() => {
     return subscribeForValues(data => {
-      if (index < 0 || index >= data.groupIndexList.length) {
+      if (index < 0 || index >= data.groupIndexList.length || data.groupIndexList[index] === undefined) {
         return;
       }
       const controlList = data.groupIndexList[index];

--- a/packages/react-components/react-carousel/library/src/components/CarouselNavButton/useCarouselNavButton.ts
+++ b/packages/react-components/react-carousel/library/src/components/CarouselNavButton/useCarouselNavButton.ts
@@ -70,10 +70,7 @@ export const useCarouselNavButton_unstable = (
 
   useIsomorphicLayoutEffect(() => {
     return subscribeForValues(data => {
-      if (index < 0 || index >= data.groupIndexList.length || data.groupIndexList[index] === undefined) {
-        return;
-      }
-      const controlList = data.groupIndexList[index];
+      const controlList = data.groupIndexList?.[index] ?? [];
       const _controlledSlideIds = controlList
         .map((slideIndex: number) => {
           return data.slideNodes[slideIndex].id;

--- a/packages/react-components/react-carousel/library/src/components/CarouselNavImageButton/useCarouselNavImageButton.ts
+++ b/packages/react-components/react-carousel/library/src/components/CarouselNavImageButton/useCarouselNavImageButton.ts
@@ -63,7 +63,7 @@ export const useCarouselNavImageButton_unstable = (
 
   useIsomorphicLayoutEffect(() => {
     return subscribeForValues(data => {
-      if (index < 0 || index >= data.groupIndexList.length) {
+      if (index < 0 || index >= data.groupIndexList.length || data.groupIndexList[index] === undefined) {
         return;
       }
       const controlList = data.groupIndexList[index];

--- a/packages/react-components/react-carousel/library/src/components/CarouselNavImageButton/useCarouselNavImageButton.ts
+++ b/packages/react-components/react-carousel/library/src/components/CarouselNavImageButton/useCarouselNavImageButton.ts
@@ -63,10 +63,7 @@ export const useCarouselNavImageButton_unstable = (
 
   useIsomorphicLayoutEffect(() => {
     return subscribeForValues(data => {
-      if (index < 0 || index >= data.groupIndexList.length || data.groupIndexList[index] === undefined) {
-        return;
-      }
-      const controlList = data.groupIndexList[index];
+      const controlList = data.groupIndexList?.[index] ?? [];
       const _controlledSlideIds = controlList
         .map((slideIndex: number) => {
           return data.slideNodes[slideIndex].id;

--- a/packages/react-components/react-carousel/library/src/components/CarouselNavImageButton/useCarouselNavImageButton.ts
+++ b/packages/react-components/react-carousel/library/src/components/CarouselNavImageButton/useCarouselNavImageButton.ts
@@ -63,6 +63,9 @@ export const useCarouselNavImageButton_unstable = (
 
   useIsomorphicLayoutEffect(() => {
     return subscribeForValues(data => {
+      if (index < 0 || index >= data.groupIndexList.length) {
+        return;
+      }
       const controlList = data.groupIndexList[index];
       const _controlledSlideIds = controlList
         .map((slideIndex: number) => {

--- a/packages/react-components/react-carousel/library/src/components/useEmblaCarousel.ts
+++ b/packages/react-components/react-carousel/library/src/components/useEmblaCarousel.ts
@@ -150,7 +150,11 @@ export function useEmblaCarousel(
   const updateIndex = () => {
     const newIndex = emblaApi.current?.selectedScrollSnap() ?? 0;
     const slides = emblaApi.current?.slideNodes();
-    const actualIndex = emblaApi.current?.internalEngine().slideRegistry[newIndex][0] ?? 0;
+    const slideRegistry = emblaApi.current?.internalEngine().slideRegistry;
+    let actualIndex = 0;
+    if (slideRegistry && slideRegistry.length > newIndex) {
+      actualIndex = slideRegistry[newIndex][0];
+    }
     // We set the first card in the current group as the default tabster index for focus capture
     slides?.forEach((slide, slideIndex) => {
       setTabsterDefault(slide, slideIndex === actualIndex);

--- a/packages/react-components/react-carousel/library/src/components/useEmblaCarousel.ts
+++ b/packages/react-components/react-carousel/library/src/components/useEmblaCarousel.ts
@@ -151,10 +151,8 @@ export function useEmblaCarousel(
     const newIndex = emblaApi.current?.selectedScrollSnap() ?? 0;
     const slides = emblaApi.current?.slideNodes();
     const slideRegistry = emblaApi.current?.internalEngine().slideRegistry;
-    let actualIndex = 0;
-    if (slideRegistry && slideRegistry.length > newIndex) {
-      actualIndex = slideRegistry[newIndex][0] ?? 0;
-    }
+    const actualIndex = slideRegistry?.[newIndex]?.[0] ?? 0;
+
     // We set the first card in the current group as the default tabster index for focus capture
     slides?.forEach((slide, slideIndex) => {
       setTabsterDefault(slide, slideIndex === actualIndex);

--- a/packages/react-components/react-carousel/library/src/components/useEmblaCarousel.ts
+++ b/packages/react-components/react-carousel/library/src/components/useEmblaCarousel.ts
@@ -153,7 +153,7 @@ export function useEmblaCarousel(
     const slideRegistry = emblaApi.current?.internalEngine().slideRegistry;
     let actualIndex = 0;
     if (slideRegistry && slideRegistry.length > newIndex) {
-      actualIndex = slideRegistry[newIndex][0];
+      actualIndex = slideRegistry[newIndex][0] ?? 0;
     }
     // We set the first card in the current group as the default tabster index for focus capture
     slides?.forEach((slide, slideIndex) => {


### PR DESCRIPTION
## Previous Behavior
An exception would be thrown when the CarouselSlider window was resized to be larger than the CarouselCards themselves.

## New Behavior
When Carousel slider is set to greater width than the combined cards width, it will default to a single page navigation icon and be array safe.

## Related Issue(s)
- Fixes #33729

