### PR TITLE
fix: update fluent ariaNotify implementation to match new API

### DIFF
--- a/change/@fluentui-react-aria-a9664252-df01-49d7-9074-980bcbd33fd7.json
+++ b/change/@fluentui-react-aria-a9664252-df01-49d7-9074-980bcbd33fd7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: update fluent ariaNotify implementation to match new API",
+  "packageName": "@fluentui/react-aria",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-aria/library/src/AriaLiveAnnouncer/useAriaNotifyAnnounce.ts
+++ b/packages/react-components/react-aria/library/src/AriaLiveAnnouncer/useAriaNotifyAnnounce.ts
@@ -5,9 +5,7 @@ import * as React from 'react';
 import type { AriaLiveAnnounceFn } from './AriaLiveAnnouncer.types';
 
 type AriaNotifyOptions = {
-  notificationID?: string;
-  priority?: 'none' | 'important';
-  interrupt?: 'all' | 'pending' | 'none';
+  priority?: 'high' | 'normal';
 };
 
 type DocumentWithAriaNotify = Document & {
@@ -24,7 +22,7 @@ export const useAriaNotifyAnnounce_unstable = (): AriaLiveAnnounceFn => {
         return;
       }
 
-      const { alert = false, polite, batchId } = options;
+      const { alert = false, polite } = options;
 
       // default priority to 0 if polite, 2 if alert, and 1 by default
       // used to set both ariaNotify's priority and interrupt
@@ -33,9 +31,7 @@ export const useAriaNotifyAnnounce_unstable = (): AriaLiveAnnounceFn => {
 
       // map fluent announce options to ariaNotify options
       const ariaNotifyOptions: AriaNotifyOptions = {
-        notificationID: batchId,
-        priority: priority > 1 ? 'important' : 'none',
-        interrupt: batchId ? (priority > 0 ? 'all' : 'pending') : 'none',
+        priority: priority > 1 ? 'high' : 'normal',
       };
 
       (targetDocument as DocumentWithAriaNotify).ariaNotify(message, ariaNotifyOptions);


### PR DESCRIPTION
The `ariaNotify` browser API has been through some continuing spec updates; this PR updates our internal implementation (behind a support check) to match the current API.

(as a note on why this is changing -- our `ariaNotify` implementation in Fluent is part of our work with Edge and the ARIA WG to help proof out the new `ariaNotify` feature by providing concrete testable use cases so it can become stable in the spec & get wide browser support. Continuing updates to the spec & implementation are expected, and shouldn't affect partner teams since `ariaNotify` support is behind a flag)
