### PR TITLE
Add CEM to package exports

### DIFF
--- a/change/@fluentui-web-components-44b1b6b4-87b6-43a1-ab12-7c09fceb3bc6.json
+++ b/change/@fluentui-web-components-44b1b6b4-87b6-43a1-ab12-7c09fceb3bc6.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Include Custom Elements Manifest in package exports",
+  "packageName": "@fluentui/web-components",
+  "email": "burtonsmith@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -71,6 +71,7 @@
       "types": "./dist/dts/*/define.d.ts",
       "default": "./dist/esm/*/define.js"
     },
+    "./custom-elements.json": "./custom-elements.json",
     "./package.json": "./package.json"
   },
   "sideEffects": [


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

The Custom Elements Manifest is not included in the package exports. This means that users cannot import and use the CEM features and plugins to add functionality in their projects.

## New Behavior

The file is now included in the exports.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
