### PR TITLE
co-locate types with es modules

### DIFF
--- a/packages/web-components/custom-elements-manifest.config.js
+++ b/packages/web-components/custom-elements-manifest.config.js
@@ -26,7 +26,6 @@ export default {
     modulePathResolverPlugin({
       modulePathTemplate: (modulePath, name, tagName) => `./dist/esm/${getFolderName(name)}/${getFileName(name)}`,
       definitionPathTemplate: (modulePath, name, tagName) => `./dist/esm/${getFolderName(name)}/define.js`,
-      typeDefinitionPathTemplate: (modulePath, name, tagName) => `./dist/dts/${getFolderName(name)}/index.d.ts`,
     }),
     typeParserPlugin(),
     cemInheritancePlugin(),

--- a/packages/web-components/docs/web-components.api.md
+++ b/packages/web-components/docs/web-components.api.md
@@ -4526,7 +4526,7 @@ export const zIndexPriority = "var(--zIndexPriority)";
 
 // Warnings were encountered during analysis:
 //
-// dist/dts/accordion-item/accordion-item.d.ts:14:5 - (ae-forgotten-export) The symbol "StaticallyComposableHTML" needs to be exported by the entry point index.d.ts
+// dist/esm/accordion-item/accordion-item.d.ts:15:5 - (ae-forgotten-export) The symbol "StaticallyComposableHTML" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -20,57 +20,23 @@
   "unpkg": "dist/web-components.min.js",
   "files": [
     "*.md",
-    "dist/dts/",
     "dist/esm/",
     "dist/*.js",
     "dist/*.d.ts",
     "custom-elements.json"
   ],
   "exports": {
-    ".": {
-      "types": "./dist/dts/index.d.ts",
-      "default": "./dist/esm/index.js"
-    },
-    "./utilities.js": {
-      "types": "./dist/dts/utils/index.d.ts",
-      "default": "./dist/esm/utils/index.js"
-    },
-    "./theme/*.js": {
-      "types": "./dist/dts/theme/*.d.ts",
-      "default": "./dist/esm/theme/*.js"
-    },
-    "./*/base.js": {
-      "types": "./dist/dts/*/*.base.d.ts",
-      "default": "./dist/esm/*/*.base.js"
-    },
-    "./*/define.js": {
-      "types": "./dist/dts/*/*.define.d.ts",
-      "default": "./dist/esm/*/*.define.js"
-    },
-    "./*/definition.js": {
-      "types": "./dist/dts/*/*.definition.d.ts",
-      "default": "./dist/esm/*/*.definition.js"
-    },
-    "./*/options.js": {
-      "types": "./dist/dts/*/*.options.d.ts",
-      "default": "./dist/esm/*/*.options.js"
-    },
-    "./*/styles.js": {
-      "types": "./dist/dts/*/*.styles.d.ts",
-      "default": "./dist/esm/*/*.styles.js"
-    },
-    "./*/template.js": {
-      "types": "./dist/dts/*/*.template.d.ts",
-      "default": "./dist/esm/*/*.template.js"
-    },
-    "./*/index.js": {
-      "types": "./dist/dts/*/index.d.ts",
-      "default": "./dist/esm/*/index.js"
-    },
-    "./*.js": {
-      "types": "./dist/dts/*/define.d.ts",
-      "default": "./dist/esm/*/define.js"
-    },
+    ".": "./dist/esm/index.js",
+    "./utilities.js": "./dist/esm/utils/index.js",
+    "./theme/*.js": "./dist/esm/theme/*.js",
+    "./*/base.js": "./dist/esm/*/*.base.js",
+    "./*/define.js": "./dist/esm/*/define.js",
+    "./*/definition.js": "./dist/esm/*/*.definition.js",
+    "./*/options.js": "./dist/esm/*/*.options.js",
+    "./*/styles.js": "./dist/esm/*/*.styles.js",
+    "./*/template.js": "./dist/esm/*/*.template.js",
+    "./*/index.js": "./dist/esm/*/index.js",
+    "./*.js": "./dist/esm/*/define.js",
     "./custom-elements.json": "./custom-elements.json",
     "./package.json": "./package.json"
   },

--- a/packages/web-components/scripts/verify-packaging.js
+++ b/packages/web-components/scripts/verify-packaging.js
@@ -70,6 +70,5 @@ function verifyPackaging(options) {
   assert.ok(micromatch(processedResultArr, 'dist/*.(min.js|js)').length, 'ships rolluped js');
   assert.equal(micromatch(processedResultArr, 'src/*').length, 0, `wont ship source code from "/src"`);
 
-  assert.ok(micromatch(processedResultArr, 'dist/esm/**/*.(js|map)').length, 'ships esm');
-  assert.ok(micromatch(processedResultArr, 'dist/dts/**/*.d.ts').length, 'ships types');
+  assert.ok(micromatch(processedResultArr, 'dist/esm/**/*.(js|map|ts)').length, 'ships esm');
 }

--- a/packages/web-components/src/accordion-item/accordion-item.ts
+++ b/packages/web-components/src/accordion-item/accordion-item.ts
@@ -6,6 +6,8 @@ import { applyMixins } from '../utils/apply-mixins.js';
 import { BaseAccordionItem } from './accordion-item.base.js';
 import { AccordionItemMarkerPosition, AccordionItemSize } from './accordion-item.options.js';
 
+export type { StaticallyComposableHTML } from '../utils/index.js';
+
 /**
  * Accordion Item configuration options
  *

--- a/packages/web-components/tsconfig.lib.json
+++ b/packages/web-components/tsconfig.lib.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "lib": ["ESNext", "DOM"],
     "declaration": true,
-    "declarationDir": "dist/dts",
     "outDir": "dist/esm",
     "importHelpers": true
   },

--- a/scripts/api-extractor/api-extractor.wc.json
+++ b/scripts/api-extractor/api-extractor.wc.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "mainEntryPointFilePath": "<projectFolder>/dist/dts/index.d.ts",
+  "mainEntryPointFilePath": "<projectFolder>/dist/esm/index.d.ts",
   "apiReport": {
     "enabled": true,
     "reportFolder": "<projectFolder>/docs"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [x] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

The types and modules were not co-located which makes it harder for tooling to properly associate types with modules

## New Behavior

Types and modules are now co-located under the `esm` directory.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
