### PR TITLE
chore: fix web-components lint setup to avoid leaking rules to json parser scope

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,12 @@
+// Default eslintrc for packages without one, or files outside a package
+// NOTE:
+//  - this is very old config (v8/v0 active era) - we don't use it anywhere
+//  - if nx migration adds any kind of overrides undo these changes as our config setup is not compatible with extending package from root
+// TODO:
+//  - this needs to be re-done when doing whole lint re-structuring within monorepo
+//  - will be used to follow standard NX linting approach
 {
+  "root": true,
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "ecmaVersion": 2018,
@@ -19,12 +27,5 @@
     "**/node_modules",
     "**/temp",
     "**/*.scss.ts"
-  ],
-  "overrides": [
-    {
-      "files": "*.json",
-      "parser": "jsonc-eslint-parser",
-      "rules": {}
-    }
   ]
 }

--- a/apps/vr-tests-web-components/.eslintrc.json
+++ b/apps/vr-tests-web-components/.eslintrc.json
@@ -1,14 +1,20 @@
 {
   "root": true,
-  "parser": "@typescript-eslint/parser",
-  "plugins": ["@typescript-eslint", "import"],
-  "extends": [
-    "eslint:recommended",
-    "plugin:@typescript-eslint/eslint-recommended",
-    "plugin:@typescript-eslint/recommended",
-    "prettier"
-  ],
-  "rules": {
-    "@typescript-eslint/explicit-module-boundary-types": "off"
-  }
+  "overrides": [
+    {
+      "files": ["src/**/*.{ts,tsx}"],
+      "parser": "@typescript-eslint/parser",
+      "plugins": ["@typescript-eslint", "import"],
+      "extends": [
+        "eslint:recommended",
+        "plugin:@typescript-eslint/eslint-recommended",
+        "plugin:@typescript-eslint/recommended",
+        "prettier"
+      ],
+      "rules": {
+        "import/no-extraneous-dependencies": ["error", { "packageDir": [".", "../.."] }],
+        "@typescript-eslint/explicit-module-boundary-types": "off"
+      }
+    }
+  ]
 }

--- a/packages/web-components/.eslintrc.json
+++ b/packages/web-components/.eslintrc.json
@@ -1,83 +1,79 @@
 {
   "root": true,
-  "parser": "@typescript-eslint/parser",
-  "plugins": ["@typescript-eslint", "import"],
-  "extends": [
-    "eslint:recommended",
-    "plugin:@typescript-eslint/eslint-recommended",
-    "plugin:@typescript-eslint/recommended",
-    "prettier",
-    "plugin:playwright/recommended"
-  ],
-  "settings": {
-    "react": {
-      "version": "latest"
-    }
-  },
-  "rules": {
-    "no-empty": [
-      "error",
-      {
-        "allowEmptyCatch": true
-      }
-    ],
-    "no-extra-boolean-cast": "off",
-    "no-prototype-builtins": "off",
-    "no-fallthrough": "off",
-    "no-unexpected-multiline": "off",
-    "no-useless-escape": "off",
-    "import/order": "error",
-    "sort-imports": [
-      "error",
-      {
-        "ignoreCase": true,
-        "ignoreDeclarationSort": true
-      }
-    ],
-    "comma-dangle": "off",
-    "prefer-const": ["error", { "destructuring": "all" }],
-    "@typescript-eslint/no-non-null-assertion": "off",
-    "@typescript-eslint/no-use-before-define": "off",
-    "@typescript-eslint/no-empty-interface": "error",
-    "@typescript-eslint/no-empty-object-type": "off",
-    "@typescript-eslint/no-unsafe-declaration-merging": "off",
-    "@typescript-eslint/explicit-module-boundary-types": "off",
-    "@typescript-eslint/explicit-function-return-type": "off",
-    "@typescript-eslint/camelcase": "off",
-    "@typescript-eslint/no-inferrable-types": "off",
-    "@typescript-eslint/no-unused-vars": [
-      "warn",
-      {
-        "args": "none"
-      }
-    ],
-    "@typescript-eslint/no-unused-expressions": "warn",
-    "@typescript-eslint/no-explicit-any": "off",
-    "@typescript-eslint/naming-convention": [
-      "error",
-      {
-        "selector": "default",
-        "format": ["UPPER_CASE", "camelCase", "PascalCase"],
-        "leadingUnderscore": "allow"
-      },
-      {
-        "selector": "property",
-        "format": null // disable for property names because of our foo__expanded convention for JSS
-        // TODO: I think we can come up with a regex that ignores variables with __ in them
-      },
-      {
-        "selector": "variable",
-        "format": null // disable for variable names because of our foo__expanded convention for JSS
-        // TODO: I think we can come up with a regex that ignores variables with __ in them
-      }
-    ]
-  },
   "overrides": [
     {
-      "files": ["**/*.json"],
+      "files": ["**/*.{js,ts,tsx}"],
+      "parser": "@typescript-eslint/parser",
+      "plugins": ["@typescript-eslint", "import"],
+      "extends": [
+        "eslint:recommended",
+        "plugin:@typescript-eslint/eslint-recommended",
+        "plugin:@typescript-eslint/recommended",
+        "prettier",
+        "plugin:playwright/recommended"
+      ],
+      "settings": {
+        "react": {
+          "version": "latest"
+        }
+      },
       "rules": {
-        "@typescript-eslint/naming-convention": "off",
-        "@typescript-eslint/no-unused-expressions": "off"
+        "no-empty": [
+          "error",
+          {
+            "allowEmptyCatch": true
+          }
+        ],
+        "no-extra-boolean-cast": "off",
+        "no-prototype-builtins": "off",
+        "no-fallthrough": "off",
+        "no-unexpected-multiline": "off",
+        "no-useless-escape": "off",
+        "import/order": "error",
+        "sort-imports": [
+          "error",
+          {
+            "ignoreCase": true,
+            "ignoreDeclarationSort": true
+          }
+        ],
+        "comma-dangle": "off",
+        "prefer-const": ["error", { "destructuring": "all" }],
+        "@typescript-eslint/no-non-null-assertion": "off",
+        "@typescript-eslint/no-use-before-define": "off",
+        "@typescript-eslint/no-empty-interface": "error",
+        "@typescript-eslint/no-empty-object-type": "off",
+        "@typescript-eslint/no-unsafe-declaration-merging": "off",
+        "@typescript-eslint/explicit-module-boundary-types": "off",
+        "@typescript-eslint/explicit-function-return-type": "off",
+        "@typescript-eslint/camelcase": "off",
+        "@typescript-eslint/no-inferrable-types": "off",
+        "@typescript-eslint/no-unused-vars": [
+          "warn",
+          {
+            "args": "none"
+          }
+        ],
+        "@typescript-eslint/no-unused-expressions": "warn",
+        "@typescript-eslint/no-explicit-any": "off",
+        "@typescript-eslint/naming-convention": [
+          "error",
+          {
+            "selector": "default",
+            "format": ["UPPER_CASE", "camelCase", "PascalCase"],
+            "leadingUnderscore": "allow"
+          },
+          {
+            "selector": "property",
+            "format": null // disable for property names because of our foo__expanded convention for JSS
+            // TODO: I think we can come up with a regex that ignores variables with __ in them
+          },
+          {
+            "selector": "variable",
+            "format": null // disable for variable names because of our foo__expanded convention for JSS
+            // TODO: I think we can come up with a regex that ignores variables with __ in them
+          }
+        ]
       }
     }
   ]

--- a/tools/workspace-plugin/.eslintrc.json
+++ b/tools/workspace-plugin/.eslintrc.json
@@ -13,13 +13,6 @@
   },
   "overrides": [
     {
-      "files": "*.json",
-      "parser": "jsonc-eslint-parser",
-      "rules": {
-        "@typescript-eslint/naming-convention": "off"
-      }
-    },
-    {
       "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
       "rules": {}
     },


### PR DESCRIPTION

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

wc doesn't follow recommended lint configuration guidelines. this ends up leaking rules execution within .json files and providing false positives

## New Behavior

wc uses overrides for lint configuration which is future proof for flat config migrations and mitigates issues with leaking scopes from json parser.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Replaces https://github.com/microsoft/fluentui/pull/33331/files
