### PR TITLE
fix(react-components): MenuItem with context menu does not dismiss Menu flyout when clicked

### DIFF
--- a/packages/react-components/react-menu/library/src/components/MenuItem/useMenuItem.tsx
+++ b/packages/react-components/react-menu/library/src/components/MenuItem/useMenuItem.tsx
@@ -37,10 +37,11 @@ const ChevronLeftIcon = bundleIcon(ChevronLeftFilled, ChevronLeftRegular);
 export const useMenuItem_unstable = (props: MenuItemProps, ref: React.Ref<ARIAButtonElement<'div'>>): MenuItemState => {
   const isSubmenuTrigger = useMenuTriggerContext_unstable();
   const persistOnClickContext = useMenuContext_unstable(context => context.persistOnItemClick);
+  const openOnContext = useMenuContext_unstable(context => context.openOnContext);
   const {
     as = 'div',
     disabled = false,
-    hasSubmenu = isSubmenuTrigger,
+    hasSubmenu = isSubmenuTrigger && !openOnContext,
     persistOnClick = persistOnClickContext,
     content: _content, // `content` is a slot and it's type clashes with the HTMLElement `content` attribute
     ...rest


### PR DESCRIPTION

<!--
Thank you for submitting a pull request!


Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior
1. The button will automatically display a sub-menu indicator on the right side.
2. Clicking this button will not close the menu pop-up layer
![20250728002254_rec_](https://github.com/user-attachments/assets/4523e715-0beb-439b-910b-0d1e0957a334)


## New Behavior
This design was originally intended to open the menu by right-clicking, but when users see the arrow on the right, they might misunderstand that sub-menus can be opened through regular operations (such as left-clicking), thus causing confusion
To solve the above two problems, it will only appear when you right-click
![20250728002637_rec_](https://github.com/user-attachments/assets/275cb02a-6625-45e2-8386-3cdd0c995811)


## Related Issue(s)

- https://github.com/microsoft/fluentui/issues/34910