### PR TITLE
fix: v8 Picker suggestions handle scroll overflow at small screen sizes

### DIFF
--- a/change/@fluentui-react-6547c0c2-af77-4383-adb6-0d4f426c9964.json
+++ b/change/@fluentui-react-6547c0c2-af77-4383-adb6-0d4f426c9964.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Picker suggestions handle scroll overflow at small screen sizes",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -772,7 +772,7 @@ export class BasePicker<T extends {}, P extends IBasePickerProps<T>> extends Rea
     // (undocumented)
     protected renderLabel(inputId: string, styles: IStyleFunctionOrObject<ILabelStyleProps, ILabelStyles> | undefined): JSX.Element | null;
     // (undocumented)
-    protected renderSuggestions(): JSX.Element | null;
+    protected renderSuggestions(styles: IStyleFunctionOrObject<ICalloutContentStyleProps, ICalloutContentStyles> | undefined): JSX.Element | null;
     // (undocumented)
     protected resetFocus(index?: number): void;
     // (undocumented)

--- a/packages/react/src/components/pickers/BasePicker.styles.ts
+++ b/packages/react/src/components/pickers/BasePicker.styles.ts
@@ -164,6 +164,14 @@ export function getStyles(props: IBasePickerStyleProps): IBasePickerStyles {
     screenReaderText: hiddenContentStyle,
     subComponentStyles: {
       label: {},
+      callout: {
+        // Picker suggestions already manage overflow and scrolling items into view
+        // for this to work at all screen sizes, we need Callout to not also have overflow
+        calloutMain: {
+          overflow: 'unset',
+          maxHeight: '100%',
+        },
+      },
     },
   };
 }

--- a/packages/react/src/components/pickers/BasePicker.tsx
+++ b/packages/react/src/components/pickers/BasePicker.tsx
@@ -1278,7 +1278,7 @@ export class BasePickerListBelow<T extends {}, P extends IBasePickerProps<T>> ex
             />
           </div>
         </div>
-        {this.renderSuggestions()}
+        {this.renderSuggestions(classNames.subComponentStyles?.callout)}
         <SelectionZone selection={this.selection} selectionMode={SelectionMode.single}>
           <div
             id={this._ariaMap.selectedItems}

--- a/packages/react/src/components/pickers/BasePicker.tsx
+++ b/packages/react/src/components/pickers/BasePicker.tsx
@@ -34,6 +34,7 @@ import type { IPickerItemProps } from './PickerItem.types';
 import { WindowContext } from '@fluentui/react-window-provider';
 import { getDocumentEx } from '../../utilities/dom';
 import type { ILabelStyleProps, ILabelStyles } from '../../Label';
+import type { ICalloutContentStyleProps, ICalloutContentStyles } from '../../Callout';
 
 const legacyStyles: any = stylesImport;
 
@@ -372,7 +373,7 @@ export class BasePicker<T extends {}, P extends IBasePickerProps<T>>
           </div>
         </SelectionZone>
         {this.renderError(classNames.error)}
-        {this.renderSuggestions()}
+        {this.renderSuggestions(classNames.subComponentStyles?.callout)}
       </div>
     );
   }
@@ -421,7 +422,9 @@ export class BasePicker<T extends {}, P extends IBasePickerProps<T>>
     );
   }
 
-  protected renderSuggestions(): JSX.Element | null {
+  protected renderSuggestions(
+    styles: IStyleFunctionOrObject<ICalloutContentStyleProps, ICalloutContentStyles> | undefined,
+  ): JSX.Element | null {
     const StyledTypedSuggestions: React.FunctionComponent<ISuggestionsProps<T>> = this._styledSuggestions;
 
     return this.state.suggestionsVisible && this.input ? (
@@ -434,6 +437,7 @@ export class BasePicker<T extends {}, P extends IBasePickerProps<T>>
         directionalHintForRTL={DirectionalHint.bottomRightEdge}
         // eslint-disable-next-line react/jsx-no-bind
         preventDismissOnEvent={(ev: Event) => this._preventDismissOnScrollOrResize(ev)}
+        styles={styles}
         {...this.props.pickerCalloutProps}
       >
         <StyledTypedSuggestions

--- a/packages/react/src/components/pickers/BasePicker.types.ts
+++ b/packages/react/src/components/pickers/BasePicker.types.ts
@@ -3,7 +3,7 @@ import { Autofill } from '../../Autofill';
 import type { IPickerItemProps } from './PickerItem.types';
 import type { IReactProps, IRefObject, IStyleFunctionOrObject } from '../../Utilities';
 import type { ISuggestionModel, ISuggestionsProps } from './Suggestions/Suggestions.types';
-import type { ICalloutProps } from '../../Callout';
+import type { ICalloutProps, ICalloutContentStyleProps, ICalloutContentStyles } from '../../Callout';
 import type { ITheme, IStyle } from '../../Styling';
 import type { ISuggestionItemProps } from '../pickers/Suggestions/SuggestionsItem.types';
 import { IIconProps } from '../Icon/Icon.types';
@@ -367,6 +367,9 @@ export type IBasePickerStyleProps = Pick<IBasePickerProps<any>, 'theme' | 'class
 export interface IBasePickerSubComponentStyles {
   /** Styling for Label child component. */
   label: IStyleFunctionOrObject<ILabelStyleProps, ILabelStyles>;
+
+  /** Styling for Callout child component. */
+  callout: IStyleFunctionOrObject<ICalloutContentStyleProps, ICalloutContentStyles>;
 }
 
 /**

--- a/packages/react/src/components/pickers/Suggestions/Suggestions.styles.ts
+++ b/packages/react/src/components/pickers/Suggestions/Suggestions.styles.ts
@@ -82,7 +82,10 @@ export function getStyles(props: ISuggestionsStyleProps): ISuggestionsStyles {
     root: [
       classNames.root,
       {
+        display: 'flex',
+        flexDirection: 'column',
         minWidth: 260,
+        maxHeight: '100%',
       },
       className,
     ],

--- a/packages/react/src/components/pickers/Suggestions/__snapshots__/Suggestions.test.tsx.snap
+++ b/packages/react/src/components/pickers/Suggestions/__snapshots__/Suggestions.test.tsx.snap
@@ -2372,6 +2372,9 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
   className=
       ms-Suggestions
       {
+        display: flex;
+        flex-direction: column;
+        max-height: 100%;
         min-width: 260px;
       }
   role="listbox"


### PR DESCRIPTION
## Previous Behavior

The scroll-into-view behavior of picker suggestion items wasn't working properly at small or zoomed-in screen sizes because of the conflicting overflow behavior of Callout and Suggestions.

<img width="309" alt="Screenshot of picker popup showing the suggestions extending below the callout scroll area, and the focused item getting clipped" src="https://github.com/user-attachments/assets/20d32563-165f-46fd-be33-f136dac8ad93" />

When pickers had greater than 300px + header/footer space for the callout containing the suggestions, everything works fine because the Suggestions control is the only one with scroll overflow because of its 300px max-height. At smaller screen sizes, both the inner Callout component and the Suggestions control had overflow styles:

![screenshot of the DOM showing both ms-Callout-main and ms-Suggestions-container elements having scroll overflow](https://github.com/user-attachments/assets/5ed75ff2-0d26-411c-9e30-f7c1402e757e)

This is caused by Callout also having scroll overflow logic for small screen sizes, since that's the component that handles positioning within the viewport. However, since scrolling is handled within Suggestions because focus doesn't actually enter the Callout, this causes items to not correctly scroll into view when the user arrows to them. Additionally, the mouse scrolling behavior is somewhat jumpy and odd because of the double scroll containers.

## New Behavior

<img width="278" alt="Screenshot of the picker popup showing a single scrollbar with a smaller thumb, indicating a larger unified scroll area" src="https://github.com/user-attachments/assets/86819250-0c11-444a-b61b-3e9ddf1bba08" />

BasePicker adds styles to its inner Callout removing the scroll overflow, and forcing the callout content to have max 100% height, which allows Suggestions to fully handle scroll.

Suggestions' layout styles are also updated so that the scroll container adjusts height correctly to fit within a smaller parent.

cc/ @emmayjiang for review, b/c she found the issue with Suggestions having the incorrect height

## Related Issue(s)

- Fixes [ADO issue 1](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/18696) and [ADO issue 2](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/26298) (and a partner team's issue)
