### PR TITLE
fix: better fallback positioning for sub menu

### DIFF
--- a/change/@fluentui-web-components-8950fce0-8257-4d8e-9fec-796dc289a160.json
+++ b/change/@fluentui-web-components-8950fce0-8257-4d8e-9fec-796dc289a160.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: better fallback positioning for sub menu",
+  "packageName": "@fluentui/web-components",
+  "email": "machi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/menu-item/menu-item.styles.ts
+++ b/packages/web-components/src/menu-item/menu-item.styles.ts
@@ -150,7 +150,7 @@ export const styles = css`
       position: absolute;
       position-anchor: --menu-trigger;
       position-area: inline-end span-block-end;
-      position-try-fallbacks: flip-inline;
+      position-try-fallbacks: flip-inline, block-start, block-end;
       z-index: 1;
     }
 


### PR DESCRIPTION
## Previous Behavior

When there's not enough space, sub menu can be cut off:
<img width="302" alt="Screenshot 2025-05-21 at 15 54 28" src="https://github.com/user-attachments/assets/34e0cddf-8af1-408f-a1f1-d7b5e7059e7e" />

## New Behavior

Added more fallback positions, now sub menu fallback positioning is aligned with React–it's positioned above the menu item when there's not enough space.
<img width="302" alt="Screenshot 2025-05-21 at 15 57 17" src="https://github.com/user-attachments/assets/416eb3d8-1fb1-404f-84a3-a8f8daa30292" />

