### PR TITLE
fix(react-charting): handle blank donut chart when labels exist without corresponding values in plotly json

### DIFF
--- a/change/@fluentui-react-charting-13afcd7d-f890-49b1-8dc6-59ca95175e60.json
+++ b/change/@fluentui-react-charting-13afcd7d-f890-49b1-8dc6-59ca95175e60.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: handle blank donut chart when labels exist without corresponding values in plotly json",
+  "packageName": "@fluentui/react-charting",
+  "email": "kumarkshitij@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charts/react-charting/src/components/DeclarativeChart/PlotlySchemaAdapter.ts
+++ b/packages/charts/react-charting/src/components/DeclarativeChart/PlotlySchemaAdapter.ts
@@ -199,13 +199,21 @@ export const transformPlotlyJsonToDonutProps = (
 ): IDonutChartProps => {
   const firstData = input.data[0] as PieData;
 
-  const donutData = firstData.labels?.map((label: string, index: number): IChartDataPoint => {
+  const mapLegendToDataPoint: Record<string, IChartDataPoint> = {};
+  firstData.labels?.forEach((label: string, index: number) => {
     const color = getColor(label, colorMap, isDarkTheme);
-    return {
-      legend: label,
-      data: firstData.values?.[index] as number, //ToDo how to handle string data?
-      color,
-    };
+    //ToDo how to handle string data?
+    const value = typeof firstData.values?.[index] === 'number' ? firstData.values[index] : 1;
+
+    if (!mapLegendToDataPoint[label]) {
+      mapLegendToDataPoint[label] = {
+        legend: label,
+        data: value,
+        color,
+      };
+    } else {
+      mapLegendToDataPoint[label].data! += value;
+    }
   });
 
   const width: number = input.layout?.width ?? 440;
@@ -223,7 +231,7 @@ export const transformPlotlyJsonToDonutProps = (
   return {
     data: {
       chartTitle,
-      chartData: donutData,
+      chartData: Object.values(mapLegendToDataPoint),
     },
     hideLegend: input.layout?.showlegend === false ? true : false,
     width: input.layout?.width,

--- a/packages/charts/react-charting/src/components/DeclarativeChart/PlotlySchemaAdapter.ts
+++ b/packages/charts/react-charting/src/components/DeclarativeChart/PlotlySchemaAdapter.ts
@@ -203,7 +203,7 @@ export const transformPlotlyJsonToDonutProps = (
   firstData.labels?.forEach((label: string, index: number) => {
     const color = getColor(label, colorMap, isDarkTheme);
     //ToDo how to handle string data?
-    const value = typeof firstData.values?.[index] === 'number' ? firstData.values[index] : 1;
+    const value = typeof firstData.values?.[index] === 'number' ? (firstData.values[index] as number) : 1;
 
     if (!mapLegendToDataPoint[label]) {
       mapLegendToDataPoint[label] = {


### PR DESCRIPTION
## Previous Behavior

The value corresponding to each label was used directly to plot the pie chart.

## New Behavior

If `labels` contain duplicates, we sum associated values or simply count occurrences if `values` is not provided. For more details, see: [Pie traces in JavaScript](https://plotly.com/javascript/reference/pie/#pie-labels)