### PR TITLE
[fix] add accessible labels to vaildation progreeBar stories

### DIFF
--- a/packages/web-components/src/progress-bar/progress-bar.stories.ts
+++ b/packages/web-components/src/progress-bar/progress-bar.stories.ts
@@ -26,10 +26,8 @@ const withText = html`
     validation-state="${story => story.validationState}"
     aria-describedby="${story => story.messageid}"
   ></fluent-progress-bar>
-  <div id="${story => story.messageid}">
-    ${story => story.message}
-</div>
-`
+  <div id="${story => story.messageid}">${story => story.message}</div>
+`;
 
 export default {
   title: 'Components/ProgressBar',

--- a/packages/web-components/src/progress-bar/progress-bar.stories.ts
+++ b/packages/web-components/src/progress-bar/progress-bar.stories.ts
@@ -16,6 +16,21 @@ const storyTemplate = html<StoryArgs<FluentProgressBar>>`
   ></fluent-progress-bar>
 `;
 
+const withText = html`
+  <fluent-progress-bar
+    thickness="${story => story.thickness}"
+    shape="${story => story.shape}"
+    max="${story => story.max}"
+    min="${story => story.min}"
+    value="${story => story.value}"
+    validation-state="${story => story.validationState}"
+    aria-describedby="${story => story.messageid}"
+  ></fluent-progress-bar>
+  <div id="${story => story.messageid}">
+    ${story => story.message}
+</div>
+`
+
 export default {
   title: 'Components/ProgressBar',
   render: renderComponent(storyTemplate),
@@ -105,19 +120,29 @@ export const SquareShape: Story = {
 };
 
 export const SuccessValidationState: Story = {
+  render: renderComponent(withText),
   args: {
+    message: 'Success ProgressBar',
+    messageid: 'success',
     validationState: 'success',
+    value: 75,
   },
 };
 
 export const WarningValidationState: Story = {
+  render: renderComponent(withText),
   args: {
+    message: 'Warning ProgressBar',
     validationState: 'warning',
+    value: 50,
   },
 };
 
 export const ErrorValidationState: Story = {
+  render: renderComponent(withText),
   args: {
+    message: 'Error ProgressBar',
     validationState: 'error',
+    value: 25,
   },
 };


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
There was no accessible labels on the storybook examples for the progress bar validations states.

## New Behavior
Adds accessible labels

<img width="1365" alt="image" src="https://github.com/user-attachments/assets/5601ae03-95cb-4833-a7dc-d6670c1c41ee" />


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
