### PR TITLE
fix(react-nav): only display actions on hover

### DIFF
--- a/change/@fluentui-react-nav-fd9297d7-b187-4e6b-8849-2b2de4f9401f.json
+++ b/change/@fluentui-react-nav-fd9297d7-b187-4e6b-8849-2b2de4f9401f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: only display actions on hover",
+  "packageName": "@fluentui/react-nav",
+  "email": "marcosvmmoura@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-nav/library/src/components/NavCategoryItem/useNavCategoryItem.tsx
+++ b/packages/react-components/react-nav/library/src/components/NavCategoryItem/useNavCategoryItem.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { getIntrinsicElementProps, mergeCallbacks, slot, useEventCallback } from '@fluentui/react-utilities';
-import { ChevronRight20Regular } from '@fluentui/react-icons';
-import { NavCategoryItemProps, NavCategoryItemState } from './NavCategoryItem.types';
+import { ChevronDown20Regular } from '@fluentui/react-icons';
+import type { NavCategoryItemProps, NavCategoryItemState } from './NavCategoryItem.types';
 import { useNavCategoryContext_unstable } from '../NavCategoryContext';
 import { useNavContext_unstable } from '../NavContext';
 
@@ -56,7 +56,7 @@ export const useNavCategoryItem_unstable = (
     ),
     expandIcon: slot.always(expandIcon, {
       defaultProps: {
-        children: <ChevronRight20Regular />,
+        children: <ChevronDown20Regular />,
         'aria-hidden': true,
       },
       elementType: 'span',

--- a/packages/react-components/react-nav/library/src/components/SplitNavItem/useSplitNavItemStyles.styles.ts
+++ b/packages/react-components/react-nav/library/src/components/SplitNavItem/useSplitNavItemStyles.styles.ts
@@ -3,6 +3,7 @@ import type { SlotClassNames } from '@fluentui/react-utilities';
 import type { SplitNavItemSlots, SplitNavItemState } from './SplitNavItem.types';
 import { navItemTokens, useRootDefaultClassName } from '../sharedNavStyles.styles';
 import { tokens } from '@fluentui/react-theme';
+import { motionTokens } from '@fluentui/react-motion/src/index';
 
 export const splitNavItemClassNames: SlotClassNames<SplitNavItemSlots> = {
   root: 'fui-SplitNavItem',
@@ -36,7 +37,15 @@ const useSplitNaveItemStyles = makeStyles({
 
     ':hover': {
       backgroundColor: navItemTokens.backgroundColorHover,
+
+      [`& .${splitNavItemClassNames.actionButton}, & .${splitNavItemClassNames.toggleButton}, & .${splitNavItemClassNames.menuButton}`]:
+        {
+          opacity: 1,
+          pointerEvents: 'auto',
+          transform: 'translate3D(0, 0, 0)',
+        },
     },
+
     ':active': {
       backgroundColor: navItemTokens.backgroundColorPressed,
     },
@@ -61,6 +70,18 @@ const useSplitNaveItemStyles = makeStyles({
   },
   baseMedium: {
     paddingBlockStart: '9px',
+  },
+
+  baseLarge: {
+    paddingBlockStart: '12px',
+  },
+
+  hoverAction: {
+    opacity: 0,
+    pointerEvents: 'none',
+    transform: 'translate3D(100%, 0, 0)',
+    transition: `opacity ${motionTokens.durationNormal}ms ${motionTokens.curveEasyEase}`,
+    willChange: 'transform, opacity',
   },
 });
 

--- a/packages/react-components/react-nav/stories/src/NavDrawer/SplitNavItems.stories.tsx
+++ b/packages/react-components/react-nav/stories/src/NavDrawer/SplitNavItems.stories.tsx
@@ -6,7 +6,6 @@ import {
   NavDrawer,
   NavDrawerBody,
   NavDrawerHeader,
-  NavDrawerProps,
   NavDensity,
   AppItem,
   AppItemStatic,
@@ -184,7 +183,7 @@ const DemoMenuPopover = () => {
   );
 };
 
-export const SplitNavItems = (props: Partial<NavDrawerProps>) => {
+export const SplitNavItems = () => {
   const styles = useStyles();
 
   const labelId = useId('type-label');


### PR DESCRIPTION
## Previous Behavior

Nav split items were always displayed

## New Behavior

Now only display split items on hover
