### PR TITLE
a11y: remove vertical margins on dialog to support 400% zoom

### DIFF
--- a/change/@fluentui-web-components-e1e8293a-32b0-4a2a-909d-9f110901c6c4.json
+++ b/change/@fluentui-web-components-e1e8293a-32b0-4a2a-909d-9f110901c6c4.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "a11y: remove vertical margins on dialog to support 400% zoom",
+  "packageName": "@fluentui/web-components",
+  "email": "rupertdavid@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/dialog-body/dialog-body.styles.ts
+++ b/packages/web-components/src/dialog-body/dialog-body.styles.ts
@@ -47,8 +47,6 @@ export const styles = css`
     margin-block-start: calc(${spacingVerticalXXL} * -1);
     padding-block-end: ${spacingVerticalS};
     padding-block-start: ${spacingVerticalXXL};
-    position: sticky;
-    z-index: 1;
   }
 
   .content {
@@ -71,8 +69,6 @@ export const styles = css`
     margin-block-end: calc(${spacingVerticalXXL} * -1);
     padding-block-end: ${spacingVerticalXXL};
     padding-block-start: ${spacingVerticalL};
-    position: sticky;
-    z-index: 2;
   }
 
   ::slotted([slot='title-action']) {
@@ -99,4 +95,15 @@ export const styles = css`
       padding-block-start: ${spacingVerticalS};
     }
   }
+
+  /* For a11y, set sticky position for title and actions when the viewport is tall enough */
+  @media (min-height: 480px) {
+    .title {
+      position: sticky;
+      z-index: 1;
+    }
+    .actions {
+      position: sticky;
+      z-index: 2;
+    }
 `;

--- a/packages/web-components/src/dialog/dialog.styles.ts
+++ b/packages/web-components/src/dialog/dialog.styles.ts
@@ -34,7 +34,7 @@ export const styles = css`
       border: none;
       box-shadow: ${shadow64};
       color: ${colorNeutralForeground1};
-      max-height: calc(-48px + 100vh);
+      max-height: 100vh;
       padding: 0;
       width: 100%;
       max-width: 600px;
@@ -45,6 +45,12 @@ export const styles = css`
       position: fixed;
       z-index: 2;
       overflow: auto;
+    }
+
+    @supports (max-height: 1dvh) {
+      dialog {
+        max-height: 100dvh;
+      }
     }
   }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Dialog content was inaccessible on 1280x1024 @ 400% zoom. 

<img width="1168" height="728" alt="Screenshot 2025-07-24 at 12 18 53 PM" src="https://github.com/user-attachments/assets/af62abe9-a23e-4b0e-88e1-e3d2bc63b87e" />


## New Behavior

Removed 24px margin on top/bottom of dialog (matches Fluent React implementation) and put position sticky rules for dialog body inside a min-height media query (based on min-viewport height 480px)

<img width="1168" height="728" alt="Screenshot 2025-07-24 at 12 19 08 PM" src="https://github.com/user-attachments/assets/bd275d15-7630-449d-9235-5de73ae9acdb" />


## Related Issue(s)

- Internally tracked
