### PR TITLE
test: replace `react-dom` apis with ReactTestingLibary in all v8 tests to make them work with react 18

### DIFF
--- a/change/@fluentui-react-62a81c04-c0d4-4d20-8748-5c1eb9cf408d.json
+++ b/change/@fluentui-react-62a81c04-c0d4-4d20-8748-5c1eb9cf408d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test: replace react-dom api with RTL to make tests compatible with react 18",
+  "packageName": "@fluentui/react",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-experiments/src/components/FloatingSuggestions/Suggestions/SuggestionsControl.test.tsx
+++ b/packages/react-experiments/src/components/FloatingSuggestions/Suggestions/SuggestionsControl.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
 
 import { SuggestionsControl } from './SuggestionsControl';
+import { render } from '@testing-library/react';
 
 const doNothing = () => {
   return;
@@ -12,8 +12,7 @@ const renderNothing = () => <></>;
 describe('Pickers', () => {
   describe('SuggestionsControl', () => {
     it('renders header/footer items with the provided className', () => {
-      const root = document.createElement('div');
-      ReactDOM.render(
+      const { container } = render(
         <SuggestionsControl
           headerItemsProps={[
             {
@@ -35,13 +34,10 @@ describe('Pickers', () => {
           onSuggestionClick={doNothing}
           onRenderSuggestion={renderNothing}
         />,
-        root,
       );
 
-      expect(root.querySelector('.header-item-wrapper .header-item-inner')).not.toBe(null);
-      expect(root.querySelector('.footer-item-wrapper .footer-item-inner')).not.toBe(null);
-
-      ReactDOM.unmountComponentAtNode(root);
+      expect(container.querySelector('.header-item-wrapper .header-item-inner')).not.toBe(null);
+      expect(container.querySelector('.footer-item-wrapper .footer-item-inner')).not.toBe(null);
     });
   });
 });

--- a/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsComposite.test.tsx
+++ b/packages/react-experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsComposite.test.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { create } from 'react-test-renderer';
 import { BaseFloatingSuggestions } from './FloatingSuggestions';
-import * as ReactDOM from 'react-dom';
-import * as ReactTestUtils from 'react-dom/test-utils';
+import { render, fireEvent } from '@testing-library/react';
 import type { IFloatingSuggestionItem } from './FloatingSuggestionsItem/FloatingSuggestionsItem.types';
 import type { IBaseFloatingSuggestionsProps } from './FloatingSuggestions.types';
 
@@ -11,7 +10,6 @@ export interface ISimple {
   name: string;
 }
 
-let container: HTMLDivElement | null;
 let _suggestions: IFloatingSuggestionItem<ISimple>[];
 
 const items: ISimple[] = [
@@ -25,8 +23,6 @@ const _onSuggestionRemoved = jest.fn();
 const picker = React.createRef<HTMLDivElement>();
 
 beforeEach(() => {
-  container = document.createElement('div');
-  document.body.appendChild(container);
   _suggestions = [
     {
       key: '1',
@@ -50,11 +46,6 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  if (container) {
-    document.body.removeChild(container);
-    ReactDOM.unmountComponentAtNode(container);
-    container = null;
-  }
   jest.clearAllMocks();
 });
 
@@ -91,32 +82,26 @@ describe('FloatingSuggestions', () => {
   });
 
   it('renders FloatingSuggestions with suggestions visible true', () => {
-    // Our functional tests need to run against actual DOM for callouts to work,
-    // since callout mount a new react root with ReactDOM.
-    //
-    // see https://github.com/facebook/react/pull/12895
-    ReactTestUtils.act(() => {
-      ReactDOM.render(
-        <BaseFloatingSuggestions
-          suggestions={_suggestions}
-          isSuggestionsVisible={true}
-          componentRef={picker}
-          targetElement={null}
-          suggestionsHeaderText={'People Test Suggestions'}
-          noResultsFoundText={'No Test Suggestions'}
-          onFloatingSuggestionsDismiss={undefined}
-          showSuggestionRemoveButton={true}
-          onSuggestionSelected={_onSuggestionSelected}
-          onRemoveSuggestion={_onSuggestionRemoved}
-        />,
-        container,
-      ) as unknown as IBaseFloatingSuggestionsProps<ISimple>;
-    });
+    // Using React Testing Library instead of ReactDOM
+    render(
+      <BaseFloatingSuggestions
+        suggestions={_suggestions}
+        isSuggestionsVisible={true}
+        componentRef={picker}
+        targetElement={null}
+        suggestionsHeaderText={'People Test Suggestions'}
+        noResultsFoundText={'No Test Suggestions'}
+        onFloatingSuggestionsDismiss={undefined}
+        showSuggestionRemoveButton={true}
+        onSuggestionSelected={_onSuggestionSelected}
+        onRemoveSuggestion={_onSuggestionRemoved}
+      />,
+    );
 
-    const floatingSuggestions = document.querySelector('.ms-FloatingSuggestions') as HTMLInputElement;
+    const floatingSuggestions = document.querySelector('.ms-FloatingSuggestions') as HTMLElement;
     expect(floatingSuggestions).toBeTruthy();
 
-    const callout = container?.getElementsByClassName('.ms-FloatingSuggestions-callout');
+    const callout = document.querySelector('.ms-FloatingSuggestions-callout');
     expect(callout).toBeTruthy();
 
     const suggestionsList = document.querySelectorAll('div[id^=FloatingSuggestionsItemId]');
@@ -130,58 +115,53 @@ describe('FloatingSuggestions', () => {
   });
 
   it('renders FloatingSuggestions and updates when suggestions are removed', () => {
-    ReactTestUtils.act(() => {
-      ReactDOM.render(
-        <BaseFloatingSuggestions
-          suggestions={_suggestions}
-          isSuggestionsVisible={true}
-          componentRef={picker}
-          targetElement={null}
-          suggestionsHeaderText={'People Test Suggestions'}
-          noResultsFoundText={'No Test Suggestions'}
-          onFloatingSuggestionsDismiss={undefined}
-          showSuggestionRemoveButton={true}
-          onSuggestionSelected={_onSuggestionSelected}
-          onRemoveSuggestion={_onSuggestionRemoved}
-        />,
-        container,
-      ) as unknown as IBaseFloatingSuggestionsProps<ISimple>;
-    });
+    render(
+      <BaseFloatingSuggestions
+        suggestions={_suggestions}
+        isSuggestionsVisible={true}
+        componentRef={picker}
+        targetElement={null}
+        suggestionsHeaderText={'People Test Suggestions'}
+        noResultsFoundText={'No Test Suggestions'}
+        onFloatingSuggestionsDismiss={undefined}
+        showSuggestionRemoveButton={true}
+        onSuggestionSelected={_onSuggestionSelected}
+        onRemoveSuggestion={_onSuggestionRemoved}
+      />,
+    );
 
     const suggestionListButtons = document.querySelectorAll('.ms-FloatingSuggestionsItem-itemButton');
     expect(suggestionListButtons.length).toEqual(2);
-    ReactTestUtils.Simulate.click(suggestionListButtons[0]);
-    ReactTestUtils.Simulate.click(suggestionListButtons[1]);
+    fireEvent.click(suggestionListButtons[0]);
+    fireEvent.click(suggestionListButtons[1]);
     expect(_onSuggestionSelected).toHaveBeenCalledTimes(2);
 
     const closeButtons = document.querySelectorAll('.ms-FloatingSuggestionsItem-closeButton');
     // There should be 2 close buttons for each suggestion.
     expect(closeButtons.length).toEqual(2);
 
-    ReactTestUtils.Simulate.click(closeButtons[0]);
+    fireEvent.click(closeButtons[0]);
     // On closing, suggestion removed should be called once.
     expect(_onSuggestionRemoved).toHaveBeenCalledTimes(1);
   });
 
   it('shows no suggestions when no suggestions are provided', () => {
     _suggestions = [];
-    ReactTestUtils.act(() => {
-      ReactDOM.render(
-        <BaseFloatingSuggestions
-          suggestions={_suggestions}
-          isSuggestionsVisible={true}
-          componentRef={picker}
-          targetElement={null}
-          suggestionsHeaderText={'People Test Suggestions'}
-          noResultsFoundText={'No Test Suggestions'}
-          onFloatingSuggestionsDismiss={undefined}
-          showSuggestionRemoveButton={true}
-          onSuggestionSelected={_onSuggestionSelected}
-          onRemoveSuggestion={_onSuggestionRemoved}
-        />,
-        container,
-      ) as unknown as IBaseFloatingSuggestionsProps<ISimple>;
-    });
+    render(
+      <BaseFloatingSuggestions
+        suggestions={_suggestions}
+        isSuggestionsVisible={true}
+        componentRef={picker}
+        targetElement={null}
+        suggestionsHeaderText={'People Test Suggestions'}
+        noResultsFoundText={'No Test Suggestions'}
+        onFloatingSuggestionsDismiss={undefined}
+        showSuggestionRemoveButton={true}
+        onSuggestionSelected={_onSuggestionSelected}
+        onRemoveSuggestion={_onSuggestionRemoved}
+      />,
+    );
+
     const suggestionsList = document.querySelectorAll('div[id^=FloatingSuggestionsItemId]');
     expect(suggestionsList.length).toEqual(0);
 

--- a/packages/react-focus/src/components/FocusZone/FocusZone.test.tsx
+++ b/packages/react-focus/src/components/FocusZone/FocusZone.test.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
+import { createPortal } from 'react-dom';
 import * as renderer from 'react-test-renderer';
-import * as ReactTestUtils from 'react-dom/test-utils';
+import { fireEvent, render } from '@testing-library/react';
+
 import { getCode, EnterKey } from '@fluentui/keyboard-key';
 import { setRTL, KeyCodes, resetIds } from '@fluentui/utilities';
 import { createTestContainer } from '@fluentui/test-utilities';
@@ -12,6 +13,13 @@ import { isConformant } from '../../common/isConformant';
 import type { IFocusZone } from './FocusZone.types';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
+
+function fireKeyDown(element: Element | HTMLElement, options: { which: number }): void {
+  fireEvent.keyDown(element, { which: options.which, keyCode: options.which });
+}
+function getFocusZone(container: HTMLElement) {
+  return container.firstChild!.firstChild;
+}
 
 describe('FocusZone', () => {
   let lastFocusedElement: HTMLElement | undefined;
@@ -24,7 +32,6 @@ describe('FocusZone', () => {
   afterEach(() => {
     lastFocusedElement = undefined;
     if (testContainer) {
-      ReactDOM.unmountComponentAtNode(testContainer);
       testContainer.remove();
       testContainer = undefined;
     }
@@ -63,7 +70,7 @@ describe('FocusZone', () => {
 
     element.setAttribute('data-is-visible', String(isVisible));
 
-    element.focus = () => ReactTestUtils.Simulate.focus(element);
+    element.focus = () => fireEvent.focus(element);
   }
 
   it('renders FocusZone correctly with no props', () => {
@@ -95,7 +102,7 @@ describe('FocusZone', () => {
   });
 
   it('can use arrows vertically', () => {
-    const component = ReactTestUtils.renderIntoDocument(
+    const { container } = render(
       <div {...{ onFocusCapture: _onFocus }}>
         <FocusZone direction={FocusZoneDirection.vertical}>
           <button className="a">a</button>
@@ -105,7 +112,7 @@ describe('FocusZone', () => {
       </div>,
     );
 
-    const focusZone = ReactDOM.findDOMNode(component as unknown as React.ReactInstance)!!.firstChild as Element;
+    const focusZone = container.firstChild!.firstChild as Element;
 
     const buttonA = focusZone.querySelector('.a') as HTMLElement;
     const buttonB = focusZone.querySelector('.b') as HTMLElement;
@@ -140,54 +147,54 @@ describe('FocusZone', () => {
     });
 
     // Focus the first button.
-    ReactTestUtils.Simulate.focus(buttonA);
+    fireEvent.focus(buttonA);
     expect(lastFocusedElement).toBe(buttonA);
 
     // Pressing down should go to b.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.down });
+    fireKeyDown(focusZone, { which: KeyCodes.down });
     expect(lastFocusedElement).toBe(buttonB);
 
     // Pressing down should go to c.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.down });
+    fireKeyDown(focusZone, { which: KeyCodes.down });
     expect(lastFocusedElement).toBe(buttonC);
 
     // Pressing down should stay on c.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.down });
+    fireKeyDown(focusZone, { which: KeyCodes.down });
     expect(lastFocusedElement).toBe(buttonC);
 
     // Pressing up should go to b.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.up });
+    fireKeyDown(focusZone, { which: KeyCodes.up });
     expect(lastFocusedElement).toBe(buttonB);
 
     // Pressing up should go to a.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.up });
+    fireKeyDown(focusZone, { which: KeyCodes.up });
     expect(lastFocusedElement).toBe(buttonA);
 
     // Pressing up should stay on a.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.up });
+    fireKeyDown(focusZone, { which: KeyCodes.up });
     expect(lastFocusedElement).toBe(buttonA);
 
     // Click on c to focus it.
-    ReactTestUtils.Simulate.focus(buttonC);
+    fireEvent.focus(buttonC);
     expect(lastFocusedElement).toBe(buttonC);
 
     // Pressing up should move to b.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.up });
+    fireKeyDown(focusZone, { which: KeyCodes.up });
     expect(lastFocusedElement).toBe(buttonB);
 
     // Test that pressing horizontal buttons don't move focus.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.left });
+    fireKeyDown(focusZone, { which: KeyCodes.left });
     expect(lastFocusedElement).toBe(buttonB);
 
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.right });
+    fireKeyDown(focusZone, { which: KeyCodes.right });
     expect(lastFocusedElement).toBe(buttonB);
 
     // Press home should go to the first target.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.home });
+    fireKeyDown(focusZone, { which: KeyCodes.home });
     expect(lastFocusedElement).toBe(buttonA);
 
     // // Press end should go to the last target.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.end });
+    fireKeyDown(focusZone, { which: KeyCodes.end });
     expect(lastFocusedElement).toBe(buttonC);
   });
 
@@ -195,7 +202,7 @@ describe('FocusZone', () => {
     testContainer = createTestContainer();
 
     // Render component.
-    ReactDOM.render(
+    render(
       <FocusZone>
         <button key="a" id="a" data-is-visible="true">
           button a
@@ -207,7 +214,7 @@ describe('FocusZone', () => {
           button c
         </button>
       </FocusZone>,
-      testContainer,
+      { container: testContainer },
     );
 
     const buttonB = testContainer.querySelector('#b') as HTMLElement;
@@ -215,7 +222,7 @@ describe('FocusZone', () => {
     buttonB.focus();
 
     // Render component without button A.
-    ReactDOM.render(
+    render(
       <FocusZone>
         <button key="a" id="a" data-is-visible="true">
           button a
@@ -224,7 +231,7 @@ describe('FocusZone', () => {
           button c
         </button>
       </FocusZone>,
-      testContainer,
+      { container: testContainer },
     );
 
     expect(document.activeElement).toBe(testContainer.querySelector('#c'));
@@ -235,7 +242,7 @@ describe('FocusZone', () => {
 
     let focusZone: FocusZone | null = null;
     // Render component.
-    ReactDOM.render(
+    render(
       <div key="-1">
         <button key="0" id="outer" data-is-visible="true">
           outer
@@ -252,7 +259,7 @@ describe('FocusZone', () => {
           </button>
         </FocusZone>
       </div>,
-      testContainer,
+      { container: testContainer },
     );
 
     const buttonOuter = testContainer.querySelector('#outer') as HTMLElement;
@@ -260,7 +267,7 @@ describe('FocusZone', () => {
     buttonOuter.focus();
 
     // Render component without button A.
-    ReactDOM.render(
+    render(
       <div key="-1">
         <button key="0" id="outer" data-is-visible="true">
           outer
@@ -274,7 +281,7 @@ describe('FocusZone', () => {
           </button>
         </FocusZone>
       </div>,
-      testContainer,
+      { container: testContainer },
     );
 
     expect(document.activeElement).toBe(testContainer.querySelector('#outer'));
@@ -287,7 +294,7 @@ describe('FocusZone', () => {
 
     let focusZone: FocusZone | null = null;
     // Render component.
-    ReactDOM.render(
+    render(
       <FocusZone key="fz" ref={focus => (focusZone = focus)}>
         <button key="a" id="a" data-is-visible="true">
           button a
@@ -299,14 +306,14 @@ describe('FocusZone', () => {
           button c
         </button>
       </FocusZone>,
-      testContainer,
+      { container: testContainer },
     );
 
     const buttonA = testContainer.querySelector('#a') as HTMLElement;
     buttonA.focus();
 
     // Render component without button A.
-    ReactDOM.render(
+    render(
       <FocusZone key="fz" ref={focus => (focusZone = focus)}>
         <button key="b" id="b" data-is-visible="true">
           button b
@@ -315,7 +322,7 @@ describe('FocusZone', () => {
           button c
         </button>
       </FocusZone>,
-      testContainer,
+      { container: testContainer },
     );
 
     expect(document.activeElement).toBe(testContainer.querySelector('#b'));
@@ -327,7 +334,7 @@ describe('FocusZone', () => {
     testContainer = createTestContainer();
 
     // Render component.
-    ReactDOM.render(
+    render(
       <FocusZone>
         <button key="a" id="a" data-is-visible="true">
           button a
@@ -339,7 +346,7 @@ describe('FocusZone', () => {
           button c
         </button>
       </FocusZone>,
-      testContainer,
+      { container: testContainer },
     );
 
     const buttonC = testContainer.querySelector('#c') as HTMLElement;
@@ -347,7 +354,7 @@ describe('FocusZone', () => {
     buttonC.focus();
 
     // Render component without button A.
-    ReactDOM.render(
+    render(
       <FocusZone>
         <button key="a" id="a" data-is-visible="true">
           button a
@@ -356,7 +363,7 @@ describe('FocusZone', () => {
           button b
         </button>
       </FocusZone>,
-      testContainer,
+      { container: testContainer },
     );
 
     expect(document.activeElement).toBe(testContainer.querySelector('#b'));
@@ -368,25 +375,25 @@ describe('FocusZone', () => {
     testContainer = createTestContainer();
 
     // Render component without button A.
-    ReactDOM.render(
+    const { unmount } = render(
       <FocusZone>
         <FocusZone>
           <button>ok</button>
         </FocusZone>
       </FocusZone>,
-      testContainer,
+      { container: testContainer },
     );
 
     expect(FocusZone.getOuterZones()).toEqual(activeZones + 1);
 
-    ReactDOM.unmountComponentAtNode(testContainer);
+    unmount();
 
     expect(FocusZone.getOuterZones()).toEqual(activeZones);
   });
 
   it('can call onActiveItemChanged when the active item is changed', () => {
     let called = false;
-    const component = ReactTestUtils.renderIntoDocument(
+    const { container } = render(
       <FocusZone onActiveElementChanged={() => (called = true)}>
         <button key="a" id="a" data-is-visible="true">
           button a
@@ -396,18 +403,18 @@ describe('FocusZone', () => {
         </button>
       </FocusZone>,
     );
-    const focusZone = ReactDOM.findDOMNode(component as unknown as React.ReactInstance)!!.firstChild as Element;
+    const focusZone = container.firstChild as Element;
     const buttonA = focusZone.querySelector('#a') as HTMLElement;
     const buttonB = focusZone.querySelector('#b') as HTMLElement;
 
-    ReactTestUtils.Simulate.mouseDown(focusZone, { target: buttonA });
-    ReactTestUtils.Simulate.focus(focusZone, { target: buttonA });
+    fireEvent.mouseDown(buttonA);
+    fireEvent.focus(buttonA);
 
     expect(called).toEqual(true);
     called = false;
 
-    ReactTestUtils.Simulate.mouseDown(focusZone, { target: buttonB });
-    ReactTestUtils.Simulate.focus(focusZone, { target: buttonB });
+    fireEvent.mouseDown(buttonB);
+    fireEvent.focus(buttonB);
 
     expect(called).toEqual(true);
     called = false;
@@ -415,10 +422,8 @@ describe('FocusZone', () => {
 
   describe('parking and unparking', () => {
     function setup() {
-      testContainer = createTestContainer();
-
       // Render component.
-      ReactDOM.render(
+      const { container, rerender } = render(
         <div>
           <button key="z" id="z" data-is-visible="true" />
           <FocusZone id="fz">
@@ -427,21 +432,19 @@ describe('FocusZone', () => {
             </button>
           </FocusZone>
         </div>,
-        testContainer,
       );
-      const buttonA = testContainer.querySelector('#a') as HTMLElement;
+      const buttonA = container.querySelector('#a') as HTMLElement;
       buttonA.focus();
 
       // Render component without button A.
-      ReactDOM.render(
+      rerender(
         <div>
           <button key="z" id="z" data-is-visible="true" />
           <FocusZone id="fz" />
         </div>,
-        testContainer,
       );
 
-      return testContainer;
+      return container;
     }
 
     it('can move focus to container when last item removed', () => {
@@ -453,7 +456,7 @@ describe('FocusZone', () => {
     it('can move focus from container to first item when added', () => {
       testContainer = setup();
 
-      ReactDOM.render(
+      render(
         <div>
           <button key="z" id="z" />
           <FocusZone id="fz">
@@ -462,7 +465,7 @@ describe('FocusZone', () => {
             </button>
           </FocusZone>
         </div>,
-        testContainer,
+        { container: testContainer },
       );
 
       expect(document.activeElement).toBe(testContainer.querySelector('#a'));
@@ -485,7 +488,7 @@ describe('FocusZone', () => {
 
       (testContainer.querySelector('#z') as HTMLElement).focus();
 
-      ReactDOM.render(
+      render(
         <div>
           <button key="z" id="z" />
           <FocusZone id="fz">
@@ -494,7 +497,7 @@ describe('FocusZone', () => {
             </button>
           </FocusZone>
         </div>,
-        testContainer,
+        { container: testContainer },
       );
 
       expect(document.activeElement).toBe(testContainer.querySelector('#z'));
@@ -502,7 +505,7 @@ describe('FocusZone', () => {
   });
 
   it('can ignore arrowing if default is prevented', () => {
-    const component = ReactTestUtils.renderIntoDocument(
+    const component = render(
       <div {...{ onFocusCapture: _onFocus }}>
         <FocusZone direction={FocusZoneDirection.vertical}>
           <button className="a">a</button>
@@ -511,7 +514,7 @@ describe('FocusZone', () => {
       </div>,
     );
 
-    const focusZone = ReactDOM.findDOMNode(component as unknown as React.ReactInstance)!!.firstChild as Element;
+    const focusZone = component.container.firstChild as Element;
 
     const buttonA = focusZone.querySelector('.a') as HTMLElement;
     const buttonB = focusZone.querySelector('.b') as HTMLElement;
@@ -536,16 +539,21 @@ describe('FocusZone', () => {
     });
 
     // Focus the first button.
-    ReactTestUtils.Simulate.focus(buttonA);
+    fireEvent.focus(buttonA);
+
     expect(lastFocusedElement).toBe(buttonA);
 
     // Pressing down should go to b.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.down, isDefaultPrevented: () => true } as any);
+    fireEvent.keyDown(focusZone, {
+      which: KeyCodes.down,
+      keyCode: KeyCodes.down,
+      isDefaultPrevented: true,
+    });
     expect(lastFocusedElement).toBe(buttonA);
   });
 
   it('can use arrows horizontally', () => {
-    const component = ReactTestUtils.renderIntoDocument(
+    const { container } = render(
       <div {...{ onFocusCapture: _onFocus }}>
         <FocusZone direction={FocusZoneDirection.horizontal}>
           <button className="a">a</button>
@@ -555,7 +563,7 @@ describe('FocusZone', () => {
       </div>,
     );
 
-    const focusZone = ReactDOM.findDOMNode(component as unknown as React.ReactInstance)!.firstChild as Element;
+    const focusZone = getFocusZone(container) as Element;
     const buttonA = focusZone.querySelector('.a') as HTMLElement;
     const buttonB = focusZone.querySelector('.b') as HTMLElement;
     const buttonC = focusZone.querySelector('.c') as HTMLElement;
@@ -589,59 +597,59 @@ describe('FocusZone', () => {
     });
 
     // Focus the first button.
-    ReactTestUtils.Simulate.focus(buttonA);
+    fireEvent.focus(buttonA);
     expect(lastFocusedElement).toBe(buttonA);
 
     // Pressing right should go to b.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.right });
+    fireKeyDown(focusZone, { which: KeyCodes.right });
     expect(lastFocusedElement).toBe(buttonB);
 
     // Pressing right should go to c.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.right });
+    fireKeyDown(focusZone, { which: KeyCodes.right });
     expect(lastFocusedElement).toBe(buttonC);
 
     // Pressing right should stay on c.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.right });
+    fireKeyDown(focusZone, { which: KeyCodes.right });
     expect(lastFocusedElement).toBe(buttonC);
 
     // Pressing left should go to b.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.left });
+    fireKeyDown(focusZone, { which: KeyCodes.left });
     expect(lastFocusedElement).toBe(buttonB);
 
     // Pressing left should go to a.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.left });
+    fireKeyDown(focusZone, { which: KeyCodes.left });
     expect(lastFocusedElement).toBe(buttonA);
 
     // Pressing left should stay on a.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.left });
+    fireKeyDown(focusZone, { which: KeyCodes.left });
     expect(lastFocusedElement).toBe(buttonA);
 
     // Click on c to focus it.
-    ReactTestUtils.Simulate.focus(buttonC);
+    fireEvent.focus(buttonC);
     expect(lastFocusedElement).toBe(buttonC);
 
     // Pressing left should move to b.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.left });
+    fireKeyDown(focusZone, { which: KeyCodes.left });
     expect(lastFocusedElement).toBe(buttonB);
 
     // Test that pressing vertical buttons don't move focus.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.up });
+    fireKeyDown(focusZone, { which: KeyCodes.up });
     expect(lastFocusedElement).toBe(buttonB);
 
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.down });
+    fireKeyDown(focusZone, { which: KeyCodes.down });
     expect(lastFocusedElement).toBe(buttonB);
 
     // Press home should go to the first target.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.home });
+    fireKeyDown(focusZone, { which: KeyCodes.home });
     expect(lastFocusedElement).toBe(buttonA);
 
     // // Press end should go to the last target.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.end });
+    fireKeyDown(focusZone, { which: KeyCodes.end });
     expect(lastFocusedElement).toBe(buttonC);
   });
 
   it('can use arrows bidirectionally', () => {
-    const component = ReactTestUtils.renderIntoDocument(
+    const { container } = render(
       <div {...{ onFocusCapture: _onFocus }}>
         <FocusZone>
           <button className="a">a</button>
@@ -654,7 +662,7 @@ describe('FocusZone', () => {
       </div>,
     );
 
-    const focusZone = ReactDOM.findDOMNode(component as unknown as React.ReactInstance)!.firstChild as Element;
+    const focusZone = getFocusZone(container) as Element;
     const buttonA = focusZone.querySelector('.a') as HTMLElement;
     const buttonB = focusZone.querySelector('.b') as HTMLElement;
     const buttonC = focusZone.querySelector('.c') as HTMLElement;
@@ -726,37 +734,37 @@ describe('FocusZone', () => {
     });
 
     // Focus the first button.
-    ReactTestUtils.Simulate.focus(buttonA);
+    fireEvent.focus(buttonA);
     expect(lastFocusedElement).toBe(buttonA);
 
     // Pressing right should go to b.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.right });
+    fireKeyDown(focusZone, { which: KeyCodes.right });
     expect(lastFocusedElement).toBe(buttonB);
 
     // Pressing down should go to c.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.down });
+    fireKeyDown(focusZone, { which: KeyCodes.down });
     expect(lastFocusedElement).toBe(buttonC);
 
     // Pressing down should go to e.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.down });
+    fireKeyDown(focusZone, { which: KeyCodes.down });
     expect(lastFocusedElement).toBe(buttonE);
 
     // Pressing left should go to d.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.left });
+    fireKeyDown(focusZone, { which: KeyCodes.left });
     expect(lastFocusedElement).toBe(buttonD);
 
     // Pressing up should go to c.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.up });
+    fireKeyDown(focusZone, { which: KeyCodes.up });
     expect(lastFocusedElement).toBe(buttonC);
 
     // Pressing up should go to a.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.up });
+    fireKeyDown(focusZone, { which: KeyCodes.up });
     expect(lastFocusedElement).toBe(buttonA);
   });
 
   it('can use arrows bidirectionally in RTL', () => {
     setRTL(true);
-    const component = ReactTestUtils.renderIntoDocument(
+    const { container } = render(
       <div {...{ onFocusCapture: _onFocus }}>
         <FocusZone>
           <button className="a">a</button>
@@ -769,7 +777,7 @@ describe('FocusZone', () => {
       </div>,
     );
 
-    const focusZone = ReactDOM.findDOMNode(component as unknown as React.ReactInstance)!.firstChild as Element;
+    const focusZone = getFocusZone(container) as Element;
     const buttonA = focusZone.querySelector('.a') as HTMLElement;
     const buttonB = focusZone.querySelector('.b') as HTMLElement;
     const buttonC = focusZone.querySelector('.c') as HTMLElement;
@@ -841,38 +849,38 @@ describe('FocusZone', () => {
     });
 
     // Focus the first button.
-    ReactTestUtils.Simulate.focus(buttonA);
+    fireEvent.focus(buttonA);
     expect(lastFocusedElement).toBe(buttonA);
 
     // Pressing left should go to b.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.left });
+    fireKeyDown(focusZone, { which: KeyCodes.left });
     expect(lastFocusedElement).toBe(buttonB);
 
     // Pressing down should go to c.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.down });
+    fireKeyDown(focusZone, { which: KeyCodes.down });
     expect(lastFocusedElement).toBe(buttonC);
 
     // Pressing down should go to e.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.down });
+    fireKeyDown(focusZone, { which: KeyCodes.down });
     expect(lastFocusedElement).toBe(buttonE);
 
     // Pressing right should go to d.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.right });
+    fireKeyDown(focusZone, { which: KeyCodes.right });
     expect(lastFocusedElement).toBe(buttonD);
 
     // Pressing up should go to c.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.up });
+    fireKeyDown(focusZone, { which: KeyCodes.up });
     expect(lastFocusedElement).toBe(buttonC);
 
     // Pressing up should go to a.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.up });
+    fireKeyDown(focusZone, { which: KeyCodes.up });
     expect(lastFocusedElement).toBe(buttonA);
 
     setRTL(false);
   });
 
   it('can focus correctly when receiving initial focus, bidirectionally', () => {
-    const component = ReactTestUtils.renderIntoDocument(
+    const { container } = render(
       <div {...{ onFocusCapture: _onFocus }}>
         <FocusZone>
           <button className="a">a</button>
@@ -883,7 +891,7 @@ describe('FocusZone', () => {
       </div>,
     );
 
-    const focusZone = ReactDOM.findDOMNode(component as unknown as React.ReactInstance)!.firstChild as Element;
+    const focusZone = getFocusZone(container) as Element;
     const buttonA = focusZone.querySelector('.a') as HTMLElement;
     const buttonB = focusZone.querySelector('.b') as HTMLElement;
     const buttonC = focusZone.querySelector('.c') as HTMLElement;
@@ -932,18 +940,18 @@ describe('FocusZone', () => {
     });
 
     // Focus the first button.
-    ReactTestUtils.Simulate.focus(buttonB);
+    fireEvent.focus(buttonB);
     expect(buttonA.getAttribute('tabindex')).toBe('-1');
     expect(buttonB.getAttribute('tabindex')).toBe('0');
     expect(lastFocusedElement).toBe(buttonB);
 
     // Pressing down should go to d.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.down });
+    fireKeyDown(focusZone, { which: KeyCodes.down });
     expect(lastFocusedElement).toBe(buttonD);
   });
 
   it('can use arrows bidirectionally with data-no-vertical-wrap', () => {
-    const component = ReactTestUtils.renderIntoDocument(
+    const { container } = render(
       <div {...{ onFocusCapture: _onFocus }}>
         <FocusZone checkForNoWrap={true} data-no-vertical-wrap={true}>
           <button className="a">a</button>
@@ -954,7 +962,7 @@ describe('FocusZone', () => {
       </div>,
     );
 
-    const focusZone = ReactDOM.findDOMNode(component as unknown as React.ReactInstance)!.firstChild as Element;
+    const focusZone = getFocusZone(container) as Element;
     const buttonA = focusZone.querySelector('.a') as HTMLElement;
     const buttonB = focusZone.querySelector('.b') as HTMLElement;
     const buttonC = focusZone.querySelector('.c') as HTMLElement;
@@ -1000,56 +1008,56 @@ describe('FocusZone', () => {
     });
 
     // Focus the first button.
-    ReactTestUtils.Simulate.focus(buttonA);
+    fireEvent.focus(buttonA);
     expect(lastFocusedElement).toBe(buttonA);
 
     // Pressing up should stay on a.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.up });
+    fireKeyDown(focusZone, { which: KeyCodes.up });
     expect(lastFocusedElement).toBe(buttonA);
 
     // Pressing left should stay on a.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.left });
+    fireKeyDown(focusZone, { which: KeyCodes.left });
     expect(lastFocusedElement).toBe(buttonA);
 
     // Pressing right should go to b.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.right });
+    fireKeyDown(focusZone, { which: KeyCodes.right });
     expect(lastFocusedElement).toBe(buttonB);
 
     // Pressing down should go to d.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.down });
+    fireKeyDown(focusZone, { which: KeyCodes.down });
     expect(lastFocusedElement).toBe(buttonD);
 
     // Pressing down stay on d.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.down });
+    fireKeyDown(focusZone, { which: KeyCodes.down });
     expect(lastFocusedElement).toBe(buttonD);
 
     // Pressing right stay on d.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.right });
+    fireKeyDown(focusZone, { which: KeyCodes.right });
     expect(lastFocusedElement).toBe(buttonD);
 
     // Pressing left should go to c.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.left });
+    fireKeyDown(focusZone, { which: KeyCodes.left });
     expect(lastFocusedElement).toBe(buttonC);
 
     // Pressing down should stay on c.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.down });
+    fireKeyDown(focusZone, { which: KeyCodes.down });
     expect(lastFocusedElement).toBe(buttonC);
 
     // Pressing left should go to b.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.left });
+    fireKeyDown(focusZone, { which: KeyCodes.left });
     expect(lastFocusedElement).toBe(buttonB);
 
     // Pressing up should stay on b.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.up });
+    fireKeyDown(focusZone, { which: KeyCodes.up });
     expect(lastFocusedElement).toBe(buttonB);
 
     // Pressing right should go to c.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.right });
+    fireKeyDown(focusZone, { which: KeyCodes.right });
     expect(lastFocusedElement).toBe(buttonC);
   });
 
   it('can use arrows bidirectionally with data-no-horizontal-wrap', () => {
-    const component = ReactTestUtils.renderIntoDocument(
+    const { container } = render(
       <div {...{ onFocusCapture: _onFocus }}>
         <FocusZone checkForNoWrap={true} data-no-horizontal-wrap={true}>
           <button className="a">a</button>
@@ -1060,7 +1068,7 @@ describe('FocusZone', () => {
       </div>,
     );
 
-    const focusZone = ReactDOM.findDOMNode(component as unknown as React.ReactInstance)!.firstChild as Element;
+    const focusZone = getFocusZone(container) as Element;
     const buttonA = focusZone.querySelector('.a') as HTMLElement;
     const buttonB = focusZone.querySelector('.b') as HTMLElement;
     const buttonC = focusZone.querySelector('.c') as HTMLElement;
@@ -1106,68 +1114,68 @@ describe('FocusZone', () => {
     });
 
     // Focus the first button.
-    ReactTestUtils.Simulate.focus(buttonA);
+    fireEvent.focus(buttonA);
     expect(lastFocusedElement).toBe(buttonA);
 
     // Pressing up should stay on a.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.up });
+    fireKeyDown(focusZone, { which: KeyCodes.up });
     expect(lastFocusedElement).toBe(buttonA);
 
     // Pressing left should stay on a.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.left });
+    fireKeyDown(focusZone, { which: KeyCodes.left });
     expect(lastFocusedElement).toBe(buttonA);
 
     // Pressing right should go to b.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.right });
+    fireKeyDown(focusZone, { which: KeyCodes.right });
     expect(lastFocusedElement).toBe(buttonB);
 
     // Pressing right should stay on b.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.right });
+    fireKeyDown(focusZone, { which: KeyCodes.right });
     expect(lastFocusedElement).toBe(buttonB);
 
     // Pressing down should go to d.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.down });
+    fireKeyDown(focusZone, { which: KeyCodes.down });
     expect(lastFocusedElement).toBe(buttonD);
 
     // Pressing down stay on d.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.down });
+    fireKeyDown(focusZone, { which: KeyCodes.down });
     expect(lastFocusedElement).toBe(buttonD);
 
     // Pressing right stay on d.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.right });
+    fireKeyDown(focusZone, { which: KeyCodes.right });
     expect(lastFocusedElement).toBe(buttonD);
 
     // Pressing left should go to c.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.left });
+    fireKeyDown(focusZone, { which: KeyCodes.left });
     expect(lastFocusedElement).toBe(buttonC);
 
     // Pressing left should stay on c.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.left });
+    fireKeyDown(focusZone, { which: KeyCodes.left });
     expect(lastFocusedElement).toBe(buttonC);
 
     // Pressing down should go to d.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.down });
+    fireKeyDown(focusZone, { which: KeyCodes.down });
     expect(lastFocusedElement).toBe(buttonD);
 
     // Pressing left should go to c.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.left });
+    fireKeyDown(focusZone, { which: KeyCodes.left });
     expect(lastFocusedElement).toBe(buttonC);
 
     // Pressing left should go to a.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.up });
+    fireKeyDown(focusZone, { which: KeyCodes.up });
     expect(lastFocusedElement).toBe(buttonA);
 
     // Pressing left should go to b.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.right });
+    fireKeyDown(focusZone, { which: KeyCodes.right });
     expect(lastFocusedElement).toBe(buttonB);
 
     // Pressing up should go to a.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.up });
+    fireKeyDown(focusZone, { which: KeyCodes.up });
     expect(lastFocusedElement).toBe(buttonA);
   });
 
   it('can reset alignment on mouse down', () => {
-    const component = ReactTestUtils.renderIntoDocument(
+    const { container } = render(
       <div {...{ onFocusCapture: _onFocus }}>
         <FocusZone>
           <button className="a">a</button>
@@ -1178,7 +1186,7 @@ describe('FocusZone', () => {
       </div>,
     );
 
-    const focusZone = ReactDOM.findDOMNode(component as unknown as React.ReactInstance)!.firstChild as Element;
+    const focusZone = getFocusZone(container) as Element;
     const buttonA = focusZone.querySelector('.a') as HTMLElement;
     const buttonB = focusZone.querySelector('.b') as HTMLElement;
     const buttonC = focusZone.querySelector('.c') as HTMLElement;
@@ -1224,35 +1232,35 @@ describe('FocusZone', () => {
     });
 
     // Focus the first button.
-    ReactTestUtils.Simulate.focus(buttonA);
+    fireEvent.focus(buttonA);
     expect(lastFocusedElement).toBe(buttonA);
 
     // Pressing up should stay on a.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.up });
+    fireKeyDown(focusZone, { which: KeyCodes.up });
     expect(lastFocusedElement).toBe(buttonA);
 
     // Pressing left should stay on a.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.left });
+    fireKeyDown(focusZone, { which: KeyCodes.left });
     expect(lastFocusedElement).toBe(buttonA);
 
     // Pressing right should go to b.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.right });
+    fireKeyDown(focusZone, { which: KeyCodes.right });
     expect(lastFocusedElement).toBe(buttonB);
 
     // Pressing down should go to d.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.down });
+    fireKeyDown(focusZone, { which: KeyCodes.down });
     expect(lastFocusedElement).toBe(buttonD);
 
     // Mousing down on a should reset alignment to a.
-    ReactTestUtils.Simulate.mouseDown(focusZone, { target: buttonA });
+    fireEvent.mouseDown(buttonA);
 
     // Pressing down should go to c.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.down });
+    fireKeyDown(focusZone, { which: KeyCodes.down });
     expect(lastFocusedElement).toBe(buttonC);
   });
 
   it('can use arrows bidirectionally with data-no-horizontal-wrap and data-no-vertical-wrap', () => {
-    const component = ReactTestUtils.renderIntoDocument(
+    const { container } = render(
       <div {...{ onFocusCapture: _onFocus }}>
         <FocusZone checkForNoWrap={true} data-no-horizontal-wrap={true} data-no-vertical-wrap={true}>
           <button className="a">a</button>
@@ -1263,7 +1271,7 @@ describe('FocusZone', () => {
       </div>,
     );
 
-    const focusZone = ReactDOM.findDOMNode(component as unknown as React.ReactInstance)!.firstChild as Element;
+    const focusZone = getFocusZone(container) as Element;
     const buttonA = focusZone.querySelector('.a') as HTMLElement;
     const buttonB = focusZone.querySelector('.b') as HTMLElement;
     const buttonC = focusZone.querySelector('.c') as HTMLElement;
@@ -1309,60 +1317,60 @@ describe('FocusZone', () => {
     });
 
     // Focus the first button.
-    ReactTestUtils.Simulate.focus(buttonA);
+    fireEvent.focus(buttonA);
     expect(lastFocusedElement).toBe(buttonA);
 
     // Pressing up should stay on a.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.up });
+    fireKeyDown(focusZone, { which: KeyCodes.up });
     expect(lastFocusedElement).toBe(buttonA);
 
     // Pressing left should stay on a.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.left });
+    fireKeyDown(focusZone, { which: KeyCodes.left });
     expect(lastFocusedElement).toBe(buttonA);
 
     // Pressing right should go to b.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.right });
+    fireKeyDown(focusZone, { which: KeyCodes.right });
     expect(lastFocusedElement).toBe(buttonB);
 
     // Pressing right should stay on b.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.right });
+    fireKeyDown(focusZone, { which: KeyCodes.right });
     expect(lastFocusedElement).toBe(buttonB);
 
     // Pressing up should stay on b.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.up });
+    fireKeyDown(focusZone, { which: KeyCodes.up });
     expect(lastFocusedElement).toBe(buttonB);
 
     // Pressing down should go to d.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.down });
+    fireKeyDown(focusZone, { which: KeyCodes.down });
     expect(lastFocusedElement).toBe(buttonD);
 
     // Pressing down stay on d.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.down });
+    fireKeyDown(focusZone, { which: KeyCodes.down });
     expect(lastFocusedElement).toBe(buttonD);
 
     // Pressing right stay on d.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.right });
+    fireKeyDown(focusZone, { which: KeyCodes.right });
     expect(lastFocusedElement).toBe(buttonD);
 
     // Pressing left should go to c.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.left });
+    fireKeyDown(focusZone, { which: KeyCodes.left });
     expect(lastFocusedElement).toBe(buttonC);
 
     // Pressing left should stay on c.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.left });
+    fireKeyDown(focusZone, { which: KeyCodes.left });
     expect(lastFocusedElement).toBe(buttonC);
 
     // Pressing down should stay on c.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.down });
+    fireKeyDown(focusZone, { which: KeyCodes.down });
     expect(lastFocusedElement).toBe(buttonC);
 
     // Pressing left should go to b.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.up });
+    fireKeyDown(focusZone, { which: KeyCodes.up });
     expect(lastFocusedElement).toBe(buttonA);
   });
 
   it('can use all arrows to move focus by following DOM order', () => {
-    const component = ReactTestUtils.renderIntoDocument(
+    const { container } = render(
       <div {...{ onFocusCapture: _onFocus }}>
         <FocusZone direction={FocusZoneDirection.domOrder}>
           <button className="a">a</button>
@@ -1372,7 +1380,7 @@ describe('FocusZone', () => {
       </div>,
     );
 
-    const focusZone = ReactDOM.findDOMNode(component as unknown as React.ReactInstance)!.firstChild as Element;
+    const focusZone = getFocusZone(container) as Element;
     const buttonA = focusZone.querySelector('.a') as HTMLElement;
     const buttonB = focusZone.querySelector('.b') as HTMLElement;
     const buttonC = focusZone.querySelector('.c') as HTMLElement;
@@ -1407,60 +1415,60 @@ describe('FocusZone', () => {
 
     // Pressing down/right arrow keys moves focus to the next focusable item.
     // Pressing up/left arrow keys moves focus to the previous focusable item.
-    ReactTestUtils.Simulate.focus(buttonA);
+    fireEvent.focus(buttonA);
     expect(lastFocusedElement).toBe(buttonA);
 
     // Pressing down should go to b.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.down });
+    fireKeyDown(focusZone, { which: KeyCodes.down });
     expect(lastFocusedElement).toBe(buttonB);
 
     // Pressing right should go to c.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.right });
+    fireKeyDown(focusZone, { which: KeyCodes.right });
     expect(lastFocusedElement).toBe(buttonC);
 
     // Pressing down should stay on c.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.down });
+    fireKeyDown(focusZone, { which: KeyCodes.down });
     expect(lastFocusedElement).toBe(buttonC);
 
     // Pressing up should go to b.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.up });
+    fireKeyDown(focusZone, { which: KeyCodes.up });
     expect(lastFocusedElement).toBe(buttonB);
 
     // Pressing left should go to a.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.left });
+    fireKeyDown(focusZone, { which: KeyCodes.left });
     expect(lastFocusedElement).toBe(buttonA);
 
     // Pressing left should stay on a.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.left });
+    fireKeyDown(focusZone, { which: KeyCodes.left });
     expect(lastFocusedElement).toBe(buttonA);
 
     // Click on c to focus it.
-    ReactTestUtils.Simulate.focus(buttonC);
+    fireEvent.focus(buttonC);
     expect(lastFocusedElement).toBe(buttonC);
 
     // Pressing up should move to b.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.up });
+    fireKeyDown(focusZone, { which: KeyCodes.up });
     expect(lastFocusedElement).toBe(buttonB);
 
     // Pressing left should move to a.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.left });
+    fireKeyDown(focusZone, { which: KeyCodes.left });
     expect(lastFocusedElement).toBe(buttonA);
 
     // Pressing right should move to b.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.right });
+    fireKeyDown(focusZone, { which: KeyCodes.right });
     expect(lastFocusedElement).toBe(buttonB);
 
     // Press home should go to the first target.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.home });
+    fireKeyDown(focusZone, { which: KeyCodes.home });
     expect(lastFocusedElement).toBe(buttonA);
 
     // Press end should go to the last target.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.end });
+    fireKeyDown(focusZone, { which: KeyCodes.end });
     expect(lastFocusedElement).toBe(buttonC);
   });
 
   it('correctly skips data-not-focusable elements', () => {
-    const component = ReactTestUtils.renderIntoDocument(
+    const { container } = render(
       <div {...{ onFocusCapture: _onFocus }}>
         <FocusZone>
           <button className="a">a</button>
@@ -1472,7 +1480,7 @@ describe('FocusZone', () => {
       </div>,
     );
 
-    const focusZone = ReactDOM.findDOMNode(component as unknown as React.ReactInstance)!.firstChild as Element;
+    const focusZone = getFocusZone(container) as Element;
     const buttonA = focusZone.querySelector('.a') as HTMLElement;
     const buttonB = focusZone.querySelector('.b') as HTMLElement;
     const buttonC = focusZone.querySelector('.c') as HTMLElement;
@@ -1512,22 +1520,22 @@ describe('FocusZone', () => {
     });
 
     // Focus the first button.
-    ReactTestUtils.Simulate.focus(buttonA);
+    fireEvent.focus(buttonA);
     expect(lastFocusedElement).toBe(buttonA);
 
     // Pressing right should go to b.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.down });
+    fireKeyDown(focusZone, { which: KeyCodes.down });
     expect(lastFocusedElement).toBe(buttonC);
 
     // Pressing down should go to c.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.up });
+    fireKeyDown(focusZone, { which: KeyCodes.up });
     expect(lastFocusedElement).toBe(buttonA);
   });
 
   it('skips subzone elements until manually entered', () => {
     const shouldEnterInnerZone = (e: React.KeyboardEvent<HTMLElement>): boolean => getCode(e) === EnterKey;
 
-    const component = ReactTestUtils.renderIntoDocument(
+    const { container } = render(
       <div {...{ onFocusCapture: _onFocus }}>
         <FocusZone direction={FocusZoneDirection.horizontal} shouldEnterInnerZone={shouldEnterInnerZone}>
           <button className="a">a</button>
@@ -1539,7 +1547,7 @@ describe('FocusZone', () => {
       </div>,
     );
 
-    const focusZone = ReactDOM.findDOMNode(component as unknown as React.ReactInstance)!.firstChild as Element;
+    const focusZone = getFocusZone(container) as Element;
 
     const buttonA = focusZone.querySelector('.a') as HTMLElement;
     const divB = focusZone.querySelector('.b') as HTMLElement;
@@ -1584,32 +1592,32 @@ describe('FocusZone', () => {
     });
 
     // Focus the first button.
-    ReactTestUtils.Simulate.focus(buttonA);
+    fireEvent.focus(buttonA);
     expect(lastFocusedElement).toBe(buttonA);
 
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.right });
+    fireKeyDown(focusZone, { which: KeyCodes.right });
     expect(lastFocusedElement).toBe(divB);
 
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.right });
+    fireKeyDown(focusZone, { which: KeyCodes.right });
     expect(lastFocusedElement).toBe(buttonC);
 
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.left });
+    fireKeyDown(focusZone, { which: KeyCodes.left });
     expect(lastFocusedElement).toBe(divB);
 
-    ReactTestUtils.Simulate.keyDown(divB, { which: KeyCodes.enter });
+    fireKeyDown(divB, { which: KeyCodes.enter });
     expect(lastFocusedElement).toBe(buttonB);
 
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.right });
+    fireKeyDown(focusZone, { which: KeyCodes.right });
     expect(lastFocusedElement).toBe(buttonC);
 
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.left });
+    fireKeyDown(focusZone, { which: KeyCodes.left });
     expect(lastFocusedElement).toBe(divB);
   });
 
   it('skips child focusZone elements until manually entered', () => {
     const shouldEnterInnerZone = (e: React.KeyboardEvent<HTMLElement>): boolean => getCode(e) === EnterKey;
 
-    const component = ReactTestUtils.renderIntoDocument(
+    const { container } = render(
       <div {...{ onFocusCapture: _onFocus }}>
         <FocusZone direction={FocusZoneDirection.horizontal} shouldEnterInnerZone={shouldEnterInnerZone}>
           <button className="a">a</button>
@@ -1621,7 +1629,7 @@ describe('FocusZone', () => {
       </div>,
     );
 
-    const focusZone = ReactDOM.findDOMNode(component as unknown as React.ReactInstance)!.firstChild as Element;
+    const focusZone = getFocusZone(container) as Element;
 
     const buttonA = focusZone.querySelector('.a') as HTMLElement;
     const divB = focusZone.querySelector('.b') as HTMLElement;
@@ -1666,25 +1674,25 @@ describe('FocusZone', () => {
     });
 
     // Focus the first button.
-    ReactTestUtils.Simulate.focus(buttonA);
+    fireEvent.focus(buttonA);
     expect(lastFocusedElement).toBe(buttonA);
 
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.right });
+    fireKeyDown(focusZone, { which: KeyCodes.right });
     expect(lastFocusedElement).toBe(divB);
 
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.right });
+    fireKeyDown(focusZone, { which: KeyCodes.right });
     expect(lastFocusedElement).toBe(buttonC);
 
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.left });
+    fireKeyDown(focusZone, { which: KeyCodes.left });
     expect(lastFocusedElement).toBe(divB);
 
-    ReactTestUtils.Simulate.keyDown(divB, { which: KeyCodes.enter });
+    fireKeyDown(divB, { which: KeyCodes.enter });
     expect(lastFocusedElement).toBe(buttonB);
 
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.right });
+    fireKeyDown(focusZone, { which: KeyCodes.right });
     expect(lastFocusedElement).toBe(buttonC);
 
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.left });
+    fireKeyDown(focusZone, { which: KeyCodes.left });
     expect(lastFocusedElement).toBe(divB);
   });
 
@@ -1692,7 +1700,7 @@ describe('FocusZone', () => {
     let focusZone: FocusZone | null = null;
     let buttonA: any;
     let buttonB: any;
-    const component = ReactTestUtils.renderIntoDocument(
+    const { container } = render(
       <div {...{ onFocusCapture: _onFocus }}>
         <textarea className="t" />
         <FocusZone
@@ -1720,7 +1728,7 @@ describe('FocusZone', () => {
       </div>,
     );
 
-    const rootNode = ReactDOM.findDOMNode(component as unknown as React.ReactInstance) as Element;
+    const rootNode = container as Element;
     const textArea = rootNode.children[0];
 
     setupElement(buttonA, {
@@ -1748,7 +1756,7 @@ describe('FocusZone', () => {
     buttonA.disabled = true;
 
     // Focus the text area, outside focus zone.
-    ReactTestUtils.Simulate.focus(textArea);
+    fireEvent.focus(textArea);
     expect(lastFocusedElement).toBe(textArea);
 
     // ButtonB should be focussed.
@@ -1759,7 +1767,7 @@ describe('FocusZone', () => {
   it('Focus is not affected by readOnly inputs with values', () => {
     const shouldEnterInnerZone = (e: React.KeyboardEvent<HTMLElement>): boolean => getCode(e) === EnterKey;
 
-    const component = ReactTestUtils.renderIntoDocument(
+    const { container } = render(
       <div {...{ onFocusCapture: _onFocus }}>
         <FocusZone shouldEnterInnerZone={shouldEnterInnerZone}>
           <input className="a" />
@@ -1769,7 +1777,7 @@ describe('FocusZone', () => {
       </div>,
     );
 
-    const focusZone = ReactDOM.findDOMNode(component as unknown as React.ReactInstance)!.firstChild as Element;
+    const focusZone = getFocusZone(container) as Element;
 
     const inputA = focusZone.querySelector('.a') as HTMLElement;
     const inputB = focusZone.querySelector('.b') as HTMLElement;
@@ -1802,14 +1810,14 @@ describe('FocusZone', () => {
       },
     });
 
-    ReactTestUtils.Simulate.focus(inputB);
+    fireEvent.focus(inputB);
     // Pressing right should go to c.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.right });
+    fireKeyDown(focusZone, { which: KeyCodes.right });
     expect(lastFocusedElement).toBe(inputC);
 
-    ReactTestUtils.Simulate.focus(inputB);
+    fireEvent.focus(inputB);
     // Pressing left from b should go back to a
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.left });
+    fireKeyDown(focusZone, { which: KeyCodes.left });
     expect(lastFocusedElement).toBe(inputA);
   });
 
@@ -1817,7 +1825,7 @@ describe('FocusZone', () => {
     let focusZone: FocusZone | null = null;
     let buttonA: HTMLButtonElement | null = null;
     let buttonB: HTMLButtonElement | null = null;
-    const component = ReactTestUtils.renderIntoDocument(
+    const { container } = render(
       <div {...{ onFocusCapture: _onFocus }}>
         <FocusZone
           ref={focus => {
@@ -1844,7 +1852,7 @@ describe('FocusZone', () => {
       </div>,
     );
 
-    const focusZoneElement = ReactDOM.findDOMNode(component as unknown as React.ReactInstance)!.firstChild as Element;
+    const focusZoneElement = getFocusZone(container) as Element;
     const buttonAElement = focusZoneElement.querySelector('.a') as HTMLElement;
 
     // HACK declare that elements are not null at this point.
@@ -1879,7 +1887,7 @@ describe('FocusZone', () => {
     expect(buttonB.tabIndex).toBe(-1);
 
     // Pressing right should go to b.
-    ReactTestUtils.Simulate.keyDown(focusZoneElement, { which: KeyCodes.right });
+    fireKeyDown(focusZoneElement, { which: KeyCodes.right });
     expect(lastFocusedElement).toBe(buttonB);
 
     expect(buttonA.tabIndex).toBe(-1);
@@ -1887,7 +1895,7 @@ describe('FocusZone', () => {
 
     // Clicking on A should enable its tab-index and disable others.
     // But it doesn't set focus (browser will do it in the default event handler)
-    ReactTestUtils.Simulate.mouseDown(buttonAElement);
+    fireEvent.mouseDown(buttonAElement);
     expect(lastFocusedElement).toBe(buttonB);
 
     expect(buttonA.tabIndex).toBe(0);
@@ -1896,7 +1904,7 @@ describe('FocusZone', () => {
 
   it('Changes our focus to the next button when we hit tab when focus zone allow tabbing', () => {
     const tabDownListener = jest.fn();
-    const component = ReactTestUtils.renderIntoDocument(
+    const { container } = render(
       <div {...{ onFocusCapture: _onFocus, onKeyDown: tabDownListener }}>
         <FocusZone {...{ handleTabKey: FocusZoneTabbableElements.all, isCircularNavigation: true }}>
           <button className="a">a</button>
@@ -1906,7 +1914,7 @@ describe('FocusZone', () => {
       </div>,
     );
 
-    const focusZone = ReactDOM.findDOMNode(component as unknown as React.ReactInstance)!.firstChild as Element;
+    const focusZone = getFocusZone(container) as Element;
 
     const buttonA = focusZone.querySelector('.a') as HTMLElement;
     const buttonB = focusZone.querySelector('.b') as HTMLElement;
@@ -1940,7 +1948,7 @@ describe('FocusZone', () => {
     });
 
     // ButtonA should be focussed.
-    ReactTestUtils.Simulate.focus(buttonA);
+    fireEvent.focus(buttonA);
     expect(lastFocusedElement).toBe(buttonA);
 
     expect(buttonA.tabIndex).toBe(0);
@@ -1948,7 +1956,7 @@ describe('FocusZone', () => {
     expect(buttonC.tabIndex).toBe(-1);
 
     // Pressing tab will shift focus to button B
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.tab });
+    fireKeyDown(focusZone, { which: KeyCodes.tab });
     expect(lastFocusedElement).toBe(buttonB);
 
     expect(buttonA.tabIndex).toBe(-1);
@@ -1956,7 +1964,7 @@ describe('FocusZone', () => {
     expect(buttonC.tabIndex).toBe(-1);
 
     // Pressing tab will shift focus to button C
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.tab });
+    fireKeyDown(focusZone, { which: KeyCodes.tab });
     expect(lastFocusedElement).toBe(buttonC);
 
     expect(buttonA.tabIndex).toBe(-1);
@@ -1964,7 +1972,7 @@ describe('FocusZone', () => {
     expect(buttonC.tabIndex).toBe(0);
 
     // Pressing tab on our final element will shift focus back to our first element A
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.tab });
+    fireKeyDown(focusZone, { which: KeyCodes.tab });
     expect(lastFocusedElement).toBe(buttonA);
 
     expect(buttonA.tabIndex).toBe(0);
@@ -1978,7 +1986,7 @@ describe('FocusZone', () => {
   it('detects tab when our focus zone does not allow tabbing', () => {
     const tabDownListener = jest.fn();
 
-    const component = ReactTestUtils.renderIntoDocument(
+    const { container } = render(
       <div {...{ onFocusCapture: _onFocus, onKeyDown: tabDownListener }}>
         <FocusZone>
           <button className="a">a</button>
@@ -1986,7 +1994,7 @@ describe('FocusZone', () => {
       </div>,
     );
 
-    const focusZone = ReactDOM.findDOMNode(component as unknown as React.ReactInstance)!.firstChild as Element;
+    const focusZone = getFocusZone(container) as Element;
 
     const buttonA = focusZone.querySelector('.a') as HTMLElement;
 
@@ -2000,12 +2008,12 @@ describe('FocusZone', () => {
     });
 
     // ButtonA should be focussed.
-    ReactTestUtils.Simulate.focus(buttonA);
+    fireEvent.focus(buttonA);
     expect(lastFocusedElement).toBe(buttonA);
     expect(buttonA.tabIndex).toBe(0);
 
     // Pressing tab when our focus zone doesn't allow tabbing should propagate our tab to our key down event handler
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.tab });
+    fireKeyDown(focusZone, { which: KeyCodes.tab });
     expect(tabDownListener.mock.calls.length).toBe(1);
     const onKeyDownEvent = tabDownListener.mock.calls[0][0];
     expect(onKeyDownEvent.which).toBe(KeyCodes.tab);
@@ -2013,7 +2021,7 @@ describe('FocusZone', () => {
 
   it('should stay in input box with arrow keys and exit with tab', () => {
     const tabDownListener = jest.fn();
-    const component = ReactTestUtils.renderIntoDocument(
+    const { container } = render(
       <div {...{ onFocusCapture: _onFocus, onKeyDown: tabDownListener }}>
         <FocusZone {...{ handleTabKey: FocusZoneTabbableElements.inputOnly, isCircularNavigation: false }}>
           <input type="text" className="a" />
@@ -2022,7 +2030,7 @@ describe('FocusZone', () => {
       </div>,
     );
 
-    const focusZone = ReactDOM.findDOMNode(component as unknown as React.ReactInstance)!.firstChild as Element;
+    const focusZone = getFocusZone(container) as Element;
 
     const inputA = focusZone.querySelector('.a') as HTMLElement;
     const buttonB = focusZone.querySelector('.b') as HTMLElement;
@@ -2050,20 +2058,20 @@ describe('FocusZone', () => {
     expect(lastFocusedElement).toBe(inputA);
 
     // When we hit right/left on the arrow key, we don't want to be able to leave focus on an input
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.right });
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.right });
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.right });
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.right });
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.right });
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.right });
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.right });
+    fireKeyDown(focusZone, { which: KeyCodes.right });
+    fireKeyDown(focusZone, { which: KeyCodes.right });
+    fireKeyDown(focusZone, { which: KeyCodes.right });
+    fireKeyDown(focusZone, { which: KeyCodes.right });
+    fireKeyDown(focusZone, { which: KeyCodes.right });
+    fireKeyDown(focusZone, { which: KeyCodes.right });
+    fireKeyDown(focusZone, { which: KeyCodes.right });
     expect(lastFocusedElement).toBe(inputA);
 
     expect(inputA.tabIndex).toBe(0);
     expect(buttonB.tabIndex).toBe(-1);
 
     // Pressing tab will be the only way for us to exit the focus zone
-    ReactTestUtils.Simulate.keyDown(inputA, { which: KeyCodes.tab });
+    fireKeyDown(inputA, { which: KeyCodes.tab });
     expect(lastFocusedElement).toBe(buttonB);
     expect(inputA.tabIndex).toBe(-1);
     expect(buttonB.tabIndex).toBe(0);
@@ -2072,7 +2080,7 @@ describe('FocusZone', () => {
   it(`focus should leave input box when arrow keys are pressed when tabbing is supported but
     shouldInputLoseFocusOnArrowKey callback method return true`, () => {
     const tabDownListener = jest.fn();
-    const component = ReactTestUtils.renderIntoDocument(
+    const { container } = render(
       <div {...{ onFocusCapture: _onFocus, onKeyDown: tabDownListener }}>
         <FocusZone
           {...{
@@ -2089,7 +2097,7 @@ describe('FocusZone', () => {
       </div>,
     );
 
-    const focusZone = ReactDOM.findDOMNode(component as unknown as React.ReactInstance)!.firstChild as Element;
+    const focusZone = getFocusZone(container) as Element;
 
     const inputA = focusZone.querySelector('.a') as HTMLElement;
     const buttonB = focusZone.querySelector('.b') as HTMLElement;
@@ -2117,7 +2125,7 @@ describe('FocusZone', () => {
     expect(lastFocusedElement).toBe(inputA);
 
     // Pressing arrow down, input should loose the focus and the button should get the focus
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.down });
+    fireKeyDown(focusZone, { which: KeyCodes.down });
     expect(lastFocusedElement).toBe(buttonB);
     expect(inputA.tabIndex).toBe(-1);
     expect(buttonB.tabIndex).toBe(0);
@@ -2125,7 +2133,7 @@ describe('FocusZone', () => {
 
   it('should call onKeyDown handler even within another FocusZone', () => {
     const keyDownHandler = jest.fn();
-    const component = ReactTestUtils.renderIntoDocument(
+    const { container } = render(
       <FocusZone>
         <FocusZone className="innerFocusZone" onKeyDown={keyDownHandler} data-is-focusable={true}>
           Inner Focus Zone
@@ -2133,26 +2141,26 @@ describe('FocusZone', () => {
       </FocusZone>,
     );
 
-    const focusZone = ReactDOM.findDOMNode(component as unknown as React.ReactInstance) as Element;
+    const focusZone = container as Element;
     const innerFocusZone = focusZone.querySelector('.innerFocusZone') as HTMLElement;
-    ReactTestUtils.Simulate.keyDown(innerFocusZone, { which: KeyCodes.del });
+    fireKeyDown(innerFocusZone, { which: KeyCodes.del });
 
     expect(keyDownHandler).toHaveBeenCalled();
   });
 
   it('should not set an element outside its DOM as its active element', () => {
     const focusZoneRef = React.createRef<IFocusZone>();
-    const component = ReactTestUtils.renderIntoDocument(
+    const { container } = render(
       <div>
         <FocusZone componentRef={focusZoneRef}>
           <button id="a">a</button>
           <button id="b">b</button>
-          {ReactDOM.createPortal(<div id="externalElement" tabIndex={0} />, window.document.body)}
+          {createPortal(<div id="externalElement" tabIndex={0} />, window.document.body)}
         </FocusZone>
       </div>,
     );
 
-    const parent = ReactDOM.findDOMNode(component as unknown as React.ReactInstance)! as Element;
+    const parent = container as Element;
     const externalElement = document.querySelector('#externalElement') as HTMLElement;
     const buttonA = parent.querySelector('#a') as HTMLElement;
 
@@ -2174,17 +2182,17 @@ describe('FocusZone', () => {
       },
     });
 
-    ReactTestUtils.Simulate.focus(buttonA);
+    fireEvent.focus(buttonA);
     // No public API to test active element. Therefore, we need to do an explicit cast.
     expect((focusZoneRef.current! as any)._activeElement.id).toBe('a');
-    ReactTestUtils.Simulate.focus(externalElement);
+    fireEvent.focus(externalElement);
     expect((focusZoneRef.current! as any)._activeElement.id).not.toBe('externalElement');
     expect((focusZoneRef.current! as any)._activeElement.id).toBe('a');
   });
 
   it('Handles focus moving to different targets in focus zone following DOM order and allowing tabbing', () => {
     const tabDownListener = jest.fn();
-    const component = ReactTestUtils.renderIntoDocument(
+    const { container } = render(
       <div {...{ onFocusCapture: _onFocus, onKeyDown: tabDownListener }}>
         <FocusZone direction={FocusZoneDirection.domOrder} handleTabKey={FocusZoneTabbableElements.all}>
           <button className="a">a</button>
@@ -2194,7 +2202,7 @@ describe('FocusZone', () => {
       </div>,
     );
 
-    const focusZone = ReactDOM.findDOMNode(component as unknown as React.ReactInstance)!.firstChild as Element;
+    const focusZone = getFocusZone(container) as Element;
 
     const buttonA = focusZone.querySelector('.a') as HTMLElement;
     const buttonB = focusZone.querySelector('.b') as HTMLElement;
@@ -2228,7 +2236,7 @@ describe('FocusZone', () => {
     });
 
     // ButtonA should be focussed.
-    ReactTestUtils.Simulate.focus(buttonA);
+    fireEvent.focus(buttonA);
     expect(lastFocusedElement).toBe(buttonA);
 
     expect(buttonA.tabIndex).toBe(0);
@@ -2236,7 +2244,7 @@ describe('FocusZone', () => {
     expect(buttonC.tabIndex).toBe(-1);
 
     // Pressing tab will shift focus to button B
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.tab });
+    fireKeyDown(focusZone, { which: KeyCodes.tab });
     expect(lastFocusedElement).toBe(buttonB);
 
     expect(buttonA.tabIndex).toBe(-1);
@@ -2244,7 +2252,7 @@ describe('FocusZone', () => {
     expect(buttonC.tabIndex).toBe(-1);
 
     // Pressing tab will shift focus to button C
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.tab });
+    fireKeyDown(focusZone, { which: KeyCodes.tab });
     expect(lastFocusedElement).toBe(buttonC);
 
     expect(buttonA.tabIndex).toBe(-1);
@@ -2257,7 +2265,7 @@ describe('FocusZone', () => {
 
   it('Focuses the last element in the FocusZone when the imperative focusLast method is used', () => {
     const focusZoneRef = React.createRef<IFocusZone>();
-    const component = ReactTestUtils.renderIntoDocument(
+    const { container } = render(
       <div {...{ onFocusCapture: _onFocus }}>
         <FocusZone
           componentRef={focusZoneRef}
@@ -2271,7 +2279,7 @@ describe('FocusZone', () => {
       </div>,
     );
 
-    const focusZone = ReactDOM.findDOMNode(component as unknown as React.ReactInstance)!.firstChild as Element;
+    const focusZone = getFocusZone(container) as Element;
 
     const buttonA = focusZone.querySelector('.a') as HTMLElement;
     const buttonB = focusZone.querySelector('.b') as HTMLElement;
@@ -2305,7 +2313,7 @@ describe('FocusZone', () => {
     });
 
     // ButtonA should be focussed.
-    ReactTestUtils.Simulate.focus(buttonA);
+    fireEvent.focus(buttonA);
     expect(lastFocusedElement).toBe(buttonA);
 
     expect(buttonA.tabIndex).toBe(0);
@@ -2322,13 +2330,13 @@ describe('FocusZone', () => {
   });
 
   it('has data-tabster=uncontrolled', () => {
-    const component = ReactTestUtils.renderIntoDocument(
+    const { container } = render(
       <FocusZone>
         <button>Button</button>
       </FocusZone>,
     );
 
-    const focusZone = ReactDOM.findDOMNode(component as unknown as React.ReactInstance) as Element;
+    const focusZone = container.firstChild as Element;
 
     expect(focusZone.getAttribute('data-tabster')).toBe('{"uncontrolled": {}}');
   });

--- a/packages/react-focus/src/components/FocusZone/FocusZone.test.tsx
+++ b/packages/react-focus/src/components/FocusZone/FocusZone.test.tsx
@@ -112,7 +112,7 @@ describe('FocusZone', () => {
       </div>,
     );
 
-    const focusZone = container.firstChild!.firstChild as Element;
+    const focusZone = getFocusZone(container) as Element;
 
     const buttonA = focusZone.querySelector('.a') as HTMLElement;
     const buttonB = focusZone.querySelector('.b') as HTMLElement;

--- a/packages/react-hooks/src/useBoolean.test.tsx
+++ b/packages/react-hooks/src/useBoolean.test.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { act } from 'react-dom/test-utils';
-import { render } from '@testing-library/react';
+import { render, act } from '@testing-library/react';
 import { useBoolean } from './useBoolean';
 import { validateHookValueNotChanged } from './testUtilities';
 import type { IUseBooleanCallbacks } from './useBoolean';

--- a/packages/react-hooks/src/useSetTimeout.test.tsx
+++ b/packages/react-hooks/src/useSetTimeout.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
+import { render, cleanup } from '@testing-library/react';
+
 import { useSetTimeout } from './useSetTimeout';
-import { safeMount } from '@fluentui/test-utilities';
 import { validateHookValueNotChanged } from './testUtilities';
 
 describe('useSetTimeout', () => {
@@ -17,6 +18,7 @@ describe('useSetTimeout', () => {
 
   afterEach(() => {
     timesCalled = 0;
+    cleanup();
   });
 
   const TestComponent = React.forwardRef((props: unknown, ref: React.Ref<{ clearTimeout: () => void }>) => {
@@ -35,21 +37,20 @@ describe('useSetTimeout', () => {
       timesCalled++;
     }, 0);
 
-    return <div />;
+    return <div data-testid="test-component" />;
   });
 
   it('updates value when mounted', () => {
-    safeMount(<TestComponent />, () => {
-      expect(timesCalled).toEqual(0);
+    render(<TestComponent />);
+    expect(timesCalled).toEqual(0);
 
-      jest.runOnlyPendingTimers();
+    jest.runOnlyPendingTimers();
 
-      expect(timesCalled).toEqual(1);
+    expect(timesCalled).toEqual(1);
 
-      jest.runOnlyPendingTimers();
+    jest.runOnlyPendingTimers();
 
-      expect(timesCalled).toEqual(1);
-    });
+    expect(timesCalled).toEqual(1);
   });
 
   validateHookValueNotChanged('returns the same callbacks each time', () => {
@@ -58,29 +59,27 @@ describe('useSetTimeout', () => {
   });
 
   it('does not execute the timeout when unmounted', () => {
-    safeMount(<TestComponent />, wrapper => {
-      expect(timesCalled).toEqual(0);
+    const { unmount } = render(<TestComponent />);
+    expect(timesCalled).toEqual(0);
 
-      wrapper.unmount();
+    unmount();
 
-      jest.runOnlyPendingTimers();
+    jest.runOnlyPendingTimers();
 
-      expect(timesCalled).toEqual(0);
-    });
+    expect(timesCalled).toEqual(0);
   });
 
   it('can cancel timeout', () => {
     const ref = React.createRef<{ clearTimeout: () => void }>();
-    safeMount(<TestComponent ref={ref} />, () => {
-      jest.runOnlyPendingTimers();
+    render(<TestComponent ref={ref} />);
+    jest.runOnlyPendingTimers();
 
-      expect(timesCalled).toEqual(1);
+    expect(timesCalled).toEqual(1);
 
-      ref.current!.clearTimeout();
+    ref.current!.clearTimeout();
 
-      jest.runOnlyPendingTimers();
+    jest.runOnlyPendingTimers();
 
-      expect(timesCalled).toEqual(1);
-    });
+    expect(timesCalled).toEqual(1);
   });
 });

--- a/packages/react-hooks/src/useUnmount.test.tsx
+++ b/packages/react-hooks/src/useUnmount.test.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import * as ReactTestUtils from 'react-dom/test-utils';
-import { render } from '@testing-library/react';
+import { render, act } from '@testing-library/react';
 import { useUnmount } from './useUnmount';
 
 describe('useUnmount', () => {
@@ -22,7 +21,7 @@ describe('useUnmount', () => {
     const { unmount } = render(<TestComponent />, { container });
     expect(onUnmount).toHaveBeenCalledTimes(0);
 
-    ReactTestUtils.act(() => {
+    act(() => {
       unmount();
     });
 

--- a/packages/react/src/common/testUtilities.ts
+++ b/packages/react/src/common/testUtilities.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
-import * as ReactTestUtils from 'react-dom/test-utils';
+import type * as ReactTestUtils from 'react-dom/test-utils';
+import { render } from '@testing-library/react';
 
 // v2 - avoiding usage of enzyme
 
@@ -32,8 +32,8 @@ export function delay(millisecond: number): Promise<void> {
 }
 
 export function renderIntoDocument(element: React.ReactElement<any>): HTMLElement {
-  const component = ReactTestUtils.renderIntoDocument(element);
-  const renderedDOM = ReactDOM.findDOMNode(component as React.ReactInstance);
+  const component = render(element);
+  const renderedDOM = component.container.firstChild;
   return renderedDOM as HTMLElement;
 }
 

--- a/packages/react/src/components/Button/Button.deprecated.test.tsx
+++ b/packages/react/src/components/Button/Button.deprecated.test.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
-
-import * as ReactTestUtils from 'react-dom/test-utils';
 import * as renderer from 'react-test-renderer';
 import { CompoundButton } from './CompoundButton/CompoundButton';
 import { resetIds, setWarningCallback } from '@fluentui/utilities';
+import { render } from '@testing-library/react';
 
 describe('Button', () => {
   beforeAll(() => {
@@ -36,15 +34,15 @@ describe('Button', () => {
 
   describe('DefaultButton', () => {
     it('applies the correct aria attributes', () => {
-      const button = ReactTestUtils.renderIntoDocument<any>(
+      const { container } = render(
         <CompoundButton description="Some awesome description" ariaDescription="Description on icon button">
           And this is the label
         </CompoundButton>,
       );
-      const renderedDOM = ReactDOM.findDOMNode(button as React.ReactInstance) as HTMLElement;
-      expect(renderedDOM.getAttribute('aria-label') === null);
-      expect(renderedDOM.getAttribute('aria-labelledby') === renderedDOM.querySelector('.ms-Button-label')!.id);
-      expect(renderedDOM.getAttribute('aria-describedby') === renderedDOM.querySelector('.ms-Button-description')!.id);
+
+      expect(container.getAttribute('aria-label') === null);
+      expect(container.getAttribute('aria-labelledby') === container.querySelector('.ms-Button-label')!.id);
+      expect(container.getAttribute('aria-describedby') === container.querySelector('.ms-Button-description')!.id);
     });
   });
 });

--- a/packages/react/src/components/ComboBox/ComboBox.test.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
 
 import { render, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -10,6 +9,13 @@ import { SelectableOptionMenuItemType } from '../../SelectableOption';
 import { resetIds } from '../../Utilities';
 import { ComboBox } from './ComboBox';
 import type { IComboBox, IComboBoxOption } from './ComboBox.types';
+
+jest.mock('react-dom', () => {
+  return {
+    ...jest.requireActual('react-dom'),
+    createPortal: jest.fn((node: any) => node),
+  };
+});
 
 const RENDER_OPTIONS: IComboBoxOption[] = [
   { key: 'header', text: 'Header', itemType: SelectableOptionMenuItemType.Header },
@@ -51,18 +57,8 @@ const RUSSIAN_OPTIONS: IComboBoxOption[] = [
 const returnUndefined = () => undefined;
 
 describe('ComboBox', () => {
-  const createPortal = ReactDOM.createPortal;
-
-  function mockCreatePortal() {
-    (ReactDOM as any).createPortal = (node: any) => node;
-  }
-
   beforeEach(() => {
     resetIds();
-  });
-
-  afterEach(() => {
-    (ReactDOM as any).createPortal = createPortal;
   });
 
   isConformant({
@@ -76,9 +72,6 @@ describe('ComboBox', () => {
   });
 
   it('Renders correctly when open', () => {
-    // Mock createPortal so that the options list ends up inside the wrapper for snapshotting.
-    mockCreatePortal();
-
     const ref = React.createRef<IComboBox>();
     const { container, getByRole } = render(
       <ComboBox options={RENDER_OPTIONS} defaultSelectedKey="2" componentRef={ref} />,
@@ -88,7 +81,6 @@ describe('ComboBox', () => {
   });
 
   it('Renders correctly when opened in multi-select mode', () => {
-    mockCreatePortal();
     const ref = React.createRef<IComboBox>();
     const { container, getByRole } = render(
       <ComboBox multiSelect options={RENDER_OPTIONS} defaultSelectedKey="2" componentRef={ref} />,

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.deprecated.test.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.deprecated.test.tsx
@@ -1,12 +1,11 @@
 import * as React from 'react';
-import * as ReactTestUtils from 'react-dom/test-utils';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { KeyCodes, setWarningCallback } from '../../Utilities';
 import { ContextualMenu } from './ContextualMenu';
 import { ContextualMenuItemType } from './ContextualMenu.types';
-import { render, screen } from '@testing-library/react';
 import { getItemClassNames } from './ContextualMenu.classNames';
 import { createTheme } from '../../Styling';
-import type { IContextualMenuProps, IContextualMenuItem } from './ContextualMenu.types';
+import type { IContextualMenuItem } from './ContextualMenu.types';
 import type { IMenuItemClassNames } from './ContextualMenu.classNames';
 
 let customClassNames: () => IMenuItemClassNames;
@@ -43,12 +42,8 @@ describe('ContextualMenu', () => {
   });
 
   afterEach(() => {
-    for (let i = 0; i < document.body.children.length; i++) {
-      if (document.body.children[i].tagName === 'DIV') {
-        document.body.removeChild(document.body.children[i]);
-        i--;
-      }
-    }
+    // Clean up any rendered elements
+    document.body.innerHTML = '';
   });
 
   it('includes the classNames on ContextualMenuItem(s)', () => {
@@ -68,9 +63,7 @@ describe('ContextualMenu', () => {
       };
     };
 
-    ReactTestUtils.renderIntoDocument<IContextualMenuProps>(
-      <ContextualMenu items={items} getMenuClassNames={getClassNames} title="Menu!" />,
-    );
+    render(<ContextualMenu items={items} getMenuClassNames={getClassNames} title="Menu!" />);
 
     const container = document.querySelector('.containerFoo') as HTMLElement;
     const rootEl = document.querySelector('.rootFoo') as HTMLElement;
@@ -113,9 +106,7 @@ describe('ContextualMenu', () => {
       },
     ];
 
-    ReactTestUtils.act(() => {
-      ReactTestUtils.renderIntoDocument<IContextualMenuProps>(<ContextualMenu items={items} />);
-    });
+    render(<ContextualMenu items={items} />);
 
     const splitContainerEl = document.querySelector('.splitContainerFoo') as HTMLElement;
     const splitPrimaryEl = document.querySelector('.splitPrimaryFoo') as HTMLElement;
@@ -142,9 +133,7 @@ describe('ContextualMenu', () => {
       },
     ];
 
-    ReactTestUtils.act(() => {
-      ReactTestUtils.renderIntoDocument<IContextualMenuProps>(<ContextualMenu items={items} />);
-    });
+    render(<ContextualMenu items={items} />);
 
     const checkmarkIconEl = document.querySelector('.checkmarkIconFoo') as HTMLElement;
 
@@ -164,9 +153,7 @@ describe('ContextualMenu', () => {
       },
     ];
 
-    ReactTestUtils.act(() => {
-      ReactTestUtils.renderIntoDocument<IContextualMenuProps>(<ContextualMenu items={items} />);
-    });
+    render(<ContextualMenu items={items} />);
 
     const iconEl = document.querySelector('.iconFoo') as HTMLElement;
 
@@ -186,9 +173,7 @@ describe('ContextualMenu', () => {
       },
     ];
 
-    ReactTestUtils.act(() => {
-      ReactTestUtils.renderIntoDocument<IContextualMenuProps>(<ContextualMenu items={items} />);
-    });
+    render(<ContextualMenu items={items} />);
 
     const dividerEl = document.querySelector('.dividerFoo') as HTMLElement;
 
@@ -208,9 +193,7 @@ describe('ContextualMenu', () => {
       },
     ];
 
-    ReactTestUtils.act(() => {
-      ReactTestUtils.renderIntoDocument<IContextualMenuProps>(<ContextualMenu items={items} />);
-    });
+    render(<ContextualMenu items={items} />);
 
     const secondaryTextEl = document.querySelector('.secondaryTextFoo') as HTMLElement;
 
@@ -227,9 +210,7 @@ describe('ContextualMenu', () => {
       },
     ];
 
-    ReactTestUtils.act(() => {
-      ReactTestUtils.renderIntoDocument<IContextualMenuProps>(<ContextualMenu items={items} />);
-    });
+    render(<ContextualMenu items={items} />);
 
     const itemEl = document.querySelector('.itemFoo') as HTMLElement;
     const rootEl = document.querySelector('.rootFoo') as HTMLElement;
@@ -257,14 +238,10 @@ describe('ContextualMenu', () => {
       },
     ];
 
-    ReactTestUtils.act(() => {
-      ReactTestUtils.renderIntoDocument<IContextualMenuProps>(<ContextualMenu items={items} />);
-    });
+    render(<ContextualMenu items={items} />);
 
     const menuItem = document.querySelector('button.ms-ContextualMenu-link') as HTMLButtonElement;
-    ReactTestUtils.act(() => {
-      ReactTestUtils.Simulate.keyDown(menuItem, { which: KeyCodes.right });
-    });
+    fireEvent.keyDown(menuItem, { key: 'ArrowRight', which: KeyCodes.right, keyCode: KeyCodes.right });
 
     expect(document.querySelector('.SubMenuClass')).toBeTruthy();
   });

--- a/packages/react/src/components/ContextualMenu/ContextualMenu.test.tsx
+++ b/packages/react/src/components/ContextualMenu/ContextualMenu.test.tsx
@@ -1,22 +1,17 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import * as ReactTestUtils from 'react-dom/test-utils';
+import * as renderer from 'react-test-renderer';
+import { act, render, fireEvent } from '@testing-library/react';
+import { resetIds } from '@fluentui/utilities';
+import { createTestContainer } from '@fluentui/test-utilities';
 import { KeyCodes } from '../../Utilities';
 import { FocusZoneDirection } from '../../FocusZone';
-import * as renderer from 'react-test-renderer';
 import { ContextualMenu } from './ContextualMenu';
 import { canAnyMenuItemsCheck } from './ContextualMenu.base';
 import { ContextualMenuItemType } from './ContextualMenu.types';
 import { DefaultButton } from '../../Button';
-import { resetIds } from '@fluentui/utilities';
-import { createTestContainer } from '@fluentui/test-utilities';
 import { isConformant } from '../../common/isConformant';
-import type {
-  IContextualMenuProps,
-  IContextualMenuStyles,
-  IContextualMenu,
-  IContextualMenuItem,
-} from './ContextualMenu.types';
+import type { IContextualMenuStyles, IContextualMenu, IContextualMenuItem } from './ContextualMenu.types';
 import type { IContextualMenuRenderItem, IContextualMenuItemStyles } from './ContextualMenuItem.types';
 import type { IButton } from '../../Button';
 
@@ -28,7 +23,7 @@ describe('ContextualMenu', () => {
         i--;
       }
     }
-    ReactTestUtils.act(() => {
+    act(() => {
       jest.useRealTimers();
       jest.restoreAllMocks();
     });
@@ -55,8 +50,8 @@ describe('ContextualMenu', () => {
       { text: 'Later Today', key: 'Today', secondaryText: '7:00 PM', ariaLabel: 'foo' },
     ];
 
-    ReactTestUtils.act(() => {
-      ReactTestUtils.renderIntoDocument<IContextualMenuProps>(<ContextualMenu items={items} />);
+    act(() => {
+      render(<ContextualMenu items={items} />);
     });
 
     const menuItemButtonEl = document.querySelector('.ms-ContextualMenu-link') as HTMLButtonElement;
@@ -71,8 +66,8 @@ describe('ContextualMenu', () => {
   it('by default aria-label is undefined per ContextualMenuItem', () => {
     const items: IContextualMenuItem[] = [{ text: 'Later Today', key: 'Today', secondaryText: '7:00 PM' }];
 
-    ReactTestUtils.act(() => {
-      ReactTestUtils.renderIntoDocument<IContextualMenuProps>(<ContextualMenu items={items} />);
+    act(() => {
+      render(<ContextualMenu items={items} />);
     });
 
     const menuItemButtonEl = document.querySelector('.ms-ContextualMenu-link') as HTMLButtonElement;
@@ -84,8 +79,8 @@ describe('ContextualMenu', () => {
   it('renders secondary text if provided per ContextualMenuItem', () => {
     const items: IContextualMenuItem[] = [{ text: 'Later Today', key: 'Today', secondaryText: 'foo' }];
 
-    ReactTestUtils.act(() => {
-      ReactTestUtils.renderIntoDocument<IContextualMenuProps>(<ContextualMenu items={items} />);
+    act(() => {
+      render(<ContextualMenu items={items} />);
     });
 
     const menuItemPrimaryText = document.querySelector('.ms-ContextualMenu-itemText') as HTMLSpanElement;
@@ -103,8 +98,8 @@ describe('ContextualMenu', () => {
       { text: 'TestText 4', key: 'TestKey4', canCheck: true, isChecked: true },
     ];
 
-    ReactTestUtils.act(() => {
-      ReactTestUtils.renderIntoDocument<IContextualMenuProps>(<ContextualMenu items={items} />);
+    act(() => {
+      render(<ContextualMenu items={items} />);
     });
 
     const menuList = document.querySelector('.ms-ContextualMenu-list') as HTMLUListElement;
@@ -122,15 +117,13 @@ describe('ContextualMenu', () => {
 
     const onDismissSpy = jest.fn();
 
-    ReactTestUtils.act(() => {
-      ReactTestUtils.renderIntoDocument<IContextualMenuProps>(
-        <ContextualMenu items={items} isSubMenu={true} onDismiss={onDismissSpy} />,
-      );
+    act(() => {
+      render(<ContextualMenu items={items} isSubMenu={true} onDismiss={onDismissSpy} />);
     });
 
     const menuList = document.querySelector('ul.ms-ContextualMenu-list') as HTMLUListElement;
-    ReactTestUtils.act(() => {
-      ReactTestUtils.Simulate.keyDown(menuList, { which: KeyCodes.left });
+    act(() => {
+      fireEvent.keyDown(menuList, { which: KeyCodes.left, keyCode: KeyCodes.left });
     });
 
     expect(onDismissSpy).toHaveBeenCalled();
@@ -146,16 +139,14 @@ describe('ContextualMenu', () => {
 
     const onDismissSpy = jest.fn();
 
-    ReactTestUtils.act(() => {
-      ReactTestUtils.renderIntoDocument<IContextualMenuProps>(
-        <ContextualMenu items={items} onDismiss={onDismissSpy} />,
-      );
+    act(() => {
+      render(<ContextualMenu items={items} onDismiss={onDismissSpy} />);
     });
 
     const menuList = document.querySelector('ul.ms-ContextualMenu-list') as HTMLUListElement;
-    ReactTestUtils.act(() => {
-      ReactTestUtils.Simulate.keyDown(menuList, { which: KeyCodes.alt });
-      ReactTestUtils.Simulate.keyUp(menuList, { which: KeyCodes.alt });
+    act(() => {
+      fireEvent.keyDown(menuList, { which: KeyCodes.alt, keyCode: KeyCodes.alt });
+      fireEvent.keyUp(menuList, { which: KeyCodes.alt, keyCode: KeyCodes.alt });
     });
 
     expect(onDismissSpy).toHaveBeenCalled();
@@ -171,15 +162,13 @@ describe('ContextualMenu', () => {
 
     const onDismissSpy = jest.fn();
 
-    ReactTestUtils.act(() => {
-      ReactTestUtils.renderIntoDocument<IContextualMenuProps>(
-        <ContextualMenu items={items} onDismiss={onDismissSpy} />,
-      );
+    act(() => {
+      render(<ContextualMenu items={items} onDismiss={onDismissSpy} />);
     });
 
     const menuList = document.querySelector('ul.ms-ContextualMenu-list') as HTMLUListElement;
-    ReactTestUtils.act(() => {
-      ReactTestUtils.Simulate.keyDown(menuList, { which: KeyCodes.up, altKey: true });
+    act(() => {
+      fireEvent.keyDown(menuList, { which: KeyCodes.up, keyCode: KeyCodes.up, altKey: true });
     });
 
     expect(onDismissSpy).toHaveBeenCalled();
@@ -195,15 +184,13 @@ describe('ContextualMenu', () => {
 
     const onDismissSpy = jest.fn();
 
-    ReactTestUtils.act(() => {
-      ReactTestUtils.renderIntoDocument<IContextualMenuProps>(
-        <ContextualMenu items={items} onDismiss={onDismissSpy} />,
-      );
+    act(() => {
+      render(<ContextualMenu items={items} onDismiss={onDismissSpy} />);
     });
 
     const menuList = document.querySelector('ul.ms-ContextualMenu-list') as HTMLUListElement;
-    ReactTestUtils.act(() => {
-      ReactTestUtils.Simulate.keyDown(menuList, { which: KeyCodes.escape });
+    act(() => {
+      fireEvent.keyDown(menuList, { which: KeyCodes.escape, keyCode: KeyCodes.escape });
     });
 
     expect(onDismissSpy).toHaveBeenCalled();
@@ -219,18 +206,16 @@ describe('ContextualMenu', () => {
 
     const onDismissSpy = jest.fn();
 
-    ReactTestUtils.act(() => {
-      ReactTestUtils.renderIntoDocument<IContextualMenuProps>(
-        <ContextualMenu items={items} onDismiss={onDismissSpy} />,
-      );
+    act(() => {
+      render(<ContextualMenu items={items} onDismiss={onDismissSpy} />);
     });
 
     const menuList = document.querySelector('ul.ms-ContextualMenu-list') as HTMLUListElement;
-    ReactTestUtils.act(() => {
-      ReactTestUtils.Simulate.keyDown(menuList, { which: KeyCodes.alt });
-      ReactTestUtils.Simulate.keyDown(menuList, { which: KeyCodes.a, altKey: true });
-      ReactTestUtils.Simulate.keyUp(menuList, { which: KeyCodes.a, altKey: true });
-      ReactTestUtils.Simulate.keyUp(menuList, { which: KeyCodes.alt });
+    act(() => {
+      fireEvent.keyDown(menuList, { which: KeyCodes.alt });
+      fireEvent.keyDown(menuList, { which: KeyCodes.a, altKey: true });
+      fireEvent.keyUp(menuList, { which: KeyCodes.a, altKey: true });
+      fireEvent.keyUp(menuList, { which: KeyCodes.alt });
     });
 
     expect(onDismissSpy).toHaveBeenCalledTimes(0);
@@ -246,8 +231,8 @@ describe('ContextualMenu', () => {
 
     const onDismissSpy = jest.fn();
 
-    ReactTestUtils.act(() => {
-      ReactTestUtils.renderIntoDocument<IContextualMenuProps>(
+    act(() => {
+      render(
         <ContextualMenu
           items={items}
           isSubMenu={true}
@@ -258,7 +243,7 @@ describe('ContextualMenu', () => {
     });
 
     const menuList = document.querySelector('ul.ms-ContextualMenu-list') as HTMLUListElement;
-    ReactTestUtils.Simulate.keyDown(menuList, { which: KeyCodes.left });
+    fireEvent.keyDown(menuList, { which: KeyCodes.left });
 
     expect(onDismissSpy).toHaveBeenCalledTimes(0);
   });
@@ -273,8 +258,8 @@ describe('ContextualMenu', () => {
 
     const onDismissSpy = jest.fn();
 
-    ReactTestUtils.act(() => {
-      ReactTestUtils.renderIntoDocument<IContextualMenuProps>(
+    act(() => {
+      render(
         <ContextualMenu
           items={items}
           isSubMenu={true}
@@ -285,8 +270,8 @@ describe('ContextualMenu', () => {
     });
 
     const menuList = document.querySelector('ul.ms-ContextualMenu-list') as HTMLUListElement;
-    ReactTestUtils.act(() => {
-      ReactTestUtils.Simulate.keyDown(menuList, { which: KeyCodes.left });
+    act(() => {
+      fireEvent.keyDown(menuList, { which: KeyCodes.left });
     });
 
     expect(onDismissSpy).toHaveBeenCalledTimes(0);
@@ -308,14 +293,14 @@ describe('ContextualMenu', () => {
         },
       },
     ];
-    ReactTestUtils.act(() => {
-      ReactTestUtils.renderIntoDocument<IContextualMenuProps>(<ContextualMenu items={items} />);
+    act(() => {
+      render(<ContextualMenu items={items} />);
     });
 
     const menuItem = document.querySelector('button.ms-ContextualMenu-link') as HTMLButtonElement;
 
-    ReactTestUtils.act(() => {
-      ReactTestUtils.Simulate.keyDown(menuItem, { which: KeyCodes.right });
+    act(() => {
+      fireEvent.keyDown(menuItem, { which: KeyCodes.right, keyCode: KeyCodes.right });
     });
 
     expect(document.querySelector('.SubMenuClass')).toBeTruthy();
@@ -338,14 +323,14 @@ describe('ContextualMenu', () => {
       },
     ];
 
-    ReactTestUtils.act(() => {
-      ReactTestUtils.renderIntoDocument<IContextualMenuProps>(<ContextualMenu items={items} />);
+    act(() => {
+      render(<ContextualMenu items={items} />);
     });
 
     const menuItem = document.querySelector('button.ms-ContextualMenu-link') as HTMLButtonElement;
 
-    ReactTestUtils.act(() => {
-      ReactTestUtils.Simulate.click(menuItem);
+    act(() => {
+      fireEvent.click(menuItem);
     });
 
     expect(document.querySelector('.SubMenuClass')).toBeTruthy();
@@ -367,13 +352,13 @@ describe('ContextualMenu', () => {
         },
       },
     ];
-    ReactTestUtils.act(() => {
-      ReactTestUtils.renderIntoDocument<IContextualMenuProps>(<ContextualMenu items={items} />);
+    act(() => {
+      render(<ContextualMenu items={items} />);
     });
 
     const menuItem = document.querySelector('button.ms-ContextualMenu-link') as HTMLButtonElement;
-    ReactTestUtils.act(() => {
-      ReactTestUtils.Simulate.keyDown(menuItem, { which: KeyCodes.down, altKey: true });
+    act(() => {
+      fireEvent.keyDown(menuItem, { which: KeyCodes.down, keyCode: KeyCodes.down, altKey: true });
     });
 
     expect(document.querySelector('.SubMenuClass')).toBeTruthy();
@@ -396,18 +381,18 @@ describe('ContextualMenu', () => {
       },
     ];
 
-    ReactTestUtils.act(() => {
-      ReactTestUtils.renderIntoDocument<IContextualMenuProps>(<ContextualMenu items={items} />);
+    act(() => {
+      render(<ContextualMenu items={items} />);
     });
 
     const menuItem = document.querySelector('button.ms-ContextualMenu-link') as HTMLButtonElement;
-    ReactTestUtils.act(() => {
-      ReactTestUtils.Simulate.click(menuItem);
+    act(() => {
+      fireEvent.click(menuItem);
     });
     let menuList = document.querySelectorAll('ul.ms-ContextualMenu-list');
     expect(menuList.length).toEqual(2);
-    ReactTestUtils.act(() => {
-      ReactTestUtils.Simulate.keyDown(menuList[1], { which: KeyCodes.up, altKey: true });
+    act(() => {
+      fireEvent.keyDown(menuList[1], { which: KeyCodes.up, altKey: true, keyCode: KeyCodes.up });
     });
     menuList = document.querySelectorAll('ul.ms-ContextualMenu-list');
     expect(menuList.length).toEqual(1);
@@ -432,18 +417,18 @@ describe('ContextualMenu', () => {
       },
     ];
 
-    ReactTestUtils.act(() => {
-      ReactTestUtils.renderIntoDocument<IContextualMenuProps>(<ContextualMenu items={items} />);
+    act(() => {
+      render(<ContextualMenu items={items} />);
     });
 
     const menuItem = document.querySelector('button.ms-ContextualMenu-link') as HTMLButtonElement;
-    ReactTestUtils.act(() => {
-      ReactTestUtils.Simulate.click(menuItem);
+    act(() => {
+      fireEvent.click(menuItem);
     });
     let menuList = document.querySelectorAll('ul.ms-ContextualMenu-list');
     expect(menuList.length).toEqual(2);
-    ReactTestUtils.act(() => {
-      ReactTestUtils.Simulate.keyDown(menuList[1], { which: KeyCodes.escape });
+    act(() => {
+      fireEvent.keyDown(menuList[1], { which: KeyCodes.escape, keyCode: KeyCodes.escape });
     });
     menuList = document.querySelectorAll('ul.ms-ContextualMenu-list');
     expect(menuList.length).toEqual(1);
@@ -475,19 +460,19 @@ describe('ContextualMenu', () => {
       },
     ];
 
-    ReactTestUtils.act(() => {
-      ReactTestUtils.renderIntoDocument<IContextualMenuProps>(<ContextualMenu items={items} />);
+    act(() => {
+      render(<ContextualMenu items={items} />);
     });
 
     const menuItem = document.querySelector('button.ms-ContextualMenu-link') as HTMLButtonElement;
-    ReactTestUtils.act(() => {
-      ReactTestUtils.Simulate.click(menuItem);
+    act(() => {
+      fireEvent.click(menuItem);
     });
     const menuList = document.querySelectorAll('ul.ms-ContextualMenu-list');
     expect(menuList.length).toEqual(2);
-    ReactTestUtils.act(() => {
-      ReactTestUtils.Simulate.keyDown(menuList[1], { which: KeyCodes.alt });
-      ReactTestUtils.Simulate.keyUp(menuList[1], { which: KeyCodes.alt });
+    act(() => {
+      fireEvent.keyDown(menuList[1], { which: KeyCodes.alt, keyCode: KeyCodes.alt });
+      fireEvent.keyUp(menuList[1], { which: KeyCodes.alt, keyCode: KeyCodes.alt });
     });
     expect(menuDismissed).toBeTruthy();
     expect(dismissedAll).toBeTruthy();
@@ -510,21 +495,21 @@ describe('ContextualMenu', () => {
       },
     ];
 
-    ReactTestUtils.act(() => {
-      ReactTestUtils.renderIntoDocument<IContextualMenuProps>(<ContextualMenu items={items} />);
+    act(() => {
+      render(<ContextualMenu items={items} />);
     });
 
     const menuItem = document.querySelector('button.ms-ContextualMenu-link') as HTMLButtonElement;
-    ReactTestUtils.act(() => {
-      ReactTestUtils.Simulate.click(menuItem);
+    act(() => {
+      fireEvent.click(menuItem);
     });
     let menuList = document.querySelectorAll('ul.ms-ContextualMenu-list');
     expect(menuList.length).toEqual(2);
-    ReactTestUtils.act(() => {
-      ReactTestUtils.Simulate.keyDown(menuList[1], { which: KeyCodes.alt });
-      ReactTestUtils.Simulate.keyDown(menuList[1], { which: KeyCodes.a, altKey: true });
-      ReactTestUtils.Simulate.keyUp(menuList[1], { which: KeyCodes.a, altKey: true });
-      ReactTestUtils.Simulate.keyUp(menuList[1], { which: KeyCodes.alt });
+    act(() => {
+      fireEvent.keyDown(menuList[1], { which: KeyCodes.alt });
+      fireEvent.keyDown(menuList[1], { which: KeyCodes.a, altKey: true });
+      fireEvent.keyUp(menuList[1], { which: KeyCodes.a, altKey: true });
+      fireEvent.keyUp(menuList[1], { which: KeyCodes.alt });
     });
     menuList = document.querySelectorAll('ul.ms-ContextualMenu-list');
     expect(menuList.length).toEqual(2);
@@ -553,8 +538,8 @@ describe('ContextualMenu', () => {
       },
     ];
 
-    ReactTestUtils.act(() => {
-      ReactTestUtils.renderIntoDocument<IContextualMenuProps>(<ContextualMenu items={items} />);
+    act(() => {
+      render(<ContextualMenu items={items} />);
     });
 
     const menuItem = document.getElementsByTagName('button')[0] as HTMLButtonElement;
@@ -562,9 +547,9 @@ describe('ContextualMenu', () => {
     // in a normal scenario, when we do a touchstart we would also cause a
     // click event to fire. This doesn't happen in the simulator so we're
     // manually adding this in.
-    ReactTestUtils.act(() => {
-      ReactTestUtils.Simulate.touchStart(menuItem);
-      ReactTestUtils.Simulate.click(menuItem);
+    act(() => {
+      fireEvent.touchStart(menuItem);
+      fireEvent.click(menuItem);
     });
 
     expect(document.querySelector('.is-expanded')).toBeTruthy();
@@ -592,16 +577,14 @@ describe('ContextualMenu', () => {
       },
     ];
 
-    ReactTestUtils.act(() => {
-      ReactTestUtils.renderIntoDocument<IContextualMenuProps>(
-        <ContextualMenu items={items} onItemClick={onItemClick} />,
-      );
+    act(() => {
+      render(<ContextualMenu items={items} onItemClick={onItemClick} />);
     });
 
     const menuItem = document.getElementsByTagName('button')[0] as HTMLButtonElement;
 
-    ReactTestUtils.act(() => {
-      ReactTestUtils.Simulate.click(menuItem);
+    act(() => {
+      fireEvent.click(menuItem);
     });
 
     const checkIcon = document.querySelector('.ms-ContextualMenu-checkmarkIcon') as HTMLElement;
@@ -610,8 +593,8 @@ describe('ContextualMenu', () => {
     expect(onPrimaryClick).toHaveBeenCalled();
     onPrimaryClick.mockClear();
 
-    ReactTestUtils.act(() => {
-      ReactTestUtils.Simulate.click(checkIcon);
+    act(() => {
+      fireEvent.click(checkIcon);
     });
 
     expect(onPrimaryClick).toHaveBeenCalled();
@@ -638,8 +621,8 @@ describe('ContextualMenu', () => {
 
     const testContainer = createTestContainer();
 
-    ReactTestUtils.act(() => {
-      ReactDOM.render(<ContextualMenu items={items} />, testContainer);
+    act(() => {
+      render(<ContextualMenu items={items} />, { container: testContainer });
     });
 
     const menuItems = document.querySelectorAll('button.ms-ContextualMenu-link') as NodeListOf<HTMLButtonElement>;
@@ -686,8 +669,8 @@ describe('ContextualMenu', () => {
       },
     ];
 
-    ReactTestUtils.act(() => {
-      ReactTestUtils.renderIntoDocument<IContextualMenuProps>(<ContextualMenu items={items} />);
+    act(() => {
+      render(<ContextualMenu items={items} />);
     });
 
     const menuItems = document.querySelectorAll('button.ms-ContextualMenu-link') as NodeListOf<HTMLButtonElement>;
@@ -721,8 +704,8 @@ describe('ContextualMenu', () => {
       },
     ];
 
-    ReactTestUtils.act(() => {
-      ReactTestUtils.renderIntoDocument<IContextualMenuProps>(<ContextualMenu items={items} />);
+    act(() => {
+      render(<ContextualMenu items={items} />);
     });
 
     const menuItems = document.querySelectorAll('li');
@@ -782,8 +765,8 @@ describe('ContextualMenu', () => {
       },
     ];
 
-    ReactTestUtils.act(() => {
-      ReactTestUtils.renderIntoDocument<IContextualMenuProps>(<ContextualMenu items={items} />);
+    act(() => {
+      render(<ContextualMenu items={items} />);
     });
 
     const menuItems = document.querySelectorAll('li');
@@ -798,8 +781,8 @@ describe('ContextualMenu', () => {
       { key: '2', text: 'Two' },
     ];
 
-    ReactTestUtils.act(() => {
-      ReactTestUtils.renderIntoDocument<IContextualMenuProps>(<ContextualMenu items={items} />);
+    act(() => {
+      render(<ContextualMenu items={items} />);
     });
 
     const menuItems = document.querySelectorAll('li button');
@@ -831,8 +814,8 @@ describe('ContextualMenu', () => {
       },
     ];
 
-    ReactTestUtils.act(() => {
-      ReactTestUtils.renderIntoDocument<IContextualMenuProps>(<ContextualMenu items={items} />);
+    act(() => {
+      render(<ContextualMenu items={items} />);
     });
 
     const menuItems = document.querySelectorAll('li button');
@@ -889,8 +872,8 @@ describe('ContextualMenu', () => {
         },
       ];
 
-      ReactTestUtils.act(() => {
-        ReactTestUtils.renderIntoDocument<IContextualMenuProps>(<ContextualMenu items={items} />);
+      act(() => {
+        render(<ContextualMenu items={items} />);
       });
 
       menuItems = document.querySelectorAll('li a');
@@ -931,14 +914,14 @@ describe('ContextualMenu', () => {
   });
 
   it('does not render a list if no items are given', () => {
-    ReactTestUtils.renderIntoDocument<IContextualMenuProps>(<ContextualMenu items={[]} />);
+    render(<ContextualMenu items={[]} />);
     const menuList = document.querySelector('.ms-ContextualMenu-list');
 
     expect(menuList).toBeNull();
   });
 
   it('Correctly focuses the second element on hover', () => {
-    ReactTestUtils.act(() => {
+    act(() => {
       jest.useFakeTimers();
     });
     const items: IContextualMenuItem[] = [
@@ -956,26 +939,26 @@ describe('ContextualMenu', () => {
 
     const testContainer = createTestContainer();
 
-    ReactTestUtils.act(() => {
-      ReactDOM.render(<ContextualMenu items={items} />, testContainer);
+    act(() => {
+      render(<ContextualMenu items={items} />, { container: testContainer });
     });
 
-    ReactTestUtils.act(() => {
+    act(() => {
       jest.runAllTimers();
     });
 
     const itemToFocus = document.querySelector('.testkey2')!.firstChild as HTMLElement;
-    ReactTestUtils.act(() => {
-      ReactTestUtils.Simulate.mouseMove(itemToFocus);
-      ReactTestUtils.Simulate.mouseEnter(itemToFocus);
+    act(() => {
+      fireEvent.mouseMove(itemToFocus);
+      fireEvent.mouseEnter(itemToFocus);
       jest.runAllTimers();
     });
     expect(document.activeElement).toEqual(itemToFocus);
   });
 
   it('merges callout classNames', () => {
-    ReactTestUtils.act(() => {
-      ReactTestUtils.renderIntoDocument<IContextualMenuProps>(
+    act(() => {
+      render(
         <ContextualMenu
           items={[
             {
@@ -1005,8 +988,8 @@ describe('ContextualMenu', () => {
       },
     ];
 
-    ReactTestUtils.act(() => {
-      ReactTestUtils.renderIntoDocument<IContextualMenuProps>(<ContextualMenu items={menuWithEmptySubMenu} />);
+    act(() => {
+      render(<ContextualMenu items={menuWithEmptySubMenu} />);
     });
 
     const menuItem = document.querySelector('button.ms-ContextualMenu-link') as HTMLButtonElement;
@@ -1032,14 +1015,14 @@ describe('ContextualMenu', () => {
       },
     ];
 
-    ReactTestUtils.act(() => {
-      ReactTestUtils.renderIntoDocument<IContextualMenuProps>(<ContextualMenu items={menuWithEmptySubMenu} />);
+    act(() => {
+      render(<ContextualMenu items={menuWithEmptySubMenu} />);
     });
 
     const menuItem = document.querySelector('button.ms-ContextualMenu-link') as HTMLButtonElement;
 
-    ReactTestUtils.act(() => {
-      ReactTestUtils.Simulate.click(menuItem);
+    act(() => {
+      fireEvent.click(menuItem);
     });
 
     expect(subMenuOpened).toEqual(true);
@@ -1058,15 +1041,13 @@ describe('ContextualMenu', () => {
     ];
     const customRenderer = jest.fn(() => null);
 
-    ReactTestUtils.act(() => {
-      ReactTestUtils.renderIntoDocument<IContextualMenuProps>(
-        <ContextualMenu items={items} contextualMenuItemAs={customRenderer} />,
-      );
+    act(() => {
+      render(<ContextualMenu items={items} contextualMenuItemAs={customRenderer} />);
     });
 
     const menuItem = document.querySelector('button.ms-ContextualMenu-link') as HTMLButtonElement;
-    ReactTestUtils.act(() => {
-      ReactTestUtils.Simulate.click(menuItem);
+    act(() => {
+      fireEvent.click(menuItem);
     });
 
     expect(customRenderer).toHaveBeenCalledTimes(2);
@@ -1144,8 +1125,8 @@ describe('ContextualMenu', () => {
     ];
 
     beforeEach(() => {
-      ReactTestUtils.act(() => {
-        ReactTestUtils.renderIntoDocument<IContextualMenuProps>(
+      act(() => {
+        render(
           <DefaultButton
             persistMenu={true}
             componentRef={button}
@@ -1160,53 +1141,65 @@ describe('ContextualMenu', () => {
     });
 
     it('ContextualMenu should be present in DOM when hidden', () => {
-      button.current!.openMenu();
-      button.current!.dismissMenu();
+      act(() => {
+        button.current!.openMenu();
+        button.current!.dismissMenu();
+      });
       expect(document.querySelector('.ms-ContextualMenu-Callout')).not.toEqual(null);
     });
 
     it('Submenu should not be shown when ContextualMenu is hidden', () => {
       // 1. Open parent menu
-      button.current!.openMenu();
+      act(() => {
+        button.current!.openMenu();
+      });
       expect(document.querySelector('.ms-ContextualMenu-Callout')).not.toEqual(null);
 
       // 2. Open sub menu
-      ReactTestUtils.act(() => {
+      act(() => {
         contextualItem.current!.openSubMenu();
       });
       expect(document.querySelector('.SubMenuClass')).not.toEqual(null);
 
       // 3. Dismiss parent menu - sub menu should disappear from DOM.
       // Submenus are not persisted using the hidden prop as of now
-      button.current!.dismissMenu();
+      act(() => {
+        button.current!.dismissMenu();
+      });
       expect(document.querySelector('.SubMenuClass')).toEqual(null);
     });
 
     it('Submenu should not be shown by default when ContextualMenu is shown', () => {
       // 1. Open parent menu
-      button.current!.openMenu();
+      act(() => {
+        button.current!.openMenu();
+      });
       expect(document.querySelector('.ms-ContextualMenu-Callout')).not.toEqual(null);
 
       // 2. Open sub menu
-      ReactTestUtils.act(() => {
+      act(() => {
         contextualItem.current!.openSubMenu();
       });
       expect(document.querySelector('.SubMenuClass')).not.toEqual(null);
 
       // 3. Dismiss parent menu - sub menu should disappear from DOM.
-      button.current!.dismissMenu();
+      act(() => {
+        button.current!.dismissMenu();
+      });
       expect(document.querySelector('.SubMenuClass')).toEqual(null);
 
       // 4. Reopen parent menu - sub menu should not be present by default
-      button.current!.openMenu();
+      act(() => {
+        button.current!.openMenu();
+      });
       expect(document.querySelector('.SubMenuClass')).toEqual(null);
     });
 
     it('Menu should correctly return focus to previously focused element when dismissed and document has focus', () => {
       const testContainer = createTestContainer();
 
-      ReactTestUtils.act(() => {
-        ReactDOM.render(<DefaultButton menuProps={{ items: menu }} text="but" id="btn" />, testContainer);
+      act(() => {
+        render(<DefaultButton menuProps={{ items: menu }} text="but" id="btn" />, { container: testContainer });
       });
 
       // Get and make sure that the button is the active element
@@ -1216,8 +1209,8 @@ describe('ContextualMenu', () => {
       expect(document.activeElement).toEqual(btn);
 
       // Click the button and make sure that the menu has opened
-      ReactTestUtils.act(() => {
-        ReactTestUtils.Simulate.click(btn);
+      act(() => {
+        fireEvent.click(btn);
       });
       const cm = document.querySelector('.ms-ContextualMenu-Callout');
       expect(cm).not.toEqual(null);
@@ -1227,8 +1220,8 @@ describe('ContextualMenu', () => {
       const menuItem = menuList.querySelector('button');
       menuItem!.focus();
       expect(document.activeElement).toEqual(menuItem);
-      ReactTestUtils.act(() => {
-        ReactTestUtils.Simulate.keyDown(menuList, { which: KeyCodes.escape });
+      act(() => {
+        fireEvent.keyDown(menuList, { which: KeyCodes.escape, keyCode: KeyCodes.escape });
       });
 
       // Ensure that the Menu has closed and that focus has returned to the button
@@ -1320,33 +1313,31 @@ describe('ContextualMenu', () => {
             },
           },
         ];
-        ReactTestUtils.act(() => {
-          ReactTestUtils.renderIntoDocument<IContextualMenuProps>(
-            <ContextualMenu onDismiss={onDismiss} items={menu} />,
-          );
+        act(() => {
+          render(<ContextualMenu onDismiss={onDismiss} items={menu} />);
         });
       });
 
       it('openSubMenu will open the item`s submenu if present', () => {
-        ReactTestUtils.act(() => {
+        act(() => {
           contextualItem.current!.openSubMenu();
         });
         expect(document.querySelector('.SubMenuClass')).not.toEqual(null);
       });
 
       it('dismissSubMenu will close the item`s submenu if present', () => {
-        ReactTestUtils.act(() => {
+        act(() => {
           contextualItem.current!.openSubMenu();
         });
         expect(document.querySelector('.SubMenuClass')).not.toEqual(null);
-        ReactTestUtils.act(() => {
+        act(() => {
           contextualItem.current!.dismissSubMenu();
         });
         expect(document.querySelector('.SubMenuClass')).toEqual(null);
       });
 
       it('dismissMenu will close the item`s menu', () => {
-        ReactTestUtils.act(() => {
+        act(() => {
           contextualItem.current!.dismissMenu();
         });
         expect(menuDismissed).toEqual(true);
@@ -1378,33 +1369,31 @@ describe('ContextualMenu', () => {
             },
           },
         ];
-        ReactTestUtils.act(() => {
-          ReactTestUtils.renderIntoDocument<IContextualMenuProps>(
-            <ContextualMenu onDismiss={onDismiss} items={menu} />,
-          );
+        act(() => {
+          render(<ContextualMenu onDismiss={onDismiss} items={menu} />);
         });
       });
 
       it('openSubMenu will open the item`s submenu if present', () => {
-        ReactTestUtils.act(() => {
+        act(() => {
           contextualItem.current!.openSubMenu();
         });
         expect(document.querySelector('.SubMenuClass')).not.toEqual(null);
       });
 
       it('dismissSubMenu will close the item`s submenu if present', () => {
-        ReactTestUtils.act(() => {
+        act(() => {
           contextualItem.current!.openSubMenu();
         });
         expect(document.querySelector('.SubMenuClass')).not.toEqual(null);
-        ReactTestUtils.act(() => {
+        act(() => {
           contextualItem.current!.dismissSubMenu();
         });
         expect(document.querySelector('.SubMenuClass')).toEqual(null);
       });
 
       it('dismissMenu will close the item`s menu', () => {
-        ReactTestUtils.act(() => {
+        act(() => {
           contextualItem.current!.dismissMenu();
         });
         expect(menuDismissed).toEqual(true);
@@ -1436,33 +1425,31 @@ describe('ContextualMenu', () => {
             },
           },
         ];
-        ReactTestUtils.act(() => {
-          ReactTestUtils.renderIntoDocument<IContextualMenuProps>(
-            <ContextualMenu onDismiss={onDismiss} items={menu} />,
-          );
+        act(() => {
+          render(<ContextualMenu onDismiss={onDismiss} items={menu} />);
         });
       });
 
       it('openSubMenu will open the item`s submenu if present', () => {
-        ReactTestUtils.act(() => {
+        act(() => {
           contextualItem.current!.openSubMenu();
         });
         expect(document.querySelector('.SubMenuClass')).not.toEqual(null);
       });
 
       it('dismissSubMenu will close the item`s submenu if present', () => {
-        ReactTestUtils.act(() => {
+        act(() => {
           contextualItem.current!.openSubMenu();
         });
         expect(document.querySelector('.SubMenuClass')).not.toEqual(null);
-        ReactTestUtils.act(() => {
+        act(() => {
           contextualItem.current!.dismissSubMenu();
         });
         expect(document.querySelector('.SubMenuClass')).toEqual(null);
       });
 
       it('dismissMenu will close the item`s menu', () => {
-        ReactTestUtils.act(() => {
+        act(() => {
           contextualItem.current!.dismissMenu();
         });
         expect(menuDismissed).toEqual(true);
@@ -1479,8 +1466,8 @@ describe('ContextualMenu', () => {
         },
       ];
 
-      ReactTestUtils.act(() => {
-        ReactTestUtils.renderIntoDocument<IContextualMenuProps>(<ContextualMenu items={items} />);
+      act(() => {
+        render(<ContextualMenu items={items} />);
       });
 
       const internalList = document.querySelector('ul.ms-ContextualMenu-list') as HTMLUListElement;
@@ -1510,10 +1497,8 @@ describe('ContextualMenu', () => {
       };
     };
 
-    ReactTestUtils.act(() => {
-      ReactTestUtils.renderIntoDocument<IContextualMenuProps>(
-        <ContextualMenu items={items} styles={getCustomStyles} title="Menu!" />,
-      );
+    act(() => {
+      render(<ContextualMenu items={items} styles={getCustomStyles} title="Menu!" />);
     });
 
     const container = document.querySelector('.containerFoo') as HTMLElement;
@@ -1549,8 +1534,8 @@ describe('ContextualMenu', () => {
       { text: 'TestText 4', key: 'TestKey4', canCheck: true, isChecked: true },
     ];
 
-    ReactTestUtils.act(() => {
-      ReactTestUtils.renderIntoDocument<IContextualMenuProps>(<ContextualMenu items={items} />);
+    act(() => {
+      render(<ContextualMenu items={items} />);
     });
 
     const customLinkContentEls = document.querySelectorAll('.linkContentFoo') as NodeListOf<HTMLElement>;

--- a/packages/react/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.test.tsx
@@ -1,21 +1,27 @@
 import '@testing-library/jest-dom';
 
 import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import * as renderer from 'react-test-renderer';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FirstWeekOfYear } from '@fluentui/date-time-utilities';
+import { resetIds } from '@fluentui/utilities';
+import { safeCreate } from '@fluentui/test-utilities';
+
 import { DatePicker } from './DatePicker';
 import { Calendar } from '../Calendar';
 import { DatePickerBase } from './DatePicker.base';
-import { FirstWeekOfYear } from '@fluentui/date-time-utilities';
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { resetIds } from '@fluentui/utilities';
 import { Callout } from '../../Callout';
-import { safeCreate } from '@fluentui/test-utilities';
 import { TextField } from '../../TextField';
-import * as renderer from 'react-test-renderer';
-import * as ReactDOM from 'react-dom';
 import { CalendarDayGridBase } from '../CalendarDayGrid/CalendarDayGrid.base';
 import { isConformant } from '../../common/isConformant';
 import { IDatePickerStrings } from './DatePicker.types';
+
+// See https://github.com/facebook/react/issues/11565
+function mockCreatePortal() {
+  return jest.spyOn(ReactDOM, 'createPortal').mockImplementation(node => node as any);
+}
 
 describe('DatePicker', () => {
   beforeEach(() => {
@@ -129,8 +135,7 @@ describe('DatePicker', () => {
   });
 
   it('should clear error message when required input has date text and allowTextInput is true', () => {
-    // See https://github.com/facebook/react/issues/11565
-    jest.spyOn(ReactDOM, 'createPortal').mockImplementation(node => node as any);
+    mockCreatePortal();
 
     safeCreate(<DatePickerBase isRequired={true} allowTextInput={true} />, datePicker => {
       const textfield = datePicker.root.findByType(TextField);
@@ -158,8 +163,7 @@ describe('DatePicker', () => {
   });
 
   it('should not set initial error when required input is empty and validateOnLoad is false', () => {
-    // See https://github.com/facebook/react/issues/11565
-    jest.spyOn(ReactDOM, 'createPortal').mockImplementation(node => node as any);
+    mockCreatePortal();
 
     safeCreate(
       <DatePickerBase isRequired={true} allowTextInput={true} textField={{ validateOnLoad: false }} />,
@@ -183,8 +187,7 @@ describe('DatePicker', () => {
   });
 
   it('clears error message when required input has date selected from calendar and allowTextInput is true', () => {
-    // See https://github.com/facebook/react/issues/11565
-    jest.spyOn(ReactDOM, 'createPortal').mockImplementation(node => node as any);
+    mockCreatePortal();
 
     safeCreate(<DatePickerBase isRequired={true} allowTextInput={true} />, datePicker => {
       const textfield = datePicker.root.findByType(TextField);
@@ -213,8 +216,7 @@ describe('DatePicker', () => {
   });
 
   it('should not clear initial error when datepicker is opened', () => {
-    // See https://github.com/facebook/react/issues/11565
-    jest.spyOn(ReactDOM, 'createPortal').mockImplementation(node => node as any);
+    mockCreatePortal();
 
     safeCreate(
       <DatePickerBase
@@ -265,8 +267,7 @@ describe('DatePicker', () => {
   });
 
   it('should reset status message after selecting a valid date', () => {
-    // See https://github.com/facebook/react/issues/11565
-    jest.spyOn(ReactDOM, 'createPortal').mockImplementation(node => node as any);
+    mockCreatePortal();
 
     safeCreate(<DatePickerBase allowTextInput={true} initialPickerDate={new Date('2021-04-15')} />, datePicker => {
       const input = datePicker.root.findByType('input');
@@ -297,8 +298,7 @@ describe('DatePicker', () => {
   });
 
   it('should call onSelectDate only once when allowTextInput is true and popup is used to select the value', () => {
-    // See https://github.com/facebook/react/issues/11565
-    jest.spyOn(ReactDOM, 'createPortal').mockImplementation(node => node as any);
+    mockCreatePortal();
     const onSelectDate = jest.fn();
 
     safeCreate(<DatePickerBase allowTextInput={true} onSelectDate={onSelectDate} />, datePicker => {
@@ -318,8 +318,7 @@ describe('DatePicker', () => {
   });
 
   it('should set "Calendar" as the Callout\'s aria-label', () => {
-    // See https://github.com/facebook/react/issues/11565
-    jest.spyOn(ReactDOM, 'createPortal').mockImplementation(node => node as any);
+    mockCreatePortal();
 
     safeCreate(<DatePickerBase />, datePicker => {
       const input = datePicker.root.findAllByType('div')[5];
@@ -340,8 +339,7 @@ describe('DatePicker', () => {
     const initiallySelectedDate = new Date('January 10, 2020');
     // initialPickerDate defaults to Date.now() if not provided so it must be given to ensure
     // that the datepicker opens on the correct month
-    // See https://github.com/facebook/react/issues/11565
-    jest.spyOn(ReactDOM, 'createPortal').mockImplementation(node => node as any);
+    mockCreatePortal();
 
     safeCreate(
       <DatePickerBase allowTextInput={true} today={today} initialPickerDate={initiallySelectedDate} />,
@@ -370,8 +368,7 @@ describe('DatePicker', () => {
     // initialPickerDate defaults to Date.now() if not provided so it must be given to ensure
     // that the datepicker opens on the correct month
 
-    // See https://github.com/facebook/react/issues/11565
-    jest.spyOn(ReactDOM, 'createPortal').mockImplementation(node => node as any);
+    mockCreatePortal();
 
     safeCreate(
       <DatePickerBase
@@ -409,8 +406,7 @@ describe('DatePickerBase - custom calendar properties', () => {
   };
 
   it('renders Calendar with provided props and custom formatter', () => {
-    // See https://github.com/facebook/react/issues/11565
-    jest.spyOn(ReactDOM, 'createPortal').mockImplementation(node => node as any);
+    mockCreatePortal();
 
     safeCreate(
       <DatePickerBase

--- a/packages/react/src/components/DetailsList/DetailsHeader.test.tsx
+++ b/packages/react/src/components/DetailsList/DetailsHeader.test.tsx
@@ -5,7 +5,7 @@ import { SelectAllVisibility } from './DetailsHeader.types';
 import { DetailsListLayoutMode, ColumnActionsMode, CheckboxVisibility } from './DetailsList.types';
 import { Selection, SelectionMode } from '../../utilities/selection/index';
 import { EventGroup } from '../../Utilities';
-import { render, screen } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import * as renderer from 'react-test-renderer';
 import { getTheme } from '../../Styling';
 import type { IDetailsHeader, IDropHintDetails } from './DetailsHeader.types';
@@ -287,16 +287,18 @@ describe('DetailsHeader', () => {
     const sizerElement = container.querySelector('[data-sizer-index="0"]') as HTMLElement;
     const header: any = headerRef.current!;
 
-    // Trigger a mousedown, which validates that the ref to focuszone is hooking up events.
-    EventGroup.raise(
-      sizerElement,
-      'mousedown',
-      {
-        clientX: 0,
-        button: 0,
-      },
-      true,
-    );
+    act(() => {
+      // Trigger a mousedown, which validates that the ref to focuszone is hooking up events.
+      EventGroup.raise(
+        sizerElement,
+        'mousedown',
+        {
+          clientX: 0,
+          button: 0,
+        },
+        true,
+      );
+    });
     // Validate we go into resize mode.
     expect(sizerElement.classList.contains('is-resizing')).toBe(true);
     expect(Boolean(header.state.isSizing)).toBe(false);

--- a/packages/react/src/components/DetailsList/DetailsList.test.tsx
+++ b/packages/react/src/components/DetailsList/DetailsList.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
 import * as renderer from 'react-test-renderer';
 import { render, fireEvent, act } from '@testing-library/react';
 
@@ -653,13 +652,11 @@ describe('DetailsList', () => {
       );
     };
 
-    const container = document.createElement('div');
     const items = mockData(5);
     const columns = mockData(5, true);
 
-    ReactDOM.render(
+    const { rerender, container } = render(
       <DetailsListBase columns={columns} skipViewportMeasures={true} items={items} dragDropEvents={_dragDropEvents} />,
-      container,
     );
 
     let detailsRowSource = container.querySelector('div[aria-rowindex="2"][role="row"]') as HTMLDivElement;
@@ -671,9 +668,8 @@ describe('DetailsList', () => {
     expect(_dragDropEvents.onDragStart).toHaveBeenCalledTimes(1);
     expect(_dragDropEvents2.onDragStart).toHaveBeenCalledTimes(0);
 
-    ReactDOM.render(
+    rerender(
       <DetailsListBase columns={columns} skipViewportMeasures={true} items={items} dragDropEvents={_dragDropEvents} />,
-      container,
     );
 
     detailsRowSource = container.querySelector('div[aria-rowindex="2"][role="row"]') as HTMLDivElement;
@@ -684,9 +680,8 @@ describe('DetailsList', () => {
     expect(_dragDropEvents.onDragStart).toHaveBeenCalledTimes(2);
     expect(_dragDropEvents2.onDragStart).toHaveBeenCalledTimes(0);
 
-    ReactDOM.render(
+    rerender(
       <DetailsListBase columns={columns} skipViewportMeasures={true} items={items} dragDropEvents={_dragDropEvents2} />,
-      container,
     );
 
     detailsRowSource = container.querySelector('div[aria-rowindex="2"][role="row"]') as HTMLDivElement;
@@ -885,7 +880,9 @@ describe('DetailsList', () => {
     expect(onRenderCheckboxMock).toHaveBeenCalledTimes(3);
     expect(onRenderCheckboxMock.mock.calls[2][0]).toEqual({ checked: false, theme });
 
-    selection.setAllSelected(true);
+    act(() => {
+      selection.setAllSelected(true);
+    });
 
     expect(onRenderCheckboxMock).toHaveBeenCalledTimes(6);
     expect(onRenderCheckboxMock.mock.calls[5][0]).toEqual({ checked: true, theme });
@@ -1104,7 +1101,6 @@ describe('DetailsList', () => {
   });
 
   it('returns an element with the correct text based on the second id passed in aria-labelledby', () => {
-    const container = document.createElement('div');
     const columns = [
       {
         key: 'column1',
@@ -1119,7 +1115,7 @@ describe('DetailsList', () => {
     ];
     const items = mockData(1);
 
-    ReactDOM.render(
+    const { container } = render(
       <DetailsListBase
         items={mockData(1)}
         columns={columns}
@@ -1127,7 +1123,6 @@ describe('DetailsList', () => {
         ariaLabelForSelectAllCheckbox="Toggle selection for all items"
         checkButtonAriaLabel="select row"
       />,
-      container,
     );
 
     const checkbox = container.querySelector('div[role="checkbox"][aria-label="select row"]') as HTMLElement;
@@ -1155,8 +1150,7 @@ describe('DetailsList', () => {
   });
 
   it('names group header checkboxes based on checkButtonGroupAriaLabel', () => {
-    const container = document.createElement('div');
-    ReactDOM.render(
+    const { container } = render(
       <DetailsList
         items={mockData(5)}
         groups={[
@@ -1175,7 +1169,6 @@ describe('DetailsList', () => {
         ]}
         checkButtonGroupAriaLabel="select section"
       />,
-      container,
     );
 
     const checkbox = container.querySelector('[role="checkbox"][aria-label="select section"]') as HTMLElement;

--- a/packages/react/src/components/DetailsList/DetailsListV2.test.tsx
+++ b/packages/react/src/components/DetailsList/DetailsListV2.test.tsx
@@ -697,7 +697,6 @@ describe('DetailsListV2', () => {
       );
     };
 
-    // const container = document.createElement('div');
     const items = mockData(5);
     const columns = mockData(5, true);
 

--- a/packages/react/src/components/DetailsList/DetailsListV2.test.tsx
+++ b/packages/react/src/components/DetailsList/DetailsListV2.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
 import * as renderer from 'react-test-renderer';
 import { render, fireEvent, act } from '@testing-library/react';
 import { EventGroup, KeyCodes, resetIds } from '../../Utilities';
@@ -698,11 +697,11 @@ describe('DetailsListV2', () => {
       );
     };
 
-    const container = document.createElement('div');
+    // const container = document.createElement('div');
     const items = mockData(5);
     const columns = mockData(5, true);
 
-    ReactDOM.render(
+    const { container, rerender } = render(
       <DetailsListBase
         columns={columns}
         skipViewportMeasures={true}
@@ -710,7 +709,6 @@ describe('DetailsListV2', () => {
         dragDropEvents={_dragDropEvents}
         groupProps={groupProps}
       />,
-      container,
     );
 
     let detailsRowSource = container.querySelector('div[aria-rowindex="2"][role="row"]') as HTMLDivElement;
@@ -722,7 +720,7 @@ describe('DetailsListV2', () => {
     expect(_dragDropEvents.onDragStart).toHaveBeenCalledTimes(1);
     expect(_dragDropEvents2.onDragStart).toHaveBeenCalledTimes(0);
 
-    ReactDOM.render(
+    rerender(
       <DetailsListBase
         columns={columns}
         skipViewportMeasures={true}
@@ -730,7 +728,6 @@ describe('DetailsListV2', () => {
         dragDropEvents={_dragDropEvents}
         groupProps={groupProps}
       />,
-      container,
     );
 
     detailsRowSource = container.querySelector('div[aria-rowindex="2"][role="row"]') as HTMLDivElement;
@@ -741,7 +738,7 @@ describe('DetailsListV2', () => {
     expect(_dragDropEvents.onDragStart).toHaveBeenCalledTimes(2);
     expect(_dragDropEvents2.onDragStart).toHaveBeenCalledTimes(0);
 
-    ReactDOM.render(
+    rerender(
       <DetailsListBase
         columns={columns}
         skipViewportMeasures={true}
@@ -749,7 +746,6 @@ describe('DetailsListV2', () => {
         dragDropEvents={_dragDropEvents2}
         groupProps={groupProps}
       />,
-      container,
     );
 
     detailsRowSource = container.querySelector('div[aria-rowindex="2"][role="row"]') as HTMLDivElement;
@@ -852,7 +848,9 @@ describe('DetailsListV2', () => {
     );
 
     // verify that focusedItemIndex is reset to 0 and 0th row is focused
-    jest.runAllTimers();
+    act(() => {
+      jest.runAllTimers();
+    });
     expect(component!.state.focusedItemIndex).toEqual(0);
     expect(
       (document.activeElement as HTMLElement).querySelector('[data-automationid=DetailsRowCell]')!.textContent,
@@ -939,7 +937,9 @@ describe('DetailsListV2', () => {
     expect(onRenderCheckboxMock).toHaveBeenCalledTimes(3);
     expect(onRenderCheckboxMock.mock.calls[2][0]).toEqual({ checked: false, theme });
 
-    selection.setAllSelected(true);
+    act(() => {
+      selection.setAllSelected(true);
+    });
 
     expect(onRenderCheckboxMock).toHaveBeenCalledTimes(6);
     expect(onRenderCheckboxMock.mock.calls[5][0]).toEqual({ checked: true, theme });
@@ -1163,7 +1163,6 @@ describe('DetailsListV2', () => {
   });
 
   it('returns an element with the correct text based on the second id passed in aria-labelledby', () => {
-    const container = document.createElement('div');
     const columns = [
       {
         key: 'column1',
@@ -1178,7 +1177,7 @@ describe('DetailsListV2', () => {
     ];
     const items = mockData(1);
 
-    ReactDOM.render(
+    const { container } = render(
       <DetailsListBase
         items={mockData(1)}
         columns={columns}
@@ -1187,7 +1186,6 @@ describe('DetailsListV2', () => {
         checkButtonAriaLabel="select row"
         groupProps={groupProps}
       />,
-      container,
     );
 
     const checkbox = container.querySelector('div[role="checkbox"][aria-label="select row"]') as HTMLElement;
@@ -1216,8 +1214,7 @@ describe('DetailsListV2', () => {
   });
 
   it('names group header checkboxes based on checkButtonGroupAriaLabel', () => {
-    const container = document.createElement('div');
-    ReactDOM.render(
+    const { container } = render(
       <DetailsList
         items={mockData(5)}
         groups={[
@@ -1237,7 +1234,6 @@ describe('DetailsListV2', () => {
         checkButtonGroupAriaLabel="select section"
         groupProps={groupProps}
       />,
-      container,
     );
 
     const checkbox = container.querySelector('[role="checkbox"][aria-label="select section"]') as HTMLElement;

--- a/packages/react/src/components/Dialog/Dialog.deprecated.test.tsx
+++ b/packages/react/src/components/Dialog/Dialog.deprecated.test.tsx
@@ -1,9 +1,15 @@
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
 import * as renderer from 'react-test-renderer';
 
 import { resetIds, setWarningCallback } from '../../Utilities';
 import { DialogBase } from './Dialog.base';
+
+jest.mock('react-dom', () => {
+  return {
+    ...jest.requireActual('react-dom'),
+    createPortal: jest.fn((node: any) => node),
+  };
+});
 
 describe('Dialog deprecated props', () => {
   beforeAll(() => {
@@ -15,9 +21,6 @@ describe('Dialog deprecated props', () => {
 
   beforeEach(() => {
     resetIds();
-    (ReactDOM.createPortal as any) = jest.fn((element, node) => {
-      return element;
-    });
   });
 
   afterAll(() => {
@@ -25,7 +28,6 @@ describe('Dialog deprecated props', () => {
   });
 
   afterEach(() => {
-    (ReactDOM.createPortal as any).mockClear();
     jest.useRealTimers();
   });
 

--- a/packages/react/src/components/ExtendedPicker/BaseExtendedPicker.test.tsx
+++ b/packages/react/src/components/ExtendedPicker/BaseExtendedPicker.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import * as ReactTestUtils from 'react-dom/test-utils';
-import * as ReactDOM from 'react-dom';
 import * as renderer from 'react-test-renderer';
+import { fireEvent, render, act } from '@testing-library/react';
+
 import { BaseExtendedPicker } from './BaseExtendedPicker';
 import { BaseFloatingPicker, SuggestionsStore } from '../FloatingPicker/index';
 import { BaseSelectedItemsList } from '../../SelectedItemsList';
@@ -87,12 +87,11 @@ describe('Pickers', () => {
     const create = (elem: React.ReactElement) => {
       hostNode = document.createElement('div');
       document.body.appendChild(hostNode);
-      ReactDOM.render(elem, hostNode);
+      render(elem, { container: hostNode });
     };
 
     afterEach(() => {
       if (hostNode) {
-        ReactDOM.unmountComponentAtNode(hostNode);
         document.body.removeChild(hostNode);
         hostNode = null;
       }
@@ -158,13 +157,13 @@ describe('Pickers', () => {
 
       if (picker.inputElement) {
         picker.inputElement.value = 'bl';
-        ReactTestUtils.Simulate.input(picker.inputElement);
-        ReactTestUtils.act(() => {
+        fireEvent.input(picker.inputElement);
+        act(() => {
           jest.runAllTimers();
         });
       }
 
-      ReactDOM.render(
+      render(
         <BaseExtendedPickerWithType
           ref={pickerRef}
           defaultSelectedItems={[]}
@@ -173,7 +172,7 @@ describe('Pickers', () => {
           onRenderSelectedItems={basicRenderSelectedItemsList}
           onRenderFloatingPicker={basicRenderFloatingPicker}
         />,
-        hostNode,
+        { container: hostNode! },
       );
 
       expect(picker.state.queryString).toBe('bl');
@@ -183,7 +182,7 @@ describe('Pickers', () => {
       // Force resolve to the first suggestions
       picker.floatingPicker.current && picker.floatingPicker.current.forceResolveSuggestion();
 
-      ReactDOM.render(
+      render(
         <BaseExtendedPickerWithType
           ref={pickerRef}
           defaultSelectedItems={[]}
@@ -192,7 +191,7 @@ describe('Pickers', () => {
           onRenderSelectedItems={basicRenderSelectedItemsList}
           onRenderFloatingPicker={basicRenderFloatingPicker}
         />,
-        hostNode,
+        { container: hostNode! },
       );
 
       expect(picker.items.length).toBe(1);
@@ -217,10 +216,10 @@ describe('Pickers', () => {
 
       if (picker.inputElement) {
         picker.inputElement.value = 'bl';
-        ReactTestUtils.Simulate.input(picker.inputElement);
+        fireEvent.input(picker.inputElement);
       }
 
-      ReactTestUtils.act(() => {
+      act(() => {
         jest.runAllTimers();
       });
 
@@ -250,9 +249,9 @@ describe('Pickers', () => {
       // setup
       if (picker.inputElement) {
         picker.inputElement.value = 'bl';
-        ReactTestUtils.Simulate.input(picker.inputElement);
-        ReactTestUtils.Simulate.keyDown(picker.inputElement, { which: KeyCodes.down });
-        ReactTestUtils.act(() => {
+        fireEvent.input(picker.inputElement);
+        fireEvent.keyDown(picker.inputElement, { which: KeyCodes.down });
+        act(() => {
           jest.runAllTimers();
         });
       }
@@ -288,12 +287,9 @@ describe('Pickers', () => {
 
     describe('aria-owns', () => {
       it('does not render an aria-owns when the floating picker has not been opened', () => {
-        const root = document.createElement('div');
-        document.body.appendChild(root);
-
         const pickerRef = React.createRef<TypedBaseExtendedPicker>();
 
-        ReactDOM.render(
+        render(
           <BaseExtendedPickerWithType
             ref={pickerRef}
             floatingPickerProps={floatingPickerProps}
@@ -301,22 +297,16 @@ describe('Pickers', () => {
             onRenderSelectedItems={basicRenderSelectedItemsList}
             onRenderFloatingPicker={basicRenderFloatingPicker}
           />,
-          root,
         );
 
         expect(document.querySelector('[aria-owns="suggestion-list"]')).not.toBeTruthy();
         expect(document.querySelector('#suggestion-list')).not.toBeTruthy();
-
-        ReactDOM.unmountComponentAtNode(root);
       });
 
       it('renders an aria-owns when the floating picker is open', () => {
-        const root = document.createElement('div');
-        document.body.appendChild(root);
-
         const pickerRef = React.createRef<TypedBaseExtendedPicker>();
 
-        ReactDOM.render(
+        render(
           <BaseExtendedPickerWithType
             ref={pickerRef}
             floatingPickerProps={floatingPickerProps}
@@ -324,15 +314,12 @@ describe('Pickers', () => {
             onRenderSelectedItems={basicRenderSelectedItemsList}
             onRenderFloatingPicker={basicRenderFloatingPicker}
           />,
-          root,
         );
 
         pickerRef.current!.floatingPicker.current!.showPicker();
 
         expect(document.querySelector('[aria-owns="suggestion-list"]')).toBeTruthy();
         expect(document.querySelector('#suggestion-list')).toBeTruthy();
-
-        ReactDOM.unmountComponentAtNode(root);
       });
 
       it('does not render an aria-owns when the floating picker has been opened and closed', () => {
@@ -341,7 +328,7 @@ describe('Pickers', () => {
 
         const pickerRef = React.createRef<TypedBaseExtendedPicker>();
 
-        ReactDOM.render(
+        render(
           <BaseExtendedPickerWithType
             ref={pickerRef}
             floatingPickerProps={floatingPickerProps}
@@ -349,7 +336,6 @@ describe('Pickers', () => {
             onRenderSelectedItems={basicRenderSelectedItemsList}
             onRenderFloatingPicker={basicRenderFloatingPicker}
           />,
-          root,
         );
 
         pickerRef.current!.floatingPicker.current!.showPicker();
@@ -358,8 +344,6 @@ describe('Pickers', () => {
 
         expect(document.querySelector('[aria-owns="suggestion-list"]')).not.toBeTruthy();
         expect(document.querySelector('#suggestion-list')).not.toBeTruthy();
-
-        ReactDOM.unmountComponentAtNode(root);
       });
     });
   });

--- a/packages/react/src/components/FloatingPicker/BaseFloatingPicker.test.tsx
+++ b/packages/react/src/components/FloatingPicker/BaseFloatingPicker.test.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
 import * as renderer from 'react-test-renderer';
-import * as ReactTestUtils from 'react-dom/test-utils';
+import { render, act } from '@testing-library/react';
 import { BaseFloatingPicker } from './BaseFloatingPicker';
 import { SuggestionsStore } from './Suggestions/SuggestionsStore';
 import type { IBaseFloatingPickerProps } from './BaseFloatingPicker.types';
@@ -62,21 +61,21 @@ describe('Pickers', () => {
     });
 
     it('shows zero query options on empty input', () => {
-      const root = document.createElement('div');
       const input = document.createElement('input');
-      document.body.appendChild(input);
-      document.body.appendChild(root);
+      const pickerRef = React.createRef<TypedBaseFloatingPicker>();
 
-      const picker: TypedBaseFloatingPicker = ReactDOM.render(
+      render(
         <BaseFloatingPickerWithType
+          componentRef={pickerRef}
           onResolveSuggestions={onResolveSuggestions}
           onRenderSuggestionsItem={basicSuggestionRenderer}
           suggestionsStore={new SuggestionsStore<ISimple>()}
           onZeroQuerySuggestion={onZeroQuerySuggestion}
           inputElement={input}
         />,
-        root,
-      ) as unknown as TypedBaseFloatingPicker;
+      );
+
+      const picker = pickerRef.current!;
 
       input.value = 'a';
       picker.onQueryStringChanged('a');
@@ -85,36 +84,33 @@ describe('Pickers', () => {
       picker.onQueryStringChanged('');
 
       expect(picker.suggestions.length).toEqual(4);
-
-      ReactDOM.unmountComponentAtNode(root);
     });
 
     it('updates suggestions on query string changed', () => {
       jest.useFakeTimers();
-      const root = document.createElement('div');
       const input = document.createElement('input');
-      document.body.appendChild(input);
-      document.body.appendChild(root);
+      const pickerRef = React.createRef<TypedBaseFloatingPicker>();
 
-      const picker: TypedBaseFloatingPicker = ReactDOM.render(
+      render(
         <BaseFloatingPickerWithType
+          componentRef={pickerRef}
           onResolveSuggestions={onResolveSuggestions}
           onRenderSuggestionsItem={basicSuggestionRenderer}
           suggestionsStore={new SuggestionsStore<ISimple>()}
           inputElement={input}
         />,
-        root,
-      ) as unknown as TypedBaseFloatingPicker;
+      );
+
+      const picker = pickerRef.current!;
 
       input.value = 'b';
       picker.onQueryStringChanged('b');
-      ReactTestUtils.act(() => {
+
+      act(() => {
         jest.runAllTimers();
       });
 
       expect(picker.suggestions.length).toEqual(3);
-
-      ReactDOM.unmountComponentAtNode(root);
     });
   });
 });

--- a/packages/react/src/components/FloatingPicker/Suggestions/SuggestionsControl.test.tsx
+++ b/packages/react/src/components/FloatingPicker/Suggestions/SuggestionsControl.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
 
 import { SuggestionsControl } from './SuggestionsControl';
+import { render } from '@testing-library/react';
 
 const doNothing = () => {
   return;
@@ -11,7 +11,7 @@ describe('Pickers', () => {
   describe('SuggestionsControl', () => {
     it('renders header/footer items with the provided className', () => {
       const root = document.createElement('div');
-      ReactDOM.render(
+      render(
         <SuggestionsControl
           headerItemsProps={[
             {
@@ -32,13 +32,11 @@ describe('Pickers', () => {
           shouldLoopSelection={true}
           onSuggestionClick={doNothing}
         />,
-        root,
+        { container: root },
       );
 
       expect(root.querySelector('.header-item-wrapper .header-item-inner')).not.toBe(null);
       expect(root.querySelector('.footer-item-wrapper .footer-item-inner')).not.toBe(null);
-
-      ReactDOM.unmountComponentAtNode(root);
     });
   });
 });

--- a/packages/react/src/components/GroupedList/GroupedListV2.test.tsx
+++ b/packages/react/src/components/GroupedList/GroupedListV2.test.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import * as path from 'path';
-import { act } from 'react-dom/test-utils';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, act } from '@testing-library/react';
 import { getBySelector } from '../../common/testUtilities';
 import { SelectionMode, Selection } from '../../Selection';
 import { GroupedListV2_unstable as GroupedListV2 } from './GroupedListV2';

--- a/packages/react/src/components/Image/Image.test.tsx
+++ b/packages/react/src/components/Image/Image.test.tsx
@@ -3,8 +3,7 @@ import { create } from '@fluentui/test-utilities';
 import { Image } from './Image';
 import { ImageBase } from './Image.base';
 import { ImageFit, ImageCoverStyle } from './Image.types';
-import { act } from 'react-dom/test-utils';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { isConformant } from '../../common/isConformant';
 
 /**

--- a/packages/react/src/components/Layer/Layer.test.tsx
+++ b/packages/react/src/components/Layer/Layer.test.tsx
@@ -1,6 +1,5 @@
 import '@testing-library/jest-dom';
 import * as React from 'react';
-import * as ReactTestUtils from 'react-dom/test-utils';
 import { Layer } from './Layer';
 import { LayerHost } from './LayerHost';
 import { FocusRectsProvider, IsFocusVisibleClassName } from '../../Utilities';
@@ -100,7 +99,7 @@ describe('Layer', () => {
       document.body.appendChild(appElement);
 
       act(() => {
-        ReactDOM.render(<TestApp hostId="foo" />, appElement);
+        render(<TestApp hostId="foo" />, { container: appElement });
       });
 
       const parentElement = appElement.querySelector('#parent');
@@ -114,7 +113,6 @@ describe('Layer', () => {
 
       expect(childElement.textContent).toEqual('bar');
     } finally {
-      ReactDOM.unmountComponentAtNode(appElement);
       appElement.remove();
     }
   });
@@ -126,12 +124,12 @@ describe('Layer', () => {
       document.body.appendChild(appElement);
       // first render with no host id
       act(() => {
-        ReactDOM.render(<TestApp />, appElement);
+        render(<TestApp />, { container: appElement }).unmount;
       });
 
       // re-render with host id
       act(() => {
-        ReactDOM.render(<TestApp hostId="foo" />, appElement);
+        render(<TestApp hostId="foo" />, { container: appElement });
       });
 
       const parentElement = appElement.querySelector('#parent');
@@ -145,7 +143,6 @@ describe('Layer', () => {
       expect(childElement).toBeTruthy();
       expect(childElement!.textContent).toEqual('bar');
     } finally {
-      ReactDOM.unmountComponentAtNode(appElement);
       appElement.remove();
     }
   });
@@ -300,15 +297,14 @@ describe('Layer', () => {
     try {
       document.body.appendChild(appElement);
 
-      ReactTestUtils.act(() => {
-        ReactDOM.render(<FocusProviderTest />, appElement);
+      act(() => {
+        render(<FocusProviderTest />, { container: appElement });
       });
 
       const focusProvider = appElement.querySelector('.innerFocusProvider');
       expect(focusProvider).toBeTruthy();
       expect(focusProvider?.classList.contains(IsFocusVisibleClassName)).toBeTruthy();
     } finally {
-      ReactDOM.unmountComponentAtNode(appElement);
       appElement.remove();
     }
   });

--- a/packages/react/src/components/Layer/Layer.test.tsx
+++ b/packages/react/src/components/Layer/Layer.test.tsx
@@ -5,7 +5,7 @@ import { Layer } from './Layer';
 import { LayerHost } from './LayerHost';
 import { FocusRectsProvider, IsFocusVisibleClassName } from '../../Utilities';
 import { safeCreate } from '@fluentui/test-utilities';
-import { render } from '@testing-library/react';
+import { render, act } from '@testing-library/react';
 import { PortalCompatContextProvider } from '@fluentui/react-portal-compat-context';
 
 const ReactDOM = require('react-dom');
@@ -99,7 +99,7 @@ describe('Layer', () => {
     try {
       document.body.appendChild(appElement);
 
-      ReactTestUtils.act(() => {
+      act(() => {
         ReactDOM.render(<TestApp hostId="foo" />, appElement);
       });
 
@@ -125,12 +125,12 @@ describe('Layer', () => {
     try {
       document.body.appendChild(appElement);
       // first render with no host id
-      ReactTestUtils.act(() => {
+      act(() => {
         ReactDOM.render(<TestApp />, appElement);
       });
 
       // re-render with host id
-      ReactTestUtils.act(() => {
+      act(() => {
         ReactDOM.render(<TestApp hostId="foo" />, appElement);
       });
 

--- a/packages/react/src/components/OverflowSet/OverflowSet.test.tsx
+++ b/packages/react/src/components/OverflowSet/OverflowSet.test.tsx
@@ -1,14 +1,14 @@
 import * as React from 'react';
-import { create } from '@fluentui/test-utilities';
-import { RenderResult, fireEvent, render } from '@testing-library/react';
+import * as path from 'path';
+import { RenderResult, act, fireEvent, render } from '@testing-library/react';
 import * as renderer from 'react-test-renderer';
-import * as ReactTestUtils from 'react-dom/test-utils';
+import { create } from '@fluentui/test-utilities';
+
 import { CommandBarButton } from '../../Button';
 import { KeytipLayer, KeytipLayerBase } from '../../KeytipLayer';
 import { arraysEqual, find } from '../../Utilities';
 import { KeytipManager, ktpTargetFromId } from '../../Keytips';
 import { OverflowSet } from './OverflowSet';
-import * as path from 'path';
 import { isConformant } from '../../common/isConformant';
 import type { IKeytipProps, IUniqueKeytip } from '../../Keytips';
 import type { IOverflowSetItemProps } from './OverflowSet.types';
@@ -36,7 +36,7 @@ function getPersistedKeytip(keytipManager: KeytipManager, keySequences: string[]
 const noOp = (): any => undefined;
 
 const runAllTimers = () =>
-  ReactTestUtils.act(() => {
+  act(() => {
     jest.runAllTimers();
   });
 

--- a/packages/react/src/components/Panel/Panel.test.tsx
+++ b/packages/react/src/components/Panel/Panel.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
 import { render, screen } from '@testing-library/react';
 
 import { Panel } from './Panel';
@@ -44,7 +43,6 @@ describe('Panel', () => {
   describe('open', () => {
     afterEach(() => {
       if (div) {
-        ReactDOM.unmountComponentAtNode(div);
         div = undefined;
       }
     });

--- a/packages/react/src/components/SelectedItemsList/BaseSelectedItemsList.test.tsx
+++ b/packages/react/src/components/SelectedItemsList/BaseSelectedItemsList.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
 import * as renderer from 'react-test-renderer';
+import { render } from '@testing-library/react';
 import { BaseSelectedItemsList } from './BaseSelectedItemsList';
 import { isConformant } from '../../common/isConformant';
 import type { IBaseSelectedItemsListProps, ISelectedItemProps } from './BaseSelectedItemsList.types';
@@ -42,15 +42,16 @@ describe('SelectedItemsList', () => {
     });
 
     it('can remove items', () => {
-      const root = document.createElement('div');
-
       const onChange = (items: ISimple[] | undefined): void => {
         expect(items!.length).toBe(1);
         expect(items![0].name).toBe('b');
       };
 
-      const itemsList: TypedBaseSelectedItemsList = ReactDOM.render(
+      const ref = React.createRef<TypedBaseSelectedItemsList>();
+
+      render(
         <BaseSelectedItemsListWithType
+          componentRef={ref}
           onRenderItem={basicItemRenderer}
           selectedItems={[
             { key: '1', name: 'a' },
@@ -58,20 +59,19 @@ describe('SelectedItemsList', () => {
           ]}
           onChange={onChange}
         />,
-        root,
-      ) as unknown as TypedBaseSelectedItemsList;
+      );
 
+      const itemsList = ref.current!;
       expect(itemsList.items.length).toEqual(2);
       itemsList.removeItemAt(0);
     });
 
     it('can add items', () => {
-      const root = document.createElement('div');
-      const itemsList: TypedBaseSelectedItemsList = ReactDOM.render(
-        <BaseSelectedItemsListWithType onRenderItem={basicItemRenderer} />,
-        root,
-      ) as unknown as TypedBaseSelectedItemsList;
+      const ref = React.createRef<TypedBaseSelectedItemsList>();
 
+      render(<BaseSelectedItemsListWithType componentRef={ref} onRenderItem={basicItemRenderer} />);
+
+      const itemsList = ref.current!;
       const items: ISimple[] = [
         { key: '1', name: 'a' },
         { key: '2', name: 'b' },

--- a/packages/react/src/components/SelectedItemsList/SelectedPeopleList/SelectedPeopleList.test.tsx
+++ b/packages/react/src/components/SelectedItemsList/SelectedPeopleList/SelectedPeopleList.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
 import * as renderer from 'react-test-renderer';
+import { render } from '@testing-library/react';
 import { isConformant } from '../../../common/isConformant';
 
 import { SelectedPeopleList } from './SelectedPeopleList';
@@ -72,13 +72,8 @@ describe('SelectedPeopleList', () => {
       const ref = React.createRef<SelectedPeopleList>();
 
       // EditingItem has unlisted constraints on being mounted on an actual DOM.
-      // so we can't render it with `renderer` and expect the internal state of the EditingItem to be
-      // initialized
-      const root = document.createElement('div');
-      ReactDOM.render(
-        <SelectedPeopleList ref={ref} editMenuItemText="REMOVE" getEditingItemText={getEditingItemText} />,
-        root,
-      );
+      render(<SelectedPeopleList ref={ref} editMenuItemText="REMOVE" getEditingItemText={getEditingItemText} />);
+
       expect(ref.current).not.toBeNull();
       const picker = ref.current;
       if (picker === null) {

--- a/packages/react/src/components/SpinButton/SpinButton.test.tsx
+++ b/packages/react/src/components/SpinButton/SpinButton.test.tsx
@@ -1,8 +1,7 @@
 import '@testing-library/jest-dom';
 import * as React from 'react';
-import * as ReactTestUtils from 'react-dom/test-utils';
 import { create } from '@fluentui/test-utilities';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 
 import { SpinButton } from './SpinButton';
 import { KeyCodes, resetIds } from '../../Utilities';
@@ -490,7 +489,7 @@ describe('SpinButton', () => {
       fireEvent.input(inputDOM, mockEvent('2 2'));
 
       simulateArrowButton('up');
-      ReactTestUtils.act(() => {
+      act(() => {
         jest.runOnlyPendingTimers();
       });
 
@@ -507,7 +506,7 @@ describe('SpinButton', () => {
       fireEvent.input(inputDOM, mockEvent('garbage'));
 
       simulateArrowKey(KeyCodes.down);
-      ReactTestUtils.act(() => {
+      act(() => {
         jest.runOnlyPendingTimers();
       });
 
@@ -756,7 +755,7 @@ describe('SpinButton', () => {
       const buttonDOM = screen.getAllByRole('button').find(node => node.classList.contains('ms-UpButton'))!;
 
       // start spinning (component will re-render after act() call)
-      ReactTestUtils.act(() => {
+      act(() => {
         fireEvent.mouseDown(buttonDOM, { type: 'mousedown', clientX: 0, clientY: 0 });
       });
       expect(onIncrement).toHaveBeenCalledTimes(1);
@@ -764,7 +763,7 @@ describe('SpinButton', () => {
       expect(onChange).toHaveBeenCalledTimes(1); // called on every spin
 
       // spin again (at one point subsequent spins were broken)
-      ReactTestUtils.act(() => {
+      act(() => {
         jest.runOnlyPendingTimers();
       });
       expect(onIncrement).toHaveBeenCalledTimes(2);
@@ -787,11 +786,11 @@ describe('SpinButton', () => {
       const buttonDOM = screen.getAllByRole('button').find(node => node.classList.contains('ms-UpButton'))!;
 
       // start spinning (component will re-render after act() call)
-      ReactTestUtils.act(() => {
+      act(() => {
         fireEvent.mouseDown(buttonDOM, { type: 'mousedown', clientX: 0, clientY: 0 });
       });
       // spin again
-      ReactTestUtils.act(() => {
+      act(() => {
         jest.runOnlyPendingTimers();
       });
 
@@ -879,7 +878,7 @@ describe('SpinButton', () => {
       verifyValue('5');
 
       // now verify that the spin was triggered
-      ReactTestUtils.act(() => {
+      act(() => {
         jest.runOnlyPendingTimers();
       });
       expect(onChange).toHaveBeenCalledTimes(2);
@@ -887,7 +886,7 @@ describe('SpinButton', () => {
       verifyValue('6');
 
       // spin again to be sure it worked
-      ReactTestUtils.act(() => {
+      act(() => {
         jest.runOnlyPendingTimers();
       });
       expect(onChange).toHaveBeenCalledTimes(3);
@@ -923,7 +922,7 @@ describe('SpinButton', () => {
       verifyValue('5');
 
       // now verify that the spin was triggered
-      ReactTestUtils.act(() => {
+      act(() => {
         jest.runOnlyPendingTimers();
       });
       expect(onChange).toHaveBeenCalledTimes(2);

--- a/packages/react/src/components/TeachingBubble/TeachingBubble.test.tsx
+++ b/packages/react/src/components/TeachingBubble/TeachingBubble.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as ReactTestUtils from 'react-dom/test-utils';
 import * as renderer from 'react-test-renderer';
 import { TeachingBubble } from './TeachingBubble';
 import { TeachingBubbleContent } from './TeachingBubbleContent';
@@ -188,7 +187,7 @@ describe('TeachingBubble', () => {
   });
 
   it('merges callout classNames', () => {
-    ReactTestUtils.renderIntoDocument(<TeachingBubbleContent headline="Title" calloutProps={{ className: 'foo' }} />);
+    render(<TeachingBubbleContent headline="Title" calloutProps={{ className: 'foo' }} />);
     setTimeout(() => {
       const callout = document.querySelector('.ms-Callout') as HTMLElement;
       expect(callout).toBeTruthy();

--- a/packages/react/src/components/Tooltip/Tooltip.test.tsx
+++ b/packages/react/src/components/Tooltip/Tooltip.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
 import * as renderer from 'react-test-renderer';
 import { render } from '@testing-library/react';
 
@@ -15,14 +14,15 @@ const defaultCalloutProps: ICalloutProps = {
   doNotLayer: false,
 };
 
-describe('Tooltip', () => {
-  beforeEach(() => {
+jest.mock('react-dom', () => {
+  return {
+    ...jest.requireActual('react-dom'),
     // Mock createPortal to capture its component hierarchy in snapshot output.
-    jest.spyOn(ReactDOM, 'createPortal').mockImplementation(element => {
-      return element as React.ReactPortal;
-    });
-  });
+    createPortal: jest.fn((node: any) => node),
+  };
+});
 
+describe('Tooltip', () => {
   it('renders default Tooltip correctly', () => {
     const component = renderer.create(<TooltipBase />);
     const tree = component.toJSON();

--- a/packages/react/src/components/Tooltip/Tooltip.test.tsx
+++ b/packages/react/src/components/Tooltip/Tooltip.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import * as renderer from 'react-test-renderer';
-import * as ReactTestUtils from 'react-dom/test-utils';
+import { render } from '@testing-library/react';
 
 import { DirectionalHint } from '../../common/DirectionalHint';
 import { TooltipBase } from './Tooltip.base';
@@ -22,6 +22,7 @@ describe('Tooltip', () => {
       return element as React.ReactPortal;
     });
   });
+
   it('renders default Tooltip correctly', () => {
     const component = renderer.create(<TooltipBase />);
     const tree = component.toJSON();
@@ -48,7 +49,11 @@ describe('Tooltip', () => {
 
     const directionalHint = DirectionalHint.bottomLeftEdge;
     const directionalHintForRTL = DirectionalHint.topRightEdge;
-    const targetElement = ReactTestUtils.renderIntoDocument(<div />) as unknown as HTMLElement;
+
+    // Create a target element with React Testing Library instead of ReactTestUtils
+    const { container } = render(<div data-testid="tooltip-target" />);
+    const targetElement = container.firstElementChild as HTMLElement;
+
     let onRenderCalled = false;
 
     const component = renderer.create(

--- a/packages/react/src/components/pickers/BasePicker.test.tsx
+++ b/packages/react/src/components/pickers/BasePicker.test.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
-import * as ReactTestUtils from 'react-dom/test-utils';
 import * as renderer from 'react-test-renderer';
+import { render, fireEvent, act } from '@testing-library/react';
+import { resetIds, KeyCodes } from '@fluentui/utilities';
 
 import { ValidationState } from './BasePicker.types';
 import { BasePicker } from './BasePicker';
-import { resetIds, KeyCodes } from '@fluentui/utilities';
 import { isConformant } from '../../common/isConformant';
 import type { IBasePickerProps, IBasePicker } from './BasePicker.types';
 import type { IPickerItemProps } from './PickerItem.types';
@@ -50,14 +49,11 @@ const getSuggestions = (root: HTMLElement | Document) => {
 };
 
 describe('BasePicker', () => {
-  let root: HTMLDivElement;
   beforeEach(() => {
-    root = document.createElement('div');
     resetIds();
   });
 
   afterEach(() => {
-    ReactDOM.unmountComponentAtNode(root);
     document.body.textContent = '';
 
     // reset any jest timers
@@ -76,7 +72,7 @@ describe('BasePicker', () => {
   );
 
   const runAllTimers = () =>
-    ReactTestUtils.act(() => {
+    act(() => {
       jest.runAllTimers();
     });
 
@@ -119,10 +115,10 @@ describe('BasePicker', () => {
 
   it('renders inline callout', () => {
     jest.useFakeTimers();
-    document.body.appendChild(root);
+
     const picker = React.createRef<IBasePicker<ISimple>>();
 
-    ReactDOM.render(
+    render(
       <BasePickerWithType
         onResolveSuggestions={onResolveSuggestions}
         onRenderItem={onRenderItem}
@@ -130,13 +126,12 @@ describe('BasePicker', () => {
         componentRef={picker}
         pickerCalloutProps={{ doNotLayer: true, id: 'test' }}
       />,
-      root,
     );
 
     const input = document.querySelector('.ms-BasePicker-input') as HTMLInputElement;
     input.focus();
     input.value = 'b';
-    ReactTestUtils.Simulate.input(input);
+    fireEvent.input(input);
     runAllTimers();
 
     const calloutParent = document.getElementById('test')?.closest('.ms-BasePicker');
@@ -145,30 +140,28 @@ describe('BasePicker', () => {
 
   it('can provide custom renderers', () => {
     jest.useFakeTimers();
-    document.body.appendChild(root);
 
     const picker = React.createRef<IBasePicker<ISimple>>();
-    ReactDOM.render(
+    render(
       <BasePickerWithType
         onResolveSuggestions={onResolveSuggestions}
         onRenderItem={onRenderItem}
         onRenderSuggestionsItem={basicSuggestionRenderer}
         componentRef={picker}
       />,
-      root,
     );
 
     const input = document.querySelector('.ms-BasePicker-input') as HTMLInputElement;
     input.focus();
     input.value = 'bl';
-    ReactTestUtils.Simulate.input(input);
+    fireEvent.input(input);
     runAllTimers();
 
     expect(getSuggestions(document)).toBeTruthy();
 
     const suggestionOptions = document.querySelectorAll('.ms-Suggestions-itemButton');
     expect(suggestionOptions.length).toEqual(2);
-    ReactTestUtils.Simulate.click(suggestionOptions[0]);
+    fireEvent.click(suggestionOptions[0]);
 
     const currentPicker = picker.current!.items;
     expect(currentPicker).toHaveLength(1);
@@ -177,7 +170,6 @@ describe('BasePicker', () => {
 
   it('can select generic items.', () => {
     jest.useFakeTimers();
-    document.body.appendChild(root);
 
     const picker = React.createRef<IBasePicker<ISimple>>();
     const onValidateInput = () => {
@@ -191,7 +183,7 @@ describe('BasePicker', () => {
       };
     };
 
-    ReactDOM.render(
+    render(
       <BasePickerWithType
         onResolveSuggestions={onResolveSuggestions}
         onRenderItem={onRenderItem}
@@ -200,20 +192,19 @@ describe('BasePicker', () => {
         createGenericItem={createGenericItem}
         onValidateInput={onValidateInput}
       />,
-      root,
     );
 
     const input = document.querySelector('.ms-BasePicker-input') as HTMLInputElement;
     input.focus();
     input.value = 'asdff';
-    ReactTestUtils.Simulate.input(input);
+    fireEvent.input(input);
     runAllTimers();
 
     expect(getSuggestions(document)).toBeTruthy();
 
     const suggestionOptions = document.querySelectorAll('.ms-Suggestions-itemButton');
     expect(suggestionOptions.length).toEqual(0);
-    ReactTestUtils.Simulate.keyDown(input, { which: KeyCodes.enter });
+    fireEvent.keyDown(input, { which: KeyCodes.enter, keyCode: KeyCodes.enter });
 
     const currentPicker = picker.current!.items;
     expect(currentPicker).toHaveLength(1);
@@ -222,7 +213,6 @@ describe('BasePicker', () => {
 
   it('has force suggestions button', () => {
     jest.useFakeTimers();
-    document.body.appendChild(root);
 
     const picker = React.createRef<IBasePicker<ISimple>>();
     const onValidateInput = () => {
@@ -238,7 +228,7 @@ describe('BasePicker', () => {
 
     const showForceSuggestionsText = () => true;
 
-    ReactDOM.render(
+    render(
       <BasePickerWithType
         onResolveSuggestions={onResolveSuggestions}
         onRenderItem={onRenderItem}
@@ -251,20 +241,19 @@ describe('BasePicker', () => {
           forceResolveText: 'Force',
         }}
       />,
-      root,
     );
 
     const input = document.querySelector('.ms-BasePicker-input') as HTMLInputElement;
     input.focus();
     input.value = 'asdff';
-    ReactTestUtils.Simulate.input(input);
+    fireEvent.input(input);
     runAllTimers();
 
     expect(getSuggestions(document)).toBeTruthy();
 
     const forceButton = document.querySelectorAll('[data-automationid=sug-forceResolve]');
     expect(forceButton.length).toEqual(1);
-    ReactTestUtils.Simulate.click(forceButton[0]);
+    fireEvent.click(forceButton[0]);
 
     const currentPicker = picker.current!.items;
     expect(currentPicker).toHaveLength(1);
@@ -273,11 +262,10 @@ describe('BasePicker', () => {
 
   it('will not render input when items reach itemLimit', () => {
     jest.useFakeTimers();
-    document.body.appendChild(root);
 
     const picker = React.createRef<IBasePicker<ISimple>>();
 
-    ReactDOM.render(
+    render(
       <BasePickerWithType
         onResolveSuggestions={onResolveSuggestions}
         onRenderItem={onRenderItem}
@@ -285,17 +273,16 @@ describe('BasePicker', () => {
         itemLimit={1}
         componentRef={picker}
       />,
-      root,
     );
 
     let input = document.querySelector('.ms-BasePicker-input') as HTMLInputElement;
     input.focus();
     input.value = 'bl';
-    ReactTestUtils.Simulate.input(input);
+    fireEvent.input(input);
     runAllTimers();
 
     const suggestionOptions = document.querySelectorAll('.ms-Suggestions-itemButton');
-    ReactTestUtils.Simulate.click(suggestionOptions[0]);
+    fireEvent.click(suggestionOptions[0]);
 
     const currentPicker = picker.current!.items;
     expect(currentPicker).toHaveLength(1);
@@ -305,16 +292,13 @@ describe('BasePicker', () => {
   });
 
   it('will still render with itemLimit set to 0', () => {
-    document.body.appendChild(root);
-
-    ReactDOM.render(
+    render(
       <BasePickerWithType
         onResolveSuggestions={onResolveSuggestions}
         onRenderItem={onRenderItem}
         onRenderSuggestionsItem={basicSuggestionRenderer}
         itemLimit={0}
       />,
-      root,
     );
 
     const input = document.querySelector('.ms-BasePicker-input') as HTMLInputElement;
@@ -322,11 +306,9 @@ describe('BasePicker', () => {
   });
 
   it('can be set with selectedItems and a lower itemLimit', () => {
-    document.body.appendChild(root);
-
     const picker = React.createRef<IBasePicker<ISimple>>();
 
-    ReactDOM.render(
+    render(
       <BasePickerWithType
         selectedItems={[
           { key: '1', name: 'blue' },
@@ -338,7 +320,6 @@ describe('BasePicker', () => {
         itemLimit={0}
         componentRef={picker}
       />,
-      root,
     );
 
     const input = document.querySelector('.ms-BasePicker-input') as HTMLInputElement;
@@ -350,11 +331,10 @@ describe('BasePicker', () => {
 
   it('can render MRU when input is focused', () => {
     const resolveSuggestions = () => onResolveSuggestions('');
-    document.body.appendChild(root);
 
     const picker = React.createRef<IBasePicker<ISimple>>();
 
-    ReactDOM.render(
+    render(
       <BasePickerWithType
         onResolveSuggestions={onResolveSuggestions}
         // eslint-disable-next-line @typescript-eslint/no-deprecated
@@ -363,11 +343,10 @@ describe('BasePicker', () => {
         onRenderSuggestionsItem={basicSuggestionRenderer}
         componentRef={picker}
       />,
-      root,
     );
 
     const input = document.querySelector('.ms-BasePicker-input') as HTMLInputElement;
-    ReactTestUtils.Simulate.focus(input);
+    fireEvent.focus(input);
 
     expect(getSuggestions(document)).toBeTruthy();
 
@@ -380,61 +359,57 @@ describe('BasePicker', () => {
 
   it('Closes menu when escape is pressed', () => {
     jest.useFakeTimers();
-    document.body.appendChild(root);
 
     const picker = React.createRef<IBasePicker<ISimple>>();
 
-    ReactDOM.render(
+    render(
       <BasePickerWithType
         onResolveSuggestions={onResolveSuggestions}
         onRenderItem={onRenderItem}
         onRenderSuggestionsItem={basicSuggestionRenderer}
         componentRef={picker}
       />,
-      root,
     );
 
     const input = document.querySelector('.ms-BasePicker-input') as HTMLInputElement;
     input.focus();
     input.value = 'asdff';
-    ReactTestUtils.Simulate.input(input);
+    fireEvent.input(input);
     runAllTimers();
 
     expect(getSuggestions(document)).toBeTruthy();
 
-    ReactTestUtils.Simulate.keyDown(input, { which: 27 });
+    fireEvent.keyDown(input, { which: 27 });
 
     expect(getSuggestions(document)).toBeFalsy();
   });
 
   it('Opens menu on click when suggestions have been dismissed', () => {
     jest.useFakeTimers();
-    document.body.appendChild(root);
 
     const picker = React.createRef<IBasePicker<ISimple>>();
 
-    ReactDOM.render(
+    render(
       <BasePickerWithType
         onResolveSuggestions={onResolveSuggestions}
         onRenderItem={onRenderItem}
         onRenderSuggestionsItem={basicSuggestionRenderer}
         componentRef={picker}
       />,
-      root,
     );
 
     const input = document.querySelector('.ms-BasePicker-input') as HTMLInputElement;
     input.focus();
     input.value = 'asdff';
-    ReactTestUtils.Simulate.input(input);
+    fireEvent.input(input);
     runAllTimers();
 
     expect(getSuggestions(document)).toBeTruthy();
 
-    ReactTestUtils.Simulate.keyDown(input, { which: 27 });
+    fireEvent.keyDown(input, { which: 27 });
 
     expect(getSuggestions(document)).toBeFalsy();
-    ReactTestUtils.Simulate.click(input, { button: 0 });
+    fireEvent.click(input, { button: 0 });
 
     runAllTimers();
 
@@ -444,11 +419,10 @@ describe('BasePicker', () => {
   it('Opens menu when input refocused after search has happened', () => {
     expect(getSuggestions(document)).toBeFalsy();
     jest.useFakeTimers();
-    document.body.appendChild(root);
 
     const picker = React.createRef<IBasePicker<ISimple>>();
 
-    ReactDOM.render(
+    render(
       <div>
         <BasePickerWithType
           onResolveSuggestions={onResolveSuggestions}
@@ -458,13 +432,12 @@ describe('BasePicker', () => {
         />
         <button id="toFocus">focus me</button>
       </div>,
-      root,
     );
 
     const input = document.querySelector('.ms-BasePicker-input') as HTMLInputElement;
     input.focus();
     input.value = 'bl';
-    ReactTestUtils.Simulate.input(input);
+    fireEvent.input(input);
     // For some reason with act() this has to be run twice to make the callout dismiss callback
     // actually be called?
     runAllTimers();
@@ -478,7 +451,7 @@ describe('BasePicker', () => {
     expect(getSuggestions(document)).toBeFalsy();
 
     runAllTimers();
-    ReactTestUtils.Simulate.focus(input);
+    fireEvent.focus(input);
     runAllTimers();
 
     expect(getSuggestions(document)).toBeTruthy();
@@ -487,12 +460,11 @@ describe('BasePicker', () => {
   // TODO: This test should be ported to Cypress due to not working in React 17
   xit('Opens calls onResolveSuggestions if it currently doesnt have suggestions', () => {
     jest.useFakeTimers();
-    document.documentElement.appendChild(root);
 
     const resolveMock = jest.fn(onResolveSuggestions);
     const picker = React.createRef<IBasePicker<ISimple>>();
 
-    ReactDOM.render(
+    render(
       <BasePickerWithType
         onResolveSuggestions={resolveMock}
         onRenderItem={onRenderItem}
@@ -500,11 +472,10 @@ describe('BasePicker', () => {
         componentRef={picker}
         inputProps={{ defaultVisibleValue: 'bl' }}
       />,
-      root,
     );
 
     const input = document.querySelector('.ms-BasePicker-input') as HTMLInputElement;
-    ReactTestUtils.Simulate.focus(input);
+    fireEvent.focus(input);
     runAllTimers();
 
     expect(resolveMock).toHaveBeenCalledTimes(1);
@@ -516,7 +487,6 @@ describe('BasePicker', () => {
 
   it('navigates to search for more button', () => {
     jest.useFakeTimers();
-    document.body.appendChild(root);
 
     const picker = React.createRef<IBasePicker<ISimple>>();
     const onValidateInput = () => {
@@ -530,7 +500,7 @@ describe('BasePicker', () => {
       };
     };
 
-    ReactDOM.render(
+    render(
       <BasePickerWithType
         onResolveSuggestions={onResolveSuggestions}
         onRenderItem={onRenderItem}
@@ -542,38 +512,34 @@ describe('BasePicker', () => {
           searchForMoreText: 'More Options',
         }}
       />,
-      root,
     );
 
     const input = document.querySelector('.ms-BasePicker-input') as HTMLInputElement;
     input.focus();
     input.value = 'b';
-    ReactTestUtils.Simulate.input(input);
+    fireEvent.input(input);
     runAllTimers();
 
     expect(getSuggestions(document)).toBeTruthy();
 
     const moreButton = document.querySelector('[data-automationid=sug-searchForMore]') as HTMLElement;
     expect(moreButton).toBeTruthy();
-    ReactTestUtils.Simulate.keyDown(input, { which: KeyCodes.up });
+    fireEvent.keyDown(input, { which: KeyCodes.up, keyCode: KeyCodes.up });
 
     expect(moreButton.id).toEqual('sug-selectedAction');
     expect(input.getAttribute('aria-activedescendant')).toEqual('sug-selectedAction');
   });
 
   it('focuses the input when the focus method is called', () => {
-    document.body.appendChild(root);
-
     const picker = React.createRef<IBasePicker<ISimple>>();
 
-    ReactDOM.render(
+    render(
       <BasePickerWithType
         componentRef={picker}
         onResolveSuggestions={onResolveSuggestions}
         onRenderItem={onRenderItem}
         onRenderSuggestionsItem={basicSuggestionRenderer}
       />,
-      root,
     );
 
     const input = document.querySelector('.ms-BasePicker-input') as HTMLInputElement;
@@ -584,31 +550,29 @@ describe('BasePicker', () => {
 
   it('focuses the last selected item after removing input', () => {
     jest.useFakeTimers();
-    document.body.appendChild(root);
 
     const onRenderFocusableItem = (props: IPickerItemProps<ISimple>): JSX.Element => (
       <div key={props.item.name} data-selection-index={props.index}>
         <button>{basicRenderer(props)}</button>
       </div>
     );
-    ReactDOM.render(
+    render(
       <BasePickerWithType
         onResolveSuggestions={onResolveSuggestions}
         onRenderItem={onRenderFocusableItem}
         onRenderSuggestionsItem={basicSuggestionRenderer}
         itemLimit={1}
       />,
-      root,
     );
 
     const input = document.querySelector('.ms-BasePicker-input') as HTMLInputElement;
     input.focus();
     input.value = 'bl';
-    ReactTestUtils.Simulate.input(input);
+    fireEvent.input(input);
     runAllTimers();
 
     const suggestionOptions = document.querySelectorAll('.ms-Suggestions-itemButton');
-    ReactTestUtils.Simulate.click(suggestionOptions[0]);
+    fireEvent.click(suggestionOptions[0]);
 
     const selectedItem = document.querySelector('[data-selection-index] > button');
 
@@ -617,7 +581,6 @@ describe('BasePicker', () => {
 
   it('focuses the next selected item after removing a selection', () => {
     jest.useFakeTimers();
-    document.body.appendChild(root);
 
     const onRenderFocusableItem = (props: IPickerItemProps<ISimple>): JSX.Element => {
       return (
@@ -626,7 +589,7 @@ describe('BasePicker', () => {
         </div>
       );
     };
-    ReactDOM.render(
+    render(
       <BasePickerWithType
         defaultSelectedItems={[
           { key: '1', name: 'blue' },
@@ -636,12 +599,11 @@ describe('BasePicker', () => {
         onRenderItem={onRenderFocusableItem}
         onRenderSuggestionsItem={basicSuggestionRenderer}
       />,
-      root,
     );
 
     const selectedEls = document.querySelectorAll('[data-selection-index] > button');
     (selectedEls[0] as HTMLButtonElement).focus();
-    ReactTestUtils.Simulate.click(selectedEls[0]);
+    fireEvent.click(selectedEls[0]);
 
     jest.runAllTimers();
 

--- a/packages/react/src/components/pickers/PeoplePicker/PeoplePicker.test.tsx
+++ b/packages/react/src/components/pickers/PeoplePicker/PeoplePicker.test.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
-import * as ReactTestUtils from 'react-dom/test-utils';
+import { render, fireEvent, act, screen } from '@testing-library/react';
 import * as renderer from 'react-test-renderer';
 import { resetIds } from '@fluentui/utilities';
 import { people } from '@fluentui/example-data';
@@ -34,19 +33,16 @@ describe('PeoplePicker', () => {
 
   it('can search for, select people and remove them', () => {
     jest.useFakeTimers();
-    const root = document.createElement('div');
-    document.body.appendChild(root);
-
     const picker = React.createRef<IBasePicker<IPersonaProps>>();
 
-    ReactDOM.render(<NormalPeoplePicker onResolveSuggestions={onResolveSuggestions} componentRef={picker} />, root);
+    render(<NormalPeoplePicker onResolveSuggestions={onResolveSuggestions} componentRef={picker} />);
 
-    const input = document.querySelector('.ms-BasePicker-input') as HTMLInputElement;
+    const input = screen.getByRole('combobox') as HTMLInputElement;
     input.focus();
     input.value = 'Valentyna';
 
-    ReactTestUtils.Simulate.input(input);
-    ReactTestUtils.act(() => {
+    fireEvent.input(input);
+    act(() => {
       jest.runAllTimers();
     });
 
@@ -56,7 +52,7 @@ describe('PeoplePicker', () => {
     const suggestionOptions = document.querySelectorAll('.ms-Suggestions-itemButton');
     expect(suggestionOptions.length).toEqual(1);
 
-    ReactTestUtils.Simulate.click(suggestionOptions[0]);
+    fireEvent.click(suggestionOptions[0]);
     const currentPicker = picker.current!.items;
     expect(currentPicker).toHaveLength(1);
     expect(currentPicker![0].text).toEqual('Valentyna Lovrique');
@@ -64,27 +60,22 @@ describe('PeoplePicker', () => {
     const removeButton = document.querySelector('.ms-PickerItem-removeButton') as HTMLButtonElement;
     expect(removeButton).toBeTruthy();
 
-    ReactTestUtils.Simulate.click(removeButton);
+    fireEvent.click(removeButton);
     const currentPickerAfterRemove = picker.current!.items;
     expect(currentPickerAfterRemove).toHaveLength(0);
-
-    ReactDOM.unmountComponentAtNode(root);
   });
 
   it('cannot remove people when disabled', () => {
-    const root = document.createElement('div');
-    document.body.appendChild(root);
-
     const picker = React.createRef<IBasePicker<IPersonaProps>>();
     const selectedPeople = people.splice(0, 1);
-    ReactDOM.render(
+
+    render(
       <NormalPeoplePicker
         onResolveSuggestions={onResolveSuggestions}
         componentRef={picker}
         disabled={true}
         defaultSelectedItems={selectedPeople}
       />,
-      root,
     );
 
     const currentPicker = picker.current!.items;
@@ -93,17 +84,15 @@ describe('PeoplePicker', () => {
     const removeButton = document.querySelector('.ms-PickerItem-removeButton') as HTMLButtonElement;
     expect(removeButton).toBeTruthy();
 
-    ReactTestUtils.Simulate.click(removeButton);
+    fireEvent.click(removeButton);
     const currentPickerAfterClick = picker.current!.items;
     expect(currentPickerAfterClick).toHaveLength(1);
-
-    ReactDOM.unmountComponentAtNode(root);
   });
 
   isConformant({
     Component: NormalPeoplePicker,
     displayName: 'NormalPeoplePicker',
-    // Problem: Doesn’t handle ref.
+    // Problem: Doesn't handle ref.
     // Solution: Add a ref to the root element.
     disabledTests: ['has-top-level-file', 'name-matches-filename', 'component-has-root-ref', 'component-handles-ref'],
   });

--- a/packages/react/src/utilities/decorators/withResponsiveMode.test.tsx
+++ b/packages/react/src/utilities/decorators/withResponsiveMode.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as ReactTestUtils from 'react-dom/test-utils';
+import { render } from '@testing-library/react';
 import { setResponsiveMode, withResponsiveMode, ResponsiveMode } from './withResponsiveMode';
 
 // eslint-disable-next-line @typescript-eslint/no-deprecated
@@ -13,6 +13,6 @@ class Example extends React.Component<any, any> {
 describe('withResponsiveMode', () => {
   it('can be used in a server scenario', () => {
     setResponsiveMode(ResponsiveMode.large);
-    expect(() => ReactTestUtils.renderIntoDocument(<Example />)).toBeTruthy();
+    expect(() => render(<Example />)).toBeTruthy();
   });
 });

--- a/packages/react/src/utilities/hooks/useResponsiveMode.test.tsx
+++ b/packages/react/src/utilities/hooks/useResponsiveMode.test.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react';
-import * as ReactTestUtils from 'react-dom/test-utils';
-import { render, cleanup } from '@testing-library/react';
+import { render, cleanup, act } from '@testing-library/react';
 import { ResponsiveMode } from '../decorators/withResponsiveMode';
 import { useResponsiveMode } from './useResponsiveMode';
 
 const resizeTo = (width: number, height: number = 100) => {
-  ReactTestUtils.act(() => {
+  act(() => {
     const win = window as any;
     Object.defineProperty(win.HTMLHtmlElement.prototype, 'clientWidth', { configurable: true, value: width });
     win.innerHeight = height;

--- a/packages/utilities/src/BaseComponent.test.tsx
+++ b/packages/utilities/src/BaseComponent.test.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-
-import * as ReactTestUtils from 'react-dom/test-utils';
+import { render } from '@testing-library/react';
 import { BaseComponent } from './BaseComponent';
 
 describe('BaseComponent', () => {
@@ -15,11 +14,9 @@ describe('BaseComponent', () => {
       }
     }
 
-    let component = ReactTestUtils.renderIntoDocument(
-      <Foo />,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ) as any;
+    const { container } = render(<Foo />);
+    const component = container.firstChild as HTMLElement;
 
-    expect(component.root).toBeTruthy();
+    expect(component).toBeTruthy();
   });
 });

--- a/packages/utilities/src/customizations/customizable.test.tsx
+++ b/packages/utilities/src/customizations/customizable.test.tsx
@@ -1,6 +1,6 @@
 /*  eslint-disable @typescript-eslint/no-deprecated */
 import * as React from 'react';
-import * as ReactDOM from 'react-dom/server';
+import { renderToStaticMarkup } from 'react-dom/server';
 import { render } from '@testing-library/react';
 import * as renderer from 'react-test-renderer';
 import { customizable } from './customizable';
@@ -70,25 +70,25 @@ describe('customizable', () => {
 
   it('can receive global customizations', () => {
     Customizations.applySettings({ field: 'globalName' });
-    expect(ReactDOM.renderToStaticMarkup(<Foo />)).toEqual('<div>globalName</div>');
+    expect(renderToStaticMarkup(<Foo />)).toEqual('<div>globalName</div>');
   });
 
   it('can receive scoped customizations', () => {
     Customizations.applySettings({ field: 'globalName' });
     Customizations.applyScopedSettings('Foo', { field: 'scopedName' });
-    expect(ReactDOM.renderToStaticMarkup(<Foo />)).toEqual('<div>scopedName</div>');
+    expect(renderToStaticMarkup(<Foo />)).toEqual('<div>scopedName</div>');
   });
 
   it('can ignore scoped customizations that do not apply', () => {
     Customizations.applySettings({ field: 'globalName' });
     Customizations.applyScopedSettings('Bar', { field: 'scopedName' });
-    expect(ReactDOM.renderToStaticMarkup(<Foo />)).toEqual('<div>globalName</div>');
+    expect(renderToStaticMarkup(<Foo />)).toEqual('<div>globalName</div>');
   });
 
   it('can accept props over global/scoped values', () => {
     Customizations.applySettings({ field: 'globalName' });
     Customizations.applyScopedSettings('Foo', { field: 'scopedName' });
-    expect(ReactDOM.renderToStaticMarkup(<Foo field="name" />)).toEqual('<div>name</div>');
+    expect(renderToStaticMarkup(<Foo field="name" />)).toEqual('<div>name</div>');
   });
 
   it('can concatenate global styles and component styles', () => {

--- a/packages/utilities/src/focus.test.tsx
+++ b/packages/utilities/src/focus.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import { createTestContainer } from '@fluentui/test-utilities';
 
 import {
@@ -13,8 +13,8 @@ import {
 } from './focus';
 
 function renderIntoDocument(element: React.ReactElement<{}>, container: HTMLElement): HTMLElement {
-  const component = ReactDOM.render(element, container) as React.ReactInstance;
-  const renderedDOM = ReactDOM.findDOMNode(component) as HTMLElement;
+  const component = render(element, { container });
+  const renderedDOM = component.container.firstChild as HTMLElement;
 
   return renderedDOM;
 }
@@ -53,7 +53,6 @@ describe('isElementVisible', () => {
 
   afterEach(() => {
     if (testContainer) {
-      ReactDOM.unmountComponentAtNode(testContainer);
       testContainer.remove();
       testContainer = undefined;
     }
@@ -207,7 +206,6 @@ describe('focusAsync', () => {
   let testContainer: HTMLElement | undefined;
   afterEach(() => {
     if (testContainer) {
-      ReactDOM.unmountComponentAtNode(testContainer);
       testContainer.remove();
       testContainer = undefined;
     }
@@ -355,7 +353,6 @@ describe('getFirstTabbable', () => {
   let testContainer: HTMLElement | undefined;
   afterEach(() => {
     if (testContainer) {
-      ReactDOM.unmountComponentAtNode(testContainer);
       testContainer.remove();
       testContainer = undefined;
     }
@@ -447,7 +444,6 @@ describe('getLastTabbable', () => {
   let testContainer: HTMLElement | undefined;
   afterEach(() => {
     if (testContainer) {
-      ReactDOM.unmountComponentAtNode(testContainer);
       testContainer.remove();
       testContainer = undefined;
     }

--- a/packages/utilities/src/useFocusRects.test.tsx
+++ b/packages/utilities/src/useFocusRects.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as ReactTestUtils from 'react-dom/test-utils';
+
 import * as renderer from 'react-test-renderer';
 import { FocusRects } from './useFocusRects';
 import { FocusRectsProvider } from './FocusRectsProvider';
@@ -412,7 +412,7 @@ describe('useFocusRects', () => {
       const { eventListeners } = providerElem;
       expect(eventListeners.keyup).toBeDefined();
 
-      ReactTestUtils.act(() => {
+      act(() => {
         eventListeners.keyup!({ target: mockTarget, which: KeyCodes.up });
       });
       expect(mockWindow.classNames.indexOf(IsFocusHiddenClassName) > -1).toBeFalsy();
@@ -421,7 +421,7 @@ describe('useFocusRects', () => {
       expect(providerElem.classList.contains(IsFocusVisibleClassName)).toBeTruthy();
 
       classNames = [];
-      ReactTestUtils.act(() => {
+      act(() => {
         eventListeners.keyup!({ target: mockTarget, which: KeyCodes.down });
       });
       expect(mockWindow.classNames.indexOf(IsFocusHiddenClassName) > -1).toBeFalsy();
@@ -429,7 +429,7 @@ describe('useFocusRects', () => {
       expect(providerElem.classList.contains(IsFocusHiddenClassName)).toBeFalsy();
       expect(providerElem.classList.contains(IsFocusVisibleClassName)).toBeTruthy();
 
-      ReactTestUtils.act(() => {
+      act(() => {
         eventListeners.keyup!({ target: mockTarget, which: KeyCodes.left });
       });
       expect(mockWindow.classNames.indexOf(IsFocusHiddenClassName) > -1).toBeFalsy();
@@ -437,7 +437,7 @@ describe('useFocusRects', () => {
       expect(providerElem.classList.contains(IsFocusHiddenClassName)).toBeFalsy();
       expect(providerElem.classList.contains(IsFocusVisibleClassName)).toBeTruthy();
 
-      ReactTestUtils.act(() => {
+      act(() => {
         eventListeners.keyup!({ target: mockTarget, which: KeyCodes.right });
       });
       expect(mockWindow.classNames.indexOf(IsFocusHiddenClassName) > -1).toBeFalsy();
@@ -445,7 +445,7 @@ describe('useFocusRects', () => {
       expect(providerElem.classList.contains(IsFocusHiddenClassName)).toBeFalsy();
       expect(providerElem.classList.contains(IsFocusVisibleClassName)).toBeTruthy();
 
-      ReactTestUtils.act(() => {
+      act(() => {
         eventListeners.keyup!({ target: mockTarget, which: KeyCodes.tab });
       });
       expect(mockWindow.classNames.indexOf(IsFocusHiddenClassName) > -1).toBeFalsy();
@@ -453,7 +453,7 @@ describe('useFocusRects', () => {
       expect(providerElem.classList.contains(IsFocusHiddenClassName)).toBeFalsy();
       expect(providerElem.classList.contains(IsFocusVisibleClassName)).toBeTruthy();
 
-      ReactTestUtils.act(() => {
+      act(() => {
         eventListeners.keyup!({ target: mockTarget, which: KeyCodes.pageUp });
       });
       expect(mockWindow.classNames.indexOf(IsFocusHiddenClassName) > -1).toBeFalsy();
@@ -461,7 +461,7 @@ describe('useFocusRects', () => {
       expect(providerElem.classList.contains(IsFocusHiddenClassName)).toBeFalsy();
       expect(providerElem.classList.contains(IsFocusVisibleClassName)).toBeTruthy();
 
-      ReactTestUtils.act(() => {
+      act(() => {
         eventListeners.keyup!({ target: mockTarget, which: KeyCodes.pageDown });
       });
       expect(mockWindow.classNames.indexOf(IsFocusHiddenClassName) > -1).toBeFalsy();
@@ -469,7 +469,7 @@ describe('useFocusRects', () => {
       expect(providerElem.classList.contains(IsFocusHiddenClassName)).toBeFalsy();
       expect(providerElem.classList.contains(IsFocusVisibleClassName)).toBeTruthy();
 
-      ReactTestUtils.act(() => {
+      act(() => {
         eventListeners.keyup!({ target: mockTarget, which: KeyCodes.home });
       });
       expect(mockWindow.classNames.indexOf(IsFocusHiddenClassName) > -1).toBeFalsy();
@@ -477,7 +477,7 @@ describe('useFocusRects', () => {
       expect(providerElem.classList.contains(IsFocusHiddenClassName)).toBeFalsy();
       expect(providerElem.classList.contains(IsFocusVisibleClassName)).toBeTruthy();
 
-      ReactTestUtils.act(() => {
+      act(() => {
         eventListeners.keyup!({ target: mockTarget, which: KeyCodes.end });
       });
       expect(mockWindow.classNames.indexOf(IsFocusHiddenClassName) > -1).toBeFalsy();
@@ -507,7 +507,7 @@ describe('useFocusRects', () => {
       const { eventListeners } = providerElem;
       expect(eventListeners.keyup).toBeDefined();
 
-      ReactTestUtils.act(() => {
+      act(() => {
         eventListeners.keyup!({ target: mockTarget, which: 127 });
       });
       expect(mockWindow.classNames.indexOf(IsFocusVisibleClassName) > -1).toBeFalsy();
@@ -537,7 +537,7 @@ describe('useFocusRects', () => {
       expect(eventListeners.keyup).toBeDefined();
       expect(eventListeners.mousedown).toBeDefined();
 
-      ReactTestUtils.act(() => {
+      act(() => {
         eventListeners.keyup!({ target: mockTarget, which: KeyCodes.down });
       });
       expect(mockWindow.classNames.indexOf(IsFocusHiddenClassName) > -1).toBeFalsy();
@@ -545,7 +545,7 @@ describe('useFocusRects', () => {
       expect(providerElem.classList.contains(IsFocusHiddenClassName)).toBeFalsy();
       expect(providerElem.classList.contains(IsFocusVisibleClassName)).toBeTruthy();
 
-      ReactTestUtils.act(() => {
+      act(() => {
         eventListeners.mousedown!({ target: mockTarget });
       });
       expect(mockWindow.classNames.indexOf(IsFocusHiddenClassName) > -1).toBeFalsy();
@@ -575,7 +575,7 @@ describe('useFocusRects', () => {
       const { eventListeners } = providerElem;
       expect(eventListeners.keyup).toBeDefined();
 
-      ReactTestUtils.act(() => {
+      act(() => {
         eventListeners.keyup!({ target: mockTarget, which: KeyCodes.f6 });
       });
       expect(mockWindow.classNames.indexOf(IsFocusVisibleClassName) > -1).toBeFalsy();
@@ -584,7 +584,7 @@ describe('useFocusRects', () => {
 
       addDirectionalKeyCode(KeyCodes.f6);
 
-      ReactTestUtils.act(() => {
+      act(() => {
         eventListeners.keyup!({ target: mockTarget, which: KeyCodes.f6 });
       });
       expect(mockWindow.classNames.indexOf(IsFocusHiddenClassName) > -1).toBeFalsy();


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

- Follows https://github.com/microsoft/fluentui/pull/34270
- Needs https://github.com/microsoft/fluentui/pull/34308
- React 18 wont work with r17 `react-dom` apis as it introduced breaking changes , thus only way forward is to refactor these patterns in all v8 code -> this PR addresses that
- Migrated projects
  - react
  - react-focus
  - react-hooks
  - react-experiments 
  - utilities

**Next/Final steps:**

> additional PR coming

Properly wrap test cases within `act` which is missing ATM and most of tests are failing with react 18

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
