### PR TITLE
tests(e2e): upgrade Cypress to version 14 for React 18 v9 tests

### DIFF
--- a/apps/react-18-tests-v8/package.json
+++ b/apps/react-18-tests-v8/package.json
@@ -25,7 +25,7 @@
     "@fluentui/react": "*",
     "@fluentui/react-hooks": "*",
     "@types/react": "18.3.20",
-    "@types/react-dom": "18.3.5",
+    "@types/react-dom": "18.3.6",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "tslib": "^2.1.0"

--- a/apps/react-18-tests-v9/cypress-react-18.config.ts
+++ b/apps/react-18-tests-v9/cypress-react-18.config.ts
@@ -1,30 +1,29 @@
 import * as path from 'path';
 import { baseConfig } from '@fluentui/scripts-cypress';
 
-// Exclude files that are not compatible with React 18 yet
-const excludedSpecs = [
-  '!' + path.resolve('../../packages/react-components/react-tag-picker/library/src/**/*.cy.{tsx,ts}'),
-  '!' + path.resolve('../../packages/react-components/react-tree/library/src/components/Tree/Tree.cy.tsx'),
-];
-
 // Include all tests from this app and the components package
-const includedSpecs = [
+const specs = [
   path.resolve('../../packages/react-components/**/library/src/**/*.cy.{tsx,ts}'),
   path.resolve('../../packages/react-components/react-tabster/src/**/*.cy.{tsx,ts}'),
 ];
-
-const specs = [...includedSpecs, ...excludedSpecs];
 const config = { ...baseConfig };
 
 config.component.specPattern = specs;
-config.component.devServer.webpackConfig.resolve ??= {};
 config.component.devServer.webpackConfig.resolve.alias = {
-  ...config.component.devServer.webpackConfig.resolve.alias,
-  '@cypress/react': path.resolve(__dirname, './node_modules/@cypress/react'),
-  '@types/react': path.resolve(__dirname, './node_modules/@types/react'),
   '@types/react-dom': path.resolve(__dirname, './node_modules/@types/react-dom'),
   react: path.resolve(__dirname, './node_modules/react'),
   'react-dom': path.resolve(__dirname, './node_modules/react-dom'),
+  'cypress-real-events': path.resolve(__dirname, './node_modules/cypress-real-events'),
 };
+
+/**
+ * Resolve the support file and index.html file paths
+ * This is a workaround for the issue where Cypress does not resolve the paths correctly, as it
+ * internally prepend the __dirname, making them invalid.
+ *
+ * TODO: Remove this workaround once we upgrade the whole repo to Cypress 14
+ */
+config.component.supportFile = '../../scripts/cypress/src/support/component.js';
+config.component.indexHtmlFile = '../../scripts/cypress/src/support/component-index.html';
 
 export default config;

--- a/apps/react-18-tests-v9/cypress-react-18.config.ts
+++ b/apps/react-18-tests-v9/cypress-react-18.config.ts
@@ -1,10 +1,16 @@
 import * as path from 'path';
 import { baseConfig } from '@fluentui/scripts-cypress';
 
+const excludedSpecs = [
+  '!' + path.resolve('../../packages/react-components/*-compat/src/**/*.cy.{tsx,ts}'),
+  '!' + path.resolve('../../packages/react-components/*-migration-*/src/**/*.cy.{tsx,ts}'),
+];
+
 // Include all tests from this app and the components package
 const specs = [
   path.resolve('../../packages/react-components/**/library/src/**/*.cy.{tsx,ts}'),
   path.resolve('../../packages/react-components/react-tabster/src/**/*.cy.{tsx,ts}'),
+  ...excludedSpecs,
 ];
 const config = { ...baseConfig };
 

--- a/apps/react-18-tests-v9/cypress-react-18.config.ts
+++ b/apps/react-18-tests-v9/cypress-react-18.config.ts
@@ -27,7 +27,7 @@ config.component.devServer.webpackConfig.resolve.alias = {
  *
  * TODO: Remove this workaround once we upgrade the whole repo to Cypress 14
  */
-config.component.supportFile = '../../scripts/cypress/src/support/component.js';
-config.component.indexHtmlFile = '../../scripts/cypress/src/support/component-index.html';
+config.component.supportFile = path.normalize('../../scripts/cypress/src/support/component.js');
+config.component.indexHtmlFile = path.normalize('../../scripts/cypress/src/support/component-index.html');
 
 export default config;

--- a/apps/react-18-tests-v9/cypress-react-18.config.ts
+++ b/apps/react-18-tests-v9/cypress-react-18.config.ts
@@ -9,7 +9,11 @@ const specs = [
 const config = { ...baseConfig };
 
 config.component.specPattern = specs;
+config.component.devServer.webpackConfig.resolve ??= {};
 config.component.devServer.webpackConfig.resolve.alias = {
+  ...config.component.devServer.webpackConfig.resolve.alias,
+  '@cypress/react': path.resolve(__dirname, './node_modules/@cypress/react'),
+  '@types/react': path.resolve(__dirname, './node_modules/@types/react'),
   '@types/react-dom': path.resolve(__dirname, './node_modules/@types/react-dom'),
   react: path.resolve(__dirname, './node_modules/react'),
   'react-dom': path.resolve(__dirname, './node_modules/react-dom'),

--- a/apps/react-18-tests-v9/package.json
+++ b/apps/react-18-tests-v9/package.json
@@ -11,9 +11,9 @@
     "format": "prettier -w . --ignore-path ../.prettierignore",
     "format:check": "yarn format -c",
     "start": "webpack-dev-server --mode=development",
-    "e2e:local": "cypress open --component",
     "e2e": "cypress run --component",
-    "e2e:integration": "cypress run --component --config-file cypress-react-18.config.ts"
+    "e2e:local": "cypress open --component",
+    "e2e:integration": "npx --yes cypress@latest run --component --config-file cypress-react-18.config.ts"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "*",
@@ -28,8 +28,9 @@
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.5.2",
     "@types/react": "18.3.20",
-    "@types/react-dom": "18.3.5",
+    "@types/react-dom": "18.3.6",
     "@types/react-test-renderer": "18.3.1",
+    "cypress-real-events": "1.14.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-test-renderer": "18.3.1",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "@cactuslab/usepubsub": "^1.0.2",
     "@ctrl/tinycolor": "3.3.4",
     "@cypress/react": "8.0.0",
-    "@cypress/webpack-dev-server": "1.8.3",
     "@dnd-kit/core": "^6.0.8",
     "@dnd-kit/sortable": "^7.0.2",
     "@dnd-kit/utilities": "^3.2.1",

--- a/scripts/cypress/src/base.config.ts
+++ b/scripts/cypress/src/base.config.ts
@@ -56,7 +56,9 @@ const cypressWebpackConfig = (): Configuration => {
 
 type BaseConfig = Omit<Cypress.ConfigOptions, 'component'> & {
   component: Omit<Cypress.ConfigOptions['component'], 'devServer'> & {
-    specPattern?: string[];
+    specPattern?: Cypress.ResolvedConfigOptions['specPattern'];
+    supportFile?: Cypress.ResolvedConfigOptions['supportFile'];
+    indexHtmlFile?: Cypress.ResolvedConfigOptions['indexHtmlFile'];
     devServer: {
       bundler: 'webpack';
       framework: 'react';

--- a/scripts/cypress/src/base.config.ts
+++ b/scripts/cypress/src/base.config.ts
@@ -54,18 +54,15 @@ const cypressWebpackConfig = (): Configuration => {
   return baseWebpackConfig;
 };
 
-type BaseConfig = Omit<Cypress.ConfigOptions, 'component'> & {
-  component: Omit<Cypress.ConfigOptions['component'], 'devServer'> & {
-    specPattern?: Cypress.ResolvedConfigOptions['specPattern'];
-    supportFile?: Cypress.ResolvedConfigOptions['supportFile'];
-    indexHtmlFile?: Cypress.ResolvedConfigOptions['indexHtmlFile'];
+interface BaseConfig extends Cypress.ConfigOptions {
+  component: Cypress.Config['component'] & {
     devServer: {
       bundler: 'webpack';
       framework: 'react';
       webpackConfig: Configuration;
     };
   };
-};
+}
 
 export const baseConfig = defineConfig({
   video: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1522,15 +1522,6 @@
     tunnel-agent "^0.6.0"
     uuid "^8.3.2"
 
-"@cypress/webpack-dev-server@1.8.3":
-  version "1.8.3"
-  resolved "https://registry.yarnpkg.com/@cypress/webpack-dev-server/-/webpack-dev-server-1.8.3.tgz#ec3f8f18396c39f918160212cdc8ac1753c51c32"
-  integrity sha512-r5udgc5ZhXYsnjhen+CI3CRjAjqY2UszbLQcda0np2JjLfLQX+F/bTF6g5NYWr3BMurXalC8JAZUrsBgvE0Wqw==
-  dependencies:
-    debug "^4.3.2"
-    semver "^7.3.4"
-    webpack-merge "^5.4.0"
-
 "@cypress/xvfb@^1.2.4":
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@cypress/xvfb/-/xvfb-1.2.4.tgz#2daf42e8275b39f4aa53c14214e557bd14e7748a"
@@ -5647,6 +5638,11 @@
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.5.tgz#45f9f87398c5dcea085b715c58ddcf1faf65f716"
   integrity sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==
 
+"@types/react-dom@18.3.6":
+  version "18.3.6"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.6.tgz#fa59a5e9a33499a792af6c1130f55921ef49d268"
+  integrity sha512-nf22//wEbKXusP6E9pfOCDwFdHAX4u172eaJI4YkDRQEZiorm6KfYnSC2SWLDMVWUOWPERmJnN0ujeAfTBLvrw==
+
 "@types/react-frame-component@^4.1.1":
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/@types/react-frame-component/-/react-frame-component-4.1.1.tgz#1d8293c062c1d43555ca80494a7b94e3088ad39e"
@@ -9309,6 +9305,11 @@ cypress-real-events@1.13.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/cypress-real-events/-/cypress-real-events-1.13.0.tgz#6b7cd32dcac172db1493608f97a2576c7d0bd5af"
   integrity sha512-LoejtK+dyZ1jaT8wGT5oASTPfsNV8/ClRp99ruN60oPj8cBJYod80iJDyNwfPAu4GCxTXOhhAv9FO65Hpwt6Hg==
+
+cypress-real-events@1.14.0:
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/cypress-real-events/-/cypress-real-events-1.14.0.tgz#c5495db50a2bd247f4accde983af7153566945d3"
+  integrity sha512-XmI8y3OZLh6cjRroPalzzS++iv+pGCaD9G9kfIbtspgv7GVsDt30dkZvSXfgZb4rAN+3pOkMVB7e0j4oXydW7Q==
 
 cypress@13.6.4:
   version "13.6.4"
@@ -24189,7 +24190,7 @@ webpack-hot-middleware@2.26.1, webpack-hot-middleware@^2.25.1:
     html-entities "^2.1.0"
     strip-ansi "^6.0.0"
 
-webpack-merge@5.10.0, webpack-merge@^5.4.0, webpack-merge@^5.7.3:
+webpack-merge@5.10.0, webpack-merge@^5.7.3:
   version "5.10.0"
   resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-5.10.0.tgz#a3ad5d773241e9c682803abf628d4cd62b8a4177"
   integrity sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -5633,11 +5633,6 @@
   dependencies:
     "@types/react" "^17"
 
-"@types/react-dom@18.3.5":
-  version "18.3.5"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.5.tgz#45f9f87398c5dcea085b715c58ddcf1faf65f716"
-  integrity sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==
-
 "@types/react-dom@18.3.6":
   version "18.3.6"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.6.tgz#fa59a5e9a33499a792af6c1130f55921ef49d268"


### PR DESCRIPTION
## Previous Behavior

Currently, the React 18 v9 test app uses the same Cypress version as the rest of the repo, which is still on React 17.

## New Behavior

This PR bumps Cypress only for the integration test for the React 18 v9 test app. This makes the integration tests to run on latest Cypress, which makes it easier for us to spot issues before bumping the whole repository to latest Cypress
