### PR TITLE
Feat: Updated docs to include getSlotClassNameProp_unstable

### DIFF
--- a/apps/public-docsite-v9/src/Concepts/AdvancedStylingTechniques.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/AdvancedStylingTechniques.stories.mdx
@@ -52,7 +52,7 @@ export function App() {
 A little scaffodling is required to get here first. Define a `useFancyButtonStyles.ts`, and calculate the style similar to how you would for any other Fluent component:
 
 ```ts
-import { makeStyles, type ButtonState } from '@fluentui/react-components';
+import { makeStyles, getSlotClassNameProp_unstable, type ButtonState } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   root: {
@@ -70,15 +70,27 @@ const useStyles = makeStyles({
 export const useFancyButtonStyles = (state: unknown) => {
   const buttonState = state as ButtonState;
   const styles = useStyles();
-  buttonState.root.className = mergeClasses(buttonState.root.className, styles.root);
+  buttonState.root.className = mergeClasses(
+    buttonState.root.className,
+    styles.root,
+    getSlotClassNameProp_unstable(buttonState.root),
+  );
 
   if (buttonState.icon) {
-    buttonState.icon.className = mergeClasses(buttonState.icon.className, styles.icon);
+    buttonState.icon.className = mergeClasses(
+      buttonState.icon.className,
+      styles.icon,
+      getSlotClassNameProp_unstable(buttonState.root),
+    );
   }
 };
 ```
 
-Define the value for `CustomStyleHooksProvider_unstable` in `FancyAppCustomStyleHooksValue.ts` that consumes custom style hooks:
+**Note:** `getSlotClassNameProp_unstable` is a function that gets the user-provided class names for each slot in the component. It is used to apply custom styles through user-provided class names in addition to customStyleHooks. This will need to be imported from `@fluentui/react-components` and added to the end of each `mergeClasses` call as shown in the example above.
+
+> 💡See [microsoft/fluentui#34166](https://github.com/microsoft/fluentui/pull/34166) for a detailed explanation.
+
+Next, define the value for `CustomStyleHooksProvider_unstable` in `FancyAppCustomStyleHooksValue.ts` that consumes custom style hooks:
 
 ```ts
 import { type CustomStyleHooksContextValue } from '@fluentui/react-components';


### PR DESCRIPTION
This pull request updates the `AdvancedStylingTechniques.stories.mdx` file to enhance the styling approach for Fluent UI components by incorporating a new utility function and improving the handling of class names. The most important changes include the addition of `getSlotClassNameProp_unstable` to support user-provided class names and updates to the `mergeClasses` calls to integrate this new functionality.

### Enhancements to Fluent UI styling in doc example:

* **Added `getSlotClassNameProp_unstable` utility**: The `getSlotClassNameProp_unstable` function was imported from `@fluentui/react-components` to retrieve user-provided class names for component slots. This enables better customization of styles.

* **Updated `mergeClasses` calls**: Modified the `mergeClasses` logic to include `getSlotClassNameProp_unstable` for both the `root` and `icon` slots, ensuring that user-provided class names are applied alongside existing styles. 

* **Added explanatory note**: Included a note explaining the purpose of `getSlotClassNameProp_unstable` and its role in applying custom styles, with a reference to the relevant Fluent UI pull request for further details.