### PR TITLE
chore(react-tree): re-introduces active state style to TreeItemLayout

### DIFF
--- a/change/@fluentui-react-tree-3750526e-3cbb-4a16-aaea-f901f9af2ace.json
+++ b/change/@fluentui-react-tree-3750526e-3cbb-4a16-aaea-f901f9af2ace.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: re-introduce active state style to TreeItemLayout",
+  "packageName": "@fluentui/react-tree",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tree/library/src/components/TreeItemLayout/useTreeItemLayoutStyles.styles.ts
+++ b/packages/react-components/react-tree/library/src/components/TreeItemLayout/useTreeItemLayoutStyles.styles.ts
@@ -23,20 +23,20 @@ const useRootBaseStyles = makeResetStyles({
   minHeight: '32px',
   boxSizing: 'border-box',
   gridArea: 'layout',
-  ':active': {
-    color: tokens.colorNeutralForeground2Pressed,
-    backgroundColor: tokens.colorSubtleBackgroundPressed,
-    // TODO: stop using treeItemLayoutClassNames.expandIcon for styling
-    [`& .${treeItemLayoutClassNames.expandIcon}`]: {
-      color: tokens.colorNeutralForeground3Pressed,
-    },
-  },
   ':hover': {
     color: tokens.colorNeutralForeground2Hover,
     backgroundColor: tokens.colorSubtleBackgroundHover,
     // TODO: stop using treeItemLayoutClassNames.expandIcon  for styling
     [`& .${treeItemLayoutClassNames.expandIcon}`]: {
       color: tokens.colorNeutralForeground3Hover,
+    },
+  },
+  ':active': {
+    color: tokens.colorNeutralForeground2Pressed,
+    backgroundColor: tokens.colorSubtleBackgroundPressed,
+    // TODO: stop using treeItemLayoutClassNames.expandIcon for styling
+    [`& .${treeItemLayoutClassNames.expandIcon}`]: {
+      color: tokens.colorNeutralForeground3Pressed,
     },
   },
 });


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

`:active` styles on `TreeItemLayout` is not being properly applied, `:hover` styles is taking precedence.
<!-- This is the behavior we have today -->

## New Behavior

Inverts order of `:active` and `:hover` declaration on `TreeItemLayout` styles to ensure `:active` takes precedence over hover

![image](https://github.com/user-attachments/assets/30dc1597-628d-456a-a4c8-250aa63fd258)


<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/34554
