### PR TITLE
fix(react-theme-stories): resolve Typography example issues

### DIFF
--- a/packages/react-components/react-theme/stories/src/Theme/typography/index.stories.mdx
+++ b/packages/react-components/react-theme/stories/src/Theme/typography/index.stories.mdx
@@ -15,7 +15,7 @@ Typography style is represented by a set of tokens instead of an individual toke
 > To take full advantage of the typography system, you should also read the [Text component documentation](./?path=/docs/components-text--docs).**
 
 <Canvas withSource="none">
-  <Story name="Page" component={Typography} />
+  <Typography />
 </Canvas>
 
 ## How to use


### PR DESCRIPTION
## Previous Behavior

<img width="2450" height="1032" alt="image" src="https://github.com/user-attachments/assets/cf4b11a1-0e6e-462e-9d2b-ba2c09a03629" />


## New Behavior

<img width="2500" height="1734" alt="image" src="https://github.com/user-attachments/assets/c5bb5fed-60c7-4aca-b8c9-5839a75c9ea1" />

Related: #34792 

Fixes: #34810 
