### PR TITLE
fix(chart-utilities): Make unsupported chart type check stricter

### DIFF
--- a/change/@fluentui-chart-utilities-d46fc54f-f5e8-4331-bf00-9762d98d2f59.json
+++ b/change/@fluentui-chart-utilities-d46fc54f-f5e8-4331-bf00-9762d98d2f59.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(chart-utilities) Make unsupported type check stricter",
+  "packageName": "@fluentui/chart-utilities",
+  "email": "98592573+AtishayMsft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-charting-350f0257-a4a6-444a-b884-23b5fa5b2a0e.json
+++ b/change/@fluentui-react-charting-350f0257-a4a6-444a-b884-23b5fa5b2a0e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(react-charting) Cleanup function removed upstream",
+  "packageName": "@fluentui/react-charting",
+  "email": "98592573+AtishayMsft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-charts-e29b43fc-d0fa-4720-8c5f-a4d0e5c75a45.json
+++ b/change/@fluentui-react-charts-e29b43fc-d0fa-4720-8c5f-a4d0e5c75a45.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(react-charts) Cleanup function removed upstream",
+  "packageName": "@fluentui/react-charts",
+  "email": "98592573+AtishayMsft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charts/chart-utilities/etc/chart-utilities.api.md
+++ b/packages/charts/chart-utilities/etc/chart-utilities.api.md
@@ -456,9 +456,6 @@ export const isDate: (value: any) => boolean;
 export const isDateArray: (data: Datum[] | Datum[][] | TypedArray | undefined) => boolean;
 
 // @public (undocumented)
-export const isLineData: (data: Partial<PlotData>) => boolean;
-
-// @public (undocumented)
 export const isNumber: (value: any) => boolean;
 
 // @public (undocumented)
@@ -1179,7 +1176,7 @@ export interface PlotData {
     // (undocumented)
     marker: Partial<PlotMarker>;
     // (undocumented)
-    mode: 'lines' | 'markers' | 'text' | 'lines+markers' | 'text+markers' | 'text+lines' | 'text+lines+markers' | 'none' | 'gauge' | 'number' | 'delta' | 'number+delta' | 'gauge+number' | 'gauge+number+delta' | 'gauge+delta';
+    mode: 'lines' | 'markers' | 'text' | 'lines+markers' | 'text+markers' | 'text+lines' | 'text+lines+markers' | 'none' | 'gauge' | 'number' | 'delta' | 'number+delta' | 'gauge+number' | 'gauge+number+delta' | 'gauge+delta' | 'markers+text';
     // (undocumented)
     name: string;
     // (undocumented)

--- a/packages/charts/chart-utilities/src/PlotlySchema.ts
+++ b/packages/charts/chart-utilities/src/PlotlySchema.ts
@@ -1149,7 +1149,8 @@ export interface PlotData {
     | 'number+delta'
     | 'gauge+number'
     | 'gauge+number+delta'
-    | 'gauge+delta';
+    | 'gauge+delta'
+    | 'markers+text';
   histfunc: 'count' | 'sum' | 'avg' | 'min' | 'max';
   histnorm: '' | 'percent' | 'probability' | 'density' | 'probability density';
   hoveron: 'points' | 'fills';

--- a/packages/charts/chart-utilities/src/index.ts
+++ b/packages/charts/chart-utilities/src/index.ts
@@ -103,7 +103,6 @@ export {
   isDateArray,
   isNumberArray,
   isYearArray,
-  isLineData,
   validate2Dseries,
   getValidSchema,
   sanitizeJson,

--- a/packages/charts/react-charting/src/components/DeclarativeChart/DeclarativeChart.tsx
+++ b/packages/charts/react-charting/src/components/DeclarativeChart/DeclarativeChart.tsx
@@ -160,7 +160,7 @@ export const DeclarativeChart: React.FunctionComponent<DeclarativeChartProps> = 
   };
 
   const renderLineArea = (plotlyData: Data[], isAreaChart: boolean): JSX.Element => {
-    const isScatterMarkers = (plotlyData[0] as PlotData)?.mode === 'markers';
+    const isScatterMarkers = ['markers', 'text+markers', 'markers+text'].includes((plotlyData[0] as PlotData)?.mode);
     const chartProps: ILineChartProps | IAreaChartProps = {
       ...transformPlotlyJsonToScatterChartProps(
         { data: plotlyData, layout: plotlyInput.layout },

--- a/packages/charts/react-charting/src/components/DeclarativeChart/PlotlySchemaAdapter.ts
+++ b/packages/charts/react-charting/src/components/DeclarativeChart/PlotlySchemaAdapter.ts
@@ -55,7 +55,6 @@ import {
   isDate,
   isDateArray,
   isNumberArray,
-  isLineData,
   isYearArray,
 } from '@fluentui/chart-utilities';
 import { timeParse } from 'd3-time-format';
@@ -295,7 +294,7 @@ export const transformPlotlyJsonToVSBCProps = (
           color,
         });
         yMaxValue = Math.max(yMaxValue, yVal);
-      } else if (series.type === 'scatter' || isLineData(series) || !!fallbackVSBC) {
+      } else if (series.type === 'scatter' || !!fallbackVSBC) {
         const color = getColor(legend, colorMap, isDarkTheme);
         const lineOptions = getLineOptions(series.line);
         const dashType = series.line?.dash || 'solid';

--- a/packages/charts/react-charts/library/src/components/DeclarativeChart/PlotlySchemaAdapter.ts
+++ b/packages/charts/react-charts/library/src/components/DeclarativeChart/PlotlySchemaAdapter.ts
@@ -48,14 +48,7 @@ import type {
   ScatterLine,
   TypedArray,
 } from '@fluentui/chart-utilities';
-import {
-  isArrayOfType,
-  isArrayOrTypedArray,
-  isDate,
-  isDateArray,
-  isNumberArray,
-  isLineData,
-} from '@fluentui/chart-utilities';
+import { isArrayOfType, isArrayOrTypedArray, isDate, isDateArray, isNumberArray } from '@fluentui/chart-utilities';
 import { timeParse } from 'd3-time-format';
 import { curveCardinal as d3CurveCardinal } from 'd3-shape';
 
@@ -272,7 +265,7 @@ export const transformPlotlyJsonToVSBCProps = (
           data: yVal,
           color,
         });
-      } else if (series.type === 'scatter' || isLineData(series) || !!fallbackVSBC) {
+      } else if (series.type === 'scatter' || !!fallbackVSBC) {
         const color = getColor(legend, colorMap, isDarkTheme);
         const lineOptions = getLineOptions(series.line);
         mapXToDataPoints[x].lineData!.push({


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
The best effort fallback to try to render chart as a line was causing issues for some charts like waterfall, funnel and 3D charts.
<!-- This is the behavior we have today -->

## New Behavior
Removed the fallback to line check since we anyways have the fallback to static images now.
Also enabled scatter chart for `markers+text` mode

Verified in test app.
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
