### PR TITLE
Fix(react-menu-grid-preview): Proper typings

### DIFF
--- a/packages/react-components/react-menu-grid-preview/library/etc/react-menu-grid-preview.api.md
+++ b/packages/react-components/react-menu-grid-preview/library/etc/react-menu-grid-preview.api.md
@@ -178,10 +178,10 @@ export const renderMenuGridRowGroup_unstable: (state: MenuGridRowGroupState, con
 export const renderMenuGridRowGroupHeader_unstable: (state: MenuGridRowGroupHeaderState, contextValues: MenuGridRowGroupHeaderContextValues) => JSX.Element;
 
 // @public
-export const useMenuGrid_unstable: (props: MenuGridProps, ref: React_2.Ref<HTMLElement>) => MenuGridState;
+export const useMenuGrid_unstable: (props: MenuGridProps, ref: React_2.Ref<HTMLDivElement>) => MenuGridState;
 
 // @public
-export function useMenuGridCell_unstable(props: MenuGridCellProps, ref: React_2.Ref<HTMLElement>): MenuGridCellState;
+export function useMenuGridCell_unstable(props: MenuGridCellProps, ref: React_2.Ref<HTMLDivElement>): MenuGridCellState;
 
 // @public (undocumented)
 export const useMenuGridCellContext_unstable: () => MenuGridCellContextValue;
@@ -199,7 +199,7 @@ export const useMenuGridContext_unstable: () => MenuGridContextValue;
 export function useMenuGridContextValues_unstable(state: MenuGridState): MenuGridContextValues;
 
 // @public
-export function useMenuGridRow_unstable(props: MenuGridRowProps, ref: React_2.Ref<HTMLElement>): MenuGridRowState;
+export function useMenuGridRow_unstable(props: MenuGridRowProps, ref: React_2.Ref<HTMLDivElement>): MenuGridRowState;
 
 // @public (undocumented)
 export const useMenuGridRowContext_unstable: () => MenuGridRowContextValue;
@@ -208,7 +208,7 @@ export const useMenuGridRowContext_unstable: () => MenuGridRowContextValue;
 export function useMenuGridRowContextValues_unstable(state: MenuGridRowState): MenuGridRowContextValues;
 
 // @public
-export function useMenuGridRowGroup_unstable(props: MenuGridRowGroupProps, ref: React_2.Ref<HTMLElement>): MenuGridRowGroupState;
+export function useMenuGridRowGroup_unstable(props: MenuGridRowGroupProps, ref: React_2.Ref<HTMLDivElement>): MenuGridRowGroupState;
 
 // @public (undocumented)
 export const useMenuGridRowGroupContext_unstable: () => MenuGridRowGroupContextValue;
@@ -217,7 +217,7 @@ export const useMenuGridRowGroupContext_unstable: () => MenuGridRowGroupContextV
 export function useMenuGridRowGroupContextValues_unstable(state: MenuGridRowGroupState): MenuGridRowGroupContextValues;
 
 // @public
-export function useMenuGridRowGroupHeader_unstable(props: MenuGridRowGroupHeaderProps, ref: React_2.Ref<HTMLElement>): MenuGridRowGroupHeaderState;
+export function useMenuGridRowGroupHeader_unstable(props: MenuGridRowGroupHeaderProps, ref: React_2.Ref<HTMLDivElement>): MenuGridRowGroupHeaderState;
 
 // @public (undocumented)
 export const useMenuGridRowGroupHeaderContext_unstable: () => MenuGridRowGroupHeaderContextValue;

--- a/packages/react-components/react-menu-grid-preview/library/src/components/MenuGrid/useMenuGrid.ts
+++ b/packages/react-components/react-menu-grid-preview/library/src/components/MenuGrid/useMenuGrid.ts
@@ -7,7 +7,7 @@ import { useMenuContext_unstable } from '@fluentui/react-menu';
 /**
  * Returns the props and state required to render the component
  */
-export const useMenuGrid_unstable = (props: MenuGridProps, ref: React.Ref<HTMLElement>): MenuGridState => {
+export const useMenuGrid_unstable = (props: MenuGridProps, ref: React.Ref<HTMLDivElement>): MenuGridState => {
   const triggerId = useMenuContext_unstable(context => context.triggerId);
   const { tableRowTabsterAttribute, tableTabsterAttribute, onTableKeyDown } = useTableCompositeNavigation();
 
@@ -17,10 +17,7 @@ export const useMenuGrid_unstable = (props: MenuGridProps, ref: React.Ref<HTMLEl
     },
     root: slot.always(
       getIntrinsicElementProps('div', {
-        // FIXME:
-        // `ref` is wrongly assigned to be `HTMLElement` instead of `HTMLDivElement`
-        // but since it would be a breaking change to fix it, we are casting ref to it's proper type
-        ref: ref as React.Ref<HTMLDivElement>,
+        ref,
         role: 'grid',
         'aria-labelledby': triggerId,
         onKeyDown: onTableKeyDown,

--- a/packages/react-components/react-menu-grid-preview/library/src/components/MenuGridCell/useMenuGridCell.ts
+++ b/packages/react-components/react-menu-grid-preview/library/src/components/MenuGridCell/useMenuGridCell.ts
@@ -5,17 +5,14 @@ import { MenuGridCellProps, MenuGridCellState } from './MenuGridCell.types';
 /**
  * Given user props, returns state and render function for a MenuGridCell.
  */
-export function useMenuGridCell_unstable(props: MenuGridCellProps, ref: React.Ref<HTMLElement>): MenuGridCellState {
+export function useMenuGridCell_unstable(props: MenuGridCellProps, ref: React.Ref<HTMLDivElement>): MenuGridCellState {
   return {
     components: {
       root: 'div',
     },
     root: slot.always(
       getIntrinsicElementProps('div', {
-        // FIXME:
-        // `ref` is wrongly assigned to be `HTMLElement` instead of `HTMLDivElement`
-        // but since it would be a breaking change to fix it, we are casting ref to it's proper type
-        ref: ref as React.Ref<HTMLDivElement>,
+        ref,
         role: 'gridcell',
         ...props,
       }),

--- a/packages/react-components/react-menu-grid-preview/library/src/components/MenuGridRow/useMenuGridRow.ts
+++ b/packages/react-components/react-menu-grid-preview/library/src/components/MenuGridRow/useMenuGridRow.ts
@@ -7,7 +7,7 @@ import { MenuGridRowProps, MenuGridRowState } from './MenuGridRow.types';
 /**
  * Given user props, returns state and render function for a MenuGridRow.
  */
-export function useMenuGridRow_unstable(props: MenuGridRowProps, ref: React.Ref<HTMLElement>): MenuGridRowState {
+export function useMenuGridRow_unstable(props: MenuGridRowProps, ref: React.Ref<HTMLDivElement>): MenuGridRowState {
   const { tableRowTabsterAttribute } = useMenuGridContext_unstable();
 
   return {
@@ -16,10 +16,7 @@ export function useMenuGridRow_unstable(props: MenuGridRowProps, ref: React.Ref<
     },
     root: slot.always(
       getIntrinsicElementProps('div', {
-        // FIXME:
-        // `ref` is wrongly assigned to be `HTMLElement` instead of `HTMLDivElement`
-        // but since it would be a breaking change to fix it, we are casting ref to it's proper type
-        ref: ref as React.Ref<HTMLDivElement>,
+        ref,
         role: 'row',
         tabIndex: 0,
         ...tableRowTabsterAttribute,

--- a/packages/react-components/react-menu-grid-preview/library/src/components/MenuGridRowGroup/useMenuGridRowGroup.ts
+++ b/packages/react-components/react-menu-grid-preview/library/src/components/MenuGridRowGroup/useMenuGridRowGroup.ts
@@ -7,7 +7,7 @@ import { MenuGridRowGroupProps, MenuGridRowGroupState } from './MenuGridRowGroup
  */
 export function useMenuGridRowGroup_unstable(
   props: MenuGridRowGroupProps,
-  ref: React.Ref<HTMLElement>,
+  ref: React.Ref<HTMLDivElement>,
 ): MenuGridRowGroupState {
   const headerId = useId('menu-grid-row-group-header');
 
@@ -17,10 +17,7 @@ export function useMenuGridRowGroup_unstable(
     },
     root: slot.always(
       getIntrinsicElementProps('div', {
-        // FIXME:
-        // `ref` is wrongly assigned to be `HTMLElement` instead of `HTMLDivElement`
-        // but since it would be a breaking change to fix it, we are casting ref to it's proper type
-        ref: ref as React.Ref<HTMLDivElement>,
+        ref,
         role: 'rowgroup',
         'aria-labelledby': headerId,
         ...props,

--- a/packages/react-components/react-menu-grid-preview/library/src/components/MenuGridRowGroupHeader/useMenuGridRowGroupHeader.ts
+++ b/packages/react-components/react-menu-grid-preview/library/src/components/MenuGridRowGroupHeader/useMenuGridRowGroupHeader.ts
@@ -9,7 +9,7 @@ import { MenuGridRowGroupHeaderProps, MenuGridRowGroupHeaderState } from './Menu
  */
 export function useMenuGridRowGroupHeader_unstable(
   props: MenuGridRowGroupHeaderProps,
-  ref: React.Ref<HTMLElement>,
+  ref: React.Ref<HTMLDivElement>,
 ): MenuGridRowGroupHeaderState {
   const { headerId: id } = useMenuGridRowGroupContext_unstable();
 
@@ -19,10 +19,7 @@ export function useMenuGridRowGroupHeader_unstable(
     },
     root: slot.always(
       getIntrinsicElementProps('div', {
-        // FIXME:
-        // `ref` is wrongly assigned to be `HTMLElement` instead of `HTMLDivElement`
-        // but since it would be a breaking change to fix it, we are casting ref to it's proper type
-        ref: ref as React.Ref<HTMLDivElement>,
+        ref,
         role: 'presentation',
         id,
         'aria-hidden': true,


### PR DESCRIPTION
### Description of changes

This PR fixes ref typings in the `MenuGrid` components.