### PR TITLE
fix(react-charting): Fixed legends disappear when hovering over the scrollbar in more legends

### DIFF
--- a/change/@fluentui-react-charting-c468de78-207f-4410-8bc9-181d0c77d894.json
+++ b/change/@fluentui-react-charting-c468de78-207f-4410-8bc9-181d0c77d894.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(react-charting): Fixing legends disappear when hovering over the scrollbar in more legends",
+  "packageName": "@fluentui/react-charting",
+  "email": "120183316+srmukher@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charts/react-charting/src/components/Legends/Legends.styles.ts
+++ b/packages/charts/react-charting/src/components/Legends/Legends.styles.ts
@@ -123,6 +123,9 @@ export const getStyles = (props: ILegendStyleProps): ILegendsStyles => {
     ],
     hoverCardRoot: {
       padding: '8px',
+      position: 'relative',
+      overflowY: 'auto',
+      maxHeight: '300px',
     },
     subComponentStyles: {
       hoverCardStyles: {


### PR DESCRIPTION
Work item: https://uifabric.visualstudio.com/iss/_workitems/edit/12233/
Fixed legends disappear when hovering over the scrollbar in more legends. 
The legend overflow container can be scrolled without crashing on hovering on the scrollbar as follow:

![image](https://github.com/user-attachments/assets/677f42bc-a812-41c3-b820-ffab0eee388f)
