### PR TITLE
Handle error cases in `element.animate()`

### DIFF
--- a/change/@fluentui-react-motion-798994c5-fba9-4fa0-8228-bd0e7a12cf8d.json
+++ b/change/@fluentui-react-motion-798994c5-fba9-4fa0-8228-bd0e7a12cf8d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: handle error cases in \"element.animate()\"",
+  "packageName": "@fluentui/react-motion",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-motion/library/src/hooks/useAnimateAtoms.ts
+++ b/packages/react-components/react-motion/library/src/hooks/useAnimateAtoms.ts
@@ -28,32 +28,42 @@ function useAnimateAtomsInSupportedEnvironment() {
       const atoms = Array.isArray(value) ? value : [value];
       const { isReducedMotion } = options;
 
-      const animations = atoms.map(motion => {
-        // Grab the custom reduced motion definition if it exists, or fall back to the default reduced motion.
-        const { keyframes: motionKeyframes, reducedMotion = DEFAULT_REDUCED_MOTION_ATOM, ...params } = motion;
-        // Grab the reduced motion keyframes if they exist, or fall back to the regular keyframes.
-        const { keyframes: reducedMotionKeyframes = motionKeyframes, ...reducedMotionParams } = reducedMotion;
+      const animations = atoms
+        .map(motion => {
+          // Grab the custom reduced motion definition if it exists, or fall back to the default reduced motion.
+          const { keyframes: motionKeyframes, reducedMotion = DEFAULT_REDUCED_MOTION_ATOM, ...params } = motion;
+          // Grab the reduced motion keyframes if they exist, or fall back to the regular keyframes.
+          const { keyframes: reducedMotionKeyframes = motionKeyframes, ...reducedMotionParams } = reducedMotion;
 
-        const animationKeyframes: Keyframe[] = isReducedMotion ? reducedMotionKeyframes : motionKeyframes;
-        const animationParams: KeyframeEffectOptions = {
-          ...DEFAULT_ANIMATION_OPTIONS,
-          ...params,
+          const animationKeyframes: Keyframe[] = isReducedMotion ? reducedMotionKeyframes : motionKeyframes;
+          const animationParams: KeyframeEffectOptions = {
+            ...DEFAULT_ANIMATION_OPTIONS,
+            ...params,
 
-          // Use reduced motion overrides (e.g. duration, easing) when reduced motion is enabled
-          ...(isReducedMotion && reducedMotionParams),
-        };
+            // Use reduced motion overrides (e.g. duration, easing) when reduced motion is enabled
+            ...(isReducedMotion && reducedMotionParams),
+          };
 
-        const animation = element.animate(animationKeyframes, animationParams);
+          try {
+            // Firefox can throw an error when calling `element.animate()`.
+            // See: https://github.com/microsoft/fluentui/issues/33902
+            const animation = element.animate(animationKeyframes, animationParams);
 
-        if (SUPPORTS_PERSIST) {
-          animation.persist();
-        } else {
-          const resultKeyframe = animationKeyframes[animationKeyframes.length - 1];
-          Object.assign(element.style ?? {}, resultKeyframe);
-        }
+            if (SUPPORTS_PERSIST) {
+              // Chromium browsers can return null when calling `element.animate()`.
+              // See: https://github.com/microsoft/fluentui/issues/33902
+              animation?.persist();
+            } else {
+              const resultKeyframe = animationKeyframes[animationKeyframes.length - 1];
+              Object.assign(element.style ?? {}, resultKeyframe);
+            }
 
-        return animation;
-      });
+            return animation;
+          } catch (e) {
+            return null;
+          }
+        })
+        .filter(animation => !!animation);
 
       return {
         set playbackRate(rate: number) {

--- a/packages/react-components/react-motion/library/src/hooks/useAnimateAtoms.ts
+++ b/packages/react-components/react-motion/library/src/hooks/useAnimateAtoms.ts
@@ -63,7 +63,7 @@ function useAnimateAtomsInSupportedEnvironment() {
             return null;
           }
         })
-        .filter(animation => !!animation);
+        .filter(animation => !!animation) as Animation[];
 
       return {
         set playbackRate(rate: number) {


### PR DESCRIPTION
## Previous Behavior

In certain situations Chromium browsers might return `null` from `element.animate()` and Firefox may throw an error. Neither of these behaviors seems to align with [MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/Element/animate) or the spec (linked from the MDN page)

## New Behavior

We now handle the `null` case as well as the thrown error. Test cases have been added to confirm the fix.

## Related Issue(s)


- Fixes #33902
