### PR TITLE
feat: deprecate `safeMount` and remove its abstractions in react project tests

### DIFF
--- a/change/@fluentui-test-utilities-ff572d4d-e62d-46fa-8b51-5dd02dab7ed5.json
+++ b/change/@fluentui-test-utilities-ff572d4d-e62d-46fa-8b51-5dd02dab7ed5.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: deprecate safeMount",
+  "packageName": "@fluentui/test-utilities",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/test-utilities/README.md
+++ b/packages/test-utilities/README.md
@@ -15,6 +15,9 @@ safeCreate(<Foo />, foo => {
 });
 ```
 
+> [!WARNING]
+> This api is deprecated. use `@testing-library/react` instead
+
 `safeMount(jsxContent, callback): void` - Abstraction on `mount` method in `enzyme` package which
 will auto unmount after executing the given callback.
 

--- a/packages/test-utilities/src/safeMount.ts
+++ b/packages/test-utilities/src/safeMount.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @fluentui/max-len */
 import * as React from 'react';
 import { mount, ReactWrapper } from 'enzyme';
 import { createTestContainer } from './createTestContainer';
@@ -5,6 +6,8 @@ import { createTestContainer } from './createTestContainer';
 /**
  * Calls `mount` from enzyme, calls the callback, and unmounts. This prevents mounted components
  * from sitting around doing unfathomable things in the background while other tests execute.
+ *
+ * @deprecated Use `@testing-library/react` directly instead. This function uses `enzyme` which doesn't work with react > v17
  *
  * @param content - JSX content to test.
  * @param callback - Function callback which receives the component to use.


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

- replaces previously abstracted `safeMount` with direct RTL usage
- officially deprecates `safeMount` in `@fluentui/testing-utilities` package as it cannot be removed because we cannot major bump v8 packages 

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows https://github.com/microsoft/fluentui/pull/34270
