### PR TITLE
fix(react-nav): focus borders being cut-off

### DIFF
--- a/change/@fluentui-react-nav-preview-70434d13-64e1-4e0f-b37c-21fe7e8d3136.json
+++ b/change/@fluentui-react-nav-preview-70434d13-64e1-4e0f-b37c-21fe7e8d3136.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: focus borders being cut-off",
+  "packageName": "@fluentui/react-nav-preview",
+  "email": "marcosvmmoura@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-nav-preview/library/src/components/AppItem/useAppItemStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/library/src/components/AppItem/useAppItemStyles.styles.ts
@@ -20,6 +20,7 @@ export const useAppItemStyles = makeStyles({
     gap: '10px',
     marginInlineStart: '-6px',
     marginInlineEnd: '0px',
+    marginTop: '2px',
     padding: `${tokens.spacingVerticalS} ${tokens.spacingHorizontalS} ${tokens.spacingVerticalS} ${tokens.spacingHorizontalMNudge}`,
     ...typographyStyles.subtitle2,
   },

--- a/packages/react-components/react-nav-preview/library/src/components/NavDrawerHeader/useNavDrawerHeaderStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/library/src/components/NavDrawerHeader/useNavDrawerHeaderStyles.styles.ts
@@ -16,6 +16,7 @@ const useStyles = makeStyles({
     margin: 'unset',
     paddingInlineStart: '14px',
     paddingBlock: '5px',
+    marginTop: '-2px',
   },
 });
 

--- a/packages/react-components/react-nav-preview/library/src/components/NavDrawerHeader/useNavDrawerHeaderStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/library/src/components/NavDrawerHeader/useNavDrawerHeaderStyles.styles.ts
@@ -4,6 +4,8 @@ import { useDrawerHeaderStyles_unstable } from '@fluentui/react-drawer';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import type { NavDrawerHeaderSlots, NavDrawerHeaderState } from './NavDrawerHeader.types';
 
+import { navDrawerBodyClassNames } from '../NavDrawerBody/useNavDrawerBodyStyles.styles';
+
 export const navDrawerHeaderClassNames: SlotClassNames<NavDrawerHeaderSlots> = {
   root: 'fui-NavDrawerHeader',
 };
@@ -16,6 +18,9 @@ const useStyles = makeStyles({
     margin: 'unset',
     paddingInlineStart: '14px',
     paddingBlock: '5px',
+  },
+
+  [`${navDrawerBodyClassNames.root} + ${navDrawerHeaderClassNames.root}`]: {
     marginTop: '-2px',
   },
 });

--- a/packages/react-components/react-nav-preview/library/src/components/sharedNavStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/library/src/components/sharedNavStyles.styles.ts
@@ -57,7 +57,11 @@ export const useRootDefaultClassName = makeResetStyles({
     backgroundColor: navItemTokens.backgroundColorHover,
   },
   ':active': {
+    zIndex: 1,
     backgroundColor: navItemTokens.backgroundColorPressed,
+  },
+  ':focus': {
+    zIndex: 1,
   },
 });
 


### PR DESCRIPTION
## Previous Behavior

Focus borders were being cut-off
![81221](https://github.com/user-attachments/assets/9728fde3-5a6d-4fd9-ab58-d373817d4eb1)
![24624](https://github.com/user-attachments/assets/d93a4adc-f9fd-402a-a09d-c860b8a7c23e)

## New Behavior

Focus borders now render correctly
![image](https://github.com/user-attachments/assets/02f56516-f560-40c4-8370-c1bb292b3d13)
![image](https://github.com/user-attachments/assets/f9f22fd6-add6-44fe-8e8a-96df1e20a281)
