### PR TITLE
[vr-approval] Use PR Number from artifact

### DIFF
--- a/.github/workflows/pr-vrt-comment.yml
+++ b/.github/workflows/pr-vrt-comment.yml
@@ -46,6 +46,13 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
+      - uses: actions/download-artifact@v4
+        with:
+          name: pr-number
+          path: ./results
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run VR Approval CLI
         uses: actions/github-script@v7
         env:
@@ -53,16 +60,39 @@ jobs:
           PRINCIPAL_CLIENT_ID: ${{ secrets.AZURE_VRT_CLIENT_ID }}
         with:
           script: |
+            const run = require('./.github/scripts/validate-pr-number');
+            const pull_number = run({filePath:'results/pr.txt'});
+
+            const result = await github.rest.pulls.get({
+              owner: context.payload.workflow_run.repository.owner.login,
+              repo: context.payload.workflow_run.repository.name,
+              pull_number,
+            });
+
+            const pr = result.data;
+
+            if (pr.head.sha !== context.payload.workflow_run.head_commit.id) {
+              console.log(
+                "PR head sha does not match the workflow run head commit id. " +
+                "There has probably been a push to the PR, so we will not run the VR Diff for the last iteration. " +
+                "Exiting the script."
+              );
+              process.exit(0);
+            }
+
+            const headOwner = pr.head.repo.owner.login;
+            const baseOwner = pr.base.repo.owner.login;
+
             const data = {
               GITHUB_RUN_ID: context.payload.workflow_run.id,
-              GITHUB_REF: `refs/pull/${context.payload.workflow_run.pull_requests[0].number}/merge`,
+              GITHUB_REF: `refs/pull/${pr.number}/merge`,
 
-              GITHUB_SHA: context.payload.workflow_run.pull_requests[0].head.sha,
-              GITHUB_HEAD_REF: context.payload.workflow_run.pull_requests[0].head.ref,
+              GITHUB_SHA: pr.head.sha,
+              GITHUB_HEAD_REF: headOwner !== baseOwner ? `${headOwner}:${pr.head.ref}` : pr.head.ref,
 
               GITHUB_REPOSITORY: context.payload.workflow_run.repository.full_name,
 
-              GITHUB_BASE_REF: context.payload.workflow_run.pull_requests[0].base.ref,
+              GITHUB_BASE_REF: pr.base.ref,
               GITHUB_WORKFLOW: context.payload.workflow_run.name
             };
 

--- a/.github/workflows/pr-vrt.yml
+++ b/.github/workflows/pr-vrt.yml
@@ -64,3 +64,14 @@ jobs:
           name: vrscreenshot
           retention-days: 1
           path: ${{steps.screenshots_root.outputs.result}}
+
+      - name: Save PR number
+        run: echo ${{ github.event.number }} > pr.txt
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pr-number
+          retention-days: 1
+          if-no-files-found: error
+          path: |
+            pr.txt


### PR DESCRIPTION

## Previous Behavior

- We were trying to fetch PR number from workflow_run event payload, howver it was not available in the payload for workflows triggered from forks. See https://github.com/orgs/community/discussions/25220.

## New Behavior

- Use the PR number from artifact method
- However we validate if the head commit of the workflow_run event is same as head commit of PR to validate that the correct PR number of present in the artifact. This verification also allows us to skip vr-approval-cli if there was a push to the PR post workflow trigger.

