### PR TITLE
React-Carousel: Ensure listeners get unmounted and handle controlled drag

### DIFF
--- a/change/@fluentui-react-carousel-5bea8031-da60-462f-aeb4-305af1343099.json
+++ b/change/@fluentui-react-carousel-5bea8031-da60-462f-aeb4-305af1343099.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Ensure documentDownListener is removed on unmount",
+  "packageName": "@fluentui/react-carousel",
+  "email": "mifraser@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-carousel/stories/src/Carousel/CarouselControlled.stories.tsx
+++ b/packages/react-components/react-carousel/stories/src/Carousel/CarouselControlled.stories.tsx
@@ -128,6 +128,7 @@ export const Controlled = () => {
       <Carousel
         activeIndex={activeIndex}
         groupSize={1}
+        draggable
         onActiveIndexChange={(e, data) => setActiveIndex(data.index)}
         announcement={getAnnouncement}
       >


### PR DESCRIPTION
## Previous Behavior
- Carousel attached listeners to the target document
- Carousel listeners were not being removed on unmount
- Carousel drag events were not firing correctly when index was controlled, and index changed multple times in a single drag event

## New Behavior
- Carousel attaches listeners to the container node itself, reducing listener surface
- Carousel now correctly removes listeners on unmount
- Carousel now correctly waits to disable 'drag' state until carousel 'settles', this ensures that drag events are always captured in controlled index scenarios - this may cause some additional indexing events to fire, however these are technically correct as until 'settled' a drag is considered in-progress.

## Related Issue(s)
- Fixes #34658 
