### PR TITLE
docs: update Tag examples to reflow

### DIFF
--- a/packages/react-components/react-tags/stories/src/InteractionTag/InteractionTagDismiss.stories.tsx
+++ b/packages/react-components/react-tags/stories/src/InteractionTag/InteractionTagDismiss.stories.tsx
@@ -15,6 +15,9 @@ const useStyles = makeStyles({
     flexDirection: 'column',
     rowGap: '10px',
   },
+  tagGroup: {
+    flexWrap: 'wrap',
+  },
   resetButton: {
     width: 'fit-content',
   },
@@ -60,7 +63,7 @@ export const Dismiss = () => {
   return (
     <div className={styles.container}>
       {visibleTags.length !== 0 && (
-        <TagGroup onDismiss={removeItem} aria-label="Dismiss example">
+        <TagGroup className={styles.tagGroup} onDismiss={removeItem} aria-label="Dismiss example">
           {visibleTags.map((tag, index) => (
             <InteractionTag value={tag.value} key={tag.value}>
               <InteractionTagPrimary hasSecondaryAction ref={index === 0 ? firstTagRef : null}>

--- a/packages/react-components/react-tags/stories/src/InteractionTag/InteractionTagShape.stories.tsx
+++ b/packages/react-components/react-tags/stories/src/InteractionTag/InteractionTagShape.stories.tsx
@@ -9,41 +9,50 @@ import {
 import { CalendarMonthRegular } from '@fluentui/react-icons';
 
 const useContainerStyles = makeStyles({
-  root: {
-    display: 'grid',
-    rowGap: '10px',
+  innerWrapper: {
+    alignItems: 'start',
     columnGap: '10px',
-    gridTemplateColumns: 'auto 1fr',
+    display: 'flex',
+    flexWrap: 'wrap',
+  },
+  outerWrapper: {
+    display: 'flex',
+    flexDirection: 'column',
+    rowGap: '10px',
   },
 });
 
 export const Shape = () => {
   const containerStyles = useContainerStyles();
   return (
-    <div className={containerStyles.root}>
-      <InteractionTag>
-        <InteractionTagPrimary media={<Avatar name="Katri Athokas" badge={{ status: 'busy' }} />}>
-          Rounded
-        </InteractionTagPrimary>
-      </InteractionTag>
-      <InteractionTag shape="circular">
-        <InteractionTagPrimary media={<Avatar name="Katri Athokas" badge={{ status: 'busy' }} />}>
-          Circular
-        </InteractionTagPrimary>
-      </InteractionTag>
+    <div className={containerStyles.outerWrapper}>
+      <div className={containerStyles.innerWrapper}>
+        <InteractionTag>
+          <InteractionTagPrimary media={<Avatar name="Katri Athokas" badge={{ status: 'busy' }} />}>
+            Rounded
+          </InteractionTagPrimary>
+        </InteractionTag>
+        <InteractionTag shape="circular">
+          <InteractionTagPrimary media={<Avatar name="Katri Athokas" badge={{ status: 'busy' }} />}>
+            Circular
+          </InteractionTagPrimary>
+        </InteractionTag>
+      </div>
 
-      <InteractionTag>
-        <InteractionTagPrimary icon={<CalendarMonthRegular />} secondaryText="Secondary text" hasSecondaryAction>
-          Rounded
-        </InteractionTagPrimary>
-        <InteractionTagSecondary aria-label="remove" />
-      </InteractionTag>
-      <InteractionTag shape="circular">
-        <InteractionTagPrimary icon={<CalendarMonthRegular />} secondaryText="Secondary text" hasSecondaryAction>
-          Circular
-        </InteractionTagPrimary>
-        <InteractionTagSecondary aria-label="remove" />
-      </InteractionTag>
+      <div className={containerStyles.innerWrapper}>
+        <InteractionTag>
+          <InteractionTagPrimary icon={<CalendarMonthRegular />} secondaryText="Secondary text" hasSecondaryAction>
+            Rounded
+          </InteractionTagPrimary>
+          <InteractionTagSecondary aria-label="remove" />
+        </InteractionTag>
+        <InteractionTag shape="circular">
+          <InteractionTagPrimary icon={<CalendarMonthRegular />} secondaryText="Secondary text" hasSecondaryAction>
+            Circular
+          </InteractionTagPrimary>
+          <InteractionTagSecondary aria-label="remove" />
+        </InteractionTag>
+      </div>
     </div>
   );
 };

--- a/packages/react-components/react-tags/stories/src/InteractionTag/InteractionTagSize.stories.tsx
+++ b/packages/react-components/react-tags/stories/src/InteractionTag/InteractionTagSize.stories.tsx
@@ -13,6 +13,7 @@ const useContainerStyles = makeStyles({
     alignItems: 'start',
     columnGap: '10px',
     display: 'flex',
+    flexWrap: 'wrap',
   },
   outerWrapper: {
     display: 'flex',

--- a/packages/react-components/react-tags/stories/src/Tag/TagAppearance.stories.tsx
+++ b/packages/react-components/react-tags/stories/src/Tag/TagAppearance.stories.tsx
@@ -6,6 +6,7 @@ const useContainerStyles = makeStyles({
   container: {
     columnGap: '10px',
     display: 'flex',
+    flexWrap: 'wrap',
   },
 });
 export const Appearance = () => {

--- a/packages/react-components/react-tags/stories/src/Tag/TagDisabled.stories.tsx
+++ b/packages/react-components/react-tags/stories/src/Tag/TagDisabled.stories.tsx
@@ -6,6 +6,7 @@ const useContainerStyles = makeStyles({
   container: {
     columnGap: '10px',
     display: 'flex',
+    flexWrap: 'wrap',
   },
 });
 export const Disabled = () => {

--- a/packages/react-components/react-tags/stories/src/Tag/TagDismiss.stories.tsx
+++ b/packages/react-components/react-tags/stories/src/Tag/TagDismiss.stories.tsx
@@ -7,6 +7,9 @@ const useStyles = makeStyles({
     flexDirection: 'column',
     rowGap: '10px',
   },
+  tagGroup: {
+    flexWrap: 'wrap',
+  },
   resetButton: {
     width: 'fit-content',
   },
@@ -52,7 +55,7 @@ export const Dismiss = () => {
   return (
     <div className={styles.container}>
       {visibleTags.length !== 0 && (
-        <TagGroup onDismiss={removeItem} aria-label="Dismiss example">
+        <TagGroup className={styles.tagGroup} onDismiss={removeItem} aria-label="Dismiss example">
           {visibleTags.map((tag, index) => (
             <Tag
               dismissible

--- a/packages/react-components/react-tags/stories/src/Tag/TagShape.stories.tsx
+++ b/packages/react-components/react-tags/stories/src/Tag/TagShape.stories.tsx
@@ -3,40 +3,49 @@ import { Tag, Avatar, makeStyles } from '@fluentui/react-components';
 import { CalendarMonthRegular } from '@fluentui/react-icons';
 
 const useContainerStyles = makeStyles({
-  root: {
-    display: 'grid',
-    rowGap: '10px',
+  innerWrapper: {
+    alignItems: 'start',
     columnGap: '10px',
-    gridTemplateColumns: 'auto 1fr',
+    display: 'flex',
+    flexWrap: 'wrap',
+  },
+  outerWrapper: {
+    display: 'flex',
+    flexDirection: 'column',
+    rowGap: '10px',
   },
 });
 
 export const Shape = () => {
   const containerStyles = useContainerStyles();
   return (
-    <div className={containerStyles.root}>
-      <Tag media={<Avatar name="Katri Athokas" badge={{ status: 'busy' }} />}>Rounded</Tag>
-      <Tag shape="circular" media={<Avatar name="Katri Athokas" badge={{ status: 'busy' }} />}>
-        Circular
-      </Tag>
+    <div className={containerStyles.outerWrapper}>
+      <div className={containerStyles.innerWrapper}>
+        <Tag media={<Avatar name="Katri Athokas" badge={{ status: 'busy' }} />}>Rounded</Tag>
+        <Tag shape="circular" media={<Avatar name="Katri Athokas" badge={{ status: 'busy' }} />}>
+          Circular
+        </Tag>
+      </div>
 
-      <Tag
-        dismissible
-        dismissIcon={{ 'aria-label': 'remove' }}
-        icon={<CalendarMonthRegular />}
-        secondaryText="Secondary text"
-      >
-        Rounded
-      </Tag>
-      <Tag
-        shape="circular"
-        dismissible
-        dismissIcon={{ 'aria-label': 'remove' }}
-        icon={<CalendarMonthRegular />}
-        secondaryText="Secondary text"
-      >
-        Circular
-      </Tag>
+      <div className={containerStyles.innerWrapper}>
+        <Tag
+          dismissible
+          dismissIcon={{ 'aria-label': 'remove' }}
+          icon={<CalendarMonthRegular />}
+          secondaryText="Secondary text"
+        >
+          Rounded
+        </Tag>
+        <Tag
+          shape="circular"
+          dismissible
+          dismissIcon={{ 'aria-label': 'remove' }}
+          icon={<CalendarMonthRegular />}
+          secondaryText="Secondary text"
+        >
+          Circular
+        </Tag>
+      </div>
     </div>
   );
 };

--- a/packages/react-components/react-tags/stories/src/Tag/TagSize.stories.tsx
+++ b/packages/react-components/react-tags/stories/src/Tag/TagSize.stories.tsx
@@ -7,6 +7,7 @@ const useContainerStyles = makeStyles({
     alignItems: 'start',
     columnGap: '10px',
     display: 'flex',
+    flexWrap: 'wrap',
   },
   outerWrapper: {
     display: 'flex',

--- a/packages/react-components/react-tags/stories/src/TagGroup/TagGroupDismiss.stories.tsx
+++ b/packages/react-components/react-tags/stories/src/TagGroup/TagGroupDismiss.stories.tsx
@@ -16,6 +16,9 @@ const useStyles = makeStyles({
     flexDirection: 'column',
     rowGap: '10px',
   },
+  tagGroup: {
+    flexWrap: 'wrap',
+  },
   resetButton: {
     width: 'fit-content',
   },
@@ -61,7 +64,11 @@ const DismissWithTags = () => {
   return (
     <>
       {visibleTags.length !== 0 && (
-        <TagGroup onDismiss={removeItem} aria-label="TagGroup example with dismissible Tags">
+        <TagGroup
+          className={styles.tagGroup}
+          onDismiss={removeItem}
+          aria-label="TagGroup example with dismissible Tags"
+        >
           {visibleTags.map((tag, index) => (
             <Tag
               dismissible
@@ -101,7 +108,7 @@ const DismissWithInteractionTags = () => {
   return (
     <>
       {visibleTags.length !== 0 && (
-        <TagGroup onDismiss={removeItem} aria-label="Dismiss example">
+        <TagGroup className={styles.tagGroup} onDismiss={removeItem} aria-label="Dismiss example">
           {visibleTags.map((tag, index) => (
             <InteractionTag value={tag.value} key={tag.value}>
               <InteractionTagPrimary hasSecondaryAction ref={index === 0 ? firstTagRef : null}>

--- a/packages/react-components/react-tags/stories/src/TagGroup/TagGroupSizes.stories.tsx
+++ b/packages/react-components/react-tags/stories/src/TagGroup/TagGroupSizes.stories.tsx
@@ -16,6 +16,9 @@ const useContainerStyles = makeStyles({
     flexDirection: 'column',
     rowGap: '10px',
   },
+  tagGroup: {
+    flexWrap: 'wrap',
+  },
 });
 
 export const Sizes = () => {
@@ -26,7 +29,7 @@ export const Sizes = () => {
       {sizes.map(size => (
         <div key={size}>
           {`${size}: `}
-          <TagGroup size={size} aria-label={`${size} tag group example`}>
+          <TagGroup className={containerStyles.tagGroup} size={size} aria-label={`${size} tag group example`}>
             <InteractionTag>
               <InteractionTagPrimary media={<Avatar name="Katri Athokas" />}>{size}</InteractionTagPrimary>
             </InteractionTag>


### PR DESCRIPTION
## Previous Behavior
<img width="298" alt="Screenshot of a tag example showing a row of tags that is clipped by the right side of the example" src="https://github.com/user-attachments/assets/fdc9664e-c03b-4ba0-bb04-2d8fb6d52857" />

## New Behavior
<img width="298" alt="same example, but demonstrating the tags wrapping and stacking" src="https://github.com/user-attachments/assets/9580a4d2-5c0c-4338-a4ee-687fc7d83f1e" />


## Related Issue(s)

- Fixes [ADO issue](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/24785)
