### PR TITLE
feat(eslint-plugin): move project to private to stop further npm releases

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@fluentui/eslint-plugin",
+  "private": true,
   "version": "1.20.0",
   "description": "ESLint configuration and custom rules for Fluent UI",
   "main": "src/index.js",

--- a/scripts/beachball/src/config.test.ts
+++ b/scripts/beachball/src/config.test.ts
@@ -118,7 +118,6 @@ describe(`beachball configs`, () => {
     expect(toolsConfig.scope).toEqual(
       expect.arrayContaining([
         ...excludedPackagesFromReleaseProcess,
-        'packages/eslint-plugin',
         'packages/react-components/babel-preset-storybook-full-source',
         'packages/react-components/eslint-plugin-react-components',
         'packages/react-components/react-conformance-griffel',


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

- moving package back to `private` to mitiage any further releases until it's being rewritten to up to date state
- also will mitigate further invalid release bumps caused by beachball not  differentiating between dependencies and devDependencies causing unwanted releases and release bumps
  - eg 1: react-conformance was supposed to be released as patch https://github.com/microsoft/fluentui/commit/8edf93c4c635df8f4c9fb36ed317a48e30262555#diff-4c5686f9d1e728be6e92ba6827bfacaef1a7f123504a994d849424f3694fbfba but because eslint-plugin was bumped as minor and dependant change type was minor it overrode the bump of conformace package, making a new release  which says based on semver that it has breaking changes - it does not
  -  eg 2: react-storybook-addon package didn't contain any change-files, but because eslint-plugin bump it was also bumped and released with invalid version https://github.com/microsoft/fluentui/commit/8edf93c4c635df8f4c9fb36ed317a48e30262555#diff-6687678984357755e3a6e4e237dff940799e4aa8e4c22d68f90e8d115ec8c9a2 

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
