### PR TITLE
chore: Update react-icons package to latest version

### DIFF
--- a/apps/vr-tests-react-components/package.json
+++ b/apps/vr-tests-react-components/package.json
@@ -35,7 +35,7 @@
     "@fluentui/react-divider": "*",
     "@fluentui/react-drawer": "*",
     "@fluentui/react-field": "*",
-    "@fluentui/react-icons": "^2.0.245",
+    "@fluentui/react-icons": "^2.0.271",
     "@fluentui/react-image": "*",
     "@fluentui/react-infolabel": "*",
     "@fluentui/react-input": "*",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@dnd-kit/sortable": "^7.0.2",
     "@dnd-kit/utilities": "^3.2.1",
     "@floating-ui/dom": "1.6.12",
-    "@fluentui/react-icons": "^2.0.245",
+    "@fluentui/react-icons": "^2.0.271",
     "@griffel/babel-preset": "1.5.8",
     "@griffel/eslint-plugin": "^1.6.4",
     "@griffel/jest-serializer": "1.1.24",

--- a/packages/react-components/react-accordion/library/package.json
+++ b/packages/react-components/react-accordion/library/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@fluentui/react-aria": "^9.13.14",
     "@fluentui/react-context-selector": "^9.1.72",
-    "@fluentui/react-icons": "^2.0.245",
+    "@fluentui/react-icons": "^2.0.271",
     "@fluentui/react-jsx-runtime": "^9.0.50",
     "@fluentui/react-shared-contexts": "^9.21.2",
     "@fluentui/react-motion": "^9.6.7",

--- a/packages/react-components/react-avatar/library/package.json
+++ b/packages/react-components/react-avatar/library/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@fluentui/react-badge": "^9.2.50",
     "@fluentui/react-context-selector": "^9.1.72",
-    "@fluentui/react-icons": "^2.0.245",
+    "@fluentui/react-icons": "^2.0.271",
     "@fluentui/react-popover": "^9.9.32",
     "@fluentui/react-shared-contexts": "^9.21.2",
     "@fluentui/react-tabster": "^9.23.3",

--- a/packages/react-components/react-badge/library/package.json
+++ b/packages/react-components/react-badge/library/package.json
@@ -18,7 +18,7 @@
     "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
-    "@fluentui/react-icons": "^2.0.245",
+    "@fluentui/react-icons": "^2.0.271",
     "@fluentui/react-jsx-runtime": "^9.0.50",
     "@fluentui/react-shared-contexts": "^9.21.2",
     "@fluentui/react-theme": "^9.1.24",

--- a/packages/react-components/react-breadcrumb/library/package.json
+++ b/packages/react-components/react-breadcrumb/library/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@fluentui/react-aria": "^9.13.14",
     "@fluentui/react-button": "^9.3.101",
-    "@fluentui/react-icons": "^2.0.245",
+    "@fluentui/react-icons": "^2.0.271",
     "@fluentui/react-link": "^9.3.7",
     "@fluentui/react-shared-contexts": "^9.21.2",
     "@fluentui/react-tabster": "^9.23.3",

--- a/packages/react-components/react-button/library/package.json
+++ b/packages/react-components/react-button/library/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@fluentui/keyboard-keys": "^9.0.8",
     "@fluentui/react-aria": "^9.13.14",
-    "@fluentui/react-icons": "^2.0.245",
+    "@fluentui/react-icons": "^2.0.271",
     "@fluentui/react-jsx-runtime": "^9.0.50",
     "@fluentui/react-shared-contexts": "^9.21.2",
     "@fluentui/react-tabster": "^9.23.3",

--- a/packages/react-components/react-calendar-compat/library/package.json
+++ b/packages/react-components/react-calendar-compat/library/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@fluentui/keyboard-keys": "^9.0.8",
-    "@fluentui/react-icons": "^2.0.245",
+    "@fluentui/react-icons": "^2.0.271",
     "@fluentui/react-jsx-runtime": "^9.0.50",
     "@fluentui/react-shared-contexts": "^9.21.2",
     "@fluentui/react-tabster": "^9.23.3",

--- a/packages/react-components/react-carousel/library/package.json
+++ b/packages/react-components/react-carousel/library/package.json
@@ -28,7 +28,7 @@
     "@fluentui/react-aria": "^9.13.14",
     "@fluentui/react-button": "^9.3.101",
     "@fluentui/react-context-selector": "^9.1.72",
-    "@fluentui/react-icons": "^2.0.245",
+    "@fluentui/react-icons": "^2.0.271",
     "@fluentui/react-jsx-runtime": "^9.0.50",
     "@fluentui/react-shared-contexts": "^9.21.2",
     "@fluentui/react-tabster": "^9.23.3",

--- a/packages/react-components/react-checkbox/library/package.json
+++ b/packages/react-components/react-checkbox/library/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@fluentui/react-field": "^9.1.86",
-    "@fluentui/react-icons": "^2.0.245",
+    "@fluentui/react-icons": "^2.0.271",
     "@fluentui/react-jsx-runtime": "^9.0.50",
     "@fluentui/react-label": "^9.1.83",
     "@fluentui/react-shared-contexts": "^9.21.2",

--- a/packages/react-components/react-combobox/library/package.json
+++ b/packages/react-components/react-combobox/library/package.json
@@ -23,7 +23,7 @@
     "@fluentui/keyboard-keys": "^9.0.8",
     "@fluentui/react-context-selector": "^9.1.72",
     "@fluentui/react-field": "^9.1.86",
-    "@fluentui/react-icons": "^2.0.245",
+    "@fluentui/react-icons": "^2.0.271",
     "@fluentui/react-jsx-runtime": "^9.0.50",
     "@fluentui/react-portal": "^9.4.42",
     "@fluentui/react-positioning": "^9.16.3",

--- a/packages/react-components/react-datepicker-compat/library/package.json
+++ b/packages/react-components/react-datepicker-compat/library/package.json
@@ -23,7 +23,7 @@
     "@fluentui/keyboard-keys": "^9.0.8",
     "@fluentui/react-calendar-compat": "^0.1.26",
     "@fluentui/react-field": "^9.1.86",
-    "@fluentui/react-icons": "^2.0.245",
+    "@fluentui/react-icons": "^2.0.271",
     "@fluentui/react-input": "^9.4.99",
     "@fluentui/react-jsx-runtime": "^9.0.50",
     "@fluentui/react-popover": "^9.9.32",

--- a/packages/react-components/react-dialog/library/package.json
+++ b/packages/react-components/react-dialog/library/package.json
@@ -32,7 +32,7 @@
     "@fluentui/react-motion-components-preview": "^0.4.3",
     "@fluentui/react-shared-contexts": "^9.21.2",
     "@fluentui/react-aria": "^9.13.14",
-    "@fluentui/react-icons": "^2.0.245",
+    "@fluentui/react-icons": "^2.0.271",
     "@fluentui/react-tabster": "^9.23.3",
     "@fluentui/react-theme": "^9.1.24",
     "@fluentui/react-portal": "^9.4.42",

--- a/packages/react-components/react-field/library/package.json
+++ b/packages/react-components/react-field/library/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@fluentui/react-context-selector": "^9.1.72",
-    "@fluentui/react-icons": "^2.0.245",
+    "@fluentui/react-icons": "^2.0.271",
     "@fluentui/react-jsx-runtime": "^9.0.50",
     "@fluentui/react-label": "^9.1.83",
     "@fluentui/react-theme": "^9.1.24",

--- a/packages/react-components/react-infolabel/library/package.json
+++ b/packages/react-components/react-infolabel/library/package.json
@@ -20,7 +20,7 @@
     "@fluentui/scripts-cypress": "*"
   },
   "dependencies": {
-    "@fluentui/react-icons": "^2.0.245",
+    "@fluentui/react-icons": "^2.0.271",
     "@fluentui/react-label": "^9.1.83",
     "@fluentui/react-popover": "^9.9.32",
     "@fluentui/react-tabster": "^9.23.3",

--- a/packages/react-components/react-menu/library/package.json
+++ b/packages/react-components/react-menu/library/package.json
@@ -23,7 +23,7 @@
     "@fluentui/keyboard-keys": "^9.0.8",
     "@fluentui/react-aria": "^9.13.14",
     "@fluentui/react-context-selector": "^9.1.72",
-    "@fluentui/react-icons": "^2.0.245",
+    "@fluentui/react-icons": "^2.0.271",
     "@fluentui/react-portal": "^9.4.42",
     "@fluentui/react-positioning": "^9.16.3",
     "@fluentui/react-shared-contexts": "^9.21.2",

--- a/packages/react-components/react-message-bar/library/package.json
+++ b/packages/react-components/react-message-bar/library/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@fluentui/react-button": "^9.3.101",
-    "@fluentui/react-icons": "^2.0.245",
+    "@fluentui/react-icons": "^2.0.271",
     "@fluentui/react-jsx-runtime": "^9.0.50",
     "@fluentui/react-motion": "^9.6.7",
     "@fluentui/react-motion-components-preview": "^0.4.3",

--- a/packages/react-components/react-migration-v0-v9/library/package.json
+++ b/packages/react-components/react-migration-v0-v9/library/package.json
@@ -23,7 +23,7 @@
     "@fluentui/react-aria": "^9.13.14",
     "@fluentui/react-components": "^9.58.2",
     "@fluentui/react-context-selector": "^9.1.72",
-    "@fluentui/react-icons": "^2.0.245",
+    "@fluentui/react-icons": "^2.0.271",
     "@fluentui/react-jsx-runtime": "^9.0.50",
     "@fluentui/react-shared-contexts": "^9.21.2",
     "@fluentui/react-tabster": "^9.23.3",

--- a/packages/react-components/react-migration-v8-v9/library/package.json
+++ b/packages/react-components/react-migration-v8-v9/library/package.json
@@ -22,7 +22,7 @@
     "@fluentui/fluent2-theme": "^8.107.126",
     "@fluentui/react": "^8.122.9",
     "@fluentui/react-components": "^9.58.2",
-    "@fluentui/react-icons": "^2.0.245",
+    "@fluentui/react-icons": "^2.0.271",
     "@fluentui/react-hooks": "^8.8.16",
     "@griffel/react": "^1.5.22",
     "@swc/helpers": "^0.5.1"

--- a/packages/react-components/react-nav-preview/library/package.json
+++ b/packages/react-components/react-nav-preview/library/package.json
@@ -24,7 +24,7 @@
     "@fluentui/react-context-selector": "^9.1.72",
     "@fluentui/react-divider": "^9.2.82",
     "@fluentui/react-drawer": "^9.6.10",
-    "@fluentui/react-icons": "^2.0.245",
+    "@fluentui/react-icons": "^2.0.271",
     "@fluentui/react-jsx-runtime": "^9.0.50",
     "@fluentui/react-shared-contexts": "^9.21.2",
     "@fluentui/react-tabster": "^9.23.3",

--- a/packages/react-components/react-provider/library/package.json
+++ b/packages/react-components/react-provider/library/package.json
@@ -18,7 +18,7 @@
     "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
-    "@fluentui/react-icons": "^2.0.245",
+    "@fluentui/react-icons": "^2.0.271",
     "@fluentui/react-shared-contexts": "^9.21.2",
     "@fluentui/react-tabster": "^9.23.3",
     "@fluentui/react-theme": "^9.1.24",

--- a/packages/react-components/react-rating/library/package.json
+++ b/packages/react-components/react-rating/library/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@fluentui/react-jsx-runtime": "^9.0.50",
-    "@fluentui/react-icons": "^2.0.245",
+    "@fluentui/react-icons": "^2.0.271",
     "@fluentui/react-theme": "^9.1.24",
     "@fluentui/react-tabster": "^9.23.3",
     "@fluentui/react-utilities": "^9.18.20",

--- a/packages/react-components/react-search/library/package.json
+++ b/packages/react-components/react-search/library/package.json
@@ -18,7 +18,7 @@
     "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
-    "@fluentui/react-icons": "^2.0.245",
+    "@fluentui/react-icons": "^2.0.271",
     "@fluentui/react-input": "^9.4.99",
     "@fluentui/react-jsx-runtime": "^9.0.50",
     "@fluentui/react-theme": "^9.1.24",

--- a/packages/react-components/react-select/library/package.json
+++ b/packages/react-components/react-select/library/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@fluentui/react-field": "^9.1.86",
-    "@fluentui/react-icons": "^2.0.245",
+    "@fluentui/react-icons": "^2.0.271",
     "@fluentui/react-jsx-runtime": "^9.0.50",
     "@fluentui/react-shared-contexts": "^9.21.2",
     "@fluentui/react-theme": "^9.1.24",

--- a/packages/react-components/react-spinbutton/library/package.json
+++ b/packages/react-components/react-spinbutton/library/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@fluentui/keyboard-keys": "^9.0.8",
     "@fluentui/react-field": "^9.1.86",
-    "@fluentui/react-icons": "^2.0.245",
+    "@fluentui/react-icons": "^2.0.271",
     "@fluentui/react-jsx-runtime": "^9.0.50",
     "@fluentui/react-shared-contexts": "^9.21.2",
     "@fluentui/react-theme": "^9.1.24",

--- a/packages/react-components/react-swatch-picker/library/package.json
+++ b/packages/react-components/react-swatch-picker/library/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@fluentui/react-context-selector": "^9.1.72",
     "@fluentui/react-field": "^9.1.86",
-    "@fluentui/react-icons": "^2.0.245",
+    "@fluentui/react-icons": "^2.0.271",
     "@fluentui/react-jsx-runtime": "^9.0.50",
     "@fluentui/react-shared-contexts": "^9.21.2",
     "@fluentui/react-tabster": "^9.23.3",

--- a/packages/react-components/react-switch/library/package.json
+++ b/packages/react-components/react-switch/library/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@fluentui/react-field": "^9.1.86",
-    "@fluentui/react-icons": "^2.0.245",
+    "@fluentui/react-icons": "^2.0.271",
     "@fluentui/react-jsx-runtime": "^9.0.50",
     "@fluentui/react-label": "^9.1.83",
     "@fluentui/react-shared-contexts": "^9.21.2",

--- a/packages/react-components/react-table/library/package.json
+++ b/packages/react-components/react-table/library/package.json
@@ -25,7 +25,7 @@
     "@fluentui/react-avatar": "^9.6.50",
     "@fluentui/react-checkbox": "^9.2.47",
     "@fluentui/react-context-selector": "^9.1.72",
-    "@fluentui/react-icons": "^2.0.245",
+    "@fluentui/react-icons": "^2.0.271",
     "@fluentui/react-radio": "^9.2.42",
     "@fluentui/react-shared-contexts": "^9.21.2",
     "@fluentui/react-tabster": "^9.23.3",

--- a/packages/react-components/react-tag-picker/library/package.json
+++ b/packages/react-components/react-tag-picker/library/package.json
@@ -35,7 +35,7 @@
     "@fluentui/react-portal": "^9.4.42",
     "@fluentui/react-tabster": "^9.23.3",
     "@fluentui/react-aria": "^9.13.14",
-    "@fluentui/react-icons": "^2.0.245",
+    "@fluentui/react-icons": "^2.0.271",
     "@fluentui/react-combobox": "^9.13.18",
     "@fluentui/react-tags": "^9.3.30",
     "@fluentui/react-context-selector": "^9.1.72",

--- a/packages/react-components/react-tags/library/package.json
+++ b/packages/react-components/react-tags/library/package.json
@@ -23,7 +23,7 @@
     "@fluentui/keyboard-keys": "^9.0.8",
     "@fluentui/react-aria": "^9.13.14",
     "@fluentui/react-avatar": "^9.6.50",
-    "@fluentui/react-icons": "^2.0.245",
+    "@fluentui/react-icons": "^2.0.271",
     "@fluentui/react-jsx-runtime": "^9.0.50",
     "@fluentui/react-shared-contexts": "^9.21.2",
     "@fluentui/react-tabster": "^9.23.3",

--- a/packages/react-components/react-teaching-popover/library/package.json
+++ b/packages/react-components/react-teaching-popover/library/package.json
@@ -33,7 +33,7 @@
     "@fluentui/react-popover": "^9.9.32",
     "@fluentui/react-button": "^9.3.101",
     "@fluentui/react-tabster": "^9.23.3",
-    "@fluentui/react-icons": "^2.0.245",
+    "@fluentui/react-icons": "^2.0.271",
     "@fluentui/react-aria": "^9.13.14",
     "@fluentui/react-context-selector": "^9.1.72",
     "use-sync-external-store": "^1.2.0"

--- a/packages/react-components/react-toast/library/package.json
+++ b/packages/react-components/react-toast/library/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@fluentui/keyboard-keys": "^9.0.8",
     "@fluentui/react-aria": "^9.13.14",
-    "@fluentui/react-icons": "^2.0.245",
+    "@fluentui/react-icons": "^2.0.271",
     "@fluentui/react-jsx-runtime": "^9.0.50",
     "@fluentui/react-motion": "^9.6.7",
     "@fluentui/react-motion-components-preview": "^0.4.3",

--- a/packages/react-components/react-tree/library/package.json
+++ b/packages/react-components/react-tree/library/package.json
@@ -26,7 +26,7 @@
     "@fluentui/react-button": "^9.3.101",
     "@fluentui/react-checkbox": "^9.2.47",
     "@fluentui/react-context-selector": "^9.1.72",
-    "@fluentui/react-icons": "^2.0.245",
+    "@fluentui/react-icons": "^2.0.271",
     "@fluentui/react-motion-components-preview": "^0.4.3",
     "@fluentui/react-motion": "^9.6.7",
     "@fluentui/react-radio": "^9.2.42",

--- a/packages/react-components/recipes/package.json
+++ b/packages/react-components/recipes/package.json
@@ -33,7 +33,7 @@
     "@fluentui/react-utilities": "^9.18.20",
     "@griffel/react": "^1.5.22",
     "@swc/helpers": "^0.5.1",
-    "@fluentui/react-icons": "^2.0.245"
+    "@fluentui/react-icons": "^2.0.271"
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <19.0.0",

--- a/packages/react-components/theme-designer/package.json
+++ b/packages/react-components/theme-designer/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@fluentui/react-components": "^9.58.2",
     "@fluentui/react-context-selector": "^9.1.72",
-    "@fluentui/react-icons": "^2.0.245",
+    "@fluentui/react-icons": "^2.0.271",
     "@fluentui/react-storybook-addon-export-to-sandbox": "^0.1.0",
     "@fluentui/react-theme": "^9.1.24",
     "@fluentui/react-utilities": "^9.18.20",


### PR DESCRIPTION
This PR updates the version of  `@fluentui/react-icons` in the project from `2.0.245` to `2.0.271`. This is a minor change that will pick up new icons added by design into the Icons Catalog.