### PR TITLE
fix(react-table): add support for native table elements

### DIFF
--- a/change/@fluentui-react-table-7050a0fe-9330-45a3-b21a-d2482027b681.json
+++ b/change/@fluentui-react-table-7050a0fe-9330-45a3-b21a-d2482027b681.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: add support for native table elements",
+  "packageName": "@fluentui/react-table",
+  "email": "marcosvmmoura@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-table/library/etc/react-table.api.md
+++ b/packages/react-components/react-table/library/etc/react-table.api.md
@@ -347,7 +347,7 @@ export type TableCellProps = ComponentProps<TableCellSlots> & {};
 
 // @public (undocumented)
 export type TableCellSlots = {
-    root: Slot<'td', 'div'>;
+    root: Slot<'td', 'th' | 'div'>;
 };
 
 // @public

--- a/packages/react-components/react-table/library/src/components/DataGrid/useDataGrid.ts
+++ b/packages/react-components/react-table/library/src/components/DataGrid/useDataGrid.ts
@@ -111,7 +111,7 @@ export const useDataGrid_unstable = (props: DataGridProps, ref: React.Ref<HTMLEl
     {
       role: 'grid',
       as: 'div',
-      noNativeElements: true,
+      noNativeElements: props.as !== 'table',
       ...(focusMode === 'cell' && gridTabsterAttribute),
       ...(focusMode === 'composite' && compositeTabsterAttribute),
       ...props,

--- a/packages/react-components/react-table/library/src/components/DataGridBody/useDataGridBody.tsx
+++ b/packages/react-components/react-table/library/src/components/DataGridBody/useDataGridBody.tsx
@@ -19,7 +19,8 @@ export const useDataGridBody_unstable = (props: DataGridBodyProps, ref: React.Re
   const sort = useDataGridContext_unstable(ctx => ctx.sort.sort);
   const rows = sortable ? sort(getRows()) : getRows();
 
-  const baseState = useTableBody_unstable({ ...props, children: null, as: 'div' }, ref);
+  const baseState = useTableBody_unstable({ as: 'div', ...props, children: null }, ref);
+
   return {
     ...baseState,
     rows,

--- a/packages/react-components/react-table/library/src/components/DataGridBody/useDataGridBodyStyles.styles.ts
+++ b/packages/react-components/react-table/library/src/components/DataGridBody/useDataGridBodyStyles.styles.ts
@@ -1,11 +1,21 @@
-import { mergeClasses } from '@griffel/react';
+import { makeStyles, mergeClasses } from '@griffel/react';
 import type { DataGridBodySlots, DataGridBodyState } from './DataGridBody.types';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import { useTableBodyStyles_unstable } from '../TableBody/useTableBodyStyles.styles';
+import { dataGridRowClassNames } from '../DataGridRow/useDataGridRowStyles.styles';
 
 export const dataGridBodyClassNames: SlotClassNames<DataGridBodySlots> = {
   root: 'fui-DataGridBody',
 };
+
+const useStyles = makeStyles({
+  root: {
+    /* Tabster creates a dummy element that acts as a table cell, making the table shifting its position */
+    [`& .${dataGridRowClassNames.root} > [data-tabster-dummy]`]: {
+      display: 'contents',
+    },
+  },
+});
 
 /**
  * Apply styling to the DataGridBody slots based on the state
@@ -13,8 +23,14 @@ export const dataGridBodyClassNames: SlotClassNames<DataGridBodySlots> = {
 export const useDataGridBodyStyles_unstable = (state: DataGridBodyState): DataGridBodyState => {
   'use no memo';
 
+  const styles = useStyles();
+
   useTableBodyStyles_unstable(state);
-  state.root.className = mergeClasses(dataGridBodyClassNames.root, state.root.className);
+  state.root.className = mergeClasses(
+    dataGridBodyClassNames.root,
+    state.root.as === 'tbody' && styles.root,
+    state.root.className,
+  );
 
   return state;
 };

--- a/packages/react-components/react-table/library/src/components/DataGridHeader/useDataGridHeader.ts
+++ b/packages/react-components/react-table/library/src/components/DataGridHeader/useDataGridHeader.ts
@@ -15,5 +15,5 @@ export const useDataGridHeader_unstable = (
   props: DataGridHeaderProps,
   ref: React.Ref<HTMLElement>,
 ): DataGridHeaderState => {
-  return useTableHeader_unstable({ ...props, as: 'div' }, ref);
+  return useTableHeader_unstable({ as: 'div', ...props }, ref);
 };

--- a/packages/react-components/react-table/library/src/components/DataGridRow/useDataGridRow.tsx
+++ b/packages/react-components/react-table/library/src/components/DataGridRow/useDataGridRow.tsx
@@ -56,6 +56,7 @@ export const useDataGridRow_unstable = (props: DataGridRowProps, ref: React.Ref<
 
   const baseState = useTableRow_unstable(
     {
+      as: 'div',
       appearance,
       'aria-selected': selectable ? selected : undefined,
       tabIndex: tabbable && !isHeader ? 0 : undefined,
@@ -64,7 +65,6 @@ export const useDataGridRow_unstable = (props: DataGridRowProps, ref: React.Ref<
       onClick,
       onKeyDown,
       children: null,
-      as: 'div',
     },
     ref,
   );

--- a/packages/react-components/react-table/library/src/components/TableCell/TableCell.types.ts
+++ b/packages/react-components/react-table/library/src/components/TableCell/TableCell.types.ts
@@ -2,7 +2,7 @@ import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utili
 import { TableContextValue } from '../Table/Table.types';
 
 export type TableCellSlots = {
-  root: Slot<'td', 'div'>;
+  root: Slot<'td', 'th' | 'div'>;
 };
 
 /**

--- a/packages/react-components/react-table/library/src/hooks/useTableSelection.ts
+++ b/packages/react-components/react-table/library/src/hooks/useTableSelection.ts
@@ -30,7 +30,7 @@ export function useTableSelectionState<TItem>(
   options: SelectionHookParams,
 ): TableFeaturesState<TItem> {
   const { items, getRowId } = tableState;
-  const { selectionMode: selectionMode, defaultSelectedItems, selectedItems, onSelectionChange } = options;
+  const { selectionMode, defaultSelectedItems, selectedItems, onSelectionChange } = options;
 
   const [selected, selectionMethods] = useSelection({
     selectionMode,

--- a/packages/react-components/react-table/stories/src/DataGrid/Default.stories.tsx
+++ b/packages/react-components/react-table/stories/src/DataGrid/Default.stories.tsx
@@ -158,21 +158,16 @@ export const Default = () => {
       getRowId={item => item.file.label}
       focusMode="composite"
       style={{ minWidth: '550px' }}
-      as="table"
     >
-      <DataGridHeader as="thead">
-        <DataGridRow as="tr" selectionCell={{ checkboxIndicator: { 'aria-label': 'Select all rows' }, as: 'th' }}>
-          {({ renderHeaderCell }) => <DataGridHeaderCell as="th">{renderHeaderCell()}</DataGridHeaderCell>}
+      <DataGridHeader>
+        <DataGridRow selectionCell={{ checkboxIndicator: { 'aria-label': 'Select all rows' } }}>
+          {({ renderHeaderCell }) => <DataGridHeaderCell>{renderHeaderCell()}</DataGridHeaderCell>}
         </DataGridRow>
       </DataGridHeader>
-      <DataGridBody<Item> as="tbody">
+      <DataGridBody<Item>>
         {({ item, rowId }) => (
-          <DataGridRow<Item>
-            as="tr"
-            key={rowId}
-            selectionCell={{ checkboxIndicator: { 'aria-label': 'Select row' }, as: 'td' }}
-          >
-            {({ renderCell }) => <DataGridCell as="td">{renderCell(item)}</DataGridCell>}
+          <DataGridRow<Item> key={rowId} selectionCell={{ checkboxIndicator: { 'aria-label': 'Select row' } }}>
+            {({ renderCell }) => <DataGridCell>{renderCell(item)}</DataGridCell>}
           </DataGridRow>
         )}
       </DataGridBody>

--- a/packages/react-components/react-table/stories/src/DataGrid/Default.stories.tsx
+++ b/packages/react-components/react-table/stories/src/DataGrid/Default.stories.tsx
@@ -158,16 +158,21 @@ export const Default = () => {
       getRowId={item => item.file.label}
       focusMode="composite"
       style={{ minWidth: '550px' }}
+      as="table"
     >
-      <DataGridHeader>
-        <DataGridRow selectionCell={{ checkboxIndicator: { 'aria-label': 'Select all rows' } }}>
-          {({ renderHeaderCell }) => <DataGridHeaderCell>{renderHeaderCell()}</DataGridHeaderCell>}
+      <DataGridHeader as="thead">
+        <DataGridRow as="tr" selectionCell={{ checkboxIndicator: { 'aria-label': 'Select all rows' }, as: 'th' }}>
+          {({ renderHeaderCell }) => <DataGridHeaderCell as="th">{renderHeaderCell()}</DataGridHeaderCell>}
         </DataGridRow>
       </DataGridHeader>
-      <DataGridBody<Item>>
+      <DataGridBody<Item> as="tbody">
         {({ item, rowId }) => (
-          <DataGridRow<Item> key={rowId} selectionCell={{ checkboxIndicator: { 'aria-label': 'Select row' } }}>
-            {({ renderCell }) => <DataGridCell>{renderCell(item)}</DataGridCell>}
+          <DataGridRow<Item>
+            as="tr"
+            key={rowId}
+            selectionCell={{ checkboxIndicator: { 'aria-label': 'Select row' }, as: 'td' }}
+          >
+            {({ renderCell }) => <DataGridCell as="td">{renderCell(item)}</DataGridCell>}
           </DataGridRow>
         )}
       </DataGridBody>


### PR DESCRIPTION
For the given code example:
<img width="1221" height="857" alt="image" src="https://github.com/user-attachments/assets/4a6f56b7-1bec-4ad0-b077-c42095bbe149" />


## Previous Behavior

DataGrid components accepted `as="table"` (also sub elements of `table`), but were not rendering them, leading to incorrect markup

<img width="227" height="869" alt="image" src="https://github.com/user-attachments/assets/d5be93d1-2983-4b73-9500-076a4b081390" />


## New Behavior

DataGrid now renders correct table elements.

<img width="140" height="839" alt="image" src="https://github.com/user-attachments/assets/7794285c-08fc-4a54-bf4b-cb061616a8c7" />

