### PR TITLE
fix: Reorder custom style hook to merge classes correctly

### DIFF
--- a/change/@fluentui-react-accordion-71c44057-5e39-4760-bf85-21cce525b16b.json
+++ b/change/@fluentui-react-accordion-71c44057-5e39-4760-bf85-21cce525b16b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Reorder custom style hook to merge classes correctly.",
+  "packageName": "@fluentui/react-accordion",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-avatar-da62e5d1-d535-4e1c-adf4-94c0cd099071.json
+++ b/change/@fluentui-react-avatar-da62e5d1-d535-4e1c-adf4-94c0cd099071.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Reorder custom style hook to merge classes correctly.",
+  "packageName": "@fluentui/react-avatar",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-badge-afaf78f7-a794-4434-b825-e105b8d724e2.json
+++ b/change/@fluentui-react-badge-afaf78f7-a794-4434-b825-e105b8d724e2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Reorder custom style hook to merge classes correctly.",
+  "packageName": "@fluentui/react-badge",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-breadcrumb-359ad74a-405d-4e64-b8a1-371872a7aee9.json
+++ b/change/@fluentui-react-breadcrumb-359ad74a-405d-4e64-b8a1-371872a7aee9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Reorder custom style hook to merge classes correctly.",
+  "packageName": "@fluentui/react-breadcrumb",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-button-d2c2b1dc-84fb-4e18-8003-b87a593aec2f.json
+++ b/change/@fluentui-react-button-d2c2b1dc-84fb-4e18-8003-b87a593aec2f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Reorder custom style hook to merge classes correctly.",
+  "packageName": "@fluentui/react-button",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-card-0d112e61-156c-4580-b923-0642a4270f3d.json
+++ b/change/@fluentui-react-card-0d112e61-156c-4580-b923-0642a4270f3d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Reorder custom style hook to merge classes correctly.",
+  "packageName": "@fluentui/react-card",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-carousel-60257ac4-01a7-468d-b6cb-98e7b7312c88.json
+++ b/change/@fluentui-react-carousel-60257ac4-01a7-468d-b6cb-98e7b7312c88.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Reorder custom style hook to merge classes correctly.",
+  "packageName": "@fluentui/react-carousel",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-checkbox-2d0b4b40-6a0e-4d48-9aa9-053c97ca28aa.json
+++ b/change/@fluentui-react-checkbox-2d0b4b40-6a0e-4d48-9aa9-053c97ca28aa.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Reorder custom style hook to merge classes correctly.",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-color-picker-81c282a0-67d6-419c-8c6f-3f9589bd5ca5.json
+++ b/change/@fluentui-react-color-picker-81c282a0-67d6-419c-8c6f-3f9589bd5ca5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Reorder custom style hook to merge classes correctly.",
+  "packageName": "@fluentui/react-color-picker",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-combobox-60b37576-4749-4e84-97e9-d15b0f28a76f.json
+++ b/change/@fluentui-react-combobox-60b37576-4749-4e84-97e9-d15b0f28a76f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Reorder custom style hook to merge classes correctly.",
+  "packageName": "@fluentui/react-combobox",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-dialog-27b5d35c-decd-413c-bb44-fc41389df42d.json
+++ b/change/@fluentui-react-dialog-27b5d35c-decd-413c-bb44-fc41389df42d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Reorder custom style hook to merge classes correctly.",
+  "packageName": "@fluentui/react-dialog",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-divider-912f73ef-0069-416a-b8c3-09241f3754b5.json
+++ b/change/@fluentui-react-divider-912f73ef-0069-416a-b8c3-09241f3754b5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Reorder custom style hook to merge classes correctly.",
+  "packageName": "@fluentui/react-divider",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-drawer-cf0f6540-0278-4b5b-a608-67efad18b7c2.json
+++ b/change/@fluentui-react-drawer-cf0f6540-0278-4b5b-a608-67efad18b7c2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Reorder custom style hook to merge classes correctly.",
+  "packageName": "@fluentui/react-drawer",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-field-6754f805-5f0e-4644-954e-24f89dd1f911.json
+++ b/change/@fluentui-react-field-6754f805-5f0e-4644-954e-24f89dd1f911.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Reorder custom style hook to merge classes correctly.",
+  "packageName": "@fluentui/react-field",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-image-a2cb41f6-930c-4883-b276-5b2031ca1783.json
+++ b/change/@fluentui-react-image-a2cb41f6-930c-4883-b276-5b2031ca1783.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Reorder custom style hook to merge classes correctly.",
+  "packageName": "@fluentui/react-image",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-infolabel-e4f61fc7-6cc6-49e4-8839-c7879af0e941.json
+++ b/change/@fluentui-react-infolabel-e4f61fc7-6cc6-49e4-8839-c7879af0e941.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Reorder custom style hook to merge classes correctly.",
+  "packageName": "@fluentui/react-infolabel",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-input-337d7032-03c9-4b0d-8c7f-667f0e272db3.json
+++ b/change/@fluentui-react-input-337d7032-03c9-4b0d-8c7f-667f0e272db3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Reorder custom style hook to merge classes correctly.",
+  "packageName": "@fluentui/react-input",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-label-f67592e1-c970-483a-b637-c033cfebc25c.json
+++ b/change/@fluentui-react-label-f67592e1-c970-483a-b637-c033cfebc25c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Reorder custom style hook to merge classes correctly.",
+  "packageName": "@fluentui/react-label",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-link-1a4c2420-7b5d-43a9-96da-3b14b2bd252d.json
+++ b/change/@fluentui-react-link-1a4c2420-7b5d-43a9-96da-3b14b2bd252d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Reorder custom style hook to merge classes correctly.",
+  "packageName": "@fluentui/react-link",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-list-dbdcade1-2084-4177-b713-2e7c11690d3c.json
+++ b/change/@fluentui-react-list-dbdcade1-2084-4177-b713-2e7c11690d3c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Reorder custom style hook to merge classes correctly.",
+  "packageName": "@fluentui/react-list",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-menu-2b0f9e95-e111-4035-aed2-d890b982ddf1.json
+++ b/change/@fluentui-react-menu-2b0f9e95-e111-4035-aed2-d890b982ddf1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Reorder custom style hook to merge classes correctly.",
+  "packageName": "@fluentui/react-menu",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-message-bar-9ca20d28-2eda-407c-9a4e-493307d7582a.json
+++ b/change/@fluentui-react-message-bar-9ca20d28-2eda-407c-9a4e-493307d7582a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Reorder custom style hook to merge classes correctly.",
+  "packageName": "@fluentui/react-message-bar",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-migration-v0-v9-d7effbd1-0b63-4f76-8d8c-1a8139074892.json
+++ b/change/@fluentui-react-migration-v0-v9-d7effbd1-0b63-4f76-8d8c-1a8139074892.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Reorder custom style hook to merge classes correctly.",
+  "packageName": "@fluentui/react-migration-v0-v9",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-nav-preview-8b133047-ec4b-41dc-9ab4-90587846150c.json
+++ b/change/@fluentui-react-nav-preview-8b133047-ec4b-41dc-9ab4-90587846150c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Reorder custom style hook to merge classes correctly.",
+  "packageName": "@fluentui/react-nav-preview",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-persona-1757d698-606c-43bb-ac8b-909ea694de19.json
+++ b/change/@fluentui-react-persona-1757d698-606c-43bb-ac8b-909ea694de19.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Reorder custom style hook to merge classes correctly.",
+  "packageName": "@fluentui/react-persona",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-popover-d93d27fe-f59b-4fd8-b87e-5e575e523e5d.json
+++ b/change/@fluentui-react-popover-d93d27fe-f59b-4fd8-b87e-5e575e523e5d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Reorder custom style hook to merge classes correctly.",
+  "packageName": "@fluentui/react-popover",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-progress-e7630d40-91eb-41af-ab89-d51cc47af3cb.json
+++ b/change/@fluentui-react-progress-e7630d40-91eb-41af-ab89-d51cc47af3cb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Reorder custom style hook to merge classes correctly.",
+  "packageName": "@fluentui/react-progress",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-radio-8f0289da-cb1e-4157-bb8b-15be4b137d76.json
+++ b/change/@fluentui-react-radio-8f0289da-cb1e-4157-bb8b-15be4b137d76.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Reorder custom style hook to merge classes correctly.",
+  "packageName": "@fluentui/react-radio",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-rating-067e46bd-f216-466c-89d7-532f792bfa5f.json
+++ b/change/@fluentui-react-rating-067e46bd-f216-466c-89d7-532f792bfa5f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Reorder custom style hook to merge classes correctly.",
+  "packageName": "@fluentui/react-rating",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-search-1a62bd6b-ea34-48f2-af0f-373594a02831.json
+++ b/change/@fluentui-react-search-1a62bd6b-ea34-48f2-af0f-373594a02831.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Reorder custom style hook to merge classes correctly.",
+  "packageName": "@fluentui/react-search",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-select-3c7c3909-c422-4261-b76f-06712c616fc9.json
+++ b/change/@fluentui-react-select-3c7c3909-c422-4261-b76f-06712c616fc9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Reorder custom style hook to merge classes correctly.",
+  "packageName": "@fluentui/react-select",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-skeleton-e97ebe55-66f7-4e55-9c58-524974f46ea0.json
+++ b/change/@fluentui-react-skeleton-e97ebe55-66f7-4e55-9c58-524974f46ea0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Reorder custom style hook to merge classes correctly.",
+  "packageName": "@fluentui/react-skeleton",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-slider-4052ef48-2766-400a-a166-7834698d9737.json
+++ b/change/@fluentui-react-slider-4052ef48-2766-400a-a166-7834698d9737.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Reorder custom style hook to merge classes correctly.",
+  "packageName": "@fluentui/react-slider",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-spinbutton-302a986d-d30e-4952-9723-93d204c75415.json
+++ b/change/@fluentui-react-spinbutton-302a986d-d30e-4952-9723-93d204c75415.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Reorder custom style hook to merge classes correctly.",
+  "packageName": "@fluentui/react-spinbutton",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-spinner-98c48b13-f4de-4bd0-a081-156e30d3ef88.json
+++ b/change/@fluentui-react-spinner-98c48b13-f4de-4bd0-a081-156e30d3ef88.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Reorder custom style hook to merge classes correctly.",
+  "packageName": "@fluentui/react-spinner",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-swatch-picker-eee6f6aa-15de-4483-8a18-c10353d437e5.json
+++ b/change/@fluentui-react-swatch-picker-eee6f6aa-15de-4483-8a18-c10353d437e5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Reorder custom style hook to merge classes correctly.",
+  "packageName": "@fluentui/react-swatch-picker",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-switch-4ea8c00d-0b9d-4202-a300-72b666b9024d.json
+++ b/change/@fluentui-react-switch-4ea8c00d-0b9d-4202-a300-72b666b9024d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Reorder custom style hook to merge classes correctly.",
+  "packageName": "@fluentui/react-switch",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-table-800e4881-0e55-499b-bc9f-bf991d3aa1ef.json
+++ b/change/@fluentui-react-table-800e4881-0e55-499b-bc9f-bf991d3aa1ef.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Reorder custom style hook to merge classes correctly.",
+  "packageName": "@fluentui/react-table",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tabs-bc0b3ddd-31d6-46cc-8084-cdb857b9ac47.json
+++ b/change/@fluentui-react-tabs-bc0b3ddd-31d6-46cc-8084-cdb857b9ac47.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Reorder custom style hook to merge classes correctly.",
+  "packageName": "@fluentui/react-tabs",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tag-picker-ddfdc014-1d81-4125-94bb-e738c9cfd22f.json
+++ b/change/@fluentui-react-tag-picker-ddfdc014-1d81-4125-94bb-e738c9cfd22f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Reorder custom style hook to merge classes correctly.",
+  "packageName": "@fluentui/react-tag-picker",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tags-25aa1d03-2d78-4139-96f6-e8c7813bb51f.json
+++ b/change/@fluentui-react-tags-25aa1d03-2d78-4139-96f6-e8c7813bb51f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Reorder custom style hook to merge classes correctly.",
+  "packageName": "@fluentui/react-tags",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-teaching-popover-abb810e0-049c-4ecd-9110-e7fdf1ffa348.json
+++ b/change/@fluentui-react-teaching-popover-abb810e0-049c-4ecd-9110-e7fdf1ffa348.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Reorder custom style hook to merge classes correctly.",
+  "packageName": "@fluentui/react-teaching-popover",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-text-d8867087-3ea7-43cc-9fdd-eab158a4f666.json
+++ b/change/@fluentui-react-text-d8867087-3ea7-43cc-9fdd-eab158a4f666.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Reorder custom style hook to merge classes correctly.",
+  "packageName": "@fluentui/react-text",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-textarea-3b271ef0-5a86-477c-a370-29f792880d39.json
+++ b/change/@fluentui-react-textarea-3b271ef0-5a86-477c-a370-29f792880d39.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Reorder custom style hook to merge classes correctly.",
+  "packageName": "@fluentui/react-textarea",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-timepicker-compat-f9d67a7b-843d-4e09-bb40-2087c5987b02.json
+++ b/change/@fluentui-react-timepicker-compat-f9d67a7b-843d-4e09-bb40-2087c5987b02.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Reorder custom style hook to merge classes correctly.",
+  "packageName": "@fluentui/react-timepicker-compat",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-toast-3b5dbc90-bbbe-4809-b58f-a16066358f72.json
+++ b/change/@fluentui-react-toast-3b5dbc90-bbbe-4809-b58f-a16066358f72.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Reorder custom style hook to merge classes correctly.",
+  "packageName": "@fluentui/react-toast",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-toolbar-23f501dc-0c00-4441-9d09-fdf2c4b3811e.json
+++ b/change/@fluentui-react-toolbar-23f501dc-0c00-4441-9d09-fdf2c4b3811e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Reorder custom style hook to merge classes correctly.",
+  "packageName": "@fluentui/react-toolbar",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tooltip-7848ae08-be05-4a19-b1ea-ffff11f36638.json
+++ b/change/@fluentui-react-tooltip-7848ae08-be05-4a19-b1ea-ffff11f36638.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Reorder custom style hook to merge classes correctly.",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tree-3c826bf7-2dc2-4fba-90de-939c9464ce6b.json
+++ b/change/@fluentui-react-tree-3c826bf7-2dc2-4fba-90de-939c9464ce6b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Reorder custom style hook to merge classes correctly.",
+  "packageName": "@fluentui/react-tree",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-virtualizer-a6545a35-9f70-4aaf-8298-41b228912abe.json
+++ b/change/@fluentui-react-virtualizer-a6545a35-9f70-4aaf-8298-41b228912abe.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: Reorder custom style hook to merge classes correctly.",
+  "packageName": "@fluentui/react-virtualizer",
+  "email": "estebanmu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-accordion/library/src/components/Accordion/Accordion.tsx
+++ b/packages/react-components/react-accordion/library/src/components/Accordion/Accordion.tsx
@@ -15,9 +15,8 @@ export const Accordion: ForwardRefComponent<AccordionProps> & (<TItem>(props: Ac
     const state = useAccordion_unstable(props, ref);
     const contextValues = useAccordionContextValues_unstable(state);
 
-    useAccordionStyles_unstable(state);
-
     useCustomStyleHook_unstable('useAccordionStyles_unstable')(state);
+    useAccordionStyles_unstable(state);
 
     return renderAccordion_unstable(state, contextValues);
   }) as ForwardRefComponent<AccordionProps> & (<TItem>(props: AccordionProps<TItem>) => JSX.Element);

--- a/packages/react-components/react-accordion/library/src/components/AccordionHeader/AccordionHeader.tsx
+++ b/packages/react-components/react-accordion/library/src/components/AccordionHeader/AccordionHeader.tsx
@@ -15,9 +15,8 @@ export const AccordionHeader: ForwardRefComponent<AccordionHeaderProps> = React.
   const state = useAccordionHeader_unstable(props, ref);
   const contextValues = useAccordionHeaderContextValues_unstable(state);
 
-  useAccordionHeaderStyles_unstable(state);
-
   useCustomStyleHook_unstable('useAccordionHeaderStyles_unstable')(state);
+  useAccordionHeaderStyles_unstable(state);
 
   return renderAccordionHeader_unstable(state, contextValues);
 });

--- a/packages/react-components/react-accordion/library/src/components/AccordionItem/AccordionItem.tsx
+++ b/packages/react-components/react-accordion/library/src/components/AccordionItem/AccordionItem.tsx
@@ -14,9 +14,8 @@ export const AccordionItem: ForwardRefComponent<AccordionItemProps> = React.forw
   const state = useAccordionItem_unstable(props, ref);
   const contextValues = useAccordionItemContextValues_unstable(state);
 
-  useAccordionItemStyles_unstable(state);
-
   useCustomStyleHook_unstable('useAccordionItemStyles_unstable')(state);
+  useAccordionItemStyles_unstable(state);
 
   return renderAccordionItem_unstable(state, contextValues);
 });

--- a/packages/react-components/react-accordion/library/src/components/AccordionPanel/AccordionPanel.tsx
+++ b/packages/react-components/react-accordion/library/src/components/AccordionPanel/AccordionPanel.tsx
@@ -12,9 +12,8 @@ import type { ForwardRefComponent } from '@fluentui/react-utilities';
 export const AccordionPanel: ForwardRefComponent<AccordionPanelProps> = React.forwardRef((props, ref) => {
   const state = useAccordionPanel_unstable(props, ref);
 
-  useAccordionPanelStyles_unstable(state);
-
   useCustomStyleHook_unstable('useAccordionPanelStyles_unstable')(state);
+  useAccordionPanelStyles_unstable(state);
 
   return renderAccordionPanel_unstable(state);
 });

--- a/packages/react-components/react-avatar/library/src/components/Avatar/Avatar.tsx
+++ b/packages/react-components/react-avatar/library/src/components/Avatar/Avatar.tsx
@@ -9,9 +9,8 @@ import type { ForwardRefComponent } from '@fluentui/react-utilities';
 export const Avatar: ForwardRefComponent<AvatarProps> = React.forwardRef((props, ref) => {
   const state = useAvatar_unstable(props, ref);
 
-  useAvatarStyles_unstable(state);
-
   useCustomStyleHook_unstable('useAvatarStyles_unstable')(state);
+  useAvatarStyles_unstable(state);
 
   return renderAvatar_unstable(state);
 });

--- a/packages/react-components/react-avatar/library/src/components/AvatarGroup/AvatarGroup.tsx
+++ b/packages/react-components/react-avatar/library/src/components/AvatarGroup/AvatarGroup.tsx
@@ -15,9 +15,8 @@ export const AvatarGroup: ForwardRefComponent<AvatarGroupProps> = React.forwardR
   const state = useAvatarGroup_unstable(props, ref);
   const contextValues = useAvatarGroupContextValues(state);
 
-  useAvatarGroupStyles_unstable(state);
-
   useCustomStyleHook_unstable('useAvatarGroupStyles_unstable')(state);
+  useAvatarGroupStyles_unstable(state);
 
   return renderAvatarGroup_unstable(state, contextValues);
 });

--- a/packages/react-components/react-avatar/library/src/components/AvatarGroupItem/AvatarGroupItem.tsx
+++ b/packages/react-components/react-avatar/library/src/components/AvatarGroupItem/AvatarGroupItem.tsx
@@ -13,9 +13,8 @@ import type { ForwardRefComponent } from '@fluentui/react-utilities';
 export const AvatarGroupItem: ForwardRefComponent<AvatarGroupItemProps> = React.forwardRef((props, ref) => {
   const state = useAvatarGroupItem_unstable(props, ref);
 
-  useAvatarGroupItemStyles_unstable(state);
-
   useCustomStyleHook_unstable('useAvatarGroupItemStyles_unstable')(state);
+  useAvatarGroupItemStyles_unstable(state);
 
   return renderAvatarGroupItem_unstable(state);
 });

--- a/packages/react-components/react-avatar/library/src/components/AvatarGroupPopover/AvatarGroupPopover.tsx
+++ b/packages/react-components/react-avatar/library/src/components/AvatarGroupPopover/AvatarGroupPopover.tsx
@@ -13,9 +13,8 @@ export const AvatarGroupPopover: React.FC<AvatarGroupPopoverProps> = props => {
   const state = useAvatarGroupPopover_unstable(props);
   const contextValues = useAvatarGroupPopoverContextValues_unstable(state);
 
-  useAvatarGroupPopoverStyles_unstable(state);
-
   useCustomStyleHook_unstable('useAvatarGroupPopoverStyles_unstable')(state);
+  useAvatarGroupPopoverStyles_unstable(state);
 
   return renderAvatarGroupPopover_unstable(state, contextValues);
 };

--- a/packages/react-components/react-badge/library/src/components/Badge/Badge.tsx
+++ b/packages/react-components/react-badge/library/src/components/Badge/Badge.tsx
@@ -12,9 +12,8 @@ import type { ForwardRefComponent } from '@fluentui/react-utilities';
 export const Badge: ForwardRefComponent<BadgeProps> = React.forwardRef((props, ref) => {
   const state = useBadge_unstable(props, ref);
 
-  useBadgeStyles_unstable(state);
-
   useCustomStyleHook_unstable('useBadgeStyles_unstable')(state);
+  useBadgeStyles_unstable(state);
 
   return renderBadge_unstable(state);
 });

--- a/packages/react-components/react-badge/library/src/components/CounterBadge/CounterBadge.tsx
+++ b/packages/react-components/react-badge/library/src/components/CounterBadge/CounterBadge.tsx
@@ -12,9 +12,8 @@ import type { ForwardRefComponent } from '@fluentui/react-utilities';
 export const CounterBadge: ForwardRefComponent<CounterBadgeProps> = React.forwardRef((props, ref) => {
   const state = useCounterBadge_unstable(props, ref);
 
-  useCounterBadgeStyles_unstable(state);
-
   useCustomStyleHook_unstable('useCounterBadgeStyles_unstable')(state);
+  useCounterBadgeStyles_unstable(state);
 
   return renderBadge_unstable(state);
 });

--- a/packages/react-components/react-badge/library/src/components/PresenceBadge/PresenceBadge.tsx
+++ b/packages/react-components/react-badge/library/src/components/PresenceBadge/PresenceBadge.tsx
@@ -12,9 +12,8 @@ import type { ForwardRefComponent } from '@fluentui/react-utilities';
 export const PresenceBadge: ForwardRefComponent<PresenceBadgeProps> = React.forwardRef((props, ref) => {
   const state = usePresenceBadge_unstable(props, ref);
 
-  usePresenceBadgeStyles_unstable(state);
-
   useCustomStyleHook_unstable('usePresenceBadgeStyles_unstable')(state);
+  usePresenceBadgeStyles_unstable(state);
 
   return renderBadge_unstable(state);
 });

--- a/packages/react-components/react-breadcrumb/library/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/packages/react-components/react-breadcrumb/library/src/components/Breadcrumb/Breadcrumb.tsx
@@ -14,8 +14,8 @@ export const Breadcrumb: ForwardRefComponent<BreadcrumbProps> = React.forwardRef
   const state = useBreadcrumb_unstable(props, ref);
   const contextValues = useBreadcrumbContextValues_unstable(state);
 
-  useBreadcrumbStyles_unstable(state);
   useCustomStyleHook_unstable('useBreadcrumbStyles_unstable')(state);
+  useBreadcrumbStyles_unstable(state);
 
   return renderBreadcrumb_unstable(state, contextValues);
 });

--- a/packages/react-components/react-breadcrumb/library/src/components/BreadcrumbButton/BreadcrumbButton.tsx
+++ b/packages/react-components/react-breadcrumb/library/src/components/BreadcrumbButton/BreadcrumbButton.tsx
@@ -12,8 +12,8 @@ import type { ForwardRefComponent } from '@fluentui/react-utilities';
 export const BreadcrumbButton: ForwardRefComponent<BreadcrumbButtonProps> = React.forwardRef((props, ref) => {
   const state = useBreadcrumbButton_unstable(props, ref);
 
-  useBreadcrumbButtonStyles_unstable(state);
   useCustomStyleHook_unstable('useBreadcrumbButtonStyles_unstable')(state);
+  useBreadcrumbButtonStyles_unstable(state);
 
   return renderBreadcrumbButton_unstable(state);
 });

--- a/packages/react-components/react-breadcrumb/library/src/components/BreadcrumbDivider/BreadcrumbDivider.tsx
+++ b/packages/react-components/react-breadcrumb/library/src/components/BreadcrumbDivider/BreadcrumbDivider.tsx
@@ -12,8 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const BreadcrumbDivider: ForwardRefComponent<BreadcrumbDividerProps> = React.forwardRef((props, ref) => {
   const state = useBreadcrumbDivider_unstable(props, ref);
 
-  useBreadcrumbDividerStyles_unstable(state);
   useCustomStyleHook_unstable('useBreadcrumbDividerStyles_unstable')(state);
+  useBreadcrumbDividerStyles_unstable(state);
 
   return renderBreadcrumbDivider_unstable(state);
 });

--- a/packages/react-components/react-breadcrumb/library/src/components/BreadcrumbItem/BreadcrumbItem.tsx
+++ b/packages/react-components/react-breadcrumb/library/src/components/BreadcrumbItem/BreadcrumbItem.tsx
@@ -13,8 +13,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const BreadcrumbItem: ForwardRefComponent<BreadcrumbItemProps> = React.forwardRef((props, ref) => {
   const state = useBreadcrumbItem_unstable(props, ref);
 
-  useBreadcrumbItemStyles_unstable(state);
   useCustomStyleHook_unstable('useBreadcrumbItemStyles_unstable')(state);
+  useBreadcrumbItemStyles_unstable(state);
 
   return renderBreadcrumbItem_unstable(state);
 });

--- a/packages/react-components/react-button/library/src/components/Button/Button.tsx
+++ b/packages/react-components/react-button/library/src/components/Button/Button.tsx
@@ -12,9 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const Button: ForwardRefComponent<ButtonProps> = React.forwardRef((props, ref) => {
   const state = useButton_unstable(props, ref);
 
-  useButtonStyles_unstable(state);
-
   useCustomStyleHook_unstable('useButtonStyles_unstable')(state);
+  useButtonStyles_unstable(state);
 
   return renderButton_unstable(state);
   // Casting is required due to lack of distributive union to support unions on @types/react

--- a/packages/react-components/react-button/library/src/components/CompoundButton/CompoundButton.tsx
+++ b/packages/react-components/react-button/library/src/components/CompoundButton/CompoundButton.tsx
@@ -12,9 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const CompoundButton: ForwardRefComponent<CompoundButtonProps> = React.forwardRef((props, ref) => {
   const state = useCompoundButton_unstable(props, ref);
 
-  useCompoundButtonStyles_unstable(state);
-
   useCustomStyleHook_unstable('useCompoundButtonStyles_unstable')(state);
+  useCompoundButtonStyles_unstable(state);
 
   return renderCompoundButton_unstable(state);
   // Casting is required due to lack of distributive union to support unions on @types/react

--- a/packages/react-components/react-button/library/src/components/MenuButton/MenuButton.tsx
+++ b/packages/react-components/react-button/library/src/components/MenuButton/MenuButton.tsx
@@ -13,9 +13,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const MenuButton: ForwardRefComponent<MenuButtonProps> = React.forwardRef((props, ref) => {
   const state = useMenuButton_unstable(props, ref);
 
-  useMenuButtonStyles_unstable(state);
-
   useCustomStyleHook_unstable('useMenuButtonStyles_unstable')(state);
+  useMenuButtonStyles_unstable(state);
 
   return renderMenuButton_unstable(state);
   // Casting is required due to lack of distributive union to support unions on @types/react

--- a/packages/react-components/react-button/library/src/components/SplitButton/SplitButton.tsx
+++ b/packages/react-components/react-button/library/src/components/SplitButton/SplitButton.tsx
@@ -13,9 +13,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const SplitButton: ForwardRefComponent<SplitButtonProps> = React.forwardRef((props, ref) => {
   const state = useSplitButton_unstable(props, ref);
 
-  useSplitButtonStyles_unstable(state);
-
   useCustomStyleHook_unstable('useSplitButtonStyles_unstable')(state);
+  useSplitButtonStyles_unstable(state);
 
   return renderSplitButton_unstable(state);
   // Casting is required due to lack of distributive union to support unions on @types/react

--- a/packages/react-components/react-button/library/src/components/ToggleButton/ToggleButton.tsx
+++ b/packages/react-components/react-button/library/src/components/ToggleButton/ToggleButton.tsx
@@ -12,9 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const ToggleButton: ForwardRefComponent<ToggleButtonProps> = React.forwardRef((props, ref) => {
   const state = useToggleButton_unstable(props, ref);
 
-  useToggleButtonStyles_unstable(state);
-
   useCustomStyleHook_unstable('useToggleButtonStyles_unstable')(state);
+  useToggleButtonStyles_unstable(state);
 
   return renderToggleButton_unstable(state);
   // Casting is required due to lack of distributive union to support unions on @types/react

--- a/packages/react-components/react-card/library/src/components/Card/Card.tsx
+++ b/packages/react-components/react-card/library/src/components/Card/Card.tsx
@@ -14,9 +14,8 @@ export const Card: ForwardRefComponent<CardProps> = React.forwardRef<HTMLDivElem
   const state = useCard_unstable(props, ref);
   const cardContextValue = useCardContextValue(state);
 
-  useCardStyles_unstable(state);
-
   useCustomStyleHook_unstable('useCardStyles_unstable')(state);
+  useCardStyles_unstable(state);
 
   return renderCard_unstable(state, cardContextValue);
 });

--- a/packages/react-components/react-card/library/src/components/CardFooter/CardFooter.tsx
+++ b/packages/react-components/react-card/library/src/components/CardFooter/CardFooter.tsx
@@ -12,9 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const CardFooter: ForwardRefComponent<CardFooterProps> = React.forwardRef((props, ref) => {
   const state = useCardFooter_unstable(props, ref);
 
-  useCardFooterStyles_unstable(state);
-
   useCustomStyleHook_unstable('useCardFooterStyles_unstable')(state);
+  useCardFooterStyles_unstable(state);
 
   return renderCardFooter_unstable(state);
 });

--- a/packages/react-components/react-card/library/src/components/CardHeader/CardHeader.tsx
+++ b/packages/react-components/react-card/library/src/components/CardHeader/CardHeader.tsx
@@ -12,9 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const CardHeader: ForwardRefComponent<CardHeaderProps> = React.forwardRef((props, ref) => {
   const state = useCardHeader_unstable(props, ref);
 
-  useCardHeaderStyles_unstable(state);
-
   useCustomStyleHook_unstable('useCardHeaderStyles_unstable')(state);
+  useCardHeaderStyles_unstable(state);
 
   return renderCardHeader_unstable(state);
 });

--- a/packages/react-components/react-card/library/src/components/CardPreview/CardPreview.tsx
+++ b/packages/react-components/react-card/library/src/components/CardPreview/CardPreview.tsx
@@ -12,9 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const CardPreview: ForwardRefComponent<CardPreviewProps> = React.forwardRef((props, ref) => {
   const state = useCardPreview_unstable(props, ref);
 
-  useCardPreviewStyles_unstable(state);
-
   useCustomStyleHook_unstable('useCardPreviewStyles_unstable')(state);
+  useCardPreviewStyles_unstable(state);
 
   return renderCardPreview_unstable(state);
 });

--- a/packages/react-components/react-carousel/library/src/components/Carousel/Carousel.tsx
+++ b/packages/react-components/react-carousel/library/src/components/Carousel/Carousel.tsx
@@ -16,8 +16,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const Carousel: ForwardRefComponent<CarouselProps> = React.forwardRef((props, ref) => {
   const state = useCarousel_unstable(props, ref);
 
-  useCarouselStyles_unstable(state);
   useCustomStyleHook_unstable('useCarouselStyles_unstable')(state);
+  useCarouselStyles_unstable(state);
 
   const contextValues = useCarouselContextValues_unstable(state);
 

--- a/packages/react-components/react-carousel/library/src/components/CarouselAutoplayButton/CarouselAutoplayButton.tsx
+++ b/packages/react-components/react-carousel/library/src/components/CarouselAutoplayButton/CarouselAutoplayButton.tsx
@@ -16,8 +16,8 @@ export const CarouselAutoplayButton: ForwardRefComponent<CarouselAutoplayButtonP
   (props, ref) => {
     const state = useCarouselAutoplayButton_unstable(props, ref);
 
-    useCarouselAutoplayButtonStyles_unstable(state);
     useCustomStyleHook_unstable('useCarouselAutoplayButtonStyles_unstable')(state);
+    useCarouselAutoplayButtonStyles_unstable(state);
 
     return renderCarouselAutoplayButton_unstable(state);
   },

--- a/packages/react-components/react-carousel/library/src/components/CarouselButton/CarouselButton.tsx
+++ b/packages/react-components/react-carousel/library/src/components/CarouselButton/CarouselButton.tsx
@@ -13,8 +13,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const CarouselButton: ForwardRefComponent<CarouselButtonProps> = React.forwardRef((props, ref) => {
   const state = useCarouselButton_unstable(props, ref);
 
-  useCarouselButtonStyles_unstable(state);
   useCustomStyleHook_unstable('useCarouselButtonStyles_unstable')(state);
+  useCarouselButtonStyles_unstable(state);
 
   return renderCarouselButton_unstable(state);
 });

--- a/packages/react-components/react-carousel/library/src/components/CarouselCard/CarouselCard.tsx
+++ b/packages/react-components/react-carousel/library/src/components/CarouselCard/CarouselCard.tsx
@@ -17,8 +17,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const CarouselCard: ForwardRefComponent<CarouselCardProps> = React.forwardRef((props, ref) => {
   const state = useCarouselCard_unstable(props, ref);
 
-  useCarouselCardStyles_unstable(state);
   useCustomStyleHook_unstable('useCarouselCardStyles_unstable')(state);
+  useCarouselCardStyles_unstable(state);
 
   return renderCarouselCard_unstable(state);
 });

--- a/packages/react-components/react-carousel/library/src/components/CarouselNav/CarouselNav.tsx
+++ b/packages/react-components/react-carousel/library/src/components/CarouselNav/CarouselNav.tsx
@@ -18,8 +18,8 @@ export const CarouselNav: ForwardRefComponent<CarouselNavProps> = React.forwardR
   const state = useCarouselNav_unstable(props, ref);
   const contextValues = useCarouselNavContextValues_unstable(state);
 
-  useCarouselNavStyles_unstable(state);
   useCustomStyleHook_unstable('useCarouselNavStyles_unstable')(state);
+  useCarouselNavStyles_unstable(state);
 
   return renderCarouselNav_unstable(state, contextValues);
 });

--- a/packages/react-components/react-carousel/library/src/components/CarouselNavButton/CarouselNavButton.tsx
+++ b/packages/react-components/react-carousel/library/src/components/CarouselNavButton/CarouselNavButton.tsx
@@ -12,8 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const CarouselNavButton: ForwardRefComponent<CarouselNavButtonProps> = React.forwardRef((props, ref) => {
   const state = useCarouselNavButton_unstable(props, ref);
 
-  useCarouselNavButtonStyles_unstable(state);
   useCustomStyleHook_unstable('useCarouselNavButtonStyles_unstable')(state);
+  useCarouselNavButtonStyles_unstable(state);
 
   return renderCarouselNavButton_unstable(state);
 });

--- a/packages/react-components/react-carousel/library/src/components/CarouselNavContainer/CarouselNavContainer.tsx
+++ b/packages/react-components/react-carousel/library/src/components/CarouselNavContainer/CarouselNavContainer.tsx
@@ -12,8 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const CarouselNavContainer: ForwardRefComponent<CarouselNavContainerProps> = React.forwardRef((props, ref) => {
   const state = useCarouselNavContainer_unstable(props, ref);
 
-  useCarouselNavContainerStyles_unstable(state);
   useCustomStyleHook_unstable('useCarouselNavContainerStyles_unstable')(state);
+  useCarouselNavContainerStyles_unstable(state);
 
   return renderCarouselNavContainer_unstable(state);
 });

--- a/packages/react-components/react-carousel/library/src/components/CarouselNavImageButton/CarouselNavImageButton.tsx
+++ b/packages/react-components/react-carousel/library/src/components/CarouselNavImageButton/CarouselNavImageButton.tsx
@@ -14,8 +14,8 @@ export const CarouselNavImageButton: ForwardRefComponent<CarouselNavImageButtonP
   (props, ref) => {
     const state = useCarouselNavImageButton_unstable(props, ref);
 
-    useCarouselNavImageButtonStyles_unstable(state);
     useCustomStyleHook_unstable('useCarouselNavImageButtonStyles_unstable')(state);
+    useCarouselNavImageButtonStyles_unstable(state);
 
     return renderCarouselNavImageButton_unstable(state);
   },

--- a/packages/react-components/react-carousel/library/src/components/CarouselSlider/CarouselSlider.tsx
+++ b/packages/react-components/react-carousel/library/src/components/CarouselSlider/CarouselSlider.tsx
@@ -14,8 +14,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const CarouselSlider: ForwardRefComponent<CarouselSliderProps> = React.forwardRef((props, ref) => {
   const state = useCarouselSlider_unstable(props, ref);
 
-  useCarouselSliderStyles_unstable(state);
   useCustomStyleHook_unstable('useCarouselSliderStyles_unstable')(state);
+  useCarouselSliderStyles_unstable(state);
 
   const context = useCarouselSliderContextValues_unstable(state);
   return renderCarouselSlider_unstable(state, context);

--- a/packages/react-components/react-carousel/library/src/components/CarouselViewport/CarouselViewport.tsx
+++ b/packages/react-components/react-carousel/library/src/components/CarouselViewport/CarouselViewport.tsx
@@ -13,8 +13,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const CarouselViewport: ForwardRefComponent<CarouselViewportProps> = React.forwardRef((props, ref) => {
   const state = useCarouselViewport_unstable(props, ref);
 
-  useCarouselViewportStyles_unstable(state);
   useCustomStyleHook_unstable('useCarouselViewportStyles_unstable')(state);
+  useCarouselViewportStyles_unstable(state);
 
   const context = useCarouselSliderContextValues_unstable(state);
 

--- a/packages/react-components/react-checkbox/library/src/components/Checkbox/Checkbox.tsx
+++ b/packages/react-components/react-checkbox/library/src/components/Checkbox/Checkbox.tsx
@@ -13,9 +13,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const Checkbox: ForwardRefComponent<CheckboxProps> = React.forwardRef((props, ref) => {
   const state = useCheckbox_unstable(props, ref);
 
-  useCheckboxStyles_unstable(state);
-
   useCustomStyleHook_unstable('useCheckboxStyles_unstable')(state);
+  useCheckboxStyles_unstable(state);
 
   return renderCheckbox_unstable(state);
 });

--- a/packages/react-components/react-color-picker/library/src/components/AlphaSlider/AlphaSlider.tsx
+++ b/packages/react-components/react-color-picker/library/src/components/AlphaSlider/AlphaSlider.tsx
@@ -12,8 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const AlphaSlider: ForwardRefComponent<AlphaSliderProps> = React.forwardRef((props, ref) => {
   const state = useAlphaSlider_unstable(props, ref);
 
-  useAlphaSliderStyles_unstable(state);
   useCustomStyleHook_unstable('useAlphaSliderStyles_unstable')(state);
+  useAlphaSliderStyles_unstable(state);
 
   return renderAlphaSlider_unstable(state);
 });

--- a/packages/react-components/react-color-picker/library/src/components/ColorArea/ColorArea.tsx
+++ b/packages/react-components/react-color-picker/library/src/components/ColorArea/ColorArea.tsx
@@ -12,8 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const ColorArea: ForwardRefComponent<ColorAreaProps> = React.forwardRef((props, ref) => {
   const state = useColorArea_unstable(props, ref);
 
-  useColorAreaStyles_unstable(state);
   useCustomStyleHook_unstable('useColorAreaStyles_unstable')(state);
+  useColorAreaStyles_unstable(state);
 
   return renderColorArea_unstable(state);
 });

--- a/packages/react-components/react-color-picker/library/src/components/ColorPicker/ColorPicker.tsx
+++ b/packages/react-components/react-color-picker/library/src/components/ColorPicker/ColorPicker.tsx
@@ -14,8 +14,8 @@ export const ColorPicker: ForwardRefComponent<ColorPickerProps> = React.forwardR
   const state = useColorPicker_unstable(props, ref);
   const contextValues = useColorPickerContextValues(state);
 
-  useColorPickerStyles_unstable(state);
   useCustomStyleHook_unstable('useColorPickerStyles_unstable')(state);
+  useColorPickerStyles_unstable(state);
 
   return renderColorPicker_unstable(state, contextValues);
 });

--- a/packages/react-components/react-color-picker/library/src/components/ColorSlider/ColorSlider.tsx
+++ b/packages/react-components/react-color-picker/library/src/components/ColorSlider/ColorSlider.tsx
@@ -12,8 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const ColorSlider: ForwardRefComponent<ColorSliderProps> = React.forwardRef((props, ref) => {
   const state = useColorSlider_unstable(props, ref);
 
-  useColorSliderStyles_unstable(state);
   useCustomStyleHook_unstable('useColorSliderStyles_unstable')(state);
+  useColorSliderStyles_unstable(state);
 
   return renderColorSlider_unstable(state);
 });

--- a/packages/react-components/react-combobox/library/src/components/Combobox/Combobox.tsx
+++ b/packages/react-components/react-combobox/library/src/components/Combobox/Combobox.tsx
@@ -14,9 +14,8 @@ export const Combobox: ForwardRefComponent<ComboboxProps> = React.forwardRef((pr
   const state = useCombobox_unstable(props, ref);
   const contextValues = useComboboxContextValues(state);
 
-  useComboboxStyles_unstable(state);
-
   useCustomStyleHook_unstable('useComboboxStyles_unstable')(state);
+  useComboboxStyles_unstable(state);
 
   return renderCombobox_unstable(state, contextValues);
 });

--- a/packages/react-components/react-combobox/library/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react-components/react-combobox/library/src/components/Dropdown/Dropdown.tsx
@@ -14,9 +14,8 @@ export const Dropdown: ForwardRefComponent<DropdownProps> = React.forwardRef((pr
   const state = useDropdown_unstable(props, ref);
   const contextValues = useComboboxContextValues(state);
 
-  useDropdownStyles_unstable(state);
-
   useCustomStyleHook_unstable('useDropdownStyles_unstable')(state);
+  useDropdownStyles_unstable(state);
 
   return renderDropdown_unstable(state, contextValues);
 });

--- a/packages/react-components/react-combobox/library/src/components/Listbox/Listbox.tsx
+++ b/packages/react-components/react-combobox/library/src/components/Listbox/Listbox.tsx
@@ -14,9 +14,8 @@ export const Listbox: ForwardRefComponent<ListboxProps> = React.forwardRef((prop
   const state = useListbox_unstable(props, ref);
   const contextValues = useListboxContextValues(state);
 
-  useListboxStyles_unstable(state);
-
   useCustomStyleHook_unstable('useListboxStyles_unstable')(state);
+  useListboxStyles_unstable(state);
 
   return renderListbox_unstable(state, contextValues);
 });

--- a/packages/react-components/react-combobox/library/src/components/Option/Option.tsx
+++ b/packages/react-components/react-combobox/library/src/components/Option/Option.tsx
@@ -12,9 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const Option: ForwardRefComponent<OptionProps> = React.forwardRef((props, ref) => {
   const state = useOption_unstable(props, ref);
 
-  useOptionStyles_unstable(state);
-
   useCustomStyleHook_unstable('useOptionStyles_unstable')(state);
+  useOptionStyles_unstable(state);
 
   return renderOption_unstable(state);
 });

--- a/packages/react-components/react-combobox/library/src/components/OptionGroup/OptionGroup.tsx
+++ b/packages/react-components/react-combobox/library/src/components/OptionGroup/OptionGroup.tsx
@@ -12,9 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const OptionGroup: ForwardRefComponent<OptionGroupProps> = React.forwardRef((props, ref) => {
   const state = useOptionGroup_unstable(props, ref);
 
-  useOptionGroupStyles_unstable(state);
-
   useCustomStyleHook_unstable('useOptionGroupStyles_unstable')(state);
+  useOptionGroupStyles_unstable(state);
 
   return renderOptionGroup_unstable(state);
 });

--- a/packages/react-components/react-dialog/library/src/components/DialogActions/DialogActions.tsx
+++ b/packages/react-components/react-dialog/library/src/components/DialogActions/DialogActions.tsx
@@ -13,9 +13,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const DialogActions: ForwardRefComponent<DialogActionsProps> = React.forwardRef((props, ref) => {
   const state = useDialogActions_unstable(props, ref);
 
-  useDialogActionsStyles_unstable(state);
-
   useCustomStyleHook_unstable('useDialogActionsStyles_unstable')(state);
+  useDialogActionsStyles_unstable(state);
 
   return renderDialogActions_unstable(state);
 });

--- a/packages/react-components/react-dialog/library/src/components/DialogBody/DialogBody.tsx
+++ b/packages/react-components/react-dialog/library/src/components/DialogBody/DialogBody.tsx
@@ -13,9 +13,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const DialogBody: ForwardRefComponent<DialogBodyProps> = React.forwardRef((props, ref) => {
   const state = useDialogBody_unstable(props, ref);
 
-  useDialogBodyStyles_unstable(state);
-
   useCustomStyleHook_unstable('useDialogBodyStyles_unstable')(state);
+  useDialogBodyStyles_unstable(state);
 
   return renderDialogBody_unstable(state);
 });

--- a/packages/react-components/react-dialog/library/src/components/DialogContent/DialogContent.tsx
+++ b/packages/react-components/react-dialog/library/src/components/DialogContent/DialogContent.tsx
@@ -13,9 +13,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const DialogContent: ForwardRefComponent<DialogContentProps> = React.forwardRef((props, ref) => {
   const state = useDialogContent_unstable(props, ref);
 
-  useDialogContentStyles_unstable(state);
-
   useCustomStyleHook_unstable('useDialogContentStyles_unstable')(state);
+  useDialogContentStyles_unstable(state);
 
   return renderDialogContent_unstable(state);
 });

--- a/packages/react-components/react-dialog/library/src/components/DialogSurface/DialogSurface.tsx
+++ b/packages/react-components/react-dialog/library/src/components/DialogSurface/DialogSurface.tsx
@@ -15,9 +15,8 @@ export const DialogSurface: ForwardRefComponent<DialogSurfaceProps> = React.forw
   const state = useDialogSurface_unstable(props, ref);
   const contextValues = useDialogSurfaceContextValues_unstable(state);
 
-  useDialogSurfaceStyles_unstable(state);
-
   useCustomStyleHook_unstable('useDialogSurfaceStyles_unstable')(state);
+  useDialogSurfaceStyles_unstable(state);
 
   return renderDialogSurface_unstable(state, contextValues);
 });

--- a/packages/react-components/react-dialog/library/src/components/DialogTitle/DialogTitle.tsx
+++ b/packages/react-components/react-dialog/library/src/components/DialogTitle/DialogTitle.tsx
@@ -13,9 +13,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const DialogTitle: ForwardRefComponent<DialogTitleProps> = React.forwardRef((props, ref) => {
   const state = useDialogTitle_unstable(props, ref);
 
-  useDialogTitleStyles_unstable(state);
-
   useCustomStyleHook_unstable('useDialogTitleStyles_unstable')(state);
+  useDialogTitleStyles_unstable(state);
 
   return renderDialogTitle_unstable(state);
 });

--- a/packages/react-components/react-divider/library/src/components/Divider/Divider.tsx
+++ b/packages/react-components/react-divider/library/src/components/Divider/Divider.tsx
@@ -12,9 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const Divider: ForwardRefComponent<DividerProps> = React.forwardRef((props, ref) => {
   const state = useDivider_unstable(props, ref);
 
-  useDividerStyles_unstable(state);
-
   useCustomStyleHook_unstable('useDividerStyles_unstable')(state);
+  useDividerStyles_unstable(state);
 
   return renderDivider_unstable(state);
 });

--- a/packages/react-components/react-drawer/library/src/components/Drawer/Drawer.tsx
+++ b/packages/react-components/react-drawer/library/src/components/Drawer/Drawer.tsx
@@ -16,8 +16,8 @@ export const Drawer: ForwardRefComponent<DrawerProps> = React.forwardRef((props,
   const state = useDrawer_unstable(props, ref);
   const contextValue = useDrawerContextValue();
 
-  useDrawerStyles_unstable(state);
   useCustomStyleHook_unstable('useDrawerStyles_unstable')(state);
+  useDrawerStyles_unstable(state);
 
   return renderDrawer_unstable(state, contextValue);
 });

--- a/packages/react-components/react-drawer/library/src/components/DrawerBody/DrawerBody.tsx
+++ b/packages/react-components/react-drawer/library/src/components/DrawerBody/DrawerBody.tsx
@@ -13,8 +13,8 @@ import type { DrawerBodyProps } from './DrawerBody.types';
 export const DrawerBody: ForwardRefComponent<DrawerBodyProps> = React.forwardRef((props, ref) => {
   const state = useDrawerBody_unstable(props, ref);
 
-  useDrawerBodyStyles_unstable(state);
   useCustomStyleHook_unstable('useDrawerBodyStyles_unstable')(state);
+  useDrawerBodyStyles_unstable(state);
 
   return renderDrawerBody_unstable(state);
 });

--- a/packages/react-components/react-drawer/library/src/components/DrawerFooter/DrawerFooter.tsx
+++ b/packages/react-components/react-drawer/library/src/components/DrawerFooter/DrawerFooter.tsx
@@ -13,8 +13,8 @@ import type { DrawerFooterProps } from './DrawerFooter.types';
 export const DrawerFooter: ForwardRefComponent<DrawerFooterProps> = React.forwardRef((props, ref) => {
   const state = useDrawerFooter_unstable(props, ref);
 
-  useDrawerFooterStyles_unstable(state);
   useCustomStyleHook_unstable('useDrawerFooterStyles_unstable')(state);
+  useDrawerFooterStyles_unstable(state);
 
   return renderDrawerFooter_unstable(state);
 });

--- a/packages/react-components/react-drawer/library/src/components/DrawerHeader/DrawerHeader.tsx
+++ b/packages/react-components/react-drawer/library/src/components/DrawerHeader/DrawerHeader.tsx
@@ -13,8 +13,8 @@ import type { DrawerHeaderProps } from './DrawerHeader.types';
 export const DrawerHeader: ForwardRefComponent<DrawerHeaderProps> = React.forwardRef((props, ref) => {
   const state = useDrawerHeader_unstable(props, ref);
 
-  useDrawerHeaderStyles_unstable(state);
   useCustomStyleHook_unstable('useDrawerHeaderStyles_unstable')(state);
+  useDrawerHeaderStyles_unstable(state);
 
   return renderDrawerHeader_unstable(state);
 });

--- a/packages/react-components/react-drawer/library/src/components/DrawerHeaderNavigation/DrawerHeaderNavigation.tsx
+++ b/packages/react-components/react-drawer/library/src/components/DrawerHeaderNavigation/DrawerHeaderNavigation.tsx
@@ -14,8 +14,8 @@ export const DrawerHeaderNavigation: ForwardRefComponent<DrawerHeaderNavigationP
   (props, ref) => {
     const state = useDrawerHeaderNavigation_unstable(props, ref);
 
-    useDrawerHeaderNavigationStyles_unstable(state);
     useCustomStyleHook_unstable('useDrawerHeaderNavigationStyles_unstable')(state);
+    useDrawerHeaderNavigationStyles_unstable(state);
 
     return renderDrawerHeaderNavigation_unstable(state);
   },

--- a/packages/react-components/react-drawer/library/src/components/DrawerHeaderTitle/DrawerHeaderTitle.tsx
+++ b/packages/react-components/react-drawer/library/src/components/DrawerHeaderTitle/DrawerHeaderTitle.tsx
@@ -13,8 +13,8 @@ import type { DrawerHeaderTitleProps } from './DrawerHeaderTitle.types';
 export const DrawerHeaderTitle: ForwardRefComponent<DrawerHeaderTitleProps> = React.forwardRef((props, ref) => {
   const state = useDrawerHeaderTitle_unstable(props, ref);
 
-  useDrawerHeaderTitleStyles_unstable(state);
   useCustomStyleHook_unstable('useDrawerHeaderTitleStyles_unstable')(state);
+  useDrawerHeaderTitleStyles_unstable(state);
 
   return renderDrawerHeaderTitle_unstable(state);
 });

--- a/packages/react-components/react-drawer/library/src/components/InlineDrawer/InlineDrawer.tsx
+++ b/packages/react-components/react-drawer/library/src/components/InlineDrawer/InlineDrawer.tsx
@@ -17,9 +17,9 @@ export const InlineDrawer: ForwardRefComponent<InlineDrawerProps> = React.forwar
   const state = useInlineDrawer_unstable(props, ref);
   const contextValue = useDrawerContextValue();
 
-  useInlineDrawerStyles_unstable(state);
   useCustomStyleHook_unstable('useDrawerInlineStyles_unstable')(state);
   useCustomStyleHook_unstable('useInlineDrawerStyles_unstable')(state);
+  useInlineDrawerStyles_unstable(state);
 
   return renderInlineDrawer_unstable(state, contextValue);
 });

--- a/packages/react-components/react-drawer/library/src/components/OverlayDrawer/OverlayDrawer.tsx
+++ b/packages/react-components/react-drawer/library/src/components/OverlayDrawer/OverlayDrawer.tsx
@@ -16,9 +16,9 @@ export const OverlayDrawer: ForwardRefComponent<OverlayDrawerProps> = React.forw
   const state = useOverlayDrawer_unstable(props, ref);
   const contextValue = useDrawerContextValue();
 
-  useOverlayDrawerStyles_unstable(state);
   useCustomStyleHook_unstable('useDrawerOverlayStyles_unstable')(state);
   useCustomStyleHook_unstable('useOverlayDrawerStyles_unstable')(state);
+  useOverlayDrawerStyles_unstable(state);
 
   return renderOverlayDrawer_unstable(state, contextValue);
 });

--- a/packages/react-components/react-field/library/src/components/Field/Field.tsx
+++ b/packages/react-components/react-field/library/src/components/Field/Field.tsx
@@ -9,8 +9,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 
 export const Field: ForwardRefComponent<FieldProps> = React.forwardRef((props, ref) => {
   const state = useField_unstable(props, ref);
-  useFieldStyles_unstable(state);
   useCustomStyleHook_unstable('useFieldStyles_unstable')(state);
+  useFieldStyles_unstable(state);
   const context = useFieldContextValues_unstable(state);
   return renderField_unstable(state, context);
 });

--- a/packages/react-components/react-image/library/src/components/Image/Image.tsx
+++ b/packages/react-components/react-image/library/src/components/Image/Image.tsx
@@ -12,9 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const Image: ForwardRefComponent<ImageProps> = React.forwardRef((props, ref) => {
   const state = useImage_unstable(props, ref);
 
-  useImageStyles_unstable(state);
-
   useCustomStyleHook_unstable('useImageStyles_unstable')(state);
+  useImageStyles_unstable(state);
 
   return renderImage_unstable(state);
 });

--- a/packages/react-components/react-infolabel/library/src/components/InfoButton/InfoButton.tsx
+++ b/packages/react-components/react-infolabel/library/src/components/InfoButton/InfoButton.tsx
@@ -12,8 +12,8 @@ import type { InfoButtonProps } from './InfoButton.types';
 export const InfoButton: ForwardRefComponent<InfoButtonProps> = React.forwardRef((props, ref) => {
   const state = useInfoButton_unstable(props, ref);
 
-  useInfoButtonStyles_unstable(state);
   useCustomStyleHook_unstable('useInfoButtonStyles_unstable')(state);
+  useInfoButtonStyles_unstable(state);
 
   return renderInfoButton_unstable(state);
 });

--- a/packages/react-components/react-infolabel/library/src/components/InfoLabel/InfoLabel.tsx
+++ b/packages/react-components/react-infolabel/library/src/components/InfoLabel/InfoLabel.tsx
@@ -13,8 +13,8 @@ import { useInfoLabelStyles_unstable } from './useInfoLabelStyles.styles';
 export const InfoLabel: ForwardRefComponent<InfoLabelProps> = React.forwardRef((props, ref) => {
   const state = useInfoLabel_unstable(props, ref);
 
-  useInfoLabelStyles_unstable(state);
   useCustomStyleHook_unstable('useInfoLabelStyles_unstable')(state);
+  useInfoLabelStyles_unstable(state);
 
   return renderInfoLabel_unstable(state);
 });

--- a/packages/react-components/react-input/library/src/components/Input/Input.tsx
+++ b/packages/react-components/react-input/library/src/components/Input/Input.tsx
@@ -12,9 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const Input: ForwardRefComponent<InputProps> = React.forwardRef((props, ref) => {
   const state = useInput_unstable(props, ref);
 
-  useInputStyles_unstable(state);
-
   useCustomStyleHook_unstable('useInputStyles_unstable')(state);
+  useInputStyles_unstable(state);
 
   return renderInput_unstable(state);
 });

--- a/packages/react-components/react-label/library/src/components/Label/Label.tsx
+++ b/packages/react-components/react-label/library/src/components/Label/Label.tsx
@@ -12,9 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const Label: ForwardRefComponent<LabelProps> = React.forwardRef((props, ref) => {
   const state = useLabel_unstable(props, ref);
 
-  useLabelStyles_unstable(state);
-
   useCustomStyleHook_unstable('useLabelStyles_unstable')(state);
+  useLabelStyles_unstable(state);
 
   return renderLabel_unstable(state);
 });

--- a/packages/react-components/react-link/library/src/components/Link/Link.tsx
+++ b/packages/react-components/react-link/library/src/components/Link/Link.tsx
@@ -12,9 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const Link: ForwardRefComponent<LinkProps> = React.forwardRef((props, ref) => {
   const state = useLink_unstable(props, ref);
 
-  useLinkStyles_unstable(state);
-
   useCustomStyleHook_unstable('useLinkStyles_unstable')(state);
+  useLinkStyles_unstable(state);
 
   return renderLink_unstable(state);
   // Work around some small mismatches in inferred types which don't matter in practice

--- a/packages/react-components/react-list/library/src/components/List/List.tsx
+++ b/packages/react-components/react-list/library/src/components/List/List.tsx
@@ -11,8 +11,8 @@ export const List: ForwardRefComponent<ListProps> = React.forwardRef((props, ref
   const state = useList_unstable(props, ref);
   const contextValues = useListContextValues_unstable(state);
 
-  useListStyles_unstable(state);
   useCustomStyleHook_unstable('useListStyles_unstable')(state);
+  useListStyles_unstable(state);
 
   return renderList_unstable(state, contextValues);
 });

--- a/packages/react-components/react-list/library/src/components/ListItem/ListItem.tsx
+++ b/packages/react-components/react-list/library/src/components/ListItem/ListItem.tsx
@@ -10,8 +10,8 @@ export const ListItem: ForwardRefComponent<ListItemProps> = React.forwardRef<HTM
   (props, ref) => {
     const state = useListItem_unstable(props, ref);
 
-    useListItemStyles_unstable(state);
     useCustomStyleHook_unstable('useListItemStyles_unstable')(state);
+    useListItemStyles_unstable(state);
     return renderListItem_unstable(state);
   },
 );

--- a/packages/react-components/react-menu/library/src/components/MenuDivider/MenuDivider.tsx
+++ b/packages/react-components/react-menu/library/src/components/MenuDivider/MenuDivider.tsx
@@ -12,9 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const MenuDivider: ForwardRefComponent<MenuDividerProps> = React.forwardRef((props, ref) => {
   const state = useMenuDivider_unstable(props, ref);
 
-  useMenuDividerStyles_unstable(state);
-
   useCustomStyleHook_unstable('useMenuDividerStyles_unstable')(state);
+  useMenuDividerStyles_unstable(state);
 
   return renderMenuDivider_unstable(state);
 });

--- a/packages/react-components/react-menu/library/src/components/MenuGroup/MenuGroup.tsx
+++ b/packages/react-components/react-menu/library/src/components/MenuGroup/MenuGroup.tsx
@@ -14,9 +14,8 @@ export const MenuGroup: ForwardRefComponent<MenuGroupProps> = React.forwardRef((
   const state = useMenuGroup_unstable(props, ref);
   const contextValues = useMenuGroupContextValues_unstable(state);
 
-  useMenuGroupStyles_unstable(state);
-
   useCustomStyleHook_unstable('useMenuGroupStyles_unstable')(state);
+  useMenuGroupStyles_unstable(state);
 
   return renderMenuGroup_unstable(state, contextValues);
 });

--- a/packages/react-components/react-menu/library/src/components/MenuGroupHeader/MenuGroupHeader.tsx
+++ b/packages/react-components/react-menu/library/src/components/MenuGroupHeader/MenuGroupHeader.tsx
@@ -12,9 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const MenuGroupHeader: ForwardRefComponent<MenuGroupHeaderProps> = React.forwardRef((props, ref) => {
   const state = useMenuGroupHeader_unstable(props, ref);
 
-  useMenuGroupHeaderStyles_unstable(state);
-
   useCustomStyleHook_unstable('useMenuGroupHeaderStyles_unstable')(state);
+  useMenuGroupHeaderStyles_unstable(state);
 
   return renderMenuGroupHeader_unstable(state);
 });

--- a/packages/react-components/react-menu/library/src/components/MenuItem/MenuItem.tsx
+++ b/packages/react-components/react-menu/library/src/components/MenuItem/MenuItem.tsx
@@ -12,9 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const MenuItem: ForwardRefComponent<MenuItemProps> = React.forwardRef((props, ref) => {
   const state = useMenuItem_unstable(props, ref);
 
-  useMenuItemStyles_unstable(state);
-
   useCustomStyleHook_unstable('useMenuItemStyles_unstable')(state);
+  useMenuItemStyles_unstable(state);
 
   return renderMenuItem_unstable(state);
 });

--- a/packages/react-components/react-menu/library/src/components/MenuItemCheckbox/MenuItemCheckbox.tsx
+++ b/packages/react-components/react-menu/library/src/components/MenuItemCheckbox/MenuItemCheckbox.tsx
@@ -12,9 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const MenuItemCheckbox: ForwardRefComponent<MenuItemCheckboxProps> = React.forwardRef((props, ref) => {
   const state = useMenuItemCheckbox_unstable(props, ref);
 
-  useMenuItemCheckboxStyles_unstable(state);
-
   useCustomStyleHook_unstable('useMenuItemCheckboxStyles_unstable')(state);
+  useMenuItemCheckboxStyles_unstable(state);
 
   return renderMenuItemCheckbox_unstable(state);
 });

--- a/packages/react-components/react-menu/library/src/components/MenuItemLink/MenuItemLink.tsx
+++ b/packages/react-components/react-menu/library/src/components/MenuItemLink/MenuItemLink.tsx
@@ -12,9 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const MenuItemLink: ForwardRefComponent<MenuItemLinkProps> = React.forwardRef((props, ref) => {
   const state = useMenuItemLink_unstable(props, ref);
 
-  useMenuItemLinkStyles_unstable(state);
-
   useCustomStyleHook_unstable('useMenuItemLinkStyles_unstable')(state);
+  useMenuItemLinkStyles_unstable(state);
 
   return renderMenuItemLink_unstable(state);
 });

--- a/packages/react-components/react-menu/library/src/components/MenuItemRadio/MenuItemRadio.tsx
+++ b/packages/react-components/react-menu/library/src/components/MenuItemRadio/MenuItemRadio.tsx
@@ -12,9 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const MenuItemRadio: ForwardRefComponent<MenuItemRadioProps> = React.forwardRef((props, ref) => {
   const state = useMenuItemRadio_unstable(props, ref);
 
-  useMenuItemRadioStyles_unstable(state);
-
   useCustomStyleHook_unstable('useMenuItemRadioStyles_unstable')(state);
+  useMenuItemRadioStyles_unstable(state);
 
   return renderMenuItemRadio_unstable(state);
 });

--- a/packages/react-components/react-menu/library/src/components/MenuItemSwitch/MenuItemSwitch.tsx
+++ b/packages/react-components/react-menu/library/src/components/MenuItemSwitch/MenuItemSwitch.tsx
@@ -9,8 +9,8 @@ import type { MenuItemSwitchProps } from './MenuItemSwitch.types';
 export const MenuItemSwitch: ForwardRefComponent<MenuItemSwitchProps> = React.forwardRef((props, ref) => {
   const state = useMenuItemSwitch_unstable(props, ref);
 
-  useMenuItemSwitchStyles_unstable(state);
   useCustomStyleHook_unstable('useMenuItemSwitchStyles_unstable')(state);
+  useMenuItemSwitchStyles_unstable(state);
   return renderMenuItemSwitch_unstable(state);
 });
 

--- a/packages/react-components/react-menu/library/src/components/MenuList/MenuList.tsx
+++ b/packages/react-components/react-menu/library/src/components/MenuList/MenuList.tsx
@@ -14,9 +14,8 @@ export const MenuList: ForwardRefComponent<MenuListProps> = React.forwardRef((pr
   const state = useMenuList_unstable(props, ref);
   const contextValues = useMenuListContextValues_unstable(state);
 
-  useMenuListStyles_unstable(state);
-
   useCustomStyleHook_unstable('useMenuListStyles_unstable')(state);
+  useMenuListStyles_unstable(state);
 
   return renderMenuList_unstable(state, contextValues);
 });

--- a/packages/react-components/react-menu/library/src/components/MenuPopover/MenuPopover.tsx
+++ b/packages/react-components/react-menu/library/src/components/MenuPopover/MenuPopover.tsx
@@ -12,9 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const MenuPopover: ForwardRefComponent<MenuPopoverProps> = React.forwardRef((props, ref) => {
   const state = useMenuPopover_unstable(props, ref);
 
-  useMenuPopoverStyles_unstable(state);
-
   useCustomStyleHook_unstable('useMenuPopoverStyles_unstable')(state);
+  useMenuPopoverStyles_unstable(state);
 
   return renderMenuPopover_unstable(state);
 });

--- a/packages/react-components/react-menu/library/src/components/MenuSplitGroup/MenuSplitGroup.tsx
+++ b/packages/react-components/react-menu/library/src/components/MenuSplitGroup/MenuSplitGroup.tsx
@@ -13,9 +13,8 @@ import { useMenuSplitGroupContextValues } from './useMenuSplitGroupContextValues
 export const MenuSplitGroup: ForwardRefComponent<MenuSplitGroupProps> = React.forwardRef((props, ref) => {
   const state = useMenuSplitGroup_unstable(props, ref);
 
-  useMenuSplitGroupStyles_unstable(state);
-
   useCustomStyleHook_unstable('useMenuSplitGroupStyles_unstable')(state);
+  useMenuSplitGroupStyles_unstable(state);
 
   return renderMenuSplitGroup_unstable(state, useMenuSplitGroupContextValues(state));
 });

--- a/packages/react-components/react-message-bar/library/src/components/MessageBar/MessageBar.tsx
+++ b/packages/react-components/react-message-bar/library/src/components/MessageBar/MessageBar.tsx
@@ -13,8 +13,8 @@ import { useMessageBarContextValue_unstable } from './useMessageBarContextValues
 export const MessageBar: ForwardRefComponent<MessageBarProps> = React.forwardRef((props, ref) => {
   const state = useMessageBar_unstable(props, ref);
 
-  useMessageBarStyles_unstable(state);
   useCustomStyleHook_unstable('useMessageBarStyles_unstable')(state);
+  useMessageBarStyles_unstable(state);
   return renderMessageBar_unstable(state, useMessageBarContextValue_unstable(state));
 });
 

--- a/packages/react-components/react-message-bar/library/src/components/MessageBarActions/MessageBarActions.tsx
+++ b/packages/react-components/react-message-bar/library/src/components/MessageBarActions/MessageBarActions.tsx
@@ -13,8 +13,8 @@ import { useMessageBarActionsContextValue_unstable } from './useMessageBarAction
 export const MessageBarActions: ForwardRefComponent<MessageBarActionsProps> = React.forwardRef((props, ref) => {
   const state = useMessageBarActions_unstable(props, ref);
 
-  useMessageBarActionsStyles_unstable(state);
   useCustomStyleHook_unstable('useMessageBarActionsStyles_unstable')(state);
+  useMessageBarActionsStyles_unstable(state);
   return renderMessageBarActions_unstable(state, useMessageBarActionsContextValue_unstable());
 });
 

--- a/packages/react-components/react-message-bar/library/src/components/MessageBarBody/MessageBarBody.tsx
+++ b/packages/react-components/react-message-bar/library/src/components/MessageBarBody/MessageBarBody.tsx
@@ -14,8 +14,8 @@ export const MessageBarBody: ForwardRefComponent<MessageBarBodyProps> = React.fo
   const state = useMessageBarBody_unstable(props, ref);
   const ctx = useMessageBarBodyContextValues_unstable(state);
 
-  useMessageBarBodyStyles_unstable(state);
   useCustomStyleHook_unstable('useMessageBarBodyStyles_unstable')(state);
+  useMessageBarBodyStyles_unstable(state);
   return renderMessageBarBody_unstable(state, ctx);
 });
 

--- a/packages/react-components/react-message-bar/library/src/components/MessageBarGroup/MessageBarGroup.tsx
+++ b/packages/react-components/react-message-bar/library/src/components/MessageBarGroup/MessageBarGroup.tsx
@@ -12,8 +12,8 @@ import type { MessageBarGroupProps } from './MessageBarGroup.types';
 export const MessageBarGroup: ForwardRefComponent<MessageBarGroupProps> = React.forwardRef((props, ref) => {
   const state = useMessageBarGroup_unstable(props, ref);
 
-  useMessageBarGroupStyles_unstable(state);
   useCustomStyleHook_unstable('useMessageBarGroupStyles_unstable')(state);
+  useMessageBarGroupStyles_unstable(state);
   return renderMessageBarGroup_unstable(state);
 });
 

--- a/packages/react-components/react-message-bar/library/src/components/MessageBarTitle/MessageBarTitle.tsx
+++ b/packages/react-components/react-message-bar/library/src/components/MessageBarTitle/MessageBarTitle.tsx
@@ -12,8 +12,8 @@ import type { MessageBarTitleProps } from './MessageBarTitle.types';
 export const MessageBarTitle: ForwardRefComponent<MessageBarTitleProps> = React.forwardRef((props, ref) => {
   const state = useMessageBarTitle_unstable(props, ref);
 
-  useMessageBarTitleStyles_unstable(state);
   useCustomStyleHook_unstable('useMessageBarTitleStyles_unstable')(state);
+  useMessageBarTitleStyles_unstable(state);
   return renderMessageBarTitle_unstable(state);
 });
 

--- a/packages/react-components/react-migration-v0-v9/library/src/components/List/List/List.tsx
+++ b/packages/react-components/react-migration-v0-v9/library/src/components/List/List/List.tsx
@@ -11,8 +11,8 @@ export const List: ForwardRefComponent<ListProps> = React.forwardRef((props, ref
   const state = useList_unstable(props, ref);
   const contextValues = useListContextValues_unstable(state);
 
-  useListStyles_unstable(state);
   useCustomStyleHook_unstable('useListStyles_unstable')(state);
+  useListStyles_unstable(state);
 
   return renderList_unstable(state, contextValues);
 });

--- a/packages/react-components/react-migration-v0-v9/library/src/components/List/ListItem/ListItem.tsx
+++ b/packages/react-components/react-migration-v0-v9/library/src/components/List/ListItem/ListItem.tsx
@@ -10,8 +10,8 @@ export const ListItem: ForwardRefComponent<ListItemProps> = React.forwardRef<HTM
   (props, ref) => {
     const state = useListItem_unstable(props, ref);
 
-    useListItemStyles_unstable(state);
     useCustomStyleHook_unstable('useListItemStyles_unstable')(state);
+    useListItemStyles_unstable(state);
     return renderListItem_unstable(state);
   },
 );

--- a/packages/react-components/react-nav-preview/library/src/components/AppItem/AppItem.tsx
+++ b/packages/react-components/react-nav-preview/library/src/components/AppItem/AppItem.tsx
@@ -11,8 +11,6 @@ import type { AppItemProps } from './AppItem.types';
 export const AppItem: ForwardRefComponent<AppItemProps> = React.forwardRef((props, ref) => {
   const state = useAppItem_unstable(props, ref);
 
-  useAppItemStyles_unstable(state);
-
   /**
    * @see https://github.com/microsoft/fluentui/blob/master/docs/react-v9/contributing/rfcs/react-components/convergence/custom-styling.md
    *
@@ -22,6 +20,7 @@ export const AppItem: ForwardRefComponent<AppItemProps> = React.forwardRef((prop
    *      - verify that custom global style override works for your component
    */
   // useCustomStyleHook_unstable('useAppItemStyles_unstable')(state);
+  useAppItemStyles_unstable(state);
 
   return renderAppItem_unstable(state);
 });

--- a/packages/react-components/react-nav-preview/library/src/components/AppItemStatic/AppItemStatic.tsx
+++ b/packages/react-components/react-nav-preview/library/src/components/AppItemStatic/AppItemStatic.tsx
@@ -11,8 +11,6 @@ import type { AppItemStaticProps } from './AppItemStatic.types';
 export const AppItemStatic: ForwardRefComponent<AppItemStaticProps> = React.forwardRef((props, ref) => {
   const state = useAppItemStatic_unstable(props, ref);
 
-  useAppItemStaticStyles_unstable(state);
-
   /**
    * @see https://github.com/microsoft/fluentui/blob/master/docs/react-v9/contributing/rfcs/react-components/convergence/custom-styling.md
    *
@@ -22,6 +20,7 @@ export const AppItemStatic: ForwardRefComponent<AppItemStaticProps> = React.forw
    *      - verify that custom global style override works for your component
    */
   // useCustomStyleHook_unstable('useAppItemStaticStyles_unstable')(state);
+  useAppItemStaticStyles_unstable(state);
 
   return renderAppItemStatic_unstable(state);
 });

--- a/packages/react-components/react-nav-preview/library/src/components/Hamburger/Hamburger.tsx
+++ b/packages/react-components/react-nav-preview/library/src/components/Hamburger/Hamburger.tsx
@@ -11,10 +11,10 @@ import type { HamburgerProps } from './Hamburger.types';
 export const Hamburger: ForwardRefComponent<HamburgerProps> = React.forwardRef((props, ref) => {
   const state = useHamburger_unstable(props, ref);
 
-  useHamburgerStyles_unstable(state);
   // TODO update types in packages/react-components/react-shared-contexts/src/CustomStyleHooksContext/CustomStyleHooksContext.ts
   // https://github.com/microsoft/fluentui/blob/master/rfcs/react-components/convergence/custom-styling.md
   // useCustomStyleHook_unstable('useHamburgerStyles_unstable')(state);
+  useHamburgerStyles_unstable(state);
   return renderButton_unstable(state);
 }) as ForwardRefComponent<HamburgerProps>;
 

--- a/packages/react-components/react-nav-preview/library/src/components/NavCategoryItem/NavCategoryItem.tsx
+++ b/packages/react-components/react-nav-preview/library/src/components/NavCategoryItem/NavCategoryItem.tsx
@@ -15,10 +15,9 @@ export const NavCategoryItem: ForwardRefComponent<NavCategoryItemProps> = React.
   const state = useNavCategoryItem_unstable(props, ref);
   const contextValues = useNavCategoryItemContextValues_unstable(state);
 
-  useNavCategoryItemStyles_unstable(state);
-
   // todo: add custom style hook
   // useCustomStyleHook_unstable('useNavCategoryItemStyles')(state);
+  useNavCategoryItemStyles_unstable(state);
 
   return renderNavCategoryItem_unstable(state, contextValues);
 });

--- a/packages/react-components/react-nav-preview/library/src/components/NavDivider/NavDivider.tsx
+++ b/packages/react-components/react-nav-preview/library/src/components/NavDivider/NavDivider.tsx
@@ -12,10 +12,10 @@ import type { NavDividerProps } from './NavDivider.types';
 export const NavDivider: ForwardRefComponent<NavDividerProps> = React.forwardRef((props, ref) => {
   const state = useNavDivider_unstable(props, ref);
 
-  useNavDividerStyles_unstable(state);
   // TODO update types in packages/react-components/react-shared-contexts/src/CustomStyleHooksContext/CustomStyleHooksContext.ts
   // https://github.com/microsoft/fluentui/blob/master/rfcs/react-components/convergence/custom-styling.md
   // useCustomStyleHook_unstable('useNavDividerStyles_unstable')(state);
+  useNavDividerStyles_unstable(state);
   return renderDivider_unstable(state);
 });
 

--- a/packages/react-components/react-nav-preview/library/src/components/NavDrawer/NavDrawer.tsx
+++ b/packages/react-components/react-nav-preview/library/src/components/NavDrawer/NavDrawer.tsx
@@ -16,10 +16,10 @@ export const NavDrawer: ForwardRefComponent<NavDrawerProps> = React.forwardRef((
   const state = useNavDrawer_unstable(props, ref);
   const contextValues = useNavContextValues_unstable(state as NavState);
 
-  useNavDrawerStyles_unstable(state);
   // TODO update types in packages/react-components/react-shared-contexts/src/CustomStyleHooksContext/CustomStyleHooksContext.ts
   // https://github.com/microsoft/fluentui/blob/master/rfcs/react-components/convergence/custom-styling.md
   // useCustomStyleHook_unstable('useNavDrawerStyles_unstable')(state);
+  useNavDrawerStyles_unstable(state);
   return renderNavDrawer_unstable(state, contextValues);
 });
 

--- a/packages/react-components/react-nav-preview/library/src/components/NavDrawerBody/NavDrawerBody.tsx
+++ b/packages/react-components/react-nav-preview/library/src/components/NavDrawerBody/NavDrawerBody.tsx
@@ -12,10 +12,10 @@ import type { NavDrawerBodyProps } from './NavDrawerBody.types';
 export const NavDrawerBody: ForwardRefComponent<NavDrawerBodyProps> = React.forwardRef((props, ref) => {
   const state = useNavDrawerBody_unstable(props, ref);
 
-  useNavDrawerBodyStyles_unstable(state);
   // TODO update types in packages/react-components/react-shared-contexts/src/CustomStyleHooksContext/CustomStyleHooksContext.ts
   // https://github.com/microsoft/fluentui/blob/master/rfcs/react-components/convergence/custom-styling.md
   // useCustomStyleHook_unstable('useNavDrawerBodyStyles_unstable')(state);
+  useNavDrawerBodyStyles_unstable(state);
   return renderDrawerBody_unstable(state);
 });
 

--- a/packages/react-components/react-nav-preview/library/src/components/NavDrawerFooter/NavDrawerFooter.tsx
+++ b/packages/react-components/react-nav-preview/library/src/components/NavDrawerFooter/NavDrawerFooter.tsx
@@ -12,10 +12,10 @@ import type { NavDrawerFooterProps } from './NavDrawerFooter.types';
 export const NavDrawerFooter: ForwardRefComponent<NavDrawerFooterProps> = React.forwardRef((props, ref) => {
   const state = useNavDrawerFooter_unstable(props, ref);
 
-  useNavDrawerFooterStyles_unstable(state);
   // TODO update types in packages/react-components/react-shared-contexts/src/CustomStyleHooksContext/CustomStyleHooksContext.ts
   // https://github.com/microsoft/fluentui/blob/master/rfcs/react-components/convergence/custom-styling.md
   // useCustomStyleHook_unstable('useNavDrawerFooterStyles_unstable')(state);
+  useNavDrawerFooterStyles_unstable(state);
   return renderDrawerFooter_unstable(state);
 });
 

--- a/packages/react-components/react-nav-preview/library/src/components/NavDrawerHeader/NavDrawerHeader.tsx
+++ b/packages/react-components/react-nav-preview/library/src/components/NavDrawerHeader/NavDrawerHeader.tsx
@@ -12,10 +12,10 @@ import type { NavDrawerHeaderProps } from './NavDrawerHeader.types';
 export const NavDrawerHeader: ForwardRefComponent<NavDrawerHeaderProps> = React.forwardRef((props, ref) => {
   const state = useNavDrawerHeader_unstable(props, ref);
 
-  useNavDrawerHeaderStyles_unstable(state);
   // TODO update types in packages/react-components/react-shared-contexts/src/CustomStyleHooksContext/CustomStyleHooksContext.ts
   // https://github.com/microsoft/fluentui/blob/master/rfcs/react-components/convergence/custom-styling.md
   // useCustomStyleHook_unstable('useNavDrawerHeaderStyles_unstable')(state);
+  useNavDrawerHeaderStyles_unstable(state);
   return renderDrawerHeader_unstable(state);
 });
 

--- a/packages/react-components/react-nav-preview/library/src/components/NavItem/NavItem.tsx
+++ b/packages/react-components/react-nav-preview/library/src/components/NavItem/NavItem.tsx
@@ -12,10 +12,10 @@ import type { NavItemProps } from './NavItem.types';
 export const NavItem: ForwardRefComponent<NavItemProps> = React.forwardRef((props, ref) => {
   const state = useNavItem_unstable(props, ref);
 
-  useNavItemStyles_unstable(state);
   // TODO update types in packages/react-components/react-shared-contexts/src/CustomStyleHooksContext/CustomStyleHooksContext.ts
   // https://github.com/microsoft/fluentui/blob/master/rfcs/react-components/convergence/custom-styling.md
   // useCustomStyleHook_unstable('useNavItemStyles_unstable')(state);
+  useNavItemStyles_unstable(state);
   return renderNavItem_unstable(state);
 });
 

--- a/packages/react-components/react-nav-preview/library/src/components/NavSectionHeader/NavSectionHeader.tsx
+++ b/packages/react-components/react-nav-preview/library/src/components/NavSectionHeader/NavSectionHeader.tsx
@@ -11,10 +11,10 @@ import type { NavSectionHeaderProps } from './NavSectionHeader.types';
 export const NavSectionHeader: ForwardRefComponent<NavSectionHeaderProps> = React.forwardRef((props, ref) => {
   const state = useNavSectionHeader_unstable(props, ref);
 
-  useNavSectionHeaderStyles_unstable(state);
   // TODO update types in packages/react-components/react-shared-contexts/src/CustomStyleHooksContext/CustomStyleHooksContext.ts
   // https://github.com/microsoft/fluentui/blob/master/rfcs/react-components/convergence/custom-styling.md
   // useCustomStyleHook_unstable('useNavSectionHeaderStyles_unstable')(state);
+  useNavSectionHeaderStyles_unstable(state);
   return renderNavSectionHeader_unstable(state);
 });
 

--- a/packages/react-components/react-nav-preview/library/src/components/NavSubItem/NavSubItem.tsx
+++ b/packages/react-components/react-nav-preview/library/src/components/NavSubItem/NavSubItem.tsx
@@ -12,10 +12,10 @@ import type { NavSubItemProps } from './NavSubItem.types';
 export const NavSubItem: ForwardRefComponent<NavSubItemProps> = React.forwardRef((props, ref) => {
   const state = useNavSubItem_unstable(props, ref);
 
-  useNavSubItemStyles_unstable(state);
   // TODO update types in packages/react-components/react-shared-contexts/src/CustomStyleHooksContext/CustomStyleHooksContext.ts
   // https://github.com/microsoft/fluentui/blob/master/rfcs/react-components/convergence/custom-styling.md
   // useCustomStyleHook_unstable('useNavSubItemStyles_unstable')(state);
+  useNavSubItemStyles_unstable(state);
   return renderNavSubItem_unstable(state);
 });
 

--- a/packages/react-components/react-nav-preview/library/src/components/NavSubItemGroup/NavSubItemGroup.tsx
+++ b/packages/react-components/react-nav-preview/library/src/components/NavSubItemGroup/NavSubItemGroup.tsx
@@ -12,10 +12,10 @@ import type { NavSubItemGroupProps } from './NavSubItemGroup.types';
 export const NavSubItemGroup: ForwardRefComponent<NavSubItemGroupProps> = React.forwardRef((props, ref) => {
   const state = useNavSubItemGroup_unstable(props, ref);
 
-  useNavSubItemGroupStyles_unstable(state);
   // TODO update types in packages/react-components/react-shared-contexts/src/CustomStyleHooksContext/CustomStyleHooksContext.ts
   // https://github.com/microsoft/fluentui/blob/master/rfcs/react-components/convergence/custom-styling.md
   // useCustomStyleHook_unstable('useNavSubItemGroupStyles_unstable')(state);
+  useNavSubItemGroupStyles_unstable(state);
   return renderNavSubItemGroup_unstable(state);
 });
 

--- a/packages/react-components/react-nav-preview/library/src/components/SplitNavItem/SplitNavItem.tsx
+++ b/packages/react-components/react-nav-preview/library/src/components/SplitNavItem/SplitNavItem.tsx
@@ -11,8 +11,6 @@ import type { SplitNavItemProps } from './SplitNavItem.types';
 export const SplitNavItem: ForwardRefComponent<SplitNavItemProps> = React.forwardRef((props, ref) => {
   const state = useSplitNavItem_unstable(props, ref);
 
-  useSplitNavItemStyles_unstable(state);
-
   /**
    * @see https://github.com/microsoft/fluentui/blob/master/docs/react-v9/contributing/rfcs/react-components/convergence/custom-styling.md
    *
@@ -22,6 +20,7 @@ export const SplitNavItem: ForwardRefComponent<SplitNavItemProps> = React.forwar
    *      - verify that custom global style override works for your component
    */
   // useCustomStyleHook_unstable('useSplitNavItemStyles_unstable')(state);
+  useSplitNavItemStyles_unstable(state);
 
   return renderSplitNavItem_unstable(state);
 });

--- a/packages/react-components/react-persona/library/src/components/Persona/Persona.tsx
+++ b/packages/react-components/react-persona/library/src/components/Persona/Persona.tsx
@@ -13,9 +13,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const Persona: ForwardRefComponent<PersonaProps> = React.forwardRef((props, ref) => {
   const state = usePersona_unstable(props, ref);
 
-  usePersonaStyles_unstable(state);
-
   useCustomStyleHook_unstable('usePersonaStyles_unstable')(state);
+  usePersonaStyles_unstable(state);
 
   return renderPersona_unstable(state);
 });

--- a/packages/react-components/react-popover/library/src/components/PopoverSurface/PopoverSurface.tsx
+++ b/packages/react-components/react-popover/library/src/components/PopoverSurface/PopoverSurface.tsx
@@ -12,9 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const PopoverSurface: ForwardRefComponent<PopoverSurfaceProps> = React.forwardRef((props, ref) => {
   const state = usePopoverSurface_unstable(props, ref);
 
-  usePopoverSurfaceStyles_unstable(state);
-
   useCustomStyleHook_unstable('usePopoverSurfaceStyles_unstable')(state);
+  usePopoverSurfaceStyles_unstable(state);
 
   return renderPopoverSurface_unstable(state);
 });

--- a/packages/react-components/react-progress/library/src/components/ProgressBar/ProgressBar.tsx
+++ b/packages/react-components/react-progress/library/src/components/ProgressBar/ProgressBar.tsx
@@ -12,9 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const ProgressBar: ForwardRefComponent<ProgressBarProps> = React.forwardRef((props, ref) => {
   const state = useProgressBar_unstable(props, ref);
 
-  useProgressBarStyles_unstable(state);
-
   useCustomStyleHook_unstable('useProgressBarStyles_unstable')(state);
+  useProgressBarStyles_unstable(state);
 
   return renderProgressBar_unstable(state);
 });

--- a/packages/react-components/react-radio/library/src/components/Radio/Radio.tsx
+++ b/packages/react-components/react-radio/library/src/components/Radio/Radio.tsx
@@ -12,9 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const Radio: ForwardRefComponent<RadioProps> = React.forwardRef((props, ref) => {
   const state = useRadio_unstable(props, ref);
 
-  useRadioStyles_unstable(state);
-
   useCustomStyleHook_unstable('useRadioStyles_unstable')(state);
+  useRadioStyles_unstable(state);
 
   return renderRadio_unstable(state);
 });

--- a/packages/react-components/react-radio/library/src/components/RadioGroup/RadioGroup.tsx
+++ b/packages/react-components/react-radio/library/src/components/RadioGroup/RadioGroup.tsx
@@ -14,9 +14,8 @@ export const RadioGroup: ForwardRefComponent<RadioGroupProps> = React.forwardRef
   const state = useRadioGroup_unstable(props, ref);
   const contextValues = useRadioGroupContextValues(state);
 
-  useRadioGroupStyles_unstable(state);
-
   useCustomStyleHook_unstable('useRadioGroupStyles_unstable')(state);
+  useRadioGroupStyles_unstable(state);
 
   return renderRadioGroup_unstable(state, contextValues);
 });

--- a/packages/react-components/react-rating/library/src/components/Rating/Rating.tsx
+++ b/packages/react-components/react-rating/library/src/components/Rating/Rating.tsx
@@ -14,8 +14,8 @@ export const Rating: ForwardRefComponent<RatingProps> = React.forwardRef((props,
   const state = useRating_unstable(props, ref);
   const contextValues = useRatingContextValues(state);
 
-  useRatingStyles_unstable(state);
   useCustomStyleHook_unstable('useRatingStyles_unstable')(state);
+  useRatingStyles_unstable(state);
   return renderRating_unstable(state, contextValues);
 });
 

--- a/packages/react-components/react-rating/library/src/components/RatingDisplay/RatingDisplay.tsx
+++ b/packages/react-components/react-rating/library/src/components/RatingDisplay/RatingDisplay.tsx
@@ -15,8 +15,8 @@ export const RatingDisplay: ForwardRefComponent<RatingDisplayProps> = React.forw
   const state = useRatingDisplay_unstable(props, ref);
   const contextValues = useRatingDisplayContextValues(state);
 
-  useRatingDisplayStyles_unstable(state);
   useCustomStyleHook_unstable('useRatingDisplayStyles_unstable')(state);
+  useRatingDisplayStyles_unstable(state);
 
   return renderRatingDisplay_unstable(state, contextValues);
 });

--- a/packages/react-components/react-rating/library/src/components/RatingItem/RatingItem.tsx
+++ b/packages/react-components/react-rating/library/src/components/RatingItem/RatingItem.tsx
@@ -12,8 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const RatingItem: ForwardRefComponent<RatingItemProps> = React.forwardRef((props, ref) => {
   const state = useRatingItem_unstable(props, ref);
 
-  useRatingItemStyles_unstable(state);
   useCustomStyleHook_unstable('useRatingItemStyles_unstable')(state);
+  useRatingItemStyles_unstable(state);
 
   return renderRatingItem_unstable(state);
 });

--- a/packages/react-components/react-search/library/src/components/SearchBox/SearchBox.tsx
+++ b/packages/react-components/react-search/library/src/components/SearchBox/SearchBox.tsx
@@ -12,9 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const SearchBox: ForwardRefComponent<SearchBoxProps> = React.forwardRef((props, ref) => {
   const state = useSearchBox_unstable(props, ref);
 
-  useSearchBoxStyles_unstable(state);
-
   useCustomStyleHook_unstable('useSearchBoxStyles_unstable')(state);
+  useSearchBoxStyles_unstable(state);
 
   return renderSearchBox_unstable(state);
 });

--- a/packages/react-components/react-select/library/src/components/Select/Select.tsx
+++ b/packages/react-components/react-select/library/src/components/Select/Select.tsx
@@ -12,9 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const Select: ForwardRefComponent<SelectProps> = React.forwardRef((props, ref) => {
   const state = useSelect_unstable(props, ref);
 
-  useSelectStyles_unstable(state);
-
   useCustomStyleHook_unstable('useSelectStyles_unstable')(state);
+  useSelectStyles_unstable(state);
 
   return renderSelect_unstable(state);
 });

--- a/packages/react-components/react-skeleton/library/src/components/Skeleton/Skeleton.tsx
+++ b/packages/react-components/react-skeleton/library/src/components/Skeleton/Skeleton.tsx
@@ -14,8 +14,8 @@ export const Skeleton: ForwardRefComponent<SkeletonProps> = React.forwardRef((pr
   const state = useSkeleton_unstable(props, ref);
   const contextValues = useSkeletonContextValues(state);
 
-  useSkeletonStyles_unstable(state);
   useCustomStyleHook_unstable('useSkeletonStyles_unstable')(state);
+  useSkeletonStyles_unstable(state);
 
   return renderSkeleton_unstable(state, contextValues);
 });

--- a/packages/react-components/react-skeleton/library/src/components/SkeletonItem/SkeletonItem.tsx
+++ b/packages/react-components/react-skeleton/library/src/components/SkeletonItem/SkeletonItem.tsx
@@ -9,8 +9,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const SkeletonItem: ForwardRefComponent<SkeletonItemProps> = React.forwardRef((props, ref) => {
   const state = useSkeletonItem_unstable(props, ref);
 
-  useSkeletonItemStyles_unstable(state);
   useCustomStyleHook_unstable('useSkeletonItemStyles_unstable')(state);
+  useSkeletonItemStyles_unstable(state);
 
   return renderSkeletonItem_unstable(state);
 });

--- a/packages/react-components/react-slider/library/src/components/Slider/Slider.tsx
+++ b/packages/react-components/react-slider/library/src/components/Slider/Slider.tsx
@@ -12,9 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const Slider: ForwardRefComponent<SliderProps> = React.forwardRef((props, ref) => {
   const state = useSlider_unstable(props, ref);
 
-  useSliderStyles_unstable(state);
-
   useCustomStyleHook_unstable('useSliderStyles_unstable')(state);
+  useSliderStyles_unstable(state);
 
   return renderSlider_unstable(state);
 });

--- a/packages/react-components/react-spinbutton/library/src/components/SpinButton/SpinButton.tsx
+++ b/packages/react-components/react-spinbutton/library/src/components/SpinButton/SpinButton.tsx
@@ -12,9 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const SpinButton: ForwardRefComponent<SpinButtonProps> = React.forwardRef((props, ref) => {
   const state = useSpinButton_unstable(props, ref);
 
-  useSpinButtonStyles_unstable(state);
-
   useCustomStyleHook_unstable('useSpinButtonStyles_unstable')(state);
+  useSpinButtonStyles_unstable(state);
 
   return renderSpinButton_unstable(state);
 });

--- a/packages/react-components/react-spinner/library/src/components/Spinner/Spinner.tsx
+++ b/packages/react-components/react-spinner/library/src/components/Spinner/Spinner.tsx
@@ -12,9 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const Spinner: ForwardRefComponent<SpinnerProps> = React.forwardRef((props, ref) => {
   const state = useSpinner_unstable(props, ref);
 
-  useSpinnerStyles_unstable(state);
-
   useCustomStyleHook_unstable('useSpinnerStyles_unstable')(state);
+  useSpinnerStyles_unstable(state);
 
   return renderSpinner_unstable(state);
 });

--- a/packages/react-components/react-swatch-picker/library/src/components/ColorSwatch/ColorSwatch.tsx
+++ b/packages/react-components/react-swatch-picker/library/src/components/ColorSwatch/ColorSwatch.tsx
@@ -12,8 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const ColorSwatch: ForwardRefComponent<ColorSwatchProps> = React.forwardRef((props, ref) => {
   const state = useColorSwatch_unstable(props, ref);
 
-  useColorSwatchStyles_unstable(state);
   useCustomStyleHook_unstable('useColorSwatchStyles_unstable')(state);
+  useColorSwatchStyles_unstable(state);
 
   return renderColorSwatch_unstable(state);
 });

--- a/packages/react-components/react-swatch-picker/library/src/components/EmptySwatch/EmptySwatch.tsx
+++ b/packages/react-components/react-swatch-picker/library/src/components/EmptySwatch/EmptySwatch.tsx
@@ -12,8 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const EmptySwatch: ForwardRefComponent<EmptySwatchProps> = React.forwardRef((props, ref) => {
   const state = useEmptySwatch_unstable(props, ref);
 
-  useEmptySwatchStyles_unstable(state);
   useCustomStyleHook_unstable('useEmptySwatchStyles_unstable')(state);
+  useEmptySwatchStyles_unstable(state);
   return renderEmptySwatch_unstable(state);
 });
 

--- a/packages/react-components/react-swatch-picker/library/src/components/ImageSwatch/ImageSwatch.tsx
+++ b/packages/react-components/react-swatch-picker/library/src/components/ImageSwatch/ImageSwatch.tsx
@@ -12,8 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const ImageSwatch: ForwardRefComponent<ImageSwatchProps> = React.forwardRef((props, ref) => {
   const state = useImageSwatch_unstable(props, ref);
 
-  useImageSwatchStyles_unstable(state);
   useCustomStyleHook_unstable('useImageSwatchStyles_unstable')(state);
+  useImageSwatchStyles_unstable(state);
 
   return renderImageSwatch_unstable(state);
 });

--- a/packages/react-components/react-swatch-picker/library/src/components/SwatchPicker/SwatchPicker.tsx
+++ b/packages/react-components/react-swatch-picker/library/src/components/SwatchPicker/SwatchPicker.tsx
@@ -14,8 +14,8 @@ export const SwatchPicker: ForwardRefComponent<SwatchPickerProps> = React.forwar
   const state = useSwatchPicker_unstable(props, ref);
   const contextValues = useSwatchPickerContextValues(state);
 
-  useSwatchPickerStyles_unstable(state);
   useCustomStyleHook_unstable('useSwatchPickerStyles_unstable')(state);
+  useSwatchPickerStyles_unstable(state);
 
   return renderSwatchPicker_unstable(state, contextValues);
 });

--- a/packages/react-components/react-swatch-picker/library/src/components/SwatchPickerRow/SwatchPickerRow.tsx
+++ b/packages/react-components/react-swatch-picker/library/src/components/SwatchPickerRow/SwatchPickerRow.tsx
@@ -12,8 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const SwatchPickerRow: ForwardRefComponent<SwatchPickerRowProps> = React.forwardRef((props, ref) => {
   const state = useSwatchPickerRow_unstable(props, ref);
 
-  useSwatchPickerRowStyles_unstable(state);
   useCustomStyleHook_unstable('useSwatchPickerRowStyles_unstable')(state);
+  useSwatchPickerRowStyles_unstable(state);
   return renderSwatchPickerRow_unstable(state);
 });
 

--- a/packages/react-components/react-switch/library/src/components/Switch/Switch.tsx
+++ b/packages/react-components/react-switch/library/src/components/Switch/Switch.tsx
@@ -12,9 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const Switch: ForwardRefComponent<SwitchProps> = React.forwardRef((props, ref) => {
   const state = useSwitch_unstable(props, ref);
 
-  useSwitchStyles_unstable(state);
-
   useCustomStyleHook_unstable('useSwitchStyles_unstable')(state);
+  useSwitchStyles_unstable(state);
 
   return renderSwitch_unstable(state);
 });

--- a/packages/react-components/react-table/library/src/components/DataGrid/DataGrid.tsx
+++ b/packages/react-components/react-table/library/src/components/DataGrid/DataGrid.tsx
@@ -13,9 +13,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const DataGrid: ForwardRefComponent<DataGridProps> = React.forwardRef((props, ref) => {
   const state = useDataGrid_unstable(props, ref);
 
-  useDataGridStyles_unstable(state);
-
   useCustomStyleHook_unstable('useDataGridStyles_unstable')(state);
+  useDataGridStyles_unstable(state);
 
   return renderDataGrid_unstable(state, useDataGridContextValues_unstable(state));
 });

--- a/packages/react-components/react-table/library/src/components/DataGridBody/DataGridBody.tsx
+++ b/packages/react-components/react-table/library/src/components/DataGridBody/DataGridBody.tsx
@@ -13,9 +13,8 @@ export const DataGridBody: ForwardRefComponent<DataGridBodyProps> &
   (<TItem>(props: DataGridBodyProps<TItem>) => JSX.Element) = React.forwardRef((props, ref) => {
   const state = useDataGridBody_unstable(props, ref);
 
-  useDataGridBodyStyles_unstable(state);
-
   useCustomStyleHook_unstable('useDataGridBodyStyles_unstable')(state);
+  useDataGridBodyStyles_unstable(state);
 
   return renderDataGridBody_unstable(state);
 }) as ForwardRefComponent<DataGridBodyProps> & (<TItem>(props: DataGridBodyProps<TItem>) => JSX.Element);

--- a/packages/react-components/react-table/library/src/components/DataGridCell/DataGridCell.tsx
+++ b/packages/react-components/react-table/library/src/components/DataGridCell/DataGridCell.tsx
@@ -13,7 +13,6 @@ export const DataGridCell: ForwardRefComponent<DataGridCellProps> = React.forwar
   const state = useDataGridCell_unstable(props, ref);
 
   useDataGridCellStyles_unstable(state);
-
   useCustomStyleHook_unstable('useDataGridCellStyles_unstable')(state);
 
   return renderDataGridCell_unstable(state);

--- a/packages/react-components/react-table/library/src/components/DataGridHeader/DataGridHeader.tsx
+++ b/packages/react-components/react-table/library/src/components/DataGridHeader/DataGridHeader.tsx
@@ -12,9 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const DataGridHeader: ForwardRefComponent<DataGridHeaderProps> = React.forwardRef((props, ref) => {
   const state = useDataGridHeader_unstable(props, ref);
 
-  useDataGridHeaderStyles_unstable(state);
-
   useCustomStyleHook_unstable('useDataGridHeaderStyles_unstable')(state);
+  useDataGridHeaderStyles_unstable(state);
 
   return renderDataGridHeader_unstable(state);
 });

--- a/packages/react-components/react-table/library/src/components/DataGridHeaderCell/DataGridHeaderCell.tsx
+++ b/packages/react-components/react-table/library/src/components/DataGridHeaderCell/DataGridHeaderCell.tsx
@@ -12,9 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const DataGridHeaderCell: ForwardRefComponent<DataGridHeaderCellProps> = React.forwardRef((props, ref) => {
   const state = useDataGridHeaderCell_unstable(props, ref);
 
-  useDataGridHeaderCellStyles_unstable(state);
-
   useCustomStyleHook_unstable('useDataGridHeaderCellStyles_unstable')(state);
+  useDataGridHeaderCellStyles_unstable(state);
 
   return renderDataGridHeaderCell_unstable(state);
 });

--- a/packages/react-components/react-table/library/src/components/DataGridRow/DataGridRow.tsx
+++ b/packages/react-components/react-table/library/src/components/DataGridRow/DataGridRow.tsx
@@ -13,9 +13,8 @@ export const DataGridRow: ForwardRefComponent<DataGridRowProps> &
   (<TItem>(props: DataGridRowProps<TItem>) => JSX.Element) = React.forwardRef((props, ref) => {
   const state = useDataGridRow_unstable(props, ref);
 
-  useDataGridRowStyles_unstable(state);
-
   useCustomStyleHook_unstable('useDataGridRowStyles_unstable')(state);
+  useDataGridRowStyles_unstable(state);
 
   return renderDataGridRow_unstable(state);
 }) as ForwardRefComponent<DataGridRowProps> & (<TItem>(props: DataGridRowProps<TItem>) => JSX.Element);

--- a/packages/react-components/react-table/library/src/components/DataGridSelectionCell/DataGridSelectionCell.tsx
+++ b/packages/react-components/react-table/library/src/components/DataGridSelectionCell/DataGridSelectionCell.tsx
@@ -12,9 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const DataGridSelectionCell: ForwardRefComponent<DataGridSelectionCellProps> = React.forwardRef((props, ref) => {
   const state = useDataGridSelectionCell_unstable(props, ref);
 
-  useDataGridSelectionCellStyles_unstable(state);
-
   useCustomStyleHook_unstable('useDataGridSelectionCellStyles_unstable')(state);
+  useDataGridSelectionCellStyles_unstable(state);
 
   return renderDataGridSelectionCell_unstable(state);
 });

--- a/packages/react-components/react-table/library/src/components/Table/Table.tsx
+++ b/packages/react-components/react-table/library/src/components/Table/Table.tsx
@@ -13,9 +13,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const Table: ForwardRefComponent<TableProps> = React.forwardRef((props, ref) => {
   const state = useTable_unstable(props, ref);
 
-  useTableStyles_unstable(state);
-
   useCustomStyleHook_unstable('useTableStyles_unstable')(state);
+  useTableStyles_unstable(state);
 
   return renderTable_unstable(state, useTableContextValues_unstable(state));
 });

--- a/packages/react-components/react-table/library/src/components/TableBody/TableBody.tsx
+++ b/packages/react-components/react-table/library/src/components/TableBody/TableBody.tsx
@@ -12,9 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const TableBody: ForwardRefComponent<TableBodyProps> = React.forwardRef((props, ref) => {
   const state = useTableBody_unstable(props, ref);
 
-  useTableBodyStyles_unstable(state);
-
   useCustomStyleHook_unstable('useTableBodyStyles_unstable')(state);
+  useTableBodyStyles_unstable(state);
 
   return renderTableBody_unstable(state);
 });

--- a/packages/react-components/react-table/library/src/components/TableCell/TableCell.tsx
+++ b/packages/react-components/react-table/library/src/components/TableCell/TableCell.tsx
@@ -12,9 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const TableCell: ForwardRefComponent<TableCellProps> = React.forwardRef((props, ref) => {
   const state = useTableCell_unstable(props, ref);
 
-  useTableCellStyles_unstable(state);
-
   useCustomStyleHook_unstable('useTableCellStyles_unstable')(state);
+  useTableCellStyles_unstable(state);
 
   return renderTableCell_unstable(state);
 });

--- a/packages/react-components/react-table/library/src/components/TableCellActions/TableCellActions.tsx
+++ b/packages/react-components/react-table/library/src/components/TableCellActions/TableCellActions.tsx
@@ -12,9 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const TableCellActions: ForwardRefComponent<TableCellActionsProps> = React.forwardRef((props, ref) => {
   const state = useTableCellActions_unstable(props, ref);
 
-  useTableCellActionsStyles_unstable(state);
-
   useCustomStyleHook_unstable('useTableCellActionsStyles_unstable')(state);
+  useTableCellActionsStyles_unstable(state);
 
   return renderTableCellActions_unstable(state);
 });

--- a/packages/react-components/react-table/library/src/components/TableCellLayout/TableCellLayout.tsx
+++ b/packages/react-components/react-table/library/src/components/TableCellLayout/TableCellLayout.tsx
@@ -13,9 +13,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const TableCellLayout: ForwardRefComponent<TableCellLayoutProps> = React.forwardRef((props, ref) => {
   const state = useTableCellLayout_unstable(props, ref);
 
-  useTableCellLayoutStyles_unstable(state);
-
   useCustomStyleHook_unstable('useTableCellLayoutStyles_unstable')(state);
+  useTableCellLayoutStyles_unstable(state);
 
   return renderTableCellLayout_unstable(state, useTableCellLayoutContextValues_unstable(state));
 });

--- a/packages/react-components/react-table/library/src/components/TableHeader/TableHeader.tsx
+++ b/packages/react-components/react-table/library/src/components/TableHeader/TableHeader.tsx
@@ -12,9 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const TableHeader: ForwardRefComponent<TableHeaderProps> = React.forwardRef((props, ref) => {
   const state = useTableHeader_unstable(props, ref);
 
-  useTableHeaderStyles_unstable(state);
-
   useCustomStyleHook_unstable('useTableHeaderStyles_unstable')(state);
+  useTableHeaderStyles_unstable(state);
 
   return renderTableHeader_unstable(state);
 });

--- a/packages/react-components/react-table/library/src/components/TableHeaderCell/TableHeaderCell.tsx
+++ b/packages/react-components/react-table/library/src/components/TableHeaderCell/TableHeaderCell.tsx
@@ -12,9 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const TableHeaderCell: ForwardRefComponent<TableHeaderCellProps> = React.forwardRef((props, ref) => {
   const state = useTableHeaderCell_unstable(props, ref);
 
-  useTableHeaderCellStyles_unstable(state);
-
   useCustomStyleHook_unstable('useTableHeaderCellStyles_unstable')(state);
+  useTableHeaderCellStyles_unstable(state);
 
   return renderTableHeaderCell_unstable(state);
 });

--- a/packages/react-components/react-table/library/src/components/TableResizeHandle/TableResizeHandle.tsx
+++ b/packages/react-components/react-table/library/src/components/TableResizeHandle/TableResizeHandle.tsx
@@ -12,9 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const TableResizeHandle: ForwardRefComponent<TableResizeHandleProps> = React.forwardRef((props, ref) => {
   const state = useTableResizeHandle_unstable(props, ref);
 
-  useTableResizeHandleStyles_unstable(state);
-
   useCustomStyleHook_unstable('useTableResizeHandleStyles_unstable')(state);
+  useTableResizeHandleStyles_unstable(state);
 
   return renderTableResizeHandle_unstable(state);
 });

--- a/packages/react-components/react-table/library/src/components/TableRow/TableRow.tsx
+++ b/packages/react-components/react-table/library/src/components/TableRow/TableRow.tsx
@@ -12,9 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const TableRow: ForwardRefComponent<TableRowProps> = React.forwardRef((props, ref) => {
   const state = useTableRow_unstable(props, ref);
 
-  useTableRowStyles_unstable(state);
-
   useCustomStyleHook_unstable('useTableRowStyles_unstable')(state);
+  useTableRowStyles_unstable(state);
 
   return renderTableRow_unstable(state);
 });

--- a/packages/react-components/react-table/library/src/components/TableSelectionCell/TableSelectionCell.tsx
+++ b/packages/react-components/react-table/library/src/components/TableSelectionCell/TableSelectionCell.tsx
@@ -12,9 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const TableSelectionCell: ForwardRefComponent<TableSelectionCellProps> = React.forwardRef((props, ref) => {
   const state = useTableSelectionCell_unstable(props, ref);
 
-  useTableSelectionCellStyles_unstable(state);
-
   useCustomStyleHook_unstable('useTableSelectionCellStyles_unstable')(state);
+  useTableSelectionCellStyles_unstable(state);
 
   return renderTableSelectionCell_unstable(state);
 });

--- a/packages/react-components/react-tabs/library/src/components/Tab/Tab.tsx
+++ b/packages/react-components/react-tabs/library/src/components/Tab/Tab.tsx
@@ -12,9 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const Tab: ForwardRefComponent<TabProps> = React.forwardRef((props, ref) => {
   const state = useTab_unstable(props, ref);
 
-  useTabStyles_unstable(state);
-
   useCustomStyleHook_unstable('useTabStyles_unstable')(state);
+  useTabStyles_unstable(state);
 
   return renderTab_unstable(state);
 });

--- a/packages/react-components/react-tabs/library/src/components/TabList/TabList.tsx
+++ b/packages/react-components/react-tabs/library/src/components/TabList/TabList.tsx
@@ -14,9 +14,8 @@ export const TabList: ForwardRefComponent<TabListProps> = React.forwardRef((prop
   const state = useTabList_unstable(props, ref);
   const contextValues = useTabListContextValues_unstable(state);
 
-  useTabListStyles_unstable(state);
-
   useCustomStyleHook_unstable('useTabListStyles_unstable')(state);
+  useTabListStyles_unstable(state);
 
   return renderTabList_unstable(state, contextValues);
 });

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerButton/TagPickerButton.tsx
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerButton/TagPickerButton.tsx
@@ -13,8 +13,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const TagPickerButton: ForwardRefComponent<TagPickerButtonProps> = React.forwardRef((props, ref) => {
   const state = useTagPickerButton_unstable(props, ref);
 
-  useTagPickerButtonStyles_unstable(state);
   useCustomStyleHook_unstable('useTagPickerButtonStyles_unstable')(state);
+  useTagPickerButtonStyles_unstable(state);
   return renderTagPickerButton_unstable(state);
 });
 

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerControl/TagPickerControl.tsx
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerControl/TagPickerControl.tsx
@@ -13,8 +13,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const TagPickerControl: ForwardRefComponent<TagPickerControlProps> = React.forwardRef((props, ref) => {
   const state = useTagPickerControl_unstable(props, ref);
 
-  useTagPickerControlStyles_unstable(state);
   useCustomStyleHook_unstable('useTagPickerControlStyles_unstable')(state);
+  useTagPickerControlStyles_unstable(state);
   return renderTagPickerControl_unstable(state);
 });
 

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerGroup/TagPickerGroup.tsx
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerGroup/TagPickerGroup.tsx
@@ -14,8 +14,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const TagPickerGroup: ForwardRefComponent<TagPickerGroupProps> = React.forwardRef((props, ref) => {
   const state = useTagPickerGroup_unstable(props, ref);
 
-  useTagPickerGroupStyles_unstable(state);
   useCustomStyleHook_unstable('useTagPickerGroupStyles_unstable')(state);
+  useTagPickerGroupStyles_unstable(state);
   return renderTagPickerGroup_unstable(state, useTagGroupContextValues_unstable(state));
 });
 

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerInput/TagPickerInput.tsx
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerInput/TagPickerInput.tsx
@@ -13,8 +13,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const TagPickerInput: ForwardRefComponent<TagPickerInputProps> = React.forwardRef((props, ref) => {
   const state = useTagPickerInput_unstable(props, ref);
 
-  useTagPickerInputStyles_unstable(state);
   useCustomStyleHook_unstable('useTagPickerInputStyles_unstable')(state);
+  useTagPickerInputStyles_unstable(state);
 
   return renderTagPickerInput_unstable(state);
 });

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerList/TagPickerList.tsx
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerList/TagPickerList.tsx
@@ -13,8 +13,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const TagPickerList: ForwardRefComponent<TagPickerListProps> = React.forwardRef((props, ref) => {
   const state = useTagPickerList_unstable(props, ref);
 
-  useTagPickerListStyles_unstable(state);
   useCustomStyleHook_unstable('useTagPickerListStyles_unstable')(state);
+  useTagPickerListStyles_unstable(state);
   return renderTagPickerList_unstable(state);
 });
 

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerOption/TagPickerOption.tsx
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerOption/TagPickerOption.tsx
@@ -13,8 +13,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const TagPickerOption: ForwardRefComponent<TagPickerOptionProps> = React.forwardRef((props, ref) => {
   const state = useTagPickerOption_unstable(props, ref);
 
-  useTagPickerOptionStyles_unstable(state);
   useCustomStyleHook_unstable('useTagPickerOptionStyles_unstable')(state);
+  useTagPickerOptionStyles_unstable(state);
   return renderTagPickerOption_unstable(state);
 });
 

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerOptionGroup/TagPickerOptionGroup.tsx
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerOptionGroup/TagPickerOptionGroup.tsx
@@ -13,8 +13,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const TagPickerOptionGroup: ForwardRefComponent<TagPickerOptionGroupProps> = React.forwardRef((props, ref) => {
   const state = useTagPickerOptionGroup(props, ref);
 
-  useTagPickerOptionGroupStyles(state);
   useCustomStyleHook_unstable('useTagPickerOptionGroupStyles_unstable')(state);
+  useTagPickerOptionGroupStyles(state);
   return renderTagPickerOptionGroup(state);
 });
 

--- a/packages/react-components/react-tags/library/src/components/InteractionTag/InteractionTag.tsx
+++ b/packages/react-components/react-tags/library/src/components/InteractionTag/InteractionTag.tsx
@@ -14,9 +14,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const InteractionTag: ForwardRefComponent<InteractionTagProps> = React.forwardRef((props, ref) => {
   const state = useInteractionTag_unstable(props, ref);
 
-  useInteractionTagStyles_unstable(state);
-
   useCustomStyleHook_unstable('useInteractionTagStyles_unstable')(state);
+  useInteractionTagStyles_unstable(state);
 
   return renderInteractionTag_unstable(state, useInteractionTagContextValues_unstable(state));
 });

--- a/packages/react-components/react-tags/library/src/components/InteractionTagPrimary/InteractionTagPrimary.tsx
+++ b/packages/react-components/react-tags/library/src/components/InteractionTagPrimary/InteractionTagPrimary.tsx
@@ -14,9 +14,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const InteractionTagPrimary: ForwardRefComponent<InteractionTagPrimaryProps> = React.forwardRef((props, ref) => {
   const state = useInteractionTagPrimary_unstable(props, ref);
 
-  useInteractionTagPrimaryStyles_unstable(state);
-
   useCustomStyleHook_unstable('useInteractionTagPrimaryStyles_unstable')(state);
+  useInteractionTagPrimaryStyles_unstable(state);
 
   return renderInteractionTagPrimary_unstable(state, useTagAvatarContextValues_unstable(state));
 });

--- a/packages/react-components/react-tags/library/src/components/InteractionTagSecondary/InteractionTagSecondary.tsx
+++ b/packages/react-components/react-tags/library/src/components/InteractionTagSecondary/InteractionTagSecondary.tsx
@@ -13,9 +13,8 @@ export const InteractionTagSecondary: ForwardRefComponent<InteractionTagSecondar
   (props, ref) => {
     const state = useInteractionTagSecondary_unstable(props, ref);
 
-    useInteractionTagSecondaryStyles_unstable(state);
-
     useCustomStyleHook_unstable('useInteractionTagSecondaryStyles_unstable')(state);
+    useInteractionTagSecondaryStyles_unstable(state);
 
     return renderInteractionTagSecondary_unstable(state);
   },

--- a/packages/react-components/react-tags/library/src/components/Tag/Tag.tsx
+++ b/packages/react-components/react-tags/library/src/components/Tag/Tag.tsx
@@ -14,9 +14,8 @@ import { useTagAvatarContextValues_unstable } from '../../utils';
 export const Tag: ForwardRefComponent<TagProps> = React.forwardRef((props, ref) => {
   const state = useTag_unstable(props, ref);
 
-  useTagStyles_unstable(state);
-
   useCustomStyleHook_unstable('useTagStyles_unstable')(state);
+  useTagStyles_unstable(state);
 
   return renderTag_unstable(state, useTagAvatarContextValues_unstable(state));
 });

--- a/packages/react-components/react-tags/library/src/components/TagGroup/TagGroup.tsx
+++ b/packages/react-components/react-tags/library/src/components/TagGroup/TagGroup.tsx
@@ -14,9 +14,8 @@ import { useTagGroupContextValues_unstable } from './useTagGroupContextValues';
 export const TagGroup: ForwardRefComponent<TagGroupProps> = React.forwardRef((props, ref) => {
   const state = useTagGroup_unstable(props, ref);
 
-  useTagGroupStyles_unstable(state);
-
   useCustomStyleHook_unstable('useTagGroupStyles_unstable')(state);
+  useTagGroupStyles_unstable(state);
 
   return renderTagGroup_unstable(state, useTagGroupContextValues_unstable(state));
 });

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverBody/TeachingPopoverBody.tsx
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverBody/TeachingPopoverBody.tsx
@@ -15,9 +15,8 @@ import type { ForwardRefComponent } from '@fluentui/react-utilities';
 export const TeachingPopoverBody: ForwardRefComponent<TeachingPopoverBodyProps> = React.forwardRef((props, ref) => {
   const state = useTeachingPopoverBody_unstable(props, ref);
 
-  useTeachingPopoverBodyStyles_unstable(state);
-
   useCustomStyleHook_unstable('useTeachingPopoverBodyStyles_unstable')(state);
+  useTeachingPopoverBodyStyles_unstable(state);
 
   return renderTeachingPopoverBody_unstable(state);
 });

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarousel/TeachingPopoverCarousel.tsx
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarousel/TeachingPopoverCarousel.tsx
@@ -18,9 +18,8 @@ export const TeachingPopoverCarousel: ForwardRefComponent<TeachingPopoverCarouse
   (props, ref) => {
     const state = useTeachingPopoverCarousel_unstable(props, ref);
 
-    useTeachingPopoverCarouselStyles_unstable(state);
-
     useCustomStyleHook_unstable('useTeachingPopoverCarouselStyles_unstable')(state);
+    useTeachingPopoverCarouselStyles_unstable(state);
 
     const contextValues = useTeachingPopoverCarouselContextValues_unstable(state);
 

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselCard/TeachingPopoverCarouselCard.tsx
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselCard/TeachingPopoverCarouselCard.tsx
@@ -16,9 +16,8 @@ export const TeachingPopoverCarouselCard: ForwardRefComponent<TeachingPopoverCar
   (props, ref) => {
     const state = useTeachingPopoverCarouselCard_unstable(props, ref);
 
-    useTeachingPopoverCarouselCardStyles_unstable(state);
-
     useCustomStyleHook_unstable('useTeachingPopoverCarouselCardStyles_unstable')(state);
+    useTeachingPopoverCarouselCardStyles_unstable(state);
 
     return renderTeachingPopoverCarouselCard_unstable(state);
   },

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselFooter/TeachingPopoverCarouselFooter.tsx
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselFooter/TeachingPopoverCarouselFooter.tsx
@@ -16,9 +16,8 @@ export const TeachingPopoverCarouselFooter: ForwardRefComponent<TeachingPopoverC
   (props, ref) => {
     const state = useTeachingPopoverCarouselFooter_unstable(props, ref);
 
-    useTeachingPopoverCarouselFooterStyles_unstable(state);
-
     useCustomStyleHook_unstable('useTeachingPopoverCarouselFooterStyles_unstable')(state);
+    useTeachingPopoverCarouselFooterStyles_unstable(state);
 
     return renderTeachingPopoverCarouselFooter_unstable(state);
   },

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselFooterButton/TeachingPopoverCarouselFooterButton.tsx
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselFooterButton/TeachingPopoverCarouselFooterButton.tsx
@@ -16,9 +16,8 @@ export const TeachingPopoverCarouselFooterButton: ForwardRefComponent<TeachingPo
   React.forwardRef((props, ref) => {
     const state = useTeachingPopoverCarouselFooterButton_unstable(props, ref);
 
-    useTeachingPopoverCarouselFooterButtonStyles_unstable(state);
-
     useCustomStyleHook_unstable('useTeachingPopoverCarouselFooterButtonStyles_unstable')(state);
+    useTeachingPopoverCarouselFooterButtonStyles_unstable(state);
 
     return renderTeachingPopoverCarouselFooterButton_unstable(state);
   });

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselNav/TeachingPopoverCarouselNav.tsx
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselNav/TeachingPopoverCarouselNav.tsx
@@ -16,9 +16,8 @@ export const TeachingPopoverCarouselNav: ForwardRefComponent<TeachingPopoverCaro
   (props, ref) => {
     const state = useTeachingPopoverCarouselNav_unstable(props, ref);
 
-    useTeachingPopoverCarouselNavStyles_unstable(state);
-
     useCustomStyleHook_unstable('useTeachingPopoverCarouselNavStyles_unstable')(state);
+    useTeachingPopoverCarouselNavStyles_unstable(state);
 
     return renderTeachingPopoverCarouselNav_unstable(state);
   },

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselNavButton/TeachingPopoverCarouselNavButton.tsx
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselNavButton/TeachingPopoverCarouselNavButton.tsx
@@ -15,9 +15,8 @@ export const TeachingPopoverCarouselNavButton: ForwardRefComponent<TeachingPopov
   React.forwardRef((props, ref) => {
     const state = useTeachingPopoverCarouselNavButton_unstable(props, ref);
 
-    useTeachingPopoverCarouselNavButtonStyles_unstable(state);
-
     useCustomStyleHook_unstable('useTeachingPopoverCarouselNavButtonStyles_unstable')(state);
+    useTeachingPopoverCarouselNavButtonStyles_unstable(state);
 
     return renderTeachingPopoverCarouselNavButton_unstable(state);
   }) as ForwardRefComponent<TeachingPopoverCarouselNavButtonProps>;

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselPageCount/TeachingPopoverCarouselPageCount.tsx
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselPageCount/TeachingPopoverCarouselPageCount.tsx
@@ -15,9 +15,8 @@ export const TeachingPopoverCarouselPageCount: ForwardRefComponent<TeachingPopov
   React.forwardRef((props, ref) => {
     const state = useTeachingPopoverCarouselPageCount_unstable(props, ref);
 
-    useTeachingPopoverCarouselPageCountStyles_unstable(state);
-
     useCustomStyleHook_unstable('useTeachingPopoverCarouselPageCountStyles_unstable')(state);
+    useTeachingPopoverCarouselPageCountStyles_unstable(state);
 
     return renderTeachingPopoverCarouselPageCount_unstable(state);
   });

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverFooter/TeachingPopoverFooter.tsx
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverFooter/TeachingPopoverFooter.tsx
@@ -18,9 +18,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const TeachingPopoverFooter: ForwardRefComponent<TeachingPopoverFooterProps> = React.forwardRef((props, ref) => {
   const state = useTeachingPopoverFooter_unstable(props, ref);
 
-  useTeachingPopoverFooterStyles_unstable(state);
-
   useCustomStyleHook_unstable('useTeachingPopoverFooterStyles_unstable')(state);
+  useTeachingPopoverFooterStyles_unstable(state);
 
   return renderTeachingPopoverFooter_unstable(state);
 });

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverHeader/TeachingPopoverHeader.tsx
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverHeader/TeachingPopoverHeader.tsx
@@ -16,9 +16,8 @@ import type { ForwardRefComponent } from '@fluentui/react-utilities';
 export const TeachingPopoverHeader: ForwardRefComponent<TeachingPopoverHeaderProps> = React.forwardRef((props, ref) => {
   const state = useTeachingPopoverHeader_unstable(props, ref);
 
-  useTeachingPopoverHeaderStyles_unstable(state);
-
   useCustomStyleHook_unstable('useTeachingPopoverHeaderStyles_unstable')(state);
+  useTeachingPopoverHeaderStyles_unstable(state);
 
   return renderTeachingPopoverHeader_unstable(state);
 });

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverSurface/TeachingPopoverSurface.tsx
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverSurface/TeachingPopoverSurface.tsx
@@ -15,9 +15,8 @@ export const TeachingPopoverSurface: ForwardRefComponent<TeachingPopoverSurfaceP
   (props, ref) => {
     const state = useTeachingPopoverSurface_unstable(props, ref);
 
-    useTeachingPopoverSurfaceStyles_unstable(state);
-
     useCustomStyleHook_unstable('useTeachingPopoverSurfaceStyles_unstable')(state);
+    useTeachingPopoverSurfaceStyles_unstable(state);
 
     return renderTeachingPopoverSurface_unstable(state);
   },

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverTitle/TeachingPopoverTitle.tsx
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverTitle/TeachingPopoverTitle.tsx
@@ -16,9 +16,8 @@ import type { ForwardRefComponent } from '@fluentui/react-utilities';
 export const TeachingPopoverTitle: ForwardRefComponent<TeachingPopoverTitleProps> = React.forwardRef((props, ref) => {
   const state = useTeachingPopoverTitle_unstable(props, ref);
 
-  useTeachingPopoverTitleStyles_unstable(state);
-
   useCustomStyleHook_unstable('useTeachingPopoverTitleStyles_unstable')(state);
+  useTeachingPopoverTitleStyles_unstable(state);
 
   return renderTeachingPopoverTitle_unstable(state);
 });

--- a/packages/react-components/react-text/library/src/components/Text/Text.tsx
+++ b/packages/react-components/react-text/library/src/components/Text/Text.tsx
@@ -12,9 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const Text: ForwardRefComponent<TextProps> = React.forwardRef((props, ref) => {
   const state = useText_unstable(props, ref);
 
-  useTextStyles_unstable(state);
-
   useCustomStyleHook_unstable('useTextStyles_unstable')(state);
+  useTextStyles_unstable(state);
 
   return renderText_unstable(state);
   // Work around some small mismatches in inferred types which don't matter in practice

--- a/packages/react-components/react-textarea/library/src/components/Textarea/Textarea.tsx
+++ b/packages/react-components/react-textarea/library/src/components/Textarea/Textarea.tsx
@@ -12,9 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const Textarea: ForwardRefComponent<TextareaProps> = React.forwardRef((props, ref) => {
   const state = useTextarea_unstable(props, ref);
 
-  useTextareaStyles_unstable(state);
-
   useCustomStyleHook_unstable('useTextareaStyles_unstable')(state);
+  useTextareaStyles_unstable(state);
 
   return renderTextarea_unstable(state);
 });

--- a/packages/react-components/react-timepicker-compat/library/src/components/TimePicker/TimePicker.tsx
+++ b/packages/react-components/react-timepicker-compat/library/src/components/TimePicker/TimePicker.tsx
@@ -14,8 +14,8 @@ export const TimePicker: ForwardRefComponent<TimePickerProps> = React.forwardRef
 
   const contextValues = useComboboxContextValues(state);
 
-  useTimePickerStyles_unstable(state);
   useCustomStyleHook_unstable('useTimePickerCompatStyles_unstable')(state);
+  useTimePickerStyles_unstable(state);
 
   return renderCombobox_unstable(state, contextValues);
 });

--- a/packages/react-components/react-toast/library/src/components/Toast/Toast.tsx
+++ b/packages/react-components/react-toast/library/src/components/Toast/Toast.tsx
@@ -13,8 +13,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const Toast: ForwardRefComponent<ToastProps> = React.forwardRef((props, ref) => {
   const state = useToast_unstable(props, ref);
 
-  useToastStyles_unstable(state);
   useCustomStyleHook_unstable('useToastStyles_unstable')(state);
+  useToastStyles_unstable(state);
 
   return renderToast_unstable(state, useToastContextValues_unstable(state));
 });

--- a/packages/react-components/react-toast/library/src/components/ToastBody/ToastBody.tsx
+++ b/packages/react-components/react-toast/library/src/components/ToastBody/ToastBody.tsx
@@ -12,8 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const ToastBody: ForwardRefComponent<ToastBodyProps> = React.forwardRef((props, ref) => {
   const state = useToastBody_unstable(props, ref);
 
-  useToastBodyStyles_unstable(state);
   useCustomStyleHook_unstable('useToastBodyStyles_unstable')(state);
+  useToastBodyStyles_unstable(state);
 
   return renderToastBody_unstable(state);
 });

--- a/packages/react-components/react-toast/library/src/components/ToastContainer/ToastContainer.tsx
+++ b/packages/react-components/react-toast/library/src/components/ToastContainer/ToastContainer.tsx
@@ -13,8 +13,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const ToastContainer: ForwardRefComponent<ToastContainerProps> = React.forwardRef((props, ref) => {
   const state = useToastContainer_unstable(props, ref);
 
-  useToastContainerStyles_unstable(state);
   useCustomStyleHook_unstable('useToastContainerStyles_unstable')(state);
+  useToastContainerStyles_unstable(state);
 
   return renderToastContainer_unstable(state, useToastContainerContextValues_unstable(state));
 });

--- a/packages/react-components/react-toast/library/src/components/ToastFooter/ToastFooter.tsx
+++ b/packages/react-components/react-toast/library/src/components/ToastFooter/ToastFooter.tsx
@@ -12,8 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const ToastFooter: ForwardRefComponent<ToastFooterProps> = React.forwardRef((props, ref) => {
   const state = useToastFooter_unstable(props, ref);
 
-  useToastFooterStyles_unstable(state);
   useCustomStyleHook_unstable('useToastFooterStyles_unstable')(state);
+  useToastFooterStyles_unstable(state);
 
   return renderToastFooter_unstable(state);
 });

--- a/packages/react-components/react-toast/library/src/components/ToastTitle/ToastTitle.tsx
+++ b/packages/react-components/react-toast/library/src/components/ToastTitle/ToastTitle.tsx
@@ -12,8 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const ToastTitle: ForwardRefComponent<ToastTitleProps> = React.forwardRef((props, ref) => {
   const state = useToastTitle_unstable(props, ref);
 
-  useToastTitleStyles_unstable(state);
   useCustomStyleHook_unstable('useToastTitleStyles_unstable')(state);
+  useToastTitleStyles_unstable(state);
 
   return renderToastTitle_unstable(state);
 });

--- a/packages/react-components/react-toast/library/src/components/Toaster/Toaster.tsx
+++ b/packages/react-components/react-toast/library/src/components/Toaster/Toaster.tsx
@@ -12,8 +12,8 @@ import type { ToasterProps } from './Toaster.types';
 export const Toaster: React.FC<ToasterProps> = props => {
   const state = useToaster_unstable(props);
 
-  useToasterStyles_unstable(state);
   useCustomStyleHook_unstable('useToasterStyles_unstable')(state);
+  useToasterStyles_unstable(state);
   return renderToaster_unstable(state);
 };
 

--- a/packages/react-components/react-toolbar/library/src/components/Toolbar/Toolbar.tsx
+++ b/packages/react-components/react-toolbar/library/src/components/Toolbar/Toolbar.tsx
@@ -14,9 +14,8 @@ export const Toolbar: ForwardRefComponent<ToolbarProps> = React.forwardRef((prop
   const state = useToolbar_unstable(props, ref);
   const contextValues = useToolbarContextValues_unstable(state);
 
-  useToolbarStyles_unstable(state);
-
   useCustomStyleHook_unstable('useToolbarStyles_unstable')(state);
+  useToolbarStyles_unstable(state);
 
   return renderToolbar_unstable(state, contextValues);
 });

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarButton/ToolbarButton.tsx
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarButton/ToolbarButton.tsx
@@ -13,9 +13,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const ToolbarButton: ForwardRefComponent<ToolbarButtonProps> = React.forwardRef((props, ref) => {
   const state = useToolbarButton_unstable(props, ref);
 
-  useToolbarButtonStyles_unstable(state);
-
   useCustomStyleHook_unstable('useToolbarButtonStyles_unstable')(state);
+  useToolbarButtonStyles_unstable(state);
 
   return renderButton_unstable(state);
   // Casting is required due to lack of distributive union to support unions on @types/react

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarDivider/ToolbarDivider.tsx
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarDivider/ToolbarDivider.tsx
@@ -12,9 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const ToolbarDivider: ForwardRefComponent<ToolbarDividerProps> = React.forwardRef((props, ref) => {
   const state = useToolbarDivider_unstable(props, ref);
 
-  useToolbarDividerStyles_unstable(state);
-
   useCustomStyleHook_unstable('useToolbarDividerStyles_unstable')(state);
+  useToolbarDividerStyles_unstable(state);
 
   return renderDivider_unstable(state);
 });

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarGroup/ToolbarGroup.tsx
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarGroup/ToolbarGroup.tsx
@@ -13,9 +13,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const ToolbarGroup: ForwardRefComponent<ToolbarGroupProps> = React.forwardRef((props, ref) => {
   const state = useToolbarGroup_unstable(props, ref);
 
-  useToolbarGroupStyles_unstable(state);
-
   useCustomStyleHook_unstable('useToolbarGroupStyles_unstable')(state);
+  useToolbarGroupStyles_unstable(state);
 
   return renderToolbarGroup_unstable(state);
   // Casting is required due to lack of distributive union to support unions on @types/react

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarRadioButton/ToolbarRadioButton.tsx
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarRadioButton/ToolbarRadioButton.tsx
@@ -12,9 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const ToolbarRadioButton: ForwardRefComponent<ToolbarRadioButtonProps> = React.forwardRef((props, ref) => {
   const state = useToolbarRadioButton_unstable(props, ref);
 
-  useToolbarRadioButtonStyles_unstable(state);
-
   useCustomStyleHook_unstable('useToolbarRadioButtonStyles_unstable')(state);
+  useToolbarRadioButtonStyles_unstable(state);
 
   return renderToggleButton_unstable(state);
 }) as ForwardRefComponent<ToolbarRadioButtonProps>;

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarRadioGroup/ToolbarRadioGroup.tsx
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarRadioGroup/ToolbarRadioGroup.tsx
@@ -15,9 +15,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const ToolbarRadioGroup: ForwardRefComponent<ToolbarRadioGroupProps> = React.forwardRef((props, ref) => {
   const state = useToolbarGroup_unstable({ role: 'radiogroup', ...props }, ref);
 
-  useToolbarGroupStyles_unstable(state);
-
   useCustomStyleHook_unstable('useToolbarGroupStyles_unstable')(state);
+  useToolbarGroupStyles_unstable(state);
 
   return renderToolbarGroup_unstable(state);
   // Casting is required due to lack of distributive union to support unions on @types/react

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarToggleButton/ToolbarToggleButton.tsx
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarToggleButton/ToolbarToggleButton.tsx
@@ -12,9 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const ToolbarToggleButton: ForwardRefComponent<ToolbarToggleButtonProps> = React.forwardRef((props, ref) => {
   const state = useToolbarToggleButton_unstable(props, ref);
 
-  useToolbarToggleButtonStyles_unstable(state);
-
   useCustomStyleHook_unstable('useToolbarToggleButtonStyles_unstable')(state);
+  useToolbarToggleButtonStyles_unstable(state);
 
   return renderToggleButton_unstable(state);
 }) as ForwardRefComponent<ToolbarToggleButtonProps>;

--- a/packages/react-components/react-tooltip/library/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react-components/react-tooltip/library/src/components/Tooltip/Tooltip.tsx
@@ -12,9 +12,8 @@ import type { FluentTriggerComponent } from '@fluentui/react-utilities';
 export const Tooltip: React.FC<TooltipProps> = props => {
   const state = useTooltip_unstable(props);
 
-  useTooltipStyles_unstable(state);
-
   useCustomStyleHook_unstable('useTooltipStyles_unstable')(state);
+  useTooltipStyles_unstable(state);
 
   return renderTooltip_unstable(state);
 };

--- a/packages/react-components/react-tree/library/src/components/FlatTree/FlatTree.tsx
+++ b/packages/react-components/react-tree/library/src/components/FlatTree/FlatTree.tsx
@@ -16,8 +16,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const FlatTree: ForwardRefComponent<FlatTreeProps> = React.forwardRef((props, ref) => {
   const state = useFlatTree_unstable(props, ref);
   const contextValues = useFlatTreeContextValues_unstable(state);
-  useFlatTreeStyles_unstable(state);
   useCustomStyleHook_unstable('useFlatTreeStyles_unstable')(state);
+  useFlatTreeStyles_unstable(state);
 
   return renderFlatTree_unstable(state, contextValues);
 });

--- a/packages/react-components/react-tree/library/src/components/Tree/Tree.tsx
+++ b/packages/react-components/react-tree/library/src/components/Tree/Tree.tsx
@@ -14,8 +14,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const Tree: ForwardRefComponent<TreeProps> = React.forwardRef((props, ref) => {
   const state = useTree_unstable(props, ref);
   const contextValues = useTreeContextValues_unstable(state);
-  useTreeStyles_unstable(state);
   useCustomStyleHook_unstable('useTreeStyles_unstable')(state);
+  useTreeStyles_unstable(state);
 
   return renderTree_unstable(state, contextValues);
 });

--- a/packages/react-components/react-tree/library/src/components/TreeItem/TreeItem.tsx
+++ b/packages/react-components/react-tree/library/src/components/TreeItem/TreeItem.tsx
@@ -22,8 +22,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const TreeItem: ForwardRefComponent<TreeItemProps> = React.forwardRef((props, ref) => {
   const state = useTreeItem_unstable(props, ref);
 
-  useTreeItemStyles_unstable(state);
   useCustomStyleHook_unstable('useTreeItemStyles_unstable')(state);
+  useTreeItemStyles_unstable(state);
 
   const contextValues = useTreeItemContextValues_unstable(state);
   return renderTreeItem_unstable(state, contextValues);

--- a/packages/react-components/react-tree/library/src/components/TreeItemLayout/TreeItemLayout.tsx
+++ b/packages/react-components/react-tree/library/src/components/TreeItemLayout/TreeItemLayout.tsx
@@ -14,8 +14,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const TreeItemLayout: ForwardRefComponent<TreeItemLayoutProps> = React.forwardRef((props, ref) => {
   const state = useTreeItemLayout_unstable(props, ref);
 
-  useTreeItemLayoutStyles_unstable(state);
   useCustomStyleHook_unstable('useTreeItemLayoutStyles_unstable')(state);
+  useTreeItemLayoutStyles_unstable(state);
 
   return renderTreeItemLayout_unstable(state);
 });

--- a/packages/react-components/react-tree/library/src/components/TreeItemPersonaLayout/TreeItemPersonaLayout.tsx
+++ b/packages/react-components/react-tree/library/src/components/TreeItemPersonaLayout/TreeItemPersonaLayout.tsx
@@ -15,8 +15,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const TreeItemPersonaLayout: ForwardRefComponent<TreeItemPersonaLayoutProps> = React.forwardRef((props, ref) => {
   const state = useTreeItemPersonaLayout_unstable(props, ref);
 
-  useTreeItemPersonaLayoutStyles_unstable(state);
   useCustomStyleHook_unstable('useTreeItemPersonaLayoutStyles_unstable')(state);
+  useTreeItemPersonaLayoutStyles_unstable(state);
 
   const contextValues = useTreeItemPersonaLayoutContextValues_unstable(state);
 

--- a/packages/react-components/react-virtualizer/library/src/components/Virtualizer/Virtualizer.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/Virtualizer/Virtualizer.ts
@@ -12,8 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
  */
 export const Virtualizer: React.FC<VirtualizerProps> = (props: VirtualizerProps) => {
   const state = useVirtualizer_unstable(props);
-  useVirtualizerStyles_unstable(state);
   useCustomStyleHook_unstable('useVirtualizerStyles_unstable')(state);
+  useVirtualizerStyles_unstable(state);
 
   return renderVirtualizer_unstable(state);
 };

--- a/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollView/VirtualizerScrollView.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollView/VirtualizerScrollView.ts
@@ -12,8 +12,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 export const VirtualizerScrollView: React.FC<VirtualizerScrollViewProps> = (props: VirtualizerScrollViewProps) => {
   const state = useVirtualizerScrollView_unstable(props);
 
-  useVirtualizerScrollViewStyles_unstable(state);
   useCustomStyleHook_unstable('useVirtualizerScrollViewStyles_unstable')(state);
+  useVirtualizerScrollViewStyles_unstable(state);
 
   return renderVirtualizerScrollView_unstable(state);
 };

--- a/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollViewDynamic/VirtualizerScrollViewDynamic.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollViewDynamic/VirtualizerScrollViewDynamic.ts
@@ -16,8 +16,8 @@ export const VirtualizerScrollViewDynamic: React.FC<VirtualizerScrollViewDynamic
 ) => {
   const state = useVirtualizerScrollViewDynamic_unstable(props);
 
-  useVirtualizerScrollViewDynamicStyles_unstable(state);
   useCustomStyleHook_unstable('useVirtualizerScrollViewDynamicStyles_unstable')(state);
+  useVirtualizerScrollViewDynamicStyles_unstable(state);
 
   return renderVirtualizerScrollViewDynamic_unstable(state);
 };

--- a/tools/workspace-plugin/src/generators/react-component/files/component/__componentName__.tsx__tmpl__
+++ b/tools/workspace-plugin/src/generators/react-component/files/component/__componentName__.tsx__tmpl__
@@ -11,8 +11,6 @@ import type { <%= componentName %>Props } from './<%= componentName %>.types';
 export const <%= componentName %>: ForwardRefComponent<<%= componentName %>Props> = React.forwardRef((props, ref) => {
   const state = use<%= componentName %>_unstable(props, ref);
 
-  use<%= componentName %>Styles_unstable(state);
-
   /**
    * @see https://github.com/microsoft/fluentui/blob/master/docs/react-v9/contributing/rfcs/react-components/convergence/custom-styling.md
    *
@@ -22,6 +20,8 @@ export const <%= componentName %>: ForwardRefComponent<<%= componentName %>Props
    *      - verify that custom global style override works for your component
    */
   // useCustomStyleHook_unstable('use<%= componentName %>Styles_unstable')(state);
+
+  use<%= componentName %>Styles_unstable(state);
 
   return render<%= componentName %>_unstable(state);
 });

--- a/tools/workspace-plugin/src/generators/react-component/index.spec.ts
+++ b/tools/workspace-plugin/src/generators/react-component/index.spec.ts
@@ -109,8 +109,6 @@ describe('react-component generator', () => {
         (props, ref) => {
           const state = useMyOne_unstable(props, ref);
 
-          useMyOneStyles_unstable(state);
-
           /**
            * @see https://github.com/microsoft/fluentui/blob/master/docs/react-v9/contributing/rfcs/react-components/convergence/custom-styling.md
            *
@@ -120,6 +118,8 @@ describe('react-component generator', () => {
            *      - verify that custom global style override works for your component
            */
           // useCustomStyleHook_unstable('useMyOneStyles_unstable')(state);
+
+          useMyOneStyles_unstable(state);
 
           return renderMyOne_unstable(state);
         }


### PR DESCRIPTION
Reorder custom style hooks to avoid classname merging errors, see issue below for more information.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #34144
