### PR TITLE
test(react-18-tests-v9): add test:integration target

### DIFF
--- a/apps/react-18-tests-v9/.swcrc
+++ b/apps/react-18-tests-v9/.swcrc
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json.schemastore.org/swcrc",
+  "exclude": [
+    "/testing",
+    "/**/*.cy.ts",
+    "/**/*.cy.tsx",
+    "/**/*.spec.ts",
+    "/**/*.spec.tsx",
+    "/**/*.test.ts",
+    "/**/*.test.tsx"
+  ],
+  "jsc": {
+    "parser": {
+      "syntax": "typescript",
+      "tsx": true,
+      "decorators": false,
+      "dynamicImport": false
+    },
+    "externalHelpers": true,
+    "transform": {
+      "react": {
+        "runtime": "classic",
+        "useSpread": true
+      }
+    },
+    "target": "es2019"
+  },
+  "minify": false,
+  "sourceMaps": true
+}

--- a/apps/react-18-tests-v9/jest-react-18.config.js
+++ b/apps/react-18-tests-v9/jest-react-18.config.js
@@ -1,0 +1,83 @@
+// @ts-check
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { pathsToModuleNameMapper } = require('ts-jest');
+const tsConfigBase = require('../../tsconfig.base.json');
+const tsPathAliases = pathsToModuleNameMapper(tsConfigBase.compilerOptions.paths, {
+  prefix: `<rootDir>/../../`,
+});
+
+const jestConfig = require('./jest.config');
+
+/**
+ * @type {import('@jest/types').Config.InitialOptions}
+ */
+const config = {
+  ...jestConfig,
+  moduleNameMapper: { ...tsPathAliases },
+  displayName: 'react-18-tests-v9-integration',
+  roots: createRoots(),
+};
+
+module.exports = config;
+
+/**
+ * Creates an array of paths to packages that don't have specific tags
+ * @returns {string[]} An array of paths to test
+ */
+function createRoots() {
+  const rootDir = path.resolve(__dirname, '../../packages/react-components');
+  return findValidPackagePaths(rootDir);
+
+  /**
+   * Recursively finds valid package paths that don't have excluded tags
+   * @param {string} dirPath - Directory to scan
+   * @returns {string[]} Array of valid package paths
+   */
+  function findValidPackagePaths(dirPath) {
+    const entries = fs.readdirSync(dirPath, { withFileTypes: true });
+    let validPaths = [];
+
+    // Check if current directory is a valid package
+    if (isValidPackage(dirPath)) {
+      validPaths.push(dirPath);
+    }
+
+    // Recursively check subdirectories
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        const fullPath = path.join(dirPath, entry.name);
+        validPaths = validPaths.concat(findValidPackagePaths(fullPath));
+      }
+    }
+
+    return validPaths;
+  }
+
+  /**
+   * Checks if a directory is a valid package based on its project.json
+   * @param {string} packagePath - Path to potential package
+   * @returns {boolean} Whether the package is valid
+   */
+  function isValidPackage(packagePath) {
+    try {
+      const projectJsonPath = path.join(packagePath, 'project.json');
+
+      if (fs.existsSync(projectJsonPath)) {
+        const projectJson = JSON.parse(fs.readFileSync(projectJsonPath, 'utf8'));
+        const tags = projectJson.tags || [];
+
+        return (
+          !['react-theme-sass'].some(projectName => projectName === projectJson.name) &&
+          !['tools', 'react-northstar', 'platform:node', 'type:stories'].some(tag => tags.includes(tag))
+        );
+      }
+
+      return false; // Only include directories with project.json
+    } catch (error) {
+      console.warn(`Error reading project.json for ${packagePath}:`, error);
+      return false; // Skip directories with invalid project.json
+    }
+  }
+}

--- a/apps/react-18-tests-v9/jest.config.js
+++ b/apps/react-18-tests-v9/jest.config.js
@@ -1,6 +1,23 @@
 // @ts-check
+/* eslint-disable */
 
+const { readFileSync } = require('node:fs');
 const { join } = require('node:path');
+
+// Reading the SWC compilation config and remove the "exclude"
+// for the test files to be compiled by SWC
+const { exclude: _, ...swcJestConfig } = JSON.parse(readFileSync(join(__dirname, '.swcrc'), 'utf-8'));
+
+// disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves.
+// If we do not disable this, SWC Core will read .swcrc and won't transform our test files due to "exclude"
+if (swcJestConfig.swcrc === undefined) {
+  swcJestConfig.swcrc = false;
+}
+
+// Uncomment if using global setup/teardown files being transformed via swc
+// https://nx.dev/packages/jest/documents/overview#global-setup/teardown-with-nx-libraries
+// jest needs EsModule Interop to find the default exported setup/teardown functions
+// swcJestConfig.module.noInterop = false;
 
 /**
  * @type {import('@jest/types').Config.InitialOptions}
@@ -13,13 +30,14 @@ module.exports = {
   moduleNameMapper: {
     '^react$': join(__dirname, '/node_modules/react'),
     '^react-dom$': join(__dirname, 'node_modules/react-dom'),
-    '^react-dom/test-utils$': join(__dirname, 'node_modules/react-dom/test-utils'),
+    '^react-dom/(test-utils|client)$': join(__dirname, 'node_modules/react-dom/$1'),
     '^react-test-renderer$': join(__dirname, 'node_modules/react-test-renderer'),
     '^@testing-library/(react|dom)$': join(__dirname, 'node_modules/@testing-library/$1'),
   },
   transform: {
-    '^.+\\.tsx?$': ['@swc/jest', {}],
+    '^.+\\.tsx?$': ['@swc/jest', swcJestConfig],
   },
   coverageDirectory: './coverage',
   setupFilesAfterEnv: ['./config/tests.js'],
+  snapshotSerializers: ['@griffel/jest-serializer'],
 };

--- a/apps/react-18-tests-v9/package.json
+++ b/apps/react-18-tests-v9/package.json
@@ -8,6 +8,7 @@
     "type-check:integration": "tsc -p tsconfig.react-18.json --noEmit",
     "lint": "ESLINT_USE_FLAT_CONFIG=false eslint --ext .js,.ts,.tsx ./src",
     "test": "jest --passWithNoTests",
+    "test:integration": "jest --passWithNoTests -c jest-react-18.config.js",
     "format": "prettier -w . --ignore-path ../.prettierignore",
     "format:check": "yarn format -c",
     "start": "webpack-dev-server --mode=development",

--- a/apps/react-18-tests-v9/project.json
+++ b/apps/react-18-tests-v9/project.json
@@ -23,6 +23,13 @@
         "!{workspaceRoot}/packages/react-components/react-migration-v[80]-v9/**",
         "!{workspaceRoot}/packages/react-components/react-[a-z]+-compat/**"
       ]
+    },
+    "test:integration": {
+      "dependsOn": ["^build"],
+      "inputs": [
+        "{projectRoot}/jest-react-18.config.js",
+        "{workspaceRoot}/packages/react-components/**/*.(test|spec).tsx?"
+      ]
     }
   }
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

Adds `test:integration` to react-18-tests-v9 application

- this target will execute all production packages `test` targets against react 18
- most of the current failures are caused by `@fluentui/react-conformance` and `@fluentui/react-conformance-griffel` 🚨
 

_current status:_

<img width="1060" alt="image" src="https://github.com/user-attachments/assets/9d887f74-3e0b-4d29-90e4-54d976bd20fa" />



## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
