### PR TITLE
feat(react-calendar-compat): added reverse Date selection

### DIFF
--- a/change/@fluentui-react-calendar-compat-a50d298f-8922-4eb6-95e2-ce2c8b814551.json
+++ b/change/@fluentui-react-calendar-compat-a50d298f-8922-4eb6-95e2-ce2c8b814551.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: added reverse Date selection",
+  "packageName": "@fluentui/react-calendar-compat",
+  "email": "vkozlova@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-calendar-compat/library/etc/react-calendar-compat.api.md
+++ b/packages/react-components/react-calendar-compat/library/etc/react-calendar-compat.api.md
@@ -70,6 +70,7 @@ export interface CalendarDayGridProps extends DayGridOptions {
     onNavigateDate: (date: Date, focusOnNavigatedDay: boolean) => void;
     onSelectDate?: (date: Date, selectedDateRangeArray?: Date[]) => void;
     restrictedDates?: Date[];
+    reverse?: boolean;
     selectedDate: Date;
     showCloseButton?: boolean;
     showWeekNumbers?: boolean;
@@ -455,7 +456,7 @@ export enum FirstWeekOfYear {
 export function getDatePartHashValue(date: Date): number;
 
 // @public
-export function getDateRangeArray(date: Date, dateRangeType: DateRangeType, firstDayOfWeek: DayOfWeek, workWeekDays?: DayOfWeek[], daysToSelectInDayView?: number): Date[];
+export function getDateRangeArray(date: Date, dateRangeType: DateRangeType, firstDayOfWeek: DayOfWeek, workWeekDays?: DayOfWeek[], daysToSelectInDayView?: number, reverse?: boolean): Date[];
 
 // @public
 export function getEndDateOfWeek(date: Date, firstDayOfWeek: DayOfWeek): Date;

--- a/packages/react-components/react-calendar-compat/library/src/components/CalendarDayGrid/CalendarDayGrid.tsx
+++ b/packages/react-components/react-calendar-compat/library/src/components/CalendarDayGrid/CalendarDayGrid.tsx
@@ -52,10 +52,18 @@ export const CalendarDayGrid: React.FunctionComponent<CalendarDayGridProps> = pr
   const activeDescendantId = useId();
 
   const onSelectDate = (selectedDate: Date): void => {
-    const { firstDayOfWeek, minDate, maxDate, workWeekDays, daysToSelectInDayView, restrictedDates } = props;
+    const { firstDayOfWeek, minDate, maxDate, workWeekDays, daysToSelectInDayView, restrictedDates, reverse } = props;
     const restrictedDatesOptions = { minDate, maxDate, restrictedDates };
 
-    let dateRange = getDateRangeArray(selectedDate, dateRangeType, firstDayOfWeek, workWeekDays, daysToSelectInDayView);
+    let dateRange = getDateRangeArray(
+      selectedDate,
+      dateRangeType,
+      firstDayOfWeek,
+      workWeekDays,
+      daysToSelectInDayView,
+      reverse,
+    );
+
     dateRange = getBoundedDateRange(dateRange, minDate, maxDate);
 
     dateRange = dateRange.filter((d: Date) => {
@@ -100,6 +108,7 @@ export const CalendarDayGrid: React.FunctionComponent<CalendarDayGridProps> = pr
       props.firstDayOfWeek,
       props.workWeekDays,
       props.daysToSelectInDayView,
+      props.reverse,
     ).map((date: Date) => date.getTime());
 
     // gets all the day refs for the given dates

--- a/packages/react-components/react-calendar-compat/library/src/components/CalendarDayGrid/CalendarDayGrid.types.ts
+++ b/packages/react-components/react-calendar-compat/library/src/components/CalendarDayGrid/CalendarDayGrid.types.ts
@@ -89,6 +89,12 @@ export interface CalendarDayGridProps extends DayGridOptions {
   daysToSelectInDayView?: number;
 
   /**
+   * The `reverse` property allows selection of days in reverse order.
+   * `daysToSelectInDayView` turnes to negative value
+   */
+  reverse?: boolean;
+
+  /**
    * Value of today. If unspecified, current time in client machine will be used.
    */
   today?: Date;

--- a/packages/react-components/react-calendar-compat/library/src/utils/dateGrid/dateGrid.types.ts
+++ b/packages/react-components/react-calendar-compat/library/src/utils/dateGrid/dateGrid.types.ts
@@ -107,4 +107,10 @@ export interface DayGridOptions extends RestrictedDatesOptions {
    * month, between 4 and 6 depending
    */
   weeksToShow?: number;
+
+  /**
+   * The `reverse` property allows selection of days in reverse order.
+   * `daysToSelectInDayView` turnes to negative value
+   */
+  reverse?: boolean;
 }

--- a/packages/react-components/react-calendar-compat/library/src/utils/dateGrid/getDayGrid.ts
+++ b/packages/react-components/react-calendar-compat/library/src/utils/dateGrid/getDayGrid.ts
@@ -24,6 +24,7 @@ export const getDayGrid = (options: DayGridOptions): Day[][] => {
     daysToSelectInDayView,
     restrictedDates,
     markedDays,
+    reverse,
   } = options;
   const restrictedDateOptions = { minDate, maxDate, restrictedDates };
 
@@ -63,6 +64,7 @@ export const getDayGrid = (options: DayGridOptions): Day[][] => {
       firstDayOfWeek,
       workWeekDays,
       daysToSelectInDayView,
+      reverse,
     );
     selectedDates = getBoundedDateRange(selectedDates, minDate, maxDate);
   }

--- a/packages/react-components/react-calendar-compat/library/src/utils/dateMath/dateMath.test.ts
+++ b/packages/react-components/react-calendar-compat/library/src/utils/dateMath/dateMath.test.ts
@@ -48,6 +48,14 @@ describe('DateMath', () => {
     expect(result.getTime()).toEqual(expected.getTime());
   });
 
+  it('can add negative days', () => {
+    const startDate = new Date(2016, Months.Feb, 28);
+    const result = DateMath.addDays(startDate, -5);
+    const expected = new Date(2016, Months.Feb, 23);
+
+    expect(result.getTime()).toEqual(expected.getTime());
+  });
+
   it('can add months', () => {
     const startDate = new Date(2015, Months.Dec, 31);
 
@@ -313,6 +321,34 @@ describe('DateMath', () => {
     expectedDates = Array(7).map((val: undefined, i: number) => new Date(2017, 2, 14 + i));
     dateRangeArray = DateMath.getDateRangeArray(date, DateRangeType.Week, DayOfWeek.Tuesday);
     Array(7).forEach((val: undefined, i: number) => expect(DateMath.compareDates(dateRangeArray[i], date)).toBe(true));
+
+    // Date range: custom
+    const customExpectedDates = [
+      new Date(2017, 2, 16),
+      new Date(2017, 2, 17),
+      new Date(2017, 2, 18),
+      new Date(2017, 2, 19),
+      new Date(2017, 2, 20),
+    ];
+    dateRangeArray = DateMath.getDateRangeArray(date, DateRangeType.Day, DayOfWeek.Sunday, undefined, 5);
+    expect(dateRangeArray.length).toEqual(5);
+    Array(5).forEach((val: undefined, i: number) =>
+      expect(DateMath.compareDates(dateRangeArray[i], customExpectedDates[i])).toBe(true),
+    );
+
+    // Date range: custom reverse
+    const reverseExpectedDates = [
+      new Date(2017, 2, 20),
+      new Date(2017, 2, 19),
+      new Date(2017, 2, 18),
+      new Date(2017, 2, 17),
+      new Date(2017, 2, 16),
+    ];
+    dateRangeArray = DateMath.getDateRangeArray(date, DateRangeType.Day, DayOfWeek.Sunday, undefined, 5, true);
+    expect(dateRangeArray.length).toEqual(5);
+    Array(5).forEach((val: undefined, i: number) =>
+      expect(DateMath.compareDates(dateRangeArray[i], reverseExpectedDates[i])).toBe(true),
+    );
   });
 
   // Generating week numbers array per month

--- a/packages/react-components/react-calendar-compat/library/src/utils/dateMath/dateMath.ts
+++ b/packages/react-components/react-calendar-compat/library/src/utils/dateMath/dateMath.ts
@@ -165,6 +165,7 @@ export function getDateRangeArray(
   firstDayOfWeek: DayOfWeek,
   workWeekDays?: DayOfWeek[],
   daysToSelectInDayView: number = 1,
+  reverse?: boolean,
 ): Date[] {
   const datesArray: Date[] = [];
   let startDate: Date;
@@ -178,8 +179,13 @@ export function getDateRangeArray(
 
   switch (dateRangeType) {
     case DateRangeType.Day:
-      startDate = getDatePart(date);
-      endDate = addDays(startDate, daysToSelectInDayView);
+      if (reverse) {
+        endDate = addDays(getDatePart(date), 1);
+        startDate = addDays(endDate, -daysToSelectInDayView);
+      } else {
+        startDate = getDatePart(date);
+        endDate = addDays(startDate, daysToSelectInDayView);
+      }
       break;
 
     case DateRangeType.Week:

--- a/packages/react-components/react-calendar-compat/stories/src/Calendar/CalendarMultiDayView.stories.tsx
+++ b/packages/react-components/react-calendar-compat/stories/src/Calendar/CalendarMultiDayView.stories.tsx
@@ -53,6 +53,14 @@ export const CalendarMultidayDayView = () => {
           ))}
         </Dropdown>
       </Field>
+      <h3>Reverse date selection</h3>
+      <Calendar
+        highlightSelectedMonth
+        showGoToToday
+        onSelectDate={onSelectDate}
+        value={selectedDate}
+        calendarDayProps={{ daysToSelectInDayView, reverse: true }}
+      />
     </div>
   );
 };


### PR DESCRIPTION
Added reverse Date selection.

## Previous Behavior
Selection was possible only in one direction

## New Behavior
Added `reverse` param for negative date range selection

## Related Issue(s)
#28961
