### PR TITLE
fix(react-storybook-addon): resolve dissapearing Slot Info message on consecutive page re-renders

### DIFF
--- a/change/@fluentui-react-storybook-addon-70139255-9dde-438f-9c7b-0370acee7afa.json
+++ b/change/@fluentui-react-storybook-addon-70139255-9dde-438f-9c7b-0370acee7afa.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: resolve dissapearing Slot Info message on consecutive page re-renders",
+  "packageName": "@fluentui/react-storybook-addon",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-storybook-addon/src/docs/FluentDocsPage.tsx
+++ b/packages/react-components/react-storybook-addon/src/docs/FluentDocsPage.tsx
@@ -172,6 +172,13 @@ function withSlotEnhancer(story: PreparedStory, options: { slotsApi?: boolean; n
   const transformPropsWithSlotShorthand = (props: Record<string, { type: { name: string } }>) => {
     Object.entries(props).forEach(([key, argType]) => {
       const value: string = argType?.type?.name;
+
+      // If DocGen was already transformed, skip the transformation but set hasArgAsSlot to true so that we can show the info message
+      if (value.includes('Slot')) {
+        hasArgAsSlot = true;
+        return;
+      }
+      // Initial Render Transformation for shorthand slot values (mutates DocGen Object reference)
       if (value.includes('WithSlotShorthandValue')) {
         hasArgAsSlot = true;
         const match = value.match(slotRegex);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

https://github.com/user-attachments/assets/630e6a0f-3edd-477e-8632-bdcec2da7f58


## New Behavior

Slot info is preserved on consecutive page re-render

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- [x] Needs: https://github.com/microsoft/fluentui/pull/34950
