### PR TITLE
Add participants menu prototypes to storybook

### DIFF
--- a/apps/public-docsite-v9/src/ParticipantsMenu/ParticipantsMenuPrototypes.stories.mdx
+++ b/apps/public-docsite-v9/src/ParticipantsMenu/ParticipantsMenuPrototypes.stories.mdx
@@ -1,0 +1,11 @@
+import { Meta } from '@storybook/addon-docs';
+import { FullscreenLink } from './utils';
+export const parentPath = 'concepts-developer-accessibility-stories';
+
+<Meta title="Concepts/Developer/Accessibility/Stories/Participants menu prototypes" />
+
+# Participants menu prototypes
+
+This page demonstrates several accessible chat participants menu prototypes.
+
+- <FullscreenLink content="Row group grid" parent={parentPath} story="participants-row-group-grid-list" />

--- a/apps/public-docsite-v9/src/ParticipantsMenu/ParticipantsRowGroupGridList.stories.tsx
+++ b/apps/public-docsite-v9/src/ParticipantsMenu/ParticipantsRowGroupGridList.stories.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import { Button, List, ListItem } from '@fluentui/react-components';
+
+import { Prototype } from './utils';
+
+import { participantsList } from './participantsList';
+
+export const ParticipantsRowGroupGridList = () => {
+  return (
+    <Prototype pageTitle="Row group grid">
+      <h1>Row group grid</h1>
+      <List navigationMode="composite">
+        <div aria-hidden="true">People</div>
+        <div role="rowgroup" aria-label="People">
+          {participantsList.people.map((name, index) => (
+            <ListItem key={index} role="row" aria-label={name}>
+              <div role="gridcell">{name}</div>
+              <div role="gridcell">
+                <Button aria-description={`Show profile card for ${name}`}>Avatar for {name}</Button>
+              </div>
+              <div role="gridcell">
+                <Button>Remove {name}</Button>
+              </div>
+            </ListItem>
+          ))}
+        </div>
+        <div aria-hidden="true">Agents and bots</div>
+        <div role="rowgroup" aria-label="Agents and bots">
+          {participantsList.agentsAndBots.map((name, index) => (
+            <ListItem key={index} role="row" aria-label={name}>
+              <div role="gridcell">{name}</div>
+              <div role="gridcell">
+                <Button aria-description={`Show profile card for ${name}`}>Avatar for {name}</Button>
+              </div>
+              <div role="gridcell">
+                <Button>Remove {name}</Button>
+              </div>
+            </ListItem>
+          ))}
+        </div>
+      </List>
+    </Prototype>
+  );
+};

--- a/apps/public-docsite-v9/src/ParticipantsMenu/index.stories.tsx
+++ b/apps/public-docsite-v9/src/ParticipantsMenu/index.stories.tsx
@@ -1,0 +1,5 @@
+export { ParticipantsRowGroupGridList } from './ParticipantsRowGroupGridList.stories';
+
+export default {
+  title: 'Concepts/Developer/Accessibility/Stories',
+};

--- a/apps/public-docsite-v9/src/ParticipantsMenu/participantsList.tsx
+++ b/apps/public-docsite-v9/src/ParticipantsMenu/participantsList.tsx
@@ -1,0 +1,10 @@
+export const participantsList = {
+  people: [
+    'Olivia Carter',
+    'Liam Thompson',
+    'Sophia Martinez',
+    'Noah Patel',
+    'Emma Robinson',
+  ],
+  agentsAndBots: ['Facilitator', 'Copilot'],
+};

--- a/apps/public-docsite-v9/src/ParticipantsMenu/utils.tsx
+++ b/apps/public-docsite-v9/src/ParticipantsMenu/utils.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+
+const APP_TITLE = 'Participants menu prototypes';
+const APP_TITLE_SEPARATOR = ' | ';
+
+interface FullscreenLinkProps {
+  parent: string;
+  story: string;
+  content: string;
+}
+
+// https://storybook.js.org/addons/@storybook/addon-links does not allow opening a story in new tab
+// so this is a naive attempt for opening a story in full screen
+export const FullscreenLink = (props: FullscreenLinkProps) => (
+  <a className="sbdocs sbdocs-a" href={`iframe.html?id=${props.parent}--${props.story}`} target="_blank">
+    {props.content}
+  </a>
+);
+
+export const PrototypesListLink: React.FC = props => (
+  <a
+    className="sbdocs sbdocs-a"
+    href={`iframe.html?id=concepts-developer-accessibility-stories-participants-menu-prototypes--docs`}
+  >
+    {props.children}
+  </a>
+);
+
+export const BackLink = () => <PrototypesListLink>Go back to prototypes list</PrototypesListLink>;
+
+export const Prototype: React.FunctionComponent<{ pageTitle: string }> = ({ pageTitle, children }) => {
+  React.useEffect(() => {
+    // eslint-disable-next-line @nx/workspace-no-restricted-globals
+    document.title = pageTitle + APP_TITLE_SEPARATOR + APP_TITLE;
+  }, [pageTitle]);
+
+  return (
+    <div role="main">
+      <BackLink />
+      <br />
+      {children}
+    </div>
+  );
+};


### PR DESCRIPTION
## Description of changes

This PR is not intended for merge. It is just to demonstrate Teams participants accessible menu prototypes.
