### PR TITLE
chore(web-components): remove flag message fields from Required stories

### DIFF
--- a/packages/web-components/src/checkbox/checkbox.stories.ts
+++ b/packages/web-components/src/checkbox/checkbox.stories.ts
@@ -24,16 +24,10 @@ const storyTemplate = html<StoryArgs<FluentCheckbox>>`
   </fluent-checkbox>
 `;
 
-const messageTemplate = html`
-  <fluent-text slot="message" size="200" flag="${story => story.flag}">
-    <span>${story => story.message}</span>
-  </fluent-text>
-`;
-
 const fieldStoryTemplate = html<StoryArgs<FluentCheckbox>>`
   <fluent-field label-position="${story => story.labelPosition}">
     <label slot="label" for="${story => story.id}">${story => story.label}</label>
-    ${story => story.storyContent} ${repeat(story => story.messages, messageTemplate)}
+    ${story => story.storyContent}
   </fluent-field>
 `;
 
@@ -117,7 +111,6 @@ export default {
       table: { category: 'slots', type: {} },
     },
     label: { table: { disable: true } },
-    messageSlottedContent: { table: { disable: true } },
   },
 } as Meta<FluentCheckbox>;
 

--- a/packages/web-components/src/dropdown/dropdown.stories.ts
+++ b/packages/web-components/src/dropdown/dropdown.stories.ts
@@ -1,9 +1,7 @@
 import { html, ref, repeat } from '@microsoft/fast-element';
-import { ValidationFlags } from '../field/field.options.js';
+
 import { type Meta, renderComponent, type StoryArgs, type StoryObj } from '../helpers.stories.js';
 import type { DropdownOption as FluentOption } from '../option/option.js';
-import { TextSize } from '../text/text.options.js';
-import { colorStatusDangerForeground1 } from '../theme/design-tokens.js';
 import type { Dropdown as FluentDropdown } from './dropdown.js';
 import { DropdownAppearance, DropdownSize, DropdownType } from './dropdown.options.js';
 
@@ -53,7 +51,6 @@ const storyTemplate = html<StoryArgs<FluentDropdown>>`
     >
       <fluent-listbox>${repeat(story => story.slottedContent?.(), optionTemplate)}</fluent-listbox>
     </fluent-dropdown>
-    ${story => story.messageSlottedContent?.()}
   </fluent-field>
 `;
 
@@ -468,15 +465,5 @@ export const Required: Story = {
     name: 'fruit',
     required: true,
     multiple: true,
-    messageSlottedContent: () => html`
-      <fluent-text
-        slot="message"
-        flag="${ValidationFlags.valueMissing}"
-        size="${TextSize._200}"
-        style="color: ${colorStatusDangerForeground1}"
-      >
-        Please select a fruit.
-      </fluent-text>
-    `,
   },
 };

--- a/packages/web-components/src/radio-group/radio-group.stories.ts
+++ b/packages/web-components/src/radio-group/radio-group.stories.ts
@@ -252,20 +252,18 @@ export const Required: Story = {
     <form
       @reset="${story => story.successMessage.toggleAttribute('hidden', true)}"
       @submit="${story => story.radioGroup.checkValidity() && story.successMessage.toggleAttribute('hidden', false)}"
+      style="display: inline-flex; flex-direction: column; gap: 1rem; max-width: 400px;"
     >
       ${storyTemplate}
-      <br />
       <div>
         <fluent-button type="submit" appearance="primary">Submit</fluent-button>
-        <fluent-button id="reset-button" type="reset" ${ref('resetButton')}> Reset </fluent-button>
+        <fluent-button id="reset-button" type="reset" ${ref('resetButton')}>Reset</fluent-button>
       </div>
       <span id="success-message" hidden ${ref('successMessage')}> Form submitted successfully! </span>
     </form>
   `),
   args: {
+    orientation: RadioGroupOrientation.vertical,
     required: true,
-    messageSlottedContent: () => html`
-      <span slot="message" flag="${ValidationFlags.valueMissing}"> Please select a fruit. </span>
-    `,
   },
 };

--- a/packages/web-components/src/switch/switch.stories.ts
+++ b/packages/web-components/src/switch/switch.stories.ts
@@ -1,5 +1,5 @@
-import { html, repeat } from '@microsoft/fast-element';
-import { LabelPosition, ValidationFlags } from '../field/field.options.js';
+import { html, ref, repeat } from '@microsoft/fast-element';
+import { LabelPosition } from '../field/field.options.js';
 import { type Meta, renderComponent, type StoryArgs, type StoryObj } from '../helpers.stories.js';
 import type { Switch as FluentSwitch } from './switch.js';
 
@@ -13,19 +13,14 @@ const storyTemplate = html<StoryArgs<FluentSwitch>>`
     name="${story => story.name}"
     ?required="${story => story.required}"
     slot="${story => story.slot}"
+    ${ref('switch')}
   ></fluent-switch>
-`;
-
-const messageTemplate = html`
-  <fluent-text slot="message" size="200" flag="${story => story.flag}">
-    <span>${story => story.message}</span>
-  </fluent-text>
 `;
 
 const fieldStoryTemplate = html<StoryArgs<FluentSwitch>>`
   <fluent-field label-position="${story => story.labelPosition}">
     <label slot="label">${story => story.label}</label>
-    ${storyTemplate} ${repeat(story => story.messages, messageTemplate)}
+    ${storyTemplate}
   </fluent-field>
 `;
 
@@ -91,13 +86,17 @@ export const Disabled: Story = {
 
 export const Required: Story = {
   render: renderComponent(html<StoryArgs<FluentSwitch>>`
-    <form style="display: flex; gap: 1em; align-items: end">
+    <form
+      @reset="${story => story.successMessage.toggleAttribute('hidden', true)}"
+      @submit="${story => story.switch.checkValidity() && story.successMessage.toggleAttribute('hidden', false)}"
+      style="display: inline-flex; flex-direction: column; gap: 1rem; max-width: 400px;"
+    >
+      ${fieldStoryTemplate}
       <div>
-        <fluent-switch id="required-fluent-switch" required></fluent-switch>
-        <label for="required-fluent-switch">Required</label>
+        <fluent-button type="submit" appearance="primary">Submit</fluent-button>
+        <fluent-button type="reset" ${ref('resetButton')}>Reset</fluent-button>
       </div>
-      <div>${fieldStoryTemplate}</div>
-      <fluent-button type="submit">Submit</fluent-button>
+      <span id="success-message" hidden ${ref('successMessage')}>Form submitted successfully!</span>
     </form>
   `),
   args: {
@@ -105,12 +104,6 @@ export const Required: Story = {
     labelPosition: LabelPosition.after,
     required: true,
     label: 'Required',
-    messages: [
-      {
-        message: 'This field is required',
-        flag: ValidationFlags.valueMissing,
-      },
-    ],
   },
 };
 


### PR DESCRIPTION
## Previous Behavior

The error messages used in various "Required" stories are using the deprecated flag message feature, which isn't accessible.

## New Behavior

The custom flag messages are removed in favor of the browser's built-in error messages.