### PR TITLE
feat(workspace-plugin): add generation regexp check in order to prevent running generators with invalid project name including npm scope

### DIFF
--- a/tools/workspace-plugin/src/generators/bundle-size-configuration/schema.json
+++ b/tools/workspace-plugin/src/generators/bundle-size-configuration/schema.json
@@ -11,6 +11,7 @@
         "$source": "argv",
         "index": 0
       },
+      "pattern": "^[a-zA-Z].*$",
       "x-prompt": "For which project do you want to add bundle-size configuration?",
       "x-dropdown": "projects"
     },

--- a/tools/workspace-plugin/src/generators/cypress-component-configuration/schema.json
+++ b/tools/workspace-plugin/src/generators/cypress-component-configuration/schema.json
@@ -13,7 +13,9 @@
         "$source": "argv",
         "index": 0
       },
-      "x-prompt": "For which project do you want to add Cypress component testing?"
+      "pattern": "^[a-zA-Z].*$",
+      "x-prompt": "For which project do you want to add Cypress component testing?",
+      "x-dropdown": "projects"
     }
   },
   "required": ["project"]

--- a/tools/workspace-plugin/src/generators/prepare-initial-release/schema.json
+++ b/tools/workspace-plugin/src/generators/prepare-initial-release/schema.json
@@ -8,6 +8,8 @@
       "type": "string",
       "description": "Library name",
       "x-prompt": "What project should be released",
+      "x-dropdown": "projects",
+      "pattern": "^[a-zA-Z].*$",
       "$default": {
         "$source": "argv",
         "index": 0


### PR DESCRIPTION


<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

- NOTE: all monorepo project names exclude `npmScope` in order to mitigate churn and verbose typing
- if you decide to avoid using prompts that we ship with our generators, or `yarn nx generate` and provide `--project` name explicitly you  may by accident provide the project name with `npmScope` 

## Previous Behavior

`yarn nx generate @fluentui/workspace-plugin:prepare-initial-release --project=@fluentui/react-color-picker-preview --phase=stable`


<img width="742" alt="image" src="https://github.com/user-attachments/assets/1c330752-e33f-49c2-ae40-99842913adcf" />


## New Behavior

`yarn nx generate @fluentui/workspace-plugin:prepare-initial-release --project=@fluentui/react-color-picker-preview --phase=stable`

<img width="1111" alt="image" src="https://github.com/user-attachments/assets/9655685e-f376-44b0-9034-3825255b1d40" />


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
