### PR TITLE
fix(react-nav): move action button to be the first

### DIFF
--- a/change/@fluentui-react-nav-4211ce34-e82f-4c11-a929-a073d79b1e26.json
+++ b/change/@fluentui-react-nav-4211ce34-e82f-4c11-a929-a073d79b1e26.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: move action button to be the first button",
+  "packageName": "@fluentui/react-nav",
+  "email": "marcosvmmoura@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-nav/library/src/components/SplitNavItem/renderSplitNavItem.tsx
+++ b/packages/react-components/react-nav/library/src/components/SplitNavItem/renderSplitNavItem.tsx
@@ -2,7 +2,35 @@
 /** @jsxImportSource @fluentui/react-jsx-runtime */
 
 import { assertSlots } from '@fluentui/react-utilities';
+
 import type { SplitNavItemState, SplitNavItemSlots } from './SplitNavItem.types';
+
+/**
+ * @internal
+ *
+ * Helper function to get button slots
+ */
+const getButtonSlot = (slot: keyof SplitNavItemSlots, state: SplitNavItemState) => {
+  assertSlots<SplitNavItemSlots>(state);
+
+  const Button = state[slot];
+  const tooltipSlotName = (slot + 'Tooltip') as keyof SplitNavItemSlots;
+  const Tooltip = state[tooltipSlotName];
+
+  if (!Button) {
+    return null;
+  }
+
+  if (Tooltip) {
+    return (
+      <Tooltip>
+        <Button />
+      </Tooltip>
+    );
+  }
+
+  return <Button />;
+};
 
 /**
  * Render the final JSX of SplitNavItem
@@ -13,26 +41,9 @@ export const renderSplitNavItem_unstable = (state: SplitNavItemState) => {
   return (
     <state.root>
       {state.navItem && <state.navItem />}
-      {state.actionButton && state.actionButtonTooltip && (
-        <state.actionButtonTooltip>
-          <state.actionButton />
-        </state.actionButtonTooltip>
-      )}
-      {state.actionButton && !state.actionButtonTooltip && <state.actionButton />}
-
-      {state.toggleButton && state.toggleButtonTooltip && (
-        <state.toggleButtonTooltip>
-          <state.toggleButton />
-        </state.toggleButtonTooltip>
-      )}
-      {state.toggleButton && !state.toggleButtonTooltip && <state.toggleButton />}
-
-      {state.menuButton && state.menuButtonTooltip && (
-        <state.menuButtonTooltip>
-          <state.menuButton />
-        </state.menuButtonTooltip>
-      )}
-      {state.menuButton && !state.menuButtonTooltip && <state.menuButton />}
+      {getButtonSlot('actionButton', state)}
+      {getButtonSlot('menuButton', state)}
+      {getButtonSlot('toggleButton', state)}
     </state.root>
   );
 };


### PR DESCRIPTION
## Previous Behavior

![image](https://github.com/user-attachments/assets/0a8623cf-c9cf-463f-a122-50493a5231b2)
The "more" action button was the last item

## New Behavior

![image](https://github.com/user-attachments/assets/b6360aa4-2f3c-4d48-be92-3d5b5213ae56)
The "more" action button is now the first item
