### PR TITLE
fix(react-tooltip): In StrictMode, Tooltip now shows correctly on elements that are focused when created

### DIFF
--- a/change/@fluentui-react-tooltip-9d7d2603-cf07-4314-b8fd-86700a7b7b46.json
+++ b/change/@fluentui-react-tooltip-9d7d2603-cf07-4314-b8fd-86700a7b7b46.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: In StrictMode, Tooltip now shows correctly on elements that are focused when created.",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tooltip/library/src/components/Tooltip/useTooltip.tsx
+++ b/packages/react-components/react-tooltip/library/src/components/Tooltip/useTooltip.tsx
@@ -97,12 +97,12 @@ export const useTooltip_unstable = (props: TooltipProps): TooltipState => {
   );
 
   // In StrictMode, the component may be unmounted while the visible delay timer is still pending.
-  // This effect will restart the timer upon remounting.
+  // Use an effect to restart the timer upon remounting.
   // See https://github.com/microsoft/fluentui/issues/34296
   React.useEffect(() => {
     if (pendingVisibleDelayRef.current) {
       const { ev, data, delayUntil } = pendingVisibleDelayRef.current;
-      setVisibleDelay(ev, data, delayUntil - Date.now());
+      setVisibleDelay(ev, data, Math.max(0, delayUntil - Date.now()));
     }
   }, [setVisibleDelay]);
 

--- a/packages/react-components/react-tooltip/library/src/components/Tooltip/useTooltip.tsx
+++ b/packages/react-components/react-tooltip/library/src/components/Tooltip/useTooltip.tsx
@@ -25,6 +25,15 @@ import { arrowHeight, tooltipBorderRadius } from './private/constants';
 import { Escape } from '@fluentui/keyboard-keys';
 
 /**
+ * The parameters to setVisibleDelay, to be stored in a ref while the timer is running.
+ */
+type PendingVisibleDelay = {
+  ev: React.PointerEvent<HTMLElement> | React.FocusEvent<HTMLElement> | undefined;
+  data: OnVisibleChangeData;
+  delayUntil: number;
+};
+
+/**
  * Create the state required to render Tooltip.
  *
  * The returned state can be modified with hooks such as useTooltipStyles_unstable,
@@ -53,10 +62,18 @@ export const useTooltip_unstable = (props: TooltipProps): TooltipState => {
     mountNode,
   } = props;
 
+  // Save the parameters to the setVisibleDelay, while the timer is running.
+  const pendingVisibleDelayRef = React.useRef<PendingVisibleDelay | undefined>(undefined);
+
+  const cancelVisibleDelay = React.useCallback(() => {
+    pendingVisibleDelayRef.current = undefined;
+    clearDelayTimeout();
+  }, [clearDelayTimeout]);
+
   const [visible, setVisibleInternal] = useControllableState({ state: props.visible, initialState: false });
   const setVisible = React.useCallback(
     (ev: React.PointerEvent<HTMLElement> | React.FocusEvent<HTMLElement> | undefined, data: OnVisibleChangeData) => {
-      clearDelayTimeout();
+      cancelVisibleDelay();
       setVisibleInternal(oldVisible => {
         if (data.visible !== oldVisible) {
           onVisibleChange?.(ev, data);
@@ -64,8 +81,30 @@ export const useTooltip_unstable = (props: TooltipProps): TooltipState => {
         return data.visible;
       });
     },
-    [clearDelayTimeout, setVisibleInternal, onVisibleChange],
+    [cancelVisibleDelay, setVisibleInternal, onVisibleChange],
   );
+
+  const setVisibleDelay = React.useCallback(
+    (
+      ev: React.PointerEvent<HTMLElement> | React.FocusEvent<HTMLElement> | undefined,
+      data: OnVisibleChangeData,
+      delay: number,
+    ) => {
+      pendingVisibleDelayRef.current = { ev, data, delayUntil: Date.now() + delay };
+      setDelayTimeout(() => setVisible(ev, data), delay);
+    },
+    [setDelayTimeout, setVisible],
+  );
+
+  // In StrictMode, the component may be unmounted while the visible delay timer is still pending.
+  // This effect will restart the timer upon remounting.
+  // See https://github.com/microsoft/fluentui/issues/34296
+  React.useEffect(() => {
+    if (pendingVisibleDelayRef.current) {
+      const { ev, data, delayUntil } = pendingVisibleDelayRef.current;
+      setVisibleDelay(ev, data, delayUntil - Date.now());
+    }
+  }, [setVisibleDelay]);
 
   const state: TooltipState = {
     withArrow,
@@ -169,13 +208,11 @@ export const useTooltip_unstable = (props: TooltipProps): TooltipState => {
       // Show immediately if another tooltip is already visible
       const delay = context.visibleTooltip ? 0 : state.showDelay;
 
-      setDelayTimeout(() => {
-        setVisible(ev, { visible: true });
-      }, delay);
+      setVisibleDelay(ev, { visible: true }, delay);
 
       ev.persist(); // Persist the event since the setVisible call will happen asynchronously
     },
-    [setDelayTimeout, setVisible, state.showDelay, context],
+    [setVisibleDelay, state.showDelay, context],
   );
 
   const isNavigatingWithKeyboard = useIsNavigatingWithKeyboard();
@@ -220,20 +257,18 @@ export const useTooltip_unstable = (props: TooltipProps): TooltipState => {
         ignoreNextFocusEventRef.current = targetDocument?.activeElement === ev.target;
       }
 
-      setDelayTimeout(() => {
-        setVisible(ev, { visible: false });
-      }, delay);
+      setVisibleDelay(ev, { visible: false }, delay);
 
       ev.persist(); // Persist the event since the setVisible call will happen asynchronously
     },
-    [setDelayTimeout, setVisible, state.hideDelay, targetDocument],
+    [setVisibleDelay, state.hideDelay, targetDocument],
   );
 
   // Cancel the hide timer when the mouse or focus enters the tooltip, and restart it when the mouse or focus leaves.
   // This keeps the tooltip visible when the mouse is moved over it, or it has focus within.
-  state.content.onPointerEnter = mergeCallbacks(state.content.onPointerEnter, clearDelayTimeout);
+  state.content.onPointerEnter = mergeCallbacks(state.content.onPointerEnter, cancelVisibleDelay);
   state.content.onPointerLeave = mergeCallbacks(state.content.onPointerLeave, onLeaveTrigger);
-  state.content.onFocus = mergeCallbacks(state.content.onFocus, clearDelayTimeout);
+  state.content.onFocus = mergeCallbacks(state.content.onFocus, cancelVisibleDelay);
   state.content.onBlur = mergeCallbacks(state.content.onBlur, onLeaveTrigger);
 
   const child = getTriggerChild(children);


### PR DESCRIPTION
## Previous Behavior

Tooltip uses a custom utilitiy `useTimeout` (`useBrowserTimer`) to manage the timer that delays showing the Tooltip. This utility creates the timer through an imperative function, but clears the timer in a useEffect cleanup function. This results in the tooltip never being shown if it is unmounted and remounted after the Tooltip was triggered but before it was shown. This can happen in StrictMode for a component that receives initial focus when it is created, such as a MenuItem.

## New Behavior

Add a ref that saves the arguments to the pending visibility change, whenever a delayed visibility change is triggered. Then, add a useEffect that runs when the component is mounted, and checks the ref to see if there is a pending change that was never completed. If so, restart the timer.

## Discussion

There are a number of different options for a fix here, with varying levels of impact on runtime performance. 

The fix in this PR has the least impact on runtime performance and behavior. However, it adds an additional suboptimal `useEffect` call to restart the timer on mount and "fix" the `useEffect` in `useBrowserTimer` that cancels the timer on unmount.

The "correct" fix would be to move the timer to be started and cleared entirely within a `useEffect`. Then use a state variable to track that the tooltip was triggered, which would cause the useEffect to be run upon re-rendering. Example code is below. This has a major drawback of re-rendering the tooltipped component any time the Tooltip timer is started or stopped, which happens on every pointerEnter, pointerLeave, focus, or blur event, _in addition to_ re-rendering whenever the tooltip shows or hides (and in React <=17, it actually adds two extra renders per show or hide, because state changes are not coalesced when using timers).

The net effect is that showing a tooltip goes from 1 re-render to 2 or 3 re-renders (same for hiding the tooltip), _and_ a quick mouseover/mouseout goes from 0 re-renders to 2-re-renders.

```ts
type PendingVisible = {
  ev: React.PointerEvent<HTMLElement> | React.FocusEvent<HTMLElement> | undefined;
  visible: boolean;
  delayUntil: number;
};
const [pendingVisible, setPendingVisible] = React.useState<PendingVisible | undefined>(undefined);

const setDelayedVisible = React.useCallback(
  (ev, visible, delay) => setPendingVisible({ ev, visible, delayUntil: Date.now() + delay }),
  [],
);

// Run the timer when there is a pending visible change
React.useEffect(() => {
  if (pendingVisible) {
    const { ev, visible, delayUntil } = pendingVisible;
    const delay = Math.max(0, delayUntil - Date.now());
    const id = targetWindow?.setTimeout(() => setVisible(ev, { visible }), delay);
    return () => {
      targetWindow?.clearTimeout(id);
    };
  }
}, [pendingVisible, targetWindow, setVisible]);
```

There are a few other possible fixes that involve moving the timer to be within a separate child component of the Tooltip. E.g. we could move all of the visibility state management into a new "TooltipContent" component that would replace the `div` currently used for the `content` slot. The major benefit to that would be that the tooltipped component would never have any re-renders caused by the tooltip (it currently re-renders once every time the tooltip shows or hides). Unfortunately that would most likely be a breaking change to the API of Tooltip, so it's not really an option for a bug fix.

## Related Issue(s)

- Fixes #34296
