### PR TITLE
chore: fix tests in Toolbar.cy.tsx

### DIFF
--- a/apps/react-18-tests-v9/cypress.config.ts
+++ b/apps/react-18-tests-v9/cypress.config.ts
@@ -5,7 +5,6 @@ import { baseConfig } from '@fluentui/scripts-cypress';
 const excludedSpecs = [
   '!' + path.resolve('../../packages/react-components/react-overflow/library/src/**/*.cy.{tsx,ts}'),
   '!' + path.resolve('../../packages/react-components/react-tag-picker/library/src/**/*.cy.{tsx,ts}'),
-  '!' + path.resolve('../../packages/react-components/react-toolbar/library/src/**/*.cy.{tsx,ts}'),
 ];
 
 // Include all tests from this app and the components package

--- a/packages/react-components/react-toolbar/library/src/components/Toolbar/Toolbar.cy.tsx
+++ b/packages/react-components/react-toolbar/library/src/components/Toolbar/Toolbar.cy.tsx
@@ -1,5 +1,3 @@
-/* @TODO: Fix tests to run on React 18 */
-
 import * as React from 'react';
 import { mount as mountBase } from '@cypress/react';
 
@@ -32,32 +30,20 @@ describe('Toolbar', () => {
         </Toolbar>,
       );
 
-      cy.get(button)
-        .eq(0)
-        .focus()
-        .get(button)
-        .eq(0)
-        .should('be.focused')
-        // Navigate with right arrow to the right
-        .type('{rightArrow}')
-        .get(button)
-        .eq(1)
-        .should('be.focused')
-        // Navigate with down arrow to the right
-        .type('{downArrow}')
-        .get(button)
-        .eq(2)
-        .should('be.focused')
-        // Navigate with up arrow to the right
-        .type('{upArrow}')
-        .get(button)
-        .eq(1)
-        .should('be.focused')
-        // Navigate with left arrow to the right
-        .type('{leftArrow}')
-        .get(button)
-        .eq(0)
-        .should('be.focused');
+      cy.get(button).eq(0).click();
+      cy.get(button).eq(0).focused();
+
+      cy.get(button).eq(0).type('{rightArrow}');
+      cy.get(button).eq(1).focused();
+
+      cy.get(button).eq(1).type('{downArrow}');
+      cy.get(button).eq(2).focused();
+
+      cy.get(button).eq(2).type('{upArrow}');
+      cy.get(button).eq(1).focused();
+
+      cy.get(button).eq(1).type('{leftArrow}');
+      cy.get(button).eq(0).focused();
     });
 
     it('should have circular navigation', () => {
@@ -70,22 +56,14 @@ describe('Toolbar', () => {
         </Toolbar>,
       );
 
-      cy.get(button)
-        .eq(3)
-        .focus()
-        .get(button)
-        .eq(3)
-        .should('be.focused')
-        // Navigate from last to first
-        .type('{rightArrow}')
-        .get(button)
-        .eq(0)
-        .should('be.focused')
-        // Navigate from first to last
-        .type('{leftArrow}')
-        .get(button)
-        .eq(3)
-        .should('be.focused');
+      cy.get(button).eq(3).click();
+      cy.get(button).eq(3).focused();
+
+      cy.get(button).eq(3).type('{rightArrow}');
+      cy.get(button).eq(0).focused();
+
+      cy.get(button).eq(0).type('{leftArrow}');
+      cy.get(button).eq(3).focused();
     });
   });
 
@@ -99,18 +77,13 @@ describe('Toolbar', () => {
         </Toolbar>,
       );
 
-      cy.get(button)
-        .eq(0)
-        .focus()
-        .get(button)
-        .eq(0)
-        .should('have.attr', 'aria-pressed', 'false')
-        .get(button)
-        .eq(0)
-        .click()
-        .get(button)
-        .eq(0)
-        .should('have.attr', 'aria-pressed', 'true');
+      cy.get(button).eq(0).should('have.attr', 'aria-pressed', 'false');
+
+      cy.get(button).eq(0).click();
+      cy.get(button).eq(0).should('have.attr', 'aria-pressed', 'true');
+
+      cy.get(button).eq(0).click();
+      cy.get(button).eq(0).should('have.attr', 'aria-pressed', 'false');
     });
 
     it('should set default checked values', () => {
@@ -140,18 +113,13 @@ describe('Toolbar', () => {
         </Toolbar>,
       );
 
-      cy.get(button)
-        .eq(0)
-        .focus()
-        .get(button)
-        .eq(0)
-        .should('have.attr', 'aria-checked', 'false')
-        .get(button)
-        .eq(0)
-        .click()
-        .get(button)
-        .eq(0)
-        .should('have.attr', 'aria-checked', 'true');
+      cy.get(button).eq(0).should('have.attr', 'aria-checked', 'false');
+
+      cy.get(button).eq(0).click();
+      cy.get(button).eq(0).should('have.attr', 'aria-checked', 'true');
+
+      cy.get(button).eq(0).click();
+      cy.get(button).eq(0).should('have.attr', 'aria-checked', 'true');
     });
 
     it('should set default checked values', () => {
@@ -186,23 +154,16 @@ describe('Toolbar', () => {
         </Toolbar>,
       );
 
-      cy.get(button)
-        .eq(0)
-        .should('have.attr', 'aria-checked', 'true')
-        .get(button)
-        .eq(1)
-        .click()
-        .get(button)
-        .eq(1)
-        .should('have.attr', 'aria-checked', 'true')
-        .get(button)
-        .eq(0)
-        .should('have.attr', 'aria-checked', 'false');
+      cy.get(button).eq(0).should('have.attr', 'aria-checked', 'true');
+      cy.get(button).eq(1).click();
+
+      cy.get(button).eq(1).should('have.attr', 'aria-checked', 'true');
+      cy.get(button).eq(0).should('have.attr', 'aria-checked', 'false');
     });
   });
 });
 
-describe('MenuTrigger', () => {
+describe('ToolbarDivider', () => {
   it('should focus first element', () => {
     mount(
       <Toolbar>
@@ -213,7 +174,7 @@ describe('MenuTrigger', () => {
       </Toolbar>,
     );
 
-    cy.get('html').type('Tab').type('{rightarrow}').get('[type="button"]').eq(0).should('be.focused');
+    cy.get('html').type('Tab').type('{rightarrow}').get(button).eq(0).focused();
   });
 
   it('should navigate with arrow key', () => {
@@ -225,14 +186,11 @@ describe('MenuTrigger', () => {
         <ToolbarButton>Item 3</ToolbarButton>
       </Toolbar>,
     );
-    cy.get('[type="button"]')
-      .eq(0)
-      .focus()
-      .type('{rightarrow}')
-      .type('{rightarrow}')
-      .get('[type="button"]')
-      .eq(1)
-      .should('be.focused');
+
+    cy.get(button).eq(0).click();
+
+    cy.get(button).eq(0).type('{rightarrow}');
+    cy.get(button).eq(1).focused();
   });
 
   it('should have circular navigation', () => {
@@ -244,6 +202,10 @@ describe('MenuTrigger', () => {
         <ToolbarButton>Item 3</ToolbarButton>
       </Toolbar>,
     );
-    cy.get('[type="button"]').eq(0).focus().type('{leftarrow}').get('[type="button"]').eq(2).should('be.focused');
+
+    cy.get(button).eq(0).click();
+
+    cy.get(button).eq(0).type('{leftarrow}');
+    cy.get(button).eq(2).focused();
   });
 });


### PR DESCRIPTION
## New Behavior

Cypress is very sensitive to timings. Looks that they don't handle well `useEffect()` timings which causes issues with Tabster & other effects.

Chained assertions were flattened, some `.focus()` calls were replaced with `.click()` which somehow waits enough ¯\_(ツ)_/¯