### PR TITLE
feat: implement shared positioning config

### DIFF
--- a/apps/vr-tests-react-components/src/stories/Positioning/Positioning.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Positioning/Positioning.stories.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react';
 import type { Meta } from '@storybook/react';
 import {
+  PositioningConfigurationProvider,
   usePositioning,
-  PositioningProps,
-  PositioningVirtualElement,
-  PositioningImperativeRef,
+  type PositioningProps,
+  type PositioningVirtualElement,
+  type PositioningImperativeRef,
   type PositioningRect,
+  type PositioningConfigurationFn,
 } from '@fluentui/react-positioning';
 import { useMergedRefs, useIsomorphicLayoutEffect } from '@fluentui/react-utilities';
 import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
@@ -1025,6 +1027,49 @@ const BoundaryRect = () => {
   );
 };
 
+const ConfigurationProviderExample = () => {
+  const { containerRef, targetRef } = usePositioning({ position: 'after' });
+
+  return (
+    <div>
+      <button ref={targetRef}>Target</button>
+      <Box ref={containerRef}>Container</Box>
+    </div>
+  );
+};
+
+const ConfigurationProvider = () => {
+  const styles = useStyles();
+  const configurationFn: PositioningConfigurationFn = React.useCallback(({ options }) => {
+    return {
+      ...options,
+      offset: { mainAxis: 20, crossAxis: 20 },
+    };
+  }, []);
+
+  return (
+    <div
+      className={styles.boundary}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-evenly',
+        flexDirection: 'column',
+
+        height: 400,
+        width: 400,
+        padding: '5px 50px',
+      }}
+    >
+      <ConfigurationProviderExample />
+
+      <PositioningConfigurationProvider value={configurationFn}>
+        <ConfigurationProviderExample />
+      </PositioningConfigurationProvider>
+    </div>
+  );
+};
+
 export default {
   title: 'Positioning',
 
@@ -1112,6 +1157,9 @@ export const AutoSizeOverflowPaddingRTL = getStoryVariant(_AutoSizeOverflowPaddi
 
 export const AutoSizeOverflowPaddingShorthand = () => <AutoSize overflowBoundaryPadding={10} />;
 AutoSizeOverflowPaddingShorthand.storyName = 'auto size overflow padding shorthand';
+
+export const _ConfigurationProvider = () => <ConfigurationProvider />;
+_ConfigurationProvider.storyName = 'configuration provider';
 
 export const AutoSizeWithAsyncContent = () => (
   <StoryWright

--- a/change/@fluentui-react-components-7e29c1a9-70bb-4a47-bb47-8744bee0fbc2.json
+++ b/change/@fluentui-react-components-7e29c1a9-70bb-4a47-bb47-8744bee0fbc2.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: export PositioningConfigurationProvider",
+  "packageName": "@fluentui/react-components",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-positioning-7e4ac846-b14b-4560-9ec4-c2dd2725bff4.json
+++ b/change/@fluentui-react-positioning-7e4ac846-b14b-4560-9ec4-c2dd2725bff4.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: implement shared positioning config",
+  "packageName": "@fluentui/react-positioning",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-components/etc/react-components.api.md
+++ b/packages/react-components/react-components/etc/react-components.api.md
@@ -720,6 +720,9 @@ import { PortalMountNodeProvider } from '@fluentui/react-shared-contexts';
 import { PortalProps } from '@fluentui/react-portal';
 import { PortalState } from '@fluentui/react-portal';
 import { PositioningBoundary } from '@fluentui/react-positioning';
+import { PositioningConfigurationFn } from '@fluentui/react-positioning';
+import { PositioningConfigurationFnOptions } from '@fluentui/react-positioning';
+import { PositioningConfigurationProvider } from '@fluentui/react-positioning';
 import { PositioningImperativeRef } from '@fluentui/react-positioning';
 import { PositioningProps } from '@fluentui/react-positioning';
 import { PositioningRect } from '@fluentui/react-positioning';
@@ -3303,6 +3306,12 @@ export { PortalProps }
 export { PortalState }
 
 export { PositioningBoundary }
+
+export { PositioningConfigurationFn }
+
+export { PositioningConfigurationFnOptions }
+
+export { PositioningConfigurationProvider }
 
 export { PositioningImperativeRef }
 

--- a/packages/react-components/react-components/src/index.ts
+++ b/packages/react-components/react-components/src/index.ts
@@ -821,7 +821,7 @@ export type {
   TooltipTriggerProps,
 } from '@fluentui/react-tooltip';
 
-export { resolvePositioningShorthand } from '@fluentui/react-positioning';
+export { resolvePositioningShorthand, PositioningConfigurationProvider } from '@fluentui/react-positioning';
 export type {
   PositioningBoundary,
   PositioningProps,
@@ -830,6 +830,8 @@ export type {
   PositioningShorthandValue,
   PositioningImperativeRef,
   PositioningVirtualElement,
+  PositioningConfigurationFn,
+  PositioningConfigurationFnOptions,
 } from '@fluentui/react-positioning';
 
 export {

--- a/packages/react-components/react-positioning/etc/react-positioning.api.md
+++ b/packages/react-components/react-positioning/etc/react-positioning.api.md
@@ -69,6 +69,19 @@ export type Position = 'above' | 'below' | 'before' | 'after';
 export type PositioningBoundary = PositioningRect | HTMLElement | Array<HTMLElement> | 'clippingParents' | 'scrollParent' | 'window';
 
 // @public (undocumented)
+export type PositioningConfigurationFn = (params: {
+    container: HTMLElement;
+    arrow: HTMLElement | null;
+    options: PositioningConfigurationFnOptions;
+}) => PositioningConfigurationFnOptions;
+
+// @public (undocumented)
+export type PositioningConfigurationFnOptions = Omit<PositioningOptions, 'disableUpdateOnResize' | 'enabled' | 'onPositioningEnd' | 'positionFixed'>;
+
+// @public
+export const PositioningConfigurationProvider: React_2.Provider<PositioningConfigurationFn | undefined>;
+
+// @public (undocumented)
 export type PositioningImperativeRef = {
     updatePosition: () => void;
     setTarget: (target: TargetElement | null) => void;

--- a/packages/react-components/react-positioning/etc/react-positioning.api.md
+++ b/packages/react-components/react-positioning/etc/react-positioning.api.md
@@ -76,7 +76,7 @@ export type PositioningConfigurationFn = (params: {
 }) => PositioningConfigurationFnOptions;
 
 // @public (undocumented)
-export type PositioningConfigurationFnOptions = Omit<PositioningOptions, 'disableUpdateOnResize' | 'enabled' | 'onPositioningEnd' | 'positionFixed'>;
+export type PositioningConfigurationFnOptions = Omit<PositioningOptions, 'enabled' | 'onPositioningEnd' | 'positionFixed'>;
 
 // @public
 export const PositioningConfigurationProvider: React_2.Provider<PositioningConfigurationFn | undefined>;

--- a/packages/react-components/react-positioning/src/PositioningConfigurationContext.ts
+++ b/packages/react-components/react-positioning/src/PositioningConfigurationContext.ts
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import type { PositioningConfigurationFn } from './types';
+
+// ---
+
+const DEFAULT_CONFIGURATION: PositioningConfigurationFn = ({ options }) => {
+  return options;
+};
+
+// ---
+
+const PositioningConfigurationContext = React.createContext<PositioningConfigurationFn | undefined>(undefined);
+
+/**
+ * A context provider for the positioning configuration.
+ *
+ * Accepts a function that takes the positioning options and returns them modified.
+ */
+export const PositioningConfigurationProvider = PositioningConfigurationContext.Provider;
+
+export const usePositioningConfiguration = (): PositioningConfigurationFn => {
+  return React.useContext(PositioningConfigurationContext) ?? DEFAULT_CONFIGURATION;
+};

--- a/packages/react-components/react-positioning/src/index.ts
+++ b/packages/react-components/react-positioning/src/index.ts
@@ -2,9 +2,13 @@ export { createVirtualElementFromClick } from './createVirtualElementFromClick';
 export { createArrowHeightStyles, createArrowStyles } from './createArrowStyles';
 export { createSlideStyles } from './createSlideStyles';
 export type { CreateArrowStylesOptions } from './createArrowStyles';
+
+export { PositioningConfigurationProvider } from './PositioningConfigurationContext';
+
 export { usePositioning } from './usePositioning';
 export { usePositioningMouseTarget } from './usePositioningMouseTarget';
 export { resolvePositioningShorthand, mergeArrowOffset } from './utils/index';
+
 export type {
   Alignment,
   AutoSize,
@@ -24,4 +28,6 @@ export type {
   PositioningShorthandValue,
   PositioningVirtualElement,
   SetVirtualMouseTarget,
+  PositioningConfigurationFn,
+  PositioningConfigurationFnOptions,
 } from './types';

--- a/packages/react-components/react-positioning/src/middleware/offset.ts
+++ b/packages/react-components/react-positioning/src/middleware/offset.ts
@@ -3,7 +3,7 @@ import type { PositioningOptions } from '../types';
 import { getFloatingUIOffset } from '../utils/getFloatingUIOffset';
 
 /**
- * Wraps floating UI offset middleware to to transform offset value
+ * Wraps floating UI offset middleware to transform offset value.
  */
 export function offset(offsetValue: PositioningOptions['offset']) {
   const floatingUIOffset = getFloatingUIOffset(offsetValue);

--- a/packages/react-components/react-positioning/src/types.ts
+++ b/packages/react-components/react-positioning/src/types.ts
@@ -268,7 +268,6 @@ export type PositioningShorthand = PositioningProps | PositioningShorthandValue;
 
 export type PositioningConfigurationFnOptions = Omit<
   PositioningOptions,
-  | 'disableUpdateOnResize'
   // Excluded as the function will never be called if disabled
   | 'enabled'
   // Callback is not subscribed from options

--- a/packages/react-components/react-positioning/src/types.ts
+++ b/packages/react-components/react-positioning/src/types.ts
@@ -263,3 +263,21 @@ export type PositioningShorthandValue =
   | 'after-bottom';
 
 export type PositioningShorthand = PositioningProps | PositioningShorthandValue;
+
+// ---
+
+export type PositioningConfigurationFnOptions = Omit<
+  PositioningOptions,
+  | 'disableUpdateOnResize'
+  // Excluded as the function will never be called if disabled
+  | 'enabled'
+  // Callback is not subscribed from options
+  | 'onPositioningEnd'
+  // Is deprecated, no need to bloat the interface
+  | 'positionFixed'
+>;
+export type PositioningConfigurationFn = (params: {
+  container: HTMLElement;
+  arrow: HTMLElement | null;
+  options: PositioningConfigurationFnOptions;
+}) => PositioningConfigurationFnOptions;

--- a/packages/react-components/react-positioning/src/usePositioningOptions.ts
+++ b/packages/react-components/react-positioning/src/usePositioningOptions.ts
@@ -1,0 +1,179 @@
+import { devtools } from '@floating-ui/devtools';
+import { hide as hideMiddleware, arrow as arrowMiddleware } from '@floating-ui/dom';
+import type { Middleware } from '@floating-ui/dom';
+import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
+import * as React from 'react';
+
+import {
+  shift as shiftMiddleware,
+  flip as flipMiddleware,
+  coverTarget as coverTargetMiddleware,
+  maxSize as maxSizeMiddleware,
+  resetMaxSize as resetMaxSizeMiddleware,
+  offset as offsetMiddleware,
+  intersecting as intersectingMiddleware,
+  matchTargetSize as matchTargetSizeMiddleware,
+} from './middleware';
+import type { PositioningConfigurationFn, PositioningConfigurationFnOptions, PositioningOptions } from './types';
+import { toFloatingUIPlacement, hasScrollParent, normalizeAutoSize } from './utils';
+import { devtoolsCallback } from './utils/devtools';
+import { usePositioningConfiguration } from './PositioningConfigurationContext';
+
+/**
+ * @internal
+ *
+ * This is redundant and exists only to manage React dependencies properly & avoid leaking individual options to the
+ * scope of `usePositioningOptions`.
+ */
+function usePositioningConfigFn(
+  configFn: PositioningConfigurationFn,
+  options: PositioningOptions,
+): (container: HTMLElement, arrow: HTMLElement | null) => PositioningConfigurationFnOptions {
+  const {
+    align,
+    arrowPadding,
+    autoSize,
+    coverTarget,
+    flipBoundary,
+    offset,
+    overflowBoundary,
+    pinned,
+    position,
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    unstable_disableTether,
+    strategy,
+    overflowBoundaryPadding,
+    fallbackPositions,
+    useTransform,
+    matchTargetSize,
+    shiftToCoverTarget,
+  } = options;
+
+  return React.useCallback(
+    (container: HTMLElement, arrow: HTMLElement | null) => {
+      return configFn({
+        container,
+        arrow,
+        options: {
+          autoSize,
+          matchTargetSize,
+          offset,
+          strategy,
+          coverTarget,
+          flipBoundary,
+          overflowBoundary,
+          useTransform,
+          overflowBoundaryPadding,
+          pinned,
+          arrowPadding,
+          align,
+          fallbackPositions,
+          shiftToCoverTarget,
+          position,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          unstable_disableTether,
+        },
+      });
+    },
+    [
+      autoSize,
+      matchTargetSize,
+      offset,
+      strategy,
+      coverTarget,
+      flipBoundary,
+      overflowBoundary,
+      useTransform,
+      overflowBoundaryPadding,
+      pinned,
+      arrowPadding,
+      align,
+      fallbackPositions,
+      shiftToCoverTarget,
+      position,
+      unstable_disableTether,
+      configFn,
+    ],
+  );
+}
+
+/**
+ * @internal
+ */
+export function usePositioningOptions(options: PositioningOptions) {
+  const { dir, targetDocument } = useFluent();
+  const isRtl = dir === 'rtl';
+
+  const configFn = usePositioningConfigFn(usePositioningConfiguration(), options);
+  const {
+    disableUpdateOnResize,
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    positionFixed,
+  } = options;
+
+  return React.useCallback(
+    (container: HTMLElement, arrow: HTMLElement | null) => {
+      const hasScrollableElement = hasScrollParent(container);
+
+      const optionsAfterEnhancement = configFn(container, arrow);
+      const {
+        autoSize,
+        matchTargetSize,
+        offset,
+        coverTarget,
+        flipBoundary,
+        overflowBoundary,
+        useTransform,
+        overflowBoundaryPadding,
+        pinned,
+        position,
+        arrowPadding,
+        strategy,
+        align,
+        fallbackPositions,
+        shiftToCoverTarget,
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        unstable_disableTether,
+      } = optionsAfterEnhancement;
+      const normalizedAutoSize = normalizeAutoSize(autoSize);
+
+      const middleware = [
+        normalizedAutoSize && resetMaxSizeMiddleware(normalizedAutoSize),
+        matchTargetSize && matchTargetSizeMiddleware(),
+        offset && offsetMiddleware(offset),
+        coverTarget && coverTargetMiddleware(),
+        !pinned && flipMiddleware({ container, flipBoundary, hasScrollableElement, isRtl, fallbackPositions }),
+        shiftMiddleware({
+          container,
+          hasScrollableElement,
+          overflowBoundary,
+          disableTether: unstable_disableTether,
+          overflowBoundaryPadding,
+          isRtl,
+          shiftToCoverTarget,
+        }),
+        normalizedAutoSize &&
+          maxSizeMiddleware(normalizedAutoSize, { container, overflowBoundary, overflowBoundaryPadding, isRtl }),
+        intersectingMiddleware(),
+        arrow && arrowMiddleware({ element: arrow, padding: arrowPadding }),
+        hideMiddleware({ strategy: 'referenceHidden' }),
+        hideMiddleware({ strategy: 'escaped' }),
+        process.env.NODE_ENV !== 'production' &&
+          targetDocument &&
+          devtools(targetDocument, devtoolsCallback(optionsAfterEnhancement)),
+      ].filter(Boolean) as Middleware[];
+
+      const placement = toFloatingUIPlacement(align, position, isRtl);
+
+      return {
+        placement,
+        middleware,
+        strategy: strategy ?? positionFixed ? ('fixed' as const) : ('absolute' as const),
+
+        disableUpdateOnResize,
+        useTransform,
+      };
+    },
+    [configFn, disableUpdateOnResize, isRtl, targetDocument, positionFixed],
+  );
+}

--- a/packages/react-components/react-positioning/src/usePositioningOptions.ts
+++ b/packages/react-components/react-positioning/src/usePositioningOptions.ts
@@ -34,6 +34,7 @@ function usePositioningConfigFn(
     arrowPadding,
     autoSize,
     coverTarget,
+    disableUpdateOnResize,
     flipBoundary,
     offset,
     overflowBoundary,
@@ -56,6 +57,7 @@ function usePositioningConfigFn(
         arrow,
         options: {
           autoSize,
+          disableUpdateOnResize,
           matchTargetSize,
           offset,
           strategy,
@@ -77,6 +79,7 @@ function usePositioningConfigFn(
     },
     [
       autoSize,
+      disableUpdateOnResize,
       matchTargetSize,
       offset,
       strategy,
@@ -106,7 +109,6 @@ export function usePositioningOptions(options: PositioningOptions) {
 
   const configFn = usePositioningConfigFn(usePositioningConfiguration(), options);
   const {
-    disableUpdateOnResize,
     // eslint-disable-next-line @typescript-eslint/no-deprecated
     positionFixed,
   } = options;
@@ -118,6 +120,7 @@ export function usePositioningOptions(options: PositioningOptions) {
       const optionsAfterEnhancement = configFn(container, arrow);
       const {
         autoSize,
+        disableUpdateOnResize,
         matchTargetSize,
         offset,
         coverTarget,
@@ -174,6 +177,6 @@ export function usePositioningOptions(options: PositioningOptions) {
         useTransform,
       };
     },
-    [configFn, disableUpdateOnResize, isRtl, targetDocument, positionFixed],
+    [configFn, isRtl, targetDocument, positionFixed],
   );
 }

--- a/packages/react-components/react-positioning/src/utils/devtools.ts
+++ b/packages/react-components/react-positioning/src/utils/devtools.ts
@@ -4,33 +4,34 @@ import { isHTMLElement } from '@fluentui/react-utilities';
 import { listScrollParents } from './listScrollParents';
 import { fromFloatingUIPlacement } from './fromFloatingUIPlacement';
 
-export const devtoolsCallback = (options: PositioningOptions) => (middlewareState: MiddlewareState) => {
-  const {
-    elements: { floating, reference },
-  } = middlewareState;
-  const scrollParentsSet = new Set<HTMLElement>();
-  if (isHTMLElement(reference)) {
-    listScrollParents(reference).forEach(scrollParent => scrollParentsSet.add(scrollParent));
-  }
-  listScrollParents(floating).forEach(scrollParent => scrollParentsSet.add(scrollParent));
-  const flipBoundaries: HTMLElement[] = Array.isArray(options.flipBoundary)
-    ? options.flipBoundary
-    : isHTMLElement(options.flipBoundary)
-    ? [options.flipBoundary]
-    : [];
-  const overflowBoundaries: HTMLElement[] = Array.isArray(options.overflowBoundary)
-    ? options.overflowBoundary
-    : isHTMLElement(options.overflowBoundary)
-    ? [options.overflowBoundary]
-    : [];
-  return {
-    type: 'FluentUIMiddleware',
-    middlewareState,
-    options,
-    initialPlacement: fromFloatingUIPlacement(middlewareState.initialPlacement),
-    placement: fromFloatingUIPlacement(middlewareState.placement),
-    flipBoundaries,
-    overflowBoundaries,
-    scrollParents: Array.from(scrollParentsSet),
-  } as const;
-};
+export const devtoolsCallback =
+  (options: Pick<PositioningOptions, 'flipBoundary' | 'overflowBoundary'>) => (middlewareState: MiddlewareState) => {
+    const {
+      elements: { floating, reference },
+    } = middlewareState;
+    const scrollParentsSet = new Set<HTMLElement>();
+    if (isHTMLElement(reference)) {
+      listScrollParents(reference).forEach(scrollParent => scrollParentsSet.add(scrollParent));
+    }
+    listScrollParents(floating).forEach(scrollParent => scrollParentsSet.add(scrollParent));
+    const flipBoundaries: HTMLElement[] = Array.isArray(options.flipBoundary)
+      ? options.flipBoundary
+      : isHTMLElement(options.flipBoundary)
+      ? [options.flipBoundary]
+      : [];
+    const overflowBoundaries: HTMLElement[] = Array.isArray(options.overflowBoundary)
+      ? options.overflowBoundary
+      : isHTMLElement(options.overflowBoundary)
+      ? [options.overflowBoundary]
+      : [];
+    return {
+      type: 'FluentUIMiddleware',
+      middlewareState,
+      options,
+      initialPlacement: fromFloatingUIPlacement(middlewareState.initialPlacement),
+      placement: fromFloatingUIPlacement(middlewareState.placement),
+      flipBoundaries,
+      overflowBoundaries,
+      scrollParents: Array.from(scrollParentsSet),
+    } as const;
+  };


### PR DESCRIPTION
## New Behavior

Implements https://github.com/microsoft/fluentui/pull/34271, exports `PositioningConfigurationProvider` that could be used to configure positioning for a components inside its tree.

### Example

```tsx
import {
  PositioningConfigurationProvider,
  type PositioningConfigurationFn,
  type PositionOptions,
} from '@fluentui/react-components';

// Default autoSize settings for specific component classes
const DEFAULT_AUTO_SIZE_OVERRIDE: Record<string, PositionOptions['autoSize']> = {
  'fui-PopoverSurface': true,
  'fui-Tooltip': 'width',
};

const configurePositioning: PositioningConfigurationFn = ({
  container /* The element being positioned */,
  arrow /* The arrow element, if present */,
  options /* User-provided options for this instance */,
}) => {
  // Note: a smarter check might be needed here
  const componentClassName = container.classList[0]; // e.g. "fui-PopoverSurface"

  // Determine the final `autoSize` value:
  // 1. Use the user's explicitly provided value if it exists.
  // 2. Otherwise, use the default override for this component class.
  // 3. Fallback to "undefined" if no user value or default override exists.
  const autoSize = options.autoSize ?? DEFAULT_AUTO_SIZE_OVERRIDE[componentClassName];
  // Example: Always use 'window' as the flip boundary unless overridden by the user
  const flipBoundary = options.flipBoundary ?? 'window';

  return {
    ...options, // Pass through original options
    // Apply the determined overrides/defaults
    autoSize,
    flipBoundary,
  };
};

function App() {
  return (
    <PositioningConfigurationProvider value={configurePositioning}>
      {/* Components within this provider will use the function */}
      {/* ... your application components ... */}
    </PositioningConfigurationProvider>
  );
}
```

