### PR TITLE
fix: updated rating-display icon color tokens to match the React version

### DIFF
--- a/change/@fluentui-web-components-52c0d036-67c0-48ab-b1a8-4de0ea9d7137.json
+++ b/change/@fluentui-web-components-52c0d036-67c0-48ab-b1a8-4de0ea9d7137.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: updated rating-display icon color tokens to match the React version.",
+  "packageName": "@fluentui/web-components",
+  "email": "601470+mlijanto@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/rating-display/rating-display.spec.ts
+++ b/packages/web-components/src/rating-display/rating-display.spec.ts
@@ -42,7 +42,7 @@ test.describe('Rating Display', () => {
     // Based on the `value` attribute, the 7th icon should be set as selected
     await expect(element.locator('svg:nth-child(7 of [aria-hidden="true"])')).toHaveAttribute('selected');
 
-    // The first 7 icons should have the default filled color (colorPaletteMarigoldBackground3)
+    // The first 7 icons should have the default filled color (colorPaletteMarigoldBorderActive)
     for (const icon of await element.locator('svg:nth-child(-n+7 of [aria-hidden="true"])').all()) {
       await expect(icon).toHaveCSS('fill', 'rgb(234, 163, 0)');
     }
@@ -82,7 +82,7 @@ test.describe('Rating Display', () => {
     }
 
     for (const icon of await unfilledIcons.all()) {
-      await expect(icon).toHaveCSS('fill', 'rgb(180, 214, 250)');
+      await expect(icon).toHaveCSS('fill', 'rgb(235, 243, 252)');
     }
 
     await element.evaluate((node: RatingDisplay) => {
@@ -97,7 +97,7 @@ test.describe('Rating Display', () => {
     }
 
     for (const icon of await unfilledIcons.all()) {
-      await expect(icon).toHaveCSS('fill', 'rgb(224, 224, 224)');
+      await expect(icon).toHaveCSS('fill', 'rgb(230, 230, 230)');
     }
   });
 

--- a/packages/web-components/src/rating-display/rating-display.styles.ts
+++ b/packages/web-components/src/rating-display/rating-display.styles.ts
@@ -1,12 +1,12 @@
 import { css } from '@microsoft/fast-element';
 import { display, forcedColorsStylesheetBehavior } from '../utils/index.js';
 import {
-  colorBrandBackground,
-  colorBrandStroke2,
-  colorNeutralBackground1Pressed,
+  colorBrandBackground2,
+  colorBrandForeground1,
+  colorNeutralBackground6,
   colorNeutralForeground1,
   colorPaletteMarigoldBackground2,
-  colorPaletteMarigoldBackground3,
+  colorPaletteMarigoldBorderActive,
   fontFamilyBase,
   fontSizeBase200,
   fontSizeBase300,
@@ -28,7 +28,7 @@ export const styles = css`
 
   :host {
     --icon-size: 16px;
-    --icon-color-filled: ${colorPaletteMarigoldBackground3};
+    --icon-color-filled: ${colorPaletteMarigoldBorderActive};
     --icon-color-empty: ${colorPaletteMarigoldBackground2};
     align-items: center;
     color: ${colorNeutralForeground1};
@@ -70,7 +70,7 @@ export const styles = css`
   }
 
   :host([color='brand']) svg {
-    --icon-color-filled: ${colorBrandBackground};
+    --icon-color-filled: ${colorBrandForeground1};
   }
 
   :host(:is([value^='-'], [value='0'])) svg,
@@ -81,12 +81,12 @@ export const styles = css`
 
   :host([color='neutral']:is([value^='-'], [value='0'], :not([value]))) svg,
   :host([color='neutral']) svg[selected] ~ svg {
-    --icon-color-empty: ${colorNeutralBackground1Pressed};
+    --icon-color-empty: ${colorNeutralBackground6};
   }
 
   :host([color='brand']:is([value^='-'], [value='0'], :not([value]))) svg,
   :host([color='brand']) svg[selected] ~ svg {
-    --icon-color-empty: ${colorBrandStroke2};
+    --icon-color-empty: ${colorBrandBackground2};
   }
 
   .value-label,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Rating-display icon colors used different tokens than the React version. This resulted in a mismatch between the icon colors in the dark theme.

## New Behavior

The rating-display icon color tokens now match the React version, ensuring consistency across themes.
