### PR TITLE
fix(react): trigger v8 release to fix production source-maps issues

### DIFF
--- a/change/@fluentui-set-version-387b41d1-8143-430e-b11f-46ccaa9f229b.json
+++ b/change/@fluentui-set-version-387b41d1-8143-430e-b11f-46ccaa9f229b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: trigger v8 release to fix production source-maps issues",
+  "packageName": "@fluentui/set-version",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

users on Windows OS started to run into build failures caused by sourcemaps.

```
ERROR in ../../.store/@fluentui-react-window-provider@2.2.28-15ac61a2cbcde8b63c53/node_modules/@fluentui/react-window-provider/lib/version.js
Module Warning (from ../../.store/source-map-loader@4.0.1-e7a97479dfc7ed968bba/node_modules/source-map-loader/dist/cjs.js):
Failed to parse source map from 'D:\project\.store\@fluentui-react-window-provider@2.2.28-15ac61a2cbcde8b63c53\node_modules\@fluentui\react-window-provider\src\version.ts' file: Error: ENOENT: no such file or directory, open 'D:\project\.store\@fluentui-react-window-provider@2.2.28-15ac61a2cbcde8b63c53\node_modules\@fluentui\react-window-provider\src\version.ts'
@ ../../.store/@fluentui-react-window-provider@2.2.28-15ac61a2cbcde8b63c53/node_modules/@fluentui/react-window-provider/lib/index.js 4:0-19
@ ../../.store/@fluentui-react@8.122.9-4e8f52f85c1f354deb12/node_modules/@fluentui/react/lib/WindowProvider.js 2:0-104 2:0-104 2:0-104 2:0-104 2:0-104
@ ../../.store/@fluentui-react@8.122.9-4e8f52f85c1f354deb12/node_modules/@fluentui/react/lib/index.js 84:0-89 84:0-89 84:0-89 84:0-89 84:0-89
@ ../../packages/devtools/lib/tools/RecordForcedLayout/RecordForcedLayoutDevTool.js 5:0-76 63:28-41 68:28-39 68:112-130
@ ./lib/DevTools/DevToolsMenu.js 5:0-127 23:187-212
@ ./lib/DevTools/DevToolsPackage.js 32:8-71 15:4-67
@ ./lib/initFlight.js 3:0-55
@ ./lib/editor.js 81:0-72 95:0-25
```

The regression is happening between `@fluentui/react-window-provider` v2.2.27 and latest (v2.2.28)

## New Behavior

Source map regression was introduced while migrating from lage to nx https://github.com/microsoft/fluentui/pull/31949/files#diff-5e8587d286147d7d9c3c06cd84688c03813f6729558eb46983753cac7c1b6a6b

> **What was the issue?:** because `lint` depends on `build` and had not set `--production` the cache was not used and production asset was rebuild without proper flag, thus not setting TS config settings as expected https://github.com/microsoft/fluentui/blob/master/scripts/tasks/src/ts.ts#L20-L25

This was then later fixed https://github.com/microsoft/fluentui/pull/32195/files#diff-5e8587d286147d7d9c3c06cd84688c03813f6729558eb46983753cac7c1b6a6b

it seems after the fix not all v8 packages have been re-released to accomodate proper changes.

This PR force bumps `set-version` package which will trigger PATCH bump release for all v8

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
