### PR TITLE
fix(react-textarea): remove custom selection styles 

### DIFF
--- a/change/@fluentui-react-textarea-4c38e943-2ebb-4a14-9a6c-6f0960ed5b2a.json
+++ b/change/@fluentui-react-textarea-4c38e943-2ebb-4a14-9a6c-6f0960ed5b2a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove custom selection styles",
+  "packageName": "@fluentui/react-textarea",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-textarea/library/src/components/Textarea/useTextareaStyles.styles.ts
+++ b/packages/react-components/react-textarea/library/src/components/Textarea/useTextareaStyles.styles.ts
@@ -163,11 +163,6 @@ const useTextareaStyles = makeStyles({
       opacity: 1,
     },
 
-    '::selection': {
-      color: tokens.colorNeutralForegroundInverted,
-      backgroundColor: tokens.colorNeutralBackgroundInverted,
-    },
-
     outlineStyle: 'none', // disable default browser outline
   },
 


### PR DESCRIPTION
This PR unifies current selection styles between input components and fixes issue with not accessible color with current tokens in Teams HC theme. 

## Previous Behavior

**Textarea** 

<img width="414" height="178" alt="image" src="https://github.com/user-attachments/assets/c544cdde-a1cd-43e3-bffd-7a7bef882859" />

**HC Teams theme* (text is not visible) 
<img width="440" height="212" alt="image" src="https://github.com/user-attachments/assets/0ceba70d-0170-4d10-8001-39256fe6a789" />

**Input**

<img width="396" height="154" alt="image" src="https://github.com/user-attachments/assets/cc6bd04f-9ef9-465e-970c-4136a7aee655" />


## New Behavior

**Textarea** 

<img width="386" height="272" alt="image" src="https://github.com/user-attachments/assets/e4b975fb-be59-4233-b723-cba2f049e32a" />

**HC Teams theme* (text is not visible) 
<img width="306" height="216" alt="image" src="https://github.com/user-attachments/assets/0ff0dc16-7d40-46d3-8e09-02081f32e821" />


## Related Issue(s)

- Fixes #34084
