### PR TITLE
Adjusting split button paddings and icon sizes to fit nee design requests

### DIFF
--- a/change/@fluentui-react-button-96a1c9d2-3ee4-41f8-ae2d-f98f20b6cbbb.json
+++ b/change/@fluentui-react-button-96a1c9d2-3ee4-41f8-ae2d-f98f20b6cbbb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Adjusting split button paddings and icon sizes to fit nee design requests",
+  "packageName": "@fluentui/react-button",
+  "email": "patrycja.fogelman@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-button/library/src/components/SplitButton/useSplitButton.ts
+++ b/packages/react-components/react-button/library/src/components/SplitButton/useSplitButton.ts
@@ -35,7 +35,7 @@ export const useSplitButton_unstable = (
       disabledFocusable,
       menuIcon,
       shape,
-      size,
+      size: size === 'medium' ? 'large' : size,
     },
     renderByDefault: true,
     elementType: MenuButton,

--- a/packages/react-components/react-button/library/src/components/SplitButton/useSplitButtonStyles.styles.ts
+++ b/packages/react-components/react-button/library/src/components/SplitButton/useSplitButtonStyles.styles.ts
@@ -110,6 +110,7 @@ const useRootStyles = makeStyles({
   transparent: {
     [`& .${splitButtonClassNames.primaryActionButton}`]: {
       borderRightColor: tokens.colorTransparentBackground,
+      paddingRight: tokens.spacingVerticalXXS,
     },
 
     ':hover': {
@@ -171,18 +172,40 @@ const useRootStyles = makeStyles({
   },
 });
 
+const useIconOnlyStyles = makeStyles({
+  outline: {},
+  secondary: {},
+  primary: {},
+  subtle: {},
+  transparent: {
+    [`& .${splitButtonClassNames.primaryActionButton}`]: {
+      paddingRight: tokens.spacingVerticalNone,
+    },
+    [`& .${splitButtonClassNames.menuButton}`]: {
+      paddingLeft: tokens.spacingVerticalNone,
+      paddingRight: tokens.spacingVerticalNone,
+    },
+  },
+});
+
 export const useSplitButtonStyles_unstable = (state: SplitButtonState): SplitButtonState => {
   'use no memo';
 
   const rootStyles = useRootStyles();
   const focusStyles = useFocusStyles();
+  const iconOnlyStyles = useIconOnlyStyles();
 
   const { appearance, disabled, disabledFocusable } = state;
+
+  const noIconClass = state.primaryActionButton
+    ? !state.primaryActionButton.children && appearance && iconOnlyStyles[appearance]
+    : undefined;
 
   state.root.className = mergeClasses(
     splitButtonClassNames.root,
     rootStyles.base,
     appearance && rootStyles[appearance],
+    noIconClass,
     (disabled || disabledFocusable) && rootStyles.disabled,
     (disabled || disabledFocusable) && rootStyles.disabledHighContrast,
     state.root.className,


### PR DESCRIPTION
- Adjusted paddings and for transparent icon-only split button
- Adjusted menu button size

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
