### PR TITLE
Fix capitalization of GitHub

### DIFF
--- a/apps/public-docsite-v9/src/Concepts/Introduction.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/Introduction.stories.mdx
@@ -45,4 +45,4 @@ Each component is designed to adhere to the following standards:
 
 <h2 className="fluent">Questions?</h2>
 
-Reach out to the Fluent UI React team on [Github](https://github.com/microsoft/fluentui)
+Reach out to the Fluent UI React team on [GitHub](https://github.com/microsoft/fluentui)


### PR DESCRIPTION
GitHub is spelled with a capital H.

## Previous Behavior

GitHub was spelled with a lowercase h.

## New Behavior

GitHub is spelled with a capital H.
