### PR TITLE
chore: migrate to latest storywright which supports storyStore v7 and re-enable it within vr-tests SB setup

### DIFF
--- a/apps/vr-tests-react-components/.storybook/main.js
+++ b/apps/vr-tests-react-components/.storybook/main.js
@@ -53,8 +53,4 @@ module.exports = /** @type {import('@storybook/react-webpack5').StorybookConfig}
       },
     };
   },
-  // 💡 NOTE: this is necessary for StoryWright. without this the current version "0.0.27-storybook7.9" wont take screenshots for Steps
-  features: {
-    storyStoreV7: false,
-  },
 });

--- a/apps/vr-tests-web-components/.storybook/main.cjs
+++ b/apps/vr-tests-web-components/.storybook/main.cjs
@@ -85,8 +85,4 @@ module.exports = /** @type {import('@storybook/react-webpack5').StorybookConfig}
 
     return config;
   },
-  // 💡 NOTE: this is necessary for StoryWright. without this the current version "0.0.27-storybook7.9" wont take screenshots for Steps
-  features: {
-    storyStoreV7: false,
-  },
 });

--- a/apps/vr-tests/.storybook/main.js
+++ b/apps/vr-tests/.storybook/main.js
@@ -51,8 +51,4 @@ module.exports = /** @type {import('@storybook/react-webpack5').StorybookConfig}
       },
     };
   },
-  // 💡 NOTE: this is necessary for StoryWright. without this the current version "0.0.27-storybook7.9" wont take screenshots for Steps
-  features: {
-    storyStoreV7: false,
-  },
 });

--- a/package.json
+++ b/package.json
@@ -324,7 +324,7 @@
     "source-map-loader": "4.0.0",
     "storybook": "7.6.20",
     "storybook-addon-performance": "0.17.3",
-    "storywright": "0.0.27-storybook7.9",
+    "storywright": "0.0.27-storybook7.11",
     "strip-ansi": "6.0.0",
     "style-loader": "2.0.0",
     "swc-loader": "0.2.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -21715,10 +21715,10 @@ storybook@7.6.20:
   dependencies:
     "@storybook/cli" "7.6.20"
 
-storywright@0.0.27-storybook7.9:
-  version "0.0.27-storybook7.9"
-  resolved "https://registry.yarnpkg.com/storywright/-/storywright-0.0.27-storybook7.9.tgz#a9e7cae664c771ab5cb45a38470ef32ae1486068"
-  integrity sha512-tfEksZ6zrZR/GqAplPlHBsE6X45k9A5p7MLzoeHGwqlSmZPSKnqlmNj74yUphAB8HVqPYucLx+jK2R3ya0YjlQ==
+storywright@0.0.27-storybook7.11:
+  version "0.0.27-storybook7.11"
+  resolved "https://registry.yarnpkg.com/storywright/-/storywright-0.0.27-storybook7.11.tgz#c032deedd83c82895b09fc17b7404d397b1ebedf"
+  integrity sha512-B/tte/PyJ6MATFvMsGlv3+Yy3dSmzmWYyLYx/ijWwbUQ8O6BqDkkmmgVlsFrgydfsCu3CX2qVXPsNEQjYW8cEQ==
   dependencies:
     playwright "^1.34.3"
     prop-types "^15.6.0"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

- bump storywright to latest version to supports storyStoreV7 ( storybook 7 and 8 ) and improve Steps API DX
  - https://github.com/microsoft/storywright/pull/70
  - https://github.com/microsoft/storywright/pull/69
  - https://github.com/microsoft/storywright/pull/71
- revert storyStorev7 disablement 
- fixes all v0 vr snapshots to proper state (700+)

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows https://github.com/microsoft/fluentui/pull/33783, https://github.com/microsoft/fluentui/issues/33759
