### PR TITLE
fix: Tab filled (not filled-subtle) appearance has border in WHCM

### DIFF
--- a/change/@fluentui-react-tabs-f8ad7559-f4e1-4c25-9c8b-910ddf5eabe0.json
+++ b/change/@fluentui-react-tabs-f8ad7559-f4e1-4c25-9c8b-910ddf5eabe0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Tab filled (not filled-subtle) appearance has border in WHCM",
+  "packageName": "@fluentui/react-tabs",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tabs/library/src/components/Tab/useTabStyles.styles.ts
+++ b/packages/react-components/react-tabs/library/src/components/Tab/useTabStyles.styles.ts
@@ -178,6 +178,7 @@ const useRootStyles = makeStyles({
 const useCircularAppearanceStyles = makeStyles({
   base: {
     borderRadius: tokens.borderRadiusCircular,
+    border: `solid ${tokens.strokeWidthThin} ${tokens.colorTransparentStroke}`,
     [`& .${tabClassNames.icon}`]: {
       color: 'inherit',
     },
@@ -190,7 +191,6 @@ const useCircularAppearanceStyles = makeStyles({
   },
   subtle: {
     backgroundColor: tokens.colorSubtleBackground,
-    border: `solid ${tokens.strokeWidthThin} transparent`,
     color: tokens.colorNeutralForeground2,
     ':enabled:hover': {
       backgroundColor: tokens.colorSubtleBackgroundHover,
@@ -201,6 +201,9 @@ const useCircularAppearanceStyles = makeStyles({
       backgroundColor: tokens.colorSubtleBackgroundPressed,
       border: `solid ${tokens.strokeWidthThin} ${tokens.colorNeutralStroke1Pressed}`,
       color: tokens.colorNeutralForeground2Pressed,
+    },
+    '@media (forced-colors: active)': {
+      border: `solid ${tokens.strokeWidthThin} Canvas`,
     },
   },
   subtleSelected: {
@@ -224,7 +227,6 @@ const useCircularAppearanceStyles = makeStyles({
   subtleDisabled: {
     backgroundColor: tokens.colorSubtleBackground,
     color: tokens.colorNeutralForegroundDisabled,
-    border: `solid ${tokens.strokeWidthThin} transparent`,
   },
   subtleDisabledSelected: {
     backgroundColor: tokens.colorNeutralBackgroundDisabled,
@@ -284,7 +286,6 @@ const useCircularAppearanceStyles = makeStyles({
   },
   filledDisabled: {
     backgroundColor: tokens.colorNeutralBackgroundDisabled,
-    border: `solid ${tokens.strokeWidthThin} transparent`,
     color: tokens.colorNeutralForegroundDisabled,
   },
   filledDisabledSelected: {


### PR DESCRIPTION
Related to #34294, it came up that it makes more sense for the filled variant to have a border in the unselected state than for filled-subtle to have one. Currently only filled-subtle has one because of the hover style.

## Previous Behavior
<img width="416" alt="Screenshot of the appearance variants in high contrast, showing the third variant filled-subtle, having borders on unselected tabs" src="https://github.com/user-attachments/assets/388b424b-8b49-41d4-bdb0-b594047531a4" />

## New Behavior
<img width="415" alt="Screenshot of the same variants, but the fourth variant, filled, has the borders and filled-subtle does not" src="https://github.com/user-attachments/assets/d0a35e50-23f7-4a19-9ea7-02a69c2d1240" />