### PR TITLE
Fixed tooltip position and background on Gauge and Pie charts

### DIFF
--- a/packages/charts/react-charting/src/components/GaugeChart/GaugeChart.base.tsx
+++ b/packages/charts/react-charting/src/components/GaugeChart/GaugeChart.base.tsx
@@ -317,6 +317,7 @@ export class GaugeChartBase extends React.Component<IGaugeChartProps, IGaugeChar
                   }}
                   maxWidth={this._innerRadius * 2 - 24}
                   wrapContent={this._wrapContent}
+                  theme={this.props.theme}
                 />
               </g>
               {this.props.sublabel && (

--- a/packages/charts/react-charting/src/components/PieChart/Arc/Arc.tsx
+++ b/packages/charts/react-charting/src/components/PieChart/Arc/Arc.tsx
@@ -96,8 +96,8 @@ export class LabeledArc extends Arc {
         <SVGTooltipText
           content={content}
           textProps={{
-            x: labelX,
-            y: labelY,
+            x: labelX + (angle > Math.PI ? -10 : 10),
+            y: labelY + (angle > Math.PI / 2 && angle < (3 * Math.PI) / 2 ? 10 : -10),
             dominantBaseline: angle > Math.PI / 2 && angle < (3 * Math.PI) / 2 ? 'hanging' : 'auto',
             textAnchor: (!this._isRTL && angle > Math.PI) || (this._isRTL && angle < Math.PI) ? 'end' : 'start',
             'aria-label': `${data?.data.x}-${convertToLocaleString(data?.data.y, culture)}`,
@@ -107,6 +107,7 @@ export class LabeledArc extends Arc {
           shouldReceiveFocus={false}
           maxWidth={40}
           wrapContent={wrapContent}
+          theme={this.props.theme}
         />
       </g>
     );

--- a/packages/charts/react-charting/src/components/PieChart/PieChart.base.tsx
+++ b/packages/charts/react-charting/src/components/PieChart/PieChart.base.tsx
@@ -33,6 +33,7 @@ export class PieChartBase extends React.Component<IPieChartProps, {}> {
 
     const TEXT_MAX_WIDTH = 40;
     const TEXT_LINE_HEIGHT = 16;
+    const PADDING = 4;
 
     /**
      * The radius for the pie chart is computed based on the space available inside the svg
@@ -47,8 +48,8 @@ export class PieChartBase extends React.Component<IPieChartProps, {}> {
         {this.props.chartTitle && <p className={this._classNames.chartTitle}>{this.props.chartTitle}</p>}
         <Pie
           culture={culture}
-          width={width!}
-          height={height!}
+          width={width! + 2 * PADDING}
+          height={height! + 2 * PADDING}
           outerRadius={outerRadius}
           innerRadius={1}
           data={data!}


### PR DESCRIPTION
Fixed tooltip position and background on Gauge and Pie charts.

When the arc is between 90 degrees and 270 degrees (arc on left side of chart), 10 pixels are added to the labelY to place the text below the arc. Otherwise, 10 pixels are subtracted to place the text above the arc. 

The labelX coordinate is adjusted by adding 10 pixels (angle>90 degrees) or subtracting 10 pixels otherwise based on the angle to ensure the text stays within the bounds of the chart.

Also, the height and width of the Pie chart is padded by 8 pixels to ensure the chart is not cut off at the edges.

Gauge:
![image](https://github.com/user-attachments/assets/5178b686-0543-468e-82d6-78bce066e78e)

Pie:
![image](https://github.com/user-attachments/assets/f85f35e8-8e5d-4321-807a-0ea29e5aef41)
