### PR TITLE
feat: shorten pollDuration to 100ms

### DIFF
--- a/change/@fluentui-react-utilities-3d0ba736-f8f5-48de-9e50-e526b755d952.json
+++ b/change/@fluentui-react-utilities-3d0ba736-f8f5-48de-9e50-e526b755d952.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Shorten pollDuration to 100ms in useIFrameFocus",
+  "packageName": "@fluentui/react-utilities",
+  "email": "xboy2008@live.cn",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-utilities/src/hooks/useOnClickOutside.ts
+++ b/packages/react-components/react-utilities/src/hooks/useOnClickOutside.ts
@@ -158,7 +158,7 @@ const useIFrameFocus = (options: UseIFrameFocusOptions) => {
     element: targetDocument,
     callback,
     contains = DEFAULT_CONTAINS,
-    pollDuration = 1000,
+    pollDuration = 100,
     refs,
   } = options;
   const timeoutRef = React.useRef<number>();


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

pollDuration was 1000ms

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

pollDuration is now shortened to 100ms, users should not notice any obvious delay now.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->


- Fixes #
