### PR TITLE
fix: avoid setting tabindex before button is connected

### DIFF
--- a/change/@fluentui-web-components-341d48dd-0e45-43a4-9cc0-b9199ac88b92.json
+++ b/change/@fluentui-web-components-341d48dd-0e45-43a4-9cc0-b9199ac88b92.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: avoid setting tabindex before button is connected",
+  "packageName": "@fluentui/web-components",
+  "email": "machi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/button/button.base.ts
+++ b/packages/web-components/src/button/button.base.ts
@@ -45,6 +45,9 @@ export class BaseButton extends FASTElement {
   disabled = false;
 
   protected disabledChanged() {
+    if (!this.$fastController.isConnected) {
+      return;
+    }
     if (this.disabled) {
       this.removeAttribute('tabindex');
     } else {
@@ -259,6 +262,7 @@ export class BaseButton extends FASTElement {
   connectedCallback(): void {
     super.connectedCallback();
     this.elementInternals.ariaDisabled = `${!!this.disabledFocusable}`;
+    this.disabledChanged();
   }
 
   constructor() {


### PR DESCRIPTION
## Previous Behavior

`document.createElement('fluent-button')` throws the following error:

```
Uncaught NotSupportedError: Failed to execute 'createElement' on 'Document': The result must not have attributes
```

Because `tabIndex` is set in `disabledChanged()` which can be called before button is connected.

## New Behavior

Only set `tabIndex` (and the `tabindex` attribute) when button is connected.
