### PR TITLE
docs(react-image): add src to default image story

### DIFF
--- a/packages/react-components/react-image/stories/src/Image/ImageDefault.stories.tsx
+++ b/packages/react-components/react-image/stories/src/Image/ImageDefault.stories.tsx
@@ -4,8 +4,15 @@ import type { ImageProps } from '@fluentui/react-components';
 import type { ArgTypes, Parameters } from '@storybook/react';
 
 export const Default = (props: ImageProps) => {
-  return <Image {...props} />;
+  return (
+    <Image
+      {...props}
+      alt="Allan's avatar"
+      src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/AllanMunger.jpg"
+    />
+  );
 };
+
 Default.argTypes = {
   alt: {
     control: 'text',


### PR DESCRIPTION
## Previous Behavior

<img width="1070" height="265" alt="Screenshot 2025-08-07 at 14 42 33" src="https://github.com/user-attachments/assets/7dd6c733-2030-43ad-8d0f-b5546625eeec" />

<img width="1067" height="316" alt="Screenshot 2025-08-07 at 14 42 56" src="https://github.com/user-attachments/assets/a0a88f91-9b0c-4554-99c3-59c1f532b91c" />


## New Behavior

<img width="1275" height="515" alt="Screenshot 2025-08-07 at 14 42 08" src="https://github.com/user-attachments/assets/4a4a2805-6885-43c1-9b48-e1e3d51d0824" />
