### PR TITLE
fix(v8 ResizeGroup): Add accessible name to overflow button

### DIFF
--- a/packages/react-examples/src/react/ResizeGroup/ResizeGroup.OverflowSet.Example.tsx
+++ b/packages/react-examples/src/react/ResizeGroup/ResizeGroup.OverflowSet.Example.tsx
@@ -107,7 +107,7 @@ export const ResizeGroupOverflowSetExample: React.FunctionComponent = () => {
   };
 
   const onRenderOverflowButton = (overflowItems: any) => (
-    <CommandBarButton role="menuitem" menuProps={{ items: overflowItems! }} />
+    <CommandBarButton aria-label="more" menuProps={{ items: overflowItems! }} />
   );
 
   const onRenderData = (data: any) => {

--- a/packages/react-examples/src/react/ResizeGroup/ResizeGroup.VerticalOverflowSet.Example.tsx
+++ b/packages/react-examples/src/react/ResizeGroup/ResizeGroup.VerticalOverflowSet.Example.tsx
@@ -61,6 +61,7 @@ const onRenderItem = (item: any) => (
 
 const onRenderOverflowButton = (overflowItems: any) => (
   <CommandBarButton
+    aria-label="more"
     styles={buttonStyles}
     menuIconProps={{ iconName: 'ChevronRight' }}
     menuProps={{ items: overflowItems!, directionalHint: DirectionalHint.rightCenter }}


### PR DESCRIPTION
## Previous Behavior

The overflow button had no accessible name.

## New Behavior

I added an `aria-label` to ResizeGroup stories to give the overflow button an accessible name.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes [Bug 24925](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/24925): [Fluent UI V8] [Web] [ResizeGroup]: Name is not Defined for the Button
