### PR TITLE
fix(react-components): fix invisible text in ghost and outline badges with subtle color

### DIFF
--- a/change/@fluentui-react-badge-64079ddf-c744-4348-baab-d7df8603baac.json
+++ b/change/@fluentui-react-badge-64079ddf-c744-4348-baab-d7df8603baac.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: fix invisible text in Badge component when using subtle color with ghost and outline appearances by changing color token from colorNeutralForegroundStaticInverted to colorNeutralForeground3",
+  "packageName": "@fluentui/react-badge",
+  "email": "1981616118@qq.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-badge/library/src/components/Badge/useBadgeStyles.styles.ts
+++ b/packages/react-components/react-badge/library/src/components/Badge/useBadgeStyles.styles.ts
@@ -160,7 +160,7 @@ const useRootStyles = makeStyles({
     color: tokens.colorPaletteDarkOrangeForeground3,
   },
   'ghost-subtle': {
-    color: tokens.colorNeutralForegroundStaticInverted,
+    color: tokens.colorNeutralForeground3,
   },
   'ghost-success': {
     color: tokens.colorPaletteGreenForeground3,
@@ -193,7 +193,7 @@ const useRootStyles = makeStyles({
     color: tokens.colorPaletteDarkOrangeForeground3,
   },
   'outline-subtle': {
-    color: tokens.colorNeutralForegroundStaticInverted,
+    color: tokens.colorNeutralForeground2,
   },
   'outline-success': {
     color: tokens.colorPaletteGreenForeground3,


### PR DESCRIPTION

## Previous Behavior

![image](https://github.com/user-attachments/assets/b8015d82-0ab3-44f4-849e-16c86d1d3904)


## New Behavior
Changed the color tokens to align with Fluent UI's design system token usage patterns:

- For `ghost-subtle`: Changed from `colorNeutralForegroundStaticInverted` to `colorNeutralForeground3`
- For `outline-subtle`: Changed from `colorNeutralForegroundStaticInverted` to `colorNeutralForeground2`

This change follows the same pattern as other subtle variants in the Badge component:
- `tint-subtle` uses `colorNeutralForeground3`
- `filled-subtle` uses `colorNeutralForeground1`

![image](https://github.com/user-attachments/assets/b4c19e2b-f3ea-499a-8ed1-4408374ba0aa)


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->
https://github.com/microsoft/fluentui/issues/34167
