### PR TITLE
Test with new vr-approval-cli version

### DIFF
--- a/.github/workflows/pr-vrt-comment.yml
+++ b/.github/workflows/pr-vrt-comment.yml
@@ -1,4 +1,4 @@
-name: VRT | Comment on PR
+name: VRT CI | Comment on PR
 on:
   workflow_run:
     workflows: ['VRT PR']

--- a/.github/workflows/pr-vrt-comment.yml
+++ b/.github/workflows/pr-vrt-comment.yml
@@ -1,14 +1,9 @@
-name: VRT CI | Comment on PR
+name: VRT | Comment on PR
 on:
   workflow_run:
-    workflows: ['VRT CI']
+    workflows: ['VRT PR']
     types:
       - completed
-
-concurrency:
-  # see https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 
 env:
   NX_PARALLEL: 4 # ubuntu-latest = 4-core CPU / 16 GB of RAM | macos-14-xlarge (arm) = 6-core CPU / 14 GB of RAM
@@ -25,6 +20,8 @@ jobs:
       # necessary to write comments to the PR from the vr-approval-cli
       pull-requests: write
       id-token: write
+      contents: read
+      actions: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -34,134 +31,104 @@ jobs:
       # downloaded artifacts will contain screenshots from affected project including 'screenshots-report.json' which contains proper image mappings for affected project
       # - see @{link file://./../scripts/prepare-vr-screenshots-for-upload.js#43}
       # - see @{link file://./pr-vrt.yml#56}
+
+      - name: Check for vrscreenshot artifact
+        id: check_artifact
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.payload.workflow_run.id
+            });
+
+            const artifactExists = artifacts.data.artifacts.some(artifact => artifact.name === "vrscreenshot");
+
+            if (artifactExists) {
+              core.info("Artifact 'vrscreenshot' found.");
+              core.exportVariable("run_diff", "true");
+            } else {
+              core.info("Artifact 'vrscreenshot' not found.");
+              core.exportVariable("run_diff", "false");
+            }
+
       - uses: actions/download-artifact@v4
+        if: ${{ env.run_diff == 'true' }}
         with:
           name: vrscreenshot
           path: ./screenshots
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/download-artifact@v4
-        with:
-          name: pr-number
-          path: ./results
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Load PR number
+      - name: Save metadata
         uses: actions/github-script@v7
-        id: pr_number
+        if: ${{ env.run_diff == 'true' }}
         with:
           script: |
-            const run = require('./.github/scripts/validate-pr-number');
-            const result = run({filePath:'results/pr.txt'});
-            return result;
-          result-encoding: string
+            const fs = require('fs');
 
-      - name: VR App - Create Policy
-        run: |
-          echo "MAKE THIS STEP WORK"
+            const data = {
+              GITHUB_RUN_ID: context.payload.workflow_run.id,
+              GITHUB_REF: `refs/pull/${context.payload.workflow_run.pull_requests[0].number}/merge`,
+
+              GITHUB_SHA: context.payload.workflow_run.pull_requests[0].head.sha,
+              GITHUB_HEAD_REF: context.payload.workflow_run.pull_requests[0].head.ref,
+
+              GITHUB_REPOSITORY: context.payload.workflow_run.repository.full_name,
+
+              GITHUB_BASE_REF: context.payload.workflow_run.pull_requests[0].base.ref,
+              GITHUB_WORKFLOW: context.payload.workflow_run.name
+            };
+
+            console.log("Metadata", data);
+
+            fs.writeFileSync('metadata.json', JSON.stringify(data, null, 2));
 
       - name: Login via Azure CLI
-        uses: azure/login@a65d910e8af852a8061c627c456678983e180302 # v2.2.0
+        uses: azure/login@a65d910e8af852a8061c627c456678983e180302
+        if: ${{ env.run_diff == 'true' }}
         with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          client-id: ${{ secrets.AZURE_VRT_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Fetch Access Token
-        run: |
-          echo "ACCESSTOKEN=$(az account get-access-token --query accessToken --output tsv)" >> $GITHUB_ENV
-
-      - name: Run screenshotdiff
+      - name: Run vr diff
+        if: ${{ env.run_diff == 'true' }}
         env:
-          VR_APP_API_URL: 'https://vrapprovaldev2.azurewebsites.net/api/'
-          STORAGE_ACCOUNT_ID: 'https://onejstestartifactsprod.blob.core.windows.net/'
-          SYSTEM_ACCESSTOKEN: ${{ env.ACCESSTOKEN }}
-          TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-          PRINCIPAL_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-          SERVICE_CONNECTION_ID: ${{ secrets.ADO_VRT_SERVICE_CONNECTION_ID }}
           GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PRINCIPAL_CLIENT_ID: ${{ secrets.AZURE_VRT_CLIENT_ID }}
         run: |
-          echo "MAKE THIS WORK"
-          npx vr-approval-cli@0.4.11 run-diff --screenshotsDirectory ./screenshots --buildType pr --clientType "FLUENTUI" --threshold '0.04' --cumThreshold '1'
 
-# 💡 NOTE:
-#   - following is manually provided setup used in previous ADO pipeline {@link file://./../../azure-pipelines.vrt-baseline.yml }
-#   - keeping for future reference
+          # Read metadata from the results directory
+          if [ -f ./metadata.json ]; then
+            # Extract values from metadata.json and set them as environment variables
+            export GITHUB_RUN_ID=$(jq -r '.GITHUB_RUN_ID' ./metadata.json)
+            export GITHUB_SHA=$(jq -r '.GITHUB_SHA' ./metadata.json)
+            export GITHUB_REF=$(jq -r '.GITHUB_REF' ./metadata.json)
+            export GITHUB_HEAD_REF=$(jq -r '.GITHUB_HEAD_REF' ./metadata.json)
+            export GITHUB_REPOSITORY=$(jq -r '.GITHUB_REPOSITORY' ./metadata.json)
+            export GITHUB_REPOSITORY_OWNER=$(jq -r '.GITHUB_REPOSITORY_OWNER' ./metadata.json)
+            export GITHUB_BASE_REF=$(jq -r '.GITHUB_BASE_REF' ./metadata.json)
+            export GITHUB_WORKFLOW=$(jq -r '.GITHUB_WORKFLOW' ./metadata.json)
+          else
+            echo "Error: metadata.json not found"
+            exit 1
+          fi
 
-# web_components:
-#   runs-on: ubuntu-latest
-#   env:
-#     pipelineId: '315'
-#     pipelineName: 'fluent-ui_VRT_Pipeline_web-components'
-#   steps:
-#     - uses: actions/checkout@v4
-#       with:
-#         fetch-depth: 0
-#     - name: Run and publish VR screenshot
-#       uses: ./.github/actions/run-publish-vr-screenshot
-#       with:
-#         fluentVersion: webcomponents
-#         vrTestPackageName: 'vr-tests-web-components'
-#         vrTestPackagePath: 'apps/vr-tests-web-components'
-#         locationPrefix: 'FluentUI-web-components'
-#         locationPostfix: 'vrscreenshotwebcomponents'
-#         clientName: 'fluentui-web-components-v3'
+          npx vr-approval-cli@1.0.0-test.1742371346259 create-policy \
+            --nonBlockingPipelines '{"301":{"pipelineStatus": "PENDING","pipelineName": "Fluent UI"}}' \
+            --clientType VCR_Testing
 
-# react_components:
-#   runs-on: ubuntu-latest
-#   env:
-#     pipelineId: '311'
-#     pipelineName: 'fluent-ui_VRT_Pipeline_v9'
-#   steps:
-#     - uses: actions/checkout@v4
-#       with:
-#         fetch-depth: 0
-#     - name: Run and publish VR screenshot
-#       uses: ./.github/actions/run-publish-vr-screenshot
-#       with:
-#         fluentVersion: v9
-#         vrTestPackageName: 'vr-tests-react-components'
-#         vrTestPackagePath: 'apps/vr-tests-react-components'
-#         locationPrefix: 'fluentuiv9'
-#         locationPostfix: 'vrscreenshotv9'
-#         clientName: 'fluentuiv9'
 
-# react:
-#   runs-on: ubuntu-latest
-#   env:
-#     pipelineId: '312'
-#     pipelineName: 'fluent-ui_VRT_Pipeline_v8'
-#   steps:
-#     - uses: actions/checkout@v4
-#       with:
-#         fetch-depth: 0
-#     - name: Run and publish VR screenshot
-#       uses: ./.github/actions/run-publish-vr-screenshot
-#       with:
-#         fluentVersion: v8
-#         vrTestPackageName: 'vr-tests'
-#         vrTestPackagePath: 'apps/vr-tests'
-#         locationPrefix: 'fluentuiv8'
-#         locationPostfix: 'vrscreenshotv8'
-#         clientName: 'fluentuiv8'
-
-# react_northstar:
-#   runs-on: ubuntu-latest
-#   env:
-#     pipelineId: '313'
-#     pipelineName: 'fluent-ui_VRT_Pipeline_v0'
-#   steps:
-#     - uses: actions/checkout@v4
-#       with:
-#         fetch-depth: 0
-#     - name: Run and publish VR screenshot
-#       uses: ./.github/actions/run-publish-vr-screenshot
-#       with:
-#         fluentVersion: v0
-#         vrTestPackageName: 'docs'
-#         vrTestPackagePath: 'packages/fluentui/docs'
-#         locationPrefix: 'FluentUI-v0'
-#         locationPostfix: 'vrscreenshotv0'
-#         clientName: 'FluentUIV0'
+          npx vr-approval-cli@1.0.0-test.1742371346259 run-diff \
+            --screenshotsDirectory ./screenshots \
+            --buildType pr \
+            --ciDefinitionId 'vrt-baseline.yml' \
+            --clientType "FLUENTUI" \
+            --groupName "Fluent UI" \
+            --locationPrefix 'fluentui-github' \
+            --locationPostfix 'vrscreenshots-github' \
+            --threshold '0.04' \
+            --pipelineId '301' \
+            --cumThreshold '1'

--- a/.github/workflows/pr-vrt-comment.yml
+++ b/.github/workflows/pr-vrt-comment.yml
@@ -39,12 +39,20 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Save metadata
+      - name: Login via Azure CLI
+        uses: azure/login@a65d910e8af852a8061c627c456678983e180302 # v2.2.0
+        with:
+          client-id: ${{ secrets.AZURE_VRT_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Run VR Approval CLI
         uses: actions/github-script@v7
+        env:
+          GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PRINCIPAL_CLIENT_ID: ${{ secrets.AZURE_VRT_CLIENT_ID }}
         with:
           script: |
-            const fs = require('fs');
-
             const data = {
               GITHUB_RUN_ID: context.payload.workflow_run.id,
               GITHUB_REF: `refs/pull/${context.payload.workflow_run.pull_requests[0].number}/merge`,
@@ -58,52 +66,31 @@ jobs:
               GITHUB_WORKFLOW: context.payload.workflow_run.name
             };
 
+            Object.keys(data).forEach(key => {
+              process.env[key] = data[key];
+            });
+
             console.log("Metadata", data);
 
-            fs.writeFileSync('metadata.json', JSON.stringify(data, null, 2));
+            const { execSync } = require('child_process');
 
-      - name: Login via Azure CLI
-        uses: azure/login@a65d910e8af852a8061c627c456678983e180302 # v2.2.0
-        with:
-          client-id: ${{ secrets.AZURE_VRT_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+            try {
+              execSync(`npx vr-approval-cli@1.0.0-test.1742371346259 create-policy \
+                --nonBlockingPipelines '{"301":{"pipelineStatus": "PENDING","pipelineName": "Fluent UI"}}' \
+                --clientType FLUENTUI`, { stdio: 'inherit' });
 
-      - name: Run vr diff
-        env:
-          GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PRINCIPAL_CLIENT_ID: ${{ secrets.AZURE_VRT_CLIENT_ID }}
-        run: |
-
-          # Read metadata from the results directory
-          if [ -f ./metadata.json ]; then
-            # Extract values from metadata.json and set them as environment variables
-            export GITHUB_RUN_ID=$(jq -r '.GITHUB_RUN_ID' ./metadata.json)
-            export GITHUB_SHA=$(jq -r '.GITHUB_SHA' ./metadata.json)
-            export GITHUB_REF=$(jq -r '.GITHUB_REF' ./metadata.json)
-            export GITHUB_HEAD_REF=$(jq -r '.GITHUB_HEAD_REF' ./metadata.json)
-            export GITHUB_REPOSITORY=$(jq -r '.GITHUB_REPOSITORY' ./metadata.json)
-            export GITHUB_REPOSITORY_OWNER=$(jq -r '.GITHUB_REPOSITORY_OWNER' ./metadata.json)
-            export GITHUB_BASE_REF=$(jq -r '.GITHUB_BASE_REF' ./metadata.json)
-            export GITHUB_WORKFLOW=$(jq -r '.GITHUB_WORKFLOW' ./metadata.json)
-          else
-            echo "Error: metadata.json not found"
-            exit 1
-          fi
-
-          npx vr-approval-cli@1.0.0-test.1742371346259 create-policy \
-            --nonBlockingPipelines '{"301":{"pipelineStatus": "PENDING","pipelineName": "Fluent UI"}}' \
-            --clientType FLUENTUI
-
-
-          npx vr-approval-cli@1.0.0-test.1742371346259 run-diff \
-            --screenshotsDirectory ./screenshots \
-            --buildType pr \
-            --ciDefinitionId 'vrt-baseline.yml' \
-            --clientType "FLUENTUI" \
-            --groupName "Fluent UI" \
-            --locationPrefix 'fluentui-github' \
-            --locationPostfix 'vrscreenshots-github' \
-            --threshold '0.04' \
-            --pipelineId '301' \
-            --cumThreshold '1'
+              execSync(`npx vr-approval-cli@1.0.0-test.1742371346259 run-diff \
+                --screenshotsDirectory ./screenshots \
+                --buildType pr \
+                --ciDefinitionId 'vrt-baseline.yml' \
+                --clientType "FLUENTUI" \
+                --groupName "Fluent UI" \
+                --locationPrefix 'fluentui-github' \
+                --locationPostfix 'vrscreenshots-github' \
+                --threshold '0.04' \
+                --pipelineId '301' \
+                --cumThreshold '1'`, { stdio: 'inherit' });
+            } catch (error) {
+              console.error("Error running vr-approval-cli commands:", error.message);
+              process.exit(1);
+            }

--- a/.github/workflows/pr-vrt-comment.yml
+++ b/.github/workflows/pr-vrt-comment.yml
@@ -32,29 +32,7 @@ jobs:
       # - see @{link file://./../scripts/prepare-vr-screenshots-for-upload.js#43}
       # - see @{link file://./pr-vrt.yml#56}
 
-      - name: Check for vrscreenshot artifact
-        id: check_artifact
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              run_id: context.payload.workflow_run.id
-            });
-
-            const artifactExists = artifacts.data.artifacts.some(artifact => artifact.name === "vrscreenshot");
-
-            if (artifactExists) {
-              core.info("Artifact 'vrscreenshot' found.");
-              core.exportVariable("run_diff", "true");
-            } else {
-              core.info("Artifact 'vrscreenshot' not found.");
-              core.exportVariable("run_diff", "false");
-            }
-
       - uses: actions/download-artifact@v4
-        if: ${{ env.run_diff == 'true' }}
         with:
           name: vrscreenshot
           path: ./screenshots
@@ -63,7 +41,6 @@ jobs:
 
       - name: Save metadata
         uses: actions/github-script@v7
-        if: ${{ env.run_diff == 'true' }}
         with:
           script: |
             const fs = require('fs');
@@ -86,15 +63,13 @@ jobs:
             fs.writeFileSync('metadata.json', JSON.stringify(data, null, 2));
 
       - name: Login via Azure CLI
-        uses: azure/login@a65d910e8af852a8061c627c456678983e180302
-        if: ${{ env.run_diff == 'true' }}
+        uses: azure/login@a65d910e8af852a8061c627c456678983e180302 # v2.2.0
         with:
           client-id: ${{ secrets.AZURE_VRT_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Run vr diff
-        if: ${{ env.run_diff == 'true' }}
         env:
           GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PRINCIPAL_CLIENT_ID: ${{ secrets.AZURE_VRT_CLIENT_ID }}

--- a/.github/workflows/pr-vrt-comment.yml
+++ b/.github/workflows/pr-vrt-comment.yml
@@ -1,7 +1,7 @@
 name: VRT CI | Comment on PR
 on:
   workflow_run:
-    workflows: ['VRT PR']
+    workflows: ['VRT CI']
     types:
       - completed
 

--- a/.github/workflows/pr-vrt-comment.yml
+++ b/.github/workflows/pr-vrt-comment.yml
@@ -118,7 +118,7 @@ jobs:
 
           npx vr-approval-cli@1.0.0-test.1742371346259 create-policy \
             --nonBlockingPipelines '{"301":{"pipelineStatus": "PENDING","pipelineName": "Fluent UI"}}' \
-            --clientType VCR_Testing
+            --clientType FLUENTUI
 
 
           npx vr-approval-cli@1.0.0-test.1742371346259 run-diff \

--- a/.github/workflows/pr-vrt.yml
+++ b/.github/workflows/pr-vrt.yml
@@ -1,4 +1,4 @@
-name: VRT PR
+name: VRT CI
 on:
   pull_request:
     # TODO: once testing is done enable pull_request on all branches again

--- a/.github/workflows/pr-vrt.yml
+++ b/.github/workflows/pr-vrt.yml
@@ -64,4 +64,3 @@ jobs:
           name: vrscreenshot
           retention-days: 1
           path: ${{steps.screenshots_root.outputs.result}}
-

--- a/.github/workflows/vrt-baseline.yml
+++ b/.github/workflows/vrt-baseline.yml
@@ -73,5 +73,3 @@ jobs:
             --threshold '0.04' \
             --pipelineId '301' \
             --cumThreshold '1'
-
-

--- a/.github/workflows/vrt-baseline.yml
+++ b/.github/workflows/vrt-baseline.yml
@@ -1,14 +1,9 @@
-name: VRT PR
+name: VRT Baseline
 on:
-  pull_request:
+  push:
     # TODO: once testing is done enable pull_request on all branches again
     branches:
       - vrt-gha-testing
-
-concurrency:
-  # see https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 
 env:
   NX_PARALLEL: 6 # ubuntu-latest = 4-core CPU / 16 GB of RAM | macos-14-xlarge (arm) = 6-core CPU / 14 GB of RAM
@@ -18,21 +13,17 @@ env:
 permissions:
   contents: 'read'
   actions: 'read'
+  id-token: write
 
 jobs:
   generate_vrt_screenshots:
     if: ${{ github.repository_owner == 'microsoft' }}
+    name: Upload VRT Baseline
     runs-on: macos-14-xlarge
-    name: Generate screenshots
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        uses: nrwl/nx-set-shas@dbe0650947e5f2c81f59190a38512cf49126fe6b # v4.3.0
-        with:
-          main-branch-name: 'master'
 
       - uses: actions/setup-node@v4
         with:
@@ -43,7 +34,7 @@ jobs:
       - run: yarn playwright install --with-deps
 
       - name: Run VR tests (generate screenshots)
-        run: yarn nx affected -t test-vr --nxBail
+        run: yarn nx run-many -t test-vr --nxBail
 
       - name: Prepare VR screenshots for upload
         uses: actions/github-script@v7
@@ -58,10 +49,29 @@ jobs:
             return result;
           result-encoding: string
 
-      - name: Upload VR screenshots
-        uses: actions/upload-artifact@v4
+      - name: Login via Azure CLI
+        uses: azure/login@a65d910e8af852a8061c627c456678983e180302
         with:
-          name: vrscreenshot
-          retention-days: 1
-          path: ${{steps.screenshots_root.outputs.result}}
+          client-id: ${{ secrets.AZURE_VRT_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Run baseline
+        env:
+          GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PRINCIPAL_CLIENT_ID: ${{ secrets.AZURE_VRT_CLIENT_ID }}
+        run: |
+          printenv
+          npx vr-approval-cli@1.0.0-test.1742371346259 run-diff \
+            --screenshotsDirectory "${{steps.screenshots_root.outputs.result}}" \
+            --buildType release \
+            --ciDefinitionId 'vrt-baseline.yml' \
+            --clientType "FLUENTUI" \
+            --groupName "Fluent UI" \
+            --locationPrefix 'fluentui-github' \
+            --locationPostfix 'vrscreenshots-github' \
+            --threshold '0.04' \
+            --pipelineId '301' \
+            --cumThreshold '1'
+
 

--- a/.github/workflows/vrt-baseline.yml
+++ b/.github/workflows/vrt-baseline.yml
@@ -50,7 +50,7 @@ jobs:
           result-encoding: string
 
       - name: Login via Azure CLI
-        uses: azure/login@a65d910e8af852a8061c627c456678983e180302
+        uses: azure/login@a65d910e8af852a8061c627c456678983e180302 # v2.2.0
         with:
           client-id: ${{ secrets.AZURE_VRT_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -61,7 +61,6 @@ jobs:
           GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PRINCIPAL_CLIENT_ID: ${{ secrets.AZURE_VRT_CLIENT_ID }}
         run: |
-          printenv
           npx vr-approval-cli@1.0.0-test.1742371346259 run-diff \
             --screenshotsDirectory "${{steps.screenshots_root.outputs.result}}" \
             --buildType release \


### PR DESCRIPTION
Testing out a new Github actions supported vr-approval-cli version. This has been tested in an internal EMU repository end-to-end. Changes include -
1. Bump up the vr-approval-cli version to `1.0.0-test.1742371346259`. This is a test only version and a proper release will be done after all testing has completed.
2. The Comment on PR workflow has been revamped to only run VRT when screenshots artifact is generated in original PR. This is to make sure that we can skip VRT when no screenshots were generated.
3. We also directly use github event payload to find PR number and more associated metadata for triggering workflow in Comment on PR workflow.
4. Baseline workflow was added. This will only run on `vrt-gha-testing` branch for now. 
5. Concurrency check removed from Comment on PR. Not sure why it was there.