### PR TITLE
docs: Minor a11y cleanup in two v9 stories

### DIFF
--- a/packages/react-components/react-datepicker-compat/stories/src/DatePicker/DatePickerControlled.stories.tsx
+++ b/packages/react-components/react-datepicker-compat/stories/src/DatePicker/DatePickerControlled.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { addDays } from '@fluentui/react-calendar-compat';
 import { DatePicker } from '@fluentui/react-datepicker-compat';
-import { Button, Field, makeStyles } from '@fluentui/react-components';
+import { AriaLiveAnnouncer, Button, Field, makeStyles, useAnnounce } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
   root: {
@@ -19,36 +19,47 @@ const useStyles = makeStyles({
 
 export const Controlled = () => {
   const styles = useStyles();
+  const { announce } = useAnnounce();
 
   const [selectedDate, setSelectedDate] = React.useState<Date | null | undefined>(null);
 
   const goPrevious = React.useCallback(() => {
-    setSelectedDate(prevSelectedDate => (prevSelectedDate ? addDays(prevSelectedDate, -1) : null));
+    setSelectedDate(prevSelectedDate => {
+      const newDate = prevSelectedDate ? addDays(prevSelectedDate, -1) : new Date();
+      announce(newDate.toDateString());
+      return newDate;
+    });
   }, []);
 
   const goNext = React.useCallback(() => {
-    setSelectedDate(prevSelectedDate => (prevSelectedDate ? addDays(prevSelectedDate, 1) : null));
+    setSelectedDate(prevSelectedDate => {
+      const newDate = prevSelectedDate ? addDays(prevSelectedDate, 1) : new Date();
+      announce(newDate.toDateString());
+      return newDate;
+    });
   }, []);
 
   return (
-    <div className={styles.root}>
-      <Field label="Select a date">
-        <DatePicker
-          value={selectedDate}
-          onSelectDate={setSelectedDate}
-          placeholder="Select a date..."
-          className={styles.control}
-        />
-      </Field>
-      <div>
-        <Button className={styles.button} onClick={goPrevious}>
-          Previous
-        </Button>
-        <Button className={styles.button} onClick={goNext}>
-          Next
-        </Button>
+    <AriaLiveAnnouncer>
+      <div className={styles.root}>
+        <Field label="Select a date">
+          <DatePicker
+            value={selectedDate}
+            onSelectDate={setSelectedDate}
+            placeholder="Select a date..."
+            className={styles.control}
+          />
+        </Field>
+        <div>
+          <Button className={styles.button} onClick={goPrevious}>
+            Previous
+          </Button>
+          <Button className={styles.button} onClick={goNext}>
+            Next
+          </Button>
+        </div>
       </div>
-    </div>
+    </AriaLiveAnnouncer>
   );
 };
 

--- a/packages/react-components/react-datepicker-compat/stories/src/DatePicker/DatePickerControlled.stories.tsx
+++ b/packages/react-components/react-datepicker-compat/stories/src/DatePicker/DatePickerControlled.stories.tsx
@@ -29,7 +29,7 @@ export const Controlled = () => {
       announce(newDate.toDateString());
       return newDate;
     });
-  }, []);
+  }, [announce]);
 
   const goNext = React.useCallback(() => {
     setSelectedDate(prevSelectedDate => {
@@ -37,7 +37,7 @@ export const Controlled = () => {
       announce(newDate.toDateString());
       return newDate;
     });
-  }, []);
+  }, [announce]);
 
   return (
     <AriaLiveAnnouncer>

--- a/packages/react-components/react-radio/stories/src/RadioGroup/RadioGroupControlledValue.stories.tsx
+++ b/packages/react-components/react-radio/stories/src/RadioGroup/RadioGroupControlledValue.stories.tsx
@@ -14,7 +14,7 @@ export const ControlledValue = () => {
           <Radio value="orange" label="Orange" />
         </RadioGroup>
       </Field>
-      <Button disabled={!value} onClick={() => setValue('')}>
+      <Button disabledFocusable={!value} onClick={() => setValue('')}>
         Clear selection
       </Button>
     </>


### PR DESCRIPTION
These are very low-severity a11y issues, but easy fixes:

1. In the RadioGroup Controlled example, the "clear selection" button uses `disabledFocusable` instead of `disabled`, so when it's activated it doesn't cause focus to be lost and jump elsewhere.
2. In the Datepicker Controlled example, using previous/next date buttons triggers an `announce` as a confirmation of action for screen reader users

## Related Issue(s)

- Resolves two ADO bugs
