### PR TITLE
docs: fix minor accessibility bugs in v8 example code

### DIFF
--- a/packages/react-examples/src/react/Button/Button.ContextualMenu.Example.tsx
+++ b/packages/react-examples/src/react/Button/Button.ContextualMenu.Example.tsx
@@ -11,7 +11,7 @@ export interface IButtonExampleProps {
 const menuProps: IContextualMenuProps = {
   // For example: disable dismiss if shift key is held down while dismissing
   onDismiss: ev => {
-    if (ev && 'shiftKey' in ev) {
+    if (ev && 'shiftKey' in ev && ev.shiftKey) {
       ev.preventDefault();
     }
   },

--- a/packages/react-examples/src/react/List/List.Basic.Example.tsx
+++ b/packages/react-examples/src/react/List/List.Basic.Example.tsx
@@ -70,6 +70,7 @@ export const ListBasicExample: React.FunctionComponent = () => {
           <Image
             className={classNames.itemImage}
             src="https://res.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-react-assets/fluent-placeholder.svg"
+            alt=""
             width={50}
             height={50}
             imageFit={ImageFit.cover}

--- a/packages/react-examples/src/react/List/List.Ghosting.Example.tsx
+++ b/packages/react-examples/src/react/List/List.Ghosting.Example.tsx
@@ -73,6 +73,7 @@ export const ListGhostingExample: React.FunctionComponent = () => {
                 ? undefined
                 : 'https://res.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-react-assets/fluent-placeholder.svg'
             }
+            alt=""
             width={50}
             height={50}
             imageFit={ImageFit.cover}

--- a/packages/react-examples/src/react/List/List.Grid.Example.tsx
+++ b/packages/react-examples/src/react/List/List.Grid.Example.tsx
@@ -98,6 +98,7 @@ export const ListGridExample: React.FunctionComponent = () => {
                 src={
                   'https://res.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-react-assets/fluent-placeholder.svg'
                 }
+                alt=""
                 className={classNames.listGridExampleImage}
               />
               <span className={classNames.listGridExampleLabel}>{`item ${index}`}</span>


### PR DESCRIPTION
This fixes two minor bugs in v8 examples:

1. List examples had images with no alt attributes; now they have `alt=""`, which marks them as presentational (and is different from a missing alt)
2. The Button - ContextualMenu example had a `onDismiss` handler that prevented any dismissal with the keyboard, rather than just preventing it when the shift key was pressed, which was the intent. Now it works :D.


- Fixes 2 ADO bugs
