### PR TITLE
Deprecate react-virtualizer API

### DIFF
--- a/change/@fluentui-react-components-3c5d3131-3158-4fc8-a39f-6af7d0806a3d.json
+++ b/change/@fluentui-react-components-3c5d3131-3158-4fc8-a39f-6af7d0806a3d.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "deprecate: react-virtualizer in process of moving to fluentui-contrib",
+  "packageName": "@fluentui/react-components",
+  "email": "mifraser@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-virtualizer-35f17c1e-5c5d-48f5-bfb4-4e3ff82ce15d.json
+++ b/change/@fluentui-react-virtualizer-35f17c1e-5c5d-48f5-bfb4-4e3ff82ce15d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "deprecate: react-virtualizer moving to fluentui-contrib",
+  "packageName": "@fluentui/react-virtualizer",
+  "email": "mifraser@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-components/src/unstable/index.ts
+++ b/packages/react-components/react-components/src/unstable/index.ts
@@ -40,48 +40,88 @@ export type {
 /* eslint-enable @typescript-eslint/no-deprecated */
 
 export {
+  /** @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.*/
   Virtualizer,
+  /** @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.*/
   virtualizerClassNames,
+  /** @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.*/
   useVirtualizer_unstable,
+  /** @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.*/
   renderVirtualizer_unstable,
+  /** @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.*/
   useVirtualizerStyles_unstable,
+  /** @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.*/
   useIntersectionObserver,
+  /** @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.*/
   useStaticVirtualizerMeasure,
+  /** @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.*/
   useDynamicVirtualizerMeasure,
+  /** @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.*/
   useResizeObserverRef_unstable,
+  /** @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.*/
   VirtualizerContextProvider,
+  /** @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.*/
   useVirtualizerContext_unstable,
+  /** @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.*/
   VirtualizerScrollView,
+  /** @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.*/
   virtualizerScrollViewClassNames,
+  /** @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.*/
   useVirtualizerScrollView_unstable,
+  /** @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.*/
   renderVirtualizerScrollView_unstable,
+  /** @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.*/
   useVirtualizerScrollViewStyles_unstable,
+  /** @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.*/
   VirtualizerScrollViewDynamic,
+  /** @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.*/
   virtualizerScrollViewDynamicClassNames,
+  /** @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.*/
   useVirtualizerScrollViewDynamic_unstable,
+  /** @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.*/
   renderVirtualizerScrollViewDynamic_unstable,
+  /** @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.*/
   useVirtualizerScrollViewDynamicStyles_unstable,
+  /** @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.*/
   scrollToItemDynamic,
+  /** @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.*/
   scrollToItemStatic,
 } from '@fluentui/react-virtualizer';
 
 export type {
+  /** @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.*/
   VirtualizerProps,
+  /** @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.*/
   VirtualizerState,
+  /** @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.*/
   VirtualizerSlots,
+  /** @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.*/
   VirtualizerChildRenderFunction,
+  /** @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.*/
   VirtualizerScrollViewProps,
+  /** @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.*/
   VirtualizerScrollViewState,
+  /** @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.*/
   VirtualizerScrollViewSlots,
+  /** @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.*/
   VirtualizerContextProps,
+  /** @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.*/
   VirtualizerScrollViewDynamicProps,
+  /** @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.*/
   VirtualizerScrollViewDynamicState,
+  /** @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.*/
   VirtualizerScrollViewDynamicSlots,
+  /** @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.*/
   VirtualizerMeasureDynamicProps,
+  /** @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.*/
   VirtualizerMeasureProps,
+  /** @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.*/
   ResizeCallbackWithRef,
+  /** @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.*/
   ScrollToInterface,
+  /** @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.*/
   ScrollToItemDynamicParams,
+  /** @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.*/
   ScrollToItemStaticParams,
 } from '@fluentui/react-virtualizer';
 

--- a/packages/react-components/react-virtualizer/library/etc/react-virtualizer.api.md
+++ b/packages/react-components/react-virtualizer/library/etc/react-virtualizer.api.md
@@ -10,25 +10,25 @@ import * as React_2 from 'react';
 import type { Slot } from '@fluentui/react-utilities';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 
-// @public
+// @public @deprecated
 export type DynamicVirtualizerContextProps = Required<VirtualizerContextProps>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export interface IndexedResizeCallbackElement {
     // (undocumented)
     handleResize: () => void;
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const renderVirtualizer_unstable: (state: VirtualizerState) => JSX.Element;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const renderVirtualizerScrollView_unstable: (state: VirtualizerScrollViewState) => JSX.Element;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const renderVirtualizerScrollViewDynamic_unstable: (state: VirtualizerScrollViewDynamicState) => JSX.Element;
 
-// @public
+// @public @deprecated
 export interface ResizeCallbackWithRef {
     // (undocumented)
     (entries: ResizeObserverEntry[], observer: ResizeObserver, scrollRef?: React_2.MutableRefObject<HTMLElement | null>): void;
@@ -69,7 +69,7 @@ export type ScrollToItemStaticParams = {
     behavior?: ScrollBehavior;
 };
 
-// @public
+// @public @deprecated
 export const useDynamicVirtualizerMeasure: <TElement extends HTMLElement>(virtualizerProps: VirtualizerMeasureDynamicProps) => {
     virtualizerLength: number;
     bufferItems: number;
@@ -79,14 +79,14 @@ export const useDynamicVirtualizerMeasure: <TElement extends HTMLElement>(virtua
     updateScrollPosition: (scrollPosition: number) => void;
 };
 
-// @public
+// @public @deprecated
 export const useIntersectionObserver: (callback: IntersectionObserverCallback, options?: IntersectionObserverInit) => {
     setObserverList: React_2.Dispatch<React_2.SetStateAction<Element[] | undefined>>;
     setObserverInit: (newInit: IntersectionObserverInit | undefined) => void;
     observer: React_2.MutableRefObject<IntersectionObserver | undefined>;
 };
 
-// @public
+// @public @deprecated
 export function useMeasureList<TElement extends HTMLElement & IndexedResizeCallbackElement = HTMLElement & IndexedResizeCallbackElement>(currentIndex: number, refLength: number, totalLength: number, defaultItemSize: number): {
     widthArray: React_2.MutableRefObject<any[]>;
     heightArray: React_2.MutableRefObject<any[]>;
@@ -95,10 +95,10 @@ export function useMeasureList<TElement extends HTMLElement & IndexedResizeCallb
     sizeUpdateCount: number;
 };
 
-// @public
+// @public @deprecated
 export const useResizeObserverRef_unstable: (resizeCallback: ResizeCallbackWithRef) => (instance: HTMLElement | HTMLDivElement | null) => void;
 
-// @public
+// @public @deprecated
 export const useStaticVirtualizerMeasure: <TElement extends HTMLElement>(virtualizerProps: VirtualizerMeasureProps) => {
     virtualizerLength: number;
     bufferItems: number;
@@ -107,47 +107,47 @@ export const useStaticVirtualizerMeasure: <TElement extends HTMLElement>(virtual
     containerSizeRef: React_2.MutableRefObject<number>;
 };
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerState;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const useVirtualizerContext_unstable: () => VirtualizerContextProps;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export function useVirtualizerScrollView_unstable(props: VirtualizerScrollViewProps): VirtualizerScrollViewState;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export function useVirtualizerScrollViewDynamic_unstable(props: VirtualizerScrollViewDynamicProps): VirtualizerScrollViewDynamicState;
 
-// @public
+// @public @deprecated
 export const useVirtualizerScrollViewDynamicStyles_unstable: (state: VirtualizerScrollViewDynamicState) => VirtualizerScrollViewDynamicState;
 
-// @public
+// @public @deprecated
 export const useVirtualizerScrollViewStyles_unstable: (state: VirtualizerScrollViewState) => VirtualizerScrollViewState;
 
-// @public
+// @public @deprecated
 export const useVirtualizerStyles_unstable: (state: VirtualizerState) => VirtualizerState;
 
-// @public
+// @public @deprecated
 export const Virtualizer: React_2.FC<VirtualizerProps>;
 
-// @public
+// @public @deprecated
 export type VirtualizerChildRenderFunction = (index: number, isScrolling: boolean) => React_2.ReactNode;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const virtualizerClassNames: SlotClassNames<VirtualizerSlots>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type VirtualizerContextProps = {
     contextIndex: number;
     setContextIndex: (index: number) => void;
     childProgressiveSizes?: React_2.MutableRefObject<number[]>;
 };
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const VirtualizerContextProvider: React_2.Provider<VirtualizerContextProps>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type VirtualizerDataRef = {
     progressiveSizes: React_2.RefObject<number[]>;
     nodeSizes: React_2.RefObject<number[]>;
@@ -155,7 +155,7 @@ export type VirtualizerDataRef = {
     currentIndex: React_2.RefObject<number>;
 };
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type VirtualizerMeasureDynamicProps = {
     defaultItemSize: number;
     virtualizerContext: DynamicVirtualizerContextProps;
@@ -166,7 +166,7 @@ export type VirtualizerMeasureDynamicProps = {
     bufferSize?: number;
 };
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type VirtualizerMeasureProps = {
     defaultItemSize: number;
     direction?: 'vertical' | 'horizontal';
@@ -174,22 +174,22 @@ export type VirtualizerMeasureProps = {
     bufferSize?: number;
 };
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type VirtualizerProps = ComponentProps<Partial<VirtualizerSlots>> & VirtualizerConfigProps;
 
-// @public
+// @public @deprecated
 export const VirtualizerScrollView: React_2.FC<VirtualizerScrollViewProps>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const virtualizerScrollViewClassNames: SlotClassNames<VirtualizerScrollViewSlots>;
 
-// @public
+// @public @deprecated
 export const VirtualizerScrollViewDynamic: React_2.FC<VirtualizerScrollViewDynamicProps>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const virtualizerScrollViewDynamicClassNames: SlotClassNames<VirtualizerScrollViewDynamicSlots>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type VirtualizerScrollViewDynamicProps = ComponentProps<Partial<VirtualizerScrollViewDynamicSlots>> & Partial<Omit<VirtualizerConfigProps, 'itemSize' | 'numItems' | 'getItemSize' | 'children' | 'flagIndex' | 'virtualizerContext'>> & {
     itemSize: number;
     getItemSize?: (index: number) => number;
@@ -200,13 +200,13 @@ export type VirtualizerScrollViewDynamicProps = ComponentProps<Partial<Virtualiz
     virtualizerContext?: DynamicVirtualizerContextProps;
 };
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type VirtualizerScrollViewDynamicSlots = VirtualizerScrollViewSlots;
 
 // @public (undocumented)
 export type VirtualizerScrollViewDynamicState = ComponentState<VirtualizerScrollViewDynamicSlots> & VirtualizerConfigState;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type VirtualizerScrollViewProps = ComponentProps<Partial<VirtualizerScrollViewSlots>> & Partial<Omit<VirtualizerConfigProps, 'itemSize' | 'numItems' | 'getItemSize' | 'children' | 'flagIndex' | 'imperativeVirtualizerRef'>> & {
     itemSize: number;
     numItems: number;
@@ -215,15 +215,15 @@ export type VirtualizerScrollViewProps = ComponentProps<Partial<VirtualizerScrol
     enablePagination?: boolean;
 };
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type VirtualizerScrollViewSlots = VirtualizerSlots & {
     container: NonNullable<Slot<'div'>>;
 };
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type VirtualizerScrollViewState = ComponentState<VirtualizerScrollViewSlots> & VirtualizerConfigState;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type VirtualizerSlots = {
     before: NonNullable<Slot<'div', 'td'>>;
     beforeContainer: NonNullable<Slot<'div', 'tr'>>;
@@ -231,7 +231,7 @@ export type VirtualizerSlots = {
     afterContainer: NonNullable<Slot<'div', 'tr'>>;
 };
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type VirtualizerState = ComponentState<VirtualizerSlots> & VirtualizerConfigState;
 
 // (No @packageDocumentation comment for this package)

--- a/packages/react-components/react-virtualizer/library/src/components/Virtualizer/Virtualizer.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/Virtualizer/Virtualizer.ts
@@ -9,6 +9,7 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
  * Virtualizer pseudo-component, this functional wrapper
  * provides a simple interface for reducing the total number
  * of elements rendered at one time in large lists.
+ * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
  */
 export const Virtualizer: React.FC<VirtualizerProps> = (props: VirtualizerProps) => {
   const state = useVirtualizer_unstable(props);

--- a/packages/react-components/react-virtualizer/library/src/components/Virtualizer/Virtualizer.types.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/Virtualizer/Virtualizer.types.ts
@@ -2,6 +2,9 @@ import * as React from 'react';
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
 import type { VirtualizerContextProps } from '../../Utilities';
 
+/**
+ * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
+ */
 export type VirtualizerSlots = {
   /**
    * The intersection observed 'before' element will detect when scrolling towards the beginning.
@@ -21,6 +24,9 @@ export type VirtualizerSlots = {
   afterContainer: NonNullable<Slot<'div', 'tr'>>;
 };
 
+/**
+ * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
+ */
 export type VirtualizerConfigState = {
   /**
    * The current virtualized array of children to show in the DOM.
@@ -71,14 +77,21 @@ export type VirtualizerConfigState = {
   childProgressiveSizes: React.MutableRefObject<number[]>;
 };
 
+/**
+ * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
+ */
 export type VirtualizerState = ComponentState<VirtualizerSlots> & VirtualizerConfigState;
 
 /**
  * The main child render method of Virtualization
  * isScrolling will only be enabled when enableScrollLoad is set to true.
+ * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
  */
 export type VirtualizerChildRenderFunction = (index: number, isScrolling: boolean) => React.ReactNode;
 
+/**
+ * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
+ */
 export type VirtualizerDataRef = {
   progressiveSizes: React.RefObject<number[]>;
   nodeSizes: React.RefObject<number[]>;
@@ -86,6 +99,9 @@ export type VirtualizerDataRef = {
   currentIndex: React.RefObject<number>;
 };
 
+/**
+ * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
+ */
 export type VirtualizerConfigProps = {
   /**
    * Child render function.
@@ -206,4 +222,7 @@ export type VirtualizerConfigProps = {
   gap?: number;
 };
 
+/**
+ * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
+ */
 export type VirtualizerProps = ComponentProps<Partial<VirtualizerSlots>> & VirtualizerConfigProps;

--- a/packages/react-components/react-virtualizer/library/src/components/Virtualizer/renderVirtualizer.tsx
+++ b/packages/react-components/react-virtualizer/library/src/components/Virtualizer/renderVirtualizer.tsx
@@ -6,6 +6,9 @@ import type { VirtualizerSlots, VirtualizerState } from './Virtualizer.types';
 
 import { assertSlots } from '@fluentui/react-utilities';
 
+/**
+ * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
+ */
 export const renderVirtualizer_unstable = (state: VirtualizerState) => {
   assertSlots<VirtualizerSlots>(state);
   return (
@@ -23,7 +26,9 @@ export const renderVirtualizer_unstable = (state: VirtualizerState) => {
     </React.Fragment>
   );
 };
-
+/**
+ * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
+ */
 export const renderVirtualizerChildPlaceholder = (child: React.ReactNode, index: number) => {
   return (
     <React.Suspense key={`fui-virtualizer-placeholder-${index}`} fallback={null}>

--- a/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizer.ts
@@ -6,6 +6,9 @@ import { useVirtualizerContextState_unstable } from '../../Utilities';
 import { slot, useTimeout } from '@fluentui/react-utilities';
 import { flushSync } from 'react-dom';
 
+/**
+ * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
+ */
 export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerState {
   'use no memo';
 

--- a/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizerStyles.styles.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/Virtualizer/useVirtualizerStyles.styles.ts
@@ -3,6 +3,9 @@ import { VirtualizerSlots, VirtualizerState } from './Virtualizer.types';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 
 const virtualizerClassName = 'fui-Virtualizer';
+/**
+ * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
+ */
 export const virtualizerClassNames: SlotClassNames<VirtualizerSlots> = {
   before: `${virtualizerClassName}__before`,
   beforeContainer: `${virtualizerClassName}__beforeContainer`,
@@ -28,6 +31,7 @@ const useStyles = makeStyles({
 
 /**
  * Apply styling to the Virtualizer states
+ * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
  */
 export const useVirtualizerStyles_unstable = (state: VirtualizerState): VirtualizerState => {
   'use no memo';

--- a/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollView/VirtualizerScrollView.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollView/VirtualizerScrollView.ts
@@ -7,8 +7,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 
 /**
  * Virtualizer ScrollView
+ * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
  */
-
 export const VirtualizerScrollView: React.FC<VirtualizerScrollViewProps> = (props: VirtualizerScrollViewProps) => {
   const state = useVirtualizerScrollView_unstable(props);
 

--- a/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollView/VirtualizerScrollView.types.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollView/VirtualizerScrollView.types.ts
@@ -8,6 +8,9 @@ import type {
 } from '../Virtualizer/Virtualizer.types';
 import type { ScrollToInterface } from '../../Utilities';
 
+/**
+ * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
+ */
 export type VirtualizerScrollViewSlots = VirtualizerSlots & {
   /**
    * The root container that provides embedded scrolling.
@@ -15,6 +18,9 @@ export type VirtualizerScrollViewSlots = VirtualizerSlots & {
   container: NonNullable<Slot<'div'>>;
 };
 
+/**
+ * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
+ */
 export type VirtualizerScrollViewProps = ComponentProps<Partial<VirtualizerScrollViewSlots>> &
   Partial<
     Omit<
@@ -48,4 +54,7 @@ export type VirtualizerScrollViewProps = ComponentProps<Partial<VirtualizerScrol
     enablePagination?: boolean;
   };
 
+/**
+ * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
+ */
 export type VirtualizerScrollViewState = ComponentState<VirtualizerScrollViewSlots> & VirtualizerConfigState;

--- a/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollView/renderVirtualizerScrollView.tsx
+++ b/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollView/renderVirtualizerScrollView.tsx
@@ -6,6 +6,9 @@ import type { VirtualizerScrollViewSlots, VirtualizerScrollViewState } from './V
 import { assertSlots } from '@fluentui/react-utilities';
 import { renderVirtualizer_unstable } from '../Virtualizer/renderVirtualizer';
 
+/**
+ * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
+ */
 export const renderVirtualizerScrollView_unstable = (state: VirtualizerScrollViewState) => {
   assertSlots<VirtualizerScrollViewSlots>(state);
 

--- a/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollView/useVirtualizerScrollView.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollView/useVirtualizerScrollView.ts
@@ -7,6 +7,9 @@ import { scrollToItemStatic } from '../../Utilities';
 import type { VirtualizerDataRef } from '../Virtualizer/Virtualizer.types';
 import { useStaticVirtualizerPagination } from '../../hooks/useStaticPagination';
 
+/**
+ * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
+ */
 export function useVirtualizerScrollView_unstable(props: VirtualizerScrollViewProps): VirtualizerScrollViewState {
   const { imperativeRef, itemSize, numItems, axis = 'vertical', reversed, enablePagination = false } = props;
   const { virtualizerLength, bufferItems, bufferSize, scrollRef, containerSizeRef } = useStaticVirtualizerMeasure({

--- a/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollView/useVirtualizerScrollViewStyles.styles.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollView/useVirtualizerScrollViewStyles.styles.ts
@@ -6,6 +6,9 @@ import { makeStyles, mergeClasses } from '@griffel/react';
 
 const virtualizerScrollViewClassName = 'fui-Virtualizer-Scroll-View';
 
+/**
+ * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
+ */
 export const virtualizerScrollViewClassNames: SlotClassNames<VirtualizerScrollViewSlots> = {
   ...virtualizerClassNames,
   container: `${virtualizerScrollViewClassName}__container`,
@@ -37,6 +40,7 @@ const useStyles = makeStyles({
 
 /**
  * Apply styling to the Virtualizer states
+ * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
  */
 export const useVirtualizerScrollViewStyles_unstable = (
   state: VirtualizerScrollViewState,

--- a/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollViewDynamic/VirtualizerScrollViewDynamic.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollViewDynamic/VirtualizerScrollViewDynamic.ts
@@ -8,8 +8,8 @@ import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 
 /**
  * Virtualizer ScrollView
+ * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
  */
-
 export const VirtualizerScrollViewDynamic: React.FC<VirtualizerScrollViewDynamicProps> = (
   props: VirtualizerScrollViewDynamicProps,
   context: React.Context<VirtualizerContextProps>,

--- a/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollViewDynamic/VirtualizerScrollViewDynamic.types.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollViewDynamic/VirtualizerScrollViewDynamic.types.ts
@@ -9,8 +9,14 @@ import type {
 import type { VirtualizerScrollViewSlots } from '../VirtualizerScrollView/VirtualizerScrollView.types';
 import type { DynamicVirtualizerContextProps, ScrollToInterface } from '../../Utilities';
 
+/**
+ * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
+ */
 export type VirtualizerScrollViewDynamicSlots = VirtualizerScrollViewSlots;
 
+/**
+ * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
+ */
 export type VirtualizerScrollViewDynamicProps = ComponentProps<Partial<VirtualizerScrollViewDynamicSlots>> &
   Partial<
     Omit<

--- a/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollViewDynamic/renderVirtualizerScrollViewDynamic.tsx
+++ b/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollViewDynamic/renderVirtualizerScrollViewDynamic.tsx
@@ -7,6 +7,9 @@ import {
 } from './VirtualizerScrollViewDynamic.types';
 import { renderVirtualizer_unstable } from '../Virtualizer/renderVirtualizer';
 
+/**
+ * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
+ */
 export const renderVirtualizerScrollViewDynamic_unstable = (state: VirtualizerScrollViewDynamicState) => {
   assertSlots<VirtualizerScrollViewDynamicSlots>(state);
   return <state.container>{renderVirtualizer_unstable(state)}</state.container>;

--- a/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollViewDynamic/useVirtualizerScrollViewDynamic.tsx
+++ b/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollViewDynamic/useVirtualizerScrollViewDynamic.tsx
@@ -12,6 +12,9 @@ import { useMeasureList } from '../../hooks/useMeasureList';
 import type { IndexedResizeCallbackElement } from '../../hooks/useMeasureList';
 import { useDynamicVirtualizerPagination } from '../../hooks/useDynamicPagination';
 
+/**
+ * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
+ */
 export function useVirtualizerScrollViewDynamic_unstable(
   props: VirtualizerScrollViewDynamicProps,
 ): VirtualizerScrollViewDynamicState {

--- a/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollViewDynamic/useVirtualizerScrollViewDynamicStyles.styles.ts
+++ b/packages/react-components/react-virtualizer/library/src/components/VirtualizerScrollViewDynamic/useVirtualizerScrollViewDynamicStyles.styles.ts
@@ -8,6 +8,9 @@ import { makeStyles, mergeClasses } from '@griffel/react';
 
 const virtualizerScrollViewDynamicClassName = 'fui-Virtualizer-Scroll-View-Dynamic';
 
+/**
+ * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
+ */
 export const virtualizerScrollViewDynamicClassNames: SlotClassNames<VirtualizerScrollViewDynamicSlots> = {
   ...virtualizerClassNames,
   container: `${virtualizerScrollViewDynamicClassName}__container`,
@@ -39,6 +42,7 @@ const useStyles = makeStyles({
 
 /**
  * Apply styling to the Virtualizer states
+ * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
  */
 export const useVirtualizerScrollViewDynamicStyles_unstable = (
   state: VirtualizerScrollViewDynamicState,

--- a/packages/react-components/react-virtualizer/library/src/hooks/hooks.types.ts
+++ b/packages/react-components/react-virtualizer/library/src/hooks/hooks.types.ts
@@ -1,6 +1,9 @@
 import * as React from 'react';
 import { DynamicVirtualizerContextProps } from '../Utilities';
 
+/**
+ * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
+ */
 export type VirtualizerMeasureProps = {
   defaultItemSize: number;
   direction?: 'vertical' | 'horizontal';
@@ -16,6 +19,9 @@ export type VirtualizerMeasureProps = {
   bufferSize?: number;
 };
 
+/**
+ * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
+ */
 export type VirtualizerMeasureDynamicProps = {
   defaultItemSize: number;
   virtualizerContext: DynamicVirtualizerContextProps;
@@ -34,6 +40,9 @@ export type VirtualizerMeasureDynamicProps = {
   bufferSize?: number;
 };
 
+/**
+ * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
+ */
 export type VirtualizerStaticPaginationProps = {
   itemSize: number;
   axis?: 'vertical' | 'horizontal';
@@ -42,6 +51,7 @@ export type VirtualizerStaticPaginationProps = {
 /**
  * Props to be passed into dynamic virtualization hooks
  * All props can be acquired from useVirtualizer hooks themselves and passed in
+ * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
  */
 export type VirtualizerDynamicPaginationProps = {
   /**
@@ -65,6 +75,7 @@ export type VirtualizerDynamicPaginationProps = {
 /**
  * Additional direct Ref prevents reading old resize entry data
  * Backwards compatible with ResizeObserverCallback if preferred
+ * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
  */
 export interface ResizeCallbackWithRef {
   (

--- a/packages/react-components/react-virtualizer/library/src/hooks/useDynamicPagination.ts
+++ b/packages/react-components/react-virtualizer/library/src/hooks/useDynamicPagination.ts
@@ -7,6 +7,7 @@ import { useTimeout } from '@fluentui/react-utilities';
  * Sizes are dynamic so we require a progressive sizing array (passed in from Dynamic virtualizer hooks)
  * On short scrolls, we will go at minimum to the next/previous item so that arrow pagination works
  * All VirtualizerDynamicPaginationProps can be grabbed from dynamic Virtualizer hooks externally and passed in
+ * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
  */
 export const useDynamicVirtualizerPagination = (
   virtualizerProps: VirtualizerDynamicPaginationProps,

--- a/packages/react-components/react-virtualizer/library/src/hooks/useDynamicVirtualizerMeasure.ts
+++ b/packages/react-components/react-virtualizer/library/src/hooks/useDynamicVirtualizerMeasure.ts
@@ -6,6 +6,7 @@ import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts
 
 /**
  * React hook that measures virtualized space dynamically to ensure optimized virtualization length.
+ * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
  */
 export const useDynamicVirtualizerMeasure = <TElement extends HTMLElement>(
   virtualizerProps: VirtualizerMeasureDynamicProps,

--- a/packages/react-components/react-virtualizer/library/src/hooks/useIntersectionObserver.ts
+++ b/packages/react-components/react-virtualizer/library/src/hooks/useIntersectionObserver.ts
@@ -10,6 +10,7 @@ import { useMutationObserver } from './useMutationObserver';
  * @param ltrRootMargin the margin to be processed and flipped if required
  * @param target target element that will have its current reading direction determined
  * @returns the corrected rootMargin (if it was necessary to correct)
+ * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
  */
 export const getRTLRootMargin = (
   ltrRootMargin: string,
@@ -47,8 +48,8 @@ export const getRTLRootMargin = (
  * enough to trigger a callback).
  * @returns An array containing a callback to update the list of Elements the observer should listen to, a callback to
  * update the init options of the IntersectionObserver and a ref to the IntersectionObserver instance itself.
+ * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
  */
-
 export const useIntersectionObserver = (
   callback: IntersectionObserverCallback,
   options?: IntersectionObserverInit,

--- a/packages/react-components/react-virtualizer/library/src/hooks/useMeasureList.ts
+++ b/packages/react-components/react-virtualizer/library/src/hooks/useMeasureList.ts
@@ -1,6 +1,9 @@
 import * as React from 'react';
 import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
 
+/**
+ * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
+ */
 export interface IndexedResizeCallbackElement {
   handleResize: () => void;
 }
@@ -10,6 +13,7 @@ export interface IndexedResizeCallbackElement {
  * `width` - element width ref (0 by default),
  * `height` - element height ref (0 by default),
  * `measureElementRef` - a ref function to be passed as `ref` to the element you want to measure
+ * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
  */
 export function useMeasureList<
   TElement extends HTMLElement & IndexedResizeCallbackElement = HTMLElement & IndexedResizeCallbackElement,
@@ -127,6 +131,7 @@ export function useMeasureList<
  * @param targetDocument - document to use to create the ResizeObserver
  * @param callback  - https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver/ResizeObserver#callback
  * @returns a ResizeObserver instance or null if the global does not exist on the document
+ * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
  */
 export function createResizeObserverFromDocument(
   targetDocument: Document | null | undefined,

--- a/packages/react-components/react-virtualizer/library/src/hooks/useMutationObserver.ts
+++ b/packages/react-components/react-virtualizer/library/src/hooks/useMutationObserver.ts
@@ -3,6 +3,9 @@ import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts
 
 const { useRef, useEffect } = React;
 
+/**
+ * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
+ */
 export const useMutationObserver = (
   target: Element | Document | undefined,
   callback: MutationCallback,

--- a/packages/react-components/react-virtualizer/library/src/hooks/useResizeObserverRef.ts
+++ b/packages/react-components/react-virtualizer/library/src/hooks/useResizeObserverRef.ts
@@ -6,6 +6,7 @@ import { ResizeCallbackWithRef } from './hooks.types';
 
 /**
  * useResizeObserverRef_unstable simplifies resize observer connection and ensures debounce/cleanup
+ * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
  */
 export const useResizeObserverRef_unstable = (resizeCallback: ResizeCallbackWithRef) => {
   'use no memo';

--- a/packages/react-components/react-virtualizer/library/src/hooks/useStaticPagination.ts
+++ b/packages/react-components/react-virtualizer/library/src/hooks/useStaticPagination.ts
@@ -6,7 +6,8 @@ import { useTimeout } from '@fluentui/react-utilities';
  * Optional hook that will enable pagination on the virtualizer so that it 'autoscrolls' to an items exact position
  * Sizes are uniform/static, we round to the nearest item on long scrolls
  * On short scrolls, we will go at minimum to the next/previous item so that arrow pagination works
- * All VirtualizerStaticPaginationProps can be grabbed from Virtualizer hooks externally and passed in
+ * All VirtualizerStaticPaginationProps can be grabbed from Virtualizer hooks externally and passed in/**
+ * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
  */
 export const useStaticVirtualizerPagination = (
   virtualizerProps: VirtualizerStaticPaginationProps,

--- a/packages/react-components/react-virtualizer/library/src/hooks/useVirtualizerMeasure.ts
+++ b/packages/react-components/react-virtualizer/library/src/hooks/useVirtualizerMeasure.ts
@@ -5,6 +5,7 @@ import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts
 
 /**
  * React hook that measures virtualized space based on a static size to ensure optimized virtualization length.
+ * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
  */
 export const useStaticVirtualizerMeasure = <TElement extends HTMLElement>(
   virtualizerProps: VirtualizerMeasureProps,

--- a/packages/react-components/react-virtualizer/library/src/utilities/VirtualizerContext/VirtualizerContext.ts
+++ b/packages/react-components/react-virtualizer/library/src/utilities/VirtualizerContext/VirtualizerContext.ts
@@ -5,12 +5,21 @@ const VirtualizerContext = React.createContext<VirtualizerContextProps | undefin
   undefined,
 ) as React.Context<VirtualizerContextProps>;
 
+/**
+ * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
+ */
 export const VirtualizerContextProvider = VirtualizerContext.Provider;
 
+/**
+ * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
+ */
 export const useVirtualizerContext_unstable = () => {
   return React.useContext(VirtualizerContext);
 };
 
+/**
+ * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
+ */
 export const useVirtualizerContextState_unstable = (
   passedContext?: VirtualizerContextProps,
 ): DynamicVirtualizerContextProps => {

--- a/packages/react-components/react-virtualizer/library/src/utilities/VirtualizerContext/types.ts
+++ b/packages/react-components/react-virtualizer/library/src/utilities/VirtualizerContext/types.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 /**
  * {@docCategory Virtualizer}
+ * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
  */
 export type VirtualizerContextProps = {
   contextIndex: number;
@@ -13,5 +14,6 @@ export type VirtualizerContextProps = {
 
 /**
  * Some props are optional on static virtualizer, but required for dynamic.
+ * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
  */
 export type DynamicVirtualizerContextProps = Required<VirtualizerContextProps>;

--- a/packages/react-components/react-virtualizer/library/src/utilities/createResizeObserverFromDocument.ts
+++ b/packages/react-components/react-virtualizer/library/src/utilities/createResizeObserverFromDocument.ts
@@ -4,6 +4,7 @@
  * @param targetDocument - document to use to create the ResizeObserver
  * @param callback  - https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver/ResizeObserver#callback
  * @returns a ResizeObserver instance or null if the global does not exist on the document
+ * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
  */
 export function createResizeObserverFromDocument(
   targetDocument: Document | null | undefined,

--- a/packages/react-components/react-virtualizer/library/src/utilities/debounce.ts
+++ b/packages/react-components/react-virtualizer/library/src/utilities/debounce.ts
@@ -3,6 +3,7 @@
  * https://developer.mozilla.org/en-US/docs/Web/API/HTML_DOM_API/Microtask_guide
  * @param fn - Function to debounce
  * @returns debounced function
+ * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
  */
 export function debounce(fn: Function) {
   let pending: boolean;


### PR DESCRIPTION
Step 1 of migrating react-virtualizer to fluentui-contrib repo

This pull request focuses on deprecating the `@fluentui/react-virtualizer` package and migrating its functionality to `@fluentui-contrib/react-virtualizer`. The changes include marking various exports as deprecated, updating documentation, and preparing for the migration to the new package.

### Deprecation of `@fluentui/react-virtualizer`:

* **Deprecation Notices in Code:**
  - Added `@deprecated` tags to all exports in `@fluentui/react-virtualizer`, including components, hooks, types, and utilities. These changes are reflected across files such as `Virtualizer.ts`, `Virtualizer.types.ts`, and `renderVirtualizer.tsx`. [[1]](diffhunk://#diff-3db181e72ec77aecd31fb642d14ff4ca8454e7d9c5c1369f4abb0466ce78f2e4R12) [[2]](diffhunk://#diff-85438ca41cd7c918a529547f0b6bf71b82885fe1832b77376f1bd96c6d6fb1d0R5-R7) [[3]](diffhunk://#diff-1f4f6f763320f4d67abb78b0e4e4d7232808b43fa4a7c0904f7e36d4d1322092R9-R11)

* **Deprecation in API Documentation:**
  - Marked all public API entries in the `react-virtualizer.api.md` file as deprecated, ensuring clear communication about the migration. [[1]](diffhunk://#diff-6c96f82a1625b2eefb577680d4e76aff5529195830f4729937f705f7f47e49a4L13-R31) [[2]](diffhunk://#diff-6c96f82a1625b2eefb577680d4e76aff5529195830f4729937f705f7f47e49a4L98-R101) [[3]](diffhunk://#diff-6c96f82a1625b2eefb577680d4e76aff5529195830f4729937f705f7f47e49a4L218-R234)

### Migration Preparation:

* **Export Updates in `@fluentui/react-components`:**
  - Deprecated all exports from `@fluentui/react-virtualizer` in the `index.ts` file of `@fluentui/react-components`, with comments pointing to the new `@fluentui-contrib/react-virtualizer` package.

* **Change Files for Release Notes:**
  - Added change files for both `@fluentui/react-components` and `@fluentui/react-virtualizer` to document the deprecation and migration process. [[1]](diffhunk://#diff-0aa88c16e6e699a53a7136932e8dbf7c70e67f081784a2e4e9a12e5b3207415eR1-R7) [[2]](diffhunk://#diff-7ad6e325b59bc723dc0230c221ab50574e0b2fd8f5c33d4fe2e3eb770763c644R1-R7)

These changes ensure a smooth transition for users of `@fluentui/react-virtualizer` while maintaining backward compatibility during the migration period.