### PR TITLE
feat(react-18-tests-v8): setup test:integration to run jest test against r18

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -160,7 +160,9 @@ jobs:
       - name: test (affected)
         id: test
         if: steps.affected_projects_test_count.outputs.value > 0
-        run: yarn nx run-many -p react-${{ matrix.react }}-tests-v${{ matrix.fluentui }} -t test:integration --nxBail
+        run: |
+          yarn nx run-many -p react-${{ matrix.react }}-tests-v${{ matrix.fluentui }} -t build:integration --nxBail
+          yarn workspace @fluentui/react-${{ matrix.react }}-tests-v${{ matrix.fluentui }} test:integration
         continue-on-error: true
 
       # run targets only on affected changes - need to run this outside nx runner context to avoid https://github.com/nrwl/nx/issues/30562

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -130,6 +130,12 @@ jobs:
           affected_count=$(yarn --silent nx show projects -t type-check:integration --affected --verbose false | wc -l | tr -d ' ')
           echo "value=$affected_count" >> $GITHUB_OUTPUT
 
+      - name: Affected test:integration Projects
+        id: affected_projects_test_count
+        run: |
+          affected_count=$(yarn --silent nx show projects -t test:integration --affected --verbose false | wc -l | tr -d ' ')
+          echo "value=$affected_count" >> $GITHUB_OUTPUT
+
       - name: type-check (affected)
         id: type-check
         if: steps.affected_projects_type_check_count.outputs.value > 0
@@ -149,6 +155,13 @@ jobs:
           name: typescript-react-${{ matrix.react }}-v${{ matrix.fluentui }}
           path: tsc-logs
           retention-days: 1
+
+      # run targets only on affected changes - need to run this outside nx runner context to avoid https://github.com/nrwl/nx/issues/30562
+      - name: test (affected)
+        id: test
+        if: steps.affected_projects_test_count.outputs.value > 0
+        run: yarn nx run-many -p react-${{ matrix.react }}-tests-v${{ matrix.fluentui }} -t test:integration --nxBail
+        continue-on-error: true
 
       # run targets only on affected changes - need to run this outside nx runner context to avoid https://github.com/nrwl/nx/issues/30562
       - name: e2e (affected)
@@ -176,14 +189,16 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "- Type-check: ${{ steps.type-check.outcome }}" >> $GITHUB_STEP_SUMMARY
           echo "- E2E: ${{ steps.e2e.outcome }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Test: ${{ steps.test.outcome }}" >> $GITHUB_STEP_SUMMARY
 
-          if [[ "${{ steps.type-check.outcome }}" == "success" && "${{ steps.e2e.outcome }}" == "success" ]]; then
+          if [[ "${{ steps.type-check.outcome }}" == "success" && "${{ steps.e2e.outcome }}" == "success" && "${{ steps.test.outcome }}" == "success" ]]; then
             echo "✅ React ${{ matrix.react }} / v${{ matrix.fluentui }} integration tests passed"
             exit 0
           else
             echo "❌ React ${{ matrix.react }} / v${{ matrix.fluentui }} integration tests failed"
             echo "Type-check: ${{ steps.type-check.outcome }}"
             echo "E2E: ${{ steps.e2e.outcome }}"
+            echo "Test: ${{ steps.test.outcome }}"
             exit 1
           fi
 

--- a/apps/react-18-tests-v8/.eslintrc.json
+++ b/apps/react-18-tests-v8/.eslintrc.json
@@ -3,6 +3,7 @@
   "root": true,
   "rules": {
     "no-restricted-globals": "off",
-    "import/no-extraneous-dependencies": "off"
+    "import/no-extraneous-dependencies": "off",
+    "@fluentui/max-len": "off"
   }
 }

--- a/apps/react-18-tests-v8/config/tests.js
+++ b/apps/react-18-tests-v8/config/tests.js
@@ -1,3 +1,7 @@
 /** Jest test setup file. */
 
 require('@testing-library/jest-dom');
+
+const { initializeIcons } = require('@fluentui/font-icons-mdl2');
+// Initialize icons.
+initializeIcons('');

--- a/apps/react-18-tests-v8/jest-react-18.config.js
+++ b/apps/react-18-tests-v8/jest-react-18.config.js
@@ -6,6 +6,7 @@ const jestConfig = require('./jest.config');
  */
 const config = {
   ...jestConfig,
+  displayName: 'react-18-tests-v8-integration',
   roots: ['<rootDir>/../../packages/react/src', '<rootDir>/../../packages/react-hooks/src'],
 };
 

--- a/apps/react-18-tests-v8/jest-react-18.config.js
+++ b/apps/react-18-tests-v8/jest-react-18.config.js
@@ -1,0 +1,12 @@
+// @ts-check
+const jestConfig = require('./jest.config');
+
+/**
+ * @type {import('@jest/types').Config.InitialOptions}
+ */
+const config = {
+  ...jestConfig,
+  roots: ['<rootDir>/../../packages/react/src', '<rootDir>/../../packages/react-hooks/src'],
+};
+
+module.exports = config;

--- a/apps/react-18-tests-v8/jest.config.js
+++ b/apps/react-18-tests-v8/jest.config.js
@@ -18,6 +18,7 @@ config.moduleNameMapper = {
   ...moduleNameMapper,
   '^react$': join(__dirname, '/node_modules/react'),
   '^react-dom$': join(__dirname, 'node_modules/react-dom'),
+  '^react-dom/test-utils$': join(__dirname, 'node_modules/react-dom/test-utils'),
   '^react-test-renderer$': join(__dirname, 'node_modules/react-test-renderer'),
   '^react-is$': join(__dirname, 'node_modules/react-is'),
   '^@testing-library/(react|dom)$': join(__dirname, 'node_modules/@testing-library/$1'),

--- a/apps/react-18-tests-v8/jest.config.js
+++ b/apps/react-18-tests-v8/jest.config.js
@@ -1,4 +1,5 @@
 // @ts-check
+const { join } = require('node:path');
 const { createV8Config: createConfig } = require('@fluentui/scripts-jest');
 
 /**
@@ -10,6 +11,17 @@ const config = createConfig({
   setupFilesAfterEnv: ['./config/tests.js'],
   snapshotSerializers: ['@fluentui/jest-serializer-merge-styles'],
 });
+
+const moduleNameMapper = config.moduleNameMapper || {};
+
+config.moduleNameMapper = {
+  ...moduleNameMapper,
+  '^react$': join(__dirname, '/node_modules/react'),
+  '^react-dom$': join(__dirname, 'node_modules/react-dom'),
+  '^react-test-renderer$': join(__dirname, 'node_modules/react-test-renderer'),
+  '^react-is$': join(__dirname, 'node_modules/react-is'),
+  '^@testing-library/(react|dom)$': join(__dirname, 'node_modules/@testing-library/$1'),
+};
 
 // use default jest config to properly resolve react-18
 delete config.moduleDirectories;

--- a/apps/react-18-tests-v8/package.json
+++ b/apps/react-18-tests-v8/package.json
@@ -13,6 +13,7 @@
     "e2e:integration": "npx --yes cypress@latest run --component --config-file cypress-react-18.config.ts",
     "lint": "ESLINT_USE_FLAT_CONFIG=false eslint --ext .js,.ts,.tsx ./src",
     "test": "jest --passWithNoTests",
+    "test:integration": "jest --passWithNoTests -c jest-react-18.config.js",
     "start": "webpack-dev-server --mode=development"
   },
   "devDependencies": {
@@ -29,11 +30,16 @@
     "@fluentui/react-cards": "*",
     "@fluentui/react-hooks": "*",
     "@fluentui/react-examples": "*",
+    "@fluentui/font-icons-mdl2": "*",
+    "@testing-library/dom": "^10.1.0",
+    "@testing-library/react": "^16.0.0",
     "@types/react": "18.3.20",
     "@types/react-dom": "18.3.6",
     "cypress-real-events": "1.14.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
+    "react-test-renderer": "18.3.1",
+    "react-is": "18.3.1",
     "tslib": "^2.1.0"
   }
 }

--- a/apps/react-18-tests-v8/project.json
+++ b/apps/react-18-tests-v8/project.json
@@ -18,6 +18,10 @@
     "e2e:integration": {
       "dependsOn": [],
       "inputs": ["{projectRoot}/cypress-react-18.config.ts", "{workspaceRoot}/packages/react-examples/**/*.e2e.tsx?"]
+    },
+    "test:integration": {
+      "dependsOn": ["^build"],
+      "inputs": ["{projectRoot}/jest-react-18.config.js", "{workspaceRoot}/packages/react/**/*.(test|spec).tsx?"]
     }
   }
 }

--- a/apps/react-18-tests-v8/project.json
+++ b/apps/react-18-tests-v8/project.json
@@ -22,6 +22,10 @@
     "test:integration": {
       "dependsOn": ["^build"],
       "inputs": ["{projectRoot}/jest-react-18.config.js", "{workspaceRoot}/packages/react/**/*.(test|spec).tsx?"]
+    },
+    "build:integration": {
+      "dependsOn": ["^build"],
+      "inputs": ["{workspaceRoot}/packages/react/**/*.(test|spec).tsx?"]
     }
   }
 }

--- a/apps/react-18-tests-v8/src/components/ContextualMenu/ContextualMenuExample.test.tsx
+++ b/apps/react-18-tests-v8/src/components/ContextualMenu/ContextualMenuExample.test.tsx
@@ -22,6 +22,7 @@ describe('ContextualMenu in React 18', () => {
     expect(queryAllByRole('menu').length).toBe(0);
 
     const menuTrigger = getByRole('button');
+
     userEvent.click(menuTrigger);
 
     expect(queryAllByRole('menu').length).toBe(1);

--- a/apps/react-18-tests-v9/jest.config.js
+++ b/apps/react-18-tests-v9/jest.config.js
@@ -1,5 +1,7 @@
 // @ts-check
 
+const { join } = require('node:path');
+
 /**
  * @type {import('@jest/types').Config.InitialOptions}
  */
@@ -9,8 +11,11 @@ module.exports = {
   // Heads up!
   // Forces React to be resolved from the root node_modules to ensure the same instance is used across all packages
   moduleNameMapper: {
-    '^react$': '<rootDir>/node_modules/react',
-    '^react-dom$': '<rootDir>/node_modules/react-dom',
+    '^react$': join(__dirname, '/node_modules/react'),
+    '^react-dom$': join(__dirname, 'node_modules/react-dom'),
+    '^react-dom/test-utils$': join(__dirname, 'node_modules/react-dom/test-utils'),
+    '^react-test-renderer$': join(__dirname, 'node_modules/react-test-renderer'),
+    '^@testing-library/(react|dom)$': join(__dirname, 'node_modules/@testing-library/$1'),
   },
   transform: {
     '^.+\\.tsx?$': ['@swc/jest', {}],

--- a/apps/react-18-tests-v9/package.json
+++ b/apps/react-18-tests-v9/package.json
@@ -26,7 +26,6 @@
     "@fluentui/react-nav-preview": "*",
     "@testing-library/dom": "^10.1.0",
     "@testing-library/react": "^16.0.0",
-    "@testing-library/user-event": "^14.5.2",
     "@types/react": "18.3.20",
     "@types/react-dom": "18.3.6",
     "@types/react-test-renderer": "18.3.1",

--- a/apps/react-19-tests-v9/jest.config.js
+++ b/apps/react-19-tests-v9/jest.config.js
@@ -1,5 +1,7 @@
 // @ts-check
 
+const { join } = require('node:path');
+
 /**
  * @type {import('@jest/types').Config.InitialOptions}
  */
@@ -9,8 +11,11 @@ module.exports = {
   // Heads up!
   // Forces React to be resolved from the root node_modules to ensure the same instance is used across all packages
   moduleNameMapper: {
-    '^react$': '<rootDir>/node_modules/react',
-    '^react-dom$': '<rootDir>/node_modules/react-dom',
+    '^react$': join(__dirname, '/node_modules/react'),
+    '^react-dom$': join(__dirname, 'node_modules/react-dom'),
+    '^react-dom/test-utils$': join(__dirname, 'node_modules/react-dom/test-utils'),
+    '^react-test-renderer$': join(__dirname, 'node_modules/react-test-renderer'),
+    '^@testing-library/(react|dom)$': join(__dirname, 'node_modules/@testing-library/$1'),
   },
   transform: {
     '^.+\\.tsx?$': ['@swc/jest', {}],

--- a/apps/react-19-tests-v9/package.json
+++ b/apps/react-19-tests-v9/package.json
@@ -26,7 +26,6 @@
     "@fluentui/react-nav-preview": "*",
     "@testing-library/dom": "^10.1.0",
     "@testing-library/react": "^16.0.0",
-    "@testing-library/user-event": "^14.5.2",
     "@types/react": "19.1.1",
     "@types/react-dom": "19.1.2",
     "@types/react-test-renderer": "19.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -28,9 +28,9 @@
     tunnel "^0.0.6"
 
 "@adobe/css-tools@^4.0.1":
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.3.2.tgz#a6abc715fb6884851fca9dad37fc34739a04fd11"
-  integrity sha512-DA5a1C0gD/pLOvhv33YMrbf2FK3oUzwNl9oOJqE4XVjuEtt6XIakRcsd7eLiOSPkp1kTRQGICTA8cKra/vFbjw==
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.4.2.tgz#c836b1bd81e6d62cd6cdf3ee4948bcdce8ea79c8"
+  integrity sha512-baYZExFpsdkBNuvGKTKWCwKH57HRZLVtycZS05WTQNVOiXVSeAki3nU35zlRbToeMW8aHlJfyS+1C4BOv27q0A==
 
 "@ampproject/remapping@^2.2.0":
   version "2.2.0"
@@ -20004,15 +20004,15 @@ react-is@18.1.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.1.0.tgz#61aaed3096d30eacf2a2127118b5b41387d32a67"
   integrity sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==
 
+react-is@18.3.1, react-is@^18.0.0, react-is@^18.3.1:
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
+  integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
+
 react-is@^16.12.0, "react-is@^16.12.0 || ^17.0.0 || ^18.0.0", react-is@^16.13.1, react-is@^16.6.0, react-is@^16.6.3, react-is@^16.7.0, react-is@^16.9.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
-
-react-is@^18.0.0, react-is@^18.3.1:
-  version "18.3.1"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
-  integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
 
 react-is@^19.1.0:
   version "19.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4766,11 +4766,6 @@
   dependencies:
     "@babel/runtime" "^7.12.5"
 
-"@testing-library/user-event@^14.5.2":
-  version "14.6.1"
-  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.6.1.tgz#13e09a32d7a8b7060fe38304788ebf4197cd2149"
-  integrity sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==
-
 "@textlint/ast-node-types@^4.2.5":
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/@textlint/ast-node-types/-/ast-node-types-4.4.3.tgz#fdba16e8126cddc50f45433ce7f6c55e7829566c"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

- Needs enzyme removal https://github.com/microsoft/fluentui/pull/34270
- adds new `test:integration` target which executes against source test files in react 18 context
- setups jest testing against v8 `react` and `react-hooks` projects

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
