### PR TITLE
fix: incorrect tokens used across multiple input components

### DIFF
--- a/change/@fluentui-react-combobox-106e472a-1ade-4d1f-bc51-5eddd30b8ecf.json
+++ b/change/@fluentui-react-combobox-106e472a-1ade-4d1f-bc51-5eddd30b8ecf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: use correct tokens for hover, active and focus states",
+  "packageName": "@fluentui/react-combobox",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tag-picker-ea411c94-0c82-44e5-87ff-5d073f48599d.json
+++ b/change/@fluentui-react-tag-picker-ea411c94-0c82-44e5-87ff-5d073f48599d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: use correct tokens for hover, active and focus states",
+  "packageName": "@fluentui/react-tag-picker",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-textarea-6305fa37-552a-4cf8-8dd6-92f2dbee276c.json
+++ b/change/@fluentui-react-textarea-6305fa37-552a-4cf8-8dd6-92f2dbee276c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: use correct tokens for hover, active and focus states",
+  "packageName": "@fluentui/react-textarea",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/library/src/components/Combobox/useComboboxStyles.styles.ts
+++ b/packages/react-components/react-combobox/library/src/components/Combobox/useComboboxStyles.styles.ts
@@ -119,16 +119,15 @@ const useStyles = makeStyles({
     border: `${tokens.strokeWidthThin} solid ${tokens.colorNeutralStroke1}`,
     borderBottomColor: tokens.colorNeutralStrokeAccessible,
   },
-
   outlineInteractive: {
     '&:hover': {
       ...shorthands.borderColor(tokens.colorNeutralStroke1Hover),
-      borderBottomColor: tokens.colorNeutralStrokeAccessible,
+      borderBottomColor: tokens.colorNeutralStrokeAccessibleHover,
     },
 
-    '&:active': {
+    '&:active, &:focus-within': {
       ...shorthands.borderColor(tokens.colorNeutralStroke1Pressed),
-      borderBottomColor: tokens.colorNeutralStrokeAccessible,
+      borderBottomColor: tokens.colorNeutralStrokeAccessiblePressed,
     },
   },
   underline: {

--- a/packages/react-components/react-combobox/library/src/components/Combobox/useComboboxStyles.styles.ts
+++ b/packages/react-components/react-combobox/library/src/components/Combobox/useComboboxStyles.styles.ts
@@ -125,7 +125,12 @@ const useStyles = makeStyles({
       borderBottomColor: tokens.colorNeutralStrokeAccessibleHover,
     },
 
-    '&:active, &:focus-within': {
+    '&:active': {
+      ...shorthands.borderColor(tokens.colorNeutralStroke1Pressed),
+      borderBottomColor: tokens.colorNeutralStrokeAccessiblePressed,
+    },
+
+    '&:focus-within': {
       ...shorthands.borderColor(tokens.colorNeutralStroke1Pressed),
       borderBottomColor: tokens.colorNeutralStrokeAccessiblePressed,
     },

--- a/packages/react-components/react-combobox/library/src/components/Dropdown/useDropdownStyles.styles.ts
+++ b/packages/react-components/react-combobox/library/src/components/Dropdown/useDropdownStyles.styles.ts
@@ -149,12 +149,12 @@ const useStyles = makeStyles({
   outlineInteractive: {
     '&:hover': {
       ...shorthands.borderColor(tokens.colorNeutralStroke1Hover),
-      borderBottomColor: tokens.colorNeutralStrokeAccessible,
+      borderBottomColor: tokens.colorNeutralStrokeAccessibleHover,
     },
 
-    '&:active': {
+    '&:active, &:focus-within': {
       ...shorthands.borderColor(tokens.colorNeutralStroke1Pressed),
-      borderBottomColor: tokens.colorNeutralStrokeAccessible,
+      borderBottomColor: tokens.colorNeutralStrokeAccessiblePressed,
     },
   },
   underline: {

--- a/packages/react-components/react-combobox/library/src/components/Dropdown/useDropdownStyles.styles.ts
+++ b/packages/react-components/react-combobox/library/src/components/Dropdown/useDropdownStyles.styles.ts
@@ -152,7 +152,12 @@ const useStyles = makeStyles({
       borderBottomColor: tokens.colorNeutralStrokeAccessibleHover,
     },
 
-    '&:active, &:focus-within': {
+    '&:active': {
+      ...shorthands.borderColor(tokens.colorNeutralStroke1Pressed),
+      borderBottomColor: tokens.colorNeutralStrokeAccessiblePressed,
+    },
+
+    '&:focus-within': {
       ...shorthands.borderColor(tokens.colorNeutralStroke1Pressed),
       borderBottomColor: tokens.colorNeutralStrokeAccessiblePressed,
     },

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerControl/useTagPickerControlStyles.styles.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerControl/useTagPickerControlStyles.styles.ts
@@ -110,12 +110,12 @@ const useStyles = makeStyles({
   outlineInteractive: {
     '&:hover': {
       ...shorthands.borderColor(tokens.colorNeutralStroke1Hover),
-      borderBottomColor: tokens.colorNeutralStrokeAccessible,
+      borderBottomColor: tokens.colorNeutralStrokeAccessibleHover,
     },
 
-    '&:active': {
+    '&:active, &:focus-within': {
       ...shorthands.borderColor(tokens.colorNeutralStroke1Pressed),
-      borderBottomColor: tokens.colorNeutralStrokeAccessible,
+      borderBottomColor: tokens.colorNeutralStrokeAccessiblePressed,
     },
   },
   underline: {

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerControl/useTagPickerControlStyles.styles.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerControl/useTagPickerControlStyles.styles.ts
@@ -113,7 +113,12 @@ const useStyles = makeStyles({
       borderBottomColor: tokens.colorNeutralStrokeAccessibleHover,
     },
 
-    '&:active, &:focus-within': {
+    '&:active': {
+      ...shorthands.borderColor(tokens.colorNeutralStroke1Pressed),
+      borderBottomColor: tokens.colorNeutralStrokeAccessiblePressed,
+    },
+
+    '&:focus-within': {
       ...shorthands.borderColor(tokens.colorNeutralStroke1Pressed),
       borderBottomColor: tokens.colorNeutralStrokeAccessiblePressed,
     },

--- a/packages/react-components/react-textarea/library/src/components/Textarea/useTextareaStyles.styles.ts
+++ b/packages/react-components/react-textarea/library/src/components/Textarea/useTextareaStyles.styles.ts
@@ -132,7 +132,7 @@ const useRootStyles = makeStyles({
     },
 
     ':focus-within': {
-      border: `${tokens.strokeWidthThin} solid ${tokens.colorNeutralStroke1}`,
+      border: `${tokens.strokeWidthThin} solid ${tokens.colorNeutralStroke1Pressed}`,
       borderBottomColor: tokens.colorCompoundBrandStroke,
     },
   },


### PR DESCRIPTION
Fixing reported issue (#33135), we have visual inconsistencies between Figma designs and our multiple input components. Those components currently do not have shared styles, so it has to be fixed on multiple places. The reported issue mention high-contrast, but it happens in all themes for outline appearance for hover, active and focus styles. Combobox & Dropdown, Textarea, TimePickerCompat (fixed by fixing combobox styles), TagPicker. 

## Previous Behavior

hover in high contrast:

![image](https://github.com/user-attachments/assets/0cf473f0-f340-44ea-a32a-813982808975)

focus in high contrast: 
![image](https://github.com/user-attachments/assets/0643e819-c200-4f35-86b0-be879074b908)

figma spec: 

- hover: 
![image](https://github.com/user-attachments/assets/34ed0ac4-a74f-4ee1-a00b-29e99f26d659)
- focus:
![image](https://github.com/user-attachments/assets/411f1556-2e5d-45bf-906e-32b4d53daa12)

## New Behavior

Updated to visually match design spec

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #33135
