### PR TITLE
fix: resolve v9 and charting public docsite dependency issues and improve performance

### DIFF
--- a/apps/chart-docsite/.storybook/main.ts
+++ b/apps/chart-docsite/.storybook/main.ts
@@ -10,7 +10,7 @@ const config: StorybookConfig = {
     '../src/**/*.mdx',
     '../src/**/index.stories.@(js|jsx|ts|tsx)',
     // packages stories
-    '../../../packages/charts/*/stories/**/index.stories.@(js|jsx|ts|tsx)',
+    '../../../packages/charts/react-charts-preview/stories/**/index.stories.@(js|jsx|ts|tsx)',
   ],
 };
 

--- a/apps/chart-docsite/.storybook/preview.tsx
+++ b/apps/chart-docsite/.storybook/preview.tsx
@@ -2,7 +2,8 @@ import type { Preview } from '@storybook/react';
 
 import * as rootPreview from '../../../.storybook/preview';
 
-import { FluentDocsContainer } from '../../public-docsite-v9/src/DocsComponents/FluentDocsContainer.stories';
+// TODO: These custom Docs implementations should be part of custom SB addon/storybook components package
+import { FluentDocsContainer } from '../src/DocsComponents/FluentDocsContainer';
 
 const preview: Preview = {
   ...rootPreview,

--- a/apps/chart-docsite/package.json
+++ b/apps/chart-docsite/package.json
@@ -2,7 +2,7 @@
   "name": "@fluentui/chart-docsite",
   "version": "1.0.0",
   "private": true,
-  "description": "Fluent UI React v9 documentation",
+  "description": "Fluent UI React Charts Preview documentation",
   "scripts": {
     "build-storybook": "storybook build -o ./dist/storybook --docs && node ./.storybook/fix-title.js 'Fluent UI Charts v9' ../dist",
     "clean": "just-scripts clean",
@@ -21,13 +21,10 @@
   },
   "dependencies": {
     "@fluentui/react-charts-preview": "*",
-    "@fluentui/react-components": "*",
-    "@griffel/react": "^1.5.22",
-    "@microsoft/applicationinsights-web": "^3",
+    "@fluentui/react-storybook-addon": "*",
+    "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "react": "17.0.2",
     "react-dom": "17.0.2",
-    "react-window": "^1.8.6",
-    "tslib": "^2.1.0",
-    "react-hook-form": "^5.7.2"
+    "tslib": "^2.1.0"
   }
 }

--- a/apps/chart-docsite/project.json
+++ b/apps/chart-docsite/project.json
@@ -2,8 +2,8 @@
   "name": "chart-docsite",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "application",
-  "implicitDependencies": ["tag:type:stories"],
-  "tags": ["platform:web", "vNext"],
+  "implicitDependencies": [],
+  "tags": ["platform:web", "vNext", "charting"],
   "targets": {
     "build-storybook": {
       "dependsOn": [

--- a/apps/chart-docsite/src/DocsComponents/FluentDocsContainer.tsx
+++ b/apps/chart-docsite/src/DocsComponents/FluentDocsContainer.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import { DocsContainer, type DocsContextProps } from '@storybook/addon-docs';
+import { type FluentStoryContext } from '@fluentui/react-storybook-addon';
+import { webLightTheme } from '@fluentui/react-theme';
+import { FluentProvider } from '@fluentui/react-provider';
+
+interface FluentDocsContainerProps {
+  context: FluentStoryContext & DocsContextProps;
+}
+
+/**
+ * A container that wraps storybook's native docs container to add extra components to the docs experience
+ */
+export const FluentDocsContainer: React.FC<FluentDocsContainerProps> = ({ children, context }) => {
+  return (
+    <>
+      {/** TODO add table of contents */}
+      <FluentProvider className="sb-unstyled" style={{ backgroundColor: 'transparent' }} theme={webLightTheme}>
+        <DocsContainer context={context}>{children}</DocsContainer>
+      </FluentProvider>
+    </>
+  );
+};

--- a/apps/public-docsite-v9/src/DocsComponents/FluentDocsContainer.stories.tsx
+++ b/apps/public-docsite-v9/src/DocsComponents/FluentDocsContainer.stories.tsx
@@ -3,7 +3,6 @@ import { DocsContainer, type DocsContextProps } from '@storybook/addon-docs';
 import { type FluentStoryContext } from '@fluentui/react-storybook-addon';
 import { webLightTheme, FluentProvider } from '@fluentui/react-components';
 
-
 interface FluentDocsContainerProps {
   context: FluentStoryContext & DocsContextProps;
 }

--- a/apps/public-docsite-v9/src/DocsComponents/FluentDocsContainer.stories.tsx
+++ b/apps/public-docsite-v9/src/DocsComponents/FluentDocsContainer.stories.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { DocsContainer, DocsContextProps } from '@storybook/addon-docs';
-import { FluentStoryContext } from '@fluentui/react-storybook-addon';
+import { DocsContainer, type DocsContextProps } from '@storybook/addon-docs';
+import { type FluentStoryContext } from '@fluentui/react-storybook-addon';
 import { webLightTheme, FluentProvider } from '@fluentui/react-components';
+
 
 interface FluentDocsContainerProps {
   context: FluentStoryContext & DocsContextProps;

--- a/change/@fluentui-chart-web-components-90a92ca1-c560-43e9-a5fa-cb87c11063ec.json
+++ b/change/@fluentui-chart-web-components-90a92ca1-c560-43e9-a5fa-cb87c11063ec.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: add new 'charting' domain tag",
+  "packageName": "@fluentui/chart-web-components",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-charting-a87fd601-35db-40d1-b7b6-be6b71ea83c2.json
+++ b/change/@fluentui-react-charting-a87fd601-35db-40d1-b7b6-be6b71ea83c2.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: add new 'charting' domain tag",
+  "packageName": "@fluentui/react-charting",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-charts-preview-cbb156e6-46e4-46d2-9772-6ba9c4778669.json
+++ b/change/@fluentui-react-charts-preview-cbb156e6-46e4-46d2-9772-6ba9c4778669.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: add new 'charting' domain tag",
+  "packageName": "@fluentui/react-charts-preview",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/charts/chart-web-components/project.json
+++ b/packages/charts/chart-web-components/project.json
@@ -3,7 +3,7 @@
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],
-  "tags": ["platform:web", "web-components"],
+  "tags": ["platform:web", "web-components", "charting"],
   "targets": {
     "e2e": { "dependsOn": ["build-storybook"] }
   }

--- a/packages/charts/react-charting/project.json
+++ b/packages/charts/react-charting/project.json
@@ -2,7 +2,7 @@
   "name": "react-charting",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
-  "tags": ["v8", "ships-bundle"],
+  "tags": ["v8", "ships-bundle", "charting"],
   "implicitDependencies": [],
   "targets": {
     "test": {

--- a/packages/charts/react-charts-preview/library/project.json
+++ b/packages/charts/react-charts-preview/library/project.json
@@ -3,6 +3,6 @@
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/charts/react-charts-preview/library/src",
-  "tags": ["platform:web", "vNext"],
+  "tags": ["platform:web", "vNext", "charting"],
   "implicitDependencies": []
 }

--- a/packages/charts/react-charts-preview/stories/project.json
+++ b/packages/charts/react-charts-preview/stories/project.json
@@ -3,6 +3,6 @@
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-charts-preview/stories/src",
-  "tags": ["vNext", "platform:web", "type:stories"],
+  "tags": ["vNext", "platform:web", "type:stories", "charting"],
   "implicitDependencies": []
 }

--- a/packages/react-components/react-storybook-addon/project.json
+++ b/packages/react-components/react-storybook-addon/project.json
@@ -4,5 +4,10 @@
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-storybook-addon/src",
   "tags": ["vNext", "platform:any", "tools"],
-  "implicitDependencies": []
+  "implicitDependencies": [],
+  "targets": {
+    "build": {
+      "dependsOn": [{ "projects": ["react-aria", "react-provider"], "target": "build" }]
+    }
+  }
 }

--- a/packages/react-components/react-storybook-addon/src/theme.ts
+++ b/packages/react-components/react-storybook-addon/src/theme.ts
@@ -1,5 +1,3 @@
-import type { Theme } from '@fluentui/react-theme';
-
 export const themes = [
   { id: 'web-light', label: 'Web Light' },
   { id: 'web-dark', label: 'Web Dark' },
@@ -12,5 +10,3 @@ export const defaultTheme = themes[0];
 
 export type ThemeIds = (typeof themes)[number]['id'];
 export type ThemeLabels = (typeof themes)[number]['label'];
-
-export type { Theme };


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

**public-docsite-v9** 
- build target executes all react-component suite deps

**charting-docs**
- depends on whole react-components v9  
- depends on projectType: application, which is forbidden ( app cannot depend on another app )
- build target suffers same issue like docsite-v9

## New Behavior

**public-docsite-v9**

- build runs only necessary build targets of its dependencies 
  - from 69 to 14 target
  - speed bump 414s to 120s / **𝚫 71% FASTER**

**charting-docs**
- depends only on charting domain + shared workspace SB addons
- removes forbidden app dependencies
- build runs only necessary build targets of its dependencies 
  -  from 69 to 14 targets 
  -  speed bump from 361s to 75s / **𝚫 79% FASTER**

_BEFORE:_

<img width="2413" alt="image" src="https://github.com/user-attachments/assets/bbf76a79-074a-49ba-baec-7b3560d27302" />

<img width="848" alt="image" src="https://github.com/user-attachments/assets/74d3fcbf-9871-45e0-8869-412437f50720" />



_AFTER:_
<img width="1758" alt="image" src="https://github.com/user-attachments/assets/a23e4d12-4d20-4c43-a455-7d7f0ffb0ebd" />


**misc:**

- introduce new `charting` domain tag

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
