### PR TITLE
fix(react-charting): Fixing Overlapping and Skewed Horizontal bars

### DIFF
--- a/change/@fluentui-react-charting-b2762e6c-2902-41d6-8375-5175c251feac.json
+++ b/change/@fluentui-react-charting-b2762e6c-2902-41d6-8375-5175c251feac.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(react-charting): Fixing Overlapping and Skewed Horizontal bars",
+  "packageName": "@fluentui/react-charting",
+  "email": "120183316+srmukher@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charts/react-charting/src/components/HorizontalBarChartWithAxis/HorizontalBarChartWithAxis.base.tsx
+++ b/packages/charts/react-charting/src/components/HorizontalBarChartWithAxis/HorizontalBarChartWithAxis.base.tsx
@@ -1,12 +1,7 @@
 import * as React from 'react';
 import { max as d3Max, min as d3Min } from 'd3-array';
 import { select as d3Select } from 'd3-selection';
-import {
-  scaleLinear as d3ScaleLinear,
-  ScaleLinear as D3ScaleLinear,
-  scaleBand as d3ScaleBand,
-  ScaleBand,
-} from 'd3-scale';
+import { scaleLinear as d3ScaleLinear, ScaleLinear as D3ScaleLinear, scaleBand as d3ScaleBand } from 'd3-scale';
 import { classNamesFunction, getId, getRTL, initializeComponentRef } from '@fluentui/react/lib/Utilities';
 import { IProcessedStyleSet, IPalette } from '@fluentui/react/lib/Styling';
 import { DirectionalHint } from '@fluentui/react/lib/Callout';

--- a/packages/charts/react-charting/src/components/HorizontalBarChartWithAxis/HorizontalBarChartWithAxisRTL.test.tsx
+++ b/packages/charts/react-charting/src/components/HorizontalBarChartWithAxis/HorizontalBarChartWithAxisRTL.test.tsx
@@ -113,10 +113,10 @@ describe('Horizontal bar chart with axis - Subcomponent bar', () => {
       // Assert
       const bars = screen.getAllByText((content, element) => element!.tagName.toLowerCase() === 'rect');
       expect(bars).toHaveLength(4);
-      expect(bars[0].getAttribute('height')).toEqual('50');
-      expect(bars[1].getAttribute('height')).toEqual('50');
-      expect(bars[2].getAttribute('height')).toEqual('50');
-      expect(bars[3].getAttribute('height')).toEqual('50');
+      expect(bars[0].getAttribute('height')).toEqual('26.25');
+      expect(bars[1].getAttribute('height')).toEqual('26.25');
+      expect(bars[2].getAttribute('height')).toEqual('26.25');
+      expect(bars[3].getAttribute('height')).toEqual('26.25');
     },
   );
 });

--- a/packages/charts/react-charting/src/components/HorizontalBarChartWithAxis/__snapshots__/HorizontalBarChartWithAxis.test.tsx.snap
+++ b/packages/charts/react-charting/src/components/HorizontalBarChartWithAxis/__snapshots__/HorizontalBarChartWithAxis.test.tsx.snap
@@ -29,14 +29,14 @@ exports[`HorizontalBarChartWithAxis snapShot testing Should render gradients on 
           outline: none;
         }
 
-    data-focuszone-id="FocusZone5"
+    data-focuszone-id="FocusZone8"
     data-tabster="{\\"uncontrolled\\": {}}"
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseDownCapture={[Function]}
   >
     <svg
-      aria-label="Horizontal bar chart with 4 bars. The X axis displays values. The Y axis displays values. "
+      aria-label="Horizontal bar chart with 4 bars. The X axis displays values. The Y axis displays categories. "
       height={0}
       role="region"
       style={
@@ -104,12 +104,117 @@ exports[`HorizontalBarChartWithAxis snapShot testing Should render gradients on 
         transform="translate(40, 0)"
       />
       <g>
-         
-         
-         
         <defs>
           <linearGradient
-            id="HBCWA_Gradient4_0_20000"
+            id="HBCWA_Gradient4_0_10000"
+          >
+            <stop
+              offset="0"
+              stopColor="#4760D5"
+            />
+            <stop
+              offset="100%"
+              stopColor="#637CEF"
+            />
+          </linearGradient>
+        </defs>
+        <rect
+          aria-label="2020/04/30. 10%."
+          aria-labelledby="toolTipcallout0"
+          className=
+
+              {
+                opacity: ;
+              }
+          data-is-focusable={true}
+          fill="url(#HBCWA_Gradient4_0_10000)"
+          height={21.75}
+          onBlur={[Function]}
+          onFocus={[Function]}
+          onMouseLeave={[Function]}
+          onMouseOver={[Function]}
+          role="img"
+          rx={0}
+          transform="translate(0,-5.125)"
+          width={15}
+          x={25}
+          y={14.25}
+        />
+        <defs>
+          <linearGradient
+            id="HBCWA_Gradient5_0_40000"
+          >
+            <stop
+              offset="0"
+              stopColor="#B146C2"
+            />
+            <stop
+              offset="100%"
+              stopColor="#C36BD1"
+            />
+          </linearGradient>
+        </defs>
+        <rect
+          aria-label="2020/04/30. 88%."
+          aria-labelledby="toolTipcallout0"
+          className=
+
+              {
+                opacity: ;
+              }
+          data-is-focusable={true}
+          fill="url(#HBCWA_Gradient5_0_40000)"
+          height={21.75}
+          onBlur={[Function]}
+          onFocus={[Function]}
+          onMouseLeave={[Function]}
+          onMouseOver={[Function]}
+          role="img"
+          rx={0}
+          transform="translate(0,-5.125)"
+          width={60}
+          x={-20}
+          y={-51}
+        />
+        <defs>
+          <linearGradient
+            id="HBCWA_Gradient6_0_25000"
+          >
+            <stop
+              offset="0"
+              stopColor="#159195"
+            />
+            <stop
+              offset="100%"
+              stopColor="#2AA0A4"
+            />
+          </linearGradient>
+        </defs>
+        <rect
+          aria-label="2020/04/30. 37%."
+          aria-labelledby="toolTipcallout0"
+          className=
+
+              {
+                opacity: ;
+              }
+          data-is-focusable={true}
+          fill="url(#HBCWA_Gradient6_0_25000)"
+          height={21.75}
+          onBlur={[Function]}
+          onFocus={[Function]}
+          onMouseLeave={[Function]}
+          onMouseOver={[Function]}
+          role="img"
+          rx={0}
+          transform="translate(0,-5.125)"
+          width={37.5}
+          x={2.5}
+          y={-29.25}
+        />
+        <defs>
+          <linearGradient
+            id="HBCWA_Gradient7_0_20000"
           >
             <stop
               offset="0"
@@ -130,17 +235,18 @@ exports[`HorizontalBarChartWithAxis snapShot testing Should render gradients on 
                 opacity: ;
               }
           data-is-focusable={true}
-          fill="url(#HBCWA_Gradient4_0_20000)"
-          height={32}
+          fill="url(#HBCWA_Gradient7_0_20000)"
+          height={21.75}
           onBlur={[Function]}
           onFocus={[Function]}
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
           role="img"
           rx={0}
+          transform="translate(0,-5.125)"
           width={30}
           x={10}
-          y={4}
+          y={-7.5}
         />
       </g>
     </svg>
@@ -191,7 +297,7 @@ exports[`HorizontalBarChartWithAxis snapShot testing Should render gradients on 
                   &:focus {
                     outline: none;
                   }
-              data-focuszone-id="FocusZone6"
+              data-focuszone-id="FocusZone9"
               data-tabster="{\\"uncontrolled\\": {}}"
               onFocus={[Function]}
               onKeyDown={[Function]}
@@ -664,14 +770,14 @@ exports[`HorizontalBarChartWithAxis snapShot testing Should render rounded corne
           outline: none;
         }
 
-    data-focuszone-id="FocusZone5"
+    data-focuszone-id="FocusZone8"
     data-tabster="{\\"uncontrolled\\": {}}"
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseDownCapture={[Function]}
   >
     <svg
-      aria-label="Horizontal bar chart with 4 bars. The X axis displays values. The Y axis displays values. "
+      aria-label="Horizontal bar chart with 4 bars. The X axis displays values. The Y axis displays categories. "
       height={0}
       role="region"
       style={
@@ -739,9 +845,72 @@ exports[`HorizontalBarChartWithAxis snapShot testing Should render rounded corne
         transform="translate(40, 0)"
       />
       <g>
-         
-         
-         
+        <rect
+          aria-label="2020/04/30. 10%."
+          aria-labelledby="toolTipcallout0"
+          className=
+
+              {
+                opacity: ;
+              }
+          data-is-focusable={true}
+          fill="#4760D5"
+          height={21.75}
+          onBlur={[Function]}
+          onFocus={[Function]}
+          onMouseLeave={[Function]}
+          onMouseOver={[Function]}
+          role="img"
+          rx={3}
+          transform="translate(0,-5.125)"
+          width={15}
+          x={25}
+          y={14.25}
+        />
+        <rect
+          aria-label="2020/04/30. 88%."
+          aria-labelledby="toolTipcallout0"
+          className=
+
+              {
+                opacity: ;
+              }
+          data-is-focusable={true}
+          fill="#B146C2"
+          height={21.75}
+          onBlur={[Function]}
+          onFocus={[Function]}
+          onMouseLeave={[Function]}
+          onMouseOver={[Function]}
+          role="img"
+          rx={3}
+          transform="translate(0,-5.125)"
+          width={60}
+          x={-20}
+          y={-51}
+        />
+        <rect
+          aria-label="2020/04/30. 37%."
+          aria-labelledby="toolTipcallout0"
+          className=
+
+              {
+                opacity: ;
+              }
+          data-is-focusable={true}
+          fill="#159195"
+          height={21.75}
+          onBlur={[Function]}
+          onFocus={[Function]}
+          onMouseLeave={[Function]}
+          onMouseOver={[Function]}
+          role="img"
+          rx={3}
+          transform="translate(0,-5.125)"
+          width={37.5}
+          x={2.5}
+          y={-29.25}
+        />
         <rect
           aria-label="2020/04/30. 20%."
           aria-labelledby="toolTipcallout0"
@@ -752,16 +921,17 @@ exports[`HorizontalBarChartWithAxis snapShot testing Should render rounded corne
               }
           data-is-focusable={true}
           fill="#795AA6"
-          height={32}
+          height={21.75}
           onBlur={[Function]}
           onFocus={[Function]}
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
           role="img"
           rx={3}
+          transform="translate(0,-5.125)"
           width={30}
           x={10}
-          y={4}
+          y={-7.5}
         />
       </g>
     </svg>
@@ -812,7 +982,7 @@ exports[`HorizontalBarChartWithAxis snapShot testing Should render rounded corne
                   &:focus {
                     outline: none;
                   }
-              data-focuszone-id="FocusZone6"
+              data-focuszone-id="FocusZone9"
               data-tabster="{\\"uncontrolled\\": {}}"
               onFocus={[Function]}
               onKeyDown={[Function]}
@@ -903,8 +1073,8 @@ exports[`HorizontalBarChartWithAxis snapShot testing Should render rounded corne
                       className=
 
                           {
-                            background-color: #0078d4;
-                            border-color: #0078d4;
+                            background-color: #4760D5;
+                            border-color: #4760D5;
                             border: 1px solid;
                             content: ;
                             height: 12px;
@@ -912,7 +1082,7 @@ exports[`HorizontalBarChartWithAxis snapShot testing Should render rounded corne
                             width: 12px;
                           }
                           @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
-                            content: linear-gradient(to right, #0078d4, #0078d4);
+                            content: linear-gradient(to right, #4760D5, #4760D5);
                             opacity: ;
                           }
                     />
@@ -1111,8 +1281,8 @@ exports[`HorizontalBarChartWithAxis snapShot testing Should render rounded corne
                       className=
 
                           {
-                            background-color: #00188f;
-                            border-color: #00188f;
+                            background-color: #159195;
+                            border-color: #159195;
                             border: 1px solid;
                             content: ;
                             height: 12px;
@@ -1120,7 +1290,7 @@ exports[`HorizontalBarChartWithAxis snapShot testing Should render rounded corne
                             width: 12px;
                           }
                           @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
-                            content: linear-gradient(to right, #00188f, #00188f);
+                            content: linear-gradient(to right, #159195, #159195);
                             opacity: ;
                           }
                     />
@@ -1215,8 +1385,8 @@ exports[`HorizontalBarChartWithAxis snapShot testing Should render rounded corne
                       className=
 
                           {
-                            background-color: #00bcf2;
-                            border-color: #00bcf2;
+                            background-color: #B146C2;
+                            border-color: #B146C2;
                             border: 1px solid;
                             content: ;
                             height: 12px;
@@ -1224,7 +1394,7 @@ exports[`HorizontalBarChartWithAxis snapShot testing Should render rounded corne
                             width: 12px;
                           }
                           @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
-                            content: linear-gradient(to right, #00bcf2, #00bcf2);
+                            content: linear-gradient(to right, #B146C2, #B146C2);
                             opacity: ;
                           }
                     />
@@ -1285,14 +1455,14 @@ exports[`HorizontalBarChartWithAxis snapShot testing renders HorizontalBarChartW
           outline: none;
         }
 
-    data-focuszone-id="FocusZone5"
+    data-focuszone-id="FocusZone8"
     data-tabster="{\\"uncontrolled\\": {}}"
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseDownCapture={[Function]}
   >
     <svg
-      aria-label="Horizontal bar chart with 4 bars. The X axis displays values. The Y axis displays values. "
+      aria-label="Horizontal bar chart with 4 bars. The X axis displays values. The Y axis displays categories. "
       height={0}
       role="region"
       style={
@@ -1360,9 +1530,72 @@ exports[`HorizontalBarChartWithAxis snapShot testing renders HorizontalBarChartW
         transform="translate(40, 0)"
       />
       <g>
-         
-         
-         
+        <rect
+          aria-label="2020/04/30. 10%."
+          aria-labelledby="toolTipcallout0"
+          className=
+
+              {
+                opacity: ;
+              }
+          data-is-focusable={true}
+          fill="#0078d4"
+          height={21.75}
+          onBlur={[Function]}
+          onFocus={[Function]}
+          onMouseLeave={[Function]}
+          onMouseOver={[Function]}
+          role="img"
+          rx={0}
+          transform="translate(0,-5.125)"
+          width={15}
+          x={25}
+          y={14.25}
+        />
+        <rect
+          aria-label="2020/04/30. 88%."
+          aria-labelledby="toolTipcallout0"
+          className=
+
+              {
+                opacity: ;
+              }
+          data-is-focusable={true}
+          fill="#00bcf2"
+          height={21.75}
+          onBlur={[Function]}
+          onFocus={[Function]}
+          onMouseLeave={[Function]}
+          onMouseOver={[Function]}
+          role="img"
+          rx={0}
+          transform="translate(0,-5.125)"
+          width={60}
+          x={-20}
+          y={-51}
+        />
+        <rect
+          aria-label="2020/04/30. 37%."
+          aria-labelledby="toolTipcallout0"
+          className=
+
+              {
+                opacity: ;
+              }
+          data-is-focusable={true}
+          fill="#00188f"
+          height={21.75}
+          onBlur={[Function]}
+          onFocus={[Function]}
+          onMouseLeave={[Function]}
+          onMouseOver={[Function]}
+          role="img"
+          rx={0}
+          transform="translate(0,-5.125)"
+          width={37.5}
+          x={2.5}
+          y={-29.25}
+        />
         <rect
           aria-label="2020/04/30. 20%."
           aria-labelledby="toolTipcallout0"
@@ -1373,16 +1606,17 @@ exports[`HorizontalBarChartWithAxis snapShot testing renders HorizontalBarChartW
               }
           data-is-focusable={true}
           fill="#002050"
-          height={32}
+          height={21.75}
           onBlur={[Function]}
           onFocus={[Function]}
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
           role="img"
           rx={0}
+          transform="translate(0,-5.125)"
           width={30}
           x={10}
-          y={4}
+          y={-7.5}
         />
       </g>
     </svg>
@@ -1433,7 +1667,7 @@ exports[`HorizontalBarChartWithAxis snapShot testing renders HorizontalBarChartW
                   &:focus {
                     outline: none;
                   }
-              data-focuszone-id="FocusZone6"
+              data-focuszone-id="FocusZone9"
               data-tabster="{\\"uncontrolled\\": {}}"
               onFocus={[Function]}
               onKeyDown={[Function]}
@@ -1906,14 +2140,14 @@ exports[`HorizontalBarChartWithAxis snapShot testing renders hideLegend correctl
           outline: none;
         }
 
-    data-focuszone-id="FocusZone5"
+    data-focuszone-id="FocusZone8"
     data-tabster="{\\"uncontrolled\\": {}}"
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseDownCapture={[Function]}
   >
     <svg
-      aria-label="Horizontal bar chart with 4 bars. The X axis displays values. The Y axis displays values. "
+      aria-label="Horizontal bar chart with 4 bars. The X axis displays values. The Y axis displays categories. "
       height={0}
       role="region"
       style={
@@ -1981,9 +2215,72 @@ exports[`HorizontalBarChartWithAxis snapShot testing renders hideLegend correctl
         transform="translate(40, 0)"
       />
       <g>
-         
-         
-         
+        <rect
+          aria-label="2020/04/30. 10%."
+          aria-labelledby="toolTipcallout0"
+          className=
+
+              {
+                opacity: ;
+              }
+          data-is-focusable={true}
+          fill="#0078d4"
+          height={21.75}
+          onBlur={[Function]}
+          onFocus={[Function]}
+          onMouseLeave={[Function]}
+          onMouseOver={[Function]}
+          role="img"
+          rx={0}
+          transform="translate(0,-5.125)"
+          width={15}
+          x={25}
+          y={14.25}
+        />
+        <rect
+          aria-label="2020/04/30. 88%."
+          aria-labelledby="toolTipcallout0"
+          className=
+
+              {
+                opacity: ;
+              }
+          data-is-focusable={true}
+          fill="#00bcf2"
+          height={21.75}
+          onBlur={[Function]}
+          onFocus={[Function]}
+          onMouseLeave={[Function]}
+          onMouseOver={[Function]}
+          role="img"
+          rx={0}
+          transform="translate(0,-5.125)"
+          width={60}
+          x={-20}
+          y={-51}
+        />
+        <rect
+          aria-label="2020/04/30. 37%."
+          aria-labelledby="toolTipcallout0"
+          className=
+
+              {
+                opacity: ;
+              }
+          data-is-focusable={true}
+          fill="#00188f"
+          height={21.75}
+          onBlur={[Function]}
+          onFocus={[Function]}
+          onMouseLeave={[Function]}
+          onMouseOver={[Function]}
+          role="img"
+          rx={0}
+          transform="translate(0,-5.125)"
+          width={37.5}
+          x={2.5}
+          y={-29.25}
+        />
         <rect
           aria-label="2020/04/30. 20%."
           aria-labelledby="toolTipcallout0"
@@ -1994,16 +2291,17 @@ exports[`HorizontalBarChartWithAxis snapShot testing renders hideLegend correctl
               }
           data-is-focusable={true}
           fill="#002050"
-          height={32}
+          height={21.75}
           onBlur={[Function]}
           onFocus={[Function]}
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
           role="img"
           rx={0}
+          transform="translate(0,-5.125)"
           width={30}
           x={10}
-          y={4}
+          y={-7.5}
         />
       </g>
     </svg>

--- a/packages/charts/react-charting/src/components/HorizontalBarChartWithAxis/__snapshots__/HorizontalBarChartWithAxisRTL.test.tsx.snap
+++ b/packages/charts/react-charting/src/components/HorizontalBarChartWithAxis/__snapshots__/HorizontalBarChartWithAxisRTL.test.tsx.snap
@@ -29,11 +29,11 @@ exports[`Horizontal bar chart with axis - Screen resolution Should remain unchan
             outline: none;
           }
 
-      data-focuszone-id="FocusZone5"
+      data-focuszone-id="FocusZone8"
       data-tabster="{\\"uncontrolled\\": {}}"
     >
       <svg
-        aria-label="Horizontal bar chart with 4 bars. The X axis displays values. The Y axis displays values. "
+        aria-label="Horizontal bar chart with 4 bars. The X axis displays values. The Y axis displays categories. "
         focusable="false"
         height="292"
         role="region"
@@ -275,27 +275,26 @@ exports[`Horizontal bar chart with axis - Screen resolution Should remain unchan
         >
           <path
             class="domain"
-            d="M-6,257.5H0.5V20.5H-6"
+            d="M-6,241.5H0.5V36.5H-6"
             stroke="currentColor"
           />
           <g
             class="tick"
             opacity="1"
-            transform="translate(0,257.5)"
+            transform="translate(0,215.375)"
           >
             <line
               stroke="currentColor"
               x2="-6"
             />
             <text
-              aria-hidden="true"
               dy="0.32em"
               fill="currentColor"
               text-align="start"
               x="-16"
             >
               <tspan
-                data-="0"
+                data-="13000"
                 dy="0.32em"
                 id="BaseSpan"
                 x="-16"
@@ -305,28 +304,27 @@ exports[`Horizontal bar chart with axis - Screen resolution Should remain unchan
                 id="LessLength"
                 x="-16"
               >
-                0
+                13000
               </tspan>
             </text>
           </g>
           <g
             class="tick"
             opacity="1"
-            transform="translate(0,210.10000000000002)"
+            transform="translate(0,164.125)"
           >
             <line
               stroke="currentColor"
               x2="-6"
             />
             <text
-              aria-hidden="true"
               dy="0.32em"
               fill="currentColor"
               text-align="start"
               x="-16"
             >
               <tspan
-                data-="10k"
+                data-="30000"
                 dy="0.32em"
                 id="BaseSpan"
                 x="-16"
@@ -336,28 +334,27 @@ exports[`Horizontal bar chart with axis - Screen resolution Should remain unchan
                 id="LessLength"
                 x="-16"
               >
-                10k
+                30000
               </tspan>
             </text>
           </g>
           <g
             class="tick"
             opacity="1"
-            transform="translate(0,162.7)"
+            transform="translate(0,112.875)"
           >
             <line
               stroke="currentColor"
               x2="-6"
             />
             <text
-              aria-hidden="true"
               dy="0.32em"
               fill="currentColor"
               text-align="start"
               x="-16"
             >
               <tspan
-                data-="20k"
+                data-="50000"
                 dy="0.32em"
                 id="BaseSpan"
                 x="-16"
@@ -367,28 +364,27 @@ exports[`Horizontal bar chart with axis - Screen resolution Should remain unchan
                 id="LessLength"
                 x="-16"
               >
-                20k
+                50000
               </tspan>
             </text>
           </g>
           <g
             class="tick"
             opacity="1"
-            transform="translate(0,115.30000000000001)"
+            transform="translate(0,61.625)"
           >
             <line
               stroke="currentColor"
               x2="-6"
             />
             <text
-              aria-hidden="true"
               dy="0.32em"
               fill="currentColor"
               text-align="start"
               x="-16"
             >
               <tspan
-                data-="30k"
+                data-="5000"
                 dy="0.32em"
                 id="BaseSpan"
                 x="-16"
@@ -398,69 +394,7 @@ exports[`Horizontal bar chart with axis - Screen resolution Should remain unchan
                 id="LessLength"
                 x="-16"
               >
-                30k
-              </tspan>
-            </text>
-          </g>
-          <g
-            class="tick"
-            opacity="1"
-            transform="translate(0,67.89999999999999)"
-          >
-            <line
-              stroke="currentColor"
-              x2="-6"
-            />
-            <text
-              aria-hidden="true"
-              dy="0.32em"
-              fill="currentColor"
-              text-align="start"
-              x="-16"
-            >
-              <tspan
-                data-="40k"
-                dy="0.32em"
-                id="BaseSpan"
-                x="-16"
-              />
-              <tspan
-                dx="1em"
-                id="LessLength"
-                x="-16"
-              >
-                40k
-              </tspan>
-            </text>
-          </g>
-          <g
-            class="tick"
-            opacity="1"
-            transform="translate(0,20.5)"
-          >
-            <line
-              stroke="currentColor"
-              x2="-6"
-            />
-            <text
-              aria-hidden="true"
-              dy="0.32em"
-              fill="currentColor"
-              text-align="start"
-              x="-16"
-            >
-              <tspan
-                data-="50k"
-                dy="0.32em"
-                id="BaseSpan"
-                x="-16"
-              />
-              <tspan
-                dx="1em"
-                id="LessLength"
-                x="-16"
-              >
-                50k
+                5000
               </tspan>
             </text>
           </g>
@@ -480,9 +414,10 @@ exports[`Horizontal bar chart with axis - Screen resolution Should remain unchan
             role="img"
             rx="0"
             tabindex="0"
+            transform="translate(0,9.625)"
             width="147.5"
             x="40"
-            y="217.3"
+            y="36"
           />
           <rect
             aria-label="88%. 2020/04/30."
@@ -498,9 +433,10 @@ exports[`Horizontal bar chart with axis - Screen resolution Should remain unchan
             role="img"
             rx="0"
             tabindex="-1"
+            transform="translate(0,9.625)"
             width="590"
             x="40"
-            y="179.38"
+            y="189.75"
           />
           <rect
             aria-label="37%. 2020/04/30."
@@ -516,9 +452,10 @@ exports[`Horizontal bar chart with axis - Screen resolution Should remain unchan
             role="img"
             rx="0"
             tabindex="-1"
+            transform="translate(0,9.625)"
             width="368.75"
             x="40"
-            y="98.80000000000001"
+            y="138.5"
           />
           <rect
             aria-label="20%. 2020/04/30."
@@ -534,9 +471,10 @@ exports[`Horizontal bar chart with axis - Screen resolution Should remain unchan
             role="img"
             rx="0"
             tabindex="-1"
+            transform="translate(0,9.625)"
             width="295"
             x="40"
-            y="4"
+            y="87.25"
           />
         </g>
       </svg>
@@ -578,7 +516,7 @@ exports[`Horizontal bar chart with axis - Screen resolution Should remain unchan
                     &:focus {
                       outline: none;
                     }
-                data-focuszone-id="FocusZone6"
+                data-focuszone-id="FocusZone9"
                 data-tabster="{\\"uncontrolled\\": {}}"
                 role="listbox"
               >
@@ -1033,11 +971,11 @@ exports[`Horizontal bar chart with axis - Screen resolution Should remain unchan
             outline: none;
           }
 
-      data-focuszone-id="FocusZone5"
+      data-focuszone-id="FocusZone8"
       data-tabster="{\\"uncontrolled\\": {}}"
     >
       <svg
-        aria-label="Horizontal bar chart with 4 bars. The X axis displays values. The Y axis displays values. "
+        aria-label="Horizontal bar chart with 4 bars. The X axis displays values. The Y axis displays categories. "
         focusable="false"
         height="292"
         role="region"
@@ -1279,27 +1217,26 @@ exports[`Horizontal bar chart with axis - Screen resolution Should remain unchan
         >
           <path
             class="domain"
-            d="M-6,257.5H0.5V20.5H-6"
+            d="M-6,241.5H0.5V36.5H-6"
             stroke="currentColor"
           />
           <g
             class="tick"
             opacity="1"
-            transform="translate(0,257.5)"
+            transform="translate(0,215.375)"
           >
             <line
               stroke="currentColor"
               x2="-6"
             />
             <text
-              aria-hidden="true"
               dy="0.32em"
               fill="currentColor"
               text-align="start"
               x="-16"
             >
               <tspan
-                data-="0"
+                data-="13000"
                 dy="0.32em"
                 id="BaseSpan"
                 x="-16"
@@ -1309,28 +1246,27 @@ exports[`Horizontal bar chart with axis - Screen resolution Should remain unchan
                 id="LessLength"
                 x="-16"
               >
-                0
+                13000
               </tspan>
             </text>
           </g>
           <g
             class="tick"
             opacity="1"
-            transform="translate(0,210.10000000000002)"
+            transform="translate(0,164.125)"
           >
             <line
               stroke="currentColor"
               x2="-6"
             />
             <text
-              aria-hidden="true"
               dy="0.32em"
               fill="currentColor"
               text-align="start"
               x="-16"
             >
               <tspan
-                data-="10k"
+                data-="30000"
                 dy="0.32em"
                 id="BaseSpan"
                 x="-16"
@@ -1340,28 +1276,27 @@ exports[`Horizontal bar chart with axis - Screen resolution Should remain unchan
                 id="LessLength"
                 x="-16"
               >
-                10k
+                30000
               </tspan>
             </text>
           </g>
           <g
             class="tick"
             opacity="1"
-            transform="translate(0,162.7)"
+            transform="translate(0,112.875)"
           >
             <line
               stroke="currentColor"
               x2="-6"
             />
             <text
-              aria-hidden="true"
               dy="0.32em"
               fill="currentColor"
               text-align="start"
               x="-16"
             >
               <tspan
-                data-="20k"
+                data-="50000"
                 dy="0.32em"
                 id="BaseSpan"
                 x="-16"
@@ -1371,28 +1306,27 @@ exports[`Horizontal bar chart with axis - Screen resolution Should remain unchan
                 id="LessLength"
                 x="-16"
               >
-                20k
+                50000
               </tspan>
             </text>
           </g>
           <g
             class="tick"
             opacity="1"
-            transform="translate(0,115.30000000000001)"
+            transform="translate(0,61.625)"
           >
             <line
               stroke="currentColor"
               x2="-6"
             />
             <text
-              aria-hidden="true"
               dy="0.32em"
               fill="currentColor"
               text-align="start"
               x="-16"
             >
               <tspan
-                data-="30k"
+                data-="5000"
                 dy="0.32em"
                 id="BaseSpan"
                 x="-16"
@@ -1402,69 +1336,7 @@ exports[`Horizontal bar chart with axis - Screen resolution Should remain unchan
                 id="LessLength"
                 x="-16"
               >
-                30k
-              </tspan>
-            </text>
-          </g>
-          <g
-            class="tick"
-            opacity="1"
-            transform="translate(0,67.89999999999999)"
-          >
-            <line
-              stroke="currentColor"
-              x2="-6"
-            />
-            <text
-              aria-hidden="true"
-              dy="0.32em"
-              fill="currentColor"
-              text-align="start"
-              x="-16"
-            >
-              <tspan
-                data-="40k"
-                dy="0.32em"
-                id="BaseSpan"
-                x="-16"
-              />
-              <tspan
-                dx="1em"
-                id="LessLength"
-                x="-16"
-              >
-                40k
-              </tspan>
-            </text>
-          </g>
-          <g
-            class="tick"
-            opacity="1"
-            transform="translate(0,20.5)"
-          >
-            <line
-              stroke="currentColor"
-              x2="-6"
-            />
-            <text
-              aria-hidden="true"
-              dy="0.32em"
-              fill="currentColor"
-              text-align="start"
-              x="-16"
-            >
-              <tspan
-                data-="50k"
-                dy="0.32em"
-                id="BaseSpan"
-                x="-16"
-              />
-              <tspan
-                dx="1em"
-                id="LessLength"
-                x="-16"
-              >
-                50k
+                5000
               </tspan>
             </text>
           </g>
@@ -1484,9 +1356,10 @@ exports[`Horizontal bar chart with axis - Screen resolution Should remain unchan
             role="img"
             rx="0"
             tabindex="0"
+            transform="translate(0,9.625)"
             width="147.5"
             x="40"
-            y="217.3"
+            y="36"
           />
           <rect
             aria-label="88%. 2020/04/30."
@@ -1502,9 +1375,10 @@ exports[`Horizontal bar chart with axis - Screen resolution Should remain unchan
             role="img"
             rx="0"
             tabindex="-1"
+            transform="translate(0,9.625)"
             width="590"
             x="40"
-            y="179.38"
+            y="189.75"
           />
           <rect
             aria-label="37%. 2020/04/30."
@@ -1520,9 +1394,10 @@ exports[`Horizontal bar chart with axis - Screen resolution Should remain unchan
             role="img"
             rx="0"
             tabindex="-1"
+            transform="translate(0,9.625)"
             width="368.75"
             x="40"
-            y="98.80000000000001"
+            y="138.5"
           />
           <rect
             aria-label="20%. 2020/04/30."
@@ -1538,9 +1413,10 @@ exports[`Horizontal bar chart with axis - Screen resolution Should remain unchan
             role="img"
             rx="0"
             tabindex="-1"
+            transform="translate(0,9.625)"
             width="295"
             x="40"
-            y="4"
+            y="87.25"
           />
         </g>
       </svg>
@@ -1582,7 +1458,7 @@ exports[`Horizontal bar chart with axis - Screen resolution Should remain unchan
                     &:focus {
                       outline: none;
                     }
-                data-focuszone-id="FocusZone6"
+                data-focuszone-id="FocusZone9"
                 data-tabster="{\\"uncontrolled\\": {}}"
                 role="listbox"
               >
@@ -2050,11 +1926,11 @@ exports[`Horizontal bar chart with axis - Theme Should reflect theme change 1`] 
               outline: none;
             }
 
-        data-focuszone-id="FocusZone8"
+        data-focuszone-id="FocusZone11"
         data-tabster="{\\"uncontrolled\\": {}}"
       >
         <svg
-          aria-label="Horizontal bar chart with 4 bars. The X axis displays values. The Y axis displays values. "
+          aria-label="Horizontal bar chart with 4 bars. The X axis displays values. The Y axis displays categories. "
           focusable="false"
           height="292"
           role="region"
@@ -2296,27 +2172,26 @@ exports[`Horizontal bar chart with axis - Theme Should reflect theme change 1`] 
           >
             <path
               class="domain"
-              d="M-6,257.5H0.5V20.5H-6"
+              d="M-6,241.5H0.5V36.5H-6"
               stroke="currentColor"
             />
             <g
               class="tick"
               opacity="1"
-              transform="translate(0,257.5)"
+              transform="translate(0,215.375)"
             >
               <line
                 stroke="currentColor"
                 x2="-6"
               />
               <text
-                aria-hidden="true"
                 dy="0.32em"
                 fill="currentColor"
                 text-align="start"
                 x="-16"
               >
                 <tspan
-                  data-="0"
+                  data-="13000"
                   dy="0.32em"
                   id="BaseSpan"
                   x="-16"
@@ -2326,28 +2201,27 @@ exports[`Horizontal bar chart with axis - Theme Should reflect theme change 1`] 
                   id="LessLength"
                   x="-16"
                 >
-                  0
+                  13000
                 </tspan>
               </text>
             </g>
             <g
               class="tick"
               opacity="1"
-              transform="translate(0,210.10000000000002)"
+              transform="translate(0,164.125)"
             >
               <line
                 stroke="currentColor"
                 x2="-6"
               />
               <text
-                aria-hidden="true"
                 dy="0.32em"
                 fill="currentColor"
                 text-align="start"
                 x="-16"
               >
                 <tspan
-                  data-="10k"
+                  data-="30000"
                   dy="0.32em"
                   id="BaseSpan"
                   x="-16"
@@ -2357,28 +2231,27 @@ exports[`Horizontal bar chart with axis - Theme Should reflect theme change 1`] 
                   id="LessLength"
                   x="-16"
                 >
-                  10k
+                  30000
                 </tspan>
               </text>
             </g>
             <g
               class="tick"
               opacity="1"
-              transform="translate(0,162.7)"
+              transform="translate(0,112.875)"
             >
               <line
                 stroke="currentColor"
                 x2="-6"
               />
               <text
-                aria-hidden="true"
                 dy="0.32em"
                 fill="currentColor"
                 text-align="start"
                 x="-16"
               >
                 <tspan
-                  data-="20k"
+                  data-="50000"
                   dy="0.32em"
                   id="BaseSpan"
                   x="-16"
@@ -2388,28 +2261,27 @@ exports[`Horizontal bar chart with axis - Theme Should reflect theme change 1`] 
                   id="LessLength"
                   x="-16"
                 >
-                  20k
+                  50000
                 </tspan>
               </text>
             </g>
             <g
               class="tick"
               opacity="1"
-              transform="translate(0,115.30000000000001)"
+              transform="translate(0,61.625)"
             >
               <line
                 stroke="currentColor"
                 x2="-6"
               />
               <text
-                aria-hidden="true"
                 dy="0.32em"
                 fill="currentColor"
                 text-align="start"
                 x="-16"
               >
                 <tspan
-                  data-="30k"
+                  data-="5000"
                   dy="0.32em"
                   id="BaseSpan"
                   x="-16"
@@ -2419,69 +2291,7 @@ exports[`Horizontal bar chart with axis - Theme Should reflect theme change 1`] 
                   id="LessLength"
                   x="-16"
                 >
-                  30k
-                </tspan>
-              </text>
-            </g>
-            <g
-              class="tick"
-              opacity="1"
-              transform="translate(0,67.89999999999999)"
-            >
-              <line
-                stroke="currentColor"
-                x2="-6"
-              />
-              <text
-                aria-hidden="true"
-                dy="0.32em"
-                fill="currentColor"
-                text-align="start"
-                x="-16"
-              >
-                <tspan
-                  data-="40k"
-                  dy="0.32em"
-                  id="BaseSpan"
-                  x="-16"
-                />
-                <tspan
-                  dx="1em"
-                  id="LessLength"
-                  x="-16"
-                >
-                  40k
-                </tspan>
-              </text>
-            </g>
-            <g
-              class="tick"
-              opacity="1"
-              transform="translate(0,20.5)"
-            >
-              <line
-                stroke="currentColor"
-                x2="-6"
-              />
-              <text
-                aria-hidden="true"
-                dy="0.32em"
-                fill="currentColor"
-                text-align="start"
-                x="-16"
-              >
-                <tspan
-                  data-="50k"
-                  dy="0.32em"
-                  id="BaseSpan"
-                  x="-16"
-                />
-                <tspan
-                  dx="1em"
-                  id="LessLength"
-                  x="-16"
-                >
-                  50k
+                  5000
                 </tspan>
               </text>
             </g>
@@ -2501,9 +2311,10 @@ exports[`Horizontal bar chart with axis - Theme Should reflect theme change 1`] 
               role="img"
               rx="0"
               tabindex="0"
+              transform="translate(0,9.625)"
               width="147.5"
               x="40"
-              y="217.3"
+              y="36"
             />
             <rect
               aria-label="88%. 2020/04/30."
@@ -2519,9 +2330,10 @@ exports[`Horizontal bar chart with axis - Theme Should reflect theme change 1`] 
               role="img"
               rx="0"
               tabindex="-1"
+              transform="translate(0,9.625)"
               width="590"
               x="40"
-              y="179.38"
+              y="189.75"
             />
             <rect
               aria-label="37%. 2020/04/30."
@@ -2537,9 +2349,10 @@ exports[`Horizontal bar chart with axis - Theme Should reflect theme change 1`] 
               role="img"
               rx="0"
               tabindex="-1"
+              transform="translate(0,9.625)"
               width="368.75"
               x="40"
-              y="98.80000000000001"
+              y="138.5"
             />
             <rect
               aria-label="20%. 2020/04/30."
@@ -2555,9 +2368,10 @@ exports[`Horizontal bar chart with axis - Theme Should reflect theme change 1`] 
               role="img"
               rx="0"
               tabindex="-1"
+              transform="translate(0,9.625)"
               width="295"
               x="40"
-              y="4"
+              y="87.25"
             />
           </g>
         </svg>
@@ -2599,7 +2413,7 @@ exports[`Horizontal bar chart with axis - Theme Should reflect theme change 1`] 
                       &:focus {
                         outline: none;
                       }
-                  data-focuszone-id="FocusZone9"
+                  data-focuszone-id="FocusZone12"
                   data-tabster="{\\"uncontrolled\\": {}}"
                   role="listbox"
                 >
@@ -3055,11 +2869,11 @@ exports[`Horizontal bar chart with axis rendering Should render the Horizontal b
             outline: none;
           }
 
-      data-focuszone-id="FocusZone5"
+      data-focuszone-id="FocusZone8"
       data-tabster="{\\"uncontrolled\\": {}}"
     >
       <svg
-        aria-label="Horizontal bar chart with 4 bars. The X axis displays values. The Y axis displays values. "
+        aria-label="Horizontal bar chart with 4 bars. The X axis displays values. The Y axis displays categories. "
         focusable="false"
         height="292"
         role="region"
@@ -3301,27 +3115,26 @@ exports[`Horizontal bar chart with axis rendering Should render the Horizontal b
         >
           <path
             class="domain"
-            d="M-6,257.5H0.5V20.5H-6"
+            d="M-6,241.5H0.5V36.5H-6"
             stroke="currentColor"
           />
           <g
             class="tick"
             opacity="1"
-            transform="translate(0,257.5)"
+            transform="translate(0,215.375)"
           >
             <line
               stroke="currentColor"
               x2="-6"
             />
             <text
-              aria-hidden="true"
               dy="0.32em"
               fill="currentColor"
               text-align="start"
               x="-16"
             >
               <tspan
-                data-="0"
+                data-="13000"
                 dy="0.32em"
                 id="BaseSpan"
                 x="-16"
@@ -3331,28 +3144,27 @@ exports[`Horizontal bar chart with axis rendering Should render the Horizontal b
                 id="LessLength"
                 x="-16"
               >
-                0
+                13000
               </tspan>
             </text>
           </g>
           <g
             class="tick"
             opacity="1"
-            transform="translate(0,210.10000000000002)"
+            transform="translate(0,164.125)"
           >
             <line
               stroke="currentColor"
               x2="-6"
             />
             <text
-              aria-hidden="true"
               dy="0.32em"
               fill="currentColor"
               text-align="start"
               x="-16"
             >
               <tspan
-                data-="10k"
+                data-="30000"
                 dy="0.32em"
                 id="BaseSpan"
                 x="-16"
@@ -3362,28 +3174,27 @@ exports[`Horizontal bar chart with axis rendering Should render the Horizontal b
                 id="LessLength"
                 x="-16"
               >
-                10k
+                30000
               </tspan>
             </text>
           </g>
           <g
             class="tick"
             opacity="1"
-            transform="translate(0,162.7)"
+            transform="translate(0,112.875)"
           >
             <line
               stroke="currentColor"
               x2="-6"
             />
             <text
-              aria-hidden="true"
               dy="0.32em"
               fill="currentColor"
               text-align="start"
               x="-16"
             >
               <tspan
-                data-="20k"
+                data-="50000"
                 dy="0.32em"
                 id="BaseSpan"
                 x="-16"
@@ -3393,28 +3204,27 @@ exports[`Horizontal bar chart with axis rendering Should render the Horizontal b
                 id="LessLength"
                 x="-16"
               >
-                20k
+                50000
               </tspan>
             </text>
           </g>
           <g
             class="tick"
             opacity="1"
-            transform="translate(0,115.30000000000001)"
+            transform="translate(0,61.625)"
           >
             <line
               stroke="currentColor"
               x2="-6"
             />
             <text
-              aria-hidden="true"
               dy="0.32em"
               fill="currentColor"
               text-align="start"
               x="-16"
             >
               <tspan
-                data-="30k"
+                data-="5000"
                 dy="0.32em"
                 id="BaseSpan"
                 x="-16"
@@ -3424,69 +3234,7 @@ exports[`Horizontal bar chart with axis rendering Should render the Horizontal b
                 id="LessLength"
                 x="-16"
               >
-                30k
-              </tspan>
-            </text>
-          </g>
-          <g
-            class="tick"
-            opacity="1"
-            transform="translate(0,67.89999999999999)"
-          >
-            <line
-              stroke="currentColor"
-              x2="-6"
-            />
-            <text
-              aria-hidden="true"
-              dy="0.32em"
-              fill="currentColor"
-              text-align="start"
-              x="-16"
-            >
-              <tspan
-                data-="40k"
-                dy="0.32em"
-                id="BaseSpan"
-                x="-16"
-              />
-              <tspan
-                dx="1em"
-                id="LessLength"
-                x="-16"
-              >
-                40k
-              </tspan>
-            </text>
-          </g>
-          <g
-            class="tick"
-            opacity="1"
-            transform="translate(0,20.5)"
-          >
-            <line
-              stroke="currentColor"
-              x2="-6"
-            />
-            <text
-              aria-hidden="true"
-              dy="0.32em"
-              fill="currentColor"
-              text-align="start"
-              x="-16"
-            >
-              <tspan
-                data-="50k"
-                dy="0.32em"
-                id="BaseSpan"
-                x="-16"
-              />
-              <tspan
-                dx="1em"
-                id="LessLength"
-                x="-16"
-              >
-                50k
+                5000
               </tspan>
             </text>
           </g>
@@ -3506,9 +3254,10 @@ exports[`Horizontal bar chart with axis rendering Should render the Horizontal b
             role="img"
             rx="0"
             tabindex="0"
+            transform="translate(0,9.625)"
             width="147.5"
             x="40"
-            y="217.3"
+            y="36"
           />
           <rect
             aria-label="88%. 2020/04/30."
@@ -3524,9 +3273,10 @@ exports[`Horizontal bar chart with axis rendering Should render the Horizontal b
             role="img"
             rx="0"
             tabindex="-1"
+            transform="translate(0,9.625)"
             width="590"
             x="40"
-            y="179.38"
+            y="189.75"
           />
           <rect
             aria-label="37%. 2020/04/30."
@@ -3542,9 +3292,10 @@ exports[`Horizontal bar chart with axis rendering Should render the Horizontal b
             role="img"
             rx="0"
             tabindex="-1"
+            transform="translate(0,9.625)"
             width="368.75"
             x="40"
-            y="98.80000000000001"
+            y="138.5"
           />
           <rect
             aria-label="20%. 2020/04/30."
@@ -3560,9 +3311,10 @@ exports[`Horizontal bar chart with axis rendering Should render the Horizontal b
             role="img"
             rx="0"
             tabindex="-1"
+            transform="translate(0,9.625)"
             width="295"
             x="40"
-            y="4"
+            y="87.25"
           />
         </g>
       </svg>
@@ -3604,7 +3356,7 @@ exports[`Horizontal bar chart with axis rendering Should render the Horizontal b
                     &:focus {
                       outline: none;
                     }
-                data-focuszone-id="FocusZone6"
+                data-focuszone-id="FocusZone9"
                 data-tabster="{\\"uncontrolled\\": {}}"
                 role="listbox"
               >
@@ -4647,11 +4399,11 @@ exports[`HorizontalBarChartWithAxis - mouse events Should render callout correct
             outline: none;
           }
 
-      data-focuszone-id="FocusZone5"
+      data-focuszone-id="FocusZone8"
       data-tabster="{\\"uncontrolled\\": {}}"
     >
       <svg
-        aria-label="Horizontal bar chart with 4 bars. The X axis displays values. The Y axis displays values. "
+        aria-label="Horizontal bar chart with 4 bars. The X axis displays values. The Y axis displays categories. "
         focusable="false"
         height="292"
         role="region"
@@ -4893,27 +4645,26 @@ exports[`HorizontalBarChartWithAxis - mouse events Should render callout correct
         >
           <path
             class="domain"
-            d="M-6,257.5H0.5V20.5H-6"
+            d="M-6,241.5H0.5V36.5H-6"
             stroke="currentColor"
           />
           <g
             class="tick"
             opacity="1"
-            transform="translate(0,257.5)"
+            transform="translate(0,215.375)"
           >
             <line
               stroke="currentColor"
               x2="-6"
             />
             <text
-              aria-hidden="true"
               dy="0.32em"
               fill="currentColor"
               text-align="start"
               x="-16"
             >
               <tspan
-                data-="0"
+                data-="13000"
                 dy="0.32em"
                 id="BaseSpan"
                 x="-16"
@@ -4923,28 +4674,27 @@ exports[`HorizontalBarChartWithAxis - mouse events Should render callout correct
                 id="LessLength"
                 x="-16"
               >
-                0
+                13000
               </tspan>
             </text>
           </g>
           <g
             class="tick"
             opacity="1"
-            transform="translate(0,210.10000000000002)"
+            transform="translate(0,164.125)"
           >
             <line
               stroke="currentColor"
               x2="-6"
             />
             <text
-              aria-hidden="true"
               dy="0.32em"
               fill="currentColor"
               text-align="start"
               x="-16"
             >
               <tspan
-                data-="10k"
+                data-="30000"
                 dy="0.32em"
                 id="BaseSpan"
                 x="-16"
@@ -4954,28 +4704,27 @@ exports[`HorizontalBarChartWithAxis - mouse events Should render callout correct
                 id="LessLength"
                 x="-16"
               >
-                10k
+                30000
               </tspan>
             </text>
           </g>
           <g
             class="tick"
             opacity="1"
-            transform="translate(0,162.7)"
+            transform="translate(0,112.875)"
           >
             <line
               stroke="currentColor"
               x2="-6"
             />
             <text
-              aria-hidden="true"
               dy="0.32em"
               fill="currentColor"
               text-align="start"
               x="-16"
             >
               <tspan
-                data-="20k"
+                data-="50000"
                 dy="0.32em"
                 id="BaseSpan"
                 x="-16"
@@ -4985,28 +4734,27 @@ exports[`HorizontalBarChartWithAxis - mouse events Should render callout correct
                 id="LessLength"
                 x="-16"
               >
-                20k
+                50000
               </tspan>
             </text>
           </g>
           <g
             class="tick"
             opacity="1"
-            transform="translate(0,115.30000000000001)"
+            transform="translate(0,61.625)"
           >
             <line
               stroke="currentColor"
               x2="-6"
             />
             <text
-              aria-hidden="true"
               dy="0.32em"
               fill="currentColor"
               text-align="start"
               x="-16"
             >
               <tspan
-                data-="30k"
+                data-="5000"
                 dy="0.32em"
                 id="BaseSpan"
                 x="-16"
@@ -5016,69 +4764,7 @@ exports[`HorizontalBarChartWithAxis - mouse events Should render callout correct
                 id="LessLength"
                 x="-16"
               >
-                30k
-              </tspan>
-            </text>
-          </g>
-          <g
-            class="tick"
-            opacity="1"
-            transform="translate(0,67.89999999999999)"
-          >
-            <line
-              stroke="currentColor"
-              x2="-6"
-            />
-            <text
-              aria-hidden="true"
-              dy="0.32em"
-              fill="currentColor"
-              text-align="start"
-              x="-16"
-            >
-              <tspan
-                data-="40k"
-                dy="0.32em"
-                id="BaseSpan"
-                x="-16"
-              />
-              <tspan
-                dx="1em"
-                id="LessLength"
-                x="-16"
-              >
-                40k
-              </tspan>
-            </text>
-          </g>
-          <g
-            class="tick"
-            opacity="1"
-            transform="translate(0,20.5)"
-          >
-            <line
-              stroke="currentColor"
-              x2="-6"
-            />
-            <text
-              aria-hidden="true"
-              dy="0.32em"
-              fill="currentColor"
-              text-align="start"
-              x="-16"
-            >
-              <tspan
-                data-="50k"
-                dy="0.32em"
-                id="BaseSpan"
-                x="-16"
-              />
-              <tspan
-                dx="1em"
-                id="LessLength"
-                x="-16"
-              >
-                50k
+                5000
               </tspan>
             </text>
           </g>
@@ -5098,9 +4784,10 @@ exports[`HorizontalBarChartWithAxis - mouse events Should render callout correct
             role="img"
             rx="0"
             tabindex="0"
+            transform="translate(0,9.625)"
             width="147.5"
             x="40"
-            y="217.3"
+            y="36"
           />
           <rect
             aria-label="2020/04/30. 88%."
@@ -5116,9 +4803,10 @@ exports[`HorizontalBarChartWithAxis - mouse events Should render callout correct
             role="img"
             rx="0"
             tabindex="-1"
+            transform="translate(0,9.625)"
             width="590"
             x="40"
-            y="179.38"
+            y="189.75"
           />
           <rect
             aria-label="2020/04/30. 37%."
@@ -5134,9 +4822,10 @@ exports[`HorizontalBarChartWithAxis - mouse events Should render callout correct
             role="img"
             rx="0"
             tabindex="-1"
+            transform="translate(0,9.625)"
             width="368.75"
             x="40"
-            y="98.80000000000001"
+            y="138.5"
           />
           <rect
             aria-label="2020/04/30. 20%."
@@ -5152,9 +4841,10 @@ exports[`HorizontalBarChartWithAxis - mouse events Should render callout correct
             role="img"
             rx="0"
             tabindex="-1"
+            transform="translate(0,9.625)"
             width="295"
             x="40"
-            y="4"
+            y="87.25"
           />
         </g>
       </svg>
@@ -5196,7 +4886,7 @@ exports[`HorizontalBarChartWithAxis - mouse events Should render callout correct
                     &:focus {
                       outline: none;
                     }
-                data-focuszone-id="FocusZone6"
+                data-focuszone-id="FocusZone9"
                 data-tabster="{\\"uncontrolled\\": {}}"
                 role="listbox"
               >

--- a/packages/charts/react-charting/src/utilities/__snapshots__/UtilityUnitTests.test.ts.snap
+++ b/packages/charts/react-charting/src/utilities/__snapshots__/UtilityUnitTests.test.ts.snap
@@ -1948,7 +1948,7 @@ exports[`createYAxisForHorizontalBarChartWithAxis should render y-axis labels co
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,80.5)"
+    transform="translate(0,83.83333333333334)"
   >
     <line
       stroke="currentColor"
@@ -1966,7 +1966,7 @@ exports[`createYAxisForHorizontalBarChartWithAxis should render y-axis labels co
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,60.5)"
+    transform="translate(0,67.16666666666667)"
   >
     <line
       stroke="currentColor"
@@ -1984,7 +1984,7 @@ exports[`createYAxisForHorizontalBarChartWithAxis should render y-axis labels co
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,40.5)"
+    transform="translate(0,50.5)"
   >
     <line
       stroke="currentColor"
@@ -2002,7 +2002,7 @@ exports[`createYAxisForHorizontalBarChartWithAxis should render y-axis labels co
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,20.499999999999996)"
+    transform="translate(0,33.833333333333336)"
   >
     <line
       stroke="currentColor"
@@ -2020,7 +2020,7 @@ exports[`createYAxisForHorizontalBarChartWithAxis should render y-axis labels co
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,0.5)"
+    transform="translate(0,17.166666666666664)"
   >
     <line
       stroke="currentColor"
@@ -2033,6 +2033,24 @@ exports[`createYAxisForHorizontalBarChartWithAxis should render y-axis labels co
       x="18"
     >
       100
+    </text>
+  </g>
+  <g
+    class="tick"
+    opacity="1"
+    transform="translate(0,0.5)"
+  >
+    <line
+      stroke="currentColor"
+      x2="6"
+    />
+    <text
+      aria-hidden="true"
+      dy="0.32em"
+      fill="currentColor"
+      x="18"
+    >
+      120
     </text>
   </g>
 </g>
@@ -2071,7 +2089,7 @@ exports[`createYAxisForHorizontalBarChartWithAxis should render y-axis labels co
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,80.5)"
+    transform="translate(0,83.83333333333334)"
   >
     <line
       stroke="currentColor"
@@ -2089,7 +2107,7 @@ exports[`createYAxisForHorizontalBarChartWithAxis should render y-axis labels co
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,60.5)"
+    transform="translate(0,67.16666666666667)"
   >
     <line
       stroke="currentColor"
@@ -2107,7 +2125,7 @@ exports[`createYAxisForHorizontalBarChartWithAxis should render y-axis labels co
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,40.5)"
+    transform="translate(0,50.5)"
   >
     <line
       stroke="currentColor"
@@ -2125,7 +2143,7 @@ exports[`createYAxisForHorizontalBarChartWithAxis should render y-axis labels co
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,20.499999999999996)"
+    transform="translate(0,33.833333333333336)"
   >
     <line
       stroke="currentColor"
@@ -2143,7 +2161,7 @@ exports[`createYAxisForHorizontalBarChartWithAxis should render y-axis labels co
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,0.5)"
+    transform="translate(0,17.166666666666664)"
   >
     <line
       stroke="currentColor"
@@ -2156,6 +2174,24 @@ exports[`createYAxisForHorizontalBarChartWithAxis should render y-axis labels co
       x="-18"
     >
       ₹100
+    </text>
+  </g>
+  <g
+    class="tick"
+    opacity="1"
+    transform="translate(0,0.5)"
+  >
+    <line
+      stroke="currentColor"
+      x2="-6"
+    />
+    <text
+      aria-hidden="true"
+      dy="0.32em"
+      fill="currentColor"
+      x="-18"
+    >
+      ₹120
     </text>
   </g>
 </g>
@@ -2194,7 +2230,7 @@ exports[`createYAxisForHorizontalBarChartWithAxis should render y-axis labels co
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,50.5)"
+    transform="translate(0,58.83333333333333)"
   >
     <line
       stroke="currentColor"
@@ -2212,7 +2248,7 @@ exports[`createYAxisForHorizontalBarChartWithAxis should render y-axis labels co
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,0.5)"
+    transform="translate(0,17.166666666666664)"
   >
     <line
       stroke="currentColor"
@@ -2386,7 +2422,7 @@ exports[`createYAxisForHorizontalBarChartWithAxis should render y-axis labels co
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,80.5)"
+    transform="translate(0,83.83333333333334)"
   >
     <line
       stroke="currentColor"
@@ -2404,7 +2440,7 @@ exports[`createYAxisForHorizontalBarChartWithAxis should render y-axis labels co
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,60.5)"
+    transform="translate(0,67.16666666666667)"
   >
     <line
       stroke="currentColor"
@@ -2422,7 +2458,7 @@ exports[`createYAxisForHorizontalBarChartWithAxis should render y-axis labels co
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,40.5)"
+    transform="translate(0,50.5)"
   >
     <line
       stroke="currentColor"
@@ -2440,7 +2476,7 @@ exports[`createYAxisForHorizontalBarChartWithAxis should render y-axis labels co
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,20.499999999999996)"
+    transform="translate(0,33.833333333333336)"
   >
     <line
       stroke="currentColor"
@@ -2458,7 +2494,7 @@ exports[`createYAxisForHorizontalBarChartWithAxis should render y-axis labels co
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,0.5)"
+    transform="translate(0,17.166666666666664)"
   >
     <line
       stroke="currentColor"
@@ -2471,6 +2507,24 @@ exports[`createYAxisForHorizontalBarChartWithAxis should render y-axis labels co
       x="-11"
     >
       100
+    </text>
+  </g>
+  <g
+    class="tick"
+    opacity="1"
+    transform="translate(0,0.5)"
+  >
+    <line
+      stroke="currentColor"
+      x2="-6"
+    />
+    <text
+      aria-hidden="true"
+      dy="0.32em"
+      fill="currentColor"
+      x="-11"
+    >
+      120
     </text>
   </g>
 </g>

--- a/packages/charts/react-charting/src/utilities/utilities.ts
+++ b/packages/charts/react-charting/src/utilities/utilities.ts
@@ -518,7 +518,7 @@ export function createYAxisForHorizontalBarChartWithAxis(yAxisParams: IYAxisPara
     // Determine the precision (x) based on the number of digits
     let x: number;
     if (numDigits >= 5) {
-      x = 1;
+      x = 4;
     } else {
       x = 3;
     }

--- a/packages/charts/react-charting/src/utilities/utilities.ts
+++ b/packages/charts/react-charting/src/utilities/utilities.ts
@@ -57,6 +57,9 @@ import {
 export type NumericAxis = D3Axis<number | { valueOf(): number }>;
 export type StringAxis = D3Axis<string>;
 
+export const GAP_PROPORTION_HBC: number = 0.2;
+export const MINIMUM_Y_AXIS_GAP_HBC: number = 0.5;
+
 export enum ChartTypes {
   AreaChart,
   LineChart,
@@ -501,29 +504,24 @@ export function createYAxisForHorizontalBarChartWithAxis(yAxisParams: IYAxisPara
     yAxisTickCount = 4,
   } = yAxisParams;
 
-  // maxOfYVal coming from only area chart and Grouped vertical bar chart(Calculation done at base file)
   const yRange = yMinMaxValues.endValue - yMinMaxValues.startValue;
-  const maxDiff = yRange * 0.2;
+  const maxDiff = Math.max(yRange * GAP_PROPORTION_HBC, MINIMUM_Y_AXIS_GAP_HBC);
   const finalYmax = Math.max(yMinMaxValues.endValue + maxDiff, yMaxValue);
   const finalYmin = Math.max(yMinMaxValues.startValue - maxDiff, Math.min(yMinValue || 0, 0));
   const yAxisScale = d3ScaleLinear()
     .domain([finalYmin, finalYmax])
     .range([containerHeight - margins.bottom!, margins.top!]);
   // Custom tick formatting function
-  const customTickFormat = (value: number, maxValue: number) => {
+  const customTickFormat = (value: number, _index: number) => {
     // Calculate the number of digits in the maximum value
-    const numDigits = Math.ceil(Math.log10(maxValue));
-
+    const numDigits = Math.max(Math.ceil(Math.log10(value)), Math.floor(Math.log10(value)) + 1);
     // Determine the precision (x) based on the number of digits
     let x: number;
     if (numDigits >= 5) {
-      x = 1; // Use 3 significant digits for large numbers
-    } else if (numDigits >= 3) {
-      x = 3; // Use 2 significant digits for medium numbers
+      x = 1;
     } else {
-      x = 3; // Use 1 significant digit for small numbers
+      x = 3;
     }
-
     // Apply the dynamically determined x in the format
     return d3Format(`.${x}~s`)(value);
   };


### PR DESCRIPTION
Fixing Overlapping and Skewed data bars.

Design Document: 
[Overlapping_Skewed_bars_HBC.docx](https://github.com/user-attachments/files/20009322/Overlapping_Skewed_bars_HBC.docx)

Before:
![image](https://github.com/user-attachments/assets/c86caf3d-b8a0-4812-abe5-f22ab132f3a8)

After: 
![image](https://github.com/user-attachments/assets/764efcf1-7999-4314-9e0c-c1e927ce2236)

Before:
![image](https://github.com/user-attachments/assets/06a16863-cd41-47cd-b78a-7da7e8832993)

After:
![image](https://github.com/user-attachments/assets/7e0ff227-47cc-4091-99d7-3aa834e8195a)

