### PR TITLE
fix(react-color-picker): place thumb outside of Sliders and ColorArea

### DIFF
--- a/change/@fluentui-react-color-picker-preview-8713fe9e-a809-45c5-9ecc-d05c8e596a2a.json
+++ b/change/@fluentui-react-color-picker-preview-8713fe9e-a809-45c5-9ecc-d05c8e596a2a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: placed thumb half outside of colorSlider and colorArea",
+  "packageName": "@fluentui/react-color-picker-preview",
+  "email": "vkozlova@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-color-picker-preview/library/src/components/AlphaSlider/useAlphaSliderStyles.styles.ts
+++ b/packages/react-components/react-color-picker-preview/library/src/components/AlphaSlider/useAlphaSliderStyles.styles.ts
@@ -20,17 +20,10 @@ export const alphaSliderCSSVars = {
   railColorVar: `--fui-AlphaSlider__rail--color`,
 };
 
-// Internal CSS variables
-const thumbPositionVar = `--fui-AlphaSlider__thumb--position`;
-const innerThumbRadiusVar = `--fui-AlphaSlider__thumb--radius`;
-
 /**
  * Styles for the root slot
  */
 const useStyles = makeStyles({
-  root: {
-    [innerThumbRadiusVar]: '6px',
-  },
   rail: {
     border: `1px solid ${tokens.colorNeutralStroke1}`,
     backgroundImage: `linear-gradient(var(${alphaSliderCSSVars.sliderDirectionVar}), transparent, var(${alphaSliderCSSVars.railColorVar})), url(${TRANSPARENT_IMAGE_URL})`,
@@ -43,18 +36,17 @@ const useStyles = makeStyles({
 const useThumbStyles = makeStyles({
   thumb: {
     backgroundColor: tokens.colorNeutralBackground1,
-    [`${thumbPositionVar}`]: `clamp(var(${innerThumbRadiusVar}), var(${alphaSliderCSSVars.sliderProgressVar}), calc(100% - var(${innerThumbRadiusVar})))`,
     '::before': {
       backgroundColor: `var(${alphaSliderCSSVars.thumbColorVar})`,
     },
   },
   horizontal: {
     transform: 'translateX(-50%)',
-    left: `var(${thumbPositionVar})`,
+    left: `var(${alphaSliderCSSVars.sliderProgressVar})`,
   },
   vertical: {
     transform: 'translateY(50%)',
-    bottom: `var(${thumbPositionVar})`,
+    bottom: `var(${alphaSliderCSSVars.sliderProgressVar})`,
   },
 });
 
@@ -66,7 +58,7 @@ export const useAlphaSliderStyles_unstable = (state: AlphaSliderState): AlphaSli
 
   const styles = useStyles();
   const thumbStyles = useThumbStyles();
-  state.root.className = mergeClasses(alphaSliderClassNames.root, styles.root, state.root.className);
+  state.root.className = mergeClasses(alphaSliderClassNames.root, state.root.className);
   state.input.className = mergeClasses(alphaSliderClassNames.input, state.input.className);
   state.rail.className = mergeClasses(alphaSliderClassNames.rail, styles.rail, state.rail.className);
 

--- a/packages/react-components/react-color-picker-preview/library/src/components/ColorArea/useColorAreaStyles.styles.ts
+++ b/packages/react-components/react-color-picker-preview/library/src/components/ColorArea/useColorAreaStyles.styles.ts
@@ -20,9 +20,6 @@ export const colorAreaCSSVars = {
 
 // Internal CSS variables
 const thumbSizeVar = `--fui-Slider__thumb--size`;
-const thumbPositionXVar = `--fui-AlphaSlider__thumb--positionX`;
-const thumbPositionYVar = `--fui-AlphaSlider__thumb--positionY`;
-const innerThumbRadiusVar = `--fui-AlphaSlider__thumb--radius`;
 
 /**
  * Styles for the root slot
@@ -40,7 +37,7 @@ const useRootStyles = makeResetStyles({
   minWidth: '300px',
   minHeight: '300px',
   boxSizing: 'border-box',
-  [innerThumbRadiusVar]: '6px',
+  marginBottom: tokens.spacingVerticalSNudge,
 });
 
 /**
@@ -59,10 +56,8 @@ const useThumbStyles = makeStyles({
     boxShadow: tokens.shadow4,
     backgroundColor: `var(${colorAreaCSSVars.thumbColorVar})`,
     transform: 'translate(-50%, 50%)',
-    [`${thumbPositionXVar}`]: `clamp(var(${innerThumbRadiusVar}), var(${colorAreaCSSVars.areaXProgressVar}), calc(100% - var(${innerThumbRadiusVar})))`,
-    [`${thumbPositionYVar}`]: `clamp(var(${innerThumbRadiusVar}), var(${colorAreaCSSVars.areaYProgressVar}), calc(100% - var(${innerThumbRadiusVar})))`,
-    left: `var(${thumbPositionXVar})`,
-    bottom: `var(${thumbPositionYVar})`,
+    left: `var(${colorAreaCSSVars.areaXProgressVar})`,
+    bottom: `var(${colorAreaCSSVars.areaYProgressVar})`,
     '::before': {
       position: 'absolute',
       inset: '0px',

--- a/packages/react-components/react-color-picker-preview/library/src/components/ColorPicker/useColorPickerStyles.styles.ts
+++ b/packages/react-components/react-color-picker-preview/library/src/components/ColorPicker/useColorPickerStyles.styles.ts
@@ -1,6 +1,7 @@
 import { makeStyles, mergeClasses } from '@griffel/react';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import type { ColorPickerSlots, ColorPickerState } from './ColorPicker.types';
+import { tokens } from '@fluentui/react-theme';
 
 export const colorPickerClassNames: SlotClassNames<ColorPickerSlots> = {
   root: 'fui-ColorPicker',
@@ -13,6 +14,7 @@ const useStyles = makeStyles({
   root: {
     display: 'flex',
     flexDirection: 'column',
+    gap: tokens.spacingVerticalXS,
   },
 });
 

--- a/packages/react-components/react-color-picker-preview/library/src/components/ColorSlider/useColorSliderStyles.styles.ts
+++ b/packages/react-components/react-color-picker-preview/library/src/components/ColorSlider/useColorSliderStyles.styles.ts
@@ -15,13 +15,9 @@ export const colorSliderCSSVars = {
   sliderProgressVar: `--fui-Slider--progress`,
   thumbColorVar: `--fui-Slider__thumb--color`,
   railColorVar: `--fui-Slider__rail--color`,
+  thumbSizeVar: `--fui-Slider__thumb--size`,
+  railSizeVar: `--fui-Slider__rail--size`,
 };
-
-// Internal CSS variables
-const thumbSizeVar = `--fui-Slider__thumb--size`;
-const railSizeVar = `--fui-Slider__rail--size`;
-const innerThumbRadiusVar = `--fui-Slider__inner-thumb--radius`;
-const thumbPositionVar = `--fui-Slider__thumb--position`;
 
 const hueBackground = `linear-gradient(${[
   `var(${colorSliderCSSVars.sliderDirectionVar})`,
@@ -43,9 +39,8 @@ const useRootStyles = makeResetStyles({
   touchAction: 'none',
   alignItems: 'center',
   justifyItems: 'center',
-  [thumbSizeVar]: '20px',
-  [railSizeVar]: '20px',
-  [innerThumbRadiusVar]: '6px',
+  [colorSliderCSSVars.thumbSizeVar]: '20px',
+  [colorSliderCSSVars.railSizeVar]: '20px',
   minHeight: '32px',
 });
 
@@ -53,7 +48,7 @@ const useStyles = makeStyles({
   horizontal: {
     minWidth: '200px',
     // 3x3 grid with the rail and thumb in the center cell [2,2] and the hidden input stretching across all cells
-    gridTemplateRows: `1fr var(${thumbSizeVar}) 1fr`,
+    gridTemplateRows: `1fr var(${colorSliderCSSVars.thumbSizeVar}) 1fr`,
     gridTemplateColumns: `1fr 100% 1fr`,
   },
 
@@ -61,7 +56,7 @@ const useStyles = makeStyles({
     minHeight: '280px',
     // 3x3 grid with the rail and thumb in the center cell [2,2] and the hidden input stretching across all cells
     gridTemplateRows: `1fr 100% 1fr`,
-    gridTemplateColumns: `1fr var(${thumbSizeVar}) 1fr`,
+    gridTemplateColumns: `1fr var(${colorSliderCSSVars.thumbSizeVar}) 1fr`,
   },
 });
 
@@ -100,19 +95,19 @@ const useRailStyles = makeStyles({
 
   horizontal: {
     width: '100%',
-    height: `var(${railSizeVar})`,
+    height: `var(${colorSliderCSSVars.railSizeVar})`,
     '::before': {
       left: '-1px',
       right: '-1px',
-      height: `var(${railSizeVar})`,
+      height: `var(${colorSliderCSSVars.railSizeVar})`,
     },
   },
 
   vertical: {
-    width: `var(${railSizeVar})`,
+    width: `var(${colorSliderCSSVars.railSizeVar})`,
     height: '100%',
     '::before': {
-      width: `var(${railSizeVar})`,
+      width: `var(${colorSliderCSSVars.railSizeVar})`,
       top: '-1px',
       bottom: '1px',
     },
@@ -129,8 +124,8 @@ const useThumbStyles = makeStyles({
     gridColumnStart: '2',
     gridColumnEnd: '2',
     position: 'absolute',
-    width: `var(${thumbSizeVar})`,
-    height: `var(${thumbSizeVar})`,
+    width: `var(${colorSliderCSSVars.thumbSizeVar})`,
+    height: `var(${colorSliderCSSVars.thumbSizeVar})`,
     pointerEvents: 'none',
     outlineStyle: 'none',
     forcedColorAdjust: 'none',
@@ -138,7 +133,6 @@ const useThumbStyles = makeStyles({
     border: `${tokens.strokeWidthThin} solid ${tokens.colorNeutralForeground4}`,
     boxShadow: tokens.shadow4,
     backgroundColor: `var(${colorSliderCSSVars.thumbColorVar})`,
-    [`${thumbPositionVar}`]: `clamp(var(${innerThumbRadiusVar}), var(${colorSliderCSSVars.sliderProgressVar}), calc(100% - var(${innerThumbRadiusVar})))`,
     '::before': {
       position: 'absolute',
       inset: '0px',
@@ -150,11 +144,11 @@ const useThumbStyles = makeStyles({
   },
   horizontal: {
     transform: 'translateX(-50%)',
-    left: `var(${thumbPositionVar})`,
+    left: `var(${colorSliderCSSVars.sliderProgressVar})`,
   },
   vertical: {
     transform: 'translateY(50%)',
-    bottom: `var(${thumbPositionVar})`,
+    bottom: `var(${colorSliderCSSVars.sliderProgressVar})`,
   },
 });
 
@@ -187,12 +181,12 @@ const useInputStyles = makeStyles({
     },
   },
   horizontal: {
-    height: `var(${thumbSizeVar})`,
+    height: `var(${colorSliderCSSVars.thumbSizeVar})`,
     width: '100%',
   },
   vertical: {
     height: '100%',
-    width: `var(${thumbSizeVar})`,
+    width: `var(${colorSliderCSSVars.thumbSizeVar})`,
     'writing-mode': 'vertical-lr',
     direction: 'rtl',
   },


### PR DESCRIPTION
Fix for thumb positioning looks weird on edges:
![thumb-positioning](https://github.com/user-attachments/assets/acc83830-1617-4782-84bc-dc1fdd3f0590)

![image](https://github.com/user-attachments/assets/e4be60f9-2b66-4700-8f6b-109df1845944)
![image](https://github.com/user-attachments/assets/4c3434e8-47e8-4050-b155-44b77e1625dd)

Talked to @gouttierre and Toshie, we decided to stay with this design which is currently in V8.
![image](https://github.com/user-attachments/assets/396d7b25-12ee-4940-b652-fc602d618ab4)
![image](https://github.com/user-attachments/assets/dc57b55d-354f-4426-8db2-f60cc5859172)

## Previous Behavior
- Slider wasn't moving on edges
- Spacing is too narrow
![image](https://github.com/user-attachments/assets/77d1ef26-94a7-4d3f-ba20-9c58f1049565)


## New Behavior
- Slider is moving on edges
- Part of thumb is visible outside of ColorSlider and ColorArea
- Spacing is bigger between sliders and color area
![image](https://github.com/user-attachments/assets/681b84e3-0df0-4b9d-a7d5-1a5a3b5a8a75)
