### PR TITLE
fix: compound-button text colors in Windows high contrast mode

### DIFF
--- a/change/@fluentui-web-components-848fb759-1e01-4df2-b8c8-dea81d054999.json
+++ b/change/@fluentui-web-components-848fb759-1e01-4df2-b8c8-dea81d054999.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixed compound-button high contrast text colors.",
+  "packageName": "@fluentui/web-components",
+  "email": "601470+mlijanto@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/compound-button/compound-button.styles.ts
+++ b/packages/web-components/src/compound-button/compound-button.styles.ts
@@ -120,7 +120,8 @@ export const styles = css`
   }
 `.withBehaviors(
   forcedColorsStylesheetBehavior(css`
-    :host([appearance='primary']:not(:hover, :focus-visible, :disabled, [disabled-focusable])) ::slotted([slot='description']) {
+    :host([appearance='primary']:not(:hover, :focus-visible, :disabled, [disabled-focusable]))
+      ::slotted([slot='description']) {
       color: HighlightText;
     }
   `),

--- a/packages/web-components/src/compound-button/compound-button.styles.ts
+++ b/packages/web-components/src/compound-button/compound-button.styles.ts
@@ -18,6 +18,7 @@ import {
   spacingHorizontalSNudge,
   spacingHorizontalXS,
 } from '../theme/design-tokens.js';
+import { forcedColorsStylesheetBehavior } from '../utils/index';
 
 // Need to support icon hover styles
 export const styles = css`
@@ -117,4 +118,10 @@ export const styles = css`
   :host([size='large']) ::slotted([slot='description']) {
     font-size: ${fontSizeBase300};
   }
-`;
+`.withBehaviors(
+  forcedColorsStylesheetBehavior(css`
+    :host([appearance='primary']:not(:hover, :focus-visible, :disabled, [disabled-focusable])) ::slotted([slot='description']) {
+      color: HighlightText;
+    }
+  `),
+);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Primary and disabled compound-button text colors did not meet the minimum contrast ratio in Windows high contrast mode.

## New Behavior

Compound-button text colors now meet the minimum contrast ratio in Windows high contrast mode.