### PR TITLE
bugfix(react-tag-picker): regression from #33689

### DIFF
--- a/change/@fluentui-react-tag-picker-47947df9-46a1-4b10-b5b4-30965038a3c8.json
+++ b/change/@fluentui-react-tag-picker-47947df9-46a1-4b10-b5b4-30965038a3c8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: regression from #33689",
+  "packageName": "@fluentui/react-tag-picker",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerOption/useTagPickerOptionStyles.styles.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerOption/useTagPickerOptionStyles.styles.ts
@@ -1,4 +1,4 @@
-import { makeStyles, mergeClasses } from '@griffel/react';
+import { makeResetStyles, makeStyles, mergeClasses } from '@griffel/react';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import type { TagPickerOptionSlots, TagPickerOptionState } from './TagPickerOption.types';
 import { useOptionStyles_unstable } from '@fluentui/react-combobox';
@@ -10,25 +10,26 @@ export const tagPickerOptionClassNames: SlotClassNames<TagPickerOptionSlots> = {
   secondaryContent: 'fui-TagPickerOption__secondaryContent',
 };
 
-/**
- * Styles for the root slot
- */
-const useStyles = makeStyles({
-  root: {
+const useRootBaseStyle = makeResetStyles({
+  display: 'flex',
+  alignItems: 'center',
+});
+
+const useRootStyles = makeStyles({
+  secondaryContent: {
     display: 'grid',
     gridTemplateColumns: 'auto 1fr',
-    alignItems: 'center',
   },
+});
 
-  secondaryContent: {
-    gridColumnStart: 2,
-    gridRowStart: 2,
-    ...typographyStyles.caption1,
-  },
+const useSecondaryContentBaseStyle = makeResetStyles({
+  gridColumnStart: 2,
+  gridRowStart: 2,
+  ...typographyStyles.caption1,
+});
 
-  media: {
-    gridRowStart: 'span 2',
-  },
+const useMediaBaseStyle = makeResetStyles({
+  gridRowStart: 'span 2',
 });
 
 /**
@@ -37,9 +38,17 @@ const useStyles = makeStyles({
 export const useTagPickerOptionStyles_unstable = (state: TagPickerOptionState): TagPickerOptionState => {
   'use no memo';
 
-  const styles = useStyles();
+  const rootBaseStyle = useRootBaseStyle();
+  const rootStyles = useRootStyles();
+  const secondaryContentBaseStyle = useSecondaryContentBaseStyle();
+  const mediaBaseStyle = useMediaBaseStyle();
 
-  state.root.className = mergeClasses(tagPickerOptionClassNames.root, styles.root, state.root.className);
+  state.root.className = mergeClasses(
+    tagPickerOptionClassNames.root,
+    rootBaseStyle,
+    state.secondaryContent && rootStyles.secondaryContent,
+    state.root.className,
+  );
   useOptionStyles_unstable({
     ...state,
     active: false,
@@ -49,13 +58,13 @@ export const useTagPickerOptionStyles_unstable = (state: TagPickerOptionState): 
     selected: false,
   });
   if (state.media) {
-    state.media.className = mergeClasses(tagPickerOptionClassNames.media, styles.media, state.media.className);
+    state.media.className = mergeClasses(tagPickerOptionClassNames.media, mediaBaseStyle, state.media.className);
   }
 
   if (state.secondaryContent) {
     state.secondaryContent.className = mergeClasses(
       tagPickerOptionClassNames.secondaryContent,
-      styles.secondaryContent,
+      secondaryContentBaseStyle,
       state.secondaryContent.className,
     );
   }

--- a/packages/react-components/react-tag-picker/stories/src/TagPicker/TagPickerDefault.stories.tsx
+++ b/packages/react-components/react-tag-picker/stories/src/TagPicker/TagPickerDefault.stories.tsx
@@ -53,7 +53,6 @@ export const Default = () => {
           {tagPickerOptions.length > 0 ? (
             tagPickerOptions.map(option => (
               <TagPickerOption
-                secondaryContent="Microsoft FTE"
                 media={<Avatar shape="square" aria-hidden name={option} color="colorful" />}
                 value={option}
                 key={option}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

PR #33689 introduced a regression whenever a `TagpickerOption` is without `secondaryContent`, this regression wasn't caught by our VR pipelines because there were no stories without `secondaryContent`

![image](https://github.com/user-attachments/assets/0088c471-ebd6-46e5-b810-76656fea9ec4)

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

1. fix regression
2. modify default story to not include `secondaryContent` to ensure this will be caught in VR


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
