### PR TITLE
fix(react-charting): Support min max for VSBC in plotly

### DIFF
--- a/change/@fluentui-react-charting-bb40eae9-21c2-4187-9ef4-db96ed00a8bf.json
+++ b/change/@fluentui-react-charting-bb40eae9-21c2-4187-9ef4-db96ed00a8bf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(react-charting): Support min max for VSBC in plotly",
+  "packageName": "@fluentui/react-charting",
+  "email": "98592573+AtishayMsft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charts/react-charting/src/components/DeclarativeChart/PlotlySchemaAdapter.ts
+++ b/packages/charts/react-charting/src/components/DeclarativeChart/PlotlySchemaAdapter.ts
@@ -856,7 +856,14 @@ const transformPlotlyJsonToScatterTraceProps = (
             mode: series.type !== 'scatterpolar' ? series.mode : 'scatterpolar',
             // originXOffset is not typed on Layout, but may be present in input.layout as a part of projection of
             // scatter polar coordingates to cartesian coordinates
-            originXOffset: (input.layout as { __polarOriginX?: number } | undefined)?.__polarOriginX,
+
+            ...(series.type === 'scatterpolar'
+              ? {
+                  originXOffset: (input.layout as { __polarOriginX?: number } | undefined)?.__polarOriginX,
+                  direction: input.layout?.polar?.angularaxis?.direction,
+                  rotation: input.layout?.polar?.angularaxis?.rotation,
+                }
+              : {}),
           },
           useSecondaryYScale: usesSecondaryYScale(series, input.layout),
         } as ILineChartPoints;
@@ -1752,6 +1759,10 @@ export const projectPolarToCartesian = (input: PlotlySchema): PlotlySchema => {
       continue;
     }
 
+    // retrieve polar axis settings
+    const dirMultiplier = input.layout?.polar?.angularaxis?.direction === 'clockwise' ? -1 : 1;
+    const startAngleInRad = ((input.layout?.polar?.angularaxis?.rotation ?? 0) * Math.PI) / 180;
+
     // Compute tick positions if categorical
     let uniqueTheta: Datum[] = [];
     let categorical = false;
@@ -1766,13 +1777,13 @@ export const projectPolarToCartesian = (input: PlotlySchema): PlotlySchema => {
       }
 
       // 4. Map theta to angle in radians
-      let thetaRad;
+      let thetaRad: number;
       if (categorical) {
         const idx = uniqueTheta.indexOf(thetas[ptindex]);
         const step = (2 * Math.PI) / uniqueTheta.length;
-        thetaRad = idx * step;
+        thetaRad = startAngleInRad + dirMultiplier * idx * step;
       } else {
-        thetaRad = ((thetas[ptindex] as number) * Math.PI) / 180;
+        thetaRad = startAngleInRad + dirMultiplier * (((thetas[ptindex] as number) * Math.PI) / 180);
       }
       // 5. Shift only the polar origin (not the cartesian)
       const rawRadius = rVals[ptindex] as number;

--- a/packages/charts/react-charting/src/components/DeclarativeChart/__snapshots__/PlotlySchemaAdapterUT.test.tsx.snap
+++ b/packages/charts/react-charting/src/components/DeclarativeChart/__snapshots__/PlotlySchemaAdapterUT.test.tsx.snap
@@ -145,7 +145,6 @@ Object {
         "lineOptions": Object {
           "curve": "linear",
           "mode": "lines",
-          "originXOffset": undefined,
         },
         "useSecondaryYScale": false,
       },
@@ -208,7 +207,6 @@ Object {
         "lineOptions": Object {
           "curve": "linear",
           "mode": "lines",
-          "originXOffset": undefined,
         },
         "useSecondaryYScale": false,
       },
@@ -271,7 +269,6 @@ Object {
         "lineOptions": Object {
           "curve": "linear",
           "mode": "lines",
-          "originXOffset": undefined,
         },
         "useSecondaryYScale": false,
       },
@@ -334,7 +331,6 @@ Object {
         "lineOptions": Object {
           "curve": "linear",
           "mode": "lines",
-          "originXOffset": undefined,
         },
         "useSecondaryYScale": false,
       },
@@ -3896,7 +3892,6 @@ Object {
         "lineOptions": Object {
           "curve": "linear",
           "mode": "lines",
-          "originXOffset": undefined,
         },
         "useSecondaryYScale": false,
       },
@@ -4409,7 +4404,6 @@ Object {
         "lineOptions": Object {
           "curve": "linear",
           "mode": "lines",
-          "originXOffset": undefined,
         },
         "useSecondaryYScale": false,
       },
@@ -4922,7 +4916,6 @@ Object {
         "lineOptions": Object {
           "curve": "linear",
           "mode": "lines",
-          "originXOffset": undefined,
         },
         "useSecondaryYScale": false,
       },
@@ -5595,7 +5588,6 @@ Object {
         "lineOptions": Object {
           "curve": "linear",
           "mode": "markers",
-          "originXOffset": undefined,
         },
         "useSecondaryYScale": false,
       },
@@ -6108,7 +6100,6 @@ Object {
         "lineOptions": Object {
           "curve": "linear",
           "mode": "markers",
-          "originXOffset": undefined,
         },
         "useSecondaryYScale": false,
       },
@@ -6621,7 +6612,6 @@ Object {
         "lineOptions": Object {
           "curve": "linear",
           "mode": "markers",
-          "originXOffset": undefined,
         },
         "useSecondaryYScale": false,
       },

--- a/packages/charts/react-charting/src/components/DeclarativeChart/__snapshots__/PlotlySchemaAdapterUT.test.tsx.snap
+++ b/packages/charts/react-charting/src/components/DeclarativeChart/__snapshots__/PlotlySchemaAdapterUT.test.tsx.snap
@@ -145,6 +145,7 @@ Object {
         "lineOptions": Object {
           "curve": "linear",
           "mode": "lines",
+          "originXOffset": undefined,
         },
         "useSecondaryYScale": false,
       },
@@ -207,6 +208,7 @@ Object {
         "lineOptions": Object {
           "curve": "linear",
           "mode": "lines",
+          "originXOffset": undefined,
         },
         "useSecondaryYScale": false,
       },
@@ -269,6 +271,7 @@ Object {
         "lineOptions": Object {
           "curve": "linear",
           "mode": "lines",
+          "originXOffset": undefined,
         },
         "useSecondaryYScale": false,
       },
@@ -331,6 +334,7 @@ Object {
         "lineOptions": Object {
           "curve": "linear",
           "mode": "lines",
+          "originXOffset": undefined,
         },
         "useSecondaryYScale": false,
       },
@@ -3892,6 +3896,7 @@ Object {
         "lineOptions": Object {
           "curve": "linear",
           "mode": "lines",
+          "originXOffset": undefined,
         },
         "useSecondaryYScale": false,
       },
@@ -4404,6 +4409,7 @@ Object {
         "lineOptions": Object {
           "curve": "linear",
           "mode": "lines",
+          "originXOffset": undefined,
         },
         "useSecondaryYScale": false,
       },
@@ -4916,6 +4922,7 @@ Object {
         "lineOptions": Object {
           "curve": "linear",
           "mode": "lines",
+          "originXOffset": undefined,
         },
         "useSecondaryYScale": false,
       },
@@ -5588,6 +5595,7 @@ Object {
         "lineOptions": Object {
           "curve": "linear",
           "mode": "markers",
+          "originXOffset": undefined,
         },
         "useSecondaryYScale": false,
       },
@@ -6100,6 +6108,7 @@ Object {
         "lineOptions": Object {
           "curve": "linear",
           "mode": "markers",
+          "originXOffset": undefined,
         },
         "useSecondaryYScale": false,
       },
@@ -6612,6 +6621,7 @@ Object {
         "lineOptions": Object {
           "curve": "linear",
           "mode": "markers",
+          "originXOffset": undefined,
         },
         "useSecondaryYScale": false,
       },


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
yMin yMax properties are not honored for declarative chart for VSBC.
<img width="1280" height="454" alt="image" src="https://github.com/user-attachments/assets/4a3d42e5-5907-4d0f-8ad4-30253bbc59e9" />

<!-- This is the behavior we have today -->
<img width="1280" height="454" alt="image" src="https://github.com/user-attachments/assets/086b2ed7-6958-4147-a5b8-00a9f70b2e58" />

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
