### PR TITLE
fix(v8 PeoplePicker): Fix PeoplePicker wrapped list example's hover styles

### DIFF
--- a/packages/react-examples/src/react/PeoplePicker/PeoplePicker.List.Example.tsx
+++ b/packages/react-examples/src/react/PeoplePicker/PeoplePicker.List.Example.tsx
@@ -127,7 +127,7 @@ export const PeoplePickerListExample: React.FunctionComponent = () => {
       <PeoplePickerItemSuggestion
         personaProps={{ ...personaProps }}
         suggestionsProps={suggestionsProps}
-        classNames={{ subComponentStyles: { persona: personaStyles } }}
+        className={{ subComponentStyles: { persona: personaStyles } }}
       />
     );
   };

--- a/packages/react-examples/src/react/PeoplePicker/PeoplePicker.List.Example.tsx
+++ b/packages/react-examples/src/react/PeoplePicker/PeoplePicker.List.Example.tsx
@@ -7,6 +7,7 @@ import {
   ListPeoplePicker,
   ValidationState,
   PeoplePickerItemSuggestion,
+  ISuggestionItemStyles,
 } from '@fluentui/react/lib/Pickers';
 import { people, mru } from '@fluentui/example-data';
 

--- a/packages/react-examples/src/react/PeoplePicker/PeoplePicker.List.Example.tsx
+++ b/packages/react-examples/src/react/PeoplePicker/PeoplePicker.List.Example.tsx
@@ -125,8 +125,9 @@ export const PeoplePickerListExample: React.FunctionComponent = () => {
   const onRenderSuggestionItem = (personaProps: IPersonaProps, suggestionsProps: IBasePickerSuggestionsProps) => {
     return (
       <PeoplePickerItemSuggestion
-        personaProps={{ ...personaProps, styles: personaStyles }}
+        personaProps={{ ...personaProps }}
         suggestionsProps={suggestionsProps}
+        classNames={{ subComponentStyles: { persona: personaStyles } }}
       />
     );
   };

--- a/packages/react-examples/src/react/PeoplePicker/PeoplePicker.List.Example.tsx
+++ b/packages/react-examples/src/react/PeoplePicker/PeoplePicker.List.Example.tsx
@@ -40,6 +40,10 @@ const personaStyles: Partial<IPersonaStyles> = {
   },
 };
 
+const suggestionItemStyles: Partial<ISuggestionItemStyles> = {
+  subComponentStyles: { persona: personaStyles },
+};
+
 export const PeoplePickerListExample: React.FunctionComponent = () => {
   const [delayResults, setDelayResults] = React.useState(false);
   const [isPickerDisabled, setIsPickerDisabled] = React.useState(false);
@@ -125,9 +129,9 @@ export const PeoplePickerListExample: React.FunctionComponent = () => {
   const onRenderSuggestionItem = (personaProps: IPersonaProps, suggestionsProps: IBasePickerSuggestionsProps) => {
     return (
       <PeoplePickerItemSuggestion
-        personaProps={{ ...personaProps }}
+        personaProps={personaProps}
         suggestionsProps={suggestionsProps}
-        className={{ subComponentStyles: { persona: personaStyles } }}
+        styles={suggestionItemStyles}
       />
     );
   };

--- a/packages/react-examples/src/react/PeoplePicker/PeoplePicker.List.Example.tsx
+++ b/packages/react-examples/src/react/PeoplePicker/PeoplePicker.List.Example.tsx
@@ -7,7 +7,7 @@ import {
   ListPeoplePicker,
   ValidationState,
   PeoplePickerItemSuggestion,
-  ISuggestionItemStyles,
+  IPeoplePickerItemSuggestionStyles,
 } from '@fluentui/react/lib/Pickers';
 import { people, mru } from '@fluentui/example-data';
 
@@ -41,7 +41,7 @@ const personaStyles: Partial<IPersonaStyles> = {
   },
 };
 
-const suggestionItemStyles: Partial<ISuggestionItemStyles> = {
+const suggestionItemStyles: Partial<IPeoplePickerItemSuggestionStyles> = {
   subComponentStyles: { persona: personaStyles },
 };
 

--- a/packages/react/src/components/pickers/PeoplePicker/PeoplePickerItems/PeoplePickerItemSuggestion.tsx
+++ b/packages/react/src/components/pickers/PeoplePicker/PeoplePickerItems/PeoplePickerItemSuggestion.tsx
@@ -10,10 +10,10 @@ import type {
   IPeoplePickerItemSuggestionStyleProps,
   IPeoplePickerItemSuggestionStyles,
 } from './PeoplePickerItem.types';
+import { concatStyleSetsWithProps } from '../../../../Styling';
 
 const getClassNames = classNamesFunction<IPeoplePickerItemSuggestionStyleProps, IPeoplePickerItemSuggestionStyles>();
 
-// eslint-disable-next-line @typescript-eslint/no-deprecated
 export const PeoplePickerItemSuggestionBase = (props: IPeoplePickerItemSuggestionProps): JSX.Element => {
   const { personaProps, suggestionsProps, compact, styles, theme, className } = props;
 

--- a/packages/react/src/components/pickers/PeoplePicker/PeoplePickerItems/PeoplePickerItemSuggestion.tsx
+++ b/packages/react/src/components/pickers/PeoplePicker/PeoplePickerItems/PeoplePickerItemSuggestion.tsx
@@ -10,10 +10,10 @@ import type {
   IPeoplePickerItemSuggestionStyleProps,
   IPeoplePickerItemSuggestionStyles,
 } from './PeoplePickerItem.types';
-import { concatStyleSetsWithProps } from '../../../../Styling';
 
 const getClassNames = classNamesFunction<IPeoplePickerItemSuggestionStyleProps, IPeoplePickerItemSuggestionStyles>();
 
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 export const PeoplePickerItemSuggestionBase = (props: IPeoplePickerItemSuggestionProps): JSX.Element => {
   const { personaProps, suggestionsProps, compact, styles, theme, className } = props;
 


### PR DESCRIPTION
## Previous Behavior

Fix style resolution in example story so that the PeoplePickerItemSuggestion's persona's styles are no longer overriden incorrectly.

<img width="792" height="314" alt="image" src="https://github.com/user-attachments/assets/5e09f079-69a4-4924-9568-a581eddcbe24" />


## New Behavior
<img width="669" height="347" alt="image" src="https://github.com/user-attachments/assets/f8c08e8e-9a58-4062-91e5-d238261a9085" />

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes [Bug 30154](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/30154): [Fluent UI V8][People Pickers-List People Picker with Wrapped Item text][high contrast]: The persons details are not clearly visible in high contrast themes when it receives keyboard focus.
