### PR TITLE
fix(TeachingPopover): TeachingPopoverCarousel calls announce() for slide changes

### DIFF
--- a/change/@fluentui-react-teaching-popover-d03a74a3-b27c-483e-88c5-5cc65d5d4da7.json
+++ b/change/@fluentui-react-teaching-popover-d03a74a3-b27c-483e-88c5-5cc65d5d4da7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: TeachingPopoverCarousel fires announce() messages on slide change",
+  "packageName": "@fluentui/react-teaching-popover",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-teaching-popover/library/etc/react-teaching-popover.api.md
+++ b/packages/react-components/react-teaching-popover/library/etc/react-teaching-popover.api.md
@@ -13,7 +13,7 @@ import { ButtonState } from '@fluentui/react-button';
 import { ComponentProps } from '@fluentui/react-utilities';
 import { ComponentState } from '@fluentui/react-utilities';
 import { EventData } from '@fluentui/react-utilities';
-import type { EventHandler } from '@fluentui/react-utilities';
+import { EventHandler } from '@fluentui/react-utilities';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import { JSXElementConstructor } from 'react';
 import { PopoverContextValue } from '@fluentui/react-popover';
@@ -232,12 +232,7 @@ export type TeachingPopoverCarouselPageCountState = ComponentState<TeachingPopov
 };
 
 // @public
-export type TeachingPopoverCarouselProps = ComponentProps<TeachingPopoverCarouselSlots> & {
-    defaultValue?: string;
-    value?: string;
-    onValueChange?: EventHandler<CarouselValueChangeData>;
-    onFinish?: EventHandler<CarouselValueChangeData>;
-};
+export type TeachingPopoverCarouselProps = ComponentProps<TeachingPopoverCarouselSlots> & UseCarouselOptions;
 
 // @public (undocumented)
 export type TeachingPopoverCarouselSlots = {

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarousel/Carousel/Carousel.types.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarousel/Carousel/Carousel.types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { EventData } from '@fluentui/react-utilities';
+import { EventData, EventHandler } from '@fluentui/react-utilities';
 
 export type CarouselStore = {
   clear: () => void;
@@ -13,6 +13,34 @@ export type CarouselStore = {
 export type CarouselItem = {
   el: HTMLElement;
   value: string | null;
+};
+
+export type UseCarouselOptions = {
+  /**
+   * Localizes the string used to announce carousel page changes to screen reader users
+   * Defaults to: undefined
+   */
+  announcement?: (newValue: string) => string;
+
+  /**
+   * The initial page to display in uncontrolled mode.
+   */
+  defaultValue?: string;
+
+  /**
+   * The value of the currently active page.
+   */
+  value?: string;
+
+  /**
+   * Callback to notify a page change.
+   */
+  onValueChange?: EventHandler<CarouselValueChangeData>;
+
+  /**
+   * Callback to notify when the final button step of a carousel has been activated.
+   */
+  onFinish?: EventHandler<CarouselValueChangeData>;
 };
 
 export type CarouselValueChangeData = EventData<'click', React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>> & {

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarousel/TeachingPopoverCarousel.types.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarousel/TeachingPopoverCarousel.types.ts
@@ -1,8 +1,8 @@
-import type { ComponentProps, ComponentState, EventHandler, Slot } from '@fluentui/react-utilities';
+import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
 import { type PopoverContextValue } from '@fluentui/react-popover';
 
 import { type CarouselContextValue } from './Carousel/CarouselContext';
-import type { CarouselValueChangeData } from './Carousel/Carousel.types';
+import type { UseCarouselOptions } from './Carousel/Carousel.types';
 
 export type TeachingPopoverCarouselSlots = {
   /**
@@ -14,27 +14,7 @@ export type TeachingPopoverCarouselSlots = {
 /**
  * TeachingPopoverCarousel Props
  */
-export type TeachingPopoverCarouselProps = ComponentProps<TeachingPopoverCarouselSlots> & {
-  /**
-   * The initial page to display in uncontrolled mode.
-   */
-  defaultValue?: string;
-
-  /**
-   * The value of the currently active page.
-   */
-  value?: string;
-
-  /**
-   * Callback to notify a page change.
-   */
-  onValueChange?: EventHandler<CarouselValueChangeData>;
-
-  /**
-   * Callback to notify when the final button step of a carousel has been activated.
-   */
-  onFinish?: EventHandler<CarouselValueChangeData>;
-};
+export type TeachingPopoverCarouselProps = ComponentProps<TeachingPopoverCarouselSlots> & UseCarouselOptions;
 
 /**
  * TeachingPopoverCarousel State and Context Hooks

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarousel/useTeachingPopoverCarousel.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarousel/useTeachingPopoverCarousel.ts
@@ -2,19 +2,20 @@ import * as React from 'react';
 import { getIntrinsicElementProps, slot, useEventCallback, useMergedRefs } from '@fluentui/react-utilities';
 import type { TeachingPopoverCarouselProps, TeachingPopoverCarouselState } from './TeachingPopoverCarousel.types';
 import { usePopoverContext_unstable } from '@fluentui/react-popover';
-import { useCarousel_unstable, type UseCarouselOptions } from './Carousel/Carousel';
+import { useCarousel_unstable } from './Carousel/Carousel';
 
 export const useTeachingPopoverCarousel_unstable = (
   props: TeachingPopoverCarouselProps,
   ref: React.Ref<HTMLDivElement>,
 ): TeachingPopoverCarouselState => {
   const toggleOpen = usePopoverContext_unstable(c => c.toggleOpen);
-  const handleFinish: UseCarouselOptions['onFinish'] = useEventCallback((event, data) => {
+  const handleFinish: TeachingPopoverCarouselProps['onFinish'] = useEventCallback((event, data) => {
     props.onFinish?.(event, data);
     toggleOpen(event as React.MouseEvent<HTMLElement>);
   });
 
   const { carousel, carouselRef } = useCarousel_unstable({
+    announcement: props.announcement,
     defaultValue: props.defaultValue,
     value: props.value,
     onValueChange: props.onValueChange,

--- a/packages/react-components/react-teaching-popover/stories/src/TeachingPopover/TeachingPopoverCarousel.stories.tsx
+++ b/packages/react-components/react-teaching-popover/stories/src/TeachingPopover/TeachingPopoverCarousel.stories.tsx
@@ -17,6 +17,10 @@ import {
 
 const swapImage = 'https://fabricweb.azureedge.net/fabric-website/assets/images/wireframe/image-square.png';
 
+const getAnnouncement = (newValue: string) => {
+  return `Carousel slide ${newValue}`;
+};
+
 export const Carousel = () => (
   <TeachingPopover>
     <TeachingPopoverTrigger>
@@ -24,7 +28,7 @@ export const Carousel = () => (
     </TeachingPopoverTrigger>
     <TeachingPopoverSurface>
       <TeachingPopoverHeader>Tips</TeachingPopoverHeader>
-      <TeachingPopoverCarousel defaultValue={'1'}>
+      <TeachingPopoverCarousel defaultValue={'1'} announcement={getAnnouncement}>
         <TeachingPopoverCarouselCard value="1">
           <TeachingPopoverBody media={<Image alt="test image" fit="cover" src={swapImage} />}>
             <TeachingPopoverTitle>Teaching Bubble Title</TeachingPopoverTitle>


### PR DESCRIPTION
## Previous Behavior

Since focus stays in place and there is no `announce()` / live region change on slide changes, there's no information exposed to screen reader users when the next/previous buttons are used.

## New Behavior

Calls `announce()` on slide changes.

There's still a tabster issue that needs to be handled before this will fully work, since right now tabster adds `aria-hidden` to the live region node when a modal dialog (like the teaching popover) is open.

## Related Issue(s)

- Fixes [ADO issue](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/22231)
