### PR TITLE
fix: add aria-pressed semantics to selectable Tag, remove default aria-pressed from InteractionTag

### DIFF
--- a/change/@fluentui-react-tags-015dcaf8-69fd-4234-9c35-f88f5499ba13.json
+++ b/change/@fluentui-react-tags-015dcaf8-69fd-4234-9c35-f88f5499ba13.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: add aria-pressed semantics to selectable Tag, remove default aria-pressed from InteractionTag",
+  "packageName": "@fluentui/react-tags",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tags/library/src/components/Tag/useTag.tsx
+++ b/packages/react-components/react-tags/library/src/components/Tag/useTag.tsx
@@ -41,7 +41,7 @@ export const useTag_unstable = (props: TagProps, ref: React.Ref<HTMLSpanElement 
     appearance = contextAppearance ?? 'filled',
     disabled = false,
     dismissible = contextDismissible ?? false,
-    selected = false,
+    selected,
     shape = 'rounded',
     size = contextSize,
     value = id,
@@ -62,6 +62,8 @@ export const useTag_unstable = (props: TagProps, ref: React.Ref<HTMLSpanElement 
   });
 
   const elementType = dismissible ? 'button' : 'span';
+  const selectedProp = tagGroupRole === 'listbox' ? 'aria-selected' : 'aria-pressed';
+  const selectable = typeof selected === 'boolean' || tagGroupRole === 'listbox';
 
   return {
     appearance,
@@ -69,7 +71,7 @@ export const useTag_unstable = (props: TagProps, ref: React.Ref<HTMLSpanElement 
     avatarSize: tagAvatarSizeMap[size],
     disabled: contextDisabled ? true : disabled,
     dismissible,
-    selected,
+    selected: !!selected,
     shape,
     size,
 
@@ -86,6 +88,7 @@ export const useTag_unstable = (props: TagProps, ref: React.Ref<HTMLSpanElement 
       getIntrinsicElementProps(elementType, {
         ref,
         role: tagGroupRole === 'listbox' ? 'option' : undefined,
+        [selectedProp]: selectable ? selected : undefined,
         ...props,
         disabled: contextDisabled ? true : disabled,
         id,

--- a/packages/react-components/react-tags/library/src/contexts/tagGroupContext.tsx
+++ b/packages/react-components/react-tags/library/src/contexts/tagGroupContext.tsx
@@ -7,7 +7,7 @@ const tagGroupContextDefaultValue: TagGroupContextValue = {
   handleTagDismiss: () => ({}),
   size: 'medium',
   role: 'toolbar',
-  handleTagSelect: () => ({}),
+  handleTagSelect: undefined,
 };
 
 /**


### PR DESCRIPTION
## Previous Behavior

There were two separate issues with selected semantics on Tag and InteractionTag:

- All InteractionTags were getting `aria-pressed` defined, because `handleTagSelect` was always defined on the parent context
- Tag + `selected="true/false"` did not have any selection semantics

## New Behavior

- InteractionTag does not always have `aria-pressed` set, and `handleTagSelect` defaults to `undefined` instead of an empty function
- Tag adds either `aria-pressed` or `aria-selected` based on parent TagGroup semantics + whether the `selected` prop is a boolean and not undefined

There is still a remaining issue that InteractionTag sets selection semantics based on `handleTagSelect` alone, and doesn't respond to directly setting `selected`, which is a bit harder to fix than with Tag since the context and state types currently require it to be a boolean. This probably needs a bit more investigation (tagging @ValentinaKozlova for her opinion)

## Related Issue(s)

- Fixes an [ADO issue](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/29086)
