### PR TITLE
Carousel: Enable dynamic autoplayInterval

### DIFF
--- a/change/@fluentui-react-carousel-da58b311-fa0d-4937-a70c-5d21bbe27170.json
+++ b/change/@fluentui-react-carousel-da58b311-fa0d-4937-a70c-5d21bbe27170.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Stop and reinitialize autoplay on carousel when autoplay interval changes",
+  "packageName": "@fluentui/react-carousel",
+  "email": "mifraser@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-carousel/library/src/components/useEmblaCarousel.ts
+++ b/packages/react-components/react-carousel/library/src/components/useEmblaCarousel.ts
@@ -229,6 +229,8 @@ export function useEmblaCarousel(
         // Use direct viewport if available, else fallback to container (includes Carousel controls).
         currentElement = viewportRef.current ?? newElement;
         if (currentElement) {
+          // Stop autoplay before reinitializing.
+          emblaApi.current?.plugins().autoplay?.stop();
           emblaApi.current = EmblaCarousel(
             currentElement,
             {
@@ -291,6 +293,8 @@ export function useEmblaCarousel(
       duration: motionDuration,
     };
 
+    // Stop autoplay before reinitializing.
+    emblaApi.current?.plugins().autoplay?.stop();
     emblaApi.current?.reInit(
       {
         ...DEFAULT_EMBLA_OPTIONS,

--- a/packages/react-components/react-carousel/library/src/components/useEmblaCarousel.ts
+++ b/packages/react-components/react-carousel/library/src/components/useEmblaCarousel.ts
@@ -230,7 +230,7 @@ export function useEmblaCarousel(
         currentElement = viewportRef.current ?? newElement;
         if (currentElement) {
           // Stop autoplay before reinitializing.
-          emblaApi.current?.plugins().autoplay?.stop();
+          emblaApi.current?.plugins?.().autoplay?.stop();
           emblaApi.current = EmblaCarousel(
             currentElement,
             {
@@ -294,7 +294,7 @@ export function useEmblaCarousel(
     };
 
     // Stop autoplay before reinitializing.
-    emblaApi.current?.plugins().autoplay?.stop();
+    emblaApi.current?.plugins?.().autoplay?.stop();
     emblaApi.current?.reInit(
       {
         ...DEFAULT_EMBLA_OPTIONS,


### PR DESCRIPTION
## Previous Behavior
AutoplayInterval changes cause a re-init of the carousel.
We did not stop previous autoplay instances, causing the autoplay to stack timing events.

## New Behavior
AutoplayInterval changes still re-init carousel
Now they do not stack, and will stop previous autoplay instances when Re-initialized.