### PR TITLE
fix(react-charting): Disable responsive container for funnel in Declarative Chart

### DIFF
--- a/change/@fluentui-react-charting-8bb4759f-7a9e-4281-bb8f-a0da9c0f3e99.json
+++ b/change/@fluentui-react-charting-8bb4759f-7a9e-4281-bb8f-a0da9c0f3e99.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(react-charting): Disable responsive container for funnel in Declarative Chart",
+  "packageName": "@fluentui/react-charting",
+  "email": "98592573+AtishayMsft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charts/react-charting/src/components/DeclarativeChart/DeclarativeChart.tsx
+++ b/packages/charts/react-charting/src/components/DeclarativeChart/DeclarativeChart.tsx
@@ -59,7 +59,8 @@ const ResponsiveGroupedVerticalBarChart = withResponsiveContainer(GroupedVertica
 const ResponsiveVerticalBarChart = withResponsiveContainer(VerticalBarChart);
 const ResponsiveScatterChart = withResponsiveContainer(ScatterChart);
 const ResponsiveChartTable = withResponsiveContainer(ChartTable);
-const ResponsiveFunnelChart = withResponsiveContainer(FunnelChart);
+// Removing responsive wrapper for FunnelChart as responsive container is not working with FunnelChart
+//const ResponsiveFunnelChart = withResponsiveContainer(FunnelChart);
 
 // Default x-axis key for grouping traces. Also applicable for PieData and SankeyData where x-axis is not defined.
 const DEFAULT_XAXIS = 'x';
@@ -216,7 +217,7 @@ type ChartTypeMap = {
   } & PreTransformHooks;
   funnel: {
     transformer: typeof transformPlotlyJsonToFunnelChartProps;
-    renderer: typeof ResponsiveFunnelChart;
+    renderer: typeof FunnelChart;
   } & PreTransformHooks;
   fallback: {
     transformer: typeof transformPlotlyJsonToVSBCProps;
@@ -282,7 +283,7 @@ const chartMap: ChartTypeMap = {
   },
   funnel: {
     transformer: transformPlotlyJsonToFunnelChartProps,
-    renderer: ResponsiveFunnelChart,
+    renderer: FunnelChart,
   },
   fallback: {
     transformer: transformPlotlyJsonToVSBCProps,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
Responsive container is not working for funnel chart.
This issue is blocking all upcoming releases.
<!-- This is the behavior we have today -->

## New Behavior
Disabled responsive container for funnel chart to unblock releases.
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
