### PR TITLE
fix (react-carousel): Update carousel story container to be responsive

### DIFF
--- a/packages/react-components/react-carousel/stories/src/Carousel/CarouselActionCards.stories.tsx
+++ b/packages/react-components/react-carousel/stories/src/Carousel/CarouselActionCards.stories.tsx
@@ -26,9 +26,8 @@ import * as React from 'react';
 const useClasses = makeStyles({
   container: {
     display: 'grid',
-    gridTemplateColumns: '1fr',
+    gridTemplateColumns: 'minmax(0, 1fr)',
     gridTemplateRows: 'auto 1fr',
-
     boxShadow: tokens.shadow16,
   },
   card: {
@@ -65,7 +64,8 @@ const useClasses = makeStyles({
     gridTemplateColumns: 'minmax(100px, max-content) 1fr',
   },
   dropdown: {
-    maxWidth: 'max-content',
+    minWidth: '100px',
+    width: '1fr',
   },
 });
 


### PR DESCRIPTION
## Previous Behavior
Carousel container would blowout on thin views (mobile) on grid story
![image](https://github.com/user-attachments/assets/3c5a1038-b27a-45d8-9298-52d8db7c60df)

## New Behavior
Carousel container now contains based on max view width as expected
![image](https://github.com/user-attachments/assets/e248f59a-a3b0-4333-9f24-1665b7462ff5)


## Related Issue(s)
- Fixes #33744 
