### PR TITLE
fix(r18-tests-v8): add all dependencies to properly run type-check:integration target agains public API within stories

### DIFF
--- a/apps/react-18-tests-v8/package.json
+++ b/apps/react-18-tests-v8/package.json
@@ -28,6 +28,7 @@
     "@fluentui/react": "*",
     "@fluentui/react-cards": "*",
     "@fluentui/react-hooks": "*",
+    "@fluentui/react-examples": "*",
     "@types/react": "18.3.20",
     "@types/react-dom": "18.3.6",
     "cypress-real-events": "1.14.0",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

v8 `type-check:integration` provides false positives

## New Behavior

v8 `type-check:integration` runs as expected against public API interface of v8 used within react-examples stories

<img width="763" alt="image" src="https://github.com/user-attachments/assets/5fe890e4-7c41-4b76-8d69-b50d8d6a15a9" />


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
