### PR TITLE
docs(react-badge): added example of Color and Appearance together.

### DIFF
--- a/packages/react-components/react-badge/stories/src/Badge/BadgeAppearance.stories.tsx
+++ b/packages/react-components/react-badge/stories/src/Badge/BadgeAppearance.stories.tsx
@@ -16,7 +16,7 @@ export const Appearance = () => {
 Appearance.parameters = {
   docs: {
     description: {
-      story: 'A badge can have a `ghost`, `filled`, `outline`, or `tint` appearance. The default is `filled`.',
+      story: 'A badge can have a `filled`, `ghost`, `outline`, or `tint` appearance. The default is `filled`.',
     },
   },
 };

--- a/packages/react-components/react-badge/stories/src/Badge/BadgeColorVsAppearance.stories.tsx
+++ b/packages/react-components/react-badge/stories/src/Badge/BadgeColorVsAppearance.stories.tsx
@@ -1,0 +1,151 @@
+import * as React from 'react';
+
+import { Badge, makeStyles, tokens } from '@fluentui/react-components';
+import { ClipboardPasteRegular as PasteIcon } from '@fluentui/react-icons';
+
+const useStyles = makeStyles({
+  example: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: tokens.spacingVerticalS,
+  },
+  badge: {
+    display: 'flex',
+    gap: tokens.spacingHorizontalS,
+  },
+  brand: {
+    display: 'flex',
+    backgroundColor: tokens.colorBrandBackground,
+    borderRadius: tokens.borderRadiusCircular,
+    padding: tokens.spacingHorizontalXXS,
+  },
+});
+
+export const ColorAndAppearance = () => {
+  const styles = useStyles();
+
+  return (
+    <div className={styles.example}>
+      <h3>Filled</h3>
+      <div className={styles.badge}>
+        <Badge appearance="filled" color="brand" icon={<PasteIcon />}>
+          999+
+        </Badge>
+        <Badge appearance="filled" color="danger" icon={<PasteIcon />}>
+          999+
+        </Badge>
+        <Badge appearance="filled" color="important" icon={<PasteIcon />}>
+          999+
+        </Badge>
+        <Badge appearance="filled" color="informative" icon={<PasteIcon />}>
+          999+
+        </Badge>
+        <Badge appearance="filled" color="severe" icon={<PasteIcon />}>
+          999+
+        </Badge>
+        <Badge appearance="filled" color="subtle" icon={<PasteIcon />}>
+          999+
+        </Badge>
+        <Badge appearance="filled" color="success" icon={<PasteIcon />}>
+          999+
+        </Badge>
+        <Badge appearance="filled" color="warning" icon={<PasteIcon />}>
+          999+
+        </Badge>
+      </div>
+      <h3>Ghost</h3>
+      <div className={styles.badge}>
+        <Badge appearance="ghost" color="brand" icon={<PasteIcon />}>
+          999+
+        </Badge>
+        <Badge appearance="ghost" color="danger" icon={<PasteIcon />}>
+          999+
+        </Badge>
+        <Badge appearance="ghost" color="important" icon={<PasteIcon />}>
+          999+
+        </Badge>
+        <Badge appearance="ghost" color="informative" icon={<PasteIcon />}>
+          999+
+        </Badge>
+        <Badge appearance="ghost" color="severe" icon={<PasteIcon />}>
+          999+
+        </Badge>
+        <div className={styles.brand}>
+          <Badge appearance="ghost" color="subtle" icon={<PasteIcon />}>
+            999+
+          </Badge>
+        </div>
+        <Badge appearance="ghost" color="success" icon={<PasteIcon />}>
+          999+
+        </Badge>
+        <Badge appearance="ghost" color="warning" icon={<PasteIcon />}>
+          999+
+        </Badge>
+      </div>
+      <h3>Outline</h3>
+      <div className={styles.badge}>
+        <Badge appearance="outline" color="brand" icon={<PasteIcon />}>
+          999+
+        </Badge>
+        <Badge appearance="outline" color="danger" icon={<PasteIcon />}>
+          999+
+        </Badge>
+        <Badge appearance="outline" color="important" icon={<PasteIcon />}>
+          999+
+        </Badge>
+        <Badge appearance="outline" color="informative" icon={<PasteIcon />}>
+          999+
+        </Badge>
+        <Badge appearance="outline" color="severe" icon={<PasteIcon />}>
+          999+
+        </Badge>
+        <div className={styles.brand}>
+          <Badge appearance="outline" color="subtle" icon={<PasteIcon />}>
+            999+
+          </Badge>
+        </div>
+        <Badge appearance="outline" color="success" icon={<PasteIcon />}>
+          999+
+        </Badge>
+        <Badge appearance="outline" color="warning" icon={<PasteIcon />}>
+          999+
+        </Badge>
+      </div>
+      <h3>Tint</h3>
+      <div className={styles.badge}>
+        <Badge appearance="tint" color="brand" icon={<PasteIcon />}>
+          999+
+        </Badge>
+        <Badge appearance="tint" color="danger" icon={<PasteIcon />}>
+          999+
+        </Badge>
+        <Badge appearance="tint" color="important" icon={<PasteIcon />}>
+          999+
+        </Badge>
+        <Badge appearance="tint" color="informative" icon={<PasteIcon />}>
+          999+
+        </Badge>
+        <Badge appearance="tint" color="severe" icon={<PasteIcon />}>
+          999+
+        </Badge>
+        <Badge appearance="tint" color="subtle" icon={<PasteIcon />}>
+          999+
+        </Badge>
+        <Badge appearance="tint" color="success" icon={<PasteIcon />}>
+          999+
+        </Badge>
+        <Badge appearance="tint" color="warning" icon={<PasteIcon />}>
+          999+
+        </Badge>
+      </div>
+    </div>
+  );
+};
+
+ColorAndAppearance.parameters = {
+  docs: {
+    description: {
+      story: 'Note: `ghost-subtle` and `outline-subtle` are intended only for use on brand background.',
+    },
+  },
+};

--- a/packages/react-components/react-badge/stories/src/Badge/BadgeColorVsAppearance.stories.tsx
+++ b/packages/react-components/react-badge/stories/src/Badge/BadgeColorVsAppearance.stories.tsx
@@ -44,8 +44,8 @@ const Badges = (props: BadgeProps) => {
             : React.Fragment;
 
         return (
-          <BadgeWrapper>
-            <Badge key={`${appearance}-${color}`} appearance={appearance} color={color} icon={<PasteIcon />}>
+          <BadgeWrapper key={`${appearance}-${color}`}>
+            <Badge appearance={appearance} color={color} icon={<PasteIcon />}>
               999+
             </Badge>
           </BadgeWrapper>

--- a/packages/react-components/react-badge/stories/src/Badge/BadgeColorVsAppearance.stories.tsx
+++ b/packages/react-components/react-badge/stories/src/Badge/BadgeColorVsAppearance.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Badge, makeStyles, tokens } from '@fluentui/react-components';
+import { Badge, makeStyles, tokens, BadgeProps } from '@fluentui/react-components';
 import { ClipboardPasteRegular as PasteIcon } from '@fluentui/react-icons';
 
 const useStyles = makeStyles({
@@ -21,123 +21,54 @@ const useStyles = makeStyles({
   },
 });
 
+const Badges = (props: BadgeProps) => {
+  const styles = useStyles();
+  const { appearance } = props;
+
+  const colors: BadgeProps['color'][] = [
+    'brand',
+    'danger',
+    'important',
+    'informative',
+    'severe',
+    'subtle',
+    'success',
+    'warning',
+  ];
+
+  return (
+    <div className={styles.badge}>
+      {colors.map(color => {
+        const BadgeWrapper =
+          color === 'subtle' && (appearance === 'ghost' || appearance === 'outline')
+            ? ({ children }: { children: React.ReactNode }) => <div className={styles.brand}>{children}</div>
+            : React.Fragment;
+
+        return (
+          <BadgeWrapper>
+            <Badge key={`${appearance}-${color}`} appearance={appearance} color={color} icon={<PasteIcon />}>
+              999+
+            </Badge>
+          </BadgeWrapper>
+        );
+      })}
+    </div>
+  );
+};
+
 export const ColorAndAppearance = () => {
   const styles = useStyles();
 
   return (
     <div className={styles.example}>
       <h3>Filled</h3>
-      <div className={styles.badge}>
-        <Badge appearance="filled" color="brand" icon={<PasteIcon />}>
-          999+
-        </Badge>
-        <Badge appearance="filled" color="danger" icon={<PasteIcon />}>
-          999+
-        </Badge>
-        <Badge appearance="filled" color="important" icon={<PasteIcon />}>
-          999+
-        </Badge>
-        <Badge appearance="filled" color="informative" icon={<PasteIcon />}>
-          999+
-        </Badge>
-        <Badge appearance="filled" color="severe" icon={<PasteIcon />}>
-          999+
-        </Badge>
-        <Badge appearance="filled" color="subtle" icon={<PasteIcon />}>
-          999+
-        </Badge>
-        <Badge appearance="filled" color="success" icon={<PasteIcon />}>
-          999+
-        </Badge>
-        <Badge appearance="filled" color="warning" icon={<PasteIcon />}>
-          999+
-        </Badge>
-      </div>
+      <Badges appearance="filled" />
       <h3>Ghost</h3>
-      <div className={styles.badge}>
-        <Badge appearance="ghost" color="brand" icon={<PasteIcon />}>
-          999+
-        </Badge>
-        <Badge appearance="ghost" color="danger" icon={<PasteIcon />}>
-          999+
-        </Badge>
-        <Badge appearance="ghost" color="important" icon={<PasteIcon />}>
-          999+
-        </Badge>
-        <Badge appearance="ghost" color="informative" icon={<PasteIcon />}>
-          999+
-        </Badge>
-        <Badge appearance="ghost" color="severe" icon={<PasteIcon />}>
-          999+
-        </Badge>
-        <div className={styles.brand}>
-          <Badge appearance="ghost" color="subtle" icon={<PasteIcon />}>
-            999+
-          </Badge>
-        </div>
-        <Badge appearance="ghost" color="success" icon={<PasteIcon />}>
-          999+
-        </Badge>
-        <Badge appearance="ghost" color="warning" icon={<PasteIcon />}>
-          999+
-        </Badge>
-      </div>
+      <Badges appearance="ghost" />
       <h3>Outline</h3>
-      <div className={styles.badge}>
-        <Badge appearance="outline" color="brand" icon={<PasteIcon />}>
-          999+
-        </Badge>
-        <Badge appearance="outline" color="danger" icon={<PasteIcon />}>
-          999+
-        </Badge>
-        <Badge appearance="outline" color="important" icon={<PasteIcon />}>
-          999+
-        </Badge>
-        <Badge appearance="outline" color="informative" icon={<PasteIcon />}>
-          999+
-        </Badge>
-        <Badge appearance="outline" color="severe" icon={<PasteIcon />}>
-          999+
-        </Badge>
-        <div className={styles.brand}>
-          <Badge appearance="outline" color="subtle" icon={<PasteIcon />}>
-            999+
-          </Badge>
-        </div>
-        <Badge appearance="outline" color="success" icon={<PasteIcon />}>
-          999+
-        </Badge>
-        <Badge appearance="outline" color="warning" icon={<PasteIcon />}>
-          999+
-        </Badge>
-      </div>
+      <Badges appearance="outline" />
       <h3>Tint</h3>
-      <div className={styles.badge}>
-        <Badge appearance="tint" color="brand" icon={<PasteIcon />}>
-          999+
-        </Badge>
-        <Badge appearance="tint" color="danger" icon={<PasteIcon />}>
-          999+
-        </Badge>
-        <Badge appearance="tint" color="important" icon={<PasteIcon />}>
-          999+
-        </Badge>
-        <Badge appearance="tint" color="informative" icon={<PasteIcon />}>
-          999+
-        </Badge>
-        <Badge appearance="tint" color="severe" icon={<PasteIcon />}>
-          999+
-        </Badge>
-        <Badge appearance="tint" color="subtle" icon={<PasteIcon />}>
-          999+
-        </Badge>
-        <Badge appearance="tint" color="success" icon={<PasteIcon />}>
-          999+
-        </Badge>
-        <Badge appearance="tint" color="warning" icon={<PasteIcon />}>
-          999+
-        </Badge>
-      </div>
+      <Badges appearance="tint" />
     </div>
   );
 };

--- a/packages/react-components/react-badge/stories/src/Badge/BadgeColorVsAppearance.stories.tsx
+++ b/packages/react-components/react-badge/stories/src/Badge/BadgeColorVsAppearance.stories.tsx
@@ -16,7 +16,6 @@ const useStyles = makeStyles({
   brand: {
     display: 'flex',
     backgroundColor: tokens.colorBrandBackground,
-    borderRadius: tokens.borderRadiusCircular,
     padding: tokens.spacingHorizontalXXS,
   },
 });

--- a/packages/react-components/react-badge/stories/src/Badge/index.stories.tsx
+++ b/packages/react-components/react-badge/stories/src/Badge/index.stories.tsx
@@ -9,6 +9,7 @@ export { Sizes } from './BadgeSizes.stories';
 export { Shapes } from './BadgeShapes.stories';
 export { Color } from './BadgeColor.stories';
 export { Icon } from './BadgeIcon.stories';
+export { ColorAndAppearance } from './BadgeColorVsAppearance.stories';
 
 export default {
   title: 'Components/Badge/Badge',


### PR DESCRIPTION
Follow up of this PR: #34172

Usage of `outline-subtle` and `ghost-subtle` was confusing. The design team confirmed that it should be used only on brand background.
- Added an example of color/appearance used together.
- Changed order of `appearance` options so there are at the same order as in example

## New Behavior
![image](https://github.com/user-attachments/assets/80dd3a38-49b1-48a7-90ef-aee52e07f4c5)

## Related Issue(s)
#34167

- Fixes #34254
