### PR TITLE
chore(react-integration): mitigate jest OOM issues caused by many roots setup

### DIFF
--- a/apps/react-17-tests-v9/jest-react-17.config.js
+++ b/apps/react-17-tests-v9/jest-react-17.config.js
@@ -21,6 +21,9 @@ const config = {
   },
   displayName: 'react-17-tests-v9-integration',
   roots: createRoots(),
+  // Keeps Jest from using too much memory as GC gets invokes more often, makes tests slower
+  // https://stackoverflow.com/a/75857711
+  workerIdleMemoryLimit: '1024MB',
 };
 
 module.exports = config;
@@ -31,7 +34,11 @@ module.exports = config;
  */
 function createRoots() {
   const rootDir = path.resolve(__dirname, '../../packages/react-components');
-  return findValidPackagePaths(rootDir);
+  const roots = findValidPackagePaths(rootDir);
+
+  console.info(`Creating Jest Testing roots: ${roots.join('\n')}`);
+
+  return roots;
 
   /**
    * Recursively finds valid package paths that don't have excluded tags
@@ -54,8 +61,8 @@ function createRoots() {
         validPaths = validPaths.concat(findValidPackagePaths(fullPath));
       }
     }
-
-    return validPaths;
+    // Sort for consistent ordering
+    return validPaths.sort();
   }
 
   /**

--- a/apps/react-18-tests-v8/jest-react-18.config.js
+++ b/apps/react-18-tests-v8/jest-react-18.config.js
@@ -8,6 +8,9 @@ const config = {
   ...jestConfig,
   displayName: 'react-18-tests-v8-integration',
   roots: ['<rootDir>/../../packages/react/src', '<rootDir>/../../packages/react-hooks/src'],
+  // Keeps Jest from using too much memory as GC gets invokes more often, makes tests slower
+  // https://stackoverflow.com/a/75857711
+  workerIdleMemoryLimit: '1024MB',
 };
 
 module.exports = config;

--- a/apps/react-18-tests-v9/jest-react-18.config.js
+++ b/apps/react-18-tests-v9/jest-react-18.config.js
@@ -18,6 +18,9 @@ const config = {
   moduleNameMapper: { ...tsPathAliases },
   displayName: 'react-18-tests-v9-integration',
   roots: createRoots(),
+  // Keeps Jest from using too much memory as GC gets invokes more often, makes tests slower
+  // https://stackoverflow.com/a/75857711
+  workerIdleMemoryLimit: '1024MB',
 };
 
 module.exports = config;
@@ -28,7 +31,11 @@ module.exports = config;
  */
 function createRoots() {
   const rootDir = path.resolve(__dirname, '../../packages/react-components');
-  return findValidPackagePaths(rootDir);
+  const roots = findValidPackagePaths(rootDir);
+
+  console.info(`Creating Jest Testing roots: ${roots.join('\n')}`);
+
+  return roots;
 
   /**
    * Recursively finds valid package paths that don't have excluded tags
@@ -52,7 +59,8 @@ function createRoots() {
       }
     }
 
-    return validPaths;
+    // Sort for consistent ordering
+    return validPaths.sort();
   }
 
   /**


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

React integration tests for v9 are creating multiple roots which causes Jest OOM issues

<img width="1902" alt="image" src="https://github.com/user-attachments/assets/e38e1f77-ce78-47cf-8062-3b0a975d6949" />


## New Behavior

memory boundary is set to avoid OOM issues whilst slowing down the test execution

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
