### PR TITLE
Virtualizer: Ensure child render function updates children immediatly

### DIFF
--- a/change/@fluentui-react-virtualizer-e04ca2a2-610b-4a84-afbc-0d2f74e7ee06.json
+++ b/change/@fluentui-react-virtualizer-e04ca2a2-610b-4a84-afbc-0d2f74e7ee06.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: Fix regression of child render function update",
+  "packageName": "@fluentui/react-virtualizer",
+  "email": "mifraser@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
@@ -104,6 +104,7 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
   const initializeScrollingTimer = React.useCallback(() => {
     if (!enableScrollLoad) {
       // Disabled by default for reduction of render callbacks
+      setIsScrolling(false);
       clearScrollTimer();
       return;
     }

--- a/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
@@ -516,7 +516,7 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
 
   /*
    * forceUpdate:
-   * We only want to trigger this when scrollLoading is enabled and set to false,
+   * We only want to trigger this when child render or scroll loading changes,
    * it will force re-render all children elements
    */
   const forceUpdate = React.useReducer(() => ({}), {})[1];

--- a/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
@@ -104,6 +104,7 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
   const initializeScrollingTimer = React.useCallback(() => {
     if (!enableScrollLoad) {
       // Disabled by default for reduction of render callbacks
+      clearScrollTimer();
       return;
     }
     /*
@@ -522,9 +523,7 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
   React.useEffect(() => {
     if (actualIndex >= 0) {
       updateChildRows(actualIndex);
-      if (enableScrollLoad && !isScrolling) {
-        forceUpdate();
-      }
+      forceUpdate();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [renderChild, isScrolling]);


### PR DESCRIPTION
## Previous Behavior
Child render hook was regressed so that it wouldn't force update on child render changes.

## New Behavior
Fixed regression, will now update on child render changes

## Related Issue(s)
- Fixes #33739
- Fixes #33157 
