### PR TITLE
chore(workspace-plugin): make generate-api executor test deterministic and ignore any __fixtures__ from type checking

### DIFF
--- a/tools/workspace-plugin/tsconfig.lib.json
+++ b/tools/workspace-plugin/tsconfig.lib.json
@@ -6,5 +6,5 @@
     "types": ["node"]
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts", "__fixtures__/**/*"]
 }

--- a/tools/workspace-plugin/tsconfig.spec.json
+++ b/tools/workspace-plugin/tsconfig.spec.json
@@ -5,5 +5,6 @@
     "module": "commonjs",
     "types": ["jest", "node"]
   },
-  "include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]
+  "include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"],
+  "exclude": ["__fixtures__/**/*"]
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

- fixtures were created under same folder which caused race conditions
- `__fixtures__` were included in type-check by accident - causing intermittent failures when type-check was executed before test was able to cleanup / https://github.com/microsoft/fluentui/actions/runs/16219241365/job/45795583521?pr=34748

## New Behavior

- fixtures are created under unique folder, preventing any clashes
- tests are deterministic in multiple workers
- `__fixtures__` are excluded from type-check




## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
