### PR TITLE
chore: fix Overflow.cy.tsx tests

### DIFF
--- a/apps/react-18-tests-v9/cypress.config.ts
+++ b/apps/react-18-tests-v9/cypress.config.ts
@@ -3,7 +3,6 @@ import { baseConfig } from '@fluentui/scripts-cypress';
 
 // Exclude files that are not compatible with React 18 yet
 const excludedSpecs = [
-  '!' + path.resolve('../../packages/react-components/react-overflow/library/src/**/*.cy.{tsx,ts}'),
   '!' + path.resolve('../../packages/react-components/react-tag-picker/library/src/**/*.cy.{tsx,ts}'),
 ];
 

--- a/packages/react-components/react-overflow/library/src/Overflow.cy.tsx
+++ b/packages/react-components/react-overflow/library/src/Overflow.cy.tsx
@@ -1,5 +1,3 @@
-/* @TODO: Fix tests to run on React 18 */
-
 import * as React from 'react';
 import { mount } from '@cypress/react';
 import {
@@ -256,6 +254,7 @@ describe('Overflow', () => {
   it(`should overflow items when there's more than one child element`, () => {
     const mapHelper = new Array(10).fill(0).map((_, i) => i);
     const overflowElementIndex = 6;
+
     mount(
       <Container size={350}>
         <div>
@@ -269,11 +268,12 @@ describe('Overflow', () => {
       </Container>,
     );
 
-    cy.get(`[${selectors.item}]`).each((value, index) => {
+    cy.get(`[${selectors.item}]`).each((el, index) => {
       if (index >= overflowElementIndex) {
-        expect(Cypress.$(value).css('display')).to.equal('none');
+        cy.wrap(el).should('be.hidden');
+        cy.wrap(el).should('have.css', 'display', 'none');
       } else {
-        expect(Cypress.$(value).css('display')).to.equal('inline-block');
+        cy.wrap(el).should('have.css', 'display', 'inline-block');
       }
     });
   });


### PR DESCRIPTION
## Previous Behavior

`Overflow.cy.tsx` is disabled in R18 test suite.

## New Behavior

- `Overflow.cy.tsx` is enabled in R18 test suite
- `cy.wrap(el)` unlike `expect(Cypress.$(value).css('display'))` waits for the state with a timeout, so tests become more predictable & stable
