### PR TITLE
chore: add Playwright installation step to docsite-publish-ghpages GA workflow

### DIFF
--- a/.github/workflows/docsite-publish-ghpages.yml
+++ b/.github/workflows/docsite-publish-ghpages.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Install packages
         run: yarn install --frozen-lockfile
 
+      - name: Install Playwright Browsers
+        run: yarn playwright install --with-deps
+
       - name: Build storybook
         run: yarn nx run public-docsite-v9:build-storybook --nxBail
         env:


### PR DESCRIPTION
… workflow

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Public docsite build fails because of missing Playwright dependency

Example: https://github.com/microsoft/fluentui/actions/runs/16783236429/job/47527237136

<img width="1481" height="1277" alt="image" src="https://github.com/user-attachments/assets/7e56396b-6e9d-4a75-bb76-c2db9473d952" />



## New Behavior

Adds playwright installation step before the `build-storybook` step

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
