### PR TITLE
fix: In usePositioning, ensure that the target ref is initialised with the positioning target if it exists

### DIFF
--- a/change/@fluentui-react-positioning-253d8c47-f0ff-42db-b41a-a16123584089.json
+++ b/change/@fluentui-react-positioning-253d8c47-f0ff-42db-b41a-a16123584089.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Initialize positioning targetRef with target passed in options if available",
+  "packageName": "@fluentui/react-positioning",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-positioning/src/usePositioning.ts
+++ b/packages/react-components/react-positioning/src/usePositioning.ts
@@ -33,7 +33,7 @@ export function usePositioning(options: PositioningProps & PositioningOptions): 
   'use no memo';
 
   const managerRef = React.useRef<PositionManager | null>(null);
-  const targetRef = React.useRef<TargetElement | null>(null);
+  const targetRef = React.useRef<TargetElement | null>(options.target ?? null);
   const overrideTargetRef = React.useRef<TargetElement | null>(null);
   const containerRef = React.useRef<HTMLElement | null>(null);
   const arrowRef = React.useRef<HTMLElement | null>(null);
@@ -131,7 +131,7 @@ export function usePositioning(options: PositioningProps & PositioningOptions): 
     }, []);
   }
 
-  const setTarget = useCallbackRef<TargetElement>(null, target => {
+  const setTarget = useCallbackRef<TargetElement>(targetRef.current, target => {
     if (targetRef.current !== target) {
       targetRef.current = target;
       updatePositionManager();

--- a/packages/react-components/react-positioning/src/usePositioning.ts
+++ b/packages/react-components/react-positioning/src/usePositioning.ts
@@ -63,6 +63,13 @@ export function usePositioning(options: PositioningProps & PositioningOptions): 
     updatePositionManager();
   });
 
+  const setTarget = useCallbackRef<TargetElement>(targetRef.current, target => {
+    if (targetRef.current !== target) {
+      targetRef.current = target;
+      updatePositionManager();
+    }
+  });
+
   React.useImperativeHandle(
     options.positioningRef,
     () => ({
@@ -77,9 +84,11 @@ export function usePositioning(options: PositioningProps & PositioningOptions): 
         }
 
         setOverrideTarget(target);
+        // Ensure the target ref is kept up to date.
+        setTarget.current = target;
       },
     }),
-    [options.target, setOverrideTarget],
+    [setTarget, options.target, setOverrideTarget],
   );
 
   useIsomorphicLayoutEffect(() => {
@@ -130,13 +139,6 @@ export function usePositioning(options: PositioningProps & PositioningOptions): 
       // TODO: Should be rework to handle options.enabled and contentRef updates
     }, []);
   }
-
-  const setTarget = useCallbackRef<TargetElement>(targetRef.current, target => {
-    if (targetRef.current !== target) {
-      targetRef.current = target;
-      updatePositionManager();
-    }
-  });
 
   const onPositioningEnd = useEventCallback(() => options.onPositioningEnd?.());
   const setContainer = useCallbackRef<HTMLElement | null>(null, container => {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [X] Code is up-to-date with the `master` branch
* [X] Your changes are covered by tests (if possible)
* [X] You've run `yarn change` locally


PR flow tips:
* [X] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
`usePositioning.ts` created a `targetRef` initialized to null. Later on, using `useCallbackRef`, it would create `setTarget` which would update the ref if used. However, in cases where a custom trigger is used, this setTarget ref is not exposed, so it is not passed into the target. Therefore, the target ref is never updated, and thus, when we use `useOnClickOutside` in `usePopover`, it thinks, clicking the custom trigger is outside the popover, therefore closing it. However, this results in the popover re-opening.

## New Behavior

The target references are initialized correctly so that the popover's click outside handlers ignore clicks on the trigger.

## Related Issue(s)

- Fixes #33862 
