### PR TITLE
chore: bump @fluentui/react-icons to ^2.0.306 to surface new icons on the docsite

### DIFF
--- a/apps/vr-tests-react-components/package.json
+++ b/apps/vr-tests-react-components/package.json
@@ -34,7 +34,7 @@
     "@fluentui/react-divider": "*",
     "@fluentui/react-drawer": "*",
     "@fluentui/react-field": "*",
-    "@fluentui/react-icons": "^2.0.301",
+    "@fluentui/react-icons": "^2.0.306",
     "@fluentui/react-image": "*",
     "@fluentui/react-infolabel": "*",
     "@fluentui/react-input": "*",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@eslint/compat": "1.2.9",
     "@eslint/js": "9.26.0",
     "@floating-ui/dom": "1.6.12",
-    "@fluentui/react-icons": "^2.0.301",
+    "@fluentui/react-icons": "^2.0.306",
     "@griffel/babel-preset": "1.5.8",
     "@griffel/eslint-plugin": "^2.0.0",
     "@griffel/jest-serializer": "1.1.24",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1979,10 +1979,10 @@
     "@fluentui/styles" "^0.66.5"
     classnames "^2.2.6"
 
-"@fluentui/react-icons@^2.0.237", "@fluentui/react-icons@^2.0.239", "@fluentui/react-icons@^2.0.245", "@fluentui/react-icons@^2.0.301":
-  version "2.0.301"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-icons/-/react-icons-2.0.301.tgz#ef0af3c94d3e5373d12dfd9a854d85cd5989e47e"
-  integrity sha512-5fC7LntTyqt63AV91ZlnzJ5671l9zG12TDq17nN/Zwdng+5ZE4ICOBvQuXJVGLLu7kIY+9+qip6sr3ttmby5OQ==
+"@fluentui/react-icons@^2.0.237", "@fluentui/react-icons@^2.0.239", "@fluentui/react-icons@^2.0.245", "@fluentui/react-icons@^2.0.306":
+  version "2.0.306"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-icons/-/react-icons-2.0.306.tgz#bf4a57e78947f2ee13895485cbca7ffa81a34bb8"
+  integrity sha512-zS66O59F8gvwjaaIchguMVTwmI3qplwJrm5F8c17rfdrqtFhJKMM2Udef6DWHA7XtnQA8OfvYz2GGrE+GBy/KA==
   dependencies:
     "@griffel/react" "^1.0.0"
     tslib "^2.1.0"


### PR DESCRIPTION
## Changes
- bumps monorepo root and apps versions of `@fluentui/react-icons` to latest version `^2.0.306` to consume latest icon additions from package. This will allow the new icons to be surfaced in our docsite. 

**Note**:  The `@fluentui/react-icons` dependency in the v9 packages has been deliberately left unchanged to avoid introducing unnecessary version churn to consumers, as the current version (`2.0.245`) satisfies all functional requirements and there is no immediate benefit or need to upgrading.


**Direct Link** to PR deployed site showing Icons catalog: https://fluentuipr.z22.web.core.windows.net/pull/34834/public-docsite-v9/storybook/index.html?path=/docs/icons-catalog--docs

## Related:
- Pulls in latest icons from https://github.com/microsoft/fluentui-system-icons/pull/857