### PR TITLE
feat(web-components): add endpoint for F2 token exports

### DIFF
--- a/change/@fluentui-web-components-90fcfd91-50b7-4219-8f26-726a1976519b.json
+++ b/change/@fluentui-web-components-90fcfd91-50b7-4219-8f26-726a1976519b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: add endpoint for f2 design token exports",
+  "packageName": "@fluentui/web-components",
+  "email": "rupertdavid@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -35,6 +35,10 @@
       "types": "./dist/dts/utils/index.d.ts",
       "default": "./dist/esm/utils/index.js"
     },
+    "./theme/*.js": {
+      "types": "./dist/dts/theme/*.d.ts",
+      "default": "./dist/esm/theme/*.js"
+    },
     "./*/base.js": {
       "types": "./dist/dts/*/*.base.d.ts",
       "default": "./dist/esm/*/*.base.js"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->
F2 tokens were only exported from `@fluentui/web-components` root index which caused challenges with linting rules that require Named Imports. Adding `@fluentui/web-components/index.js` then broke other build tools because that resolves to `/dist/esm/index/define.js` (which doesn't exist).

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

Add a `./theme/*.js` export rule to allow us to export `@fluentui/web-components/theme/design-tokens.js`

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
