### PR TITLE
chore: Re-exporting `CellRenderFunction` from `@fluentui/react-components`

### DIFF
--- a/change/@fluentui-react-components-2a9d64d4-7c5d-4507-9d09-f0abba5ad631.json
+++ b/change/@fluentui-react-components-2a9d64d4-7c5d-4507-9d09-f0abba5ad631.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "chore: Re-exporting CellRenderFunction from @fluentui/react-components.",
+  "packageName": "@fluentui/react-components",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -386,5 +386,6 @@
   },
   "nx": {
     "includedScripts": []
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha224.b3354a4448ff7f95109b317dcf100acbb19dd7a067ff7fad9acf941f"
 }

--- a/package.json
+++ b/package.json
@@ -386,6 +386,5 @@
   },
   "nx": {
     "includedScripts": []
-  },
-  "packageManager": "yarn@1.22.22+sha224.b3354a4448ff7f95109b317dcf100acbb19dd7a067ff7fad9acf941f"
+  }
 }

--- a/packages/react-components/react-components/etc/react-components.api.md
+++ b/packages/react-components/react-components/etc/react-components.api.md
@@ -213,6 +213,7 @@ import { carouselViewportClassNames } from '@fluentui/react-carousel';
 import { CarouselViewportProps } from '@fluentui/react-carousel';
 import { CarouselViewportSlots } from '@fluentui/react-carousel';
 import { CarouselViewportState } from '@fluentui/react-carousel';
+import { CellRenderFunction } from '@fluentui/react-table';
 import { Checkbox } from '@fluentui/react-checkbox';
 import { checkboxClassNames } from '@fluentui/react-checkbox';
 import { CheckboxOnChangeData } from '@fluentui/react-checkbox';
@@ -2279,6 +2280,8 @@ export { CarouselViewportProps }
 export { CarouselViewportSlots }
 
 export { CarouselViewportState }
+
+export { CellRenderFunction }
 
 export { Checkbox }
 

--- a/packages/react-components/react-components/src/index.ts
+++ b/packages/react-components/react-components/src/index.ts
@@ -1151,6 +1151,7 @@ export type {
   DataGridSelectionCellProps,
   DataGridSelectionCellState,
   DataGridSelectionCellSlots,
+  CellRenderFunction,
 } from '@fluentui/react-table';
 
 export {


### PR DESCRIPTION
This pull request includes updates to the `@fluentui/react-components` package to re-export the `CellRenderFunction` type from `@fluentui/react-table`.

The most important changes include:

* Added import statement for `CellRenderFunction` from `@fluentui/react-table` in `packages/react-components/react-components/etc/react-components.api.md`.
* Added export statement for `CellRenderFunction` in `packages/react-components/react-components/etc/react-components.api.md`.
* Added `CellRenderFunction` to the export type list in `packages/react-components/react-components/src/index.ts`.
