### PR TITLE
fix(web-components): text-input setValidity fails if control is not available

### DIFF
--- a/change/@fluentui-web-components-9406853b-9f9d-4ff9-8825-9aeb0c8ecce0.json
+++ b/change/@fluentui-web-components-9406853b-9f9d-4ff9-8825-9aeb0c8ecce0.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: text-input setValidity fails if control is not available",
+  "packageName": "@fluentui/web-components",
+  "email": "863023+radium-v@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/docs/web-components.api.md
+++ b/packages/web-components/docs/web-components.api.md
@@ -868,6 +868,8 @@ export class BaseTextInput extends FASTElement {
     // @internal
     control: HTMLInputElement;
     // @internal
+    controlChanged(prev: HTMLInputElement | undefined, next: HTMLInputElement | undefined): void;
+    // @internal
     controlLabel: HTMLLabelElement;
     currentValue: string;
     // @internal

--- a/packages/web-components/src/text-input/text-input.base.ts
+++ b/packages/web-components/src/text-input/text-input.base.ts
@@ -292,7 +292,20 @@ export class BaseTextInput extends FASTElement {
    *
    * @internal
    */
+  @observable
   public control!: HTMLInputElement;
+
+  /**
+   * Calls the `setValidity` method when the control reference changes.
+   *
+   * @param prev - the previous control reference
+   * @param next - the current control reference
+   *
+   * @internal
+   */
+  public controlChanged(prev: HTMLInputElement | undefined, next: HTMLInputElement | undefined): void {
+    this.setValidity();
+  }
 
   /**
    * A reference to the internal label element.
@@ -589,18 +602,18 @@ export class BaseTextInput extends FASTElement {
    *
    * @internal
    */
-  public setValidity(
-    flags: Partial<ValidityState> = this.control.validity,
-    message: string = this.validationMessage,
-    anchor: HTMLElement = this.control,
-  ): void {
-    if (this.$fastController.isConnected) {
+  public setValidity(flags?: Partial<ValidityState>, message?: string, anchor?: HTMLElement): void {
+    if (this.$fastController.isConnected && this.control) {
       if (this.disabled) {
         this.elementInternals.setValidity({});
         return;
       }
 
-      this.elementInternals.setValidity(flags, message, anchor);
+      this.elementInternals.setValidity(
+        flags ?? this.control.validity,
+        message ?? this.validationMessage,
+        anchor ?? this.control,
+      );
     }
   }
 }


### PR DESCRIPTION
## Previous Behavior

In certain scenarios where the control is not yet available, the `setValidity()` call in the `connectedCallback()` may fail.

## New Behavior

* The default parameter assignments have been swapped out for in-place value checks.
* The `control` property is marked as observable. The added `controlChanged()` method calls `setValidity()` when the control reference is changed.