### PR TITLE
feat(react-charting): Enable negative Y support for horizontal bar chart

### DIFF
--- a/change/@fluentui-react-charting-c87b89f1-fec8-4243-bbb1-3df37d7513e0.json
+++ b/change/@fluentui-react-charting-c87b89f1-fec8-4243-bbb1-3df37d7513e0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(react-charting): Enable support for negative Y for horizontal bar chart",
+  "packageName": "@fluentui/react-charting",
+  "email": "98592573+AtishayMsft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charts/react-charting/src/components/HorizontalBarChartWithAxis/HorizontalBarChartWithAxis.base.tsx
+++ b/packages/charts/react-charting/src/components/HorizontalBarChartWithAxis/HorizontalBarChartWithAxis.base.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { max as d3Max } from 'd3-array';
+import { max as d3Max, min as d3Min } from 'd3-array';
 import { select as d3Select } from 'd3-selection';
 import { scaleLinear as d3ScaleLinear, ScaleLinear as D3ScaleLinear, scaleBand as d3ScaleBand } from 'd3-scale';
 import { classNamesFunction, getId, getRTL, initializeComponentRef } from '@fluentui/react/lib/Utilities';
@@ -487,12 +487,18 @@ export class HorizontalBarChartWithAxisBase
     const xDomain = [Math.min(this.X_ORIGIN, xMin), Math.max(this.X_ORIGIN, xMax)];
     if (isNumericScale) {
       const yMax = d3Max(this._points, (point: IHorizontalBarChartWithAxisDataPoint) => point.y as number)!;
+      const yMin = d3Min(this._points, (point: IHorizontalBarChartWithAxisDataPoint) => point.y as number)!;
+      const yDomainMax = Math.max(yMax, this.props.yMaxValue || 0);
+      const yMinProp = this.props.yMinValue || 0;
+      const yDomainMin = yMin < yMinProp ? Math.min(0, yMin) : yMinProp;
+
+      const yDomainPadding = Math.abs((yMax - yMin) * 0.1);
       const xBarScale = d3ScaleLinear()
         .domain(xDomain)
         .nice()
         .range([this.margins.left!, containerWidth - this.margins.right!]);
       const yBarScale = d3ScaleLinear()
-        .domain([0, yMax])
+        .domain([yDomainMin - yDomainPadding, yDomainMax + yDomainPadding])
         .range([containerHeight - this.margins.bottom!, this.margins.top!]);
       return { xBarScale, yBarScale };
     } else {

--- a/packages/charts/react-charting/src/components/HorizontalBarChartWithAxis/__snapshots__/HorizontalBarChartWithAxis.test.tsx.snap
+++ b/packages/charts/react-charting/src/components/HorizontalBarChartWithAxis/__snapshots__/HorizontalBarChartWithAxis.test.tsx.snap
@@ -140,7 +140,7 @@ exports[`HorizontalBarChartWithAxis snapShot testing Should render gradients on 
           rx={0}
           width={30}
           x={10}
-          y={4}
+          y={-0.19491525423729072}
         />
       </g>
     </svg>
@@ -761,7 +761,7 @@ exports[`HorizontalBarChartWithAxis snapShot testing Should render rounded corne
           rx={3}
           width={30}
           x={10}
-          y={4}
+          y={-0.19491525423729072}
         />
       </g>
     </svg>
@@ -1382,7 +1382,7 @@ exports[`HorizontalBarChartWithAxis snapShot testing renders HorizontalBarChartW
           rx={0}
           width={30}
           x={10}
-          y={4}
+          y={-0.19491525423729072}
         />
       </g>
     </svg>
@@ -2003,7 +2003,7 @@ exports[`HorizontalBarChartWithAxis snapShot testing renders hideLegend correctl
           rx={0}
           width={30}
           x={10}
-          y={4}
+          y={-0.19491525423729072}
         />
       </g>
     </svg>

--- a/packages/charts/react-charting/src/components/HorizontalBarChartWithAxis/__snapshots__/HorizontalBarChartWithAxisRTL.test.tsx.snap
+++ b/packages/charts/react-charting/src/components/HorizontalBarChartWithAxis/__snapshots__/HorizontalBarChartWithAxisRTL.test.tsx.snap
@@ -281,7 +281,7 @@ exports[`Horizontal bar chart with axis - Screen resolution Should remain unchan
           <g
             class="tick"
             opacity="1"
-            transform="translate(0,257.5)"
+            transform="translate(0,237.74999999999997)"
           >
             <line
               stroke="currentColor"
@@ -312,38 +312,7 @@ exports[`Horizontal bar chart with axis - Screen resolution Should remain unchan
           <g
             class="tick"
             opacity="1"
-            transform="translate(0,210.10000000000002)"
-          >
-            <line
-              stroke="currentColor"
-              x2="-6"
-            />
-            <text
-              aria-hidden="true"
-              dy="0.32em"
-              fill="currentColor"
-              text-align="start"
-              x="-16"
-            >
-              <tspan
-                data-="10k"
-                dy="0.32em"
-                id="BaseSpan"
-                x="-16"
-              />
-              <tspan
-                dx="1em"
-                id="LessLength"
-                x="-16"
-              >
-                10k
-              </tspan>
-            </text>
-          </g>
-          <g
-            class="tick"
-            opacity="1"
-            transform="translate(0,162.7)"
+            transform="translate(0,158.75)"
           >
             <line
               stroke="currentColor"
@@ -374,38 +343,7 @@ exports[`Horizontal bar chart with axis - Screen resolution Should remain unchan
           <g
             class="tick"
             opacity="1"
-            transform="translate(0,115.30000000000001)"
-          >
-            <line
-              stroke="currentColor"
-              x2="-6"
-            />
-            <text
-              aria-hidden="true"
-              dy="0.32em"
-              fill="currentColor"
-              text-align="start"
-              x="-16"
-            >
-              <tspan
-                data-="30k"
-                dy="0.32em"
-                id="BaseSpan"
-                x="-16"
-              />
-              <tspan
-                dx="1em"
-                id="LessLength"
-                x="-16"
-              >
-                30k
-              </tspan>
-            </text>
-          </g>
-          <g
-            class="tick"
-            opacity="1"
-            transform="translate(0,67.89999999999999)"
+            transform="translate(0,79.75)"
           >
             <line
               stroke="currentColor"
@@ -433,37 +371,6 @@ exports[`Horizontal bar chart with axis - Screen resolution Should remain unchan
               </tspan>
             </text>
           </g>
-          <g
-            class="tick"
-            opacity="1"
-            transform="translate(0,20.5)"
-          >
-            <line
-              stroke="currentColor"
-              x2="-6"
-            />
-            <text
-              aria-hidden="true"
-              dy="0.32em"
-              fill="currentColor"
-              text-align="start"
-              x="-16"
-            >
-              <tspan
-                data-="50k"
-                dy="0.32em"
-                id="BaseSpan"
-                x="-16"
-              />
-              <tspan
-                dx="1em"
-                id="LessLength"
-                x="-16"
-              >
-                50k
-              </tspan>
-            </text>
-          </g>
         </g>
         <g>
           <rect
@@ -482,7 +389,7 @@ exports[`Horizontal bar chart with axis - Screen resolution Should remain unchan
             tabindex="0"
             width="147.5"
             x="40"
-            y="217.3"
+            y="202.83898305084745"
           />
           <rect
             aria-label="88%. 2020/04/30."
@@ -500,7 +407,7 @@ exports[`Horizontal bar chart with axis - Screen resolution Should remain unchan
             tabindex="-1"
             width="590"
             x="40"
-            y="179.38"
+            y="170.70338983050848"
           />
           <rect
             aria-label="37%. 2020/04/30."
@@ -518,7 +425,7 @@ exports[`Horizontal bar chart with axis - Screen resolution Should remain unchan
             tabindex="-1"
             width="368.75"
             x="40"
-            y="98.80000000000001"
+            y="102.41525423728814"
           />
           <rect
             aria-label="20%. 2020/04/30."
@@ -536,7 +443,7 @@ exports[`Horizontal bar chart with axis - Screen resolution Should remain unchan
             tabindex="-1"
             width="295"
             x="40"
-            y="4"
+            y="22.076271186440678"
           />
         </g>
       </svg>
@@ -1285,7 +1192,7 @@ exports[`Horizontal bar chart with axis - Screen resolution Should remain unchan
           <g
             class="tick"
             opacity="1"
-            transform="translate(0,257.5)"
+            transform="translate(0,237.74999999999997)"
           >
             <line
               stroke="currentColor"
@@ -1316,38 +1223,7 @@ exports[`Horizontal bar chart with axis - Screen resolution Should remain unchan
           <g
             class="tick"
             opacity="1"
-            transform="translate(0,210.10000000000002)"
-          >
-            <line
-              stroke="currentColor"
-              x2="-6"
-            />
-            <text
-              aria-hidden="true"
-              dy="0.32em"
-              fill="currentColor"
-              text-align="start"
-              x="-16"
-            >
-              <tspan
-                data-="10k"
-                dy="0.32em"
-                id="BaseSpan"
-                x="-16"
-              />
-              <tspan
-                dx="1em"
-                id="LessLength"
-                x="-16"
-              >
-                10k
-              </tspan>
-            </text>
-          </g>
-          <g
-            class="tick"
-            opacity="1"
-            transform="translate(0,162.7)"
+            transform="translate(0,158.75)"
           >
             <line
               stroke="currentColor"
@@ -1378,38 +1254,7 @@ exports[`Horizontal bar chart with axis - Screen resolution Should remain unchan
           <g
             class="tick"
             opacity="1"
-            transform="translate(0,115.30000000000001)"
-          >
-            <line
-              stroke="currentColor"
-              x2="-6"
-            />
-            <text
-              aria-hidden="true"
-              dy="0.32em"
-              fill="currentColor"
-              text-align="start"
-              x="-16"
-            >
-              <tspan
-                data-="30k"
-                dy="0.32em"
-                id="BaseSpan"
-                x="-16"
-              />
-              <tspan
-                dx="1em"
-                id="LessLength"
-                x="-16"
-              >
-                30k
-              </tspan>
-            </text>
-          </g>
-          <g
-            class="tick"
-            opacity="1"
-            transform="translate(0,67.89999999999999)"
+            transform="translate(0,79.75)"
           >
             <line
               stroke="currentColor"
@@ -1437,37 +1282,6 @@ exports[`Horizontal bar chart with axis - Screen resolution Should remain unchan
               </tspan>
             </text>
           </g>
-          <g
-            class="tick"
-            opacity="1"
-            transform="translate(0,20.5)"
-          >
-            <line
-              stroke="currentColor"
-              x2="-6"
-            />
-            <text
-              aria-hidden="true"
-              dy="0.32em"
-              fill="currentColor"
-              text-align="start"
-              x="-16"
-            >
-              <tspan
-                data-="50k"
-                dy="0.32em"
-                id="BaseSpan"
-                x="-16"
-              />
-              <tspan
-                dx="1em"
-                id="LessLength"
-                x="-16"
-              >
-                50k
-              </tspan>
-            </text>
-          </g>
         </g>
         <g>
           <rect
@@ -1486,7 +1300,7 @@ exports[`Horizontal bar chart with axis - Screen resolution Should remain unchan
             tabindex="0"
             width="147.5"
             x="40"
-            y="217.3"
+            y="202.83898305084745"
           />
           <rect
             aria-label="88%. 2020/04/30."
@@ -1504,7 +1318,7 @@ exports[`Horizontal bar chart with axis - Screen resolution Should remain unchan
             tabindex="-1"
             width="590"
             x="40"
-            y="179.38"
+            y="170.70338983050848"
           />
           <rect
             aria-label="37%. 2020/04/30."
@@ -1522,7 +1336,7 @@ exports[`Horizontal bar chart with axis - Screen resolution Should remain unchan
             tabindex="-1"
             width="368.75"
             x="40"
-            y="98.80000000000001"
+            y="102.41525423728814"
           />
           <rect
             aria-label="20%. 2020/04/30."
@@ -1540,7 +1354,7 @@ exports[`Horizontal bar chart with axis - Screen resolution Should remain unchan
             tabindex="-1"
             width="295"
             x="40"
-            y="4"
+            y="22.076271186440678"
           />
         </g>
       </svg>
@@ -2302,7 +2116,7 @@ exports[`Horizontal bar chart with axis - Theme Should reflect theme change 1`] 
             <g
               class="tick"
               opacity="1"
-              transform="translate(0,257.5)"
+              transform="translate(0,237.74999999999997)"
             >
               <line
                 stroke="currentColor"
@@ -2333,38 +2147,7 @@ exports[`Horizontal bar chart with axis - Theme Should reflect theme change 1`] 
             <g
               class="tick"
               opacity="1"
-              transform="translate(0,210.10000000000002)"
-            >
-              <line
-                stroke="currentColor"
-                x2="-6"
-              />
-              <text
-                aria-hidden="true"
-                dy="0.32em"
-                fill="currentColor"
-                text-align="start"
-                x="-16"
-              >
-                <tspan
-                  data-="10k"
-                  dy="0.32em"
-                  id="BaseSpan"
-                  x="-16"
-                />
-                <tspan
-                  dx="1em"
-                  id="LessLength"
-                  x="-16"
-                >
-                  10k
-                </tspan>
-              </text>
-            </g>
-            <g
-              class="tick"
-              opacity="1"
-              transform="translate(0,162.7)"
+              transform="translate(0,158.75)"
             >
               <line
                 stroke="currentColor"
@@ -2395,38 +2178,7 @@ exports[`Horizontal bar chart with axis - Theme Should reflect theme change 1`] 
             <g
               class="tick"
               opacity="1"
-              transform="translate(0,115.30000000000001)"
-            >
-              <line
-                stroke="currentColor"
-                x2="-6"
-              />
-              <text
-                aria-hidden="true"
-                dy="0.32em"
-                fill="currentColor"
-                text-align="start"
-                x="-16"
-              >
-                <tspan
-                  data-="30k"
-                  dy="0.32em"
-                  id="BaseSpan"
-                  x="-16"
-                />
-                <tspan
-                  dx="1em"
-                  id="LessLength"
-                  x="-16"
-                >
-                  30k
-                </tspan>
-              </text>
-            </g>
-            <g
-              class="tick"
-              opacity="1"
-              transform="translate(0,67.89999999999999)"
+              transform="translate(0,79.75)"
             >
               <line
                 stroke="currentColor"
@@ -2454,37 +2206,6 @@ exports[`Horizontal bar chart with axis - Theme Should reflect theme change 1`] 
                 </tspan>
               </text>
             </g>
-            <g
-              class="tick"
-              opacity="1"
-              transform="translate(0,20.5)"
-            >
-              <line
-                stroke="currentColor"
-                x2="-6"
-              />
-              <text
-                aria-hidden="true"
-                dy="0.32em"
-                fill="currentColor"
-                text-align="start"
-                x="-16"
-              >
-                <tspan
-                  data-="50k"
-                  dy="0.32em"
-                  id="BaseSpan"
-                  x="-16"
-                />
-                <tspan
-                  dx="1em"
-                  id="LessLength"
-                  x="-16"
-                >
-                  50k
-                </tspan>
-              </text>
-            </g>
           </g>
           <g>
             <rect
@@ -2503,7 +2224,7 @@ exports[`Horizontal bar chart with axis - Theme Should reflect theme change 1`] 
               tabindex="0"
               width="147.5"
               x="40"
-              y="217.3"
+              y="202.83898305084745"
             />
             <rect
               aria-label="88%. 2020/04/30."
@@ -2521,7 +2242,7 @@ exports[`Horizontal bar chart with axis - Theme Should reflect theme change 1`] 
               tabindex="-1"
               width="590"
               x="40"
-              y="179.38"
+              y="170.70338983050848"
             />
             <rect
               aria-label="37%. 2020/04/30."
@@ -2539,7 +2260,7 @@ exports[`Horizontal bar chart with axis - Theme Should reflect theme change 1`] 
               tabindex="-1"
               width="368.75"
               x="40"
-              y="98.80000000000001"
+              y="102.41525423728814"
             />
             <rect
               aria-label="20%. 2020/04/30."
@@ -2557,7 +2278,7 @@ exports[`Horizontal bar chart with axis - Theme Should reflect theme change 1`] 
               tabindex="-1"
               width="295"
               x="40"
-              y="4"
+              y="22.076271186440678"
             />
           </g>
         </svg>
@@ -3307,7 +3028,7 @@ exports[`Horizontal bar chart with axis rendering Should render the Horizontal b
           <g
             class="tick"
             opacity="1"
-            transform="translate(0,257.5)"
+            transform="translate(0,237.74999999999997)"
           >
             <line
               stroke="currentColor"
@@ -3338,38 +3059,7 @@ exports[`Horizontal bar chart with axis rendering Should render the Horizontal b
           <g
             class="tick"
             opacity="1"
-            transform="translate(0,210.10000000000002)"
-          >
-            <line
-              stroke="currentColor"
-              x2="-6"
-            />
-            <text
-              aria-hidden="true"
-              dy="0.32em"
-              fill="currentColor"
-              text-align="start"
-              x="-16"
-            >
-              <tspan
-                data-="10k"
-                dy="0.32em"
-                id="BaseSpan"
-                x="-16"
-              />
-              <tspan
-                dx="1em"
-                id="LessLength"
-                x="-16"
-              >
-                10k
-              </tspan>
-            </text>
-          </g>
-          <g
-            class="tick"
-            opacity="1"
-            transform="translate(0,162.7)"
+            transform="translate(0,158.75)"
           >
             <line
               stroke="currentColor"
@@ -3400,38 +3090,7 @@ exports[`Horizontal bar chart with axis rendering Should render the Horizontal b
           <g
             class="tick"
             opacity="1"
-            transform="translate(0,115.30000000000001)"
-          >
-            <line
-              stroke="currentColor"
-              x2="-6"
-            />
-            <text
-              aria-hidden="true"
-              dy="0.32em"
-              fill="currentColor"
-              text-align="start"
-              x="-16"
-            >
-              <tspan
-                data-="30k"
-                dy="0.32em"
-                id="BaseSpan"
-                x="-16"
-              />
-              <tspan
-                dx="1em"
-                id="LessLength"
-                x="-16"
-              >
-                30k
-              </tspan>
-            </text>
-          </g>
-          <g
-            class="tick"
-            opacity="1"
-            transform="translate(0,67.89999999999999)"
+            transform="translate(0,79.75)"
           >
             <line
               stroke="currentColor"
@@ -3459,37 +3118,6 @@ exports[`Horizontal bar chart with axis rendering Should render the Horizontal b
               </tspan>
             </text>
           </g>
-          <g
-            class="tick"
-            opacity="1"
-            transform="translate(0,20.5)"
-          >
-            <line
-              stroke="currentColor"
-              x2="-6"
-            />
-            <text
-              aria-hidden="true"
-              dy="0.32em"
-              fill="currentColor"
-              text-align="start"
-              x="-16"
-            >
-              <tspan
-                data-="50k"
-                dy="0.32em"
-                id="BaseSpan"
-                x="-16"
-              />
-              <tspan
-                dx="1em"
-                id="LessLength"
-                x="-16"
-              >
-                50k
-              </tspan>
-            </text>
-          </g>
         </g>
         <g>
           <rect
@@ -3508,7 +3136,7 @@ exports[`Horizontal bar chart with axis rendering Should render the Horizontal b
             tabindex="0"
             width="147.5"
             x="40"
-            y="217.3"
+            y="202.83898305084745"
           />
           <rect
             aria-label="88%. 2020/04/30."
@@ -3526,7 +3154,7 @@ exports[`Horizontal bar chart with axis rendering Should render the Horizontal b
             tabindex="-1"
             width="590"
             x="40"
-            y="179.38"
+            y="170.70338983050848"
           />
           <rect
             aria-label="37%. 2020/04/30."
@@ -3544,7 +3172,7 @@ exports[`Horizontal bar chart with axis rendering Should render the Horizontal b
             tabindex="-1"
             width="368.75"
             x="40"
-            y="98.80000000000001"
+            y="102.41525423728814"
           />
           <rect
             aria-label="20%. 2020/04/30."
@@ -3562,7 +3190,7 @@ exports[`Horizontal bar chart with axis rendering Should render the Horizontal b
             tabindex="-1"
             width="295"
             x="40"
-            y="4"
+            y="22.076271186440678"
           />
         </g>
       </svg>
@@ -4899,7 +4527,7 @@ exports[`HorizontalBarChartWithAxis - mouse events Should render callout correct
           <g
             class="tick"
             opacity="1"
-            transform="translate(0,257.5)"
+            transform="translate(0,237.74999999999997)"
           >
             <line
               stroke="currentColor"
@@ -4930,38 +4558,7 @@ exports[`HorizontalBarChartWithAxis - mouse events Should render callout correct
           <g
             class="tick"
             opacity="1"
-            transform="translate(0,210.10000000000002)"
-          >
-            <line
-              stroke="currentColor"
-              x2="-6"
-            />
-            <text
-              aria-hidden="true"
-              dy="0.32em"
-              fill="currentColor"
-              text-align="start"
-              x="-16"
-            >
-              <tspan
-                data-="10k"
-                dy="0.32em"
-                id="BaseSpan"
-                x="-16"
-              />
-              <tspan
-                dx="1em"
-                id="LessLength"
-                x="-16"
-              >
-                10k
-              </tspan>
-            </text>
-          </g>
-          <g
-            class="tick"
-            opacity="1"
-            transform="translate(0,162.7)"
+            transform="translate(0,158.75)"
           >
             <line
               stroke="currentColor"
@@ -4992,38 +4589,7 @@ exports[`HorizontalBarChartWithAxis - mouse events Should render callout correct
           <g
             class="tick"
             opacity="1"
-            transform="translate(0,115.30000000000001)"
-          >
-            <line
-              stroke="currentColor"
-              x2="-6"
-            />
-            <text
-              aria-hidden="true"
-              dy="0.32em"
-              fill="currentColor"
-              text-align="start"
-              x="-16"
-            >
-              <tspan
-                data-="30k"
-                dy="0.32em"
-                id="BaseSpan"
-                x="-16"
-              />
-              <tspan
-                dx="1em"
-                id="LessLength"
-                x="-16"
-              >
-                30k
-              </tspan>
-            </text>
-          </g>
-          <g
-            class="tick"
-            opacity="1"
-            transform="translate(0,67.89999999999999)"
+            transform="translate(0,79.75)"
           >
             <line
               stroke="currentColor"
@@ -5051,37 +4617,6 @@ exports[`HorizontalBarChartWithAxis - mouse events Should render callout correct
               </tspan>
             </text>
           </g>
-          <g
-            class="tick"
-            opacity="1"
-            transform="translate(0,20.5)"
-          >
-            <line
-              stroke="currentColor"
-              x2="-6"
-            />
-            <text
-              aria-hidden="true"
-              dy="0.32em"
-              fill="currentColor"
-              text-align="start"
-              x="-16"
-            >
-              <tspan
-                data-="50k"
-                dy="0.32em"
-                id="BaseSpan"
-                x="-16"
-              />
-              <tspan
-                dx="1em"
-                id="LessLength"
-                x="-16"
-              >
-                50k
-              </tspan>
-            </text>
-          </g>
         </g>
         <g>
           <rect
@@ -5100,7 +4635,7 @@ exports[`HorizontalBarChartWithAxis - mouse events Should render callout correct
             tabindex="0"
             width="147.5"
             x="40"
-            y="217.3"
+            y="202.83898305084745"
           />
           <rect
             aria-label="2020/04/30. 88%."
@@ -5118,7 +4653,7 @@ exports[`HorizontalBarChartWithAxis - mouse events Should render callout correct
             tabindex="-1"
             width="590"
             x="40"
-            y="179.38"
+            y="170.70338983050848"
           />
           <rect
             aria-label="2020/04/30. 37%."
@@ -5136,7 +4671,7 @@ exports[`HorizontalBarChartWithAxis - mouse events Should render callout correct
             tabindex="-1"
             width="368.75"
             x="40"
-            y="98.80000000000001"
+            y="102.41525423728814"
           />
           <rect
             aria-label="2020/04/30. 20%."
@@ -5154,7 +4689,7 @@ exports[`HorizontalBarChartWithAxis - mouse events Should render callout correct
             tabindex="-1"
             width="295"
             x="40"
-            y="4"
+            y="22.076271186440678"
           />
         </g>
       </svg>

--- a/packages/charts/react-charting/src/utilities/__snapshots__/UtilityUnitTests.test.ts.snap
+++ b/packages/charts/react-charting/src/utilities/__snapshots__/UtilityUnitTests.test.ts.snap
@@ -1930,7 +1930,7 @@ exports[`createYAxisForHorizontalBarChartWithAxis should render y-axis labels co
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,100.5)"
+    transform="translate(0,92.16666666666666)"
   >
     <line
       stroke="currentColor"
@@ -1948,7 +1948,7 @@ exports[`createYAxisForHorizontalBarChartWithAxis should render y-axis labels co
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,80.5)"
+    transform="translate(0,75.5)"
   >
     <line
       stroke="currentColor"
@@ -1966,7 +1966,7 @@ exports[`createYAxisForHorizontalBarChartWithAxis should render y-axis labels co
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,60.5)"
+    transform="translate(0,58.83333333333333)"
   >
     <line
       stroke="currentColor"
@@ -1984,7 +1984,7 @@ exports[`createYAxisForHorizontalBarChartWithAxis should render y-axis labels co
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,40.5)"
+    transform="translate(0,42.166666666666664)"
   >
     <line
       stroke="currentColor"
@@ -2002,7 +2002,7 @@ exports[`createYAxisForHorizontalBarChartWithAxis should render y-axis labels co
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,20.499999999999996)"
+    transform="translate(0,25.5)"
   >
     <line
       stroke="currentColor"
@@ -2020,7 +2020,7 @@ exports[`createYAxisForHorizontalBarChartWithAxis should render y-axis labels co
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,0.5)"
+    transform="translate(0,8.833333333333337)"
   >
     <line
       stroke="currentColor"
@@ -2053,7 +2053,7 @@ exports[`createYAxisForHorizontalBarChartWithAxis should render y-axis labels co
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,100.5)"
+    transform="translate(0,92.16666666666666)"
   >
     <line
       stroke="currentColor"
@@ -2071,7 +2071,7 @@ exports[`createYAxisForHorizontalBarChartWithAxis should render y-axis labels co
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,80.5)"
+    transform="translate(0,75.5)"
   >
     <line
       stroke="currentColor"
@@ -2089,7 +2089,7 @@ exports[`createYAxisForHorizontalBarChartWithAxis should render y-axis labels co
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,60.5)"
+    transform="translate(0,58.83333333333333)"
   >
     <line
       stroke="currentColor"
@@ -2107,7 +2107,7 @@ exports[`createYAxisForHorizontalBarChartWithAxis should render y-axis labels co
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,40.5)"
+    transform="translate(0,42.166666666666664)"
   >
     <line
       stroke="currentColor"
@@ -2125,7 +2125,7 @@ exports[`createYAxisForHorizontalBarChartWithAxis should render y-axis labels co
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,20.499999999999996)"
+    transform="translate(0,25.5)"
   >
     <line
       stroke="currentColor"
@@ -2143,7 +2143,7 @@ exports[`createYAxisForHorizontalBarChartWithAxis should render y-axis labels co
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,0.5)"
+    transform="translate(0,8.833333333333337)"
   >
     <line
       stroke="currentColor"
@@ -2176,7 +2176,7 @@ exports[`createYAxisForHorizontalBarChartWithAxis should render y-axis labels co
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,100.5)"
+    transform="translate(0,92.16666666666666)"
   >
     <line
       stroke="currentColor"
@@ -2212,7 +2212,7 @@ exports[`createYAxisForHorizontalBarChartWithAxis should render y-axis labels co
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,0.5)"
+    transform="translate(0,8.833333333333337)"
   >
     <line
       stroke="currentColor"
@@ -2245,7 +2245,7 @@ exports[`createYAxisForHorizontalBarChartWithAxis should render y-axis labels co
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,100.5)"
+    transform="translate(0,92.16666666666666)"
   >
     <line
       stroke="currentColor"
@@ -2263,7 +2263,7 @@ exports[`createYAxisForHorizontalBarChartWithAxis should render y-axis labels co
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,80.5)"
+    transform="translate(0,75.5)"
   >
     <line
       stroke="currentColor"
@@ -2281,7 +2281,7 @@ exports[`createYAxisForHorizontalBarChartWithAxis should render y-axis labels co
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,60.5)"
+    transform="translate(0,58.83333333333333)"
   >
     <line
       stroke="currentColor"
@@ -2299,7 +2299,7 @@ exports[`createYAxisForHorizontalBarChartWithAxis should render y-axis labels co
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,40.5)"
+    transform="translate(0,42.166666666666664)"
   >
     <line
       stroke="currentColor"
@@ -2317,7 +2317,7 @@ exports[`createYAxisForHorizontalBarChartWithAxis should render y-axis labels co
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,20.499999999999996)"
+    transform="translate(0,25.5)"
   >
     <line
       stroke="currentColor"
@@ -2335,7 +2335,7 @@ exports[`createYAxisForHorizontalBarChartWithAxis should render y-axis labels co
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,0.5)"
+    transform="translate(0,8.833333333333337)"
   >
     <line
       stroke="currentColor"
@@ -2368,7 +2368,7 @@ exports[`createYAxisForHorizontalBarChartWithAxis should render y-axis labels co
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,100.5)"
+    transform="translate(0,92.16666666666666)"
   >
     <line
       stroke="currentColor"
@@ -2386,7 +2386,7 @@ exports[`createYAxisForHorizontalBarChartWithAxis should render y-axis labels co
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,80.5)"
+    transform="translate(0,75.5)"
   >
     <line
       stroke="currentColor"
@@ -2404,7 +2404,7 @@ exports[`createYAxisForHorizontalBarChartWithAxis should render y-axis labels co
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,60.5)"
+    transform="translate(0,58.83333333333333)"
   >
     <line
       stroke="currentColor"
@@ -2422,7 +2422,7 @@ exports[`createYAxisForHorizontalBarChartWithAxis should render y-axis labels co
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,40.5)"
+    transform="translate(0,42.166666666666664)"
   >
     <line
       stroke="currentColor"
@@ -2440,7 +2440,7 @@ exports[`createYAxisForHorizontalBarChartWithAxis should render y-axis labels co
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,20.499999999999996)"
+    transform="translate(0,25.5)"
   >
     <line
       stroke="currentColor"
@@ -2458,7 +2458,7 @@ exports[`createYAxisForHorizontalBarChartWithAxis should render y-axis labels co
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,0.5)"
+    transform="translate(0,8.833333333333337)"
   >
     <line
       stroke="currentColor"

--- a/packages/charts/react-charting/src/utilities/utilities.ts
+++ b/packages/charts/react-charting/src/utilities/utilities.ts
@@ -505,9 +505,10 @@ export function createYAxisForHorizontalBarChartWithAxis(yAxisParams: IYAxisPara
   // maxOfYVal coming from only area chart and Grouped vertical bar chart(Calculation done at base file)
   const tempVal = maxOfYVal || yMinMaxValues.endValue;
   const finalYmax = tempVal > yMaxValue ? tempVal : yMaxValue!;
-  const finalYmin = yMinMaxValues.startValue < yMinValue ? 0 : yMinValue!;
+  const finalYmin = yMinMaxValues.startValue < yMinValue ? Math.min(0, yMinMaxValues.startValue) : yMinValue!;
+  const yDomainPadding = Math.abs(finalYmax - finalYmin) * 0.1;
   const yAxisScale = d3ScaleLinear()
-    .domain([finalYmin, finalYmax])
+    .domain([finalYmin - yDomainPadding, finalYmax + yDomainPadding])
     .range([containerHeight - margins.bottom!, margins.top!]);
   const axis = isRtl ? d3AxisRight(yAxisScale) : d3AxisLeft(yAxisScale);
   const yAxis = axis.tickPadding(tickPadding).ticks(yAxisTickCount);

--- a/packages/react-examples/src/react-charting/DeclarativeChart/schema/fluent_donut.json
+++ b/packages/react-examples/src/react-charting/DeclarativeChart/schema/fluent_donut.json
@@ -1,577 +1,65 @@
 {
+  "visualizer": "plotly",
   "data": [
     {
-      "hovertemplate": "r=%{r}\u003cbr\u003etheta=%{theta}\u003cextra\u003e\u003c\u002fextra\u003e",
-      "legendgroup": "",
-      "line": {
-        "color": "#636efa",
-        "dash": "solid"
-      },
+      "hole": 0.6,
+      "type": "pie",
+      "frame": null,
       "marker": {
-        "symbol": "circle"
+        "line": {
+          "color": "transparent"
+        },
+        "color": "rgba(31,119,180,1)",
+        "fillcolor": "rgba(31,119,180,1)"
       },
-      "mode": "lines",
-      "name": "",
-      "r": {
-        "dtype": "i1",
-        "bdata": "ChQeKDIK"
-      },
-      "showlegend": false,
-      "subplot": "polar",
-      "theta": ["A", "B", "C", "D", "E", "A"],
-      "type": "scatterpolar"
+      "labels": [
+        "AMC",
+        "Cadillac",
+        "Camaro",
+        "Chrysler",
+        "Datsun",
+        "Dodge",
+        "Duster",
+        "Ferrari",
+        "Fiat",
+        "Ford",
+        "Honda",
+        "Hornet",
+        "Lincoln",
+        "Lotus",
+        "Maserati",
+        "Mazda",
+        "Merc",
+        "Pontiac",
+        "Porsche",
+        "Toyota",
+        "Valiant",
+        "Volvo"
+      ],
+      "values": [1, 1, 1, 1, 1, 1, 1, 1, 2, 1, 1, 2, 1, 1, 1, 2, 7, 1, 1, 2, 1, 1]
     }
   ],
   "layout": {
-    "template": {
-      "data": {
-        "histogram2dcontour": [
-          {
-            "type": "histogram2dcontour",
-            "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-            },
-            "colorscale": [
-              [0.0, "#0d0887"],
-              [0.1111111111111111, "#46039f"],
-              [0.2222222222222222, "#7201a8"],
-              [0.3333333333333333, "#9c179e"],
-              [0.4444444444444444, "#bd3786"],
-              [0.5555555555555556, "#d8576b"],
-              [0.6666666666666666, "#ed7953"],
-              [0.7777777777777778, "#fb9f3a"],
-              [0.8888888888888888, "#fdca26"],
-              [1.0, "#f0f921"]
-            ]
-          }
-        ],
-        "choropleth": [
-          {
-            "type": "choropleth",
-            "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-            }
-          }
-        ],
-        "histogram2d": [
-          {
-            "type": "histogram2d",
-            "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-            },
-            "colorscale": [
-              [0.0, "#0d0887"],
-              [0.1111111111111111, "#46039f"],
-              [0.2222222222222222, "#7201a8"],
-              [0.3333333333333333, "#9c179e"],
-              [0.4444444444444444, "#bd3786"],
-              [0.5555555555555556, "#d8576b"],
-              [0.6666666666666666, "#ed7953"],
-              [0.7777777777777778, "#fb9f3a"],
-              [0.8888888888888888, "#fdca26"],
-              [1.0, "#f0f921"]
-            ]
-          }
-        ],
-        "heatmap": [
-          {
-            "type": "heatmap",
-            "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-            },
-            "colorscale": [
-              [0.0, "#0d0887"],
-              [0.1111111111111111, "#46039f"],
-              [0.2222222222222222, "#7201a8"],
-              [0.3333333333333333, "#9c179e"],
-              [0.4444444444444444, "#bd3786"],
-              [0.5555555555555556, "#d8576b"],
-              [0.6666666666666666, "#ed7953"],
-              [0.7777777777777778, "#fb9f3a"],
-              [0.8888888888888888, "#fdca26"],
-              [1.0, "#f0f921"]
-            ]
-          }
-        ],
-        "contourcarpet": [
-          {
-            "type": "contourcarpet",
-            "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-            }
-          }
-        ],
-        "contour": [
-          {
-            "type": "contour",
-            "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-            },
-            "colorscale": [
-              [0.0, "#0d0887"],
-              [0.1111111111111111, "#46039f"],
-              [0.2222222222222222, "#7201a8"],
-              [0.3333333333333333, "#9c179e"],
-              [0.4444444444444444, "#bd3786"],
-              [0.5555555555555556, "#d8576b"],
-              [0.6666666666666666, "#ed7953"],
-              [0.7777777777777778, "#fb9f3a"],
-              [0.8888888888888888, "#fdca26"],
-              [1.0, "#f0f921"]
-            ]
-          }
-        ],
-        "surface": [
-          {
-            "type": "surface",
-            "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-            },
-            "colorscale": [
-              [0.0, "#0d0887"],
-              [0.1111111111111111, "#46039f"],
-              [0.2222222222222222, "#7201a8"],
-              [0.3333333333333333, "#9c179e"],
-              [0.4444444444444444, "#bd3786"],
-              [0.5555555555555556, "#d8576b"],
-              [0.6666666666666666, "#ed7953"],
-              [0.7777777777777778, "#fb9f3a"],
-              [0.8888888888888888, "#fdca26"],
-              [1.0, "#f0f921"]
-            ]
-          }
-        ],
-        "mesh3d": [
-          {
-            "type": "mesh3d",
-            "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-            }
-          }
-        ],
-        "scatter": [
-          {
-            "fillpattern": {
-              "fillmode": "overlay",
-              "size": 10,
-              "solidity": 0.2
-            },
-            "type": "scatter"
-          }
-        ],
-        "parcoords": [
-          {
-            "type": "parcoords",
-            "line": {
-              "colorbar": {
-                "outlinewidth": 0,
-                "ticks": ""
-              }
-            }
-          }
-        ],
-        "scatterpolargl": [
-          {
-            "type": "scatterpolargl",
-            "marker": {
-              "colorbar": {
-                "outlinewidth": 0,
-                "ticks": ""
-              }
-            }
-          }
-        ],
-        "bar": [
-          {
-            "error_x": {
-              "color": "#2a3f5f"
-            },
-            "error_y": {
-              "color": "#2a3f5f"
-            },
-            "marker": {
-              "line": {
-                "color": "#E5ECF6",
-                "width": 0.5
-              },
-              "pattern": {
-                "fillmode": "overlay",
-                "size": 10,
-                "solidity": 0.2
-              }
-            },
-            "type": "bar"
-          }
-        ],
-        "scattergeo": [
-          {
-            "type": "scattergeo",
-            "marker": {
-              "colorbar": {
-                "outlinewidth": 0,
-                "ticks": ""
-              }
-            }
-          }
-        ],
-        "scatterpolar": [
-          {
-            "type": "scatterpolar",
-            "marker": {
-              "colorbar": {
-                "outlinewidth": 0,
-                "ticks": ""
-              }
-            }
-          }
-        ],
-        "histogram": [
-          {
-            "marker": {
-              "pattern": {
-                "fillmode": "overlay",
-                "size": 10,
-                "solidity": 0.2
-              }
-            },
-            "type": "histogram"
-          }
-        ],
-        "scattergl": [
-          {
-            "type": "scattergl",
-            "marker": {
-              "colorbar": {
-                "outlinewidth": 0,
-                "ticks": ""
-              }
-            }
-          }
-        ],
-        "scatter3d": [
-          {
-            "type": "scatter3d",
-            "line": {
-              "colorbar": {
-                "outlinewidth": 0,
-                "ticks": ""
-              }
-            },
-            "marker": {
-              "colorbar": {
-                "outlinewidth": 0,
-                "ticks": ""
-              }
-            }
-          }
-        ],
-        "scattermap": [
-          {
-            "type": "scattermap",
-            "marker": {
-              "colorbar": {
-                "outlinewidth": 0,
-                "ticks": ""
-              }
-            }
-          }
-        ],
-        "scattermapbox": [
-          {
-            "type": "scattermapbox",
-            "marker": {
-              "colorbar": {
-                "outlinewidth": 0,
-                "ticks": ""
-              }
-            }
-          }
-        ],
-        "scatterternary": [
-          {
-            "type": "scatterternary",
-            "marker": {
-              "colorbar": {
-                "outlinewidth": 0,
-                "ticks": ""
-              }
-            }
-          }
-        ],
-        "scattercarpet": [
-          {
-            "type": "scattercarpet",
-            "marker": {
-              "colorbar": {
-                "outlinewidth": 0,
-                "ticks": ""
-              }
-            }
-          }
-        ],
-        "carpet": [
-          {
-            "aaxis": {
-              "endlinecolor": "#2a3f5f",
-              "gridcolor": "white",
-              "linecolor": "white",
-              "minorgridcolor": "white",
-              "startlinecolor": "#2a3f5f"
-            },
-            "baxis": {
-              "endlinecolor": "#2a3f5f",
-              "gridcolor": "white",
-              "linecolor": "white",
-              "minorgridcolor": "white",
-              "startlinecolor": "#2a3f5f"
-            },
-            "type": "carpet"
-          }
-        ],
-        "table": [
-          {
-            "cells": {
-              "fill": {
-                "color": "#EBF0F8"
-              },
-              "line": {
-                "color": "white"
-              }
-            },
-            "header": {
-              "fill": {
-                "color": "#C8D4E3"
-              },
-              "line": {
-                "color": "white"
-              }
-            },
-            "type": "table"
-          }
-        ],
-        "barpolar": [
-          {
-            "marker": {
-              "line": {
-                "color": "#E5ECF6",
-                "width": 0.5
-              },
-              "pattern": {
-                "fillmode": "overlay",
-                "size": 10,
-                "solidity": 0.2
-              }
-            },
-            "type": "barpolar"
-          }
-        ],
-        "pie": [
-          {
-            "automargin": true,
-            "type": "pie"
-          }
-        ]
-      },
-      "layout": {
-        "autotypenumbers": "strict",
-        "colorway": [
-          "#636efa",
-          "#EF553B",
-          "#00cc96",
-          "#ab63fa",
-          "#FFA15A",
-          "#19d3f3",
-          "#FF6692",
-          "#B6E880",
-          "#FF97FF",
-          "#FECB52"
-        ],
-        "font": {
-          "color": "#2a3f5f"
-        },
-        "hovermode": "closest",
-        "hoverlabel": {
-          "align": "left"
-        },
-        "paper_bgcolor": "white",
-        "plot_bgcolor": "#E5ECF6",
-        "polar": {
-          "bgcolor": "#E5ECF6",
-          "angularaxis": {
-            "gridcolor": "white",
-            "linecolor": "white",
-            "ticks": ""
-          },
-          "radialaxis": {
-            "gridcolor": "white",
-            "linecolor": "white",
-            "ticks": ""
-          }
-        },
-        "ternary": {
-          "bgcolor": "#E5ECF6",
-          "aaxis": {
-            "gridcolor": "white",
-            "linecolor": "white",
-            "ticks": ""
-          },
-          "baxis": {
-            "gridcolor": "white",
-            "linecolor": "white",
-            "ticks": ""
-          },
-          "caxis": {
-            "gridcolor": "white",
-            "linecolor": "white",
-            "ticks": ""
-          }
-        },
-        "coloraxis": {
-          "colorbar": {
-            "outlinewidth": 0,
-            "ticks": ""
-          }
-        },
-        "colorscale": {
-          "sequential": [
-            [0.0, "#0d0887"],
-            [0.1111111111111111, "#46039f"],
-            [0.2222222222222222, "#7201a8"],
-            [0.3333333333333333, "#9c179e"],
-            [0.4444444444444444, "#bd3786"],
-            [0.5555555555555556, "#d8576b"],
-            [0.6666666666666666, "#ed7953"],
-            [0.7777777777777778, "#fb9f3a"],
-            [0.8888888888888888, "#fdca26"],
-            [1.0, "#f0f921"]
-          ],
-          "sequentialminus": [
-            [0.0, "#0d0887"],
-            [0.1111111111111111, "#46039f"],
-            [0.2222222222222222, "#7201a8"],
-            [0.3333333333333333, "#9c179e"],
-            [0.4444444444444444, "#bd3786"],
-            [0.5555555555555556, "#d8576b"],
-            [0.6666666666666666, "#ed7953"],
-            [0.7777777777777778, "#fb9f3a"],
-            [0.8888888888888888, "#fdca26"],
-            [1.0, "#f0f921"]
-          ],
-          "diverging": [
-            [0, "#8e0152"],
-            [0.1, "#c51b7d"],
-            [0.2, "#de77ae"],
-            [0.3, "#f1b6da"],
-            [0.4, "#fde0ef"],
-            [0.5, "#f7f7f7"],
-            [0.6, "#e6f5d0"],
-            [0.7, "#b8e186"],
-            [0.8, "#7fbc41"],
-            [0.9, "#4d9221"],
-            [1, "#276419"]
-          ]
-        },
-        "xaxis": {
-          "gridcolor": "white",
-          "linecolor": "white",
-          "ticks": "",
-          "title": {
-            "standoff": 15
-          },
-          "zerolinecolor": "white",
-          "automargin": true,
-          "zerolinewidth": 2
-        },
-        "yaxis": {
-          "gridcolor": "white",
-          "linecolor": "white",
-          "ticks": "",
-          "title": {
-            "standoff": 15
-          },
-          "zerolinecolor": "white",
-          "automargin": true,
-          "zerolinewidth": 2
-        },
-        "scene": {
-          "xaxis": {
-            "backgroundcolor": "#E5ECF6",
-            "gridcolor": "white",
-            "linecolor": "white",
-            "showbackground": true,
-            "ticks": "",
-            "zerolinecolor": "white",
-            "gridwidth": 2
-          },
-          "yaxis": {
-            "backgroundcolor": "#E5ECF6",
-            "gridcolor": "white",
-            "linecolor": "white",
-            "showbackground": true,
-            "ticks": "",
-            "zerolinecolor": "white",
-            "gridwidth": 2
-          },
-          "zaxis": {
-            "backgroundcolor": "#E5ECF6",
-            "gridcolor": "white",
-            "linecolor": "white",
-            "showbackground": true,
-            "ticks": "",
-            "zerolinecolor": "white",
-            "gridwidth": 2
-          }
-        },
-        "shapedefaults": {
-          "line": {
-            "color": "#2a3f5f"
-          }
-        },
-        "annotationdefaults": {
-          "arrowcolor": "#2a3f5f",
-          "arrowhead": 0,
-          "arrowwidth": 1
-        },
-        "geo": {
-          "bgcolor": "white",
-          "landcolor": "#E5ECF6",
-          "subunitcolor": "white",
-          "showland": true,
-          "showlakes": true,
-          "lakecolor": "white"
-        },
-        "title": {
-          "x": 0.05
-        },
-        "mapbox": {
-          "style": "light"
-        }
-      }
+    "title": "Donut charts using Plotly",
+    "xaxis": {
+      "showgrid": false,
+      "zeroline": false,
+      "showticklabels": false
     },
-    "polar": {
-      "domain": {
-        "x": [0.0, 1.0],
-        "y": [0.0, 1.0]
-      },
-      "angularaxis": {
-        "direction": "clockwise",
-        "rotation": 90
-      }
+    "yaxis": {
+      "showgrid": false,
+      "zeroline": false,
+      "showticklabels": false
     },
-    "legend": {
-      "tracegroupgap": 0
+    "margin": {
+      "b": 40,
+      "l": 60,
+      "r": 10,
+      "t": 25
     },
-    "title": {
-      "text": "Polar Area Chart"
-    }
+    "hovermode": "closest",
+    "showlegend": true
   },
-  "id": 431
+  "frames": [],
+  "selectedLegends": ["Cadillac"]
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
Horizontal bar chart with axis did not support negative y values. They were filtered out
<!-- This is the behavior we have today -->

## New Behavior
Added support for negative y values.
Also honoring the user provided yMin and yMax properties.
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
