### PR TITLE
feat(Menu): add event.isDefaultPrevented() to `onKeyDown`

### DIFF
--- a/change/@fluentui-react-menu-45270348-52b5-4989-bde5-28a68bc7338d.json
+++ b/change/@fluentui-react-menu-45270348-52b5-4989-bde5-28a68bc7338d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: add event.isDefaultPrevented() to `onKeyDown`",
+  "packageName": "@fluentui/react-menu",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-menu/library/src/components/MenuTrigger/useMenuTrigger.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuTrigger/useMenuTrigger.ts
@@ -89,7 +89,7 @@ export const useMenuTrigger_unstable = (props: MenuTriggerProps): MenuTriggerSta
   };
 
   const onKeyDown = (event: React.KeyboardEvent<HTMLButtonElement & HTMLAnchorElement & HTMLDivElement>) => {
-    if (isTargetDisabled(event)) {
+    if (isTargetDisabled(event) || event.isDefaultPrevented()) {
       return;
     }
 


### PR DESCRIPTION
## New Behavior

This pull request introduces a feature enhancement to the `@fluentui/react-menu` package, adding support for `event.isDefaultPrevented()` in the `onKeyDown` handler. This change ensures better event handling by allowing developers to prevent default behaviors more effectively:

```tsx
import * as React from "react";
import {
  Button,
  Menu,
  MenuTrigger,
  MenuList,
  MenuItem,
  MenuPopover,
} from "@fluentui/react-components";

export const Default = () => (
  <Menu>
    <MenuTrigger disableButtonEnhancement>
      <Button
        onKeyDown={(ev) => {
          if (ev.key === "ArrowDown") {
            ev.preventDefault();
          }
        }}
      >
        Toggle menu
      </Button>
    </MenuTrigger>

    <MenuPopover>
      <MenuList>
        <MenuItem>New </MenuItem>
        <MenuItem>New Window</MenuItem>
        <MenuItem disabled>Open File</MenuItem>
        <MenuItem>Open Folder</MenuItem>
      </MenuList>
    </MenuPopover>
  </Menu>
);

```