### PR TITLE
Carousel: Tooltips for CarouselNavContainer layout helper

### DIFF
--- a/change/@fluentui-react-carousel-ad1cf6aa-5b30-49a3-ad4b-3fa6a1e650f2.json
+++ b/change/@fluentui-react-carousel-ad1cf6aa-5b30-49a3-ad4b-3fa6a1e650f2.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: Add tooltip wrappers for icon buttons in nav container",
+  "packageName": "@fluentui/react-carousel",
+  "email": "mifraser@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-carousel/library/etc/react-carousel.api.md
+++ b/packages/react-components/react-carousel/library/etc/react-carousel.api.md
@@ -25,6 +25,7 @@ import type { Slot } from '@fluentui/react-utilities';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import { ToggleButtonProps } from '@fluentui/react-button';
 import { ToggleButtonState } from '@fluentui/react-button';
+import { TooltipProps } from '@fluentui/react-tooltip';
 
 // @public
 export const Carousel: ForwardRefComponent<CarouselProps>;
@@ -159,8 +160,11 @@ export type CarouselNavContainerProps = ComponentProps<CarouselNavContainerSlots
 export type CarouselNavContainerSlots = {
     root: Slot<'div'>;
     next?: Slot<CarouselButtonProps>;
+    nextTooltip?: Slot<TooltipProps>;
     prev?: Slot<CarouselButtonProps>;
+    prevTooltip?: Slot<TooltipProps>;
     autoplay?: Slot<typeof CarouselAutoplayButton>;
+    autoplayTooltip?: Slot<TooltipProps>;
 };
 
 // @public

--- a/packages/react-components/react-carousel/library/package.json
+++ b/packages/react-components/react-carousel/library/package.json
@@ -29,6 +29,7 @@
     "@fluentui/react-button": "^9.3.102",
     "@fluentui/react-context-selector": "^9.1.72",
     "@fluentui/react-icons": "^2.0.245",
+    "@fluentui/react-tooltip": "^9.5.5",
     "@fluentui/react-jsx-runtime": "^9.0.50",
     "@fluentui/react-shared-contexts": "^9.21.2",
     "@fluentui/react-tabster": "^9.23.3",

--- a/packages/react-components/react-carousel/library/src/components/CarouselNavContainer/CarouselNavContainer.types.ts
+++ b/packages/react-components/react-carousel/library/src/components/CarouselNavContainer/CarouselNavContainer.types.ts
@@ -1,12 +1,16 @@
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
 import { CarouselAutoplayButton } from '../CarouselAutoplayButton/CarouselAutoplayButton';
 import { CarouselButtonProps } from '../CarouselButton/CarouselButton.types';
+import { TooltipProps } from '@fluentui/react-tooltip';
 
 export type CarouselNavContainerSlots = {
   root: Slot<'div'>;
   next?: Slot<CarouselButtonProps>;
+  nextTooltip?: Slot<TooltipProps>;
   prev?: Slot<CarouselButtonProps>;
+  prevTooltip?: Slot<TooltipProps>;
   autoplay?: Slot<typeof CarouselAutoplayButton>;
+  autoplayTooltip?: Slot<TooltipProps>;
 };
 
 /**

--- a/packages/react-components/react-carousel/library/src/components/CarouselNavContainer/renderCarouselNavContainer.tsx
+++ b/packages/react-components/react-carousel/library/src/components/CarouselNavContainer/renderCarouselNavContainer.tsx
@@ -12,10 +12,25 @@ export const renderCarouselNavContainer_unstable = (state: CarouselNavContainerS
 
   return (
     <state.root>
-      {state.autoplay && <state.autoplay />}
-      {state.prev && <state.prev />}
+      {!state.autoplayTooltip && state.autoplay && <state.autoplay />}
+      {state.autoplayTooltip && state.autoplay && (
+        <state.autoplayTooltip>
+          <state.autoplay />
+        </state.autoplayTooltip>
+      )}
+      {!state.prevTooltip && state.prev && <state.prev />}
+      {state.prevTooltip && state.prev && (
+        <state.prevTooltip>
+          <state.prev />
+        </state.prevTooltip>
+      )}
       {state.root.children}
-      {state.next && <state.next />}
+      {!state.nextTooltip && state.next && <state.next />}
+      {state.nextTooltip && state.next && (
+        <state.nextTooltip>
+          <state.next />
+        </state.nextTooltip>
+      )}
     </state.root>
   );
 };

--- a/packages/react-components/react-carousel/library/src/components/CarouselNavContainer/useCarouselNavContainer.ts
+++ b/packages/react-components/react-carousel/library/src/components/CarouselNavContainer/useCarouselNavContainer.ts
@@ -3,6 +3,7 @@ import { getIntrinsicElementProps, slot } from '@fluentui/react-utilities';
 import type { CarouselNavContainerProps, CarouselNavContainerState } from './CarouselNavContainer.types';
 import { CarouselAutoplayButton } from '../CarouselAutoplayButton/CarouselAutoplayButton';
 import { CarouselButton } from '../CarouselButton/CarouselButton';
+import { Tooltip } from '@fluentui/react-tooltip';
 
 /**
  * Create the state required to render CarouselNavContainer.
@@ -35,8 +36,26 @@ export const useCarouselNavContainer_unstable = (
   });
 
   const autoplay: CarouselNavContainerState['autoplay'] = slot.optional(props.autoplay, {
-    renderByDefault: false,
     elementType: CarouselAutoplayButton,
+    renderByDefault: !!props.autoplay || !!props.autoplayTooltip,
+  });
+
+  const nextTooltip: CarouselNavContainerState['nextTooltip'] = slot.optional(props.nextTooltip, {
+    defaultProps: {},
+    elementType: Tooltip,
+    renderByDefault: false,
+  });
+
+  const prevTooltip: CarouselNavContainerState['prevTooltip'] = slot.optional(props.prevTooltip, {
+    defaultProps: {},
+    elementType: Tooltip,
+    renderByDefault: false,
+  });
+
+  const autoplayTooltip: CarouselNavContainerState['autoplayTooltip'] = slot.optional(props.autoplayTooltip, {
+    defaultProps: {},
+    elementType: Tooltip,
+    renderByDefault: false,
   });
 
   return {
@@ -46,6 +65,9 @@ export const useCarouselNavContainer_unstable = (
       next: CarouselButton,
       prev: CarouselButton,
       autoplay: CarouselAutoplayButton,
+      nextTooltip: Tooltip,
+      prevTooltip: Tooltip,
+      autoplayTooltip: Tooltip,
     },
     root: slot.always(
       getIntrinsicElementProps('div', {
@@ -57,5 +79,8 @@ export const useCarouselNavContainer_unstable = (
     next,
     prev,
     autoplay,
+    nextTooltip,
+    prevTooltip,
+    autoplayTooltip,
   };
 };

--- a/packages/react-components/react-carousel/library/src/components/CarouselNavContainer/useCarouselNavContainerStyles.styles.ts
+++ b/packages/react-components/react-carousel/library/src/components/CarouselNavContainer/useCarouselNavContainerStyles.styles.ts
@@ -8,6 +8,12 @@ export const carouselNavContainerClassNames: SlotClassNames<CarouselNavContainer
   next: 'fui-CarouselNavContainer__next',
   prev: 'fui-CarouselNavContainer__prev',
   autoplay: 'fui-CarouselNavContainer__autoplay',
+  /* Tooltip classNames are listed for type compatibility only (cannot assign root className to portal)
+   * Use 'content' slot to style Tooltip content instead
+   */
+  nextTooltip: 'fui-CarouselNavContainer__nextTooltip',
+  prevTooltip: 'fui-CarouselNavContainer__prevTooltip',
+  autoplayTooltip: 'fui-CarouselNavContainer__autoplayTooltip',
 };
 
 /**

--- a/packages/react-components/react-carousel/stories/src/Carousel/CarouselDefault.stories.tsx
+++ b/packages/react-components/react-carousel/stories/src/Carousel/CarouselDefault.stories.tsx
@@ -90,11 +90,9 @@ export const Default = () => (
     </CarouselViewport>
     <CarouselNavContainer
       layout="inline"
-      autoplay={{
-        'aria-label': 'Enable autoplay',
-      }}
-      next={{ 'aria-label': 'go to next' }}
-      prev={{ 'aria-label': 'go to prev' }}
+      autoplayTooltip={{ content: 'Autoplay', relationship: 'label' }}
+      nextTooltip={{ content: 'Go to next', relationship: 'label' }}
+      prevTooltip={{ content: 'Go to prev', relationship: 'label' }}
     >
       <CarouselNav>{index => <CarouselNavButton aria-label={`Carousel Nav Button ${index}`} />}</CarouselNav>
     </CarouselNavContainer>


### PR DESCRIPTION
## Previous Behavior
IconButtons in CarouselNavContainer relied on aria labelling for accessibility
Individual CarouselButtons can be wrapped via a Tooltip when used directly.

## New Behavior
IconButtons in CarouselNavContainer now have the option to wrap Tooltips or use directly with aria.
Individual CarouselButtons can still be wrapped via a Tooltip when used directly.