### PR TITLE
fix(chart-utilities): Decode data in provided shape if present in schema

### DIFF
--- a/change/@fluentui-chart-utilities-8a0d537b-e58b-4ddd-af21-2022c3c47f6b.json
+++ b/change/@fluentui-chart-utilities-8a0d537b-e58b-4ddd-af21-2022c3c47f6b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(chart-utilities): Decode data in provided shape if present in schema",
+  "packageName": "@fluentui/chart-utilities",
+  "email": "120183316+srmukher@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charts/chart-utilities/src/DecodeBase64Data.UT.test.ts
+++ b/packages/charts/chart-utilities/src/DecodeBase64Data.UT.test.ts
@@ -1,0 +1,45 @@
+import { reshapeArray } from './DecodeBase64Data';
+
+describe('reshapeArray', () => {
+  it('should return the same array for 1D shape', () => {
+    const data = [1, 2, 3, 4];
+    const shape = [4];
+    expect(reshapeArray(data, shape)).toEqual([1, 2, 3, 4]);
+  });
+
+  it('should reshape a flat array into 2D array', () => {
+    const data = [1, 2, 3, 4, 5, 6];
+    const shape = [2, 3];
+    expect(reshapeArray(data, shape)).toEqual([
+      [1, 2, 3],
+      [4, 5, 6],
+    ]);
+  });
+
+  it('should reshape a flat array into 3D array', () => {
+    const data = [1, 2, 3, 4, 5, 6, 7, 8];
+    const shape = [2, 2, 2];
+    expect(reshapeArray(data, shape)).toEqual([
+      [
+        [1, 2],
+        [3, 4],
+      ],
+      [
+        [5, 6],
+        [7, 8],
+      ],
+    ]);
+  });
+
+  it('should throw an error if data cannot be reshaped into the given shape', () => {
+    const data = [1, 2, 3, 4];
+    const shape = [3, 2];
+    expect(() => reshapeArray(data, shape)).toThrowError();
+  });
+
+  it('should handle empty data and shape', () => {
+    const data: number[] = [];
+    const shape: number[] = [];
+    expect(reshapeArray(data, shape)).toEqual([]);
+  });
+});

--- a/packages/charts/chart-utilities/src/DecodeBase64Data.UT.test.ts
+++ b/packages/charts/chart-utilities/src/DecodeBase64Data.UT.test.ts
@@ -34,7 +34,7 @@ describe('reshapeArray', () => {
   it('should throw an error if data cannot be reshaped into the given shape', () => {
     const data = [1, 2, 3, 4];
     const shape = [3, 2];
-    expect(() => reshapeArray(data, shape)).toThrowError();
+    expect(reshapeArray(data, shape)).toEqual([[1, 2], [3, 4], []]);
   });
 
   it('should handle empty data and shape', () => {

--- a/packages/charts/chart-utilities/src/DecodeBase64Data.ts
+++ b/packages/charts/chart-utilities/src/DecodeBase64Data.ts
@@ -97,7 +97,9 @@ function decodeBdataInDict(d: any): void {
 
 // Helper to reshape a flat array into the given shape (e.g., [rows, cols])
 function reshapeArray(data: number[], shape: number[]): number[] | number[][] | number[][][] {
-  if (shape.length === 1) {return data;}
+  if (shape.length === 1) {
+    return data;
+  }
   if (shape.length === 2) {
     const [rows, cols] = shape;
     const result: number[][] = [];

--- a/packages/charts/chart-utilities/src/DecodeBase64Data.ts
+++ b/packages/charts/chart-utilities/src/DecodeBase64Data.ts
@@ -1,4 +1,5 @@
 import { PlotlySchema } from './PlotlySchema';
+import { isArrayOrTypedArray } from './PlotlySchemaConverter';
 
 function addBase64Padding(s: string): string {
   const paddingNeeded = (4 - (s.length % 4)) % 4;
@@ -94,6 +95,27 @@ function decodeBdataInDict(d: any): void {
   }
 }
 
+// Helper to reshape a flat array into the given shape (e.g., [rows, cols])
+function reshapeArray(data: number[], shape: number[]): number[] | number[][] | number[][][] {
+  if (shape.length === 1) {return data;}
+  if (shape.length === 2) {
+    const [rows, cols] = shape;
+    const result: number[][] = [];
+    for (let r = 0; r < rows; r++) {
+      result.push(data.slice(r * cols, (r + 1) * cols));
+    }
+    return result;
+  }
+  // For higher dimensions, recursively reshape
+  const [dim, ...rest] = shape;
+  const step = data.length / dim;
+  const result: number[][][] = [];
+  for (let i = 0; i < dim; i++) {
+    result.push(reshapeArray(data.slice(i * step, (i + 1) * step), rest) as number[][]);
+  }
+  return result;
+}
+
 // Function to process a PlotlySchema object
 export function decodeBase64Fields(plotlySchema: PlotlySchema): PlotlySchema {
   // Create a deep copy of the original data
@@ -113,7 +135,36 @@ export function decodeBase64Fields(plotlySchema: PlotlySchema): PlotlySchema {
           'bdata' in (item[key as keyof typeof item] as Record<string, number[]>)
         ) {
           const bdata = (item[key as keyof typeof item] as { bdata: number[] }).bdata;
-          (item[key as keyof typeof item] as number[]) = bdata as number[];
+          let shape = (item[key as keyof typeof item] as { shape?: string | number[] }).shape;
+          // convert to an array if shape is a string
+          if (typeof shape === 'string') {
+            let parsedShape: number[] | undefined = undefined;
+            try {
+              // Try to parse as JSON array
+              parsedShape = JSON.parse(shape);
+              if (!isArrayOrTypedArray(parsedShape)) {
+                parsedShape = undefined;
+              }
+            } catch (error) {
+              // If JSON.parse fails, try to parse as comma-separated numbers
+              const parts = shape.split(',').map(s => Number(s.trim()));
+              if (parts.every(n => !isNaN(n))) {
+                parsedShape = parts;
+              } else {
+                shape = undefined; // If parsing fails, set shape to undefined
+              }
+            }
+            shape = parsedShape;
+          }
+          // If shape exists, decode bdata into that shape
+          if (shape !== undefined && isArrayOrTypedArray(shape)) {
+            (item[key as keyof typeof item] as number[] | number[][] | number[][][]) = reshapeArray(
+              bdata,
+              shape as number[],
+            );
+          } else {
+            (item[key as keyof typeof item] as number[]) = bdata as number[];
+          }
         }
       });
     }

--- a/packages/charts/chart-utilities/src/DecodeBase64Data.ts
+++ b/packages/charts/chart-utilities/src/DecodeBase64Data.ts
@@ -96,7 +96,7 @@ function decodeBdataInDict(d: any): void {
 }
 
 // Helper to reshape a flat array into the given shape (e.g., [rows, cols])
-function reshapeArray(data: number[], shape: number[]): number[] | number[][] | number[][][] {
+export function reshapeArray(data: number[], shape: number[]): number[] | number[][] | number[][][] {
   if (shape.length === 1) {
     return data;
   }


### PR DESCRIPTION
Work item: https://uifabric.visualstudio.com/iss/_workitems/edit/13376
Works for all below shape formats in schema:

1. "shape": "10, 10"
2. "shape": "[10, 10]"
3. "shape": [10, 10]

Before:
<img width="296" height="350" alt="image" src="https://github.com/user-attachments/assets/2df08123-d201-4fce-807c-0bd6d0e99529" />

After:
<img width="653" height="431" alt="image" src="https://github.com/user-attachments/assets/5911f74c-d2f5-4632-b787-3adea04b4a24" />
