### PR TITLE
docs(`react-examples`): Preventing dismiss on resize on `ContextualMenu` example that renders a `SearchBox` within its menu list

### DIFF
--- a/packages/react-examples/src/react/ContextualMenu/ContextualMenu.CustomMenuList.Example.tsx
+++ b/packages/react-examples/src/react/ContextualMenu/ContextualMenu.CustomMenuList.Example.tsx
@@ -72,6 +72,12 @@ export const ContextualMenuWithCustomMenuListExample: React.FunctionComponent = 
 
   const menuProps = React.useMemo(
     () => ({
+      calloutProps: {
+        // This is needed for Android devices since focus automatically goes to the first focusable element in the
+        // callout, which in this case is the SearchBox. This in turn opens the keyboard, which on the aforementioned
+        // Android devices causes a window resize that will dismiss the menu if this prop is not set to true.
+        preventDismissOnResize: true,
+      },
       onRenderMenuList: renderMenuList,
       title: 'Actions',
       shouldFocusOnMount: true,


### PR DESCRIPTION
## Change

This PR adds `preventDismissOnResize` to the `ContextualMenu` example that renders a `SearchBox` within the menu list. This is done to prevent the menu from being dismissed in Android devices when the keyboard is opened on focus of the `SearchBox` (which is automatically focused as the first item when the menu is opened), as this triggers a window resize event in Android devices.