### PR TITLE
fix(workspace-plugin): add proper input cache globs for bundle-size target

### DIFF
--- a/tools/workspace-plugin/src/plugins/workspace-plugin.ts
+++ b/tools/workspace-plugin/src/plugins/workspace-plugin.ts
@@ -364,6 +364,8 @@ function buildBundleSizeTarget(
     command: `${config.pmc.exec} monosize measure`,
     options: { cwd: projectRoot },
     inputs: [
+      `{workspaceRoot}/monosize.config.mjs`,
+      `{projectRoot}/monosize.config.mjs`,
       `{projectRoot}/bundle-size`,
       `{projectRoot}/src/**/*.tsx?`,
       { externalDependencies: ['monosize', 'monosize-bundler-webpack'] },


### PR DESCRIPTION

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

adding/modifying monosize configs wont invalidate the cache for `bundle-size` target

## New Behavior

adding/modifying monosize configs properly invalidates the cache for `bundle-size` target

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
