### PR TITLE
docs(storybook): fix export-to-sandbox-button 

### DIFF
--- a/change/@fluentui-react-storybook-addon-export-to-sandbox-65ddd6b6-f2de-4e72-986c-e97e40b35dd2.json
+++ b/change/@fluentui-react-storybook-addon-export-to-sandbox-65ddd6b6-f2de-4e72-986c-e97e40b35dd2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(storybook-addon-export-to-sandbox): add mutation observer to wait for dom changes",
+  "packageName": "@fluentui/react-storybook-addon-export-to-sandbox",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-storybook-addon-export-to-sandbox/src/decorators/with-export-to-sandbox-button.ts
+++ b/packages/react-components/react-storybook-addon-export-to-sandbox/src/decorators/with-export-to-sandbox-button.ts
@@ -1,14 +1,21 @@
 import { addDemoActionButton } from '../sandbox-factory';
-
 import { StoryContext } from '../types';
 
 export const withExportToSandboxButton = (
-  storyFn: (context: StoryContext) => // eslint-disable-next-line @typescript-eslint/no-deprecated
-  JSX.Element,
+  // eslint-disable-line @typescript-eslint/no-deprecated
+  storyFn: (context: StoryContext) => JSX.Element,
   context: StoryContext,
 ) => {
-  if (context.viewMode === 'docs') {
-    addDemoActionButton(context);
+  if (context.viewMode === 'docs' && typeof window !== 'undefined') {
+    const observer = new MutationObserver(() => {
+      const toolbarContainer = document.querySelector('.docblock-controls');
+      if (toolbarContainer) {
+        addDemoActionButton(context);
+        observer.disconnect();
+      }
+    });
+
+    observer.observe(document.body, { childList: true, subtree: true });
   }
 
   return storyFn(context);


### PR DESCRIPTION
[Reported in FluentUI React (Web) channel](https://teams.microsoft.com/l/message/19:86b094239256467da9dfa96ba0897ca2@thread.skype/1752683615143?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=ffe264f2-14d0-48b5-9384-64f808b81294&parentMessageId=1752683615143&teamName=Fluent%20Community&channelName=Fluent%20UI%20React%20(Web)&createdTime=1752683615143)

## Previous Behavior

<img width="2450" height="1032" alt="image" src="https://github.com/user-attachments/assets/cf4b11a1-0e6e-462e-9d2b-ba2c09a03629" />


## New Behavior

<img width="2500" height="1734" alt="image" src="https://github.com/user-attachments/assets/c5bb5fed-60c7-4aca-b8c9-5839a75c9ea1" />

