### PR TITLE
Adding inline legend and annotation support for horizontal stacked bar charts

### DIFF
--- a/change/@fluentui-react-charts-28a8dead-2cfc-4eb9-be51-3a6eecbf9495.json
+++ b/change/@fluentui-react-charts-28a8dead-2cfc-4eb9-be51-3a6eecbf9495.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Adding a variation of horizontal stacked bar chart with inline legends that accept optiona annotation JSX from client to be displayed next the legend items. Also an option to hide the hover callout card.",
+  "packageName": "@fluentui/react-charts",
+  "email": "aknowles@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charts/react-charts/library/src/components/AreaChart/__snapshots__/AreaChart.test.tsx.snap
+++ b/packages/charts/react-charts/library/src/components/AreaChart/__snapshots__/AreaChart.test.tsx.snap
@@ -14555,7 +14555,8 @@ Object {
               style="display: flex; flex-wrap: wrap; overflow: auto;"
             >
               <div
-                style="flex: 0 1 auto; margin: 4px;"
+                class="fui-legend__legendContainer"
+                id="0"
               >
                 <button
                   aria-label="legend1"
@@ -14577,7 +14578,8 @@ Object {
                 </button>
               </div>
               <div
-                style="flex: 0 1 auto; margin: 4px;"
+                class="fui-legend__legendContainer"
+                id="1"
               >
                 <button
                   aria-label="legend2"
@@ -14599,7 +14601,8 @@ Object {
                 </button>
               </div>
               <div
-                style="flex: 0 1 auto; margin: 4px;"
+                class="fui-legend__legendContainer"
+                id="2"
               >
                 <button
                   aria-label="legend3"
@@ -15406,7 +15409,8 @@ Object {
             style="display: flex; flex-wrap: wrap; overflow: auto;"
           >
             <div
-              style="flex: 0 1 auto; margin: 4px;"
+              class="fui-legend__legendContainer"
+              id="0"
             >
               <button
                 aria-label="legend1"
@@ -15428,7 +15432,8 @@ Object {
               </button>
             </div>
             <div
-              style="flex: 0 1 auto; margin: 4px;"
+              class="fui-legend__legendContainer"
+              id="1"
             >
               <button
                 aria-label="legend2"
@@ -15450,7 +15455,8 @@ Object {
               </button>
             </div>
             <div
-              style="flex: 0 1 auto; margin: 4px;"
+              class="fui-legend__legendContainer"
+              id="2"
             >
               <button
                 aria-label="legend3"

--- a/packages/charts/react-charts/library/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
+++ b/packages/charts/react-charts/library/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
@@ -2562,12 +2562,8 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
         }
       >
         <div
-          style={
-            Object {
-              "flex": "0 1 auto",
-              "margin": "4px",
-            }
-          }
+          className="fui-legend__legendContainer"
+          id="0"
         >
           <button
             aria-label="first"
@@ -2615,12 +2611,8 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
           </button>
         </div>
         <div
-          style={
-            Object {
-              "flex": "0 1 auto",
-              "margin": "4px",
-            }
-          }
+          className="fui-legend__legendContainer"
+          id="1"
         >
           <button
             aria-label="second"
@@ -2668,12 +2660,8 @@ exports[`DonutChart snapShot testing renders enabledLegendsWrapLines correctly 1
           </button>
         </div>
         <div
-          style={
-            Object {
-              "flex": "0 1 auto",
-              "margin": "4px",
-            }
-          }
+          className="fui-legend__legendContainer"
+          id="2"
         >
           <button
             aria-label="third"

--- a/packages/charts/react-charts/library/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
+++ b/packages/charts/react-charts/library/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
@@ -2524,7 +2524,8 @@ Object {
               style="display: flex; flex-wrap: wrap; overflow: auto;"
             >
               <div
-                style="flex: 0 1 auto; margin: 4px;"
+                class="fui-legend__legendContainer"
+                id="0"
               >
                 <button
                   aria-label="MetaData1"
@@ -2546,7 +2547,8 @@ Object {
                 </button>
               </div>
               <div
-                style="flex: 0 1 auto; margin: 4px;"
+                class="fui-legend__legendContainer"
+                id="1"
               >
                 <button
                   aria-label="MetaData4"
@@ -2934,7 +2936,8 @@ Object {
             style="display: flex; flex-wrap: wrap; overflow: auto;"
           >
             <div
-              style="flex: 0 1 auto; margin: 4px;"
+              class="fui-legend__legendContainer"
+              id="0"
             >
               <button
                 aria-label="MetaData1"
@@ -2956,7 +2959,8 @@ Object {
               </button>
             </div>
             <div
-              style="flex: 0 1 auto; margin: 4px;"
+              class="fui-legend__legendContainer"
+              id="1"
             >
               <button
                 aria-label="MetaData4"

--- a/packages/charts/react-charts/library/src/components/HeatMapChart/__snapshots__/HeatMapChart.test.tsx.snap
+++ b/packages/charts/react-charts/library/src/components/HeatMapChart/__snapshots__/HeatMapChart.test.tsx.snap
@@ -52,7 +52,7 @@ Object {
                   fill="currentColor"
                   y="10"
                 >
-                  Mar/01
+                  Feb/29
                 </text>
               </g>
               <g
@@ -70,7 +70,7 @@ Object {
                   fill="currentColor"
                   y="10"
                 >
-                  Mar/02
+                  Mar/01
                 </text>
               </g>
             </g>
@@ -150,7 +150,7 @@ Object {
               </g>
             </g>
             <g
-              aria-label="Mar/01, p2. Nasty, 50/2391. a good day to start with in Texas with best air quality."
+              aria-label="Feb/29, p2. Nasty, 50/2391. a good day to start with in Texas with best air quality."
               fill-opacity="1"
               role="img"
               tabindex="0"
@@ -172,7 +172,7 @@ Object {
               </text>
             </g>
             <g
-              aria-label="Mar/02, p2. Execllent (0-200), 25/2479. Due to unexpected heavy rain, all the pollutants are washed
+              aria-label="Mar/01, p2. Execllent (0-200), 25/2479. Due to unexpected heavy rain, all the pollutants are washed
         off and people of alaska are hoping for more of this days."
               fill-opacity="1"
               role="img"
@@ -195,7 +195,7 @@ Object {
               </text>
             </g>
             <g
-              aria-label="Mar/01, p1. Execllent (0-200), 50/2391. a good day to start with in Texas with best air quality."
+              aria-label="Feb/29, p1. Execllent (0-200), 50/2391. a good day to start with in Texas with best air quality."
               fill-opacity="1"
               role="img"
               tabindex="0"
@@ -217,7 +217,7 @@ Object {
               </text>
             </g>
             <g
-              aria-label="Mar/02, p1. Nasty, 25/2479. Due to unexpected heavy rain, all the pollutants are washed
+              aria-label="Mar/01, p1. Nasty, 25/2479. Due to unexpected heavy rain, all the pollutants are washed
       off and people of alaska are hoping for more of this days."
               fill-opacity="1"
               role="img"
@@ -345,7 +345,7 @@ Object {
                 fill="currentColor"
                 y="10"
               >
-                Mar/01
+                Feb/29
               </text>
             </g>
             <g
@@ -363,7 +363,7 @@ Object {
                 fill="currentColor"
                 y="10"
               >
-                Mar/02
+                Mar/01
               </text>
             </g>
           </g>
@@ -443,7 +443,7 @@ Object {
             </g>
           </g>
           <g
-            aria-label="Mar/01, p2. Nasty, 50/2391. a good day to start with in Texas with best air quality."
+            aria-label="Feb/29, p2. Nasty, 50/2391. a good day to start with in Texas with best air quality."
             fill-opacity="1"
             role="img"
             tabindex="0"
@@ -465,7 +465,7 @@ Object {
             </text>
           </g>
           <g
-            aria-label="Mar/02, p2. Execllent (0-200), 25/2479. Due to unexpected heavy rain, all the pollutants are washed
+            aria-label="Mar/01, p2. Execllent (0-200), 25/2479. Due to unexpected heavy rain, all the pollutants are washed
         off and people of alaska are hoping for more of this days."
             fill-opacity="1"
             role="img"
@@ -488,7 +488,7 @@ Object {
             </text>
           </g>
           <g
-            aria-label="Mar/01, p1. Execllent (0-200), 50/2391. a good day to start with in Texas with best air quality."
+            aria-label="Feb/29, p1. Execllent (0-200), 50/2391. a good day to start with in Texas with best air quality."
             fill-opacity="1"
             role="img"
             tabindex="0"
@@ -510,7 +510,7 @@ Object {
             </text>
           </g>
           <g
-            aria-label="Mar/02, p1. Nasty, 25/2479. Due to unexpected heavy rain, all the pollutants are washed
+            aria-label="Mar/01, p1. Nasty, 25/2479. Due to unexpected heavy rain, all the pollutants are washed
       off and people of alaska are hoping for more of this days."
             fill-opacity="1"
             role="img"
@@ -1338,7 +1338,7 @@ Object {
                   fill="currentColor"
                   y="10"
                 >
-                  Mar/01
+                  Feb/29
                 </text>
               </g>
               <g
@@ -1356,7 +1356,7 @@ Object {
                   fill="currentColor"
                   y="10"
                 >
-                  Mar/02
+                  Mar/01
                 </text>
               </g>
             </g>
@@ -1436,7 +1436,7 @@ Object {
               </g>
             </g>
             <g
-              aria-label="Mar/01, p2. Nasty, 50/2391. a good day to start with in Texas with best air quality."
+              aria-label="Feb/29, p2. Nasty, 50/2391. a good day to start with in Texas with best air quality."
               fill-opacity="1"
               role="img"
               tabindex="0"
@@ -1458,7 +1458,7 @@ Object {
               </text>
             </g>
             <g
-              aria-label="Mar/02, p2. Execllent (0-200), 25/2479. Due to unexpected heavy rain, all the pollutants are washed
+              aria-label="Mar/01, p2. Execllent (0-200), 25/2479. Due to unexpected heavy rain, all the pollutants are washed
         off and people of alaska are hoping for more of this days."
               fill-opacity="1"
               role="img"
@@ -1481,7 +1481,7 @@ Object {
               </text>
             </g>
             <g
-              aria-label="Mar/01, p1. Execllent (0-200), 50/2391. a good day to start with in Texas with best air quality."
+              aria-label="Feb/29, p1. Execllent (0-200), 50/2391. a good day to start with in Texas with best air quality."
               fill-opacity="1"
               role="img"
               tabindex="0"
@@ -1503,7 +1503,7 @@ Object {
               </text>
             </g>
             <g
-              aria-label="Mar/02, p1. Nasty, 25/2479. Due to unexpected heavy rain, all the pollutants are washed
+              aria-label="Mar/01, p1. Nasty, 25/2479. Due to unexpected heavy rain, all the pollutants are washed
       off and people of alaska are hoping for more of this days."
               fill-opacity="1"
               role="img"
@@ -1576,7 +1576,7 @@ Object {
                 fill="currentColor"
                 y="10"
               >
-                Mar/01
+                Feb/29
               </text>
             </g>
             <g
@@ -1594,7 +1594,7 @@ Object {
                 fill="currentColor"
                 y="10"
               >
-                Mar/02
+                Mar/01
               </text>
             </g>
           </g>
@@ -1674,7 +1674,7 @@ Object {
             </g>
           </g>
           <g
-            aria-label="Mar/01, p2. Nasty, 50/2391. a good day to start with in Texas with best air quality."
+            aria-label="Feb/29, p2. Nasty, 50/2391. a good day to start with in Texas with best air quality."
             fill-opacity="1"
             role="img"
             tabindex="0"
@@ -1696,7 +1696,7 @@ Object {
             </text>
           </g>
           <g
-            aria-label="Mar/02, p2. Execllent (0-200), 25/2479. Due to unexpected heavy rain, all the pollutants are washed
+            aria-label="Mar/01, p2. Execllent (0-200), 25/2479. Due to unexpected heavy rain, all the pollutants are washed
         off and people of alaska are hoping for more of this days."
             fill-opacity="1"
             role="img"
@@ -1719,7 +1719,7 @@ Object {
             </text>
           </g>
           <g
-            aria-label="Mar/01, p1. Execllent (0-200), 50/2391. a good day to start with in Texas with best air quality."
+            aria-label="Feb/29, p1. Execllent (0-200), 50/2391. a good day to start with in Texas with best air quality."
             fill-opacity="1"
             role="img"
             tabindex="0"
@@ -1741,7 +1741,7 @@ Object {
             </text>
           </g>
           <g
-            aria-label="Mar/02, p1. Nasty, 25/2479. Due to unexpected heavy rain, all the pollutants are washed
+            aria-label="Mar/01, p1. Nasty, 25/2479. Due to unexpected heavy rain, all the pollutants are washed
       off and people of alaska are hoping for more of this days."
             fill-opacity="1"
             role="img"
@@ -1873,7 +1873,7 @@ Object {
                   fill="currentColor"
                   y="10"
                 >
-                  Mar/01
+                  Feb/29
                 </text>
               </g>
               <g
@@ -1891,7 +1891,7 @@ Object {
                   fill="currentColor"
                   y="10"
                 >
-                  Mar/02
+                  Mar/01
                 </text>
               </g>
             </g>
@@ -1971,7 +1971,7 @@ Object {
               </g>
             </g>
             <g
-              aria-label="Mar/01, p2. Nasty, 50/2391. a good day to start with in Texas with best air quality."
+              aria-label="Feb/29, p2. Nasty, 50/2391. a good day to start with in Texas with best air quality."
               fill-opacity="1"
               role="img"
               tabindex="0"
@@ -1993,7 +1993,7 @@ Object {
               </text>
             </g>
             <g
-              aria-label="Mar/02, p2. Execllent (0-200), 25/2479. Due to unexpected heavy rain, all the pollutants are washed
+              aria-label="Mar/01, p2. Execllent (0-200), 25/2479. Due to unexpected heavy rain, all the pollutants are washed
         off and people of alaska are hoping for more of this days."
               fill-opacity="1"
               role="img"
@@ -2016,7 +2016,7 @@ Object {
               </text>
             </g>
             <g
-              aria-label="Mar/01, p1. Execllent (0-200), 50/2391. a good day to start with in Texas with best air quality."
+              aria-label="Feb/29, p1. Execllent (0-200), 50/2391. a good day to start with in Texas with best air quality."
               fill-opacity="1"
               role="img"
               tabindex="0"
@@ -2038,7 +2038,7 @@ Object {
               </text>
             </g>
             <g
-              aria-label="Mar/02, p1. Nasty, 25/2479. Due to unexpected heavy rain, all the pollutants are washed
+              aria-label="Mar/01, p1. Nasty, 25/2479. Due to unexpected heavy rain, all the pollutants are washed
       off and people of alaska are hoping for more of this days."
               fill-opacity="1"
               role="img"
@@ -2166,7 +2166,7 @@ Object {
                 fill="currentColor"
                 y="10"
               >
-                Mar/01
+                Feb/29
               </text>
             </g>
             <g
@@ -2184,7 +2184,7 @@ Object {
                 fill="currentColor"
                 y="10"
               >
-                Mar/02
+                Mar/01
               </text>
             </g>
           </g>
@@ -2264,7 +2264,7 @@ Object {
             </g>
           </g>
           <g
-            aria-label="Mar/01, p2. Nasty, 50/2391. a good day to start with in Texas with best air quality."
+            aria-label="Feb/29, p2. Nasty, 50/2391. a good day to start with in Texas with best air quality."
             fill-opacity="1"
             role="img"
             tabindex="0"
@@ -2286,7 +2286,7 @@ Object {
             </text>
           </g>
           <g
-            aria-label="Mar/02, p2. Execllent (0-200), 25/2479. Due to unexpected heavy rain, all the pollutants are washed
+            aria-label="Mar/01, p2. Execllent (0-200), 25/2479. Due to unexpected heavy rain, all the pollutants are washed
         off and people of alaska are hoping for more of this days."
             fill-opacity="1"
             role="img"
@@ -2309,7 +2309,7 @@ Object {
             </text>
           </g>
           <g
-            aria-label="Mar/01, p1. Execllent (0-200), 50/2391. a good day to start with in Texas with best air quality."
+            aria-label="Feb/29, p1. Execllent (0-200), 50/2391. a good day to start with in Texas with best air quality."
             fill-opacity="1"
             role="img"
             tabindex="0"
@@ -2331,7 +2331,7 @@ Object {
             </text>
           </g>
           <g
-            aria-label="Mar/02, p1. Nasty, 25/2479. Due to unexpected heavy rain, all the pollutants are washed
+            aria-label="Mar/01, p1. Nasty, 25/2479. Due to unexpected heavy rain, all the pollutants are washed
       off and people of alaska are hoping for more of this days."
             fill-opacity="1"
             role="img"
@@ -2518,7 +2518,7 @@ Object {
                   fill="currentColor"
                   y="10"
                 >
-                  Mar/01
+                  Feb/29
                 </text>
               </g>
               <g
@@ -2536,7 +2536,7 @@ Object {
                   fill="currentColor"
                   y="10"
                 >
-                  Mar/02
+                  Mar/01
                 </text>
               </g>
             </g>
@@ -2616,7 +2616,7 @@ Object {
               </g>
             </g>
             <g
-              aria-label="Mar/01, p2. Nasty, 50/2391. a good day to start with in Texas with best air quality."
+              aria-label="Feb/29, p2. Nasty, 50/2391. a good day to start with in Texas with best air quality."
               fill-opacity="1"
               role="img"
               tabindex="0"
@@ -2638,7 +2638,7 @@ Object {
               </text>
             </g>
             <g
-              aria-label="Mar/02, p2. Execllent (0-200), 25/2479. Due to unexpected heavy rain, all the pollutants are washed
+              aria-label="Mar/01, p2. Execllent (0-200), 25/2479. Due to unexpected heavy rain, all the pollutants are washed
         off and people of alaska are hoping for more of this days."
               fill-opacity="1"
               role="img"
@@ -2661,7 +2661,7 @@ Object {
               </text>
             </g>
             <g
-              aria-label="Mar/01, p1. Execllent (0-200), 50/2391. a good day to start with in Texas with best air quality."
+              aria-label="Feb/29, p1. Execllent (0-200), 50/2391. a good day to start with in Texas with best air quality."
               fill-opacity="1"
               role="img"
               tabindex="0"
@@ -2683,7 +2683,7 @@ Object {
               </text>
             </g>
             <g
-              aria-label="Mar/02, p1. Nasty, 25/2479. Due to unexpected heavy rain, all the pollutants are washed
+              aria-label="Mar/01, p1. Nasty, 25/2479. Due to unexpected heavy rain, all the pollutants are washed
       off and people of alaska are hoping for more of this days."
               fill-opacity="1"
               role="img"
@@ -2811,7 +2811,7 @@ Object {
                 fill="currentColor"
                 y="10"
               >
-                Mar/01
+                Feb/29
               </text>
             </g>
             <g
@@ -2829,7 +2829,7 @@ Object {
                 fill="currentColor"
                 y="10"
               >
-                Mar/02
+                Mar/01
               </text>
             </g>
           </g>
@@ -2909,7 +2909,7 @@ Object {
             </g>
           </g>
           <g
-            aria-label="Mar/01, p2. Nasty, 50/2391. a good day to start with in Texas with best air quality."
+            aria-label="Feb/29, p2. Nasty, 50/2391. a good day to start with in Texas with best air quality."
             fill-opacity="1"
             role="img"
             tabindex="0"
@@ -2931,7 +2931,7 @@ Object {
             </text>
           </g>
           <g
-            aria-label="Mar/02, p2. Execllent (0-200), 25/2479. Due to unexpected heavy rain, all the pollutants are washed
+            aria-label="Mar/01, p2. Execllent (0-200), 25/2479. Due to unexpected heavy rain, all the pollutants are washed
         off and people of alaska are hoping for more of this days."
             fill-opacity="1"
             role="img"
@@ -2954,7 +2954,7 @@ Object {
             </text>
           </g>
           <g
-            aria-label="Mar/01, p1. Execllent (0-200), 50/2391. a good day to start with in Texas with best air quality."
+            aria-label="Feb/29, p1. Execllent (0-200), 50/2391. a good day to start with in Texas with best air quality."
             fill-opacity="1"
             role="img"
             tabindex="0"
@@ -2976,7 +2976,7 @@ Object {
             </text>
           </g>
           <g
-            aria-label="Mar/02, p1. Nasty, 25/2479. Due to unexpected heavy rain, all the pollutants are washed
+            aria-label="Mar/01, p1. Nasty, 25/2479. Due to unexpected heavy rain, all the pollutants are washed
       off and people of alaska are hoping for more of this days."
             fill-opacity="1"
             role="img"
@@ -3167,7 +3167,7 @@ Object {
                     fill="currentColor"
                     y="10"
                   >
-                    Mar/01
+                    Feb/29
                   </text>
                 </g>
                 <g
@@ -3185,7 +3185,7 @@ Object {
                     fill="currentColor"
                     y="10"
                   >
-                    Mar/02
+                    Mar/01
                   </text>
                 </g>
               </g>
@@ -3265,7 +3265,7 @@ Object {
                 </g>
               </g>
               <g
-                aria-label="Mar/01, p2. Nasty, 50/2391. a good day to start with in Texas with best air quality."
+                aria-label="Feb/29, p2. Nasty, 50/2391. a good day to start with in Texas with best air quality."
                 fill-opacity="1"
                 role="img"
                 tabindex="0"
@@ -3287,7 +3287,7 @@ Object {
                 </text>
               </g>
               <g
-                aria-label="Mar/02, p2. Execllent (0-200), 25/2479. Due to unexpected heavy rain, all the pollutants are washed
+                aria-label="Mar/01, p2. Execllent (0-200), 25/2479. Due to unexpected heavy rain, all the pollutants are washed
         off and people of alaska are hoping for more of this days."
                 fill-opacity="1"
                 role="img"
@@ -3310,7 +3310,7 @@ Object {
                 </text>
               </g>
               <g
-                aria-label="Mar/01, p1. Execllent (0-200), 50/2391. a good day to start with in Texas with best air quality."
+                aria-label="Feb/29, p1. Execllent (0-200), 50/2391. a good day to start with in Texas with best air quality."
                 fill-opacity="1"
                 role="img"
                 tabindex="0"
@@ -3332,7 +3332,7 @@ Object {
                 </text>
               </g>
               <g
-                aria-label="Mar/02, p1. Nasty, 25/2479. Due to unexpected heavy rain, all the pollutants are washed
+                aria-label="Mar/01, p1. Nasty, 25/2479. Due to unexpected heavy rain, all the pollutants are washed
       off and people of alaska are hoping for more of this days."
                 fill-opacity="1"
                 role="img"
@@ -3465,7 +3465,7 @@ Object {
                   fill="currentColor"
                   y="10"
                 >
-                  Mar/01
+                  Feb/29
                 </text>
               </g>
               <g
@@ -3483,7 +3483,7 @@ Object {
                   fill="currentColor"
                   y="10"
                 >
-                  Mar/02
+                  Mar/01
                 </text>
               </g>
             </g>
@@ -3563,7 +3563,7 @@ Object {
               </g>
             </g>
             <g
-              aria-label="Mar/01, p2. Nasty, 50/2391. a good day to start with in Texas with best air quality."
+              aria-label="Feb/29, p2. Nasty, 50/2391. a good day to start with in Texas with best air quality."
               fill-opacity="1"
               role="img"
               tabindex="0"
@@ -3585,7 +3585,7 @@ Object {
               </text>
             </g>
             <g
-              aria-label="Mar/02, p2. Execllent (0-200), 25/2479. Due to unexpected heavy rain, all the pollutants are washed
+              aria-label="Mar/01, p2. Execllent (0-200), 25/2479. Due to unexpected heavy rain, all the pollutants are washed
         off and people of alaska are hoping for more of this days."
               fill-opacity="1"
               role="img"
@@ -3608,7 +3608,7 @@ Object {
               </text>
             </g>
             <g
-              aria-label="Mar/01, p1. Execllent (0-200), 50/2391. a good day to start with in Texas with best air quality."
+              aria-label="Feb/29, p1. Execllent (0-200), 50/2391. a good day to start with in Texas with best air quality."
               fill-opacity="1"
               role="img"
               tabindex="0"
@@ -3630,7 +3630,7 @@ Object {
               </text>
             </g>
             <g
-              aria-label="Mar/02, p1. Nasty, 25/2479. Due to unexpected heavy rain, all the pollutants are washed
+              aria-label="Mar/01, p1. Nasty, 25/2479. Due to unexpected heavy rain, all the pollutants are washed
       off and people of alaska are hoping for more of this days."
               fill-opacity="1"
               role="img"
@@ -3821,7 +3821,7 @@ Object {
                     fill="currentColor"
                     y="10"
                   >
-                    Mar/01
+                    Feb/29
                   </text>
                 </g>
                 <g
@@ -3839,7 +3839,7 @@ Object {
                     fill="currentColor"
                     y="10"
                   >
-                    Mar/02
+                    Mar/01
                   </text>
                 </g>
               </g>
@@ -3919,7 +3919,7 @@ Object {
                 </g>
               </g>
               <g
-                aria-label="Mar/01, p2. Nasty, 50/2391. a good day to start with in Texas with best air quality."
+                aria-label="Feb/29, p2. Nasty, 50/2391. a good day to start with in Texas with best air quality."
                 fill-opacity="1"
                 role="img"
                 tabindex="0"
@@ -3941,7 +3941,7 @@ Object {
                 </text>
               </g>
               <g
-                aria-label="Mar/02, p2. Execllent (0-200), 25/2479. Due to unexpected heavy rain, all the pollutants are washed
+                aria-label="Mar/01, p2. Execllent (0-200), 25/2479. Due to unexpected heavy rain, all the pollutants are washed
         off and people of alaska are hoping for more of this days."
                 fill-opacity="1"
                 role="img"
@@ -3964,7 +3964,7 @@ Object {
                 </text>
               </g>
               <g
-                aria-label="Mar/01, p1. Execllent (0-200), 50/2391. a good day to start with in Texas with best air quality."
+                aria-label="Feb/29, p1. Execllent (0-200), 50/2391. a good day to start with in Texas with best air quality."
                 fill-opacity="1"
                 role="img"
                 tabindex="0"
@@ -3986,7 +3986,7 @@ Object {
                 </text>
               </g>
               <g
-                aria-label="Mar/02, p1. Nasty, 25/2479. Due to unexpected heavy rain, all the pollutants are washed
+                aria-label="Mar/01, p1. Nasty, 25/2479. Due to unexpected heavy rain, all the pollutants are washed
       off and people of alaska are hoping for more of this days."
                 fill-opacity="1"
                 role="img"
@@ -4118,7 +4118,7 @@ Object {
                   fill="currentColor"
                   y="10"
                 >
-                  Mar/01
+                  Feb/29
                 </text>
               </g>
               <g
@@ -4136,7 +4136,7 @@ Object {
                   fill="currentColor"
                   y="10"
                 >
-                  Mar/02
+                  Mar/01
                 </text>
               </g>
             </g>
@@ -4216,7 +4216,7 @@ Object {
               </g>
             </g>
             <g
-              aria-label="Mar/01, p2. Nasty, 50/2391. a good day to start with in Texas with best air quality."
+              aria-label="Feb/29, p2. Nasty, 50/2391. a good day to start with in Texas with best air quality."
               fill-opacity="1"
               role="img"
               tabindex="0"
@@ -4238,7 +4238,7 @@ Object {
               </text>
             </g>
             <g
-              aria-label="Mar/02, p2. Execllent (0-200), 25/2479. Due to unexpected heavy rain, all the pollutants are washed
+              aria-label="Mar/01, p2. Execllent (0-200), 25/2479. Due to unexpected heavy rain, all the pollutants are washed
         off and people of alaska are hoping for more of this days."
               fill-opacity="1"
               role="img"
@@ -4261,7 +4261,7 @@ Object {
               </text>
             </g>
             <g
-              aria-label="Mar/01, p1. Execllent (0-200), 50/2391. a good day to start with in Texas with best air quality."
+              aria-label="Feb/29, p1. Execllent (0-200), 50/2391. a good day to start with in Texas with best air quality."
               fill-opacity="1"
               role="img"
               tabindex="0"
@@ -4283,7 +4283,7 @@ Object {
               </text>
             </g>
             <g
-              aria-label="Mar/02, p1. Nasty, 25/2479. Due to unexpected heavy rain, all the pollutants are washed
+              aria-label="Mar/01, p1. Nasty, 25/2479. Due to unexpected heavy rain, all the pollutants are washed
       off and people of alaska are hoping for more of this days."
               fill-opacity="1"
               role="img"

--- a/packages/charts/react-charts/library/src/components/HorizontalBarChart/HorizontalBarChart.test.tsx
+++ b/packages/charts/react-charts/library/src/components/HorizontalBarChart/HorizontalBarChart.test.tsx
@@ -13,7 +13,7 @@ const chartPoints: ChartProps[] = [
     chartTitle: 'one',
     chartData: [
       {
-        legend: 'one',
+        legend: 'one.one',
         horizontalBarChartdata: { x: 1543, total: 15000 },
         color: '#004b50',
         xAxisCalloutData: '2020/04/30',
@@ -62,6 +62,30 @@ const chartPointsWithBenchMark: ChartProps[] = [
   },
 ];
 
+const chartPointsForStackedInlineLegend: ChartProps[] = [
+  {
+    chartTitle: 'one',
+    chartData: [
+      { legend: 'one.one', horizontalBarChartdata: { x: 10, total: 100 }, color: '#004b50' },
+      { legend: 'one.two', horizontalBarChartdata: { x: 90, total: 100 }, color: '#a4262c' },
+    ],
+  },
+  {
+    chartTitle: 'two',
+    chartData: [
+      { legend: 'two.one', horizontalBarChartdata: { x: 30, total: 200 }, color: '#5c2d91' },
+      { legend: 'two.two', horizontalBarChartdata: { x: 170, total: 200 }, color: '#a4262c' },
+    ],
+  },
+  {
+    chartTitle: 'three',
+    chartData: [
+      { legend: 'three.one', horizontalBarChartdata: { x: 15, total: 50 }, color: '#a4262c' },
+      { legend: 'three.two', horizontalBarChartdata: { x: 35, total: 50 }, color: '#5c2d91' },
+    ],
+  },
+];
+
 describe('Horizontal bar chart rendering', () => {
   beforeEach(() => {
     jest.spyOn(global.Math, 'random').mockReturnValue(0.1);
@@ -74,6 +98,16 @@ describe('Horizontal bar chart rendering', () => {
     'Should render the Horizontal bar chart legend with string data',
     HorizontalBarChart,
     { data: chartPoints },
+    container => {
+      // Assert
+      expect(container).toMatchSnapshot();
+    },
+  );
+
+  testWithoutWait(
+    'Should render the Horizontal bar chart with inline legends',
+    HorizontalBarChart,
+    { data: chartPointsForStackedInlineLegend, chartDataMode: 'legendInline' },
     container => {
       // Assert
       expect(container).toMatchSnapshot();
@@ -175,6 +209,19 @@ describe('Horizontal bar chart - Subcomponent bar', () => {
       expect(screen.queryByText('10%')).not.toBeNull();
       expect(screen.queryByText('5%')).not.toBeNull();
       expect(screen.queryByText('59%')).not.toBeNull();
+    },
+  );
+
+  testWithWait(
+    'Should not render the bars right side value when chartDataMode is legendInline',
+    HorizontalBarChart,
+    { data: chartPoints, chartDataMode: 'legendInline' },
+    container => {
+      // Assert
+      expect(screen.queryByText('10%')).toBeNull();
+      expect(screen.queryByText('5%')).toBeNull();
+      expect(screen.queryByText('59%')).toBeNull();
+      expect(getByClass(container, /fui-hbc__textDenom/i)).toHaveLength(0);
     },
   );
 

--- a/packages/charts/react-charts/library/src/components/HorizontalBarChart/HorizontalBarChart.types.ts
+++ b/packages/charts/react-charts/library/src/components/HorizontalBarChart/HorizontalBarChart.types.ts
@@ -195,7 +195,7 @@ export interface HorizontalBarChartStyles {
  * percentage: show the percentage of (datapoint.x/datapoint.y)%
  * {@docCategory HorizontalBarChart}
  */
-export type ChartDataMode = 'default' | 'fraction' | 'percentage';
+export type ChartDataMode = 'default' | 'fraction' | 'percentage' | 'legendInline';
 
 /**
  * {@docCategory HorizontalBarChart}

--- a/packages/charts/react-charts/library/src/components/HorizontalBarChart/__snapshots__/HorizontalBarChart.test.tsx.snap
+++ b/packages/charts/react-charts/library/src/components/HorizontalBarChart/__snapshots__/HorizontalBarChart.test.tsx.snap
@@ -199,7 +199,7 @@ exports[`Horizontal bar chart - Screen resolution Should remain unchanged on zoo
     </div>
     <div
       class="fui-cart__calloutContainer"
-      id="calloutr25"
+      id="calloutr2f"
     />
   </div>
 </div>
@@ -404,7 +404,7 @@ exports[`Horizontal bar chart - Screen resolution Should remain unchanged on zoo
     </div>
     <div
       class="fui-cart__calloutContainer"
-      id="calloutr2a"
+      id="calloutr2k"
     />
   </div>
 </div>
@@ -413,7 +413,7 @@ exports[`Horizontal bar chart - Screen resolution Should remain unchanged on zoo
 exports[`Horizontal bar chart - Theme Should reflect theme change 1`] = `
 <div>
   <div
-    class="fui-FluentProvider fui-FluentProviderr2b"
+    class="fui-FluentProvider fui-FluentProviderr2l"
     dir="ltr"
   >
     <div
@@ -613,7 +613,7 @@ exports[`Horizontal bar chart - Theme Should reflect theme change 1`] = `
       </div>
       <div
         class="fui-cart__calloutContainer"
-        id="calloutr2g"
+        id="calloutr2q"
       />
     </div>
   </div>
@@ -624,7 +624,7 @@ exports[`Horizontal bar chart re-rendering Should re-render the Horizontal bar c
 <div>
   <div
     aria-label="Graph has no data to display"
-    id="_HBC_emptyr2h"
+    id="_HBC_emptyr2r"
     role="alert"
     style="opacity: 0;"
   />
@@ -831,7 +831,7 @@ exports[`Horizontal bar chart re-rendering Should re-render the Horizontal bar c
     </div>
     <div
       class="fui-cart__calloutContainer"
-      id="calloutr2l"
+      id="calloutr2v"
     />
   </div>
 </div>
@@ -1042,6 +1042,403 @@ exports[`Horizontal bar chart rendering Should render the Horizontal bar chart l
 </div>
 `;
 
+exports[`Horizontal bar chart rendering Should render the Horizontal bar chart with inline legends 1`] = `
+<div>
+  <div
+    class="fui-hbc__root"
+  >
+    <div>
+      <div
+        class="fui-hbc__items"
+        data-tabster="{\\"groupper\\":{},\\"focusable\\":{}}"
+      >
+        <div
+          class="fui-hbc__chartTitle"
+        >
+          <div
+            class="fui-hbc__chartTitleLeft"
+            tabindex="0"
+          >
+            <span
+              data-is-focusable="false"
+              role="text"
+            >
+              one
+            </span>
+            <span
+              hidden=""
+            />
+          </div>
+        </div>
+        <svg
+          aria-label="one"
+          class="fui-hbc__chart"
+        >
+          <g
+            id="_HorizontalLine_lllllm_0"
+          >
+            <rect
+              aria-label="one.one, 10/100."
+              class="fui-hbc__barWrapper"
+              fill="#004b50"
+              height="12"
+              opacity="1"
+              role="img"
+              tabindex="0"
+              width="10%"
+              x="0%"
+              y="0"
+            />
+            <rect
+              aria-label="one.two, 90/100."
+              class="fui-hbc__barWrapper"
+              fill="#a4262c"
+              height="12"
+              opacity="1"
+              role="img"
+              tabindex="0"
+              width="90%"
+              x="10%"
+              y="0"
+            />
+          </g>
+        </svg>
+        <div
+          class="fui-hbc__legendContainer"
+        >
+          <div
+            aria-label="Legends"
+            aria-multiselectable="false"
+            class="fui-legend__root"
+            data-tabster="{\\"mover\\":{\\"cyclic\\":false,\\"direction\\":2,\\"memorizeCurrent\\":true}}"
+            role="listbox"
+            style="justify-content: unset; flex-wrap: wrap;"
+          >
+            <div
+              class="fui-legend__resizableArea"
+              style="display: flex; flex-wrap: wrap; overflow: auto;"
+            >
+              <div
+                class="fui-legend__legendContainer"
+                id="0"
+              >
+                <button
+                  aria-label="one.one"
+                  aria-selected="false"
+                  class="fui-Button fui-legend__legend"
+                  role="option"
+                  style="--rect-height: 12px; --rect-backgroundColor: #004b50; --rect-borderColor: #004b50;"
+                  type="button"
+                >
+                  <div
+                    class="fui-legend__rect"
+                    style="height: 12px; background-color: rgb(0, 75, 80); border-color: #004b50; --rect-content-high-contrast: linear-gradient(to right, #004b50, #004b50);"
+                  />
+                  <div
+                    class="fui-legend__text"
+                  >
+                    one.one
+                  </div>
+                </button>
+                <div
+                  class=""
+                />
+              </div>
+              <div
+                class="fui-legend__legendContainer"
+                id="1"
+              >
+                <button
+                  aria-label="one.two"
+                  aria-selected="false"
+                  class="fui-Button fui-legend__legend"
+                  role="option"
+                  style="--rect-height: 12px; --rect-backgroundColor: #a4262c; --rect-borderColor: #a4262c;"
+                  type="button"
+                >
+                  <div
+                    class="fui-legend__rect"
+                    style="height: 12px; background-color: rgb(164, 38, 44); border-color: #a4262c; --rect-content-high-contrast: linear-gradient(to right, #a4262c, #a4262c);"
+                  />
+                  <div
+                    class="fui-legend__text"
+                  >
+                    one.two
+                  </div>
+                </button>
+                <div
+                  class=""
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div>
+      <div
+        class="fui-hbc__items"
+        data-tabster="{\\"groupper\\":{},\\"focusable\\":{}}"
+      >
+        <div
+          class="fui-hbc__chartTitle"
+        >
+          <div
+            class="fui-hbc__chartTitleLeft"
+            tabindex="0"
+          >
+            <span
+              data-is-focusable="false"
+              role="text"
+            >
+              two
+            </span>
+            <span
+              hidden=""
+            />
+          </div>
+        </div>
+        <svg
+          aria-label="two"
+          class="fui-hbc__chart"
+        >
+          <g
+            id="_HorizontalLine_lllllm_1"
+          >
+            <rect
+              aria-label="two.one, 30/200."
+              class="fui-hbc__barWrapper"
+              fill="#5c2d91"
+              height="12"
+              opacity="1"
+              role="img"
+              tabindex="0"
+              width="15%"
+              x="0%"
+              y="0"
+            />
+            <rect
+              aria-label="two.two, 170/200."
+              class="fui-hbc__barWrapper"
+              fill="#a4262c"
+              height="12"
+              opacity="1"
+              role="img"
+              tabindex="0"
+              width="85%"
+              x="15%"
+              y="0"
+            />
+          </g>
+        </svg>
+        <div
+          class="fui-hbc__legendContainer"
+        >
+          <div
+            aria-label="Legends"
+            aria-multiselectable="false"
+            class="fui-legend__root"
+            data-tabster="{\\"mover\\":{\\"cyclic\\":false,\\"direction\\":2,\\"memorizeCurrent\\":true}}"
+            role="listbox"
+            style="justify-content: unset; flex-wrap: wrap;"
+          >
+            <div
+              class="fui-legend__resizableArea"
+              style="display: flex; flex-wrap: wrap; overflow: auto;"
+            >
+              <div
+                class="fui-legend__legendContainer"
+                id="0"
+              >
+                <button
+                  aria-label="two.one"
+                  aria-selected="false"
+                  class="fui-Button fui-legend__legend"
+                  role="option"
+                  style="--rect-height: 12px; --rect-backgroundColor: #5c2d91; --rect-borderColor: #5c2d91;"
+                  type="button"
+                >
+                  <div
+                    class="fui-legend__rect"
+                    style="height: 12px; background-color: rgb(92, 45, 145); border-color: #5c2d91; --rect-content-high-contrast: linear-gradient(to right, #5c2d91, #5c2d91);"
+                  />
+                  <div
+                    class="fui-legend__text"
+                  >
+                    two.one
+                  </div>
+                </button>
+                <div
+                  class=""
+                />
+              </div>
+              <div
+                class="fui-legend__legendContainer"
+                id="1"
+              >
+                <button
+                  aria-label="two.two"
+                  aria-selected="false"
+                  class="fui-Button fui-legend__legend"
+                  role="option"
+                  style="--rect-height: 12px; --rect-backgroundColor: #a4262c; --rect-borderColor: #a4262c;"
+                  type="button"
+                >
+                  <div
+                    class="fui-legend__rect"
+                    style="height: 12px; background-color: rgb(164, 38, 44); border-color: #a4262c; --rect-content-high-contrast: linear-gradient(to right, #a4262c, #a4262c);"
+                  />
+                  <div
+                    class="fui-legend__text"
+                  >
+                    two.two
+                  </div>
+                </button>
+                <div
+                  class=""
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div>
+      <div
+        class="fui-hbc__items"
+        data-tabster="{\\"groupper\\":{},\\"focusable\\":{}}"
+      >
+        <div
+          class="fui-hbc__chartTitle"
+        >
+          <div
+            class="fui-hbc__chartTitleLeft"
+            tabindex="0"
+          >
+            <span
+              data-is-focusable="false"
+              role="text"
+            >
+              three
+            </span>
+            <span
+              hidden=""
+            />
+          </div>
+        </div>
+        <svg
+          aria-label="three"
+          class="fui-hbc__chart"
+        >
+          <g
+            id="_HorizontalLine_lllllm_2"
+          >
+            <rect
+              aria-label="three.one, 15/50."
+              class="fui-hbc__barWrapper"
+              fill="#a4262c"
+              height="12"
+              opacity="1"
+              role="img"
+              tabindex="0"
+              width="30%"
+              x="0%"
+              y="0"
+            />
+            <rect
+              aria-label="three.two, 35/50."
+              class="fui-hbc__barWrapper"
+              fill="#5c2d91"
+              height="12"
+              opacity="1"
+              role="img"
+              tabindex="0"
+              width="70%"
+              x="30%"
+              y="0"
+            />
+          </g>
+        </svg>
+        <div
+          class="fui-hbc__legendContainer"
+        >
+          <div
+            aria-label="Legends"
+            aria-multiselectable="false"
+            class="fui-legend__root"
+            data-tabster="{\\"mover\\":{\\"cyclic\\":false,\\"direction\\":2,\\"memorizeCurrent\\":true}}"
+            role="listbox"
+            style="justify-content: unset; flex-wrap: wrap;"
+          >
+            <div
+              class="fui-legend__resizableArea"
+              style="display: flex; flex-wrap: wrap; overflow: auto;"
+            >
+              <div
+                class="fui-legend__legendContainer"
+                id="0"
+              >
+                <button
+                  aria-label="three.one"
+                  aria-selected="false"
+                  class="fui-Button fui-legend__legend"
+                  role="option"
+                  style="--rect-height: 12px; --rect-backgroundColor: #a4262c; --rect-borderColor: #a4262c;"
+                  type="button"
+                >
+                  <div
+                    class="fui-legend__rect"
+                    style="height: 12px; background-color: rgb(164, 38, 44); border-color: #a4262c; --rect-content-high-contrast: linear-gradient(to right, #a4262c, #a4262c);"
+                  />
+                  <div
+                    class="fui-legend__text"
+                  >
+                    three.one
+                  </div>
+                </button>
+                <div
+                  class=""
+                />
+              </div>
+              <div
+                class="fui-legend__legendContainer"
+                id="1"
+              >
+                <button
+                  aria-label="three.two"
+                  aria-selected="false"
+                  class="fui-Button fui-legend__legend"
+                  role="option"
+                  style="--rect-height: 12px; --rect-backgroundColor: #5c2d91; --rect-borderColor: #5c2d91;"
+                  type="button"
+                >
+                  <div
+                    class="fui-legend__rect"
+                    style="height: 12px; background-color: rgb(92, 45, 145); border-color: #5c2d91; --rect-content-high-contrast: linear-gradient(to right, #5c2d91, #5c2d91);"
+                  />
+                  <div
+                    class="fui-legend__text"
+                  >
+                    three.two
+                  </div>
+                </button>
+                <div
+                  class=""
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="fui-cart__calloutContainer"
+      id="calloutr9"
+    />
+  </div>
+</div>
+`;
+
 exports[`HorizontalBarChart snapShot testing Should not render bar labels in absolute-scale variant 1`] = `
 Object {
   "asFragment": [Function],
@@ -1195,7 +1592,7 @@ Object {
         </div>
         <div
           class="fui-cart__calloutContainer"
-          id="calloutr34"
+          id="calloutr3e"
         />
       </div>
     </div>
@@ -1206,7 +1603,7 @@ Object {
     >
       <div
         class="fui-Tooltip__content"
-        id="tooltip-r31"
+        id="tooltip-r3b"
         role="tooltip"
       >
         one
@@ -1219,7 +1616,7 @@ Object {
     >
       <div
         class="fui-Tooltip__content"
-        id="tooltip-r32"
+        id="tooltip-r3c"
         role="tooltip"
       >
         two
@@ -1232,7 +1629,7 @@ Object {
     >
       <div
         class="fui-Tooltip__content"
-        id="tooltip-r33"
+        id="tooltip-r3d"
         role="tooltip"
       >
         three
@@ -1386,7 +1783,7 @@ Object {
       </div>
       <div
         class="fui-cart__calloutContainer"
-        id="calloutr34"
+        id="calloutr3e"
       />
     </div>
   </div>,
@@ -1624,7 +2021,7 @@ Object {
         </div>
         <div
           class="fui-cart__calloutContainer"
-          id="calloutr2v"
+          id="calloutr39"
         />
       </div>
     </div>
@@ -1635,7 +2032,7 @@ Object {
     >
       <div
         class="fui-Tooltip__content"
-        id="tooltip-r2s"
+        id="tooltip-r36"
         role="tooltip"
       >
         one
@@ -1648,7 +2045,7 @@ Object {
     >
       <div
         class="fui-Tooltip__content"
-        id="tooltip-r2t"
+        id="tooltip-r37"
         role="tooltip"
       >
         two
@@ -1661,7 +2058,7 @@ Object {
     >
       <div
         class="fui-Tooltip__content"
-        id="tooltip-r2u"
+        id="tooltip-r38"
         role="tooltip"
       >
         three
@@ -1842,7 +2239,7 @@ Object {
       </div>
       <div
         class="fui-cart__calloutContainer"
-        id="calloutr2v"
+        id="calloutr39"
       />
     </div>
   </div>,

--- a/packages/charts/react-charts/library/src/components/Legends/Legends.tsx
+++ b/packages/charts/react-charts/library/src/components/Legends/Legends.tsx
@@ -22,6 +22,7 @@ interface LegendItem extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   opacity?: number;
   stripePattern?: boolean;
   isLineLegendInBarChart?: boolean;
+  legendAnnotation?: () => React.ReactNode;
 }
 
 interface LegendMap {
@@ -122,8 +123,13 @@ export const Legends: React.FunctionComponent<LegendsProps> = React.forwardRef<H
         >
           <div className={classes.resizableArea} style={{ display: 'flex', flexWrap: 'wrap', overflow: 'auto' }}>
             {dataToRender.map((item, id) => (
-              <div key={id} style={{ flex: '0 1 auto', margin: '4px' }}>
+              <div className={classes.legendContainer} key={id} id={id.toString()}>
                 {_renderButton(item)}
+                {item.legendAnnotation && (
+                  <div className={''} key={`${id}-annotation`}>
+                    {item.legendAnnotation()}
+                  </div>
+                )}
               </div>
             ))}
           </div>
@@ -157,6 +163,7 @@ export const Legends: React.FunctionComponent<LegendsProps> = React.forwardRef<H
           isLineLegendInBarChart: legend.isLineLegendInBarChart,
           opacity: legend.opacity,
           key: index,
+          legendAnnotation: legend.legendAnnotation,
         };
       });
       return dataItems;

--- a/packages/charts/react-charts/library/src/components/Legends/Legends.types.ts
+++ b/packages/charts/react-charts/library/src/components/Legends/Legends.types.ts
@@ -46,6 +46,11 @@ export interface LegendsStyles {
    * Style for the area that is resizable
    */
   resizableArea?: string;
+
+  /*
+   * Style for the container that holds the legend and any optional JSX annotation from client is used
+   */
+  legendContainer?: string;
 }
 
 /**
@@ -103,6 +108,11 @@ export interface Legend {
    *  native button props for the legend button
    */
   nativeButtonProps?: React.ButtonHTMLAttributes<HTMLButtonElement>;
+
+  /**
+   * The annotation for the legend, function returning a React node
+   */
+  legendAnnotation?: () => React.ReactNode;
 }
 
 /**

--- a/packages/charts/react-charts/library/src/components/Legends/useLegendsStyles.styles.ts
+++ b/packages/charts/react-charts/library/src/components/Legends/useLegendsStyles.styles.ts
@@ -16,6 +16,7 @@ export const legendClassNames: SlotClassNames<LegendsStyles> = {
   text: 'fui-legend__text',
   hoverChange: 'fui-legend__hoverChange',
   resizableArea: 'fui-legend__resizableArea',
+  legendContainer: 'fui-legend__legendContainer',
 };
 
 const useStyles = makeStyles({
@@ -99,6 +100,13 @@ const useStyles = makeStyles({
       ...shorthands.borderLeft('-2px'),
     },
   },
+  legendContainer: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '4px',
+    flex: '0 1 auto',
+    margin: '4px',
+  },
 });
 
 export const useLegendStyles = (props: LegendsProps): LegendsStyles => {
@@ -114,5 +122,10 @@ export const useLegendStyles = (props: LegendsProps): LegendsStyles => {
     text: mergeClasses(legendClassNames.text, baseStyles.text, props.styles?.text),
     hoverChange: mergeClasses(legendClassNames.hoverChange, baseStyles.hoverChange, props.styles?.hoverChange),
     resizableArea: mergeClasses(legendClassNames.resizableArea, baseStyles.resizableArea, props.styles?.resizableArea),
+    legendContainer: mergeClasses(
+      legendClassNames.legendContainer,
+      baseStyles.legendContainer,
+      props.styles?.legendContainer,
+    ),
   };
 };

--- a/packages/charts/react-charts/library/src/components/LineChart/__snapshots__/LineChart.test.tsx.snap
+++ b/packages/charts/react-charts/library/src/components/LineChart/__snapshots__/LineChart.test.tsx.snap
@@ -4229,7 +4229,8 @@ Object {
               style="display: flex; flex-wrap: wrap; overflow: auto;"
             >
               <div
-                style="flex: 0 1 auto; margin: 4px;"
+                class="fui-legend__legendContainer"
+                id="0"
               >
                 <button
                   aria-label="metaData1"
@@ -4251,7 +4252,8 @@ Object {
                 </button>
               </div>
               <div
-                style="flex: 0 1 auto; margin: 4px;"
+                class="fui-legend__legendContainer"
+                id="1"
               >
                 <button
                   aria-label="metaData2"
@@ -4273,7 +4275,8 @@ Object {
                 </button>
               </div>
               <div
-                style="flex: 0 1 auto; margin: 4px;"
+                class="fui-legend__legendContainer"
+                id="2"
               >
                 <button
                   aria-label="metaData3"
@@ -4697,7 +4700,8 @@ Object {
             style="display: flex; flex-wrap: wrap; overflow: auto;"
           >
             <div
-              style="flex: 0 1 auto; margin: 4px;"
+              class="fui-legend__legendContainer"
+              id="0"
             >
               <button
                 aria-label="metaData1"
@@ -4719,7 +4723,8 @@ Object {
               </button>
             </div>
             <div
-              style="flex: 0 1 auto; margin: 4px;"
+              class="fui-legend__legendContainer"
+              id="1"
             >
               <button
                 aria-label="metaData2"
@@ -4741,7 +4746,8 @@ Object {
               </button>
             </div>
             <div
-              style="flex: 0 1 auto; margin: 4px;"
+              class="fui-legend__legendContainer"
+              id="2"
             >
               <button
                 aria-label="metaData3"

--- a/packages/charts/react-charts/library/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
+++ b/packages/charts/react-charts/library/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
@@ -3890,7 +3890,8 @@ exports[`VerticalBarChart - mouse events Should render callout correctly on mous
           style="display: flex; flex-wrap: wrap; overflow: auto;"
         >
           <div
-            style="flex: 0 1 auto; margin: 4px;"
+            class="fui-legend__legendContainer"
+            id="0"
           >
             <button
               aria-label="First"
@@ -3912,7 +3913,8 @@ exports[`VerticalBarChart - mouse events Should render callout correctly on mous
             </button>
           </div>
           <div
-            style="flex: 0 1 auto; margin: 4px;"
+            class="fui-legend__legendContainer"
+            id="1"
           >
             <button
               aria-label="Second"
@@ -3934,7 +3936,8 @@ exports[`VerticalBarChart - mouse events Should render callout correctly on mous
             </button>
           </div>
           <div
-            style="flex: 0 1 auto; margin: 4px;"
+            class="fui-legend__legendContainer"
+            id="2"
           >
             <button
               aria-label="Third"
@@ -4489,7 +4492,8 @@ exports[`VerticalBarChart - mouse events Should render customized callout on mou
           style="display: flex; flex-wrap: wrap; overflow: auto;"
         >
           <div
-            style="flex: 0 1 auto; margin: 4px;"
+            class="fui-legend__legendContainer"
+            id="0"
           >
             <button
               aria-label="First"
@@ -4511,7 +4515,8 @@ exports[`VerticalBarChart - mouse events Should render customized callout on mou
             </button>
           </div>
           <div
-            style="flex: 0 1 auto; margin: 4px;"
+            class="fui-legend__legendContainer"
+            id="1"
           >
             <button
               aria-label="Second"
@@ -4533,7 +4538,8 @@ exports[`VerticalBarChart - mouse events Should render customized callout on mou
             </button>
           </div>
           <div
-            style="flex: 0 1 auto; margin: 4px;"
+            class="fui-legend__legendContainer"
+            id="2"
           >
             <button
               aria-label="Third"
@@ -5696,12 +5702,8 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
         }
       >
         <div
-          style={
-            Object {
-              "flex": "0 1 auto",
-              "margin": "4px",
-            }
-          }
+          className="fui-legend__legendContainer"
+          id="0"
         >
           <button
             aria-label="First"
@@ -5749,12 +5751,8 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
           </button>
         </div>
         <div
-          style={
-            Object {
-              "flex": "0 1 auto",
-              "margin": "4px",
-            }
-          }
+          className="fui-legend__legendContainer"
+          id="1"
         >
           <button
             aria-label="Second"
@@ -5802,12 +5800,8 @@ exports[`VerticalBarChart snapShot testing renders enabledLegendsWrapLines corre
           </button>
         </div>
         <div
-          style={
-            Object {
-              "flex": "0 1 auto",
-              "margin": "4px",
-            }
-          }
+          className="fui-legend__legendContainer"
+          id="2"
         >
           <button
             aria-label="Third"

--- a/packages/charts/react-charts/library/src/components/VerticalStackedBarChart/__snapshots__/VerticalStackedBarChart.test.tsx.snap
+++ b/packages/charts/react-charts/library/src/components/VerticalStackedBarChart/__snapshots__/VerticalStackedBarChart.test.tsx.snap
@@ -1951,7 +1951,8 @@ exports[`VerticalStackedBarChart - mouse events Should render callout correctly 
           style="display: flex; flex-wrap: wrap; overflow: auto;"
         >
           <div
-            style="flex: 0 1 auto; margin: 4px;"
+            class="fui-legend__legendContainer"
+            id="0"
           >
             <button
               aria-label="Metadata1"
@@ -1973,7 +1974,8 @@ exports[`VerticalStackedBarChart - mouse events Should render callout correctly 
             </button>
           </div>
           <div
-            style="flex: 0 1 auto; margin: 4px;"
+            class="fui-legend__legendContainer"
+            id="1"
           >
             <button
               aria-label="Metadata2"
@@ -2498,7 +2500,8 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
           style="display: flex; flex-wrap: wrap; overflow: auto;"
         >
           <div
-            style="flex: 0 1 auto; margin: 4px;"
+            class="fui-legend__legendContainer"
+            id="0"
           >
             <button
               aria-label="Metadata1"
@@ -2520,7 +2523,8 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
             </button>
           </div>
           <div
-            style="flex: 0 1 auto; margin: 4px;"
+            class="fui-legend__legendContainer"
+            id="1"
           >
             <button
               aria-label="Metadata2"
@@ -3048,7 +3052,8 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
           style="display: flex; flex-wrap: wrap; overflow: auto;"
         >
           <div
-            style="flex: 0 1 auto; margin: 4px;"
+            class="fui-legend__legendContainer"
+            id="0"
           >
             <button
               aria-label="Line1"
@@ -3070,7 +3075,8 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
             </button>
           </div>
           <div
-            style="flex: 0 1 auto; margin: 4px;"
+            class="fui-legend__legendContainer"
+            id="1"
           >
             <button
               aria-label="Metadata1"
@@ -3092,7 +3098,8 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
             </button>
           </div>
           <div
-            style="flex: 0 1 auto; margin: 4px;"
+            class="fui-legend__legendContainer"
+            id="2"
           >
             <button
               aria-label="Metadata2"
@@ -4304,12 +4311,8 @@ exports[`VerticalStackedBarChart snapShot testing renders enabledLegendsWrapLine
         }
       >
         <div
-          style={
-            Object {
-              "flex": "0 1 auto",
-              "margin": "4px",
-            }
-          }
+          className="fui-legend__legendContainer"
+          id="0"
         >
           <button
             aria-label="Metadata1"
@@ -4357,12 +4360,8 @@ exports[`VerticalStackedBarChart snapShot testing renders enabledLegendsWrapLine
           </button>
         </div>
         <div
-          style={
-            Object {
-              "flex": "0 1 auto",
-              "margin": "4px",
-            }
-          }
+          className="fui-legend__legendContainer"
+          id="1"
         >
           <button
             aria-label="Metadata2"

--- a/packages/charts/react-charts/library/src/types/DataPoint.ts
+++ b/packages/charts/react-charts/library/src/types/DataPoint.ts
@@ -126,6 +126,11 @@ export interface ChartDataPoint {
   horizontalBarChartdata?: HorizontalDataPoint;
 
   /**
+   * additional annotation information per data point of the bar chart
+   */
+  annotation?: () => React.ReactNode;
+
+  /**
    * onClick action for each datapoint in the chart
    */
   onClick?: VoidFunction;

--- a/packages/charts/react-charts/stories/src/HorizontalBarChart/HorizontalBarChartStackedAnnotatedInlineLegend.stories.tsx
+++ b/packages/charts/react-charts/stories/src/HorizontalBarChart/HorizontalBarChartStackedAnnotatedInlineLegend.stories.tsx
@@ -1,0 +1,177 @@
+import * as React from 'react';
+import { HorizontalBarChart, getColorFromToken, DataVizPalette } from '@fluentui/react-charts';
+
+import { ChevronDown20Regular } from '@fluentui/react-icons';
+import { Popover, PopoverTrigger, PopoverSurface } from '@fluentui/react-popover';
+import { Persona } from '@fluentui/react-persona';
+
+export const HorizontalBarStackedAnnotatedInlineLegend = () => {
+  const annotationPopover = (names: string[]) => (
+    <Popover>
+      <PopoverTrigger disableButtonEnhancement>
+        <button /* styling here */
+          style={{
+            background: 'transparent',
+            border: 'none',
+            padding: 0,
+            cursor: 'pointer',
+            display: 'flex',
+            alignItems: 'center',
+            height: '16px', // smaller height
+            width: '16px', // smaller width
+          }}
+        >
+          <ChevronDown20Regular />
+        </button>
+      </PopoverTrigger>
+      <PopoverSurface>
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            gap: '4px',
+            flex: '0 1 auto',
+            margin: '4px',
+          }}
+        >
+          {names.map(name => (
+            <Persona key={name} name={name} />
+          ))}
+        </div>
+      </PopoverSurface>
+    </Popover>
+  );
+
+  const data = [
+    {
+      chartTitle: 'one',
+      chartData: [
+        {
+          legend: 'One.One',
+          horizontalBarChartdata: { x: 1543 },
+          color: getColorFromToken(DataVizPalette.color1),
+          annotation: () => annotationPopover(['Person 1', 'Person 2']),
+        },
+        {
+          legend: 'One.Two',
+          horizontalBarChartdata: { x: 1000 },
+          color: getColorFromToken(DataVizPalette.color2),
+          annotation: () => annotationPopover(['Person 3']),
+        },
+        {
+          legend: 'One.Three',
+          horizontalBarChartdata: { x: 547 },
+          color: getColorFromToken(DataVizPalette.color3),
+          annotation: () => annotationPopover(['Person 4', 'Person 5', 'Person 6']),
+        },
+        {
+          legend: 'One.One',
+          horizontalBarChartdata: { x: 1543 },
+          color: getColorFromToken(DataVizPalette.color4),
+          annotation: () => annotationPopover(['Person 1', 'Person 2']),
+        },
+        {
+          legend: 'One.Two',
+          horizontalBarChartdata: { x: 1000 },
+          color: getColorFromToken(DataVizPalette.color5),
+          annotation: () => annotationPopover(['Person 3']),
+        },
+      ],
+    },
+    {
+      chartTitle: 'two',
+      chartData: [
+        {
+          legend: 'Two.One',
+          horizontalBarChartdata: { x: 987 },
+          color: getColorFromToken(DataVizPalette.color7),
+          annotation: () => annotationPopover(['Person 7']),
+        },
+        {
+          legend: 'Two.Two',
+          horizontalBarChartdata: { x: 1987 },
+          color: getColorFromToken(DataVizPalette.color8),
+          annotation: () => annotationPopover(['Person 8', 'Person 9']),
+        },
+        {
+          legend: 'Two.One',
+          horizontalBarChartdata: { x: 987 },
+          color: getColorFromToken(DataVizPalette.color9),
+          annotation: () => annotationPopover(['Person 7']),
+        },
+        {
+          legend: 'Two.Two',
+          horizontalBarChartdata: { x: 1987 },
+          color: getColorFromToken(DataVizPalette.color10),
+          annotation: () => annotationPopover(['Person 8', 'Person 9']),
+        },
+      ],
+    },
+    {
+      chartTitle: 'three',
+      chartData: [
+        {
+          legend: 'Three.One',
+          horizontalBarChartdata: { x: 872 },
+          color: getColorFromToken(DataVizPalette.color13),
+          annotation: () => annotationPopover(['Person 10']),
+        },
+        {
+          legend: 'Three.Two',
+          horizontalBarChartdata: { x: 128 },
+          color: getColorFromToken(DataVizPalette.color14),
+          annotation: () => annotationPopover(['Person 11', 'Person 12']),
+        },
+        {
+          legend: 'Three.One',
+          horizontalBarChartdata: { x: 872 },
+          color: getColorFromToken(DataVizPalette.color13),
+          annotation: () => annotationPopover(['Person 10']),
+        },
+        {
+          legend: 'Three.Two',
+          horizontalBarChartdata: { x: 128 },
+          color: getColorFromToken(DataVizPalette.color15),
+          annotation: () => annotationPopover(['Person 11', 'Person 12']),
+        },
+        {
+          legend: 'Three.One',
+          horizontalBarChartdata: { x: 872 },
+          color: getColorFromToken(DataVizPalette.color16),
+          annotation: () => annotationPopover(['Person 10']),
+        },
+        {
+          legend: 'Three.Two',
+          horizontalBarChartdata: { x: 128 },
+          color: getColorFromToken(DataVizPalette.color17),
+          annotation: () => annotationPopover(['Person 11', 'Person 12']),
+        },
+        {
+          legend: 'Three.Two',
+          horizontalBarChartdata: { x: 128 },
+          color: getColorFromToken(DataVizPalette.color18),
+          annotation: () => annotationPopover(['Person 11', 'Person 12']),
+        },
+      ],
+    },
+  ];
+
+  return (
+    <div style={{ maxWidth: 600 }}>
+      <HorizontalBarChart
+        data={data}
+        chartDataMode={'legendInline'}
+        className={'hbcstacked'}
+        hideTooltip={true}
+        legendProps={{ enabledWrapLines: true }}
+      />
+    </div>
+  );
+};
+
+HorizontalBarStackedAnnotatedInlineLegend.parameters = {
+  docs: {
+    description: {},
+  },
+};

--- a/packages/charts/react-charts/stories/src/HorizontalBarChart/index.stories.tsx
+++ b/packages/charts/react-charts/stories/src/HorizontalBarChart/index.stories.tsx
@@ -9,6 +9,7 @@ export { HorizontalBarBenchmark } from './HorizontalBarChartBenchmark.stories';
 export { HorizontalBarStacked } from './HorizontalBarChartStacked.stories';
 export { HorizontalBarCustomAccessibility } from './HorizontalBarChartCustomAccessibility.stories';
 export { HorizontalBarCustomCallout } from './HorizontalBarChartCustomCallout.stories';
+export { HorizontalBarStackedAnnotatedInlineLegend } from './HorizontalBarChartStackedAnnotatedInlineLegend.stories';
 
 export default {
   title: 'Charts/HorizontalBarChart',


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [Yes] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [Yes] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->
Today, we do not have a way to display legends under each bar for a stacked horizontal bar chart. Also, we cannot pass in any additional props to be displayed next to the legend items. The legend items themselves only accept strings. 

<img width="1252" height="492" alt="image" src="https://github.com/user-attachments/assets/d93e21c2-0033-424c-a118-a7f03d2c49ec" />


## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

1. We’ve added a new chart data mode that, when enabled, hides the values displayed at the top right of each bar and instead shows the corresponding legends directly below each bar.

2. This mode also supports custom annotations provided by the client. These annotations are rendered alongside each one as React nodes (JSX elements). In this case, dummy data is passing a popover with names on clicking the chevron icon.

3. Additionally, the hidetooltip prop was not properly implemented and there was no way to suppress the hover call out card. This bug has also been fixed and we can disabled the hover call out if we want.

Note: Additional annotation can only be added to inline legends that wrap to next line and do not have an overflow component. We wanted to not change the existing behavior of legends that wrap, since we doubt this will be needed.

**We have not altered the rendering of the bars or segment logic themselves in any way**

<img width="1426" height="903" alt="image" src="https://github.com/user-attachments/assets/ffcb1014-d2ab-4e28-a323-f0fe2a22b1a5" />

<img width="1048" height="953" alt="image" src="https://github.com/user-attachments/assets/4a86fcb4-bd37-4149-a43e-d214fc6e5ffa" />




## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
