### PR TITLE
feat: enhance carousel styles with theme tokens follow desing guidence

### DIFF
--- a/change/@fluentui-react-carousel-a7426f68-6e99-4c35-8751-b8a3c86f5ce0.json
+++ b/change/@fluentui-react-carousel-a7426f68-6e99-4c35-8751-b8a3c86f5ce0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat/enhance-carousel-styles-theme-tokens",
+  "packageName": "@fluentui/react-carousel",
+  "email": "Oleksandr.Katrukhin@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-carousel/library/src/components/Carousel/useCarouselStyles.styles.ts
+++ b/packages/react-components/react-carousel/library/src/components/Carousel/useCarouselStyles.styles.ts
@@ -1,5 +1,6 @@
 import { makeStyles, mergeClasses } from '@griffel/react';
 import type { SlotClassNames } from '@fluentui/react-utilities';
+import { tokens } from '@fluentui/react-theme';
 
 import type { CarouselSlots, CarouselState } from './Carousel.types';
 
@@ -16,6 +17,8 @@ const useStyles = makeStyles({
     overflowX: 'hidden',
     overflowAnchor: 'none',
     position: 'relative',
+    margin: tokens.spacingVerticalL,
+    padding: tokens.spacingVerticalL,
   },
 });
 

--- a/packages/react-components/react-carousel/library/src/components/CarouselCard/useCarouselCardStyles.styles.ts
+++ b/packages/react-components/react-carousel/library/src/components/CarouselCard/useCarouselCardStyles.styles.ts
@@ -1,6 +1,7 @@
 import { makeStyles, mergeClasses } from '@griffel/react';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import type { CarouselCardSlots, CarouselCardState } from './CarouselCard.types';
+import { tokens } from '@fluentui/react-theme';
 
 export const carouselCardClassNames: SlotClassNames<CarouselCardSlots> = {
   root: 'fui-CarouselCard',
@@ -13,6 +14,8 @@ const useStyles = makeStyles({
   root: {
     flex: '0 0 100%',
     maxWidth: '100%',
+    borderRadius: tokens.borderRadiusXLarge,
+    boxShadow: tokens.shadow16,
   },
   autoSize: {
     flex: '0 0 auto' /* Adapt slide size to its content */,

--- a/packages/react-components/react-carousel/library/src/components/CarouselSlider/useCarouselSliderStyles.styles.ts
+++ b/packages/react-components/react-carousel/library/src/components/CarouselSlider/useCarouselSliderStyles.styles.ts
@@ -1,5 +1,6 @@
 import { makeStyles, mergeClasses } from '@griffel/react';
 import type { SlotClassNames } from '@fluentui/react-utilities';
+import { tokens } from '@fluentui/react-theme';
 
 import type { CarouselSliderSlots, CarouselSliderState } from './CarouselSlider.types';
 
@@ -14,6 +15,7 @@ const useStyles = makeStyles({
   root: {
     display: 'flex',
     overflowAnchor: 'none',
+    gap: tokens.spacingHorizontalXXL,
   },
 });
 

--- a/packages/react-components/react-carousel/stories/src/Carousel/CarouselDefault.stories.tsx
+++ b/packages/react-components/react-carousel/stories/src/Carousel/CarouselDefault.stories.tsx
@@ -14,10 +14,12 @@ import * as React from 'react';
 const useClasses = makeStyles({
   bannerCard: {
     alignContent: 'center',
-    borderRadius: tokens.borderRadiusLarge,
     height: '450px',
     textAlign: 'left',
     position: 'relative',
+  },
+  image: {
+    borderRadius: 'inherit',
   },
   cardContainer: {
     display: 'flex',
@@ -55,7 +57,7 @@ const BannerCard: React.FC<{ children: React.ReactNode; imageSrc: string; index:
 
   return (
     <CarouselCard className={classes.bannerCard} aria-label={`${index + 1} of ${IMAGES.length}`} id={`test-${index}`}>
-      <Image fit="cover" src={imageSrc} role="presentation" />
+      <Image fit="cover" src={imageSrc} className={classes.image} role="presentation" />
 
       <div className={classes.cardContainer}>
         <div className={classes.title}>{children}</div>


### PR DESCRIPTION
## Previous Behavior
The carousel component styles were not fully customizable via theme tokens, limiting flexibility in design and theming.

## New Behavior
Enhanced the carousel component styles to support customization through theme tokens, allowing for better alignment with design requirements and improved theming capabilities.

<img width="450" alt="image" src="https://github.com/user-attachments/assets/86a5274f-a7a8-4f57-b359-b20ec989b14a" />

[Design specs](https://www.figma.com/design/gIRF2PuXOJu4b1I8BJjnnW/Paginated-Carousel?node-id=3210-17798&p=f&t=luxoilsVBk1zPNAN-0)