### PR TITLE
docs(Icon): add accNames to icon catalog and overview examples

### DIFF
--- a/apps/public-docsite-v9/src/DocsComponents/ReactIconGrid.stories.tsx
+++ b/apps/public-docsite-v9/src/DocsComponents/ReactIconGrid.stories.tsx
@@ -118,7 +118,7 @@ const renderIconCell = (itemProps: GridChildComponentProps & { data: IconCellDat
   }
 
   return (
-    <div aria-label={Icon.displayName} style={style}>
+    <div style={style}>
       <div className={classes.iconCell}>
         <div className={classes.iconCopyButton}>
           <Button
@@ -128,7 +128,7 @@ const renderIconCell = (itemProps: GridChildComponentProps & { data: IconCellDat
             title="Copy icon name to clipboard"
           />
         </div>
-        <Icon className={classes.iconGlyph} />
+        <Icon className={classes.iconGlyph} aria-label={Icon.displayName} />
         <div className={classes.iconCode}>
           <code>{Icon.displayName}</code>
         </div>

--- a/apps/public-docsite-v9/src/Icons/IconsDefault.stories.tsx
+++ b/apps/public-docsite-v9/src/Icons/IconsDefault.stories.tsx
@@ -19,14 +19,14 @@ export const Default = () => {
   return (
     <>
       <div className={classes.container}>
-        <SendRegular className={classes.icon24} />
-        <SendRegular className={classes.icon32} />
-        <SendRegular className={classes.icon48} />
+        <SendRegular className={classes.icon24} aria-label="SendRegular size 24" />
+        <SendRegular className={classes.icon32} aria-label="SendRegular size 32" />
+        <SendRegular className={classes.icon48} aria-label="SendRegular size 48" />
       </div>
       <div className={classes.container}>
-        <SendFilled className={classes.icon24} />
-        <SendFilled className={classes.icon32} />
-        <SendFilled className={classes.icon48} />
+        <SendFilled className={classes.icon24} aria-label="SendFilled size 24" />
+        <SendFilled className={classes.icon32} aria-label="SendFilled size 32" />
+        <SendFilled className={classes.icon48} aria-label="SendFilled size 48" />
       </div>
     </>
   );


### PR DESCRIPTION
## Previous Behavior

There was an `aria-label` on a generic `div` in the icons catalog, but the icons themselves didn't have an accName. I've removed the div `aria-label` that wasn't doing anything, and added one to the `Icon`s themselves (which also exposes them as images).

The Basic example also was missing accNames, which are now added; the other examples all already have them.

## New Behavior

accNames everywhere!

## Related Issue(s)

- Fixes [ADO issue](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/27982)
