### PR TITLE
Semantic-tokens: React-search

### DIFF
--- a/packages/react-components/semantic-style-hooks-preview/library/etc/semantic-style-hooks-preview.api.md
+++ b/packages/react-components/semantic-style-hooks-preview/library/etc/semantic-style-hooks-preview.api.md
@@ -58,6 +58,7 @@ import { ProgressBarState } from '@fluentui/react-progress';
 import { RadioState } from '@fluentui/react-radio';
 import { RatingDisplayState } from '@fluentui/react-rating';
 import { RatingItemState } from '@fluentui/react-rating';
+import { SearchBoxState } from '@fluentui/react-search';
 import { SliderState } from '@fluentui/react-slider';
 import { SpinButtonState } from '@fluentui/react-spinbutton';
 import { SpinnerState } from '@fluentui/react-spinner';
@@ -256,6 +257,9 @@ export const useSemanticRatingDisplayStyles: (_state: unknown) => RatingDisplayS
 
 // @public
 export const useSemanticRatingItemStyles: (_state: unknown) => RatingItemState;
+
+// @public
+export const useSemanticSearchBoxStyles: (_state: unknown) => SearchBoxState;
 
 // @public
 export const useSemanticSliderStyles: (_state: unknown) => SliderState;

--- a/packages/react-components/semantic-style-hooks-preview/library/package.json
+++ b/packages/react-components/semantic-style-hooks-preview/library/package.json
@@ -51,6 +51,7 @@
     "@fluentui/react-provider": "^9.20.6",
     "@fluentui/react-radio": "^9.3.6",
     "@fluentui/react-rating": "^9.1.6",
+    "@fluentui/react-search": "^9.3.0",
     "@fluentui/react-shared-contexts": "^9.23.1",
     "@fluentui/react-slider": "^9.3.7",
     "@fluentui/react-spinbutton": "^9.3.6",

--- a/packages/react-components/semantic-style-hooks-preview/library/src/component-styles/Search/index.ts
+++ b/packages/react-components/semantic-style-hooks-preview/library/src/component-styles/Search/index.ts
@@ -1,0 +1,1 @@
+export { useSemanticSearchBoxStyles } from './useSemanticSearchStyles.styles';

--- a/packages/react-components/semantic-style-hooks-preview/library/src/component-styles/Search/useSemanticSearchStyles.styles.ts
+++ b/packages/react-components/semantic-style-hooks-preview/library/src/component-styles/Search/useSemanticSearchStyles.styles.ts
@@ -1,0 +1,173 @@
+import { makeResetStyles, makeStyles, mergeClasses } from '@griffel/react';
+import { getSlotClassNameProp_unstable } from '@fluentui/react-utilities';
+import { tokens } from '@fluentui/react-theme';
+import { useSemanticInputStyles } from '../Input';
+import { type SearchBoxState, searchBoxClassNames } from '@fluentui/react-search';
+import * as semanticTokens from '@fluentui/semantic-tokens';
+
+/**
+ * Styles for the root slot
+ */
+const useRootStyles = makeStyles({
+  small: {
+    columnGap: 0,
+    maxWidth: '468px',
+
+    paddingLeft: tokens.spacingHorizontalSNudge,
+    paddingRight: tokens.spacingHorizontalSNudge,
+  },
+  medium: {
+    columnGap: 0,
+    maxWidth: '468px',
+
+    paddingLeft: tokens.spacingHorizontalS,
+    paddingRight: tokens.spacingHorizontalS,
+  },
+  large: {
+    columnGap: 0,
+    maxWidth: '468px',
+
+    paddingLeft: tokens.spacingHorizontalMNudge,
+    paddingRight: tokens.spacingHorizontalMNudge,
+  },
+
+  input: {
+    paddingLeft: tokens.spacingHorizontalSNudge,
+    paddingRight: 0,
+
+    // removes the WebKit pseudoelement styling
+    '::-webkit-search-decoration': {
+      display: 'none',
+    },
+    '::-webkit-search-cancel-button': {
+      display: 'none',
+    },
+  },
+
+  unfocusedNoContentAfter: {
+    paddingRight: 0,
+  },
+});
+
+const useInputStyles = makeStyles({
+  small: {
+    paddingRight: tokens.spacingHorizontalSNudge,
+  },
+  medium: {
+    paddingRight: tokens.spacingHorizontalS,
+  },
+  large: {
+    paddingRight: tokens.spacingHorizontalMNudge,
+  },
+});
+
+const useContentAfterStyles = makeStyles({
+  contentAfter: {
+    paddingLeft: tokens.spacingHorizontalM,
+    columnGap: tokens.spacingHorizontalXS,
+  },
+  rest: {
+    height: 0,
+    width: 0,
+    paddingLeft: 0,
+    overflow: 'hidden',
+  },
+});
+
+const useDismissClassName = makeResetStyles({
+  boxSizing: 'border-box',
+  color: semanticTokens.foregroundCtrlIconOnNeutralRest, // "icon color" in design spec
+  display: 'flex',
+  // special case styling for icons (most common case) to ensure they're centered vertically
+  // size: medium (default)
+  '> svg': { fontSize: '20px' },
+  cursor: 'pointer',
+});
+
+const useDismissStyles = makeStyles({
+  disabled: {
+    color: semanticTokens.backgroundCtrlSubtleRest,
+  },
+  // Ensure resizable icons show up with the proper font size
+  small: {
+    '> svg': { fontSize: '16px' },
+  },
+  medium: {
+    // included in useDismissClassName
+  },
+  large: {
+    '> svg': { fontSize: '24px' },
+  },
+});
+
+/**
+ * Apply styling to the SearchBox slots based on the state
+ */
+export const useSemanticSearchBoxStyles = (_state: unknown): SearchBoxState => {
+  'use no memo';
+
+  const state = _state as SearchBoxState;
+
+  const { disabled, focused, size } = state;
+
+  const rootStyles = useRootStyles();
+  const inputStyles = useInputStyles();
+  const contentAfterStyles = useContentAfterStyles();
+  const dismissClassName = useDismissClassName();
+  const dismissStyles = useDismissStyles();
+
+  state.root.className = mergeClasses(
+    state.root.className,
+    searchBoxClassNames.root,
+    rootStyles[size],
+    !focused && rootStyles.unfocusedNoContentAfter,
+    getSlotClassNameProp_unstable(state.root),
+  );
+
+  state.input.className = mergeClasses(
+    state.input.className,
+    searchBoxClassNames.input,
+    rootStyles.input,
+    !focused && inputStyles[size],
+    getSlotClassNameProp_unstable(state.input),
+  );
+
+  if (state.dismiss) {
+    state.dismiss.className = mergeClasses(
+      state.dismiss.className,
+      searchBoxClassNames.dismiss,
+      dismissClassName,
+      disabled && dismissStyles.disabled,
+      dismissStyles[size],
+      getSlotClassNameProp_unstable(state.dismiss),
+    );
+  }
+
+  if (state.contentBefore) {
+    state.contentBefore.className = mergeClasses(
+      state.contentBefore.className,
+      searchBoxClassNames.contentBefore,
+      getSlotClassNameProp_unstable(state.contentBefore),
+    );
+  }
+
+  if (state.contentAfter) {
+    state.contentAfter.className = mergeClasses(
+      state.contentAfter.className,
+      searchBoxClassNames.contentAfter,
+      contentAfterStyles.contentAfter,
+      !focused && contentAfterStyles.rest,
+      getSlotClassNameProp_unstable(state.contentAfter),
+    );
+  } else if (state.dismiss) {
+    state.dismiss.className = mergeClasses(
+      contentAfterStyles.contentAfter,
+      state.dismiss.className,
+      getSlotClassNameProp_unstable(state.dismiss),
+    );
+  }
+
+  useSemanticInputStyles(state);
+
+  return state;
+};

--- a/packages/react-components/semantic-style-hooks-preview/library/src/component-styles/semanticStyleHooks.ts
+++ b/packages/react-components/semantic-style-hooks-preview/library/src/component-styles/semanticStyleHooks.ts
@@ -107,6 +107,7 @@ import {
   useSemanticToastStyles,
   useSemanticToastTitleStyles,
 } from './Toast';
+import { useSemanticSearchBoxStyles } from './Search';
 
 export const SEMANTIC_STYLE_HOOKS: FluentProviderCustomStyleHooks = {
   // Accordion styles
@@ -183,6 +184,8 @@ export const SEMANTIC_STYLE_HOOKS: FluentProviderCustomStyleHooks = {
   useRadioStyles_unstable: useSemanticRadioStyles,
   // Persona styles
   usePersonaStyles_unstable: useSemanticPersonaStyles,
+  // Search styles
+  useSearchBoxStyles_unstable: useSemanticSearchBoxStyles,
   // Checkbox styles
   useCheckboxStyles_unstable: useSemanticCheckboxStyles,
   // Breadcrumb styles

--- a/packages/react-components/semantic-style-hooks-preview/library/src/index.ts
+++ b/packages/react-components/semantic-style-hooks-preview/library/src/index.ts
@@ -110,3 +110,4 @@ export {
   useSemanticToastStyles,
   useSemanticToastTitleStyles,
 } from './component-styles/Toast';
+export { useSemanticSearchBoxStyles } from './component-styles/Search';


### PR DESCRIPTION
Testing to see if this fixes the yarn build issues (separate cache).

This pull request introduces a new set of semantic styles for the `SearchBox` component in the Fluent UI library. The changes include adding the `useSemanticSearchBoxStyles` hook, defining its styling logic, and integrating it into the existing semantic style hooks infrastructure.

### New `SearchBox` Semantic Styles:

* **Added `useSemanticSearchBoxStyles` Hook**: Created a new hook in `useSemanticSearchStyles.styles.ts` to define the semantic styles for the `SearchBox` component, including styles for different states and slots like `root`, `input`, `dismiss`, `contentBefore`, and `contentAfter`.

* **Exported the Hook**: Exported the `useSemanticSearchBoxStyles` hook from `index.ts` and `Search/index.ts` for usage across the library. [[1]](diffhunk://#diff-b8bd051698391c44b493d55874029a0631a55145cd5bc1f9d23b70a23b01cfedR113) [[2]](diffhunk://#diff-a867b78c37ba6301d23e47ba43ff48112ee38b295ed9a5108ff6f4c7ec4fbb57R1)

### Integration into Semantic Style Hooks:

* **Added to `SEMANTIC_STYLE_HOOKS`**: Integrated the `useSemanticSearchBoxStyles` hook into the `SEMANTIC_STYLE_HOOKS` object in `semanticStyleHooks.ts` to make it available as part of the library's custom style hooks. [[1]](diffhunk://#diff-775b75e8cc2fcd3f999a473a888f25c94ed7791b4859b47ae795a24d1981359dR110) [[2]](diffhunk://#diff-775b75e8cc2fcd3f999a473a888f25c94ed7791b4859b47ae795a24d1981359dR187-R188)

### Dependency Updates:

* **Updated Dependencies**: Added `@fluentui/react-search` as a new dependency in `package.json` to support the `SearchBox` component.

### API Documentation:

* **Updated API Markdown**: Documented the `SearchBoxState` and the `useSemanticSearchBoxStyles` hook in the API markdown file. [[1]](diffhunk://#diff-03b609b8fcb6f7dee9c9ee2971f09eb254bfcf767c07c5faf76c45d33a38b2f7R61) [[2]](diffhunk://#diff-03b609b8fcb6f7dee9c9ee2971f09eb254bfcf767c07c5faf76c45d33a38b2f7R261-R263)