### PR TITLE
feat(react-utilities): add RefAttributes type to ensure consumers do not use LegacyRef

### DIFF
--- a/change/@fluentui-react-utilities-78413d0a-ee8e-4701-a36a-6c05406a2170.json
+++ b/change/@fluentui-react-utilities-78413d0a-ee8e-4701-a36a-6c05406a2170.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add RefAttributes type to ensure consumers not using LegacyRef",
+  "packageName": "@fluentui/react-utilities",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-utilities/etc/react-utilities.api.md
+++ b/packages/react-components/react-utilities/etc/react-utilities.api.md
@@ -191,6 +191,12 @@ export interface PriorityQueue<T> {
 export type ReactTouchOrMouseEvent = React_2.MouseEvent | React_2.TouchEvent;
 
 // @public
+export interface RefAttributes<T> extends React_2.Attributes {
+    // (undocumented)
+    ref?: React_2.Ref<T> | undefined;
+}
+
+// @public
 export type RefObjectFunction<T> = React_2.RefObject<T> & ((value: T | null) => void);
 
 // @public

--- a/packages/react-components/react-utilities/src/index.ts
+++ b/packages/react-components/react-utilities/src/index.ts
@@ -73,7 +73,7 @@ export {
   createPriorityQueue,
 } from './utils/index';
 
-export type { DistributiveOmit, UnionToIntersection } from './utils/types';
+export type { DistributiveOmit, UnionToIntersection, RefAttributes } from './utils/types';
 
 export type { PriorityQueue } from './utils/priorityQueue';
 

--- a/packages/react-components/react-utilities/src/utils/types.ts
+++ b/packages/react-components/react-utilities/src/utils/types.ts
@@ -1,3 +1,5 @@
+import * as React from 'react';
+
 /**
  * Helper type that works similar to Omit,
  * but when modifying an union type it will distribute the omission to all the union members.
@@ -31,3 +33,12 @@ export type UnionToIntersection<U> = (U extends unknown ? (x: U) => U : never) e
  * If type T includes `null`, remove it and add `undefined` instead.
  */
 export type ReplaceNullWithUndefined<T> = T extends null ? Exclude<T, null> | undefined : T;
+
+/**
+ * In React 18, the built-in `RefAttributes` type uses `LegacyRef<T>`, which allows string refs.
+ * Since string refs are deprecated and not supported in our API, we define our own `RefAttributes`
+ * type that only accepts function and object refs for stricter type safety and compatibility.
+ */
+export interface RefAttributes<T> extends React.Attributes {
+  ref?: React.Ref<T> | undefined;
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

With React 18, RefAttributes includes LegacyRef, which supports string refs — something we don’t allow. 

## New Behavior

Added new `RefAttributes` utility type to enforce our internal API constraints and use `Ref` instead of `LegacyRef` for all React 17 and 18+ versions.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
