### PR TITLE
docs: add confirmation dialog example for a11y pattern

### DIFF
--- a/packages/react-components/react-dialog/stories/src/Dialog/DialogConfirmation.stories.tsx
+++ b/packages/react-components/react-dialog/stories/src/Dialog/DialogConfirmation.stories.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import {
+  Dialog,
+  DialogTrigger,
+  DialogSurface,
+  DialogTitle,
+  DialogBody,
+  DialogContent,
+  DialogActions,
+  Button,
+  useId,
+} from '@fluentui/react-components';
+
+export const Confirmation = () => {
+  const dialogId = useId('dialog-');
+  return (
+    <Dialog>
+      <DialogTrigger disableButtonEnhancement>
+        <Button>Delete file</Button>
+      </DialogTrigger>
+      <DialogSurface aria-labelledby={`${dialogId}-title`} aria-describedby={`${dialogId}-content`}>
+        <DialogBody>
+          <DialogTitle id={`${dialogId}-title`}>Delete dialogSpec_final_FINAL_v3.jpg</DialogTitle>
+          <DialogContent id={`${dialogId}-content`}>
+            This action is permanent. Are you sure you want to continue?
+          </DialogContent>
+          <DialogActions>
+            <DialogTrigger disableButtonEnhancement>
+              <Button appearance="primary">Delete file</Button>
+            </DialogTrigger>
+            <DialogTrigger disableButtonEnhancement>
+              <Button appearance="secondary">Cancel</Button>
+            </DialogTrigger>
+          </DialogActions>
+        </DialogBody>
+      </DialogSurface>
+    </Dialog>
+  );
+};
+
+Confirmation.parameters = {
+  docs: {
+    description: {
+      story:
+        "A confirmation dialog is a type of very short dialog that sends focus directly to an action button, usually at the end of the dialog. For this type of dialog it makes sense to set the dialog's accessible name to the title, and the accessible description to the content via `aria-labelledby` and `aria-describedby`. This should not be done for dialogs with longer content.",
+    },
+  },
+};

--- a/packages/react-components/react-dialog/stories/src/Dialog/index.stories.tsx
+++ b/packages/react-components/react-dialog/stories/src/Dialog/index.stories.tsx
@@ -18,6 +18,7 @@ export { CustomTrigger } from './DialogCustomTrigger.stories';
 export { WithForm } from './DialogWithForm.stories';
 export { TitleCustomAction } from './DialogTitleCustomAction.stories';
 export { TitleNoAction } from './DialogTitleNoAction.stories';
+export { Confirmation } from './DialogConfirmation.stories';
 
 // Typing with Meta<typeof Dialog> generates a type error for the `subcomponents` property.
 // https://github.com/storybookjs/storybook/issues/27535


### PR DESCRIPTION
(docs only change, added a story)

I've had a specific dialog accessibility question come up a few times now -- how to have screen readers auto-read a short (usually confirmation) dialog's content when focus is directly sent to a button at the end of the dialog.

I added a story w/ description showing the recommend ARIA pattern for that type of dialog.