### PR TITLE
Fix: #34617 - Export DeepPartialV2 and its type dependants in index

### DIFF
--- a/packages/merge-styles/etc/merge-styles.api.md
+++ b/packages/merge-styles/etc/merge-styles.api.md
@@ -38,8 +38,6 @@ export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4, 
 // @public
 export function concatStyleSets(...styleSets: (IStyleSet | MissingOrShadowConfig_2)[]): IConcatenatedStyleSet<any>;
 
-// Warning: (ae-forgotten-export) The symbol "DeepPartialV2" needs to be exported by the entry point index.d.ts
-//
 // @public
 export function concatStyleSetsWithProps<TStyleProps, TStyleSet extends IStyleSetBase>(styleProps: TStyleProps, ...allStyles: (IStyleFunctionOrObject<TStyleProps, TStyleSet> | undefined)[]): DeepPartialV2<TStyleSet>;
 
@@ -47,6 +45,14 @@ export function concatStyleSetsWithProps<TStyleProps, TStyleSet extends IStyleSe
 export type DeepPartial<T> = {
     [P in keyof T]?: T[P] extends Array<infer U> ? Array<DeepPartial<U>> : T[P] extends object ? DeepPartial<T[P]> : T[P];
 };
+
+// @public (undocumented)
+export type DeepPartialObject<T> = {
+    [Key in keyof T]?: DeepPartialV2<T[Key]>;
+};
+
+// @public (undocumented)
+export type DeepPartialV2<T> = T extends Function ? T : T extends Array<infer U> ? IDeepPartialArray<U> : T extends object ? DeepPartialObject<T> : T;
 
 // @public (undocumented)
 export const DEFAULT_SHADOW_CONFIG: ShadowConfig;
@@ -84,6 +90,10 @@ export type ICSSPixelUnitRule = string | number;
 
 // @public (undocumented)
 export type ICSSRule = 'initial' | 'inherit' | 'unset';
+
+// @public (undocumented)
+export interface IDeepPartialArray<T> extends Array<DeepPartialV2<T>> {
+}
 
 // @public
 export interface IFontFace extends IRawFontStyle {

--- a/packages/merge-styles/src/DeepPartial.ts
+++ b/packages/merge-styles/src/DeepPartial.ts
@@ -7,9 +7,9 @@ export type DeepPartial<T> = {
   [P in keyof T]?: T[P] extends Array<infer U> ? Array<DeepPartial<U>> : T[P] extends object ? DeepPartial<T[P]> : T[P];
 };
 
-interface IDeepPartialArray<T> extends Array<DeepPartialV2<T>> {}
+export interface IDeepPartialArray<T> extends Array<DeepPartialV2<T>> {}
 
-type DeepPartialObject<T> = {
+export type DeepPartialObject<T> = {
   [Key in keyof T]?: DeepPartialV2<T[Key]>;
 };
 

--- a/packages/merge-styles/src/index.ts
+++ b/packages/merge-styles/src/index.ts
@@ -7,7 +7,7 @@ export type { IKeyframes } from './IKeyframes';
 export type { IStyleFunction, IStyleFunctionOrObject } from './IStyleFunction';
 
 // eslint-disable-next-line @typescript-eslint/no-deprecated
-export type { DeepPartial } from './DeepPartial';
+export type { DeepPartial, DeepPartialV2, DeepPartialObject, IDeepPartialArray } from './DeepPartial';
 
 // eslint-disable-next-line @typescript-eslint/no-deprecated
 export type { IConcatenatedStyleSet, IProcessedStyleSet, IStyleSet, IStyleSetBase, Omit } from './IStyleSet';


### PR DESCRIPTION
- Fixes #34617 
