### PR TITLE
ci: don't fail react integration pipelines if stepps are skipped

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -195,7 +195,12 @@ jobs:
           echo "- E2E: ${{ steps.e2e.outcome }}" >> $GITHUB_STEP_SUMMARY
           echo "- Test: ${{ steps.test.outcome }}" >> $GITHUB_STEP_SUMMARY
 
-          if [[ "${{ steps.type-check.outcome }}" == "success" && "${{ steps.e2e.outcome }}" == "success" && "${{ steps.test.outcome }}" == "success" ]]; then
+          # Treat skipped steps as successful since they indicate no affected projects
+          type_check_success=$([[ "${{ steps.type-check.outcome }}" == "success" || "${{ steps.type-check.outcome }}" == "skipped" ]] && echo "true" || echo "false")
+          e2e_success=$([[ "${{ steps.e2e.outcome }}" == "success" || "${{ steps.e2e.outcome }}" == "skipped" ]] && echo "true" || echo "false")
+          test_success=$([[ "${{ steps.test.outcome }}" == "success" || "${{ steps.test.outcome }}" == "skipped" ]] && echo "true" || echo "false")
+
+          if [[ "$type_check_success" == "true" && "$e2e_success" == "true" && "$test_success" == "true" ]]; then
             echo "✅ React ${{ matrix.react }} / v${{ matrix.fluentui }} integration tests passed"
             exit 0
           else


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

When steps were skipped it was considered as failure and pipeline was forced to fail.

https://github.com/microsoft/fluentui/actions/runs/15607371524/job/43959942038

<img width="1412" alt="image" src="https://github.com/user-attachments/assets/f1402b6d-a90d-4fad-9afc-1f36352ca329" />


## New Behavior

if steps are skipped the result will be green pass

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
