### PR TITLE
fix(react-tooltip): do not show tooltip if it's trigger has aria-expa…

### DIFF
--- a/change/@fluentui-react-tooltip-cc9e74f2-a26d-4d38-ae22-3e4247792978.json
+++ b/change/@fluentui-react-tooltip-cc9e74f2-a26d-4d38-ae22-3e4247792978.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: rely on aria-expanded to prevent showing Tooltip when it's trigger opens Popover",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tooltip/library/src/components/Tooltip/useTooltip.tsx
+++ b/packages/react-components/react-tooltip/library/src/components/Tooltip/useTooltip.tsx
@@ -238,7 +238,7 @@ export const useTooltip_unstable = (props: TooltipProps): TooltipState => {
   const child = getTriggerChild(children);
 
   const triggerAriaProps: Pick<TooltipChildProps, 'aria-label' | 'aria-labelledby' | 'aria-describedby'> = {};
-  const isMenuTrigger = child?.props?.['aria-haspopup'] === 'menu' && child?.props?.['aria-expanded'];
+  const isExpanded = child?.props?.['aria-expanded'] === true || child?.props?.['aria-expanded'] === 'true';
 
   if (relationship === 'label') {
     // aria-label only works if the content is a string. Otherwise, need to use aria-labelledby.
@@ -257,7 +257,7 @@ export const useTooltip_unstable = (props: TooltipProps): TooltipState => {
 
   // Case 1: Don't render the Tooltip in SSR to avoid hydration errors
   // Case 2: Don't render the Tooltip, if it triggers Menu and it's already opened
-  if (isServerSideRender || isMenuTrigger) {
+  if (isServerSideRender || isExpanded) {
     state.shouldRenderTooltip = false;
   }
 


### PR DESCRIPTION

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Previously reported with similar issue specifically for menus here: #31639.

## New Behavior

Removes the check for `aria-haspopup="menu"`, now it won't show tooltip based on `aria-expanded`. 

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #33873 
