### PR TITLE
fix: selected Tag and InteractionTag styles are visible in high contrast mode

### DIFF
--- a/change/@fluentui-react-tags-f462d7a3-2afd-45c7-8922-ab92af7124ec.json
+++ b/change/@fluentui-react-tags-f462d7a3-2afd-45c7-8922-ab92af7124ec.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: selected Tag and InteractionTag styles are visible in high contrast mode",
+  "packageName": "@fluentui/react-tags",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tags/library/src/components/InteractionTagPrimary/useInteractionTagPrimaryStyles.styles.ts
+++ b/packages/react-components/react-tags/library/src/components/InteractionTagPrimary/useInteractionTagPrimaryStyles.styles.ts
@@ -194,11 +194,21 @@ const useRootStyles = makeStyles({
     background: tokens.colorBrandBackground,
     color: tokens.colorNeutralForegroundOnBrand,
     ...shorthands.borderColor(tokens.colorBrandStroke1),
+    '@media (forced-colors: active)': {
+      forcedColorAdjust: 'none',
+      backgroundColor: 'Highlight',
+      color: 'HighlightText',
+    },
+
     ':hover': {
       backgroundColor: tokens.colorBrandBackgroundHover,
       color: tokens.colorNeutralForegroundOnBrand,
       [`& .${iconFilledClassName}`]: {
         color: tokens.colorNeutralForegroundOnBrand,
+      },
+      '@media (forced-colors: active)': {
+        backgroundColor: 'Highlight',
+        color: 'HighlightText',
       },
     },
     ':active': {
@@ -206,6 +216,10 @@ const useRootStyles = makeStyles({
       color: tokens.colorNeutralForegroundOnBrand,
       [`& .${iconFilledClassName}`]: {
         color: tokens.colorNeutralForegroundOnBrand,
+      },
+      '@media (forced-colors: active)': {
+        backgroundColor: 'Highlight',
+        color: 'HighlightText',
       },
     },
   },

--- a/packages/react-components/react-tags/library/src/components/InteractionTagSecondary/useInteractionTagSecondaryStyles.styles.ts
+++ b/packages/react-components/react-tags/library/src/components/InteractionTagSecondary/useInteractionTagSecondaryStyles.styles.ts
@@ -108,13 +108,27 @@ const useRootStyles = makeStyles({
     background: tokens.colorBrandBackground,
     color: tokens.colorNeutralForegroundOnBrand,
     ...shorthands.borderColor(tokens.colorBrandStroke1),
+    '@media (forced-colors: active)': {
+      forcedColorAdjust: 'none',
+      backgroundColor: 'Highlight',
+      color: 'HighlightText',
+    },
+
     ':hover': {
       backgroundColor: tokens.colorBrandBackgroundHover,
       color: tokens.colorNeutralForegroundOnBrand,
+      '@media (forced-colors: active)': {
+        backgroundColor: 'Highlight',
+        color: 'HighlightText',
+      },
     },
     ':active': {
       backgroundColor: tokens.colorBrandBackgroundPressed,
       color: tokens.colorNeutralForegroundOnBrand,
+      '@media (forced-colors: active)': {
+        backgroundColor: 'Highlight',
+        color: 'HighlightText',
+      },
     },
     // divider
     borderLeftColor: tokens.colorNeutralStrokeOnBrand2,

--- a/packages/react-components/react-tags/library/src/components/Tag/useTagStyles.styles.ts
+++ b/packages/react-components/react-tags/library/src/components/Tag/useTagStyles.styles.ts
@@ -120,6 +120,12 @@ const useRootStyles = makeStyles({
     backgroundColor: tokens.colorBrandBackground,
     color: tokens.colorNeutralForegroundOnBrand,
     ...shorthands.borderColor(tokens.colorBrandStroke1),
+
+    '@media (forced-colors: active)': {
+      forcedColorAdjust: 'none',
+      backgroundColor: 'Highlight',
+      color: 'HighlightText',
+    },
   },
   medium: {
     height: '32px',


### PR DESCRIPTION
## Previous Behavior
Selected tags are not visually distinguishable from unselected tags in high contrast:

<img width="354" alt="Screenshot of the selected TagGroup example with all tags looking the same in high contrast" src="https://github.com/user-attachments/assets/49525636-7fd3-4de1-a296-e229359220bb" />

## New Behavior

Fixed!
<img width="320" alt="Screenshot of the same example, except that the second tag shows a highlight colored background" src="https://github.com/user-attachments/assets/a195f14a-ca30-45de-b006-a4bb48ae5079" />

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes [ADO issue](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/29016)
