### PR TITLE
fix(web-components): dropdown should emit change event when value changes via user input

### DIFF
--- a/change/@fluentui-web-components-faa00d2e-ce58-4ae2-88af-ae49ab82bd76.json
+++ b/change/@fluentui-web-components-faa00d2e-ce58-4ae2-88af-ae49ab82bd76.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: dropdown should emit a change event when the value changes via user input",
+  "packageName": "@fluentui/web-components",
+  "email": "863023+radium-v@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/docs/web-components.api.md
+++ b/packages/web-components/docs/web-components.api.md
@@ -653,7 +653,7 @@ export class BaseDropdown extends FASTElement {
     // @internal
     get selectedIndex(): number;
     get selectedOptions(): DropdownOption[];
-    selectOption(index?: number): void;
+    selectOption(index?: number, shouldEmit?: boolean): void;
     // @internal
     setValidity(flags?: Partial<ValidityState>, message?: string, anchor?: HTMLElement): void;
     type: DropdownType;

--- a/packages/web-components/src/dropdown/dropdown.spec.ts
+++ b/packages/web-components/src/dropdown/dropdown.spec.ts
@@ -1,19 +1,20 @@
 import { expect, test } from '../../test/playwright/index.js';
+import type { Dropdown } from './dropdown.js';
 
 test.describe('Dropdown', () => {
   test.use({
     tagName: 'fluent-dropdown',
     innerHTML: /* html */ `
       <fluent-listbox>
-          <fluent-option value="apple">Apple</fluent-option>
-          <fluent-option value="banana">Banana</fluent-option>
-          <fluent-option value="orange">Orange</fluent-option>
-          <fluent-option value="mango">Mango</fluent-option>
-          <fluent-option value="kiwi">Kiwi</fluent-option>
-          <fluent-option value="cherry">Cherry</fluent-option>
-          <fluent-option value="grapefruit">Grapefruit</fluent-option>
-          <fluent-option value="papaya">Papaya</fluent-option>
-        </fluent-listbox>
+        <fluent-option value="apple">Apple</fluent-option>
+        <fluent-option value="banana">Banana</fluent-option>
+        <fluent-option value="orange">Orange</fluent-option>
+        <fluent-option value="mango">Mango</fluent-option>
+        <fluent-option value="kiwi">Kiwi</fluent-option>
+        <fluent-option value="cherry">Cherry</fluent-option>
+        <fluent-option value="grapefruit">Grapefruit</fluent-option>
+        <fluent-option value="papaya">Papaya</fluent-option>
+      </fluent-listbox>
     `,
     waitFor: ['fluent-listbox', 'fluent-option'],
   });
@@ -345,5 +346,113 @@ test.describe('Dropdown', () => {
 
       await expect(input).toHaveValue('Kiwi');
     });
+
+    test('should emit a `change` event when the value changes and the control loses focus via blur', async ({
+      fastPage,
+      page,
+    }) => {
+      const { element } = fastPage;
+      const input = element.locator('input');
+      const listbox = element.locator('fluent-listbox');
+
+      await fastPage.setTemplate({ attributes: { type: 'combobox' } });
+
+      await input.fill('kiwi');
+
+      await expect(listbox).toBeVisible();
+
+      await expect(input).toHaveValue('kiwi');
+
+      await expect(input).toBeFocused();
+
+      await element.evaluate((el: Dropdown) => {
+        el.addEventListener('change', () => el.insertAdjacentText('afterend', 'changed'), { once: true });
+      });
+
+      await input.blur();
+
+      await expect(page.locator('text=changed')).toBeVisible();
+    });
+  });
+
+  test('should emit a `change` event when value changes and the control loses focus via click', async ({
+    fastPage,
+    page,
+  }) => {
+    const { element } = fastPage;
+    const listbox = element.locator('fluent-listbox');
+
+    await element.click();
+
+    await expect(listbox).toBeVisible();
+
+    await expect(page.locator('text=changed')).toHaveCount(0);
+
+    await element.evaluate((el: Dropdown) => {
+      el.addEventListener('change', () => el.insertAdjacentText('afterend', 'changed'), { once: true });
+    });
+
+    await expect(page.locator('text=changed')).toHaveCount(0);
+
+    await element.locator('[value=kiwi]').click();
+
+    await expect(page.locator('text=changed')).toHaveCount(1);
+
+    await expect(page.locator('text=changed')).toBeVisible();
+  });
+
+  test('should emit a `change` event when the value is confirmed by pressing Enter', async ({ fastPage }) => {
+    const { element } = fastPage;
+    const listbox = element.locator('fluent-listbox');
+
+    await element.click();
+
+    await expect(listbox).toBeVisible();
+
+    await element.press('ArrowDown');
+    await element.press('ArrowDown');
+    await element.press('ArrowDown');
+    await element.press('ArrowDown');
+    await element.press('ArrowDown');
+
+    await expect(element).toHaveJSProperty('activeIndex', 4);
+
+    const [wasChanged] = await Promise.all([
+      element.evaluate(
+        el =>
+          new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => reject('change event was not emitted'), 1000);
+            el.addEventListener(
+              'change',
+              () => {
+                clearTimeout(timeout);
+                resolve('changed');
+              },
+              { once: true },
+            );
+          }),
+      ),
+      element.evaluate(el => el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }))),
+    ]);
+
+    expect(wasChanged).toBe('changed');
+  });
+
+  test('should NOT emit a `change` event when the value is changed programmatically', async ({ fastPage, page }) => {
+    const { element } = fastPage;
+
+    await element.evaluate((el: Dropdown) => {
+      el.addEventListener('change', () => el.insertAdjacentText('afterend', 'changed'), { once: true });
+    });
+
+    await element.evaluate((el: Dropdown) => {
+      el.value = 'kiwi';
+    });
+
+    await expect(page.locator('text=changed')).toHaveCount(0);
+
+    await expect(element).toHaveJSProperty('value', 'kiwi');
+
+    await expect(element.locator('fluent-option[value=kiwi]')).toHaveJSProperty('selected', true);
   });
 });

--- a/packages/web-components/src/dropdown/dropdown.ts
+++ b/packages/web-components/src/dropdown/dropdown.ts
@@ -539,7 +539,7 @@ export class BaseDropdown extends FASTElement {
       ? this.enabledOptions.findIndex(x => x.text === this.control.value)
       : this.enabledOptions.indexOf(e.target as DropdownOption);
 
-    this.selectOption(optionIndex);
+    this.selectOption(optionIndex, true);
 
     return true;
   }
@@ -570,17 +570,21 @@ export class BaseDropdown extends FASTElement {
       return true;
     }
 
-    if (isDropdownOption(target) && !this.multiple) {
+    if (isDropdownOption(target)) {
       if (target.disabled) {
         return;
       }
 
-      if (this.isCombobox) {
-        this.control.value = target.text;
-        this.updateFreeformOption();
-      }
+      this.selectOption(this.enabledOptions.indexOf(target), true);
 
-      this.listbox.hidePopover();
+      if (!this.multiple) {
+        if (this.isCombobox) {
+          this.control.value = target.text;
+          this.updateFreeformOption();
+        }
+
+        this.listbox.hidePopover();
+      }
     }
 
     return true;
@@ -732,7 +736,7 @@ export class BaseDropdown extends FASTElement {
       case 'Enter':
       case 'Tab': {
         if (this.open) {
-          this.selectOption(this.activeIndex);
+          this.selectOption(this.activeIndex, true);
           if (this.multiple) {
             break;
           }
@@ -797,13 +801,17 @@ export class BaseDropdown extends FASTElement {
    * @param index - The index of the option to select.
    * @public
    */
-  public selectOption(index: number = this.selectedIndex): void {
+  public selectOption(index: number = this.selectedIndex, shouldEmit: boolean = false): void {
     this.listbox.selectOption(index);
     this.control.value = this.displayValue;
 
     this.setValidity();
 
     this.updateFreeformOption();
+
+    if (shouldEmit) {
+      this.$emit('change');
+    }
   }
 
   /**

--- a/packages/web-components/src/listbox/listbox.ts
+++ b/packages/web-components/src/listbox/listbox.ts
@@ -144,6 +144,10 @@ export class Listbox extends FASTElement {
    * @public
    */
   public clickHandler(e: PointerEvent): boolean | void {
+    if (this.dropdown) {
+      return true;
+    }
+
     const target = e.target as HTMLElement;
 
     if (isDropdownOption(target)) {


### PR DESCRIPTION
## Previous Behavior

The `<fluent-dropdown>` web component doesn't emit a `change` event when the value is changed via user interaction.

## New Behavior

Clicking, pressing enter, or tabbing away from the dropdown causes the dropdown to emit a `change` event when the value changes.