### PR TITLE
fix(`react-tabster`): Making `tabster` instance live for the duration of component calling `useTabster` hook

### DIFF
--- a/change/@fluentui-react-tabster-a86ba0cf-08fd-4f69-b4d6-8d7a29f54e20.json
+++ b/change/@fluentui-react-tabster-a86ba0cf-08fd-4f69-b4d6-8d7a29f54e20.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Making tabster instance live for the duration of component calling useTabster hook.",
+  "packageName": "@fluentui/react-tabster",
+  "email": "makotom@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tabster/src/hooks/useTabster.ts
+++ b/packages/react-components/react-tabster/src/hooks/useTabster.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { createTabster, disposeTabster, Types as TabsterTypes } from 'tabster';
 import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
-import { getParent, usePrevious } from '@fluentui/react-utilities';
+import { getParent, useIsomorphicLayoutEffect, usePrevious } from '@fluentui/react-utilities';
 
 interface WindowWithTabsterShadowDOMAPI extends Window {
   __tabsterShadowDOMAPI?: TabsterTypes.DOMAPI;
@@ -52,7 +52,7 @@ export function useTabster<FactoryResult>(factory = DEFAULT_FACTORY) {
   const factoryResultRef = React.useRef<FactoryResult | null>(null);
 
   const tabster = createTabsterWithConfig(targetDocument);
-  React.useEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (tabster) {
       factoryResultRef.current = factory(tabster) as FactoryResult;
 

--- a/packages/react-components/react-tabster/src/hooks/useTabster.ts
+++ b/packages/react-components/react-tabster/src/hooks/useTabster.ts
@@ -61,7 +61,7 @@ export function useTabster<FactoryResult>(factory = DEFAULT_FACTORY) {
         factoryResultRef.current = null;
       };
     }
-  }, [targetDocument, factory]);
+  }, [factory, tabster, targetDocument]);
 
   if (process.env.NODE_ENV !== 'production') {
     // eslint-disable-next-line

--- a/packages/react-components/react-tabster/src/hooks/useTabster.ts
+++ b/packages/react-components/react-tabster/src/hooks/useTabster.ts
@@ -51,9 +51,8 @@ export function useTabster<FactoryResult>(factory = DEFAULT_FACTORY) {
   const { targetDocument } = useFluent();
   const factoryResultRef = React.useRef<FactoryResult | null>(null);
 
+  const tabster = createTabsterWithConfig(targetDocument);
   React.useEffect(() => {
-    const tabster = createTabsterWithConfig(targetDocument);
-
     if (tabster) {
       factoryResultRef.current = factory(tabster) as FactoryResult;
 


### PR DESCRIPTION
While performing a `@fluentui/react-components` version bump in another repo, we noticed that some of the unit tests started failing with the following error:

![image](https://github.com/user-attachments/assets/d739b0dd-8489-4325-9b3a-475f339ef737)

After some investigation, it was determined that the issue happened in components calling the `useFocusObserved` hook in `@fluentui/react-tabster`. Digging deeper, we found that the rejected promise was happening in the `_rejectWaiting` method of `ObservedElement` [here](https://github.com/microsoft/tabster/blob/10c06a7c5b5abaf99b72e0173fff0f0483dedc63/src/State/ObservedElement.ts#L106), which was being called by the `dispose` method [here](https://github.com/microsoft/tabster/blob/10c06a7c5b5abaf99b72e0173fff0f0483dedc63/src/State/ObservedElement.ts#L62).

After some more investigation, we traced down this issue to change #34113, specifically [these lines](https://github.com/microsoft/fluentui/blob/master/packages/react-components/react-tabster/src/hooks/useTabster.ts#L54-L55). Before the change, the creation of the `tabster` instance happened before the `useEffect` hook call, but it's happening within it after the change. This means that the `tabster` instance lives in the scope of the `useEffect` hook and gets disposed after it has finished running, instead of living for the life of the component calling the `useTabster` hook. Moving the `tabster` instance creation outside of the `useEffect` hook call fixes the issue, which we have confirmed in place with the tests that were failing before.

We're also reverting to use `useIsomorphicLayoutEffect` instead of `useEffect` since some e2e tests fail otherwise.