### PR TITLE
revert(react-accordion): adjust accordion header alignment #34616

### DIFF
--- a/apps/vr-tests-react-components/src/stories/Accordion/Accordion.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Accordion/Accordion.stories.tsx
@@ -138,29 +138,3 @@ Disabled.storyName = 'disabled';
 
 export const DisabledDarkMode = getStoryVariant(Disabled, DARK_MODE);
 export const DisabledHighContrast = getStoryVariant(Disabled, HIGH_CONTRAST);
-
-export const MultilineHeading = () => (
-  <Accordion>
-    <AccordionItem value={0}>
-      <AccordionHeader>
-        Multi-line heading with a lot of text. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod
-        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.
-      </AccordionHeader>
-      <AccordionPanel>
-        <div>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque euismod, nisi eu consectetur
-          consectetur, nisl nisi consectetur nisi, eu consectetur nisl nisi euismod nisi.
-        </div>
-      </AccordionPanel>
-    </AccordionItem>
-    <AccordionItem value={1}>
-      <AccordionHeader>Single-line heading</AccordionHeader>
-      <AccordionPanel>
-        <div>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque euismod, nisi eu consectetur
-          consectetur, nisl nisi consectetur nisi, eu consectetur nisl nisi euismod nisi.
-        </div>
-      </AccordionPanel>
-    </AccordionItem>
-  </Accordion>
-);

--- a/change/@fluentui-react-accordion-2f4cb0bf-8d38-4f83-a328-7111bec26987.json
+++ b/change/@fluentui-react-accordion-2f4cb0bf-8d38-4f83-a328-7111bec26987.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "revert: adjust accordion header chevron alignment styles #34616",
+  "packageName": "@fluentui/react-accordion",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-accordion/library/src/components/AccordionHeader/useAccordionHeaderStyles.styles.ts
+++ b/packages/react-components/react-accordion/library/src/components/AccordionHeader/useAccordionHeaderStyles.styles.ts
@@ -46,7 +46,7 @@ const useStyles = makeStyles({
     padding: `0 ${tokens.spacingHorizontalM} 0 ${tokens.spacingHorizontalMNudge}`,
     minHeight: '44px',
     display: 'flex',
-    alignItems: 'flex-start',
+    alignItems: 'center',
     cursor: 'pointer',
     ...typographyStyles.body1,
     boxSizing: 'border-box',

--- a/packages/react-components/react-accordion/stories/src/Accordion/AccordionDefault.stories.tsx
+++ b/packages/react-components/react-accordion/stories/src/Accordion/AccordionDefault.stories.tsx
@@ -4,17 +4,9 @@ import { Accordion, AccordionHeader, AccordionItem, AccordionPanel } from '@flue
 export const Default = () => (
   <Accordion>
     <AccordionItem value="1">
-      <AccordionHeader>
-        {' '}
-        This is a very very very long heading. This is a very very very long heading. This is a very very very long
-        heading. This is a very very very long heading.
-      </AccordionHeader>
+      <AccordionHeader>Accordion Header 1</AccordionHeader>
       <AccordionPanel>
-        <div>
-          {' '}
-          This is a very very very long heading. This is a very very very long heading. This is a very very very long
-          heading. This is a very very very long heading.
-        </div>
+        <div>Accordion Panel 1</div>
       </AccordionPanel>
     </AccordionItem>
     <AccordionItem value="2">


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Incorrect alignment applied for icons in accordion header. 

## New Behavior

This reverts #34616, as it's recommended to keep accordion header text to a single line—see https://www.figma.com/design/7X3Tgd3fTurii3FACrfhzo/Accordion?node-id=3042-83180&t=wZYKNnu2C1c4mYLS-4. For single-lined components, center alignment works best. If a multi-line title is necessary, custom styles should be applied to achieve the desired result.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Closes #33347 
- Fixes #34874
