### PR TITLE
fix: button slots spacing

### DIFF
--- a/change/@fluentui-web-components-23edc611-4d8c-4176-975a-3530019982d5.json
+++ b/change/@fluentui-web-components-23edc611-4d8c-4176-975a-3530019982d5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixed button start and end slots inline spacing.",
+  "packageName": "@fluentui/web-components",
+  "email": "601470+mlijanto@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/button/button.styles.ts
+++ b/packages/web-components/src/button/button.styles.ts
@@ -140,15 +140,12 @@ export const baseButtonStyles = css`
     fill: currentColor;
   }
 
-  :is([slot='start'], ::slotted([slot='start'])) {
+  ::slotted([slot='start']) {
     margin-inline-end: var(--icon-spacing);
   }
 
-  :is([slot='end'], ::slotted([slot='end'])) {
+  ::slotted([slot='end']) {
     flex-shrink: 0;
-  }
-
-  :host(:not(${iconOnlyState})) :is([slot='end'], :host(:not(${iconOnlyState}))::slotted([slot='end'])) {
     margin-inline-start: var(--icon-spacing);
   }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

There is no gap between button component's start/end slots and the default slot.

## New Behavior

Button's start slot has inline-end spacing and end slot has inline-start spacing.
