### PR TITLE
fix(react-charts): Enabling multiple legend selection for Scatter Chart in v9

### DIFF
--- a/change/@fluentui-react-charts-e55ab3f2-a848-4cee-abef-5548469f52f5.json
+++ b/change/@fluentui-react-charts-e55ab3f2-a848-4cee-abef-5548469f52f5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(react-charts): Enabling multiple legend selection for Scatter Chart in v9",
+  "packageName": "@fluentui/react-charts",
+  "email": "120183316+srmukher@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charts/react-charts/library/src/components/ScatterChart/ScatterChart.tsx
+++ b/packages/charts/react-charts/library/src/components/ScatterChart/ScatterChart.tsx
@@ -473,7 +473,7 @@ export const ScatterChart: React.FunctionComponent<ScatterChartProps> = React.fo
    * This function checks if none of the legends is selected or hovered.*/
 
   function _noLegendHighlighted(): boolean {
-    return _getHighlightedLegend().length === 0;
+    return selectedLegends.length === 0;
   }
 
   function _getHighlightedLegend(): string[] {

--- a/packages/charts/react-charts/library/src/components/ScatterChart/ScatterChart.tsx
+++ b/packages/charts/react-charts/library/src/components/ScatterChart/ScatterChart.tsx
@@ -6,7 +6,7 @@ import { select as d3Select } from 'd3-selection';
 import { Legend, Legends } from '../Legends/index';
 import { max as d3Max, min as d3Min } from 'd3-array';
 import { useId } from '@fluentui/react-utilities';
-import { find } from '../../utilities/index';
+import { areArraysEqual, find } from '../../utilities/index';
 import {
   AccessibilityProps,
   CartesianChart,
@@ -76,6 +76,17 @@ export const ScatterChart: React.FunctionComponent<ScatterChartProps> = React.fo
   const [clickPosition, setClickPosition] = React.useState({ x: 0, y: 0 });
   const [isPopoverOpen, setPopoverOpen] = React.useState(false);
   const [selectedLegends, setSelectedLegends] = React.useState<string[]>([]);
+  const prevPropsRef = React.useRef<ScatterChartProps | null>(null);
+
+  React.useEffect(() => {
+    if (prevPropsRef.current) {
+      const prevProps = prevPropsRef.current;
+      if (!areArraysEqual(prevProps.legendProps?.selectedLegends, props.legendProps?.selectedLegends)) {
+        setSelectedLegends(props.legendProps?.selectedLegends || []);
+      }
+    }
+    prevPropsRef.current = props;
+  }, [props]);
 
   const _xAxisType: XAxisTypes =
     props.data.lineChartData! &&

--- a/packages/charts/react-charts/library/src/components/ScatterChart/ScatterChart.tsx
+++ b/packages/charts/react-charts/library/src/components/ScatterChart/ScatterChart.tsx
@@ -67,7 +67,6 @@ export const ScatterChart: React.FunctionComponent<ScatterChartProps> = React.fo
   const [hoverXValue, setHoverXValue] = React.useState<string | number>('');
   const [activeLegend, setActiveLegend] = React.useState<string>('');
   const [YValueHover, setYValueHover] = React.useState<[]>([]);
-  const [selectedLegend, setSelectedLegend] = React.useState<string>('');
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [selectedLegendPoints, setSelectedLegendPoints] = React.useState<any[]>([]);
   const [isSelectedLegend, setIsSelectedLegend] = React.useState<boolean>(false);
@@ -158,28 +157,9 @@ export const ScatterChart: React.FunctionComponent<ScatterChartProps> = React.fo
     renderSeries = _createPlot(xElement!, containerHeight!);
   }
 
-  function _handleSingleLegendSelectionAction(scatterChartItem: ScatterChartDataWithIndex | ColorFillBarsProps) {
-    if (selectedLegend === scatterChartItem.legend) {
-      setSelectedLegend('');
-      _handleLegendClick(scatterChartItem, null);
-    } else {
-      setSelectedLegend(scatterChartItem.legend);
-      _handleLegendClick(scatterChartItem, scatterChartItem.legend);
-    }
-  }
-
   function _onHoverCardHide() {
     setSelectedLegendPoints([]);
     setIsSelectedLegend(false);
-  }
-
-  function _handleLegendClick(
-    scatterChartItem: ScatterChartDataWithIndex | ColorFillBarsProps,
-    selectedLegend: string | null | string[],
-  ): void {
-    if (scatterChartItem.onLegendClick) {
-      scatterChartItem.onLegendClick(selectedLegend);
-    }
   }
 
   function _createLegends(data: ScatterChartDataWithIndex[]): JSX.Element {
@@ -191,13 +171,6 @@ export const ScatterChart: React.FunctionComponent<ScatterChartProps> = React.fo
       const legend: Legend = {
         title: point.legend!,
         color,
-        action: () => {
-          if (isLegendMultiSelectEnabled) {
-            _handleMultipleSeriesLegendSelectionAction(point);
-          } else {
-            _handleSingleLegendSelectionAction(point);
-          }
-        },
         onMouseOutAction: () => {
           setActiveLegend('');
         },
@@ -481,39 +454,6 @@ export const ScatterChart: React.FunctionComponent<ScatterChartProps> = React.fo
     }
   }
 
-  function _handleMultipleSeriesLegendSelectionAction(selectedSeries: ScatterChartDataWithIndex) {
-    const selectedSeriesIndex = selectedLegendPoints.reduce((acc, series, index) => {
-      if (acc > -1 || series.legend !== selectedSeries.legend) {
-        return acc;
-      } else {
-        return index;
-      }
-    }, -1);
-
-    let selectedSerieses: ScatterChartDataWithIndex[];
-    if (selectedSeriesIndex === -1) {
-      selectedSerieses = [...selectedLegendPoints, selectedSeries];
-    } else {
-      selectedSerieses = selectedLegendPoints
-        .slice(0, selectedSeriesIndex)
-        .concat(selectedLegendPoints.slice(selectedSeriesIndex + 1));
-    }
-
-    const areAllSeriesLegendsSelected = props.data && selectedSerieses.length === props.data.lineChartData!.length;
-
-    if (areAllSeriesLegendsSelected || !selectedSerieses.length) {
-      // Clear all legends if no legends including color fill bar legends are selected
-      _clearMultipleLegendSelections();
-    } else {
-      // Otherwise, set state when one or more legends are selected, including color fill bar legends
-      setSelectedLegendPoints(selectedSerieses);
-      setIsSelectedLegend(true);
-    }
-
-    const selectedLegendTitlesToPass = selectedSerieses.map((series: ScatterChartDataWithIndex) => series.legend);
-    _handleLegendClick(selectedSeries, selectedLegendTitlesToPass);
-  }
-
   function _clearMultipleLegendSelections() {
     setSelectedLegendPoints([]);
     setIsSelectedLegend(false);
@@ -533,7 +473,7 @@ export const ScatterChart: React.FunctionComponent<ScatterChartProps> = React.fo
    * This function checks if none of the legends is selected or hovered.*/
 
   function _noLegendHighlighted(): boolean {
-    return selectedLegends.length === 0;
+    return _getHighlightedLegend().length === 0;
   }
 
   function _getHighlightedLegend(): string[] {

--- a/packages/charts/react-charts/library/src/components/ScatterChart/ScatterChart.tsx
+++ b/packages/charts/react-charts/library/src/components/ScatterChart/ScatterChart.tsx
@@ -15,7 +15,6 @@ import {
   CustomizedCalloutData,
   Margins,
   RefArrayData,
-  ColorFillBarsProps,
   ScatterChartDataPoint,
 } from '../../index';
 import { tokens } from '@fluentui/react-theme';
@@ -452,11 +451,6 @@ export const ScatterChart: React.FunctionComponent<ScatterChartProps> = React.fo
     if (isPopoverOpen) {
       setPopoverOpen(false);
     }
-  }
-
-  function _clearMultipleLegendSelections() {
-    setSelectedLegendPoints([]);
-    setIsSelectedLegend(false);
   }
 
   /**

--- a/packages/charts/react-charts/library/src/components/ScatterChart/ScatterChart.tsx
+++ b/packages/charts/react-charts/library/src/components/ScatterChart/ScatterChart.tsx
@@ -75,6 +75,7 @@ export const ScatterChart: React.FunctionComponent<ScatterChartProps> = React.fo
   const [stackCalloutProps, setStackCalloutProps] = React.useState<CustomizedCalloutData>();
   const [clickPosition, setClickPosition] = React.useState({ x: 0, y: 0 });
   const [isPopoverOpen, setPopoverOpen] = React.useState(false);
+  const [selectedLegends, setSelectedLegends] = React.useState<string[]>([]);
 
   const _xAxisType: XAxisTypes =
     props.data.lineChartData! &&
@@ -207,8 +208,26 @@ export const ScatterChart: React.FunctionComponent<ScatterChartProps> = React.fo
         overflowText={props.legendsOverflowText}
         {...(isLegendMultiSelectEnabled && { onLegendHoverCardLeave: _onHoverCardHide })}
         {...props.legendProps}
+        selectedLegends={selectedLegends}
+        onChange={_onLegendSelectionChange}
       />
     );
+  }
+
+  function _onLegendSelectionChange(
+    legendsSelected: string[],
+    event: React.MouseEvent<HTMLButtonElement>,
+    currentLegend?: Legend,
+  ): void {
+    if (props.legendProps?.canSelectMultipleLegends) {
+      setSelectedLegends(legendsSelected);
+    } else {
+      setSelectedLegends(legendsSelected.slice(-1));
+    }
+
+    if (props.legendProps?.onChange) {
+      props.legendProps.onChange(legendsSelected, event, currentLegend);
+    }
   }
 
   function _getPointFill(seriesColor: string, pointId: string, pointIndex: number, isLastPoint: boolean) {
@@ -495,15 +514,19 @@ export const ScatterChart: React.FunctionComponent<ScatterChartProps> = React.fo
    * 1. selection: if the user clicks on it
    * 2. hovering: if there is no selected legend and the user hovers over it*/
 
-  function _legendHighlighted(legend: string) {
-    return selectedLegend === legend || (selectedLegend === '' && activeLegend === legend);
+  function _legendHighlighted(legend: string): boolean {
+    return _getHighlightedLegend().includes(legend);
   }
 
   /**
    * This function checks if none of the legends is selected or hovered.*/
 
-  function _noLegendHighlighted() {
-    return selectedLegend === '' && activeLegend === '';
+  function _noLegendHighlighted(): boolean {
+    return selectedLegends.length === 0;
+  }
+
+  function _getHighlightedLegend(): string[] {
+    return selectedLegends.length > 0 ? selectedLegends : activeLegend ? [activeLegend] : [];
   }
 
   function _getAriaLabel(seriesIndex: number, pointIndex: number): string {

--- a/packages/charts/react-charts/stories/src/ScatterChart/ScatterChartDefault.stories.tsx
+++ b/packages/charts/react-charts/stories/src/ScatterChart/ScatterChartDefault.stories.tsx
@@ -25,28 +25,74 @@ export const ScatterChartDefault = () => {
       {
         legend: 'Phase 1',
         data: [
-          { x: 10, y: 50000, markerSize: 12 },
-          { x: 20, y: 75000, markerSize: 15 },
-          { x: 30, y: 90000, markerSize: 18 },
-          { x: 40, y: 120000, markerSize: 22 },
-          { x: 50, y: 150000, markerSize: 25 },
+          {
+            x: 10,
+            y: 50000,
+            markerSize: 12, // Number of transactions
+          },
+          {
+            x: 20,
+            y: 75000,
+            markerSize: 15,
+          },
+          {
+            x: 30,
+            y: 90000,
+            markerSize: 18,
+          },
+          {
+            x: 40,
+            y: 120000,
+            markerSize: 22,
+          },
+          {
+            x: 50,
+            y: 150000,
+            markerSize: 25,
+          },
         ],
         color: DataVizPalette.color3,
       },
       {
         legend: 'Phase 2',
         data: [
-          { x: 60, y: 180000, markerSize: 28 },
-          { x: 70, y: 200000, markerSize: 30 },
-          { x: 80, y: 220000, markerSize: 32 },
-          { x: 90, y: 250000, markerSize: 35 },
-          { x: 100, y: 300000, markerSize: 40 },
+          {
+            x: 60,
+            y: 180000,
+            markerSize: 28,
+          },
+          {
+            x: 70,
+            y: 200000,
+            markerSize: 30,
+          },
+          {
+            x: 80,
+            y: 220000,
+            markerSize: 32,
+          },
+          {
+            x: 90,
+            y: 250000,
+            markerSize: 35,
+          },
+          {
+            x: 100,
+            y: 300000,
+            markerSize: 40,
+          },
         ],
         color: DataVizPalette.color4,
       },
       {
         legend: 'Milestone',
-        data: [{ x: 75, y: 250000, markerSize: 50 }],
+        data: [
+          {
+            x: 75,
+            y: 250000,
+            markerSize: 50, // Large number of transactions
+          },
+        ],
         color: DataVizPalette.color5,
       },
     ],

--- a/packages/charts/react-charts/stories/src/ScatterChart/ScatterChartDefault.stories.tsx
+++ b/packages/charts/react-charts/stories/src/ScatterChart/ScatterChartDefault.stories.tsx
@@ -1,16 +1,23 @@
 import * as React from 'react';
 import { ScatterChart, DataVizPalette, ChartProps } from '@fluentui/react-charts';
+import { Switch } from '@fluentui/react-components';
 
 export const ScatterChartDefault = () => {
   const [width, setWidth] = React.useState<number>(650);
   const [height, setHeight] = React.useState<number>(350);
+  const [selectMultipleLegends, setSelectMultipleLegends] = React.useState<boolean>(false);
 
   const _onWidthChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setWidth(parseInt(e.target.value, 10));
   };
+
   const _onHeightChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setHeight(parseInt(e.target.value, 10));
   };
+
+  const _onToggleMultiLegendSelection = React.useCallback(ev => {
+    setSelectMultipleLegends(ev.currentTarget.checked);
+  }, []);
 
   const data: ChartProps = {
     chartTitle: 'Project Revenue and Transactions Over Time',
@@ -18,80 +25,35 @@ export const ScatterChartDefault = () => {
       {
         legend: 'Phase 1',
         data: [
-          {
-            x: 10,
-            y: 50000,
-            markerSize: 12, // Number of transactions
-          },
-          {
-            x: 20,
-            y: 75000,
-            markerSize: 15,
-          },
-          {
-            x: 30,
-            y: 90000,
-            markerSize: 18,
-          },
-          {
-            x: 40,
-            y: 120000,
-            markerSize: 22,
-          },
-          {
-            x: 50,
-            y: 150000,
-            markerSize: 25,
-          },
+          { x: 10, y: 50000, markerSize: 12 },
+          { x: 20, y: 75000, markerSize: 15 },
+          { x: 30, y: 90000, markerSize: 18 },
+          { x: 40, y: 120000, markerSize: 22 },
+          { x: 50, y: 150000, markerSize: 25 },
         ],
         color: DataVizPalette.color3,
       },
       {
         legend: 'Phase 2',
         data: [
-          {
-            x: 60,
-            y: 180000,
-            markerSize: 28,
-          },
-          {
-            x: 70,
-            y: 200000,
-            markerSize: 30,
-          },
-          {
-            x: 80,
-            y: 220000,
-            markerSize: 32,
-          },
-          {
-            x: 90,
-            y: 250000,
-            markerSize: 35,
-          },
-          {
-            x: 100,
-            y: 300000,
-            markerSize: 40,
-          },
+          { x: 60, y: 180000, markerSize: 28 },
+          { x: 70, y: 200000, markerSize: 30 },
+          { x: 80, y: 220000, markerSize: 32 },
+          { x: 90, y: 250000, markerSize: 35 },
+          { x: 100, y: 300000, markerSize: 40 },
         ],
         color: DataVizPalette.color4,
       },
       {
         legend: 'Milestone',
-        data: [
-          {
-            x: 75,
-            y: 250000,
-            markerSize: 50, // Large number of transactions
-          },
-        ],
+        data: [{ x: 75, y: 250000, markerSize: 50 }],
         color: DataVizPalette.color5,
       },
     ],
   };
 
   const rootStyle = { width: `${width}px`, height: `${height}px` };
+
   return (
     <>
       <text>Scatter chart numeric x example.</text>
@@ -116,6 +78,13 @@ export const ScatterChartDefault = () => {
         onChange={_onHeightChange}
         aria-valuetext={`ChangeHeightslider${height}`}
       />
+      <div style={{ marginBottom: '10px' }}>
+        <Switch
+          label="Select Multiple Legends"
+          checked={selectMultipleLegends}
+          onChange={_onToggleMultiLegendSelection}
+        />
+      </div>
       <div style={rootStyle}>
         <ScatterChart
           culture={window.navigator.language}
@@ -124,11 +93,15 @@ export const ScatterChartDefault = () => {
           width={width}
           xAxisTitle={'Days since project start'}
           yAxisTitle={'Revenue in dollars'}
+          legendProps={{
+            canSelectMultipleLegends: selectMultipleLegends,
+          }}
         />
       </div>
     </>
   );
 };
+
 ScatterChartDefault.parameters = {
   docs: {
     description: {},


### PR DESCRIPTION
Enabling multiple legend selection for Scatter Chart in v9.