### PR TITLE
update fluentOverrides test to dedupe shadow tokens first

### DIFF
--- a/packages/semantic-tokens/utils/fluentOverrides.test.ts
+++ b/packages/semantic-tokens/utils/fluentOverrides.test.ts
@@ -1,12 +1,15 @@
 import { fluentOverrides } from '../src/fluentOverrides';
 import tokens from '../scripts/tokens.json';
+import { dedupeShadowTokens } from './dedupeShadowTokens';
+
+const tokensJSON = dedupeShadowTokens(tokens);
 
 describe('Ensure all fluentOverrides are valid tokens', () => {
   // We'll use this to catch any breaking changes in tokens.json
   it('Splits and camel cases strings separated by forward slash', () => {
     Object.keys(fluentOverrides).forEach(fluentOverrideKey => {
       console.log(`Checking ${fluentOverrideKey}`);
-      expect(tokens[fluentOverrideKey as keyof typeof tokens]).toBeTruthy();
+      expect(tokensJSON[fluentOverrideKey as keyof typeof tokensJSON]).toBeTruthy();
     });
   });
 });


### PR DESCRIPTION
## Previous Behavior

fluentOverrides tested tokens before they were deduped, which caused the test to fail for the new simplified shadow tokens

## New Behavior

fluentOverrides tests the output from dedupeShadowTokens

