### PR TITLE
docs(react-color-picker): removed line from preview stage

### DIFF
--- a/change/@fluentui-react-color-picker-874b61c9-eeae-4d2e-a3a1-a8220e5a4154.json
+++ b/change/@fluentui-react-color-picker-874b61c9-eeae-4d2e-a3a1-a8220e5a4154.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "docs: removed text from preview stage",
+  "packageName": "@fluentui/react-color-picker",
+  "email": "vkozlova@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-color-picker/library/README.md
+++ b/packages/react-components/react-color-picker/library/README.md
@@ -2,8 +2,6 @@
 
 **React Color Picker components for [Fluent UI React](https://react.fluentui.dev/)**
 
-These are not production-ready components and **should never be used in product**. This space is useful for testing new components whose APIs might change before final release.
-
 The ColorPicker allows users to browse and select colors.
 By default, it enables navigation through a color spectrum and operates in HSV/HSL format.
 However, it is also possible to specify a color using Red-Green-Blue (RGB), an alpha color code, or hexadecimal values in the text boxes.


### PR DESCRIPTION
Removed line from the preview stage: "These are not production-ready components and **should never be used in product**..."