### PR TITLE
fix(react-charting): Support for using opacity provided in schema for decalarative charts

### DIFF
--- a/change/@fluentui-react-charting-06a42e4c-0e77-44a5-8acc-3fcd055b4bda.json
+++ b/change/@fluentui-react-charting-06a42e4c-0e77-44a5-8acc-3fcd055b4bda.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(react-charting): Support for using opacity provided in schema for decalarative charts",
+  "packageName": "@fluentui/react-charting",
+  "email": "120183316+srmukher@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
Enabled for Scatter (Line, Area, Scatter), Vertical bar, Vertical stacked bar, Grouped vertical bar, Horizontal bar charts.
![image](https://github.com/user-attachments/assets/51f94037-b28a-40a9-b6b1-395354d42f0f)