### PR TITLE
fix(react-link): update inverted link styles to use neutral color tokens

### DIFF
--- a/change/@fluentui-react-link-b7b54d14-d92f-4d02-8e55-c440294dfe7f.json
+++ b/change/@fluentui-react-link-b7b54d14-d92f-4d02-8e55-c440294dfe7f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: update inverted link styles to use neutral color tokens",
+  "packageName": "@fluentui/react-link",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-link/library/src/components/Link/useLinkStyles.styles.ts
+++ b/packages/react-components/react-link/library/src/components/Link/useLinkStyles.styles.ts
@@ -91,12 +91,12 @@ const useStyles = makeStyles({
   },
 
   inverted: {
-    color: tokens.colorBrandForegroundInverted,
+    color: tokens.colorNeutralForegroundInvertedLink,
     ':hover': {
-      color: tokens.colorBrandForegroundInvertedHover,
+      color: tokens.colorNeutralForegroundInvertedLinkHover,
     },
     ':active': {
-      color: tokens.colorBrandForegroundInvertedPressed,
+      color: tokens.colorNeutralForegroundInvertedLinkPressed,
     },
   },
 });


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Tokens used for the `inverted` Link variant did not align with the Figma specification:

- The code used `colorBrandForegroundInverted*` tokens
- Figma used `colorNeutralForegroundInvertedLink*` tokens

Figma: https://www.figma.com/design/ZhYpaByCXhprTWpF2097yE/Link?node-id=1105-3387&t=98NVbCUII05TFmti-4

## New Behavior

The `inverted` Link variant tokens are now consistent between the component and Figma.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #34911
