### PR TITLE
[fix]: add click event for close slot for drawer

### DIFF
--- a/change/@fluentui-web-components-a43a8034-1ec2-4583-853b-890ff7506ccd.json
+++ b/change/@fluentui-web-components-a43a8034-1ec2-4583-853b-890ff7506ccd.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adds click event to close slot of drawer",
+  "packageName": "@fluentui/web-components",
+  "email": "jes@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/docs/web-components.api.md
+++ b/packages/web-components/docs/web-components.api.md
@@ -2433,6 +2433,8 @@ export class Drawer extends FASTElement {
 //
 // @public
 export class DrawerBody extends FASTElement {
+    // @internal
+    clickHandler(event: MouseEvent): boolean | void;
 }
 
 // @public (undocumented)

--- a/packages/web-components/docs/web-components.api.md
+++ b/packages/web-components/docs/web-components.api.md
@@ -2312,7 +2312,7 @@ export class Dialog extends FASTElement {
 // @public
 export class DialogBody extends FASTElement {
     // @internal
-    clickHandler(event: MouseEvent): boolean | void;
+    clickHandler(event: PointerEvent): boolean | void;
 }
 
 // @public
@@ -2434,7 +2434,7 @@ export class Drawer extends FASTElement {
 // @public
 export class DrawerBody extends FASTElement {
     // @internal
-    clickHandler(event: MouseEvent): boolean | void;
+    clickHandler(event: PointerEvent): boolean | void;
 }
 
 // @public (undocumented)

--- a/packages/web-components/src/dialog-body/dialog-body.ts
+++ b/packages/web-components/src/dialog-body/dialog-body.ts
@@ -15,7 +15,7 @@ export class DialogBody extends FASTElement {
    * @param e - the click event
    * @internal
    */
-  public clickHandler(event: MouseEvent): boolean | void {
+  public clickHandler(event: PointerEvent): boolean | void {
     if (!event.defaultPrevented) {
       const dialog = this.parentElement;
 

--- a/packages/web-components/src/drawer-body/drawer-body.template.ts
+++ b/packages/web-components/src/drawer-body/drawer-body.template.ts
@@ -9,7 +9,7 @@ export function drawerBodyTemplate<T extends DrawerBody>(): ElementViewTemplate<
   return html<T>`
     <div class="header" part="header">
       <slot name="title"></slot>
-      <slot name="close"></slot>
+      <slot name="close" @click="${(x, c) => x.clickHandler(c.event as PointerEvent)}"></slot>
     </div>
     <div class="content" part="content">
       <slot></slot>

--- a/packages/web-components/src/drawer-body/drawer-body.ts
+++ b/packages/web-components/src/drawer-body/drawer-body.ts
@@ -1,4 +1,5 @@
 import { FASTElement } from '@microsoft/fast-element';
+import { isDialog } from '../dialog/dialog.options';
 
 /**
  * A DrawerBody component to layout drawer content
@@ -20,4 +21,22 @@ import { FASTElement } from '@microsoft/fast-element';
  *
  * @tag fluent-drawer-body
  */
-export class DrawerBody extends FASTElement {}
+export class DrawerBody extends FASTElement {
+  /**
+   * Handles click event for the close slot
+   *
+   * @param e - the click event
+   * @internal
+   */
+  public clickHandler(event: MouseEvent): boolean | void {
+    if (!event.defaultPrevented) {
+      const dialog = this.parentElement;
+
+      if (isDialog(dialog, '-drawer')) {
+        dialog.hide();
+      }
+    }
+
+    return true;
+  }
+}

--- a/packages/web-components/src/drawer-body/drawer-body.ts
+++ b/packages/web-components/src/drawer-body/drawer-body.ts
@@ -28,7 +28,7 @@ export class DrawerBody extends FASTElement {
    * @param e - the click event
    * @internal
    */
-  public clickHandler(event: MouseEvent): boolean | void {
+  public clickHandler(event: PointerEvent): boolean | void {
     if (!event.defaultPrevented) {
       const dialog = this.parentElement;
 

--- a/packages/web-components/src/drawer/drawer.spec.ts
+++ b/packages/web-components/src/drawer/drawer.spec.ts
@@ -148,4 +148,29 @@ test.describe('Drawer', () => {
 
     await expect(wasDismissed).resolves.toBe(true);
   });
+
+  test('should close after a button is slotted into the close slot and clicked', async ({ fastPage, page }) => {
+    const { element } = fastPage;
+    const closeButton = element.locator('fluent-button[slot="close"]');
+    const content = element.locator('#content');
+
+    await fastPage.setTemplate(/* html */ `
+        <fluent-drawer>
+          <fluent-drawer-body>
+              <fluent-button slot="close">Close</fluent-button>
+              <div id="content">content</div>
+          </fluent-drawer-body>
+        </fluent-drawer>
+      `);
+
+    await element.evaluate((node: Drawer) => {
+      node.show();
+    });
+
+    await expect(content).toBeVisible();
+
+    await closeButton.click();
+
+    await expect(content).toBeHidden();
+  });
 });

--- a/packages/web-components/src/drawer/drawer.stories.ts
+++ b/packages/web-components/src/drawer/drawer.stories.ts
@@ -47,13 +47,7 @@ const storyTemplate = html<StoryArgs<FluentDrawer>>`
   >
     <fluent-drawer-body>
       <h2 slot="title">Drawer Header</h2>
-      <fluent-button
-        slot="close"
-        appearance="transparent"
-        icon-only
-        aria-label="close"
-        @click="${() => hideDrawer('drawer-default')}"
-      >
+      <fluent-button slot="close" appearance="transparent" icon-only aria-label="close">
         ${dismissed20Regular}
       </fluent-button>
       <div>


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
Previously implementation of drawer would require you to call the close event on the click event of the element slotted into the close slot

## New Behavior
Now you no longer need to call the close event on the drawer (though you still can). This matches the new api for dialog with this PR.

Dialog PR:
https://github.com/microsoft/fluentui/pull/34469.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
