### PR TITLE
feat(workspace-plugin): add `enableGriffelRawStyles` config support for `build` executor

### DIFF
--- a/tools/workspace-plugin/src/executors/build/executor.spec.ts
+++ b/tools/workspace-plugin/src/executors/build/executor.spec.ts
@@ -76,15 +76,6 @@ const measureEndMock = measureEnd as jest.Mock;
 
 describe('Build Executor', () => {
   it('runs build and api-generation and fails on api update', async () => {
-    // mute api extractor - START
-    jest.spyOn(console, 'warn').mockImplementation(() => {
-      return;
-    });
-    jest.spyOn(console, 'log').mockImplementation(() => {
-      return;
-    });
-    // mute api extractor - END
-
     const loggerLogSpy = jest.spyOn(logger, 'log').mockImplementation(() => {
       return;
     });
@@ -287,4 +278,103 @@ describe('Build Executor', () => {
       process.env.CI = existingEnvVariableCi;
     }
   }, 60000);
+
+  describe(`#enableGriffelRawStyles`, () => {
+    beforeEach(() => {
+      // mute api extractor - START
+      jest.spyOn(console, 'log').mockImplementation(() => {
+        return;
+      });
+      jest.spyOn(console, 'warn').mockImplementation(() => {
+        return;
+      });
+      // mute api extractor - END
+    });
+
+    it('generates raw styles files when enableGriffelRawStyles is enabled', async () => {
+      const optionsWithRawStyles: BuildExecutorSchema = {
+        ...options,
+        enableGriffelRawStyles: true,
+      };
+
+      const output = await executor(optionsWithRawStyles, context);
+      expect(output.success).toBe(true);
+
+      // =====================
+      // assert raw styles files are generated
+      // =====================
+      expect(existsSync(join(workspaceRoot, 'libs/proj/lib/greeter.styles.raw.js'))).toBe(true);
+      expect(existsSync(join(workspaceRoot, 'libs/proj/lib/greeter.styles.raw.js.map'))).toBe(true);
+      expect(existsSync(join(workspaceRoot, 'libs/proj/lib-commonjs/greeter.styles.raw.js'))).toBe(true);
+      expect(existsSync(join(workspaceRoot, 'libs/proj/lib-commonjs/greeter.styles.raw.js.map'))).toBe(true);
+
+      // =====================
+      // assert raw styles content matches the original SWC-compiled styles (before Griffel transformation)
+      // =====================
+      expect(readFileSync(join(workspaceRoot, 'libs/proj/lib/greeter.styles.raw.js'), 'utf-8')).toMatchInlineSnapshot(`
+      "import { makeStyles } from '@griffel/react';
+      export const useStyles = makeStyles({
+          root: {
+              color: 'red'
+          }
+      });
+      "
+    `);
+      expect(readFileSync(join(workspaceRoot, 'libs/proj/lib-commonjs/greeter.styles.raw.js'), 'utf-8'))
+        .toMatchInlineSnapshot(`
+      "\\"use strict\\";
+      Object.defineProperty(exports, \\"__esModule\\", {
+          value: true
+      });
+      Object.defineProperty(exports, \\"useStyles\\", {
+          enumerable: true,
+          get: function() {
+              return useStyles;
+          }
+      });
+      const _react = require(\\"@griffel/react\\");
+      const useStyles = (0, _react.makeStyles)({
+          root: {
+              color: 'red'
+          }
+      });
+      "
+    `);
+
+      // =====================
+      // showcase that babel transformation creates invalid source map - which differs with raw styles source maps produced by SWC-compiled source maps (before Griffel transformation)
+      // =====================
+      const originalMapContent = readFileSync(join(workspaceRoot, 'libs/proj/lib/greeter.styles.js.map'), 'utf-8');
+      const rawMapContent = readFileSync(join(workspaceRoot, 'libs/proj/lib/greeter.styles.raw.js.map'), 'utf-8');
+      expect(rawMapContent).not.toBe(originalMapContent);
+
+      const originalMapContentCommonjs = readFileSync(
+        join(workspaceRoot, 'libs/proj/lib-commonjs/greeter.styles.js.map'),
+        'utf-8',
+      );
+      const rawMapContentCommonjs = readFileSync(
+        join(workspaceRoot, 'libs/proj/lib-commonjs/greeter.styles.raw.js.map'),
+        'utf-8',
+      );
+      expect(rawMapContentCommonjs).not.toBe(originalMapContentCommonjs);
+    }, 60000);
+
+    it('does not generate raw styles files when enableGriffelRawStyles is disabled', async () => {
+      const optionsWithoutRawStyles: BuildExecutorSchema = {
+        ...options,
+        enableGriffelRawStyles: false,
+      };
+
+      const output = await executor(optionsWithoutRawStyles, context);
+      expect(output.success).toBe(true);
+
+      // =====================
+      // assert raw styles files are NOT generated
+      // =====================
+      expect(existsSync(join(workspaceRoot, 'libs/proj/lib/greeter.styles.raw.js'))).toBe(false);
+      expect(existsSync(join(workspaceRoot, 'libs/proj/lib/greeter.styles.raw.js.map'))).toBe(false);
+      expect(existsSync(join(workspaceRoot, 'libs/proj/lib-commonjs/greeter.styles.raw.js'))).toBe(false);
+      expect(existsSync(join(workspaceRoot, 'libs/proj/lib-commonjs/greeter.styles.raw.js.map'))).toBe(false);
+    }, 60000);
+  });
 });

--- a/tools/workspace-plugin/src/executors/build/lib/file-processor.ts
+++ b/tools/workspace-plugin/src/executors/build/lib/file-processor.ts
@@ -1,0 +1,25 @@
+import { copyFile } from 'node:fs/promises';
+
+export interface FileProcessor {
+  shouldProcess(filePath: string): boolean;
+  process(filePath: string): Promise<void>;
+}
+
+export class GriffelRawStylesProcessor implements FileProcessor {
+  shouldProcess(filePath: string): boolean {
+    return filePath.includes('.styles.js');
+  }
+
+  async process(filePath: string): Promise<void> {
+    const rawFilePath = filePath.replace('.styles.', '.styles.raw.');
+    await copyFile(filePath, rawFilePath);
+  }
+}
+
+export async function applyFileProcessors(filePath: string, processors: FileProcessor[]): Promise<void> {
+  for (const processor of processors) {
+    if (processor.shouldProcess(filePath)) {
+      await processor.process(filePath);
+    }
+  }
+}

--- a/tools/workspace-plugin/src/executors/build/lib/shared.ts
+++ b/tools/workspace-plugin/src/executors/build/lib/shared.ts
@@ -51,6 +51,7 @@ export function normalizeOptions(schema: BuildExecutorSchema, context: ExecutorC
   const absoluteProjectRoot = join(context.root, project.root);
   const absoluteSourceRoot = join(context.root, resolvedSourceRoot);
   const absoluteOutputPathRoot = join(context.root, schema.outputPathRoot);
+  const enableGriffelRawStyles = schema.enableGriffelRawStyles ?? false;
 
   return {
     ...defaults,
@@ -60,6 +61,7 @@ export function normalizeOptions(schema: BuildExecutorSchema, context: ExecutorC
     absoluteSourceRoot,
     absoluteProjectRoot,
     absoluteOutputPathRoot,
+    enableGriffelRawStyles,
 
     workspaceRoot: context.root,
   };

--- a/tools/workspace-plugin/src/executors/build/schema.d.ts
+++ b/tools/workspace-plugin/src/executors/build/schema.d.ts
@@ -35,6 +35,11 @@ export interface BuildExecutorSchema {
    */
   generateApi?: boolean;
   /**
+   * Enable Griffel raw styles output.
+   * This will generate additional files with '.styles.raw.js' extension that contain Griffel raw styles
+   */
+  enableGriffelRawStyles?: boolean;
+  /**
    * List of static assets.
    */
   assets?: (

--- a/tools/workspace-plugin/src/executors/build/schema.json
+++ b/tools/workspace-plugin/src/executors/build/schema.json
@@ -33,6 +33,11 @@
       "description": "Generate rolluped 'd.ts' bundle including 'api.md' that provides project public API",
       "default": true
     },
+    "enableGriffelRawStyles": {
+      "type": "boolean",
+      "description": "Enable Griffel raw styles output. This will generate additional files with '.styles.raw.js' extension that contain Griffel raw styles",
+      "default": false
+    },
     "assets": {
       "type": "array",
       "description": "List of static assets.",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

Introduces opt-in support for `build` executor to generate Griffel raw styles files 

**Configuration:**

> - new `enableGriffelRawStyles` schema option 
> - `false` by default


1. via `nx.json#targetDefaults` to enable for every `build` target

```json
{
"build": {
      "options" {
          "enableGriffelRawStyles": true
       } 
    },
}
```

2. via local `project.json` or CLI parameter

```sh
yarn nx run react-text:build --enableGriffelRawStyles
```

**Usage:**

If this flag is enabled production assets will contain unprocessed (raw) griffel style module file (without griffel babel transform applied )

Default output:

```
|- lib/
   - useText.styles.js
```

Enabled `enableGriffelRawStyles` output:
```
|- lib/
   - useText.styles.js
   - useText.styles.raw.js
```


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows https://github.com/microsoft/fluentui/blob/master/docs/react-v9/contributing/rfcs/shared/build-system/stop-styles-transforms.md
