### PR TITLE
feat: auto associate tabpanels with tabs

### DIFF
--- a/change/@fluentui-web-components-41bd9d29-ee1e-4b05-b599-add4a1718f07.json
+++ b/change/@fluentui-web-components-41bd9d29-ee1e-4b05-b599-add4a1718f07.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: auto associate tabpanels with tabs",
+  "packageName": "@fluentui/web-components",
+  "email": "machi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/tablist/tablist.spec.ts
+++ b/packages/web-components/src/tablist/tablist.spec.ts
@@ -310,4 +310,42 @@ test.describe('Tablist', () => {
 
     await expect(element).toHaveJSProperty('activeid', secondTabId);
   });
+
+  test("should associate panel elements with `aria-controls` attributes", async ({
+      fastPage,
+      page,
+  }) => {
+      const { element } = fastPage;
+      await fastPage.setTemplate(`
+          <fluent-tablist>
+              <fluent-tab aria-controls="panel1">Tab one</fluent-tab>
+              <fluent-tab aria-controls="panel2">Tab two</fluent-tab>
+              <fluent-tab aria-controls="panel3">Tab three</fluent-tab>
+          </fluent-tablist>
+          <div id="panel1">Panel one</div>
+          <div id="panel2">Panel two</div>
+          <div id="panel3">Panel three</div>
+      `);
+
+      const tabs = element.getByRole("tab");
+      const firstTab = tabs.nth(0);
+      const secondTab = tabs.nth(1);
+      const firstPanel = page.getByText("Panel one");
+      const secondPanel = page.getByText("Panel two");
+      const thirdPanel = page.getByText("Panel three");
+
+      await expect(firstTab).toHaveAttribute("aria-selected", "true");
+      await expect(firstPanel).toBeVisible();
+      await expect(firstPanel).toHaveRole("tabpanel");
+      await expect(secondPanel).toBeHidden();
+      await expect(secondPanel).toHaveRole("tabpanel");
+      await expect(thirdPanel).toBeHidden();
+      await expect(thirdPanel).toHaveRole("tabpanel");
+
+      await secondTab.click();
+
+      await expect(firstPanel).toBeHidden();
+      await expect(secondPanel).toBeVisible();
+      await expect(thirdPanel).toBeHidden();
+    });
 });

--- a/packages/web-components/src/tablist/tablist.spec.ts
+++ b/packages/web-components/src/tablist/tablist.spec.ts
@@ -311,12 +311,9 @@ test.describe('Tablist', () => {
     await expect(element).toHaveJSProperty('activeid', secondTabId);
   });
 
-  test("should associate panel elements with `aria-controls` attributes", async ({
-      fastPage,
-      page,
-  }) => {
-      const { element } = fastPage;
-      await fastPage.setTemplate(`
+  test('should associate panel elements with `aria-controls` attributes', async ({ fastPage, page }) => {
+    const { element } = fastPage;
+    await fastPage.setTemplate(`
           <fluent-tablist>
               <fluent-tab aria-controls="panel1">Tab one</fluent-tab>
               <fluent-tab aria-controls="panel2">Tab two</fluent-tab>
@@ -327,25 +324,25 @@ test.describe('Tablist', () => {
           <div id="panel3">Panel three</div>
       `);
 
-      const tabs = element.getByRole("tab");
-      const firstTab = tabs.nth(0);
-      const secondTab = tabs.nth(1);
-      const firstPanel = page.getByText("Panel one");
-      const secondPanel = page.getByText("Panel two");
-      const thirdPanel = page.getByText("Panel three");
+    const tabs = element.getByRole('tab');
+    const firstTab = tabs.nth(0);
+    const secondTab = tabs.nth(1);
+    const firstPanel = page.getByText('Panel one');
+    const secondPanel = page.getByText('Panel two');
+    const thirdPanel = page.getByText('Panel three');
 
-      await expect(firstTab).toHaveAttribute("aria-selected", "true");
-      await expect(firstPanel).toBeVisible();
-      await expect(firstPanel).toHaveRole("tabpanel");
-      await expect(secondPanel).toBeHidden();
-      await expect(secondPanel).toHaveRole("tabpanel");
-      await expect(thirdPanel).toBeHidden();
-      await expect(thirdPanel).toHaveRole("tabpanel");
+    await expect(firstTab).toHaveAttribute('aria-selected', 'true');
+    await expect(firstPanel).toBeVisible();
+    await expect(firstPanel).toHaveRole('tabpanel');
+    await expect(secondPanel).toBeHidden();
+    await expect(secondPanel).toHaveRole('tabpanel');
+    await expect(thirdPanel).toBeHidden();
+    await expect(thirdPanel).toHaveRole('tabpanel');
 
-      await secondTab.click();
+    await secondTab.click();
 
-      await expect(firstPanel).toBeHidden();
-      await expect(secondPanel).toBeVisible();
-      await expect(thirdPanel).toBeHidden();
-    });
+    await expect(firstPanel).toBeHidden();
+    await expect(secondPanel).toBeVisible();
+    await expect(thirdPanel).toBeHidden();
+  });
 });

--- a/packages/web-components/src/tablist/tablist.stories.ts
+++ b/packages/web-components/src/tablist/tablist.stories.ts
@@ -148,3 +148,20 @@ export const LargeSizeVerticalOrientation: Story = {
     },
   ],
 };
+
+export const AutoPanelAssociation: Story = {
+  render: renderComponent(html<StoryArgs<FluentTablist>>`
+    <div style="display: flex; flex-direction: column; gap: 1rem;">
+      <fluent-tablist>
+        <fluent-tab aria-controls="panel1">First Tab</fluent-tab>
+        <fluent-tab aria-controls="panel2">Second Tab</fluent-tab>
+        <fluent-tab aria-controls="panel3">Third Tab</fluent-tab>
+        <fluent-tab aria-controls="panel4">Fourth Tab</fluent-tab>
+      </fluent-tablist>
+      <div id="panel1">First panel</div>
+      <div id="panel2">Second panel</div>
+      <div id="panel3">Third panel</div>
+      <div id="panel4">Fourth panel</div>
+    </div>
+  `),
+};

--- a/packages/web-components/src/tablist/tablist.ts
+++ b/packages/web-components/src/tablist/tablist.ts
@@ -117,15 +117,15 @@ export class BaseTablist extends FASTElement {
       this.setTabs();
 
       for (const tab of this.tabs) {
-        const ariaControls = tab.getAttribute("aria-controls") ?? "";
+        const ariaControls = tab.getAttribute('aria-controls') ?? '';
         const rootNode = this.getRootNode() as Document | ShadowRoot;
         const panel = rootNode.getElementById(ariaControls);
         if (ariaControls && panel) {
-	        panel.role ??= "tabpanel";
-	        panel.hidden = this.activeid !== tab.id;
-	        this.tabPanelMap.set(tab, panel);
+          panel.role ??= 'tabpanel';
+          panel.hidden = this.activeid !== tab.id;
+          this.tabPanelMap.set(tab, panel);
         }
-			}
+      }
     }
   }
 

--- a/packages/web-components/src/tablist/tablist.ts
+++ b/packages/web-components/src/tablist/tablist.ts
@@ -85,6 +85,21 @@ export class BaseTablist extends FASTElement {
     if (this.$fastController.isConnected && this.tabs.length > 0) {
       this.prevActiveTabIndex = this.tabs.findIndex((item: HTMLElement) => item.id === oldValue);
       this.setTabs();
+
+      if (oldValue) {
+        const prevActiveTab = this.tabs[this.prevActiveTabIndex];
+        const prevActivePanel = this.tabPanelMap.get(prevActiveTab);
+        if (prevActivePanel) {
+          prevActivePanel.hidden = true;
+        }
+      }
+
+      if (newValue && this.activetab) {
+        const activePanel = this.tabPanelMap.get(this.activetab);
+        if (activePanel) {
+          activePanel.hidden = false;
+        }
+      }
     }
   }
 
@@ -100,6 +115,17 @@ export class BaseTablist extends FASTElement {
     if (this.$fastController.isConnected && this.tabs.length > 0) {
       this.tabIds = this.getTabIds();
       this.setTabs();
+
+      for (const tab of this.tabs) {
+        const ariaControls = tab.getAttribute("aria-controls") ?? "";
+        const rootNode = this.getRootNode() as Document | ShadowRoot;
+        const panel = rootNode.getElementById(ariaControls);
+        if (ariaControls && panel) {
+	        panel.role ??= "tabpanel";
+	        panel.hidden = this.activeid !== tab.id;
+	        this.tabPanelMap.set(tab, panel);
+        }
+			}
     }
   }
 
@@ -112,6 +138,8 @@ export class BaseTablist extends FASTElement {
   private prevActiveTabIndex: number = 0;
   private activeTabIndex: number = 0;
   private tabIds!: Array<string>;
+
+  private tabPanelMap = new WeakMap<HTMLElement, HTMLElement>();
 
   private change = (): void => {
     this.$emit('change', this.activetab);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

The component requires developers to listen to the `change` event to handle tab selection changes and panel changes manually.

## New Behavior

Developers can add `aria-controls` attribute to `<fluent-tab>`, and the element that `aria-controls` references to will be automatically associated to the `<fluent-tab>` element, and will show/hide (by toggling `hidden` attribute) based on selected tabs in the tab list.