### PR TITLE
fix(Tablist): subtle-circular appearance variant shows selected tab in high contrast

### DIFF
--- a/change/@fluentui-react-tabs-74f15f82-3c33-4e73-8abe-9ef2d9c3d35c.json
+++ b/change/@fluentui-react-tabs-74f15f82-3c33-4e73-8abe-9ef2d9c3d35c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: filled-circular appearance variant shows selected tab in high contrast",
+  "packageName": "@fluentui/react-tabs",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tabs/library/src/components/Tab/useTabStyles.styles.ts
+++ b/packages/react-components/react-tabs/library/src/components/Tab/useTabStyles.styles.ts
@@ -217,6 +217,9 @@ const useCircularAppearanceStyles = makeStyles({
       border: `solid ${tokens.strokeWidthThin} ${tokens.colorCompoundBrandStrokePressed}`,
       color: tokens.colorBrandForeground2Pressed,
     },
+    '@media (forced-colors: active)': {
+      border: `solid ${tokens.strokeWidthThin} Highlight`,
+    },
   },
   subtleDisabled: {
     backgroundColor: tokens.colorSubtleBackground,

--- a/packages/react-components/react-tabs/stories/src/Tabs/TabListAppearance.stories.tsx
+++ b/packages/react-components/react-tabs/stories/src/Tabs/TabListAppearance.stories.tsx
@@ -30,16 +30,16 @@ export const Appearance = () => {
 
   return (
     <div className={styles.root}>
-      <TabList defaultSelectedValue="tab2" appearance="transparent">
+      <TabList defaultSelectedValue="tab3" appearance="transparent">
         {renderTabs()}
       </TabList>
-      <TabList defaultSelectedValue="tab2" appearance="subtle">
+      <TabList defaultSelectedValue="tab3" appearance="subtle">
         {renderTabs()}
       </TabList>
-      <TabList defaultSelectedValue="tab2" appearance="subtle-circular">
+      <TabList defaultSelectedValue="tab3" appearance="subtle-circular">
         {renderTabs()}
       </TabList>
-      <TabList defaultSelectedValue="tab2" appearance="filled-circular">
+      <TabList defaultSelectedValue="tab3" appearance="filled-circular">
         {renderTabs()}
       </TabList>
     </div>


### PR DESCRIPTION
## Previous Behavior

While the text of the selected item is technically semi-bold for the subtle-circular variant (the 3rd), it's very subtle:

<img width="410" alt="Screenshot of tablist appearance variants in high contrast mode. All variants except subtle-circular have a visible selected tab indicator" src="https://github.com/user-attachments/assets/f8434d06-51bf-42a9-a538-90772e1698a3" />

## New Behavior

Now the subtle-circular selected tab has `Highlight` as the border-color:
<img width="410" alt="Screenshot of the same tablist example, but now the filled-circular variant's selected tab has a blue border" src="https://github.com/user-attachments/assets/7dcd451d-77d8-4282-ae1f-12c55ef7fe5c" />

I also updated the example to have the 3rd tab be selected by default, so the default-selected tab is not the disabled tab.

## Related Issue(s)

- Fixes a partner ADO issue
