### PR TITLE
fix(react-integration): add missing grid-preview, unify ts configs and run type-check on compat packages against R19

### DIFF
--- a/apps/react-17-tests-v9/package.json
+++ b/apps/react-17-tests-v9/package.json
@@ -22,11 +22,12 @@
     "@fluentui/scripts-tasks": "*"
   },
   "dependencies": {
-    "@fluentui/react-calendar-compat": "*",
     "@fluentui/react-components": "*",
+    "@fluentui/react-calendar-compat": "*",
     "@fluentui/react-datepicker-compat": "*",
-    "@fluentui/react-migration-v8-v9": "*",
     "@fluentui/react-timepicker-compat": "*",
+    "@fluentui/react-migration-v8-v9": "*",
+    "@fluentui/react-menu-grid-preview": "*",
     "@cypress/react": "8.0.0",
     "@testing-library/dom": "8.11.3",
     "@testing-library/react": "12.1.2",

--- a/apps/react-17-tests-v9/tsconfig.react-17.json
+++ b/apps/react-17-tests-v9/tsconfig.react-17.json
@@ -27,9 +27,9 @@
     "../../packages/react-components/**/index.stories.tsx",
     "../../packages/react-components/**/index.stories.ts",
     "../../packages/react-components/react-migration-v0-v9/**",
-    "../../packages/react-components/react-migration-v8-v9/library/**/*.spec.tsx",
-    "../../packages/react-components/react-migration-v8-v9/library/**/*.test.tsx",
-    "../../packages/react-components/react-migration-v8-v9/library/src/testing/**"
+    "../../**/*.spec.tsx",
+    "../../**/*.test.tsx",
+    "../../**/src/testing/**"
   ],
   "include": [
     "../../packages/react-components/*/stories/**/*.stories.tsx",

--- a/apps/react-18-tests-v9/package.json
+++ b/apps/react-18-tests-v9/package.json
@@ -22,11 +22,12 @@
     "@fluentui/scripts-tasks": "*"
   },
   "dependencies": {
-    "@fluentui/react-calendar-compat": "*",
     "@fluentui/react-components": "*",
+    "@fluentui/react-calendar-compat": "*",
     "@fluentui/react-datepicker-compat": "*",
-    "@fluentui/react-migration-v8-v9": "*",
     "@fluentui/react-timepicker-compat": "*",
+    "@fluentui/react-migration-v8-v9": "*",
+    "@fluentui/react-menu-grid-preview": "*",
     "@cypress/react": "9.0.1",
     "@testing-library/dom": "^10.1.0",
     "@testing-library/react": "^16.0.0",

--- a/apps/react-18-tests-v9/tsconfig.react-18.json
+++ b/apps/react-18-tests-v9/tsconfig.react-18.json
@@ -27,9 +27,9 @@
     "../../packages/react-components/**/index.stories.tsx",
     "../../packages/react-components/**/index.stories.ts",
     "../../packages/react-components/react-migration-v0-v9/**",
-    "../../packages/react-components/react-migration-v8-v9/library/**/*.spec.tsx",
-    "../../packages/react-components/react-migration-v8-v9/library/**/*.test.tsx",
-    "../../packages/react-components/react-migration-v8-v9/library/src/testing/**"
+    "../../**/*.spec.tsx",
+    "../../**/*.test.tsx",
+    "../../**/src/testing/**"
   ],
   "include": [
     "../../packages/react-components/*/stories/**/*.stories.tsx",

--- a/apps/react-19-tests-v9/package.json
+++ b/apps/react-19-tests-v9/package.json
@@ -22,11 +22,12 @@
     "@fluentui/scripts-tasks": "*"
   },
   "dependencies": {
-    "@fluentui/react-calendar-compat": "*",
     "@fluentui/react-components": "*",
+    "@fluentui/react-calendar-compat": "*",
     "@fluentui/react-datepicker-compat": "*",
-    "@fluentui/react-migration-v8-v9": "*",
     "@fluentui/react-timepicker-compat": "*",
+    "@fluentui/react-migration-v8-v9": "*",
+    "@fluentui/react-menu-grid-preview": "*",
     "@cypress/react": "9.0.1",
     "@testing-library/dom": "^10.1.0",
     "@testing-library/react": "^16.0.0",

--- a/apps/react-19-tests-v9/tsconfig.react-19.json
+++ b/apps/react-19-tests-v9/tsconfig.react-19.json
@@ -28,7 +28,6 @@
     "../../packages/react-components/**/index.stories.ts",
     "../../packages/react-components/react-migration-v0-v9/**",
     "../../packages/react-components/react-migration-v8-v9/**",
-    "../../packages/react-components/react-*-compat/**",
     "../../**/*.spec.tsx",
     "../../**/*.test.tsx",
     "../../**/src/testing/**"

--- a/apps/react-19-tests-v9/tsconfig.react-19.json
+++ b/apps/react-19-tests-v9/tsconfig.react-19.json
@@ -28,7 +28,10 @@
     "../../packages/react-components/**/index.stories.ts",
     "../../packages/react-components/react-migration-v0-v9/**",
     "../../packages/react-components/react-migration-v8-v9/**",
-    "../../packages/react-components/react-*-compat/**"
+    "../../packages/react-components/react-*-compat/**",
+    "../../**/*.spec.tsx",
+    "../../**/*.test.tsx",
+    "../../**/src/testing/**"
   ],
   "include": [
     "../../packages/react-components/*/stories/**/*.stories.tsx",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

- adds `grid-preview` to integration apps deps as it cause type-checks to fail https://github.com/microsoft/fluentui/actions/runs/16574493283/job/46875280246?pr=34923
- enables COMPAT packages to be type-checked against React 19 - these packages need to pass as well ( we have this for R17,R18 already )

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
