### PR TITLE
docs(react-avatar): Added subcomponents object to the stories

### DIFF
--- a/packages/react-components/react-avatar/stories/src/AvatarGroup/index.stories.tsx
+++ b/packages/react-components/react-avatar/stories/src/AvatarGroup/index.stories.tsx
@@ -1,4 +1,4 @@
-import { AvatarGroup } from '@fluentui/react-components';
+import { AvatarGroup, AvatarGroupItem, Avatar, AvatarGroupPopover } from '@fluentui/react-components';
 
 import bestPracticesMd from './AvatarGroupBestPractices.md';
 import descriptionMd from './AvatarGroupDescription.md';
@@ -14,6 +14,11 @@ export { Tooltip } from './AvatarGroupTooltip.stories';
 export default {
   title: 'Components/AvatarGroup',
   component: AvatarGroup,
+  subcomponents: {
+    AvatarGroupItem,
+    Avatar,
+    AvatarGroupPopover,
+  },
   parameters: {
     docs: {
       description: {


### PR DESCRIPTION
## Previous Behavior
No subcomponent props on the page

![image](https://github.com/user-attachments/assets/9eb3ee8a-5e83-462b-9d9a-83fccc16e891)

## New Behavior
Added subcomponents props

![image](https://github.com/user-attachments/assets/2621a1e7-23d1-4f5e-a27f-0fd91f88c976)

- Fixes #32310
