### PR TITLE
MenuList's MenuItem steals focus when hovered, cannot override as a user

### DIFF
--- a/change/@fluentui-react-menu-6b0a1909-046e-4202-9d42-06b71cfe5d24.json
+++ b/change/@fluentui-react-menu-6b0a1909-046e-4202-9d42-06b71cfe5d24.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Currently, FluentUI MenuItem has no way of letting users override focus on hover behavior. This change allows that by a small reordering of lines.",
+  "packageName": "@fluentui/react-menu",
+  "email": "57237883+lekevin-microsoft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-menu/library/src/components/MenuItem/useMenuItem.tsx
+++ b/packages/react-components/react-menu/library/src/components/MenuItem/useMenuItem.tsx
@@ -75,11 +75,11 @@ export const useMenuItem_unstable = (props: MenuItemProps, ref: React.Ref<ARIABu
             }
           }),
           onMouseMove: useEventCallback(event => {
-            if (event.currentTarget.ownerDocument.activeElement !== event.currentTarget) {
+            props.onMouseMove?.(event);
+            if (!event.isDefaultPrevented() && 
+                event.currentTarget.ownerDocument.activeElement !== event.currentTarget) {
               innerRef.current?.focus();
             }
-
-            props.onMouseMove?.(event);
           }),
           onClick: useEventCallback(event => {
             if (!hasSubmenu && !persistOnClick) {

--- a/packages/react-components/react-menu/library/src/components/MenuItem/useMenuItem.tsx
+++ b/packages/react-components/react-menu/library/src/components/MenuItem/useMenuItem.tsx
@@ -76,8 +76,11 @@ export const useMenuItem_unstable = (props: MenuItemProps, ref: React.Ref<ARIABu
           }),
           onMouseMove: useEventCallback(event => {
             props.onMouseMove?.(event);
-            if (!event.isDefaultPrevented() && 
-                event.currentTarget.ownerDocument.activeElement !== event.currentTarget) {
+
+            if (
+              !event.isDefaultPrevented() &&
+              event.currentTarget.ownerDocument.activeElement !== event.currentTarget
+            ) {
               innerRef.current?.focus();
             }
           }),


### PR DESCRIPTION
Please see https://github.com/microsoft/fluentui/issues/33818 for full detailed description.

### Current Behavior

I'm seeing an issue where when a user has focus within the input box, if they hover over any of the `<MenuItem>`s then focus will immediately jump to the menu item. This is particularly unwanted behavior as input boxes can have lots of ongoing text, and when focus is reset to a menu item, pressing keys like "r" will trigger certain hotkeys (e.g. "Reload the window") which is particularly unwanted.

![Image](https://github.com/user-attachments/assets/db7def31-1cc2-4d13-8b1b-68b7413a693d)

Of note, this is the exact same issue that was fixed back in 2021 with `ContextualMenu` via this ticket: [Ticket #20552.](https://github.com/microsoft/fluentui/issues/20552) The fix here was that `ContextualMenu` has a `delayUpdateFocusOnHover` prop added that wasn't quite working, which was fixed from that ticket ([PR here](https://github.com/microsoft/fluentui/pull/21528)). 

I am looking for an ask to have it implemented in <MenuItem> or <MenuList> a similar mechanism such that a user can opt in or out of the functionality that on-hover for MenuItems will automatically focus. 

The code that is causing this auto-focus is here: 

![Image](https://github.com/user-attachments/assets/42b9de5a-6258-4604-aeb1-67ab95ef077b)

From [useMenuItem.tsx](https://github.com/microsoft/fluentui/blob/master/packages/react-components/react-menu/library/src/components/MenuItem/useMenuItem.tsx) on line 77. I've tested locally that when this block of code is commented out, the behavior is resolved and focus is no longer stolen away.

### Proposed PR Fix

The expected behavior is that hovering over a menu item does not steal away focus from another active menu item. In this case, a user should be able to continue typing in the Input component while moving the mouse around their screen, without worry that focus would be stolen and any subsequent button presses would trigger browser hotkeys.

**Two options here:** First, we could do something similar to [Ticket #20552.](https://github.com/microsoft/fluentui/issues/20552), where a property `delayUpdateFocusOnHover` is added. The user would then say `delayUpdateFocusOnHover={true}` in their creation of `MenuItem` and it would enforce that hover does not take focus.

Another option (that this PR is starting with) is a bit lighter-weight. It simply rearranges the call such that a user calling `e.preventDefault()` will work in preventing what FluentUI is doing. Before, it was calling focus() first and then the user's `props.onMouseMove?.(event)`. Now, it would call `onMouseMove` first, and then `focus()` if it isn't prevented.

As it stands before the PR, the code is like so:
```ts
          onMouseMove: useEventCallback(event => {
            if (event.currentTarget.ownerDocument.activeElement !== event.currentTarget) {
              innerRef.current?.focus();
            }

            props.onMouseMove?.(event);
          }),
```
`props.onMouseMove()` is called _after_ the focus() call, so it's too late to do anything. A way to fix this would be:
```ts
          onMouseMove: useEventCallback(event => {
            props.onMouseMove?.(event);  // Move this to be the first call

            if (!event.isDefaultPrevented() && // First call `isDefaultPrevented()` check
                 event.currentTarget.ownerDocument.activeElement !== event.currentTarget) {
              innerRef.current?.focus();
            }
          }),
```

### Reproduction

https://stackblitz.com/edit/vprprnxa?file=src%2Fexample.tsx

### Steps to reproduce

1. Click on "Toggle Menu" in the Stackblitz
2. Click into the Input component (first one) in the dropdown
3. Begin typing the word "test"
4. After the letter 's', move your mouse to any other menu item within the dropdown like "New" or "New Window"
5. Observe that focus is lost, and that if you press that final letter 't' in "test", you will invoke the browser's default behavior which is opening a new tab.
