### PR TITLE
fix(public-docsite-v9): add spacing between additional info section items

### DIFF
--- a/apps/public-docsite-v9/src/DocsComponents/FluentDocsPage.stories.tsx
+++ b/apps/public-docsite-v9/src/DocsComponents/FluentDocsPage.stories.tsx
@@ -51,6 +51,11 @@ const useStyles = makeStyles({
     display: 'grid',
     gridTemplateColumns: '1fr min-content',
   },
+  additionalInfoWrapper: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: tokens.spacingVerticalM,
+  },
   additionalInfo: {
     display: 'flex',
     flexDirection: 'column',
@@ -203,43 +208,46 @@ const AdditionalApiDocs: React.FC<{ children: React.ReactElement | React.ReactEl
 };
 const RenderArgsTable = ({ hideArgsTable, story }: { story: PrimaryStory; hideArgsTable: boolean }) => {
   const { component, hasArgAsProp, hasArgAsSlot, argAsProp } = withSlotEnhancer(story);
+  const styles = useStyles();
 
   return hideArgsTable ? null : (
     <>
-      {hasArgAsProp && (
-        <AdditionalApiDocs>
-          <p>
-            <b>
-              Native props are supported <span role="presentation">🙌</span>
+      <div className={styles.additionalInfoWrapper}>
+        {hasArgAsProp && (
+          <AdditionalApiDocs>
+            <p>
+              <b>
+                Native props are supported <span role="presentation">🙌</span>
+                <br />
+              </b>
+              <span>
+                All HTML attributes native to the
+                {getNativeElementsList(argAsProp!)}, including all <code>aria-*</code> and <code>data-*</code>{' '}
+                attributes, can be applied as native props on this component.
+              </span>
+            </p>
+          </AdditionalApiDocs>
+        )}
+        {hasArgAsSlot && (
+          <AdditionalApiDocs>
+            <p>
+              <b>
+                Customizing components with slots <span role="presentation">🙌</span>
+              </b>
               <br />
-            </b>
-            <span>
-              All HTML attributes native to the
-              {getNativeElementsList(argAsProp!)}, including all <code>aria-*</code> and <code>data-*</code> attributes,
-              can be applied as native props on this component.
-            </span>
-          </p>
-        </AdditionalApiDocs>
-      )}
-      {hasArgAsSlot && (
-        <AdditionalApiDocs>
-          <p>
-            <b>
-              Customizing components with slots <span role="presentation">🙌</span>
-            </b>
-            <br />
-            <span>
-              Slots in Fluent UI React components are designed to be modified or replaced, providing a flexible approach
-              to customizing components. Each slot is exposed as a top-level prop and can be filled with primitive
-              values, JSX/TSX, props objects, or render functions. This allows for more dynamic and reusable component
-              structures, similar to slots in other frameworks.{' '}
-              <Link href="/?path=/docs/concepts-developer-customizing-components-with-slots--docs">
-                Customizing components with slots{' '}
-              </Link>
-            </span>
-          </p>
-        </AdditionalApiDocs>
-      )}
+              <span>
+                Slots in Fluent UI React components are designed to be modified or replaced, providing a flexible
+                approach to customizing components. Each slot is exposed as a top-level prop and can be filled with
+                primitive values, JSX/TSX, props objects, or render functions. This allows for more dynamic and reusable
+                component structures, similar to slots in other frameworks.{' '}
+                <Link href="/?path=/docs/concepts-developer-customizing-components-with-slots--docs">
+                  Customizing components with slots{' '}
+                </Link>
+              </span>
+            </p>
+          </AdditionalApiDocs>
+        )}
+      </div>
       <ArgsTable of={component} />
     </>
   );


### PR DESCRIPTION
💅🏻 💅🏻 💅🏻 💅🏻 💅🏻 

## Previous Behavior

<img width="821" alt="before" src="https://github.com/user-attachments/assets/8155b3ab-3a01-4bb1-8ec8-fe4f2cd0435c" />

## New Behavior

<img width="831" alt="after" src="https://github.com/user-attachments/assets/7b1a2625-d9e6-4516-902b-0612b3d86201" />




