### PR TITLE
fix(scripts-cypress): resolve specPattern from projectRoot

### DIFF
--- a/scripts/cypress/src/base.config.ts
+++ b/scripts/cypress/src/base.config.ts
@@ -79,7 +79,7 @@ const projectSupportDir = path.relative(projectRoot, sharedConfigSupportRootDir)
 export const baseConfig = defineConfig({
   video: false,
   component: {
-    specPattern: [path.join(projectRoot, '**/*.e2e.tsx'), path.join(process.cwd(), '**/*.cy.tsx')],
+    specPattern: [path.join(projectRoot, '**/*.e2e.tsx'), path.join(projectRoot, '**/*.cy.tsx')],
     devServer: {
       framework: 'react',
       bundler: 'webpack',


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

local mode works (make sure to run `yarn nx reset` once you update from latest master

<img width="1842" height="732" alt="image" src="https://github.com/user-attachments/assets/5e2d19a5-4445-429a-83c7-bffc4e538bcd" />


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes https://github.com/microsoft/fluentui/issues/34800
