### PR TITLE
feat(motion): Presence enter & exit motions can be used separately with `.In` & `.Out` 

### DIFF
--- a/change/@fluentui-react-motion-ea2e7c9b-8a6a-4c18-b5a8-b065abac4258.json
+++ b/change/@fluentui-react-motion-ea2e7c9b-8a6a-4c18-b5a8-b065abac4258.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(motion): give Presence `In` and `Out` references to enter & exit motions",
+  "packageName": "@fluentui/react-motion",
+  "email": "robertpenner@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-motion-ea2e7c9b-8a6a-4c18-b5a8-b065abac4258.json
+++ b/change/@fluentui-react-motion-ea2e7c9b-8a6a-4c18-b5a8-b065abac4258.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "feat(motion): give Presence `In` and `Out` references to enter & exit motions",
+  "comment": "Presence enter & exit motions can be used separately with .In & .Out",
   "packageName": "@fluentui/react-motion",
   "email": "robertpenner@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/react-components/react-motion/library/etc/react-motion.api.md
+++ b/packages/react-components/react-motion/library/etc/react-motion.api.md
@@ -98,6 +98,8 @@ export const motionTokens: {
 export type PresenceComponent<MotionParams extends Record<string, MotionParam> = {}> = {
     (props: PresenceComponentProps & MotionParams): React_2.ReactElement | null;
     [MOTION_DEFINITION]: PresenceMotionFn<MotionParams>;
+    In: React_2.FC<MotionComponentProps & MotionParams>;
+    Out: React_2.FC<MotionComponentProps & MotionParams>;
 };
 
 // @public (undocumented)

--- a/packages/react-components/react-motion/library/etc/react-motion.api.md
+++ b/packages/react-components/react-motion/library/etc/react-motion.api.md
@@ -98,8 +98,8 @@ export const motionTokens: {
 export type PresenceComponent<MotionParams extends Record<string, MotionParam> = {}> = {
     (props: PresenceComponentProps & MotionParams): React_2.ReactElement | null;
     [MOTION_DEFINITION]: PresenceMotionFn<MotionParams>;
-    In: ReturnType<typeof createMotionComponent<MotionParams>>;
-    Out: ReturnType<typeof createMotionComponent<MotionParams>>;
+    In: React_2.FC<MotionComponentProps & MotionParams>;
+    Out: React_2.FC<MotionComponentProps & MotionParams>;
 };
 
 // @public (undocumented)

--- a/packages/react-components/react-motion/library/etc/react-motion.api.md
+++ b/packages/react-components/react-motion/library/etc/react-motion.api.md
@@ -98,8 +98,8 @@ export const motionTokens: {
 export type PresenceComponent<MotionParams extends Record<string, MotionParam> = {}> = {
     (props: PresenceComponentProps & MotionParams): React_2.ReactElement | null;
     [MOTION_DEFINITION]: PresenceMotionFn<MotionParams>;
-    In: React_2.FC<MotionComponentProps & MotionParams>;
-    Out: React_2.FC<MotionComponentProps & MotionParams>;
+    In: ReturnType<typeof createMotionComponent<MotionParams>>;
+    Out: ReturnType<typeof createMotionComponent<MotionParams>>;
 };
 
 // @public (undocumented)

--- a/packages/react-components/react-motion/library/src/factories/createPresenceComponent.test.tsx
+++ b/packages/react-components/react-motion/library/src/factories/createPresenceComponent.test.tsx
@@ -475,6 +475,72 @@ describe('createPresenceComponent', () => {
       expect(animateMock).toHaveBeenCalledWith(exitKeyframes, options);
     });
   });
+
+  describe('.In static method', () => {
+    it('references the enter motion object', () => {
+      const TestPresence = createPresenceComponent(motion);
+      const { animateMock, ElementMock } = createElementMock();
+
+      render(
+        <TestPresence.In>
+          <ElementMock />
+        </TestPresence.In>,
+      );
+
+      expect(animateMock).toHaveBeenCalledWith(enterKeyframes, options);
+    });
+
+    it('references the enter motion function', () => {
+      const fnMotion = jest.fn().mockImplementation(() => motion);
+      const TestPresence = createPresenceComponent(fnMotion);
+      const { animateMock, ElementMock } = createElementMock();
+
+      render(
+        <TestPresence.In>
+          <ElementMock />
+        </TestPresence.In>,
+      );
+
+      expect(fnMotion).toHaveBeenCalledTimes(1);
+      expect(fnMotion).toHaveBeenCalledWith({ element: { animate: animateMock } /* mock of html element */ });
+
+      expect(animateMock).toHaveBeenCalledTimes(1);
+      expect(animateMock).toHaveBeenCalledWith(enterKeyframes, options);
+    });
+  });
+
+  describe('.Out static method', () => {
+    it('references the exit motion object', () => {
+      const TestPresence = createPresenceComponent(motion);
+      const { animateMock, ElementMock } = createElementMock();
+
+      render(
+        <TestPresence.Out>
+          <ElementMock />
+        </TestPresence.Out>,
+      );
+
+      expect(animateMock).toHaveBeenCalledWith(exitKeyframes, options);
+    });
+
+    it('references the exit motion function', () => {
+      const fnMotion = jest.fn().mockImplementation(() => motion);
+      const TestPresence = createPresenceComponent(fnMotion);
+      const { animateMock, ElementMock } = createElementMock();
+
+      render(
+        <TestPresence.Out>
+          <ElementMock />
+        </TestPresence.Out>,
+      );
+
+      expect(fnMotion).toHaveBeenCalledTimes(1);
+      expect(fnMotion).toHaveBeenCalledWith({ element: { animate: animateMock } /* mock of html element */ });
+
+      expect(animateMock).toHaveBeenCalledTimes(1);
+      expect(animateMock).toHaveBeenCalledWith(exitKeyframes, options);
+    });
+  });
 });
 
 describe('PresenceGroupChildContext', () => {

--- a/packages/react-components/react-motion/library/src/factories/createPresenceComponent.ts
+++ b/packages/react-components/react-motion/library/src/factories/createPresenceComponent.ts
@@ -78,8 +78,8 @@ export type PresenceComponentProps = {
 export type PresenceComponent<MotionParams extends Record<string, MotionParam> = {}> = {
   (props: PresenceComponentProps & MotionParams): React.ReactElement | null;
   [MOTION_DEFINITION]: PresenceMotionFn<MotionParams>;
-  In: React.FC<MotionComponentProps & MotionParams>;
-  Out: React.FC<MotionComponentProps & MotionParams>;
+  In: ReturnType<typeof createMotionComponent<MotionParams>>;
+  Out: ReturnType<typeof createMotionComponent<MotionParams>>;
 };
 
 const INTERRUPTABLE_MOTION_SYMBOL = Symbol.for('interruptablePresence');

--- a/packages/react-components/react-motion/library/src/factories/createPresenceComponent.ts
+++ b/packages/react-components/react-motion/library/src/factories/createPresenceComponent.ts
@@ -16,6 +16,7 @@ import type {
   AnimationHandle,
 } from '../types';
 import { useMotionBehaviourContext } from '../contexts/MotionBehaviourContext';
+import { createMotionComponent, MotionComponentProps } from './createMotionComponent';
 
 /**
  * @internal A private symbol to store the motion definition on the component for variants.
@@ -77,6 +78,8 @@ export type PresenceComponentProps = {
 export type PresenceComponent<MotionParams extends Record<string, MotionParam> = {}> = {
   (props: PresenceComponentProps & MotionParams): React.ReactElement | null;
   [MOTION_DEFINITION]: PresenceMotionFn<MotionParams>;
+  In: React.FC<MotionComponentProps & MotionParams>;
+  Out: React.FC<MotionComponentProps & MotionParams>;
 };
 
 const INTERRUPTABLE_MOTION_SYMBOL = Symbol.for('interruptablePresence');
@@ -243,6 +246,21 @@ export function createPresenceComponent<MotionParams extends Record<string, Moti
       // Heads up!
       // Always normalize it to a function to simplify types
       [MOTION_DEFINITION]: typeof value === 'function' ? value : () => value,
+    },
+    {
+      // Wrap `enter` in its own motion component as a static method, e.g. <Fade.In>
+      In: createMotionComponent(
+        // If we have a motion function, wrap it to forward the runtime params and pick `enter`.
+        // Otherwise, pass the `enter` motion object directly.
+        typeof value !== 'function' ? value.enter : (...args: Parameters<typeof value>) => value(...args).enter,
+      ),
+
+      // Wrap `exit` in its own motion component as a static method, e.g. <Fade.Out>
+      Out: createMotionComponent(
+        // If we have a motion function, wrap it to forward the runtime params and pick `exit`.
+        // Otherwise, pass the `exit` motion object directly.
+        typeof value !== 'function' ? value.exit : (...args: Parameters<typeof value>) => value(...args).exit,
+      ),
     },
   );
 }

--- a/packages/react-components/react-motion/library/src/factories/createPresenceComponent.ts
+++ b/packages/react-components/react-motion/library/src/factories/createPresenceComponent.ts
@@ -78,8 +78,8 @@ export type PresenceComponentProps = {
 export type PresenceComponent<MotionParams extends Record<string, MotionParam> = {}> = {
   (props: PresenceComponentProps & MotionParams): React.ReactElement | null;
   [MOTION_DEFINITION]: PresenceMotionFn<MotionParams>;
-  In: ReturnType<typeof createMotionComponent<MotionParams>>;
-  Out: ReturnType<typeof createMotionComponent<MotionParams>>;
+  In: React.FC<MotionComponentProps & MotionParams>;
+  Out: React.FC<MotionComponentProps & MotionParams>;
 };
 
 const INTERRUPTABLE_MOTION_SYMBOL = Symbol.for('interruptablePresence');

--- a/packages/react-components/react-motion/library/src/factories/createPresenceComponent.ts
+++ b/packages/react-components/react-motion/library/src/factories/createPresenceComponent.ts
@@ -16,7 +16,7 @@ import type {
   AnimationHandle,
 } from '../types';
 import { useMotionBehaviourContext } from '../contexts/MotionBehaviourContext';
-import { createMotionComponent, MotionComponentProps } from './createMotionComponent';
+import { createMotionComponent } from './createMotionComponent';
 
 /**
  * @internal A private symbol to store the motion definition on the component for variants.

--- a/packages/react-components/react-motion/library/src/factories/createPresenceComponent.ts
+++ b/packages/react-components/react-motion/library/src/factories/createPresenceComponent.ts
@@ -16,7 +16,7 @@ import type {
   AnimationHandle,
 } from '../types';
 import { useMotionBehaviourContext } from '../contexts/MotionBehaviourContext';
-import { createMotionComponent } from './createMotionComponent';
+import { createMotionComponent, MotionComponentProps } from './createMotionComponent';
 
 /**
  * @internal A private symbol to store the motion definition on the component for variants.

--- a/packages/react-components/react-motion/library/src/factories/createPresenceComponent.ts
+++ b/packages/react-components/react-motion/library/src/factories/createPresenceComponent.ts
@@ -252,14 +252,14 @@ export function createPresenceComponent<MotionParams extends Record<string, Moti
       In: createMotionComponent(
         // If we have a motion function, wrap it to forward the runtime params and pick `enter`.
         // Otherwise, pass the `enter` motion object directly.
-        typeof value !== 'function' ? value.enter : (...args: Parameters<typeof value>) => value(...args).enter,
+        typeof value === 'function' ? (...args: Parameters<typeof value>) => value(...args).enter : value.enter,
       ),
 
       // Wrap `exit` in its own motion component as a static method, e.g. <Fade.Out>
       Out: createMotionComponent(
         // If we have a motion function, wrap it to forward the runtime params and pick `exit`.
         // Otherwise, pass the `exit` motion object directly.
-        typeof value !== 'function' ? value.exit : (...args: Parameters<typeof value>) => value(...args).exit,
+        typeof value === 'function' ? (...args: Parameters<typeof value>) => value(...args).exit : value.exit,
       ),
     },
   );

--- a/packages/react-components/react-motion/stories/src/CreatePresenceComponent/CreatePresenceComponentInAndOut.stories.md
+++ b/packages/react-components/react-motion/stories/src/CreatePresenceComponent/CreatePresenceComponentInAndOut.stories.md
@@ -1,4 +1,4 @@
-Every presence component has two halves, the `enter` and `exit` motions, which can played in isolation using the static `.In` and `.Out` methods.
+Every presence component has two halves, the `enter` and `exit` motions, which can be played in isolation using the static `.In` and `.Out` methods.
 
 For example, a presence called `MyFade` will contain `<MyFade.In>` and `<MyFade.Out>` motion components, which play the `enter` and `exit` as one-off motions:
 

--- a/packages/react-components/react-motion/stories/src/CreatePresenceComponent/CreatePresenceComponentInAndOut.stories.md
+++ b/packages/react-components/react-motion/stories/src/CreatePresenceComponent/CreatePresenceComponentInAndOut.stories.md
@@ -1,0 +1,35 @@
+Every presence component has two halves, the `enter` and `exit` motions, which can played in isolation using the static `.In` and `.Out` methods.
+
+For example, a presence called `MyFade` will contain `<MyFade.In>` and `<MyFade.Out>` motion components, which play the `enter` and `exit` as one-off motions:
+
+```tsx
+// Create the presence component
+
+const MyFade = createPresenceComponent({
+  enter: {
+    keyframes: [{ opacity: 0 }, { opacity: 1 }],
+    duration: 4000,
+  },
+
+  exit: {
+    keyframes: [{ opacity: 1 }, { opacity: 0 }],
+    duration: 2000,
+  },
+});
+```
+
+In the render, each of the 2 motions can be played separately:
+
+```tsx
+// plays the enter animation (4000 ms fade-in)
+<MyFade.In>
+  {/* Content */}
+</MyFade.In>
+
+// plays the exit animation (2000 ms fade-out)
+<MyFade.Out>
+  {/* Content */}
+</MyFade.Out>
+```
+
+This can be useful when choreographing a series of motions, or mixing and matching the enter and exit animations from different presence components.

--- a/packages/react-components/react-motion/stories/src/CreatePresenceComponent/CreatePresenceComponentInAndOut.stories.tsx
+++ b/packages/react-components/react-motion/stories/src/CreatePresenceComponent/CreatePresenceComponentInAndOut.stories.tsx
@@ -42,12 +42,18 @@ const MyFade = createPresenceComponent({
     keyframes: [{ opacity: 0 }, { opacity: 1 }],
     duration: 4000,
     iterations: Infinity,
+    reducedMotion: {
+      duration: 8000,
+    },
   },
 
   exit: {
     keyframes: [{ opacity: 1 }, { opacity: 0 }],
     duration: 2000,
     iterations: Infinity,
+    reducedMotion: {
+      duration: 8000,
+    },
   },
 });
 

--- a/packages/react-components/react-motion/stories/src/CreatePresenceComponent/CreatePresenceComponentInAndOut.stories.tsx
+++ b/packages/react-components/react-motion/stories/src/CreatePresenceComponent/CreatePresenceComponentInAndOut.stories.tsx
@@ -1,0 +1,77 @@
+import { createPresenceComponent, makeStyles, tokens } from '@fluentui/react-components';
+import * as React from 'react';
+
+import description from './CreatePresenceComponentInAndOut.stories.md';
+
+const useClasses = makeStyles({
+  container: {
+    display: 'grid',
+    gridTemplate: `"card card" "controls ." / 1fr 1fr`,
+    gap: '20px 10px',
+  },
+
+  card: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: '10px',
+    gridArea: 'card',
+
+    border: `${tokens.strokeWidthThicker} solid ${tokens.colorNeutralForeground3}`,
+    borderRadius: tokens.borderRadiusMedium,
+    boxShadow: tokens.shadow16,
+    padding: '10px',
+  },
+
+  item: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: tokens.colorBrandBackground,
+    border: `${tokens.strokeWidthThicker} solid ${tokens.colorTransparentStroke}`,
+    borderRadius: '50%',
+
+    width: '100px',
+    height: '100px',
+    color: 'white',
+  },
+});
+
+const MyFade = createPresenceComponent({
+  enter: {
+    keyframes: [{ opacity: 0 }, { opacity: 1 }],
+    duration: 4000,
+    iterations: Infinity,
+  },
+
+  exit: {
+    keyframes: [{ opacity: 1 }, { opacity: 0 }],
+    duration: 2000,
+    iterations: Infinity,
+  },
+});
+
+export const CreatePresenceComponentInAndOut = () => {
+  const classes = useClasses();
+
+  return (
+    <div className={classes.container}>
+      <div className={classes.card}>
+        <MyFade.In>
+          <div className={classes.item}>MyFade.In</div>
+        </MyFade.In>
+        <MyFade.Out>
+          <div className={classes.item}>MyFade.Out</div>
+        </MyFade.Out>
+      </div>
+    </div>
+  );
+};
+
+CreatePresenceComponentInAndOut.parameters = {
+  docs: {
+    description: {
+      story: description,
+    },
+  },
+};

--- a/packages/react-components/react-motion/stories/src/CreatePresenceComponent/index.stories.ts
+++ b/packages/react-components/react-motion/stories/src/CreatePresenceComponent/index.stories.ts
@@ -6,6 +6,7 @@ import { CreatePresenceComponentDefault } from './CreatePresenceComponentDefault
 export { CreatePresenceComponentDefault as Default } from './CreatePresenceComponentDefault.stories';
 
 export { CreatePresenceComponentFactory as createPresenceComponent } from './CreatePresenceComponentFactory.stories';
+export { CreatePresenceComponentInAndOut as InAndOut } from './CreatePresenceComponentInAndOut.stories';
 
 export { CreatePresenceComponentAppear as appear } from './CreatePresenceComponentAppear.stories';
 export { CreatePresenceComponentReducedMotion as reducedMotion } from './CreatePresenceComponentReducedMotion.stories';


### PR DESCRIPTION
## Previous Behavior

* There was no easy way to use one of a presence's `enter` or `exit` motions in isolation.
* E.g. we have a two-way `<Fade>` component, but how would a one-way fade be implemented and used?

## New Behavior

* This PR adds `In` and `Out` static methods to the `Presence` component for playing enter and exit motions in isolation. 
* So for the existing `<Fade>` presence, we can now invoke `<Fade.In>` and `<Fade.Out>` as one-way motion components.
* This feature is given to all transitions created with `createPresenceComponent`.

### Example from scratch:
```
// Create a presence component
const MyFade = createPresenceComponent({
  enter: {
    keyframes: [{ opacity: 0 }, { opacity: 1 }],
    duration: 4000,
  },

  exit: {
    keyframes: [{ opacity: 1 }, { opacity: 0 }],
    duration: 2000,
  },
});
```

Now in JSX, the fade-in and fade-out can be used independently as one-way motion components:

```tsx
// plays the enter animation (4000 ms fade-in)
<MyFade.In>
  {/* Content */}
</MyFade.In>

// plays the exit animation (2000 ms fade-out)
<MyFade.Out>
  {/* Content */}
</MyFade.Out>
```

- `MyFade` is built to be interactive: it's toggled by the `visible` prop (as a two-way presence transition).
- `MyFade.In` and `MyFade.Out` are one-way motion components: they start playing as soon as they're rendered.
- These standalone components for fade-in, scale-in, etc. will play nicely with choreography components like Stagger and Series (WIP).

## Testing

* Added unit tests for the `.In` and `.Out` methods.
* Added a [story](https://fluentuipr.z22.web.core.windows.net/pull/33930/public-docsite-v9/storybook/index.html?path=/docs/motion-apis-createpresencecomponent--docs#in-and-out) showing how to use `.In` and `.Out` in JSX:

![image](https://github.com/user-attachments/assets/0dad9cf2-1344-4ca0-9af2-f9e032d14e5a)
![image](https://github.com/user-attachments/assets/757a0dce-7947-4cfb-b19a-29895229e2c7)


## Future Work
- Stagger choreography component
- Series choreography component