### PR TITLE
chore: disable Tree.cy.tsx for React 18 E2E

### DIFF
--- a/apps/react-18-tests-v9/cypress.config.ts
+++ b/apps/react-18-tests-v9/cypress.config.ts
@@ -5,6 +5,7 @@ import { baseConfig } from '@fluentui/scripts-cypress';
 const excludedSpecs = [
   '!' + path.resolve('../../packages/react-components/react-overflow/library/src/**/*.cy.{tsx,ts}'),
   '!' + path.resolve('../../packages/react-components/react-tag-picker/library/src/**/*.cy.{tsx,ts}'),
+  '!' + path.resolve('../../packages/react-components/react-tree/library/src/components/Tree/Tree.cy.tsx'),
 ];
 
 // Include all tests from this app and the components package

--- a/packages/react-components/react-tree/library/src/components/Tree/Tree.cy.tsx
+++ b/packages/react-components/react-tree/library/src/components/Tree/Tree.cy.tsx
@@ -1,3 +1,5 @@
+/* @TODO: Fix tests to run on React 18 */
+
 import 'cypress-real-events';
 import * as React from 'react';
 import { mount as mountBase } from '@cypress/react';


### PR DESCRIPTION
## Previous Behavior

<img width="1262" alt="image" src="https://github.com/user-attachments/assets/e1b2a9ba-dd5e-4e74-8f29-ff947f81e830" />


The test breaks CI.

## New Behavior

Test is disabled for React 18 suite. CI is passing.
