### PR TITLE
fix(react-toolbar): properly apply overrides in `ToolbarRadioButton`, `ToolbarToggleButton` & `ToolbarButton`

### DIFF
--- a/change/@fluentui-react-toolbar-697073d8-9508-4810-999d-7a02bbf83a87.json
+++ b/change/@fluentui-react-toolbar-697073d8-9508-4810-999d-7a02bbf83a87.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: properly apply overrides in ToolbarRadioButton, ToolbarToggleButton & ToolbarButton",
+  "packageName": "@fluentui/react-toolbar",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarButton/useToolbarButtonStyles.styles.ts
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarButton/useToolbarButtonStyles.styles.ts
@@ -21,8 +21,8 @@ export const useToolbarButtonStyles_unstable = (state: ToolbarButtonState) => {
   useButtonStyles_unstable(state);
   const buttonStyles = useBaseStyles();
 
-  state.root.className = mergeClasses(state.root.className, state.vertical && buttonStyles.vertical);
+  state.root.className = mergeClasses(state.vertical && buttonStyles.vertical, state.root.className);
   if (state.icon) {
-    state.icon.className = mergeClasses(state.icon.className, state.vertical && buttonStyles.verticalIcon);
+    state.icon.className = mergeClasses(state.vertical && buttonStyles.verticalIcon, state.icon.className);
   }
 };

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarButton/useToolbarButtonStyles.styles.ts
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarButton/useToolbarButtonStyles.styles.ts
@@ -18,11 +18,13 @@ const useBaseStyles = makeStyles({
 export const useToolbarButtonStyles_unstable = (state: ToolbarButtonState) => {
   'use no memo';
 
-  useButtonStyles_unstable(state);
   const buttonStyles = useBaseStyles();
 
   state.root.className = mergeClasses(state.vertical && buttonStyles.vertical, state.root.className);
+
   if (state.icon) {
     state.icon.className = mergeClasses(state.vertical && buttonStyles.verticalIcon, state.icon.className);
   }
+
+  useButtonStyles_unstable(state);
 };

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarRadioButton/useToolbarRadioButtonStyles.styles.ts
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarRadioButton/useToolbarRadioButtonStyles.styles.ts
@@ -21,7 +21,6 @@ const useBaseStyles = makeStyles({
 export const useToolbarRadioButtonStyles_unstable = (state: ToolbarRadioButtonState): ToolbarRadioButtonState => {
   'use no memo';
 
-  useToggleButtonStyles_unstable(state);
   const toggleButtonStyles = useBaseStyles();
 
   state.root.className = mergeClasses(state.checked && toggleButtonStyles.selected, state.root.className);
@@ -29,6 +28,8 @@ export const useToolbarRadioButtonStyles_unstable = (state: ToolbarRadioButtonSt
   if (state.icon) {
     state.icon.className = mergeClasses(state.checked && toggleButtonStyles.iconSelected, state.icon.className);
   }
+
+  useToggleButtonStyles_unstable(state);
 
   return state;
 };

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarRadioButton/useToolbarRadioButtonStyles.styles.ts
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarRadioButton/useToolbarRadioButtonStyles.styles.ts
@@ -24,10 +24,10 @@ export const useToolbarRadioButtonStyles_unstable = (state: ToolbarRadioButtonSt
   useToggleButtonStyles_unstable(state);
   const toggleButtonStyles = useBaseStyles();
 
-  state.root.className = mergeClasses(state.root.className, state.checked && toggleButtonStyles.selected);
+  state.root.className = mergeClasses(state.checked && toggleButtonStyles.selected, state.root.className);
 
   if (state.icon) {
-    state.icon.className = mergeClasses(state.icon.className, state.checked && toggleButtonStyles.iconSelected);
+    state.icon.className = mergeClasses(state.checked && toggleButtonStyles.iconSelected, state.icon.className);
   }
 
   return state;

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarToggleButton/useToolbarToggleButtonStyles.styles.ts
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarToggleButton/useToolbarToggleButtonStyles.styles.ts
@@ -21,7 +21,6 @@ const useBaseStyles = makeStyles({
 export const useToolbarToggleButtonStyles_unstable = (state: ToolbarToggleButtonState): ToolbarToggleButtonState => {
   'use no memo';
 
-  useToggleButtonStyles_unstable(state);
   const toggleButtonStyles = useBaseStyles();
 
   state.root.className = mergeClasses(state.checked && toggleButtonStyles.selected, state.root.className);
@@ -29,6 +28,8 @@ export const useToolbarToggleButtonStyles_unstable = (state: ToolbarToggleButton
   if (state.icon) {
     state.icon.className = mergeClasses(state.checked && toggleButtonStyles.iconSelected, state.icon.className);
   }
+
+  useToggleButtonStyles_unstable(state);
 
   return state;
 };

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarToggleButton/useToolbarToggleButtonStyles.styles.ts
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarToggleButton/useToolbarToggleButtonStyles.styles.ts
@@ -24,10 +24,10 @@ export const useToolbarToggleButtonStyles_unstable = (state: ToolbarToggleButton
   useToggleButtonStyles_unstable(state);
   const toggleButtonStyles = useBaseStyles();
 
-  state.root.className = mergeClasses(state.root.className, state.checked && toggleButtonStyles.selected);
+  state.root.className = mergeClasses(state.checked && toggleButtonStyles.selected, state.root.className);
 
   if (state.icon) {
-    state.icon.className = mergeClasses(state.icon.className, state.checked && toggleButtonStyles.iconSelected);
+    state.icon.className = mergeClasses(state.checked && toggleButtonStyles.iconSelected, state.icon.className);
   }
 
   return state;


### PR DESCRIPTION
## Previous Behavior

Styles overrides can't be applied. 

## New Behavior

- Styles overrides can be applied
- Fixes order of style hooks

## Related Issue(s)

Fixes https://github.com/microsoft/fluentui/issues/34850.