### PR TITLE
[fix]: Improve slider directional css and make direction change obser…

### DIFF
--- a/change/@fluentui-web-components-7dc89f98-c6de-4087-b1ac-dd614ef21c57.json
+++ b/change/@fluentui-web-components-7dc89f98-c6de-4087-b1ac-dd614ef21c57.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "makes direction change observable for slider",
+  "packageName": "@fluentui/web-components",
+  "email": "jes@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/docs/web-components.api.md
+++ b/packages/web-components/docs/web-components.api.md
@@ -3504,6 +3504,8 @@ export class Slider extends FASTElement implements SliderConfiguration {
     decrement(): void;
     // @internal (undocumented)
     direction: Direction;
+    // (undocumented)
+    directionChanged(): void;
     disabled: boolean;
     // (undocumented)
     protected disabledChanged(): void;

--- a/packages/web-components/src/slider/slider.styles.ts
+++ b/packages/web-components/src/slider/slider.styles.ts
@@ -144,7 +144,6 @@ export const styles = css`
     width: calc(100% - var(--slider-progress));
   }
 
-
   :host(${verticalState}) .track::before {
     width: 100%;
     bottom: 0;

--- a/packages/web-components/src/slider/slider.styles.ts
+++ b/packages/web-components/src/slider/slider.styles.ts
@@ -140,6 +140,11 @@ export const styles = css`
     width: var(--slider-progress);
   }
 
+  :host(:dir(rtl)) .track::before {
+    width: calc(100% - var(--slider-progress));
+  }
+
+
   :host(${verticalState}) .track::before {
     width: 100%;
     bottom: 0;

--- a/packages/web-components/src/slider/slider.ts
+++ b/packages/web-components/src/slider/slider.ts
@@ -634,7 +634,12 @@ export class Slider extends FASTElement implements SliderConfiguration {
    * Places the thumb based on the current value
    */
   private setSliderPosition(): void {
-    const newPct: number = convertPixelToPercent(parseFloat(this.value), this.minAsNumber, this.maxAsNumber, this.direction);
+    const newPct: number = convertPixelToPercent(
+      parseFloat(this.value),
+      this.minAsNumber,
+      this.maxAsNumber,
+      this.direction,
+    );
     const percentage: number = newPct * 100;
     this.position = `--slider-thumb: ${percentage}%; --slider-progress: ${percentage}%`;
   }

--- a/packages/web-components/src/slider/slider.ts
+++ b/packages/web-components/src/slider/slider.ts
@@ -68,7 +68,7 @@ export class Slider extends FASTElement implements SliderConfiguration {
     switch (propertyName) {
       case 'min':
       case 'max':
-        this.setSliderPosition(this.direction);
+        this.setSliderPosition();
       case 'step':
         this.handleStepStyles();
         break;
@@ -225,7 +225,10 @@ export class Slider extends FASTElement implements SliderConfiguration {
    */
   public get value(): string {
     Observable.track(this, 'value');
-    return this._value.toString();
+    if(this._value) {
+      return this._value.toString();
+    }
+    return "";
   }
 
   public set value(value: string) {
@@ -245,7 +248,7 @@ export class Slider extends FASTElement implements SliderConfiguration {
     this._value = value.toString();
     this.elementInternals.ariaValueNow = this._value;
     this.elementInternals.ariaValueText = this.valueTextFormatter(this._value);
-    this.setSliderPosition(this.direction);
+    this.setSliderPosition();
     this.$emit('change');
     this.setFormValue(value);
     Observable.notify(this, 'value');
@@ -303,6 +306,9 @@ export class Slider extends FASTElement implements SliderConfiguration {
    */
   @observable
   public direction: Direction = Direction.ltr;
+  public directionChanged(): void {
+    this.setSliderPosition();
+  }
 
   /**
    * @internal
@@ -502,7 +508,7 @@ export class Slider extends FASTElement implements SliderConfiguration {
     swapStates(this.elementInternals, prev, next, Orientation);
 
     if (this.$fastController.isConnected) {
-      this.setSliderPosition(this.direction);
+      this.setSliderPosition();
     }
   }
 
@@ -536,7 +542,7 @@ export class Slider extends FASTElement implements SliderConfiguration {
     this.setupTrackConstraints();
     this.setupListeners();
     this.setupDefaultValue();
-    this.setSliderPosition(this.direction);
+    this.setSliderPosition();
 
     Observable.getNotifier(this).subscribe(this, 'max');
     Observable.getNotifier(this).subscribe(this, 'min');
@@ -632,15 +638,10 @@ export class Slider extends FASTElement implements SliderConfiguration {
    *
    * @param direction - writing mode
    */
-  private setSliderPosition(direction: Direction): void {
-    const newPct: number = convertPixelToPercent(parseFloat(this.value), this.minAsNumber, this.maxAsNumber, direction);
-    const percentage: number = (1 - newPct) * 100;
-    const thumbPosition = `calc(100% - ${percentage}%)`;
-    const trackProgress =
-      !(this.orientation === Orientation.vertical) && direction === Direction.rtl
-        ? `${percentage}%`
-        : `calc(100% - ${percentage}%)`;
-    this.position = `--slider-thumb: ${thumbPosition}; --slider-progress: ${trackProgress}`;
+  private setSliderPosition(): void {
+    const newPct: number = convertPixelToPercent(parseFloat(this.value), this.minAsNumber, this.maxAsNumber, this.direction);
+    const percentage: number = newPct * 100;
+    this.position = `--slider-thumb: ${percentage}%; --slider-progress: ${percentage}%`;
   }
 
   /**

--- a/packages/web-components/src/slider/slider.ts
+++ b/packages/web-components/src/slider/slider.ts
@@ -225,10 +225,7 @@ export class Slider extends FASTElement implements SliderConfiguration {
    */
   public get value(): string {
     Observable.track(this, 'value');
-    if(this._value) {
-      return this._value.toString();
-    }
-    return "";
+    return this._value?.toString() ?? '';
   }
 
   public set value(value: string) {
@@ -635,8 +632,6 @@ export class Slider extends FASTElement implements SliderConfiguration {
 
   /**
    * Places the thumb based on the current value
-   *
-   * @param direction - writing mode
    */
   private setSliderPosition(): void {
     const newPct: number = convertPixelToPercent(parseFloat(this.value), this.minAsNumber, this.maxAsNumber, this.direction);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
Currently in order for direction to properly work with slider you need to set `dir` and then refresh the element so the connectedCallback in slider can set its direction property properly. This is not ideal becase it forces consumers to refresh the page. A possible solution is to set the `document.dir` along side the `direction` property. However due to how the compoent was built the thumb would get out of sync until your interacted with the slider. As shown here:

https://stackblitz.com/edit/fluentui-webcomponents-l8fx1gpx?file=src%2Frepro.ts

## New Behavior
This makes `direction` observable so when the direction property is updated the thumb position is reflected in the UI. This still requires you to set both `document.dir` and the `direction` property on slider, but now the thumb will be in the correct position without needing to interact with the slider. This PR moves some positioning logic out of js and into css.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
