### PR TITLE
docs(docsite-v9): add official RAW modules support docs

### DIFF
--- a/apps/public-docsite-v9/src/Concepts/UnprocessedStyles.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/UnprocessedStyles.stories.mdx
@@ -1,0 +1,107 @@
+import { Meta, Source } from '@storybook/addon-docs';
+
+<Meta title="Concepts/Developer/Unprocessed Styles" />
+
+## Unprocessed Styles (Raw Modules)
+
+### Overview
+
+Fluent UI v9 components now ship with **raw module alternatives** to solve CSS style conflicts in multi-bundle applications. This feature addresses critical issues where Griffel-processed styles clash when multiple application bundles are loaded simultaneously.
+
+### The Problem: Style Clashes in Multi-Bundle Apps
+
+Modern applications often split code into multiple bundles (main app bundle, CDN bundles, micro-frontends, etc.). When each bundle contains pre-processed Griffel styles, CSS class conflicts can occur:
+
+```html
+<!-- Main bundle styles -->
+<style>
+  .order0 {
+    padding: 10px;
+  }
+  .order1 {
+    padding-left: 5px;
+  }
+</style>
+
+<!-- CDN bundle styles (loaded later) -->
+<style>
+  .order0 {
+    padding: 10px;
+  } /* Overrides main bundle! */
+</style>
+
+<!-- Result: Expected padding-left: 5px, but got padding: 10px -->
+<div class="order0 order1"></div>
+```
+
+### The Solution: Raw Modules with Style Prefixing
+
+Raw modules contain unprocessed Griffel styles that can be configured with unique prefixes at build time, preventing CSS conflicts:
+
+```html
+<!-- With prefixed styles -->
+<style>
+  .main-order0 {
+    padding: 10px;
+  }
+  .main-order1 {
+    padding-left: 5px;
+  }
+</style>
+
+<style>
+  .cdn-order0 {
+    padding: 10px;
+  } /* No conflict! */
+</style>
+```
+
+### How to Use Raw Modules
+
+Configure your bundler to prioritize `.raw.js` extension resolution:
+
+**Webpack Configuration:**
+
+```js
+// webpack.config.js
+module.exports = {
+  resolve: {
+    extensions: ['.raw.js', '...'],
+  },
+};
+```
+
+**Vite Configuration:**
+
+```js
+// vite.config.js
+export default {
+  resolve: {
+    extensions: ['.raw.js', '.mjs', '.js', '.ts', '.jsx', '.tsx', '.json'],
+  },
+};
+```
+
+### Package Support Status
+
+| Package                      | Ships Processed Styles | Raw Modules Available | Version                                                                                                                                                                                                                                                                                                                       |
+| ---------------------------- | ---------------------- | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@fluentui/react-components` | ⚠️ Yes                 | ✅ Available          | [v9.67.0+](https://www.npmjs.com/package/@fluentui/react-components/v/9.67.0)                                                                                                                                                                                                                                                 |
+| `@fluentui-contrib/*`        | ✅ No                  | ✅ Not needed         | N/A                                                                                                                                                                                                                                                                                                                           |
+| `@fluentui-copilot/*`        | ⚠️ Yes                 | ✅ Available          | [v0.28.4+](https://www.npmjs.com/package/@fluentui-copilot/react-copilot/v/0.28.4), Older major version back-ports / [v0.26.2-hotfix.1](https://www.npmjs.com/package/@fluentui-copilot/react-copilot/v/0.26.2-hotfix.1), [v0.25.3-hotfix.1](https://www.npmjs.com/package/@fluentui-copilot/react-copilot/v/0.25.3-hotfix.1) |
+| `@fluentui/react-icons`      | ⚠️ Yes                 | ✅ Available          | [v2.0.307+](https://www.npmjs.com/package/@fluentui/react-icons/v/2.0.307)                                                                                                                                                                                                                                                    |
+| `@fluentui/react-charts`     | ⚠️ Yes                 | ✅ Available          | [v9.2.0+](https://www.npmjs.com/package/@fluentui/react-charts/v/9.2.0)                                                                                                                                                                                                                                                       |
+| MSFT Design react-icons      | ⚠️ Yes                 | ❌ Not planned        | -                                                                                                                                                                                                                                                                                                                             |
+
+### Benefits
+
+- **✅ Backward Compatible**: Existing apps continue to work without changes
+- **✅ Zero Breaking Changes**: Raw modules are opt-in via bundler configuration
+- **✅ Performance**: Avoids CSS specificity hacks and runtime overhead
+- **✅ Future-Proof**: Enables style prefixing and better multi-bundle support
+
+### Learn More
+
+- 📖 [RFC: Stop pre-processing styles with Griffel](https://github.com/microsoft/fluentui/blob/master/docs/react-v9/contributing/rfcs/shared/build-system/stop-styles-transforms.md)
+- 🐛 [Griffel Issue #453](https://github.com/microsoft/griffel/issues/453)
+- 🐛 [Griffel Issue #526](https://github.com/microsoft/griffel/issues/526)


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

adds official docs for griffel RAW style consumption
- https://fluentuipr.z22.web.core.windows.net/pull/34969/public-docsite-v9/storybook/index.html?path=/docs/concepts-developer-unprocessed-styles--docs

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows #34853 
