### PR TITLE
Fix: SearchBox CustomStyleHook Implementation

### DIFF
--- a/change/@fluentui-react-search-1ad2aa86-fd4b-49da-b241-b5b55bbb02e2.json
+++ b/change/@fluentui-react-search-1ad2aa86-fd4b-49da-b241-b5b55bbb02e2.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "fix: Implemented customStyleHooks for SearchBox Component",
+  "packageName": "@fluentui/react-search",
+  "email": "terynkum@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-search-1ad2aa86-fd4b-49da-b241-b5b55bbb02e2.json
+++ b/change/@fluentui-react-search-1ad2aa86-fd4b-49da-b241-b5b55bbb02e2.json
@@ -1,5 +1,5 @@
 {
-  "type": "minor",
+  "type": "patch",
   "comment": "fix: Implemented customStyleHooks for SearchBox Component",
   "packageName": "@fluentui/react-search",
   "email": "terynkum@microsoft.com",

--- a/change/@fluentui-react-shared-contexts-dad685da-3118-47dc-9bee-668dd722a0b3.json
+++ b/change/@fluentui-react-shared-contexts-dad685da-3118-47dc-9bee-668dd722a0b3.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "fix: Implemented customStyleHooks for SearchBox Component",
+  "packageName": "@fluentui/react-shared-contexts",
+  "email": "terynkum@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-search/library/package.json
+++ b/packages/react-components/react-search/library/package.json
@@ -21,6 +21,7 @@
     "@fluentui/react-icons": "^2.0.245",
     "@fluentui/react-input": "^9.5.0",
     "@fluentui/react-jsx-runtime": "^9.0.50",
+    "@fluentui/react-shared-contexts": "^9.21.2",
     "@fluentui/react-theme": "^9.1.24",
     "@fluentui/react-utilities": "^9.18.20",
     "@griffel/react": "^1.5.22",

--- a/packages/react-components/react-search/library/src/components/SearchBox/SearchBox.tsx
+++ b/packages/react-components/react-search/library/src/components/SearchBox/SearchBox.tsx
@@ -4,6 +4,7 @@ import { renderSearchBox_unstable } from './renderSearchBox';
 import { useSearchBoxStyles_unstable } from './useSearchBoxStyles.styles';
 import type { SearchBoxProps } from './SearchBox.types';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
+import { useCustomStyleHook_unstable } from '../../../../../react-shared-contexts/library/src/index';
 
 /**
  * SearchBox component - TODO: add more docs
@@ -12,6 +13,9 @@ export const SearchBox: ForwardRefComponent<SearchBoxProps> = React.forwardRef((
   const state = useSearchBox_unstable(props, ref);
 
   useSearchBoxStyles_unstable(state);
+
+  useCustomStyleHook_unstable('useSearchBoxStyles_unstable')(state);
+
   return renderSearchBox_unstable(state);
 });
 

--- a/packages/react-components/react-search/library/src/components/SearchBox/SearchBox.tsx
+++ b/packages/react-components/react-search/library/src/components/SearchBox/SearchBox.tsx
@@ -4,7 +4,7 @@ import { renderSearchBox_unstable } from './renderSearchBox';
 import { useSearchBoxStyles_unstable } from './useSearchBoxStyles.styles';
 import type { SearchBoxProps } from './SearchBox.types';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
-import { useCustomStyleHook_unstable } from '../../../../../react-shared-contexts/library/src/index';
+import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 
 /**
  * SearchBox component - TODO: add more docs

--- a/packages/react-components/react-search/stories/src/SearchBox/SearchBoxDefault.stories.tsx
+++ b/packages/react-components/react-search/stories/src/SearchBox/SearchBoxDefault.stories.tsx
@@ -1,13 +1,31 @@
 import * as React from 'react';
 import type { ArgTypes } from '@storybook/react';
-import { Field, SearchBox } from '@fluentui/react-components';
-import type { SearchBoxProps } from '@fluentui/react-components';
+import { Field, mergeClasses, makeStyles, SearchBox, FluentProvider } from '@fluentui/react-components';
+import type { SearchBoxProps, SearchBoxState, FluentProviderCustomStyleHooks } from '@fluentui/react-components';
+
+const useSearchBoxStyle = makeStyles({
+  root: {
+    backgroundColor: 'red',
+  },
+});
+
+const useSearchBoxStyles = (state: unknown) => {
+  const styles = useSearchBoxStyle();
+  const componentState = state as SearchBoxState;
+  componentState.root.className = mergeClasses(componentState.root.className, styles.root);
+};
+
+const CUSTOM_STYLE_HOOK: FluentProviderCustomStyleHooks = {
+  useSearchBoxStyles_unstable: useSearchBoxStyles,
+};
 
 export const Default = (props: SearchBoxProps) => {
   return (
-    <Field label="Sample SearchBox">
-      <SearchBox {...props} />
-    </Field>
+    <FluentProvider customStyleHooks_unstable={CUSTOM_STYLE_HOOK}>
+      <Field label="Sample SearchBox">
+        <SearchBox {...props} />
+      </Field>
+    </FluentProvider>
   );
 };
 

--- a/packages/react-components/react-search/stories/src/SearchBox/SearchBoxDefault.stories.tsx
+++ b/packages/react-components/react-search/stories/src/SearchBox/SearchBoxDefault.stories.tsx
@@ -1,31 +1,13 @@
 import * as React from 'react';
 import type { ArgTypes } from '@storybook/react';
-import { Field, mergeClasses, makeStyles, SearchBox, FluentProvider } from '@fluentui/react-components';
-import type { SearchBoxProps, SearchBoxState, FluentProviderCustomStyleHooks } from '@fluentui/react-components';
-
-const useSearchBoxStyle = makeStyles({
-  root: {
-    backgroundColor: 'red',
-  },
-});
-
-const useSearchBoxStyles = (state: unknown) => {
-  const styles = useSearchBoxStyle();
-  const componentState = state as SearchBoxState;
-  componentState.root.className = mergeClasses(componentState.root.className, styles.root);
-};
-
-const CUSTOM_STYLE_HOOK: FluentProviderCustomStyleHooks = {
-  useSearchBoxStyles_unstable: useSearchBoxStyles,
-};
+import { Field, SearchBox } from '@fluentui/react-components';
+import type { SearchBoxProps } from '@fluentui/react-components';
 
 export const Default = (props: SearchBoxProps) => {
   return (
-    <FluentProvider customStyleHooks_unstable={CUSTOM_STYLE_HOOK}>
-      <Field label="Sample SearchBox">
-        <SearchBox {...props} />
-      </Field>
-    </FluentProvider>
+    <Field label="Sample SearchBox">
+      <SearchBox {...props} />
+    </Field>
   );
 };
 

--- a/packages/react-components/react-shared-contexts/library/etc/react-shared-contexts.api.md
+++ b/packages/react-components/react-shared-contexts/library/etc/react-shared-contexts.api.md
@@ -84,6 +84,7 @@ export const CustomStyleHooksContext_unstable: React_2.Context<Partial<{
     usePopoverSurfaceStyles_unstable: CustomStyleHook;
     useRadioGroupStyles_unstable: CustomStyleHook;
     useRadioStyles_unstable: CustomStyleHook;
+    useSearchBoxStyles_unstable: CustomStyleHook;
     useSelectStyles_unstable: CustomStyleHook;
     useSliderStyles_unstable: CustomStyleHook;
     useSpinButtonStyles_unstable: CustomStyleHook;
@@ -240,6 +241,7 @@ export type CustomStyleHooksContextValue_unstable = Partial<{
     usePopoverSurfaceStyles_unstable: CustomStyleHook;
     useRadioGroupStyles_unstable: CustomStyleHook;
     useRadioStyles_unstable: CustomStyleHook;
+    useSearchBoxStyles_unstable: CustomStyleHook;
     useSelectStyles_unstable: CustomStyleHook;
     useSliderStyles_unstable: CustomStyleHook;
     useSpinButtonStyles_unstable: CustomStyleHook;
@@ -396,6 +398,7 @@ export const CustomStyleHooksProvider_unstable: React_2.Provider<Partial<{
     usePopoverSurfaceStyles_unstable: CustomStyleHook;
     useRadioGroupStyles_unstable: CustomStyleHook;
     useRadioStyles_unstable: CustomStyleHook;
+    useSearchBoxStyles_unstable: CustomStyleHook;
     useSelectStyles_unstable: CustomStyleHook;
     useSliderStyles_unstable: CustomStyleHook;
     useSpinButtonStyles_unstable: CustomStyleHook;

--- a/packages/react-components/react-shared-contexts/library/src/CustomStyleHooksContext/CustomStyleHooksContext.ts
+++ b/packages/react-components/react-shared-contexts/library/src/CustomStyleHooksContext/CustomStyleHooksContext.ts
@@ -56,6 +56,7 @@ export type CustomStyleHooksContextValue = Partial<{
   usePopoverSurfaceStyles_unstable: CustomStyleHook;
   useRadioGroupStyles_unstable: CustomStyleHook;
   useRadioStyles_unstable: CustomStyleHook;
+  useSearchBoxStyles_unstable: CustomStyleHook;
   useSelectStyles_unstable: CustomStyleHook;
   useSliderStyles_unstable: CustomStyleHook;
   useSpinButtonStyles_unstable: CustomStyleHook;


### PR DESCRIPTION
## Previous Behavior
Users were unable to apply CustomStyleHooks to SearchBox component.

## New Behavior
Users can now apply CustomStyleHooks to SearchBox. The screen shots below show test cases for each component that demonstrate the ability to apply Custom Hooks. In each Custom Hook, the backgroundColor of the component was updated to 'red'. The test code will be REMOVED but can be found in [this commit](https://github.com/microsoft/fluentui/commit/25ef567d0951095e588339094d2d62d1e9448cf6)  The test code applies Custom Style Hooks to the Default styling.

## Test Screenshot
<img width="626" alt="Screenshot 2025-03-07 at 1 55 46 PM" src="https://github.com/user-attachments/assets/dc435e84-d31c-4f20-a3fe-ffa466ed5456" />
