### PR TITLE
fix(react-charts): Full YAxis labels in Heatmap chart

### DIFF
--- a/change/@fluentui-react-charts-2efa7f19-884c-4d88-9a48-b75502f5c98e.json
+++ b/change/@fluentui-react-charts-2efa7f19-884c-4d88-9a48-b75502f5c98e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Full Y Axis labels in Heatmap chart",
+  "packageName": "@fluentui/react-charts",
+  "email": "anushgupta@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charts/react-charts/library/src/components/CommonComponents/CartesianChart.tsx
+++ b/packages/charts/react-charts/library/src/components/CommonComponents/CartesianChart.tsx
@@ -176,12 +176,12 @@ export const CartesianChart: React.FunctionComponent<ModifiedCartesianChartProps
   ): number {
     if (chartType === ChartTypes.HeatMapChart) {
       return calculateLongestLabelWidth(
-        points[0].data.map((point: HeatMapChartDataPoint) => point.y),
+        points[0]?.data?.map((point: HeatMapChartDataPoint) => point.y),
         `.${className} text`,
       );
     } else {
       return calculateLongestLabelWidth(
-        points.map((point: HorizontalBarChartWithAxisDataPoint) => point.y),
+        points?.map((point: HorizontalBarChartWithAxisDataPoint) => point.y),
         `.${className} text`,
       );
     }

--- a/packages/charts/react-charts/library/src/components/CommonComponents/CartesianChart.tsx
+++ b/packages/charts/react-charts/library/src/components/CommonComponents/CartesianChart.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { ModifiedCartesianChartProps, HorizontalBarChartWithAxisDataPoint } from '../../index';
+import { ModifiedCartesianChartProps, HorizontalBarChartWithAxisDataPoint, HeatMapChartDataPoint } from '../../index';
 import { useCartesianChartStyles } from './useCartesianChartStyles.styles';
 import {
   createNumericXAxis,
@@ -58,6 +58,7 @@ export const CartesianChart: React.FunctionComponent<ModifiedCartesianChartProps
   const [startFromX, setStartFromX] = React.useState<number>(0);
   const [prevProps, setPrevProps] = React.useState<ModifiedCartesianChartProps | null>(null);
 
+  const chartTypesToCheck = [ChartTypes.HorizontalBarChartWithAxis, ChartTypes.HeatMapChart];
   /**
    * In RTL mode, Only graph will be rendered left/right. We need to provide left and right margins manually.
    * So that, in RTL, left margins becomes right margins and viceversa.
@@ -92,11 +93,8 @@ export const CartesianChart: React.FunctionComponent<ModifiedCartesianChartProps
     if (props !== null) {
       setPrevProps(props);
     }
-    if (props.chartType === ChartTypes.HorizontalBarChartWithAxis && props.showYAxisLables && yAxisElement.current) {
-      const maxYAxisLabelLength = calculateLongestLabelWidth(
-        props.points.map((point: HorizontalBarChartWithAxisDataPoint) => point.y),
-        `.${classes.yAxis} text`,
-      );
+    if (chartTypesToCheck.includes(props.chartType) && props.showYAxisLables && yAxisElement) {
+      const maxYAxisLabelLength = calculateMaxYAxisLabelLength(props.chartType, props.points, classes.yAxis!);
       if (startFromX !== maxYAxisLabelLength) {
         setStartFromX(maxYAxisLabelLength);
       }
@@ -117,11 +115,8 @@ export const CartesianChart: React.FunctionComponent<ModifiedCartesianChartProps
         _fitParentContainer();
       }
     }
-    if (props.chartType === ChartTypes.HorizontalBarChartWithAxis && props.showYAxisLables && yAxisElement.current) {
-      const maxYAxisLabelLength = calculateLongestLabelWidth(
-        props.points.map((point: HorizontalBarChartWithAxisDataPoint) => point.y),
-        `.${classes.yAxis} text`,
-      );
+    if (chartTypesToCheck.includes(props.chartType) && props.showYAxisLables && yAxisElement) {
+      const maxYAxisLabelLength = calculateMaxYAxisLabelLength(props.chartType, props.points, classes.yAxis!);
       if (startFromX !== maxYAxisLabelLength) {
         setStartFromX(maxYAxisLabelLength);
       }
@@ -173,6 +168,25 @@ export const CartesianChart: React.FunctionComponent<ModifiedCartesianChartProps
     return <ChartPopover {...calloutProps} />;
   }
 
+  function calculateMaxYAxisLabelLength(
+    chartType: ChartTypes,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    points: any[],
+    className: string,
+  ): number {
+    if (chartType === ChartTypes.HeatMapChart) {
+      return calculateLongestLabelWidth(
+        points[0].data.map((point: HeatMapChartDataPoint) => point.y),
+        `.${className} text`,
+      );
+    } else {
+      return calculateLongestLabelWidth(
+        points.map((point: HorizontalBarChartWithAxisDataPoint) => point.y),
+        `.${className} text`,
+      );
+    }
+  }
+
   const {
     calloutProps,
     points,
@@ -187,7 +201,7 @@ export const CartesianChart: React.FunctionComponent<ModifiedCartesianChartProps
     _fitParentContainer();
   }
   const margin = { ...margins };
-  if (props.chartType === ChartTypes.HorizontalBarChartWithAxis) {
+  if (chartTypesToCheck.includes(props.chartType)) {
     if (!_useRtl) {
       margin.left! += startFromX;
     } else {
@@ -370,7 +384,7 @@ export const CartesianChart: React.FunctionComponent<ModifiedCartesianChartProps
     truncating the rest of the text and showing elipsis
     or showing the whole string,
      * */
-    props.chartType === ChartTypes.HorizontalBarChartWithAxis &&
+    chartTypesToCheck.includes(props.chartType) &&
       yScale &&
       createYAxisLabels(
         yAxisElement.current!,

--- a/packages/charts/react-charts/library/src/components/HeatMapChart/__snapshots__/HeatMapChartRTL.test.tsx.snap
+++ b/packages/charts/react-charts/library/src/components/HeatMapChart/__snapshots__/HeatMapChartRTL.test.tsx.snap
@@ -94,9 +94,22 @@ exports[`HeatMapChart snapshot tests should render HeatMapChart correctly with n
             <text
               dy="0.32em"
               fill="currentColor"
+              text-align="start"
               x="-10"
             >
-              10
+              <tspan
+                data-="10"
+                dy="0.32em"
+                id="BaseSpan-0"
+                x="-10"
+              />
+              <tspan
+                dx="1em"
+                id="LessLength-0"
+                x="-10"
+              >
+                10
+              </tspan>
             </text>
           </g>
           <g
@@ -111,9 +124,22 @@ exports[`HeatMapChart snapshot tests should render HeatMapChart correctly with n
             <text
               dy="0.32em"
               fill="currentColor"
+              text-align="start"
               x="-10"
             >
-              20
+              <tspan
+                data-="20"
+                dy="0.32em"
+                id="BaseSpan-1"
+                x="-10"
+              />
+              <tspan
+                dx="1em"
+                id="LessLength-1"
+                x="-10"
+              >
+                20
+              </tspan>
             </text>
           </g>
         </g>
@@ -352,9 +378,22 @@ exports[`HeatMapChart snapshot tests should render axis labels correctly When cu
             <text
               dy="0.32em"
               fill="currentColor"
+              text-align="start"
               x="-10"
             >
-              yPoint p1
+              <tspan
+                data-="yPoint p1"
+                dy="0.32em"
+                id="BaseSpan-0"
+                x="-10"
+              />
+              <tspan
+                dx="1em"
+                id="LessLength-0"
+                x="-10"
+              >
+                yPoint p1
+              </tspan>
             </text>
           </g>
           <g
@@ -369,9 +408,22 @@ exports[`HeatMapChart snapshot tests should render axis labels correctly When cu
             <text
               dy="0.32em"
               fill="currentColor"
+              text-align="start"
               x="-10"
             >
-              yPoint p2
+              <tspan
+                data-="yPoint p2"
+                dy="0.32em"
+                id="BaseSpan-1"
+                x="-10"
+              />
+              <tspan
+                dx="1em"
+                id="LessLength-1"
+                x="-10"
+              >
+                yPoint p2
+              </tspan>
             </text>
           </g>
         </g>

--- a/packages/charts/react-charts/library/src/utilities/__snapshots__/UtilityUnitTests.test.ts.snap
+++ b/packages/charts/react-charts/library/src/utilities/__snapshots__/UtilityUnitTests.test.ts.snap
@@ -3767,12 +3767,12 @@ exports[`createYAxisLabels should retain full y-axis labels when truncateLabel i
       <tspan
         data-="Y-axis label 1"
         dy="0.32em"
-        id="BaseSpan"
+        id="BaseSpan-0"
         x="-18"
       />
       <tspan
         dx="1em"
-        id="LessLength"
+        id="LessLength-0"
         x="-18"
       >
         Y-axis label 1
@@ -3797,12 +3797,12 @@ exports[`createYAxisLabels should retain full y-axis labels when truncateLabel i
       <tspan
         data-="Y-axis label 2"
         dy="0.32em"
-        id="BaseSpan"
+        id="BaseSpan-1"
         x="-18"
       />
       <tspan
         dx="1em"
-        id="LessLength"
+        id="LessLength-1"
         x="-18"
       >
         Y-axis label 2
@@ -3827,12 +3827,12 @@ exports[`createYAxisLabels should retain full y-axis labels when truncateLabel i
       <tspan
         data-="Y-axis label 3"
         dy="0.32em"
-        id="BaseSpan"
+        id="BaseSpan-2"
         x="-18"
       />
       <tspan
         dx="1em"
-        id="LessLength"
+        id="LessLength-2"
         x="-18"
       >
         Y-axis label 3
@@ -3872,13 +3872,13 @@ exports[`createYAxisLabels should truncate y-axis labels when their length excee
       <tspan
         data-="Y-axis label 1"
         dy="0.32em"
-        id="BaseSpan"
+        id="BaseSpan-0"
         x="-18"
       />
       <tspan
         dx="1.5em"
         dy="0.32"
-        id="showDots"
+        id="showDots-0"
         x="-18"
       >
         Y-axis lab...
@@ -3902,13 +3902,13 @@ exports[`createYAxisLabels should truncate y-axis labels when their length excee
       <tspan
         data-="Y-axis label 2"
         dy="0.32em"
-        id="BaseSpan"
+        id="BaseSpan-1"
         x="-18"
       />
       <tspan
         dx="1.5em"
         dy="0.32"
-        id="showDots"
+        id="showDots-1"
         x="-18"
       >
         Y-axis lab...
@@ -3932,13 +3932,13 @@ exports[`createYAxisLabels should truncate y-axis labels when their length excee
       <tspan
         data-="Y-axis label 3"
         dy="0.32em"
-        id="BaseSpan"
+        id="BaseSpan-2"
         x="-18"
       />
       <tspan
         dx="1.5em"
         dy="0.32"
-        id="showDots"
+        id="showDots-2"
         x="-18"
       >
         Y-axis lab...

--- a/packages/charts/react-charts/library/src/utilities/utilities.ts
+++ b/packages/charts/react-charts/library/src/utilities/utilities.ts
@@ -911,6 +911,7 @@ export function createYAxisLabels(
   if (node === null) {
     return;
   }
+  let tickIndex = 0;
   const axisNode = d3Select(node).call(yAxis);
   axisNode.selectAll('.tick text').each(function () {
     const text = d3Select(this);
@@ -924,19 +925,20 @@ export function createYAxisLabels(
     const x = text.attr('x');
     const dy = parseFloat(text.attr('dy'));
     const dx = 0;
+    const uid = tickIndex++;
     text
       .text(null)
       .append('tspan')
       .attr('x', x)
       .attr('y', y)
-      .attr('id', 'BaseSpan')
+      .attr('id', `BaseSpan-${uid}`)
       .attr('dy', dy + 'em')
       .attr('data-', totalWord);
 
     if (truncateLabel && totalWordLength > noOfCharsToTruncate) {
       text
         .append('tspan')
-        .attr('id', 'showDots')
+        .attr('id', `showDots-${uid}`)
         .attr('x', isRtl ? 0 : x)
         .attr('y', y)
         .attr('dy', dy)
@@ -946,7 +948,7 @@ export function createYAxisLabels(
       text
         .attr('text-align', 'start')
         .append('tspan')
-        .attr('id', 'LessLength')
+        .attr('id', `LessLength-${uid}`)
         .attr('x', isRtl ? 0 : x)
         .attr('y', y)
         .attr('dx', padding + dx + 'em')


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->
## New Behavior

Ported Full Y axis labels in Heatmap chart change to v9.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
