### PR TITLE
fix(Autofill): Revert #33700

### DIFF
--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -477,7 +477,7 @@ export class Autofill extends React_2.Component<IAutofillProps, IAutofillState> 
     // Warning: (ae-forgotten-export) The symbol "ICursorLocation" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    componentDidUpdate(_: any, previousState: IAutofillState, cursor: ICursorLocation | null): void;
+    componentDidUpdate(_: any, _1: any, cursor: ICursorLocation | null): void;
     // (undocumented)
     componentWillUnmount(): void;
     // (undocumented)

--- a/packages/react/src/components/Autofill/Autofill.tsx
+++ b/packages/react/src/components/Autofill/Autofill.tsx
@@ -98,7 +98,7 @@ export class Autofill extends React.Component<IAutofillProps, IAutofillState> im
     return this._inputElement.current;
   }
 
-  public componentDidUpdate(_: any, previousState: IAutofillState, cursor: ICursorLocation | null) {
+  public componentDidUpdate(_: any, _1: any, cursor: ICursorLocation | null) {
     const { suggestedDisplayValue, shouldSelectFullInputValueInComponentDidUpdate, preventValueSelection } = this.props;
     let differenceIndex = 0;
 
@@ -114,8 +114,7 @@ export class Autofill extends React.Component<IAutofillProps, IAutofillState> im
       this._autoFillEnabled &&
       this.value &&
       suggestedDisplayValue &&
-      _doesTextStartWith(suggestedDisplayValue, this.value) &&
-      previousState.inputValue !== this.value
+      _doesTextStartWith(suggestedDisplayValue, this.value)
     ) {
       let shouldSelectFullRange = false;
 
@@ -250,7 +249,6 @@ export class Autofill extends React.Component<IAutofillProps, IAutofillState> im
     if (!(ev.nativeEvent as any).isComposing) {
       // eslint-disable-next-line @typescript-eslint/no-deprecated
       switch (ev.which) {
-        case KeyCodes.del:
         case KeyCodes.backspace:
           this._autoFillEnabled = false;
           break;


### PR DESCRIPTION
This PR reverts commit 75fc0440a890f12af8845061d9cafd983d9a4e33. This is needed due to pickers relying on the previous bug otherwise when typing a letter it autocompletes the whole word without selection. 

For example typing "b" in the pickers example sets the value to Black instead of setting B and leaving lack as a selection.

This has caused a sev 2 issue in Sharepoint therefore we're reverting since this was the original behavior of v8.

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Related #33700
