### PR TITLE
fix(react-charting): Fixing x-axis ticks overlap on width change

### DIFF
--- a/change/@fluentui-react-charting-b82a600c-2de0-48f3-a864-e20717057e25.json
+++ b/change/@fluentui-react-charting-b82a600c-2de0-48f3-a864-e20717057e25.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(react-charting): Fixing x-axis ticks overlap on width change",
+  "packageName": "@fluentui/react-charting",
+  "email": "120183316+srmukher@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charts/react-charting/UnitTests/__snapshots__/VerticalBarChartUT.test.tsx.snap
+++ b/packages/charts/react-charting/UnitTests/__snapshots__/VerticalBarChartUT.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`vertical bar chart with numeric x-axis data Should render the vertical 
           font-size: 14px;
           font-weight: 400;
           height: 100%;
-          overflow: hidden;
+          overflow: auto;
           width: 100%;
         }
     id="chart_3"

--- a/packages/charts/react-charting/src/components/AreaChart/__snapshots__/AreaChart.test.tsx.snap
+++ b/packages/charts/react-charting/src/components/AreaChart/__snapshots__/AreaChart.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`AreaChart - mouse events Should render callout correctly on mouseover 1
         font-size: 14px;
         font-weight: 400;
         height: 100%;
-        overflow: hidden;
+        overflow: auto;
         width: 100%;
       }
   id="chart_6"
@@ -581,7 +581,7 @@ exports[`AreaChart - mouse events Should render customized callout on mouseover 
         font-size: 14px;
         font-weight: 400;
         height: 100%;
-        overflow: hidden;
+        overflow: auto;
         width: 100%;
       }
   id="chart_6"
@@ -1046,7 +1046,7 @@ exports[`AreaChart - mouse events Should render customized callout per stack on 
         font-size: 14px;
         font-weight: 400;
         height: 100%;
-        overflow: hidden;
+        overflow: auto;
         width: 100%;
       }
   id="chart_6"

--- a/packages/charts/react-charting/src/components/AreaChart/__snapshots__/AreaChartRTL.test.tsx.snap
+++ b/packages/charts/react-charting/src/components/AreaChart/__snapshots__/AreaChartRTL.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`Area chart rendering Should render the Area Chart with negative y value
           font-size: 14px;
           font-weight: 400;
           height: 100%;
-          overflow: hidden;
+          overflow: auto;
           width: 100%;
         }
     id="chart_6"
@@ -1151,7 +1151,7 @@ exports[`Area chart rendering Should render the Area Chart with tozeroy mode 1`]
           font-size: 14px;
           font-weight: 400;
           height: 100%;
-          overflow: hidden;
+          overflow: auto;
           width: 100%;
         }
     id="chart_6"
@@ -6145,7 +6145,7 @@ exports[`Area chart rendering Should render the Area chart with secondary Y axis
           font-size: 14px;
           font-weight: 400;
           height: 100%;
-          overflow: hidden;
+          overflow: auto;
           width: 100%;
         }
     id="chart_6"
@@ -9753,7 +9753,7 @@ exports[`Area chart rendering Should render the area chart with numeric x-axis d
           font-size: 14px;
           font-weight: 400;
           height: 100%;
-          overflow: hidden;
+          overflow: auto;
           width: 100%;
         }
     id="chart_6"
@@ -10903,7 +10903,7 @@ exports[`AreaChart - Theme Should reflect theme change 1`] = `
             font-size: 14px;
             font-weight: 400;
             height: 100%;
-            overflow: hidden;
+            overflow: auto;
             width: 100%;
           }
       id="chart_9"
@@ -12041,7 +12041,7 @@ exports[`Screen resolution Should remain unchanged on zoom in 1`] = `
           font-size: 14px;
           font-weight: 400;
           height: 100%;
-          overflow: hidden;
+          overflow: auto;
           width: 100%;
         }
     id="chart_6"
@@ -13178,7 +13178,7 @@ exports[`Screen resolution Should remain unchanged on zoom out 1`] = `
           font-size: 14px;
           font-weight: 400;
           height: 100%;
-          overflow: hidden;
+          overflow: auto;
           width: 100%;
         }
     id="chart_6"

--- a/packages/charts/react-charting/src/components/CommonComponents/CartesianChart.styles.ts
+++ b/packages/charts/react-charting/src/components/CommonComponents/CartesianChart.styles.ts
@@ -24,7 +24,7 @@ export const getStyles = (props: ICartesianChartStyleProps): ICartesianChartStyl
         width: '100%',
         height: '100%',
         flexDirection: 'column',
-        overflow: 'hidden',
+        overflow: 'auto',
       },
       className,
     ],

--- a/packages/charts/react-charting/src/components/DeclarativeChart/__snapshots__/DeclarativeChartRTL.test.tsx.snap
+++ b/packages/charts/react-charting/src/components/DeclarativeChart/__snapshots__/DeclarativeChartRTL.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`DeclarativeChart Should render areachart in DeclarativeChart 1`] = `
             font-size: 14px;
             font-weight: 400;
             height: 100%;
-            overflow: hidden;
+            overflow: auto;
             width: 100%;
           }
       id="chart_6"
@@ -4864,7 +4864,7 @@ exports[`DeclarativeChart Should render heatmapchart in DeclarativeChart 1`] = `
             font-size: 14px;
             font-weight: 400;
             height: 100%;
-            overflow: hidden;
+            overflow: auto;
             width: 100%;
           }
       id="chart_1"
@@ -18751,7 +18751,7 @@ exports[`DeclarativeChart Should render linechart in DeclarativeChart 1`] = `
             font-size: 14px;
             font-weight: 400;
             height: 100%;
-            overflow: hidden;
+            overflow: auto;
             width: 100%;
           }
       id="chart_9"

--- a/packages/charts/react-charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
+++ b/packages/charts/react-charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`GroupedVerticalBarChart - mouse events Should render callout correctly 
         font-size: 14px;
         font-weight: 400;
         height: 100%;
-        overflow: hidden;
+        overflow: auto;
         width: 100%;
       }
   id="chart_3"
@@ -834,7 +834,7 @@ exports[`GroupedVerticalBarChart - mouse events Should render customized callout
         font-size: 14px;
         font-weight: 400;
         height: 100%;
-        overflow: hidden;
+        overflow: auto;
         width: 100%;
       }
   id="chart_3"
@@ -2203,7 +2203,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
         font-size: 14px;
         font-weight: 400;
         height: 100%;
-        overflow: hidden;
+        overflow: auto;
         width: 100%;
       }
   id="chart_3"
@@ -2827,7 +2827,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
         font-size: 14px;
         font-weight: 400;
         height: 100%;
-        overflow: hidden;
+        overflow: auto;
         width: 100%;
       }
   id="chart_3"

--- a/packages/charts/react-charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChartRTL.test.tsx.snap
+++ b/packages/charts/react-charting/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChartRTL.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`Grouped Vertical Bar chart rendering Should re-render the Grouped Verti
           font-size: 14px;
           font-weight: 400;
           height: 100%;
-          overflow: hidden;
+          overflow: auto;
           width: 100%;
         }
     id="chart_3"
@@ -763,7 +763,7 @@ exports[`Grouped Vertical bar chart rendering Should render the grouped vertical
           font-size: 14px;
           font-weight: 400;
           height: 100%;
-          overflow: hidden;
+          overflow: auto;
           width: 100%;
         }
     id="chart_3"
@@ -1501,7 +1501,7 @@ exports[`Grouped Vertical bar chart rendering Should render the vertical bar cha
           font-size: 14px;
           font-weight: 400;
           height: 100%;
-          overflow: hidden;
+          overflow: auto;
           width: 100%;
         }
     id="chart_3"
@@ -2239,7 +2239,7 @@ exports[`Grouped vertical bar chart - Screen resolution Should remain unchanged 
           font-size: 14px;
           font-weight: 400;
           height: 100%;
-          overflow: hidden;
+          overflow: auto;
           width: 100%;
         }
     id="chart_3"
@@ -2977,7 +2977,7 @@ exports[`Grouped vertical bar chart - Screen resolution Should remain unchanged 
           font-size: 14px;
           font-weight: 400;
           height: 100%;
-          overflow: hidden;
+          overflow: auto;
           width: 100%;
         }
     id="chart_3"
@@ -3714,7 +3714,7 @@ exports[`GroupedVerticalBarChart - mouse events Should render callout correctly 
         font-size: 14px;
         font-weight: 400;
         height: 100%;
-        overflow: hidden;
+        overflow: auto;
         width: 100%;
       }
   id="chart_3"
@@ -4535,7 +4535,7 @@ exports[`GroupedVerticalBarChart - mouse events Should render customized callout
         font-size: 14px;
         font-weight: 400;
         height: 100%;
-        overflow: hidden;
+        overflow: auto;
         width: 100%;
       }
   id="chart_3"
@@ -5904,7 +5904,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders enabledLegendsWrapLine
         font-size: 14px;
         font-weight: 400;
         height: 100%;
-        overflow: hidden;
+        overflow: auto;
         width: 100%;
       }
   id="chart_3"
@@ -6528,7 +6528,7 @@ exports[`GroupedVerticalBarChart snapShot testing renders hideLegend correctly 1
         font-size: 14px;
         font-weight: 400;
         height: 100%;
-        overflow: hidden;
+        overflow: auto;
         width: 100%;
       }
   id="chart_3"
@@ -9348,7 +9348,7 @@ exports[`Vertical stacked bar chart - Theme Should reflect theme change 1`] = `
             font-size: 14px;
             font-weight: 400;
             height: 100%;
-            overflow: hidden;
+            overflow: auto;
             width: 100%;
           }
       id="chart_6"

--- a/packages/charts/react-charting/src/components/HeatMapChart/__snapshots__/HeatMapChartRTL.test.tsx.snap
+++ b/packages/charts/react-charting/src/components/HeatMapChart/__snapshots__/HeatMapChartRTL.test.tsx.snap
@@ -608,7 +608,7 @@ exports[`HeatMapChart snapshot tests should render HeatMapChart correctly with n
           font-size: 14px;
           font-weight: 400;
           height: 100%;
-          overflow: hidden;
+          overflow: auto;
           width: 100%;
         }
     id="chart_1"
@@ -1206,7 +1206,7 @@ exports[`HeatMapChart snapshot tests should render axis labels correctly When cu
           font-size: 14px;
           font-weight: 400;
           height: 100%;
-          overflow: hidden;
+          overflow: auto;
           width: 100%;
         }
     id="chart_1"

--- a/packages/charts/react-charting/src/components/HorizontalBarChartWithAxis/__snapshots__/HorizontalBarChartWithAxis.test.tsx.snap
+++ b/packages/charts/react-charting/src/components/HorizontalBarChartWithAxis/__snapshots__/HorizontalBarChartWithAxis.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`HorizontalBarChartWithAxis snapShot testing Should render gradients on 
         font-size: 14px;
         font-weight: 400;
         height: 100%;
-        overflow: hidden;
+        overflow: auto;
         width: 100%;
       }
   id="chart_2"
@@ -648,7 +648,7 @@ exports[`HorizontalBarChartWithAxis snapShot testing Should render rounded corne
         font-size: 14px;
         font-weight: 400;
         height: 100%;
-        overflow: hidden;
+        overflow: auto;
         width: 100%;
       }
   id="chart_2"
@@ -1269,7 +1269,7 @@ exports[`HorizontalBarChartWithAxis snapShot testing renders HorizontalBarChartW
         font-size: 14px;
         font-weight: 400;
         height: 100%;
-        overflow: hidden;
+        overflow: auto;
         width: 100%;
       }
   id="chart_2"
@@ -1890,7 +1890,7 @@ exports[`HorizontalBarChartWithAxis snapShot testing renders hideLegend correctl
         font-size: 14px;
         font-weight: 400;
         height: 100%;
-        overflow: hidden;
+        overflow: auto;
         width: 100%;
       }
   id="chart_2"
@@ -2024,7 +2024,7 @@ exports[`HorizontalBarChartWithAxis snapShot testing renders showToolTipForYAxis
         font-size: 14px;
         font-weight: 400;
         height: 100%;
-        overflow: hidden;
+        overflow: auto;
         width: 100%;
       }
   id="chart_2"
@@ -2334,7 +2334,7 @@ exports[`HorizontalBarChartWithAxis snapShot testing renders showYAxisLables cor
         font-size: 14px;
         font-weight: 400;
         height: 100%;
-        overflow: hidden;
+        overflow: auto;
         width: 100%;
       }
   id="chart_2"

--- a/packages/charts/react-charting/src/components/HorizontalBarChartWithAxis/__snapshots__/HorizontalBarChartWithAxisRTL.test.tsx.snap
+++ b/packages/charts/react-charting/src/components/HorizontalBarChartWithAxis/__snapshots__/HorizontalBarChartWithAxisRTL.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`Horizontal bar chart with axis - Screen resolution Should remain unchan
           font-size: 14px;
           font-weight: 400;
           height: 100%;
-          overflow: hidden;
+          overflow: auto;
           width: 100%;
         }
     id="chart_2"
@@ -1018,7 +1018,7 @@ exports[`Horizontal bar chart with axis - Screen resolution Should remain unchan
           font-size: 14px;
           font-weight: 400;
           height: 100%;
-          overflow: hidden;
+          overflow: auto;
           width: 100%;
         }
     id="chart_2"
@@ -2035,7 +2035,7 @@ exports[`Horizontal bar chart with axis - Theme Should reflect theme change 1`] 
             font-size: 14px;
             font-weight: 400;
             height: 100%;
-            overflow: hidden;
+            overflow: auto;
             width: 100%;
           }
       id="chart_5"
@@ -3040,7 +3040,7 @@ exports[`Horizontal bar chart with axis rendering Should render the Horizontal b
           font-size: 14px;
           font-weight: 400;
           height: 100%;
-          overflow: hidden;
+          overflow: auto;
           width: 100%;
         }
     id="chart_2"
@@ -4044,7 +4044,7 @@ exports[`Horizontal bar chart with axis rendering Should render the Horizontal b
           font-size: 14px;
           font-weight: 400;
           height: 100%;
-          overflow: hidden;
+          overflow: auto;
           width: 100%;
         }
     id="chart_2"
@@ -4632,7 +4632,7 @@ exports[`HorizontalBarChartWithAxis - mouse events Should render callout correct
           font-size: 14px;
           font-weight: 400;
           height: 100%;
-          overflow: hidden;
+          overflow: auto;
           width: 100%;
         }
     id="chart_2"

--- a/packages/charts/react-charting/src/components/LineChart/__snapshots__/LineChartRTL.test.tsx.snap
+++ b/packages/charts/react-charting/src/components/LineChart/__snapshots__/LineChartRTL.test.tsx.snap
@@ -3896,7 +3896,7 @@ exports[`Line chart rendering Should render the Line chart with numeric x-axis d
           font-size: 14px;
           font-weight: 400;
           height: 100%;
-          overflow: hidden;
+          overflow: auto;
           width: 100%;
         }
     id="chart_9"
@@ -4766,7 +4766,7 @@ exports[`Line chart rendering Should render the Line chart with points in multip
           font-size: 14px;
           font-weight: 400;
           height: 100%;
-          overflow: hidden;
+          overflow: auto;
           width: 100%;
         }
     id="chart_9"
@@ -5638,7 +5638,7 @@ exports[`Line chart rendering Should render the line chart with secondary Y axis
           font-size: 14px;
           font-weight: 400;
           height: 100%;
-          overflow: hidden;
+          overflow: auto;
           width: 100%;
         }
     id="chart_9"
@@ -6638,7 +6638,7 @@ exports[`Line chart rendering should render the line chart with all negative y v
           font-size: 14px;
           font-weight: 400;
           height: 100%;
-          overflow: hidden;
+          overflow: auto;
           width: 100%;
         }
     id="chart_9"
@@ -7508,7 +7508,7 @@ exports[`Line chart rendering should render the line chart with negative y value
           font-size: 14px;
           font-weight: 400;
           height: 100%;
-          overflow: hidden;
+          overflow: auto;
           width: 100%;
         }
     id="chart_9"
@@ -8396,7 +8396,7 @@ exports[`Screen resolution Should remain unchanged on zoom in 1`] = `
           font-size: 14px;
           font-weight: 400;
           height: 100%;
-          overflow: hidden;
+          overflow: auto;
           width: 100%;
         }
     id="chart_9"
@@ -9266,7 +9266,7 @@ exports[`Screen resolution Should remain unchanged on zoom out 1`] = `
           font-size: 14px;
           font-weight: 400;
           height: 100%;
-          overflow: hidden;
+          overflow: auto;
           width: 100%;
         }
     id="chart_9"
@@ -10149,7 +10149,7 @@ exports[`Theme and accessibility Should reflect theme change 1`] = `
             font-size: 14px;
             font-weight: 400;
             height: 100%;
-            overflow: hidden;
+            overflow: auto;
             width: 100%;
           }
       id="chart_12"

--- a/packages/charts/react-charting/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
+++ b/packages/charts/react-charting/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`VerticalBarChart snapShot testing Should not render bar labels 1`] = `
         font-size: 14px;
         font-weight: 400;
         height: 100%;
-        overflow: hidden;
+        overflow: auto;
         width: 100%;
       }
   id="chart_3"
@@ -509,7 +509,7 @@ exports[`VerticalBarChart snapShot testing Should render gradients on bars 1`] =
         font-size: 14px;
         font-weight: 400;
         height: 100%;
-        overflow: hidden;
+        overflow: auto;
         width: 100%;
       }
   id="chart_3"
@@ -1005,7 +1005,7 @@ exports[`VerticalBarChart snapShot testing Should render rounded corners on bars
         font-size: 14px;
         font-weight: 400;
         height: 100%;
-        overflow: hidden;
+        overflow: auto;
         width: 100%;
       }
   id="chart_3"
@@ -1501,7 +1501,7 @@ exports[`VerticalBarChart snapShot testing renders VerticalBarChart correctly 1`
         font-size: 14px;
         font-weight: 400;
         height: 100%;
-        overflow: hidden;
+        overflow: auto;
         width: 100%;
       }
   id="chart_3"
@@ -1997,7 +1997,7 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
         font-size: 14px;
         font-weight: 400;
         height: 100%;
-        overflow: hidden;
+        overflow: auto;
         width: 100%;
       }
   id="chart_3"
@@ -2473,7 +2473,7 @@ exports[`VerticalBarChart snapShot testing renders hideLegend correctly 1`] = `
         font-size: 14px;
         font-weight: 400;
         height: 100%;
-        overflow: hidden;
+        overflow: auto;
         width: 100%;
       }
   id="chart_3"
@@ -2586,7 +2586,7 @@ exports[`VerticalBarChart snapShot testing renders hideTooltip correctly 1`] = `
         font-size: 14px;
         font-weight: 400;
         height: 100%;
-        overflow: hidden;
+        overflow: auto;
         width: 100%;
       }
   id="chart_3"
@@ -3082,7 +3082,7 @@ exports[`VerticalBarChart snapShot testing renders showXAxisLablesTooltip correc
         font-size: 14px;
         font-weight: 400;
         height: 100%;
-        overflow: hidden;
+        overflow: auto;
         width: 100%;
       }
   id="chart_3"
@@ -3578,7 +3578,7 @@ exports[`VerticalBarChart snapShot testing renders wrapXAxisLables correctly 1`]
         font-size: 14px;
         font-weight: 400;
         height: 100%;
-        overflow: hidden;
+        overflow: auto;
         width: 100%;
       }
   id="chart_3"
@@ -4074,7 +4074,7 @@ exports[`VerticalBarChart snapShot testing renders yAxisTickFormat correctly 1`]
         font-size: 14px;
         font-weight: 400;
         height: 100%;
-        overflow: hidden;
+        overflow: auto;
         width: 100%;
       }
   id="chart_3"

--- a/packages/charts/react-charting/src/components/VerticalBarChart/__snapshots__/VerticalBarChartRTL.test.tsx.snap
+++ b/packages/charts/react-charting/src/components/VerticalBarChart/__snapshots__/VerticalBarChartRTL.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`Screen resolution Should remain unchanged on zoom in 1`] = `
           font-size: 14px;
           font-weight: 400;
           height: 100%;
-          overflow: hidden;
+          overflow: auto;
           width: 100%;
         }
     id="chart_3"
@@ -801,7 +801,7 @@ exports[`Screen resolution Should remain unchanged on zoom out 1`] = `
           font-size: 14px;
           font-weight: 400;
           height: 100%;
-          overflow: hidden;
+          overflow: auto;
           width: 100%;
         }
     id="chart_3"
@@ -1601,7 +1601,7 @@ exports[`Theme Change Should reflect theme change 1`] = `
             font-size: 14px;
             font-weight: 400;
             height: 100%;
-            overflow: hidden;
+            overflow: auto;
             width: 100%;
           }
       id="chart_6"
@@ -2400,7 +2400,7 @@ exports[`Vertical bar chart re-rendering Should re-render the vertical bar chart
           font-size: 14px;
           font-weight: 400;
           height: 100%;
-          overflow: hidden;
+          overflow: auto;
           width: 100%;
         }
     id="chart_3"
@@ -9964,7 +9964,7 @@ exports[`Vertical bar chart rendering Should render the vertical bar chart with 
           font-size: 14px;
           font-weight: 400;
           height: 100%;
-          overflow: hidden;
+          overflow: auto;
           width: 100%;
         }
     id="chart_3"
@@ -12233,7 +12233,7 @@ exports[`Vertical bar chart rendering Should render the vertical bar chart with 
           font-size: 14px;
           font-weight: 400;
           height: 100%;
-          overflow: hidden;
+          overflow: auto;
           width: 100%;
         }
     id="chart_3"
@@ -13020,7 +13020,7 @@ exports[`Vertical bar chart rendering Should render the vertical bar chart with 
           font-size: 14px;
           font-weight: 400;
           height: 100%;
-          overflow: hidden;
+          overflow: auto;
           width: 100%;
         }
     id="chart_3"
@@ -13937,7 +13937,7 @@ exports[`Vertical bar chart rendering Should render the vertical bar chart with 
           font-size: 14px;
           font-weight: 400;
           height: 100%;
-          overflow: hidden;
+          overflow: auto;
           width: 100%;
         }
     id="chart_3"
@@ -14531,7 +14531,7 @@ exports[`Vertical bar chart rendering should render the vertical bar chart with 
           font-size: 14px;
           font-weight: 400;
           height: 100%;
-          overflow: hidden;
+          overflow: auto;
           width: 100%;
         }
     id="chart_3"
@@ -15336,7 +15336,7 @@ exports[`VerticalBarChart - mouse events Should render callout correctly on mous
           font-size: 14px;
           font-weight: 400;
           height: 100%;
-          overflow: hidden;
+          overflow: auto;
           width: 100%;
         }
     id="chart_3"
@@ -16169,7 +16169,7 @@ exports[`VerticalBarChart - mouse events Should render customized callout on mou
           font-size: 14px;
           font-weight: 400;
           height: 100%;
-          overflow: hidden;
+          overflow: auto;
           width: 100%;
         }
     id="chart_3"

--- a/packages/charts/react-charting/src/components/VerticalStackedBarChart/__snapshots__/VerticalStackedBarChart.test.tsx.snap
+++ b/packages/charts/react-charting/src/components/VerticalStackedBarChart/__snapshots__/VerticalStackedBarChart.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`VerticalStackedBarChart snapShot testing Should not render bar labels 1
         font-size: 14px;
         font-weight: 400;
         height: 100%;
-        overflow: hidden;
+        overflow: auto;
         width: 100%;
       }
   id="chart_3"
@@ -511,7 +511,7 @@ exports[`VerticalStackedBarChart snapShot testing Should render gradients on bar
         font-size: 14px;
         font-weight: 400;
         height: 100%;
-        overflow: hidden;
+        overflow: auto;
         width: 100%;
       }
   id="chart_3"
@@ -1081,7 +1081,7 @@ exports[`VerticalStackedBarChart snapShot testing Should render rounded corners 
         font-size: 14px;
         font-weight: 400;
         height: 100%;
-        overflow: hidden;
+        overflow: auto;
         width: 100%;
       }
   id="chart_3"
@@ -1579,7 +1579,7 @@ exports[`VerticalStackedBarChart snapShot testing renders VerticalStackedBarChar
         font-size: 14px;
         font-weight: 400;
         height: 100%;
-        overflow: hidden;
+        overflow: auto;
         width: 100%;
       }
   id="chart_3"
@@ -2077,7 +2077,7 @@ exports[`VerticalStackedBarChart snapShot testing renders enabledLegendsWrapLine
         font-size: 14px;
         font-weight: 400;
         height: 100%;
-        overflow: hidden;
+        overflow: auto;
         width: 100%;
       }
   id="chart_3"
@@ -2555,7 +2555,7 @@ exports[`VerticalStackedBarChart snapShot testing renders hideLegend correctly 1
         font-size: 14px;
         font-weight: 400;
         height: 100%;
-        overflow: hidden;
+        overflow: auto;
         width: 100%;
       }
   id="chart_3"
@@ -2774,7 +2774,7 @@ exports[`VerticalStackedBarChart snapShot testing renders hideTooltip correctly 
         font-size: 14px;
         font-weight: 400;
         height: 100%;
-        overflow: hidden;
+        overflow: auto;
         width: 100%;
       }
   id="chart_3"
@@ -3272,7 +3272,7 @@ exports[`VerticalStackedBarChart snapShot testing renders isCalloutForStack corr
         font-size: 14px;
         font-weight: 400;
         height: 100%;
-        overflow: hidden;
+        overflow: auto;
         width: 100%;
       }
   id="chart_3"
@@ -3752,7 +3752,7 @@ exports[`VerticalStackedBarChart snapShot testing renders showXAxisLablesTooltip
         font-size: 14px;
         font-weight: 400;
         height: 100%;
-        overflow: hidden;
+        overflow: auto;
         width: 100%;
       }
   id="chart_3"
@@ -4250,7 +4250,7 @@ exports[`VerticalStackedBarChart snapShot testing renders wrapXAxisLables correc
         font-size: 14px;
         font-weight: 400;
         height: 100%;
-        overflow: hidden;
+        overflow: auto;
         width: 100%;
       }
   id="chart_3"
@@ -4748,7 +4748,7 @@ exports[`VerticalStackedBarChart snapShot testing renders yAxisTickFormat correc
         font-size: 14px;
         font-weight: 400;
         height: 100%;
-        overflow: hidden;
+        overflow: auto;
         width: 100%;
       }
   id="chart_3"

--- a/packages/charts/react-charting/src/components/VerticalStackedBarChart/__snapshots__/VerticalStackedBarChartRTL.test.tsx.snap
+++ b/packages/charts/react-charting/src/components/VerticalStackedBarChart/__snapshots__/VerticalStackedBarChartRTL.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`Vertical stacked bar chart - Screen resolution Should remain unchanged 
           font-size: 14px;
           font-weight: 400;
           height: 100%;
-          overflow: hidden;
+          overflow: auto;
           width: 100%;
         }
     id="chart_3"
@@ -1003,7 +1003,7 @@ exports[`Vertical stacked bar chart - Screen resolution Should remain unchanged 
           font-size: 14px;
           font-weight: 400;
           height: 100%;
-          overflow: hidden;
+          overflow: auto;
           width: 100%;
         }
     id="chart_3"
@@ -1992,7 +1992,7 @@ exports[`Vertical stacked bar chart - Subcomponent Line Should render the vertic
           font-size: 14px;
           font-weight: 400;
           height: 100%;
-          overflow: hidden;
+          overflow: auto;
           width: 100%;
         }
     id="chart_3"
@@ -2994,7 +2994,7 @@ exports[`Vertical stacked bar chart - Theme Should reflect theme change 1`] = `
             font-size: 14px;
             font-weight: 400;
             height: 100%;
-            overflow: hidden;
+            overflow: auto;
             width: 100%;
           }
       id="chart_6"
@@ -9770,7 +9770,7 @@ exports[`Vertical stacked bar chart rendering Should render the vertical stacked
           font-size: 14px;
           font-weight: 400;
           height: 100%;
-          overflow: hidden;
+          overflow: auto;
           width: 100%;
         }
     id="chart_3"
@@ -10759,7 +10759,7 @@ exports[`Vertical stacked bar chart rendering Should render the vertical stacked
           font-size: 14px;
           font-weight: 400;
           height: 100%;
-          overflow: hidden;
+          overflow: auto;
           width: 100%;
         }
     id="chart_3"
@@ -11446,7 +11446,7 @@ exports[`VerticalStackedBarChart - mouse events Should render callout correctly 
           font-size: 14px;
           font-weight: 400;
           height: 100%;
-          overflow: hidden;
+          overflow: auto;
           width: 100%;
         }
     id="chart_3"
@@ -12122,7 +12122,7 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
           font-size: 14px;
           font-weight: 400;
           height: 100%;
-          overflow: hidden;
+          overflow: auto;
           width: 100%;
         }
     id="chart_3"
@@ -12798,7 +12798,7 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
           font-size: 14px;
           font-weight: 400;
           height: 100%;
-          overflow: hidden;
+          overflow: auto;
           width: 100%;
         }
     id="chart_3"


### PR DESCRIPTION
Before:
![horizontal x axis](https://github.com/user-attachments/assets/d7ef2bfd-f665-44a7-96c7-b64b3fda3fac)


After:
![image](https://github.com/user-attachments/assets/8ac2fbc0-2cf0-421e-81ca-86baf0ffbe73)
