### PR TITLE
fix: manage focus only when menu is open

### DIFF
--- a/change/@fluentui-web-components-f3428123-2fef-418d-86e5-1266218f1b6e.json
+++ b/change/@fluentui-web-components-f3428123-2fef-418d-86e5-1266218f1b6e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "manage focus only when menu is open",
+  "packageName": "@fluentui/web-components",
+  "email": "machi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/menu/menu.ts
+++ b/packages/web-components/src/menu/menu.ts
@@ -233,10 +233,12 @@ export class Menu extends FASTElement {
     // @ts-expect-error - Baseline 2024
     if (e.type === 'toggle' && e.newState) {
       // @ts-expect-error - Baseline 2024
-      const newState = e.newState === 'open' ? true : false;
+      const newState = e.newState === 'open';
       this._trigger?.setAttribute('aria-expanded', `${newState}`);
       this._open = newState;
-      this.focusMenuList();
+      if (this._open) {
+        this.focusMenuList();
+      }
     }
   };
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

When menu is toggled, JavaScript always focus on the menu list, even when the menu is being closed. This could cause the page to jump to the bottom in Safari (possibly because the focused element (menu list) is no longer visible), this only happens when the menu's closure is animated.

## New Behavior

JavaScript only manages focus when the menu is being opened.
