### PR TITLE
fix(v8 Dropdown): VoiceOver on iOS safari can reach Dropdown options

### DIFF
--- a/change/@fluentui-react-0176e502-3aa8-49db-8e83-b9922b012ec6.json
+++ b/change/@fluentui-react-0176e502-3aa8-49db-8e83-b9922b012ec6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: VoiceOver on iOS safari can reach Dropdown options",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.base.tsx
@@ -324,6 +324,7 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
       onRenderLabel = this._onRenderLabel,
       onRenderItem = this._onRenderItem,
       hoisted: { selectedIndices },
+      responsiveMode,
     } = props;
     const { isOpen, calloutRenderEdge, hasFocus } = this.state;
     // eslint-disable-next-line @typescript-eslint/no-deprecated
@@ -338,6 +339,8 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
     const divProps = getNativeProps(props, divProperties);
 
     const disabled = this._isDisabled();
+
+    const isSmall = responsiveMode! <= ResponsiveMode.medium;
 
     const errorMessageId = id + '-errorMessage';
 
@@ -361,7 +364,7 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
       <div
         className={this._classNames.root}
         ref={this.props.hoisted.rootRef}
-        aria-owns={isOpen ? this._listId : undefined}
+        aria-owns={isOpen && !isSmall ? this._listId : undefined}
       >
         {onRenderLabel(this.props, this._onRenderLabel)}
         <div
@@ -379,7 +382,7 @@ class DropdownInternal extends React.Component<IDropdownInternalProps, IDropdown
           aria-required={required}
           aria-disabled={disabled}
           aria-invalid={hasErrorMessage}
-          aria-controls={isOpen ? this._listId : undefined}
+          aria-controls={isOpen && !isSmall ? this._listId : undefined}
           {...divProps}
           className={this._classNames.dropdown}
           onBlur={this._onDropdownBlur}


### PR DESCRIPTION
## Previous Behavior

This is specific to the mobile view of Dropdown, which renders the listbox in a Panel.

We added `aria-owns` from an element outside the modal dialog/Panel pointing at the listbox, which re-parented it outside the dialog in the accessibility tree. Only Safari actually breaks on this, so with VoiceOver on mobile safari fails to access listbox options (or desktop safari if you make the window small enough to trigger the mobile view).

## New Behavior

It works!

## Related Issue(s)

- Fixes [ADO issue](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/23798) (and partner team issue)
