### PR TITLE
fix: useAnnounce live regions do not get aria-hidden from tabster

### DIFF
--- a/change/@fluentui-react-aria-f408c823-66bb-4037-9e44-2fbbd8b12345.json
+++ b/change/@fluentui-react-aria-f408c823-66bb-4037-9e44-2fbbd8b12345.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: useAnnounce live regions do not get aria-hidden from tabster",
+  "packageName": "@fluentui/react-aria",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tabster-b7fd7b03-782c-45a5-b1ff-aa78ac6fad3d.json
+++ b/change/@fluentui-react-tabster-b7fd7b03-782c-45a5-b1ff-aa78ac6fad3d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: provide methods for elements such as live regions to not get hidden by modals",
+  "packageName": "@fluentui/react-tabster",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-aria/library/src/AriaLiveAnnouncer/useDomAnnounce.ts
+++ b/packages/react-components/react-aria/library/src/AriaLiveAnnouncer/useDomAnnounce.ts
@@ -1,7 +1,7 @@
 import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
 import type { AnnounceOptions } from '@fluentui/react-shared-contexts';
 import { createPriorityQueue, useTimeout } from '@fluentui/react-utilities';
-import { useDangerousNeverHidden } from '@fluentui/react-tabster';
+import { useDangerousNeverHidden_unstable as useDangerousNeverHidden } from '@fluentui/react-tabster';
 import * as React from 'react';
 
 import type { AriaLiveAnnounceFn, AriaLiveMessage } from './AriaLiveAnnouncer.types';
@@ -138,8 +138,10 @@ export const useDomAnnounce_unstable = (): AriaLiveAnnounceFn => {
     const element = targetDocument.createElement('div');
     element.setAttribute('aria-live', 'assertive');
 
-    for (let key in tabsterNeverHiddenAttributes) {
-      element.setAttribute(key, tabsterNeverHiddenAttributes[key]);
+    for (const key in tabsterNeverHiddenAttributes) {
+      if (tabsterNeverHiddenAttributes.hasOwnProperty(key)) {
+        element.setAttribute(key, tabsterNeverHiddenAttributes[key]);
+      }
     }
 
     Object.assign(element.style, VISUALLY_HIDDEN_STYLES);
@@ -153,7 +155,7 @@ export const useDomAnnounce_unstable = (): AriaLiveAnnounceFn => {
       clearAnnounceTimeout();
       timeoutRef.current = undefined;
     };
-  }, [clearAnnounceTimeout, targetDocument]);
+  }, [clearAnnounceTimeout, tabsterNeverHiddenAttributes, targetDocument]);
 
   return announce;
 };

--- a/packages/react-components/react-aria/library/src/AriaLiveAnnouncer/useDomAnnounce.ts
+++ b/packages/react-components/react-aria/library/src/AriaLiveAnnouncer/useDomAnnounce.ts
@@ -138,11 +138,9 @@ export const useDomAnnounce_unstable = (): AriaLiveAnnounceFn => {
     const element = targetDocument.createElement('div');
     element.setAttribute('aria-live', 'assertive');
 
-    for (const key in tabsterNeverHiddenAttributes) {
-      if (tabsterNeverHiddenAttributes.hasOwnProperty(key)) {
-        element.setAttribute(key, tabsterNeverHiddenAttributes[key]);
-      }
-    }
+    Object.entries(tabsterNeverHiddenAttributes).forEach((key, value) => {
+        element.setAttribute(key, value);
+    });
 
     Object.assign(element.style, VISUALLY_HIDDEN_STYLES);
     targetDocument.body.append(element);

--- a/packages/react-components/react-aria/library/src/AriaLiveAnnouncer/useDomAnnounce.ts
+++ b/packages/react-components/react-aria/library/src/AriaLiveAnnouncer/useDomAnnounce.ts
@@ -138,8 +138,8 @@ export const useDomAnnounce_unstable = (): AriaLiveAnnounceFn => {
     const element = targetDocument.createElement('div');
     element.setAttribute('aria-live', 'assertive');
 
-    Object.entries(tabsterNeverHiddenAttributes).forEach((key, value) => {
-        element.setAttribute(key, value);
+    Object.entries(tabsterNeverHiddenAttributes).forEach(([key, value]) => {
+      element.setAttribute(key, value);
     });
 
     Object.assign(element.style, VISUALLY_HIDDEN_STYLES);

--- a/packages/react-components/react-aria/library/src/AriaLiveAnnouncer/useDomAnnounce.ts
+++ b/packages/react-components/react-aria/library/src/AriaLiveAnnouncer/useDomAnnounce.ts
@@ -1,6 +1,7 @@
 import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
 import type { AnnounceOptions } from '@fluentui/react-shared-contexts';
 import { createPriorityQueue, useTimeout } from '@fluentui/react-utilities';
+import { useDangerousNeverHidden } from '@fluentui/react-tabster';
 import * as React from 'react';
 
 import type { AriaLiveAnnounceFn, AriaLiveMessage } from './AriaLiveAnnouncer.types';
@@ -24,6 +25,7 @@ export const useDomAnnounce_unstable = (): AriaLiveAnnounceFn => {
 
   const timeoutRef = React.useRef<number | undefined>(undefined);
   const [setAnnounceTimeout, clearAnnounceTimeout] = useTimeout();
+  const tabsterNeverHiddenAttributes = useDangerousNeverHidden();
 
   const elementRef = React.useRef<HTMLDivElement | null>(null);
 
@@ -135,6 +137,10 @@ export const useDomAnnounce_unstable = (): AriaLiveAnnounceFn => {
 
     const element = targetDocument.createElement('div');
     element.setAttribute('aria-live', 'assertive');
+
+    for (let key in tabsterNeverHiddenAttributes) {
+      element.setAttribute(key, tabsterNeverHiddenAttributes[key]);
+    }
 
     Object.assign(element.style, VISUALLY_HIDDEN_STYLES);
     targetDocument.body.append(element);

--- a/packages/react-components/react-tabster/etc/react-tabster.api.md
+++ b/packages/react-components/react-tabster/etc/react-tabster.api.md
@@ -1452,7 +1452,7 @@ export interface UseArrowNavigationGroupOptions {
 }
 
 // @public
-export function useDangerousNeverHidden(): {
+export function useDangerousNeverHidden_unstable(): {
     [key: string]: string;
 };
 

--- a/packages/react-components/react-tabster/etc/react-tabster.api.md
+++ b/packages/react-components/react-tabster/etc/react-tabster.api.md
@@ -1452,6 +1452,11 @@ export interface UseArrowNavigationGroupOptions {
 }
 
 // @public
+export function useDangerousNeverHidden(): {
+    [key: string]: string;
+};
+
+// @public
 export const useFocusableGroup: (options?: UseFocusableGroupOptions) => Types.TabsterDOMAttribute;
 
 // @public (undocumented)

--- a/packages/react-components/react-tabster/src/hooks/index.ts
+++ b/packages/react-components/react-tabster/src/hooks/index.ts
@@ -8,7 +8,7 @@ export { useFocusWithin } from './useFocusWithin';
 export { useKeyboardNavAttribute } from './useKeyboardNavAttribute';
 export { useOnKeyboardNavigationChange } from './useOnKeyboardNavigationChange';
 export type { UseModalAttributesOptions } from './useModalAttributes';
-export { useModalAttributes } from './useModalAttributes';
+export { useDangerousNeverHidden, useModalAttributes } from './useModalAttributes';
 export { useTabsterAttributes } from './useTabsterAttributes';
 export { useObservedElement } from './useObservedElement';
 export { useMergedTabsterAttributes_unstable } from './useMergeTabsterAttributes';

--- a/packages/react-components/react-tabster/src/hooks/index.ts
+++ b/packages/react-components/react-tabster/src/hooks/index.ts
@@ -8,7 +8,7 @@ export { useFocusWithin } from './useFocusWithin';
 export { useKeyboardNavAttribute } from './useKeyboardNavAttribute';
 export { useOnKeyboardNavigationChange } from './useOnKeyboardNavigationChange';
 export type { UseModalAttributesOptions } from './useModalAttributes';
-export { useDangerousNeverHidden, useModalAttributes } from './useModalAttributes';
+export { useDangerousNeverHidden_unstable, useModalAttributes } from './useModalAttributes';
 export { useTabsterAttributes } from './useTabsterAttributes';
 export { useObservedElement } from './useObservedElement';
 export { useMergedTabsterAttributes_unstable } from './useMergeTabsterAttributes';

--- a/packages/react-components/react-tabster/src/hooks/useModalAttributes.ts
+++ b/packages/react-components/react-tabster/src/hooks/useModalAttributes.ts
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { useId } from '@fluentui/react-utilities';
 import { useTabsterAttributes } from './useTabsterAttributes';
 import { getModalizer, getRestorer, Types as TabsterTypes, RestorerTypes } from 'tabster';

--- a/packages/react-components/react-tabster/src/hooks/useModalAttributes.ts
+++ b/packages/react-components/react-tabster/src/hooks/useModalAttributes.ts
@@ -3,6 +3,8 @@ import { useTabsterAttributes } from './useTabsterAttributes';
 import { getModalizer, getRestorer, Types as TabsterTypes, RestorerTypes } from 'tabster';
 import { useTabster } from './useTabster';
 
+const DangerousNeverHiddenAttribute = 'data-tabster-never-hide';
+
 export interface UseModalAttributesOptions {
   /**
    * Traps focus inside the elements the attributes are applied.
@@ -31,6 +33,19 @@ export interface UseModalAttributesOptions {
 }
 
 /**
+ * Designates an element that will not be hidden even when outside an open modal.
+ * Only works for top-level elements; should be used with extreme care.
+ * @returns Attribute to apply to the target element that should never receive aria-hidden
+ */
+export function useDangerousNeverHidden(): { [key: string]: string } {
+  return { [DangerousNeverHiddenAttribute]: '' };
+}
+
+const tabsterAccessibleCheck: TabsterTypes.ModalizerElementAccessibleCheck = element => {
+  return element.hasAttribute(DangerousNeverHiddenAttribute);
+};
+
+/**
  * Applies modal dialog behaviour through DOM attributes
  * Modal element will focus trap and hide other content on the page
  * The trigger element will be focused if focus is lost after the modal element is removed
@@ -44,7 +59,7 @@ export const useModalAttributes = (
   const tabster = useTabster();
   // Initializes the modalizer and restorer APIs
   if (tabster) {
-    getModalizer(tabster);
+    getModalizer(tabster, undefined, tabsterAccessibleCheck);
     getRestorer(tabster);
   }
 

--- a/packages/react-components/react-tabster/src/hooks/useModalAttributes.ts
+++ b/packages/react-components/react-tabster/src/hooks/useModalAttributes.ts
@@ -5,6 +5,7 @@ import { getModalizer, getRestorer, Types as TabsterTypes, RestorerTypes } from 
 import { useTabster } from './useTabster';
 
 const DangerousNeverHiddenAttribute = 'data-tabster-never-hide';
+const DangerousNeverHiddenPropObject = { [DangerousNeverHiddenAttribute]: '' };
 
 export interface UseModalAttributesOptions {
   /**
@@ -39,7 +40,7 @@ export interface UseModalAttributesOptions {
  * @returns Attribute to apply to the target element that should never receive aria-hidden
  */
 export function useDangerousNeverHidden_unstable(): { [key: string]: string } {
-  return React.useRef({ [DangerousNeverHiddenAttribute]: '' }).current;
+  return DangerousNeverHiddenPropObject;
 }
 
 const tabsterAccessibleCheck: TabsterTypes.ModalizerElementAccessibleCheck = element => {

--- a/packages/react-components/react-tabster/src/hooks/useModalAttributes.ts
+++ b/packages/react-components/react-tabster/src/hooks/useModalAttributes.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { useId } from '@fluentui/react-utilities';
 import { useTabsterAttributes } from './useTabsterAttributes';
 import { getModalizer, getRestorer, Types as TabsterTypes, RestorerTypes } from 'tabster';
@@ -38,7 +39,7 @@ export interface UseModalAttributesOptions {
  * @returns Attribute to apply to the target element that should never receive aria-hidden
  */
 export function useDangerousNeverHidden_unstable(): { [key: string]: string } {
-  return { [DangerousNeverHiddenAttribute]: '' };
+  return React.useRef({ [DangerousNeverHiddenAttribute]: '' }).current;
 }
 
 const tabsterAccessibleCheck: TabsterTypes.ModalizerElementAccessibleCheck = element => {

--- a/packages/react-components/react-tabster/src/hooks/useModalAttributes.ts
+++ b/packages/react-components/react-tabster/src/hooks/useModalAttributes.ts
@@ -33,11 +33,11 @@ export interface UseModalAttributesOptions {
 }
 
 /**
- * Designates an element that will not be hidden even when outside an open modal.
+ * !!DANGEROUS!! Designates an element that will not be hidden even when outside an open modal.
  * Only works for top-level elements; should be used with extreme care.
  * @returns Attribute to apply to the target element that should never receive aria-hidden
  */
-export function useDangerousNeverHidden(): { [key: string]: string } {
+export function useDangerousNeverHidden_unstable(): { [key: string]: string } {
   return { [DangerousNeverHiddenAttribute]: '' };
 }
 

--- a/packages/react-components/react-tabster/src/index.ts
+++ b/packages/react-components/react-tabster/src/index.ts
@@ -5,7 +5,7 @@ export {
   useFocusVisible,
   useFocusWithin,
   useKeyboardNavAttribute,
-  useDangerousNeverHidden,
+  useDangerousNeverHidden_unstable,
   useModalAttributes,
   useTabsterAttributes,
   useObservedElement,

--- a/packages/react-components/react-tabster/src/index.ts
+++ b/packages/react-components/react-tabster/src/index.ts
@@ -5,6 +5,7 @@ export {
   useFocusVisible,
   useFocusWithin,
   useKeyboardNavAttribute,
+  useDangerousNeverHidden,
   useModalAttributes,
   useTabsterAttributes,
   useObservedElement,


### PR DESCRIPTION
## Previous Behavior

Fluent v9 modals would hide live regions generated by `useAnnounce`, which prevents them from being picked up by screen readers when a modal is open.

## New Behavior

The v9 react-tabster modal hook makes use of the tabster option to provide an opt-out from `aria-hidden`, exposed as a hook.

## Related Issue(s)

- Fixes [ADO issue on TeachingPopover](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/22231)
