### PR TITLE
[fix] tree-item bugs

### DIFF
--- a/change/@fluentui-web-components-05138dd2-442b-4395-9b03-37eed7665793.json
+++ b/change/@fluentui-web-components-05138dd2-442b-4395-9b03-37eed7665793.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "tree item initial selection, tree item expands for sub selected item",
+  "packageName": "@fluentui/web-components",
+  "email": "jes@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/tree-item/tree-item.base.ts
+++ b/packages/web-components/src/tree-item/tree-item.base.ts
@@ -115,10 +115,7 @@ export class BaseTreeItem extends FASTElement {
     }
 
     //If a tree item is nested and initially set to selected expand the tree items so the selected item is visible
-    const selectedItems = this.querySelectorAll('[selected]');
-    if (selectedItems.length > 0) {
-      this.expanded = true;
-    }
+    this.expanded = Array.from(this.querySelectorAll('*')).some(el => isTreeItem(el) && el.selected);
 
     this.childTreeItems.forEach(item => {
       this.setIndent(item);
@@ -153,15 +150,6 @@ export class BaseTreeItem extends FASTElement {
     if (this.childTreeItems?.length) {
       this.expanded = !this.expanded;
     }
-  }
-
-  /**
-   * Sets the selection state of the tree item
-   *
-   * @public
-   */
-  public setSelection() {
-    this.selected = true;
   }
 
   /**

--- a/packages/web-components/src/tree-item/tree-item.base.ts
+++ b/packages/web-components/src/tree-item/tree-item.base.ts
@@ -130,16 +130,6 @@ export class BaseTreeItem extends FASTElement {
     item.dataIndent = indent + 1;
   }
 
-  /**
-   * Handle blur events
-   *
-   * @public
-   */
-  public blurHandler(e: FocusEvent): void {
-    if (e.target === this) {
-      this.setAttribute('tabindex', '-1');
-    }
-  }
 
   /**
    * Toggle the expansion state of the tree item

--- a/packages/web-components/src/tree-item/tree-item.base.ts
+++ b/packages/web-components/src/tree-item/tree-item.base.ts
@@ -130,7 +130,6 @@ export class BaseTreeItem extends FASTElement {
     item.dataIndent = indent + 1;
   }
 
-
   /**
    * Toggle the expansion state of the tree item
    *

--- a/packages/web-components/src/tree-item/tree-item.base.ts
+++ b/packages/web-components/src/tree-item/tree-item.base.ts
@@ -114,6 +114,12 @@ export class BaseTreeItem extends FASTElement {
       return;
     }
 
+    //If a tree item is nested and initially set to selected expand the tree items so the selected item is visible
+    const selectedItems = this.querySelectorAll('[selected]');
+    if (selectedItems.length > 0) {
+      this.expanded = true;
+    }
+
     this.childTreeItems.forEach(item => {
       this.setIndent(item);
     });
@@ -125,22 +131,6 @@ export class BaseTreeItem extends FASTElement {
   private setIndent(item: BaseTreeItem): void {
     const indent = this.dataIndent ?? 0;
     item.dataIndent = indent + 1;
-  }
-
-  /**
-   * Handle focus events
-   *
-   * @public
-   */
-  public focusHandler(e: FocusEvent): void {
-    if (
-      e.target === this ||
-      // In case where the tree-item contains a focusable element, we should not set the tabindex to 0 when the focus is on its child focusable element,
-      // so users can shift+tab to navigate to the tree-item from its child focusable element.
-      this.contains(e.target as Node)
-    ) {
-      this.setAttribute('tabindex', '0');
-    }
   }
 
   /**
@@ -166,12 +156,12 @@ export class BaseTreeItem extends FASTElement {
   }
 
   /**
-   * Toggle the single selection state of the tree item
+   * Sets the selection state of the tree item
    *
    * @public
    */
-  public toggleSelection() {
-    this.selected = !this.selected;
+  public setSelection() {
+    this.selected = true;
   }
 
   /**

--- a/packages/web-components/src/tree-item/tree-item.spec.ts
+++ b/packages/web-components/src/tree-item/tree-item.spec.ts
@@ -75,4 +75,24 @@ test.describe('Tree Item', () => {
     });
     expect(await element.getAttribute('selected')).not.toBeNull();
   });
+
+  test('should expand parent items when child item is set to selected', async ({ fastPage }) => {
+    const { element } = fastPage;
+    await fastPage.setTemplate({
+      innerHTML: /* html */ `
+        Item 1
+        <fluent-tree-item>
+          Nested Item A
+          <fluent-tree-item>
+            Nested Item B
+            <fluent-tree-item selected>Nested Item C</fluent-tree-item>
+          </fluent-tree-item>
+        </fluent-tree-item>
+      `,
+    });
+    const selectedItems = element.locator('[selected]');
+
+    await expect(element.nth(0)).toHaveAttribute('expanded');
+    await expect(selectedItems).toBeVisible();
+  });
 });

--- a/packages/web-components/src/tree-item/tree-item.stories.ts
+++ b/packages/web-components/src/tree-item/tree-item.stories.ts
@@ -39,7 +39,7 @@ const storyTemplate = html<StoryArgs<FluentTreeItem>>`
           (item as TreeItem).selected = false;
         }
       });
-      target.setSelection();
+      target.selected = true;
     }}
   >
     ${story => story.startSlottedContent?.()} ${story => story.slottedContent?.()}

--- a/packages/web-components/src/tree-item/tree-item.stories.ts
+++ b/packages/web-components/src/tree-item/tree-item.stories.ts
@@ -19,7 +19,7 @@ const CalendarIcon = html`<svg
     fill="currentColor"
   ></path>
 </svg>`;
-const FilterIcon = html`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+const FilterIcon = html`<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 20 20">
   <path
     fill="currentColor"
     d="M7.5 13h5a.5.5 0 0 1 .09.992L12.5 14h-5a.5.5 0 0 1-.09-.992zh5zm-2-4h9a.5.5 0 0 1 .09.992L14.5 10h-9a.5.5 0 0 1-.09-.992zh9zm-2-4h13a.5.5 0 0 1 .09.992L16.5 6h-13a.5.5 0 0 1-.09-.992zh13z"

--- a/packages/web-components/src/tree-item/tree-item.stories.ts
+++ b/packages/web-components/src/tree-item/tree-item.stories.ts
@@ -39,7 +39,7 @@ const storyTemplate = html<StoryArgs<FluentTreeItem>>`
           (item as TreeItem).selected = false;
         }
       });
-      target.toggleSelection();
+      target.setSelection();
     }}
   >
     ${story => story.startSlottedContent?.()} ${story => story.slottedContent?.()}

--- a/packages/web-components/src/tree-item/tree-item.template.ts
+++ b/packages/web-components/src/tree-item/tree-item.template.ts
@@ -14,7 +14,6 @@ export const template = html<TreeItem>`
   <template
     tabindex="-1"
     slot="${x => (x.isNestedItem ? 'item' : void 0)}"
-    @focusin="${(x, c) => x.focusHandler(c.event as FocusEvent)}"
     @focusout="${(x, c) => x.blurHandler(c.event as FocusEvent)}"
     ${children({
       property: 'childTreeItems',

--- a/packages/web-components/src/tree-item/tree-item.template.ts
+++ b/packages/web-components/src/tree-item/tree-item.template.ts
@@ -12,9 +12,8 @@ const chevronIcon = html`
 
 export const template = html<TreeItem>`
   <template
-    tabindex="-1"
+    tabindex="${x => x.selected ? 0 : -1}"
     slot="${x => (x.isNestedItem ? 'item' : void 0)}"
-    @focusout="${(x, c) => x.blurHandler(c.event as FocusEvent)}"
     ${children({
       property: 'childTreeItems',
       filter: node => isTreeItem(node),

--- a/packages/web-components/src/tree-item/tree-item.template.ts
+++ b/packages/web-components/src/tree-item/tree-item.template.ts
@@ -12,7 +12,7 @@ const chevronIcon = html`
 
 export const template = html<TreeItem>`
   <template
-    tabindex="${x => x.selected ? 0 : -1}"
+    tabindex="${x => (x.selected ? 0 : -1)}"
     slot="${x => (x.isNestedItem ? 'item' : void 0)}"
     ${children({
       property: 'childTreeItems',

--- a/packages/web-components/src/tree/tree.base.ts
+++ b/packages/web-components/src/tree/tree.base.ts
@@ -52,7 +52,7 @@ export class BaseTree extends FASTElement {
   private updateCurrentSelected() {
     // force single selection
     // defaults to first one found
-    const selectedItem = this.querySelector<HTMLElement>(`[aria-selected='true']`);
+    const selectedItem = this.querySelector<HTMLElement>(`[selected]`);
     this.currentSelected = selectedItem;
 
     // invalidate the current focused item if it is no longer valid
@@ -124,7 +124,7 @@ export class BaseTree extends FASTElement {
         return;
       }
       case keySpace: {
-        item.toggleSelection();
+        item.setSelection();
         return;
       }
     }
@@ -145,13 +145,8 @@ export class BaseTree extends FASTElement {
     }
 
     if (e.target === this) {
-      if (this.currentFocused === null) {
-        this.currentFocused = this.getValidFocusableItem();
-      }
-
-      if (this.currentFocused !== null) {
-        this.currentFocused.focus();
-      }
+      this.currentFocused = this.getValidFocusableItem();
+      this.currentFocused?.focus();
 
       return;
     }
@@ -193,7 +188,7 @@ export class BaseTree extends FASTElement {
 
     const item = e.target as BaseTreeItem;
     item.toggleExpansion();
-    item.toggleSelection();
+    item.setSelection();
   }
 
   /**

--- a/packages/web-components/src/tree/tree.base.ts
+++ b/packages/web-components/src/tree/tree.base.ts
@@ -124,7 +124,7 @@ export class BaseTree extends FASTElement {
         return;
       }
       case keySpace: {
-        item.setSelection();
+        item.selected = true;
         return;
       }
     }
@@ -188,7 +188,7 @@ export class BaseTree extends FASTElement {
 
     const item = e.target as BaseTreeItem;
     item.toggleExpansion();
-    item.setSelection();
+    item.selected = true;
   }
 
   /**

--- a/packages/web-components/src/tree/tree.spec.ts
+++ b/packages/web-components/src/tree/tree.spec.ts
@@ -167,6 +167,10 @@ test.describe('Tree', () => {
     await treeItemEl.nth(1).click();
     await expect(treeItemEl.nth(0)).not.toHaveAttribute('selected');
     await expect(treeItemEl.nth(1)).toHaveAttribute('selected');
+    // select item 2 again
+    await treeItemEl.nth(1).click();
+    await expect(treeItemEl.nth(0)).not.toHaveAttribute('selected');
+    await expect(treeItemEl.nth(1)).toHaveAttribute('selected');
   });
 
   test('should not scroll when pressing space key', async ({ fastPage, page }) => {

--- a/packages/web-components/src/tree/tree.spec.ts
+++ b/packages/web-components/src/tree/tree.spec.ts
@@ -224,6 +224,8 @@ test.describe('Tree', () => {
     const treeItems = page.locator('fluent-tree-item');
     await element.focus();
     await expect(treeItems.nth(0)).toBeFocused();
+    await page.keyboard.press('Enter');
+    await expect(treeItems.nth(0)).toHaveAttribute('selected');
     await page.keyboard.press(browserName === 'webkit' ? 'Alt+Tab' : 'Tab');
     await expect(anchor).toBeFocused();
   });

--- a/packages/web-components/src/tree/tree.stories.ts
+++ b/packages/web-components/src/tree/tree.stories.ts
@@ -95,11 +95,11 @@ const storyTemplate = html<StoryArgs<FluentTree>>`
           fill="red"
         ></path>
       </svg>
-      <fluent-tree-item expanded>
+      <fluent-tree-item>
         Item 2-1
         <fluent-tree-item>
           Item 2-1-1
-          <fluent-tree-item>Item 2-1-1-1</fluent-tree-item>
+          <fluent-tree-item selected>Item 2-1-1-1</fluent-tree-item>
           <fluent-tree-item>Item 2-1-1-1</fluent-tree-item>
         </fluent-tree-item>
         <fluent-tree-item>Item 2-1-2</fluent-tree-item>

--- a/packages/web-components/src/tree/tree.template.ts
+++ b/packages/web-components/src/tree/tree.template.ts
@@ -1,5 +1,5 @@
 import { children, elements, html } from '@microsoft/fast-element';
-import { isTreeItem } from '../tree-item/tree-item.options';
+import { isTreeItem } from '../tree-item/tree-item.options.js';
 import type { Tree } from './tree.js';
 
 export const template = html<Tree>`


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
This PR fixes several issues

1. If a tree item is selected clicking the selected item unselects it
2. If a sub item was set to be initially selected it was hidden if its parent tree items weren'y explicity set to expanded
3. If a item was set to initially selected the intially selected item would not unselect when a new item was selected
4. If a sub item was selected and you focused the tree then hit `shift+tab` it would focus the parent item, then if you focused the tree again it would focus the parent item and not the selected item

## New Behavior

1. clicking an item no longer toggles selection
2. If a sub item is insitally set to selected it automatically expands all parent tree items
3. Initially selected items unselect when I new item is selected
4. If no items are selected the first tree item gets focus, if one is selected only the selected item gets focus and `shift+tab` or `tab` exits the tree

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
