### PR TITLE
feat: Add 'scrollParents' option to Popover component

### DIFF
--- a/packages/react-components/react-popover/library/src/components/Popover/Popover.types.ts
+++ b/packages/react-components/react-popover/library/src/components/Popover/Popover.types.ts
@@ -141,6 +141,10 @@ export type PopoverProps = Pick<PortalProps, 'mountNode'> & {
    */
   // eslint-disable-next-line @typescript-eslint/naming-convention
   unstable_disableAutoFocus?: boolean;
+  /**
+   * Enables users to pass in custom scroll parent elements to listen to scroll events on
+   */
+  scrollParents?: HTMLElement[];
 };
 
 /**

--- a/packages/react-components/react-popover/library/src/components/Popover/usePopover.ts
+++ b/packages/react-components/react-popover/library/src/components/Popover/usePopover.ts
@@ -192,7 +192,7 @@ function useOpenState(
  */
 function usePopoverRefs(
   state: Pick<PopoverState, 'size' | 'contextTarget'> &
-    Pick<PopoverProps, 'positioning' | 'openOnContext' | 'withArrow'>,
+    Pick<PopoverProps, 'positioning' | 'openOnContext' | 'withArrow' | 'scrollParents'>,
 ) {
   'use no memo';
 
@@ -202,6 +202,7 @@ function usePopoverRefs(
     arrowPadding: 2 * popoverSurfaceBorderRadius,
     target: state.openOnContext ? state.contextTarget : undefined,
     ...resolvePositioningShorthand(state.positioning),
+    scrollParents: state.scrollParents,
   };
 
   // no reason to render arrow when covering the target

--- a/packages/react-components/react-positioning/src/createPositionManager.ts
+++ b/packages/react-components/react-positioning/src/createPositionManager.ts
@@ -42,6 +42,10 @@ interface PositionManagerOptions {
    * Disables the resize observer that updates position on target or dimension change
    */
   disableUpdateOnResize?: boolean;
+  /**
+   * Allows the user to pass in custom scroll parent elements to listen to scroll events on
+   */
+  scrollParents?: HTMLElement[];
 }
 
 /**
@@ -84,7 +88,7 @@ export function createPositionManager(options: PositionManagerOptions): Position
       });
 
   let isFirstUpdate = true;
-  const scrollParents: Set<HTMLElement> = new Set<HTMLElement>();
+  const scrollParents: Set<HTMLElement> = options.scrollParents ? new Set<HTMLElement>(options.scrollParents) : new Set<HTMLElement>();
 
   // When the container is first resolved, set position `fixed` to avoid scroll jumps.
   // Without this scroll jumps can occur when the element is rendered initially and receives focus

--- a/packages/react-components/react-positioning/src/types.ts
+++ b/packages/react-components/react-positioning/src/types.ts
@@ -213,6 +213,10 @@ export interface PositioningOptions {
    * @default false
    */
   shiftToCoverTarget?: boolean;
+    /**
+   * Enables users to pass in custom scroll parent elements to listen to scroll events on
+   */
+    scrollParents?: HTMLElement[];
 }
 
 /**

--- a/packages/react-components/react-positioning/src/usePositioning.ts
+++ b/packages/react-components/react-positioning/src/usePositioning.ts
@@ -182,6 +182,7 @@ function usePositioningOptions(options: PositioningOptions) {
     matchTargetSize,
     disableUpdateOnResize = false,
     shiftToCoverTarget,
+    scrollParents
   } = options;
 
   const { dir, targetDocument } = useFluent();
@@ -247,6 +248,7 @@ function usePositioningOptions(options: PositioningOptions) {
       matchTargetSize,
       targetDocument,
       disableUpdateOnResize,
+      scrollParents
     ],
   );
 }


### PR DESCRIPTION


https://github.com/user-attachments/assets/4c889af1-83e1-44b1-bb4e-dd55a6858fe6

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Currently, when a user opens a Popover component in a nested scroll window and they scroll outside of that scroll window, the Popover will remain on the same part of the page and will not follow its parent component around on the page (see linked video).

## New Behavior

 This PR adds a property to Popover components that allow users to pass in their own `scrollParents` elements to listen to so Popover component positioning will behave as expected.

## Related Issue(s)
- Fixes #33948 
