### PR TITLE
feat(react-18-v9): add more type issues examples

### DIFF
--- a/apps/react-18-tests-v9/.eslintrc.json
+++ b/apps/react-18-tests-v9/.eslintrc.json
@@ -1,6 +1,7 @@
 {
   "extends": ["plugin:@fluentui/eslint-plugin/react"],
   "root": true,
+  "ignorePatterns": ["!**/*", "src/issues.tsx"],
   "rules": {
     "@nx/workspace-no-restricted-globals": "off",
     "import/no-extraneous-dependencies": "off"

--- a/apps/react-18-tests-v9/src/issues.tsx
+++ b/apps/react-18-tests-v9/src/issues.tsx
@@ -1,0 +1,37 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import * as React from 'react';
+import { Icon } from '@fluentui/react';
+import { Caption1, ComponentProps, Slot } from '@fluentui/react-components';
+import type { FluentProviderProps } from '@fluentui/react-provider';
+
+{
+  type Slots = {
+    root: NonNullable<Slot<'i'>>;
+  };
+  type Props = ComponentProps<Partial<Slots>> & { greeting: string; condition: boolean };
+
+  function CustomIcon(props: Props) {
+    return <div />;
+  }
+
+  function Problem(props: Props) {
+    return props.condition ? <CustomIcon {...props} /> : <Icon {...props} />;
+  }
+}
+
+{
+  function Component(props: { textType: React.ComponentType<React.PropsWithChildren<{ className?: string }>> }) {
+    return <div />;
+  }
+
+  function Problem(props: {}) {
+    return <Component textType={Caption1} />;
+  }
+}
+
+{
+  type Props = Pick<FluentProviderProps, 'children'>;
+  function Problem(props: Props) {
+    return <div>{props.children}</div>;
+  }
+}

--- a/apps/react-18-tests-v9/tsconfig.app.json
+++ b/apps/react-18-tests-v9/tsconfig.app.json
@@ -9,6 +9,14 @@
     "inlineSources": true,
     "types": []
   },
-  "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.test.ts", "**/*.test.tsx", "**/*.cy.tsx", "**/*.cy.ts"],
+  "exclude": [
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.cy.tsx",
+    "**/*.cy.ts",
+    "src/issues.tsx"
+  ],
   "include": ["./src/**/*.ts", "./src/**/*.tsx"]
 }

--- a/apps/react-18-tests-v9/tsconfig.react-18.json
+++ b/apps/react-18-tests-v9/tsconfig.react-18.json
@@ -11,7 +11,7 @@
     "isolatedModules": true,
     "importHelpers": true,
     "jsx": "react",
-    "noUnusedLocals": true,
+    "noUnusedLocals": false,
     "preserveConstEnums": true,
     "skipLibCheck": true,
     "typeRoots": ["./node_modules/@types"],
@@ -30,7 +30,8 @@
   ],
   "include": [
     "../../packages/react-components/*/stories/**/*.stories.tsx",
-    "../../packages/react-components/*/stories/**/*.stories.ts"
+    "../../packages/react-components/*/stories/**/*.stories.ts",
+    "./src/issues.tsx"
   ],
   "files": ["../../typings/static-assets/index.d.ts"]
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

adds examples causing following error:

`Type '{}' is not assignable to type 'ReactNode'`

with Root cause in `WithSlotRenderFunction` type 
<img width="659" alt="image" src="https://github.com/user-attachments/assets/129dc7b9-4ac5-4697-8783-b7da5a255366" />



## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
