### PR TITLE
docs(Nav): add a11y docs and update Basic example with aria-expanded

### DIFF
--- a/packages/react-components/react-nav-preview/stories/src/Nav/NavAccessibility.md
+++ b/packages/react-components/react-nav-preview/stories/src/Nav/NavAccessibility.md
@@ -1,0 +1,11 @@
+## Accessibility
+
+### Do
+
+- Use `href` on all NavItems that alter the URL, even if using JS routing
+- Ensure all `Hamburger` icon buttons have an accessible name
+- Add `aria-expanded` to buttons that toggle the expanded/collapsed state of inline Navs (this is not needed for overlay navs)
+
+### Don't
+
+- Combine expand/collapse items with linking behavior. Voice control and screen reader users cannot perform different actions through the same semantic button, even if a nested item has a separate click event attached.

--- a/packages/react-components/react-nav-preview/stories/src/Nav/NavDescription.md
+++ b/packages/react-components/react-nav-preview/stories/src/Nav/NavDescription.md
@@ -1,0 +1,1 @@
+A component that provides up to two levels of nesting for navigation.

--- a/packages/react-components/react-nav-preview/stories/src/Nav/index.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/src/Nav/index.stories.tsx
@@ -1,8 +1,10 @@
 import { Nav } from '@fluentui/react-nav-preview';
 
-// Todo: light these up
-// import descriptionMd from './NavDescription.md';
+// Todo: add best practices
 // import bestPracticesMd from './NavBestPractices.md';
+
+import descriptionMd from './NavDescription.md';
+import accessibilityMd from './NavAccessibility.md';
 
 export { Basic } from '../NavDrawer/Basic.stories';
 export { VariableDensityItems } from '../NavDrawer/VariableDensityItems.stories';
@@ -13,10 +15,10 @@ export default {
   title: 'Preview Components/Nav',
   component: Nav,
   parameters: {
-    // docs: {
-    //   description: {
-    //     component: [descriptionMd, bestPracticesMd].join('\n'),
-    //   },
-    // },
+    docs: {
+      description: {
+        component: [descriptionMd, accessibilityMd].join('\n'),
+      },
+    },
   },
 };

--- a/packages/react-components/react-nav-preview/stories/src/NavDrawer/Basic.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/src/NavDrawer/Basic.stories.tsx
@@ -229,7 +229,7 @@ export const Basic = (props: Partial<NavDrawerProps>) => {
             label={enabledLinks ? 'Enabled' : 'Disabled'}
             aria-labelledby={linkLabelId}
           />
-          <Label id={multipleLabelId}>Categories</Label>
+          <Label id={multipleLabelId}>Allow multiple expanded categories</Label>
           <Switch
             checked={isMultiple}
             onChange={(_, data) => setIsMultiple(!!data.checked)}

--- a/packages/react-components/react-nav-preview/stories/src/NavDrawer/Basic.stories.tsx
+++ b/packages/react-components/react-nav-preview/stories/src/NavDrawer/Basic.stories.tsx
@@ -210,7 +210,7 @@ export const Basic = (props: Partial<NavDrawerProps>) => {
       </NavDrawer>
       <div className={styles.content}>
         <Tooltip content="Toggle navigation pane" relationship="label">
-          <Hamburger onClick={() => setIsOpen(!isOpen)} {...restoreFocusTargetAttributes} />
+          <Hamburger onClick={() => setIsOpen(!isOpen)} {...restoreFocusTargetAttributes} aria-expanded={isOpen} />
         </Tooltip>
         <div className={styles.field}>
           <Label id={typeLableId}>Type</Label>


### PR DESCRIPTION
## Previous Behavior

no a11y docs, and no `aria-expanded` on the inline toggle (it's in preview, so this makes sense, just getting on top of adding the a11y docs b/c it got tested)

## New Behavior

Adds `aria-expanded` for the inline Nav toggle button, and docs for it + a few other a11y docs points (what I could think of off the top of my head, we can add more later).

## Related Issue(s)

- Fixes [ADO issue](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/27004)
