### PR TITLE
chore(react-dialog): remove boxShadow on DialogSurfaceMotion

### DIFF
--- a/change/@fluentui-react-dialog-0c54e0ac-f23d-454e-9fad-b6235e9b4085.json
+++ b/change/@fluentui-react-dialog-0c54e0ac-f23d-454e-9fad-b6235e9b4085.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore(react-dialog): remove boxShadow on DialogSurfaceMotion",
+  "packageName": "@fluentui/react-dialog",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-dialog/library/src/components/DialogSurfaceMotion.ts
+++ b/packages/react-components/react-dialog/library/src/components/DialogSurfaceMotion.ts
@@ -1,10 +1,11 @@
 import { createPresenceComponent, motionTokens } from '@fluentui/react-motion';
-import { tokens } from '@fluentui/react-theme';
 
 const keyframes = [
-  { opacity: 0, boxShadow: '0px 0px 0px 0px rgba(0, 0, 0, 0.1)', transform: 'scale(0.85) translateZ(0)' },
   {
-    boxShadow: tokens.shadow64,
+    opacity: 0,
+    transform: 'scale(0.85) translateZ(0)',
+  },
+  {
     transform: 'scale(1) translateZ(0)',
     opacity: 1,
   },


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

It seems like animations on `boxShadow` are causing a significant drop of frame rate for the `DialogSurfaceMotion`

<!-- This is the behavior we have today -->

## New Behavior

1. removes `boxShadow` animation entirely

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/34642
