### PR TITLE
fix(react-drawer): Updating motion values

### DIFF
--- a/change/@fluentui-react-drawer-d03bab6a-9eda-4011-a5c2-247b22ab916e.json
+++ b/change/@fluentui-react-drawer-d03bab6a-9eda-4011-a5c2-247b22ab916e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Changing motion values (durations/curves) to Copilot values",
+  "packageName": "@fluentui/react-drawer",
+  "email": "kegorr@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-drawer/library/src/shared/drawerMotions.ts
+++ b/packages/react-components/react-drawer/library/src/shared/drawerMotions.ts
@@ -134,12 +134,12 @@ export const OverlaySurfaceBackdropMotion = createPresenceComponent(({ size }: O
     enter: {
       keyframes,
       easing: motionTokens.curveLinear,
-      duration,
+      duration: duration.open,
     },
     exit: {
       keyframes: [...keyframes].reverse(),
       easing: motionTokens.curveLinear,
-      duration,
+      duration: duration.close,
     },
   };
 });

--- a/packages/react-components/react-drawer/library/src/shared/drawerMotions.ts
+++ b/packages/react-components/react-drawer/library/src/shared/drawerMotions.ts
@@ -10,11 +10,23 @@ export type DrawerMotionParams = Required<
 >;
 export type OverlayDrawerSurfaceMotionParams = Required<Pick<DrawerBaseProps, 'size'>>;
 
-const durations: Record<NonNullable<DrawerBaseProps['size']>, number> = {
-  small: motionTokens.durationGentle,
-  medium: motionTokens.durationSlow,
-  large: motionTokens.durationSlower,
-  full: motionTokens.durationUltraSlow,
+const durations: Record<NonNullable<DrawerBaseProps['size']>, { open: number; close: number }> = {
+  small: {
+    open: motionTokens.durationNormal, // 200ms
+    close: motionTokens.durationFast, // 150ms
+  },
+  medium: {
+    open: motionTokens.durationGentle, // 250ms
+    close: motionTokens.durationNormal, // 200ms
+  },
+  large: {
+    open: motionTokens.durationSlow, // 300ms
+    close: motionTokens.durationGentle, // 250ms
+  },
+  full: {
+    open: motionTokens.durationSlower, // 400ms
+    close: motionTokens.durationSlow, // 300ms
+  },
 };
 
 /**
@@ -64,12 +76,12 @@ export const InlineDrawerMotion = createPresenceComponent<DrawerMotionParams>(({
   return {
     enter: {
       keyframes,
-      duration,
-      easing: motionTokens.curveDecelerateMid,
+      duration: duration.open,
+      easing: motionTokens.curveDecelerateMax,
     },
     exit: {
       keyframes: [...keyframes].reverse(),
-      duration,
+      duration: duration.close,
       easing: motionTokens.curveAccelerateMin,
     },
   };
@@ -100,12 +112,12 @@ export const OverlayDrawerMotion = createPresenceComponent<DrawerMotionParams>((
   return {
     enter: {
       keyframes,
-      duration,
-      easing: motionTokens.curveDecelerateMid,
+      duration: duration.open,
+      easing: motionTokens.curveDecelerateMax,
     },
     exit: {
       keyframes: [...keyframes].reverse(),
-      duration,
+      duration: duration.close,
       easing: motionTokens.curveAccelerateMin,
     },
   };


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ X] Code is up-to-date with the `master` branch
* [-] Your changes are covered by tests (if possible)
* [X] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Overview

I was asked to add the new copilot motion values to the v9 drawer.
The v9 drawer is currently being used in copilot
Moving values over from here: [https://github.com/microsoft/fluentai/blob/main/packages/react-copilot/react-copilot-drawer/src/shared/copilotDrawerMotion.ts](https://github.com/microsoft/fluentai/blob/main/packages/react-copilot/react-copilot-drawer/src/shared/copilotDrawerMotion.ts)

