### PR TITLE
fix(`chart-utilities`): Fixing failing webpack step in `chart-utilities` package

### DIFF
--- a/change/@fluentui-chart-utilities-ac603907-8d2a-4923-b99d-97107c6d32bf.json
+++ b/change/@fluentui-chart-utilities-ac603907-8d2a-4923-b99d-97107c6d32bf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Fixing failing webpack step in chart-utilities package.",
+  "packageName": "@fluentui/chart-utilities",
+  "email": "makotom@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charts/chart-utilities/webpack.config.js
+++ b/packages/charts/chart-utilities/webpack.config.js
@@ -37,6 +37,8 @@ module.exports = [
       },
     },
   }),
+  // This should be uncommented if we want to build the legacy demo app for the PR deploy site, which should only happen
+  // if examples are added under the react-examples/chart-utilities folder.
   // Also build the legacy demo app for the PR deploy site
-  require('./webpack.serve.config'),
+  // require('./webpack.serve.config'),
 ];


### PR DESCRIPTION
This pull request includes a small change to the `webpack.config.js` file in `packages/charts/chart-utilities`. The change comments out the line that requires `webpack.serve.config` and adds a note explaining that it should be uncommented only if examples are added under the `react-examples/chart-utilities` folder.

This line, when uncommented, was breaking the release pipeline because it was failing the `webpack` step when buildilng the `chart-utilities` package.

Related to #34043.