### PR TITLE
fix(vr-tests-react-components): migrate to new StoryWright api to define Steps to resolve VR snapshoting issues

### DIFF
--- a/apps/vr-tests-react-components/package.json
+++ b/apps/vr-tests-react-components/package.json
@@ -11,7 +11,7 @@
     "start": "storybook dev",
     "test": "just-scripts test",
     "type-check": "tsc -p . --noEmit --baseUrl .",
-    "test-vr": "storywright  --browsers chromium --url dist/storybook --destpath dist/screenshots --waitTimeScreenshot 500 --concurrency 4 --headless true"
+    "test-vr": "storywright  --browsers chromium --url dist/storybook --destpath dist/screenshots --waitTimeScreenshot 500 --concurrency 4 --headless true --bailOnStoriesError"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",

--- a/apps/vr-tests-react-components/src/stories/Badge/BadgeAppearance.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Badge/BadgeAppearance.stories.tsx
@@ -5,6 +5,7 @@ import { mergeClasses } from '@griffel/react';
 import { propValues, useStyles } from './utils';
 import type { Meta } from '@storybook/react';
 import { getStoryVariant, DARK_MODE, HIGH_CONTRAST } from '../../utilities';
+import { Steps, type StoryParameters } from 'storywright';
 
 const BadgeAppearanceTemplate: React.FC<{ appearance: Required<BadgeProps>['appearance'] }> = ({ appearance }) => {
   const styles = useStyles();
@@ -77,6 +78,7 @@ const BadgeAppearanceTemplate: React.FC<{ appearance: Required<BadgeProps>['appe
 
 export default {
   title: 'Badge Converged',
+  parameters: { storyWright: { steps: new Steps().snapshot('normal').end() } } satisfies StoryParameters,
 } satisfies Meta<typeof Badge>;
 
 export const Filled = () => <BadgeAppearanceTemplate appearance={'filled'} />;

--- a/apps/vr-tests-react-components/src/stories/Badge/BadgeSize.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Badge/BadgeSize.stories.tsx
@@ -4,6 +4,7 @@ import { CircleRegular } from '@fluentui/react-icons';
 import { propValues, useStyles } from './utils';
 import type { Meta } from '@storybook/react';
 import { getStoryVariant, RTL } from '../../utilities';
+import { Steps, type StoryParameters } from 'storywright';
 
 const BadgeSampleRow: React.FC<BadgeProps> = props => {
   const styles = useStyles();
@@ -35,6 +36,7 @@ const BadgeSampleRow: React.FC<BadgeProps> = props => {
 
 export default {
   title: 'Badge Converged',
+  parameters: { storyWright: { steps: new Steps().snapshot('normal').end() } } satisfies StoryParameters,
 } satisfies Meta<typeof Badge>;
 
 export const SizeTiny = () => {

--- a/apps/vr-tests-react-components/src/stories/Button/Button.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Button/Button.stories.tsx
@@ -2,15 +2,16 @@ import * as React from 'react';
 import { Button } from '@fluentui/react-button';
 import { bundleIcon, CalendarMonthFilled, CalendarMonthRegular } from '@fluentui/react-icons';
 import type { Meta } from '@storybook/react';
-import { getStoryVariant, withStoryWrightSteps, DARK_MODE, HIGH_CONTRAST, RTL } from '../../utilities';
+import { getStoryVariant, DARK_MODE, HIGH_CONTRAST, RTL } from '../../utilities';
 import { buttonId, steps, useStyles } from './utils';
+import type { StoryParameters } from 'storywright';
 
 const CalendarMonth = bundleIcon(CalendarMonthFilled, CalendarMonthRegular);
 
 export default {
   title: 'Button Converged',
   component: Button,
-  decorators: [story => withStoryWrightSteps({ story, steps })],
+  parameters: { storyWright: { steps } } satisfies StoryParameters,
 } satisfies Meta<typeof Button>;
 
 export const Default = () => <Button id={buttonId}>Hello, world</Button>;

--- a/apps/vr-tests-react-components/src/stories/Button/CompoundButton.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Button/CompoundButton.stories.tsx
@@ -2,15 +2,16 @@ import * as React from 'react';
 import { CompoundButton } from '@fluentui/react-button';
 import { bundleIcon, CalendarMonthFilled, CalendarMonthRegular } from '@fluentui/react-icons';
 import type { Meta } from '@storybook/react';
-import { getStoryVariant, withStoryWrightSteps, RTL } from '../../utilities';
+import { getStoryVariant, RTL } from '../../utilities';
 import { buttonId, steps, useStyles } from './utils';
+import type { StoryParameters } from 'storywright';
 
 const CalendarMonth = bundleIcon(CalendarMonthFilled, CalendarMonthRegular);
 
 export default {
   title: 'CompoundButton Converged',
   component: CompoundButton,
-  decorators: [story => withStoryWrightSteps({ story, steps })],
+  parameters: { storyWright: { steps } } satisfies StoryParameters,
 } satisfies Meta<typeof CompoundButton>;
 
 export const Outline = () => (

--- a/apps/vr-tests-react-components/src/stories/Button/CompoundButtonDefault.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Button/CompoundButtonDefault.stories.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { Steps } from 'storywright';
+import { Steps, type StoryParameters } from 'storywright';
 import { CompoundButton } from '@fluentui/react-button';
 import { bundleIcon, CalendarMonthFilled, CalendarMonthRegular } from '@fluentui/react-icons';
 import type { Meta } from '@storybook/react';
-import { getStoryVariant, withStoryWrightSteps, RTL } from '../../utilities';
+import { getStoryVariant, RTL } from '../../utilities';
 import { buttonId } from './utils';
 
 const CalendarMonth = bundleIcon(CalendarMonthFilled, CalendarMonthRegular);
@@ -20,7 +20,7 @@ const steps = new Steps()
 export default {
   title: 'CompoundButton Converged',
   component: CompoundButton,
-  decorators: [story => withStoryWrightSteps({ story, steps })],
+  parameters: { storyWright: { steps } } satisfies StoryParameters,
 } satisfies Meta<typeof CompoundButton>;
 
 export const Default = () => (

--- a/apps/vr-tests-react-components/src/stories/Button/MenuButton.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Button/MenuButton.stories.tsx
@@ -2,15 +2,16 @@ import * as React from 'react';
 import { MenuButton } from '@fluentui/react-button';
 import { bundleIcon, CalendarMonthFilled, CalendarMonthRegular } from '@fluentui/react-icons';
 import type { Meta } from '@storybook/react';
-import { getStoryVariant, withStoryWrightSteps, RTL } from '../../utilities';
+import { getStoryVariant, RTL } from '../../utilities';
 import { buttonId, steps, useStyles } from './utils';
+import type { StoryParameters } from 'storywright';
 
 const CalendarMonth = bundleIcon(CalendarMonthFilled, CalendarMonthRegular);
 
 export default {
   title: 'MenuButton Converged',
   component: MenuButton,
-  decorators: [story => withStoryWrightSteps({ story, steps })],
+  parameters: { storyWright: { steps } } satisfies StoryParameters,
 } satisfies Meta<typeof MenuButton>;
 
 export const Default = () => <MenuButton id={buttonId}>Hello, world</MenuButton>;

--- a/apps/vr-tests-react-components/src/stories/Button/SplitButton.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Button/SplitButton.stories.tsx
@@ -2,15 +2,16 @@ import * as React from 'react';
 import { SplitButton } from '@fluentui/react-button';
 import { bundleIcon, CalendarMonthFilled, CalendarMonthRegular } from '@fluentui/react-icons';
 import type { Meta } from '@storybook/react';
-import { getStoryVariant, withStoryWrightSteps, DARK_MODE, HIGH_CONTRAST, RTL } from '../../utilities';
+import { getStoryVariant, DARK_MODE, HIGH_CONTRAST, RTL } from '../../utilities';
 import { buttonId, steps, useStyles } from './utils';
+import type { StoryParameters } from 'storywright';
 
 const CalendarMonth = bundleIcon(CalendarMonthFilled, CalendarMonthRegular);
 
 export default {
   title: 'SplitButton Converged',
   component: SplitButton,
-  decorators: [story => withStoryWrightSteps({ story, steps })],
+  parameters: { storyWright: { steps } } satisfies StoryParameters,
 } satisfies Meta<typeof SplitButton>;
 
 export const Default = () => <SplitButton id={buttonId}>Hello, world</SplitButton>;

--- a/apps/vr-tests-react-components/src/stories/Button/ToggleButton.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Button/ToggleButton.stories.tsx
@@ -2,15 +2,16 @@ import * as React from 'react';
 import { ToggleButton } from '@fluentui/react-button';
 import { bundleIcon, CalendarMonthFilled, CalendarMonthRegular } from '@fluentui/react-icons';
 import type { Meta } from '@storybook/react';
-import { getStoryVariant, withStoryWrightSteps, DARK_MODE, HIGH_CONTRAST, RTL } from '../../utilities';
+import { getStoryVariant, DARK_MODE, HIGH_CONTRAST, RTL } from '../../utilities';
 import { buttonId, steps, useStyles } from './utils';
+import type { StoryParameters } from 'storywright';
 
 const CalendarMonth = bundleIcon(CalendarMonthFilled, CalendarMonthRegular);
 
 export default {
   title: 'ToggleButton Converged',
   component: ToggleButton,
-  decorators: [story => withStoryWrightSteps({ story, steps })],
+  parameters: { storyWright: { steps } } satisfies StoryParameters,
 } satisfies Meta<typeof ToggleButton>;
 
 export const Default = () => <ToggleButton id={buttonId}>Hello, world</ToggleButton>;

--- a/apps/vr-tests-react-components/src/stories/Card/Card.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Card/Card.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Steps, StoryWright } from 'storywright';
+import { Steps, type StoryParameters } from 'storywright';
 import { Card, CardHeader, CardPreview } from '@fluentui/react-card';
 import { MoreHorizontal24Filled, MoreHorizontal20Filled } from '@fluentui/react-icons';
 import { Body1, Caption1, Text } from '@fluentui/react-text';
@@ -15,13 +15,14 @@ export default {
 
   decorators: [
     story => (
-      <StoryWright steps={new Steps().snapshot('normal', { cropTo: '.testWrapper' }).end()}>
-        <div className="testWrapper" style={{ width: '600px' }}>
-          {story()}
-        </div>
-      </StoryWright>
+      <div className="testWrapper" style={{ width: '600px' }}>
+        {story()}
+      </div>
     ),
   ],
+  parameters: {
+    storyWright: { steps: new Steps().snapshot('normal', { cropTo: '.testWrapper' }).end() },
+  } satisfies StoryParameters,
 } satisfies Meta<typeof Card>;
 
 export const CardTemplates = () => (

--- a/apps/vr-tests-react-components/src/stories/Charts/Legend.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Charts/Legend.stories.tsx
@@ -4,6 +4,8 @@ import { DARK_MODE, getStoryVariant, RTL, TestWrapperDecorator } from '../../uti
 import { Steps, StoryWright } from 'storywright';
 import { Legend, Legends } from '@fluentui/react-charts-preview';
 
+const overflowText = 'Overflow Items';
+
 export default {
   title: 'Charts/Legend',
 
@@ -13,7 +15,16 @@ export default {
       const steps = context.name.includes('Overflow')
         ? new Steps()
             .snapshot('default', { cropTo: '.testWrapper' })
-            .executeScript(`document.querySelectorAll('div[class^="overflowIndicationTextStyle"]')[0].click()`)
+            .executeScript(
+              `document.evaluate(
+                  "//button[contains(text(), 'Overflow Items')]",
+                  document,
+                  null,
+                  XPathResult.FIRST_ORDERED_NODE_TYPE,
+                  null
+              ).singleNodeValue
+              .click()`,
+            )
             .snapshot('expanded', { cropTo: '.testWrapper' })
             .end()
         : new Steps().snapshot('default', { cropTo: '.testWrapper' }).end();
@@ -278,7 +289,7 @@ export const Overflow = () => {
     <div style={{ width: 400, height: 600, padding: 10, display: 'flex' }}>
       <Legends
         legends={legends}
-        overflowText={'Overflow Items'}
+        overflowText={overflowText}
         allowFocusOnLegends={true}
         canSelectMultipleLegends={false}
       />

--- a/apps/vr-tests-react-components/src/stories/Combobox/ComboboxOptionInteractions.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Combobox/ComboboxOptionInteractions.stories.tsx
@@ -13,7 +13,7 @@ export default {
       <StoryWright
         steps={new Steps()
           .snapshot('default', { cropTo: '.testWrapper' })
-          .hover('[role=option]')
+          .hover('input')
           .snapshot('hover', { cropTo: '.testWrapper' })
           .keys('input', 'ArrowDown')
           .snapshot('active option', { cropTo: '.testWrapper' })

--- a/apps/vr-tests-react-components/src/stories/CustomStyleHooks.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/CustomStyleHooks.stories.tsx
@@ -10,10 +10,14 @@ import type {
 } from '@fluentui/react-button';
 import { FluentProvider, FluentProviderCustomStyleHooks } from '@fluentui/react-provider';
 import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
+import { type StoryParameters, Steps } from 'storywright';
 
 export default {
   title: 'FluentProvider CustomStyleHooks',
   component: FluentProvider,
+  parameters: {
+    storyWright: { steps: new Steps().snapshot('normal').end() },
+  } satisfies StoryParameters,
 } satisfies Meta<typeof FluentProvider>;
 
 export const Default = () => <FluentProvider>Hello, world</FluentProvider>;

--- a/apps/vr-tests-react-components/src/stories/Dropdown/Dropdown.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Dropdown/Dropdown.stories.tsx
@@ -13,9 +13,9 @@ export default {
       <StoryWright
         steps={new Steps()
           .snapshot('default', { cropTo: '.testWrapper' })
-          .hover('input')
+          .hover('[role=combobox]')
           .snapshot('hover', { cropTo: '.testWrapper' })
-          .focus('input')
+          .focus('[role=combobox]')
           .wait(250) // let focus border animation finish
           .snapshot('focused', { cropTo: '.testWrapper' })
           .end()}

--- a/apps/vr-tests-react-components/src/stories/Dropdown/DropdownOptionInteractions.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Dropdown/DropdownOptionInteractions.stories.tsx
@@ -14,7 +14,7 @@ export default {
       <StoryWright
         steps={new Steps()
           .snapshot('default', { cropTo: '.testWrapper' })
-          .hover('[role=option]')
+          .hover('[role=combobox]')
           .snapshot('hover', { cropTo: '.testWrapper' })
           .keys('input', 'ArrowDown')
           .snapshot('active option', { cropTo: '.testWrapper' })

--- a/apps/vr-tests-react-components/src/stories/Menu/MenuGroups.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Menu/MenuGroups.stories.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import type { Meta } from '@storybook/react';
-import { StoryWright } from 'storywright';
 import {
   Menu,
   MenuTrigger,
@@ -17,8 +16,6 @@ import { DARK_MODE, getStoryVariant, HIGH_CONTRAST, RTL } from '../../utilities'
 
 export default {
   title: 'Menu Converged - groups',
-
-  decorators: [story => <StoryWright>{story()}</StoryWright>],
 } satisfies Meta<typeof Menu>;
 
 export const Default = () => (

--- a/apps/vr-tests-react-components/src/stories/Menu/MenuItemSelectableWIthLongText.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Menu/MenuItemSelectableWIthLongText.stories.tsx
@@ -1,14 +1,12 @@
 import * as React from 'react';
 import type { Meta } from '@storybook/react';
 import { Menu, MenuTrigger, MenuPopover, MenuList, MenuItemCheckbox, MenuItem } from '@fluentui/react-menu';
-import { StoryWright } from 'storywright';
 import { CutRegular, CutFilled, bundleIcon } from '@fluentui/react-icons';
 
 const CutIcon = bundleIcon(CutFilled, CutRegular);
 
 export default {
   title: 'Menu Converged - selection',
-  decorators: [story => <StoryWright>{story()}</StoryWright>],
 } satisfies Meta<typeof Menu>;
 
 export const SelectableWithLongText = () => (

--- a/apps/vr-tests-react-components/src/stories/Menu/MenuLongContent.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Menu/MenuLongContent.stories.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import type { Meta } from '@storybook/react';
-import { StoryWright } from 'storywright';
 import { Menu, MenuTrigger, MenuPopover, MenuList, MenuItem, MenuDivider } from '@fluentui/react-menu';
 import { CutRegular, ClipboardPasteRegular } from '@fluentui/react-icons';
 
@@ -8,8 +7,6 @@ import { getStoryVariant, RTL } from '../../utilities';
 
 export default {
   title: 'Menu Converged - long content',
-
-  decorators: [story => <StoryWright>{story()}</StoryWright>],
 } satisfies Meta<typeof Menu>;
 
 export const Default = () => (

--- a/apps/vr-tests-react-components/src/stories/ProgressBar.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/ProgressBar.stories.tsx
@@ -1,17 +1,10 @@
 import * as React from 'react';
 import type { Meta } from '@storybook/react';
 import { ProgressBar } from '@fluentui/react-progress';
-import { Steps } from 'storywright';
+import { Steps, type StoryParameters } from 'storywright';
 import { makeStyles } from '@griffel/react';
 
-import {
-  getStoryVariant,
-  withStoryWrightSteps,
-  TestWrapperDecoratorFixedWidth,
-  DARK_MODE,
-  HIGH_CONTRAST,
-  RTL,
-} from '../utilities';
+import { getStoryVariant, TestWrapperDecoratorFixedWidth, DARK_MODE, HIGH_CONTRAST, RTL } from '../utilities';
 
 const useStyles = makeStyles({
   paused: {
@@ -25,10 +18,10 @@ const useStyles = makeStyles({
 export default {
   title: 'ProgressBar converged',
 
-  decorators: [
-    TestWrapperDecoratorFixedWidth,
-    story => withStoryWrightSteps({ story, steps: new Steps().snapshot('default', { cropTo: '.testWrapper' }).end() }),
-  ],
+  decorators: [TestWrapperDecoratorFixedWidth],
+  parameters: {
+    storyWright: { steps: new Steps().snapshot('default', { cropTo: '.testWrapper' }).end() },
+  } satisfies StoryParameters,
 } satisfies Meta<typeof ProgressBar>;
 
 export const IndeterminateThickness = () => (

--- a/apps/vr-tests-react-components/src/stories/Skeleton.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Skeleton.stories.tsx
@@ -1,17 +1,10 @@
 import * as React from 'react';
 import type { Meta } from '@storybook/react';
 import { Skeleton, SkeletonItem } from '@fluentui/react-skeleton';
-import { Steps } from 'storywright';
+import { Steps, type StoryParameters } from 'storywright';
 import { makeStyles } from '@griffel/react';
 
-import {
-  getStoryVariant,
-  withStoryWrightSteps,
-  TestWrapperDecoratorFixedWidth,
-  HIGH_CONTRAST,
-  DARK_MODE,
-  RTL,
-} from '../utilities';
+import { getStoryVariant, TestWrapperDecoratorFixedWidth, HIGH_CONTRAST, DARK_MODE, RTL } from '../utilities';
 
 const useStyles = makeStyles({
   paused: {
@@ -25,10 +18,10 @@ const useStyles = makeStyles({
 export default {
   title: 'Skeleton converged',
 
-  decorators: [
-    TestWrapperDecoratorFixedWidth,
-    story => withStoryWrightSteps({ story, steps: new Steps().snapshot('default', { cropTo: '.testWrapper' }).end() }),
-  ],
+  decorators: [TestWrapperDecoratorFixedWidth],
+  parameters: {
+    storyWright: { steps: new Steps().snapshot('default', { cropTo: '.testWrapper' }).end() },
+  } satisfies StoryParameters,
 } satisfies Meta<typeof Skeleton>;
 
 export const OpaqueSkeletonWithRectangle = () => (

--- a/apps/vr-tests-react-components/src/stories/Slider/Slider.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Slider/Slider.stories.tsx
@@ -1,16 +1,16 @@
 import * as React from 'react';
 import type { Meta } from '@storybook/react';
-import { Steps } from 'storywright';
+import { Steps, type StoryParameters } from 'storywright';
 import { Slider } from '@fluentui/react-slider';
-import { getStoryVariant, RTL, TestWrapperDecorator, withStoryWrightSteps } from '../../utilities';
-import { SampleCustomizedSlider } from './utils';
+import { getStoryVariant, RTL, TestWrapperDecorator } from '../../utilities';
+import { useStyles } from './utils';
 
 export default {
   title: 'Slider Converged',
-  decorators: [
-    TestWrapperDecorator,
-    story => withStoryWrightSteps({ story, steps: new Steps().snapshot('default', { cropTo: '.testWrapper' }).end() }),
-  ],
+  decorators: [TestWrapperDecorator],
+  parameters: {
+    storyWright: { steps: new Steps().snapshot('default', { cropTo: '.testWrapper' }).end() },
+  } satisfies StoryParameters,
 } satisfies Meta<typeof Slider>;
 
 export const Horizontal0 = () => <Slider defaultValue={0} />;
@@ -33,4 +33,8 @@ Vertical100.storyName = 'Vertical - 100%';
 
 export const Vertical100RTL = getStoryVariant(Vertical100, RTL);
 
-export const CustomizedSlider = <SampleCustomizedSlider />;
+export const CustomizedSlider = () => {
+  const styles = useStyles();
+
+  return <Slider className={styles.enabled} thumb={{ className: styles.thumb }} defaultValue={20} size="small" />;
+};

--- a/apps/vr-tests-react-components/src/stories/Slider/SliderInteractions.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Slider/SliderInteractions.stories.tsx
@@ -1,33 +1,24 @@
 import * as React from 'react';
 import type { Meta } from '@storybook/react';
-import { Steps } from 'storywright';
+import { Steps, type StoryParameters } from 'storywright';
 import { Slider } from '@fluentui/react-slider';
-import {
-  DARK_MODE,
-  getStoryVariant,
-  HIGH_CONTRAST,
-  RTL,
-  TestWrapperDecorator,
-  withStoryWrightSteps,
-} from '../../utilities';
+import { DARK_MODE, getStoryVariant, HIGH_CONTRAST, RTL, TestWrapperDecorator } from '../../utilities';
 
 export default {
   title: 'Slider Converged',
-  decorators: [
-    TestWrapperDecorator,
-    story =>
-      withStoryWrightSteps({
-        story,
-        steps: new Steps()
-          .snapshot('default', { cropTo: '.testWrapper' })
-          .hover('.test-class')
-          .snapshot('hover', { cropTo: '.testWrapper' })
-          .mouseDown('.test-class')
-          .snapshot('pressed', { cropTo: '.testWrapper' })
-          .mouseUp('.test-class')
-          .end(),
-      }),
-  ],
+  decorators: [TestWrapperDecorator],
+  parameters: {
+    storyWright: {
+      steps: new Steps()
+        .snapshot('default', { cropTo: '.testWrapper' })
+        .hover('.test-class')
+        .snapshot('hover', { cropTo: '.testWrapper' })
+        .mouseDown('.test-class')
+        .snapshot('pressed', { cropTo: '.testWrapper' })
+        .mouseUp('.test-class')
+        .end(),
+    },
+  } satisfies StoryParameters,
 } satisfies Meta<typeof Slider>;
 
 export const Root = () => <Slider className="test-class" defaultValue={30} />;

--- a/apps/vr-tests-react-components/src/stories/Slider/utils.ts
+++ b/apps/vr-tests-react-components/src/stories/Slider/utils.ts
@@ -1,9 +1,8 @@
-import * as React from 'react';
-import { Slider, sliderCSSVars } from '@fluentui/react-slider';
+import { sliderCSSVars } from '@fluentui/react-slider';
 import { makeStyles } from '@griffel/react';
 const { sliderProgressColorVar, sliderRailColorVar, sliderThumbColorVar, sliderThumbSizeVar } = sliderCSSVars;
 
-const useStyles = makeStyles({
+export const useStyles = makeStyles({
   enabled: {
     [sliderProgressColorVar]: '#ff0764',
     [sliderRailColorVar]: '##242424',
@@ -25,9 +24,3 @@ const useStyles = makeStyles({
     },
   },
 });
-
-export const SampleCustomizedSlider = () => {
-  const styles = useStyles();
-
-  return <Slider className={styles.enabled} thumb={{ className: styles.thumb }} defaultValue={20} size="small" />;
-};

--- a/apps/vr-tests-react-components/src/stories/SpinButton/SpinButton.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/SpinButton/SpinButton.stories.tsx
@@ -1,25 +1,18 @@
 import * as React from 'react';
 import type { Meta } from '@storybook/react';
-import { Steps } from 'storywright';
+import { Steps, type StoryParameters } from 'storywright';
 import { SpinButton } from '@fluentui/react-spinbutton';
 import { FluentProvider } from '@fluentui/react-provider';
 import { makeStyles } from '@griffel/react';
 
-import {
-  DARK_MODE,
-  getStoryVariant,
-  HIGH_CONTRAST,
-  RTL,
-  TestWrapperDecoratorFixedWidth,
-  withStoryWrightSteps,
-} from '../../utilities';
+import { DARK_MODE, getStoryVariant, HIGH_CONTRAST, RTL, TestWrapperDecoratorFixedWidth } from '../../utilities';
 
 export default {
   title: 'SpinButton Converged',
-  decorators: [
-    TestWrapperDecoratorFixedWidth,
-    story => withStoryWrightSteps({ story, steps: new Steps().snapshot('default', { cropTo: '.testWrapper' }).end() }),
-  ],
+  decorators: [TestWrapperDecoratorFixedWidth],
+  parameters: {
+    storyWright: { steps: new Steps().snapshot('default', { cropTo: '.testWrapper' }).end() },
+  } satisfies StoryParameters,
 } satisfies Meta<typeof SpinButton>;
 
 export const SizeSmall = () => <SpinButton size="small" value={10} />;

--- a/apps/vr-tests-react-components/src/stories/SpinButton/SpinButtonInteractions.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/SpinButton/SpinButtonInteractions.stories.tsx
@@ -1,53 +1,44 @@
 import * as React from 'react';
 import type { Meta } from '@storybook/react';
-import { Steps } from 'storywright';
+import { Steps, StoryParameters } from 'storywright';
 import { SpinButton, spinButtonClassNames } from '@fluentui/react-spinbutton';
 
-import {
-  getStoryVariant,
-  withStoryWrightSteps,
-  TestWrapperDecoratorFixedWidth,
-  DARK_MODE,
-  RTL,
-  HIGH_CONTRAST,
-} from '../../utilities';
+import { getStoryVariant, TestWrapperDecoratorFixedWidth, DARK_MODE, RTL, HIGH_CONTRAST } from '../../utilities';
 
 const cropTo = '.testWrapper';
 
 export default {
   title: 'SpinButton Converged',
-  decorators: [
-    TestWrapperDecoratorFixedWidth,
-    story =>
-      withStoryWrightSteps({
-        story,
-        steps: new Steps()
-          .snapshot('rest', { cropTo })
-          .hover('input')
-          .snapshot('hoverInput', { cropTo })
+  decorators: [TestWrapperDecoratorFixedWidth],
+  parameters: {
+    storyWright: {
+      steps: new Steps()
+        .snapshot('rest', { cropTo })
+        .hover('input')
+        .snapshot('hoverInput', { cropTo })
 
-          .hover(`.${spinButtonClassNames.incrementButton}`)
-          .snapshot('hoverIncrement', { cropTo })
+        .hover(`.${spinButtonClassNames.incrementButton}`)
+        .snapshot('hoverIncrement', { cropTo })
 
-          .hover(`.${spinButtonClassNames.decrementButton}`)
-          .snapshot('hoverDecrement', { cropTo })
+        .hover(`.${spinButtonClassNames.decrementButton}`)
+        .snapshot('hoverDecrement', { cropTo })
 
-          .mouseDown(`.${spinButtonClassNames.incrementButton}`)
-          .wait(250)
-          .snapshot('mouseDownIncrement', { cropTo })
-          .mouseUp(`.${spinButtonClassNames.incrementButton}`)
+        .mouseDown(`.${spinButtonClassNames.incrementButton}`)
+        .wait(250)
+        .snapshot('mouseDownIncrement', { cropTo })
+        .mouseUp(`.${spinButtonClassNames.incrementButton}`)
 
-          .mouseDown(`.${spinButtonClassNames.decrementButton}`)
-          .wait(250)
-          .snapshot('mouseDownDecrement', { cropTo })
-          .mouseUp(`.${spinButtonClassNames.decrementButton}`)
+        .mouseDown(`.${spinButtonClassNames.decrementButton}`)
+        .wait(250)
+        .snapshot('mouseDownDecrement', { cropTo })
+        .mouseUp(`.${spinButtonClassNames.decrementButton}`)
 
-          .click('input')
-          .wait(250) // let focus border animation finish
-          .snapshot('focused', { cropTo })
-          .end(),
-      }),
-  ],
+        .click('input')
+        .wait(250) // let focus border animation finish
+        .snapshot('focused', { cropTo })
+        .end(),
+    },
+  } satisfies StoryParameters,
 } satisfies Meta<typeof SpinButton>;
 
 export const AppearanceOutlineDefault = () => <SpinButton value={10} />;

--- a/apps/vr-tests-react-components/src/stories/Spinner.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Spinner.stories.tsx
@@ -2,10 +2,10 @@ import * as React from 'react';
 import type { Decorator, Meta } from '@storybook/react';
 import { Spinner, spinnerClassNames } from '@fluentui/react-spinner';
 import { tokens } from '@fluentui/react-theme';
-import { Steps } from 'storywright';
+import { Steps, type StoryParameters } from 'storywright';
 import { makeResetStyles, mergeClasses } from '@griffel/react';
 
-import { DARK_MODE, getStoryVariant, HIGH_CONTRAST, RTL, withStoryWrightSteps } from '../utilities';
+import { DARK_MODE, getStoryVariant, HIGH_CONTRAST, RTL } from '../utilities';
 
 const usePauseWrapperClass = makeResetStyles({
   minWidth: '300px',
@@ -33,10 +33,10 @@ const InvertedWrapper: React.FC = ({ children }) => {
 export default {
   title: 'Spinner converged',
 
-  decorators: [
-    TestWrapperDecoratorPauseAnimation,
-    story => withStoryWrightSteps({ story, steps: new Steps().snapshot('default', { cropTo: '.testWrapper' }).end() }),
-  ],
+  decorators: [TestWrapperDecoratorPauseAnimation],
+  parameters: {
+    storyWright: { steps: new Steps().snapshot('default', { cropTo: '.testWrapper' }).end() },
+  } satisfies StoryParameters,
 } satisfies Meta<typeof Spinner>;
 
 export const Primary = () => <Spinner />;

--- a/apps/vr-tests-react-components/src/stories/Tag/InteractionTag.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Tag/InteractionTag.stories.tsx
@@ -2,19 +2,19 @@ import * as React from 'react';
 import { InteractionTag, InteractionTagPrimary, InteractionTagSecondary } from '@fluentui/react-tags';
 import { bundleIcon, CalendarMonthFilled, CalendarMonthRegular } from '@fluentui/react-icons';
 import type { Meta } from '@storybook/react';
-import { getStoryVariant, withStoryWrightSteps, DARK_MODE, HIGH_CONTRAST, RTL } from '../../utilities';
+import { getStoryVariant, DARK_MODE, HIGH_CONTRAST, RTL } from '../../utilities';
 import { Avatar } from '@fluentui/react-avatar';
-import { Steps } from 'storywright';
+import { Steps, type StoryParameters } from 'storywright';
 import { makeStyles } from '@griffel/react';
 
 const CalendarMonth = bundleIcon(CalendarMonthFilled, CalendarMonthRegular);
 
-const steps = new Steps().snapshot('default').end();
-
 export default {
   title: 'InteractionTag Converged',
   component: InteractionTag,
-  decorators: [story => withStoryWrightSteps({ story, steps })],
+  parameters: {
+    storyWright: { steps: new Steps().snapshot('default').end() },
+  } satisfies StoryParameters,
 } satisfies Meta<typeof InteractionTag>;
 
 export const Default = () => (

--- a/apps/vr-tests-react-components/src/stories/Tag/InteractionTagShape.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Tag/InteractionTagShape.stories.tsx
@@ -1,15 +1,25 @@
 import * as React from 'react';
 import { InteractionTag, InteractionTagPrimary, InteractionTagSecondary } from '@fluentui/react-tags';
 import type { Meta } from '@storybook/react';
-import { getStoryVariant, withStoryWrightSteps, RTL } from '../../utilities';
+import { getStoryVariant, RTL } from '../../utilities';
 import { Avatar } from '@fluentui/react-avatar';
-import { Steps } from 'storywright';
+import { Steps, type StoryParameters } from 'storywright';
 
 const contentId = 'content-id';
 const dismissButtonId = 'dismiss-button-id';
-const steps = new Steps()
+
+const defaultSteps = new Steps()
   .snapshot('default')
 
+  // This needs to be added so that the focus outline is shown correctly
+  .executeScript(`document.querySelector('#${contentId}').setAttribute('data-fui-focus-visible', '')`)
+  .focus(`#${contentId}`)
+  .snapshot('focus content')
+  .executeScript(`document.querySelector('#${contentId}').removeAttribute('data-fui-focus-visible')`)
+  .end();
+
+const dismissSteps = new Steps()
+  .snapshot('default')
   // This needs to be added so that the focus outline is shown correctly
   .executeScript(`document.querySelector('#${contentId}').setAttribute('data-fui-focus-visible', '')`)
   .focus(`#${contentId}`)
@@ -21,13 +31,12 @@ const steps = new Steps()
   .focus(`#${dismissButtonId}`)
   .snapshot('focus dismiss')
   .executeScript(`document.querySelector('#${dismissButtonId}').removeAttribute('data-fui-focus-visible')`)
-
   .end();
 
 export default {
   title: 'InteractionTag Converged',
   component: InteractionTag,
-  decorators: [story => withStoryWrightSteps({ story, steps })],
+  parameters: { storyWright: { steps: defaultSteps } } satisfies StoryParameters,
 } satisfies Meta<typeof InteractionTag>;
 
 export const Rounded = () => (
@@ -61,6 +70,7 @@ export const RoundedDismissible = () => (
     <InteractionTagSecondary id={dismissButtonId} />
   </InteractionTag>
 );
+RoundedDismissible.parameters = { storyWright: { steps: dismissSteps } } satisfies StoryParameters;
 export const RoundedDismissibleRTL = getStoryVariant(RoundedDismissible, RTL);
 
 export const Circular = () => (
@@ -94,4 +104,6 @@ export const CircularDismissible = () => (
     <InteractionTagSecondary id={dismissButtonId} />
   </InteractionTag>
 );
+CircularDismissible.parameters = { storyWright: { steps: dismissSteps } } satisfies StoryParameters;
+
 export const CircularDismissibleRTL = getStoryVariant(CircularDismissible, RTL);

--- a/apps/vr-tests-react-components/src/stories/Tag/TagAppearances.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Tag/TagAppearances.stories.tsx
@@ -10,9 +10,9 @@ const CalendarMonth = bundleIcon(CalendarMonthFilled, CalendarMonthRegular);
 const dismissIconId = 'dismiss-icon-id';
 const steps = new Steps()
   .snapshot('default')
-  .hover(`#${dismissIconId}}`)
+  .hover(`#${dismissIconId}`)
   .snapshot('hover')
-  .mouseDown(`#${dismissIconId}}`)
+  .mouseDown(`#${dismissIconId}`)
   .snapshot('pressed')
   .end();
 

--- a/apps/vr-tests-react-components/src/stories/Tag/TagShape.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Tag/TagShape.stories.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { Tag } from '@fluentui/react-tags';
 import type { Meta } from '@storybook/react';
-import { getStoryVariant, withStoryWrightSteps, RTL } from '../../utilities';
+import { getStoryVariant, RTL } from '../../utilities';
 import { Avatar } from '@fluentui/react-avatar';
-import { Steps } from 'storywright';
+import { Steps, type StoryParameters } from 'storywright';
 
 const tagId = 'tag-id';
 const steps = new Steps()
@@ -18,7 +18,6 @@ const steps = new Steps()
 export default {
   title: 'Tag Converged',
   component: Tag,
-  decorators: [story => withStoryWrightSteps({ story, steps })],
 } satisfies Meta<typeof Tag>;
 
 export const Rounded = () => <Tag>Primary Text</Tag>;
@@ -35,6 +34,8 @@ export const RoundedDismissible = () => (
     Primary Text
   </Tag>
 );
+RoundedDismissible.parameters = { storyWright: { steps } } satisfies StoryParameters;
+
 export const RoundedDismissibleRTL = getStoryVariant(RoundedDismissible, RTL);
 
 export const Circular = () => <Tag shape="circular">Primary Text</Tag>;
@@ -53,4 +54,6 @@ export const CircularDismissible = () => (
     Primary Text
   </Tag>
 );
+CircularDismissible.parameters = { storyWright: { steps } } satisfies StoryParameters;
+
 export const CircularDismissibleRTL = getStoryVariant(CircularDismissible, RTL);

--- a/apps/vr-tests-react-components/src/stories/TagPicker.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/TagPicker.stories.tsx
@@ -14,7 +14,7 @@ import { Tag } from '@fluentui/react-tags';
 import { Avatar } from '@fluentui/react-avatar';
 import { makeStyles, mergeClasses, shorthands } from '@griffel/react';
 import { tokens } from '@fluentui/react-theme';
-import { Steps, StoryWright } from 'storywright';
+import { Steps, type StoryParameters } from 'storywright';
 import { ArrowDownFilled } from '@fluentui/react-icons';
 import { Button } from '@fluentui/react-button';
 
@@ -22,6 +22,9 @@ import { DARK_MODE, getStoryVariant, HIGH_CONTRAST, RTL } from '../utilities';
 
 export default {
   title: 'TagPicker',
+  parameters: {
+    storyWright: { steps: new Steps().snapshot('default').end() },
+  } satisfies StoryParameters,
 } satisfies Meta<typeof TagPicker>;
 
 const options = [
@@ -92,51 +95,53 @@ export const DefaultOpen = () => {
   };
 
   return (
-    <StoryWright
-      steps={new Steps()
-        .hover('#tag-picker-option-1')
-        .snapshot('default open option hover')
-        .mouseDown('#tag-picker-option-1')
-        .snapshot('default open option mouse down')}
-    >
-      <div style={{ maxWidth: 400 }}>
-        <TagPicker defaultOpen onOptionSelect={onOptionSelect} selectedOptions={selectedOptions}>
-          <TagPickerControl>
-            <TagPickerGroup>
-              {selectedOptions.map(option => (
-                <Tag
-                  key={option}
-                  shape="rounded"
-                  media={<Avatar aria-hidden name={option} color="colorful" />}
-                  value={option}
-                >
-                  {option}
-                </Tag>
-              ))}
-            </TagPickerGroup>
-            <TagPickerInput aria-label="Select Employees" />
-          </TagPickerControl>
-          <TagPickerList>
-            {options
-              .filter(option => !selectedOptions.includes(option))
-              .map((option, index) => (
-                <TagPickerOption
-                  id={`tag-picker-option-${index}`}
-                  secondaryContent="Microsoft FTE"
-                  media={<Avatar aria-hidden name={option} color="colorful" />}
-                  value={option}
-                  key={option}
-                >
-                  {option}
-                </TagPickerOption>
-              ))}
-          </TagPickerList>
-        </TagPicker>
-      </div>
-    </StoryWright>
+    <div style={{ maxWidth: 400 }}>
+      <TagPicker defaultOpen onOptionSelect={onOptionSelect} selectedOptions={selectedOptions}>
+        <TagPickerControl>
+          <TagPickerGroup>
+            {selectedOptions.map(option => (
+              <Tag
+                key={option}
+                shape="rounded"
+                media={<Avatar aria-hidden name={option} color="colorful" />}
+                value={option}
+              >
+                {option}
+              </Tag>
+            ))}
+          </TagPickerGroup>
+          <TagPickerInput aria-label="Select Employees" />
+        </TagPickerControl>
+        <TagPickerList>
+          {options
+            .filter(option => !selectedOptions.includes(option))
+            .map((option, index) => (
+              <TagPickerOption
+                id={`tag-picker-option-${index}`}
+                secondaryContent="Microsoft FTE"
+                media={<Avatar aria-hidden name={option} color="colorful" />}
+                value={option}
+                key={option}
+              >
+                {option}
+              </TagPickerOption>
+            ))}
+        </TagPickerList>
+      </TagPicker>
+    </div>
   );
 };
 DefaultOpen.storyName = 'default open';
+DefaultOpen.parameters = {
+  storyWright: {
+    steps: new Steps()
+      .hover('#tag-picker-option-1')
+      .snapshot('default open option hover')
+      .mouseDown('#tag-picker-option-1')
+      .snapshot('default open option mouse down')
+      .end(),
+  },
+} satisfies StoryParameters;
 
 export const DefaultOpenDarkMode = getStoryVariant(DefaultOpen, DARK_MODE);
 
@@ -223,44 +228,47 @@ export const Disabled = () => {
   };
 
   return (
-    <StoryWright steps={new Steps().hover('#tag-picker-input').snapshot('disabled input hover')}>
-      <div style={{ maxWidth: 400 }}>
-        <TagPicker disabled onOptionSelect={onOptionSelect} selectedOptions={selectedOptions}>
-          <TagPickerControl>
-            <TagPickerGroup>
-              {selectedOptions.map(option => (
-                <Tag
-                  key={option}
-                  shape="rounded"
-                  media={<Avatar aria-hidden name={option} color="colorful" />}
-                  value={option}
-                >
-                  {option}
-                </Tag>
-              ))}
-            </TagPickerGroup>
-            <TagPickerInput id="tag-picker-input" aria-label="Select Employees" />
-          </TagPickerControl>
-          <TagPickerList>
-            {options
-              .filter(option => !selectedOptions.includes(option))
-              .map(option => (
-                <TagPickerOption
-                  secondaryContent="Microsoft FTE"
-                  media={<Avatar aria-hidden name={option} color="colorful" />}
-                  value={option}
-                  key={option}
-                >
-                  {option}
-                </TagPickerOption>
-              ))}
-          </TagPickerList>
-        </TagPicker>
-      </div>
-    </StoryWright>
+    <div style={{ maxWidth: 400 }}>
+      <TagPicker disabled onOptionSelect={onOptionSelect} selectedOptions={selectedOptions}>
+        <TagPickerControl>
+          <TagPickerGroup>
+            {selectedOptions.map(option => (
+              <Tag
+                key={option}
+                shape="rounded"
+                media={<Avatar aria-hidden name={option} color="colorful" />}
+                value={option}
+              >
+                {option}
+              </Tag>
+            ))}
+          </TagPickerGroup>
+          <TagPickerInput id="tag-picker-input" aria-label="Select Employees" />
+        </TagPickerControl>
+        <TagPickerList>
+          {options
+            .filter(option => !selectedOptions.includes(option))
+            .map(option => (
+              <TagPickerOption
+                secondaryContent="Microsoft FTE"
+                media={<Avatar aria-hidden name={option} color="colorful" />}
+                value={option}
+                key={option}
+              >
+                {option}
+              </TagPickerOption>
+            ))}
+        </TagPickerList>
+      </TagPicker>
+    </div>
   );
 };
 Disabled.storyName = 'disabled';
+Disabled.parameters = {
+  storyWright: {
+    steps: new Steps().hover('#tag-picker-input').snapshot('disabled input hover').end(),
+  },
+} satisfies StoryParameters;
 
 export const DisabledDarkMode = getStoryVariant(Disabled, DARK_MODE);
 

--- a/apps/vr-tests-react-components/src/stories/Toolbar/Toolbar.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Toolbar/Toolbar.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { StoryWright } from 'storywright';
+import { Steps, type StoryParameters } from 'storywright';
 import { makeStyles } from '@griffel/react';
 import {
   Toolbar,
@@ -19,20 +19,28 @@ import {
   TextFontRegular,
 } from '@fluentui/react-icons';
 import type { Meta } from '@storybook/react';
-import { steps } from './utils';
 
 export default {
   title: 'Toolbar Converged',
   component: Toolbar,
   decorators: [
     story => (
-      <StoryWright steps={steps}>
-        <div className="testWrapper" style={{ width: '600px' }}>
-          {story()}
-        </div>
-      </StoryWright>
+      <div className="testWrapper" style={{ width: '600px' }}>
+        {story()}
+      </div>
     ),
   ],
+  parameters: {
+    storyWright: {
+      steps: new Steps()
+        .snapshot('default', { cropTo: '.testWrapper' })
+        .click('#snooze-toggle')
+        .snapshot('Toggle On', { cropTo: '.testWrapper' })
+        .mouseDown('#bold-button')
+        .snapshot('Button Pressed', { cropTo: '.testWrapper' })
+        .end(),
+    },
+  } satisfies StoryParameters,
 } satisfies Meta<typeof Toolbar>;
 
 export const Default = (props: Partial<ToolbarProps>) => (

--- a/apps/vr-tests-react-components/src/stories/Toolbar/utils.ts
+++ b/apps/vr-tests-react-components/src/stories/Toolbar/utils.ts
@@ -1,9 +1,0 @@
-import { Steps } from 'storywright';
-
-export const steps = new Steps()
-  .snapshot('default', { cropTo: '.testWrapper' })
-  .click('#snooze-toggle')
-  .snapshot('Toggle On', { cropTo: '.testWrapper' })
-  .mouseDown('#bold-button')
-  .snapshot('Button Pressed', { cropTo: '.testWrapper' })
-  .end();

--- a/apps/vr-tests-react-components/src/stories/Tooltip/Tooltip.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Tooltip/Tooltip.stories.tsx
@@ -4,10 +4,16 @@ import { Tooltip } from '@fluentui/react-tooltip';
 
 import { useStyles } from './utils';
 import { DARK_MODE, getStoryVariant, HIGH_CONTRAST, TestWrapperDecorator } from '../../utilities';
+import { Steps, type StoryParameters } from 'storywright';
 
 export default {
   title: 'Tooltip Converged',
   decorators: [TestWrapperDecorator],
+  parameters: {
+    storyWright: {
+      steps: new Steps().snapshot('default', { cropTo: '.testWrapper' }).end(),
+    },
+  } satisfies StoryParameters,
 } satisfies Meta<typeof Tooltip>;
 
 export const Basic = () => (

--- a/apps/vr-tests-react-components/src/stories/Tooltip/TooltipPositioning.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Tooltip/TooltipPositioning.stories.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import type { Meta } from '@storybook/react';
-import { Steps } from 'storywright';
+import { Steps, type StoryParameters } from 'storywright';
 import { Tooltip } from '@fluentui/react-tooltip';
 import type { PositioningProps } from '@fluentui/react-positioning';
 import { useStyles } from './utils';
-import { getStoryVariant, withStoryWrightSteps, TestWrapperDecorator, RTL, HIGH_CONTRAST } from '../../utilities';
+import { getStoryVariant, TestWrapperDecorator, RTL, HIGH_CONTRAST } from '../../utilities';
 
 const TooltipPositioning: React.FC = () => {
   const positions = [
@@ -129,24 +129,26 @@ const TooltipPositioningWithFallbacks: React.FC = () => {
 
 export default {
   title: 'Tooltip Converged',
-
-  decorators: [
-    TestWrapperDecorator,
-    story =>
-      withStoryWrightSteps({
-        story,
-        steps: new Steps().click('#show-tooltips').snapshot('positioned tooltips', { cropTo: '.testWrapper' }).end(),
-      }),
-  ],
+  decorators: [TestWrapperDecorator],
 } satisfies Meta<typeof Tooltip>;
 
 export const Positioning = () => <TooltipPositioning />;
 
 Positioning.storyName = 'positioning';
+Positioning.parameters = {
+  storyWright: {
+    steps: new Steps().click('#show-tooltips').snapshot('positioned tooltips', { cropTo: '.testWrapper' }).end(),
+  },
+} satisfies StoryParameters;
 
 export const PositioningwithFallbacks = () => <TooltipPositioningWithFallbacks />;
 
 PositioningwithFallbacks.storyName = 'positioning with fallbacks';
+PositioningwithFallbacks.parameters = {
+  storyWright: {
+    steps: new Steps().snapshot('positioning fallbacks', { cropTo: '.testWrapper' }).end(),
+  },
+} satisfies StoryParameters;
 
 export const PositioningRTL = getStoryVariant(Positioning, RTL);
 

--- a/apps/vr-tests-react-components/src/stories/Tree.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Tree.stories.tsx
@@ -16,7 +16,7 @@ import { Button } from '@fluentui/react-button';
 import { Menu, MenuItem, MenuList, MenuPopover, MenuTrigger } from '@fluentui/react-menu';
 import type { Meta } from '@storybook/react';
 import { DARK_MODE, getStoryVariant, HIGH_CONTRAST, RTL } from '../utilities';
-import { Steps, StoryWright } from 'storywright';
+import { Steps, type StoryParameters } from 'storywright';
 import {
   CaretDownRegular,
   CaretRightRegular,
@@ -33,6 +33,9 @@ import { Avatar } from '@fluentui/react-avatar';
 
 export default {
   title: 'Tree',
+  parameters: {
+    storyWright: { steps: new Steps().snapshot('default').end() },
+  } satisfies StoryParameters,
 } satisfies Meta<typeof Tree>;
 
 export const Default = () => (
@@ -128,22 +131,7 @@ export const DefaultOpenTreeRTL = getStoryVariant(DefaultOpenTree, RTL);
 
 export const Appearance = () => {
   return (
-    <StoryWright
-      steps={new Steps()
-        .hover('#subtle-tree')
-        .snapshot('Subtle tree hover')
-        .mouseDown('#subtle-tree')
-        .snapshot('Subtle tree mousedown')
-        .hover('#subtle-alpha-tree')
-        .snapshot('Subtle alpha tree hover')
-        .mouseDown('#subtle-alpha-tree')
-        .snapshot('Subtle alpha tree mousedown')
-        .hover('#transparent-tree')
-        .snapshot('Transparent tree hover')
-        .mouseDown('#transparent-tree')
-        .snapshot('Transparent tree mousedown')
-        .end()}
-    >
+    <>
       <Tree id="subtle-tree" aria-label="Tree">
         <TreeItem itemType="leaf">
           <TreeItemLayout>Subtle tree item</TreeItemLayout>
@@ -159,10 +147,28 @@ export const Appearance = () => {
           <TreeItemLayout>Transparent tree item</TreeItemLayout>
         </TreeItem>
       </Tree>
-    </StoryWright>
+    </>
   );
 };
 Appearance.storyName = 'appearance';
+Appearance.parameters = {
+  storyWright: {
+    steps: new Steps()
+      .hover('#subtle-tree')
+      .snapshot('Subtle tree hover')
+      .mouseDown('#subtle-tree')
+      .snapshot('Subtle tree mousedown')
+      .hover('#subtle-alpha-tree')
+      .snapshot('Subtle alpha tree hover')
+      .mouseDown('#subtle-alpha-tree')
+      .snapshot('Subtle alpha tree mousedown')
+      .hover('#transparent-tree')
+      .snapshot('Transparent tree hover')
+      .mouseDown('#transparent-tree')
+      .snapshot('Transparent tree mousedown')
+      .end(),
+  },
+} satisfies StoryParameters;
 
 export const AppearanceDarkMode = getStoryVariant(Appearance, DARK_MODE);
 
@@ -539,20 +545,26 @@ export const FlatTreeSingleSelection = () => {
   });
 
   return (
-    <StoryWright steps={new Steps().click('#2-1').snapshot('flat tree single selection selected 1').end()}>
-      <FlatTree selectionMode="single" {...flatTree.getTreeProps()} aria-label="Tree">
-        {Array.from(flatTree.items(), item => {
-          return (
-            <TreeItem {...item.getTreeItemProps()} key={item.value}>
-              <TreeItemLayout>{item.value}</TreeItemLayout>
-            </TreeItem>
-          );
-        })}
-      </FlatTree>
-    </StoryWright>
+    <FlatTree selectionMode="single" {...flatTree.getTreeProps()} aria-label="Tree">
+      {Array.from(flatTree.items(), item => {
+        return (
+          <TreeItem {...item.getTreeItemProps()} key={item.value}>
+            <TreeItemLayout>{item.value}</TreeItemLayout>
+          </TreeItem>
+        );
+      })}
+    </FlatTree>
   );
 };
 FlatTreeSingleSelection.storyName = 'flat tree single selection';
+FlatTreeSingleSelection.parameters = {
+  storyWright: {
+    steps: new Steps()
+      .click(`#${CSS.escape('2-1')}`)
+      .snapshot('flat tree single selection selected 1')
+      .end(),
+  },
+} satisfies StoryParameters;
 
 export const FlatTreeSingleSelectionDarkMode = getStoryVariant(FlatTreeSingleSelection, DARK_MODE);
 
@@ -567,20 +579,26 @@ export const FlatTreeMultiSelection = () => {
   });
 
   return (
-    <StoryWright steps={new Steps().click('#1-1').snapshot('flat tree multi selection selected 1-1').end()}>
-      <FlatTree {...flatTree.getTreeProps()} aria-label="Tree">
-        {Array.from(flatTree.items(), item => {
-          return (
-            <TreeItem {...item.getTreeItemProps()} key={item.value}>
-              <TreeItemLayout>{item.value}</TreeItemLayout>
-            </TreeItem>
-          );
-        })}
-      </FlatTree>
-    </StoryWright>
+    <FlatTree {...flatTree.getTreeProps()} aria-label="Tree">
+      {Array.from(flatTree.items(), item => {
+        return (
+          <TreeItem {...item.getTreeItemProps()} key={item.value}>
+            <TreeItemLayout>{item.value}</TreeItemLayout>
+          </TreeItem>
+        );
+      })}
+    </FlatTree>
   );
 };
 FlatTreeMultiSelection.storyName = 'flat tree multi selection';
+FlatTreeMultiSelection.parameters = {
+  storyWright: {
+    steps: new Steps()
+      .click(`#${CSS.escape('1-1')}`)
+      .snapshot('flat tree multi selection selected 1-1')
+      .end(),
+  },
+} satisfies StoryParameters;
 
 export const FlatTreeMultiSelectionDarkMode = getStoryVariant(FlatTreeMultiSelection, DARK_MODE);
 

--- a/apps/vr-tests-react-components/src/utilities/getStoryVariant.tsx
+++ b/apps/vr-tests-react-components/src/utilities/getStoryVariant.tsx
@@ -9,15 +9,19 @@ export const RTL = 'RTL';
 
 type StoryVariant = typeof DARK_MODE | typeof HIGH_CONTRAST | typeof RTL;
 
+function isStoryFn(story: StoryFn | StoryObj): story is StoryFn {
+  return typeof story === 'function';
+}
+
 /** Helper function that returns RTL, Dark Mode or High Contrast variant of an existing story. */
-export function getStoryVariant(story: StoryFn, variant: StoryVariant) {
+export function getStoryVariant(story: StoryFn | StoryObj, variant: StoryVariant): StoryObj {
   const theme = getTheme(variant);
   const dir = getDir(variant);
   const decorators = story.decorators ?? [];
 
   return {
     ...story,
-    render: story,
+    render: isStoryFn(story) ? story : story.render,
     storyName: `${getStoryName(story)} - ${variant}`,
     parameters: {
       ...story.parameters,
@@ -52,6 +56,6 @@ function getDir(variant: StoryVariant) {
   return variant === RTL ? 'rtl' : 'ltr';
 }
 
-function getStoryName<TArgs = Args>({ name, storyName }: StoryFn<TArgs>) {
+function getStoryName<TArgs = Args>({ name, storyName }: StoryFn<TArgs> | StoryObj<TArgs>) {
   return storyName ?? name?.replace(/([a-z])([A-Z])/g, '$1 $2');
 }

--- a/apps/vr-tests-react-components/src/utilities/getStoryVariant.tsx
+++ b/apps/vr-tests-react-components/src/utilities/getStoryVariant.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import type { Args, Decorator, StoryFn, StoryObj } from '@storybook/react';
 import { FluentProvider } from '@fluentui/react-provider';
-import { webLightTheme, webDarkTheme, teamsHighContrastTheme } from '@fluentui/react-theme';
+import { webLightTheme, webDarkTheme, teamsHighContrastTheme, type Theme } from '@fluentui/react-theme';
 
 export const DARK_MODE = 'Dark Mode';
 export const HIGH_CONTRAST = 'High Contrast';
@@ -13,8 +13,13 @@ function isStoryFn(story: StoryFn | StoryObj): story is StoryFn {
   return typeof story === 'function';
 }
 
+interface StoryObjVariant extends StoryObj {
+  storyName: string;
+  parameters: StoryObj['parameters'] & { dir: ReturnType<typeof getDir>; theme: Theme; mode: 'vr-test' };
+}
+
 /** Helper function that returns RTL, Dark Mode or High Contrast variant of an existing story. */
-export function getStoryVariant(story: StoryFn | StoryObj, variant: StoryVariant): StoryObj {
+export function getStoryVariant(story: StoryFn | StoryObj, variant: StoryVariant): StoryObjVariant {
   const theme = getTheme(variant);
   const dir = getDir(variant);
   const decorators = story.decorators ?? [];
@@ -30,7 +35,7 @@ export function getStoryVariant(story: StoryFn | StoryObj, variant: StoryVariant
       theme,
     },
     decorators: [...(Array.isArray(decorators) ? decorators : [decorators]), StoryVariantDecorator],
-  } satisfies StoryObj;
+  } satisfies StoryObjVariant;
 }
 
 const StoryVariantDecorator: Decorator = (storyFn, context) => {

--- a/apps/vr-tests-react-components/src/utilities/withStoryWrightSteps.tsx
+++ b/apps/vr-tests-react-components/src/utilities/withStoryWrightSteps.tsx
@@ -2,6 +2,11 @@ import * as React from 'react';
 import { StoryWright, Step } from 'storywright';
 import type { StoryContext } from '@storybook/react';
 
+/**
+ *
+ * @deprecated - set Steps via Story.parameters.storyWright API
+ * This throws error if griffel `makeStyles` apis are used to tweak story rendering
+ */
 export const withStoryWrightSteps = ({
   story,
   context,

--- a/package.json
+++ b/package.json
@@ -325,7 +325,7 @@
     "source-map-loader": "4.0.0",
     "storybook": "7.6.20",
     "storybook-addon-performance": "0.17.3",
-    "storywright": "0.0.27-storybook7.11",
+    "storywright": "0.0.27-storybook7.12",
     "strip-ansi": "6.0.0",
     "style-loader": "2.0.0",
     "swc-loader": "0.2.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -21741,10 +21741,10 @@ storybook@7.6.20:
   dependencies:
     "@storybook/cli" "7.6.20"
 
-storywright@0.0.27-storybook7.11:
-  version "0.0.27-storybook7.11"
-  resolved "https://registry.yarnpkg.com/storywright/-/storywright-0.0.27-storybook7.11.tgz#c032deedd83c82895b09fc17b7404d397b1ebedf"
-  integrity sha512-B/tte/PyJ6MATFvMsGlv3+Yy3dSmzmWYyLYx/ijWwbUQ8O6BqDkkmmgVlsFrgydfsCu3CX2qVXPsNEQjYW8cEQ==
+storywright@0.0.27-storybook7.12:
+  version "0.0.27-storybook7.12"
+  resolved "https://registry.yarnpkg.com/storywright/-/storywright-0.0.27-storybook7.12.tgz#73622ccbacade15621036df584da71cefe7c5c7a"
+  integrity sha512-EmkTHFfOH09YiAMgziIT53c4MIt/J8an7X2Ebwvt+NYuOBiZteH620AkyIFhiIRXEzATzNrpkBf7f/JSuYdXXQ==
   dependencies:
     playwright "^1.34.3"
     prop-types "^15.6.0"
@@ -21791,7 +21791,7 @@ string-length@^5.0.1:
     char-regex "^2.0.0"
     strip-ansi "^7.0.1"
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -21825,15 +21825,6 @@ string-width@^3.0.0, string-width@^3.1.0:
     emoji-regex "^7.0.1"
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -21935,7 +21926,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -21969,13 +21960,6 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
@@ -24306,7 +24290,7 @@ workspace-tools@^0.27.0:
     js-yaml "^4.1.0"
     micromatch "^4.0.0"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -24336,15 +24320,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

- migrates to new StoryWright version
- migrates problematic v9 VR Tests to new StoryWright API
- enables failing CI if invalid VR Tests are part of PR

> NOTE: `v9` - `vr-tests-react-components` (includes charting as well)

| Issue | Before | After |
|--------|--------|--------|
| `Steps object is undefined (v9)` | 545 | 0 / 𝚫100% improvement  |
| `errors occurred while processing Stories to obtain Steps definitions:` | 149 | 0 / 𝚫100% improvement  |
| `VR tests count (v9)` | 2750 | 2850 / 𝚫4% improvement  |
|`making screenshots pass rate` | 70% | 100%  | 

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Needs https://github.com/microsoft/storywright/pull/73
- Fixes https://github.com/microsoft/fluentui/issues/33861
