### PR TITLE
fix(PeoplePicker): high contrast color for tag items uses system color

### DIFF
--- a/change/@fluentui-react-37482984-c3b2-466a-85c7-5733f627c8e3.json
+++ b/change/@fluentui-react-37482984-c3b2-466a-85c7-5733f627c8e3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(PeoplePicker): high contrast color for tag items uses system color",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/pickers/PeoplePicker/PeoplePickerItems/PeoplePickerItem.styles.ts
+++ b/packages/react/src/components/pickers/PeoplePicker/PeoplePickerItems/PeoplePickerItem.styles.ts
@@ -127,6 +127,11 @@ export function getStyles(props: IPeoplePickerItemSelectedStyleProps): IPeoplePi
               ':focus-within': {
                 background: palette.themePrimary,
                 color: palette.white,
+
+                [HighContrastSelector]: {
+                  color: 'HighLightText',
+                  background: 'Highlight',
+                },
               },
               [HighContrastSelector]: {
                 borderColor: 'HighLight',

--- a/packages/react/src/components/pickers/TagPicker/TagItem.styles.ts
+++ b/packages/react/src/components/pickers/TagPicker/TagItem.styles.ts
@@ -72,6 +72,11 @@ export function getStyles(props: ITagItemStyleProps): ITagItemStyles {
             ':focus-within': {
               background: palette.themePrimary,
               color: palette.white,
+
+              [HighContrastSelector]: {
+                color: 'HighLightText',
+                background: 'Highlight',
+              },
             },
           },
         ],


### PR DESCRIPTION
## Previous Behavior

When picker selected tags are focused, they use `forced-color-adjust: none`, so any higher-specificity styles will override the system color styles. The `:focus-within` style did that for the tag background, making the text sometimes unreadable (depending on the theme).

## New Behavior

Adds system color keyword styles for `:focus-within`

## Related Issue(s)

- Fixes [ADO issue](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/26432)
