### PR TITLE
fix(react-tabs): fix circular tab sizes according to Figma spec

### DIFF
--- a/change/@fluentui-react-tabs-a4a4d97e-57aa-45af-a514-efc3c99c6417.json
+++ b/change/@fluentui-react-tabs-a4a4d97e-57aa-45af-a514-efc3c99c6417.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: adjust circular sizes to Figma spec",
+  "packageName": "@fluentui/react-tabs",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tabs/library/src/components/Tab/useTabStyles.styles.ts
+++ b/packages/react-components/react-tabs/library/src/components/Tab/useTabStyles.styles.ts
@@ -187,13 +187,13 @@ const useCircularAppearanceStyles = makeStyles({
     },
   },
   small: {
-    paddingBlock: `calc(${tokens.spacingVerticalXXS} - 1px)`,
+    paddingBlock: `calc(${tokens.spacingVerticalXXS} - ${tokens.strokeWidthThin})`,
   },
   medium: {
-    paddingBlock: `calc(${tokens.spacingVerticalSNudge} - 1px)`,
+    paddingBlock: `calc(${tokens.spacingVerticalSNudge} - ${tokens.strokeWidthThin})`,
   },
   large: {
-    paddingBlock: `calc(${tokens.spacingVerticalS} - 1px)`,
+    paddingBlock: `calc(${tokens.spacingVerticalS} - ${tokens.strokeWidthThin})`,
   },
   subtle: {
     backgroundColor: tokens.colorSubtleBackground,

--- a/packages/react-components/react-tabs/library/src/components/Tab/useTabStyles.styles.ts
+++ b/packages/react-components/react-tabs/library/src/components/Tab/useTabStyles.styles.ts
@@ -186,8 +186,14 @@ const useCircularAppearanceStyles = makeStyles({
       color: 'inherit',
     },
   },
+  small: {
+    paddingBlock: `calc(${tokens.spacingVerticalXXS} - 1px)`,
+  },
   medium: {
-    paddingBlock: `${tokens.spacingVerticalSNudge}`,
+    paddingBlock: `calc(${tokens.spacingVerticalSNudge} - 1px)`,
+  },
+  large: {
+    paddingBlock: `calc(${tokens.spacingVerticalS} - 1px)`,
   },
   subtle: {
     backgroundColor: tokens.colorSubtleBackground,
@@ -680,7 +686,9 @@ export const useTabButtonStyles_unstable = (state: TabState, slot: TabState['roo
     circularStyles.base,
     focusStyles.circular,
     // sizes
+    size === 'small' && circularStyles.small,
     size === 'medium' && circularStyles.medium,
+    size === 'large' && circularStyles.large,
     // subtle-circular appearance
     isSubtleCircular && circularStyles.subtle,
     selected && isSubtleCircular && circularStyles.subtleSelected,


### PR DESCRIPTION
### **Previous behaviour** 

**SMALL**
<p>
<img width="300" height="594" alt="image" src="https://github.com/user-attachments/assets/3a9ddb89-1143-4e17-aff7-f57ccc7cf3f3" />

<img width="300" height="182" alt="image" src="https://github.com/user-attachments/assets/c2f29492-6096-404d-95dc-7b9cbaf31e14" />
</p> 


**MEDIUM** 
<p>
<img width="300" height="594" alt="image" src="https://github.com/user-attachments/assets/da256344-f5dd-452c-9afc-32019786b891" />

<img width="300" height="182" alt="Screenshot 2025-07-16 at 23 49 26" src="https://github.com/user-attachments/assets/293ace7a-adf0-4ae6-b975-c9ddcb03b0d6" />
</p> 


**LARGE** 
<p>
<img width="300" height="392" alt="Screenshot 2025-07-17 at 0 01 08" src="https://github.com/user-attachments/assets/3719d250-adc7-469f-8ab5-2e8c589f94aa" />

<img width="273" height="125" alt="Screenshot 2025-07-17 at 0 01 58" src="https://github.com/user-attachments/assets/ee6bc38a-2673-4dc0-b61c-777b3ed294ce" />
</p> 

### **New behaviour** 

Updated circular sizes according Figma spec: 
- small: 24px
- medium: 32px
- large: 40px 



<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #34854
