### PR TITLE
fix(KeytipTree): refactor updateNode to improve parent handling

### DIFF
--- a/change/@fluentui-react-cbf71cd7-350f-40b3-8bad-303f3e8a150b.json
+++ b/change/@fluentui-react-cbf71cd7-350f-40b3-8bad-303f3e8a150b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(KeytipTree): refactor updateNode to improve parent handling",
+  "packageName": "@fluentui/react",
+  "email": "walterb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/KeytipLayer/KeytipTree.ts
+++ b/packages/react/src/components/KeytipLayer/KeytipTree.ts
@@ -58,16 +58,15 @@ export class KeytipTree {
    * @param uniqueID - Unique ID for this keytip
    */
   public updateNode(keytipProps: IKeytipProps, uniqueID: string): void {
-    const fullSequence = this._getFullSequence(keytipProps);
-    const nodeID = sequencesToID(fullSequence);
-
-    // Take off the last item to calculate the parent sequence
-    fullSequence.pop();
-    // Parent ID is the root if there aren't any more sequences
-    const parentID = this._getParentID(fullSequence);
     const node = this.nodeMap[uniqueID];
-    const prevParent = node.parent;
     if (node) {
+      const fullSequence = this._getFullSequence(keytipProps);
+      const nodeID = sequencesToID(fullSequence);
+      // Take off the last item to calculate the parent sequence
+      fullSequence.pop();
+      // Parent ID is the root if there aren't any more sequences
+      const parentID = this._getParentID(fullSequence);
+      const prevParent = node.parent;
       // Fix parent nodes if needed
       if (prevParent !== parentID) {
         // If parent has changed, remove child from old parent


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

**COMPONENT ERROR: Cannot read properties of undefined (reading 'parent')**

webpack://owa/node_modules/@fluentui/react/lib/components/src/components/KeytipLayer/KeytipTree.ts parent 69
webpack://owa/node_modules/@fluentui/react/lib/components/src/components/KeytipLayer/KeytipLayer.base.tsx updateNode 520
webpack://owa/node_modules/@fluentui/utilities/src/EventGroup.ts apply 258
webpack://owa/node_modules/@fluentui/utilities/src/EventGroup.ts call 109
webpack://owa/node_modules/@fluentui/react/lib/utilities/src/utilities/keytips/KeytipManager.ts raise 107
webpack://owa/node_modules/@fluentui/react/lib/components/src/components/KeytipData/useKeytipData.ts update 35

## New Behavior

No errors should occur when obtaining the parent node.

## Related Issue(s)

- Fixes #33866
