### PR TITLE
fix(Nav): minor accessibility cleanup

### DIFF
--- a/packages/react-components/react-nav-preview/library/src/components/AppItem/useAppItem.ts
+++ b/packages/react-components/react-nav-preview/library/src/components/AppItem/useAppItem.ts
@@ -26,7 +26,6 @@ export const useAppItem_unstable = (
     getIntrinsicElementProps(
       rootElementType,
       useARIAButtonProps(rootElementType, {
-        role: rootElementType,
         ...props,
       }),
     ),

--- a/packages/react-components/react-nav-preview/library/src/components/NavDrawer/useNavDrawer.ts
+++ b/packages/react-components/react-nav-preview/library/src/components/NavDrawer/useNavDrawer.ts
@@ -26,7 +26,6 @@ export const useNavDrawer_unstable = (props: NavDrawerProps, ref: React.Ref<HTML
 
   const navState = useNav_unstable(
     {
-      role: 'navigation',
       ...props,
     },
     ref,
@@ -44,7 +43,7 @@ export const useNavDrawer_unstable = (props: NavDrawerProps, ref: React.Ref<HTML
     },
 
     root: slot.always(
-      { ref, ...props, ...focusAttributes },
+      { ref, role: 'navigation', ...props, ...focusAttributes },
       {
         // TODO: remove once React v18 slot API is modified
         // this is a problem with the lack of support for union types on React v18

--- a/packages/react-components/react-nav-preview/library/src/components/NavItem/useNavItem.ts
+++ b/packages/react-components/react-nav-preview/library/src/components/NavItem/useNavItem.ts
@@ -42,7 +42,6 @@ export const useNavItem_unstable = (
       rootElementType,
       useARIAButtonProps(rootElementType, {
         'aria-current': selected ? 'page' : 'false',
-        role: rootElementType,
         ...props,
       }),
     ),

--- a/packages/react-components/react-nav-preview/library/src/components/NavSubItem/useNavSubItem.ts
+++ b/packages/react-components/react-nav-preview/library/src/components/NavSubItem/useNavSubItem.ts
@@ -45,7 +45,6 @@ export const useNavSubItem_unstable = (
       rootElementType,
       useARIAButtonProps(rootElementType, {
         'aria-current': selected ? 'page' : 'false',
-        role: rootElementType,
         ...props,
       }),
     ),

--- a/packages/react-components/react-nav-preview/library/src/components/sharedNavStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/library/src/components/sharedNavStyles.styles.ts
@@ -98,7 +98,8 @@ export const useIndicatorStyles = makeStyles({
     },
     '@media (forced-colors: active)': {
       '::after': {
-        backgroundColor: 'ButtonText',
+        outline: `solid 2px ${tokens.colorTransparentStroke}`,
+        outlineOffset: '-2px',
       },
     },
   },

--- a/packages/react-components/react-nav-preview/stories/src/NavDrawer/Basic.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/src/NavDrawer/Basic.stories.tsx
@@ -15,7 +15,17 @@ import {
   NavSubItemGroup,
 } from '@fluentui/react-nav-preview';
 import { DrawerProps } from '@fluentui/react-drawer';
-import { Label, Radio, RadioGroup, Switch, Tooltip, makeStyles, tokens, useId } from '@fluentui/react-components';
+import {
+  Label,
+  Radio,
+  RadioGroup,
+  Switch,
+  Tooltip,
+  makeStyles,
+  tokens,
+  useId,
+  useRestoreFocusTarget,
+} from '@fluentui/react-components';
 import {
   Board20Filled,
   Board20Regular,
@@ -52,6 +62,9 @@ const useStyles = makeStyles({
     overflow: 'hidden',
     display: 'flex',
     height: '600px',
+  },
+  nav: {
+    minWidth: '200px',
   },
   content: {
     flex: '1',
@@ -97,15 +110,10 @@ export const Basic = (props: Partial<NavDrawerProps>) => {
   const [type, setType] = React.useState<DrawerType>('inline');
   const [isMultiple, setIsMultiple] = React.useState(true);
 
-  const linkDestination = enabledLinks ? 'https://www.bing.com' : '';
+  // Tabster prop used to restore focus to the navigation trigger for overlay nav drawers
+  const restoreFocusTargetAttributes = useRestoreFocusTarget();
 
-  const renderHamburgerWithToolTip = () => {
-    return (
-      <Tooltip content="Navigation" relationship="label">
-        <Hamburger onClick={() => setIsOpen(!isOpen)} />
-      </Tooltip>
-    );
-  };
+  const linkDestination = enabledLinks ? 'https://www.bing.com' : '';
 
   return (
     <div className={styles.root}>
@@ -115,8 +123,13 @@ export const Basic = (props: Partial<NavDrawerProps>) => {
         open={isOpen}
         type={type}
         multiple={isMultiple}
+        className={styles.nav}
       >
-        <NavDrawerHeader>{renderHamburgerWithToolTip()}</NavDrawerHeader>
+        <NavDrawerHeader>
+          <Tooltip content="Close Navigation" relationship="label">
+            <Hamburger onClick={() => setIsOpen(!isOpen)} />
+          </Tooltip>
+        </NavDrawerHeader>
 
         <NavDrawerBody>
           <AppItem icon={<PersonCircle32Regular />} as="a" href={linkDestination}>
@@ -196,7 +209,9 @@ export const Basic = (props: Partial<NavDrawerProps>) => {
         </NavDrawerBody>
       </NavDrawer>
       <div className={styles.content}>
-        {!isOpen && renderHamburgerWithToolTip()}
+        <Tooltip content="Toggle navigation pane" relationship="label">
+          <Hamburger onClick={() => setIsOpen(!isOpen)} {...restoreFocusTargetAttributes} />
+        </Tooltip>
         <div className={styles.field}>
           <Label id={typeLableId}>Type</Label>
           <RadioGroup

--- a/packages/react-components/react-nav-preview/stories/src/NavDrawer/Controlled.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/src/NavDrawer/Controlled.stories.tsx
@@ -54,6 +54,9 @@ const useStyles = makeStyles({
     display: 'flex',
     height: '600px',
   },
+  nav: {
+    minWidth: '200px',
+  },
   content: {
     flex: '1',
     padding: '16px',
@@ -210,6 +213,7 @@ export const Controlled = (props: Partial<NavDrawerProps>) => {
         selectedCategoryValue={selectedCategoryValue}
         type={'inline'}
         open={true}
+        className={styles.nav}
       >
         <NavDrawerHeader>{renderHamburgerWithToolTip()}</NavDrawerHeader>
 

--- a/packages/react-components/react-nav-preview/stories/src/NavDrawer/SplitNavItems.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/src/NavDrawer/SplitNavItems.stories.tsx
@@ -75,6 +75,9 @@ const useStyles = makeStyles({
     display: 'flex',
     height: '600px',
   },
+  nav: {
+    minWidth: '200px',
+  },
   content: {
     flex: '1',
     padding: '16px',
@@ -295,7 +298,7 @@ export const SplitNavItems = (props: Partial<NavDrawerProps>) => {
 
   return (
     <div className={styles.root}>
-      <NavDrawer defaultSelectedValue="5" open={true} density={density} type={'inline'}>
+      <NavDrawer defaultSelectedValue="5" open={true} density={density} type={'inline'} className={styles.nav}>
         <NavDrawerHeader>
           <Tooltip content="Navigation" relationship="label">
             <Hamburger />

--- a/packages/react-components/react-nav-preview/stories/src/NavDrawer/VariableDensityItems.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/src/NavDrawer/VariableDensityItems.stories.tsx
@@ -55,6 +55,9 @@ const useStyles = makeStyles({
     display: 'flex',
     height: '600px',
   },
+  nav: {
+    minWidth: '200px',
+  },
   content: {
     flex: '1',
     padding: '16px',
@@ -124,6 +127,7 @@ export const VariableDensityItems = (props: Partial<NavDrawerProps>) => {
         open={true}
         type={'inline'}
         density={density}
+        className={styles.nav}
       >
         <NavDrawerHeader>
           <Tooltip content="Navigation" relationship="label">


### PR DESCRIPTION
Found some minor a11y bugfixes when doing the accessibility review checklist. This PR addresses them:

Package fixes:
- The left border indicator for current page didn't show up in high contrast mode, so I added a transparent inset outline style to the `::after` that causes it to show
- Removed the `role` for two reasons -- since it was already set to the same thing as the element type, it was unnecessary, and the role for `<a>` is oddly enough `link`, so it was causing automated errors.
- The `role=navigation` prop was added to the state but not the root slot props, so it wasn't making it to the element. It looked like it wasn't being used on `state`, so I moved it to the root slot props object.

Example/doc fixes:
- At small screen sizes, the Nav collapsed past usability, so I added a `min-width` to the examples
- For the Basic example where the Nav can collapse, I added focus restoration to the trigger (for which the trigger needed to be always be present in the DOM, not conditionally rendered, and the in-Nav vs. outside-Nav triggers are treated slightly differently)
- Tweaked the tooltips and accName of the Basic example's in-Nav vs. outside-Nav buttons (if you don't like this, feel free to comment & I can revert it; just didn't want two co-existing buttons to have the exact same name)