### PR TITLE
chore: change React.FC to React.FC<React.PropsWithChildren> to support React 18

### DIFF
--- a/change/@fluentui-react-storybook-addon-279c334d-3963-4030-a3a0-2ae922e7a1f8.json
+++ b/change/@fluentui-react-storybook-addon-279c334d-3963-4030-a3a0-2ae922e7a1f8.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: change React.FC to React.FC<React.PropsWithChildren> to support React 18",
+  "packageName": "@fluentui/react-storybook-addon",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tag-picker-f1155089-92bf-4777-bf21-24a3aca954e3.json
+++ b/change/@fluentui-react-tag-picker-f1155089-92bf-4777-bf21-24a3aca954e3.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: change React.FC to React.FC<React.PropsWithChildren> to support React 18",
+  "packageName": "@fluentui/react-tag-picker",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-toast-8d145448-6bc8-4611-800d-f5caaa3574c0.json
+++ b/change/@fluentui-react-toast-8d145448-6bc8-4611-800d-f5caaa3574c0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: change React.FC to React.FC<React.PropsWithChildren> to support React 18",
+  "packageName": "@fluentui/react-toast",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-accordion/library/src/components/AccordionHeader/useAccordionHeader.test.tsx
+++ b/packages/react-components/react-accordion/library/src/components/AccordionHeader/useAccordionHeader.test.tsx
@@ -9,7 +9,7 @@ import { mockAccordionContextValue, mockAccordionItemContextValue } from '../../
 describe('useAccordionHeader_unstable', () => {
   it('should return button props as disabled even when it is not disabled (forceDisabled)', () => {
     const ref = React.createRef<HTMLElement>();
-    const wrapper: React.FC = ({ children }) => (
+    const wrapper: React.FC<React.PropsWithChildren<{}>> = ({ children }) => (
       <AccordionProvider
         value={mockAccordionContextValue({
           openItems: [1],

--- a/packages/react-components/react-accordion/library/src/components/AccordionPanel/AccordionPanel.test.tsx
+++ b/packages/react-components/react-accordion/library/src/components/AccordionPanel/AccordionPanel.test.tsx
@@ -6,7 +6,7 @@ import { AccordionItemProvider } from '../../contexts/accordionItem';
 import { mockAccordionItemContextValue } from '../../testing/mockContextValue';
 
 describe('AccordionPanel', () => {
-  const Wrapper: React.FC = props => (
+  const Wrapper: React.FC<React.PropsWithChildren<{}>> = props => (
     <AccordionItemProvider
       value={mockAccordionItemContextValue({
         open: true,

--- a/packages/react-components/react-aria/library/src/AriaLiveAnnouncer/useAriaLiveAnnouncer.test.tsx
+++ b/packages/react-components/react-aria/library/src/AriaLiveAnnouncer/useAriaLiveAnnouncer.test.tsx
@@ -19,7 +19,7 @@ describe('useAriaLiveAnnouncer', () => {
       },
       defaultView: global,
     } as unknown as Document;
-    const ContextWrapper: React.FC = props => {
+    const ContextWrapper: React.FC<React.PropsWithChildren<{}>> = props => {
       return <Provider value={{ dir: 'ltr', targetDocument }}>{props.children}</Provider>;
     };
 

--- a/packages/react-components/react-avatar/library/src/components/AvatarGroupItem/AvatarGroupItem.test.tsx
+++ b/packages/react-components/react-avatar/library/src/components/AvatarGroupItem/AvatarGroupItem.test.tsx
@@ -6,7 +6,7 @@ import { isConformant } from '../../testing/isConformant';
 
 const testId = 'testId';
 
-const ContextWrapper: React.FC = ({ children }) => (
+const ContextWrapper: React.FC<React.PropsWithChildren<{}>> = ({ children }) => (
   <AvatarGroupContext.Provider value={{ isOverflow: true }}>{children}</AvatarGroupContext.Provider>
 );
 

--- a/packages/react-components/react-breadcrumb/stories/src/Breadcrumb/index.stories.tsx
+++ b/packages/react-components/react-breadcrumb/stories/src/Breadcrumb/index.stories.tsx
@@ -7,7 +7,7 @@ export { BreadcrumbWithTooltip } from './BreadcrumbWithTooltip.stories';
 
 import type { Meta } from '@storybook/react';
 
-const metadata: Meta<typeof Breadcrumb> = {
+const metadata = {
   title: 'Components/Breadcrumb',
   component: Breadcrumb,
   subcomponents: {
@@ -22,6 +22,6 @@ const metadata: Meta<typeof Breadcrumb> = {
       },
     },
   },
-};
+} as Meta<typeof Breadcrumb>;
 
 export default metadata;

--- a/packages/react-components/react-context-selector/src/useContextSelector.test.tsx
+++ b/packages/react-components/react-context-selector/src/useContextSelector.test.tsx
@@ -16,7 +16,7 @@ const TestComponent: React.FC<{ index: number; onUpdate?: () => void }> = props 
   return <div className="test-component" data-active={active} />;
 };
 
-const TestProvider: React.FC = props => {
+const TestProvider: React.FC<React.PropsWithChildren<{}>> = props => {
   const [index, setIndex] = React.useState<number>(0);
 
   return (

--- a/packages/react-components/react-context-selector/src/useHasParentContext.test.tsx
+++ b/packages/react-components/react-context-selector/src/useHasParentContext.test.tsx
@@ -8,7 +8,9 @@ const TestContext = createContext<number>(1);
 describe('useHasParentContext', () => {
   it('should return true if wrapped with context', () => {
     // Arrange
-    const wrapper: React.FC = ({ children }) => <TestContext.Provider value={1}>{children}</TestContext.Provider>;
+    const wrapper: React.FC<React.PropsWithChildren<{}>> = ({ children }) => (
+      <TestContext.Provider value={1}>{children}</TestContext.Provider>
+    );
     const { result } = renderHook(() => useHasParentContext(TestContext), { wrapper });
 
     // Assert

--- a/packages/react-components/react-list/library/src/components/List/List.cy.tsx
+++ b/packages/react-components/react-list/library/src/components/List/List.cy.tsx
@@ -85,9 +85,12 @@ type SelectionTestListProps = {
 const SelectionTestList = ({ selectionMode, defaultSelectedItems, controlled }: SelectionTestListProps) => {
   const [selectedItems, setSelectedItems] = React.useState(defaultSelectedItems || []);
 
-  const onChange = React.useCallback((_: React.SyntheticEvent | Event, { selectedItems: selected }) => {
-    setSelectedItems(selected);
-  }, []);
+  const onChange = React.useCallback(
+    (_: React.SyntheticEvent | Event, { selectedItems: selected }: { selectedItems: SelectionItemId[] }) => {
+      setSelectedItems(selected);
+    },
+    [],
+  );
 
   const onSelectLastClick = React.useCallback(() => {
     setSelectedItems(['list-item-3']);

--- a/packages/react-components/react-motion/library/src/factories/createPresenceComponent.test.tsx
+++ b/packages/react-components/react-motion/library/src/factories/createPresenceComponent.test.tsx
@@ -483,7 +483,7 @@ describe('PresenceGroupChildContext', () => {
     const TestPresence = createPresenceComponent(motion);
     const { ElementMock } = createElementMock();
 
-    const Wrapper: React.FC<{ visible: boolean }> = ({ children, visible }) => (
+    const Wrapper: React.FC<React.PropsWithChildren<{ visible: boolean }>> = ({ children, visible }) => (
       <PresenceGroupChildContext.Provider value={{ appear: false, onExit, visible, unmountOnExit: true }}>
         {children}
       </PresenceGroupChildContext.Provider>

--- a/packages/react-components/react-motion/library/src/hooks/useIsReducedMotion.test.tsx
+++ b/packages/react-components/react-motion/library/src/hooks/useIsReducedMotion.test.tsx
@@ -25,7 +25,7 @@ describe('useIsReducedMotion', () => {
   it('should return "false" if matchMedia is not supported', () => {
     const targetDocument = createDocumentMock(undefined);
     const { result } = renderHook(() => useIsReducedMotion(), {
-      wrapper: ({ children }) => (
+      wrapper: ({ children }: React.PropsWithChildren<{}>) => (
         <Provider_unstable value={{ targetDocument, dir: 'ltr' }}>{children}</Provider_unstable>
       ),
     });
@@ -38,7 +38,7 @@ describe('useIsReducedMotion', () => {
     const targetDocument = createDocumentMock(matchMediaMock);
 
     const { result } = renderHook(() => useIsReducedMotion(), {
-      wrapper: ({ children }) => (
+      wrapper: ({ children }: React.PropsWithChildren<{}>) => (
         <Provider_unstable value={{ targetDocument, dir: 'ltr' }}>{children}</Provider_unstable>
       ),
     });

--- a/packages/react-components/react-motion/library/src/slots/presenceMotionSlot.test.tsx
+++ b/packages/react-components/react-motion/library/src/slots/presenceMotionSlot.test.tsx
@@ -21,11 +21,10 @@ const TestMotion = jest.fn(
 const TestComponent: React.FC<TestComponentProps> = props => {
   const state: TestComponentState = {
     components: {
-      // TODO: remove once React v18 slot API is modified
       // This is a problem at the moment due to UnknownSlotProps assumption
       // that `children` property is `ReactNode`, which in this case is not valid
       // as PresenceComponentProps['children'] is `ReactElement`
-      presenceMotion: TestMotion as React.FC<PresenceMotionSlotProps>,
+      presenceMotion: TestMotion as unknown as React.FC<PresenceMotionSlotProps>,
     },
     presenceMotion: presenceMotionSlot(props.presenceMotion, {
       elementType: TestMotion,

--- a/packages/react-components/react-nav-preview/library/src/components/NavSubItemGroup/NavSubItemGroup.test.tsx
+++ b/packages/react-components/react-nav-preview/library/src/components/NavSubItemGroup/NavSubItemGroup.test.tsx
@@ -11,7 +11,7 @@ export function mockNavCategoryContextValue(partialValue?: Partial<NavCategoryCo
   };
 }
 
-const Wrapper: React.FC = props => (
+const Wrapper: React.FC<React.PropsWithChildren<{}>> = props => (
   <NavCategoryProvider
     value={mockNavCategoryContextValue({
       open: true,

--- a/packages/react-components/react-overflow/library/src/useOverflowItem.test.tsx
+++ b/packages/react-components/react-overflow/library/src/useOverflowItem.test.tsx
@@ -23,7 +23,9 @@ describe('useOverflowItem', () => {
         (ref as React.MutableRefObject<HTMLDivElement>).current = document.createElement('div');
       },
       {
-        wrapper: ({ children }) => <OverflowContext.Provider value={value}>{children}</OverflowContext.Provider>,
+        wrapper: ({ children }: React.PropsWithChildren<{}>) => (
+          <OverflowContext.Provider value={value}>{children}</OverflowContext.Provider>
+        ),
       },
     );
 
@@ -50,7 +52,9 @@ describe('useOverflowItem', () => {
         (ref as React.MutableRefObject<HTMLDivElement>).current = document.createElement('div');
       },
       {
-        wrapper: ({ children }) => <OverflowContext.Provider value={value}>{children}</OverflowContext.Provider>,
+        wrapper: ({ children }: React.PropsWithChildren<{}>) => (
+          <OverflowContext.Provider value={value}>{children}</OverflowContext.Provider>
+        ),
       },
     );
 

--- a/packages/react-components/react-portal-compat/src/PortalCompatProvider.test.tsx
+++ b/packages/react-components/react-portal-compat/src/PortalCompatProvider.test.tsx
@@ -10,7 +10,7 @@ import { PortalCompatProvider, useProviderThemeClasses } from './PortalCompatPro
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = () => {};
 
-const TestWrapperWithMultipleClasses: React.FC = props => {
+const TestWrapperWithMultipleClasses: React.FC<React.PropsWithChildren<{}>> = props => {
   // Creates a second className with CSS variables
   const { styleTagId } = useFluentProviderThemeStyleTag({
     theme: { borderRadiusCircular: '50px' },
@@ -32,7 +32,7 @@ describe('useProviderThemeClasses', () => {
 
   it('handles classes from FluentProvider', () => {
     const { result } = renderHook(() => useProviderThemeClasses(), {
-      wrapper: props => (
+      wrapper: (props: React.PropsWithChildren<{}>) => (
         <FluentProvider theme={{ colorNeutralBackground1: '#ccc' }}>
           <PortalCompatProvider>{props.children}</PortalCompatProvider>
         </FluentProvider>
@@ -61,7 +61,7 @@ describe('useProviderThemeClasses', () => {
 
   it('handles classes with custom ID prefix', () => {
     const { result } = renderHook(() => useProviderThemeClasses(), {
-      wrapper: props => (
+      wrapper: (props: React.PropsWithChildren<{}>) => (
         <IdPrefixProvider value="custom1-">
           <FluentProvider theme={{ colorNeutralBackground1: '#ccc' }}>
             <PortalCompatProvider>{props.children}</PortalCompatProvider>
@@ -79,7 +79,7 @@ describe('useProviderThemeClasses', () => {
 
   it('handles classes with a React 18 compatible ID', () => {
     const { result } = renderHook(() => useProviderThemeClasses(), {
-      wrapper: props => (
+      wrapper: (props: React.PropsWithChildren<{}>) => (
         <ThemeClassNameProvider value="fui-FluentProviderR1a">
           <PortalCompatProvider>{props.children}</PortalCompatProvider>
         </ThemeClassNameProvider>
@@ -95,7 +95,7 @@ describe('useProviderThemeClasses', () => {
 
   it('returns only proper classes', () => {
     const { result } = renderHook(() => useProviderThemeClasses(), {
-      wrapper: props => (
+      wrapper: (props: React.PropsWithChildren<{}>) => (
         <ThemeClassNameProvider value="foo bar baz">
           <PortalCompatProvider>{props.children}</PortalCompatProvider>
         </ThemeClassNameProvider>
@@ -133,7 +133,7 @@ describe('PortalCompatProvider', () => {
   it('during register adds a className from "ThemeClassNameContext" context', () => {
     const element = document.createElement('div');
     const { result } = renderHook(() => usePortalCompat(), {
-      wrapper: props => (
+      wrapper: (props: React.PropsWithChildren<{}>) => (
         <FluentProvider theme={{ colorNeutralBackground1: '#ccc' }}>
           <PortalCompatProvider>{props.children}</PortalCompatProvider>
         </FluentProvider>
@@ -167,7 +167,7 @@ describe('PortalCompatProvider', () => {
     const element = document.createElement('div');
 
     const { result } = renderHook(() => usePortalCompat(), {
-      wrapper: props => (
+      wrapper: (props: React.PropsWithChildren<{}>) => (
         <FluentProvider theme={{ colorNeutralBackground1: '#ccc' }}>
           <PortalCompatProvider>{props.children}</PortalCompatProvider>
         </FluentProvider>

--- a/packages/react-components/react-portal/library/src/components/Portal/usePortalMountNode.test.tsx
+++ b/packages/react-components/react-portal/library/src/components/Portal/usePortalMountNode.test.tsx
@@ -16,7 +16,7 @@ describe('usePortalMountNode', () => {
   it('creates an element and attaches it to "mountNode"', () => {
     const mountNode = document.createElement('div');
     const { result } = renderHook(() => usePortalMountNode({}), {
-      wrapper: props => <PortalMountNodeProvider {...props} value={mountNode} />,
+      wrapper: (props: React.PropsWithChildren<{}>) => <PortalMountNodeProvider {...props} value={mountNode} />,
     });
 
     expect(result.current).toBeInstanceOf(HTMLDivElement);

--- a/packages/react-components/react-provider/library/src/components/FluentProvider/useFluentProvider.test.tsx
+++ b/packages/react-components/react-provider/library/src/components/FluentProvider/useFluentProvider.test.tsx
@@ -17,7 +17,9 @@ describe('useFluentProvider_unstable', () => {
   });
 
   it(`should warn user if no theme was set in parent or child`, () => {
-    const Wrapper: React.FC = ({ children }) => <FluentProvider>{children}</FluentProvider>;
+    const Wrapper: React.FC<React.PropsWithChildren<{}>> = ({ children }) => (
+      <FluentProvider>{children}</FluentProvider>
+    );
 
     const { result } = renderHook(() => useFluentProvider_unstable({}, React.createRef()), {
       wrapper: Wrapper,
@@ -41,7 +43,9 @@ describe('useFluentProvider_unstable', () => {
       strokeWidthThin: '20px',
     };
 
-    const Wrapper: React.FC = ({ children }) => <FluentProvider theme={themeA}>{children}</FluentProvider>;
+    const Wrapper: React.FC<React.PropsWithChildren<{}>> = ({ children }) => (
+      <FluentProvider theme={themeA}>{children}</FluentProvider>
+    );
 
     const { result } = renderHook(() => useFluentProvider_unstable({ theme: themeB }, React.createRef()), {
       wrapper: Wrapper,
@@ -66,7 +70,7 @@ describe('useFluentProvider_unstable', () => {
       inputDefaultAppearance: 'filled-darker',
     };
 
-    const Wrapper: React.FC = ({ children }) => (
+    const Wrapper: React.FC<React.PropsWithChildren<{}>> = ({ children }) => (
       <FluentProvider overrides_unstable={overridesA}>{children}</FluentProvider>
     );
 
@@ -131,7 +135,7 @@ describe('useFluentProvider_unstable', () => {
         // eslint-disable-next-line @typescript-eslint/naming-convention
         () => useFluentProvider_unstable({ customStyleHooks_unstable: customStylesB }, React.createRef()),
         {
-          wrapper: ({ children }) => (
+          wrapper: ({ children }: React.PropsWithChildren<{}>) => (
             <FluentProvider customStyleHooks_unstable={customStylesA}>{children}</FluentProvider>
           ),
         },

--- a/packages/react-components/react-storybook-addon/src/decorators/withFluentProvider.tsx
+++ b/packages/react-components/react-storybook-addon/src/decorators/withFluentProvider.tsx
@@ -47,7 +47,7 @@ export const withFluentProvider = (StoryFn: () => JSX.Element, context: FluentSt
   );
 };
 
-const FluentExampleContainer: React.FC<{ theme: Theme }> = props => {
+const FluentExampleContainer: React.FC<React.PropsWithChildren<{ theme: Theme }>> = props => {
   const { theme } = props;
 
   const backgroundColor = theme.colorNeutralBackground2;

--- a/packages/react-components/react-table/library/src/components/DataGridRow/DataGridRow.test.tsx
+++ b/packages/react-components/react-table/library/src/components/DataGridRow/DataGridRow.test.tsx
@@ -9,7 +9,7 @@ import { useColumnIdContext } from '../../contexts/columnIdContext';
 import { DataGridHeader } from '../DataGridHeader/DataGridHeader';
 
 describe('DataGridRow', () => {
-  const Wrapper: React.FC = props => {
+  const Wrapper: React.FC<React.PropsWithChildren<{}>> = props => {
     const ctx = mockDataGridContext({ selectableRows: true });
     return <DataGridContextProvider value={ctx}>{props.children}</DataGridContextProvider>;
   };

--- a/packages/react-components/react-tabster/src/hooks/useFocusVisible.test.tsx
+++ b/packages/react-components/react-tabster/src/hooks/useFocusVisible.test.tsx
@@ -20,7 +20,7 @@ const createDocumentMock = (): Document => {
 describe('useFocusVisible', () => {
   describe('targetWindow', () => {
     it('uses a window from context by default', () => {
-      const Wrapper: React.FC<{ targetDocument: Document | undefined }> = props => (
+      const Wrapper: React.FC<React.PropsWithChildren<{ targetDocument: Document | undefined }>> = props => (
         <Provider_unstable value={{ dir: 'ltr', targetDocument: props.targetDocument }}>
           {props.children}
         </Provider_unstable>
@@ -52,7 +52,7 @@ describe('useFocusVisible', () => {
         { targetDocument: Document | undefined },
         React.MutableRefObject<HTMLElement | null>
       >(props => useFocusVisible({ targetDocument: props.targetDocument }), {
-        wrapper: props => (
+        wrapper: (props: React.PropsWithChildren<{ targetDocument: Document | undefined }>) => (
           <Provider_unstable value={{ dir: 'ltr', targetDocument: undefined }}>{props.children}</Provider_unstable>
         ),
         initialProps: { targetDocument: undefined },

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerButton/useTagPickerButton.tsx
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerButton/useTagPickerButton.tsx
@@ -35,6 +35,9 @@ export const useTagPickerButton_unstable = (
     defaultProps: {
       type: 'button',
       tabIndex: 0,
+      // FIXME: props.placeholder is not a valid prop for button in React 18,
+      // so we should add it to the props types or remove it from here
+      // @ts-ignore
       children: value || props.placeholder,
       'aria-controls': open ? popoverId : undefined,
       ref,

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerButton/useTagPickerButton.tsx
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerButton/useTagPickerButton.tsx
@@ -37,6 +37,7 @@ export const useTagPickerButton_unstable = (
       tabIndex: 0,
       // FIXME: props.placeholder is not a valid prop for button in React 18,
       // so we should add it to the props types or remove it from here
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       children: value || props.placeholder,
       'aria-controls': open ? popoverId : undefined,

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerGroup/TagPickerGroup.test.tsx
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerGroup/TagPickerGroup.test.tsx
@@ -4,7 +4,7 @@ import { isConformant } from '../../testing/isConformant';
 import { TagPickerGroup } from './TagPickerGroup';
 import { TagPickerContextProvider, tagPickerContextDefaultValue } from '../../contexts/TagPickerContext';
 
-const Wrapper: React.FC = props => (
+const Wrapper: React.FC<React.PropsWithChildren<{}>> = props => (
   <TagPickerContextProvider
     value={{
       ...tagPickerContextDefaultValue,

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerList/TagPickerList.test.tsx
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerList/TagPickerList.test.tsx
@@ -4,7 +4,7 @@ import { isConformant } from '../../testing/isConformant';
 import { TagPickerList } from './TagPickerList';
 import { TagPickerContextProvider, tagPickerContextDefaultValue } from '../../contexts/TagPickerContext';
 
-const Wrapper: React.FC = props => (
+const Wrapper: React.FC<React.PropsWithChildren<{}>> = props => (
   <TagPickerContextProvider
     value={{
       ...tagPickerContextDefaultValue,

--- a/packages/react-components/react-tags/library/src/components/Tag/useTag.test.tsx
+++ b/packages/react-components/react-tags/library/src/components/Tag/useTag.test.tsx
@@ -11,7 +11,7 @@ describe('useTag_unstable', () => {
     // We don't want 'clickable' announcement when Tag is a simple span and not dismissible.
 
     const ref = React.createRef<HTMLElement>();
-    const wrapper: React.FC = ({ children }) => (
+    const wrapper: React.FC<React.PropsWithChildren<{}>> = ({ children }) => (
       <TagGroupContextProvider
         value={{
           handleTagDismiss: () => ({}),

--- a/packages/react-components/react-toast/library/src/components/AriaLive/AriaLive.tsx
+++ b/packages/react-components/react-toast/library/src/components/AriaLive/AriaLive.tsx
@@ -7,7 +7,7 @@ import type { AriaLiveProps } from './AriaLive.types';
 /**
  * A component that manages aria live announcements imperatively
  */
-export const AriaLive: React.FC<AriaLiveProps> = props => {
+export const AriaLive: React.FC<React.PropsWithChildren<AriaLiveProps>> = props => {
   const state = useAriaLive_unstable(props);
 
   useAriaLiveStyles_unstable(state);

--- a/packages/react-components/react-toast/library/src/components/AriaLive/AriaLive.tsx
+++ b/packages/react-components/react-toast/library/src/components/AriaLive/AriaLive.tsx
@@ -7,7 +7,7 @@ import type { AriaLiveProps } from './AriaLive.types';
 /**
  * A component that manages aria live announcements imperatively
  */
-export const AriaLive: React.FC<React.PropsWithChildren<AriaLiveProps>> = props => {
+export const AriaLive: React.FC<AriaLiveProps> = props => {
   const state = useAriaLive_unstable(props);
 
   useAriaLiveStyles_unstable(state);

--- a/packages/react-components/react-toast/library/src/components/AriaLive/AriaLive.types.ts
+++ b/packages/react-components/react-toast/library/src/components/AriaLive/AriaLive.types.ts
@@ -13,6 +13,7 @@ export type AriaLivePoliteness = 'polite' | 'assertive';
  */
 export type AriaLiveProps = ComponentProps<Partial<AriaLiveSlots>> & {
   announceRef: React.Ref<Announce>;
+  children?: React.ReactNode;
 };
 
 /**

--- a/packages/react-components/react-tree/library/src/components/TreeItemLayout/TreeItemLayout.test.tsx
+++ b/packages/react-components/react-tree/library/src/components/TreeItemLayout/TreeItemLayout.test.tsx
@@ -4,7 +4,7 @@ import { TreeItemLayout } from './TreeItemLayout';
 import { isConformant } from '../../testing/isConformant';
 import { TreeItemProvider } from '../../contexts';
 
-const Wrapper: React.FC = ({ children }) => (
+const Wrapper: React.FC<React.PropsWithChildren<{}>> = ({ children }) => (
   <TreeItemProvider
     value={{
       value: '',

--- a/packages/react-components/react-tree/library/src/components/TreeItemPersonaLayout/TreeItemPersonaLayout.test.tsx
+++ b/packages/react-components/react-tree/library/src/components/TreeItemPersonaLayout/TreeItemPersonaLayout.test.tsx
@@ -4,7 +4,7 @@ import { TreeItemPersonaLayout } from './TreeItemPersonaLayout';
 import { isConformant } from '../../testing/isConformant';
 import { TreeItemProvider } from '../../contexts';
 
-const Wrapper: React.FC = ({ children }) => (
+const Wrapper: React.FC<React.PropsWithChildren<{}>> = ({ children }) => (
   <TreeItemProvider
     value={{
       value: '',

--- a/packages/react-components/react-utilities/src/hooks/useId.test.tsx
+++ b/packages/react-components/react-utilities/src/hooks/useId.test.tsx
@@ -41,7 +41,9 @@ describe('useId', () => {
 
   it('consumers prefix from a context', () => {
     const { result } = renderHook(() => useId(), {
-      wrapper: ({ children }) => <IdPrefixProvider value="scope-">{children}</IdPrefixProvider>,
+      wrapper: ({ children }: React.PropsWithChildren<{}>) => (
+        <IdPrefixProvider value="scope-">{children}</IdPrefixProvider>
+      ),
     });
 
     expect(result.current).toMatch(/^scope-fui-/);

--- a/packages/react-components/react-utilities/src/trigger/applyTriggerPropsToChildren.test.tsx
+++ b/packages/react-components/react-utilities/src/trigger/applyTriggerPropsToChildren.test.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
 import { render } from '@testing-library/react';
 import { applyTriggerPropsToChildren } from './applyTriggerPropsToChildren';
-import type { FluentTriggerComponent } from './types';
+import type { FluentTriggerComponent, TriggerProps } from './types';
 
-export const TestTrigger: React.FC<{ id?: string }> & FluentTriggerComponent = props => <>{props.children}</>;
+export const TestTrigger: React.FC<TriggerProps & { id?: string }> & FluentTriggerComponent = props => (
+  <>{props.children}</>
+);
 TestTrigger.displayName = 'TestTrigger';
 TestTrigger.isFluentTriggerComponent = true;
 

--- a/packages/react-components/react-utilities/src/trigger/getTriggerChild.test.tsx
+++ b/packages/react-components/react-utilities/src/trigger/getTriggerChild.test.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { getTriggerChild } from './getTriggerChild';
-import type { FluentTriggerComponent } from './types';
+import type { FluentTriggerComponent, TriggerProps } from './types';
 
-const TestTrigger: React.FC<{ id?: string }> & FluentTriggerComponent = props => <>{props.children}</>;
+const TestTrigger: React.FC<TriggerProps & { id?: string }> & FluentTriggerComponent = props => <>{props.children}</>;
 TestTrigger.displayName = 'TestTrigger';
 TestTrigger.isFluentTriggerComponent = true;
 

--- a/packages/react-components/recipes/src/recipes/media-object/code-snippets/MediaObject.tsx
+++ b/packages/react-components/recipes/src/recipes/media-object/code-snippets/MediaObject.tsx
@@ -40,7 +40,7 @@ const MediaObject: React.VoidFunctionComponent<MediaObjectTypes> = ({
   );
 };
 
-const Legend: React.FC<{ colorClassName: string }> = ({ children, colorClassName }) => {
+const Legend: React.FC<React.PropsWithChildren<{ colorClassName: string }>> = ({ children, colorClassName }) => {
   const skeletonStyles = useSkeletonStyles();
   return (
     <div className={skeletonStyles.legend}>

--- a/packages/react-components/recipes/src/templates/Example.tsx
+++ b/packages/react-components/recipes/src/templates/Example.tsx
@@ -4,7 +4,7 @@ import { webLightTheme } from '@fluentui/react-theme';
 import { mergeClasses } from '@griffel/react';
 import { useExampleStyles } from './Example.styles';
 
-export const TemplateExample: React.FC<{ centered?: boolean }> = ({ children, centered }) => {
+export const TemplateExample: React.FC<React.PropsWithChildren<{ centered?: boolean }>> = ({ children, centered }) => {
   const exampleStyles = useExampleStyles();
 
   const innerContainerClassName = mergeClasses(exampleStyles.innerContainer, centered && exampleStyles.centered);


### PR DESCRIPTION
Fix React 18 type issues in tests and stories in v9


The only non-dev/component change is the `AriaLive` component