### PR TITLE
Semantic-Tokens: React-Link

### DIFF
--- a/change/@fluentui-react-link-934b9c1a-08e7-4b38-a2cf-518acb9dd861.json
+++ b/change/@fluentui-react-link-934b9c1a-08e7-4b38-a2cf-518acb9dd861.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: Implement semantic tokens for react-link",
+  "packageName": "@fluentui/react-link",
+  "email": "mifraser@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-link/library/package.json
+++ b/packages/react-components/react-link/library/package.json
@@ -25,6 +25,7 @@
     "@fluentui/react-tabster": "^9.24.1",
     "@fluentui/react-theme": "^9.1.24",
     "@fluentui/react-utilities": "^9.18.21",
+    "@fluentui/semantic-tokens": "0.0.0-alpha.1",
     "@griffel/react": "^1.5.22",
     "@swc/helpers": "^0.5.1"
   },

--- a/packages/react-components/react-link/library/src/components/Link/useLinkStyles.styles.ts
+++ b/packages/react-components/react-link/library/src/components/Link/useLinkStyles.styles.ts
@@ -1,20 +1,7 @@
 import { shorthands, makeStyles, mergeClasses } from '@griffel/react';
 import { createCustomFocusIndicatorStyle } from '@fluentui/react-tabster';
 import { tokens } from '@fluentui/react-theme';
-import {
-  ctrlFocusOuterStroke,
-  ctrlLinkForegroundBrandHover,
-  ctrlLinkForegroundBrandPressed,
-  ctrlLinkForegroundNeutralRest,
-  ctrlLinkForegroundNeutralHover,
-  ctrlLinkForegroundNeutralPressed,
-  foregroundCtrlNeutralPrimaryDisabled,
-  textGlobalBody3Fontsize,
-  textStyleDefaultRegularFontfamily,
-  textStyleDefaultRegularWeight,
-  strokewidthDefault,
-  ctrlLinkForegroundBrandRest,
-} from '@fluentui/semantic-tokens';
+import * as semanticTokens from '@fluentui/semantic-tokens';
 import type { LinkSlots, LinkState } from './Link.types';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 
@@ -24,7 +11,7 @@ export const linkClassNames: SlotClassNames<LinkSlots> = {
 
 const useStyles = makeStyles({
   focusIndicator: createCustomFocusIndicatorStyle({
-    textDecorationColor: ctrlFocusOuterStroke,
+    textDecorationColor: semanticTokens.ctrlFocusOuterStroke,
     textDecorationLine: 'underline',
     textDecorationStyle: 'double',
     outlineStyle: 'none',
@@ -36,29 +23,29 @@ const useStyles = makeStyles({
     },
     backgroundColor: 'transparent',
     boxSizing: 'border-box',
-    color: ctrlLinkForegroundBrandRest,
+    color: semanticTokens.ctrlLinkForegroundBrandRest,
     cursor: 'pointer',
     display: 'inline',
-    fontFamily: textStyleDefaultRegularFontfamily,
-    fontSize: textGlobalBody3Fontsize,
-    fontWeight: textStyleDefaultRegularWeight,
+    fontFamily: semanticTokens.textStyleDefaultRegularFontfamily,
+    fontSize: semanticTokens.textGlobalBody3Fontsize,
+    fontWeight: semanticTokens.textStyleDefaultRegularWeight,
     margin: '0',
     padding: '0',
     overflow: 'inherit',
     textAlign: 'left',
     textDecorationLine: 'none',
-    textDecorationThickness: strokewidthDefault,
+    textDecorationThickness: semanticTokens.strokewidthDefault,
     textOverflow: 'inherit',
     userSelect: 'text',
 
     ':hover': {
       textDecorationLine: 'underline',
-      color: ctrlLinkForegroundBrandHover,
+      color: semanticTokens.ctrlLinkForegroundBrandHover,
     },
 
     ':active': {
       textDecorationLine: 'underline',
-      color: ctrlLinkForegroundBrandPressed,
+      color: semanticTokens.ctrlLinkForegroundBrandPressed,
     },
   },
   // Overrides when the Link renders as a button.
@@ -71,16 +58,16 @@ const useStyles = makeStyles({
   },
   // Overrides when the Link appears subtle.
   subtle: {
-    color: ctrlLinkForegroundNeutralRest,
+    color: semanticTokens.ctrlLinkForegroundNeutralRest,
 
     ':hover': {
       textDecorationLine: 'underline',
-      color: ctrlLinkForegroundNeutralHover,
+      color: semanticTokens.ctrlLinkForegroundNeutralHover,
     },
 
     ':active': {
       textDecorationLine: 'underline',
-      color: ctrlLinkForegroundNeutralPressed,
+      color: semanticTokens.ctrlLinkForegroundNeutralPressed,
     },
   },
   // Overrides when the Link is rendered inline within text.
@@ -90,17 +77,17 @@ const useStyles = makeStyles({
   // Overrides when the Link is disabled.
   disabled: {
     textDecorationLine: 'none',
-    color: foregroundCtrlNeutralPrimaryDisabled,
+    color: semanticTokens.foregroundCtrlNeutralPrimaryDisabled,
     cursor: 'not-allowed',
 
     ':hover': {
       textDecorationLine: 'none',
-      color: foregroundCtrlNeutralPrimaryDisabled,
+      color: semanticTokens.foregroundCtrlNeutralPrimaryDisabled,
     },
 
     ':active': {
       textDecorationLine: 'none',
-      color: foregroundCtrlNeutralPrimaryDisabled,
+      color: semanticTokens.foregroundCtrlNeutralPrimaryDisabled,
     },
   },
 

--- a/packages/react-components/react-link/library/src/components/Link/useLinkStyles.styles.ts
+++ b/packages/react-components/react-link/library/src/components/Link/useLinkStyles.styles.ts
@@ -1,6 +1,20 @@
 import { shorthands, makeStyles, mergeClasses } from '@griffel/react';
 import { createCustomFocusIndicatorStyle } from '@fluentui/react-tabster';
 import { tokens } from '@fluentui/react-theme';
+import {
+  ctrlFocusOuterStroke,
+  ctrlLinkForegroundBrandHover,
+  ctrlLinkForegroundBrandPressed,
+  ctrlLinkForegroundNeutralRest,
+  ctrlLinkForegroundNeutralHover,
+  ctrlLinkForegroundNeutralPressed,
+  foregroundCtrlNeutralPrimaryDisabled,
+  textGlobalBody3Fontsize,
+  textStyleDefaultRegularFontfamily,
+  textStyleDefaultRegularWeight,
+  strokewidthDefault,
+  ctrlLinkForegroundBrandRest,
+} from '@fluentui/semantic-tokens';
 import type { LinkSlots, LinkState } from './Link.types';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 
@@ -10,7 +24,7 @@ export const linkClassNames: SlotClassNames<LinkSlots> = {
 
 const useStyles = makeStyles({
   focusIndicator: createCustomFocusIndicatorStyle({
-    textDecorationColor: tokens.colorStrokeFocus2,
+    textDecorationColor: ctrlFocusOuterStroke,
     textDecorationLine: 'underline',
     textDecorationStyle: 'double',
     outlineStyle: 'none',
@@ -22,29 +36,29 @@ const useStyles = makeStyles({
     },
     backgroundColor: 'transparent',
     boxSizing: 'border-box',
-    color: tokens.colorBrandForegroundLink,
+    color: ctrlLinkForegroundBrandRest,
     cursor: 'pointer',
     display: 'inline',
-    fontFamily: tokens.fontFamilyBase,
-    fontSize: tokens.fontSizeBase300,
-    fontWeight: tokens.fontWeightRegular,
+    fontFamily: textStyleDefaultRegularFontfamily,
+    fontSize: textGlobalBody3Fontsize,
+    fontWeight: textStyleDefaultRegularWeight,
     margin: '0',
     padding: '0',
     overflow: 'inherit',
     textAlign: 'left',
     textDecorationLine: 'none',
-    textDecorationThickness: tokens.strokeWidthThin,
+    textDecorationThickness: strokewidthDefault,
     textOverflow: 'inherit',
     userSelect: 'text',
 
     ':hover': {
       textDecorationLine: 'underline',
-      color: tokens.colorBrandForegroundLinkHover,
+      color: ctrlLinkForegroundBrandHover,
     },
 
     ':active': {
       textDecorationLine: 'underline',
-      color: tokens.colorBrandForegroundLinkPressed,
+      color: ctrlLinkForegroundBrandPressed,
     },
   },
   // Overrides when the Link renders as a button.
@@ -57,16 +71,16 @@ const useStyles = makeStyles({
   },
   // Overrides when the Link appears subtle.
   subtle: {
-    color: tokens.colorNeutralForeground2,
+    color: ctrlLinkForegroundNeutralRest,
 
     ':hover': {
       textDecorationLine: 'underline',
-      color: tokens.colorNeutralForeground2Hover,
+      color: ctrlLinkForegroundNeutralHover,
     },
 
     ':active': {
       textDecorationLine: 'underline',
-      color: tokens.colorNeutralForeground2Pressed,
+      color: ctrlLinkForegroundNeutralPressed,
     },
   },
   // Overrides when the Link is rendered inline within text.
@@ -76,20 +90,21 @@ const useStyles = makeStyles({
   // Overrides when the Link is disabled.
   disabled: {
     textDecorationLine: 'none',
-    color: tokens.colorNeutralForegroundDisabled,
+    color: foregroundCtrlNeutralPrimaryDisabled,
     cursor: 'not-allowed',
 
     ':hover': {
       textDecorationLine: 'none',
-      color: tokens.colorNeutralForegroundDisabled,
+      color: foregroundCtrlNeutralPrimaryDisabled,
     },
 
     ':active': {
       textDecorationLine: 'none',
-      color: tokens.colorNeutralForegroundDisabled,
+      color: foregroundCtrlNeutralPrimaryDisabled,
     },
   },
 
+  // Semantic-tokens does not include inverted tokens, use existing tokens for now.
   inverted: {
     color: tokens.colorBrandForegroundInverted,
     ':hover': {


### PR DESCRIPTION
Updates React-link to use semantic tokens
To be landed after https://github.com/microsoft/fluentui/pull/34217
Extended tokens branch will be PR'd against master to validate via bundle size tool.

## Previous Behavior
React-link used existing fluentui/tokens set

## New Behavior
React-link now uses fluentui/semantic-tokens set
