### PR TITLE
bugfix(react-list): ensure external tabster attributes are merged with internals

### DIFF
--- a/change/@fluentui-react-list-5af220e8-3ce1-4651-9bf6-0855a012082e.json
+++ b/change/@fluentui-react-list-5af220e8-3ce1-4651-9bf6-0855a012082e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: ensure external tabster attributes are merged with internals",
+  "packageName": "@fluentui/react-list",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-list/library/src/components/ListItem/useListItem.tsx
+++ b/packages/react-components/react-list/library/src/components/ListItem/useListItem.tsx
@@ -7,6 +7,7 @@ import {
   useArrowNavigationGroup,
   useFocusableGroup,
   useMergedTabsterAttributes_unstable,
+  type TabsterDOMAttribute,
 } from '@fluentui/react-tabster';
 import {
   elementContains,
@@ -179,6 +180,7 @@ export const useListItem_unstable = (
   const tabsterAttributes = useMergedTabsterAttributes_unstable(
     focusableItems ? arrowNavigationAttributes : {},
     focusableGroupAttrs,
+    props as Partial<TabsterDOMAttribute>,
   );
 
   const root = slot.always(
@@ -190,8 +192,8 @@ export const useListItem_unstable = (
       ...(isSelectionEnabled && {
         'aria-selected': isSelected,
       }),
-      ...tabsterAttributes,
       ...props,
+      ...tabsterAttributes,
       onKeyDown: handleKeyDown,
       onClick: isSelectionEnabled || onClick || onAction ? handleClick : undefined,
     }),


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

restorer attributes passed to `ListItem` are overwriting internal tabster attributes set by the `ListItem`.
All FUI components which set tabster attributes should properly merge them with the incoming prop

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

Ensures external and internal tabster attributes are properly merged

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/33844
