### PR TITLE
docs: Motion tokens page supports windows high contrast

### DIFF
--- a/packages/react-components/react-motion/stories/src/Tokens/Cards.styles.ts
+++ b/packages/react-components/react-motion/stories/src/Tokens/Cards.styles.ts
@@ -57,6 +57,10 @@ export const useCardClasses = makeStyles({
     animationDuration: '2s',
     animationIterationCount: 'infinite',
     animationFillMode: 'forwards',
+
+    '@media (forced-colors: active)': {
+      backgroundColor: 'LinkText',
+    },
   },
 
   graph: {
@@ -67,6 +71,10 @@ export const useCardClasses = makeStyles({
       ".      graphT" / min-content 1fr
     `,
     gap: '6px',
+
+    '@media (forced-colors: active)': {
+      backgroundColor: 'Canvas',
+    },
   },
   graphP: {
     gridArea: 'graphP',
@@ -89,6 +97,15 @@ export const useCardClasses = makeStyles({
     height: 'var(--container-size)',
     width: 'var(--container-size)',
   },
+  path: {
+    fill: 'none',
+    stroke: tokens.colorNeutralStrokeAccessible,
+    strokeWidth: '2',
+
+    '@media (forced-colors: active)': {
+      stroke: 'CanvasText',
+    },
+  },
 
   duration: {
     placeSelf: 'center',
@@ -103,6 +120,10 @@ export const useCardClasses = makeStyles({
       to: { transform: 'rotate(180deg)' },
     },
     animationIterationCount: 'infinite',
+
+    '@media (forced-colors: active)': {
+      backgroundColor: 'CanvasText',
+    },
   },
 
   view: {

--- a/packages/react-components/react-motion/stories/src/Tokens/Cards.tsx
+++ b/packages/react-components/react-motion/stories/src/Tokens/Cards.tsx
@@ -1,4 +1,4 @@
-import { Divider, tokens, Switch } from '@fluentui/react-components';
+import { Divider, Switch } from '@fluentui/react-components';
 import { curves, durations } from '@fluentui/react-motion';
 import * as React from 'react';
 
@@ -32,9 +32,7 @@ const MotionCurveCard: React.FC<{ animationEnabled: boolean; tokenName: string; 
             d={`M 0 100 C ${easingPoints[0]} ${100 - easingPoints[1]}, ${easingPoints[2]} ${
               100 - easingPoints[3]
             }, 100 0`}
-            fill="none"
-            stroke={tokens.colorNeutralStrokeAccessible}
-            strokeWidth="2"
+            className={classes.path}
           />
         </svg>
 


### PR DESCRIPTION
Docs-only change, adds high contrast tokens for the visual demonstrations on the motion tokens page.

## Previous Behavior
<img width="1225" alt="Screenshot of the motion curves, with a light curve line and no moving pointer" src="https://github.com/user-attachments/assets/b43342d4-28be-4324-9bf1-d44754d820b5" />

![screenshot of motion durations, showing an empty black square above the text of the token](https://github.com/user-attachments/assets/79a5d4c2-b0ab-442a-a862-e230cae3a784)

## New Behavior
<img width="1221" alt="Screenshot of the same motion curves, with a contrasty curve and yellow pointer against black" src="https://github.com/user-attachments/assets/644c4208-423c-4447-91cd-1c2ed66a422c" />

<img width="1219" alt="Screenshot of the duration tokens, showing the white lines against black in the demo space" src="https://github.com/user-attachments/assets/1afd914c-af45-46ef-bb8e-7bef5381dae3" />

## Related Issue(s)

- Fixes [ADO issue](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/24789)
