### PR TITLE
fix(declarative-chart): Gauge chart crash fix

### DIFF
--- a/change/@fluentui-react-charting-3e1ae476-d4f7-4de9-a64c-75551a66123a.json
+++ b/change/@fluentui-react-charting-3e1ae476-d4f7-4de9-a64c-75551a66123a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix chart crashes of plotly examples",
+  "packageName": "@fluentui/react-charting",
+  "email": "74965306+Anush2303@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charts/react-charting/src/components/DeclarativeChart/DeclarativeChart.tsx
+++ b/packages/charts/react-charting/src/components/DeclarativeChart/DeclarativeChart.tsx
@@ -198,7 +198,7 @@ export const DeclarativeChart: React.FunctionComponent<DeclarativeChartProps> = 
       return <DonutChart {...transformPlotlyJsonToDonutProps(plotlySchema, colorMap, isDarkTheme)} {...commonProps} />;
     case 'bar':
       const orientation = plotlyInput.data[0].orientation;
-      if (orientation === 'h') {
+      if (orientation === 'h' && isNumberArray((plotlyInput.data[0] as PlotData).x)) {
         return (
           <HorizontalBarChartWithAxis
             {...transformPlotlyJsonToHorizontalBarWithAxisProps(plotlySchema, colorMap, isDarkTheme)}
@@ -245,7 +245,8 @@ export const DeclarativeChart: React.FunctionComponent<DeclarativeChartProps> = 
         <SankeyChart {...transformPlotlyJsonToSankeyProps(plotlySchema, colorMap, isDarkTheme)} {...commonProps} />
       );
     case 'indicator':
-      if (plotlyInput.data?.[0]?.mode?.includes('gauge')) {
+    case 'gauge':
+      if (plotlyInput.data?.[0]?.mode?.includes('gauge') || plotlyInput.data?.[0]?.type === 'gauge') {
         return (
           <GaugeChart {...transformPlotlyJsonToGaugeProps(plotlySchema, colorMap, isDarkTheme)} {...commonProps} />
         );

--- a/packages/charts/react-charting/src/components/DeclarativeChart/DeclarativeChart.tsx
+++ b/packages/charts/react-charting/src/components/DeclarativeChart/DeclarativeChart.tsx
@@ -245,8 +245,7 @@ export const DeclarativeChart: React.FunctionComponent<DeclarativeChartProps> = 
         <SankeyChart {...transformPlotlyJsonToSankeyProps(plotlySchema, colorMap, isDarkTheme)} {...commonProps} />
       );
     case 'indicator':
-    case 'gauge':
-      if (plotlyInput.data?.[0]?.mode?.includes('gauge') || plotlyInput.data?.[0]?.type === 'gauge') {
+      if (plotlyInput.data?.[0]?.mode?.includes('gauge')) {
         return (
           <GaugeChart {...transformPlotlyJsonToGaugeProps(plotlySchema, colorMap, isDarkTheme)} {...commonProps} />
         );
@@ -256,6 +255,8 @@ export const DeclarativeChart: React.FunctionComponent<DeclarativeChartProps> = 
       return (
         <VerticalBarChart {...transformPlotlyJsonToVBCProps(plotlySchema, colorMap, isDarkTheme)} {...commonProps} />
       );
+    case 'gauge':
+      return <GaugeChart {...transformPlotlyJsonToGaugeProps(plotlySchema, colorMap, isDarkTheme)} {...commonProps} />;
     default:
       const xValues = (plotlyInput.data[0] as PlotData).x;
       const yValues = (plotlyInput.data[0] as PlotData).y;

--- a/packages/charts/react-charting/src/components/DeclarativeChart/DeclarativeChart.tsx
+++ b/packages/charts/react-charting/src/components/DeclarativeChart/DeclarativeChart.tsx
@@ -245,7 +245,8 @@ export const DeclarativeChart: React.FunctionComponent<DeclarativeChartProps> = 
         <SankeyChart {...transformPlotlyJsonToSankeyProps(plotlySchema, colorMap, isDarkTheme)} {...commonProps} />
       );
     case 'indicator':
-      if (plotlyInput.data?.[0]?.mode?.includes('gauge')) {
+    case 'gauge':
+      if (plotlyInput.data?.[0]?.mode?.includes('gauge') || plotlyInput.data?.[0]?.type === 'gauge') {
         return (
           <GaugeChart {...transformPlotlyJsonToGaugeProps(plotlySchema, colorMap, isDarkTheme)} {...commonProps} />
         );
@@ -255,8 +256,6 @@ export const DeclarativeChart: React.FunctionComponent<DeclarativeChartProps> = 
       return (
         <VerticalBarChart {...transformPlotlyJsonToVBCProps(plotlySchema, colorMap, isDarkTheme)} {...commonProps} />
       );
-    case 'gauge':
-      return <GaugeChart {...transformPlotlyJsonToGaugeProps(plotlySchema, colorMap, isDarkTheme)} {...commonProps} />;
     default:
       const xValues = (plotlyInput.data[0] as PlotData).x;
       const yValues = (plotlyInput.data[0] as PlotData).y;

--- a/packages/charts/react-charting/src/components/DeclarativeChart/PlotlySchema.ts
+++ b/packages/charts/react-charting/src/components/DeclarativeChart/PlotlySchema.ts
@@ -1076,7 +1076,7 @@ export type PlotType =
   | 'violin'
   | 'volume'
   | 'waterfall'
-  // adding custom plot types as we get in plotly schemas
+  // adding custom plot types as seen in AI generated plotly schema
   | 'gauge';
 
 export type Data = Partial<PlotData> | Partial<PieData> | Partial<SankeyData>;

--- a/packages/charts/react-charting/src/components/DeclarativeChart/PlotlySchema.ts
+++ b/packages/charts/react-charting/src/components/DeclarativeChart/PlotlySchema.ts
@@ -1075,7 +1075,9 @@ export type PlotType =
   | 'treemap'
   | 'violin'
   | 'volume'
-  | 'waterfall';
+  | 'waterfall'
+  // adding custom plot types as we get in plotly schemas
+  | 'gauge';
 
 export type Data = Partial<PlotData> | Partial<PieData> | Partial<SankeyData>;
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## New Behavior

1. Gauge chart not crashing
![image](https://github.com/user-attachments/assets/1dd59ca7-4a16-4fc1-8fc1-ff3709db77a0)

2. Added check for falling back to VSBC if xAxisType data is not of number type in HBCWithAxis.


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
