### PR TITLE
chore: fix tests in List.cy.tsx & useFocusedElementChange.cy.tsx

### DIFF
--- a/packages/react-components/react-list/library/src/components/List/List.cy.tsx
+++ b/packages/react-components/react-list/library/src/components/List/List.cy.tsx
@@ -23,7 +23,12 @@ const mount = (element: JSX.Element) => {
  * ])
  */
 const testSequence = (sequence: Array<string>) => {
+  cy.get('#outside-button').click();
+  cy.get('#outside-button').focused();
+
   cy.get('[data-test^=list-item-]').first().focus();
+  cy.get('[data-test^=list-item-]').focused();
+
   for (const command of sequence) {
     if (command.startsWith('focused:')) {
       const tid = command.split(':')[1];
@@ -36,30 +41,38 @@ const testSequence = (sequence: Array<string>) => {
 
 const mountSimpleList = () => {
   mount(
-    <List navigationMode="items">
-      <ListItem data-test="list-item-1">List Item 1</ListItem>
-      <ListItem data-test="list-item-2">List Item 2</ListItem>
-      <ListItem data-test="list-item-3">List Item 3</ListItem>
-    </List>,
+    <>
+      <button id="outside-button">Outside Button</button>
+
+      <List navigationMode="items">
+        <ListItem data-test="list-item-1">List Item 1</ListItem>
+        <ListItem data-test="list-item-2">List Item 2</ListItem>
+        <ListItem data-test="list-item-3">List Item 3</ListItem>
+      </List>
+    </>,
   );
 };
 
 const mountListWithSecondaryActions = () => {
   mount(
-    <List navigationMode="composite">
-      <ListItem data-test="list-item-1">
-        List Item 1<button data-test="list-item-1-button-1">1:button1</button>
-        <button data-test="list-item-1-button-2">1:button2</button>
-      </ListItem>
-      <ListItem data-test="list-item-2">
-        List Item 2<button data-test="list-item-2-button-1">2:button1</button>
-        <button data-test="button-2-2">2:button2</button>
-      </ListItem>
-      <ListItem data-test="list-item-3">
-        List Item 3<button data-test="button-3-1">3:button1</button>
-        <button data-test="button-3-2">3:button2</button>
-      </ListItem>
-    </List>,
+    <>
+      <button id="outside-button">Outside Button</button>
+
+      <List navigationMode="composite">
+        <ListItem data-test="list-item-1">
+          List Item 1<button data-test="list-item-1-button-1">1:button1</button>
+          <button data-test="list-item-1-button-2">1:button2</button>
+        </ListItem>
+        <ListItem data-test="list-item-2">
+          List Item 2<button data-test="list-item-2-button-1">2:button1</button>
+          <button data-test="button-2-2">2:button2</button>
+        </ListItem>
+        <ListItem data-test="list-item-3">
+          List Item 3<button data-test="button-3-1">3:button1</button>
+          <button data-test="button-3-2">3:button2</button>
+        </ListItem>
+      </List>
+    </>,
   );
 };
 

--- a/packages/react-components/react-tabster/src/hooks/useFocusedElementChange.cy.tsx
+++ b/packages/react-components/react-tabster/src/hooks/useFocusedElementChange.cy.tsx
@@ -1,13 +1,19 @@
 import * as React from 'react';
-import { useFocusedElementChange } from './useFocusedElementChange';
 import { mount } from '@cypress/react';
+
+import { useFocusedElementChange } from './useFocusedElementChange';
 
 const Example = (props: { callback: () => void }) => {
   useFocusedElementChange(props.callback);
+
   return (
     <>
+      <a id="anchor" href="#">
+        Anchor
+      </a>
+
       <div tabIndex={0}>before</div>
-      <button id="btn-1">Button 1</button>
+      <button id="button">Button</button>
       <div tabIndex={0}>after</div>
     </>
   );
@@ -18,19 +24,30 @@ describe('useFocusedElementChange', () => {
     const callback = cy.stub().as('callback');
     mount(<Example callback={callback} />);
 
-    cy.get('#btn-1').focus();
-    cy.get('@callback').should('have.been.calledOnceWith', Cypress.sinon.match.instanceOf(HTMLButtonElement), {
-      relatedTarget: Cypress.sinon.match.any,
+    cy.get('#anchor').click();
+    cy.get('#anchor').focused();
+
+    cy.get('#button').focus();
+    cy.get('#button').focused();
+
+    cy.get('@callback').should('have.been.calledWith', Cypress.sinon.match.instanceOf(HTMLButtonElement), {
+      relatedTarget: Cypress.sinon.match.instanceOf(HTMLAnchorElement),
       isFocusedProgrammatically: false,
     });
   });
+
   it('should call the callback when the focused element changes programmatically', () => {
     const callback = cy.stub().as('callback');
     mount(<Example callback={callback} />);
 
-    cy.get('#btn-1').invoke('focus');
-    cy.get('@callback').should('have.been.calledOnceWith', Cypress.sinon.match.instanceOf(HTMLButtonElement), {
-      relatedTarget: Cypress.sinon.match.any,
+    cy.get('#anchor').click();
+    cy.get('#anchor').focused();
+
+    cy.get('#button').invoke('focus');
+    cy.get('#button').focused();
+
+    cy.get('@callback').should('have.been.calledWith', Cypress.sinon.match.instanceOf(HTMLButtonElement), {
+      relatedTarget: Cypress.sinon.match.instanceOf(HTMLAnchorElement),
       isFocusedProgrammatically: true,
     });
   });


### PR DESCRIPTION
## New Behavior

Cypress is very sensitive to timings. Looks that they don't handle well `useEffect()` timings which causes issues with Tabster & other effects.

`.focus()` calls were prepended with `.click()` which somehow waits enough ¯\_(ツ)_/¯