### PR TITLE
fix(v8): add change files to trigger new publish of v8

### DIFF
--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -124,7 +124,7 @@ extends:
               - script: |
                   yarn publish:beachball -n $(npmToken) --config scripts/beachball/src/release-v8.config.js --message 'release: applying package updates - react v8'
                   git reset --hard origin/master
-                condition: eq(variables.dryRun, false)
+                condition: and(succeeded(), eq(variables.dryRun, false))
                 env:
                   GITHUB_PAT: $(githubPAT)
                 displayName: Publish changes and bump versions

--- a/change/@fluentui-react-3d6721bd-6a4a-4765-8b22-10887f020883.json
+++ b/change/@fluentui-react-3d6721bd-6a4a-4765-8b22-10887f020883.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: restore missing files from last publish.",
+  "packageName": "@fluentui/react",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-charting-1cd013bc-87ec-4613-bd70-f4e65a6746a4.json
+++ b/change/@fluentui-react-charting-1cd013bc-87ec-4613-bd70-f4e65a6746a4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: restore missing files from last publish.",
+  "packageName": "@fluentui/react-charting",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
## Changes
- Adds change files for packages from [last bad release](https://github.com/microsoft/fluentui/commit/a51bd4ada5d54ce74895ce0e63df7ffd533ca964#diff-18f2df2bf681f29d5d093df7dc7977f9adb068aad1ebbc23f4f338fde0462a86) (excluding `@fluentui/charting-utilities` since its build assets [seem correct](https://www.npmjs.com/package/@fluentui/chart-utilities?activeTab=code)). This should trigger a new publish for all packages affected by the last bad release.
![image](https://github.com/user-attachments/assets/f77dc45a-5efe-4246-b18f-33e582f89bbd)
- Adds success condition to publishing step as the [last release failed](https://uifabric.visualstudio.com/UI%20Fabric/_build/results?buildId=372039&view=logs&j=7494ae37-3ecd-50c6-9ffe-c77a2768c545&t=b34903f2-f316-5902-ee0a-84fbdf331090) at the build step but still published
<img width="957" alt="image" src="https://github.com/user-attachments/assets/2d4eaa4e-d194-4fd0-b544-a9ecff577457" />

 

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows #34044
- Fixes #34043

