### PR TITLE
fix: Spinbutton aria-valuenow vs native value update timing fix

### DIFF
--- a/change/@fluentui-react-spinbutton-d2901e1c-c4b6-47ad-b78e-0ae03c8814f6.json
+++ b/change/@fluentui-react-spinbutton-d2901e1c-c4b6-47ad-b78e-0ae03c8814f6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Spinbutton aria-valuenow vs native value timing fix",
+  "packageName": "@fluentui/react-spinbutton",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
## Previous Behavior

The basic problem is that we use `<input type="text" role="spinbutton">`, which creates tension between the native input `value` and the spinbutton role's expectation for `aria-valuenow`. Some screen readers will use `value`, and others will use `aria-valuenow`. However, if we set `aria-valuenow` with React, the timing of the update is one cycle after the native input/change happens. The result is that some screen readers (Narrator and VoiceOver) will read the previous value instead of the new value on value changes.

I previously removed the default `aria-valuetext` (which is similar to `valuenow` for the purposes of this bug) to avoid having two separate sources of providing the value, but both VO and Narrator will not use the native `value` to calculate a spinbutton value, and will default to saying 0.

## New Behavior

To get around the timing problem that comes with using DOM attribute updates to provide `aria-valuenow`, I instead updated our code to set the IDL attribute directly (i.e. `el.ariaValueNow = newValue`).

Testing with VoiceOver, Narrator, NVDA, and JAWS, this seems to now work as expected.

## Related Issue(s)

- Fixes [ADO issue](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/19601)
