### PR TITLE
fix(react-menu): fix regression with ".hoverDelay" handling

### DIFF
--- a/change/@fluentui-react-menu-ec4c6227-fd16-4811-9405-63bc55a2e65e.json
+++ b/change/@fluentui-react-menu-ec4c6227-fd16-4811-9405-63bc55a2e65e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: resolve regression with \".hoverDelay\" handling",
+  "packageName": "@fluentui/react-menu",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-menu/library/etc/react-menu.api.md
+++ b/packages/react-components/react-menu/library/etc/react-menu.api.md
@@ -383,7 +383,9 @@ export type MenuState = ComponentState<MenuSlots> & Required<Pick<MenuProps, 'ha
     menuPopoverRef: React_2.MutableRefObject<HTMLElement>;
     menuTrigger: React_2.ReactNode;
     setContextTarget: SetVirtualMouseTarget;
-    setOpen: (e: MenuOpenEvent, data: MenuOpenChangeData) => void;
+    setOpen: (e: MenuOpenEvent, data: MenuOpenChangeData & {
+        ignoreHoverDelay?: boolean;
+    }) => void;
     triggerId: string;
     triggerRef: React_2.MutableRefObject<HTMLElement>;
     onOpenChange?: (e: MenuOpenEvent, data: MenuOpenChangeData) => void;

--- a/packages/react-components/react-menu/library/src/components/Menu/Menu.cy.tsx
+++ b/packages/react-components/react-menu/library/src/components/Menu/Menu.cy.tsx
@@ -708,11 +708,11 @@ describe(`Nested Menus`, () => {
   const MenuL22Uncontrolled = () => (
     <Menu>
       <MenuTrigger disableButtonEnhancement>
-        <MenuItem>Editor Layout</MenuItem>
+        <MenuItem id="menu-l2-2-trigger">Editor Layout</MenuItem>
       </MenuTrigger>
 
       <MenuPopover>
-        <MenuList>
+        <MenuList id="menu-l2-2">
           <MenuItem>Split Up</MenuItem>
           <MenuItem>Split Down</MenuItem>
           <MenuItem>Single</MenuItem>
@@ -721,14 +721,14 @@ describe(`Nested Menus`, () => {
     </Menu>
   );
 
-  const MenuL2Uncontrolled = () => (
+  const MenuL21Uncontrolled = () => (
     <Menu>
       <MenuTrigger disableButtonEnhancement>
-        <MenuItem>Appearance</MenuItem>
+        <MenuItem id="menu-l2-1-trigger">Appearance</MenuItem>
       </MenuTrigger>
 
       <MenuPopover>
-        <MenuList>
+        <MenuList id="menu-l2-1">
           <MenuItem>Centered Layout</MenuItem>
           <MenuItem>Zen</MenuItem>
           <MenuItem disabled>Zoom In</MenuItem>
@@ -741,15 +741,15 @@ describe(`Nested Menus`, () => {
   const MenuL1Uncontrolled = () => (
     <Menu>
       <MenuTrigger disableButtonEnhancement>
-        <MenuItem>Preferences</MenuItem>
+        <MenuItem id="menu-l1-trigger">Preferences</MenuItem>
       </MenuTrigger>
 
       <MenuPopover>
-        <MenuList>
+        <MenuList id="menu-l1">
           <MenuItem>Settings</MenuItem>
           <MenuItem>Online Services Settings</MenuItem>
           <MenuItem>Extensions</MenuItem>
-          <MenuL2Uncontrolled />
+          <MenuL21Uncontrolled />
           <MenuL22Uncontrolled />
         </MenuList>
       </MenuPopover>
@@ -764,7 +764,7 @@ describe(`Nested Menus`, () => {
 
       <MenuPopover>
         <MenuList>
-          <MenuItem>New </MenuItem>
+          <MenuItem>New</MenuItem>
           <MenuItem>New Window</MenuItem>
           <MenuItem disabled>Open File</MenuItem>
           <MenuItem>Open Folder</MenuItem>
@@ -773,6 +773,29 @@ describe(`Nested Menus`, () => {
       </MenuPopover>
     </Menu>
   );
+
+  const MenuL21Controlled = () => {
+    const [open, setOpen] = React.useState(false);
+    const onOpenChange: MenuProps['onOpenChange'] = (e, data) => {
+      setOpen(data.open);
+    };
+
+    return (
+      <Menu open={open} onOpenChange={onOpenChange}>
+        <MenuTrigger disableButtonEnhancement>
+          <MenuItem id="menu-l2-1-trigger">Editor Layout</MenuItem>
+        </MenuTrigger>
+
+        <MenuPopover>
+          <MenuList id="menu-l2-1">
+            <MenuItem>Split Up</MenuItem>
+            <MenuItem>Split Down</MenuItem>
+            <MenuItem>Single</MenuItem>
+          </MenuList>
+        </MenuPopover>
+      </Menu>
+    );
+  };
 
   const MenuL22Controlled = () => {
     const [open, setOpen] = React.useState(false);
@@ -783,34 +806,11 @@ describe(`Nested Menus`, () => {
     return (
       <Menu open={open} onOpenChange={onOpenChange}>
         <MenuTrigger disableButtonEnhancement>
-          <MenuItem>Editor Layout</MenuItem>
+          <MenuItem id="menu-l2-2-trigger">Appearance</MenuItem>
         </MenuTrigger>
 
         <MenuPopover>
-          <MenuList>
-            <MenuItem>Split Up</MenuItem>
-            <MenuItem>Split Down</MenuItem>
-            <MenuItem>Single</MenuItem>
-          </MenuList>
-        </MenuPopover>
-      </Menu>
-    );
-  };
-
-  const MenuL2Controlled = () => {
-    const [open, setOpen] = React.useState(false);
-    const onOpenChange: MenuProps['onOpenChange'] = (e, data) => {
-      setOpen(data.open);
-    };
-
-    return (
-      <Menu open={open} onOpenChange={onOpenChange}>
-        <MenuTrigger disableButtonEnhancement>
-          <MenuItem>Appearance</MenuItem>
-        </MenuTrigger>
-
-        <MenuPopover>
-          <MenuList>
+          <MenuList id="menu-l2-2">
             <MenuItem>Centered Layout</MenuItem>
             <MenuItem>Zen</MenuItem>
             <MenuItem disabled>Zoom In</MenuItem>
@@ -830,16 +830,16 @@ describe(`Nested Menus`, () => {
     return (
       <Menu open={open} onOpenChange={onOpenChange}>
         <MenuTrigger disableButtonEnhancement>
-          <MenuItem>Preferences</MenuItem>
+          <MenuItem id="menu-l1-trigger">Preferences</MenuItem>
         </MenuTrigger>
 
         <MenuPopover>
-          <MenuList>
+          <MenuList id="menu-l1">
             <MenuItem>Settings</MenuItem>
             <MenuItem>Online Services Settings</MenuItem>
             <MenuItem>Extensions</MenuItem>
+            <MenuL21Controlled />
             <MenuL22Controlled />
-            <MenuL2Controlled />
           </MenuList>
         </MenuPopover>
       </Menu>
@@ -855,7 +855,7 @@ describe(`Nested Menus`, () => {
 
         <MenuPopover>
           <MenuList>
-            <MenuItem>New </MenuItem>
+            <MenuItem>New</MenuItem>
             <MenuItem>New Window</MenuItem>
             <MenuItem disabled>Open File</MenuItem>
             <MenuItem>Open Folder</MenuItem>
@@ -1038,6 +1038,25 @@ describe(`Nested Menus`, () => {
           .eq(1)
           .realPress(['Shift', 'Tab']);
         cy.contains('Before').should('be.focused').get(menuSelector).should('not.exist');
+      });
+
+      it('respects ".hoverDelay" for opening via hover', () => {
+        mount(<Example />);
+
+        cy.get(menuTriggerSelector).click();
+
+        cy.get('#menu-l1-trigger').realHover();
+        cy.get('#menu-l1').should('be.visible');
+
+        cy.get('#menu-l2-2-trigger').realHover();
+        cy.get('#menu-l2-2').should('be.visible');
+
+        // Quickly hover over the second item to ensure it doesn't open due to the timeout
+        cy.get('#menu-l2-1-trigger').realHover();
+        cy.get('#menu-l2-2-trigger').realHover();
+
+        cy.get('#menu-l2-1').should('not.exist');
+        cy.get('#menu-l2-2').should('be.visible');
       });
     });
   });

--- a/packages/react-components/react-menu/library/src/components/Menu/Menu.types.ts
+++ b/packages/react-components/react-menu/library/src/components/Menu/Menu.types.ts
@@ -143,7 +143,7 @@ export type MenuState = ComponentState<MenuSlots> &
     /**
      * Callback to open/close the popup
      */
-    setOpen: (e: MenuOpenEvent, data: MenuOpenChangeData) => void;
+    setOpen: (e: MenuOpenEvent, data: MenuOpenChangeData & { ignoreHoverDelay?: boolean }) => void;
 
     /**
      * Id for the MenuTrigger element for aria relationship

--- a/packages/react-components/react-menu/library/src/components/Menu/useMenu.tsx
+++ b/packages/react-components/react-menu/library/src/components/Menu/useMenu.tsx
@@ -105,7 +105,7 @@ export const useMenu_unstable = (props: MenuProps & { safeZone?: boolean }): Men
 
   const safeZoneHandle = useSafeZoneArea({
     disabled: !enableSafeZone,
-    timeout: 1500,
+    timeout: 1000,
 
     onSafeZoneEnter: e => {
       setOpen(e, { open: true, keyboard: false, type: 'menuSafeZoneMouseEnter', event: e });
@@ -260,16 +260,20 @@ const useMenuOpenState = (
 
   const [setOpenTimeout, clearOpenTimeout] = useTimeout();
 
-  const setOpen = useEventCallback((e: MenuOpenEvent, data: MenuOpenChangeData) => {
+  const setOpen = useEventCallback((e: MenuOpenEvent, data: MenuOpenChangeData & { ignoreHoverDelay?: boolean }) => {
     clearOpenTimeout();
     if (!(e instanceof Event) && e.persist) {
       // < React 17 still uses pooled synthetic events
       e.persist();
     }
 
-    if (e.type === 'mouseleave' || e.type === 'mouseenter' || e.type === 'mousemove' || e.type === MENU_ENTER_EVENT) {
+    const shouldUseDelay =
+      !data.ignoreHoverDelay &&
+      (e.type === 'mouseleave' || e.type === 'mouseover' || e.type === 'mousemove' || e.type === MENU_ENTER_EVENT);
+
+    if (shouldUseDelay) {
       if (state.triggerRef.current?.contains(e.target as HTMLElement)) {
-        enteringTriggerRef.current = e.type === 'mouseenter' || e.type === 'mousemove';
+        enteringTriggerRef.current = e.type === 'mouseover' || e.type === 'mousemove';
       }
 
       setOpenTimeout(() => trySetOpen(e, data), state.hoverDelay);

--- a/packages/react-components/react-menu/library/src/components/MenuTrigger/useMenuTrigger.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuTrigger/useMenuTrigger.ts
@@ -46,7 +46,8 @@ export const useMenuTrigger_unstable = (props: MenuTriggerProps): MenuTriggerSta
   }, [findFirstFocusable, menuPopoverRef]);
 
   const openedWithKeyboardRef = React.useRef(false);
-  const hasMouseMoved = React.useRef(false);
+  const openedViaSafeZoneRef = React.useRef(false);
+  const hasMouseMovedRef = React.useRef(false);
 
   const { dir } = useFluent();
   const OpenArrowKey = dir === 'ltr' ? ArrowRight : ArrowLeft;
@@ -60,7 +61,7 @@ export const useMenuTrigger_unstable = (props: MenuTriggerProps): MenuTriggerSta
   const safeZoneHandlerRef = useOnMenuSafeZoneTimeout(
     useEventCallback(() => {
       if (isSubmenu) {
-        hasMouseMoved.current = true;
+        openedViaSafeZoneRef.current = true;
       }
     }),
   );
@@ -112,8 +113,14 @@ export const useMenuTrigger_unstable = (props: MenuTriggerProps): MenuTriggerSta
     if (isTargetDisabled(event)) {
       return;
     }
-    if (openOnHover && hasMouseMoved.current) {
-      setOpen(event, { open: true, keyboard: false, type: 'menuTriggerMouseEnter', event });
+
+    if (openOnHover) {
+      if (hasMouseMovedRef.current) {
+        setOpen(event, { open: true, keyboard: false, type: 'menuTriggerMouseEnter', event });
+      } else if (openedViaSafeZoneRef.current) {
+        setOpen(event, { open: true, keyboard: false, ignoreHoverDelay: true, type: 'menuTriggerMouseEnter', event });
+        openedViaSafeZoneRef.current = false;
+      }
     }
   };
 
@@ -124,9 +131,9 @@ export const useMenuTrigger_unstable = (props: MenuTriggerProps): MenuTriggerSta
     if (isTargetDisabled(event)) {
       return;
     }
-    if (openOnHover && !hasMouseMoved.current) {
+    if (openOnHover && !hasMouseMovedRef.current) {
       setOpen(event, { open: true, keyboard: false, type: 'menuTriggerMouseMove', event });
-      hasMouseMoved.current = true;
+      hasMouseMovedRef.current = true;
     }
   };
 


### PR DESCRIPTION
This PR a regression in the behavior of `.hoverDelay` after #34457: the previous PR switched to `mouseover` events while `setOpen()` in `useMenu()` was not updated to handle this event.

### Before (regressed)

https://github.com/user-attachments/assets/8417aabc-2ea4-4552-9e9b-8b778cdbac9e

### After

https://github.com/user-attachments/assets/d1b63e8d-0b2e-44f1-b0b8-5cfe421ae1e9

---

### Changes for safe zone handling

`MenuItem` should trigger an instant opening of a `Menu` (i.e. ignore `.hoverDelay`) if an event comes from a safe zone timeout. To do so:
- Updated the `setOpen` method to include an `ignoreHoverDelay` flag
- Added `openedViaSafeZoneRef` to track safe zone interactions 

Also reduced the safe zone timeout from 1500ms to 1000ms for quicker responsiveness based on feedback (we should make this configurable?).

Tests added.
