### PR TITLE
test(react-migration-v0,v8): add memory limit to make jest not fail OOM on ci

### DIFF
--- a/packages/react-components/react-migration-v0-v9/library/jest.config.js
+++ b/packages/react-components/react-migration-v0-v9/library/jest.config.js
@@ -28,6 +28,9 @@ module.exports = {
   transform: {
     '^.+\\.tsx?$': ['@swc/jest', swcJestConfig],
   },
+  // Keeps Jest from using too much memory as GC gets invokes more often, makes tests slower
+  // https://stackoverflow.com/a/75857711
+  workerIdleMemoryLimit: '1024MB',
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],
   snapshotSerializers: ['@griffel/jest-serializer'],

--- a/packages/react-components/react-migration-v8-v9/library/jest.config.js
+++ b/packages/react-components/react-migration-v8-v9/library/jest.config.js
@@ -28,6 +28,9 @@ module.exports = {
   transform: {
     '^.+\\.tsx?$': ['@swc/jest', swcJestConfig],
   },
+  // Keeps Jest from using too much memory as GC gets invokes more often, makes tests slower
+  // https://stackoverflow.com/a/75857711
+  workerIdleMemoryLimit: '1024MB',
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],
   snapshotSerializers: ['@griffel/jest-serializer'],


### PR DESCRIPTION

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

intermittent OOM issues started to occur more regularly  https://github.com/microsoft/fluentui/actions/runs/13795119408/job/38584776289

<img width="1643" alt="image" src="https://github.com/user-attachments/assets/a1ea2628-5afb-40fa-9279-6c42eda7c703" />

because v0 and v8 migration will import whole v0/v8 respectively witin the test the memory limit is reached very easily

## New Behavior

adding memory limit to jest should prevent these OOM issues

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows https://github.com/microsoft/fluentui/pull/33556/files#diff-1093fac4db13e4684822c88854b913a5466e53b5b82a52d53e0e7c7e4ee04bb9
