### PR TITLE
chore: update tests in Tree.cy.tsx and enable in R18 suite

### DIFF
--- a/packages/react-components/react-tree/library/src/components/Tree/Tree.cy.tsx
+++ b/packages/react-components/react-tree/library/src/components/Tree/Tree.cy.tsx
@@ -1,5 +1,3 @@
-/* @TODO: Fix tests to run on React 18 */
-
 import 'cypress-real-events';
 import * as React from 'react';
 import { mount as mountBase } from '@cypress/react';
@@ -21,39 +19,45 @@ const mount = (element: JSX.Element) => {
 
 const TreeTest: React.FC<TreeProps> = props => {
   return (
-    <Tree id="tree" aria-label="Tree" {...props}>
-      {props.children ?? (
-        <>
-          <TreeItem itemType="branch" value="item1" data-testid="item1">
-            <TreeItemLayout>level 1, item 1</TreeItemLayout>
-            <Tree>
-              <TreeItem itemType="leaf" value="item1__item1" data-testid="item1__item1">
-                <TreeItemLayout>level 2, item 1</TreeItemLayout>
-              </TreeItem>
-              <TreeItem itemType="leaf" value="item1__item2" data-testid="item1__item2">
-                <TreeItemLayout>level 2, item 2</TreeItemLayout>
-              </TreeItem>
-              <TreeItem itemType="leaf" value="item1__item3" data-testid="item1__item3">
-                <TreeItemLayout>level 2, item 3</TreeItemLayout>
-              </TreeItem>
-            </Tree>
-          </TreeItem>
-          <TreeItem itemType="branch" value="item2" data-testid="item2">
-            <TreeItemLayout>level 1, item 2</TreeItemLayout>
-            <Tree>
-              <TreeItem itemType="branch" value="item2__item1" data-testid="item2__item1">
-                <TreeItemLayout>level 2, item 1</TreeItemLayout>
-                <Tree>
-                  <TreeItem itemType="leaf" value="item2__item1__item1" data-testid="item2__item1__item1">
-                    <TreeItemLayout>level 3, item 1</TreeItemLayout>
-                  </TreeItem>
-                </Tree>
-              </TreeItem>
-            </Tree>
-          </TreeItem>
-        </>
-      )}
-    </Tree>
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+      <button id="before-button">before button</button>
+
+      <Tree id="tree" aria-label="Tree" {...props}>
+        {props.children ?? (
+          <>
+            <TreeItem itemType="branch" value="item1" data-testid="item1">
+              <TreeItemLayout>level 1, item 1</TreeItemLayout>
+              <Tree>
+                <TreeItem itemType="leaf" value="item1__item1" data-testid="item1__item1">
+                  <TreeItemLayout>level 2, item 1</TreeItemLayout>
+                </TreeItem>
+                <TreeItem itemType="leaf" value="item1__item2" data-testid="item1__item2">
+                  <TreeItemLayout>level 2, item 2</TreeItemLayout>
+                </TreeItem>
+                <TreeItem itemType="leaf" value="item1__item3" data-testid="item1__item3">
+                  <TreeItemLayout>level 2, item 3</TreeItemLayout>
+                </TreeItem>
+              </Tree>
+            </TreeItem>
+            <TreeItem itemType="branch" value="item2" data-testid="item2">
+              <TreeItemLayout>level 1, item 2</TreeItemLayout>
+              <Tree>
+                <TreeItem itemType="branch" value="item2__item1" data-testid="item2__item1">
+                  <TreeItemLayout>level 2, item 1</TreeItemLayout>
+                  <Tree>
+                    <TreeItem itemType="leaf" value="item2__item1__item1" data-testid="item2__item1__item1">
+                      <TreeItemLayout>level 3, item 1</TreeItemLayout>
+                    </TreeItem>
+                  </Tree>
+                </TreeItem>
+              </Tree>
+            </TreeItem>
+          </>
+        )}
+      </Tree>
+
+      <button id="after-button">after button</button>
+    </div>
   );
 };
 TreeTest.displayName = 'Tree';
@@ -61,6 +65,7 @@ TreeTest.displayName = 'Tree';
 describe('Tree', () => {
   it('should have all but first level items hidden', () => {
     mount(<TreeTest />);
+
     cy.get('[data-testid="item1__item1"]').should('not.exist');
     cy.get('[data-testid="item1__item2"]').should('not.exist');
     cy.get('[data-testid="item1__item3"]').should('not.exist');
@@ -70,6 +75,7 @@ describe('Tree', () => {
 
   it('should have all items visible', () => {
     mount(<TreeTest defaultOpenItems={['item1', 'item2', 'item2__item1']} />);
+
     cy.get('[data-testid="item1__item1"]').should('exist');
     cy.get('[data-testid="item1__item2"]').should('exist');
     cy.get('[data-testid="item1__item3"]').should('exist');
@@ -80,12 +86,14 @@ describe('Tree', () => {
   describe('Mouse interactions', () => {
     it('should expand/collapse item on layout click', () => {
       mount(<TreeTest />);
+
       cy.get('[data-testid="item1__item1"]').should('not.exist');
       cy.get(`[data-testid="item1"] .${treeItemLayoutClassNames.root}`).realClick();
       cy.get('[data-testid="item1__item1"]').should('exist');
       cy.get(`[data-testid="item1"] .${treeItemLayoutClassNames.root}`).realClick();
       cy.get('[data-testid="item1__item1"]').should('not.exist');
     });
+
     it('should expand/collapse item on expandIcon click only', () => {
       const ExpandIconTest = () => {
         const [openItems, setOpenItems] = React.useState<Set<TreeItemValue>>(() => new Set());
@@ -102,7 +110,9 @@ describe('Tree', () => {
           />
         );
       };
+
       mount(<ExpandIconTest />);
+
       cy.get('[data-testid="item1__item1"]').should('not.exist');
       cy.get(`[data-testid="item1"] .${treeItemLayoutClassNames.expandIcon}`).realClick();
       cy.get('[data-testid="item1__item1"]').should('exist');
@@ -112,6 +122,7 @@ describe('Tree', () => {
       cy.get(`[data-testid="item1"] .${treeItemLayoutClassNames.root}`).realClick();
       cy.get('[data-testid="item1__item1"]').should('not.exist');
     });
+
     it('should not expand/collapse item on actions click', () => {
       mount(
         <TreeTest id="tree" aria-label="Tree">
@@ -125,52 +136,70 @@ describe('Tree', () => {
           </TreeItem>
         </TreeTest>,
       );
+
       cy.get('[data-testid="item1__item1"]').should('not.exist');
-      cy.get('[data-testid="item1"]').focus();
+      cy.get('#before-button').realClick().realPress('Tab');
+      cy.get('[data-testid="item1"]').should('be.focused');
       cy.get(`#action`).realClick();
       cy.get('[data-testid="item1__item1"]').should('not.exist');
     });
   });
+
   describe('Keyboard interactions', () => {
     it('should expand/collapse item on Enter key', () => {
       mount(<TreeTest />);
-      cy.get('[data-testid="item1"]').focus();
+
+      cy.get('#before-button').realClick().realPress('Tab');
+      cy.get('[data-testid="item1"]').should('be.focused');
       cy.get('[data-testid="item1__item1"]').should('not.exist');
       cy.get(`[data-testid="item1"] .${treeItemLayoutClassNames.root}`).realPress('{enter}');
       cy.get('[data-testid="item1__item1"]').should('exist');
     });
+
     it('should expand item on right key', () => {
       mount(<TreeTest />);
-      cy.get('[data-testid="item1"]').focus();
+
+      cy.get('#before-button').realClick().realPress('Tab');
+      cy.get('[data-testid="item1"]').should('be.focused');
       cy.get('[data-testid="item1__item1"]').should('not.exist');
       cy.get(`[data-testid="item1"] .${treeItemLayoutClassNames.root}`).realPress('{rightarrow}');
       cy.get('[data-testid="item1__item1"]').should('exist');
     });
+
     it('should not expand item on alt + right key', () => {
       mount(<TreeTest />);
-      cy.get('[data-testid="item1"]').focus();
+
+      cy.get('#before-button').realClick().realPress('Tab');
+      cy.get('[data-testid="item1"]').should('be.focused');
       cy.get('[data-testid="item1__item1"]').should('not.exist');
       cy.get(`[data-testid="item1"] .${treeItemLayoutClassNames.root}`).realPress(['Alt', 'ArrowRight']);
       cy.get('[data-testid="item1__item1"]').should('not.exist');
     });
+
     it('should collapse item on left key', () => {
       mount(<TreeTest />);
-      cy.get('[data-testid="item1"]').focus();
+
+      cy.get('#before-button').realClick().realPress('Tab');
+      cy.get('[data-testid="item1"]').should('be.focused');
       cy.get('[data-testid="item1__item1"]').should('not.exist');
       cy.get(`[data-testid="item1"] .${treeItemLayoutClassNames.root}`).realPress('{rightarrow}');
       cy.get('[data-testid="item1__item1"]').should('exist');
       cy.get(`[data-testid="item1"] .${treeItemLayoutClassNames.root}`).realPress('{leftarrow}');
       cy.get('[data-testid="item1__item1"]').should('not.exist');
     });
+
     it('should not collapse item on alt + left key', () => {
       mount(<TreeTest />);
-      cy.get('[data-testid="item1"]').focus();
+
+      cy.get('#before-button').realClick().realPress('Tab');
+      cy.get('[data-testid="item1"]').should('be.focused');
       cy.get('[data-testid="item1__item1"]').should('not.exist');
       cy.get(`[data-testid="item1"] .${treeItemLayoutClassNames.root}`).realPress('ArrowRight');
       cy.get('[data-testid="item1__item1"]').should('exist');
       cy.get(`[data-testid="item1"] .${treeItemLayoutClassNames.root}`).realPress(['Alt', 'ArrowLeft']);
       cy.get('[data-testid="item1__item1"]').should('exist');
     });
+
     it('should focus on actions when pressing tab key', () => {
       mount(
         <TreeTest id="tree" aria-label="Tree">
@@ -184,12 +213,13 @@ describe('Tree', () => {
           </TreeItem>
         </TreeTest>,
       );
-      cy.focused().should('not.exist');
-      cy.document().realPress('Tab');
+
+      cy.get('#before-button').realClick().realPress('Tab');
       cy.get('[data-testid="item1"]').should('be.focused');
-      cy.document().realPress('Tab');
+      cy.focused().realPress('Tab');
       cy.get('#action').should('be.focused');
     });
+
     describe('navigationMode="treegrid"', () => {
       it('should focus on actions/treeitem when pressing right/left arrow', () => {
         mount(
@@ -204,11 +234,14 @@ describe('Tree', () => {
             </TreeItem>
           </TreeTest>,
         );
-        cy.get('[data-testid="item1"]').focus().realPress('{rightarrow}');
+
+        cy.get('#before-button').realClick().realPress('Tab');
+        cy.get('[data-testid="item1"]').should('be.focused').realPress('{rightarrow}');
         cy.get('#action').should('be.focused').realPress('{leftarrow}');
         cy.get('[data-testid="item1"]').should('be.focused');
       });
     });
+
     it('should not expand/collapse item on actions Enter/Space key', () => {
       mount(
         <TreeTest id="tree" aria-label="Tree">
@@ -222,36 +255,43 @@ describe('Tree', () => {
           </TreeItem>
         </TreeTest>,
       );
-      cy.focused().should('not.exist');
-      cy.document().realPress('Tab');
+
+      cy.get('#before-button').realClick().realPress('Tab');
       cy.get('[data-testid="item1"]').should('be.focused');
-      cy.document().realPress('Tab');
+      cy.focused().realPress('Tab');
       cy.get('#action').should('be.focused').realPress('{enter}');
       cy.get('[data-testid="item1__item1"]').should('not.exist');
       cy.get('#action').should('be.focused').realPress('Space');
       cy.get('[data-testid="item1__item1"]').should('not.exist');
     });
+
     it('should focus on first item when pressing tab key', () => {
       mount(<TreeTest />);
-      cy.focused().should('not.exist');
-      cy.document().realPress('Tab');
+
+      cy.get('#before-button').realClick().realPress('Tab');
       cy.get('[data-testid="item1"]').should('be.focused');
     });
+
     it('should focus out of tree when pressing tab key inside tree.', () => {
       mount(<TreeTest />);
-      cy.focused().should('not.exist');
-      cy.document().realPress('Tab');
+
+      cy.get('#before-button').realClick().realPress('Tab');
       cy.get('[data-testid="item1"]').should('be.focused');
       cy.focused().realPress('Tab');
-      cy.focused().should('not.exist');
+      cy.focused().should('have.id', 'after-button');
     });
+
     describe('Navigation', () => {
       it('should move with Up/Down keys', () => {
         mount(<TreeTest />);
-        cy.get('[data-testid="item1"]').focus().realPress('{downarrow}');
+
+        cy.get('#before-button').realClick().realPress('Tab');
+        cy.get('[data-testid="item1"]').should('be.focused').realPress('{downarrow}');
         cy.get('[data-testid="item2"]').should('be.focused');
-        cy.focused().realPress('Tab').should('not.exist');
+        cy.focused().realPress('Tab');
+        cy.focused().should('have.id', 'after-button');
       });
+
       describe('navigationMode="treegrid"', () => {
         it('should move with Up/Down keys', () => {
           mount(
@@ -269,25 +309,34 @@ describe('Tree', () => {
               </TreeItem>
             </TreeTest>,
           );
-          cy.get('[data-testid="item1__item1"]').focus().realPress('{rightarrow}');
+
+          cy.get('#before-button').realClick().realPress('Tab');
+          cy.get('[data-testid="item1"]').should('be.focused').realPress('{downarrow}');
+          cy.get('[data-testid="item1__item1"]').should('be.focused').realPress('{rightarrow}');
           cy.get('#action').should('be.focused').realPress('{uparrow}');
-          cy.get('[data-testid="item1"]').should('be.focused');
-          cy.get('[data-testid="item1__item1"]').focus().realPress('{rightarrow}');
+          cy.get('[data-testid="item1"]').should('be.focused').realPress('{downarrow}');
+          cy.get('[data-testid="item1__item1"]').should('be.focused').realPress('{rightarrow}');
           cy.get('#action').should('be.focused').realPress('{downarrow}');
           cy.get('[data-testid="item1__item2"]').should('be.focused');
         });
+
         it('should move with Left keys', () => {
           mount(<TreeTest navigationMode="treegrid" defaultOpenItems={['item2', 'item2__item1']} />);
-          cy.get('[data-testid="item1"]').focus().realPress('{downarrow}');
+
+          cy.get('#before-button').realClick().realPress('Tab');
+          cy.get('[data-testid="item1"]').should('be.focused').realPress('{downarrow}');
           cy.get('[data-testid="item2"]').should('be.focused').realPress('{downarrow}');
           cy.get('[data-testid="item2__item1"]').should('be.focused').realPress('{downarrow}');
           cy.get('[data-testid="item2__item1__item1"]').should('be.focused').realPress('{leftarrow}');
           cy.get('[data-testid="item2__item1"]').should('be.focused').realPress('{leftarrow}').realPress('{leftarrow}');
           cy.get('[data-testid="item2"]').should('be.focused');
         });
+
         it('should not move with Alt + Left keys', () => {
           mount(<TreeTest navigationMode="treegrid" defaultOpenItems={['item2', 'item2__item1']} />);
-          cy.get('[data-testid="item1"]').focus().realPress('{downarrow}');
+
+          cy.get('#before-button').realClick().realPress('Tab');
+          cy.get('[data-testid="item1"]').should('be.focused').realPress('{downarrow}');
           cy.get('[data-testid="item2"]').should('be.focused').realPress('{downarrow}');
           cy.get('[data-testid="item2__item1"]').should('be.focused').realPress('{downarrow}');
           cy.get('[data-testid="item2__item1__item1"]').should('be.focused').realPress(['Alt', '{leftarrow}']);
@@ -296,17 +345,24 @@ describe('Tree', () => {
           cy.get('[data-testid="item2"]').should('be.focused');
         });
       });
+
       it('should move to last item with End key', () => {
         mount(<TreeTest defaultOpenItems={['item1', 'item2', 'item2__item1']} />);
-        cy.get('[data-testid="item1"]').focus().realPress('{end}');
+
+        cy.get('#before-button').realClick().realPress('Tab');
+        cy.get('[data-testid="item1"]').should('be.focused').realPress('{end}');
         cy.get('[data-testid="item2__item1__item1"]').should('be.focused');
       });
+
       it('should move to first item with Home key', () => {
         mount(<TreeTest defaultOpenItems={['item1', 'item2', 'item2__item1']} />);
-        cy.get('[data-testid="item1"]').focus().realPress('{end}');
+
+        cy.get('#before-button').realClick().realPress('Tab');
+        cy.get('[data-testid="item1"]').should('be.focused').realPress('{end}');
         cy.get('[data-testid="item2__item1__item1"]').should('be.focused').realPress('{home}');
         cy.get('[data-testid="item1"]').should('be.focused');
       });
+
       it('should prevent scrolling when `preventScroll()` is called in navigation', () => {
         mount(
           <TreeTest
@@ -322,11 +378,14 @@ describe('Tree', () => {
             ))}
           </TreeTest>,
         );
-        cy.get('[data-testid="item0"]').focus().realPress('{end}');
+
+        cy.get('#before-button').realClick().realPress('Tab');
+        cy.get('[data-testid="item0"]').should('be.focused').realPress('{end}');
         cy.get('[data-testid="item199"]').should('be.focused').isOutsideViewport();
       });
     });
   });
+
   describe('Keyboard + Mouse interactions', () => {
     it('actions should remain visible whenever a focused treeitem is hovered in/out', () => {
       mount(
@@ -344,8 +403,8 @@ describe('Tree', () => {
           </TreeItem>
         </TreeTest>,
       );
-      cy.focused().should('not.exist');
-      cy.document().realPress('Tab');
+
+      cy.get('#before-button').realClick().realPress('Tab');
       cy.get('[data-testid="item1"]').should('be.focused');
       cy.get('#action').should('be.visible').realHover();
       cy.get('[data-testid=item2]').realHover();
@@ -388,7 +447,9 @@ describe('Tree', () => {
           </Tree>
         );
       };
+
       mount(<OpenItemControlled />);
+
       cy.get('[data-testid="tree-item-1"]').should('exist');
       cy.get('[data-testid="tree-item-2"]').should('exist');
       cy.get('[data-testid="tree-item-2-1"]').should('not.exist');
@@ -396,6 +457,7 @@ describe('Tree', () => {
       cy.get('[data-testid="tree-item-1"]').realClick();
       cy.get('[data-testid="tree-item-1-1"]').should('exist');
     });
+
     it('should remain closed when opening/closing a controlled item', () => {
       const OpenItemControlled = () => {
         return (
@@ -430,12 +492,15 @@ describe('Tree', () => {
           </Tree>
         );
       };
+
       mount(<OpenItemControlled />);
+
       cy.get('[data-testid="tree-item-1"]').should('exist');
       cy.get('[data-testid="tree-item-1-1"]').should('not.exist');
       cy.get('[data-testid="tree-item-1"]').realClick();
       cy.get('[data-testid="tree-item-1-1"]').should('not.exist');
     });
+
     it('should not affect other items open state when opening/closing a controlled item', () => {
       const OpenItemControlled = () => {
         return (
@@ -470,7 +535,9 @@ describe('Tree', () => {
           </Tree>
         );
       };
+
       mount(<OpenItemControlled />);
+
       cy.get('[data-testid="tree-item-2"]').should('exist');
       cy.get('[data-testid="tree-item-2-1"]').should('exist');
       cy.get('[data-testid="tree-item-2-1-1"]').should('not.exist');
@@ -481,17 +548,16 @@ describe('Tree', () => {
 
   describe('roving tab indexes', () => {
     it('should ensure roving tab indexes when focusing programmatically', () => {
-      mount(
-        <>
-          <button id="btn-before-tree">before tree</button>
-          <TreeTest defaultOpenItems={['item1', 'item2', 'item2__item1']} />
-          <button id="btn-after-tree">after tree</button>
-        </>,
-      );
-      cy.get('#btn-before-tree').focus().realPress('Tab');
-      cy.get('[data-testid="item1"]').should('be.focused');
-      cy.get('[data-testid="item2__item1"]').focus().realPress('Tab');
-      cy.get('#btn-after-tree').should('be.focused').realPress(['Shift', 'Tab']);
+      mount(<TreeTest defaultOpenItems={['item1', 'item2', 'item2__item1']} />);
+
+      cy.get('#before-button').realClick().realPress('Tab');
+      cy.get('[data-testid="item1"]').should('be.focused').realPress('{downarrow}');
+      cy.get('[data-testid="item1__item1"]').should('be.focused').realPress('{downarrow}');
+      cy.get('[data-testid="item1__item2"]').should('be.focused').realPress('{downarrow}');
+      cy.get('[data-testid="item1__item3"]').should('be.focused').realPress('{downarrow}');
+      cy.get('[data-testid="item2"]').should('be.focused').realPress('{downarrow}');
+      cy.get('[data-testid="item2__item1"]').should('be.focused').realPress('Tab');
+      cy.get('#after-button').should('be.focused').realPress(['Shift', 'Tab']);
       cy.get('[data-testid="item2__item1"]').should('be.focused');
     });
 
@@ -526,7 +592,10 @@ describe('Tree', () => {
       };
 
       mount(<RovingTreeTest />);
-      cy.get('[data-testid="item1"]').should('have.attr', 'tabindex', '0').focus().realPress('ArrowDown');
+
+      cy.get('[data-testid="item1"]').should('have.attr', 'tabindex', '0');
+      cy.get('#before-button').realClick().realPress('Tab');
+      cy.get('[data-testid="item1"]').should('be.focused').realPress('{downarrow}');
       cy.get('[data-testid="item2"]')
         .should('be.focused')
         .should('have.attr', 'tabindex', '0')
@@ -570,9 +639,14 @@ describe('Tree', () => {
           </>
         );
       };
+
       mount(<RovingTreeTest />);
-      cy.get('[data-testid="item1"]').should('have.attr', 'tabindex', '0').focus().realPress('Enter');
-      cy.get('[data-testid="item1-1"]').should('exist').focus().should('have.attr', 'tabindex', '0');
+
+      cy.get('[data-testid="item1"]').should('have.attr', 'tabindex', '0');
+      cy.get('#btn-before-tree').realClick().realPress('Tab');
+      cy.get('[data-testid="item1"]').should('be.focused').realPress('Enter').realPress('{downarrow}');
+      cy.get('[data-testid="item1-1"]').should('be.focused').should('have.attr', 'tabindex', '0');
+
       cy.get('#btn-before-tree').realClick();
       cy.get('[data-testid="item1-1"]').should('not.exist');
       cy.get('[data-testid="item1"]').should('have.attr', 'tabindex', '0');
@@ -583,9 +657,10 @@ describe('Tree', () => {
         const [show, setShow] = React.useState(true);
         return (
           <>
-            <button onClick={() => setShow(current => !current)} id="btn-before-tree">
+            <button onClick={() => setShow(current => !current)} id="toggle-tree">
               toggle tree
             </button>
+            <button id="before-tree">before tree</button>
             <Tree>
               <TreeItem itemType="leaf" value="item1" data-testid="item1">
                 <TreeItemLayout>level 1, item 1</TreeItemLayout>
@@ -605,10 +680,14 @@ describe('Tree', () => {
           </>
         );
       };
+
       mount(<RovingTreeTest />);
-      cy.get('[data-testid="item1"]').should('have.attr', 'tabindex', '0').focus().realPress('ArrowDown');
+
+      cy.get('[data-testid="item1"]').should('have.attr', 'tabindex', '0');
+      cy.get('#before-tree').realClick().realPress('Tab');
+      cy.get('[data-testid="item1"]').should('be.focused').realPress('{downarrow}');
       cy.get('[data-testid="item2"]').should('be.focused').should('have.attr', 'tabindex', '0');
-      cy.get('#btn-before-tree').realClick();
+      cy.get('#toggle-tree').realClick();
       cy.get('[data-testid="item1"]').should('have.attr', 'tabindex', '0');
     });
 
@@ -635,7 +714,9 @@ describe('Tree', () => {
           </>
         );
       };
+
       mount(<RovingTreeTest />);
+
       cy.get('#btn-before-tree').realClick();
       cy.get('[data-testid="item1"]').should('have.attr', 'tabindex', '0');
       cy.get('[data-testid="item2"]').should('have.attr', 'tabindex', '-1');
@@ -652,6 +733,7 @@ describe('Tree', () => {
 describe('TreeItem', () => {
   it('should not call onClick when clicking on: expand icon, actions or subtree', () => {
     const handleClick = cy.stub().as('onClick');
+
     mount(
       <TreeTest id="tree" aria-label="Tree">
         <TreeItem open onClick={handleClick} itemType="branch" value="item1" data-testid="item1">
@@ -669,6 +751,7 @@ describe('TreeItem', () => {
         </TreeItem>
       </TreeTest>,
     );
+
     cy.get('[data-testid="item1__item1"]').should('exist');
     cy.get(`#action`).realClick();
     cy.get('[data-testid="item1__item1"]').realClick();


### PR DESCRIPTION
## New Behavior

Updates tests to use `.click()` as the first action. It makes tests more stable and predictable.

Functionality and assertions in tests are not affected.