### PR TITLE
fix(vr-tests-react-components): make sure build-storybook has all deps build assets before it runs

### DIFF
--- a/apps/vr-tests-react-components/package.json
+++ b/apps/vr-tests-react-components/package.json
@@ -57,7 +57,6 @@
     "@fluentui/react-spinner": "*",
     "@fluentui/react-spinbutton": "*",
     "@fluentui/react-storybook-addon": "*",
-    "@fluentui/react-storybook-addon-export-to-sandbox": "*",
     "@fluentui/react-swatch-picker": "*",
     "@fluentui/react-switch": "*",
     "@fluentui/react-table": "*",

--- a/apps/vr-tests-react-components/project.json
+++ b/apps/vr-tests-react-components/project.json
@@ -3,5 +3,10 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "application",
   "implicitDependencies": [],
-  "tags": ["vNext"]
+  "tags": ["vNext"],
+  "targets": {
+    "build-storybook": {
+      "dependsOn": [{ "projects": ["react-storybook-addon"], "target": "build" }]
+    }
+  }
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

workspace SB addon are transpiled and consumed as expected within production storybook build that is served to storywright

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows https://github.com/microsoft/fluentui/pull/33825
