### PR TITLE
fix(react-field): use semantic status color tokens for validation icon

### DIFF
--- a/change/@fluentui-react-field-44520c15-9e3b-40d9-881c-c4c68afab9e1.json
+++ b/change/@fluentui-react-field-44520c15-9e3b-40d9-881c-c4c68afab9e1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: use semantic status color tokens for validation icon",
+  "packageName": "@fluentui/react-field",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-field/library/src/components/Field/useFieldStyles.styles.ts
+++ b/packages/react-components/react-field/library/src/components/Field/useFieldStyles.styles.ts
@@ -79,7 +79,7 @@ const useSecondaryTextBaseClassName = makeResetStyles({
 
 const useSecondaryTextStyles = makeStyles({
   error: {
-    color: tokens.colorPaletteRedForeground1,
+    color: tokens.colorStatusDangerForeground1,
   },
 
   withIcon: {
@@ -102,13 +102,13 @@ const useValidationMessageIconBaseClassName = makeResetStyles({
 
 const useValidationMessageIconStyles = makeStyles({
   error: {
-    color: tokens.colorPaletteRedForeground1,
+    color: tokens.colorStatusDangerForeground1,
   },
   warning: {
-    color: tokens.colorPaletteDarkOrangeForeground1,
+    color: tokens.colorStatusWarningForeground3,
   },
   success: {
-    color: tokens.colorPaletteGreenForeground1,
+    color: tokens.colorStatusSuccessForeground1,
   },
 });
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Field `validationMessage` states use palette colors instead of status color tokens

## New Behavior

Field `validationMessage` states use correct status color tokens

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #33707
