### PR TITLE
chore:  slot api react v17/18 support

### DIFF
--- a/change/@fluentui-react-accordion-70e37d4f-804b-494a-9d94-31840668c018.json
+++ b/change/@fluentui-react-accordion-70e37d4f-804b-494a-9d94-31840668c018.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "chore: slot api react v17/18 support",
+  "packageName": "@fluentui/react-accordion",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-aria-7315db23-bdae-4372-8c87-60449326a492.json
+++ b/change/@fluentui-react-aria-7315db23-bdae-4372-8c87-60449326a492.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "chore: slot api react v17/18 support",
+  "packageName": "@fluentui/react-aria",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-dialog-ca8b08cc-1dd4-48ef-bca4-dbc92125076d.json
+++ b/change/@fluentui-react-dialog-ca8b08cc-1dd4-48ef-bca4-dbc92125076d.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "chore: slot api react v17/18 support",
+  "packageName": "@fluentui/react-dialog",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-drawer-e41fbdeb-e121-4581-b878-3e5b347014d2.json
+++ b/change/@fluentui-react-drawer-e41fbdeb-e121-4581-b878-3e5b347014d2.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "chore: slot api react v17/18 support",
+  "packageName": "@fluentui/react-drawer",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-menu-0ff32a7c-9022-4bb0-a248-a264c594dd8d.json
+++ b/change/@fluentui-react-menu-0ff32a7c-9022-4bb0-a248-a264c594dd8d.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "chore: slot api react v17/18 support",
+  "packageName": "@fluentui/react-menu",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-migration-v0-v9-cd6b824f-ed5f-42f2-a7f1-7dc092156272.json
+++ b/change/@fluentui-react-migration-v0-v9-cd6b824f-ed5f-42f2-a7f1-7dc092156272.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "chore: slot api react v17/18 support",
+  "packageName": "@fluentui/react-migration-v0-v9",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-motion-144e4fd8-32af-4d8f-884f-0fc35f3fc444.json
+++ b/change/@fluentui-react-motion-144e4fd8-32af-4d8f-884f-0fc35f3fc444.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "chore: slot api react v17/18 support",
+  "packageName": "@fluentui/react-motion",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-search-85a9961d-3d0a-436a-95a5-ebf0cc3e8078.json
+++ b/change/@fluentui-react-search-85a9961d-3d0a-436a-95a5-ebf0cc3e8078.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "chore: slot api react v17/18 support",
+  "packageName": "@fluentui/react-search",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-table-23e6ee8d-8a67-46de-b73b-f91e33ff9620.json
+++ b/change/@fluentui-react-table-23e6ee8d-8a67-46de-b73b-f91e33ff9620.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "chore: slot api react v17/18 support",
+  "packageName": "@fluentui/react-table",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tabs-82a0e2be-25f8-446a-ad2f-0a7eea97d9b3.json
+++ b/change/@fluentui-react-tabs-82a0e2be-25f8-446a-ad2f-0a7eea97d9b3.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "chore: slot api react v17/18 support",
+  "packageName": "@fluentui/react-tabs",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tag-picker-8e7b7750-4364-47ef-882a-6a1fe583a08f.json
+++ b/change/@fluentui-react-tag-picker-8e7b7750-4364-47ef-882a-6a1fe583a08f.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "chore: slot api react v17/18 support",
+  "packageName": "@fluentui/react-tag-picker",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-toast-b8edc307-0cbe-4c48-a497-983989809ad7.json
+++ b/change/@fluentui-react-toast-b8edc307-0cbe-4c48-a497-983989809ad7.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "chore: slot api react v17/18 support",
+  "packageName": "@fluentui/react-toast",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tree-050271d4-8526-4aaa-a0ec-3f009240b858.json
+++ b/change/@fluentui-react-tree-050271d4-8526-4aaa-a0ec-3f009240b858.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "chore: slot api react v17/18 support",
+  "packageName": "@fluentui/react-tree",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-utilities-158b5bca-5551-4171-a402-6023509a0626.json
+++ b/change/@fluentui-react-utilities-158b5bca-5551-4171-a402-6023509a0626.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "chore: slot api react v17/18 support",
+  "packageName": "@fluentui/react-utilities",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-virtualizer-66488148-0108-4253-a5e2-c4b61e9dc30b.json
+++ b/change/@fluentui-react-virtualizer-66488148-0108-4253-a5e2-c4b61e9dc30b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: slot api react v17/18 support",
+  "packageName": "@fluentui/react-virtualizer",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-accordion/library/src/components/AccordionPanel/useAccordionPanel.ts
+++ b/packages/react-components/react-accordion/library/src/components/AccordionPanel/useAccordionPanel.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { getIntrinsicElementProps, slot } from '@fluentui/react-utilities';
 import { useTabsterAttributes } from '@fluentui/react-tabster';
-import { presenceMotionSlot, type PresenceMotionSlotProps } from '@fluentui/react-motion';
+import { presenceMotionSlot } from '@fluentui/react-motion';
 import { Collapse } from '@fluentui/react-motion-components-preview';
 import { useAccordionContext_unstable } from '../../contexts/accordion';
 import type { AccordionPanelProps, AccordionPanelState } from './AccordionPanel.types';
@@ -24,11 +24,7 @@ export const useAccordionPanel_unstable = (
     open,
     components: {
       root: 'div',
-      // TODO: remove once React v18 slot API is modified
-      // This is a problem at the moment due to UnknownSlotProps assumption
-      // that `children` property is `ReactNode`, which in this case is not valid
-      // as PresenceComponentProps['children'] is `ReactElement`
-      collapseMotion: Collapse as React.FC<PresenceMotionSlotProps>,
+      collapseMotion: Collapse,
     },
     root: slot.always(
       getIntrinsicElementProps('div', {

--- a/packages/react-components/react-aria/library/etc/react-aria.api.md
+++ b/packages/react-components/react-aria/library/etc/react-aria.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import type { AnnounceContextValue } from '@fluentui/react-shared-contexts';
+import type { DistributiveOmit } from '@fluentui/react-utilities';
 import type { ExtractSlotProps } from '@fluentui/react-utilities';
 import * as React_2 from 'react';
 import type { ResolveShorthandFunction } from '@fluentui/react-utilities';
@@ -73,7 +74,7 @@ export type ARIAButtonElement<AlternateAs extends 'a' | 'div' = 'a' | 'div'> = H
 export type ARIAButtonElementIntersection<AlternateAs extends 'a' | 'div' = 'a' | 'div'> = UnionToIntersection<ARIAButtonElement<AlternateAs>>;
 
 // @public
-export type ARIAButtonProps<Type extends ARIAButtonType = ARIAButtonType> = React_2.PropsWithRef<JSX.IntrinsicElements[Type]> & {
+export type ARIAButtonProps<Type extends ARIAButtonType = ARIAButtonType> = DistributiveOmit<React_2.PropsWithRef<JSX.IntrinsicElements[Type]>, 'children'> & {
     disabled?: boolean;
     disabledFocusable?: boolean;
 };

--- a/packages/react-components/react-aria/library/src/button/types.ts
+++ b/packages/react-components/react-aria/library/src/button/types.ts
@@ -1,4 +1,4 @@
-import type { ExtractSlotProps, Slot, UnionToIntersection } from '@fluentui/react-utilities';
+import type { DistributiveOmit, ExtractSlotProps, Slot, UnionToIntersection } from '@fluentui/react-utilities';
 import * as React from 'react';
 
 export type ARIAButtonType = 'button' | 'a' | 'div';
@@ -18,8 +18,9 @@ export type ARIAButtonElementIntersection<AlternateAs extends 'a' | 'div' = 'a' 
 /**
  * Props expected by `useARIAButtonProps` hooks
  */
-export type ARIAButtonProps<Type extends ARIAButtonType = ARIAButtonType> = React.PropsWithRef<
-  JSX.IntrinsicElements[Type]
+export type ARIAButtonProps<Type extends ARIAButtonType = ARIAButtonType> = DistributiveOmit<
+  React.PropsWithRef<JSX.IntrinsicElements[Type]>,
+  'children'
 > & {
   disabled?: boolean;
   /**

--- a/packages/react-components/react-aria/library/src/button/useARIAButtonShorthand.ts
+++ b/packages/react-components/react-aria/library/src/button/useARIAButtonShorthand.ts
@@ -14,10 +14,10 @@ import type { ARIAButtonProps, ARIAButtonSlotProps, ARIAButtonType } from './typ
  * for multiple scenarios of shorthand properties. Ensuring 1st rule of ARIA for cases
  * where no attribute addition is required.
  */
-// eslint-disable-next-line @typescript-eslint/no-deprecated
 export const useARIAButtonShorthand = ((value, options) => {
   // eslint-disable-next-line @typescript-eslint/no-deprecated
   const shorthand = resolveShorthand(value, options);
   const shorthandARIAButton = useARIAButtonProps<ARIAButtonType, ARIAButtonProps>(shorthand?.as ?? 'button', shorthand);
   return shorthand && shorthandARIAButton;
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
 }) as ResolveShorthandFunction<ARIAButtonSlotProps>;

--- a/packages/react-components/react-aria/library/src/button/useARIAButtonShorthand.ts
+++ b/packages/react-components/react-aria/library/src/button/useARIAButtonShorthand.ts
@@ -15,9 +15,9 @@ import type { ARIAButtonProps, ARIAButtonSlotProps, ARIAButtonType } from './typ
  * where no attribute addition is required.
  */
 // eslint-disable-next-line @typescript-eslint/no-deprecated
-export const useARIAButtonShorthand: ResolveShorthandFunction<ARIAButtonSlotProps> = (value, options) => {
+export const useARIAButtonShorthand = ((value, options) => {
   // eslint-disable-next-line @typescript-eslint/no-deprecated
   const shorthand = resolveShorthand(value, options);
   const shorthandARIAButton = useARIAButtonProps<ARIAButtonType, ARIAButtonProps>(shorthand?.as ?? 'button', shorthand);
   return shorthand && shorthandARIAButton;
-};
+}) as ResolveShorthandFunction<ARIAButtonSlotProps>;

--- a/packages/react-components/react-dialog/library/src/components/Dialog/useDialog.ts
+++ b/packages/react-components/react-dialog/library/src/components/Dialog/useDialog.ts
@@ -1,6 +1,6 @@
 import { useHasParentContext } from '@fluentui/react-context-selector';
 import { useModalAttributes } from '@fluentui/react-tabster';
-import { presenceMotionSlot, type PresenceMotionSlotProps } from '@fluentui/react-motion';
+import { presenceMotionSlot } from '@fluentui/react-motion';
 import { useControllableState, useEventCallback, useId } from '@fluentui/react-utilities';
 import * as React from 'react';
 
@@ -48,11 +48,7 @@ export const useDialog_unstable = (props: DialogProps): DialogState => {
 
   return {
     components: {
-      // TODO: remove once React v18 slot API is modified
-      // This is a problem at the moment due to UnknownSlotProps assumption
-      // that `children` property is `ReactNode`, which in this case is not valid
-      // as PresenceComponentProps['children'] is `ReactElement`
-      surfaceMotion: DialogSurfaceMotion as React.FC<PresenceMotionSlotProps>,
+      surfaceMotion: DialogSurfaceMotion,
     },
     inertTrapFocus,
     open,

--- a/packages/react-components/react-dialog/library/src/components/DialogSurface/useDialogSurface.ts
+++ b/packages/react-components/react-dialog/library/src/components/DialogSurface/useDialogSurface.ts
@@ -1,5 +1,5 @@
 import { Escape } from '@fluentui/keyboard-keys';
-import { presenceMotionSlot, type PresenceMotionSlotProps } from '@fluentui/react-motion';
+import { presenceMotionSlot } from '@fluentui/react-motion';
 import {
   useEventCallback,
   useMergedRefs,
@@ -97,11 +97,7 @@ export const useDialogSurface_unstable = (
     components: {
       backdrop: 'div',
       root: 'div',
-      // TODO: remove once React v18 slot API is modified
-      // This is a problem at the moment due to UnknownSlotProps assumption
-      // that `children` property is `ReactNode`, which in this case is not valid
-      // as PresenceComponentProps['children'] is `ReactElement`
-      backdropMotion: DialogBackdropMotion as React.FC<PresenceMotionSlotProps>,
+      backdropMotion: DialogBackdropMotion,
     },
     open,
     backdrop,

--- a/packages/react-components/react-drawer/library/src/components/DrawerHeaderTitle/useDrawerHeaderTitleStyles.styles.ts
+++ b/packages/react-components/react-drawer/library/src/components/DrawerHeaderTitle/useDrawerHeaderTitleStyles.styles.ts
@@ -35,6 +35,11 @@ export const useDrawerHeaderTitleStyles_unstable = (state: DrawerHeaderTitleStat
 
   const styles = useStyles();
 
+  // We should not use components to pass along the base element type of a slot
+  // but there's no way to retrieve the element type of a slot from the slot definition
+  // right now without using SLOT_ELEMENT_TYPE_SYMBOL
+  // TODO: create a method to retrieve the element type of a slot
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   const { heading: root = {}, action, components } = state;
 
   useDialogTitleStyles_unstable({

--- a/packages/react-components/react-jsx-runtime/src/interop.test.tsx
+++ b/packages/react-components/react-jsx-runtime/src/interop.test.tsx
@@ -171,6 +171,7 @@ describe('resolveShorthand with assertSlots', () => {
       const TestComponent = (props: TestComponentProps) => {
         const higherOrderState = useHigherOrderStateHook(props);
         const state: TestComponentState = {
+          // eslint-disable-next-line @typescript-eslint/no-deprecated
           components: { ...higherOrderState.components, slot: 'span' },
           slot: {
             ...higherOrderState.slot,

--- a/packages/react-components/react-menu/library/src/components/MenuItem/useMenuItem.tsx
+++ b/packages/react-components/react-menu/library/src/components/MenuItem/useMenuItem.tsx
@@ -5,6 +5,7 @@ import {
   getIntrinsicElementProps,
   slot,
   useIsomorphicLayoutEffect,
+  omit,
 } from '@fluentui/react-utilities';
 import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
 import { useCharacterSearch } from './useCharacterSearch';
@@ -37,7 +38,13 @@ const ChevronLeftIcon = bundleIcon(ChevronLeftFilled, ChevronLeftRegular);
 export const useMenuItem_unstable = (props: MenuItemProps, ref: React.Ref<ARIAButtonElement<'div'>>): MenuItemState => {
   const isSubmenuTrigger = useMenuTriggerContext_unstable();
   const persistOnClickContext = useMenuContext_unstable(context => context.persistOnItemClick);
-  const { as = 'div', disabled = false, hasSubmenu = isSubmenuTrigger, persistOnClick = persistOnClickContext } = props;
+  const {
+    as = 'div',
+    disabled = false,
+    hasSubmenu = isSubmenuTrigger,
+    persistOnClick = persistOnClickContext,
+    ...rest
+  } = props;
   const { hasIcons, hasCheckmarks } = useIconAndCheckmarkAlignment({ hasSubmenu });
   const setOpen = useMenuContext_unstable(context => context.setOpen);
   useNotifySplitItemMultiline({ multiline: !!props.subText, hasSubmenu });
@@ -60,11 +67,12 @@ export const useMenuItem_unstable = (props: MenuItemProps, ref: React.Ref<ARIABu
       subText: 'span',
     },
     root: slot.always(
-      getIntrinsicElementProps(
+      getIntrinsicElementProps<MenuItemProps, 'content'>(
         as,
         useARIAButtonProps<'div', ARIAButtonProps<'div'>>(as, {
           role: 'menuitem',
-          ...props,
+          // `content` is a slot and it's type clashes with the HTMLElement `content` attribute
+          ...omit(rest, ['content']),
           disabled: false,
           disabledFocusable: disabled,
           ref: useMergedRefs(ref, innerRef) as React.Ref<ARIAButtonElementIntersection<'div'>>,
@@ -96,6 +104,7 @@ export const useMenuItem_unstable = (props: MenuItemProps, ref: React.Ref<ARIABu
             props.onClick?.(event);
           }),
         }),
+        ['content'],
       ),
       { elementType: 'div' },
     ),

--- a/packages/react-components/react-menu/library/src/components/MenuItemLink/useMenuItemLink.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuItemLink/useMenuItemLink.ts
@@ -27,6 +27,7 @@ export const useMenuItemLink_unstable = (
   return {
     ...baseState,
     components: {
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       ...baseState.components,
       root: 'a',
     },

--- a/packages/react-components/react-menu/library/src/components/MenuItemSwitch/useMenuItemSwitch.tsx
+++ b/packages/react-components/react-menu/library/src/components/MenuItemSwitch/useMenuItemSwitch.tsx
@@ -29,6 +29,7 @@ export const useMenuItemSwitch_unstable = (
       },
     }),
     components: {
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       ...baseState.components,
       switchIndicator: 'span',
     },

--- a/packages/react-components/react-menu/library/src/components/MenuItemSwitch/useMenuItemSwitchStyles.styles.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuItemSwitch/useMenuItemSwitchStyles.styles.ts
@@ -135,6 +135,7 @@ export const useMenuItemSwitchStyles_unstable = (state: MenuItemSwitchState): Me
   useMenuItemStyles_unstable({
     ...state,
     components: {
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       ...state.components,
       checkmark: 'span',
       submenuIndicator: 'span',

--- a/packages/react-components/react-migration-v0-v9/library/etc/react-migration-v0-v9.api.md
+++ b/packages/react-components/react-migration-v0-v9/library/etc/react-migration-v0-v9.api.md
@@ -21,7 +21,6 @@ import type { SelectionMode as SelectionMode_2 } from '@fluentui/react-utilities
 import { Slot } from '@fluentui/react-components';
 import { Slot as Slot_2 } from '@fluentui/react-utilities';
 import type { SlotClassNames } from '@fluentui/react-utilities';
-import { SlotRenderFunction } from '@fluentui/react-utilities';
 
 // @public (undocumented)
 export const Attachment: React_2.ForwardRefExoticComponent<AttachmentProps & React_2.RefAttributes<HTMLDivElement>>;
@@ -157,12 +156,10 @@ export const input: {
 // @public (undocumented)
 export const ItemLayout: React_2.ForwardRefExoticComponent<Omit<ItemLayoutSlots, "root"> & Omit<{
     as?: "div" | undefined;
-} & Pick<React_2.DetailedHTMLProps<React_2.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, "key" | keyof React_2.HTMLAttributes<HTMLDivElement>> & {
+} & Omit<Pick<React_2.DetailedHTMLProps<React_2.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, "key" | keyof React_2.HTMLAttributes<HTMLDivElement>> & {
     ref?: ((instance: HTMLDivElement | null) => void) | React_2.RefObject<HTMLDivElement> | null | undefined;
-} & {
-    children?: React_2.ReactNode | SlotRenderFunction<Pick<React_2.DetailedHTMLProps<React_2.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, "key" | keyof React_2.HTMLAttributes<HTMLDivElement>> & {
-    ref?: ((instance: HTMLDivElement | null) => void) | React_2.RefObject<HTMLDivElement> | null | undefined;
-    }>;
+}, "children"> & {
+    children?: any;
 }, "ref"> & React_2.RefAttributes<HTMLDivElement>>;
 
 // @public (undocumented)

--- a/packages/react-components/react-motion/library/src/slots/presenceMotionSlot.tsx
+++ b/packages/react-components/react-motion/library/src/slots/presenceMotionSlot.tsx
@@ -30,8 +30,6 @@ export type PresenceMotionSlotProps<MotionParams extends Record<string, MotionPa
    */
   as?: keyof JSX.IntrinsicElements;
 
-  // TODO: remove once React v18 slot API is modified ComponentProps is not properly adding render function as a
-  //       possible value for children
   children?: SlotRenderFunction<PresenceMotionSlotRenderProps & MotionParams & { children: React.ReactElement }>;
 };
 

--- a/packages/react-components/react-provider/stories/src/Provider/FluentProviderFrame.stories.tsx
+++ b/packages/react-components/react-provider/stories/src/Provider/FluentProviderFrame.stories.tsx
@@ -53,7 +53,7 @@ const FrameRenderer: React.FunctionComponent<FrameRendererProps> = ({ children }
   );
 };
 
-const Example: React.FC = props => {
+const Example: React.FC<React.PropsWithChildren<{}>> = props => {
   const styles = useExampleStyles();
 
   return (

--- a/packages/react-components/react-search/library/src/components/SearchBox/useSearchBox.tsx
+++ b/packages/react-components/react-search/library/src/components/SearchBox/useSearchBox.tsx
@@ -111,6 +111,7 @@ export const useSearchBox_unstable = (props: SearchBoxProps, ref: React.Ref<HTML
   const state: SearchBoxState = {
     ...inputState,
     components: {
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       ...inputState.components,
       dismiss: 'span',
     },

--- a/packages/react-components/react-table/library/src/components/DataGridBody/DataGridBody.tsx
+++ b/packages/react-components/react-table/library/src/components/DataGridBody/DataGridBody.tsx
@@ -10,14 +10,16 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
  * DataGridBody component
  */
 export const DataGridBody: ForwardRefComponent<DataGridBodyProps> &
-  (<TItem>(props: DataGridBodyProps<TItem>) => JSX.Element) = React.forwardRef((props, ref) => {
-  const state = useDataGridBody_unstable(props, ref);
+  (<TItem>(props: DataGridBodyProps<TItem>) => JSX.Element) = React.forwardRef<HTMLElement, DataGridBodyProps>(
+  (props, ref) => {
+    const state = useDataGridBody_unstable(props, ref);
 
-  useDataGridBodyStyles_unstable(state);
+    useDataGridBodyStyles_unstable(state);
 
-  useCustomStyleHook_unstable('useDataGridBodyStyles_unstable')(state);
+    useCustomStyleHook_unstable('useDataGridBodyStyles_unstable')(state);
 
-  return renderDataGridBody_unstable(state);
-}) as ForwardRefComponent<DataGridBodyProps> & (<TItem>(props: DataGridBodyProps<TItem>) => JSX.Element);
+    return renderDataGridBody_unstable(state);
+  },
+) as ForwardRefComponent<DataGridBodyProps> & (<TItem>(props: DataGridBodyProps<TItem>) => JSX.Element);
 
 DataGridBody.displayName = 'DataGridBody';

--- a/packages/react-components/react-table/library/src/components/DataGridRow/DataGridRow.tsx
+++ b/packages/react-components/react-table/library/src/components/DataGridRow/DataGridRow.tsx
@@ -10,14 +10,16 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
  * DataGridRow component
  */
 export const DataGridRow: ForwardRefComponent<DataGridRowProps> &
-  (<TItem>(props: DataGridRowProps<TItem>) => JSX.Element) = React.forwardRef((props, ref) => {
-  const state = useDataGridRow_unstable(props, ref);
+  (<TItem>(props: DataGridRowProps<TItem>) => JSX.Element) = React.forwardRef<HTMLElement, DataGridRowProps>(
+  (props, ref) => {
+    const state = useDataGridRow_unstable(props, ref);
 
-  useDataGridRowStyles_unstable(state);
+    useDataGridRowStyles_unstable(state);
 
-  useCustomStyleHook_unstable('useDataGridRowStyles_unstable')(state);
+    useCustomStyleHook_unstable('useDataGridRowStyles_unstable')(state);
 
-  return renderDataGridRow_unstable(state);
-}) as ForwardRefComponent<DataGridRowProps> & (<TItem>(props: DataGridRowProps<TItem>) => JSX.Element);
+    return renderDataGridRow_unstable(state);
+  },
+) as ForwardRefComponent<DataGridRowProps> & (<TItem>(props: DataGridRowProps<TItem>) => JSX.Element);
 
 DataGridRow.displayName = 'DataGridRow';

--- a/packages/react-components/react-table/library/src/components/DataGridRow/useDataGridRow.tsx
+++ b/packages/react-components/react-table/library/src/components/DataGridRow/useDataGridRow.tsx
@@ -72,6 +72,7 @@ export const useDataGridRow_unstable = (props: DataGridRowProps, ref: React.Ref<
   return {
     ...baseState,
     components: {
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       ...baseState.components,
       selectionCell: DataGridSelectionCell,
     },

--- a/packages/react-components/react-table/library/src/components/TableCellLayout/useTableCellLayout.ts
+++ b/packages/react-components/react-table/library/src/components/TableCellLayout/useTableCellLayout.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getIntrinsicElementProps, slot } from '@fluentui/react-utilities';
+import { getIntrinsicElementProps, slot, omit } from '@fluentui/react-utilities';
 import type { TableCellLayoutProps, TableCellLayoutState } from './TableCellLayout.types';
 import { useTableContext } from '../../contexts/tableContext';
 
@@ -38,7 +38,8 @@ export const useTableCellLayout_unstable = (
         // `ref` is wrongly assigned to be `HTMLElement` instead of `HTMLDivElement`
         // but since it would be a breaking change to fix it, we are casting ref to it's proper type
         ref: ref as React.Ref<HTMLDivElement>,
-        ...props,
+        // `content` is a slot and it's type clashes with the HTMLElement `content` attribute
+        ...omit(props, ['content']),
       }),
       { elementType: 'div' },
     ),

--- a/packages/react-components/react-table/library/src/components/TableSelectionCell/useTableSelectionCell.tsx
+++ b/packages/react-components/react-table/library/src/components/TableSelectionCell/useTableSelectionCell.tsx
@@ -34,6 +34,7 @@ export const useTableSelectionCell_unstable = (
   return {
     ...tableCellState,
     components: {
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       ...tableCellState.components,
       checkboxIndicator: Checkbox,
       radioIndicator: Radio,

--- a/packages/react-components/react-tabs/library/src/components/Tab/useTab.ts
+++ b/packages/react-components/react-tabs/library/src/components/Tab/useTab.ts
@@ -78,7 +78,8 @@ export const useTab_unstable = (props: TabProps, ref: React.Ref<HTMLElement>): T
         // according to https://www.w3.org/TR/wai-aria-1.1/#aria-selected
         'aria-selected': disabled ? undefined : (`${selected}` as 'true' | 'false'),
         ...focusProps,
-        ...props,
+        // `content` is a slot and it's type clashes with the HTMLElement `content` attribute
+        ...omit(props, ['content']),
         disabled,
         onClick: onTabClick,
         onFocus: selectTabOnFocus ? onTabFocus : onFocus,

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerOption/useTagPickerOption.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerOption/useTagPickerOption.ts
@@ -19,6 +19,7 @@ export const useTagPickerOption_unstable = (
   const optionState = useOption_unstable(props, ref);
   const state: TagPickerOptionState = {
     components: {
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       ...optionState.components,
       media: 'div',
       secondaryContent: 'span',

--- a/packages/react-components/react-toast/library/src/components/ToastContainer/useToastContainer.ts
+++ b/packages/react-components/react-toast/library/src/components/ToastContainer/useToastContainer.ts
@@ -7,6 +7,7 @@ import {
   useEventCallback,
   useId,
   slot,
+  omit,
 } from '@fluentui/react-utilities';
 import { useFluent_unstable } from '@fluentui/react-shared-contexts';
 import { Delete, Tab } from '@fluentui/keyboard-keys';
@@ -210,7 +211,8 @@ export const useToastContainer_unstable = (
         role: 'listitem',
         'aria-labelledby': titleId,
         'aria-describedby': bodyId,
-        ...rest,
+        // The `content` type doesn't match the HTMLElement `content` attribute
+        ...omit(rest, ['content']),
         ...userRootSlot,
         ...focusableGroupAttribute,
         onMouseEnter,

--- a/packages/react-components/react-tree/library/src/hooks/useRootTree.ts
+++ b/packages/react-components/react-tree/library/src/hooks/useRootTree.ts
@@ -2,7 +2,6 @@ import { getIntrinsicElementProps, useEventCallback, slot } from '@fluentui/reac
 import type { TreeCheckedChangeData, TreeProps, TreeState } from '../Tree';
 import * as React from 'react';
 import { Collapse } from '@fluentui/react-motion-components-preview';
-import { PresenceMotionSlotProps } from '@fluentui/react-motion';
 import { TreeContextValue, TreeItemRequest } from '../contexts/treeContext';
 import { createCheckedItems } from '../utils/createCheckedItems';
 import { treeDataTypes } from '../utils/tokens';
@@ -80,11 +79,7 @@ export function useRootTree(
   return {
     components: {
       root: 'div',
-      // TODO: remove once React v18 slot API is modified
-      // This is a problem at the moment due to UnknownSlotProps assumption
-      // that `children` property is `ReactNode`, which in this case is not valid
-      // as PresenceComponentProps['children'] is `ReactElement`
-      collapseMotion: Collapse as React.FC<PresenceMotionSlotProps>,
+      collapseMotion: Collapse,
     },
     contextType: 'root',
     selectionMode,

--- a/packages/react-components/react-tree/library/src/hooks/useSubtree.ts
+++ b/packages/react-components/react-tree/library/src/hooks/useSubtree.ts
@@ -3,7 +3,7 @@ import { TreeProps, TreeState } from '../Tree';
 import { SubtreeContextValue, useSubtreeContext_unstable, useTreeItemContext_unstable } from '../contexts/index';
 import { getIntrinsicElementProps, useMergedRefs, slot } from '@fluentui/react-utilities';
 import { Collapse } from '@fluentui/react-motion-components-preview';
-import { presenceMotionSlot, PresenceMotionSlotProps } from '@fluentui/react-motion';
+import { presenceMotionSlot } from '@fluentui/react-motion';
 
 /**
  * Create the state required to render a sub-level tree.
@@ -26,11 +26,7 @@ export function useSubtree(
     open,
     components: {
       root: 'div',
-      // TODO: remove once React v18 slot API is modified
-      // This is a problem at the moment due to UnknownSlotProps assumption
-      // that `children` property is `ReactNode`, which in this case is not valid
-      // as PresenceComponentProps['children'] is `ReactElement`
-      collapseMotion: Collapse as React.FC<PresenceMotionSlotProps>,
+      collapseMotion: Collapse,
     },
     level: parentLevel + 1,
     root: slot.always(

--- a/packages/react-components/react-utilities/src/compose/assertSlots.ts
+++ b/packages/react-components/react-utilities/src/compose/assertSlots.ts
@@ -34,6 +34,7 @@ export function assertSlots<Slots extends SlotPropsRecord>(state: unknown): asse
    */
   if (process.env.NODE_ENV !== 'production') {
     const typedState = state as ComponentState<Slots>;
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     for (const slotName of Object.keys(typedState.components)) {
       const slotElement = typedState[slotName];
       if (slotElement === undefined) {
@@ -44,6 +45,7 @@ export function assertSlots<Slots extends SlotPropsRecord>(state: unknown): asse
       // FIXME: this slot will still fail to support child render function scenario
       if (!isSlot(slotElement)) {
         typedState[slotName as keyof ComponentState<Slots>] = slot.always(slotElement, {
+          // eslint-disable-next-line @typescript-eslint/no-deprecated
           elementType: typedState.components[slotName] as React.ComponentType<{}>,
         }) as ComponentState<Slots>[keyof ComponentState<Slots>];
         // eslint-disable-next-line no-console
@@ -56,13 +58,17 @@ export function assertSlots<Slots extends SlotPropsRecord>(state: unknown): asse
         // This means a slot is being declared by using resolveShorthand on the state hook,
         // but the render method is using the new `assertSlots` method. That scenario can be solved by simply updating the slot element with the proper element type
         const { [SLOT_ELEMENT_TYPE_SYMBOL]: elementType } = slotElement;
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         if (elementType !== typedState.components[slotName]) {
+          // eslint-disable-next-line @typescript-eslint/no-deprecated
           slotElement[SLOT_ELEMENT_TYPE_SYMBOL] = typedState.components[slotName] as React.ComponentType<{}>;
           // eslint-disable-next-line no-console
           console.warn(/** #__DE-INDENT__ */ `
             @fluentui/react-utilities [${assertSlots.name}]:
             "state.${slotName}" element type differs from "state.components.${slotName}",
-            ${elementType} !== ${typedState.components[slotName]}.
+            ${elementType} !== ${
+            typedState.components[slotName] /* eslint-disable-line @typescript-eslint/no-deprecated */
+          }.
             Be sure to create slots properly by using "slot.always" or "slot.optional" with the correct elementType.
           `);
         }

--- a/packages/react-components/react-utilities/src/compose/deprecated/getSlots.ts
+++ b/packages/react-components/react-utilities/src/compose/deprecated/getSlots.ts
@@ -1,40 +1,23 @@
 import * as React from 'react';
 import { omit } from '../../utils/omit';
-import type {
-  AsIntrinsicElement,
-  ComponentState,
-  ExtractSlotProps,
-  SlotPropsRecord,
-  SlotRenderFunction,
-  UnknownSlotProps,
-} from '../types';
+import type { ComponentState, SlotPropsRecord, SlotRenderFunction, UnknownSlotProps } from '../types';
 import { isSlot } from '../isSlot';
 import { SLOT_RENDER_FUNCTION_SYMBOL } from '../constants';
-import { UnionToIntersection } from '../../utils/types';
 
 /**
  * @deprecated - use slot.always or slot.optional combined with assertSlots instead
  */
 export type Slots<S extends SlotPropsRecord> = {
-  [K in keyof S]: ExtractSlotProps<S[K]> extends AsIntrinsicElement<infer As>
-    ? // for slots with an `as` prop, the slot will be any one of the possible values of `as`
-      As
-    : ExtractSlotProps<S[K]> extends React.ComponentType<infer P>
-    ? React.ElementType<NonNullable<P>>
-    : React.ElementType<ExtractSlotProps<S[K]>>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [K in keyof S]: React.ElementType<any>;
 };
 
 /**
  * @deprecated - use slot.always or slot.optional combined with assertSlots instead
  */
 export type ObjectSlotProps<S extends SlotPropsRecord> = {
-  [K in keyof S]-?: ExtractSlotProps<S[K]> extends AsIntrinsicElement<infer As>
-    ? // For intrinsic element types, return the intersection of all possible
-      // element's props, to be compatible with the As type returned by Slots<>
-      UnionToIntersection<JSX.IntrinsicElements[As]> // Slot<'div', 'span'>
-    : ExtractSlotProps<S[K]> extends React.ComponentType<infer P>
-    ? P // Slot<typeof Button>
-    : ExtractSlotProps<S[K]>; // Slot<ButtonProps>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [K in keyof S]-?: any; // Slot<ButtonProps>
 };
 
 /**
@@ -57,20 +40,22 @@ export type ObjectSlotProps<S extends SlotPropsRecord> = {
  * @returns An object containing the `slots` map and `slotProps` map.
  */
 export function getSlots<R extends SlotPropsRecord>(
-  state: ComponentState<R>,
+  state: unknown,
 ): {
   // eslint-disable-next-line @typescript-eslint/no-deprecated
   slots: Slots<R>;
   // eslint-disable-next-line @typescript-eslint/no-deprecated
   slotProps: ObjectSlotProps<R>;
 } {
+  const typeState = state as ComponentState<R>;
   // eslint-disable-next-line @typescript-eslint/no-deprecated
   const slots = {} as Slots<R>;
   const slotProps = {} as R;
 
-  const slotNames: (keyof R)[] = Object.keys(state.components);
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
+  const slotNames: (keyof R)[] = Object.keys(typeState.components);
   for (const slotName of slotNames) {
-    const [slot, props] = getSlot(state, slotName);
+    const [slot, props] = getSlot(typeState, slotName);
     // eslint-disable-next-line @typescript-eslint/no-deprecated
     slots[slotName] = slot as Slots<R>[typeof slotName];
     slotProps[slotName] = props;
@@ -96,15 +81,19 @@ function getSlot<R extends SlotPropsRecord, K extends keyof R>(
   const renderFunction = isSlot(props) ? props[SLOT_RENDER_FUNCTION_SYMBOL] : undefined;
 
   const slot = (
-    state.components?.[slotName] === undefined || typeof state.components[slotName] === 'string'
-      ? asProp || state.components?.[slotName] || 'div'
-      : state.components[slotName]
+    state.components?.[slotName] === undefined || // eslint-disable-line @typescript-eslint/no-deprecated
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    typeof state.components[slotName] === 'string'
+      ? // eslint-disable-next-line @typescript-eslint/no-deprecated
+        asProp || state.components?.[slotName] || 'div'
+      : // eslint-disable-next-line @typescript-eslint/no-deprecated
+        state.components[slotName]
   ) as React.ElementType<R[K]>;
 
   if (renderFunction || typeof children === 'function') {
     const render = (renderFunction || children) as SlotRenderFunction<R[K]>;
     return [
-      React.Fragment,
+      React.Fragment as React.ElementType<R[K]>,
       {
         children: render(slot, rest as Omit<R[K], 'as'>),
       } as unknown as R[K],
@@ -112,6 +101,7 @@ function getSlot<R extends SlotPropsRecord, K extends keyof R>(
   }
 
   const shouldOmitAsProp = typeof slot === 'string' && asProp;
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   const slotProps = (shouldOmitAsProp ? omit(props, ['as']) : (props as UnknownSlotProps)) as R[K];
   return [slot, slotProps];
 }

--- a/packages/react-components/react-utilities/src/compose/deprecated/getSlotsNext.ts
+++ b/packages/react-components/react-utilities/src/compose/deprecated/getSlotsNext.ts
@@ -13,21 +13,23 @@ import { ObjectSlotProps, Slots } from './getSlots';
  * @deprecated use slot.always or slot.optional combined with assertSlots instead
  */
 export function getSlotsNext<R extends SlotPropsRecord>(
-  state: ComponentState<R>,
+  state: unknown,
 ): {
   // eslint-disable-next-line @typescript-eslint/no-deprecated
   slots: Slots<R>;
   // eslint-disable-next-line @typescript-eslint/no-deprecated
   slotProps: ObjectSlotProps<R>;
 } {
+  const typedState = state as ComponentState<R>;
   // eslint-disable-next-line @typescript-eslint/no-deprecated
   const slots = {} as Slots<R>;
   const slotProps = {} as R;
 
-  const slotNames: (keyof R)[] = Object.keys(state.components);
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
+  const slotNames: (keyof R)[] = Object.keys(typedState.components);
   for (const slotName of slotNames) {
     // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const [slot, props] = getSlotNext(state, slotName);
+    const [slot, props] = getSlotNext(typedState, slotName);
     // eslint-disable-next-line @typescript-eslint/no-deprecated
     slots[slotName] = slot as Slots<R>[typeof slotName];
     slotProps[slotName] = props;
@@ -54,12 +56,17 @@ function getSlotNext<R extends SlotPropsRecord, K extends keyof R>(
   const { as: asProp, ...propsWithoutAs } = props as NonUndefined<typeof props>;
 
   const slot = (
-    state.components?.[slotName] === undefined || typeof state.components[slotName] === 'string'
-      ? asProp || state.components?.[slotName] || 'div'
-      : state.components[slotName]
+    state.components?.[slotName] === undefined || // eslint-disable-line @typescript-eslint/no-deprecated
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    typeof state.components[slotName] === 'string'
+      ? // eslint-disable-next-line @typescript-eslint/no-deprecated
+        asProp || state.components?.[slotName] || 'div'
+      : // eslint-disable-next-line @typescript-eslint/no-deprecated
+        state.components[slotName]
   ) as React.ElementType<R[K]>;
 
   const shouldOmitAsProp = typeof slot === 'string' && asProp;
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   const slotProps: UnknownSlotProps = shouldOmitAsProp ? propsWithoutAs : props;
 
   return [slot, slotProps as R[K]];

--- a/packages/react-components/react-utilities/src/compose/deprecated/resolveShorthand.ts
+++ b/packages/react-components/react-utilities/src/compose/deprecated/resolveShorthand.ts
@@ -1,5 +1,5 @@
 import * as slot from '../slot';
-import type { SlotShorthandValue, UnknownSlotProps } from '../types';
+import type { UnknownSlotProps, SlotShorthandValue, WithoutSlotRenderFunction } from '../types';
 
 /**
  * @deprecated - use slot.always or slot.optional combined with assertSlots instead
@@ -12,11 +12,14 @@ export type ResolveShorthandOptions<Props, Required extends boolean = false> = R
  * @deprecated use slot.always or slot.optional combined with assertSlots instead
  */
 export type ResolveShorthandFunction<Props extends UnknownSlotProps = UnknownSlotProps> = {
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
-  <P extends Props>(value: P | SlotShorthandValue | undefined, options: ResolveShorthandOptions<P, true>): P;
+  <P extends Props>(
+    value: P | SlotShorthandValue | undefined,
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    options: ResolveShorthandOptions<P, true>,
+  ): WithoutSlotRenderFunction<P>;
   // eslint-disable-next-line @typescript-eslint/no-deprecated
   <P extends Props>(value: P | SlotShorthandValue | null | undefined, options?: ResolveShorthandOptions<P, boolean>):
-    | P
+    | WithoutSlotRenderFunction<P>
     | undefined;
 };
 
@@ -27,7 +30,7 @@ export type ResolveShorthandFunction<Props extends UnknownSlotProps = UnknownSlo
  * @param value - the base shorthand props
  * @param options - options to resolve shorthand props
  *
- * @deprecated use slot.always or slot.optional combined with assertSlots instead
+ * @deprecated use slot.always, slot.optional, slot.resolveShorthand combined with assertSlots instead
  */
 // eslint-disable-next-line @typescript-eslint/no-deprecated
 export const resolveShorthand: ResolveShorthandFunction<UnknownSlotProps> = (value, options) =>
@@ -37,4 +40,4 @@ export const resolveShorthand: ResolveShorthandFunction<UnknownSlotProps> = (val
     // elementType as undefined is the way to identify between a slot and a resolveShorthand call
     // in the case elementType is undefined assertSlots will fail, ensuring it'll only work with slot method.
     elementType: undefined!,
-  });
+  }) as WithoutSlotRenderFunction<UnknownSlotProps>;

--- a/packages/react-components/react-utilities/src/compose/index.ts
+++ b/packages/react-components/react-utilities/src/compose/index.ts
@@ -10,8 +10,6 @@ export type {
   ForwardRefComponent,
   InferredElementRefType,
   IsSingleton,
-  PropsWithoutChildren,
-  PropsWithoutRef,
   Slot,
   SlotClassNames,
   SlotComponentType,
@@ -20,6 +18,7 @@ export type {
   SlotShorthandValue,
   UnknownSlotProps,
 } from './types';
+
 export { isResolvedShorthand } from './isResolvedShorthand';
 export { SLOT_CLASS_NAME_PROP_SYMBOL, SLOT_ELEMENT_TYPE_SYMBOL, SLOT_RENDER_FUNCTION_SYMBOL } from './constants';
 export { isSlot } from './isSlot';
@@ -40,3 +39,4 @@ export { getSlotsNext } from './deprecated/getSlotsNext';
 
 export { slot };
 export type { SlotOptions } from './slot';
+export type { PropsWithoutChildren, PropsWithoutRef } from '../utils/types';

--- a/packages/react-components/react-utilities/src/compose/slot.ts
+++ b/packages/react-components/react-utilities/src/compose/slot.ts
@@ -4,6 +4,7 @@ import type {
   SlotRenderFunction,
   SlotShorthandValue,
   UnknownSlotProps,
+  InferredElementRefType,
 } from './types';
 import * as React from 'react';
 import { SLOT_CLASS_NAME_PROP_SYMBOL, SLOT_ELEMENT_TYPE_SYMBOL, SLOT_RENDER_FUNCTION_SYMBOL } from './constants';
@@ -12,7 +13,7 @@ export type SlotOptions<Props extends UnknownSlotProps> = {
   elementType:
     | React.ComponentType<Props>
     | (Props extends AsIntrinsicElement<infer As> ? As : keyof JSX.IntrinsicElements);
-  defaultProps?: Partial<Props>;
+  defaultProps?: Partial<Props & { ref?: React.Ref<InferredElementRefType<Props>> }>;
 };
 
 /**
@@ -86,7 +87,7 @@ export function resolveShorthand<Props extends UnknownSlotProps | null | undefin
   if (
     typeof value === 'string' ||
     typeof value === 'number' ||
-    Array.isArray(value) ||
+    isIterable(value) ||
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     React.isValidElement<any>(value)
   ) {
@@ -105,3 +106,7 @@ export function resolveShorthand<Props extends UnknownSlotProps | null | undefin
 
   return value;
 }
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const isIterable = (value: unknown): value is Iterable<any> =>
+  typeof value === 'object' && value !== null && Symbol.iterator in value;

--- a/packages/react-components/react-utilities/src/compose/types.ts
+++ b/packages/react-components/react-utilities/src/compose/types.ts
@@ -1,11 +1,17 @@
 import * as React from 'react';
 import { SLOT_CLASS_NAME_PROP_SYMBOL, SLOT_ELEMENT_TYPE_SYMBOL, SLOT_RENDER_FUNCTION_SYMBOL } from './constants';
-import { DistributiveOmit, ReplaceNullWithUndefined } from '../utils/types';
+import {
+  ComponentType,
+  FunctionComponent,
+  NamedExoticComponent,
+  PropsWithoutChildren,
+  PropsWithoutRef,
+  ReactNode,
+  RefAttributes,
+  ReplaceNullWithUndefined,
+} from '../utils/types';
 
-export type SlotRenderFunction<Props> = (
-  Component: React.ElementType<Props>,
-  props: Omit<Props, 'as'>,
-) => React.ReactNode;
+export type SlotRenderFunction<Props> = (Component: React.ElementType<Props>, props: Omit<Props, 'as'>) => ReactNode;
 
 /**
  * Matches any component's Slots type (such as ButtonSlots).
@@ -18,7 +24,7 @@ export type SlotPropsRecord = Record<string, UnknownSlotProps | SlotShorthandVal
 /**
  * The shorthand value of a slot allows specifying its child
  */
-export type SlotShorthandValue = React.ReactChild | React.ReactNode[] | React.ReactPortal;
+export type SlotShorthandValue = React.ReactElement | string | number | Iterable<ReactNode> | React.ReactPortal;
 
 /**
  * Matches any slot props type.
@@ -26,8 +32,9 @@ export type SlotShorthandValue = React.ReactChild | React.ReactNode[] | React.Re
  * This should ONLY be used in type templates as in `extends UnknownSlotProps`;
  * it shouldn't be used as the type of a slot.
  */
-export type UnknownSlotProps = Pick<React.HTMLAttributes<HTMLElement>, 'children' | 'className' | 'style'> & {
+export type UnknownSlotProps = Pick<React.HTMLAttributes<HTMLElement>, 'className' | 'style'> & {
   as?: keyof JSX.IntrinsicElements;
+  children?: ReactNode;
 };
 
 /**
@@ -38,12 +45,22 @@ type WithSlotShorthandValue<Props> =
   | ('children' extends keyof Props ? Extract<SlotShorthandValue, Props['children']> : never);
 
 /**
+ * @internal
  * Helper type for {@link Slot}. Takes the props we want to support for a slot and adds the ability for `children`
  * to be a render function that takes those props.
  */
-type WithSlotRenderFunction<Props> = Props & {
-  children?: ('children' extends keyof Props ? Props['children'] : never) | SlotRenderFunction<Props>;
+export type WithSlotRenderFunction<Props> = Omit<Props, 'children'> & {
+  children?: ('children' extends keyof Props ? ReactNode : never) | SlotRenderFunction<Props>;
 };
+
+/**
+ * @internal
+ */
+export type WithoutSlotRenderFunction<Props> = Props extends unknown
+  ? 'children' extends keyof Props
+    ? Omit<Props, 'children'> & { children?: Exclude<Props['children'], Function> }
+    : Props
+  : never;
 
 /**
  * HTML element types that are not allowed to have children.
@@ -98,20 +115,23 @@ type IntrinsicElementProps<Type extends keyof JSX.IntrinsicElements> = Type exte
  * ```
  */
 export type Slot<
-  Type extends keyof JSX.IntrinsicElements | React.ComponentType | React.VoidFunctionComponent | UnknownSlotProps,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Type extends keyof JSX.IntrinsicElements | ComponentType<any> | UnknownSlotProps,
   AlternateAs extends keyof JSX.IntrinsicElements = never,
 > = IsSingleton<Extract<Type, string>> extends true
   ?
       | WithSlotShorthandValue<
           Type extends keyof JSX.IntrinsicElements // Intrinsic elements like `div`
             ? { as?: Type } & WithSlotRenderFunction<IntrinsicElementProps<Type>>
-            : Type extends React.ComponentType<infer Props> // Component types like `typeof Button`
-            ? WithSlotRenderFunction<Props>
+            : Type extends ComponentType<infer Props> // Component types like `typeof Button`
+            ? Props extends UnknownSlotProps
+              ? Props
+              : WithSlotRenderFunction<Props>
             : Type // Props types like `ButtonProps`
         >
-      | {
-          [As in AlternateAs]: { as: As } & WithSlotRenderFunction<IntrinsicElementProps<As>>;
-        }[AlternateAs]
+      | (AlternateAs extends unknown
+          ? { as: AlternateAs } & WithSlotRenderFunction<IntrinsicElementProps<AlternateAs>>
+          : never)
       | null
   : 'Error: First parameter to Slot must not be not a union of types. See documentation of Slot type.';
 
@@ -136,24 +156,6 @@ export type IsSingleton<T extends string> = { [K in T]: Exclude<T, K> extends ne
 export type AsIntrinsicElement<As extends keyof JSX.IntrinsicElements> = { as?: As };
 
 /**
- * Removes the 'ref' prop from the given Props type, leaving unions intact (such as the discriminated union created by
- * IntrinsicSlotProps). This allows IntrinsicSlotProps to be used with React.forwardRef.
- *
- * The conditional "extends unknown" (always true) exploits a quirk in the way TypeScript handles conditional
- * types, to prevent unions from being expanded.
- */
-export type PropsWithoutRef<P> = 'ref' extends keyof P ? DistributiveOmit<P, 'ref'> : P;
-
-/**
- * Removes the 'ref' prop from the given Props type, leaving unions intact (such as the discriminated union created by
- * IntrinsicSlotProps). This allows IntrinsicSlotProps to be used with React.forwardRef.
- *
- * The conditional "extends unknown" (always true) exploits a quirk in the way TypeScript handles conditional
- * types, to prevent unions from being expanded.
- */
-export type PropsWithoutChildren<P> = 'children' extends keyof P ? DistributiveOmit<P, 'children'> : P;
-
-/**
  * Removes SlotShorthandValue and null from the slot type, extracting just the slot's Props object.
  */
 export type ExtractSlotProps<S> = Exclude<S, SlotShorthandValue | null | undefined>;
@@ -164,30 +166,33 @@ export type ExtractSlotProps<S> = Exclude<S, SlotShorthandValue | null | undefin
  */
 export type ComponentProps<Slots extends SlotPropsRecord, Primary extends keyof Slots = 'root'> =
   // Include a prop for each slot (see note below about the Omit)
+  // Note: the `Omit<Slots, Primary & 'root'>` here is a little tricky. Here's what it's doing:
+  // * If the Primary slot is 'root', then omit the `root` slot prop.
+  // * Otherwise, don't omit any props: include *both* the Primary and `root` props.
+  //   We need both props to allow the user to specify native props for either slot because the `root` slot is
+  //   special and always gets className and style props, per RFC https://github.com/microsoft/fluentui/pull/18983
   Omit<Slots, Primary & 'root'> &
     // Include all of the props of the primary slot inline in the component's props
     PropsWithoutRef<ExtractSlotProps<Slots[Primary]>>;
-
-// Note: the `Omit<Slots, Primary & 'root'>` above is a little tricky. Here's what it's doing:
-// * If the Primary slot is 'root', then omit the `root` slot prop.
-// * Otherwise, don't omit any props: include *both* the Primary and `root` props.
-//   We need both props to allow the user to specify native props for either slot because the `root` slot is
-//   special and always gets className and style props, per RFC https://github.com/microsoft/fluentui/pull/18983
 
 /**
  * Defines the State object of a component given its slots.
  */
 export type ComponentState<Slots extends SlotPropsRecord> = {
+  /**
+   * @deprecated
+   * The base element type for each slot.
+   * This property is deprecated and will be removed in a future version.
+   * The slot base element type is declared through `slot.*(slotShorthand, {elementType: ElementType})` instead.
+   */
   components: {
-    [Key in keyof Slots]-?:
-      | React.ComponentType<ExtractSlotProps<Slots[Key]>>
-      | (ExtractSlotProps<Slots[Key]> extends AsIntrinsicElement<infer As> ? As : keyof JSX.IntrinsicElements);
+    [Key in keyof Slots]-?: React.ElementType;
   };
 } & {
   // Include a prop for each slot, with the shorthand resolved to a props object
   // The root slot can never be null, so also exclude null from it
   [Key in keyof Slots]: ReplaceNullWithUndefined<
-    Exclude<Slots[Key], SlotShorthandValue | (Key extends 'root' ? null : never)>
+    WithoutSlotRenderFunction<Exclude<Slots[Key], SlotShorthandValue | (Key extends 'root' ? null : never)>>
   >;
 };
 
@@ -216,15 +221,10 @@ export type InferredElementRefType<Props> = ObscureEventName extends keyof Props
 
 /**
  * Return type for `React.forwardRef`, including inference of the proper typing for the ref.
+ *
+ * Note: {@link React.RefAttributes} is {@link https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/69756 | leaking string references} into forwardRef components, forwardRef component do not support string refs.
  */
-export type ForwardRefComponent<Props> = React.ForwardRefExoticComponent<
-  Props & React.RefAttributes<InferredElementRefType<Props>>
->;
-// A definition like this would also work, but typescript is more likely to unnecessarily expand
-// the props type with this version (and it's likely much more expensive to evaluate)
-// export type ForwardRefComponent<Props> = Props extends React.DOMAttributes<infer Element>
-//   ? React.ForwardRefExoticComponent<Props> & React.RefAttributes<Element>
-//   : never;
+export type ForwardRefComponent<Props> = NamedExoticComponent<Props & RefAttributes<InferredElementRefType<Props>>>;
 
 /**
  * Helper type to correctly define the slot class names object.
@@ -237,27 +237,24 @@ export type SlotClassNames<Slots> = {
  * A definition of a slot, as a component, very similar to how a React component is declared,
  * but with some additional metadata that is used to determine how to render the slot.
  */
-export type SlotComponentType<Props> = Props & {
-  /**
-   * **NOTE**: Slot components are not callable.
-   */
-  (props: React.PropsWithChildren<{}>): React.ReactElement | null;
-  /**
-   * @internal
-   */
-  [SLOT_RENDER_FUNCTION_SYMBOL]?: SlotRenderFunction<Props>;
-  /**
-   * @internal
-   */
-  [SLOT_ELEMENT_TYPE_SYMBOL]:
-    | React.ComponentType<Props>
-    | (Props extends AsIntrinsicElement<infer As> ? As : keyof JSX.IntrinsicElements);
-  /**
-   * @internal
-   * The original className prop for the slot, before being modified by the useStyles hook.
-   */
-  [SLOT_CLASS_NAME_PROP_SYMBOL]?: string;
-};
+export type SlotComponentType<Props> = WithoutSlotRenderFunction<Props> &
+  FunctionComponent<{ children?: React.ReactNode }> & {
+    /**
+     * @internal
+     */
+    [SLOT_RENDER_FUNCTION_SYMBOL]?: SlotRenderFunction<Props>;
+    /**
+     * @internal
+     */
+    [SLOT_ELEMENT_TYPE_SYMBOL]:
+      | ComponentType<Props>
+      | (Props extends AsIntrinsicElement<infer As> ? As : keyof JSX.IntrinsicElements);
+    /**
+     * @internal
+     * The original className prop for the slot, before being modified by the useStyles hook.
+     */
+    [SLOT_CLASS_NAME_PROP_SYMBOL]?: string;
+  };
 
 /**
  * Data type for event handlers. It makes data a discriminated union, where each object requires `event` and `type` property.

--- a/packages/react-components/react-utilities/src/hooks/useMergedRefs.ts
+++ b/packages/react-components/react-utilities/src/hooks/useMergedRefs.ts
@@ -6,21 +6,35 @@ import * as React from 'react';
  */
 export type RefObjectFunction<T> = React.RefObject<T> & ((value: T | null) => void);
 
+/** @internal */
+type MutableRefObjectFunction<T> = React.MutableRefObject<T | null> & ((value: T | null) => void);
+
 /**
  * React hook to merge multiple React refs (either MutableRefObjects or ref callbacks) into a single ref callback that
  * updates all provided refs
  * @param refs - Refs to collectively update with one ref value.
  * @returns A function with an attached "current" prop, so that it can be treated like a RefObject.
  */
+// LegacyRef is actually not supported, but in React v18 types this is leaking directly from forwardRef component declaration
 export function useMergedRefs<T>(...refs: (React.Ref<T> | undefined)[]): RefObjectFunction<T> {
   'use no memo';
 
-  const mergedCallback: RefObjectFunction<T> = React.useCallback(
+  const mergedCallback = React.useCallback(
     (value: T | null) => {
       // Update the "current" prop hanging on the function.
-      (mergedCallback as React.MutableRefObject<T | null>).current = value;
+      mergedCallback.current = value;
 
       for (const ref of refs) {
+        if (typeof ref === 'string' && process.env.NODE_ENV !== 'production') {
+          // eslint-disable-next-line no-console
+          console.error(/** #__DE-INDENT__ */ `
+            @fluentui/react-utilities [useMergedRefs]:
+            This hook does not support the usage of string refs. Please use React.useRef instead.
+
+            For more info on 'React.useRef', see https://react.dev/reference/react/useRef.
+            For more info on string refs, see https://react.dev/blog/2024/04/25/react-19-upgrade-guide#removed-string-refs.
+          `);
+        }
         if (typeof ref === 'function') {
           ref(value);
         } else if (ref) {
@@ -31,7 +45,7 @@ export function useMergedRefs<T>(...refs: (React.Ref<T> | undefined)[]): RefObje
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps -- already exhaustive
     [...refs],
-  ) as RefObjectFunction<T>;
+  ) as MutableRefObjectFunction<T>;
 
   return mergedCallback;
 }

--- a/packages/react-components/react-utilities/src/index.ts
+++ b/packages/react-components/react-utilities/src/index.ts
@@ -31,6 +31,7 @@ export type {
   SlotPropsRecord,
   SlotRenderFunction,
   SlotShorthandValue,
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   UnknownSlotProps,
   SlotComponentType,
   SlotOptions,
@@ -73,7 +74,7 @@ export {
   createPriorityQueue,
 } from './utils/index';
 
-export type { DistributiveOmit, UnionToIntersection } from './utils/types';
+export type { DistributiveOmit, UnionToIntersection, RefAttributes } from './utils/types';
 
 export type { PriorityQueue } from './utils/priorityQueue';
 

--- a/packages/react-components/react-utilities/src/trigger/applyTriggerPropsToChildren.ts
+++ b/packages/react-components/react-utilities/src/trigger/applyTriggerPropsToChildren.ts
@@ -27,7 +27,7 @@ export function applyTriggerPropsToChildren<TriggerChildProps>(
  * a FluentTriggerComponent or React Fragment (the same element returned by {@link getTriggerChild}).
  */
 function cloneTriggerTree<TriggerChildProps>(
-  child: React.ReactNode,
+  child: TriggerProps['children'],
   triggerProps: TriggerChildProps,
 ): React.ReactElement {
   if (!React.isValidElement(child) || child.type === React.Fragment) {

--- a/packages/react-components/react-utilities/src/utils/types.ts
+++ b/packages/react-components/react-utilities/src/utils/types.ts
@@ -1,3 +1,5 @@
+import * as React from 'react';
+
 /**
  * Helper type that works similar to Omit,
  * but when modifying an union type it will distribute the omission to all the union members.
@@ -22,6 +24,16 @@
 export type DistributiveOmit<T, K extends keyof any> = T extends unknown ? Omit<T, K> : T;
 
 /**
+ * @public
+ *
+ * Helper type that works similar to Pick,
+ * but when modifying an union type it will distribute the picking to all the union members.
+ *
+ * See {@link https://www.typescriptlang.org/docs/handbook/2/conditional-types.html#distributive-conditional-types} for more information
+ */
+export type DistributivePick<T, K> = T extends unknown ? Pick<T, K & keyof T> : never;
+
+/**
  * Converts a union type (`A | B | C`) to an intersection type (`A & B & C`)
  */
 export type UnionToIntersection<U> = (U extends unknown ? (x: U) => U : never) extends (x: infer I) => U ? I : never;
@@ -31,3 +43,90 @@ export type UnionToIntersection<U> = (U extends unknown ? (x: U) => U : never) e
  * If type T includes `null`, remove it and add `undefined` instead.
  */
 export type ReplaceNullWithUndefined<T> = T extends null ? Exclude<T, null> | undefined : T;
+
+/**
+ * @internal
+ * With react 18, our `children` type starts leaking everywhere and that causes conflicts on component declaration, specially in the `propTypes` property of
+ * both `ComponentClass` and `FunctionComponent`.
+ *
+ * This type substitutes `React.ComponentType` only keeping the function signature, it omits `propTypes`, `displayName` and other properties that are not
+ * required for the inference.
+ */
+export type ComponentType<P = {}> = ComponentClass<P> | FunctionComponent<P>;
+
+/**
+ * @internal
+ *
+ * On types/react 18 there are two types being delivered,
+ * they rely on the typescript version to decide which will be consumed {@link https://github.com/DefinitelyTyped/DefinitelyTyped/blob/b59dc3ac1e2770fbd6cdbb90ba52abe04c168196/types/react/package.json#L10}
+ *
+ * If TS is higher than 5.0 then the `FunctionComponent` will be returning ReactNode (which we don't support)
+ * If TS is below or equal to 5.0 then the `FunctionComponent` will be returning ReactElement | null (which we support)
+ *
+ * Since it's not possible to have a single type that works for both cases
+ * (as ReactNode is more specific, and this will break while evaluating functions),
+ * we need to create our own `FunctionComponent` type
+ * that will work for both cases.
+ *
+ * **THIS TYPE IS INTERNAL AND SHOULD NEVER BE EXPOSED**
+ */
+export interface FunctionComponent<P> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (props: P): any;
+  displayName?: string;
+}
+
+export type FC<P> = FunctionComponent<P>;
+
+export interface ExoticComponent<P> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (props: P): any;
+  $$typeof: symbol;
+}
+
+export interface NamedExoticComponent<P> extends ExoticComponent<P> {
+  displayName?: string;
+}
+
+export interface RefAttributes<T> extends React.Attributes {
+  ref?: React.Ref<T> | undefined;
+}
+
+/**
+ * @internal
+ * **THIS TYPE IS INTERNAL AND SHOULD NEVER BE EXPOSED**
+ */
+export interface ComponentClass<P = {}, S = React.ComponentState> extends React.StaticLifecycle<P, S> {
+  new (props: P): React.Component<P, S>;
+}
+
+/**
+ * @internal
+ *
+ * on types/react 18 ReactNode becomes a more strict type, which is not compatible with our current implementation. to avoid any issues we are creating our own ReactNode type which allows anything.
+ *
+ * This type should only be used for inference purposes, and should never be exposed.
+ *
+ * **THIS TYPE IS INTERNAL AND SHOULD NEVER BE EXPOSED**
+ *
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type ReactNode = any;
+
+/**
+ * Removes the 'ref' prop from the given Props type, leaving unions intact (such as the discriminated union created by
+ * IntrinsicSlotProps). This allows IntrinsicSlotProps to be used with React.forwardRef.
+ *
+ * The conditional "extends unknown" (always true) exploits a quirk in the way TypeScript handles conditional
+ * types, to prevent unions from being expanded.
+ */
+export type PropsWithoutRef<P> = 'ref' extends keyof P ? DistributiveOmit<P, 'ref'> : P;
+
+/**
+ * Removes the 'ref' prop from the given Props type, leaving unions intact (such as the discriminated union created by
+ * IntrinsicSlotProps). This allows IntrinsicSlotProps to be used with React.forwardRef.
+ *
+ * The conditional "extends unknown" (always true) exploits a quirk in the way TypeScript handles conditional
+ * types, to prevent unions from being expanded.
+ */
+export type PropsWithoutChildren<P> = 'children' extends keyof P ? DistributiveOmit<P, 'children'> : P;

--- a/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollView/useVirtualizerScrollView.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollView/useVirtualizerScrollView.ts
@@ -68,6 +68,7 @@ export function useVirtualizerScrollView_unstable(props: VirtualizerScrollViewPr
   return {
     ...virtualizerState,
     components: {
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       ...virtualizerState.components,
       container: 'div',
     },

--- a/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollViewDynamic/useVirtualizerScrollViewDynamic.tsx
+++ b/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollViewDynamic/useVirtualizerScrollViewDynamic.tsx
@@ -183,6 +183,7 @@ export function useVirtualizerScrollViewDynamic_unstable(
   return {
     ...virtualizerState,
     components: {
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       ...virtualizerState.components,
       container: 'div',
     },


### PR DESCRIPTION
This PR aims to address the Slot API type issues in React 18. It is not meant to be merged into the master branch yet, as we need to verify its functionality in partners' codebases before release. Therefore, the target branch is `react-components/react-18`.

This PR builds on @bsunderhus's PR - https://github.com/microsoft/fluentui/pull/31548 with some modifications.

There are no changes to the components' public API. The only public API changes in this PR are related to `react-utilities` Slot types.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/27090
- Fixes https://github.com/microsoft/fluentui/issues/31482
- Fixes https://github.com/microsoft/fluentui/issues/29578
