### PR TITLE
feat: setup react 18 integration type checking

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -81,6 +81,35 @@ jobs:
           git status --porcelain
           git diff-index --quiet HEAD -- || exit 1
 
+  react_18_integration:
+    if: ${{ github.repository_owner == 'microsoft' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      actions: 'read'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Derive appropriate SHAs for base and head for `nx affected` commands
+        uses: nrwl/nx-set-shas@dbe0650947e5f2c81f59190a38512cf49126fe6b # v4.3.0
+        with:
+          main-branch-name: 'master'
+
+      - uses: actions/setup-node@v4
+        with:
+          cache: 'yarn'
+          node-version: '20'
+
+      - run: echo number of CPUs "$(getconf _NPROCESSORS_ONLN)"
+
+      - run: yarn install --frozen-lockfile
+
+      # add more targets as needed
+      - name: type-check (affected)
+        run: yarn nx affected -t type-check:integration --nxBail
+
   e2e:
     if: ${{ github.repository_owner == 'microsoft' }}
     # TODO: switch to macos once problematic tests are fixed

--- a/apps/react-18-tests-v9/README.md
+++ b/apps/react-18-tests-v9/README.md
@@ -4,6 +4,24 @@
 
 ## Usage
 
+### React 18 integration tests against all v9 code in monorepo
+
+Following Targets are used:
+
+#### type-check:integration
+
+`yarn nx run react-18-tests-v9:type-check:integration`
+
+runs `tsc` against all monorepo v9 stories with properly pinned `@types/react@18`
+
+_Note:_ react-migration-v8-v9, react-migration-v0-v9 and any `react-*-compat` are excluded from this check
+
+#### e2e
+
+`yarn nx run react-18-tests-v9:e2e`
+
+runs `cypress` against all monorepo v9 `*.cy.tsx?` with properly pinned `react18` runtime deps
+
 ### `start`
 
 ```shell

--- a/apps/react-18-tests-v9/package.json
+++ b/apps/react-18-tests-v9/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "type-check": "just-scripts type-check",
+    "type-check:integration": "tsc -p tsconfig.react-18.json --noEmit",
     "lint": "ESLINT_USE_FLAT_CONFIG=false eslint --ext .js,.ts,.tsx ./src",
     "test": "jest --passWithNoTests",
     "format": "prettier -w . --ignore-path ../.prettierignore",

--- a/apps/react-18-tests-v9/project.json
+++ b/apps/react-18-tests-v9/project.json
@@ -3,5 +3,17 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "application",
   "implicitDependencies": [],
-  "tags": ["vNext"]
+  "tags": ["vNext"],
+  "targets": {
+    "type-check:integration": {
+      "dependsOn": ["^build"],
+      "inputs": [
+        "{projectRoot}/tsconfig.react-18.json",
+        "{workspaceRoot}/packages/react-components/*/stories/**/*.stories.tsx?",
+        "!{workspaceRoot}/packages/react-components/*/stories/**/index.stories.tsx?",
+        "!{workspaceRoot}/packages/react-components/react-migration-v[80]-v9/**",
+        "!{workspaceRoot}/packages/react-components/react-[a-z]+-compat/**"
+      ]
+    }
+  }
 }

--- a/apps/react-18-tests-v9/tsconfig.react-18.json
+++ b/apps/react-18-tests-v9/tsconfig.react-18.json
@@ -1,0 +1,38 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "lib": ["ES2019", "dom"],
+    "sourceMap": true,
+    "strict": true,
+    "pretty": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "importHelpers": true,
+    "jsx": "react",
+    "noUnusedLocals": true,
+    "preserveConstEnums": true,
+    "skipLibCheck": true,
+    "typeRoots": ["./node_modules/@types"],
+    "types": [],
+    "baseUrl": ".",
+    "paths": {
+      "react/jsx-runtime": ["./node_modules/@types/react/jsx-runtime.d.ts"],
+      "react": ["./node_modules/@types/react/index.d.ts"],
+      "react-dom": ["./node_modules/@types/react-dom/index.d.ts"]
+    }
+  },
+  "exclude": [
+    "../../packages/react-components/**/index.stories.tsx",
+    "../../packages/react-components/**/index.stories.ts",
+    "../../packages/react-components/react-migration-v0-v9/**",
+    "../../packages/react-components/react-migration-v8-v9/**",
+    "../../packages/react-components/react-*-compat/**"
+  ],
+  "include": [
+    "../../packages/react-components/*/stories/**/*.stories.tsx",
+    "../../packages/react-components/*/stories/**/*.stories.ts"
+  ],
+  "files": ["../../typings/static-assets/index.d.ts"]
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

- adds new `type-check:integration` target to execute properly scoped `@types/react@18` against all v9 story files
- adds new workflow job which executes react 18 specific integration tests without affecting rest of pipelines
<img width="831" alt="image" src="https://github.com/user-attachments/assets/c948a1b5-31d2-434d-b8ca-4f060cd837c2" />


**NOTE:** the intent to see the job failing is EXPECTED to have transparent metric tracking progress of making v9 compatible with react 18


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
