### PR TITLE
fix(react-drawer): increase target size for resizable Drawer.

### DIFF
--- a/packages/react-components/react-drawer/stories/src/Drawer/DrawerResizable.stories.tsx
+++ b/packages/react-components/react-drawer/stories/src/Drawer/DrawerResizable.stories.tsx
@@ -35,15 +35,23 @@ const useStyles = makeStyles({
   },
 
   resizer: {
-    borderRight: `1px solid ${tokens.colorNeutralBackground5}`,
-
-    width: '8px',
+    width: '24px',
     position: 'absolute',
     top: 0,
     right: 0,
     bottom: 0,
     cursor: 'col-resize',
     resize: 'horizontal',
+
+    '&:before': {
+      content: '""',
+      position: 'absolute',
+      borderRight: `1px solid ${tokens.colorNeutralBackground5}`,
+      width: '1px',
+      height: '100%',
+      transform: 'translateX(-50%)',
+      left: '50%',
+    },
 
     ':hover': {
       borderRightWidth: '4px',


### PR DESCRIPTION
## Previous Behavior
Resizable area is 8px. By WCAG standards target area should be 24x24 minimum

## New Behavior
Added pseudo-element for resizer

- Fixes #33648
