### PR TITLE
Handle duplicate tokens and enable null for f2 overrides

### DIFF
--- a/packages/semantic-tokens/scripts/fluentOverrides.ts
+++ b/packages/semantic-tokens/scripts/fluentOverrides.ts
@@ -8,7 +8,7 @@ export type FluentOverrideValue =
       rawValue: string;
     };
 
-export type FluentOverrides = Record<string, FluentOverrideValue>;
+export type FluentOverrides = Record<string, FluentOverrideValue | null>;
 
 export const fluentOverrides: FluentOverrides = {
   ctrlFocusOuterStroke: {

--- a/packages/semantic-tokens/scripts/legacyTokens.ts
+++ b/packages/semantic-tokens/scripts/legacyTokens.ts
@@ -15,12 +15,8 @@ const generateLegacyTokens = () => {
 
   const generatedTokens = semanticTokenFallbacks.reduce((acc, t) => {
     const tokenOverride = fluentOverrides[t];
-    if (!tokenOverride) {
-      // Token has inline variants, skip
-      return acc;
-    }
-    const fluent2Fallback = tokenOverride.f2Token;
-    if (!fluent2Fallback || exportedTokens.includes(fluent2Fallback)) {
+    const fluent2Fallback = tokenOverride?.f2Token;
+    if (!tokenOverride || !fluent2Fallback || exportedTokens.includes(fluent2Fallback)) {
       return acc;
     }
     // Add it to our list of exported tokens

--- a/packages/semantic-tokens/scripts/legacyTokens.ts
+++ b/packages/semantic-tokens/scripts/legacyTokens.ts
@@ -10,17 +10,25 @@ const generateLegacyTokens = () => {
   console.log('Importing required fluent legacy tokens as flat export');
 
   const semanticTokenFallbacks = Object.keys(fluentOverrides);
+  const exportedTokens: string[] = [];
   const comment = '// THIS FILE IS GENERATED AS PART OF THE BUILD PROCESS. DO NOT MANUALLY MODIFY THIS FILE\n';
 
   const generatedTokens = semanticTokenFallbacks.reduce((acc, t) => {
-    const fluent2Fallback = fluentOverrides[t].f2Token;
-    if (!fluent2Fallback) {
-      return '';
+    const tokenOverride = fluentOverrides[t];
+    if (!tokenOverride) {
+      // Token has inline variants, skip
+      return acc;
     }
+    const fluent2Fallback = tokenOverride.f2Token;
+    if (!fluent2Fallback || exportedTokens.includes(fluent2Fallback)) {
+      return acc;
+    }
+    // Add it to our list of exported tokens
+    exportedTokens.push(fluent2Fallback);
     if (!Object.keys(tokensPackage.tokens).includes(fluent2Fallback)) {
       // Token does not exist in F2 tokens
       // This should never occur, but let's flag if a mistake was made in fallback token names
-      throw new Error(`Fluent token ${fluentOverrides[t].f2Token} not found in fluent tokens`);
+      throw new Error(`Fluent token ${tokenOverride.f2Token} not found in fluent tokens`);
     }
     const tokenValue = tokensPackage.tokens[fluent2Fallback as keyof typeof tokensPackage.tokens];
     const token = `/**


### PR DESCRIPTION
## Previous Behavior
Duplicate legacy tokens would get re-exported
There was no way to define a token as 'has inline fallbacks'

## New Behavior
Duplicate legacy tokens only get exported once
Any tokens set to 'null' are inferred to have inline fallbacks and should not be overwritten with other fallbacks (use inline instead).
