### PR TITLE
feat(react-18-tests-v8): add r18 integration pipelines for v8

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -87,11 +87,12 @@ jobs:
     strategy:
       matrix:
         react: [18, 19]
+        fluentui: [8, 9]
       fail-fast: false
     permissions:
       contents: 'read'
       actions: 'read'
-    name: React ${{ matrix.react }} Integration
+    name: React ${{ matrix.react }} / v${{ matrix.fluentui }} Integration
     steps:
       - uses: actions/checkout@v4
         with:
@@ -129,20 +130,20 @@ jobs:
       - name: type-check (affected)
         id: type-check
         if: steps.affected_projects_type_check_count.outputs.value > 0
-        run: yarn nx run-many -p react-${{ matrix.react }}-tests-v9 -t type-check:integration --nxBail
+        run: yarn nx run-many -p react-${{ matrix.react }}-tests-v${{ matrix.fluentui }} -t type-check:integration --nxBail
         continue-on-error: true
 
       - name: Prepare TSC logs
         if: always() && steps.type-check.outcome == 'failure'
         run: |
           mkdir -p tsc-logs
-          yarn tsc -p apps/react-${{ matrix.react }}-tests-v9/tsconfig.react-${{ matrix.react }}.json --listFilesOnly > tsc-logs/tsc-debug-files-map.md
+          yarn tsc -p apps/react-${{ matrix.react }}-tests-v${{ matrix.fluentui }}/tsconfig.react-${{ matrix.react }}.json --listFilesOnly > tsc-logs/tsc-debug-files-map.md
 
       - name: Upload TSC logs
         if: always() && steps.type-check.outcome == 'failure'
         uses: actions/upload-artifact@v4
         with:
-          name: typescript-react-${{ matrix.react }}
+          name: typescript-react-${{ matrix.react }}-v${{ matrix.fluentui }}
           path: tsc-logs
           retention-days: 1
 
@@ -151,7 +152,7 @@ jobs:
         id: e2e
         if: steps.affected_projects_e2e_count.outputs.value > 0
         run: |
-          yarn workspace @fluentui/react-${{ matrix.react }}-tests-v9 e2e:integration
+          yarn workspace @fluentui/react-${{ matrix.react }}-tests-v{${{ matrix.fluentui }}} e2e:integration
           echo $?
         continue-on-error: true
 
@@ -159,7 +160,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always() && steps.e2e.outcome == 'failure'
         with:
-          name: cypress-screenshots-react-${{ matrix.react }}
+          name: cypress-screenshots-react-${{ matrix.react }}-v${{ matrix.fluentui }}
           path: |
             apps/*/cypress/screenshots/**/*.png
             packages/**/cypress/screenshots/**/*.png
@@ -168,16 +169,16 @@ jobs:
       - name: Integration tests summary
         if: always()
         run: |
-          echo "### React ${{ matrix.react }} Integration Tests Results" >> $GITHUB_STEP_SUMMARY
+          echo "### React ${{ matrix.react }} / v${{ matrix.fluentui }} Integration Tests Results" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "- Type-check: ${{ steps.type-check.outcome }}" >> $GITHUB_STEP_SUMMARY
           echo "- E2E: ${{ steps.e2e.outcome }}" >> $GITHUB_STEP_SUMMARY
 
           if [[ "${{ steps.type-check.outcome }}" == "success" && "${{ steps.e2e.outcome }}" == "success" ]]; then
-            echo "✅ React ${{ matrix.react }} integration tests passed"
+            echo "✅ React ${{ matrix.react }} / v${{ matrix.fluentui }} integration tests passed"
             exit 0
           else
-            echo "❌ React ${{ matrix.react }} integration tests failed"
+            echo "❌ React ${{ matrix.react }} / v${{ matrix.fluentui }} integration tests failed"
             echo "Type-check: ${{ steps.type-check.outcome }}"
             echo "E2E: ${{ steps.e2e.outcome }}"
             exit 1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -155,7 +155,7 @@ jobs:
         id: e2e
         if: steps.affected_projects_e2e_count.outputs.value > 0
         run: |
-          yarn workspace @fluentui/react-${{ matrix.react }}-tests-v{${{ matrix.fluentui }}} e2e:integration
+          yarn workspace @fluentui/react-${{ matrix.react }}-tests-v${{ matrix.fluentui }} e2e:integration
           echo $?
         continue-on-error: true
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -88,6 +88,9 @@ jobs:
       matrix:
         react: [18, 19]
         fluentui: [8, 9]
+        exclude:
+          - react: 19
+            fluentui: 8
       fail-fast: false
     permissions:
       contents: 'read'

--- a/apps/react-18-tests-v8/.eslintrc.json
+++ b/apps/react-18-tests-v8/.eslintrc.json
@@ -2,6 +2,7 @@
   "extends": ["plugin:@fluentui/eslint-plugin/react--legacy"],
   "root": true,
   "rules": {
-    "no-restricted-globals": "off"
+    "no-restricted-globals": "off",
+    "import/no-extraneous-dependencies": "off"
   }
 }

--- a/apps/react-18-tests-v8/cypress-react-18.config.ts
+++ b/apps/react-18-tests-v8/cypress-react-18.config.ts
@@ -1,0 +1,33 @@
+import * as path from 'path';
+import { baseConfig, baseWebpackConfig } from '@fluentui/scripts-cypress';
+import { createStorybookWebpackConfig } from '@fluentui/scripts-webpack';
+
+// Include all tests from this app and the components package
+const specs = [path.resolve('src/**/*.cy.{tsx,ts}'), path.resolve('../../packages/react-examples/**/*.e2e.{tsx,ts}')];
+
+const config = { ...baseConfig };
+
+config.component.specPattern = specs;
+config.component.devServer.webpackConfig = createStorybookWebpackConfig(baseWebpackConfig);
+config.component.devServer.webpackConfig.resolve ??= {};
+config.component.devServer.webpackConfig.resolve.alias = {
+  ...config.component.devServer.webpackConfig.resolve.alias,
+  '@cypress/react': path.resolve(__dirname, './node_modules/@cypress/react'),
+  '@types/react': path.resolve(__dirname, './node_modules/@types/react'),
+  '@types/react-dom': path.resolve(__dirname, './node_modules/@types/react-dom'),
+  react: path.resolve(__dirname, './node_modules/react'),
+  'react-dom': path.resolve(__dirname, './node_modules/react-dom'),
+  'cypress-real-events': path.resolve(__dirname, './node_modules/cypress-real-events'),
+};
+
+/**
+ * Resolve the support file and index.html file paths
+ * This is a workaround for the issue where Cypress does not resolve the paths correctly, as it
+ * internally prepend the __dirname, making them invalid.
+ *
+ * TODO: Remove this workaround once we upgrade the whole repo to Cypress 14
+ */
+config.component.supportFile = path.normalize('../../scripts/cypress/src/support/component.js');
+config.component.indexHtmlFile = path.normalize('../../scripts/cypress/src/support/component-index.html');
+
+export default config;

--- a/apps/react-18-tests-v8/cypress.config.ts
+++ b/apps/react-18-tests-v8/cypress.config.ts
@@ -1,11 +1,21 @@
 import * as path from 'node:path';
 import { baseConfig } from '@fluentui/scripts-cypress';
-const { registerTsPaths } = require('@fluentui/scripts-storybook');
+import { registerTsPaths } from '@fluentui/scripts-storybook';
 
 const tsConfigPath = path.resolve(__dirname, '../../tsconfig.base.v8.json');
 
 const config = { ...baseConfig };
 
 registerTsPaths({ config: config.component.devServer.webpackConfig, configFile: tsConfigPath });
+
+config.component.devServer.webpackConfig.resolve ??= {};
+config.component.devServer.webpackConfig.resolve.alias = {
+  ...config.component.devServer.webpackConfig.resolve.alias,
+  '@cypress/react': path.resolve(__dirname, './node_modules/@cypress/react'),
+  '@types/react': path.resolve(__dirname, './node_modules/@types/react'),
+  '@types/react-dom': path.resolve(__dirname, './node_modules/@types/react-dom'),
+  react: path.resolve(__dirname, './node_modules/react'),
+  'react-dom': path.resolve(__dirname, './node_modules/react-dom'),
+};
 
 export default config;

--- a/apps/react-18-tests-v8/package.json
+++ b/apps/react-18-tests-v8/package.json
@@ -5,10 +5,12 @@
   "private": true,
   "scripts": {
     "type-check": "just-scripts type-check",
+    "type-check:integration": "tsc -p tsconfig.react-18.json --noEmit",
     "format": "prettier -w . --ignore-path ../.prettierignore",
     "format:check": "yarn format -c",
     "e2e": "cypress run --component",
     "e2e:local": "cypress open --component",
+    "e2e:integration": "npx --yes cypress@latest run --component --config-file cypress-react-18.config.ts",
     "lint": "ESLINT_USE_FLAT_CONFIG=false eslint --ext .js,.ts,.tsx ./src",
     "test": "jest --passWithNoTests",
     "start": "webpack-dev-server --mode=development"
@@ -22,10 +24,13 @@
     "@fluentui/scripts-storybook": "*"
   },
   "dependencies": {
+    "@cypress/react": "9.0.1",
     "@fluentui/react": "*",
+    "@fluentui/react-cards": "*",
     "@fluentui/react-hooks": "*",
     "@types/react": "18.3.20",
     "@types/react-dom": "18.3.6",
+    "cypress-real-events": "1.14.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "tslib": "^2.1.0"

--- a/apps/react-18-tests-v8/project.json
+++ b/apps/react-18-tests-v8/project.json
@@ -7,6 +7,17 @@
   "targets": {
     "test": {
       "dependsOn": ["^build"]
+    },
+    "type-check:integration": {
+      "dependsOn": ["^build"],
+      "inputs": [
+        "{projectRoot}/tsconfig.react-18.json",
+        "{workspaceRoot}/packages/react-examples/*/stories/**/index.stories.tsx"
+      ]
+    },
+    "e2e:integration": {
+      "dependsOn": [],
+      "inputs": ["{projectRoot}/cypress-react-18.config.ts", "{workspaceRoot}/packages/react-examples/**/*.e2e.tsx?"]
     }
   }
 }

--- a/apps/react-18-tests-v8/tsconfig.react-18.json
+++ b/apps/react-18-tests-v8/tsconfig.react-18.json
@@ -1,0 +1,32 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "lib": ["ES2019", "dom"],
+    "sourceMap": true,
+    "strict": true,
+    "pretty": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "importHelpers": true,
+    "jsx": "react",
+    "noUnusedLocals": true,
+    "preserveConstEnums": true,
+    "skipLibCheck": true,
+    "typeRoots": ["./node_modules/@types"],
+    "types": [],
+    "baseUrl": ".",
+    "paths": {
+      "react/jsx-runtime": ["./node_modules/@types/react/jsx-runtime.d.ts"],
+      "react": ["./node_modules/@types/react/index.d.ts"],
+      "react-dom": ["./node_modules/@types/react-dom/index.d.ts"]
+    }
+  },
+  "exclude": [
+    "../../packages/react-examples/src/react-charting/**",
+    "../../packages/react-examples/src/react-experiments/**"
+  ],
+  "include": ["../../packages/react-examples/**/index.stories.tsx"],
+  "files": ["../../typings/static-assets/index.d.ts"]
+}

--- a/apps/react-18-tests-v8/tsconfig.react-18.json
+++ b/apps/react-18-tests-v8/tsconfig.react-18.json
@@ -6,6 +6,7 @@
     "lib": ["ES2019", "dom"],
     "sourceMap": true,
     "strict": true,
+    "strictFunctionTypes": false,
     "pretty": true,
     "noEmit": true,
     "isolatedModules": true,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

- adds type-check and e2e integration against v8 assets / follows https://github.com/microsoft/fluentui/pull/34247
- excludes react-charting and react-experiments for type-check integration for now
- new pipeline check 
![image](https://github.com/user-attachments/assets/ce85f25e-542d-4bf8-86ec-b6e75a2465df)


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
