### PR TITLE
ci: add v9 nightly releases support from branch

### DIFF
--- a/azure-pipelines.release-vnext-nightly.yml
+++ b/azure-pipelines.release-vnext-nightly.yml
@@ -75,7 +75,7 @@ extends:
                 # Bumps all v9 packages to a x.x.x-nightly.commitSha version and checks in change files
               - script: |
                   date=$(date +"%Y%m%d-%H%M")
-                  #release version name will follow a 0.0.0-nightly-{year}{month}{day}-{hour}{minute} format.
+                  # release version name will follow a 0.0.0-nightly-{year}{month}{day}-{hour}{minute} format.
                   yarn nx g @fluentui/workspace-plugin:version-bump --all --bumpType nightly --prereleaseTag "nightly-${date}"
                   git add .
                   git commit -m "bump nightly versions"
@@ -95,8 +95,8 @@ extends:
                 displayName: test
 
               - script: |
-                  yarn publish:beachball -n $(npmToken) --no-push --tag nightly --config scripts/beachball/src/release-vNext.config.js
-                  git reset --hard origin/master
+                  yarn publish:beachball -b origin/$(Build.SourceBranchName) -n $(npmToken) --no-push --tag nightly --config scripts/beachball/src/release-vNext.config.js
+                  git reset --hard origin/$(Build.SourceBranchName)
                 displayName: Publish changes and bump versions
 
               - template: .devops/templates/cleanup.yml@self


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

adds support to manually trigger nightly from different branch 
<img width="1383" alt="image" src="https://github.com/user-attachments/assets/7b870f9d-1e7b-43eb-9278-d74c1296fa29" />


**NOTE:** This is suitable for testing purposes without affecting main branch and official stable release


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
