### PR TITLE
fix(web-components): add missing export for AnchorButtonStyles

### DIFF
--- a/change/@fluentui-web-components-3a4a3e2e-f57b-4d30-aa6b-774b0a3d7ac5.json
+++ b/change/@fluentui-web-components-3a4a3e2e-f57b-4d30-aa6b-774b0a3d7ac5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: add missing export for AnchorButtonStyles",
+  "packageName": "@fluentui/web-components",
+  "email": "wes.ngrongsen@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/docs/web-components.api.md
+++ b/packages/web-components/docs/web-components.api.md
@@ -165,6 +165,11 @@ export const AnchorButtonSize: {
 // @public
 export type AnchorButtonSize = ValuesOf<typeof AnchorButtonSize>;
 
+// Warning: (ae-missing-release-tag) "styles" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export const AnchorButtonStyles: ElementStyles;
+
 // @public
 export const AnchorButtonTemplate: ElementViewTemplate<AnchorButton>;
 

--- a/packages/web-components/src/index.ts
+++ b/packages/web-components/src/index.ts
@@ -147,6 +147,7 @@ export {
   AnchorButtonDefinition,
   AnchorButtonShape,
   AnchorButtonSize,
+  AnchorButtonStyles,
   AnchorButtonTemplate,
   AnchorTarget,
 } from './anchor-button/index.js';


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

#33957 missed updating `src/index.ts` to export `AnchorButtonStyles`.

<!-- This is the behavior we have today -->

```ts
import { AnchorStyles } from '@fluentui/web-components';

// '"@fluentui/web-components"' has no exported member named 'AnchorButtonStyles'. Did you mean 'ButtonStyles'?ts(2724)
```

## New Behavior

This PR addresses that oversight, allowing `AnchorButtonStyles` to be imported directly from `@fluentui/web-components`.

```ts
import { AnchorStyles } from '@fluentui/web-components'; // no ts error
```

## Related Issue(s)

1. Fixes oversight in #33957.
