### PR TITLE
feat: export isHTMLElement from public API

### DIFF
--- a/change/@fluentui-react-components-ad800f8d-e8e3-461f-9e10-98fdd18d2f48.json
+++ b/change/@fluentui-react-components-ad800f8d-e8e3-461f-9e10-98fdd18d2f48.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: export isHTMLElement from public API",
+  "packageName": "@fluentui/react-components",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-components/etc/react-components.api.md
+++ b/packages/react-components/react-components/etc/react-components.api.md
@@ -482,6 +482,7 @@ import { InteractionTagSecondarySlots } from '@fluentui/react-tags';
 import { InteractionTagSecondaryState } from '@fluentui/react-tags';
 import { InteractionTagSlots } from '@fluentui/react-tags';
 import { InteractionTagState } from '@fluentui/react-tags';
+import { isHTMLElement } from '@fluentui/react-utilities';
 import { isTruncatableBreadcrumbContent } from '@fluentui/react-breadcrumb';
 import { Label } from '@fluentui/react-label';
 import { labelClassNames } from '@fluentui/react-label';
@@ -2784,6 +2785,8 @@ export { InteractionTagSecondaryState }
 export { InteractionTagSlots }
 
 export { InteractionTagState }
+
+export { isHTMLElement }
 
 export { isTruncatableBreadcrumbContent }
 

--- a/packages/react-components/react-components/src/index.ts
+++ b/packages/react-components/react-components/src/index.ts
@@ -128,6 +128,7 @@ export {
   useScrollbarWidth,
   useSelection,
   useTimeout,
+  isHTMLElement,
 } from '@fluentui/react-utilities';
 export type {
   ComponentProps,


### PR DESCRIPTION
The Fluent implementation is better than all other versions I've seen implemented in product and supports multiwindow/iframes with better typing support that returns the type of the desired HTML element.

Exporting this so that others can share in the love


