### PR TITLE
fix(react-charting): set button role for event labels in line chart

### DIFF
--- a/change/@fluentui-react-charting-742b0fc0-7183-487c-ae50-b76bd8270a6d.json
+++ b/change/@fluentui-react-charting-742b0fc0-7183-487c-ae50-b76bd8270a6d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: set button role for event labels in line chart",
+  "packageName": "@fluentui/react-charting",
+  "email": "kumarkshitij@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charts/react-charting/src/components/LineChart/eventAnnotation/LabelLink.tsx
+++ b/packages/charts/react-charting/src/components/LineChart/eventAnnotation/LabelLink.tsx
@@ -73,7 +73,7 @@ export const LabelLink: React.FunctionComponent<ILabelLinkProps> = props => {
 
   return (
     <>
-      <g ref={gRef} onClick={onClick} data-is-focusable={true} style={{ cursor: 'pointer' }}>
+      <g ref={gRef} onClick={onClick} data-is-focusable={true} style={{ cursor: 'pointer' }} role="button">
         <Textbox
           text={text}
           x={props.labelDef.x}


### PR DESCRIPTION
## Previous Behavior

Screen reader does not announce the name or role for events in LineChart.

## New Behavior

Screen reader announces the event labels in LineChart and identifies them as buttons.