### PR TITLE
fix(react-swatch-picker): design change of selected state for ColorSwatch

### DIFF
--- a/change/@fluentui-react-swatch-picker-9a3c1595-b8f0-4556-889c-6c515243b67b.json
+++ b/change/@fluentui-react-swatch-picker-9a3c1595-b8f0-4556-889c-6c515243b67b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: design change of selected state for ColorSwatch",
+  "packageName": "@fluentui/react-swatch-picker",
+  "email": "v.kozlova13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-swatch-picker/library/src/components/ColorSwatch/useColorSwatchStyles.styles.ts
+++ b/packages/react-components/react-swatch-picker/library/src/components/ColorSwatch/useColorSwatchStyles.styles.ts
@@ -92,16 +92,36 @@ const useStyles = makeStyles({
       boxShadow: `inset 0 0 0 ${tokens.strokeWidthThicker} ${tokens.colorBrandStroke2Pressed}, inset 0 0 0 5px ${tokens.colorStrokeFocus1}`,
     },
   },
+  selectedSmall: {
+    boxShadow: `inset 0 0 0 ${tokens.strokeWidthThick} ${tokens.colorBrandStroke1}, inset 0 0 0 ${tokens.strokeWidthThicker} ${tokens.colorStrokeFocus1}`,
+    ':hover': {
+      boxShadow: `inset 0 0 0 ${tokens.strokeWidthThick} ${tokens.colorCompoundBrandStrokeHover}, inset 0 0 0 ${tokens.strokeWidthThicker} ${tokens.colorStrokeFocus1}`,
+    },
+    ':hover:active': {
+      boxShadow: `inset 0 0 0 ${tokens.strokeWidthThicker} ${tokens.colorCompoundBrandStrokePressed}, inset 0 0 0 ${tokens.strokeWidthThickest} ${tokens.colorStrokeFocus1}`,
+    },
+  },
 });
 
 const useSizeStyles = makeStyles({
   'extra-small': {
     width: '20px',
     height: '20px',
+    ':hover': {
+      boxShadow: `inset 0 0 0 ${tokens.strokeWidthThin} ${tokens.colorBrandStroke1}, inset 0 0 0 ${tokens.strokeWidthThick} ${tokens.colorStrokeFocus1}`,
+    },
+    ':hover:active': {
+      border: 'none',
+      boxShadow: `inset 0 0 0 ${tokens.strokeWidthThick} ${tokens.colorCompoundBrandStrokePressed}, inset 0 0 0 ${tokens.strokeWidthThicker} ${tokens.colorStrokeFocus1}`,
+    },
   },
   small: {
     width: '24px',
     height: '24px',
+    ':hover:active': {
+      border: 'none',
+      boxShadow: `inset 0 0 0 ${tokens.strokeWidthThick} ${tokens.colorCompoundBrandStrokePressed}, inset 0 0 0 ${tokens.strokeWidthThicker} ${tokens.colorStrokeFocus1}`,
+    },
   },
   medium: {
     width: '28px',
@@ -158,13 +178,14 @@ const useIconStyles = makeStyles({
 export const useColorSwatchStyles_unstable = (state: ColorSwatchState): ColorSwatchState => {
   'use no memo';
 
+  const { size = 'medium', shape = 'square' } = state;
+
   const resetStyles = useResetStyles();
   const styles = useStyles();
   const sizeStyles = useSizeStyles();
   const shapeStyles = useShapeStyles();
   const iconStyles = useIconStyles();
-
-  const { size = 'medium', shape = 'square' } = state;
+  const smallerSelectedStyles = size === 'small' || size === 'extra-small' ? styles.selectedSmall : '';
 
   state.root.className = mergeClasses(
     colorSwatchClassNames.root,
@@ -172,6 +193,7 @@ export const useColorSwatchStyles_unstable = (state: ColorSwatchState): ColorSwa
     sizeStyles[size],
     shapeStyles[shape],
     state.selected && styles.selected,
+    state.selected && smallerSelectedStyles,
     state.disabled && styles.disabled,
     state.root.className,
   );


### PR DESCRIPTION
Partners ask. For custom small sizes original design of `selected` state looks not accessible:
![image](https://github.com/user-attachments/assets/d6ac35e0-0f25-4919-92ad-8c2a1cc900cd)
![image](https://github.com/user-attachments/assets/50717481-7953-444c-8228-b3c796b6313a)


## Previous Behavior
![image](https://github.com/user-attachments/assets/9b733b36-4d63-4f02-95ec-c2124fda16ed)

## New Behavior
![image](https://github.com/user-attachments/assets/1171c149-67aa-4a0e-a5bc-730e5ef1a9f3)
