### PR TITLE
fix(react-tag-picker): avoid "ResizeObserver loop limit exceeded" exception

### DIFF
--- a/change/@fluentui-react-tag-picker-4a80240e-8a98-47e9-86e2-b5978a0ff4a3.json
+++ b/change/@fluentui-react-tag-picker-4a80240e-8a98-47e9-86e2-b5978a0ff4a3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: avoid \"ResizeObserver loop limit exceeded\" being thrown",
+  "packageName": "@fluentui/react-tag-picker",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tag-picker/library/src/components/TagPicker/TagPicker.cy.tsx
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPicker/TagPicker.cy.tsx
@@ -17,17 +17,6 @@ import { Button } from '@fluentui/react-button';
 
 import 'cypress-real-events';
 import { tagPickerControlClassNames } from '../TagPickerControl/useTagPickerControlStyles.styles';
-/**
- * This error means that ResizeObserver
- * was not able to deliver all observations within a single animation frame.
- * https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded
- */
-const resizeObserverLoopErrRe = /^[^(ResizeObserver loop limit exceeded)]/;
-Cypress.on('uncaught:exception', err => {
-  if (resizeObserverLoopErrRe.test(err.message)) {
-    return false;
-  }
-});
 
 const mount = (element: JSX.Element) => {
   mountBase(<FluentProvider theme={teamsLightTheme}>{element}</FluentProvider>);

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerControl/useTagPickerControl.tsx
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerControl/useTagPickerControl.tsx
@@ -80,11 +80,7 @@ export const useTagPickerControl_unstable = (
     const targetWindow = targetDocument?.defaultView;
 
     if (targetWindow) {
-      if (rafIdRef.current) {
-        targetWindow.cancelAnimationFrame(rafIdRef.current);
-      }
-
-      targetWindow.requestAnimationFrame(() => {
+      rafIdRef.current = targetWindow.requestAnimationFrame(() => {
         innerRef.current?.style.setProperty(tagPickerControlAsideWidthToken, `${entry.contentRect.width}px`);
       });
     }

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerControl/useTagPickerControl.tsx
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerControl/useTagPickerControl.tsx
@@ -9,6 +9,7 @@ import {
   useId,
   useMergedRefs,
 } from '@fluentui/react-utilities';
+import { useFluent_unstable } from '@fluentui/react-shared-contexts';
 import type { TagPickerControlProps, TagPickerControlState } from './TagPickerControl.types';
 import { useTagPickerContext_unstable } from '../../contexts/TagPickerContext';
 import { ChevronDownRegular } from '@fluentui/react-icons';
@@ -43,7 +44,9 @@ export const useTagPickerControl_unstable = (
   const invalid = useFieldContext_unstable()?.validationState === 'error';
   const noPopover = useTagPickerContext_unstable(ctx => ctx.noPopover ?? false);
 
+  const { targetDocument } = useFluent_unstable();
   const tagPickerId = useId('tagPicker-');
+  const rafIdRef = React.useRef<number | null>(null);
 
   const innerRef = React.useRef<HTMLDivElement>(null);
   const expandIconRef = React.useRef<HTMLSpanElement>(null);
@@ -74,7 +77,17 @@ export const useTagPickerControl_unstable = (
   }
 
   const observerRef = useResizeObserverRef<HTMLSpanElement>(([entry]) => {
-    innerRef.current?.style.setProperty(tagPickerControlAsideWidthToken, `${entry.contentRect.width}px`);
+    const targetWindow = targetDocument?.defaultView;
+
+    if (targetWindow) {
+      if (rafIdRef.current) {
+        targetWindow.cancelAnimationFrame(rafIdRef.current);
+      }
+
+      targetWindow.requestAnimationFrame(() => {
+        innerRef.current?.style.setProperty(tagPickerControlAsideWidthToken, `${entry.contentRect.width}px`);
+      });
+    }
   });
   const aside = slot.optional<ExtractSlotProps<Slot<'span'>>>(undefined, {
     elementType: 'span',
@@ -135,6 +148,12 @@ export const useTagPickerControl_unstable = (
   if (state.expandIcon) {
     state.expandIcon.ref = expandIconLabelMergeRef;
   }
+
+  React.useEffect(() => {
+    if (rafIdRef.current && targetDocument?.defaultView) {
+      targetDocument.defaultView.cancelAnimationFrame(rafIdRef.current);
+    }
+  }, [targetDocument]);
 
   return state;
 };


### PR DESCRIPTION
## New Behavior

Pushes layout changes (i.e. `innerRef.current?.style.setProperty()`) into a microtask queue:
- 👍 no errors from `ResizeObserver`
- 👍 better performance (single update per a frame)

Uses the advice from SO linked in the test comment.