### PR TITLE
React-Virtualizer: Ensure recalc of indexes on numItems change

### DIFF
--- a/change/@fluentui-react-virtualizer-0a2800f6-33f8-43c4-955d-72fd611ac1a0.json
+++ b/change/@fluentui-react-virtualizer-0a2800f6-33f8-43c4-955d-72fd611ac1a0.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: Ensure virtualizer recalcs on numItems change",
+  "packageName": "@fluentui/react-virtualizer",
+  "email": "mifraser@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
@@ -297,6 +297,8 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
     return childProgressiveSizes.current[numItems - 1] - childProgressiveSizes.current[lastItemIndex - 1];
   }, [actualIndex, getItemSize, itemSize, numItems, virtualizerLength, gap]);
 
+  // We use this ref as a constant source to access the virtualizer's state imperatively
+  const previousNumItems = React.useRef<number>(numItems);
   // Observe intersections of virtualized components
   const { setObserverList } = useIntersectionObserver(
     React.useCallback(
@@ -408,10 +410,16 @@ export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerSta
         const newStartIndex = Math.min(Math.max(startIndex, 0), maxIndex);
         flushSync(() => {
           // Callback to allow measure functions to check virtualizer length
-          if (newStartIndex + virtualizerLength >= numItems && actualIndex + virtualizerLength >= numItems) {
+          if (
+            previousNumItems.current === numItems &&
+            newStartIndex + virtualizerLength >= numItems &&
+            actualIndex + virtualizerLength >= numItems
+          ) {
             // We've already hit the end, no need to update state.
             return;
           }
+          // We should ensure we update virtualizer calculations if the length changes
+          previousNumItems.current = virtualizerLength;
           updateScrollPosition?.(measurementPos);
           if (actualIndex !== newStartIndex) {
             batchUpdateNewIndex(newStartIndex);


### PR DESCRIPTION
## Previous Behavior
Virtualizer would not recalc it's indexes when items were removed
If enough indexes were removed, it would enter whitespace without a recalc

## New Behavior
Virtualizer now re-calcs on numItems change, correctly assuring index at all times

## Related Issue(s)
- Fixes #34588
