### PR TITLE
Users/jes/tree expansion

### DIFF
--- a/change/@fluentui-web-components-518be343-8367-40e9-8214-f456b8fc0de3.json
+++ b/change/@fluentui-web-components-518be343-8367-40e9-8214-f456b8fc0de3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[fix] only set expanded is expanded is not set",
+  "packageName": "@fluentui/web-components",
+  "email": "jes@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/tree-item/tree-item.base.ts
+++ b/packages/web-components/src/tree-item/tree-item.base.ts
@@ -115,7 +115,7 @@ export class BaseTreeItem extends FASTElement {
     }
 
     //If a tree item is nested and initially set to selected expand the tree items so the selected item is visible
-    if(!this.expanded) {
+    if (!this.expanded) {
       this.expanded = Array.from(this.querySelectorAll('[selected]')).some(el => isTreeItem(el));
     }
 

--- a/packages/web-components/src/tree-item/tree-item.base.ts
+++ b/packages/web-components/src/tree-item/tree-item.base.ts
@@ -116,7 +116,7 @@ export class BaseTreeItem extends FASTElement {
 
     //If a tree item is nested and initially set to selected expand the tree items so the selected item is visible
     if(!this.expanded) {
-      this.expanded = Array.from(this.querySelectorAll('*')).some(el => isTreeItem(el) && el.selected);
+      this.expanded = Array.from(this.querySelectorAll('[selected]')).some(el => isTreeItem(el));
     }
 
     this.childTreeItems.forEach(item => {

--- a/packages/web-components/src/tree-item/tree-item.base.ts
+++ b/packages/web-components/src/tree-item/tree-item.base.ts
@@ -115,7 +115,9 @@ export class BaseTreeItem extends FASTElement {
     }
 
     //If a tree item is nested and initially set to selected expand the tree items so the selected item is visible
-    this.expanded = Array.from(this.querySelectorAll('*')).some(el => isTreeItem(el) && el.selected);
+    if(!this.expanded) {
+      this.expanded = Array.from(this.querySelectorAll('*')).some(el => isTreeItem(el) && el.selected);
+    }
 
     this.childTreeItems.forEach(item => {
       this.setIndent(item);

--- a/packages/web-components/src/tree-item/tree-item.spec.ts
+++ b/packages/web-components/src/tree-item/tree-item.spec.ts
@@ -95,4 +95,24 @@ test.describe('Tree Item', () => {
     await expect(element.nth(0)).toHaveAttribute('expanded');
     await expect(selectedItems).toBeVisible();
   });
+
+  test('should keep intitally set expanded attribute when no child item is set to selected', async ({ fastPage }) => {
+    const { element } = fastPage;
+    await fastPage.setTemplate({
+      attributes: { expanded: true },
+      innerHTML: /* html */ `
+        Item 1
+        <fluent-tree-item>
+          Nested Item A
+          <fluent-tree-item>
+            Nested Item B
+            <fluent-tree-item>Nested Item C</fluent-tree-item>
+          </fluent-tree-item>
+        </fluent-tree-item>
+      `,
+    });
+    const nestedItem = element.nth(0).locator('fluent-tree-item').nth(0);
+    await expect(element.nth(0)).toHaveAttribute('expanded');
+    await expect(nestedItem).toBeVisible();
+  });
 });

--- a/packages/web-components/src/tree/tree.stories.ts
+++ b/packages/web-components/src/tree/tree.stories.ts
@@ -7,7 +7,7 @@ type Story = StoryObj<FluentTree>;
 
 const storyTemplate = html<StoryArgs<FluentTree>>`
   <fluent-tree size="${x => x.size}" appearance="${x => x.appearance}">
-    <fluent-tree-item>
+    <fluent-tree-item expanded>
       Item 1
       <fluent-tree-item>
         <span slot="start">


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
If you initially set expanded but no child item is set to selected the childItemChnaged event removed the attribute because its was strictly based on whther a child was set to selected.

## New Behavior
Added a check to only set expanded when there is a child selected item if expanded is not set.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
