### PR TITLE
feat(web-components): ensure fluent-label has an associated label element

### DIFF
--- a/change/@fluentui-web-components-f1f22b19-9cf2-4f2b-a4f3-2590a975c29f.json
+++ b/change/@fluentui-web-components-f1f22b19-9cf2-4f2b-a4f3-2590a975c29f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: ensure fluent-label element has an associated label ",
+  "packageName": "@fluentui/web-components",
+  "email": "863023+radium-v@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/docs/web-components.api.md
+++ b/packages/web-components/docs/web-components.api.md
@@ -690,14 +690,24 @@ export class BaseField extends FASTElement {
     messageSlot: Element[];
     // @internal
     messageSlotChanged(prev: Element[], next: Element[]): void;
-    // @internal
-    setStates(): void;
     // (undocumented)
     setValidationStates(): void;
     // @internal
     slottedInputs: SlottableInput[];
     // @internal
     slottedInputsChanged(prev: SlottableInput[] | undefined, next: SlottableInput[] | undefined): void;
+}
+
+// @public
+export class BaseLabel extends FASTElement {
+    clickHandler(e: MouseEvent): boolean | void;
+    defaultSlottedContent: Node[];
+    defaultSlottedContentChanged(prev: Node[] | undefined, next: Node[] | undefined): void;
+    disabled: boolean;
+    htmlFor: string;
+    protected insertLabel(): void;
+    labelElement: HTMLLabelElement;
+    required: boolean;
 }
 
 // @public
@@ -2795,15 +2805,16 @@ export function isDropdown(element?: Node | null, tagName?: string): element is 
 export function isDropdownOption(value: Node | null, tagName?: string): value is DropdownOption;
 
 // @public
+export function isLabel(element?: Element | Node | null, tagName?: string): element is BaseLabel;
+
+// @public
 export function isListbox(element?: Node | null, tagName?: string): element is Listbox;
 
 // @public
 export function isTreeItem(element?: Node | null, tagName?: string): element is BaseTreeItem;
 
 // @public
-export class Label extends FASTElement {
-    disabled: boolean;
-    required: boolean;
+export class Label extends BaseLabel {
     size?: LabelSize;
     weight?: LabelWeight;
 }

--- a/packages/web-components/src/field/field.stories.ts
+++ b/packages/web-components/src/field/field.stories.ts
@@ -27,7 +27,6 @@ export default {
   excludeStories: ['storyTemplate'],
   args: {
     label: {
-      id: uniqueId('field-'),
       text: 'Example',
     },
     message: {
@@ -35,9 +34,9 @@ export default {
       icon: () => html`${SuccessIcon}`,
     },
     labelSlottedContent: () =>
-      html`<label slot="label" for="${story => story.label.id}">${story => story.label.text}</label>`,
+      html`<fluent-label slot="label" for="${story => story.label.id}">${story => story.label.text}</fluent-label>`,
     inputSlottedContent: () =>
-      html`<fluent-text-input slot="input" id="${story => story.label.id}"></fluent-text-input>`,
+      html`<fluent-text-input slot="input" id="${story => story.label.id}" required></fluent-text-input>`,
     messageSlottedContent: () =>
       html`<fluent-text slot="message" flag="${story => story.message?.flag}" size="200"
         >${story => story.message?.icon?.()} ${story => story.message?.message}</fluent-text
@@ -97,7 +96,7 @@ export const LabelPositions: Story = {
       html`
         <div>
           <fluent-field label-position="${story => story.labelPosition}">
-            <label slot="label" for="${story => story.id}">${story => story.label}</label>
+            <fluent-label slot="label" for="${story => story.id}">${story => story.label}</fluent-label>
             <fluent-text-input slot="input" id="${story => story.id}"></fluent-text-input
           ></fluent-field>
         </div>
@@ -137,15 +136,15 @@ export const DisabledControl: Story = {
 export const Size: Story = {
   render: renderComponent(html`
     <fluent-field size="small">
-      <label slot="label" for="field-small-size">Small field</label>
+      <fluent-label slot="label" for="field-small-size">Small field</fluent-label>
       <fluent-text-input control-size="small" slot="input" id="field-small-size"></fluent-text-input>
     </fluent-field>
     <fluent-field size="medium">
-      <label slot="label" for="field-medium-size">Medium field</label>
+      <fluent-label slot="label" for="field-medium-size">Medium field</fluent-label>
       <fluent-text-input control-size="medium" slot="input" id="field-medium-size"></fluent-text-input>
     </fluent-field>
     <fluent-field size="large">
-      <label slot="label" for="field-large-size">Large field</label>
+      <fluent-label slot="label" for="field-large-size">Large field</fluent-label>
       <fluent-text-input control-size="large" slot="input" id="field-large-size"></fluent-text-input>
     </fluent-field>
   `),
@@ -155,14 +154,14 @@ export const ValidationMessage: Story = {
   render: renderComponent(html<StoryArgs<FluentField>>`
     <form id="validation-messages-form" action="#" style="display:flex;flex-flow:column;align-items:start;gap:10px;">
       <fluent-field>
-        <label slot="label" for="field-required">Required</label>
+        <fluent-label slot="label" for="field-required">Required</fluent-label>
         <fluent-text-input required slot="input" id="field-required"></fluent-text-input>
         <fluent-text slot="message" flag="value-missing" size="200" style="color: ${colorStatusDangerForeground1}">
           This field is required.
         </fluent-text>
       </fluent-field>
       <fluent-field>
-        <label slot="label" for="field-pattern-mismatch">Unique ID</label>
+        <fluent-label slot="label" for="field-pattern-mismatch">Unique ID</fluent-label>
         <fluent-text-input
           pattern="\\w+"
           slot="input"
@@ -174,56 +173,56 @@ export const ValidationMessage: Story = {
         </fluent-text>
       </fluent-field>
       <fluent-field>
-        <label slot="label" for="field-too-long">Too Long</label>
+        <fluent-label slot="label" for="field-too-long">Too Long</fluent-label>
         <fluent-text-input maxlength="5" value="123456789" slot="input" id="field-too-long"></fluent-text-input>
         <fluent-text slot="message" flag="too-long" size="200" style="color: ${colorStatusDangerForeground1}">
           This value is too long.
         </fluent-text>
       </fluent-field>
       <fluent-field>
-        <label slot="label" for="field-too-short">Too Short</label>
+        <fluent-label slot="label" for="field-too-short">Too Short</fluent-label>
         <fluent-text-input minlength="5" value="123" slot="input" id="field-too-short"></fluent-text-input>
         <fluent-text slot="message" flag="too-short" size="200" style="color: ${colorStatusDangerForeground1}">
           This value is too short.
         </fluent-text>
       </fluent-field>
       <fluent-field>
-        <label slot="label" for="field-range-overflow">Range Overflow</label>
+        <fluent-label slot="label" for="field-range-overflow">Range Overflow</fluent-label>
         <fluent-text-input type="number" max="5" value="7" slot="input" id="field-range-overflow"></fluent-text-input>
         <fluent-text slot="message" flag="range-overflow" size="200" style="color: ${colorStatusDangerForeground1}">
           This value must be less than 5.
         </fluent-text>
       </fluent-field>
       <fluent-field>
-        <label slot="label" for="field-range-underflow">Range Underflow</label>
+        <fluent-label slot="label" for="field-range-underflow">Range Underflow</fluent-label>
         <fluent-text-input type="number" min="5" value="3" slot="input" id="field-range-underflow"></fluent-text-input>
         <fluent-text slot="message" flag="range-underflow" size="200" style="color: ${colorStatusDangerForeground1}">
           This value must be greater than 5.
         </fluent-text>
       </fluent-field>
       <fluent-field>
-        <label slot="label" for="field-step-mismatch">Step Mismatch</label>
+        <fluent-label slot="label" for="field-step-mismatch">Step Mismatch</fluent-label>
         <fluent-text-input type="number" step="5" value="0" slot="input" id="field-step-mismatch"></fluent-text-input>
         <fluent-text slot="message" flag="step-mismatch" size="200" style="color: ${colorStatusDangerForeground1}">
           This value must be a multiple of 5.
         </fluent-text>
       </fluent-field>
       <fluent-field>
-        <label slot="label" for="field-type-mismatch">Type Mismatch</label>
+        <fluent-label slot="label" for="field-type-mismatch">Type Mismatch</fluent-label>
         <fluent-text-input value="not an email" type="email" slot="input" id="field-type-mismatch"></fluent-text-input>
         <fluent-text slot="message" flag="type-mismatch" size="200" style="color: ${colorStatusDangerForeground1}">
           This value is not a valid email address.
         </fluent-text>
       </fluent-field>
       <fluent-field>
-        <label slot="label" for="field-type-tooshort2">Too short (TextArea)</label>
+        <fluent-label slot="label" for="field-type-tooshort2">Too short (TextArea)</fluent-label>
         <fluent-textarea minlength="10" slot="input" id="field-type-tooshort2"> 12345 </fluent-textarea>
         <fluent-text slot="message" flag="too-short" size="200" style="color: ${colorStatusDangerForeground1}">
           This field requires at least 10 characters.
         </fluent-text>
       </fluent-field>
       <fluent-field>
-        <label slot="label" for="field-type-toolong2">Too long (TextArea)</label>
+        <fluent-label slot="label" for="field-type-toolong2">Too long (TextArea)</fluent-label>
         <fluent-textarea maxlength="2" slot="input" id="field-type-toolong2"> 123456789 </fluent-textarea>
         <fluent-text slot="message" flag="too-long" size="200" style="color: ${colorStatusDangerForeground1}">
           This field can only have up to 2 characters
@@ -268,30 +267,49 @@ export const ComponentExamples: Story = {
   render: renderComponent(html`
     <div style="display: flex; flex-direction: column; gap: 10px;">
       <fluent-field label-position="above">
-        <label slot="label" for="field-text">Text Input</label>
+        <fluent-label slot="label" for="field-text">Text Input</fluent-label>
         <fluent-text-input slot="input" id="field-text"></fluent-text-input>
       </fluent-field>
       <fluent-field label-position="above" style="max-width: 400px">
-        <label slot="label" for="field-slider">Slider</label>
+        <fluent-label slot="label" for="field-slider">Slider</fluent-label>
         <fluent-slider size="medium" slot="input" id="field-slider"></fluent-slider>
       </fluent-field>
       <fluent-field label-position="after">
-        <label slot="label" for="field-checkbox">Checkbox</label>
+        <fluent-label slot="label" for="field-checkbox">Checkbox</fluent-label>
         <fluent-checkbox slot="input" id="field-checkbox"></fluent-checkbox>
       </fluent-field>
+
       <fluent-field label-position="above">
-        <label slot="label" for="field-radio">Radio Group</label>
-        <fluent-radio-group slot="input" name="field-radio" orientation="vertical">
-          <fluent-radio value="Apple">Apple</fluent-radio>
-          <fluent-radio value="pear">Pear</fluent-radio>
-          <fluent-radio value="banana">Banana</fluent-radio>
-          <fluent-radio value="orange">Orange</fluent-radio>
+        <fluent-label slot="label" for="field-radio">Radio Group</fluent-label>
+
+        <fluent-radio-group slot="input" name="field-radio" id="field-radio" orientation="vertical">
+          <fluent-field label-position="after">
+            <fluent-label slot="label">Apple</fluent-label>
+            <fluent-radio slot="input" value="Apple"></fluent-radio>
+          </fluent-field>
+          <fluent-field label-position="after">
+            <fluent-label slot="label">Pear</fluent-label>
+            <fluent-radio slot="input" value="pear">Pear</fluent-radio>
+          </fluent-field>
+          <fluent-field label-position="after">
+            <fluent-label slot="label">Banana</fluent-label>
+            <fluent-radio slot="input" value="banana">Banana</fluent-radio>
+          </fluent-field>
+          <fluent-field label-position="after">
+            <fluent-label slot="label">Orange</fluent-label>
+            <fluent-radio slot="input" value="orange">Orange</fluent-radio>
+          </fluent-field>
         </fluent-radio-group>
       </fluent-field>
+
       <fluent-field>
-        <label slot="label" for="field-textarea">Text Area</label>
-        <fluent-textarea slot="input" id="field-textarea" placeholder="Placeholder text" resize="both">
-        </fluent-textarea>
+        <fluent-label slot="label" for="field-textarea">Text Area</fluent-label>
+        <fluent-textarea
+          slot="input"
+          id="field-textarea"
+          placeholder="Placeholder text"
+          resize="both"
+        ></fluent-textarea>
       </fluent-field>
     </div>
   `),
@@ -301,11 +319,11 @@ export const ThirdPartyControls: Story = {
   render: renderComponent(html`
     <form action="#" style="display:flex;flex-flow:column;align-items:start;gap:10px">
       <fluent-field label-position="above" style="max-width: 400px">
-        <label slot="label" for="native-text-input">Text Input</label>
+        <fluent-label slot="label" for="native-text-input">Text Input</fluent-label>
         <input slot="input" id="native-text-input" required />
       </fluent-field>
       <fluent-field label-position="before">
-        <label slot="label" for="native-checkbox">Checkbox</label>
+        <fluent-label slot="label" for="native-checkbox">Checkbox</fluent-label>
         <input slot="input" type="checkbox" id="native-checkbox" />
       </fluent-field>
     </form>

--- a/packages/web-components/src/field/field.styles.ts
+++ b/packages/web-components/src/field/field.styles.ts
@@ -19,17 +19,7 @@ import {
   borderRadiusMedium,
   colorNeutralForeground1,
   colorStrokeFocus2,
-  fontFamilyBase,
-  fontSizeBase200,
-  fontSizeBase300,
-  fontSizeBase400,
-  fontWeightRegular,
-  fontWeightSemibold,
-  lineHeightBase200,
-  lineHeightBase300,
-  lineHeightBase400,
   spacingHorizontalM,
-  spacingHorizontalS,
   spacingVerticalM,
   spacingVerticalS,
   spacingVerticalXXS,
@@ -95,7 +85,7 @@ export const styles = css`
     grid-template-areas: 'input' 'label';
   }
 
-  ::slotted([slot='label'])::after {
+  ::slotted(label[slot='label'])::after {
     content: '';
     display: block;
     position: absolute;
@@ -121,28 +111,8 @@ export const styles = css`
   ::slotted(label),
   ::slotted([slot='label']) {
     cursor: inherit;
-    display: inline-flex;
-    font-family: ${fontFamilyBase};
-    font-size: ${fontSizeBase300};
-    font-weight: ${fontWeightRegular};
     grid-area: label;
-    line-height: ${lineHeightBase300};
     user-select: none;
-  }
-
-  :host([size='small']) ::slotted(label) {
-    font-size: ${fontSizeBase200};
-    line-height: ${lineHeightBase200};
-  }
-
-  :host([size='large']) ::slotted(label) {
-    font-size: ${fontSizeBase400};
-    line-height: ${lineHeightBase400};
-  }
-
-  :host([size='large']) ::slotted(label),
-  :host([weight='semibold']) ::slotted(label) {
-    font-weight: ${fontWeightSemibold};
   }
 
   :host(${disabledState}) {

--- a/packages/web-components/src/index.ts
+++ b/packages/web-components/src/index.ts
@@ -139,7 +139,16 @@ export {
 export type { SlottableInput } from './field/index.js';
 export { FluentDesignSystem } from './fluent-design-system.js';
 export { Image, ImageDefinition, ImageFit, ImageShape, ImageStyles, ImageTemplate } from './image/index.js';
-export { Label, LabelDefinition, LabelSize, LabelStyles, LabelTemplate, LabelWeight } from './label/index.js';
+export {
+  BaseLabel,
+  isLabel,
+  Label,
+  LabelDefinition,
+  LabelSize,
+  LabelStyles,
+  LabelTemplate,
+  LabelWeight,
+} from './label/index.js';
 export {
   BaseAnchor,
   AnchorButton,

--- a/packages/web-components/src/label/index.ts
+++ b/packages/web-components/src/label/index.ts
@@ -1,5 +1,6 @@
-export { Label } from './label.js';
-export { LabelSize, LabelWeight } from './label.options.js';
+export { BaseLabel } from './label.base.js';
 export { definition as LabelDefinition } from './label.definition.js';
+export { Label } from './label.js';
+export { isLabel, LabelSize, LabelWeight } from './label.options.js';
 export { styles as LabelStyles } from './label.styles.js';
 export { template as LabelTemplate } from './label.template.js';

--- a/packages/web-components/src/label/label.base.ts
+++ b/packages/web-components/src/label/label.base.ts
@@ -1,0 +1,41 @@
+import { attr, FASTElement, observable, Updates } from '@microsoft/fast-element';
+import { labelElementTemplate } from './label.template.js';
+
+/**
+ * The base class used for constructing a fluent-label custom element
+ *
+ * @tag fluent-label
+ *
+ * @public
+ */
+export class BaseLabel extends FASTElement {
+  /**
+   * 	Specifies styles for label when associated input is disabled
+   *
+   * @public
+   * @remarks
+   * HTML Attribute: `disabled`
+   */
+  @attr({ mode: 'boolean' })
+  public disabled: boolean = false;
+
+  /**
+   * The label's for attribute.
+   *
+   * @public
+   * @remarks
+   * HTML Attribute: `for`
+   */
+  @attr({ attribute: 'for' })
+  public htmlFor!: string;
+
+  /**
+   * 	Specifies styles for label when associated input is a required field
+   *
+   * @public
+   * @remarks
+   * HTML Attribute: `required`
+   */
+  @attr({ mode: 'boolean' })
+  public required: boolean = false;
+}

--- a/packages/web-components/src/label/label.base.ts
+++ b/packages/web-components/src/label/label.base.ts
@@ -1,4 +1,4 @@
-import { attr, FASTElement, observable, Updates } from '@microsoft/fast-element';
+import { attr, FASTElement, observable } from '@microsoft/fast-element';
 import { labelElementTemplate } from './label.template.js';
 
 /**
@@ -38,4 +38,78 @@ export class BaseLabel extends FASTElement {
    */
   @attr({ mode: 'boolean' })
   public required: boolean = false;
+
+  /**
+   * The default slotted content.
+   *
+   * @public
+   */
+  @observable
+  defaultSlottedContent!: Node[];
+
+  /**
+   * Ensures that a label element is present in the light DOM. It may be a child or parent of this element.
+   *
+   * @param prev - The previous list of slotted content
+   * @param next - The current list of slotted content
+   * @public
+   *
+   * @remarks
+   * If a `<label>` element is not present when connected, one will be created and inserted into the light DOM, and all
+   * slotted content will be moved into the element.
+   */
+  defaultSlottedContentChanged(prev: Node[] | undefined, next: Node[] | undefined): void {
+    const labelElement =
+      this.closest('label') ??
+      next?.find<HTMLLabelElement>((x): x is HTMLLabelElement => x instanceof HTMLLabelElement);
+
+    if (labelElement) {
+      this.labelElement = labelElement;
+      return;
+    }
+
+    if (next?.length) {
+      this.insertLabel();
+    }
+  }
+
+  /**
+   * Reference to the associated label element.
+   *
+   * @public
+   */
+  @observable
+  public labelElement!: HTMLLabelElement;
+
+  /**
+   * Redirects `click` events to the label element.
+   *
+   * @param e - The event object
+   * @public
+   */
+  public clickHandler(e: MouseEvent): boolean | void {
+    if (this.disabled) {
+      return;
+    }
+
+    if (this === e.target) {
+      this.labelElement.click();
+    }
+
+    return true;
+  }
+
+  /**
+   * Renders the label element and inserts all slotted content into the label.
+   *
+   * @public
+   * @remarks
+   * This method is called when the label element is not present in the light DOM, either as a child or parent of this
+   * element. This method can be overridden in derived classes to provide a custom label element or to disable the
+   * behavior entirely.
+   */
+  protected insertLabel(): void {
+    labelElementTemplate.render(this, this);
+    this.labelElement.prepend(...this.defaultSlottedContent.filter(x => x !== this.labelElement));
+  }
 }

--- a/packages/web-components/src/label/label.options.ts
+++ b/packages/web-components/src/label/label.options.ts
@@ -1,4 +1,21 @@
 import type { ValuesOf } from '../utils/index.js';
+import type { BaseLabel } from './label.base.js';
+
+/**
+ * Predicate function that determines if the element should be considered a label.
+ *
+ * @param element - The element to check.
+ * @param tagName - The tag name to check.
+ * @returns true if the element is a label.
+ * @public
+ */
+export function isLabel(element?: Element | Node | null, tagName: string = '-label'): element is BaseLabel {
+  if (element?.nodeType !== Node.ELEMENT_NODE) {
+    return false;
+  }
+
+  return (element as Element).tagName.toLowerCase().endsWith(tagName);
+}
 
 /**
  * A Labels font size can be small, medium, or large

--- a/packages/web-components/src/label/label.spec.ts
+++ b/packages/web-components/src/label/label.spec.ts
@@ -80,4 +80,111 @@ test.describe('Label', () => {
       await expect(asterisk).toBeHidden();
     });
   });
+
+  test('should insert all slotted content into a generated label element when no slotted label is provided', async ({
+    fastPage,
+  }) => {
+    const { element } = fastPage;
+
+    await fastPage.setTemplate({
+      innerHTML: /* html */ `Hello <span>World</span><span>!</span>`,
+    });
+
+    const labelElement = element.locator('label');
+
+    await expect(labelElement).toHaveCount(1);
+
+    await expect(labelElement).toBeVisible();
+
+    await expect(labelElement).toHaveText('Hello World!');
+  });
+
+  test('should NOT insert slotted content into a generated label element when a slotted label is provided', async ({
+    fastPage,
+  }) => {
+    const { element } = fastPage;
+
+    await fastPage.setTemplate({
+      innerHTML: /* html */ `<label>Hello</label> <span>World</span><span>!</span>`,
+    });
+
+    const label = element.locator('label');
+
+    await expect(label).toHaveCount(1);
+
+    await expect(label).toBeVisible();
+
+    await expect(label).toHaveText('Hello');
+
+    await expect(element).toContainText('Hello World!');
+  });
+
+  test('should NOT create a label element when the element is the child of a label element', async ({
+    fastPage,
+    page,
+  }) => {
+    await fastPage.setTemplate(/* html */ `<label><fluent-label>Hello</fluent-label></label>`);
+
+    const label = page.locator('label');
+
+    await expect(label).toHaveCount(1);
+
+    await expect(label).toContainText('Hello');
+  });
+
+  test('should NOT move slotted content that has been added to the element when a slotted label is provided', async ({
+    fastPage,
+    page,
+  }) => {
+    const { element } = fastPage;
+
+    await fastPage.setTemplate({
+      innerHTML: /* html */ `<label>Hello</label> <span>World</span><span>!</span>`,
+    });
+
+    const label = page.locator('label');
+
+    await expect(label).toHaveCount(1);
+
+    await expect(label).toBeVisible();
+
+    await expect(label).toHaveText('Hello');
+
+    await expect(element).toContainText('Hello World!');
+
+    await element.evaluate(node => {
+      node.appendChild(document.createTextNode('!'));
+    });
+
+    await expect(label).toHaveText('Hello');
+
+    await expect(element).toContainText('Hello World!!');
+  });
+
+  test('should NOT move slotted content that has been added to the element after connection when no slotted label is provided', async ({
+    fastPage,
+    page,
+  }) => {
+    const { element } = fastPage;
+
+    await fastPage.setTemplate({
+      innerHTML: /* html */ `Hello <span>World</span><span>!</span>`,
+    });
+
+    const label = page.locator('label');
+
+    await expect(label).toHaveCount(1);
+
+    await expect(label).toBeVisible();
+
+    await expect(label).toHaveText('Hello World!');
+
+    await element.evaluate(node => {
+      node.appendChild(document.createTextNode('!'));
+    });
+
+    await expect(label).toHaveText('Hello World!');
+
+    await expect(element).toContainText('Hello World!!');
+  });
 });

--- a/packages/web-components/src/label/label.styles.ts
+++ b/packages/web-components/src/label/label.styles.ts
@@ -55,4 +55,12 @@ export const styles = css`
   :host([disabled]) .asterisk {
     color: ${colorNeutralForegroundDisabled};
   }
+
+  :host([slot='label'])::after {
+    content: '';
+    display: block;
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+  }
 `;

--- a/packages/web-components/src/label/label.template.ts
+++ b/packages/web-components/src/label/label.template.ts
@@ -1,5 +1,17 @@
-import { type ElementViewTemplate, html } from '@microsoft/fast-element';
+import { type ElementViewTemplate, html, ref, slotted } from '@microsoft/fast-element';
+import type { BaseLabel } from './label.base.js';
 import type { Label } from './label.js';
+
+/**
+ * The template partial for the slotted label element.
+ *
+ * @public
+ * @remarks
+ * Since the label element must be present in the light DOM for ARIA to function correctly, this template should not be
+ * overridden.
+ * @see {@link BaseLabel.insertLabel}
+ */
+export const labelElementTemplate = html<BaseLabel>`<label for="${x => x.htmlFor}" ${ref('labelElement')}></label>`;
 
 /**
  * The template for the Fluent label web-component.
@@ -7,8 +19,10 @@ import type { Label } from './label.js';
  */
 export function labelTemplate<T extends Label>(): ElementViewTemplate<T> {
   return html<T>`
-    <slot></slot>
-    <span part="asterisk" class="asterisk" ?hidden="${x => !x.required}">*</span>
+    <template @click="${(x, c) => x.clickHandler(c.event as MouseEvent)}">
+      <slot ${slotted('defaultSlottedContent')}></slot>
+      <span aria-hidden="true" part="asterisk" class="asterisk" ?hidden="${x => !x.required}">*</span>
+    </template>
   `;
 }
 

--- a/packages/web-components/src/label/label.ts
+++ b/packages/web-components/src/label/label.ts
@@ -1,51 +1,32 @@
-import { attr, FASTElement } from '@microsoft/fast-element';
-import { LabelSize, LabelWeight } from './label.options.js';
+import { attr } from '@microsoft/fast-element';
+import { BaseLabel } from './label.base.js';
+import type { LabelSize, LabelWeight } from './label.options.js';
 
 /**
- * The base class used for constructing a fluent-label custom element
+ * The Fluent Label Element. Implements {@link BaseLabel}.
  *
  * @tag fluent-label
  *
  * @public
  */
-export class Label extends FASTElement {
+export class Label extends BaseLabel {
   /**
-   * 	Specifies font size of a label
+   * The size of the label.
    *
    * @public
    * @remarks
-   * HTML Attribute: size
+   * HTML Attribute: `size`
    */
   @attr
   public size?: LabelSize;
 
   /**
-   * 	Specifies font weight of a label
+   * The font weight of the label.
    *
    * @public
    * @remarks
-   * HTML Attribute: weight
+   * HTML Attribute: `weight`
    */
   @attr
   public weight?: LabelWeight;
-
-  /**
-   * 	Specifies styles for label when associated input is disabled
-   *
-   * @public
-   * @remarks
-   * HTML Attribute: disabled
-   */
-  @attr({ mode: 'boolean' })
-  public disabled: boolean = false;
-
-  /**
-   * 	Specifies styles for label when associated input is a required field
-   *
-   * @public
-   * @remarks
-   * HTML Attribute: required
-   */
-  @attr({ mode: 'boolean' })
-  public required: boolean = false;
 }

--- a/packages/web-components/src/label/label.ts
+++ b/packages/web-components/src/label/label.ts
@@ -6,6 +6,7 @@ import type { LabelSize, LabelWeight } from './label.options.js';
  * The Fluent Label Element. Implements {@link BaseLabel}.
  *
  * @tag fluent-label
+ * @slot - The default slot. Expects a `<label>` element.
  *
  * @public
  */


### PR DESCRIPTION
## Previous Behavior

The `<fluent-label>` component doesn't have any semantic meaning since the `<label>` element's functionality cannot be fully replicated with with `ElementInternals` or ARIA.

## New Behavior

This change ensures that a `<fluent-label>` is associated with a `<label>` element. It does this by checking if any of its ancestors or children of are `<label>`s, and if not, creates and inserts a controlled `<label>` element. All child nodes are moved into a controlled `<label>`, which is then appended in the Light DOM.

## Related Issue(s)

- Fixes #34066
