### PR TITLE
ci: disable dependabot major deps updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,7 @@ updates:
       - dependency-type: 'development'
     open-pull-requests-limit: 6
     versioning-strategy: increase
+    ignore:
+      # Ignore major version bumps for all npm dependencies
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major']


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

Dependabot wont trigger major bump updates - these should be handled manually

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/pull/34014
