### PR TITLE
fix: MessageBarActions renders slots with keys

### DIFF
--- a/packages/react-components/react-message-bar/library/cypress.config.ts
+++ b/packages/react-components/react-message-bar/library/cypress.config.ts
@@ -1,0 +1,3 @@
+import { baseConfig } from '@fluentui/scripts-cypress';
+
+export default baseConfig;

--- a/packages/react-components/react-message-bar/library/package.json
+++ b/packages/react-components/react-message-bar/library/package.json
@@ -15,7 +15,8 @@
     "@fluentui/eslint-plugin": "*",
     "@fluentui/react-conformance": "*",
     "@fluentui/react-conformance-griffel": "*",
-    "@fluentui/scripts-api-extractor": "*"
+    "@fluentui/scripts-api-extractor": "*",
+    "@fluentui/scripts-cypress": "*"
   },
   "dependencies": {
     "@fluentui/react-button": "^9.5.3",

--- a/packages/react-components/react-message-bar/library/src/components/MessageBar/MessageBar.cy.tsx
+++ b/packages/react-components/react-message-bar/library/src/components/MessageBar/MessageBar.cy.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import { mount as mountBase } from '@cypress/react';
+
+import { FluentProvider } from '@fluentui/react-provider';
+import { teamsLightTheme } from '@fluentui/react-theme';
+
+import { MessageBar, MessageBarActions, MessageBarBody, MessageBarTitle } from '@fluentui/react-message-bar';
+
+const mount = (element: JSX.Element) => {
+  mountBase(<FluentProvider theme={teamsLightTheme}>{element}</FluentProvider>);
+};
+
+const Test = () => {
+  const actionRef = React.useRef<HTMLButtonElement>(null);
+
+  React.useEffect(() => {
+    actionRef.current?.focus();
+  }, []);
+
+  return (
+    <div style={{ width: 400 }}>
+      <MessageBar intent="success">
+        <MessageBarBody>
+          <MessageBarTitle>Descriptive title</MessageBarTitle>
+          Message providing information to the user with actionable insights. <a>Link</a>
+        </MessageBarBody>
+        <MessageBarActions containerAction={<button id="containerAction">XXX</button>}>
+          <button id="action" ref={actionRef}>
+            Action
+          </button>
+        </MessageBarActions>
+      </MessageBar>
+    </div>
+  );
+};
+
+describe('MessageBar', () => {
+  // ⚠️ - This test will fail on headed cypress runs, since cypress element highlighting injects divs that
+  // trigger resize observer updates
+  it('Should render MessageActions slots with correct keys', () => {
+    mount(<Test />);
+
+    // wait for resize observer to trigger
+    cy.wait(1000).get('#action').should('be.focused').get('#containerAction').should('not.be.focused');
+  });
+});

--- a/packages/react-components/react-message-bar/library/src/components/MessageBarActions/renderMessageBarActions.tsx
+++ b/packages/react-components/react-message-bar/library/src/components/MessageBarActions/renderMessageBarActions.tsx
@@ -17,19 +17,12 @@ export const renderMessageBarActions_unstable = (
   contexts: MessageBarActionsContextValues,
 ) => {
   assertSlots<MessageBarActionsSlots>(state);
-  if (state.layout === 'multiline') {
-    return (
-      <ButtonContextProvider value={contexts.button}>
-        {state.containerAction && <state.containerAction />}
-        <state.root />
-      </ButtonContextProvider>
-    );
-  }
 
   return (
     <ButtonContextProvider value={contexts.button}>
+      {state.layout === 'multiline' && state.containerAction && <state.containerAction key="containerAction" />}
       <state.root />
-      {state.containerAction && <state.containerAction />}
+      {state.layout !== 'multiline' && state.containerAction && <state.containerAction key="containerAction" />}
     </ButtonContextProvider>
   );
 };

--- a/packages/react-components/react-message-bar/library/tsconfig.cy.json
+++ b/packages/react-components/react-message-bar/library/tsconfig.cy.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "isolatedModules": false,
+    "types": ["node", "cypress", "cypress-real-events"],
+    "typeRoots": ["../../../node_modules", "../../../node_modules/@types"],
+    "lib": ["ES2019", "dom"]
+  },
+  "include": ["**/*.cy.ts", "**/*.cy.tsx"]
+}

--- a/packages/react-components/react-message-bar/library/tsconfig.json
+++ b/packages/react-components/react-message-bar/library/tsconfig.json
@@ -17,6 +17,9 @@
     },
     {
       "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./tsconfig.cy.json"
     }
   ]
 }

--- a/packages/react-components/react-message-bar/library/tsconfig.lib.json
+++ b/packages/react-components/react-message-bar/library/tsconfig.lib.json
@@ -16,7 +16,9 @@
     "**/*.test.ts",
     "**/*.test.tsx",
     "**/*.stories.ts",
-    "**/*.stories.tsx"
+    "**/*.stories.tsx",
+    "**/*.cy.ts",
+    "**/*.cy.tsx"
   ],
   "include": ["./src/**/*.ts", "./src/**/*.tsx"]
 }


### PR DESCRIPTION
Addresses issue where first mount will not keep stable refs to elements as the `if` condition in the renderer will remount HTML elements.

This is reproducible in this stackblitz https://stackblitz.com/edit/k8xphvqw-5xbsegok?file=package.json, where the correct button is never focused