### PR TITLE
feat: react 18 slots conditional types for WithSlotRenderFunction

### DIFF
--- a/packages/react-components/react-utilities/src/compose/types.ts
+++ b/packages/react-components/react-utilities/src/compose/types.ts
@@ -7,6 +7,7 @@ import {
   PropsWithoutChildren,
   PropsWithoutRef,
   ReactNode,
+  ReactVersionDependent,
   RefAttributes,
   ReplaceNullWithUndefined,
 } from '../utils/types';
@@ -51,7 +52,7 @@ type WithSlotShorthandValue<Props> =
  */
 export type WithSlotRenderFunction<Props> = PropsWithoutChildren<Props> & {
   children?: 'children' extends keyof Props
-    ? Props['children'] | SlotRenderFunction<PropsWithoutRef<Props>> | {}
+    ? ReactVersionDependent<ReactNode, Props['children'] | SlotRenderFunction<PropsWithoutRef<Props>>>
     : never;
 };
 

--- a/packages/react-components/react-utilities/src/utils/types.ts
+++ b/packages/react-components/react-utilities/src/utils/types.ts
@@ -130,3 +130,19 @@ export type PropsWithoutRef<P> = 'ref' extends keyof P ? DistributiveOmit<P, 're
  * types, to prevent unions from being expanded.
  */
 export type PropsWithoutChildren<P> = 'children' extends keyof P ? DistributiveOmit<P, 'children'> : P;
+
+/**
+ * @internal
+ *
+ * This type is used to determine if the current version of React is 18+ or not.
+ *
+ * It checks if the `children` prop is present in the `FunctionComponent` type.
+ * If it is, then it means that the current version of React is lower than 18.
+ * If it is not, then it means that the current version of React is 18 or higher.
+ * This is useful for ensuring compatibility with different versions of React.
+ *
+ * **THIS TYPE IS INTERNAL AND SHOULD NEVER BE EXPOSED**
+ */
+export type ReactVersionDependent<Modern, Legacy> = 'children' extends keyof Parameters<React.FunctionComponent<{}>>[0]
+  ? Legacy
+  : Modern;


### PR DESCRIPTION
This pull request introduces a new utility type, `ReactVersionDependent`, to handle compatibility between React versions 18+ and earlier. It also updates existing `WithSlotRenderFunction` to leverage this utility to support Slots API for both React 17 and React 18+.