### PR TITLE
[fix] inverted spinner story to not theme background

### DIFF
--- a/packages/web-components/src/spinner/spinner.stories.ts
+++ b/packages/web-components/src/spinner/spinner.stories.ts
@@ -41,7 +41,7 @@ export const Default: Story = {};
 export const InvertedAppearance: Story = {
   render: renderComponent(html<StoryArgs<FluentSpinner>>`
     <div
-      style="padding: 40px; background-color: var(--colorNeutralBackgroundInverted); color: var(--colorNeutralForegroundInverted);"
+      style="padding: 40px; background-color: #0F6CBD; color: white;"
     >
       ${storyTemplate}
     </div>

--- a/packages/web-components/src/spinner/spinner.stories.ts
+++ b/packages/web-components/src/spinner/spinner.stories.ts
@@ -40,11 +40,7 @@ export const Default: Story = {};
 
 export const InvertedAppearance: Story = {
   render: renderComponent(html<StoryArgs<FluentSpinner>>`
-    <div
-      style="padding: 40px; background-color: #0F6CBD; color: white;"
-    >
-      ${storyTemplate}
-    </div>
+    <div style="padding: 40px; background-color: #0F6CBD; color: white;">${storyTemplate}</div>
   `),
   parameters: {
     layout: 'fullscreen',


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

The inverted story example was using a themeable background. The inverted spinner style stays the same across light and dark theme so the solution is to just hard code the background in the story example. Used the blue from the figma file and the react example.

<img width="1188" alt="Screenshot 2025-05-07 at 9 28 58 AM" src="https://github.com/user-attachments/assets/81945616-bb9d-4441-839d-e17ba9974114" />

## New Behavior

<img width="1187" alt="Screenshot 2025-05-07 at 9 28 42 AM" src="https://github.com/user-attachments/assets/d6343c72-aa3f-417d-b189-9918a9a863b7" />

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
