### PR TITLE
Use colorscale for heatmap charts

### DIFF
--- a/change/@fluentui-chart-utilities-91030aba-267f-46a0-8da5-c1fc09d3774c.json
+++ b/change/@fluentui-chart-utilities-91030aba-267f-46a0-8da5-c1fc09d3774c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(chart-utilities): Adding properties to plotly schema",
+  "packageName": "@fluentui/chart-utilities",
+  "email": "120183316+srmukher@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-charting-1dba4621-fdda-4bca-8a2d-5bed378a8503.json
+++ b/change/@fluentui-react-charting-1dba4621-fdda-4bca-8a2d-5bed378a8503.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(react-charting): Use colorscale for heatmap charts",
+  "packageName": "@fluentui/react-charting",
+  "email": "120183316+srmukher@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charts/chart-utilities/etc/chart-utilities.api.md
+++ b/packages/charts/chart-utilities/etc/chart-utilities.api.md
@@ -521,6 +521,14 @@ export interface Layout {
     // (undocumented)
     clickmode: 'event' | 'select' | 'event+select' | 'none';
     // (undocumented)
+    coloraxis: Partial<ColorAxis>;
+    // (undocumented)
+    colorscale: Array<[number, string]> | Partial<{
+        diverging: Array<[number, string]>;
+        sequential: Array<[number, string]>;
+        sequentialminus: Array<[number, string]>;
+    }>;
+    // (undocumented)
     colorway: string[];
     // (undocumented)
     datarevision: number | string;

--- a/packages/charts/chart-utilities/src/PlotlySchema.ts
+++ b/packages/charts/chart-utilities/src/PlotlySchema.ts
@@ -295,6 +295,20 @@ export interface PlotlySchema {
   config?: Partial<Config>;
 }
 
+export interface ColorAxis {
+  colorscale?: Array<[number, string]>;
+  cmin?: number;
+  cmax?: number;
+  colorbar?: {
+    title?: string | { text: string };
+    thickness?: number;
+    len?: number;
+    outlinewidth?: number;
+  };
+  reversescale?: boolean;
+  showscale?: boolean;
+}
+
 // Layout
 export interface Layout {
   colorway: string[];
@@ -419,6 +433,14 @@ export interface Layout {
   datarevision: number | string;
   editrevision: number | string;
   selectionrevision: number | string;
+  colorscale:
+    | Array<[number, string]>
+    | Partial<{
+        diverging: Array<[number, string]>;
+        sequential: Array<[number, string]>;
+        sequentialminus: Array<[number, string]>;
+      }>;
+  coloraxis: Partial<ColorAxis>;
 }
 
 export interface Legend extends Label {

--- a/packages/charts/react-charting/src/components/DeclarativeChart/PlotlySchemaAdapter.ts
+++ b/packages/charts/react-charting/src/components/DeclarativeChart/PlotlySchemaAdapter.ts
@@ -763,12 +763,39 @@ export const transformPlotlyJsonToHeatmapProps = (input: PlotlySchema): IHeatMap
     getColorFromToken(DataVizPalette.color2),
     getColorFromToken(DataVizPalette.color3),
   ];
-  const domainValuesForColorScale: number[] = Array.isArray(firstData.colorscale)
-    ? (firstData.colorscale as Array<[number, string]>).map(arr => arr[0] * (zMax - zMin) + zMin)
+
+  let colorscale =
+    firstData?.colorscale ??
+    input.layout?.colorscale ??
+    input.layout?.coloraxis?.colorscale ??
+    input.layout?.template?.layout?.colorscale ??
+    input.layout?.template?.data?.heatmap?.[0]?.colorscale;
+
+  // determine if the types diverging, sequential or sequentialminus are present in colorscale
+  if (
+    colorscale &&
+    typeof colorscale === 'object' &&
+    ('diverging' in colorscale || 'sequential' in colorscale || 'sequentialminus' in colorscale)
+  ) {
+    const isDivergent = zMin < 0 && zMax > 0; // Data spans both positive and negative values
+    const isSequential = zMin >= 0; // Data is entirely positive
+    const isSequentialMinus = zMax <= 0; // Data is entirely negative
+
+    if (isDivergent) {
+      colorscale = colorscale?.diverging;
+    } else if (isSequential) {
+      colorscale = colorscale?.sequential;
+    } else if (isSequentialMinus) {
+      colorscale = colorscale?.sequentialminus;
+    }
+  }
+
+  const domainValuesForColorScale: number[] = Array.isArray(colorscale)
+    ? (colorscale as Array<[number, string]>).map(arr => arr[0] * (zMax - zMin) + zMin)
     : defaultDomain;
 
-  const rangeValuesForColorScale: string[] = Array.isArray(firstData.colorscale)
-    ? (firstData.colorscale as Array<[number, string]>).map(arr => arr[1])
+  const rangeValuesForColorScale: string[] = Array.isArray(colorscale)
+    ? (colorscale as Array<[number, string]>).map(arr => arr[1])
     : defaultRange;
 
   const { chartTitle, xAxisTitle, yAxisTitle } = getTitles(input.layout);

--- a/packages/charts/react-charting/src/components/DeclarativeChart/PlotlySchemaAdapter.ts
+++ b/packages/charts/react-charting/src/components/DeclarativeChart/PlotlySchemaAdapter.ts
@@ -769,6 +769,7 @@ export const transformPlotlyJsonToHeatmapProps = (input: PlotlySchema): IHeatMap
     input.layout?.colorscale ??
     input.layout?.coloraxis?.colorscale ??
     input.layout?.template?.layout?.colorscale ??
+    (firstData.type === 'histogram2d' && input.layout?.template?.data?.histogram2d?.[0]?.colorscale) ??
     input.layout?.template?.data?.heatmap?.[0]?.colorscale;
 
   // determine if the types diverging, sequential or sequentialminus are present in colorscale


### PR DESCRIPTION
Use colorscale for heatmap charts.
Fixes 710, 712, 716, 717, 718, 721 in test app.
Work item: https://uifabric.visualstudio.com/iss/_workitems/edit/12850/