### PR TITLE
docs(react-calendar-compat): fixed options in Multiday Calendar dropd…

### DIFF
--- a/packages/react-components/react-calendar-compat/stories/src/Calendar/CalendarMultiDayView.stories.tsx
+++ b/packages/react-components/react-calendar-compat/stories/src/Calendar/CalendarMultiDayView.stories.tsx
@@ -49,7 +49,9 @@ export const CalendarMultidayDayView = () => {
       <Field label="Choose days to select">
         <Dropdown className={styles.dropdown} onOptionSelect={onOptionSelect}>
           {dayOptions.map(option => (
-            <Option key={option} text={option} value={option} />
+            <Option key={option} text={option} value={option}>
+              {option}
+            </Option>
           ))}
         </Dropdown>
       </Field>


### PR DESCRIPTION
## Previous Behavior
Options are empty in Multiday Calendar view dropdown
![image](https://github.com/user-attachments/assets/75fba93d-6dda-4063-a399-de3161b2b475)

## New Behavior
Options are visible
![image](https://github.com/user-attachments/assets/49d49ad5-20dd-4171-b8e3-7f2cc0282685)

Fixes: #34507