### PR TITLE
feat: add useTypingAnnounce hook for managing live regions triggered by user input

### DIFF
--- a/packages/react-components/react-aria/library/src/AriaLiveAnnouncer/useAriaLiveAnnouncer.test.tsx
+++ b/packages/react-components/react-aria/library/src/AriaLiveAnnouncer/useAriaLiveAnnouncer.test.tsx
@@ -54,6 +54,7 @@ describe('useAriaLiveAnnouncer', () => {
       const { result } = renderHook(() => useAriaLiveAnnouncer({}), { wrapper: ContextWrapper });
 
       result.current.announce('message loaded');
+      jest.advanceTimersByTime(0);
       expect(innerNode?.innerText).toBe('message loaded' + ANNOUNCE_SUFFIX);
     });
 
@@ -105,6 +106,19 @@ describe('useAriaLiveAnnouncer', () => {
       );
     });
 
+    it('should handle batched messages in the same tick, and announce only the last', () => {
+      const appendChild = jest.spyOn(liveRegionNode!, 'appendChild');
+      const { result } = renderHook(() => useAriaLiveAnnouncer({}), { wrapper: ContextWrapper });
+
+      result.current.announce('message loaded', { batchId: 'test' });
+      result.current.announce('message reloaded', { batchId: 'test' });
+      result.current.announce('message revolutions', { batchId: 'test' });
+      jest.advanceTimersByTime(100);
+
+      expect(appendChild).toHaveBeenCalledTimes(1);
+      expect(innerNode?.innerText).toBe('message revolutions' + ANNOUNCE_SUFFIX);
+    });
+
     it('should announce batched and unbatched messages', () => {
       const { result } = renderHook(() => useAriaLiveAnnouncer({}), { wrapper: ContextWrapper });
 
@@ -123,6 +137,7 @@ describe('useAriaLiveAnnouncer', () => {
       const { result } = renderHook(() => useAriaLiveAnnouncer({}), { wrapper: ContextWrapper });
 
       result.current.announce('message resurrections');
+      jest.advanceTimersByTime(0);
       expect(innerNode?.innerText).toBe('message resurrections' + ANNOUNCE_SUFFIX);
 
       jest.advanceTimersByTime(ANNOUNCE_TIMEOUT);

--- a/packages/react-components/react-aria/library/src/AriaLiveAnnouncer/useDomAnnounce.ts
+++ b/packages/react-components/react-aria/library/src/AriaLiveAnnouncer/useDomAnnounce.ts
@@ -70,6 +70,7 @@ export const useDomAnnounce_unstable = (): AriaLiveAnnounceFn => {
 
         elementRef.current.innerText = '';
         elementRef.current.appendChild(wrappingEl);
+        console.log('Announcing:', wrappingEl.innerText);
 
         messageQueue.clear();
         batchMessages.current = [];
@@ -86,7 +87,12 @@ export const useDomAnnounce_unstable = (): AriaLiveAnnounceFn => {
       }
     };
 
-    runCycle();
+    // Run the first cycle with a 0 timeout to ensure multiple messages in the same tick are handled
+    timeoutRef.current = setAnnounceTimeout(() => {
+      runCycle();
+    }, 0);
+
+    // runCycle();
   }, [clearAnnounceTimeout, messageQueue, setAnnounceTimeout, targetDocument]);
 
   const announce: AriaLiveAnnounceFn = React.useCallback(

--- a/packages/react-components/react-aria/library/src/useTypingAnnounce/useTypingAnnounce.ts
+++ b/packages/react-components/react-aria/library/src/useTypingAnnounce/useTypingAnnounce.ts
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import { useTimeout } from '@fluentui/react-utilities';
+import { useAnnounce } from '@fluentui/react-components';
+import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
+import type { AnnounceOptions } from '@fluentui/react-shared-contexts';
+import { AriaLiveAnnounceFn } from '../AriaLiveAnnouncer/AriaLiveAnnouncer.types';
+
+const valueMutationOptions = {
+  attributes: true,
+  subtree: true,
+  characterData: true,
+  attributeFilter: ['value'],
+};
+
+export const useTypingAnnounce = (inputEl: React.RefObject<HTMLElement>): { typingAnnounce: AriaLiveAnnounceFn } => {
+  const [setTypingTimeout, clearTypingTimeout] = useTimeout();
+  const { targetDocument } = useFluent();
+  const win = targetDocument?.defaultView;
+  const { announce } = useAnnounce();
+
+  const typingAnnounce: AriaLiveAnnounceFn = React.useCallback((message: string, options: AnnounceOptions = {}) => {
+    if (!win || !inputEl?.current) {
+      return;
+    }
+
+    const callback: MutationCallback = (mutationList, observer) => {
+      clearTypingTimeout();
+      setTypingTimeout(() => {
+        console.log('announcing:', message);
+        announce(message, options);
+        observer.disconnect();
+      }, 500);
+    };
+
+    // create mutation observer
+    const observer = new win.MutationObserver(callback);
+    observer.observe(inputEl.current, valueMutationOptions);
+
+    setTypingTimeout(() => {
+      announce(message, options);
+    }, 500);
+  }, []);
+
+  return { typingAnnounce };
+};

--- a/packages/react-components/react-aria/stories/src/useTypingAnnounce/index.stories.tsx
+++ b/packages/react-components/react-aria/stories/src/useTypingAnnounce/index.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta } from '@storybook/react';
 // import descriptionMd from './AriaLiveAnnouncerDescription.md';
 
 export { Default } from './useTypingAnnounceDefault.stories';
+export { ContentEditable } from './useTypingAnnounceContentEditable.stories';
 
 export default {
   title: 'Utilities/ARIA live/useTypingAnnounce',

--- a/packages/react-components/react-aria/stories/src/useTypingAnnounce/index.stories.tsx
+++ b/packages/react-components/react-aria/stories/src/useTypingAnnounce/index.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta } from '@storybook/react';
+
+// import descriptionMd from './AriaLiveAnnouncerDescription.md';
+
+export { Default } from './useTypingAnnounceDefault.stories';
+
+export default {
+  title: 'Utilities/ARIA live/useTypingAnnounce',
+  parameters: {
+    docs: {
+      description: {
+        // component: [descriptionMd].join('\n'),
+      },
+    },
+  },
+} as Meta;

--- a/packages/react-components/react-aria/stories/src/useTypingAnnounce/useTypingAnnounceContentEditable.stories.tsx
+++ b/packages/react-components/react-aria/stories/src/useTypingAnnounce/useTypingAnnounceContentEditable.stories.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import { AriaLiveAnnouncer, Field, makeStyles, tokens, useId } from '@fluentui/react-components';
+import { useTypingAnnounce } from '../../../library/src/useTypingAnnounce/useTypingAnnounce';
+
+const useStyles = makeStyles({
+  contentEditable: {
+    border: `1px solid ${tokens.colorNeutralStroke1}`,
+    borderRadius: '4px',
+    padding: '0.5em',
+  },
+});
+
+const charCountMessage = (count: number) => {
+  // the threshold for announcing character count updates is 10 characters
+  const threshold = 10;
+
+  // the maxLength is 100
+  const maxLength = 100;
+
+  if (count >= maxLength) {
+    return `You have reached the maximum character limit, ${maxLength}`;
+  } else if (maxLength - count === 1) {
+    return `You have 1 character remaining`;
+  } else if (maxLength - count <= threshold) {
+    return `You have ${maxLength - count} characters remaining`;
+  } else return undefined;
+};
+
+export const ContentEditable = () => {
+  const inputRef = React.useRef<HTMLSpanElement>(null);
+  const [count, setCount] = React.useState(0);
+  const styles = useStyles();
+
+  // pass typingAnnounce a batchId to ensure new charCount updates override old ones
+  const announceId = useId('charCount');
+
+  const { typingAnnounce } = useTypingAnnounce(inputRef);
+
+  const onInput = ev => {
+    setCount(ev.target.textContent.length);
+
+    const message = charCountMessage(ev.target.textContent.length);
+    if (message) {
+      typingAnnounce(message, { batchId: announceId });
+    }
+  };
+
+  return (
+    <AriaLiveAnnouncer>
+      <Field label="A contenteditable div with a maxlength of 100" hint={`${count}/100`}>
+        {fieldProps => (
+          <span contentEditable ref={inputRef} onInput={onInput} className={styles.contentEditable} {...fieldProps} />
+        )}
+      </Field>
+    </AriaLiveAnnouncer>
+  );
+};

--- a/packages/react-components/react-aria/stories/src/useTypingAnnounce/useTypingAnnounceDefault.stories.tsx
+++ b/packages/react-components/react-aria/stories/src/useTypingAnnounce/useTypingAnnounceDefault.stories.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { AriaLiveAnnouncer, Field, Input } from '@fluentui/react-components';
+import { useTypingAnnounce } from '../../../library/src/useTypingAnnounce/useTypingAnnounce';
+
+export const Default = () => {
+  const inputRef = React.useRef<HTMLInputElement>(null);
+  const [overLimit, setOverLimit] = React.useState(false);
+
+  const { typingAnnounce } = useTypingAnnounce(inputRef);
+
+  const onChange = (_, data: any) => {
+    setOverLimit(data.value.length > 20);
+
+    if (overLimit) {
+      typingAnnounce('You have reached the maximum character limit');
+    }
+  };
+
+  return (
+    <AriaLiveAnnouncer>
+      <Field label="A field with a maxlength of 20" validationState={overLimit ? 'error' : undefined}>
+        <Input onChange={onChange} ref={inputRef} />
+      </Field>
+    </AriaLiveAnnouncer>
+  );
+};

--- a/packages/react-components/react-aria/stories/src/useTypingAnnounce/useTypingAnnounceDefault.stories.tsx
+++ b/packages/react-components/react-aria/stories/src/useTypingAnnounce/useTypingAnnounceDefault.stories.tsx
@@ -1,18 +1,19 @@
 import * as React from 'react';
-import { AriaLiveAnnouncer, Field, Input } from '@fluentui/react-components';
+import { AriaLiveAnnouncer, Field, Input, useId } from '@fluentui/react-components';
 import { useTypingAnnounce } from '../../../library/src/useTypingAnnounce/useTypingAnnounce';
 
 export const Default = () => {
   const inputRef = React.useRef<HTMLInputElement>(null);
   const [overLimit, setOverLimit] = React.useState(false);
+  const announceId = useId('charLimit');
 
   const { typingAnnounce } = useTypingAnnounce(inputRef);
 
   const onChange = (_, data: any) => {
     setOverLimit(data.value.length > 20);
 
-    if (overLimit) {
-      typingAnnounce('You have reached the maximum character limit');
+    if (data.value.length > 20) {
+      typingAnnounce('You have reached the maximum character limit', { batchId: announceId });
     }
   };
 


### PR DESCRIPTION
## Previous Behavior

It's tricky to handle live region messages that are triggered while the user is typing, since firing them immediately risks either interrupting or being immediately interrupted buy the keyboard echo of the user's continued input. The general best practice is to have a debounce based on keyboard input, and fire the live region after ~0.5s of no typing.

We've had a number of partner teams who need this and have either implemented it poorly, or reached out to ask how to do it correctly (e.g. because the live region was never coming through in the screen reader, since the speech queue was always immediately overridden by continued typing).

## New Behavior

This hook builds in that behavior for partner teams without them needing to know or code that specific typing/live region guidance. Instead, they can just call `typingAnnounce('message')` for any notifications triggered by user input.

Uses `announce()` under the hood, so batching and other options are handled by that hook.