### PR TITLE
fix(public-docsite-v9): increase heap size to prevent OOM failures

### DIFF
--- a/.github/workflows/pr-website-deploy.yml
+++ b/.github/workflows/pr-website-deploy.yml
@@ -38,6 +38,8 @@ jobs:
           node-version: '20'
 
       - run: echo number of CPUs "$(getconf _NPROCESSORS_ONLN)"
+      - name: NodeJS heap default size
+        run: node -e 'console.log(v8.getHeapStatistics().heap_size_limit / 1024 / 1024 + " MB");'
 
       - run: yarn install --frozen-lockfile
 

--- a/apps/public-docsite-v9/.storybook/main.js
+++ b/apps/public-docsite-v9/.storybook/main.js
@@ -18,6 +18,10 @@ module.exports = /** @type {Omit<import('../../../.storybook/main'), 'typescript
       excludeStoriesInsertionFromPackages: [
         '@fluentui/react-storybook-addon',
         '@fluentui/theme-designer',
+        // Exclude non v9 stories
+        '@fluentui/react',
+        '@fluentui/react-northstar',
+        '@fluentui/react-icons-northstar',
         // Exclude the package as we are including only the `Nav` component stories from the package below.
         '@fluentui/react-nav-preview',
       ],

--- a/apps/public-docsite-v9/package.json
+++ b/apps/public-docsite-v9/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "Fluent UI React v9 documentation",
   "scripts": {
-    "build-storybook": "storybook build -o ./dist/storybook --docs",
+    "build-storybook": "cross-env NODE_OPTIONS=--max_old_space_size=3072 storybook build -o ./dist/storybook --docs",
     "postbuild-storybook": "node -r ../../scripts/ts-node/src/register ../../scripts/storybook/src/scripts/rewrite-title.ts --title 'Fluent UI React v9' --distPath ./dist/storybook",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Starting 4 weeks ago pr website deploy runs started to fail with OOM errors. This issues started to appear almost on every 2nd pipeline run this week.

https://github.com/microsoft/fluentui/actions/workflows/pr-website-deploy.yml

## New Behavior

After further troubleshooting the issue is with DocGen (via  react docgen) generation while running `storybook build` for`public-docsite-v9`
- caused by ever increasing TS code we ship as part of stories that is non trivial to parse from TS through the react-docgen ( Slot api for example ) 

This PR overrides default Image Node heap size to accomodate heavy RAM usage while building production assets for v9 docsite

> NOTE: tested multiple re-runs with 100% success https://github.com/microsoft/fluentui/actions/runs/13291099420?pr=33826

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
