### PR TITLE
feat(react-charts): Add negative y support and fix bar overlapping issue in HBC With Axis

### DIFF
--- a/packages/charts/react-charts/library/etc/react-charts.api.md
+++ b/packages/charts/react-charts/library/etc/react-charts.api.md
@@ -1042,6 +1042,7 @@ export interface ModifiedCartesianChartProps extends CartesianChartProps {
         startValue: number;
         endValue: number;
     };
+    getYDomainMargins?: (containerHeight: number) => Margins;
     isCalloutForStack?: boolean;
     legendBars: JSX.Element | null;
     maxOfYVal?: number;

--- a/packages/charts/react-charts/library/src/components/CommonComponents/CartesianChart.tsx
+++ b/packages/charts/react-charts/library/src/components/CommonComponents/CartesianChart.tsx
@@ -258,7 +258,7 @@ export const CartesianChart: React.FunctionComponent<ModifiedCartesianChartProps
     };
 
     const YAxisParams = {
-      margins: margins,
+      margins: props.getYDomainMargins ? props.getYDomainMargins(containerHeight) : margins,
       containerWidth: containerWidth,
       containerHeight: containerHeight - removalValueForTextTuncate!,
       yAxisElement: yAxisElement.current,

--- a/packages/charts/react-charts/library/src/components/CommonComponents/CartesianChart.types.ts
+++ b/packages/charts/react-charts/library/src/components/CommonComponents/CartesianChart.types.ts
@@ -554,6 +554,9 @@ export interface ModifiedCartesianChartProps extends CartesianChartProps {
   /** Callback method to get extra margins for domain */
   getDomainMargins?: (containerWidth: number) => Margins;
 
+  /** Callback method to get extra margins for Y-axis domain */
+  getYDomainMargins?: (containerHeight: number) => Margins;
+
   /** Padding between each bar/line-point */
   xAxisInnerPadding?: number;
 

--- a/packages/charts/react-charts/library/src/components/HorizontalBarChartWithAxis/__snapshots__/HorizontalBarChartWithAxis.test.tsx.snap
+++ b/packages/charts/react-charts/library/src/components/HorizontalBarChartWithAxis/__snapshots__/HorizontalBarChartWithAxis.test.tsx.snap
@@ -205,13 +205,13 @@ exports[`Horizontal bar chart with axis rendering Should render the Horizontal b
         >
           <path
             class="domain"
-            d="M-6,265.5H0.5V20.5H-6"
+            d="M-6,249.5H0.5V36.5H-6"
             stroke="currentColor"
           />
           <g
             class="tick"
             opacity="1"
-            transform="translate(0,265.5)"
+            transform="translate(0,249.5)"
           >
             <line
               stroke="currentColor"
@@ -242,7 +242,7 @@ exports[`Horizontal bar chart with axis rendering Should render the Horizontal b
           <g
             class="tick"
             opacity="1"
-            transform="translate(0,216.5)"
+            transform="translate(0,206.9)"
           >
             <line
               stroke="currentColor"
@@ -273,7 +273,7 @@ exports[`Horizontal bar chart with axis rendering Should render the Horizontal b
           <g
             class="tick"
             opacity="1"
-            transform="translate(0,167.5)"
+            transform="translate(0,164.3)"
           >
             <line
               stroke="currentColor"
@@ -304,7 +304,7 @@ exports[`Horizontal bar chart with axis rendering Should render the Horizontal b
           <g
             class="tick"
             opacity="1"
-            transform="translate(0,118.5)"
+            transform="translate(0,121.7)"
           >
             <line
               stroke="currentColor"
@@ -335,7 +335,7 @@ exports[`Horizontal bar chart with axis rendering Should render the Horizontal b
           <g
             class="tick"
             opacity="1"
-            transform="translate(0,69.49999999999999)"
+            transform="translate(0,79.1)"
           >
             <line
               stroke="currentColor"
@@ -366,7 +366,7 @@ exports[`Horizontal bar chart with axis rendering Should render the Horizontal b
           <g
             class="tick"
             opacity="1"
-            transform="translate(0,20.5)"
+            transform="translate(0,36.5)"
           >
             <line
               stroke="currentColor"
@@ -401,56 +401,56 @@ exports[`Horizontal bar chart with axis rendering Should render the Horizontal b
             aria-labelledby="toolTipcallout1"
             data-is-focusable="true"
             fill="#0078d4"
-            height="32"
+            height="16"
             opacity="1"
             role="img"
             rx="0"
             tabindex="0"
             width="147.5"
             x="40"
-            y="224.5"
+            y="219.7"
           />
           <rect
             aria-label="88%. 2020/04/30."
             aria-labelledby="toolTipcallout1"
             data-is-focusable="true"
             fill="#002050"
-            height="32"
+            height="16"
             opacity="1"
             role="img"
             rx="0"
             tabindex="0"
             width="590"
             x="40"
-            y="185.29999999999998"
+            y="185.62"
           />
           <rect
             aria-label="37%. 2020/04/30."
             aria-labelledby="toolTipcallout1"
             data-is-focusable="true"
             fill="#00188f"
-            height="32"
+            height="16"
             opacity="1"
             role="img"
             rx="0"
             tabindex="0"
             width="368.75"
             x="40"
-            y="102"
+            y="113.2"
           />
           <rect
             aria-label="20%. 2020/04/30."
             aria-labelledby="toolTipcallout1"
             data-is-focusable="true"
             fill="#00bcf2"
-            height="32"
+            height="16"
             opacity="1"
             role="img"
             rx="0"
             tabindex="0"
             width="295"
             x="40"
-            y="4"
+            y="28"
           />
         </g>
       </svg>
@@ -793,13 +793,13 @@ exports[`Horizontal bar chart with axis rendering Should render the Horizontal b
         >
           <path
             class="domain"
-            d="M-6,249.5H0.5V36.5H-6"
+            d="M-6,257.5H0.5V28.5H-6"
             stroke="currentColor"
           />
           <g
             class="tick"
             opacity="1"
-            transform="translate(0,222.375)"
+            transform="translate(0,218.83333333333334)"
           >
             <line
               stroke="currentColor"
@@ -829,7 +829,7 @@ exports[`Horizontal bar chart with axis rendering Should render the Horizontal b
           <g
             class="tick"
             opacity="1"
-            transform="translate(0,169.125)"
+            transform="translate(0,167.94444444444446)"
           >
             <line
               stroke="currentColor"
@@ -859,7 +859,7 @@ exports[`Horizontal bar chart with axis rendering Should render the Horizontal b
           <g
             class="tick"
             opacity="1"
-            transform="translate(0,115.875)"
+            transform="translate(0,117.05555555555557)"
           >
             <line
               stroke="currentColor"
@@ -889,7 +889,7 @@ exports[`Horizontal bar chart with axis rendering Should render the Horizontal b
           <g
             class="tick"
             opacity="1"
-            transform="translate(0,62.625)"
+            transform="translate(0,66.16666666666669)"
           >
             <line
               stroke="currentColor"
@@ -923,60 +923,60 @@ exports[`Horizontal bar chart with axis rendering Should render the Horizontal b
             aria-labelledby="toolTipcallout5"
             data-is-focusable="true"
             fill="#0078d4"
-            height="32"
+            height="32.714285714285715"
             opacity="1"
             role="img"
             rx="0"
             tabindex="0"
-            transform="translate(0,10.625)"
+            transform="translate(0,-3.634920634920636)"
             width="118"
             x="40"
-            y="36"
+            y="53.44444444444446"
           />
           <rect
             aria-label="5000. String Two."
             aria-labelledby="toolTipcallout5"
             data-is-focusable="true"
             fill="#00bcf2"
-            height="32"
+            height="32.714285714285715"
             opacity="1"
             role="img"
             rx="0"
             tabindex="0"
-            transform="translate(0,10.625)"
+            transform="translate(0,-3.634920634920636)"
             width="590"
             x="40"
-            y="89.25"
+            y="104.33333333333334"
           />
           <rect
             aria-label="3000. String Three."
             aria-labelledby="toolTipcallout5"
             data-is-focusable="true"
             fill="#00188f"
-            height="32"
+            height="32.714285714285715"
             opacity="1"
             role="img"
             rx="0"
             tabindex="0"
-            transform="translate(0,10.625)"
+            transform="translate(0,-3.634920634920636)"
             width="354"
             x="40"
-            y="142.5"
+            y="155.22222222222223"
           />
           <rect
             aria-label="2000. String Four."
             aria-labelledby="toolTipcallout5"
             data-is-focusable="true"
             fill="#002050"
-            height="32"
+            height="32.714285714285715"
             opacity="1"
             role="img"
             rx="0"
             tabindex="0"
-            transform="translate(0,10.625)"
+            transform="translate(0,-3.634920634920636)"
             width="236"
             x="40"
-            y="195.75"
+            y="206.11111111111111"
           />
         </g>
       </svg>
@@ -1236,13 +1236,13 @@ Object {
             >
               <path
                 class="domain"
-                d="M-6,265.5H0.5V20.5H-6"
+                d="M-6,249.5H0.5V36.5H-6"
                 stroke="currentColor"
               />
               <g
                 class="tick"
                 opacity="1"
-                transform="translate(0,265.5)"
+                transform="translate(0,249.5)"
               >
                 <line
                   stroke="currentColor"
@@ -1273,7 +1273,7 @@ Object {
               <g
                 class="tick"
                 opacity="1"
-                transform="translate(0,216.5)"
+                transform="translate(0,206.9)"
               >
                 <line
                   stroke="currentColor"
@@ -1304,7 +1304,7 @@ Object {
               <g
                 class="tick"
                 opacity="1"
-                transform="translate(0,167.5)"
+                transform="translate(0,164.3)"
               >
                 <line
                   stroke="currentColor"
@@ -1335,7 +1335,7 @@ Object {
               <g
                 class="tick"
                 opacity="1"
-                transform="translate(0,118.5)"
+                transform="translate(0,121.7)"
               >
                 <line
                   stroke="currentColor"
@@ -1366,7 +1366,7 @@ Object {
               <g
                 class="tick"
                 opacity="1"
-                transform="translate(0,69.49999999999999)"
+                transform="translate(0,79.1)"
               >
                 <line
                   stroke="currentColor"
@@ -1397,7 +1397,7 @@ Object {
               <g
                 class="tick"
                 opacity="1"
-                transform="translate(0,20.5)"
+                transform="translate(0,36.5)"
               >
                 <line
                   stroke="currentColor"
@@ -1432,56 +1432,56 @@ Object {
                 aria-labelledby="toolTipcallout79"
                 data-is-focusable="true"
                 fill="#0078d4"
-                height="32"
+                height="16"
                 opacity="1"
                 role="img"
                 rx="0"
                 tabindex="0"
                 width="147.5"
                 x="40"
-                y="224.5"
+                y="219.7"
               />
               <rect
                 aria-label="88%. 2020/04/30."
                 aria-labelledby="toolTipcallout79"
                 data-is-focusable="true"
                 fill="#002050"
-                height="32"
+                height="16"
                 opacity="1"
                 role="img"
                 rx="0"
                 tabindex="0"
                 width="590"
                 x="40"
-                y="185.29999999999998"
+                y="185.62"
               />
               <rect
                 aria-label="37%. 2020/04/30."
                 aria-labelledby="toolTipcallout79"
                 data-is-focusable="true"
                 fill="#00188f"
-                height="32"
+                height="16"
                 opacity="1"
                 role="img"
                 rx="0"
                 tabindex="0"
                 width="368.75"
                 x="40"
-                y="102"
+                y="113.2"
               />
               <rect
                 aria-label="20%. 2020/04/30."
                 aria-labelledby="toolTipcallout79"
                 data-is-focusable="true"
                 fill="#00bcf2"
-                height="32"
+                height="16"
                 opacity="1"
                 role="img"
                 rx="0"
                 tabindex="0"
                 width="295"
                 x="40"
-                y="4"
+                y="28"
               />
             </g>
           </svg>
@@ -1786,13 +1786,13 @@ Object {
           >
             <path
               class="domain"
-              d="M-6,265.5H0.5V20.5H-6"
+              d="M-6,249.5H0.5V36.5H-6"
               stroke="currentColor"
             />
             <g
               class="tick"
               opacity="1"
-              transform="translate(0,265.5)"
+              transform="translate(0,249.5)"
             >
               <line
                 stroke="currentColor"
@@ -1823,7 +1823,7 @@ Object {
             <g
               class="tick"
               opacity="1"
-              transform="translate(0,216.5)"
+              transform="translate(0,206.9)"
             >
               <line
                 stroke="currentColor"
@@ -1854,7 +1854,7 @@ Object {
             <g
               class="tick"
               opacity="1"
-              transform="translate(0,167.5)"
+              transform="translate(0,164.3)"
             >
               <line
                 stroke="currentColor"
@@ -1885,7 +1885,7 @@ Object {
             <g
               class="tick"
               opacity="1"
-              transform="translate(0,118.5)"
+              transform="translate(0,121.7)"
             >
               <line
                 stroke="currentColor"
@@ -1916,7 +1916,7 @@ Object {
             <g
               class="tick"
               opacity="1"
-              transform="translate(0,69.49999999999999)"
+              transform="translate(0,79.1)"
             >
               <line
                 stroke="currentColor"
@@ -1947,7 +1947,7 @@ Object {
             <g
               class="tick"
               opacity="1"
-              transform="translate(0,20.5)"
+              transform="translate(0,36.5)"
             >
               <line
                 stroke="currentColor"
@@ -1982,56 +1982,56 @@ Object {
               aria-labelledby="toolTipcallout79"
               data-is-focusable="true"
               fill="#0078d4"
-              height="32"
+              height="16"
               opacity="1"
               role="img"
               rx="0"
               tabindex="0"
               width="147.5"
               x="40"
-              y="224.5"
+              y="219.7"
             />
             <rect
               aria-label="88%. 2020/04/30."
               aria-labelledby="toolTipcallout79"
               data-is-focusable="true"
               fill="#002050"
-              height="32"
+              height="16"
               opacity="1"
               role="img"
               rx="0"
               tabindex="0"
               width="590"
               x="40"
-              y="185.29999999999998"
+              y="185.62"
             />
             <rect
               aria-label="37%. 2020/04/30."
               aria-labelledby="toolTipcallout79"
               data-is-focusable="true"
               fill="#00188f"
-              height="32"
+              height="16"
               opacity="1"
               role="img"
               rx="0"
               tabindex="0"
               width="368.75"
               x="40"
-              y="102"
+              y="113.2"
             />
             <rect
               aria-label="20%. 2020/04/30."
               aria-labelledby="toolTipcallout79"
               data-is-focusable="true"
               fill="#00bcf2"
-              height="32"
+              height="16"
               opacity="1"
               role="img"
               rx="0"
               tabindex="0"
               width="295"
               x="40"
-              y="4"
+              y="28"
             />
           </g>
         </svg>
@@ -2400,13 +2400,13 @@ Object {
             >
               <path
                 class="domain"
-                d="M-6,265.5H0.5V20.5H-6"
+                d="M-6,249.5H0.5V36.5H-6"
                 stroke="currentColor"
               />
               <g
                 class="tick"
                 opacity="1"
-                transform="translate(0,265.5)"
+                transform="translate(0,249.5)"
               >
                 <line
                   stroke="currentColor"
@@ -2437,7 +2437,7 @@ Object {
               <g
                 class="tick"
                 opacity="1"
-                transform="translate(0,216.5)"
+                transform="translate(0,206.9)"
               >
                 <line
                   stroke="currentColor"
@@ -2468,7 +2468,7 @@ Object {
               <g
                 class="tick"
                 opacity="1"
-                transform="translate(0,167.5)"
+                transform="translate(0,164.3)"
               >
                 <line
                   stroke="currentColor"
@@ -2499,7 +2499,7 @@ Object {
               <g
                 class="tick"
                 opacity="1"
-                transform="translate(0,118.5)"
+                transform="translate(0,121.7)"
               >
                 <line
                   stroke="currentColor"
@@ -2530,7 +2530,7 @@ Object {
               <g
                 class="tick"
                 opacity="1"
-                transform="translate(0,69.49999999999999)"
+                transform="translate(0,79.1)"
               >
                 <line
                   stroke="currentColor"
@@ -2561,7 +2561,7 @@ Object {
               <g
                 class="tick"
                 opacity="1"
-                transform="translate(0,20.5)"
+                transform="translate(0,36.5)"
               >
                 <line
                   stroke="currentColor"
@@ -2596,56 +2596,56 @@ Object {
                 aria-labelledby="toolTipcallout83"
                 data-is-focusable="true"
                 fill="#0078d4"
-                height="32"
+                height="16"
                 opacity="1"
                 role="img"
                 rx="3"
                 tabindex="0"
                 width="147.5"
                 x="40"
-                y="224.5"
+                y="219.7"
               />
               <rect
                 aria-label="88%. 2020/04/30."
                 aria-labelledby="toolTipcallout83"
                 data-is-focusable="true"
                 fill="#002050"
-                height="32"
+                height="16"
                 opacity="1"
                 role="img"
                 rx="3"
                 tabindex="0"
                 width="590"
                 x="40"
-                y="185.29999999999998"
+                y="185.62"
               />
               <rect
                 aria-label="37%. 2020/04/30."
                 aria-labelledby="toolTipcallout83"
                 data-is-focusable="true"
                 fill="#00188f"
-                height="32"
+                height="16"
                 opacity="1"
                 role="img"
                 rx="3"
                 tabindex="0"
                 width="368.75"
                 x="40"
-                y="102"
+                y="113.2"
               />
               <rect
                 aria-label="20%. 2020/04/30."
                 aria-labelledby="toolTipcallout83"
                 data-is-focusable="true"
                 fill="#00bcf2"
-                height="32"
+                height="16"
                 opacity="1"
                 role="img"
                 rx="3"
                 tabindex="0"
                 width="295"
                 x="40"
-                y="4"
+                y="28"
               />
             </g>
           </svg>
@@ -2950,13 +2950,13 @@ Object {
           >
             <path
               class="domain"
-              d="M-6,265.5H0.5V20.5H-6"
+              d="M-6,249.5H0.5V36.5H-6"
               stroke="currentColor"
             />
             <g
               class="tick"
               opacity="1"
-              transform="translate(0,265.5)"
+              transform="translate(0,249.5)"
             >
               <line
                 stroke="currentColor"
@@ -2987,7 +2987,7 @@ Object {
             <g
               class="tick"
               opacity="1"
-              transform="translate(0,216.5)"
+              transform="translate(0,206.9)"
             >
               <line
                 stroke="currentColor"
@@ -3018,7 +3018,7 @@ Object {
             <g
               class="tick"
               opacity="1"
-              transform="translate(0,167.5)"
+              transform="translate(0,164.3)"
             >
               <line
                 stroke="currentColor"
@@ -3049,7 +3049,7 @@ Object {
             <g
               class="tick"
               opacity="1"
-              transform="translate(0,118.5)"
+              transform="translate(0,121.7)"
             >
               <line
                 stroke="currentColor"
@@ -3080,7 +3080,7 @@ Object {
             <g
               class="tick"
               opacity="1"
-              transform="translate(0,69.49999999999999)"
+              transform="translate(0,79.1)"
             >
               <line
                 stroke="currentColor"
@@ -3111,7 +3111,7 @@ Object {
             <g
               class="tick"
               opacity="1"
-              transform="translate(0,20.5)"
+              transform="translate(0,36.5)"
             >
               <line
                 stroke="currentColor"
@@ -3146,56 +3146,56 @@ Object {
               aria-labelledby="toolTipcallout83"
               data-is-focusable="true"
               fill="#0078d4"
-              height="32"
+              height="16"
               opacity="1"
               role="img"
               rx="3"
               tabindex="0"
               width="147.5"
               x="40"
-              y="224.5"
+              y="219.7"
             />
             <rect
               aria-label="88%. 2020/04/30."
               aria-labelledby="toolTipcallout83"
               data-is-focusable="true"
               fill="#002050"
-              height="32"
+              height="16"
               opacity="1"
               role="img"
               rx="3"
               tabindex="0"
               width="590"
               x="40"
-              y="185.29999999999998"
+              y="185.62"
             />
             <rect
               aria-label="37%. 2020/04/30."
               aria-labelledby="toolTipcallout83"
               data-is-focusable="true"
               fill="#00188f"
-              height="32"
+              height="16"
               opacity="1"
               role="img"
               rx="3"
               tabindex="0"
               width="368.75"
               x="40"
-              y="102"
+              y="113.2"
             />
             <rect
               aria-label="20%. 2020/04/30."
               aria-labelledby="toolTipcallout83"
               data-is-focusable="true"
               fill="#00bcf2"
-              height="32"
+              height="16"
               opacity="1"
               role="img"
               rx="3"
               tabindex="0"
               width="295"
               x="40"
-              y="4"
+              y="28"
             />
           </g>
         </svg>
@@ -3559,13 +3559,13 @@ Object {
             >
               <path
                 class="domain"
-                d="M-6,265.5H0.5V20.5H-6"
+                d="M-6,249.5H0.5V36.5H-6"
                 stroke="currentColor"
               />
               <g
                 class="tick"
                 opacity="1"
-                transform="translate(0,265.5)"
+                transform="translate(0,249.5)"
               >
                 <line
                   stroke="currentColor"
@@ -3596,7 +3596,7 @@ Object {
               <g
                 class="tick"
                 opacity="1"
-                transform="translate(0,216.5)"
+                transform="translate(0,206.9)"
               >
                 <line
                   stroke="currentColor"
@@ -3627,7 +3627,7 @@ Object {
               <g
                 class="tick"
                 opacity="1"
-                transform="translate(0,167.5)"
+                transform="translate(0,164.3)"
               >
                 <line
                   stroke="currentColor"
@@ -3658,7 +3658,7 @@ Object {
               <g
                 class="tick"
                 opacity="1"
-                transform="translate(0,118.5)"
+                transform="translate(0,121.7)"
               >
                 <line
                   stroke="currentColor"
@@ -3689,7 +3689,7 @@ Object {
               <g
                 class="tick"
                 opacity="1"
-                transform="translate(0,69.49999999999999)"
+                transform="translate(0,79.1)"
               >
                 <line
                   stroke="currentColor"
@@ -3720,7 +3720,7 @@ Object {
               <g
                 class="tick"
                 opacity="1"
-                transform="translate(0,20.5)"
+                transform="translate(0,36.5)"
               >
                 <line
                   stroke="currentColor"
@@ -3755,56 +3755,56 @@ Object {
                 aria-labelledby="toolTipcallout60"
                 data-is-focusable="true"
                 fill="#0078d4"
-                height="32"
+                height="16"
                 opacity="1"
                 role="img"
                 rx="0"
                 tabindex="0"
                 width="147.5"
                 x="40"
-                y="224.5"
+                y="219.7"
               />
               <rect
                 aria-label="88%. 2020/04/30."
                 aria-labelledby="toolTipcallout60"
                 data-is-focusable="true"
                 fill="#002050"
-                height="32"
+                height="16"
                 opacity="1"
                 role="img"
                 rx="0"
                 tabindex="0"
                 width="590"
                 x="40"
-                y="185.29999999999998"
+                y="185.62"
               />
               <rect
                 aria-label="37%. 2020/04/30."
                 aria-labelledby="toolTipcallout60"
                 data-is-focusable="true"
                 fill="#00188f"
-                height="32"
+                height="16"
                 opacity="1"
                 role="img"
                 rx="0"
                 tabindex="0"
                 width="368.75"
                 x="40"
-                y="102"
+                y="113.2"
               />
               <rect
                 aria-label="20%. 2020/04/30."
                 aria-labelledby="toolTipcallout60"
                 data-is-focusable="true"
                 fill="#00bcf2"
-                height="32"
+                height="16"
                 opacity="1"
                 role="img"
                 rx="0"
                 tabindex="0"
                 width="295"
                 x="40"
-                y="4"
+                y="28"
               />
             </g>
           </svg>
@@ -4109,13 +4109,13 @@ Object {
           >
             <path
               class="domain"
-              d="M-6,265.5H0.5V20.5H-6"
+              d="M-6,249.5H0.5V36.5H-6"
               stroke="currentColor"
             />
             <g
               class="tick"
               opacity="1"
-              transform="translate(0,265.5)"
+              transform="translate(0,249.5)"
             >
               <line
                 stroke="currentColor"
@@ -4146,7 +4146,7 @@ Object {
             <g
               class="tick"
               opacity="1"
-              transform="translate(0,216.5)"
+              transform="translate(0,206.9)"
             >
               <line
                 stroke="currentColor"
@@ -4177,7 +4177,7 @@ Object {
             <g
               class="tick"
               opacity="1"
-              transform="translate(0,167.5)"
+              transform="translate(0,164.3)"
             >
               <line
                 stroke="currentColor"
@@ -4208,7 +4208,7 @@ Object {
             <g
               class="tick"
               opacity="1"
-              transform="translate(0,118.5)"
+              transform="translate(0,121.7)"
             >
               <line
                 stroke="currentColor"
@@ -4239,7 +4239,7 @@ Object {
             <g
               class="tick"
               opacity="1"
-              transform="translate(0,69.49999999999999)"
+              transform="translate(0,79.1)"
             >
               <line
                 stroke="currentColor"
@@ -4270,7 +4270,7 @@ Object {
             <g
               class="tick"
               opacity="1"
-              transform="translate(0,20.5)"
+              transform="translate(0,36.5)"
             >
               <line
                 stroke="currentColor"
@@ -4305,56 +4305,56 @@ Object {
               aria-labelledby="toolTipcallout60"
               data-is-focusable="true"
               fill="#0078d4"
-              height="32"
+              height="16"
               opacity="1"
               role="img"
               rx="0"
               tabindex="0"
               width="147.5"
               x="40"
-              y="224.5"
+              y="219.7"
             />
             <rect
               aria-label="88%. 2020/04/30."
               aria-labelledby="toolTipcallout60"
               data-is-focusable="true"
               fill="#002050"
-              height="32"
+              height="16"
               opacity="1"
               role="img"
               rx="0"
               tabindex="0"
               width="590"
               x="40"
-              y="185.29999999999998"
+              y="185.62"
             />
             <rect
               aria-label="37%. 2020/04/30."
               aria-labelledby="toolTipcallout60"
               data-is-focusable="true"
               fill="#00188f"
-              height="32"
+              height="16"
               opacity="1"
               role="img"
               rx="0"
               tabindex="0"
               width="368.75"
               x="40"
-              y="102"
+              y="113.2"
             />
             <rect
               aria-label="20%. 2020/04/30."
               aria-labelledby="toolTipcallout60"
               data-is-focusable="true"
               fill="#00bcf2"
-              height="32"
+              height="16"
               opacity="1"
               role="img"
               rx="0"
               tabindex="0"
               width="295"
               x="40"
-              y="4"
+              y="28"
             />
           </g>
         </svg>
@@ -4826,13 +4826,13 @@ Object {
             >
               <path
                 class="domain"
-                d="M-6,249.5H0.5V36.5H-6"
+                d="M-6,257.5H0.5V28.5H-6"
                 stroke="currentColor"
               />
               <g
                 class="tick"
                 opacity="1"
-                transform="translate(0,213.5)"
+                transform="translate(0,207.92857142857142)"
               >
                 <line
                   stroke="currentColor"
@@ -4892,7 +4892,7 @@ Object {
               <g
                 class="tick"
                 opacity="1"
-                transform="translate(0,71.5)"
+                transform="translate(0,77.07142857142857)"
               >
                 <line
                   stroke="currentColor"
@@ -4926,135 +4926,135 @@ Object {
                 aria-labelledby="toolTipcallout64"
                 data-is-focusable="true"
                 fill="#0078d4"
-                height="32"
+                height="45.8"
                 opacity="1"
                 role="img"
                 rx="0"
                 tabindex="0"
-                transform="translate(0,19.5)"
+                transform="translate(0,-6.542857142857141)"
                 width="208.71428571428575"
                 x="208.57142857142858"
-                y="36"
+                y="60.71428571428571"
               />
               <rect
                 aria-label="-5K. Q1."
                 aria-labelledby="toolTipcallout64"
                 data-is-focusable="true"
                 fill="#ff8c00"
-                height="32"
+                height="45.8"
                 opacity="1"
                 role="img"
                 rx="0"
                 tabindex="0"
-                transform="translate(0,19.5)"
+                transform="translate(0,-6.542857142857141)"
                 width="103.35714285714286"
                 x="103.21428571428572"
-                y="36"
+                y="60.71428571428571"
               />
               <rect
                 aria-label="8K. Q1."
                 aria-labelledby="toolTipcallout64"
                 data-is-focusable="true"
                 fill="#107c10"
-                height="32"
+                height="45.8"
                 opacity="1"
                 role="img"
                 rx="0"
                 tabindex="0"
-                transform="translate(0,19.5)"
+                transform="translate(0,-6.542857142857141)"
                 width="168.57142857142858"
                 x="419.28571428571433"
-                y="36"
+                y="60.71428571428571"
               />
               <rect
                 aria-label="-7K. Q2."
                 aria-labelledby="toolTipcallout64"
                 data-is-focusable="true"
                 fill="#0078d4"
-                height="32"
+                height="45.8"
                 opacity="1"
                 role="img"
                 rx="0"
                 tabindex="0"
-                transform="translate(0,19.5)"
+                transform="translate(0,-6.542857142857141)"
                 width="145.5"
                 x="61.07142857142857"
-                y="107"
+                y="126.14285714285714"
               />
               <rect
                 aria-label="12K. Q2."
                 aria-labelledby="toolTipcallout64"
                 data-is-focusable="true"
                 fill="#ff8c00"
-                height="32"
+                height="45.8"
                 opacity="1"
                 role="img"
                 rx="0"
                 tabindex="0"
-                transform="translate(0,19.5)"
+                transform="translate(0,-6.542857142857141)"
                 width="250.85714285714286"
                 x="208.57142857142858"
-                y="107"
+                y="126.14285714285714"
               />
               <rect
                 aria-label="3K. Q2."
                 aria-labelledby="toolTipcallout64"
                 data-is-focusable="true"
                 fill="#107c10"
-                height="32"
+                height="45.8"
                 opacity="1"
                 role="img"
                 rx="0"
                 tabindex="0"
-                transform="translate(0,19.5)"
+                transform="translate(0,-6.542857142857141)"
                 width="63.214285714285694"
                 x="461.42857142857144"
-                y="107"
+                y="126.14285714285714"
               />
               <rect
                 aria-label="15K. Q3."
                 aria-labelledby="toolTipcallout64"
                 data-is-focusable="true"
                 fill="#0078d4"
-                height="32"
+                height="45.8"
                 opacity="1"
                 role="img"
                 rx="0"
                 tabindex="0"
-                transform="translate(0,19.5)"
+                transform="translate(0,-6.542857142857141)"
                 width="314.07142857142856"
                 x="208.57142857142858"
-                y="178"
+                y="191.57142857142856"
               />
               <rect
                 aria-label="-4K. Q3."
                 aria-labelledby="toolTipcallout64"
                 data-is-focusable="true"
                 fill="#ff8c00"
-                height="32"
+                height="45.8"
                 opacity="1"
                 role="img"
                 rx="0"
                 tabindex="0"
-                transform="translate(0,19.5)"
+                transform="translate(0,-6.542857142857141)"
                 width="82.28571428571429"
                 x="124.28571428571429"
-                y="178"
+                y="191.57142857142856"
               />
               <rect
                 aria-label="5K. Q3."
                 aria-labelledby="toolTipcallout64"
                 data-is-focusable="true"
                 fill="#107c10"
-                height="32"
+                height="45.8"
                 opacity="1"
                 role="img"
                 rx="0"
                 tabindex="0"
-                transform="translate(0,19.5)"
+                transform="translate(0,-6.542857142857141)"
                 width="105.35714285714286"
                 x="524.6428571428571"
-                y="178"
+                y="191.57142857142856"
               />
             </g>
           </svg>
@@ -5448,13 +5448,13 @@ Object {
           >
             <path
               class="domain"
-              d="M-6,249.5H0.5V36.5H-6"
+              d="M-6,257.5H0.5V28.5H-6"
               stroke="currentColor"
             />
             <g
               class="tick"
               opacity="1"
-              transform="translate(0,213.5)"
+              transform="translate(0,207.92857142857142)"
             >
               <line
                 stroke="currentColor"
@@ -5514,7 +5514,7 @@ Object {
             <g
               class="tick"
               opacity="1"
-              transform="translate(0,71.5)"
+              transform="translate(0,77.07142857142857)"
             >
               <line
                 stroke="currentColor"
@@ -5548,135 +5548,135 @@ Object {
               aria-labelledby="toolTipcallout64"
               data-is-focusable="true"
               fill="#0078d4"
-              height="32"
+              height="45.8"
               opacity="1"
               role="img"
               rx="0"
               tabindex="0"
-              transform="translate(0,19.5)"
+              transform="translate(0,-6.542857142857141)"
               width="208.71428571428575"
               x="208.57142857142858"
-              y="36"
+              y="60.71428571428571"
             />
             <rect
               aria-label="-5K. Q1."
               aria-labelledby="toolTipcallout64"
               data-is-focusable="true"
               fill="#ff8c00"
-              height="32"
+              height="45.8"
               opacity="1"
               role="img"
               rx="0"
               tabindex="0"
-              transform="translate(0,19.5)"
+              transform="translate(0,-6.542857142857141)"
               width="103.35714285714286"
               x="103.21428571428572"
-              y="36"
+              y="60.71428571428571"
             />
             <rect
               aria-label="8K. Q1."
               aria-labelledby="toolTipcallout64"
               data-is-focusable="true"
               fill="#107c10"
-              height="32"
+              height="45.8"
               opacity="1"
               role="img"
               rx="0"
               tabindex="0"
-              transform="translate(0,19.5)"
+              transform="translate(0,-6.542857142857141)"
               width="168.57142857142858"
               x="419.28571428571433"
-              y="36"
+              y="60.71428571428571"
             />
             <rect
               aria-label="-7K. Q2."
               aria-labelledby="toolTipcallout64"
               data-is-focusable="true"
               fill="#0078d4"
-              height="32"
+              height="45.8"
               opacity="1"
               role="img"
               rx="0"
               tabindex="0"
-              transform="translate(0,19.5)"
+              transform="translate(0,-6.542857142857141)"
               width="145.5"
               x="61.07142857142857"
-              y="107"
+              y="126.14285714285714"
             />
             <rect
               aria-label="12K. Q2."
               aria-labelledby="toolTipcallout64"
               data-is-focusable="true"
               fill="#ff8c00"
-              height="32"
+              height="45.8"
               opacity="1"
               role="img"
               rx="0"
               tabindex="0"
-              transform="translate(0,19.5)"
+              transform="translate(0,-6.542857142857141)"
               width="250.85714285714286"
               x="208.57142857142858"
-              y="107"
+              y="126.14285714285714"
             />
             <rect
               aria-label="3K. Q2."
               aria-labelledby="toolTipcallout64"
               data-is-focusable="true"
               fill="#107c10"
-              height="32"
+              height="45.8"
               opacity="1"
               role="img"
               rx="0"
               tabindex="0"
-              transform="translate(0,19.5)"
+              transform="translate(0,-6.542857142857141)"
               width="63.214285714285694"
               x="461.42857142857144"
-              y="107"
+              y="126.14285714285714"
             />
             <rect
               aria-label="15K. Q3."
               aria-labelledby="toolTipcallout64"
               data-is-focusable="true"
               fill="#0078d4"
-              height="32"
+              height="45.8"
               opacity="1"
               role="img"
               rx="0"
               tabindex="0"
-              transform="translate(0,19.5)"
+              transform="translate(0,-6.542857142857141)"
               width="314.07142857142856"
               x="208.57142857142858"
-              y="178"
+              y="191.57142857142856"
             />
             <rect
               aria-label="-4K. Q3."
               aria-labelledby="toolTipcallout64"
               data-is-focusable="true"
               fill="#ff8c00"
-              height="32"
+              height="45.8"
               opacity="1"
               role="img"
               rx="0"
               tabindex="0"
-              transform="translate(0,19.5)"
+              transform="translate(0,-6.542857142857141)"
               width="82.28571428571429"
               x="124.28571428571429"
-              y="178"
+              y="191.57142857142856"
             />
             <rect
               aria-label="5K. Q3."
               aria-labelledby="toolTipcallout64"
               data-is-focusable="true"
               fill="#107c10"
-              height="32"
+              height="45.8"
               opacity="1"
               role="img"
               rx="0"
               tabindex="0"
-              transform="translate(0,19.5)"
+              transform="translate(0,-6.542857142857141)"
               width="105.35714285714286"
               x="524.6428571428571"
-              y="178"
+              y="191.57142857142856"
             />
           </g>
         </svg>
@@ -6021,13 +6021,13 @@ Object {
             >
               <path
                 class="domain"
-                d="M-6,15.5H0.5V20.5H-6"
+                d="M-6,7H0.5V29H-6"
                 stroke="currentColor"
               />
               <g
                 class="tick"
                 opacity="1"
-                transform="translate(0,15.5)"
+                transform="translate(0,7)"
               >
                 <line
                   stroke="currentColor"
@@ -6058,7 +6058,7 @@ Object {
               <g
                 class="tick"
                 opacity="1"
-                transform="translate(0,16.5)"
+                transform="translate(0,11.4)"
               >
                 <line
                   stroke="currentColor"
@@ -6089,7 +6089,7 @@ Object {
               <g
                 class="tick"
                 opacity="1"
-                transform="translate(0,17.5)"
+                transform="translate(0,15.8)"
               >
                 <line
                   stroke="currentColor"
@@ -6120,7 +6120,7 @@ Object {
               <g
                 class="tick"
                 opacity="1"
-                transform="translate(0,18.5)"
+                transform="translate(0,20.2)"
               >
                 <line
                   stroke="currentColor"
@@ -6151,7 +6151,7 @@ Object {
               <g
                 class="tick"
                 opacity="1"
-                transform="translate(0,19.5)"
+                transform="translate(0,24.6)"
               >
                 <line
                   stroke="currentColor"
@@ -6182,7 +6182,7 @@ Object {
               <g
                 class="tick"
                 opacity="1"
-                transform="translate(0,20.5)"
+                transform="translate(0,29)"
               >
                 <line
                   stroke="currentColor"
@@ -6217,56 +6217,56 @@ Object {
                 aria-labelledby="toolTipcallout68"
                 data-is-focusable="true"
                 fill="#0078d4"
-                height="32"
+                height="1"
                 opacity="1"
                 role="img"
                 rx="0"
                 tabindex="0"
                 width="147.5"
                 x="40"
-                y="-0.5"
+                y="8.200000000000001"
               />
               <rect
                 aria-label="88%. 2020/04/30."
                 aria-labelledby="toolTipcallout68"
                 data-is-focusable="true"
                 fill="#002050"
-                height="32"
+                height="1"
                 opacity="1"
                 role="img"
                 rx="0"
                 tabindex="0"
                 width="590"
                 x="40"
-                y="0.3000000000000007"
+                y="11.719999999999999"
               />
               <rect
                 aria-label="37%. 2020/04/30."
                 aria-labelledby="toolTipcallout68"
                 data-is-focusable="true"
                 fill="#00188f"
-                height="32"
+                height="1"
                 opacity="1"
                 role="img"
                 rx="0"
                 tabindex="0"
                 width="368.75"
                 x="40"
-                y="2"
+                y="19.2"
               />
               <rect
                 aria-label="20%. 2020/04/30."
                 aria-labelledby="toolTipcallout68"
                 data-is-focusable="true"
                 fill="#00bcf2"
-                height="32"
+                height="1"
                 opacity="1"
                 role="img"
                 rx="0"
                 tabindex="0"
                 width="295"
                 x="40"
-                y="4"
+                y="28"
               />
             </g>
           </svg>
@@ -6478,13 +6478,13 @@ Object {
           >
             <path
               class="domain"
-              d="M-6,15.5H0.5V20.5H-6"
+              d="M-6,7H0.5V29H-6"
               stroke="currentColor"
             />
             <g
               class="tick"
               opacity="1"
-              transform="translate(0,15.5)"
+              transform="translate(0,7)"
             >
               <line
                 stroke="currentColor"
@@ -6515,7 +6515,7 @@ Object {
             <g
               class="tick"
               opacity="1"
-              transform="translate(0,16.5)"
+              transform="translate(0,11.4)"
             >
               <line
                 stroke="currentColor"
@@ -6546,7 +6546,7 @@ Object {
             <g
               class="tick"
               opacity="1"
-              transform="translate(0,17.5)"
+              transform="translate(0,15.8)"
             >
               <line
                 stroke="currentColor"
@@ -6577,7 +6577,7 @@ Object {
             <g
               class="tick"
               opacity="1"
-              transform="translate(0,18.5)"
+              transform="translate(0,20.2)"
             >
               <line
                 stroke="currentColor"
@@ -6608,7 +6608,7 @@ Object {
             <g
               class="tick"
               opacity="1"
-              transform="translate(0,19.5)"
+              transform="translate(0,24.6)"
             >
               <line
                 stroke="currentColor"
@@ -6639,7 +6639,7 @@ Object {
             <g
               class="tick"
               opacity="1"
-              transform="translate(0,20.5)"
+              transform="translate(0,29)"
             >
               <line
                 stroke="currentColor"
@@ -6674,56 +6674,56 @@ Object {
               aria-labelledby="toolTipcallout68"
               data-is-focusable="true"
               fill="#0078d4"
-              height="32"
+              height="1"
               opacity="1"
               role="img"
               rx="0"
               tabindex="0"
               width="147.5"
               x="40"
-              y="-0.5"
+              y="8.200000000000001"
             />
             <rect
               aria-label="88%. 2020/04/30."
               aria-labelledby="toolTipcallout68"
               data-is-focusable="true"
               fill="#002050"
-              height="32"
+              height="1"
               opacity="1"
               role="img"
               rx="0"
               tabindex="0"
               width="590"
               x="40"
-              y="0.3000000000000007"
+              y="11.719999999999999"
             />
             <rect
               aria-label="37%. 2020/04/30."
               aria-labelledby="toolTipcallout68"
               data-is-focusable="true"
               fill="#00188f"
-              height="32"
+              height="1"
               opacity="1"
               role="img"
               rx="0"
               tabindex="0"
               width="368.75"
               x="40"
-              y="2"
+              y="19.2"
             />
             <rect
               aria-label="20%. 2020/04/30."
               aria-labelledby="toolTipcallout68"
               data-is-focusable="true"
               fill="#00bcf2"
-              height="32"
+              height="1"
               opacity="1"
               role="img"
               rx="0"
               tabindex="0"
               width="295"
               x="40"
-              y="4"
+              y="28"
             />
           </g>
         </svg>
@@ -7030,13 +7030,13 @@ Object {
             >
               <path
                 class="domain"
-                d="M-6,249.5H0.5V36.5H-6"
+                d="M-6,257.5H0.5V28.5H-6"
                 stroke="currentColor"
               />
               <g
                 class="tick"
                 opacity="1"
-                transform="translate(0,222.375)"
+                transform="translate(0,218.83333333333334)"
               >
                 <line
                   stroke="currentColor"
@@ -7066,7 +7066,7 @@ Object {
               <g
                 class="tick"
                 opacity="1"
-                transform="translate(0,169.125)"
+                transform="translate(0,167.94444444444446)"
               >
                 <line
                   stroke="currentColor"
@@ -7096,7 +7096,7 @@ Object {
               <g
                 class="tick"
                 opacity="1"
-                transform="translate(0,115.875)"
+                transform="translate(0,117.05555555555557)"
               >
                 <line
                   stroke="currentColor"
@@ -7126,7 +7126,7 @@ Object {
               <g
                 class="tick"
                 opacity="1"
-                transform="translate(0,62.625)"
+                transform="translate(0,66.16666666666669)"
               >
                 <line
                   stroke="currentColor"
@@ -7160,60 +7160,60 @@ Object {
                 aria-labelledby="toolTipcallout71"
                 data-is-focusable="true"
                 fill="#0078d4"
-                height="32"
+                height="32.714285714285715"
                 opacity="1"
                 role="img"
                 rx="0"
                 tabindex="0"
-                transform="translate(0,10.625)"
+                transform="translate(0,-3.634920634920636)"
                 width="118"
                 x="40"
-                y="36"
+                y="53.44444444444446"
               />
               <rect
                 aria-label="5000. String Two."
                 aria-labelledby="toolTipcallout71"
                 data-is-focusable="true"
                 fill="#00bcf2"
-                height="32"
+                height="32.714285714285715"
                 opacity="1"
                 role="img"
                 rx="0"
                 tabindex="0"
-                transform="translate(0,10.625)"
+                transform="translate(0,-3.634920634920636)"
                 width="590"
                 x="40"
-                y="89.25"
+                y="104.33333333333334"
               />
               <rect
                 aria-label="3000. String Three."
                 aria-labelledby="toolTipcallout71"
                 data-is-focusable="true"
                 fill="#00188f"
-                height="32"
+                height="32.714285714285715"
                 opacity="1"
                 role="img"
                 rx="0"
                 tabindex="0"
-                transform="translate(0,10.625)"
+                transform="translate(0,-3.634920634920636)"
                 width="354"
                 x="40"
-                y="142.5"
+                y="155.22222222222223"
               />
               <rect
                 aria-label="2000. String Four."
                 aria-labelledby="toolTipcallout71"
                 data-is-focusable="true"
                 fill="#002050"
-                height="32"
+                height="32.714285714285715"
                 opacity="1"
                 role="img"
                 rx="0"
                 tabindex="0"
-                transform="translate(0,10.625)"
+                transform="translate(0,-3.634920634920636)"
                 width="236"
                 x="40"
-                y="195.75"
+                y="206.11111111111111"
               />
             </g>
           </svg>
@@ -7502,13 +7502,13 @@ Object {
           >
             <path
               class="domain"
-              d="M-6,249.5H0.5V36.5H-6"
+              d="M-6,257.5H0.5V28.5H-6"
               stroke="currentColor"
             />
             <g
               class="tick"
               opacity="1"
-              transform="translate(0,222.375)"
+              transform="translate(0,218.83333333333334)"
             >
               <line
                 stroke="currentColor"
@@ -7538,7 +7538,7 @@ Object {
             <g
               class="tick"
               opacity="1"
-              transform="translate(0,169.125)"
+              transform="translate(0,167.94444444444446)"
             >
               <line
                 stroke="currentColor"
@@ -7568,7 +7568,7 @@ Object {
             <g
               class="tick"
               opacity="1"
-              transform="translate(0,115.875)"
+              transform="translate(0,117.05555555555557)"
             >
               <line
                 stroke="currentColor"
@@ -7598,7 +7598,7 @@ Object {
             <g
               class="tick"
               opacity="1"
-              transform="translate(0,62.625)"
+              transform="translate(0,66.16666666666669)"
             >
               <line
                 stroke="currentColor"
@@ -7632,60 +7632,60 @@ Object {
               aria-labelledby="toolTipcallout71"
               data-is-focusable="true"
               fill="#0078d4"
-              height="32"
+              height="32.714285714285715"
               opacity="1"
               role="img"
               rx="0"
               tabindex="0"
-              transform="translate(0,10.625)"
+              transform="translate(0,-3.634920634920636)"
               width="118"
               x="40"
-              y="36"
+              y="53.44444444444446"
             />
             <rect
               aria-label="5000. String Two."
               aria-labelledby="toolTipcallout71"
               data-is-focusable="true"
               fill="#00bcf2"
-              height="32"
+              height="32.714285714285715"
               opacity="1"
               role="img"
               rx="0"
               tabindex="0"
-              transform="translate(0,10.625)"
+              transform="translate(0,-3.634920634920636)"
               width="590"
               x="40"
-              y="89.25"
+              y="104.33333333333334"
             />
             <rect
               aria-label="3000. String Three."
               aria-labelledby="toolTipcallout71"
               data-is-focusable="true"
               fill="#00188f"
-              height="32"
+              height="32.714285714285715"
               opacity="1"
               role="img"
               rx="0"
               tabindex="0"
-              transform="translate(0,10.625)"
+              transform="translate(0,-3.634920634920636)"
               width="354"
               x="40"
-              y="142.5"
+              y="155.22222222222223"
             />
             <rect
               aria-label="2000. String Four."
               aria-labelledby="toolTipcallout71"
               data-is-focusable="true"
               fill="#002050"
-              height="32"
+              height="32.714285714285715"
               opacity="1"
               role="img"
               rx="0"
               tabindex="0"
-              transform="translate(0,10.625)"
+              transform="translate(0,-3.634920634920636)"
               width="236"
               x="40"
-              y="195.75"
+              y="206.11111111111111"
             />
           </g>
         </svg>
@@ -8033,13 +8033,13 @@ Object {
             >
               <path
                 class="domain"
-                d="M-6,249.5H0.5V36.5H-6"
+                d="M-6,257.5H0.5V28.5H-6"
                 stroke="currentColor"
               />
               <g
                 class="tick"
                 opacity="1"
-                transform="translate(0,222.375)"
+                transform="translate(0,218.83333333333334)"
               >
                 <line
                   stroke="currentColor"
@@ -8069,7 +8069,7 @@ Object {
               <g
                 class="tick"
                 opacity="1"
-                transform="translate(0,169.125)"
+                transform="translate(0,167.94444444444446)"
               >
                 <line
                   stroke="currentColor"
@@ -8099,7 +8099,7 @@ Object {
               <g
                 class="tick"
                 opacity="1"
-                transform="translate(0,115.875)"
+                transform="translate(0,117.05555555555557)"
               >
                 <line
                   stroke="currentColor"
@@ -8129,7 +8129,7 @@ Object {
               <g
                 class="tick"
                 opacity="1"
-                transform="translate(0,62.625)"
+                transform="translate(0,66.16666666666669)"
               >
                 <line
                   stroke="currentColor"
@@ -8163,60 +8163,60 @@ Object {
                 aria-labelledby="toolTipcallout75"
                 data-is-focusable="true"
                 fill="#0078d4"
-                height="32"
+                height="32.714285714285715"
                 opacity="1"
                 role="img"
                 rx="0"
                 tabindex="0"
-                transform="translate(0,10.625)"
+                transform="translate(0,-3.634920634920636)"
                 width="118"
                 x="40"
-                y="36"
+                y="53.44444444444446"
               />
               <rect
                 aria-label="5000. String Two."
                 aria-labelledby="toolTipcallout75"
                 data-is-focusable="true"
                 fill="#00bcf2"
-                height="32"
+                height="32.714285714285715"
                 opacity="1"
                 role="img"
                 rx="0"
                 tabindex="0"
-                transform="translate(0,10.625)"
+                transform="translate(0,-3.634920634920636)"
                 width="590"
                 x="40"
-                y="89.25"
+                y="104.33333333333334"
               />
               <rect
                 aria-label="3000. String Three."
                 aria-labelledby="toolTipcallout75"
                 data-is-focusable="true"
                 fill="#00188f"
-                height="32"
+                height="32.714285714285715"
                 opacity="1"
                 role="img"
                 rx="0"
                 tabindex="0"
-                transform="translate(0,10.625)"
+                transform="translate(0,-3.634920634920636)"
                 width="354"
                 x="40"
-                y="142.5"
+                y="155.22222222222223"
               />
               <rect
                 aria-label="2000. String Four."
                 aria-labelledby="toolTipcallout75"
                 data-is-focusable="true"
                 fill="#002050"
-                height="32"
+                height="32.714285714285715"
                 opacity="1"
                 role="img"
                 rx="0"
                 tabindex="0"
-                transform="translate(0,10.625)"
+                transform="translate(0,-3.634920634920636)"
                 width="236"
                 x="40"
-                y="195.75"
+                y="206.11111111111111"
               />
             </g>
           </svg>
@@ -8500,13 +8500,13 @@ Object {
           >
             <path
               class="domain"
-              d="M-6,249.5H0.5V36.5H-6"
+              d="M-6,257.5H0.5V28.5H-6"
               stroke="currentColor"
             />
             <g
               class="tick"
               opacity="1"
-              transform="translate(0,222.375)"
+              transform="translate(0,218.83333333333334)"
             >
               <line
                 stroke="currentColor"
@@ -8536,7 +8536,7 @@ Object {
             <g
               class="tick"
               opacity="1"
-              transform="translate(0,169.125)"
+              transform="translate(0,167.94444444444446)"
             >
               <line
                 stroke="currentColor"
@@ -8566,7 +8566,7 @@ Object {
             <g
               class="tick"
               opacity="1"
-              transform="translate(0,115.875)"
+              transform="translate(0,117.05555555555557)"
             >
               <line
                 stroke="currentColor"
@@ -8596,7 +8596,7 @@ Object {
             <g
               class="tick"
               opacity="1"
-              transform="translate(0,62.625)"
+              transform="translate(0,66.16666666666669)"
             >
               <line
                 stroke="currentColor"
@@ -8630,60 +8630,60 @@ Object {
               aria-labelledby="toolTipcallout75"
               data-is-focusable="true"
               fill="#0078d4"
-              height="32"
+              height="32.714285714285715"
               opacity="1"
               role="img"
               rx="0"
               tabindex="0"
-              transform="translate(0,10.625)"
+              transform="translate(0,-3.634920634920636)"
               width="118"
               x="40"
-              y="36"
+              y="53.44444444444446"
             />
             <rect
               aria-label="5000. String Two."
               aria-labelledby="toolTipcallout75"
               data-is-focusable="true"
               fill="#00bcf2"
-              height="32"
+              height="32.714285714285715"
               opacity="1"
               role="img"
               rx="0"
               tabindex="0"
-              transform="translate(0,10.625)"
+              transform="translate(0,-3.634920634920636)"
               width="590"
               x="40"
-              y="89.25"
+              y="104.33333333333334"
             />
             <rect
               aria-label="3000. String Three."
               aria-labelledby="toolTipcallout75"
               data-is-focusable="true"
               fill="#00188f"
-              height="32"
+              height="32.714285714285715"
               opacity="1"
               role="img"
               rx="0"
               tabindex="0"
-              transform="translate(0,10.625)"
+              transform="translate(0,-3.634920634920636)"
               width="354"
               x="40"
-              y="142.5"
+              y="155.22222222222223"
             />
             <rect
               aria-label="2000. String Four."
               aria-labelledby="toolTipcallout75"
               data-is-focusable="true"
               fill="#002050"
-              height="32"
+              height="32.714285714285715"
               opacity="1"
               role="img"
               rx="0"
               tabindex="0"
-              transform="translate(0,10.625)"
+              transform="translate(0,-3.634920634920636)"
               width="236"
               x="40"
-              y="195.75"
+              y="206.11111111111111"
             />
           </g>
         </svg>

--- a/packages/charts/react-charts/library/src/utilities/__snapshots__/UtilityUnitTests.test.ts.snap
+++ b/packages/charts/react-charts/library/src/utilities/__snapshots__/UtilityUnitTests.test.ts.snap
@@ -1917,13 +1917,13 @@ exports[`createStringYAxis should render y-axis labels correctly for horizontal 
 >
   <path
     class="domain"
-    d="M-6,92.5H0.5V8.5H-6"
+    d="M-6,100.5H0.5V0.5H-6"
     stroke="currentColor"
   />
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,78)"
+    transform="translate(0,78.57142857142857)"
   >
     <line
       stroke="currentColor"
@@ -1940,7 +1940,7 @@ exports[`createStringYAxis should render y-axis labels correctly for horizontal 
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,50)"
+    transform="translate(0,50.00000000000001)"
   >
     <line
       stroke="currentColor"
@@ -1957,7 +1957,7 @@ exports[`createStringYAxis should render y-axis labels correctly for horizontal 
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,22)"
+    transform="translate(0,21.428571428571427)"
   >
     <line
       stroke="currentColor"
@@ -2049,13 +2049,13 @@ exports[`createStringYAxisForHorizontalBarChartWithAxis should render y-axis lab
 >
   <path
     class="domain"
-    d="M6,92.5H0.5V8.5H6"
+    d="M6,100.5H0.5V0.5H6"
     stroke="currentColor"
   />
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,78)"
+    transform="translate(0,78.57142857142857)"
   >
     <line
       stroke="currentColor"
@@ -2072,7 +2072,7 @@ exports[`createStringYAxisForHorizontalBarChartWithAxis should render y-axis lab
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,50)"
+    transform="translate(0,50.00000000000001)"
   >
     <line
       stroke="currentColor"
@@ -2089,7 +2089,7 @@ exports[`createStringYAxisForHorizontalBarChartWithAxis should render y-axis lab
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,22)"
+    transform="translate(0,21.428571428571427)"
   >
     <line
       stroke="currentColor"
@@ -2115,13 +2115,13 @@ exports[`createStringYAxisForHorizontalBarChartWithAxis should render y-axis lab
 >
   <path
     class="domain"
-    d="M-6,92.5H0.5V8.5H-6"
+    d="M-6,100.5H0.5V0.5H-6"
     stroke="currentColor"
   />
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,78)"
+    transform="translate(0,78.57142857142857)"
   >
     <line
       stroke="currentColor"
@@ -2138,7 +2138,7 @@ exports[`createStringYAxisForHorizontalBarChartWithAxis should render y-axis lab
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,50)"
+    transform="translate(0,50.00000000000001)"
   >
     <line
       stroke="currentColor"
@@ -2155,7 +2155,7 @@ exports[`createStringYAxisForHorizontalBarChartWithAxis should render y-axis lab
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,22)"
+    transform="translate(0,21.428571428571427)"
   >
     <line
       stroke="currentColor"
@@ -2181,13 +2181,13 @@ exports[`createStringYAxisForHorizontalBarChartWithAxis should render y-axis lab
 >
   <path
     class="domain"
-    d="M-6,92.5H0.5V8.5H-6"
+    d="M-6,100.5H0.5V0.5H-6"
     stroke="currentColor"
   />
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,78)"
+    transform="translate(0,78.57142857142857)"
   >
     <line
       stroke="currentColor"
@@ -2204,7 +2204,7 @@ exports[`createStringYAxisForHorizontalBarChartWithAxis should render y-axis lab
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,50)"
+    transform="translate(0,50.00000000000001)"
   >
     <line
       stroke="currentColor"
@@ -2221,7 +2221,7 @@ exports[`createStringYAxisForHorizontalBarChartWithAxis should render y-axis lab
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,22)"
+    transform="translate(0,21.428571428571427)"
   >
     <line
       stroke="currentColor"
@@ -3746,13 +3746,13 @@ exports[`createYAxisLabels should retain full y-axis labels when truncateLabel i
 >
   <path
     class="domain"
-    d="M-6,92.5H0.5V8.5H-6"
+    d="M-6,100.5H0.5V0.5H-6"
     stroke="currentColor"
   />
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,78)"
+    transform="translate(0,78.57142857142857)"
   >
     <line
       stroke="currentColor"
@@ -3782,7 +3782,7 @@ exports[`createYAxisLabels should retain full y-axis labels when truncateLabel i
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,50)"
+    transform="translate(0,50.00000000000001)"
   >
     <line
       stroke="currentColor"
@@ -3812,7 +3812,7 @@ exports[`createYAxisLabels should retain full y-axis labels when truncateLabel i
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,22)"
+    transform="translate(0,21.428571428571427)"
   >
     <line
       stroke="currentColor"
@@ -3852,13 +3852,13 @@ exports[`createYAxisLabels should truncate y-axis labels when their length excee
 >
   <path
     class="domain"
-    d="M-6,92.5H0.5V8.5H-6"
+    d="M-6,100.5H0.5V0.5H-6"
     stroke="currentColor"
   />
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,78)"
+    transform="translate(0,78.57142857142857)"
   >
     <line
       stroke="currentColor"
@@ -3888,7 +3888,7 @@ exports[`createYAxisLabels should truncate y-axis labels when their length excee
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,50)"
+    transform="translate(0,50.00000000000001)"
   >
     <line
       stroke="currentColor"
@@ -3918,7 +3918,7 @@ exports[`createYAxisLabels should truncate y-axis labels when their length excee
   <g
     class="tick"
     opacity="1"
-    transform="translate(0,22)"
+    transform="translate(0,21.428571428571427)"
   >
     <line
       stroke="currentColor"

--- a/packages/charts/react-charts/library/src/utilities/utilities.ts
+++ b/packages/charts/react-charts/library/src/utilities/utilities.ts
@@ -60,6 +60,8 @@ import {
   getMultiLevelDateTimeFormatOptions,
 } from '@fluentui/chart-utilities';
 
+export const MIN_DOMAIN_MARGIN = 8;
+
 export type NumericAxis = D3Axis<number | { valueOf(): number }>;
 export type StringAxis = D3Axis<string>;
 
@@ -668,10 +670,10 @@ export function createYAxisForHorizontalBarChartWithAxis(
     yAxisTickCount = 4,
   } = yAxisParams;
 
-  // maxOfYVal coming from only area chart and Grouped vertical bar chart(Calculation done at base file)
+  // maxOfYVal coming from horizontal bar chart with axis (Calculation done at base file)
   const tempVal = maxOfYVal || yMinMaxValues.endValue;
   const finalYmax = tempVal > yMaxValue ? tempVal : yMaxValue!;
-  const finalYmin = yMinMaxValues.startValue < yMinValue ? 0 : yMinValue!;
+  const finalYmin = yMinMaxValues.startValue < yMinValue ? Math.min(0, yMinMaxValues.startValue) : yMinValue!;
   const yAxisScale = d3ScaleLinear()
     .domain([finalYmin, finalYmax])
     .range([containerHeight - margins.bottom!, margins.top!]);
@@ -764,11 +766,14 @@ export const createStringYAxisForHorizontalBarChartWithAxis = (
   barWidth: number,
   culture?: string,
 ) => {
-  const { containerHeight, tickPadding = 12, margins, yAxisTickFormat, yAxisElement } = yAxisParams;
+  const { containerHeight, tickPadding = 12, margins, yAxisTickFormat, yAxisElement, yAxisPadding } = yAxisParams;
 
+  let yAxisPaddingValue = yAxisPadding ?? 0.5;
+  yAxisPaddingValue = yAxisPaddingValue === 1 ? 0.99 : yAxisPaddingValue;
   const yAxisScale = d3ScaleBand()
     .domain(dataPoints)
-    .range([containerHeight - margins.bottom! - barWidth / 2, margins.top! + barWidth / 2]);
+    .range([containerHeight - margins.bottom!, margins.top!])
+    .padding(yAxisPaddingValue);
   const axis = isRtl ? d3AxisRight(yAxisScale) : d3AxisLeft(yAxisScale);
   const yAxis = axis.tickPadding(tickPadding).ticks(dataPoints);
   if (yAxisTickFormat) {

--- a/packages/charts/react-charts/stories/src/HorizontalBarChartWithAxis/HorizontalBarChartWithAxisDynamic.stories.tsx
+++ b/packages/charts/react-charts/stories/src/HorizontalBarChartWithAxis/HorizontalBarChartWithAxisDynamic.stories.tsx
@@ -1,0 +1,201 @@
+import * as React from 'react';
+import {
+  DataVizPalette,
+  getColorFromToken,
+  HorizontalBarChartWithAxis,
+  HorizontalBarChartWithAxisDataPoint,
+} from '@fluentui/react-charts';
+import {
+  Checkbox,
+  CheckboxOnChangeData,
+  Switch,
+  Field,
+  Radio,
+  RadioGroup,
+  RadioGroupOnChangeData,
+  Button,
+} from '@fluentui/react-components';
+
+/** This style is commonly used to visually hide text that is still available for the screen reader to announce. */
+const screenReaderOnlyStyle: React.CSSProperties = {
+  position: 'absolute',
+  width: '1px',
+  height: '1px',
+  padding: 0,
+  margin: '-1px',
+  overflow: 'hidden',
+  clip: 'rect(0,0,0,0)',
+  border: 0,
+};
+
+const _colors = [
+  getColorFromToken(DataVizPalette.color1),
+  getColorFromToken(DataVizPalette.color2),
+  getColorFromToken(DataVizPalette.color3),
+];
+
+export const HorizontalBarWithAxisDynamic = () => {
+  const _randomX = () => {
+    return Math.floor(Math.random() * 90) + 1;
+  };
+
+  const _getData = (dataSize: number, yAxisType: string) => {
+    const data: HorizontalBarChartWithAxisDataPoint[] = [];
+    if (yAxisType === 'string') {
+      for (let i = 0; i < dataSize; i++) {
+        data.push({
+          x: _randomX(),
+          y: `Label ${i + 1}`,
+          legend: `Label ${i + 1}`,
+          color: _colors[i % _colors.length],
+        });
+      }
+    } else {
+      const yPoints = new Set<number>();
+      while (yPoints.size !== dataSize) {
+        const y = Math.floor(Math.random() * 75) + 1;
+        if (!yPoints.has(y)) {
+          yPoints.add(y);
+          data.push({
+            x: _randomX(),
+            y,
+            legend: `Label ${yPoints.size}`,
+            color: _colors[y % _colors.length],
+          });
+        }
+      }
+    }
+    return data;
+  };
+  const initialyAxisType = 'number';
+  const initialDataSize = 5;
+  const [dynamicData, setDynamicData] = React.useState<HorizontalBarChartWithAxisDataPoint[]>(
+    _getData(initialDataSize, initialyAxisType),
+  );
+  const [statusKey, setStatusKey] = React.useState<number>(0);
+  const [statusMessage, setStatusMessage] = React.useState<string>('');
+  const [width, setWidth] = React.useState<number>(650);
+  const [yAxisType, setYAxisType] = React.useState<string>(initialyAxisType);
+  const [dataSize, setDataSize] = React.useState<number>(initialDataSize);
+  const [roundCorners, setRoundCorners] = React.useState<boolean>(false);
+  const [yAxisPadding, setYAxisPadding] = React.useState<number | undefined>(0);
+  const [yAxisPaddingEnabled, setYAxisPaddingEnabled] = React.useState<boolean | undefined>(false);
+
+  const _changeData = () => {
+    setDynamicData(_getData(dataSize, yAxisType));
+    setStatusKey(statusKey + 1);
+    setStatusMessage('Horizontal bar chart with Axis data changed');
+  };
+  const _onWidthChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setWidth(parseInt(e.target.value, 10));
+  };
+  const _onAxisTypeChange = (ev: React.FormEvent<HTMLDivElement>, data: RadioGroupOnChangeData): void => {
+    setYAxisType(data.value);
+    setDynamicData(_getData(dataSize, data.value));
+    setStatusKey(statusKey + 1);
+  };
+  const _onYAxisPaddingChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setYAxisPadding(Number(e.target.value));
+    setStatusKey(statusKey + 1);
+  };
+
+  const _onYAxisPaddingCheckChange = (ev: React.ChangeEvent<HTMLElement>, checked: CheckboxOnChangeData) => {
+    setYAxisPaddingEnabled(checked.checked as boolean);
+    setStatusKey(statusKey + 1);
+  };
+  const _onDataSizeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const size = Number(e.target.value);
+    setDataSize(size);
+    setDynamicData(_getData(size, yAxisType));
+    setStatusKey(statusKey + 1);
+  };
+
+  const _onSwitchRoundCorners = React.useCallback(ev => {
+    setRoundCorners(ev.currentTarget.checked);
+  }, []);
+
+  return (
+    <div className="containerDiv">
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '15px 30px', marginBottom: '16px' }}>
+        <div style={{ display: 'flex', alignItems: 'center' }}>
+          <label htmlFor="input-width" style={{ fontWeight: 400 }}>
+            width:&nbsp;
+          </label>
+          <input type="range" id="input-width" value={width} min={200} max={1000} onChange={_onWidthChange} />
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center' }}>
+          <label htmlFor="input-datasize" style={{ fontWeight: 400 }}>
+            Data Size:&nbsp;
+          </label>
+          <input type="range" id="input-datasize" value={dataSize} min={0} max={50} onChange={_onDataSizeChange} />
+        </div>
+      </div>
+
+      <div style={{ display: 'flex', alignItems: 'center', marginBottom: '16px' }}>
+        <Checkbox
+          label="yAxisPadding:&nbsp;"
+          checked={yAxisPaddingEnabled}
+          onChange={_onYAxisPaddingCheckChange}
+          disabled={yAxisType !== 'string'}
+        />
+        <input
+          type="range"
+          value={yAxisPadding}
+          min={0}
+          max={1}
+          step={0.1}
+          onChange={_onYAxisPaddingChange}
+          disabled={!yAxisPaddingEnabled}
+        />
+        <span style={{ marginLeft: '8px' }}>{yAxisPadding}</span>
+      </div>
+
+      <div style={{ marginTop: '20px', display: 'flex', alignItems: 'center' }}>
+        <div>
+          <label>X-Axis type:</label>
+          <Field label="Pick one">
+            <RadioGroup defaultValue="number" onChange={_onAxisTypeChange}>
+              <Radio value="number" label="Number" />
+              <Radio value="string" label="String" />
+            </RadioGroup>
+          </Field>
+        </div>
+        <div style={{ marginLeft: '20px' }}>
+          <Switch
+            checked={roundCorners}
+            onChange={_onSwitchRoundCorners}
+            label={roundCorners ? 'Rounded Corners ON' : 'Rounded Corners OFF'}
+          />
+        </div>
+      </div>
+
+      <div style={{ width: `${width}px`, height: '350px', marginTop: '20px' }}>
+        <HorizontalBarChartWithAxis
+          key={`${yAxisType}-${statusKey}`}
+          chartTitle="Horizontal bar chart dynamic example"
+          data={dynamicData}
+          colors={_colors}
+          hideLegend={true}
+          width={width}
+          roundCorners={roundCorners}
+          hideTickOverlap={true}
+          yAxisPadding={yAxisPaddingEnabled ? yAxisPadding : undefined}
+        />
+      </div>
+
+      <div style={{ marginTop: '16px' }}>
+        <Button onClick={_changeData}>Change data</Button>
+        <div aria-live="polite" aria-atomic="true">
+          <p key={statusKey} style={screenReaderOnlyStyle}>
+            {statusMessage}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};
+HorizontalBarWithAxisDynamic.parameters = {
+  docs: {
+    description: {},
+  },
+};

--- a/packages/charts/react-charts/stories/src/HorizontalBarChartWithAxis/index.stories.tsx
+++ b/packages/charts/react-charts/stories/src/HorizontalBarChartWithAxis/index.stories.tsx
@@ -5,6 +5,7 @@ import bestPracticesMd from './HorizontalBarChartWithAxisBestPractices.md';
 
 export { HorizontalBarWithAxisBasic } from './HorizontalBarChartWithAxisDefault.stories';
 export { HorizontalBarWithAxisStringAxisTooltip } from './HorizontalBarChartWithAxisStringAxisTooltip.stories';
+export { HorizontalBarWithAxisDynamic } from './HorizontalBarChartWithAxisDynamic.stories';
 
 export default {
   title: 'Charts/HorizontalBarChartWithAxis',


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## New Behavior

Corresponding v8 commits:
1. Negative y support: https://github.com/microsoft/fluentui/commit/f4294bea66d3de91319d82f3e47790a350b42239
2. Fix bar overlapping issue: https://github.com/microsoft/fluentui/commit/5c55efc73f551bfdf70b5492da9e5b8a694f4653

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
