### PR TITLE
Fix broken Figma links in Resources Design Resources page

### DIFF
--- a/apps/public-docsite/src/pages/Overviews/ResourcesPage/docs/default/ResourcesDesignResources.md
+++ b/apps/public-docsite/src/pages/Overviews/ResourcesPage/docs/default/ResourcesDesignResources.md
@@ -9,7 +9,6 @@ These design toolkits provide styles, controls and layout templates that enable 
   <li className="mdut--half">[Download iOS toolkit (Figma)](https://www.figma.com/community/file/836833645402438850/microsoft-fluent-2-ios)</li>
   <li className="mdut--half">[Download Android toolkit (Sketch)](https://aka.ms/FluentToolkits/Android/Sketch)</li>
   <li className="mdut--half">[Download Android toolkit (Figma)](https://www.figma.com/community/file/836835062056249539/microsoft-fluent-android)</li>
-  <li className="mdut--half">[Download Windows toolkit (Figma)](https://fluent2.microsoft.design/get-started/design)</li>
 </ul>
 
 <!-- headings get auto-generated IDs usually, and this page has two "SharePoint Framework" headings -->

--- a/apps/public-docsite/src/pages/Overviews/ResourcesPage/docs/default/ResourcesDesignResources.md
+++ b/apps/public-docsite/src/pages/Overviews/ResourcesPage/docs/default/ResourcesDesignResources.md
@@ -4,12 +4,12 @@ These design toolkits provide styles, controls and layout templates that enable 
 
 <ul className="md-list--flex">
   <li className="mdut--half">[Download Web toolkit (Sketch)](https://aka.ms/FluentToolkits/Web/Sketch)</li>
-  <li className="mdut--half">[Download Web toolkit (Figma)](https://aka.ms/FluentToolkits/Web/Figma)</li>
+  <li className="mdut--half">[Download Web toolkit (Figma)](https://www.figma.com/community/file/836828295772957889/microsoft-fluent-2-web)</li>
   <li className="mdut--half">[Download iOS toolkit (Sketch)](https://aka.ms/FluentToolkits/iOS/Sketch)</li>
-  <li className="mdut--half">[Download iOS toolkit (Figma)](https://aka.ms/FluentToolkits/iOS/Figma)</li>
+  <li className="mdut--half">[Download iOS toolkit (Figma)](https://www.figma.com/community/file/836833645402438850/microsoft-fluent-2-ios)</li>
   <li className="mdut--half">[Download Android toolkit (Sketch)](https://aka.ms/FluentToolkits/Android/Sketch)</li>
-  <li className="mdut--half">[Download Android toolkit (Figma)](https://aka.ms/FluentToolkits/Android/Figma)</li>
-  <li className="mdut--half">[Download Windows toolkit (Figma)](https://aka.ms/figmatoolkit)</li>
+  <li className="mdut--half">[Download Android toolkit (Figma)](https://www.figma.com/community/file/836835062056249539/microsoft-fluent-android)</li>
+  <li className="mdut--half">[Download Windows toolkit (Figma)](https://fluent2.microsoft.design/get-started/design)</li>
 </ul>
 
 <!-- headings get auto-generated IDs usually, and this page has two "SharePoint Framework" headings -->


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->
The documentation page contains broken Figma links that use redirects which are no longer working:
- Web UI Kit: https://aka.ms/FluentToolkits/Web/Figma
- iOS UI Kit: https://aka.ms/FluentToolkits/iOS/Figma
- Android UI Kit: https://aka.ms/FluentToolkits/Android/Figma
- Figma Toolkits landing: https://aka.ms/figmatoolkit

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
Updated all broken Figma links to point directly to their destinations:
- Web UI Kit: https://www.figma.com/community/file/836828295772957889/microsoft-fluent-2-web
- iOS UI Kit: https://www.figma.com/community/file/836833645402438850/microsoft-fluent-2-ios
- Android UI Kit: https://www.figma.com/community/file/836835062056249539/microsoft-fluent-android
- Figma Toolkits landing: removed

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #34287
