### PR TITLE
React-Carousel: Ensure compliant brand variant contrast

### DIFF
--- a/change/@fluentui-react-carousel-4bb9f3b6-bcf9-4a88-9583-34578c45712c.json
+++ b/change/@fluentui-react-carousel-4bb9f3b6-bcf9-4a88-9583-34578c45712c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bug: Fix branded carousel nav button colors to be WCAG contrast compliant",
+  "packageName": "@fluentui/react-carousel",
+  "email": "mifraser@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-carousel/library/src/components/CarouselNavButton/useCarouselNavButtonStyles.styles.ts
+++ b/packages/react-components/react-carousel/library/src/components/CarouselNavButton/useCarouselNavButtonStyles.styles.ts
@@ -47,7 +47,7 @@ const useStyles = makeStyles({
       borderRadius: tokens.borderRadiusMedium,
     }),
     '::after': {
-      opacity: 0.65,
+      opacity: 0.6,
     },
     ':hover': {
       '::after': {
@@ -104,13 +104,18 @@ const useStyles = makeStyles({
   },
   unselectedBrand: {
     '::after': {
-      opacity: 0.66,
-      backgroundColor: tokens.colorCompoundBrandBackground,
-      // backgroundColor: `color-mix(in srgb, ${tokens.colorCompoundBrandBackground} 75%, ${tokens.colorNeutralBackground1})`,
-      // '@supports not (color: color-mix(in lch, white, black))': {
-      //   opacity: 0.6,
-      //   backgroundColor: tokens.colorBrandBackground,
-      // },
+      opacity: 0.6,
+      backgroundColor: tokens.colorNeutralForeground1,
+    },
+    ':hover': {
+      '::after': {
+        opacity: 0.75,
+      },
+    },
+    ':active': {
+      '::after': {
+        opacity: 1,
+      },
     },
   },
 });

--- a/packages/react-components/react-carousel/library/src/components/CarouselNavButton/useCarouselNavButtonStyles.styles.ts
+++ b/packages/react-components/react-carousel/library/src/components/CarouselNavButton/useCarouselNavButtonStyles.styles.ts
@@ -105,6 +105,12 @@ const useStyles = makeStyles({
   unselectedBrand: {
     '::after': {
       opacity: 0.6,
+      backgroundColor: tokens.colorNeutralForeground1,
+      // backgroundColor: `color-mix(in srgb, ${tokens.colorBrandBackground} 70%, ${tokens.colorNeutralForeground1})`,
+      // '@supports not (color: color-mix(in lch, white, black))': {
+      //   opacity: 0.6,
+      //   backgroundColor: tokens.colorBrandBackground,
+      // },
     },
   },
 });

--- a/packages/react-components/react-carousel/library/src/components/CarouselNavButton/useCarouselNavButtonStyles.styles.ts
+++ b/packages/react-components/react-carousel/library/src/components/CarouselNavButton/useCarouselNavButtonStyles.styles.ts
@@ -86,27 +86,27 @@ const useStyles = makeStyles({
   },
   brand: {
     '::after': {
-      backgroundColor: tokens.colorBrandBackground,
+      backgroundColor: tokens.colorCompoundBrandBackground,
       opacity: 1,
     },
     ':hover': {
       '::after': {
-        backgroundColor: tokens.colorBrandBackgroundHover,
+        backgroundColor: tokens.colorCompoundBrandBackgroundHover,
         opacity: 1,
       },
     },
     ':active': {
       '::after': {
-        backgroundColor: tokens.colorBrandBackgroundPressed,
+        backgroundColor: tokens.colorCompoundBrandBackgroundPressed,
         opacity: 1,
       },
     },
   },
   unselectedBrand: {
     '::after': {
-      opacity: 0.6,
-      backgroundColor: tokens.colorNeutralForeground1,
-      // backgroundColor: `color-mix(in srgb, ${tokens.colorBrandBackground} 70%, ${tokens.colorNeutralForeground1})`,
+      opacity: 0.66,
+      backgroundColor: tokens.colorCompoundBrandBackground,
+      // backgroundColor: `color-mix(in srgb, ${tokens.colorCompoundBrandBackground} 75%, ${tokens.colorNeutralBackground1})`,
       // '@supports not (color: color-mix(in lch, white, black))': {
       //   opacity: 0.6,
       //   backgroundColor: tokens.colorBrandBackground,


### PR DESCRIPTION
## Previous Behavior
- Brand color variants of the react-carousel were using Brand button colors, these are compliant due to foreground text contrast, without text, the contrast of colors against neutral background are below 3:1 and invalid.

![image](https://github.com/user-attachments/assets/07859019-0f59-4a0b-8a64-66a45c446897)
![image](https://github.com/user-attachments/assets/ed0fe811-3ef5-4eaf-b036-10a92fb69cbb)

## New Behavior
We keep unselected state as neutral, and moved brand color to 'brandColorCompound' to ensure it passes contrast in any theme:
![image](https://github.com/user-attachments/assets/8742e9d8-f682-4163-a98a-46fe686eb4c9)
![image](https://github.com/user-attachments/assets/23717ddc-6345-4c84-a996-cff8155f1819)
