### PR TITLE
fix(react-charts): Add fixture.js for remaining charts to calculate monosize

### DIFF
--- a/packages/charts/react-charts/library/bundle-size/AreaChart.fixture.js
+++ b/packages/charts/react-charts/library/bundle-size/AreaChart.fixture.js
@@ -1,0 +1,7 @@
+import { AreaChart } from '@fluentui/react-charts';
+
+console.log(AreaChart);
+
+export default {
+  name: 'AreaChart',
+};

--- a/packages/charts/react-charts/library/bundle-size/HeatMapChart.fixture.js
+++ b/packages/charts/react-charts/library/bundle-size/HeatMapChart.fixture.js
@@ -1,0 +1,7 @@
+import { HeatMapChart } from '@fluentui/react-charts';
+
+console.log(HeatMapChart);
+
+export default {
+  name: 'HeatMapChart',
+};

--- a/packages/charts/react-charts/library/bundle-size/HorizontalBarChartWithAxis.fixture.js
+++ b/packages/charts/react-charts/library/bundle-size/HorizontalBarChartWithAxis.fixture.js
@@ -1,0 +1,7 @@
+import { HorizontalBarChartWithAxisChart } from '@fluentui/react-charts';
+
+console.log(HorizontalBarChartWithAxis);
+
+export default {
+  name: 'HorizontalBarChartWithAxis',
+};

--- a/packages/charts/react-charts/library/bundle-size/SankeyChart.fixture.js
+++ b/packages/charts/react-charts/library/bundle-size/SankeyChart.fixture.js
@@ -1,0 +1,7 @@
+import { SankeyChart } from '@fluentui/react-charts';
+
+console.log(SankeyChart);
+
+export default {
+  name: 'SankeyChart',
+};

--- a/packages/charts/react-charts/library/bundle-size/ScatterChart.fixture.js
+++ b/packages/charts/react-charts/library/bundle-size/ScatterChart.fixture.js
@@ -1,0 +1,7 @@
+import { ScatterChart } from '@fluentui/react-charts';
+
+console.log(ScatterChart);
+
+export default {
+  name: 'ScatterChart',
+};

--- a/packages/charts/react-charts/library/bundle-size/VerticalStackedBarChart.fixture.js
+++ b/packages/charts/react-charts/library/bundle-size/VerticalStackedBarChart.fixture.js
@@ -1,0 +1,7 @@
+import { VerticalStackedBarChart } from '@fluentui/react-charts';
+
+console.log(VerticalStackedBarChart);
+
+export default {
+  name: 'VerticalStackedBarChart',
+};


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## New Behavior

Add fixture.js for remaining charts to calculate monosize of components.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
