### PR TITLE
[Hotfix] GetNativeProps: guard against non-truthy values

### DIFF
--- a/change/@fluentui-react-utilities-7c6ec6c3-387b-455a-a53e-3c5bc4381d02.json
+++ b/change/@fluentui-react-utilities-7c6ec6c3-387b-455a-a53e-3c5bc4381d02.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "GetNativeProps: guard against non-truthy values",
+  "packageName": "@fluentui/react-utilities",
+  "email": "acenassri@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-utilities-40eeaa07-0544-4488-99a9-40b80de070cd.json
+++ b/change/@fluentui-utilities-40eeaa07-0544-4488-99a9-40b80de070cd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "GetNativeProps: guard against non-truthy values",
+  "packageName": "@fluentui/utilities",
+  "email": "acenassri@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-utilities/src/utils/properties.test.ts
+++ b/packages/react-components/react-utilities/src/utils/properties.test.ts
@@ -89,4 +89,18 @@ describe('getNativeProps', () => {
     expect(result.a).toBeDefined();
     expect(result.b).toBeUndefined();
   });
+
+  it('can handle null values', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let result = getNativeProps<any>(null as any, ['a', 'b'], ['b']);
+
+    expect(result).toEqual(null);
+  });
+
+  it('can handle undefined values', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let result = getNativeProps<any>(undefined as any, ['a', 'b'], ['b']);
+
+    expect(result).toBeUndefined();
+  });
 });

--- a/packages/react-components/react-utilities/src/utils/properties.ts
+++ b/packages/react-components/react-utilities/src/utils/properties.ts
@@ -458,6 +458,10 @@ export function getNativeProps<T extends Record<string, any>>(
   // return native props.
   // We should be able to do this once this PR is merged: https://github.com/microsoft/TypeScript/pull/26797
 
+  // Guard against invalid `props` values
+  // (These will break `Object.keys()` and result in runtime errors.)
+  if (!props) { return props; }
+
   const isArray = Array.isArray(allowedPropNames);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const result: Record<string, any> = {};

--- a/packages/utilities/src/properties.test.ts
+++ b/packages/utilities/src/properties.test.ts
@@ -66,4 +66,18 @@ describe('getNativeProps', () => {
     expect(result.a).toBeDefined();
     expect(result.b).toBeUndefined();
   });
+
+  it('can handle null values', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let result = getNativeProps<any>(null as any, ['a', 'b'], ['b']);
+
+    expect(result).toEqual(null);
+  });
+
+  it('can handle undefined values', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let result = getNativeProps<any>(undefined as any, ['a', 'b'], ['b']);
+
+    expect(result).toBeUndefined();
+  });
 });

--- a/packages/utilities/src/properties.ts
+++ b/packages/utilities/src/properties.ts
@@ -419,6 +419,10 @@ export function getNativeProps<T extends Record<string, any>>(
   // return native props.
   // We should be able to do this once this PR is merged: https://github.com/microsoft/TypeScript/pull/26797
 
+  // Guard against invalid `props` values
+  // (These will break `Object.keys()` and result in runtime errors.)
+  if (!props) { return props; }
+
   const isArray = Array.isArray(allowedPropNames);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const result: Record<string, any> = {};


### PR DESCRIPTION
## Summary
This PR prevents `getNativeProps` from throwing an error when a `falsy` value is passed to it.

## Context
As part of the team's pre-release testing, the [Dynamics 365 Project Operations](https://www.microsoft.com/en-us/dynamics-365/products/project-operations) team has identified a release-blocking issue within an internal dependency. (Essentially, there's an internal dependency that is passing non-truthy values to `getNativeProps()`. This causes runtime errors that prevent the Project Operations webapp from loading.)

While the root cause of this issue is (almost certainly) upstream of this repo, we do know that:
1) this repo's `getNativeProps()` function is part of the "causality chain" of the issue, _and_
2) applying this patch to the `getNativeProps()` function restores normal behavior of our app.
