### PR TITLE
Revert "fix(react-badge): Use min-width: max-content on Badge

### DIFF
--- a/apps/vr-tests-react-components/src/stories/Badge/BadgeSize.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Badge/BadgeSize.stories.tsx
@@ -161,23 +161,3 @@ export const SizeExtraLarge = () => {
 SizeExtraLarge.storyName = 'size: extra-large';
 
 export const SizeExtraLargeRTL = getStoryVariant(SizeExtraLarge, RTL);
-
-export const WidthConstrained = () => {
-  const styles = useStyles();
-  return (
-    <div className={styles.group}>
-      <div className={styles.widthConstrained}>
-        <Badge>1</Badge>
-        <Badge icon={<CircleRegular />} />
-        <Badge>BADGE</Badge>
-        <Badge icon={<CircleRegular />}>BADGE</Badge>
-        <Badge icon={<CircleRegular />} iconPosition="after">
-          BADGE
-        </Badge>
-      </div>
-      <span className={styles.description}>Badges should not clip their content when space constrained.</span>
-    </div>
-  );
-};
-
-WidthConstrained.storyName = 'width constrained';

--- a/apps/vr-tests-react-components/src/stories/Badge/utils.ts
+++ b/apps/vr-tests-react-components/src/stories/Badge/utils.ts
@@ -57,18 +57,4 @@ export const useStyles = makeStyles({
     alignItems: 'center',
     columnGap: tokens.spacingHorizontalS,
   },
-
-  widthConstrained: {
-    display: 'inline-flex',
-    width: '150px',
-    columnGap: tokens.spacingHorizontalS,
-    ...shorthands.padding('1px'),
-    ...shorthands.border('2px', 'dashed', tokens.colorPaletteRedBorder1),
-    backgroundColor: tokens.colorPaletteRedBackground1,
-  },
-
-  description: {
-    color: tokens.colorNeutralForeground3,
-    ...typographyStyles.caption1,
-  },
 });

--- a/change/@fluentui-react-badge-4691165c-bbe4-4d80-b499-d48e64a95426.json
+++ b/change/@fluentui-react-badge-4691165c-bbe4-4d80-b499-d48e64a95426.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: revert min-width: max-content for Badge",
+  "packageName": "@fluentui/react-badge",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-badge/library/src/components/Badge/useBadgeStyles.styles.ts
+++ b/packages/react-components/react-badge/library/src/components/Badge/useBadgeStyles.styles.ts
@@ -20,8 +20,7 @@ const useRootClassName = makeResetStyles({
   position: 'relative',
   ...typographyStyles.caption1Strong,
   height: '20px',
-  width: '20px',
-  minWidth: 'max-content',
+  minWidth: '20px',
   padding: `0 calc(${tokens.spacingHorizontalXS} + ${textPadding})`,
   borderRadius: tokens.borderRadiusCircular,
   // Use a transparent stroke (rather than no border) so the border is visible in high contrast
@@ -65,7 +64,7 @@ const useRootStyles = makeStyles({
     padding: 'unset',
   },
   small: {
-    width: '16px',
+    minWidth: '16px',
     height: '16px',
     padding: `0 calc(${tokens.spacingHorizontalXXS} + ${textPadding})`,
   },
@@ -73,12 +72,12 @@ const useRootStyles = makeStyles({
     // Set by useRootClassName
   },
   large: {
-    width: '24px',
+    minWidth: '24px',
     height: '24px',
     padding: `0 calc(${tokens.spacingHorizontalXS} + ${textPadding})`,
   },
   'extra-large': {
-    width: '32px',
+    minWidth: '32px',
     height: '32px',
     padding: `0 calc(${tokens.spacingHorizontalSNudge} + ${textPadding})`,
   },


### PR DESCRIPTION
This reverts commit 72acd40b2319325eb725760888185a2fabdd46e7.

Initially it had `minWidth: <size>`, later was [changed](https://github.com/microsoft/fluentui/pull/27489) to `minWidth: max-content` and `width: <badge size>` to prevent the badge from shrinking smaller than the content. Although, this is introducing bugs and inconsistent behavior in Safari with other browsers. I suggest, we can revert this change to make behavior more predictable and if needed, users can handle it by themselves. 

## Previous Behavior

Badge has `width: 20px` and `minWidth: max-content`

![image](https://github.com/user-attachments/assets/64fa4749-c2fe-4f87-bc7f-79451473802e)

![before](https://github.com/user-attachments/assets/f99103df-6518-4d8b-a5f4-b30b15f44a8e)


## New Behavior

Badge has only `minWidth: <size>`. 

![image](https://github.com/user-attachments/assets/8d76536c-2376-4f7a-ad2e-c4cfb83bde25)

![new](https://github.com/user-attachments/assets/51bce633-2ed7-4f3f-bfd8-ea81e3f70785)


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #34089
