### PR TITLE
chore: upload screenshots for failing tests

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -118,3 +118,12 @@ jobs:
 
       - name: Cypress/Playwright E2E tests
         run: yarn nx affected -t e2e --nxBail --parallel 1
+
+      - name: Upload Cypress screenshots if exist
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: cypress-screenshots
+          path: apps/*/cypress/screenshots/**/*.png
+            packages/**/cypress/screenshots/**/*.png
+          retention-days: 1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -124,6 +124,7 @@ jobs:
         if: failure()
         with:
           name: cypress-screenshots
-          path: apps/*/cypress/screenshots/**/*.png
+          path: |
+            apps/*/cypress/screenshots/**/*.png
             packages/**/cypress/screenshots/**/*.png
           retention-days: 1

--- a/packages/react-components/react-list/library/src/components/List/List.cy.tsx
+++ b/packages/react-components/react-list/library/src/components/List/List.cy.tsx
@@ -193,6 +193,7 @@ describe('List', () => {
           'UpArrow',
           'focused:list-item-1',
         ]);
+        expect(1).eq(2);
       });
 
       it('Home/End arrow keys work', () => {

--- a/packages/react-components/react-list/library/src/components/List/List.cy.tsx
+++ b/packages/react-components/react-list/library/src/components/List/List.cy.tsx
@@ -193,7 +193,6 @@ describe('List', () => {
           'UpArrow',
           'focused:list-item-1',
         ]);
-        expect(1).eq(2);
       });
 
       it('Home/End arrow keys work', () => {


### PR DESCRIPTION
## New Behavior

Currently there are flaky Cypress that fail. Due https://github.com/nrwl/nx/issues/30562 we cannot identify them.

Cypress captures screenshots for failed scenario, so by uploading them we can identify flaky tests.