### PR TITLE
test: migrate tests from enzyme to testing-library/react-test-renderer

### DIFF
--- a/change/@fluentui-foundation-legacy-4fc6c4ad-d979-43c8-9a95-76a0c18d68d8.json
+++ b/change/@fluentui-foundation-legacy-4fc6c4ad-d979-43c8-9a95-76a0c18d68d8.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "fix(foundation-legacy): add proper ts lib types so tsc wont complain",
+  "packageName": "@fluentui/foundation-legacy",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-experiments-076a9937-dd8b-4254-ab9e-14b0d7767f7f.json
+++ b/change/@fluentui-react-experiments-076a9937-dd8b-4254-ab9e-14b0d7767f7f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "fix(react-experiments): add proper ts lib types so tsc wont complain",
+  "packageName": "@fluentui/react-experiments",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-icons-mdl2-17cc26d9-27b2-4524-a440-327754df1cd3.json
+++ b/change/@fluentui-react-icons-mdl2-17cc26d9-27b2-4524-a440-327754df1cd3.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "fix(react-icons-mdl2): add proper ts lib types so tsc wont complain",
+  "packageName": "@fluentui/react-icons-mdl2",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/foundation-legacy/src/slots.test.tsx
+++ b/packages/foundation-legacy/src/slots.test.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import * as renderer from 'react-test-renderer';
-import { mount } from 'enzyme';
 import { withSlots, createFactory, getSlots } from './slots';
 import { IHTMLElementSlot, IHTMLSlot } from './IHTMLSlots';
 import {
@@ -213,14 +212,14 @@ describe('createFactory', () => {
   };
 
   it(`passes componentProps without userProps`, () => {
-    const component = mount(
+    const component = renderer.create(
       createFactory<TComponentProps, any>(TestDiv)(componentProps, undefined, undefined, undefined) as JSX.Element,
     );
-    expect(component.props()).toEqual({ ...componentProps, ...emptyClassName });
+    expect(component.root.props).toEqual({ ...componentProps, ...emptyClassName });
   });
 
   it(`passes userProp string as child`, () => {
-    const component = mount(
+    const component = renderer.create(
       createFactory<TComponentProps, string>(TestDiv)(
         componentProps,
         userPropString,
@@ -228,18 +227,18 @@ describe('createFactory', () => {
         undefined,
       ) as JSX.Element,
     );
-    expect(component.props()).toEqual({ ...componentProps, children: userPropString, ...emptyClassName });
+    expect(component.root.props).toEqual({ ...componentProps, children: userPropString, ...emptyClassName });
   });
 
   it(`passes userProp integer as child`, () => {
-    const component = mount(
+    const component = renderer.create(
       createFactory<TComponentProps, number>(TestDiv)(componentProps, 42, undefined, undefined) as JSX.Element,
     );
-    expect(component.props()).toEqual({ ...componentProps, children: 42, ...emptyClassName });
+    expect(component.root.props).toEqual({ ...componentProps, children: 42, ...emptyClassName });
   });
 
   it(`passes userProp string as defaultProp`, () => {
-    const component = mount(
+    const component = renderer.create(
       createFactory<TComponentProps, string>(TestDiv, factoryOptions)(
         componentProps,
         userPropString,
@@ -247,11 +246,11 @@ describe('createFactory', () => {
         undefined,
       ) as JSX.Element,
     );
-    expect(component.props()).toEqual({ ...componentProps, [defaultProp]: userPropString, ...emptyClassName });
+    expect(component.root.props).toEqual({ ...componentProps, [defaultProp]: userPropString, ...emptyClassName });
   });
 
   it(`passes userProp integer as defaultProp`, () => {
-    const component = mount(
+    const component = renderer.create(
       createFactory<TComponentProps, number>(TestDiv, factoryOptions)(
         componentProps,
         42,
@@ -259,11 +258,11 @@ describe('createFactory', () => {
         undefined,
       ) as JSX.Element,
     );
-    expect(component.props()).toEqual({ ...componentProps, [defaultProp]: 42, ...emptyClassName });
+    expect(component.root.props).toEqual({ ...componentProps, [defaultProp]: 42, ...emptyClassName });
   });
 
   it('merges userProps over componentProps', () => {
-    const component = mount(
+    const component = renderer.create(
       createFactory<TComponentProps>(TestDiv, factoryOptions)(
         componentProps,
         userProps,
@@ -271,7 +270,7 @@ describe('createFactory', () => {
         undefined,
       ) as JSX.Element,
     );
-    expect(component.props()).toEqual({ ...componentProps, ...userProps, ...emptyClassName });
+    expect(component.root.props).toEqual({ ...componentProps, ...userProps, ...emptyClassName });
   });
 
   it('renders div and userProp integer as children', () => {
@@ -429,7 +428,7 @@ describe('getSlots', () => {
     expect(createdSlots.testSlot2.isSlot).toBeTruthy();
 
     // Mount to trigger slot component render functions
-    mount(createdSlots.testSlot1(testSlot1Props) as JSX.Element);
-    mount(createdSlots.testSlot2(testSlot2Props) as JSX.Element);
+    renderer.create(createdSlots.testSlot1(testSlot1Props) as JSX.Element);
+    renderer.create(createdSlots.testSlot2(testSlot2Props) as JSX.Element);
   });
 });

--- a/packages/foundation-legacy/tsconfig.json
+++ b/packages/foundation-legacy/tsconfig.json
@@ -15,7 +15,7 @@
     "moduleResolution": "node",
     "preserveConstEnums": true,
     "isolatedModules": true,
-    "lib": ["es5", "dom", "ES2015.Iterable"],
+    "lib": ["es5", "dom", "ES2015.Iterable", "ES2015.Core"],
     "typeRoots": ["../../node_modules/@types", "../../typings"],
     "types": ["jest", "custom-global"]
   },

--- a/packages/react-cards/src/components/Card/CardItem/CardItem.test.tsx
+++ b/packages/react-cards/src/components/Card/CardItem/CardItem.test.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
-import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
 import { Card } from '../Card';
 import * as renderer from 'react-test-renderer';
 
 describe('Card Item', () => {
   it('can handle not having a class', () => {
-    const wrapper = mount(
+    const wrapper = render(
       <Card>
         <Card.Item>
           <div />
@@ -13,7 +13,7 @@ describe('Card Item', () => {
       </Card>,
     );
 
-    expect(wrapper.find('.test').length).toBe(0);
+    expect(wrapper.container.querySelectorAll('.test').length).toBe(0);
   });
 
   it('renders correctly', () => {

--- a/packages/react-cards/src/components/Card/CardSection/CardSection.test.tsx
+++ b/packages/react-cards/src/components/Card/CardSection/CardSection.test.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
-import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
 import { Card } from '../Card';
 import * as renderer from 'react-test-renderer';
 
 describe('Card Section', () => {
   it('can handle not having a class', () => {
-    const wrapper = mount(
+    const wrapper = render(
       <Card>
         <Card.Section>
           <div />
@@ -13,7 +13,7 @@ describe('Card Section', () => {
       </Card>,
     );
 
-    expect(wrapper.find('.test').length).toBe(0);
+    expect(wrapper.container.querySelectorAll('.test').length).toBe(0);
   });
 
   it('renders correctly', () => {

--- a/packages/react-experiments/src/components/PersonaCoin/PersonaCoin.test.tsx
+++ b/packages/react-experiments/src/components/PersonaCoin/PersonaCoin.test.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import * as renderer from 'react-test-renderer';
-import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import { PersonaCoin } from './index';
-import { Icon, Image, Text } from '@fluentui/react';
 import { setRTL } from '../../Utilities';
 import { PersonaTestImages } from '../../common/TestImages';
 import type { IPersonaCoinComponent } from './PersonaCoin.types';
@@ -62,65 +62,60 @@ describe('PersonaCoin', () => {
   });
 
   it('calculates an expected initials in LTR if one was not specified', () => {
-    let wrapper = mount(<PersonaCoin text="Kat Larrson" styles={testPersonaCoinStyles} />);
-    let result = wrapper.find(Text);
-    expect(result).toHaveLength(1);
-    expect(result.props().children).toEqual('KL');
-    wrapper.unmount();
+    // Kat Larrson
+    let { container } = render(<PersonaCoin text="Kat Larrson" styles={testPersonaCoinStyles} />);
+    let textElement = container.querySelector(`.${testPersonaCoinStyles.initials}`);
+    expect(textElement).toHaveTextContent('KL');
 
-    wrapper = mount(<PersonaCoin text="David Zearing-Goff" styles={testPersonaCoinStyles} />);
-    result = wrapper.find(Text);
-    expect(result).toHaveLength(1);
-    expect(result.props().children).toEqual('DZ');
-    wrapper.unmount();
+    // David Zearing-Goff
+    ({ container } = render(<PersonaCoin text="David Zearing-Goff" styles={testPersonaCoinStyles} />));
+    textElement = container.querySelector(`.${testPersonaCoinStyles.initials}`);
+    expect(textElement).toHaveTextContent('DZ');
 
-    wrapper = mount(<PersonaCoin text="4lex 5loo" styles={testPersonaCoinStyles} />);
-    result = wrapper.find(Text);
-    expect(result).toHaveLength(1);
-    expect(result.props().children).toEqual('45');
-    wrapper.unmount();
+    // 4lex 5loo
+    ({ container } = render(<PersonaCoin text="4lex 5loo" styles={testPersonaCoinStyles} />));
+    textElement = container.querySelector(`.${testPersonaCoinStyles.initials}`);
+    expect(textElement).toHaveTextContent('45');
 
-    wrapper = mount(<PersonaCoin text="Swapnil Vaibhav" styles={testPersonaCoinStyles} />);
-    result = wrapper.find(Text);
-    expect(result).toHaveLength(1);
-    expect(result.props().children).toEqual('SV');
-    wrapper.unmount();
+    // Swapnil Vaibhav
+    ({ container } = render(<PersonaCoin text="Swapnil Vaibhav" styles={testPersonaCoinStyles} />));
+    textElement = container.querySelector(`.${testPersonaCoinStyles.initials}`);
+    expect(textElement).toHaveTextContent('SV');
 
-    wrapper = mount(<PersonaCoin text="+1 (555) 6789" styles={testPersonaCoinStyles} />);
-    const iconResult = wrapper.find(Icon);
-    expect(iconResult).toHaveLength(1);
-    expect((iconResult.props() as any).iconName).toEqual('Contact');
-    wrapper.unmount();
+    // +1 (555) 6789
+    ({ container } = render(<PersonaCoin text="+1 (555) 6789" styles={testPersonaCoinStyles} />));
+    // For icons we need to check if the Contact icon is present
+    const iconElement = container.querySelector('i');
+    expect(iconElement?.getAttribute('data-icon-name')).toBe('Contact');
 
-    wrapper = mount(<PersonaCoin text="+1 (555) 6789" allowPhoneInitials={true} styles={testPersonaCoinStyles} />);
-    result = wrapper.find(Text);
-    expect(result).toHaveLength(1);
-    expect(result.props().children).toEqual('16');
-    wrapper.unmount();
+    // +1 (555) 6789 with phone initials allowed
+    ({ container } = render(
+      <PersonaCoin text="+1 (555) 6789" allowPhoneInitials={true} styles={testPersonaCoinStyles} />,
+    ));
+    textElement = container.querySelector(`.${testPersonaCoinStyles.initials}`);
+    expect(textElement).toHaveTextContent('16');
 
-    wrapper = mount(<PersonaCoin text="David (The man) Goff" styles={testPersonaCoinStyles} />);
-    result = wrapper.find(Text);
-    expect(result).toHaveLength(1);
-    expect(result.props().children).toEqual('DG');
+    // David (The man) Goff
+    ({ container } = render(<PersonaCoin text="David (The man) Goff" styles={testPersonaCoinStyles} />));
+    textElement = container.querySelector(`.${testPersonaCoinStyles.initials}`);
+    expect(textElement).toHaveTextContent('DG');
   });
 
   it('calculates an expected initials in RTL if one was not specified', () => {
     setRTL(true);
 
-    const wrapper = mount(<PersonaCoin text="Kat Larrson" styles={testPersonaCoinStyles} />);
-    const result = wrapper.find(Text);
-    expect(result).toHaveLength(1);
-    expect(result.props().children).toEqual('LK');
+    const { container } = render(<PersonaCoin text="Kat Larrson" styles={testPersonaCoinStyles} />);
+    const textElement = container.querySelector(`.${testPersonaCoinStyles.initials}`);
+    expect(textElement).toHaveTextContent('LK');
 
     setRTL(false);
   });
 
   it('uses provided initial', () => {
     setRTL(true);
-    const wrapper = mount(<PersonaCoin text="Kat Larrson" initials="AT" styles={testPersonaCoinStyles} />);
-    const result = wrapper.find(Text);
-    expect(result).toHaveLength(1);
-    expect(result.props().children).toEqual('AT');
+    const { container } = render(<PersonaCoin text="Kat Larrson" initials="AT" styles={testPersonaCoinStyles} />);
+    const textElement = container.querySelector(`.${testPersonaCoinStyles.initials}`);
+    expect(textElement).toHaveTextContent('AT');
 
     setRTL(false);
   });
@@ -130,19 +125,19 @@ describe('PersonaCoin', () => {
       'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQImWP4DwQACfsD/eNV8pwAAAAASUVORK5CYII=';
 
     it('renders empty alt text by default', () => {
-      const wrapper = mount(<PersonaCoin text="Kat Larrson" imageUrl={testImage1x1} styles={testPersonaCoinStyles} />);
-      const image = wrapper.find(Image);
-
-      expect(image.props().alt).toEqual('');
+      const { container } = render(
+        <PersonaCoin text="Kat Larrson" imageUrl={testImage1x1} styles={testPersonaCoinStyles} />,
+      );
+      const image = container.querySelector('img');
+      expect(image).toHaveAttribute('alt', '');
     });
 
     it('renders its given alt text', () => {
-      const wrapper = mount(
+      const { container } = render(
         <PersonaCoin text="Kat Larrson" imageUrl={testImage1x1} imageAlt="ALT TEXT" styles={testPersonaCoinStyles} />,
       );
-      const image = wrapper.find(Image);
-
-      expect(image.props().alt).toEqual('ALT TEXT');
+      const image = container.querySelector('img');
+      expect(image).toHaveAttribute('alt', 'ALT TEXT');
     });
   });
 });

--- a/packages/react-experiments/src/components/SelectedItemsList/SelectedItemsList.test.tsx
+++ b/packages/react-experiments/src/components/SelectedItemsList/SelectedItemsList.test.tsx
@@ -2,8 +2,8 @@ import * as React from 'react';
 import { create } from 'react-test-renderer';
 
 import { SelectedItemsList } from './SelectedItemsList';
-import { mount } from 'enzyme';
-import type { ISelectedItemProps, ISelectedItemsList } from './SelectedItemsList.types';
+import { render } from '@testing-library/react';
+import type { ISelectedItemProps } from './SelectedItemsList.types';
 
 export interface ISimple {
   key: string;
@@ -32,7 +32,7 @@ describe('SelectedItemsList', () => {
     });
 
     it('render all items in selectedItemsList', () => {
-      const wrapper = mount<ISelectedItemsList<ISimple>>(
+      const wrapper = render(
         <SelectedItemsList
           onRenderItem={basicItemRenderer}
           selectedItems={[
@@ -41,16 +41,16 @@ describe('SelectedItemsList', () => {
           ]}
         />,
       );
-      expect(wrapper.exists()).toBeTruthy();
-      expect(wrapper.find('div').length).toEqual(2);
-      expect(wrapper.find('div').first().text()).toEqual('a');
-      expect(wrapper.find('div').last().text()).toEqual('b');
+      expect(wrapper.container).toBeTruthy();
+      expect(wrapper.container.querySelectorAll('div').length).toEqual(2);
+      expect(wrapper.container.querySelector('div')!.textContent).toEqual('a');
+      expect(wrapper.container.querySelectorAll('div')[1].textContent).toEqual('b');
     });
   });
 
   it('render between selected and default selected items in selectedItemsList', () => {
     const removeItems = jest.fn();
-    const wrapper = mount<ISelectedItemsList<ISimple>>(
+    const wrapper = render(
       <SelectedItemsList
         onRenderItem={basicItemRenderer}
         selectedItems={[
@@ -64,14 +64,14 @@ describe('SelectedItemsList', () => {
         onItemsRemoved={removeItems}
       />,
     );
-    expect(wrapper.exists()).toBeTruthy();
-    expect(wrapper.find('div').length).toEqual(2);
-    expect(wrapper.find('div').first().text()).toEqual('da');
-    expect(wrapper.find('div').last().text()).toEqual('db');
+    expect(wrapper.container).toBeTruthy();
+    expect(wrapper.container.querySelectorAll('div').length).toEqual(2);
+    expect(wrapper.container.querySelector('div')!.textContent).toEqual('da');
+    expect(wrapper.container.querySelectorAll('div')[1].textContent).toEqual('db');
   });
 
   it('renders items that are passed in as default', () => {
-    const wrapper = mount<ISelectedItemsList<ISimple>>(
+    const wrapper = render(
       <SelectedItemsList
         onRenderItem={basicItemRenderer}
         defaultSelectedItems={[
@@ -80,9 +80,9 @@ describe('SelectedItemsList', () => {
         ]}
       />,
     );
-    expect(wrapper.exists()).toBeTruthy();
-    expect(wrapper.find('div').length).toEqual(2);
-    expect(wrapper.find('div').first().text()).toEqual('Person A');
-    expect(wrapper.find('div').last().text()).toEqual('Person B');
+    expect(wrapper.container).toBeTruthy();
+    expect(wrapper.container.querySelectorAll('div').length).toEqual(2);
+    expect(wrapper.container.querySelector('div')!.textContent).toEqual('Person A');
+    expect(wrapper.container.querySelectorAll('div')[1].textContent).toEqual('Person B');
   });
 });

--- a/packages/react-experiments/src/components/SelectedItemsList/SelectedPeopleList/SelectedPeopleList.test.tsx
+++ b/packages/react-experiments/src/components/SelectedItemsList/SelectedPeopleList/SelectedPeopleList.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { create } from 'react-test-renderer';
 
 import { people } from '@fluentui/example-data';
-import { mount } from 'enzyme';
+import { fireEvent, render } from '@testing-library/react';
 import { SelectedPeopleList, SelectedPersona, ItemWithContextMenu, TriggerOnContextMenu } from '../index';
 import type { ISelectedPeopleList, ItemCanDispatchTrigger } from '../index';
 
@@ -43,7 +43,7 @@ describe('SelectedPeopleList', () => {
 
   it('remove personas', () => {
     const onItemsRemoved = jest.fn();
-    const wrapper = mount(
+    const wrapper = render(
       <SelectedPeopleList
         key="normal"
         removeButtonAriaLabel="Remove"
@@ -52,12 +52,12 @@ describe('SelectedPeopleList', () => {
       />,
     );
 
-    wrapper.find('button.ms-PickerItem-removeButton').at(1).simulate('click');
+    fireEvent.click(wrapper.container.querySelectorAll('button.ms-PickerItem-removeButton')[1]);
 
     expect(onItemsRemoved).toHaveBeenCalledTimes(1);
   });
 
-  it('edit render of the items in selected items list', () => {
+  it('edit render of the items in selected items list', async () => {
     const SelectedItem: ItemCanDispatchTrigger<any> = ItemWithContextMenu({
       menuItems: item => [
         {
@@ -77,7 +77,7 @@ describe('SelectedPeopleList', () => {
     const removeItems = jest.fn();
     const _getCopyItemsText = jest.fn();
     const onItemsRemoved = jest.fn();
-    const wrapper = mount(
+    const wrapper = render(
       <SelectedPeopleList
         key="normal"
         removeButtonAriaLabel="Remove"
@@ -88,15 +88,15 @@ describe('SelectedPeopleList', () => {
     );
 
     // Simulate right click to get the context menu
-    wrapper.find('.ms-PickerPersona-container').simulate('contextmenu');
+    fireEvent.contextMenu(wrapper.container.querySelector('.ms-PickerPersona-container')!);
 
     // Remove and copy should show up in the menu
-    expect(wrapper.find('.ms-ContextualMenu-item')).toHaveLength(2);
-    expect(wrapper.find('.ms-ContextualMenu-item').at(0).text()).toEqual('Remove');
+    expect(wrapper.baseElement.querySelectorAll('.ms-ContextualMenu-item')).toHaveLength(2);
+    expect(wrapper.baseElement.querySelector('.ms-ContextualMenu-item')!.textContent).toEqual('Remove');
 
-    expect(wrapper.find('.ms-ContextualMenu-item').at(1).text()).toEqual('Copy');
+    expect(wrapper.baseElement.querySelectorAll('.ms-ContextualMenu-item')[1].textContent).toEqual('Copy');
 
-    wrapper.find('.ms-ContextualMenu-item').at(0).simulate('click');
+    fireEvent.click(wrapper.baseElement.querySelector('.ms-ContextualMenu-item')!);
     expect(removeItems).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/react-experiments/src/components/SelectedItemsList/SelectedPeopleList/SelectedPeopleList.test.tsx
+++ b/packages/react-experiments/src/components/SelectedItemsList/SelectedPeopleList/SelectedPeopleList.test.tsx
@@ -57,7 +57,7 @@ describe('SelectedPeopleList', () => {
     expect(onItemsRemoved).toHaveBeenCalledTimes(1);
   });
 
-  it('edit render of the items in selected items list', async () => {
+  it('edit render of the items in selected items list', () => {
     const SelectedItem: ItemCanDispatchTrigger<any> = ItemWithContextMenu({
       menuItems: item => [
         {

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/UnifiedPeoplePicker.test.tsx
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/UnifiedPeoplePicker.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { mount, ReactWrapper } from 'enzyme';
+import { fireEvent, render } from '@testing-library/react';
 import { create } from 'react-test-renderer';
 import { UnifiedPeoplePicker } from './UnifiedPeoplePicker';
 import { people, mru } from '@fluentui/example-data';
@@ -9,8 +9,6 @@ import type {
   IFloatingPeopleSuggestionsProps,
 } from '../../../FloatingPeopleSuggestionsComposite';
 import type { ISelectedPeopleListProps } from '../../../SelectedItemsList';
-
-type InputElementWrapper = ReactWrapper<React.InputHTMLAttributes<any>, any>;
 
 const _onSuggestionRemoved = jest.fn();
 const _onSuggestionSelected = jest.fn();
@@ -78,7 +76,7 @@ describe('UnifiedPeoplePicker', () => {
       const allPeople = people;
       const suggestions = allPeople.filter((item: IPersonaProps) => _startsWith(item.text || '', filterText));
       suggestionList = suggestions.map(item => {
-        return { item: item, isSelected: false, key: item.key } as IFloatingSuggestionItem<IPersonaProps>;
+        return { item, isSelected: false, key: item.key } as IFloatingSuggestionItem<IPersonaProps>;
       });
     };
 
@@ -88,7 +86,7 @@ describe('UnifiedPeoplePicker', () => {
 
     floatingPeoplePickerProps.suggestions = suggestionList;
 
-    const wrapper = mount(
+    const wrapper = render(
       <UnifiedPeoplePicker
         floatingSuggestionProps={floatingPeoplePickerProps}
         selectedItemsListProps={selectedPeopleListProps}
@@ -96,9 +94,9 @@ describe('UnifiedPeoplePicker', () => {
       />,
     );
 
-    const inputElement: InputElementWrapper = wrapper.find('input');
-    expect(inputElement).toHaveLength(1);
-    inputElement.simulate('input', { target: { value: 'annie' } });
+    const inputElement = wrapper.container.querySelector('input') as HTMLInputElement;
+    expect(inputElement).toBeDefined();
+    fireEvent.input(inputElement, { target: { value: 'annie' } });
 
     // still just validating the suggestionlist, as enzyme has a bug for
     // re-render

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.test.tsx
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.test.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { UnifiedPicker } from './UnifiedPicker';
-import { mount, ReactWrapper } from 'enzyme';
 import { BaseFloatingSuggestions } from '../FloatingSuggestionsComposite';
 import { create } from 'react-test-renderer';
+import { fireEvent, render } from '@testing-library/react';
 import { SelectedItemsList } from '../SelectedItemsList';
 import type { ISelectedItemProps, ISelectedItemsListProps } from '../SelectedItemsList/SelectedItemsList.types';
 import type { IBaseFloatingSuggestionsProps } from '../FloatingSuggestionsComposite';
@@ -12,7 +12,6 @@ export interface ISimple {
   key: string;
   name: string;
 }
-type InputElementWrapper = ReactWrapper<React.InputHTMLAttributes<any>, any>;
 
 const basicSuggestionRenderer = (props: ISimple) => {
   return <div key={props.key}> {props.name} </div>;
@@ -142,7 +141,7 @@ describe('UnifiedPicker', () => {
         return { item: newItem, isSelected: false } as unknown as IFloatingSuggestionItem<ISimple>;
       });
     };
-    const wrapper = mount(
+    const wrapper = render(
       <UnifiedPicker
         floatingSuggestionProps={floatingPickerProps}
         selectedItemsListProps={selectedItemsListProps}
@@ -151,10 +150,11 @@ describe('UnifiedPicker', () => {
         onInputChange={_onInputChange}
       />,
     );
-    expect(wrapper.find('.ms-BaseExtendedPicker')).toHaveLength(1);
-    expect(wrapper.find('.ms-FloatingSuggestions')).toHaveLength(1);
-    const inputElement: InputElementWrapper = wrapper.find('input');
-    inputElement.simulate('input', { target: { value: 'bl' } });
+    expect(wrapper.container.querySelectorAll('.ms-BaseExtendedPicker')).toHaveLength(1);
+    expect(wrapper.container.querySelectorAll('.ms-FloatingSuggestions')).toHaveLength(1);
+    const inputElement = wrapper.container.querySelector('input') as HTMLInputElement;
+    fireEvent.input(inputElement, { target: { value: 'bl' } });
+
     floatingPickerProps = {
       onRenderSuggestion: basicSuggestionRenderer,
       targetElement: null,
@@ -203,7 +203,7 @@ describe('UnifiedPicker', () => {
       });
     };
 
-    const wrapper = mount(
+    const wrapper = render(
       <UnifiedPicker
         floatingSuggestionProps={floatingPickerProps}
         selectedItemsListProps={selectedItemsListProps}
@@ -213,18 +213,18 @@ describe('UnifiedPicker', () => {
       />,
     );
 
-    const inputElement: InputElementWrapper = wrapper.find('input');
-    expect(inputElement).toHaveLength(1);
-    inputElement.simulate('input', { target: { value: 'bl' } });
-    expect(wrapper.find('.ms-FloatingSuggestionsList-container')).toHaveLength(1);
+    const inputElement = wrapper.container.querySelector('input') as HTMLInputElement;
+    expect(inputElement).toBeDefined();
+    fireEvent.input(inputElement, { target: { value: 'bl' } });
+    expect(wrapper.baseElement.querySelectorAll('.ms-FloatingSuggestionsList-container')).toHaveLength(1);
     expect(suggestionList).toHaveLength(2);
     // Both suggestions are shown, picker is shown
-    expect(wrapper.find('#FloatingSuggestionsItemId-0')).toHaveLength(1);
-    expect(wrapper.find('#FloatingSuggestionsItemId-1')).toHaveLength(1);
-    expect(wrapper.find('.ms-FloatingSuggestions-callout').length).toBeGreaterThan(1);
+    expect(wrapper.baseElement.querySelectorAll('#FloatingSuggestionsItemId-0')).toHaveLength(1);
+    expect(wrapper.baseElement.querySelectorAll('#FloatingSuggestionsItemId-1')).toHaveLength(1);
+    expect(wrapper.baseElement.querySelectorAll('.ms-FloatingSuggestions-callout')).toHaveLength(1);
 
     floatingPickerProps.isSuggestionsVisible = false;
-    const secondwrapper = mount(
+    const secondwrapper = render(
       <UnifiedPicker
         floatingSuggestionProps={floatingPickerProps}
         selectedItemsListProps={selectedItemsListProps}
@@ -234,7 +234,7 @@ describe('UnifiedPicker', () => {
       />,
     );
     // Hidden suggestion, no picker
-    expect(secondwrapper.find('#FloatingSuggestionsItemId-0')).toHaveLength(0);
-    expect(secondwrapper.find('.ms-FloatingSuggestions-callout')).toHaveLength(0);
+    expect(secondwrapper.container.querySelectorAll('#FloatingSuggestionsItemId-0')).toHaveLength(0);
+    expect(secondwrapper.container.querySelectorAll('.ms-FloatingSuggestions-callout')).toHaveLength(0);
   });
 });

--- a/packages/react-experiments/tsconfig.json
+++ b/packages/react-experiments/tsconfig.json
@@ -15,7 +15,7 @@
     "moduleResolution": "node",
     "preserveConstEnums": true,
     "skipLibCheck": true,
-    "lib": ["es5", "dom"],
+    "lib": ["es5", "dom", "ES2016.Array.Include", "ES2015.Core"],
     "typeRoots": ["../../node_modules/@types", "../../typings"],
     "types": ["jest", "custom-global"],
     "isolatedModules": true

--- a/packages/react-icons-mdl2/src/utils/createSvgIcon.test.tsx
+++ b/packages/react-icons-mdl2/src/utils/createSvgIcon.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
 import createSvgIcon from './createSvgIcon';
 
 const testSvg = () => <svg />;
@@ -18,22 +18,18 @@ describe('createSvgIcon', () => {
   it('spreads unhandled props on the root element', () => {
     const TestIcon = createSvgIcon({ svg: testSvg, displayName: 'TestIcon' });
 
-    const wrapper = mount(<TestIcon id="test-id" data-bar="data-test-value" />);
+    const wrapper = render(<TestIcon id="test-id" data-bar="data-test-value" />);
 
-    expect(wrapper.find('span').props()).toEqual(
-      expect.objectContaining({
-        id: 'test-id',
-        'data-bar': 'data-test-value',
-      }),
-    );
+    expect(wrapper.container.querySelector('span')?.getAttribute('data-bar')).toEqual('data-test-value');
+    expect(wrapper.container.querySelector('span')?.getAttribute('id')).toEqual('test-id');
   });
 
   it("merged user's className on the root element with the generated", () => {
     const TestIcon = createSvgIcon({ svg: testSvg, displayName: 'TestIcon' });
 
-    const wrapper = mount(<TestIcon className="test-className" />);
+    const wrapper = render(<TestIcon className="test-className" />);
 
-    expect(wrapper.find('span').props().className!.includes('test-className')).toEqual(true);
+    expect(wrapper.container.querySelector('span')?.className!.includes('test-className')).toEqual(true);
   });
 
   it('provides all props on the svg function', () => {
@@ -46,8 +42,8 @@ describe('createSvgIcon', () => {
       displayName: 'BookIcon',
     });
 
-    const wrapper = mount(<BookIcon foo />);
+    const wrapper = render(<BookIcon foo />);
 
-    expect(wrapper.find('svg').prop('data-foo')).toEqual('true');
+    expect(wrapper.container.querySelector('svg')?.getAttribute('data-foo')).toEqual('true');
   });
 });

--- a/packages/react-icons-mdl2/tsconfig.json
+++ b/packages/react-icons-mdl2/tsconfig.json
@@ -15,7 +15,7 @@
     "moduleResolution": "node",
     "preserveConstEnums": true,
     "lib": ["ES2019", "DOM"],
-    "types": ["jest"],
+    "types": ["jest", "node"],
     "isolatedModules": true
   },
   "include": ["src"]

--- a/packages/utilities/src/asAsync.test.tsx
+++ b/packages/utilities/src/asAsync.test.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react';
 import { asAsync } from './asAsync';
-import { mount } from 'enzyme';
+import * as renderer from 'react-test-renderer';
+import type { ReactTestRenderer, ReactTestRendererJSON } from 'react-test-renderer';
+
+const getChildren = (testRenderer: ReactTestRenderer) => (testRenderer.toJSON() as ReactTestRendererJSON)?.children;
 
 describe('asAsync', () => {
   it('can async load exports', (done: () => undefined) => {
@@ -17,23 +20,24 @@ describe('asAsync', () => {
         return loadThingPromise;
       },
     });
-    const wrapper = mount(<AsyncThing />);
+    const component = renderer.create(<AsyncThing />);
 
     expect(_loadCalled).toBe(true);
-    expect(wrapper.text()).toBeFalsy();
+    expect(getChildren(component)).toBeUndefined();
     expect(_resolve).toBeTruthy();
 
     _resolve(() => <div>thing</div>);
 
     process.nextTick(() => {
-      wrapper.update();
-      expect(wrapper.text()).toEqual('thing');
+      component.update(<AsyncThing />);
+
+      expect(getChildren(component)![0]).toEqual('thing');
       _loadCalled = false;
 
       // Test cached case.
-      mount(<AsyncThing />);
+      renderer.create(<AsyncThing />);
       expect(_loadCalled).toBe(false);
-      expect(wrapper.text()).toEqual('thing');
+      expect(getChildren(component)![0]).toEqual('thing');
       done();
     });
   });
@@ -52,17 +56,17 @@ describe('asAsync', () => {
         return loadThingPromise;
       },
     });
-    const wrapper = mount(<AsyncThing asyncPlaceholder={() => <div>placeholder</div>} />);
+    const component = renderer.create(<AsyncThing asyncPlaceholder={() => <div>placeholder</div>} />);
 
     expect(_loadCalled).toBe(true);
-    expect(wrapper.text()).toEqual('placeholder');
+    expect(getChildren(component)![0]).toEqual('placeholder');
     expect(_resolve).toBeTruthy();
 
     _resolve(() => <div>thing</div>);
 
     process.nextTick(() => {
-      wrapper.update();
-      expect(wrapper.text()).toEqual('thing');
+      component.update(<AsyncThing asyncPlaceholder={() => <div>placeholder</div>} />);
+      expect(getChildren(component)![0]).toEqual('thing');
       done();
     });
   });

--- a/packages/utilities/src/createMergedRef.test.tsx
+++ b/packages/utilities/src/createMergedRef.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { createMergedRef } from './createMergedRef';
-import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
 
 describe('createMergedRef', () => {
   it('can merge refs', () => {
@@ -13,7 +13,7 @@ describe('createMergedRef', () => {
       }
     }
     const ref2 = React.createRef<HTMLDivElement>();
-    const wrapper = mount(<Foo domRef={ref2} />);
+    const wrapper = render(<Foo domRef={ref2} />);
 
     expect(ref1.current).toBeTruthy();
     expect(ref2.current).toBeTruthy();

--- a/packages/utilities/src/customizations/Customizer.test.tsx
+++ b/packages/utilities/src/customizations/Customizer.test.tsx
@@ -1,9 +1,10 @@
 /*  eslint-disable @typescript-eslint/no-deprecated */
+import '@testing-library/jest-dom';
 import * as React from 'react';
+import { render, screen } from '@testing-library/react';
 import { customizable } from './customizable';
 import { Customizer } from './Customizer';
 import { Customizations } from './Customizations';
-import { safeMount } from '@fluentui/test-utilities';
 
 @customizable('Foo', ['field'])
 class Foo extends React.Component<{ field?: string }, {}> {
@@ -31,40 +32,34 @@ describe('Customizer', () => {
   });
 
   it('can provide new defaults', () => {
-    safeMount(
+    render(
       <Customizer settings={{ field: 'customName' }}>
         <Foo />
       </Customizer>,
-      wrapper => {
-        expect(wrapper.html()).toEqual('<div>customName</div>');
-      },
     );
+    expect(screen.getByText('customName')).toBeInTheDocument();
   });
 
   it('can pass through global settings', () => {
     Customizations.applySettings({ field: 'globalName' });
 
-    safeMount(
+    render(
       <Customizer settings={{ nonMatch: 'customName' }}>
         <Foo />
       </Customizer>,
-      wrapper => {
-        expect(wrapper.html()).toEqual('<div>globalName</div>');
-      },
     );
+    expect(screen.getByText('globalName')).toBeInTheDocument();
   });
 
   it('can override global settings', () => {
     Customizations.applySettings({ field: 'globalName' });
 
-    safeMount(
+    render(
       <Customizer settings={{ field: 'customName' }}>
         <Foo />
       </Customizer>,
-      wrapper => {
-        expect(wrapper.html()).toEqual('<div>customName</div>');
-      },
     );
+    expect(screen.getByText('customName')).toBeInTheDocument();
   });
 
   it('can scope settings to specific components', () => {
@@ -73,51 +68,46 @@ describe('Customizer', () => {
       Bar: { field: 'scopedToBar' },
     };
 
-    safeMount(
+    render(
       <Customizer scopedSettings={scopedSettings}>
         <div>
           <Foo />
           <Bar />
         </div>
       </Customizer>,
-      wrapper => {
-        expect(wrapper.html()).toEqual('<div><div>scopedToFoo</div><div>scopedToBar</div></div>');
-      },
     );
+    expect(screen.getByText('scopedToFoo')).toBeInTheDocument();
+    expect(screen.getByText('scopedToBar')).toBeInTheDocument();
   });
 
   it('can layer global settings', () => {
-    safeMount(
+    render(
       <Customizer settings={{ field: 'field' }}>
         <Customizer settings={{ field2: 'field2' }}>
           <Bar />
         </Customizer>
       </Customizer>,
-      wrapper => {
-        expect(wrapper.html()).toEqual('<div>fieldfield2</div>');
-      },
     );
+    expect(screen.getByText('fieldfield2')).toBeInTheDocument();
   });
 
   it('can layer scoped settings', () => {
     Customizations.applySettings({ field3: 'field3' });
 
-    safeMount(
+    render(
       <Customizer scopedSettings={{ Bar: { field: 'field', field2: 'oldfield2' } }}>
         <Customizer scopedSettings={{ Bar: { field2: 'field2' } }}>
           <Bar />
         </Customizer>
       </Customizer>,
-      wrapper => {
-        expect(wrapper.html()).toEqual('<div>fieldfield2field3</div>');
-      },
     );
+    expect(screen.getByText('fieldfield2field3')).toBeInTheDocument();
   });
 
   it('can layer scoped settings with scopedSettingsFunction', () => {
     Customizations.applySettings({ field3: 'field3' });
 
-    safeMount(
+    render(
       <Customizer scopedSettings={{ Bar: { field: 'field' } }}>
         <Customizer
           scopedSettings={(scopedSettings: { Bar: { field2: string } }) => ({
@@ -127,14 +117,12 @@ describe('Customizer', () => {
           <Bar />
         </Customizer>
       </Customizer>,
-      wrapper => {
-        expect(wrapper.html()).toEqual('<div>fieldfield2field3</div>');
-      },
     );
+    expect(screen.getByText('fieldfield2field3')).toBeInTheDocument();
   });
 
   it('it allows scopedSettings to be merged when a function is passed', () => {
-    safeMount(
+    render(
       <Customizer scopedSettings={{ Foo: { field: 'scopedToFoo' } }}>
         <Customizer
           scopedSettings={(settings: { Foo: { field: string } }) => ({ ...settings, Bar: { field: 'scopedToBar' } })}
@@ -145,86 +133,77 @@ describe('Customizer', () => {
           </div>
         </Customizer>
       </Customizer>,
-      wrapper => {
-        expect(wrapper.html()).toEqual('<div><div>scopedToFoo</div><div>scopedToBar</div></div>');
-      },
     );
+    expect(screen.getByText('scopedToFoo')).toBeInTheDocument();
+    expect(screen.getByText('scopedToBar')).toBeInTheDocument();
   });
 
   it('overrides previously set settings', () => {
-    safeMount(
+    render(
       <Customizer settings={{ field: 'field1' }}>
         <Customizer settings={{ field: 'field2' }}>
           <Bar />
         </Customizer>
       </Customizer>,
-      wrapper => {
-        expect(wrapper.html()).toEqual('<div>field2</div>');
-      },
     );
+    expect(screen.getByText('field2')).toBeInTheDocument();
   });
 
   it('overrides the old settings when the parameter is ignored', () => {
-    safeMount(
+    render(
       <Customizer settings={{ field: 'field1' }}>
         <Customizer settings={(settings: { field: string }) => ({ field: 'field2' })}>
           <Bar />
         </Customizer>
       </Customizer>,
-      wrapper => {
-        expect(wrapper.html()).toEqual('<div>field2</div>');
-      },
     );
+    expect(screen.getByText('field2')).toBeInTheDocument();
   });
 
   it('can use a function to merge settings', () => {
-    safeMount(
+    render(
       <Customizer settings={{ field: 'field1' }}>
         <Customizer settings={(settings: { field: string }) => ({ field: settings.field + 'field2' })}>
           <Bar />
         </Customizer>
       </Customizer>,
-      wrapper => {
-        expect(wrapper.html()).toEqual('<div>field1field2</div>');
-      },
     );
+    expect(screen.getByText('field1field2')).toBeInTheDocument();
   });
 
   it('can suppress updates', () => {
     Customizations.applySettings({ field: 'globalName' });
 
-    safeMount(
+    render(
       <Customizer settings={{ nonMatch: 'customName' }}>
         <Bar />
       </Customizer>,
-      wrapper => {
-        // verify base state
-        expect(wrapper.html()).toEqual('<div>globalName</div>');
-
-        // verify it doesn't update during suppressUpdates(), and it works through errors, and it updates after
-        Customizations.applyBatchedUpdates(() => {
-          Customizations.applySettings({ field: 'notGlobalName' });
-          // it should not update inside
-          expect(wrapper.html()).toEqual('<div>globalName</div>');
-          throw new Error();
-        });
-        // afterwards it should have updated
-        expect(wrapper.html()).toEqual('<div>notGlobalName</div>');
-
-        // verify it doesn't update during suppressUpdates(), works through errors, and can suppress final update
-        Customizations.applyBatchedUpdates(() => {
-          Customizations.applySettings({ field: 'notUpdated' });
-          // it should not update inside
-          expect(wrapper.html()).toEqual('<div>notGlobalName</div>');
-          throw new Error();
-        }, true);
-        // afterwards, it should still be on the old value
-        expect(wrapper.html()).toEqual('<div>notGlobalName</div>');
-
-        // verify it updates after suppressUpdates()
-        Customizations.applySettings({ field2: 'lastGlobalName' });
-        expect(wrapper.html()).toEqual('<div>notUpdatedlastGlobalName</div>');
-      },
     );
+    // verify base state
+    expect(screen.getByText('globalName')).toBeInTheDocument();
+
+    // verify it doesn't update during suppressUpdates(), and it works through errors, and it updates after
+    Customizations.applyBatchedUpdates(() => {
+      Customizations.applySettings({ field: 'notGlobalName' });
+      // it should not update inside
+      expect(screen.getByText('globalName')).toBeInTheDocument();
+      throw new Error();
+    });
+    // afterwards it should have updated
+    expect(screen.getByText('notGlobalName')).toBeInTheDocument();
+
+    // verify it doesn't update during suppressUpdates(), works through errors, and can suppress final update
+    Customizations.applyBatchedUpdates(() => {
+      Customizations.applySettings({ field: 'notUpdated' });
+      // it should not update inside
+      expect(screen.getByText('notGlobalName')).toBeInTheDocument();
+      throw new Error();
+    }, true);
+    // afterwards, it should still be on the old value
+    expect(screen.getByText('notGlobalName')).toBeInTheDocument();
+
+    // verify it updates after suppressUpdates()
+    Customizations.applySettings({ field2: 'lastGlobalName' });
+    expect(screen.getByText('notUpdatedlastGlobalName')).toBeInTheDocument();
   });
 });

--- a/packages/utilities/src/customizations/customizable.test.tsx
+++ b/packages/utilities/src/customizations/customizable.test.tsx
@@ -1,7 +1,8 @@
 /*  eslint-disable @typescript-eslint/no-deprecated */
 import * as React from 'react';
 import * as ReactDOM from 'react-dom/server';
-import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
+import * as renderer from 'react-test-renderer';
 import { customizable } from './customizable';
 import { Customizations } from './Customizations';
 import { Customizer } from './Customizer';
@@ -30,21 +31,35 @@ interface IComponentStyleFunctionProps {
 @customizable('ConcatStyles', ['styles'], true)
 class ConcatStyles extends React.Component<IComponentProps, {}> {
   public render(): JSX.Element {
-    return <div />;
+    return (
+      <div
+        data-testid="concat-styles"
+        // @ts-expect-error - for testing purposes
+        style={this.props.styles}
+        data-style={JSON.stringify(this.props.styles.root)}
+      />
+    );
   }
 }
 
 @customizable('OverrideStyles', ['styles'])
 class OverrideStyles extends React.Component<IComponentProps, {}> {
   public render(): JSX.Element {
-    return <div />;
+    return (
+      <div
+        data-testid="override-styles"
+        // @ts-expect-error - for testing purposes
+        style={this.props.styles}
+        data-style={JSON.stringify(this.props.styles.root)}
+      />
+    );
   }
 }
 
 @customizable('StyleFunction', ['styles'])
 class StyleFunction extends React.Component<IComponentStyleFunctionProps> {
   public render(): JSX.Element {
-    return <div />;
+    return <div data-testid="style-function" />;
   }
 }
 
@@ -81,15 +96,18 @@ describe('customizable', () => {
     const componentStyles = { color: 'blue' };
 
     Customizations.applySettings({ styles: { root: globalStyles } });
-    const wrapper = mount(
+
+    const rtl = render(
       <Customizer>
         <ConcatStyles styles={{ root: componentStyles }} />
       </Customizer>,
     );
-    const component = wrapper.find('ConcatStyles');
-    const props = component.props() as IComponentProps;
-    expect(Object.keys(props.styles)).toEqual(['root', '__shadowConfig__']);
-    expect(props.styles.root).toEqual([globalStyles, componentStyles]);
+
+    const concatStyleRoot = rtl.getByTestId('concat-styles');
+    const rootStyles = JSON.parse(concatStyleRoot.getAttribute('data-style')!);
+
+    expect(Object.keys(concatStyleRoot.style)).toEqual(expect.arrayContaining(['root', '__shadowConfig__']));
+    expect(rootStyles).toEqual([globalStyles, componentStyles]);
   });
 
   it('can concatenate global styles and component styles', () => {
@@ -99,16 +117,17 @@ describe('customizable', () => {
     const componentStyles = { root: { color: 'blue' } };
 
     Customizations.applySettings({ styles: globalStyles });
-    const wrapper = mount(
+    const rtl = render(
       <Customizer>
         <ConcatStyles styles={componentStyles} />
       </Customizer>,
     );
 
-    const component = wrapper.find('ConcatStyles');
-    const props = component.props() as IComponentProps;
-    expect(Object.keys(props.styles)).toEqual(['root', '__shadowConfig__']);
-    expect(props.styles.root).toEqual([globalStyles({} as IComponentProps).root, componentStyles.root]);
+    const concatStyleRoot = rtl.getByTestId('concat-styles');
+    const rootStyles = JSON.parse(concatStyleRoot.getAttribute('data-style')!);
+
+    expect(Object.keys(concatStyleRoot.style)).toEqual(expect.arrayContaining(['root', '__shadowConfig__']));
+    expect(rootStyles).toEqual([globalStyles({} as IComponentProps).root, componentStyles.root]);
   });
 
   it('will apply component style function when no global styles are present', () => {
@@ -116,14 +135,13 @@ describe('customizable', () => {
       return { root: { color: 'red', background: 'green' } };
     };
 
-    const wrapper = mount(
+    const wrapper = renderer.create(
       <Customizer>
         <StyleFunction styles={componentStyles} />
       </Customizer>,
     );
-
-    const component = wrapper.find('StyleFunction');
-    const props = component.props() as IComponentProps;
+    const component = wrapper.root.findByType(StyleFunction);
+    const props = component.props as IComponentProps;
     expect(typeof props.styles).toBe('function');
     expect(props.styles.__shadowConfig__).toBeTruthy();
   });
@@ -133,15 +151,18 @@ describe('customizable', () => {
     const componentStyles = { color: 'blue' };
 
     Customizations.applyScopedSettings('ConcatStyles', { styles: { root: scopedStyles } });
-    const wrapper = mount(
+
+    const rtl = render(
       <Customizer>
         <ConcatStyles styles={{ root: componentStyles }} />
       </Customizer>,
     );
-    const component = wrapper.find('ConcatStyles');
-    const props = component.props() as IComponentProps;
-    expect(Object.keys(props.styles)).toEqual(['root', '__shadowConfig__']);
-    expect(props.styles.root).toEqual([scopedStyles, componentStyles]);
+
+    const concatStyleRoot = rtl.getByTestId('concat-styles');
+    const rootStyles = JSON.parse(concatStyleRoot.getAttribute('data-style')!);
+
+    expect(Object.keys(concatStyleRoot.style)).toEqual(expect.arrayContaining(['root', '__shadowConfig__']));
+    expect(rootStyles).toEqual([scopedStyles, componentStyles]);
   });
 
   it('can override global styles with component styles', () => {
@@ -149,15 +170,16 @@ describe('customizable', () => {
     const componentStyles = { color: 'blue' };
 
     Customizations.applySettings({ styles: { root: globalStyles } });
-    const wrapper = mount(
+    const rtl = render(
       <Customizer>
         <OverrideStyles styles={{ root: componentStyles }} />
       </Customizer>,
     );
-    const component = wrapper.find('OverrideStyles');
-    const props = component.props() as IComponentProps;
-    expect(Object.keys(props.styles)).toEqual(['root', '__shadowConfig__']);
-    expect(props.styles.root).toEqual(componentStyles);
+    const overrideStyleRoot = rtl.getByTestId('override-styles');
+    const rootStyles = JSON.parse(overrideStyleRoot.getAttribute('data-style')!);
+
+    expect(Object.keys(overrideStyleRoot.style)).toEqual(expect.arrayContaining(['root', '__shadowConfig__']));
+    expect(rootStyles).toEqual(componentStyles);
   });
 
   it('can override scoped styles with component styles', () => {
@@ -165,15 +187,16 @@ describe('customizable', () => {
     const componentStyles = { color: 'blue' };
 
     Customizations.applyScopedSettings('OverrideStyles', { styles: { root: scopedStyles } });
-    const wrapper = mount(
+    const rtl = render(
       <Customizer>
         <OverrideStyles styles={{ root: componentStyles }} />
       </Customizer>,
     );
-    const component = wrapper.find('OverrideStyles');
-    const props = component.props() as IComponentProps;
-    expect(Object.keys(props.styles)).toEqual(['root', '__shadowConfig__']);
-    expect(props.styles.root).toEqual(componentStyles);
+    const overrideStyleRoot = rtl.getByTestId('override-styles');
+    const rootStyles = JSON.parse(overrideStyleRoot.getAttribute('data-style')!);
+
+    expect(Object.keys(overrideStyleRoot.style)).toEqual(expect.arrayContaining(['root', '__shadowConfig__']));
+    expect(rootStyles).toEqual(componentStyles);
   });
 
   it('should not mutate styles if no change to component and global styles', () => {
@@ -182,43 +205,58 @@ describe('customizable', () => {
     const componentStyles = { root: componentRootStyles };
 
     Customizations.applySettings({ styles: { root: globalRootStyles } });
-    const wrapper = mount(
+
+    const rtl = render(
       <Customizer>
         <ConcatStyles styles={componentStyles} />
       </Customizer>,
     );
-    const component = wrapper.find('ConcatStyles');
-    const finalStyles = (component.props() as IComponentProps).styles;
-    expect(Object.keys(finalStyles)).toEqual(['root', '__shadowConfig__']);
-    expect(finalStyles.root).toEqual([globalRootStyles, componentRootStyles]);
 
-    wrapper.setProps({});
+    let overrideStyleRoot = rtl.getByTestId('concat-styles');
+    let rootStyles = JSON.parse(overrideStyleRoot.getAttribute('data-style')!);
 
-    const updatedComponent = wrapper.find('ConcatStyles');
-    const finalStylesAfterRerender = (updatedComponent.props() as IComponentProps).styles;
-    expect(finalStylesAfterRerender).toBe(finalStyles);
-    expect(finalStylesAfterRerender).toEqual(finalStyles);
+    expect(Object.keys(overrideStyleRoot.style)).toEqual(expect.arrayContaining(['root', '__shadowConfig__']));
+    expect(rootStyles).toEqual([globalRootStyles, componentRootStyles]);
+
+    rtl.rerender(
+      <Customizer>
+        <ConcatStyles styles={componentStyles} />
+      </Customizer>,
+    );
+
+    const updatedOverrideStyleRoot = rtl.getByTestId('concat-styles');
+    const updatedRootStyles = JSON.parse(updatedOverrideStyleRoot.getAttribute('data-style')!);
+
+    expect(updatedRootStyles).toStrictEqual(rootStyles);
+    expect(updatedRootStyles).toEqual(rootStyles);
   });
 
   it('should not mutate styles if no change to component styles without global styles', () => {
     const componentStyles = { root: { color: 'blue' } };
 
-    const wrapper = mount(
+    const rtl = render(
       <Customizer>
         <ConcatStyles styles={componentStyles} />
       </Customizer>,
     );
-    const component = wrapper.find('ConcatStyles');
-    const finalStyles = (component.props() as IComponentProps).styles;
-    expect(Object.keys(finalStyles)).toEqual(['root', '__shadowConfig__']);
-    expect(finalStyles.root).toEqual(componentStyles.root);
 
-    wrapper.setProps({});
+    let concatStyleRoot = rtl.getByTestId('concat-styles');
+    let rootStyles = JSON.parse(concatStyleRoot.getAttribute('data-style')!);
 
-    const updatedComponent = wrapper.find('ConcatStyles');
-    const finalStylesAfterRerender = (updatedComponent.props() as IComponentProps).styles;
-    expect(finalStylesAfterRerender).toStrictEqual(finalStyles);
-    expect(finalStylesAfterRerender).toEqual(finalStyles);
+    expect(Object.keys(concatStyleRoot.style)).toEqual(expect.arrayContaining(['root', '__shadowConfig__']));
+    expect(rootStyles).toEqual(componentStyles.root);
+
+    rtl.rerender(
+      <Customizer>
+        <ConcatStyles styles={componentStyles} />
+      </Customizer>,
+    );
+
+    const updatedConcatStyleRoot = rtl.getByTestId('concat-styles');
+    let updatedRootStyles = JSON.parse(updatedConcatStyleRoot.getAttribute('data-style')!);
+
+    expect(updatedRootStyles).toStrictEqual(rootStyles);
+    expect(updatedRootStyles).toEqual(rootStyles);
   });
 
   it('should update styles if component styles changed', () => {
@@ -227,27 +265,31 @@ describe('customizable', () => {
     const componentStyles = { root: componentRootStyles };
 
     Customizations.applySettings({ styles: { root: globalRootStyles } });
-    const wrapper = mount(
+
+    const rtl = render(
       <Customizer>
         <ConcatStyles styles={componentStyles} />
       </Customizer>,
     );
-    const component = wrapper.find('ConcatStyles');
-    const finalStyles = (component.props() as IComponentProps).styles;
-    expect(Object.keys(finalStyles)).toEqual(['root', '__shadowConfig__']);
-    expect(finalStyles.root).toEqual([globalRootStyles, componentRootStyles]);
+    let concatStyleRoot = rtl.getByTestId('concat-styles');
+    let rootStyles = JSON.parse(concatStyleRoot.getAttribute('data-style')!);
+
+    expect(Object.keys(concatStyleRoot.style)).toEqual(expect.arrayContaining(['root', '__shadowConfig__']));
+    expect(rootStyles).toEqual([globalRootStyles, componentRootStyles]);
 
     const newComponentRootStyles = { color: 'red' };
     const newComponentStyles = { root: newComponentRootStyles };
 
-    // re-render ConcatStyles with new styles
-    wrapper.setProps({
-      children: React.cloneElement(wrapper.props().children, { styles: newComponentStyles }),
-    });
+    rtl.rerender(
+      <Customizer>
+        <ConcatStyles styles={newComponentStyles} />
+      </Customizer>,
+    );
 
-    const updatedComponent = wrapper.find('ConcatStyles');
-    const finalStylesAfterRerender = (updatedComponent.props() as IComponentProps).styles;
-    expect(Object.keys(finalStylesAfterRerender)).toEqual(['root', '__shadowConfig__']);
-    expect(finalStylesAfterRerender.root).toEqual([globalRootStyles, newComponentRootStyles]);
+    const updatedConcatStyleRoot = rtl.getByTestId('concat-styles');
+    let updatedRootStyles = JSON.parse(updatedConcatStyleRoot.getAttribute('data-style')!);
+
+    expect(Object.keys(updatedConcatStyleRoot.style)).toEqual(expect.arrayContaining(['root', '__shadowConfig__']));
+    expect(updatedRootStyles).toEqual([globalRootStyles, newComponentRootStyles]);
   });
 });

--- a/packages/utilities/src/customizations/useCustomizationSettings.test.tsx
+++ b/packages/utilities/src/customizations/useCustomizationSettings.test.tsx
@@ -1,18 +1,19 @@
 import * as React from 'react';
-import * as ReactTestUtils from 'react-dom/test-utils';
-import { mount, ReactWrapper } from 'enzyme';
+import * as renderer from 'react-test-renderer';
 import { Customizations } from './Customizations';
 import { CustomizerContext } from './CustomizerContext';
 import { useCustomizationSettings } from './useCustomizationSettings';
 import type { ISettings } from './Customizations';
 
+const { act } = renderer;
+
 describe('useCustomizatioSettings', () => {
-  let wrapper: ReactWrapper | undefined;
+  let component: renderer.ReactTestRenderer | undefined;
 
   afterEach(() => {
-    ReactTestUtils.act(() => {
-      wrapper?.unmount();
-      wrapper = undefined;
+    act(() => {
+      component?.unmount();
+      component = undefined;
     });
     Customizations.reset();
   });
@@ -28,7 +29,9 @@ describe('useCustomizatioSettings', () => {
       return null;
     };
 
-    wrapper = mount(<TestComponent />);
+    act(() => {
+      component = renderer.create(<TestComponent />);
+    });
     expect(settingsStates.length).toBe(1);
     expect(settingsStates[0]).toEqual({ a: 'a' });
   });
@@ -44,10 +47,14 @@ describe('useCustomizatioSettings', () => {
       return null;
     };
 
-    wrapper = mount(<TestComponent />);
-    ReactTestUtils.act(() => {
+    act(() => {
+      component = renderer.create(<TestComponent />);
+    });
+
+    act(() => {
       Customizations.applySettings({ a: 'aa' });
     });
+
     expect(settingsStates.length).toBe(2);
     expect(settingsStates[0]).toEqual({ a: 'a' });
     expect(settingsStates[1]).toEqual({ a: 'aa' });
@@ -63,7 +70,9 @@ describe('useCustomizatioSettings', () => {
       return null;
     };
 
-    wrapper = mount(<TestComponent />);
+    act(() => {
+      component = renderer.create(<TestComponent />);
+    });
     expect(settingsStates.length).toBe(1);
     expect(settingsStates[0]).toEqual({ a: undefined });
   });
@@ -79,16 +88,24 @@ describe('useCustomizatioSettings', () => {
     };
 
     const newContext = { customizations: { settings: { theme: { color: 'red' } }, scopedSettings: {} } };
-    wrapper = mount(
-      <CustomizerContext.Provider value={newContext}>
-        <TestComponent />
-      </CustomizerContext.Provider>,
-    );
+    act(() => {
+      component = renderer.create(
+        <CustomizerContext.Provider value={newContext}>
+          <TestComponent />
+        </CustomizerContext.Provider>,
+      );
+    });
     expect(settingsStates.length).toBe(1);
     expect(settingsStates[0]).toEqual({ theme: { color: 'red' } });
 
     const updatedContext = { customizations: { settings: { theme: { color: 'green' } }, scopedSettings: {} } };
-    wrapper.setProps({ value: updatedContext });
+    act(() => {
+      component!.update(
+        <CustomizerContext.Provider value={updatedContext}>
+          <TestComponent />
+        </CustomizerContext.Provider>,
+      );
+    });
 
     expect(settingsStates.length).toBe(2);
     expect(settingsStates[1]).toEqual({ theme: { color: 'green' } });
@@ -106,13 +123,15 @@ describe('useCustomizatioSettings', () => {
     };
 
     const newContext = { customizations: { settings: { a: 'aa' }, scopedSettings: {}, inCustomizerContext: true } };
-    wrapper = mount(
-      <CustomizerContext.Provider value={newContext}>
-        <TestComponent />
-      </CustomizerContext.Provider>,
-    );
+    act(() => {
+      component = renderer.create(
+        <CustomizerContext.Provider value={newContext}>
+          <TestComponent />
+        </CustomizerContext.Provider>,
+      );
+    });
 
-    ReactTestUtils.act(() => {
+    act(() => {
       Customizations.applySettings({ a: 'aaa' });
     });
 

--- a/packages/utilities/src/extendComponent.test.tsx
+++ b/packages/utilities/src/extendComponent.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { mount } from 'enzyme';
+import * as renderer from 'react-test-renderer';
 import { extendComponent } from './extendComponent';
 
 describe('extendComponent', () => {
@@ -26,8 +26,8 @@ describe('extendComponent', () => {
         return <div />;
       }
     }
-    const wrapper = mount(<Foo />);
-    wrapper.unmount();
+    const component = renderer.create(<Foo />);
+    component.unmount();
 
     expect(didMount).toEqual(2);
     expect(willUnmount).toEqual(2);

--- a/packages/utilities/src/initializeComponentRef.test.tsx
+++ b/packages/utilities/src/initializeComponentRef.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { initializeComponentRef } from './initializeComponentRef';
-import { mount } from 'enzyme';
+import * as renderer from 'react-test-renderer';
 import type { IBaseProps } from './BaseComponent.types';
 
 describe('initializeComponentRef', () => {
@@ -18,11 +18,11 @@ describe('initializeComponentRef', () => {
   it('can resolve componentRef', () => {
     const fooRef = React.createRef();
 
-    const wrapper = mount(<Foo componentRef={fooRef} />);
+    const component = renderer.create(<Foo componentRef={fooRef} />);
 
-    expect(fooRef.current).toBe(wrapper.instance());
+    expect(fooRef.current).toBe(component.getInstance());
 
-    wrapper.unmount();
+    component.unmount();
 
     expect(fooRef.current).toBeNull();
   });

--- a/packages/utilities/src/safeRequestAnimationFrame.test.tsx
+++ b/packages/utilities/src/safeRequestAnimationFrame.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { safeRequestAnimationFrame } from './safeRequestAnimationFrame';
-import { mount } from 'enzyme';
+import * as renderer from 'react-test-renderer';
 
 describe('safeRequestAnimationFrame', () => {
   let rafCalled = false;
@@ -32,7 +32,7 @@ describe('safeRequestAnimationFrame', () => {
   });
 
   it('can request animation frame', () => {
-    mount(<Foo />);
+    renderer.create(<Foo />);
 
     expect(rafCalled).toEqual(false);
 
@@ -42,11 +42,11 @@ describe('safeRequestAnimationFrame', () => {
   });
 
   it('can cancel request animation frame', () => {
-    const wrapper = mount(<Foo />);
+    const component = renderer.create(<Foo />);
 
     expect(rafCalled).toEqual(false);
 
-    wrapper.unmount();
+    component.unmount();
 
     jest.runOnlyPendingTimers();
 

--- a/packages/utilities/src/safeSetTimeout.test.tsx
+++ b/packages/utilities/src/safeSetTimeout.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { safeSetTimeout } from './safeSetTimeout';
-import { mount } from 'enzyme';
+import * as renderer from 'react-test-renderer';
 
 describe('safeSetTimeout', () => {
   let setTimeoutCalled = false;
@@ -31,7 +31,7 @@ describe('safeSetTimeout', () => {
   });
 
   it('can request animation frame', () => {
-    mount(<Foo />);
+    renderer.create(<Foo />);
 
     expect(setTimeoutCalled).toEqual(false);
 
@@ -41,11 +41,11 @@ describe('safeSetTimeout', () => {
   });
 
   it('can cancel request animation frame', () => {
-    const wrapper = mount(<Foo />);
+    const component = renderer.create(<Foo />);
 
     expect(setTimeoutCalled).toEqual(false);
 
-    wrapper.unmount();
+    component.unmount();
 
     jest.advanceTimersByTime(100);
 

--- a/packages/utilities/src/setFocusVisibility.test.tsx
+++ b/packages/utilities/src/setFocusVisibility.test.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
+import * as renderer from 'react-test-renderer';
 import { FocusRects } from './useFocusRects';
 import { IsFocusHiddenClassName, IsFocusVisibleClassName, setFocusVisibility } from './setFocusVisibility';
 import * as getWindow from './dom/getWindow';
-import { mount, ReactWrapper } from 'enzyme';
 
 describe('setFocusVisibility', () => {
-  let wrapper: ReactWrapper;
+  let component: renderer.ReactTestRenderer;
   let classNames: string[] = [];
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -48,10 +48,10 @@ describe('setFocusVisibility', () => {
     jest.spyOn(getWindow, 'getWindow').mockReturnValue(mockWindow as Window);
     classNames = [];
 
-    wrapper = mount(<FocusRects />);
+    component = renderer.create(<FocusRects />);
   });
 
-  afterEach(() => wrapper.unmount());
+  afterEach(() => component.unmount());
 
   it('hints to show focus', () => {
     setFocusVisibility(true);

--- a/packages/utilities/src/useFocusRects.test.tsx
+++ b/packages/utilities/src/useFocusRects.test.tsx
@@ -1,15 +1,17 @@
 import * as React from 'react';
 import * as ReactTestUtils from 'react-dom/test-utils';
+import * as renderer from 'react-test-renderer';
 import { FocusRects } from './useFocusRects';
 import { FocusRectsProvider } from './FocusRectsProvider';
 import { IsFocusHiddenClassName, IsFocusVisibleClassName } from './setFocusVisibility';
 import { KeyCodes } from './KeyCodes';
 import { addDirectionalKeyCode, removeDirectionalKeyCode } from './keyboard';
-import { mount, ReactWrapper } from 'enzyme';
+
+const { act } = renderer;
 
 describe('useFocusRects', () => {
-  let focusRects1: ReactWrapper;
-  let focusRects2: ReactWrapper;
+  let focusRects1: renderer.ReactTestRenderer;
+  let focusRects2: renderer.ReactTestRenderer;
 
   class MockWindow {
     public classNames: string[] = [];
@@ -87,8 +89,10 @@ describe('useFocusRects', () => {
 
   describe('when attaching the classnames to the window body', () => {
     it('can hint to show focus when you press a directional key', () => {
-      focusRects1 = mount(<FocusRects rootRef={mockRefObject} />);
-      focusRects2 = mount(<FocusRects rootRef={mockRefObject} />);
+      act(() => {
+        focusRects1 = renderer.create(<FocusRects rootRef={mockRefObject} />);
+        focusRects2 = renderer.create(<FocusRects rootRef={mockRefObject} />);
+      });
 
       const { eventListeners } = mockWindow;
       expect(eventListeners.keyup).toBeDefined();
@@ -138,19 +142,23 @@ describe('useFocusRects', () => {
 
       expect(mockWindow.addEventListenerCallCount).toBe(4);
       expect(mockWindow.removeEventListenerCallCount).toBe(0);
-      ReactTestUtils.act(() => {
+
+      act(() => {
         focusRects1.unmount();
       });
       expect(mockWindow.removeEventListenerCallCount).toBe(0);
-      ReactTestUtils.act(() => {
+
+      act(() => {
         focusRects2.unmount();
       });
       expect(mockWindow.removeEventListenerCallCount).toBe(4);
     });
 
     it('can hint to show focus when you press a directional key with multi-window', () => {
-      focusRects1 = mount(<FocusRects rootRef={mockRefObject} />);
-      focusRects2 = mount(<FocusRects rootRef={mockRefObject2} />);
+      act(() => {
+        focusRects1 = renderer.create(<FocusRects rootRef={mockRefObject} />);
+        focusRects2 = renderer.create(<FocusRects rootRef={mockRefObject2} />);
+      });
 
       expect(mockWindow.eventListeners.keyup).toBeDefined();
       mockWindow.eventListeners.keyup!({ target: mockTarget, which: KeyCodes.up });
@@ -175,22 +183,26 @@ describe('useFocusRects', () => {
 
       expect(mockWindow.addEventListenerCallCount).toBe(4);
       expect(mockWindow.removeEventListenerCallCount).toBe(0);
-      ReactTestUtils.act(() => {
+
+      act(() => {
         focusRects1.unmount();
       });
       expect(mockWindow.removeEventListenerCallCount).toBe(4);
 
       expect(mockWindow2.addEventListenerCallCount).toBe(4);
       expect(mockWindow2.removeEventListenerCallCount).toBe(0);
-      ReactTestUtils.act(() => {
+
+      act(() => {
         focusRects2.unmount();
       });
       expect(mockWindow2.removeEventListenerCallCount).toBe(4);
     });
 
     it('no-ops when you press a non-directional key', () => {
-      focusRects1 = mount(<FocusRects rootRef={mockRefObject} />);
-      focusRects2 = mount(<FocusRects rootRef={mockRefObject} />);
+      act(() => {
+        focusRects1 = renderer.create(<FocusRects rootRef={mockRefObject} />);
+        focusRects2 = renderer.create(<FocusRects rootRef={mockRefObject} />);
+      });
 
       const { eventListeners } = mockWindow;
 
@@ -201,18 +213,22 @@ describe('useFocusRects', () => {
 
       expect(mockWindow.addEventListenerCallCount).toBe(4);
       expect(mockWindow.removeEventListenerCallCount).toBe(0);
-      ReactTestUtils.act(() => {
+
+      act(() => {
         focusRects1.unmount();
       });
       expect(mockWindow.removeEventListenerCallCount).toBe(0);
-      ReactTestUtils.act(() => {
+
+      act(() => {
         focusRects2.unmount();
       });
       expect(mockWindow.removeEventListenerCallCount).toBe(4);
     });
 
     it('can hint to hide focus on mouse click', () => {
-      focusRects1 = mount(<FocusRects rootRef={mockRefObject} />);
+      act(() => {
+        focusRects1 = renderer.create(<FocusRects rootRef={mockRefObject} />);
+      });
 
       const { eventListeners } = mockWindow;
 
@@ -228,15 +244,18 @@ describe('useFocusRects', () => {
 
       expect(mockWindow.addEventListenerCallCount).toBe(4);
       expect(mockWindow.removeEventListenerCallCount).toBe(0);
-      ReactTestUtils.act(() => {
+
+      act(() => {
         focusRects1.unmount();
       });
       expect(mockWindow.removeEventListenerCallCount).toBe(4);
     });
 
     it('can hint to show focus when you press a custom directional key', () => {
-      focusRects1 = mount(<FocusRects rootRef={mockRefObject} />);
-      focusRects2 = mount(<FocusRects rootRef={mockRefObject} />);
+      act(() => {
+        focusRects1 = renderer.create(<FocusRects rootRef={mockRefObject} />);
+        focusRects2 = renderer.create(<FocusRects rootRef={mockRefObject} />);
+      });
 
       const { eventListeners } = mockWindow;
 
@@ -253,11 +272,13 @@ describe('useFocusRects', () => {
 
       expect(mockWindow.addEventListenerCallCount).toBe(4);
       expect(mockWindow.removeEventListenerCallCount).toBe(0);
-      ReactTestUtils.act(() => {
+
+      act(() => {
         focusRects1.unmount();
       });
       expect(mockWindow.removeEventListenerCallCount).toBe(0);
-      ReactTestUtils.act(() => {
+
+      act(() => {
         focusRects2.unmount();
       });
       expect(mockWindow.removeEventListenerCallCount).toBe(4);
@@ -269,7 +290,10 @@ describe('useFocusRects', () => {
       mockWindow.FabricConfig = {
         disableFocusRects: true,
       };
-      const focusRect = mount(<FocusRects rootRef={mockRefObject} />);
+      let component: renderer.ReactTestRenderer;
+      act(() => {
+        component = renderer.create(<FocusRects rootRef={mockRefObject} />);
+      });
 
       const { eventListeners } = mockWindow;
 
@@ -279,8 +303,9 @@ describe('useFocusRects', () => {
 
       expect(mockWindow.addEventListenerCallCount).toBe(0);
       expect(mockWindow.removeEventListenerCallCount).toBe(0);
-      ReactTestUtils.act(() => {
-        focusRect.unmount();
+
+      act(() => {
+        component.unmount();
       });
       expect(mockWindow.removeEventListenerCallCount).toBe(0);
       expect(mockWindow.removeEventListenerCallCount).toBe(0);
@@ -379,7 +404,9 @@ describe('useFocusRects', () => {
     it('can hint to show focus when you press a directional key', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const providerRef = React.createRef<any>();
-      focusRects1 = mount(<FocusRectsWithProvider providerRef={providerRef} rootRef={mockRefObject} />);
+      act(() => {
+        focusRects1 = renderer.create(<FocusRectsWithProvider providerRef={providerRef} rootRef={mockRefObject} />);
+      });
 
       const providerElem = providerRef.current as MockProviderRef;
       const { eventListeners } = providerElem;
@@ -461,7 +488,8 @@ describe('useFocusRects', () => {
       expect(mockWindow.addEventListenerCallCount).toBe(0);
       expect(addEventListenerCallCount).toBe(4);
       expect(removeEventListenerCallCount).toBe(0);
-      ReactTestUtils.act(() => {
+
+      act(() => {
         focusRects1.unmount();
       });
       expect(mockWindow.removeEventListenerCallCount).toBe(0);
@@ -471,7 +499,9 @@ describe('useFocusRects', () => {
     it('no-ops when you press a non-directional key', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const providerRef = React.createRef<any>();
-      focusRects1 = mount(<FocusRectsWithProvider providerRef={providerRef} rootRef={mockRefObject} />);
+      act(() => {
+        focusRects1 = renderer.create(<FocusRectsWithProvider providerRef={providerRef} rootRef={mockRefObject} />);
+      });
 
       const providerElem = providerRef.current as MockProviderRef;
       const { eventListeners } = providerElem;
@@ -487,7 +517,8 @@ describe('useFocusRects', () => {
       expect(mockWindow.addEventListenerCallCount).toBe(0);
       expect(addEventListenerCallCount).toBe(4);
       expect(removeEventListenerCallCount).toBe(0);
-      ReactTestUtils.act(() => {
+
+      act(() => {
         focusRects1.unmount();
       });
       expect(mockWindow.removeEventListenerCallCount).toBe(0);
@@ -497,7 +528,9 @@ describe('useFocusRects', () => {
     it('can hint to hide focus on mouse click', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const providerRef = React.createRef<any>();
-      focusRects1 = mount(<FocusRectsWithProvider providerRef={providerRef} rootRef={mockRefObject} />);
+      act(() => {
+        focusRects1 = renderer.create(<FocusRectsWithProvider providerRef={providerRef} rootRef={mockRefObject} />);
+      });
 
       const providerElem = providerRef.current as MockProviderRef;
       const { eventListeners } = providerElem;
@@ -523,7 +556,8 @@ describe('useFocusRects', () => {
       expect(mockWindow.addEventListenerCallCount).toBe(0);
       expect(addEventListenerCallCount).toBe(4);
       expect(removeEventListenerCallCount).toBe(0);
-      ReactTestUtils.act(() => {
+
+      act(() => {
         focusRects1.unmount();
       });
       expect(mockWindow.removeEventListenerCallCount).toBe(0);
@@ -533,7 +567,9 @@ describe('useFocusRects', () => {
     it('can hint to show focus when you press a custom directional key', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const providerRef = React.createRef<any>();
-      focusRects1 = mount(<FocusRectsWithProvider providerRef={providerRef} rootRef={mockRefObject} />);
+      act(() => {
+        focusRects1 = renderer.create(<FocusRectsWithProvider providerRef={providerRef} rootRef={mockRefObject} />);
+      });
 
       const providerElem = providerRef.current as MockProviderRef;
       const { eventListeners } = providerElem;
@@ -559,7 +595,8 @@ describe('useFocusRects', () => {
       expect(mockWindow.addEventListenerCallCount).toBe(0);
       expect(addEventListenerCallCount).toBe(4);
       expect(removeEventListenerCallCount).toBe(0);
-      ReactTestUtils.act(() => {
+
+      act(() => {
         focusRects1.unmount();
       });
       expect(mockWindow.removeEventListenerCallCount).toBe(0);
@@ -575,7 +612,10 @@ describe('useFocusRects', () => {
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const providerRef = React.createRef<any>();
-      const focusRect = mount(<FocusRectsWithProvider providerRef={providerRef} rootRef={mockRefObject} />);
+      let component: renderer.ReactTestRenderer;
+      act(() => {
+        component = renderer.create(<FocusRectsWithProvider providerRef={providerRef} rootRef={mockRefObject} />);
+      });
 
       const providerElem = providerRef.current as MockProviderRef;
       const { eventListeners } = providerElem;
@@ -589,8 +629,9 @@ describe('useFocusRects', () => {
       expect(mockWindow.addEventListenerCallCount).toBe(0);
       expect(addEventListenerCallCount).toBe(0);
       expect(removeEventListenerCallCount).toBe(0);
-      ReactTestUtils.act(() => {
-        focusRect.unmount();
+
+      act(() => {
+        component.unmount();
       });
       expect(mockWindow.removeEventListenerCallCount).toBe(0);
       expect(removeEventListenerCallCount).toBe(0);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

Follows #34270 to refactor v8 tests to remove enzyme

**Test migrated**
- utilities
- react-experiments
- react-icons-mdl2
- react-cards
- foundation-legacy

**Type issues resolved**
- changes in react-experiments,foundation-legacy and react-icons-mdl2 triggered TSC errors in test files and implementation files. This PR adjust the configs to make `tsc` deterministic and without errors

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
