### PR TITLE
fix: emit change event on tablist only when active tab has changed

### DIFF
--- a/change/@fluentui-web-components-8c986d26-b108-4f9d-9fa2-41363776a5b2.json
+++ b/change/@fluentui-web-components-8c986d26-b108-4f9d-9fa2-41363776a5b2.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: emit change event on tablist only when active tab changed",
+  "packageName": "@fluentui/web-components",
+  "email": "machi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/tablist/tablist.base.ts
+++ b/packages/web-components/src/tablist/tablist.base.ts
@@ -97,6 +97,10 @@ export class BaseTablist extends FASTElement {
           activePanel.hidden = false;
         }
       }
+
+      if (oldValue !== newValue) {
+        this.change();
+      }
     }
   }
 
@@ -173,7 +177,6 @@ export class BaseTablist extends FASTElement {
           this.activetab = tab;
           this.activeid = tabId;
         }
-        this.change();
       }
     });
   }
@@ -188,7 +191,6 @@ export class BaseTablist extends FASTElement {
     if (this.activeTabIndex !== this.prevActiveTabIndex) {
       this.activeid = this.tabIds[this.activeTabIndex] as string;
       this.focusTab();
-      this.change();
     }
   }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

`change` event emits multiple times when active tab changed.

## New Behavior

`change` event only emit once when active tab changed