### PR TITLE
Allow keyboard event to be received by onLinkClick event

### DIFF
--- a/packages/react/src/components/Pivot/Pivot.base.tsx
+++ b/packages/react/src/components/Pivot/Pivot.base.tsx
@@ -180,11 +180,14 @@ export const PivotBase: React.FunctionComponent<IPivotProps> = React.forwardRef<
       // eslint-disable-next-line @typescript-eslint/no-deprecated
       if (ev.which === KeyCodes.enter) {
         ev.preventDefault();
-        updateSelectedItem(itemKey);
+        updateSelectedItem(itemKey, ev);
       }
     };
 
-    const updateSelectedItem = (itemKey: string, ev?: React.MouseEvent<HTMLElement>): void => {
+    const updateSelectedItem = (
+      itemKey: string,
+      ev?: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>,
+    ): void => {
       setSelectedKey(itemKey);
       linkCollection = getLinkItems(props, pivotId);
       if (props.onLinkClick && linkCollection.keyToIndexMapping[itemKey] >= 0) {

--- a/packages/react/src/components/Pivot/Pivot.types.ts
+++ b/packages/react/src/components/Pivot/Pivot.types.ts
@@ -58,7 +58,7 @@ export interface IPivotProps extends React.HTMLAttributes<HTMLDivElement>, React
   /**
    * Callback for when the selected pivot item is changed.
    */
-  onLinkClick?: (item?: PivotItem, ev?: React.MouseEvent<HTMLElement>) => void;
+  onLinkClick?: (item?: PivotItem, ev?: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => void;
 
   /**
    * Link size (normal, large)


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [X] Code is up-to-date with the `master` branch
* [X] Your changes are covered by tests (if possible)
* [X] You've run `yarn change` locally


PR flow tips:
* [X] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

We do not pass the keydown event to `updateSelectedItem` (possibly because this method previously only took mouse event). However, it is also triggered by keyboard enter, so clients should expect to be able to access the target property.

## New Behavior

Pass the event from keydown to the updateSelectedItem method 

## Related Issue(s)

- Fixes #34272
