### PR TITLE
feat: setup react 18 integration e2e outside main pipeline

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -106,9 +106,71 @@ jobs:
 
       - run: yarn install --frozen-lockfile
 
+      - name: Verify Cypress install
+        run: yarn cypress verify
+
       # add more targets as needed
       - name: type-check (affected)
+        id: type-check
         run: yarn nx affected -t type-check:integration --nxBail
+        continue-on-error: true
+
+      - name: Prepare TSC logs
+        if: always() && steps.type-check.outcome == 'failure'
+        run: |
+          mkdir -p tsc-logs
+          yarn tsc -p apps/react-18-tests-v9/tsconfig.react-18.json --listFilesOnly > tsc-logs/tsc-debug-files-map.md
+
+      - name: Upload TSC logs
+        if: always() && steps.type-check.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: typescript-react-18
+          path: tsc-logs
+          retention-days: 1
+
+      - name: Affected e2e:integration Projects
+        id: affected_projects_count
+        run: |
+          affected_count=$(yarn --silent nx show projects -t e2e:integration --affected --verbose false | wc -l | tr -d ' ')
+          echo "value=$affected_count" >> $GITHUB_OUTPUT
+
+      # run targets only on affected changes - need to run this outside nx runner context to avoid https://github.com/nrwl/nx/issues/30562
+      - name: e2e (affected)
+        id: e2e
+        if: steps.affected_projects_count.outputs.value > 0
+        run: yarn workspace @fluentui/react-18-tests-v9 e2e:integration
+        continue-on-error: true
+
+      - name: Upload Cypress screenshots if exist
+        uses: actions/upload-artifact@v4
+        if: always() && steps.type-check.outcome == 'failure'
+        with:
+          name: cypress-screenshots-react-18
+          path: |
+            apps/*/cypress/screenshots/**/*.png
+            packages/**/cypress/screenshots/**/*.png
+          retention-days: 1
+
+      - name: Integration tests success
+        if: steps.type-check.outcome == 'success' && steps.e2e.outcome == 'success'
+        run: |
+          echo "React 18 integration tests passed"
+
+      - name: Integration tests failure
+        if: steps.type-check.outcome == 'failure' || steps.e2e.outcome == 'failure'
+        run: |
+          echo "React 18 integration tests failed"
+          echo "Type-check: ${{ steps.type-check.outcome }}"
+          echo "E2E: ${{ steps.e2e.outcome }}"
+          echo "Exiting with error code 1"
+
+          echo "### React 18 Integration Tests Failure" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- Type-check: ${{ steps.type-check.outcome }}" >> $GITHUB_STEP_SUMMARY
+          echo "- E2E: ${{ steps.e2e.outcome }}" >> $GITHUB_STEP_SUMMARY
+
+          exit 1
 
   e2e:
     if: ${{ github.repository_owner == 'microsoft' }}

--- a/apps/react-18-tests-v9/.eslintrc.json
+++ b/apps/react-18-tests-v9/.eslintrc.json
@@ -2,6 +2,7 @@
   "extends": ["plugin:@fluentui/eslint-plugin/react"],
   "root": true,
   "rules": {
-    "@nx/workspace-no-restricted-globals": "off"
+    "@nx/workspace-no-restricted-globals": "off",
+    "import/no-extraneous-dependencies": "off"
   }
 }

--- a/apps/react-18-tests-v9/README.md
+++ b/apps/react-18-tests-v9/README.md
@@ -16,9 +16,9 @@ runs `tsc` against all monorepo v9 stories with properly pinned `@types/react@18
 
 _Note:_ react-migration-v8-v9, react-migration-v0-v9 and any `react-*-compat` are excluded from this check
 
-#### e2e
+#### e2e:integration
 
-`yarn nx run react-18-tests-v9:e2e`
+`yarn nx run react-18-tests-v9:e2e:integration`
 
 runs `cypress` against all monorepo v9 `*.cy.tsx?` with properly pinned `react18` runtime deps
 

--- a/apps/react-18-tests-v9/cypress-react-18.config.ts
+++ b/apps/react-18-tests-v9/cypress-react-18.config.ts
@@ -1,8 +1,22 @@
 import * as path from 'path';
 import { baseConfig } from '@fluentui/scripts-cypress';
 
+// Exclude files that are not compatible with React 18 yet
+const excludedSpecs = [
+  '!' + path.resolve('../../packages/react-components/react-tag-picker/library/src/**/*.cy.{tsx,ts}'),
+  '!' + path.resolve('../../packages/react-components/react-tree/library/src/components/Tree/Tree.cy.tsx'),
+];
+
+// Include all tests from this app and the components package
+const includedSpecs = [
+  path.resolve('../../packages/react-components/**/library/src/**/*.cy.{tsx,ts}'),
+  path.resolve('../../packages/react-components/react-tabster/src/**/*.cy.{tsx,ts}'),
+];
+
+const specs = [...includedSpecs, ...excludedSpecs];
 const config = { ...baseConfig };
 
+config.component.specPattern = specs;
 config.component.devServer.webpackConfig.resolve ??= {};
 config.component.devServer.webpackConfig.resolve.alias = {
   ...config.component.devServer.webpackConfig.resolve.alias,

--- a/apps/react-18-tests-v9/package.json
+++ b/apps/react-18-tests-v9/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@cypress/react": "9.0.1",
     "@fluentui/react-components": "*",
+    "@fluentui/react-nav-preview": "*",
     "@testing-library/dom": "^10.1.0",
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.5.2",

--- a/apps/react-18-tests-v9/package.json
+++ b/apps/react-18-tests-v9/package.json
@@ -12,7 +12,8 @@
     "format:check": "yarn format -c",
     "start": "webpack-dev-server --mode=development",
     "e2e:local": "cypress open --component",
-    "e2e": "cypress run --component"
+    "e2e": "cypress run --component",
+    "e2e:integration": "cypress run --component --config-file cypress-react-18.config.ts"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",

--- a/apps/react-18-tests-v9/project.json
+++ b/apps/react-18-tests-v9/project.json
@@ -14,6 +14,15 @@
         "!{workspaceRoot}/packages/react-components/react-migration-v[80]-v9/**",
         "!{workspaceRoot}/packages/react-components/react-[a-z]+-compat/**"
       ]
+    },
+    "e2e:integration": {
+      "dependsOn": [],
+      "inputs": [
+        "{projectRoot}/cypress-react-18.config.ts",
+        "{workspaceRoot}/packages/react-components/**/*.cy.tsx?",
+        "!{workspaceRoot}/packages/react-components/react-migration-v[80]-v9/**",
+        "!{workspaceRoot}/packages/react-components/react-[a-z]+-compat/**"
+      ]
     }
   }
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Needs

- [x] https://github.com/microsoft/fluentui/pull/34211

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

moves repo cypress integration tests against react 18 to unified react-18 job
- mitigates perf hit to main e2e pipeline
- moves react 18 tests agains all cypress v9 files to new `react_18_integration` job
- scoped metric for react 18 migration
- runs cypress outside nx runner scope to get full error logs https://github.com/nrwl/nx/issues/30562
- uses summaries for nicer outputs https://github.com/microsoft/fluentui/actions/runs/14358190753?pr=34212#summary-40252580079

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
