### PR TITLE
fix(focusVisiblePolyfill): Strict mode compat after portal changes

### DIFF
--- a/apps/react-18-tests-v9/src/components/Portal/Portal.cy.tsx
+++ b/apps/react-18-tests-v9/src/components/Portal/Portal.cy.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import { Portal, teamsLightTheme, FluentProvider } from '@fluentui/react-components';
+import { mount as mountBase } from '@cypress/react';
+import { Provider } from '../../components/Provider/Provider';
+
+const mount = (element: React.JSX.Element) => {
+  mountBase(<Provider>{element}</Provider>);
+};
+
+const TestComponent: React.FC = () => {
+  const ref = React.useRef<HTMLButtonElement>(null);
+  const [open, setOpen] = React.useState(false);
+  React.useEffect(() => {
+    if (ref.current) {
+      ref.current.focus();
+    }
+  }, [open]);
+
+  return (
+    <FluentProvider theme={teamsLightTheme}>
+      <button id="trigger" onClick={() => setOpen(!open)}>
+        Toggle Portal
+      </button>
+      {open && (
+        <Portal>
+          <div>
+            <button id="focusTarget" ref={ref}>
+              Test Button
+            </button>
+          </div>
+        </Portal>
+      )}
+    </FluentProvider>
+  );
+};
+
+it('should set focus visible attribute on content when focused', () => {
+  mount(<TestComponent />);
+  cy.realPress('Tab');
+  cy.get('#trigger').focus().realPress('Enter');
+  cy.get('#focusTarget').should('have.attr', 'data-fui-focus-visible');
+});

--- a/change/@fluentui-react-tabster-79753e32-1543-432e-9d29-94091d5aaf9a.json
+++ b/change/@fluentui-react-tabster-79753e32-1543-432e-9d29-94091d5aaf9a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(focusVisiblePolyfill): Strict mode compat after portal changes",
+  "packageName": "@fluentui/react-tabster",
+  "email": "lingfangao@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tabster/src/focus/focusVisiblePolyfill.ts
+++ b/packages/react-components/react-tabster/src/focus/focusVisiblePolyfill.ts
@@ -90,7 +90,7 @@ export function applyFocusVisiblePolyfill(scope: HTMLElement, targetWindow: Wind
 
     scope.removeEventListener(KEYBORG_FOCUSIN, keyborgListener as ListenerOverride);
     scope.removeEventListener('focusout', blurListener);
-    delete (scope as HTMLElementWithFocusVisibleScope).focusVisible;
+    (scope as HTMLElementWithFocusVisibleScope).focusVisible = undefined;
 
     disposeKeyborg(keyborg);
   };


### PR DESCRIPTION
Fixes a regression introduced in #33978

The portal element was updated to use a HTMLElement proxy. This means that the disposal function that tries to delete a 'hidden' property a HTMLElement does not actually do anything.

This PR updates the disposal to set an explicit value

