### PR TITLE
fix(react-nav): Inset focus outlines to fix focus borders being cut off.

### DIFF
--- a/change/@fluentui-react-nav-preview-386d75e9-e200-487e-8d69-03ff4dc5ffe4.json
+++ b/change/@fluentui-react-nav-preview-386d75e9-e200-487e-8d69-03ff4dc5ffe4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(react-nav): Inset focus outlines to fix focus borders being cut off",
+  "packageName": "@fluentui/react-nav-preview",
+  "email": "jiangemma@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-nav-preview/library/src/components/AppItem/useAppItemStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/library/src/components/AppItem/useAppItemStyles.styles.ts
@@ -20,7 +20,6 @@ export const useAppItemStyles = makeStyles({
     gap: '10px',
     marginInlineStart: '-6px',
     marginInlineEnd: '0px',
-    marginTop: '2px',
     padding: `${tokens.spacingVerticalS} ${tokens.spacingHorizontalS} ${tokens.spacingVerticalS} ${tokens.spacingHorizontalMNudge}`,
     ...typographyStyles.subtitle2,
   },

--- a/packages/react-components/react-nav-preview/library/src/components/NavDrawerHeader/useNavDrawerHeaderStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/library/src/components/NavDrawerHeader/useNavDrawerHeaderStyles.styles.ts
@@ -4,8 +4,6 @@ import { useDrawerHeaderStyles_unstable } from '@fluentui/react-drawer';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import type { NavDrawerHeaderSlots, NavDrawerHeaderState } from './NavDrawerHeader.types';
 
-import { navDrawerBodyClassNames } from '../NavDrawerBody/useNavDrawerBodyStyles.styles';
-
 export const navDrawerHeaderClassNames: SlotClassNames<NavDrawerHeaderSlots> = {
   root: 'fui-NavDrawerHeader',
 };
@@ -18,10 +16,6 @@ const useStyles = makeStyles({
     margin: 'unset',
     paddingInlineStart: '14px',
     paddingBlock: '5px',
-  },
-
-  [`${navDrawerBodyClassNames.root} + ${navDrawerHeaderClassNames.root}`]: {
-    marginTop: '-2px',
   },
 });
 

--- a/packages/react-components/react-nav-preview/library/src/components/sharedNavStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/library/src/components/sharedNavStyles.styles.ts
@@ -56,13 +56,6 @@ export const useRootDefaultClassName = makeResetStyles({
   ':hover': {
     backgroundColor: navItemTokens.backgroundColorHover,
   },
-  ':active': {
-    zIndex: 1,
-    backgroundColor: navItemTokens.backgroundColorPressed,
-  },
-  ':focus': {
-    zIndex: 1,
-  },
 });
 
 export const useSmallStyles = makeStyles({

--- a/packages/react-components/react-nav-preview/library/src/components/sharedNavStyles.styles.ts
+++ b/packages/react-components/react-nav-preview/library/src/components/sharedNavStyles.styles.ts
@@ -56,6 +56,12 @@ export const useRootDefaultClassName = makeResetStyles({
   ':hover': {
     backgroundColor: navItemTokens.backgroundColorHover,
   },
+
+  // Use custom insert focus indicator
+  '&:focus-visible': {
+    outline: `${tokens.strokeWidthThick} solid ${tokens.colorStrokeFocus2}`,
+    outlineOffset: `calc(${tokens.strokeWidthThick} * -1)`,
+  },
 });
 
 export const useSmallStyles = makeStyles({


### PR DESCRIPTION
## Previous Behavior

The original focus outline fix changed two things:
- Added a 2px top margin to `AppItem`s, and added a -2px top margin to the drawer header.
- Added zIndex to NavItem focus and active states

Neither of these behaviors are ideal, unfortunately. If for example a partner wants to include more than one `AppItem` inside their `Nav`, they would have an extra 2px margin on their second `AppItem`. If they didn't want to include an `AppItem` or wanted to add it somewhere besides the top of the `Nav`, the first item in the `Nav` would be cut off.

For the added zIndex: as Mason said, we don't want to bake in z indexes to shared components because product code often has their own z indexing strategy that can clash with ours.

## New Behavior

A safer approach with less potential impact to partners to fixing the issue of focus border being cut off would be to make the focus borders inset instead. This way there is lower impact to customers who want to use controls differently than the way they are set up in the storybook. We have used the inset focus outline approach in the Fluent AI `CopilotNav` as well as other similar controls.

<img width="286" alt="image" src="https://github.com/user-attachments/assets/209af435-1c1d-4be2-8532-208e281cfc21" /><img width="288" alt="image" src="https://github.com/user-attachments/assets/51f8f6fe-d8a3-49a2-bfc0-774469653f10" />


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- #34565