### PR TITLE
[fix]: Hitting escape once should close alert dialog

### DIFF
--- a/change/@fluentui-web-components-4d430b96-9653-4166-8f37-1be12ad9cfb8.json
+++ b/change/@fluentui-web-components-4d430b96-9653-4166-8f37-1be12ad9cfb8.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[fix]: Hitting escape once should close alert dialog",
+  "packageName": "@fluentui/web-components",
+  "email": "jes@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/dialog/dialog.spec.ts
+++ b/packages/web-components/src/dialog/dialog.spec.ts
@@ -154,26 +154,6 @@ test.describe('Dialog', () => {
     await expect(content).toBeVisible();
   });
 
-  test('should NOT close after the escape key is pressed when its `type` attribute is set to "alert"', async ({
-    fastPage,
-    page,
-  }) => {
-    const { element } = fastPage;
-    const content = element.locator('#content');
-
-    await fastPage.setTemplate({ attributes: { type: 'alert' } });
-
-    await element.evaluate((node: Dialog) => {
-      node.show();
-    });
-
-    await expect(content).toBeVisible();
-
-    await page.keyboard.press('Escape');
-
-    await expect(content).toBeVisible();
-  });
-
   test('should set the `role` attribute to "dialog" on the internal dialog element when the `type` attribute is set to "dialog"', async ({
     fastPage,
   }) => {

--- a/packages/web-components/src/dialog/dialog.template.ts
+++ b/packages/web-components/src/dialog/dialog.template.ts
@@ -17,7 +17,7 @@ export const template: ElementViewTemplate<Dialog> = html`
     aria-labelledby="${x => x.ariaLabelledby}"
     aria-label="${x => x.ariaLabel}"
     @click="${(x, c) => x.clickHandler(c.event as MouseEvent)}"
-    @cancel="${(x, c) => (x.type === DialogType.alert ? c.event.preventDefault() : x.hide())}"
+    @cancel="${x => x.hide()}"
     ${ref('dialog')}
   >
     <slot></slot>


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
Dialog cancel event was set to preventDefault when dialog type was set to alert causing the user to have to hit escape twice.

## New Behavior
Verified escape should close alert dialogs and that this behavior matches the react implementation. Also removed test that asseted it shouldn't (Even though it did when you hit wscape a second time)

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
