### PR TITLE
[fix] remove non-theming text from drawer stories

### DIFF
--- a/change/@fluentui-web-components-d531c495-234e-434c-8df1-5e11c0ea1532.json
+++ b/change/@fluentui-web-components-d531c495-234e-434c-8df1-5e11c0ea1532.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[fix] drawer title should use h2 tag",
+  "packageName": "@fluentui/web-components",
+  "email": "jes@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/.storybook/docs-root.css
+++ b/packages/web-components/.storybook/docs-root.css
@@ -63,7 +63,7 @@
   border-top: 1px solid #ebebeb;
 }
 
-#storybook-docs .sbdocs h2 {
+#storybook-docs .sbdocs h2:not([slot]) {
   font-family: 'Segoe UI', 'Segoe UI Web (West European)', -apple-system, BlinkMacSystemFont, Roboto, 'Helvetica Neue',
     sans-serif;
   font-size: 24px;
@@ -139,10 +139,12 @@
 
 #storybook-docs .sbdocs-preview {
   border-radius: 16px;
-  background: #fff; /* --colorBrandBackgroundInverted */
+  background: #fff;
+  /* --colorBrandBackgroundInverted */
   padding: 0;
   box-shadow: none;
-  border: 1px solid #d1d1d1; /* --colorNeutralStroke1 */
+  border: 1px solid #d1d1d1;
+  /* --colorNeutralStroke1 */
 }
 
 /* Apply the currently selected Fluent UI theme to the relevant areas of the docs */
@@ -300,7 +302,8 @@
   display: inline-block;
   background-color: rgba(17, 16, 15, 0.1);
   border-radius: 2px;
-  width: fit-content; /* prevent wrapping kebab-case words when they'll fit on one line */
+  width: fit-content;
+  /* prevent wrapping kebab-case words when they'll fit on one line */
 }
 
 .os-content-glue {
@@ -409,9 +412,11 @@ h1.fluent {
 
 h1 .fluent-version {
   display: block;
-  font-size: 24px; /* --font-size-base-600 */
+  font-size: 24px;
+  /* --font-size-base-600 */
   line-height: 32px;
-  color: #707070; /* --color-neutral-foreground-3 */
+  color: #707070;
+  /* --color-neutral-foreground-3 */
 }
 
 h2.fluent {
@@ -444,7 +449,8 @@ h2.fluent {
   padding: 12px;
   width: 100%;
   top: 0;
-  box-sizing: border-box; /* keep from overflowing body making x scroll bar*/
+  box-sizing: border-box;
+  /* keep from overflowing body making x scroll bar*/
   background: #fff;
   box-shadow: 0 0 3px rgb(0 0 0 / 22%);
   z-index: 10;

--- a/packages/web-components/src/drawer-body/drawer-body.styles.ts
+++ b/packages/web-components/src/drawer-body/drawer-body.styles.ts
@@ -28,4 +28,10 @@ export const styles = css`
     justify-content: flex-start;
     gap: ${spacingHorizontalM};
   }
+
+  ::slotted([slot="title"]) {
+    font: inherit;
+    padding: 0;
+    margin: 0;
+  }
 `;

--- a/packages/web-components/src/drawer-body/drawer-body.styles.ts
+++ b/packages/web-components/src/drawer-body/drawer-body.styles.ts
@@ -29,7 +29,7 @@ export const styles = css`
     gap: ${spacingHorizontalM};
   }
 
-  ::slotted([slot="title"]) {
+  ::slotted([slot='title']) {
     font: inherit;
     padding: 0;
     margin: 0;

--- a/packages/web-components/src/drawer/drawer.stories.ts
+++ b/packages/web-components/src/drawer/drawer.stories.ts
@@ -49,7 +49,7 @@ const storyTemplate = html<StoryArgs<FluentDrawer>>`
         story['--dialog-backdrop'] !== '' ? `--dialog-backdrop: ${story['--dialog-backdrop']};` : ''}"
     >
       <fluent-drawer-body>
-        <span slot="title"> Drawer Header</span>
+        <h2 slot="title"> Drawer Header</h2>
         <fluent-button
           slot="close"
           appearance="transparent"

--- a/packages/web-components/src/drawer/drawer.stories.ts
+++ b/packages/web-components/src/drawer/drawer.stories.ts
@@ -36,30 +36,9 @@ const hideDrawer = (drawerID: string) => {
 };
 
 const storyTemplate = html<StoryArgs<FluentDrawer>>`
-  <style>
-    #docs-root .innerZoomElementWrapper > div,
-    #docs-root .innerZoomElementWrapper > div > div {
-      padding: 0;
-    }
-
-    .demo {
-      display: flex;
-      align-items: center;
-      min-height: 22rem;
-      width: 100%;
-    }
-
-    .demo-content {
-      grid-area: content;
-      padding: 48px 24px;
-    }
-
-    .demo:has([position='end']) [position='end'] {
-      order: 1;
-    }
-  </style>
-
-  <div class="demo">
+    <fluent-button appearance="primary" @click="${() => toggleDrawer('drawer-default')}">
+      Toggle Drawer
+    </fluent-button>
     <fluent-drawer
       id="drawer-default"
       position="${story => story.position}"
@@ -114,27 +93,6 @@ const storyTemplate = html<StoryArgs<FluentDrawer>>`
         </div>
       </fluent-drawer-body>
     </fluent-drawer>
-    <div class="demo-content">
-      <fluent-text font="base" size="300" weight="regular" as="p">
-        <p>
-          The Drawer gives users a quick entry point to configuration and information. It should be used when retaining
-          context is beneficial to users.
-        </p>
-      </fluent-text>
-      <br />
-      <br />
-      <fluent-text font="monospace" size="300" weight="regular">
-        <code>fluent-drawer</code>
-      </fluent-text>
-      <br />
-      <br />
-      <div>
-        <fluent-button appearance="primary" @click="${() => toggleDrawer('drawer-default')}"
-          >Toggle Drawer</fluent-button
-        >
-      </div>
-    </div>
-  </div>
 `;
 
 export default {

--- a/packages/web-components/src/drawer/drawer.stories.ts
+++ b/packages/web-components/src/drawer/drawer.stories.ts
@@ -36,63 +36,60 @@ const hideDrawer = (drawerID: string) => {
 };
 
 const storyTemplate = html<StoryArgs<FluentDrawer>>`
-    <fluent-button appearance="primary" @click="${() => toggleDrawer('drawer-default')}">
-      Toggle Drawer
-    </fluent-button>
-    <fluent-drawer
-      id="drawer-default"
-      position="${story => story.position}"
-      size="${story => story.size}"
-      type="${story => story.type}"
-      style="${story =>
-        story['--drawer-width'] !== '' ? `--drawer-width: ${story['--drawer-width']};` : ''} ${story =>
-        story['--dialog-backdrop'] !== '' ? `--dialog-backdrop: ${story['--dialog-backdrop']};` : ''}"
-    >
-      <fluent-drawer-body>
-        <h2 slot="title"> Drawer Header</h2>
-        <fluent-button
-          slot="close"
-          appearance="transparent"
-          icon-only
-          aria-label="close"
-          @click="${() => hideDrawer('drawer-default')}"
-        >
-          ${dismissed20Regular}
-        </fluent-button>
-        <div>
-          <fluent-text>
-            The drawer gives users a quick entry point to configuration and information. It should be used when
-            retaining context is beneficial to users. An overlay is optional depending on whether or not interacting
-            with the background content is beneficial to the user's context/scenario. An overlay makes the drawer
-            blocking and signifies that the users full attention is required when making configurations.
-          </fluent-text>
+  <fluent-button appearance="primary" @click="${() => toggleDrawer('drawer-default')}"> Toggle Drawer </fluent-button>
+  <fluent-drawer
+    id="drawer-default"
+    position="${story => story.position}"
+    size="${story => story.size}"
+    type="${story => story.type}"
+    style="${story => (story['--drawer-width'] !== '' ? `--drawer-width: ${story['--drawer-width']};` : '')} ${story =>
+      story['--dialog-backdrop'] !== '' ? `--dialog-backdrop: ${story['--dialog-backdrop']};` : ''}"
+  >
+    <fluent-drawer-body>
+      <h2 slot="title">Drawer Header</h2>
+      <fluent-button
+        slot="close"
+        appearance="transparent"
+        icon-only
+        aria-label="close"
+        @click="${() => hideDrawer('drawer-default')}"
+      >
+        ${dismissed20Regular}
+      </fluent-button>
+      <div>
+        <fluent-text>
+          The drawer gives users a quick entry point to configuration and information. It should be used when retaining
+          context is beneficial to users. An overlay is optional depending on whether or not interacting with the
+          background content is beneficial to the user's context/scenario. An overlay makes the drawer blocking and
+          signifies that the users full attention is required when making configurations.
+        </fluent-text>
 
-          <div>
-            <fluent-field>
-              <label slot="label">Please select an option</label>
-              <fluent-radio-group id="demo-options" slot="input" orientation="vertical">
-                <fluent-field label-position="after">
-                  <label for="option-one" slot="label">Option 1</label>
-                  <fluent-radio id="option-one" slot="input" name="demo-options" value="1"></fluent-radio>
-                </fluent-field>
-                <fluent-field label-position="after">
-                  <label for="option-two" slot="label">Option 2</label>
-                  <fluent-radio id="option-two" slot="input" name="demo-options" value="2"></fluent-radio>
-                </fluent-field>
-                <fluent-field label-position="after">
-                  <label for="option-three" slot="label">Option 3</label>
-                  <fluent-radio id="option-three" slot="input" name="demo-options" value="3"></fluent-radio>
-                </fluent-field>
-              </fluent-radio-group>
-            </fluent-field>
-          </div>
+        <div>
+          <fluent-field>
+            <label slot="label">Please select an option</label>
+            <fluent-radio-group id="demo-options" slot="input" orientation="vertical">
+              <fluent-field label-position="after">
+                <label for="option-one" slot="label">Option 1</label>
+                <fluent-radio id="option-one" slot="input" name="demo-options" value="1"></fluent-radio>
+              </fluent-field>
+              <fluent-field label-position="after">
+                <label for="option-two" slot="label">Option 2</label>
+                <fluent-radio id="option-two" slot="input" name="demo-options" value="2"></fluent-radio>
+              </fluent-field>
+              <fluent-field label-position="after">
+                <label for="option-three" slot="label">Option 3</label>
+                <fluent-radio id="option-three" slot="input" name="demo-options" value="3"></fluent-radio>
+              </fluent-field>
+            </fluent-radio-group>
+          </fluent-field>
         </div>
-        <div slot="footer">
-          <fluent-button appearance="primary" @click="${() => hideDrawer('drawer-default')}">Close</fluent-button>
-          <fluent-button appearance="secondary">Do Something</fluent-button>
-        </div>
-      </fluent-drawer-body>
-    </fluent-drawer>
+      </div>
+      <div slot="footer">
+        <fluent-button appearance="primary" @click="${() => hideDrawer('drawer-default')}">Close</fluent-button>
+        <fluent-button appearance="secondary">Do Something</fluent-button>
+      </div>
+    </fluent-drawer-body>
+  </fluent-drawer>
 `;
 
 export default {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
Story had text that would not theme
<img width="1188" alt="Screenshot 2025-05-06 at 9 40 57 AM" src="https://github.com/user-attachments/assets/b45651e7-4657-44fc-b848-e30f8d021576" />



## New Behavior
Text is not necessary for story so removed.
<img width="1295" alt="Screenshot 2025-05-06 at 9 40 49 AM" src="https://github.com/user-attachments/assets/adba6cba-a1bd-4ae2-882f-6ab10550816e" />


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
