### PR TITLE
fix: remove unnecessary tabindex logic from switch template

### DIFF
--- a/change/@fluentui-web-components-37103e2a-f73e-4bbd-b50b-3c7c3a080c13.json
+++ b/change/@fluentui-web-components-37103e2a-f73e-4bbd-b50b-3c7c3a080c13.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: remove unnecessary tabindex logic from switch template",
+  "packageName": "@fluentui/web-components",
+  "email": "machi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/switch/switch.styles.ts
+++ b/packages/web-components/src/switch/switch.styles.ts
@@ -45,6 +45,9 @@ export const styles = css`
     background-color: ${colorTransparentBackground};
     border: 1px solid ${colorNeutralStrokeAccessible};
     border-radius: ${borderRadiusCircular};
+  }
+
+  :host(:enabled) {
     cursor: pointer;
   }
 

--- a/packages/web-components/src/switch/switch.template.ts
+++ b/packages/web-components/src/switch/switch.template.ts
@@ -5,7 +5,6 @@ import type { Switch, SwitchOptions } from './switch.js';
 export function switchTemplate<T extends Switch>(options: SwitchOptions = {}): ElementViewTemplate<T> {
   return html<T>`
     <template
-      tabindex="${x => (!x.disabled ? 0 : void 0)}"
       @click="${(x, c) => x.clickHandler(c.event as MouseEvent)}"
       @input="${(x, c) => x.inputHandler(c.event as InputEvent)}"
       @keydown="${(x, c) => x.keydownHandler(c.event as KeyboardEvent)}"


### PR DESCRIPTION
## Previous Behavior

There's `tabindex` logic in Switch's template, but it's unncessary since Switch extends CheckboxBase, which handles `tabindex`'s logic in its JS class already.

## New Behavior

`tabindex` logic in template is removed.
