### PR TITLE
fix(react-integration-apps): fix invalid input glob to properly trigger integration CI steps if stories are changed

### DIFF
--- a/apps/react-17-tests-v9/project.json
+++ b/apps/react-17-tests-v9/project.json
@@ -9,8 +9,8 @@
       "dependsOn": ["^build"],
       "inputs": [
         "{projectRoot}/tsconfig.react-17.json",
-        "{workspaceRoot}/packages/react-components/*/stories/**/*.stories.{ts,tsx}",
-        "!{workspaceRoot}/packages/react-components/*/stories/**/index.stories.{ts,tsx}",
+        "{workspaceRoot}/packages/react-components/*/stories/**/*.stories.ts(x)?",
+        "!{workspaceRoot}/packages/react-components/*/stories/**/index.stories.ts(x)?",
         "!{workspaceRoot}/packages/react-components/react-migration-v[80]-v9/**",
         "!{workspaceRoot}/packages/react-components/react-[a-z]+-compat/**"
       ]
@@ -19,7 +19,7 @@
       "dependsOn": [],
       "inputs": [
         "{projectRoot}/cypress-react-17.config.ts",
-        "{workspaceRoot}/packages/react-components/**/*.cy.{ts,tsx}",
+        "{workspaceRoot}/packages/react-components/**/*.cy.ts(x)?",
         "!{workspaceRoot}/packages/react-components/react-migration-v[80]-v9/**",
         "!{workspaceRoot}/packages/react-components/react-[a-z]+-compat/**"
       ]

--- a/apps/react-18-tests-v9/project.json
+++ b/apps/react-18-tests-v9/project.json
@@ -9,8 +9,8 @@
       "dependsOn": ["^build"],
       "inputs": [
         "{projectRoot}/tsconfig.react-18.json",
-        "{workspaceRoot}/packages/react-components/*/stories/**/*.stories.{ts,tsx}",
-        "!{workspaceRoot}/packages/react-components/*/stories/**/index.stories.{ts,tsx}",
+        "{workspaceRoot}/packages/react-components/*/stories/**/*.stories.ts(x)?",
+        "!{workspaceRoot}/packages/react-components/*/stories/**/index.stories.ts(x)?",
         "!{workspaceRoot}/packages/react-components/react-migration-v[80]-v9/**",
         "!{workspaceRoot}/packages/react-components/react-[a-z]+-compat/**"
       ]
@@ -19,7 +19,7 @@
       "dependsOn": [],
       "inputs": [
         "{projectRoot}/cypress-react-18.config.ts",
-        "{workspaceRoot}/packages/react-components/**/*.cy.{ts,tsx}",
+        "{workspaceRoot}/packages/react-components/**/*.cy.ts(x)?",
         "!{workspaceRoot}/packages/react-components/react-migration-v[80]-v9/**",
         "!{workspaceRoot}/packages/react-components/react-[a-z]+-compat/**"
       ]

--- a/apps/react-19-tests-v9/project.json
+++ b/apps/react-19-tests-v9/project.json
@@ -9,8 +9,8 @@
       "dependsOn": ["^build"],
       "inputs": [
         "{projectRoot}/tsconfig.react-19.json",
-        "{workspaceRoot}/packages/react-components/*/stories/**/*.stories.{ts,tsx}",
-        "!{workspaceRoot}/packages/react-components/*/stories/**/index.stories.{ts,tsx}",
+        "{workspaceRoot}/packages/react-components/*/stories/**/*.stories.ts(x)?",
+        "!{workspaceRoot}/packages/react-components/*/stories/**/index.stories.ts(x)?",
         "!{workspaceRoot}/packages/react-components/react-migration-v[80]-v9/**",
         "!{workspaceRoot}/packages/react-components/react-[a-z]+-compat/**"
       ]
@@ -19,7 +19,7 @@
       "dependsOn": [],
       "inputs": [
         "{projectRoot}/cypress-react-19.config.ts",
-        "{workspaceRoot}/packages/react-components/**/*.cy.{ts,tsx}",
+        "{workspaceRoot}/packages/react-components/**/*.cy.ts(x)?",
         "!{workspaceRoot}/packages/react-components/react-migration-v[80]-v9/**",
         "!{workspaceRoot}/packages/react-components/react-[a-z]+-compat/**"
       ]


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

- ❌ *.stories.tsx? - Unreliable matching due to incorrect ? usage

## New Behavior

fixes invalid glob to:

- ✅ *.stories.ts(x)? - Proper optional group syntax that matches both .ts and .tsx

now integration project targets are triggered as expected when story files matching the input chache globs are changed

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/pull/34722/files#r2168739340
