### PR TITLE
fix: Button sets correct disabledFocusable icon color in forced-colors mode

### DIFF
--- a/change/@fluentui-react-button-cb94dc1b-6be7-4fdb-aff3-9c27f8051fa3.json
+++ b/change/@fluentui-react-button-cb94dc1b-6be7-4fdb-aff3-9c27f8051fa3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Button sets correct disabledFocusable icon color",
+  "packageName": "@fluentui/react-button",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-button/library/src/components/Button/useButtonStyles.styles.ts
+++ b/packages/react-components/react-button/library/src/components/Button/useButtonStyles.styles.ts
@@ -373,6 +373,10 @@ const useRootDisabledStyles = makeStyles({
       ...shorthands.borderColor('GrayText'),
       color: 'GrayText',
 
+      [`& .${buttonClassNames.icon}`]: {
+        color: 'GrayText',
+      },
+
       ':focus': {
         ...shorthands.borderColor('GrayText'),
       },
@@ -381,12 +385,20 @@ const useRootDisabledStyles = makeStyles({
         backgroundColor: 'ButtonFace',
         ...shorthands.borderColor('GrayText'),
         color: 'GrayText',
+
+        [`& .${buttonClassNames.icon}`]: {
+          color: 'GrayText',
+        },
       },
 
       ':hover:active': {
         backgroundColor: 'ButtonFace',
         ...shorthands.borderColor('GrayText'),
         color: 'GrayText',
+
+        [`& .${buttonClassNames.icon}`]: {
+          color: 'GrayText',
+        },
       },
     },
   },


### PR DESCRIPTION
## Previous Behavior

The `disabledFocusable` button icon does not inherit the `GrayText` system color keyword set on the button, since the icon's color is set with a higher specificity. We already handle this for things like `:hover`, it was just missing for the `disabledFocusable` state (which is different from `disabled` since we need to set the `GrayText` color manually):

```css
'@media (forced-colors: active)': {
      ':hover': {
        color: 'Highlight',

        [`& .${buttonClassNames.icon}`]: {
          color: 'Highlight',
        },
      },
      ':hover:active': {
        color: 'Highlight',

        [`& .${buttonClassNames.icon}`]: {
          color: 'Highlight',
        },
      },
    },
  },
```

<img width="516" alt="Screenshot of the disabled Button variants in high contrast mode, showing the disabledFocusable icon in white instead of green" src="https://github.com/user-attachments/assets/df656b49-b2b9-4734-8876-c83560fea12a" />


## New Behavior

The icon color is set correctly:
<img width="521" alt="Screenshot of the same button variants, but with the icon matching the text" src="https://github.com/user-attachments/assets/01858248-33dd-4ac3-b16d-2519dbea4562" />

## Related Issue(s)

Fixes an issue in FAI
