### PR TITLE
fix(Carousel): fixed re-focus to opposite navigation button in 2 card edge case

### DIFF
--- a/change/@fluentui-react-carousel-4c48e35c-8149-4e69-8f0d-78257985a6f8.json
+++ b/change/@fluentui-react-carousel-4c48e35c-8149-4e69-8f0d-78257985a6f8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(Carousel): fixed re-focus to opposite navigation button in 2 card edge case",
+  "packageName": "@fluentui/react-carousel",
+  "email": "mathis.michel@outlook.de",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-carousel/library/src/components/CarouselButton/useCarouselButton.tsx
+++ b/packages/react-components/react-carousel/library/src/components/CarouselButton/useCarouselButton.tsx
@@ -7,6 +7,7 @@ import {
   slot,
   useIsomorphicLayoutEffect,
   useMergedRefs,
+  useAnimationFrame,
 } from '@fluentui/react-utilities';
 import * as React from 'react';
 
@@ -34,6 +35,8 @@ export const useCarouselButton_unstable = (
   // Locally tracks the total number of slides, will only update if this changes.
   const [totalSlides, setTotalSlides] = React.useState(0);
 
+  const [requestAnimationFrame] = useAnimationFrame();
+
   const { dir } = useFluent();
   const buttonRef = React.useRef<HTMLButtonElement>();
   const circular = useCarouselContext(ctx => ctx.circular);
@@ -55,33 +58,46 @@ export const useCarouselButton_unstable = (
     return ctx.activeIndex === totalSlides - 1;
   });
 
+  const isTrailingAfterNavigation = (nextIndex: number): boolean => {
+    return navType === 'prev' ? nextIndex === 0 : nextIndex === totalSlides - 1;
+  };
+
+  const focusOppositeNavigationButton = () => {
+    if (!containerRef?.current) {
+      return;
+    }
+
+    const buttonRefs: NodeListOf<HTMLButtonElement> = containerRef.current.querySelectorAll(
+      `.${carouselButtonClassNames.root}`,
+    );
+
+    const changeFocus = () => {
+      buttonRefs.forEach(_buttonRef => {
+        if (_buttonRef !== buttonRef.current) {
+          _buttonRef.focus();
+        }
+      });
+    };
+
+    // A sync focus would work in most cases, as the opposite button is enabled.
+    // However, in the case of only 2 slides, the opposite button is still disabled.
+    requestAnimationFrame(changeFocus);
+  };
+
   const handleClick = (event: React.MouseEvent<HTMLButtonElement & HTMLAnchorElement>) => {
     if (event.isDefaultPrevented()) {
       return;
     }
 
     const nextIndex = selectPageByDirection(event, navType);
-
-    let _trailing = false;
-    if (navType === 'prev') {
-      _trailing = nextIndex === 0;
-    } else {
-      _trailing = nextIndex === totalSlides - 1;
-    }
-
-    if (!circular && _trailing && containerRef?.current) {
-      // Focus non-disabled element
-      const buttonRefs: NodeListOf<HTMLButtonElement> = containerRef.current.querySelectorAll(
-        `.${carouselButtonClassNames.root}`,
-      );
-      buttonRefs.forEach(_buttonRef => {
-        if (_buttonRef !== buttonRef.current) {
-          _buttonRef.focus();
-        }
-      });
-    }
-
     resetAutoplay();
+
+    // No need to handle focus if using circular navigation or not at a trailing position
+    if (circular || (!isTrailingAfterNavigation(nextIndex) && containerRef?.current)) {
+      return;
+    }
+
+    focusOppositeNavigationButton();
   };
 
   useIsomorphicLayoutEffect(() => {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->
When having 2 slides in the carousel either the prev or next button is disabled.  
The current behavior does a re-focus from one to the other button if clicked/invoked if certain conditions are met(not relevant for this fix).

The focus call happend syncronously with the invoke. This led to the opposite button not receiving focused as it is still disabled.

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
Changed the focus call to be executed after layout is resolved by using requestAnimationFrame.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #34610
