### PR TITLE
chore(7.0): add change file to trigger new v7 publish

### DIFF
--- a/change/@uifabric-icons-3b4073c5-cede-4e71-9cd8-1ec204871583.json
+++ b/change/@uifabric-icons-3b4073c5-cede-4e71-9cd8-1ec204871583.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: update icons base URL to point to new CDN.",
+  "packageName": "@uifabric/icons",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@uifabric-icons-3b4073c5-cede-4e71-9cd8-1ec204871583.json
+++ b/change/@uifabric-icons-3b4073c5-cede-4e71-9cd8-1ec204871583.json
@@ -2,6 +2,6 @@
   "type": "patch",
   "comment": "fix: update icons base URL to point to new CDN.",
   "packageName": "@uifabric/icons",
-  "email": "tristan.watanabe@gmail.com",
+  "email": "twatanabe@microsoft.com",
   "dependentChangeType": "patch"
 }

--- a/packages/icons/src/index.ts
+++ b/packages/icons/src/index.ts
@@ -21,6 +21,7 @@ import { initializeIcons as i17 } from './fabric-icons-17';
 import { IIconOptions } from '@uifabric/styling';
 import { registerIconAliases } from './iconAliases';
 import { getWindow } from '@uifabric/utilities';
+
 const DEFAULT_BASE_URL = 'https://res.cdn.office.net/files/fabric-cdn-prod_20241209.001/assets/icons/';
 
 /*

--- a/packages/icons/src/index.ts
+++ b/packages/icons/src/index.ts
@@ -21,7 +21,6 @@ import { initializeIcons as i17 } from './fabric-icons-17';
 import { IIconOptions } from '@uifabric/styling';
 import { registerIconAliases } from './iconAliases';
 import { getWindow } from '@uifabric/utilities';
-
 const DEFAULT_BASE_URL = 'https://res.cdn.office.net/files/fabric-cdn-prod_20241209.001/assets/icons/';
 
 /*


### PR DESCRIPTION
## Changes:
- A fix was made in #33639 to update the icon's base URL to the new CDN but nothing was published due to a missing change file. This PR adds a change file to trigger the publish.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows #33639
