### PR TITLE
Extended-tokens: Fix link focus reference (changed in latest JSON update)

### DIFF
--- a/packages/react-components/react-link/library/src/components/Link/useLinkStyles.styles.ts
+++ b/packages/react-components/react-link/library/src/components/Link/useLinkStyles.styles.ts
@@ -11,7 +11,7 @@ export const linkClassNames: SlotClassNames<LinkSlots> = {
 
 const useStyles = makeStyles({
   focusIndicator: createCustomFocusIndicatorStyle({
-    textDecorationColor: semanticTokens.ctrlFocusOuterStroke,
+    textDecorationColor: semanticTokens.ctrlFocusInnerStroke,
     textDecorationLine: 'underline',
     textDecorationStyle: 'double',
     outlineStyle: 'none',


### PR DESCRIPTION
## Previous Behavior
Previously we used 'ctrlFocusOuterStroke' for link focus state

## New Behavior
After confirming with other component specs, it was confirmed this should be using `ctrlFocusInnerStroke`