### PR TITLE
fix(v8 FocusZone): Add wrapping to FocusZone examples to avoid truncation on smaller screens

### DIFF
--- a/packages/react-examples/src/react-focus/FocusZone/FocusZone.Disabled.Example.tsx
+++ b/packages/react-examples/src/react-focus/FocusZone/FocusZone.Disabled.Example.tsx
@@ -12,7 +12,7 @@ export const FocusZoneDisabledExample: React.FunctionComponent = () => {
   return (
     <Stack tokens={tokens} horizontalAlign="start">
       <FocusZone direction={FocusZoneDirection.horizontal}>
-        <Stack tokens={tokens} horizontal verticalAlign="center">
+        <Stack tokens={tokens} horizontal verticalAlign="center" wrap>
           <span>Enabled FocusZone: </span>
           <DefaultButton>Button 1</DefaultButton>
           <DefaultButton>Button 2</DefaultButton>
@@ -22,7 +22,7 @@ export const FocusZoneDisabledExample: React.FunctionComponent = () => {
       </FocusZone>
       <DefaultButton>Tabbable Element 1</DefaultButton>
       <FocusZone disabled={true}>
-        <Stack tokens={tokens} horizontal verticalAlign="center">
+        <Stack tokens={tokens} horizontal verticalAlign="center" wrap>
           <span>Disabled FocusZone: </span>
           <DefaultButton>Button 1</DefaultButton>
           <DefaultButton>Button 2</DefaultButton>

--- a/packages/react-examples/src/react-focus/FocusZone/FocusZone.Tabbable.Example.tsx
+++ b/packages/react-examples/src/react-focus/FocusZone/FocusZone.Tabbable.Example.tsx
@@ -28,7 +28,7 @@ export const FocusZoneTabbableExample: React.FunctionComponent = () => {
         handleTabKey={FocusZoneTabbableElements.all}
         isCircularNavigation={true}
       >
-        <Stack tokens={tokens} horizontal verticalAlign="center">
+        <Stack tokens={tokens} horizontal verticalAlign="center" wrap>
           <span>Circular Tabbable FocusZone: </span>
           <DefaultButton>Button 1</DefaultButton>
           <DefaultButton>Button 2</DefaultButton>
@@ -48,7 +48,7 @@ export const FocusZoneTabbableExample: React.FunctionComponent = () => {
         handleTabKey={FocusZoneTabbableElements.inputOnly}
         isCircularNavigation={false}
       >
-        <Stack tokens={tokens} horizontal verticalAlign="center">
+        <Stack tokens={tokens} horizontal verticalAlign="center" wrap>
           <span>Input Only FocusZone: </span>
           <DefaultButton>Button 1</DefaultButton>
           <DefaultButton>Button 2</DefaultButton>


### PR DESCRIPTION
## Previous Behavior

On smaller screens, the third button was being cut off:
<img width="1280" height="768" alt="image" src="https://github.com/user-attachments/assets/76a01f2e-c083-4cfb-bc08-0e838fba93ee" />


## New Behavior

Instead of cutting the button off, we wrap the content: 
<img width="608" height="258" alt="image" src="https://github.com/user-attachments/assets/7c54a586-a60d-4078-8897-cecfe1019e2a" />


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes [Bug 24924](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/24924): [Fluent UI V8] [Web] [Focus Zone]: After Applying Resize Button3 is not Visible
