### PR TITLE
chore(CI): migrate NPM Deprecate pipeline to 1ESPT

### DIFF
--- a/azure-pipelines.deprecate-package.yml
+++ b/azure-pipelines.deprecate-package.yml
@@ -15,7 +15,6 @@ parameters:
 
 variables:
   - group: 'Github and NPM secrets'
-  - template: .devops/templates/variables.yml
     parameters:
       skipComponentGovernanceDetection: false
   - name: tags

--- a/azure-pipelines.deprecate-package.yml
+++ b/azure-pipelines.deprecate-package.yml
@@ -21,20 +21,38 @@ variables:
   - name: tags
     value: production,externalfacing
 
-pool: '1ES-Host-Ubuntu'
+resources:
+  repositories:
+    - repository: 1esPipelines
+      type: git
+      name: 1ESPipelineTemplates/1ESPipelineTemplates
+      ref: refs/tags/release
 
-jobs:
-  - job: DeprecatePublishedPackage
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
+  parameters:
     pool:
-      name: '1ES-Host-Ubuntu'
-      image: '1ES-PT-Ubuntu-20.04'
-      os: linux
-    workspace:
-      clean: all
-    steps:
-      - template: .devops/templates/tools.yml@self
-
-      - script: |
-          npm deprecate ${{ parameters.packageSpec }} "${{ parameters.message }}" --registry https://registry.npmjs.org/ --//registry.npmjs.org/:_authToken=$(npmToken)
-        displayName: 'Deprecate package'
-        condition: eq(variables.dryRun, false)
+      name: Azure-Pipelines-1ESPT-ExDShared
+      image: windows-latest
+      os: windows # We need windows because compliance task only run on windows.
+    stages:
+      - stage: main
+        jobs:
+          - job: Release
+            pool:
+              name: '1ES-Host-Ubuntu'
+              image: '1ES-PT-Ubuntu-20.04'
+              os: linux
+            workspace:
+              clean: all
+            templateContext:
+              outputs:
+                - output: pipelineArtifact
+                  targetPath: $(System.DefaultWorkingDirectory)
+                  artifactName: output
+            steps:
+              - template: .devops/templates/tools.yml@self
+              - script: |
+                  npm deprecate ${{ parameters.packageSpec }} "${{ parameters.message }}" --registry https://registry.npmjs.org/ --//registry.npmjs.org/:_authToken=$(npmToken)
+                displayName: 'Deprecate package'
+                condition: eq(variables.dryRun, false)

--- a/azure-pipelines.deprecate-package.yml
+++ b/azure-pipelines.deprecate-package.yml
@@ -35,7 +35,7 @@ extends:
     stages:
       - stage: main
         jobs:
-          - job: Release
+          - job: DeprecateRelease
             pool:
               name: '1ES-Host-Ubuntu'
               image: '1ES-PT-Ubuntu-20.04'

--- a/azure-pipelines.deprecate-package.yml
+++ b/azure-pipelines.deprecate-package.yml
@@ -15,8 +15,6 @@ parameters:
 
 variables:
   - group: 'Github and NPM secrets'
-    parameters:
-      skipComponentGovernanceDetection: false
   - name: tags
     value: production,externalfacing
 


### PR DESCRIPTION
## Changes:
- updates Deprecate Published Package pipeline to use 1ESPT similar to other production pipelines #29702

Successful [test run](https://uifabric.visualstudio.com/UI%20Fabric/_build/results?buildId=371596&view=logs&j=7494ae37-3ecd-50c6-9ffe-c77a2768c545&t=b959630e-d70a-505e-fcef-1e91d82979e4)
