### PR TITLE
chore: move ownership of React 18 v9 tests app

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -130,7 +130,7 @@ apps/pr-deploy-site @microsoft/fluentui-react-build
 apps/public-docsite-v9 @microsoft/cxe-red @microsoft/cxe-prg @microsoft/teams-prg @microsoft/fluentui-react-build
 apps/theming-designer @microsoft/fluentui-react
 apps/ssr-tests-v9 @microsoft/fluentui-react-build
-apps/react-18-tests-v8 @microsoft/cxe-red @micahgodbolt
+apps/react-18-tests-v8 @microsoft/fluentui-react-build
 apps/react-18-tests-v9 @microsoft/fluentui-react-build
 apps/chart-docsite @microsoft/charting-team
 


### PR DESCRIPTION
This PR only updates the ownership of the React 18 tests for v8 library.
As v-build is focusing on making updates to React 18, the ownership needs to be updated.
