### PR TITLE
fix(react-charts): Dark mode theme colors for declarative charts in v9

### DIFF
--- a/change/@fluentui-react-charts-42300240-f157-4a51-89ad-d8e994a31a28.json
+++ b/change/@fluentui-react-charts-42300240-f157-4a51-89ad-d8e994a31a28.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(react-charts): Dark mode theme colors for declarative charts in v9",
+  "packageName": "@fluentui/react-charts",
+  "email": "120183316+srmukher@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charts/react-charts/library/src/components/DeclarativeChart/DeclarativeChart.tsx
+++ b/packages/charts/react-charts/library/src/components/DeclarativeChart/DeclarativeChart.tsx
@@ -15,6 +15,9 @@ import { VerticalBarChart } from '../VerticalBarChart/index';
 import { ImageExportOptions, toImage } from './imageExporter';
 import { Chart } from '../../types/index';
 import { tokens } from '@fluentui/react-theme';
+import { ThemeContext_unstable as V9ThemeContext } from '@fluentui/react-shared-contexts';
+import { Theme, webLightTheme } from '@fluentui/react-components';
+import * as d3Color from 'd3-color';
 
 /**
  * DeclarativeChart schema.
@@ -62,6 +65,19 @@ const useColorMapping = () => {
   return colorMap;
 };
 
+const useIsDarkTheme = (): boolean => {
+  const parentV9Theme = React.useContext(V9ThemeContext) as Theme;
+  const v9Theme: Theme = parentV9Theme ? parentV9Theme : webLightTheme;
+
+  // Get background and foreground colors
+  const backgroundColor = d3Color.hsl(v9Theme.colorNeutralBackground1);
+  const foregroundColor = d3Color.hsl(v9Theme.colorNeutralForeground1);
+
+  const isDarkTheme = backgroundColor.l < foregroundColor.l;
+
+  return isDarkTheme;
+};
+
 /**
  * DeclarativeChart component.
  * {@docCategory DeclarativeChart}
@@ -74,7 +90,7 @@ export const DeclarativeChart: React.FunctionComponent<DeclarativeChartProps> = 
   const plotlyInput = plotlySchema as PlotlySchema;
   let { selectedLegends } = plotlySchema;
   const colorMap = useColorMapping();
-  const isDarkTheme = false;
+  const isDarkTheme = useIsDarkTheme();
   const chartRef = React.useRef<Chart>(null);
 
   if (!isArrayOrTypedArray(selectedLegends)) {


### PR DESCRIPTION
Dark mode theme colors for declarative charts in v9.

Before:

![image](https://github.com/user-attachments/assets/b5f93238-30dc-4fc2-a67a-cf4d2113a17b)

After:

![image](https://github.com/user-attachments/assets/5cc739dd-98c3-4f6f-af10-0c13cf037752)
