### PR TITLE
fix: remove useEffect storybook/preview-api and directly trigger 'Open in ...' button rendering

### DIFF
--- a/packages/react-components/react-storybook-addon-export-to-sandbox/src/decorators/with-export-to-sandbox-button.ts
+++ b/packages/react-components/react-storybook-addon-export-to-sandbox/src/decorators/with-export-to-sandbox-button.ts
@@ -1,4 +1,3 @@
-import { useEffect } from '@storybook/preview-api';
 import { addDemoActionButton } from '../sandbox-factory';
 
 import { StoryContext } from '../types';
@@ -8,11 +7,9 @@ export const withExportToSandboxButton = (
   JSX.Element,
   context: StoryContext,
 ) => {
-  useEffect(() => {
-    if (context.viewMode === 'docs') {
-      addDemoActionButton(context);
-    }
-  }, [context]);
+  if (context.viewMode === 'docs') {
+    addDemoActionButton(context);
+  }
 
   return storyFn(context);
 };


### PR DESCRIPTION


<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
