### PR TITLE
feat(react-motion): implement interruptible motions [experimental]

### DIFF
--- a/change/@fluentui-react-motion-24284c59-9a62-4f23-9c8e-4aca459271e5.json
+++ b/change/@fluentui-react-motion-24284c59-9a62-4f23-9c8e-4aca459271e5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: experimental createInterruptablePresence()",
+  "packageName": "@fluentui/react-motion",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-motion/library/src/hooks/useAnimateAtoms.ts
+++ b/packages/react-components/react-motion/library/src/hooks/useAnimateAtoms.ts
@@ -1,4 +1,6 @@
 import * as React from 'react';
+
+import { isAnimationRunning } from '../utils/isAnimationRunning';
 import type { AnimationHandle, AtomMotion } from '../types';
 
 export const DEFAULT_ANIMATION_OPTIONS: KeyframeEffectOptions = {
@@ -78,6 +80,9 @@ function useAnimateAtomsInSupportedEnvironment() {
               oncancel();
             });
         },
+        isRunning() {
+          return animations.some(animation => isAnimationRunning(animation));
+        },
 
         cancel: () => {
           animations.forEach(animation => {
@@ -97,6 +102,18 @@ function useAnimateAtomsInSupportedEnvironment() {
         finish: () => {
           animations.forEach(animation => {
             animation.finish();
+          });
+        },
+        reverse: () => {
+          // Heads up!
+          //
+          // This is used for the interruptible motion. If the animation is running, we need to reverse it.
+          //
+          // TODO: what do with animations that have "delay"?
+          // TODO: what do with animations that have different "durations"?
+
+          animations.forEach(animation => {
+            animation.reverse();
           });
         },
       };
@@ -148,6 +165,10 @@ function useAnimateAtomsInTestEnvironment() {
         set playbackRate(rate: number) {
           /* no-op */
         },
+        isRunning() {
+          return false;
+        },
+
         cancel() {
           /* no-op */
         },
@@ -158,6 +179,9 @@ function useAnimateAtomsInTestEnvironment() {
           /* no-op */
         },
         finish() {
+          /* no-op */
+        },
+        reverse() {
           /* no-op */
         },
       };

--- a/packages/react-components/react-motion/library/src/types.ts
+++ b/packages/react-components/react-motion/library/src/types.ts
@@ -31,8 +31,9 @@ export type PresenceMotionFn<MotionParams extends Record<string, MotionParam> = 
 
 // ---
 
-export type AnimationHandle = Pick<Animation, 'cancel' | 'finish' | 'pause' | 'play' | 'playbackRate'> & {
+export type AnimationHandle = Pick<Animation, 'cancel' | 'finish' | 'pause' | 'play' | 'playbackRate' | 'reverse'> & {
   setMotionEndCallbacks: (onfinish: () => void, oncancel: () => void) => void;
+  isRunning: () => boolean;
 };
 
 export type MotionImperativeRef = {

--- a/packages/react-components/react-motion/library/src/utils/isAnimationRunning.test.ts
+++ b/packages/react-components/react-motion/library/src/utils/isAnimationRunning.test.ts
@@ -1,0 +1,51 @@
+import { isAnimationRunning } from './isAnimationRunning';
+
+// Heads up!
+// Unit tests are funny as JSDOM doesn't support the Web Animation API
+
+function createModernAnimationMock(playState: Animation['playState'], overallProgress: number): Animation {
+  return {
+    playState,
+    overallProgress,
+  } as Partial<Animation> as Animation;
+}
+
+function createLegacyAnimationMock(
+  playState: Animation['playState'],
+  currentTime: number,
+  duration: number,
+): Animation {
+  return {
+    playState,
+    currentTime,
+    effect: {
+      getTiming: () => ({
+        duration,
+      }),
+    },
+  } as Partial<Animation> as Animation;
+}
+
+describe('isAnimationRunning', () => {
+  it('returns "true" if the animation is running & started', () => {
+    expect(isAnimationRunning(createModernAnimationMock('running', 0.5))).toBe(true);
+  });
+
+  it('returns "false" if the animation is running & not started yet', () => {
+    expect(isAnimationRunning(createModernAnimationMock('running', 0))).toBe(false);
+    expect(isAnimationRunning(createModernAnimationMock('running', 1))).toBe(false);
+  });
+
+  it('returns "false" if the animation is not running', () => {
+    expect(isAnimationRunning(createModernAnimationMock('paused', 0.5))).toBe(false);
+    expect(isAnimationRunning(createModernAnimationMock('finished', 1))).toBe(false);
+    expect(isAnimationRunning(createModernAnimationMock('idle', 0))).toBe(false);
+  });
+
+  it('fallbacks to "currentTime" is "overallProgress" is not supported', () => {
+    expect(isAnimationRunning(createLegacyAnimationMock('running', 500, 1000))).toBe(true);
+
+    expect(isAnimationRunning(createLegacyAnimationMock('running', 0, 1000))).toBe(false);
+    expect(isAnimationRunning(createLegacyAnimationMock('running', 1000, 1000))).toBe(false);
+  });
+});

--- a/packages/react-components/react-motion/library/src/utils/isAnimationRunning.ts
+++ b/packages/react-components/react-motion/library/src/utils/isAnimationRunning.ts
@@ -1,0 +1,27 @@
+/**
+ * Checks if the animation is running at the moment.
+ */
+export function isAnimationRunning(animation: Animation & { readonly overallProgress?: number | null }) {
+  if (animation.playState === 'running') {
+    // Heads up!
+    //
+    // There is an edge case where the animation is running, but the overall progress is 0 or 1. In this case, we
+    // consider the animation to be not running. If it will be reversed it will flip from 1 to 0, and we will observe a
+    // glitch.
+
+    // "overallProgress" is not supported in all browsers, so we need to check if it exists.
+    // We will fall back to the currentTime and duration if "overallProgress" is not supported.
+    if (animation.overallProgress !== undefined) {
+      const overallProgress = animation.overallProgress ?? 0;
+
+      return overallProgress > 0 && overallProgress < 1;
+    }
+
+    const currentTime = Number(animation.currentTime ?? 0);
+    const totalTime = Number(animation.effect?.getTiming().duration ?? 0);
+
+    return currentTime > 0 && currentTime < totalTime;
+  }
+
+  return false;
+}


### PR DESCRIPTION
## New Behavior

This PR implements interruptible motions with `createPresence()`.

> ⚠️ Heads up!
>
> This feature is experimental, please do not rely on it for your production code as APIs will change.

The main problem with CSS animations (& Web Animations) that unlike CSS transitions they don't provide a smooth way to interrupt the animation (_well, they do but_):

> If a user decides to close and open again before the close animation is complete, CSS Animations will restart at 0% while CSS transition values will keep their transit state while trying to transition back to the closed state.

> Note
> In the most cases motions are too short to notice the difference, but there are cases when it becomes noticeable.

This PR aims to improve UX. Current limitations:

- Sequences are not supported (& were not tested)
- "delay" may end up with a glitchy behavior
- `exit` & `enter` atoms should be mirrored **including curves**:
   ```ts
   const keyframes = [{ opacity: 0 }, { opacity: 1 }];
   const duration = 500;
   const fill = 'both';
   
   const enter = { keyframes, duration, fill, easing: 'cubic-bezier(1,0,1,1)' }
   const exit = { keyframes, duration, fill, easing: 'cubic-bezier(0,0,0,1)' }
   ```

> The complete solution should be more advanced and work for the scenarios above.

## Example

https://github.com/user-attachments/assets/b61b03b7-b33f-447e-b8b5-bf798be7ea02