### PR TITLE
docs: update positioning examples to work with page resize

### DIFF
--- a/apps/public-docsite-v9/src/Concepts/Positioning/PositioningCoverTarget.stories.tsx
+++ b/apps/public-docsite-v9/src/Concepts/Positioning/PositioningCoverTarget.stories.tsx
@@ -219,7 +219,7 @@ CoverTarget.parameters = {
 
 CoverTarget.decorators = [
   (Story: React.ElementType) => (
-    <div style={{ height: 700, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
       <Story />
     </div>
   ),

--- a/apps/public-docsite-v9/src/Concepts/Positioning/PositioningCoverTarget.stories.tsx
+++ b/apps/public-docsite-v9/src/Concepts/Positioning/PositioningCoverTarget.stories.tsx
@@ -20,32 +20,34 @@ const useExampleStyles = makeStyles({
 });
 
 const useGridExampleStyles = makeStyles({
+  wrapper: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '1em',
+    width: '100%',
+    overflow: 'scroll',
+  },
+
+  instructions: {
+    textAlign: 'center',
+  },
+
   targetContainer: {
     display: 'inline-grid',
-    gridTemplateColumns: 'repeat(5, 1fr)',
+    gridTemplateColumns: 'repeat(3, 1fr)',
     gridTemplateRows: 'repeat(5, 64px)',
     gap: '20px',
     margin: '16px 128px',
   },
 
-  instructions: {
-    gridRowStart: '3',
-    gridColumnStart: '2',
-    gridRowEnd: 'span 1',
-    gridColumnEnd: 'span 3',
-    display: 'flex',
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-
   aboveStart: {
     gridRowStart: '1',
-    gridColumnStart: '2',
+    gridColumnStart: '1',
     flexDirection: 'row-reverse',
   },
   above: {
     gridRowStart: '1',
-    gridColumnStart: '3',
+    gridColumnStart: '2',
     justifyContent: 'center',
     '& div:nth-child(2)': {
       display: 'none',
@@ -53,7 +55,7 @@ const useGridExampleStyles = makeStyles({
   },
   aboveEnd: {
     gridRowStart: '1',
-    gridColumnStart: '4',
+    gridColumnStart: '3',
   },
   beforeTop: {
     gridRowStart: '2',
@@ -82,7 +84,7 @@ const useGridExampleStyles = makeStyles({
   },
   afterTop: {
     gridRowStart: '2',
-    gridColumnStart: '5',
+    gridColumnStart: '3',
     flexDirection: 'column-reverse',
     '& div:nth-child(2)': {
       transform: 'rotate(90deg)',
@@ -90,7 +92,7 @@ const useGridExampleStyles = makeStyles({
   },
   after: {
     gridRowStart: '3',
-    gridColumnStart: '5',
+    gridColumnStart: '3',
     justifyContent: 'center',
     '& div:nth-child(2)': {
       display: 'none',
@@ -98,7 +100,7 @@ const useGridExampleStyles = makeStyles({
   },
   afterBottom: {
     gridRowStart: '4',
-    gridColumnStart: '5',
+    gridColumnStart: '3',
     flexDirection: 'column',
     '& div:nth-child(2)': {
       transform: 'rotate(90deg)',
@@ -107,14 +109,14 @@ const useGridExampleStyles = makeStyles({
   belowStart: {
     flexDirection: 'row-reverse',
     gridRowStart: '5',
-    gridColumnStart: '2',
+    gridColumnStart: '1',
     '& div:nth-child(2)': {
       transform: 'rotate(180deg)',
     },
   },
   below: {
     gridRowStart: '5',
-    gridColumnStart: '3',
+    gridColumnStart: '2',
     justifyContent: 'center',
     '& div:nth-child(2)': {
       display: 'none',
@@ -122,7 +124,7 @@ const useGridExampleStyles = makeStyles({
   },
   belowEnd: {
     gridRowStart: '5',
-    gridColumnStart: '4',
+    gridColumnStart: '3',
     '& div:nth-child(2)': {
       transform: 'rotate(180deg)',
     },
@@ -133,69 +135,71 @@ export const CoverTarget = () => {
   const styles = useGridExampleStyles();
 
   return (
-    <div className={styles.targetContainer}>
+    <div className={styles.wrapper}>
       <div className={styles.instructions}>Click each button to see its positioned element</div>
-      <PositionedComponent
-        positioning={{ position: 'above', align: 'start', coverTarget: true }}
-        targetClassName={styles.aboveStart}
-        targetContent="above-start"
-      />
-      <PositionedComponent
-        positioning={{ position: 'above', coverTarget: true }}
-        targetClassName={styles.above}
-        targetContent="above"
-      />
-      <PositionedComponent
-        positioning={{ position: 'above', align: 'end', coverTarget: true }}
-        targetClassName={styles.aboveEnd}
-        targetContent="above-end"
-      />
+      <div className={styles.targetContainer}>
+        <PositionedComponent
+          positioning={{ position: 'above', align: 'start', coverTarget: true }}
+          targetClassName={styles.aboveStart}
+          targetContent="above-start"
+        />
+        <PositionedComponent
+          positioning={{ position: 'above', coverTarget: true }}
+          targetClassName={styles.above}
+          targetContent="above"
+        />
+        <PositionedComponent
+          positioning={{ position: 'above', align: 'end', coverTarget: true }}
+          targetClassName={styles.aboveEnd}
+          targetContent="above-end"
+        />
 
-      <PositionedComponent
-        positioning={{ position: 'before', align: 'top', coverTarget: true }}
-        targetClassName={styles.beforeTop}
-        targetContent="before-top"
-      />
-      <PositionedComponent
-        positioning={{ position: 'before', coverTarget: true }}
-        targetClassName={styles.before}
-        targetContent="before"
-      />
-      <PositionedComponent
-        positioning={{ position: 'before', align: 'bottom', coverTarget: true }}
-        targetClassName={styles.beforeBottom}
-        targetContent="before-bottom"
-      />
-      <PositionedComponent
-        positioning={{ position: 'after', align: 'top', coverTarget: true }}
-        targetClassName={styles.afterTop}
-        targetContent="after-top"
-      />
-      <PositionedComponent
-        positioning={{ position: 'after', coverTarget: true }}
-        targetClassName={styles.after}
-        targetContent="after"
-      />
-      <PositionedComponent
-        positioning={{ position: 'after', align: 'bottom', coverTarget: true }}
-        targetClassName={styles.afterBottom}
-        targetContent="after-bottom"
-      />
-      <PositionedComponent
-        positioning={{ position: 'below', align: 'start', coverTarget: true }}
-        targetClassName={styles.belowStart}
-        targetContent="below-start"
-      />
-      <PositionedComponent
-        positioning={{ position: 'below', coverTarget: true }}
-        targetClassName={styles.below}
-        targetContent="below"
-      />
-      <PositionedComponent
-        positioning={{ position: 'below', align: 'end', coverTarget: true }}
-        targetClassName={styles.belowEnd}
-        targetContent="below-end"
-      />
+        <PositionedComponent
+          positioning={{ position: 'before', align: 'top', coverTarget: true }}
+          targetClassName={styles.beforeTop}
+          targetContent="before-top"
+        />
+        <PositionedComponent
+          positioning={{ position: 'before', coverTarget: true }}
+          targetClassName={styles.before}
+          targetContent="before"
+        />
+        <PositionedComponent
+          positioning={{ position: 'before', align: 'bottom', coverTarget: true }}
+          targetClassName={styles.beforeBottom}
+          targetContent="before-bottom"
+        />
+        <PositionedComponent
+          positioning={{ position: 'after', align: 'top', coverTarget: true }}
+          targetClassName={styles.afterTop}
+          targetContent="after-top"
+        />
+        <PositionedComponent
+          positioning={{ position: 'after', coverTarget: true }}
+          targetClassName={styles.after}
+          targetContent="after"
+        />
+        <PositionedComponent
+          positioning={{ position: 'after', align: 'bottom', coverTarget: true }}
+          targetClassName={styles.afterBottom}
+          targetContent="after-bottom"
+        />
+        <PositionedComponent
+          positioning={{ position: 'below', align: 'start', coverTarget: true }}
+          targetClassName={styles.belowStart}
+          targetContent="below-start"
+        />
+        <PositionedComponent
+          positioning={{ position: 'below', coverTarget: true }}
+          targetClassName={styles.below}
+          targetContent="below"
+        />
+        <PositionedComponent
+          positioning={{ position: 'below', align: 'end', coverTarget: true }}
+          targetClassName={styles.belowEnd}
+          targetContent="below-end"
+        />
+      </div>
     </div>
   );
 };

--- a/apps/public-docsite-v9/src/Concepts/Positioning/PositioningShorthandPositions.stories.tsx
+++ b/apps/public-docsite-v9/src/Concepts/Positioning/PositioningShorthandPositions.stories.tsx
@@ -188,7 +188,7 @@ ShorthandPositions.parameters = {
 
 ShorthandPositions.decorators = [
   (Story: React.ElementType) => (
-    <div style={{ height: 700, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
       <Story />
     </div>
   ),

--- a/apps/public-docsite-v9/src/Concepts/Positioning/PositioningShorthandPositions.stories.tsx
+++ b/apps/public-docsite-v9/src/Concepts/Positioning/PositioningShorthandPositions.stories.tsx
@@ -20,32 +20,34 @@ const useExampleStyles = makeStyles({
 });
 
 const useGridExampleStyles = makeStyles({
+  wrapper: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '1em',
+    width: '100%',
+    overflow: 'scroll',
+  },
+
+  instructions: {
+    textAlign: 'center',
+  },
+
   targetContainer: {
     display: 'inline-grid',
-    gridTemplateColumns: 'repeat(5, 1fr)',
+    gridTemplateColumns: 'repeat(3, 1fr)',
     gridTemplateRows: 'repeat(5, 64px)',
     gap: '20px',
     margin: '16px 128px',
   },
 
-  instructions: {
-    gridRowStart: '3',
-    gridColumnStart: '2',
-    gridRowEnd: 'span 1',
-    gridColumnEnd: 'span 3',
-    display: 'flex',
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-
   aboveStart: {
     gridRowStart: '1',
-    gridColumnStart: '2',
+    gridColumnStart: '1',
     flexDirection: 'row-reverse',
   },
   above: {
     gridRowStart: '1',
-    gridColumnStart: '3',
+    gridColumnStart: '2',
     justifyContent: 'center',
     '& div:nth-child(2)': {
       display: 'none',
@@ -53,7 +55,7 @@ const useGridExampleStyles = makeStyles({
   },
   aboveEnd: {
     gridRowStart: '1',
-    gridColumnStart: '4',
+    gridColumnStart: '3',
   },
   beforeTop: {
     gridRowStart: '2',
@@ -82,7 +84,7 @@ const useGridExampleStyles = makeStyles({
   },
   afterTop: {
     gridRowStart: '2',
-    gridColumnStart: '5',
+    gridColumnStart: '3',
     flexDirection: 'column-reverse',
     '& div:nth-child(2)': {
       transform: 'rotate(90deg)',
@@ -90,7 +92,7 @@ const useGridExampleStyles = makeStyles({
   },
   after: {
     gridRowStart: '3',
-    gridColumnStart: '5',
+    gridColumnStart: '3',
     justifyContent: 'center',
     '& div:nth-child(2)': {
       display: 'none',
@@ -98,7 +100,7 @@ const useGridExampleStyles = makeStyles({
   },
   afterBottom: {
     gridRowStart: '4',
-    gridColumnStart: '5',
+    gridColumnStart: '3',
     flexDirection: 'column',
     '& div:nth-child(2)': {
       transform: 'rotate(90deg)',
@@ -107,14 +109,14 @@ const useGridExampleStyles = makeStyles({
   belowStart: {
     flexDirection: 'row-reverse',
     gridRowStart: '5',
-    gridColumnStart: '2',
+    gridColumnStart: '1',
     '& div:nth-child(2)': {
       transform: 'rotate(180deg)',
     },
   },
   below: {
     gridRowStart: '5',
-    gridColumnStart: '3',
+    gridColumnStart: '2',
     justifyContent: 'center',
     '& div:nth-child(2)': {
       display: 'none',
@@ -122,7 +124,7 @@ const useGridExampleStyles = makeStyles({
   },
   belowEnd: {
     gridRowStart: '5',
-    gridColumnStart: '4',
+    gridColumnStart: '3',
     '& div:nth-child(2)': {
       transform: 'rotate(180deg)',
     },
@@ -133,9 +135,9 @@ export const ShorthandPositions = () => {
   const styles = useGridExampleStyles();
 
   return (
-    <>
+    <div className={styles.wrapper}>
+      <div className={styles.instructions}>Click each button to see its positioned element</div>
       <div className={styles.targetContainer}>
-        <div className={styles.instructions}>Click each button to see its positioned element</div>
         <PositionedComponent
           positioning="above-start"
           targetClassName={styles.aboveStart}
@@ -168,7 +170,7 @@ export const ShorthandPositions = () => {
         <PositionedComponent positioning="below" targetClassName={styles.below} targetContent="below" />
         <PositionedComponent positioning="below-end" targetClassName={styles.belowEnd} targetContent="below-end" />
       </div>
-    </>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Previous Behavior

The cover & shorthand examples on the positioning docs page were clipped when the page zoomed/resized down at all:

![screenshot of the docs page showing only three of the positioning buttons](https://github.com/user-attachments/assets/117a0e46-155b-48cb-a3ac-05b8558e1985)

While this could theoretically be solved by just adding a scroll overflow without changing the layout at all, the issue is that the current layout doesn't even fit within storybook at full size. So adding a scroll overflow style makes it scroll-overflow all the time, looking rather odd:

<img width="1039" alt="screenshot of the same page at full screen, with the button grid aligned to the right side of the story, and also with the right-most buttons clipped at the edge of the story" src="https://github.com/user-attachments/assets/869ac6aa-d8e6-458d-a3dc-a64f8d49bf14" />

(the left margin of the story is necessary to ensure the popup has enough space to render at smaller sizes)

## New Behavior

I updated the grid layout to be a more compact grid so it would fit within the story at full width, and also be able to scroll-overflow at smaller screens:
<img width="1008" alt="screenshot of the same button grid, but as a 3 by 5 grid instead of 5 by 5, with the instructions outside and above the grid" src="https://github.com/user-attachments/assets/bbf98da6-b5b3-4716-b69d-588dd66610bd" />

<img width="307" alt="screenshot of the same UI at a mobile width, and only the last line of right-most buttons is visible and scrolled into view" src="https://github.com/user-attachments/assets/c7a2b2a0-0933-4121-8c80-fbc29cc85ba7" />

## Related Issue(s)

- Fixes [ADO issue](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/24784)
