### PR TITLE
Extended-tokens: Fix regressions from new JSON refactor

### DIFF
--- a/packages/semantic-tokens/etc/semantic-tokens.api.md
+++ b/packages/semantic-tokens/etc/semantic-tokens.api.md
@@ -1553,7 +1553,7 @@ export const ctrlFabShadowRestKey = "var(--smtc-ctrl-fab-shadow-rest-key)";
 export const ctrlFabShadowRestKeyRaw = "--smtc-ctrl-fab-shadow-rest-key";
 
 // @public (undocumented)
-export const ctrlFocusInnerStroke = "var(--smtc-ctrl-focus-inner-stroke)";
+export const ctrlFocusInnerStroke = "var(--smtc-ctrl-focus-inner-stroke, var(--colorStrokeFocus2))";
 
 // @public (undocumented)
 export const ctrlFocusInnerStrokeRaw = "--smtc-ctrl-focus-inner-stroke";
@@ -1565,7 +1565,7 @@ export const ctrlFocusInnerStrokeWidth = "var(--smtc-ctrl-focus-inner-stroke-wid
 export const ctrlFocusInnerStrokeWidthRaw = "--smtc-ctrl-focus-inner-stroke-width";
 
 // @public (undocumented)
-export const ctrlFocusOuterStroke = "var(--smtc-ctrl-focus-outer-stroke, var(--smtc-background-ctrl-brand-rest, var(--colorStrokeFocus2)))";
+export const ctrlFocusOuterStroke = "var(--smtc-ctrl-focus-outer-stroke, var(--smtc-background-ctrl-brand-rest, var(--colorTransparentStroke)))";
 
 // @public (undocumented)
 export const ctrlFocusOuterStrokeRaw = "--smtc-ctrl-focus-outer-stroke";

--- a/packages/semantic-tokens/scripts/tokenGen.ts
+++ b/packages/semantic-tokens/scripts/tokenGen.ts
@@ -47,7 +47,7 @@ const isInvalidToken = (token: string) => {
     return true;
   }
   // Blacklist for non-valid tokens
-  if (token.includes('Figmaonly') || token.startsWith('null')) {
+  if (token.includes('Figmaonly') || token.toLocaleLowerCase().startsWith('null')) {
     // Superfluous tokens - SKIP
     return true;
   }
@@ -140,10 +140,6 @@ const getResolvedToken = (token: string, tokenData: Token, tokenNameRaw: string)
     return `var(${escapeInlineToken(tokenNameRaw)}, var(${escapeInlineToken(
       tokenSemanticRef,
     )}, ${escapeMixedInlineToken(fluentFallback)}))`;
-  }
-
-  if (fluentFallback && tokenData.nullable) {
-    return `var(${escapeInlineToken(tokenNameRaw)}, var(${escapeMixedInlineToken(fluentFallback)}}, unset))`;
   }
 
   if (fluentFallback) {

--- a/packages/semantic-tokens/src/components/focus/tokens.ts
+++ b/packages/semantic-tokens/src/components/focus/tokens.ts
@@ -1,6 +1,6 @@
 // THIS FILE IS GENERATED AS PART OF THE BUILD PROCESS. DO NOT MANUALLY MODIFY THIS FILE
 import { strokeWidthDefaultRaw, backgroundCtrlBrandRestRaw } from '../../control/variables';
-import { colorStrokeFocus2 } from '../../legacy/tokens';
+import { colorStrokeFocus2, colorTransparentStroke } from '../../legacy/tokens';
 import {
   ctrlFocusInnerStrokeWidthRaw,
   ctrlFocusInnerStrokeRaw,
@@ -9,6 +9,6 @@ import {
 } from './variables';
 
 export const ctrlFocusInnerStrokeWidth = `var(${ctrlFocusInnerStrokeWidthRaw}, var(${strokeWidthDefaultRaw}))`;
-export const ctrlFocusInnerStroke = `var(${ctrlFocusInnerStrokeRaw})`;
+export const ctrlFocusInnerStroke = `var(${ctrlFocusInnerStrokeRaw}, ${colorStrokeFocus2})`;
 export const ctrlFocusOuterStrokeWidth = `var(${ctrlFocusOuterStrokeWidthRaw})`;
-export const ctrlFocusOuterStroke = `var(${ctrlFocusOuterStrokeRaw}, var(${backgroundCtrlBrandRestRaw}, ${colorStrokeFocus2}))`;
+export const ctrlFocusOuterStroke = `var(${ctrlFocusOuterStrokeRaw}, var(${backgroundCtrlBrandRestRaw}, ${colorTransparentStroke}))`;

--- a/packages/semantic-tokens/src/fluentOverrides.ts
+++ b/packages/semantic-tokens/src/fluentOverrides.ts
@@ -12,7 +12,8 @@ export type FluentOverrides = Record<string, FluentOverrideValue | null>;
 
 export const fluentOverrides: FluentOverrides = {
   cornerZero: { f2Token: 'borderRadiusNone' },
-  ctrlFocusOuterStroke: { f2Token: 'colorStrokeFocus2' },
+  ctrlFocusInnerStroke: { f2Token: 'colorStrokeFocus2' },
+  ctrlFocusOuterStroke: { f2Token: 'colorTransparentStroke' },
   ctrlLinkForegroundBrandHover: { f2Token: 'colorBrandForegroundLinkHover' },
   ctrlLinkForegroundBrandPressed: { f2Token: 'colorBrandForegroundLinkPressed' },
   ctrlLinkForegroundBrandRest: { f2Token: 'colorBrandForegroundLink' },

--- a/packages/semantic-tokens/src/legacy/tokens.ts
+++ b/packages/semantic-tokens/src/legacy/tokens.ts
@@ -10,6 +10,11 @@ export const borderRadiusNone = 'var(--borderRadiusNone)';
  */
 export const colorStrokeFocus2 = 'var(--colorStrokeFocus2)';
 /**
+ * CSS custom property value for the {@link @fluentui/tokens#colorTransparentStroke | `colorTransparentStroke`} design token.
+ * @public
+ */
+export const colorTransparentStroke = 'var(--colorTransparentStroke)';
+/**
  * CSS custom property value for the {@link @fluentui/tokens#colorBrandForegroundLinkHover | `colorBrandForegroundLinkHover`} design token.
  * @public
  */


### PR DESCRIPTION
## Previous Behavior
NULL was skipped originally, but new casing sensitivity prevented us from catching null tokens

## New Behavior
Now remove null tokens
We also ignore 'unset' for any tokens with proper fallbacks in place.
Updated link to use the correct focus token