### PR TITLE
fix(react-calendar-compat): aria-label for year selection

### DIFF
--- a/change/@fluentui-react-calendar-compat-c0ccc335-e13d-4b87-b19e-6008000ee813.json
+++ b/change/@fluentui-react-calendar-compat-c0ccc335-e13d-4b87-b19e-6008000ee813.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: aria-label for year selection",
+  "packageName": "@fluentui/react-calendar-compat",
+  "email": "v.kozlova13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-calendar-compat/library/src/components/CalendarMonth/CalendarMonth.tsx
+++ b/packages/react-components/react-calendar-compat/library/src/components/CalendarMonth/CalendarMonth.tsx
@@ -327,7 +327,7 @@ function getYearStrings({
       rangeAriaLabel: yearRangeToString,
       prevRangeAriaLabel: yearRangeToPrevDecadeLabel,
       nextRangeAriaLabel: yearRangeToNextDecadeLabel,
-      headerAriaLabelFormatString: strings.yearPickerHeaderAriaLabel,
+      headerAriaLabelFormatString: strings.monthPickerHeaderAriaLabel,
     } as const,
   ] as const;
 }


### PR DESCRIPTION
## Previous Behavior
After clicking on Year picker header the screen reader says "2024-2035, change month"

## New Behavior
For year picker header screen reader says "2024-2035, change year"

- Fixes #32827
