### PR TITLE
fix(v8 PeoplePicker): Add WHCM styles to the `PeoplePickerItem` remove button

### DIFF
--- a/change/@fluentui-react-b45b6d89-5982-4205-be05-5fa7e439605f.json
+++ b/change/@fluentui-react-b45b6d89-5982-4205-be05-5fa7e439605f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(v8 PeoplePicker): Add WHCM styles to the PeoplePickerItem remove button",
+  "packageName": "@fluentui/react",
+  "email": "jiangemma@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/pickers/PeoplePicker/PeoplePickerItems/PeoplePickerItem.styles.ts
+++ b/packages/react/src/components/pickers/PeoplePicker/PeoplePickerItems/PeoplePickerItem.styles.ts
@@ -185,7 +185,7 @@ export function getStyles(props: IPeoplePickerItemSelectedStyleProps): IPeoplePi
         getFocusStyle(theme, {
           inset: 2,
           borderColor: 'transparent',
-          highContrastStyle: { inset: 2, left: 1, top: 1, bottom: 1, right: 1, outlineColor: 'ButtonText' },
+          highContrastStyle: { inset: 2, left: 1, top: 1, bottom: 1, right: 1, outlineColor: 'HighlightText' },
           outlineColor: palette.white,
           borderRadius: PICKER_PERSONA_RADIUS,
         }),
@@ -201,6 +201,10 @@ export function getStyles(props: IPeoplePickerItemSelectedStyleProps): IPeoplePi
             },
             ':focus': {
               color: palette.white,
+
+              [HighContrastSelector]: {
+                color: 'HighlightText',
+              },
             },
             [HighContrastSelector]: {
               color: 'HighlightText',


### PR DESCRIPTION
## Previous Behavior

<img width="237" height="115" alt="image" src="https://github.com/user-attachments/assets/a6b79aab-dc73-40ef-ba00-ce5b33296640" />


## New Behavior

<img width="518" height="56" alt="image" src="https://github.com/user-attachments/assets/fe067301-34bf-404e-b668-c50830882375" />


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes [Bug 26432](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/26432): [Fluent UI] [Web] [PeoplePicker]: In Aquatic and Desert mode, Contrast ratio for the selected people picker text is less than 4.5:1 once user navigate to the buttons.
