### PR TITLE
Combobox: Set combobox story to scroll to selected option on open

### DIFF
--- a/packages/react-components/react-combobox/stories/src/Combobox/ComboboxVirtualizer.stories.tsx
+++ b/packages/react-components/react-combobox/stories/src/Combobox/ComboboxVirtualizer.stories.tsx
@@ -56,7 +56,7 @@ export const ComboboxVirtualizer = (props: Partial<ComboboxProps>) => {
           }}
           onOptionSelect={(e, data) => {
             if (data.optionValue) {
-              selectedIndex.current = parseInt(data.optionValue);
+              selectedIndex.current = parseInt(data.optionValue, 10);
             }
           }}
         >

--- a/packages/react-components/react-combobox/stories/src/Combobox/ComboboxVirtualizer.stories.tsx
+++ b/packages/react-components/react-combobox/stories/src/Combobox/ComboboxVirtualizer.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Combobox, Option, makeStyles, useId } from '@fluentui/react-components';
+import { Combobox, Option, makeStyles, useId, useMergedRefs, useTimeout } from '@fluentui/react-components';
 import type { ComboboxProps } from '@fluentui/react-components';
 
 import { Virtualizer, useStaticVirtualizerMeasure } from '@fluentui/react-components/unstable';
@@ -18,7 +18,8 @@ export const ComboboxVirtualizer = (props: Partial<ComboboxProps>) => {
   const comboId = useId('combobox');
 
   //This should include the item height (32px) and account for rowGap (2px)
-  const itemHeight = 34;
+  const itemHeight = 32;
+  const rowGap = 2;
   const numberOfItems = 10000;
 
   const { virtualizerLength, bufferItems, bufferSize, scrollRef, containerSizeRef } = useStaticVirtualizerMeasure({
@@ -29,8 +30,12 @@ export const ComboboxVirtualizer = (props: Partial<ComboboxProps>) => {
     // We need to recalculate index when at least 10 items (+1px) from the bottom or top for page up/down
     bufferSize: itemHeight * 10 + 1,
   });
+  const selectedIndex = React.useRef(0);
 
   const styles = useStyles();
+  const mergedRefs = useMergedRefs(scrollRef);
+  // Scroll timer required to post scrollTo on stack post-open state change
+  const [setScrollTimer, clearScrollTimer] = useTimeout();
 
   return (
     <div>
@@ -40,7 +45,20 @@ export const ComboboxVirtualizer = (props: Partial<ComboboxProps>) => {
           id={`${comboId}`}
           placeholder="Select a number"
           positioning={{ autoSize: 'width' }}
-          listbox={{ ref: scrollRef, className: styles.listbox }}
+          listbox={{ ref: mergedRefs, className: styles.listbox }}
+          onOpenChange={(e, data) => {
+            clearScrollTimer();
+            if (data.open) {
+              setScrollTimer(() => {
+                mergedRefs.current?.scrollTo({ top: (itemHeight + rowGap) * selectedIndex.current });
+              }, 0);
+            }
+          }}
+          onOptionSelect={(e, data) => {
+            if (data.optionValue) {
+              selectedIndex.current = parseInt(data.optionValue);
+            }
+          }}
         >
           <Virtualizer
             numItems={numberOfItems}
@@ -49,6 +67,7 @@ export const ComboboxVirtualizer = (props: Partial<ComboboxProps>) => {
             bufferSize={bufferSize}
             itemSize={itemHeight}
             containerSizeRef={containerSizeRef}
+            gap={rowGap}
           >
             {index => {
               return (
@@ -57,7 +76,10 @@ export const ComboboxVirtualizer = (props: Partial<ComboboxProps>) => {
                   aria-posinset={index}
                   aria-setsize={numberOfItems}
                   key={`item-${index}`}
-                >{`Item ${index + 1}`}</Option>
+                  value={index.toString()}
+                >
+                  {`Item ${index + 1}`}
+                </Option>
               );
             }}
           </Virtualizer>


### PR DESCRIPTION
## Previous Behavior
Combobox did not scroll to it's currently selected item as it's virtualized on open

## New Behavior
Combobox now scrolls to item on open, relies on timeout to scroll on the stack immediately after render - I did try implement this on state change of open with useEffect, however it was calling the scrollTo prior to the open render completion.

## Related Issue(s)
- Fixes #31437
