### PR TITLE
fix(react-menu): Fix disabled styles for `secondaryContent` and `subText`

### DIFF
--- a/change/@fluentui-react-menu-838fbd3c-a5f1-4cee-986e-5ed3232d6691.json
+++ b/change/@fluentui-react-menu-838fbd3c-a5f1-4cee-986e-5ed3232d6691.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(react-menu): Fix disabled styles for secondaryContent and subText",
+  "packageName": "@fluentui/react-menu",
+  "email": "jiangemma@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-menu/library/src/components/MenuItem/useMenuItemStyles.styles.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuItem/useMenuItemStyles.styles.ts
@@ -147,9 +147,6 @@ const useStyles = makeStyles({
   },
   disabled: {
     color: tokens.colorNeutralForegroundDisabled,
-    [`& .${menuItemClassNames.subText}`]: {
-      color: tokens.colorNeutralForegroundDisabled,
-    },
     ':hover': {
       color: tokens.colorNeutralForegroundDisabled,
       backgroundColor: tokens.colorNeutralBackground1,
@@ -183,9 +180,6 @@ const useStyles = makeStyles({
 
     '@media (forced-colors: active)': {
       color: 'GrayText',
-      [`& .${menuItemClassNames.subText}`]: {
-        color: 'GrayText',
-      },
       ':hover': {
         color: 'GrayText',
         backgroundColor: 'Canvas',
@@ -208,6 +202,16 @@ const useStyles = makeStyles({
         color: 'GrayText',
         backgroundColor: 'Canvas',
       },
+    },
+  },
+});
+
+const useSubTextStyles = makeStyles({
+  disabled: {
+    color: tokens.colorNeutralForegroundDisabled,
+
+    '@media (forced-colors: active)': {
+      color: 'GrayText',
     },
   },
 });
@@ -239,6 +243,7 @@ export const useMenuItemStyles_unstable = (state: MenuItemState): MenuItemState 
   const submenuIndicatorBaseStyles = useSubmenuIndicatorBaseStyles();
   const multilineStyles = useMultilineStyles();
   const subtextBaseStyles = useSubtextBaseStyles();
+  const subTextStyles = useSubTextStyles();
   const multiline = !!state.subText;
   state.root.className = mergeClasses(
     menuItemClassNames.root,
@@ -284,7 +289,12 @@ export const useMenuItemStyles_unstable = (state: MenuItemState): MenuItemState 
   }
 
   if (state.subText) {
-    state.subText.className = mergeClasses(menuItemClassNames.subText, state.subText.className, subtextBaseStyles);
+    state.subText.className = mergeClasses(
+      menuItemClassNames.subText,
+      state.disabled && subTextStyles.disabled,
+      state.subText.className,
+      subtextBaseStyles,
+    );
   }
 
   useCheckmarkStyles_unstable(state as MenuItemCheckboxState);

--- a/packages/react-components/react-menu/library/src/components/MenuItem/useMenuItemStyles.styles.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuItem/useMenuItemStyles.styles.ts
@@ -199,6 +199,7 @@ const useStyles = makeStyles({
       },
       ':hover:active': {
         color: 'GrayText',
+        backgroundColor: 'Canvas',
         [`& .${menuItemClassNames.subText}`]: {
           color: 'GrayText',
         },

--- a/packages/react-components/react-menu/library/src/components/MenuItem/useMenuItemStyles.styles.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuItem/useMenuItemStyles.styles.ts
@@ -147,6 +147,9 @@ const useStyles = makeStyles({
   },
   disabled: {
     color: tokens.colorNeutralForegroundDisabled,
+    [`& .${menuItemClassNames.subText}`]: {
+      color: tokens.colorNeutralForegroundDisabled,
+    },
     ':hover': {
       color: tokens.colorNeutralForegroundDisabled,
       backgroundColor: tokens.colorNeutralBackground1,
@@ -160,11 +163,18 @@ const useStyles = makeStyles({
       [`& .${menuItemClassNames.icon}`]: {
         color: tokens.colorNeutralForegroundDisabled,
       },
+      [`& .${menuItemClassNames.subText}`]: {
+        color: tokens.colorNeutralForegroundDisabled,
+      },
     },
 
     ':hover:active': {
       color: tokens.colorNeutralForegroundDisabled,
       backgroundColor: tokens.colorNeutralBackground1,
+
+      [`& .${menuItemClassNames.subText}`]: {
+        color: tokens.colorNeutralForegroundDisabled,
+      },
     },
 
     ':focus': {
@@ -173,12 +183,24 @@ const useStyles = makeStyles({
 
     '@media (forced-colors: active)': {
       color: 'GrayText',
+      [`& .${menuItemClassNames.subText}`]: {
+        color: 'GrayText',
+      },
       ':hover': {
         color: 'GrayText',
         backgroundColor: 'Canvas',
         [`& .${menuItemClassNames.icon}`]: {
           color: 'GrayText',
           backgroundColor: 'Canvas',
+        },
+        [`& .${menuItemClassNames.subText}`]: {
+          color: 'GrayText',
+        },
+      },
+      ':hover:active': {
+        color: 'GrayText',
+        [`& .${menuItemClassNames.subText}`]: {
+          color: 'GrayText',
         },
       },
       ':focus': {
@@ -240,7 +262,8 @@ export const useMenuItemStyles_unstable = (state: MenuItemState): MenuItemState 
   if (state.secondaryContent) {
     state.secondaryContent.className = mergeClasses(
       menuItemClassNames.secondaryContent,
-      !state.disabled && secondaryContentBaseStyles,
+      secondaryContentBaseStyles,
+      state.disabled && styles.disabled,
       state.secondaryContent.className,
       multiline && multilineStyles.secondaryContent,
     );

--- a/packages/react-components/react-menu/stories/src/Menu/MenuMultilineItems.stories.tsx
+++ b/packages/react-components/react-menu/stories/src/Menu/MenuMultilineItems.stories.tsx
@@ -8,11 +8,14 @@ import {
   CutFilled,
   ClipboardPasteRegular,
   ClipboardPasteFilled,
+  DeleteFilled,
+  DeleteRegular,
 } from '@fluentui/react-icons';
 
 const EditIcon = bundleIcon(EditFilled, EditRegular);
 const CutIcon = bundleIcon(CutFilled, CutRegular);
 const PasteIcon = bundleIcon(ClipboardPasteFilled, ClipboardPasteRegular);
+const DeleteIcon = bundleIcon(DeleteFilled, DeleteRegular);
 
 export const MultilineItems = () => {
   return (
@@ -28,8 +31,11 @@ export const MultilineItems = () => {
           <MenuItem subText="Paste from clipboard" icon={<PasteIcon />}>
             Paste
           </MenuItem>
-          <MenuItem subText="Edit file" icon={<EditIcon />}>
+          <MenuItem subText="Edit file" icon={<EditIcon />} disabled>
             Edit
+          </MenuItem>
+          <MenuItem subText="Delete file" icon={<DeleteIcon />}>
+            Delete
           </MenuItem>
         </MenuList>
       </MenuPopover>

--- a/packages/react-components/react-menu/stories/src/Menu/MenuSecondaryContentForMenuItems.stories.tsx
+++ b/packages/react-components/react-menu/stories/src/Menu/MenuSecondaryContentForMenuItems.stories.tsx
@@ -12,6 +12,9 @@ export const SecondaryContentForMenuItems = () => (
       <MenuList>
         <MenuItem secondaryContent="Ctrl+N">New File</MenuItem>
         <MenuItem secondaryContent="Ctrl+Shift+N">New Window</MenuItem>
+        <MenuItem secondaryContent="Ctrl+T" disabled>
+          New Tab
+        </MenuItem>
         <MenuItem secondaryContent="Ctrl+O">Open File</MenuItem>
       </MenuList>
     </MenuPopover>


### PR DESCRIPTION
## Previous Behavior

Disabled `secondaryText` has different font size. Had hover+active state in HCM when it shouldn't. Did not have disabled appearance in storybook.
<img width="238" alt="image" src="https://github.com/user-attachments/assets/22136ff3-fb19-4316-9713-626e3e9ad77c" /><img width="237" alt="image" src="https://github.com/user-attachments/assets/f5a6109c-5fc4-464c-b4f3-feae04ee5267" />

Disabled `subText` did not have disabled appearance, not in HCM either. Had hover+active state in HCM. Had hover+active state in HCM when it shouldn't. Did not have disabled appearance in storybook.
<img width="197" alt="image" src="https://github.com/user-attachments/assets/65dfd0d2-8f24-454c-b75d-3c43408b8d74" /><img width="193" alt="image" src="https://github.com/user-attachments/assets/71e9d7d7-9578-45e1-ad05-38c3529318d7" />

## New Behavior
<img width="236" alt="image" src="https://github.com/user-attachments/assets/0575b59a-33e9-4141-a30f-7c1bbad3a4fb" /><img width="234" alt="image" src="https://github.com/user-attachments/assets/6c8c06ab-eebb-4ff3-8864-81a715b8f9d3" />

<img width="190" alt="image" src="https://github.com/user-attachments/assets/d836fe24-0478-493f-b3a0-010d35a7f1d4" /><img width="194" alt="image" src="https://github.com/user-attachments/assets/39b1d74a-e5cc-40f0-94d7-fe0171f18832" />

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes N/A
