### PR TITLE
chore: deprecate tabs in favor of tablist

### DIFF
--- a/change/@fluentui-web-components-e4f19076-a214-475b-a1f9-3853d012186e.json
+++ b/change/@fluentui-web-components-e4f19076-a214-475b-a1f9-3853d012186e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "deprecate tabs in favor of tablist",
+  "packageName": "@fluentui/web-components",
+  "email": "13071055+chrisdholt@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/docs/web-components.api.md
+++ b/packages/web-components/docs/web-components.api.md
@@ -3936,7 +3936,7 @@ export const TabPanelTemplate: ElementViewTemplate<TabPanel, any>;
 // Warning: (ae-missing-release-tag) "Tabs" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 // Warning: (ae-missing-release-tag) "Tabs" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export class Tabs extends BaseTabs {
     // (undocumented)
     activeidChanged(oldValue: string, newValue: string): void;

--- a/packages/web-components/src/tabs/define.ts
+++ b/packages/web-components/src/tabs/define.ts
@@ -1,4 +1,7 @@
 import { FluentDesignSystem } from '../fluent-design-system.js';
 import { definition } from './tabs.definition.js';
 
+/**
+ * @deprecated - Use tablist instead
+ */
 definition.define(FluentDesignSystem.registry);

--- a/packages/web-components/src/tabs/tabs.base.ts
+++ b/packages/web-components/src/tabs/tabs.base.ts
@@ -14,7 +14,7 @@ import { TabsOrientation } from './tabs.options.js';
 /**
  * A Tabs component that wraps a collection of tab and tab panel elements.
  *
- * @public
+ * @deprecated - use tablist instead
  */
 export class BaseTabs extends FASTElement {
   /**

--- a/packages/web-components/src/tabs/tabs.stories.ts
+++ b/packages/web-components/src/tabs/tabs.stories.ts
@@ -28,7 +28,7 @@ const tabsDefault = html<StoryArgs<FluentTabs>>`
 `;
 
 export default {
-  title: 'Components/Tabs',
+  title: 'Components/Tabs (Deprecated)',
   render: renderComponent(tabsDefault),
   argTypes: {
     appearance: {

--- a/packages/web-components/src/tabs/tabs.template.ts
+++ b/packages/web-components/src/tabs/tabs.template.ts
@@ -3,6 +3,9 @@ import { endSlotTemplate, startSlotTemplate } from '../patterns/index.js';
 import type { Tabs } from './tabs.js';
 import type { TabsOptions } from './tabs.options.js';
 
+/**
+ * @deprecated - Use tablist instead
+ */
 export function tabsTemplate<T extends Tabs>(options: TabsOptions = {}): ElementViewTemplate<T> {
   return html<T>`
     ${startSlotTemplate(options)}

--- a/packages/web-components/src/tabs/tabs.ts
+++ b/packages/web-components/src/tabs/tabs.ts
@@ -7,6 +7,9 @@ import { TabsAppearance, TabsOrientation, type TabsSize } from './tabs.options.j
 
 type TabData = Omit<DOMRect, 'top' | 'bottom' | 'left' | 'right' | 'toJSON'>;
 
+/**
+ * @deprecated - Use tablist instead
+ */
 export class Tabs extends BaseTabs {
   /**
    * activeTabData


### PR DESCRIPTION
## Previous Behavior
Both `Tabs` and `Tablist` exist.

## New Behavior
This PR deprecates `Tabs` in favor of `Tablist`.

## Related Issue(s)
- Fixes #34181
