### PR TITLE
fix(utilities): safe hasOwnProperty in filteredAssign

### DIFF
--- a/packages/utilities/src/object.ts
+++ b/packages/utilities/src/object.ts
@@ -61,7 +61,7 @@ export function filteredAssign(isAllowed: (propName: string) => boolean, target:
   for (let sourceObject of args) {
     if (sourceObject) {
       for (let propName in sourceObject) {
-        if (sourceObject.hasOwnProperty(propName) && (!isAllowed || isAllowed(propName))) {
+        if (Object.prototype.hasOwnProperty.call(sourceObject, propName) && (!isAllowed || isAllowed(propName))) {
           target[propName] = sourceObject[propName];
         }
       }


### PR DESCRIPTION
### Description
[filteredAssign](cci:1://file:///c:/Users/T2430514/Downloads/fluentui/packages/utilities/src/object.ts:44:0-71:1) (and therefore [assign](cci:1://file:///c:/Users/T2430514/Downloads/fluentui/packages/utilities/src/object.ts:29:0-42:1)) could throw if the
source object overrode `hasOwnProperty`.  
Replaced the direct call with
`Object.prototype.hasOwnProperty.call(...)` to guarantee safety
and keep object merging reliable.