### PR TITLE
Clarify update messaging

### DIFF
--- a/scripts/package-manager/src/notify-on-file-changes.js
+++ b/scripts/package-manager/src/notify-on-file-changes.js
@@ -16,6 +16,11 @@ function main(changedFiles) {
   if (wasNxChanged) {
     console.warn(renderNotification('nx.json changed, please run `yarn nx reset` to ensure nx graph is up to date.'));
   }
+  if (wasYarnLockChanged && wasNxChanged) {
+    console.warn(
+      renderNotification('Run `yarn install` first to ensure you get any `nx` updates before updating the nx graph.'),
+    );
+  }
 }
 
 /**


### PR DESCRIPTION
## Previous Behavior

When both `yarn install` and `yarn nx reset` need to be run the order in which they are run is important.

The messages appear in the correct order but it was not clear to me that the order was significant.

## New Behavior

This commit adds a message when both Yarn and nx need to be run to clarify that the order in which they run matters.

