### PR TITLE
Feature(react-menu-grid-preview): Add custom style hooks

### DIFF
--- a/change/@fluentui-react-shared-contexts-4e93f96f-b1ea-40dd-8c3a-f0cf719a412b.json
+++ b/change/@fluentui-react-shared-contexts-4e93f96f-b1ea-40dd-8c3a-f0cf719a412b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add custom style hooks.",
+  "packageName": "@fluentui/react-shared-contexts",
+  "email": "adam.samec@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-menu-grid-preview/library/src/components/MenuGrid/MenuGrid.tsx
+++ b/packages/react-components/react-menu-grid-preview/library/src/components/MenuGrid/MenuGrid.tsx
@@ -5,7 +5,7 @@ import { useMenuGridContextValues_unstable } from './useMenuGridContextValues';
 import { useMenuGridStyles_unstable } from './useMenuGridStyles.styles';
 import type { MenuGridProps } from './MenuGrid.types';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
-// import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
+import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 
 /**
  * Define a styled MenuGrid, using the `useMenuGrid_unstable` hook.
@@ -15,8 +15,7 @@ export const MenuGrid: ForwardRefComponent<MenuGridProps> = React.forwardRef((pr
   const contextValues = useMenuGridContextValues_unstable(state);
 
   useMenuGridStyles_unstable(state);
-
-  // useCustomStyleHook_unstable('useMenuGridStyles_unstable')(state);
+  useCustomStyleHook_unstable('useMenuGridStyles_unstable')(state);
 
   return renderMenuGrid_unstable(state, contextValues);
 });

--- a/packages/react-components/react-menu-grid-preview/library/src/components/MenuGridCell/MenuGridCell.tsx
+++ b/packages/react-components/react-menu-grid-preview/library/src/components/MenuGridCell/MenuGridCell.tsx
@@ -5,7 +5,7 @@ import { useMenuGridCellContextValues_unstable } from './useMenuGridCellContextV
 import type { MenuGridCellProps } from './MenuGridCell.types';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import { useMenuGridCellStyles_unstable } from './useMenuGridCellStyles.styles';
-// import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
+import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 
 /**
  * Define a MenuGridCell, using the `useMenuGridCell_unstable` hook.
@@ -15,8 +15,7 @@ export const MenuGridCell: ForwardRefComponent<MenuGridCellProps> = React.forwar
   const contextValues = useMenuGridCellContextValues_unstable(state);
 
   useMenuGridCellStyles_unstable(state);
-
-  // useCustomStyleHook_unstable('useMenuGridCellStyles_unstable')(state);
+  useCustomStyleHook_unstable('useMenuGridCellStyles_unstable')(state);
 
   return renderMenuGridCell_unstable(state, contextValues);
 });

--- a/packages/react-components/react-menu-grid-preview/library/src/components/MenuGridRow/MenuGridRow.tsx
+++ b/packages/react-components/react-menu-grid-preview/library/src/components/MenuGridRow/MenuGridRow.tsx
@@ -5,7 +5,7 @@ import { useMenuGridRowContextValues_unstable } from './useMenuGridRowContextVal
 import type { MenuGridRowProps } from './MenuGridRow.types';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import { useMenuGridRowStyles_unstable } from './useMenuGridRowStyles.styles';
-// import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
+import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 
 /**
  * Define a MenuGridRow, using the `useMenuGridRow_unstable` hook.
@@ -15,8 +15,7 @@ export const MenuGridRow: ForwardRefComponent<MenuGridRowProps> = React.forwardR
   const contextValues = useMenuGridRowContextValues_unstable(state);
 
   useMenuGridRowStyles_unstable(state);
-
-  // useCustomStyleHook_unstable('useMenuGridRowStyles_unstable')(state);
+  useCustomStyleHook_unstable('useMenuGridRowStyles_unstable')(state);
 
   return renderMenuGridRow_unstable(state, contextValues);
 });

--- a/packages/react-components/react-menu-grid-preview/library/src/components/MenuGridRowGroup/MenuGridRowGroup.tsx
+++ b/packages/react-components/react-menu-grid-preview/library/src/components/MenuGridRowGroup/MenuGridRowGroup.tsx
@@ -5,7 +5,7 @@ import { useMenuGridRowGroupContextValues_unstable } from './useMenuGridRowGroup
 import type { MenuGridRowGroupProps } from './MenuGridRowGroup.types';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import { useMenuGridRowGroupStyles_unstable } from './useMenuGridRowGroupStyles.styles';
-// import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
+import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 
 /**
  * Define a MenuGridRowGroup, using the `useMenuGridRowGroup_unstable` hook.
@@ -15,8 +15,7 @@ export const MenuGridRowGroup: ForwardRefComponent<MenuGridRowGroupProps> = Reac
   const contextValues = useMenuGridRowGroupContextValues_unstable(state);
 
   useMenuGridRowGroupStyles_unstable(state);
-
-  // useCustomStyleHook_unstable('useMenuGridRowGroupStyles_unstable')(state);
+  useCustomStyleHook_unstable('useMenuGridRowGroupStyles_unstable')(state);
 
   return renderMenuGridRowGroup_unstable(state, contextValues);
 });

--- a/packages/react-components/react-menu-grid-preview/library/src/components/MenuGridRowGroupHeader/MenuGridRowGroupHeader.tsx
+++ b/packages/react-components/react-menu-grid-preview/library/src/components/MenuGridRowGroupHeader/MenuGridRowGroupHeader.tsx
@@ -5,7 +5,7 @@ import { useMenuGridRowGroupHeaderContextValues_unstable } from './useMenuGridRo
 import type { MenuGridRowGroupHeaderProps } from './MenuGridRowGroupHeader.types';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import { useMenuGridRowGroupHeaderStyles_unstable } from './useMenuGridRowGroupHeaderStyles.styles';
-// import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
+import { useCustomStyleHook_unstable } from '@fluentui/react-shared-contexts';
 
 /**
  * Define a MenuGridRowGroupHeader, using the `useMenuGridRowGroupHeader_unstable` hook.
@@ -16,8 +16,7 @@ export const MenuGridRowGroupHeader: ForwardRefComponent<MenuGridRowGroupHeaderP
     const contextValues = useMenuGridRowGroupHeaderContextValues_unstable(state);
 
     useMenuGridRowGroupHeaderStyles_unstable(state);
-
-    // useCustomStyleHook_unstable('useMenuGridRowGroupHeaderStyles_unstable')(state);
+    useCustomStyleHook_unstable('useMenuGridRowGroupHeaderStyles_unstable')(state);
 
     return renderMenuGridRowGroupHeader_unstable(state, contextValues);
   },

--- a/packages/react-components/react-shared-contexts/library/etc/react-shared-contexts.api.md
+++ b/packages/react-components/react-shared-contexts/library/etc/react-shared-contexts.api.md
@@ -114,6 +114,11 @@ export const CustomStyleHooksContext_unstable: React_2.Context<Partial<{
     useListboxStyles_unstable: CustomStyleHook;
     useMenuButtonStyles_unstable: CustomStyleHook;
     useMenuDividerStyles_unstable: CustomStyleHook;
+    useMenuGridStyles_unstable: CustomStyleHook;
+    useMenuGridCellStyles_unstable: CustomStyleHook;
+    useMenuGridRowStyles_unstable: CustomStyleHook;
+    useMenuGridRowGroupStyles_unstable: CustomStyleHook;
+    useMenuGridRowGroupHeaderStyles_unstable: CustomStyleHook;
     useMenuGroupHeaderStyles_unstable: CustomStyleHook;
     useMenuGroupStyles_unstable: CustomStyleHook;
     useMenuItemCheckboxStyles_unstable: CustomStyleHook;
@@ -310,6 +315,11 @@ export type CustomStyleHooksContextValue_unstable = Partial<{
     useListboxStyles_unstable: CustomStyleHook;
     useMenuButtonStyles_unstable: CustomStyleHook;
     useMenuDividerStyles_unstable: CustomStyleHook;
+    useMenuGridStyles_unstable: CustomStyleHook;
+    useMenuGridCellStyles_unstable: CustomStyleHook;
+    useMenuGridRowStyles_unstable: CustomStyleHook;
+    useMenuGridRowGroupStyles_unstable: CustomStyleHook;
+    useMenuGridRowGroupHeaderStyles_unstable: CustomStyleHook;
     useMenuGroupHeaderStyles_unstable: CustomStyleHook;
     useMenuGroupStyles_unstable: CustomStyleHook;
     useMenuItemCheckboxStyles_unstable: CustomStyleHook;
@@ -506,6 +516,11 @@ export const CustomStyleHooksProvider_unstable: React_2.Provider<Partial<{
     useListboxStyles_unstable: CustomStyleHook;
     useMenuButtonStyles_unstable: CustomStyleHook;
     useMenuDividerStyles_unstable: CustomStyleHook;
+    useMenuGridStyles_unstable: CustomStyleHook;
+    useMenuGridCellStyles_unstable: CustomStyleHook;
+    useMenuGridRowStyles_unstable: CustomStyleHook;
+    useMenuGridRowGroupStyles_unstable: CustomStyleHook;
+    useMenuGridRowGroupHeaderStyles_unstable: CustomStyleHook;
     useMenuGroupHeaderStyles_unstable: CustomStyleHook;
     useMenuGroupStyles_unstable: CustomStyleHook;
     useMenuItemCheckboxStyles_unstable: CustomStyleHook;

--- a/packages/react-components/react-shared-contexts/library/src/CustomStyleHooksContext/CustomStyleHooksContext.ts
+++ b/packages/react-components/react-shared-contexts/library/src/CustomStyleHooksContext/CustomStyleHooksContext.ts
@@ -88,6 +88,11 @@ export type CustomStyleHooksContextValue = Partial<{
   useListboxStyles_unstable: CustomStyleHook;
   useMenuButtonStyles_unstable: CustomStyleHook;
   useMenuDividerStyles_unstable: CustomStyleHook;
+  useMenuGridStyles_unstable: CustomStyleHook;
+  useMenuGridCellStyles_unstable: CustomStyleHook;
+  useMenuGridRowStyles_unstable: CustomStyleHook;
+  useMenuGridRowGroupStyles_unstable: CustomStyleHook;
+  useMenuGridRowGroupHeaderStyles_unstable: CustomStyleHook;
   useMenuGroupHeaderStyles_unstable: CustomStyleHook;
   useMenuGroupStyles_unstable: CustomStyleHook;
   useMenuItemCheckboxStyles_unstable: CustomStyleHook;


### PR DESCRIPTION
### Description of changes

This PR adds custom style hooks for the `MenuGrid` component and its subcomponents.