### PR TITLE
fix(react-utilities): add mpath svg intrinsic element to compat JSXIntrinsicElementKeysCompat

### DIFF
--- a/packages/react-components/react-utilities/project.json
+++ b/packages/react-components/react-utilities/project.json
@@ -10,7 +10,7 @@
       "executor": "nx:run-commands",
       "options": {
         "commands": [
-          "node -r ../../../scripts/ts-node/src/register scripts/expand-jsx-intrinsic-elements.ts --target-file ./src/utils/generated-types.ts --omit-elements set,mpath,center,search",
+          "node -r ../../../scripts/ts-node/src/register scripts/expand-jsx-intrinsic-elements.ts --target-file ./src/utils/generated-types.ts --omit-elements set,center,search",
           "prettier -w src/utils/generated-types.ts"
         ],
         "cwd": "{projectRoot}",

--- a/packages/react-components/react-utilities/src/utils/generated-types.ts
+++ b/packages/react-components/react-utilities/src/utils/generated-types.ts
@@ -120,6 +120,7 @@ export type JSXIntrinsicElementKeysCompat =
   | 'meta'
   | 'metadata'
   | 'meter'
+  | 'mpath'
   | 'nav'
   | 'noindex'
   | 'noscript'
@@ -187,4 +188,4 @@ export type JSXIntrinsicElementKeysCompat =
 /**
  * Unwrapped type for 'keyof JSX.IntrinsicElement'
  */
-export type JSXIntrinsicElementKeysLatest = 'set' | 'mpath' | 'center' | 'search' | JSXIntrinsicElementKeysCompat;
+export type JSXIntrinsicElementKeysLatest = 'set' | 'center' | 'search' | JSXIntrinsicElementKeysCompat;


### PR DESCRIPTION


<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
