### PR TITLE
fix(react-nav-preview): Fix icon animation in Safari by animating opacity instead of display

### DIFF
--- a/change/@fluentui-react-nav-preview-596583ea-bfcb-49c8-b127-ac61c5781a41.json
+++ b/change/@fluentui-react-nav-preview-596583ea-bfcb-49c8-b127-ac61c5781a41.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Change Nav icon display animations to opacity animations",
+  "packageName": "@fluentui/react-nav-preview",
+  "email": "jiangemma@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-nav-preview/library/src/components/sharedNavStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/library/src/components/sharedNavStyles.styles.ts
@@ -135,11 +135,11 @@ export const useIconStyles = makeStyles({
       display: 'inline',
       animationName: {
         '0%': {
-          display: 'none',
+          opacity: 0,
           color: 'transparent',
         },
         '100%': {
-          display: 'inline',
+          opacity: 1,
           color: tokens.colorNeutralForeground2BrandSelected,
         },
       },
@@ -148,11 +148,11 @@ export const useIconStyles = makeStyles({
       ...navItemTokens.animationTokens,
       animationName: {
         '0%': {
-          display: 'inline',
+          opacity: 1,
           color: tokens.colorNeutralForeground2,
         },
         '100%': {
-          display: 'none',
+          opacity: 0,
           color: 'transparent',
         },
       },


### PR DESCRIPTION
## Previous Behavior

The icons disappeared when selected and unselected in Safari.

## New Behavior

The icons no longer disappear when selected and unselected in Safari.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes [Partner Bug](https://office.visualstudio.com/OC/_workitems/edit/10129155)
