### PR TITLE
fix(web-components): dialog click events prevent default

### DIFF
--- a/change/@fluentui-web-components-bcec3960-1a82-4919-8a79-515c6dbd38cd.json
+++ b/change/@fluentui-web-components-bcec3960-1a82-4919-8a79-515c6dbd38cd.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: dialog click event prevents default for arbitrary content clicks",
+  "packageName": "@fluentui/web-components",
+  "email": "863023+radium-v@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/dialog/dialog.spec.ts
+++ b/packages/web-components/src/dialog/dialog.spec.ts
@@ -299,4 +299,40 @@ test.describe('Dialog', () => {
 
     await expect(dialog).toHaveAttribute('aria-describedby', 'elementID');
   });
+
+  test('should not prevent default on clicks for dialog content', async ({ fastPage, page }) => {
+    const { element } = fastPage;
+    const content = element.locator('#content');
+    const label = page.locator('label');
+    const input = page.locator('input');
+
+    await fastPage.setTemplate(/* html */ `
+      <fluent-dialog>
+        <fluent-dialog-body id="content">
+          <label for="input">Label</label>
+          <input id="input" />
+        </fluent-dialog-body>
+      </fluent-dialog>
+    `);
+
+    await element.evaluate((node: Dialog) => {
+      node.show();
+    });
+
+    await expect(content).toBeVisible();
+
+    await label.click();
+
+    await expect(content).toBeVisible();
+
+    await expect(input).toBeFocused();
+
+    // Get point outside the element
+    const { x, y } = await getPointOutside(element);
+
+    // Dispatch a click event at the calculated point
+    await page.mouse.click(x, y);
+
+    await expect(content).toBeHidden();
+  });
 });

--- a/packages/web-components/src/dialog/dialog.stories.ts
+++ b/packages/web-components/src/dialog/dialog.stories.ts
@@ -274,41 +274,43 @@ export const AlertWithNoTitleOrActions: Story = {
 export const TwoColumnLayout: Story = {
   args: {
     titleSlottedContent: () => html` <div slot="title">Two Column Layout</div> `,
-    slottedContent: () => html`
+    slottedContent: () => html<StoryArgs<FluentDialog>>`
       <div style="margin-bottom: 12px;">
         <fluent-text block>
-          <p>
-            The dialog is designed with flexibility in mind, accommodating multiple column layouts within its structure.
-          </p>
+          The dialog is designed with flexibility in mind, accommodating multiple column layouts within its structure.
         </fluent-text>
       </div>
-      <div
+      <form
         style="display: grid; grid-template-columns: 1fr 1.5fr; grid-column-gap: 12px; margin-bottom: 4px; overflow-x: hidden;"
+        @submit="${story => story.successMessage.toggleAttribute('hidden', false)}"
       >
         <div style="height: 248px;">
           <fluent-image fit="cover">
             <img alt="image layout story" src="${generateImage({ width: 240 })}" />
           </fluent-image>
         </div>
-        <div>
-          <fluent-text weight="semibold" block>
-            <p>Don't have an account? Sign up now!</p>
-          </fluent-text>
-          <br />
-          <fluent-text-input type="email">
-            <fluent-label>Email</fluent-label>
-          </fluent-text-input>
-          <br />
-          <fluent-text-input>
-            <fluent-label>Username</fluent-label>
-          </fluent-text-input>
-          <br />
-          <fluent-text-input type="password">
-            <fluent-label>Password</fluent-label>
-          </fluent-text-input>
-          <br />
+        <div style="display: flex; flex-direction: column; align-items: flex-start; gap: 1em">
+          <fluent-text weight="semibold" block>Here's an Example Form! </fluent-text>
+
+          <fluent-field>
+            <label slot="label">Text Input</label>
+            <fluent-text-input slot="input"></fluent-text-input>
+          </fluent-field>
+
+          <fluent-field>
+            <label slot="label">Range Slider</label>
+            <fluent-slider slot="input" min="0" max="100" value="50"></fluent-slider>
+          </fluent-field>
+
+          <fluent-field label-position="after">
+            <label slot="label">Checkbox</label>
+            <fluent-checkbox slot="input"></fluent-checkbox>
+          </fluent-field>
+
+          <fluent-button type="submit" appearance="primary">Submit</fluent-button>
+          <span id="success-message" hidden ${ref('successMessage')}>Form submitted successfully!</span>
         </div>
-      </div>
+      </form>
     `,
   },
 };

--- a/packages/web-components/src/dialog/dialog.ts
+++ b/packages/web-components/src/dialog/dialog.ts
@@ -94,10 +94,10 @@ export class Dialog extends FASTElement {
    * @returns boolean
    */
   public clickHandler(event: Event): boolean {
-    event.preventDefault();
     if (this.dialog.open && this.type !== DialogType.alert && event.target === this.dialog) {
       this.hide();
     }
+
     return true;
   }
 }


### PR DESCRIPTION
## Previous Behavior

Clicking certain elements in a dialog caused the click event to be prevented.

## New Behavior

Clicking on labels in `<fluent-field>` for dialogs allows the associated input to be focused.