### PR TITLE
[fix]: storybook style was preventing dialog text from theming

### DIFF
--- a/packages/web-components/.storybook/docs-root.css
+++ b/packages/web-components/.storybook/docs-root.css
@@ -43,7 +43,6 @@
   font-size: 18px;
   line-height: 27px;
   letter-spacing: -0.01em;
-  color: #000000;
   margin-top: 24px;
 }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<img width="690" alt="Screenshot 2025-05-07 at 8 45 31 AM" src="https://github.com/user-attachments/assets/6d47e18f-99b3-4fa3-a79e-2ceea7181bea" />


## New Behavior

<img width="749" alt="Screenshot 2025-05-07 at 8 45 07 AM" src="https://github.com/user-attachments/assets/d9d54b8b-29d2-49b7-9a37-6a96e8530720" />


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
