### PR TITLE
fix(react tabs): Selected tab is not visible in HC on Windows

### DIFF
--- a/change/@fluentui-react-tabs-855dafe2-e21a-4274-9fa5-9e20c5b28761.json
+++ b/change/@fluentui-react-tabs-855dafe2-e21a-4274-9fa5-9e20c5b28761.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: selected state in HC on Windows",
+  "packageName": "@fluentui/react-tabs",
+  "email": "v.kozlova13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tabs/library/src/components/Tab/useTabStyles.styles.ts
+++ b/packages/react-components/react-tabs/library/src/components/Tab/useTabStyles.styles.ts
@@ -22,6 +22,11 @@ const iconClassNames = {
   regular: 'fui-Icon-regular',
 };
 
+const windowsHCStyles = {
+  color: 'HighlightText',
+  forcedColorAdjust: 'none',
+};
+
 /**
  * Styles for the root slot
  */
@@ -242,18 +247,9 @@ const useCircularAppearanceStyles = makeStyles({
     '@media (forced-colors: active)': {
       ':enabled:hover': {
         backgroundColor: 'Highlight',
-        [`& .${tabClassNames.content}`]: {
-          color: 'HighlightText',
-          forcedColorAdjust: 'none',
-        },
-        [`& .${iconClassNames.filled}`]: {
-          color: 'HighlightText',
-          forcedColorAdjust: 'none',
-        },
-        [`& .${iconClassNames.regular}`]: {
-          color: 'HighlightText',
-          forcedColorAdjust: 'none',
-        },
+        [`& .${tabClassNames.content}`]: windowsHCStyles,
+        [`& .${iconClassNames.filled}`]: windowsHCStyles,
+        [`& .${iconClassNames.regular}`]: windowsHCStyles,
       },
     },
   },
@@ -271,10 +267,7 @@ const useCircularAppearanceStyles = makeStyles({
     '@media (forced-colors: active)': {
       ':enabled': {
         backgroundColor: 'ButtonText',
-        [`& .${tabClassNames.content}`]: {
-          color: 'HighlightText',
-          forcedColorAdjust: 'none',
-        },
+        [`& .${tabClassNames.content}`]: windowsHCStyles,
       },
       [`:enabled .${tabClassNames.icon}`]: {
         color: 'HighlightText',

--- a/packages/react-components/react-tabs/library/src/components/Tab/useTabStyles.styles.ts
+++ b/packages/react-components/react-tabs/library/src/components/Tab/useTabStyles.styles.ts
@@ -239,6 +239,23 @@ const useCircularAppearanceStyles = makeStyles({
       backgroundColor: tokens.colorNeutralBackground3Pressed,
       color: tokens.colorNeutralForeground2Pressed,
     },
+    '@media (forced-colors: active)': {
+      ':enabled:hover': {
+        backgroundColor: 'Highlight',
+        [`& .${tabClassNames.content}`]: {
+          color: 'HighlightText',
+          forcedColorAdjust: 'none',
+        },
+        [`& .${iconClassNames.filled}`]: {
+          color: 'HighlightText',
+          forcedColorAdjust: 'none',
+        },
+        [`& .${iconClassNames.regular}`]: {
+          color: 'HighlightText',
+          forcedColorAdjust: 'none',
+        },
+      },
+    },
   },
   filledSelected: {
     backgroundColor: tokens.colorBrandBackground,
@@ -250,6 +267,18 @@ const useCircularAppearanceStyles = makeStyles({
     ':enabled:active': {
       backgroundColor: tokens.colorBrandBackgroundPressed,
       color: tokens.colorNeutralForegroundOnBrand,
+    },
+    '@media (forced-colors: active)': {
+      ':enabled': {
+        backgroundColor: 'ButtonText',
+        [`& .${tabClassNames.content}`]: {
+          color: 'HighlightText',
+          forcedColorAdjust: 'none',
+        },
+      },
+      [`:enabled .${tabClassNames.icon}`]: {
+        color: 'HighlightText',
+      },
     },
   },
   filledDisabled: {
@@ -332,6 +361,14 @@ const usePendingIndicatorStyles = makeStyles({
     },
     ':active::before': {
       backgroundColor: tokens.colorTransparentStroke,
+    },
+    '@media (forced-colors: active)': {
+      ':hover::before': {
+        backgroundColor: 'transparent',
+      },
+      ':active::before': {
+        backgroundColor: 'transparent',
+      },
     },
   },
   smallHorizontal: {

--- a/packages/react-components/react-tabs/library/src/components/Tab/useTabStyles.styles.ts
+++ b/packages/react-components/react-tabs/library/src/components/Tab/useTabStyles.styles.ts
@@ -22,11 +22,6 @@ const iconClassNames = {
   regular: 'fui-Icon-regular',
 };
 
-const windowsHCStyles = {
-  color: 'HighlightText',
-  forcedColorAdjust: 'none',
-};
-
 /**
  * Styles for the root slot
  */
@@ -247,9 +242,16 @@ const useCircularAppearanceStyles = makeStyles({
     '@media (forced-colors: active)': {
       ':enabled:hover': {
         backgroundColor: 'Highlight',
-        [`& .${tabClassNames.content}`]: windowsHCStyles,
-        [`& .${iconClassNames.filled}`]: windowsHCStyles,
-        [`& .${iconClassNames.regular}`]: windowsHCStyles,
+        forcedColorAdjust: 'none',
+        [`& .${tabClassNames.content}`]: {
+          color: 'HighlightText',
+        },
+        [`& .${iconClassNames.filled}`]: {
+          color: 'HighlightText',
+        },
+        [`& .${iconClassNames.regular}`]: {
+          color: 'HighlightText',
+        },
       },
     },
   },
@@ -267,10 +269,13 @@ const useCircularAppearanceStyles = makeStyles({
     '@media (forced-colors: active)': {
       ':enabled': {
         backgroundColor: 'ButtonText',
-        [`& .${tabClassNames.content}`]: windowsHCStyles,
+        [`& .${tabClassNames.content}`]: {
+          color: 'ButtonFace',
+          forcedColorAdjust: 'none',
+        },
       },
       [`:enabled .${tabClassNames.icon}`]: {
-        color: 'HighlightText',
+        color: 'ButtonFace',
       },
     },
   },


### PR DESCRIPTION
**Description of the bug in ADO:**
When using subtle-circular/filled-circular appearance in high contrast aquatic or dessert theme, it is hard to differentiate what tab is selected in the tablist.

This is mostly due to having no background color for selected tab in these theme.

| Previous behavior                                           | Screenshot | New Behavior |
| ----------------------------------------------------------- | ---------- | ------------ |
| Selected state                                              |     ![image](https://github.com/user-attachments/assets/7fb983bf-f947-4713-b305-1862ab71d2c9)    ![image](https://github.com/user-attachments/assets/07e7a118-0c5c-48f7-97ae-813f89f54483)     |     ![image](https://github.com/user-attachments/assets/4bae6a94-cf86-4e08-9434-be7ecb668cb1) ![image](https://github.com/user-attachments/assets/a62d25d0-6d35-4561-bdf1-e828da7ef719)         |
| Disabled on hover has a border                              |     ![image](https://github.com/user-attachments/assets/87239fe9-540d-4371-8d3d-b0f6a20a2ee1)       |        No border on hover in `disabled` state      |
| `filled-circular` on hover doesn't change background color: |       ![image](https://github.com/user-attachments/assets/214a0f46-7aa1-437c-8c91-5b1132a8e65c)     |      ![image](https://github.com/user-attachments/assets/52927784-33b7-45b4-bffc-9f7c8ecae050)        |

## Related Issue(s)
ADO issue 24802
