### PR TITLE
fix(Pagination): update styles to match existing aria-checked attribute

### DIFF
--- a/packages/react-experiments/src/components/Pagination/Pagination.styles.ts
+++ b/packages/react-experiments/src/components/Pagination/Pagination.styles.ts
@@ -47,13 +47,13 @@ export function getStyles(props: IPaginationStyleProps): IPaginationStyles {
         minHeight: '32px',
         color: palette.black,
         selectors: {
-          '&[aria-selected=true]': {
+          '&[aria-checked=true]': {
             color: palette.blue,
             cursor: 'default',
             fontWeight: 'bold',
             textDecoration: 'underline',
           },
-          '&:hover[aria-selected=true]': {
+          '&:hover[aria-checked=true]': {
             color: palette.blue,
             backgroundColor: 'transparent',
           },

--- a/packages/react-experiments/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/react-experiments/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -457,13 +457,13 @@ exports[`Pagination render buttons Pagination correctly 1`] = `
             position: relative;
             top: 0px;
           }
-          &[aria-selected=true] {
+          &[aria-checked=true] {
             color: #0078d4;
             cursor: default;
             font-weight: bold;
             text-decoration: underline;
           }
-          &:hover[aria-selected=true] {
+          &:hover[aria-checked=true] {
             background-color: transparent;
             color: #0078d4;
           }
@@ -583,13 +583,13 @@ exports[`Pagination render buttons Pagination correctly 1`] = `
             position: relative;
             top: 0px;
           }
-          &[aria-selected=true] {
+          &[aria-checked=true] {
             color: #0078d4;
             cursor: default;
             font-weight: bold;
             text-decoration: underline;
           }
-          &:hover[aria-selected=true] {
+          &:hover[aria-checked=true] {
             background-color: transparent;
             color: #0078d4;
           }
@@ -709,13 +709,13 @@ exports[`Pagination render buttons Pagination correctly 1`] = `
             position: relative;
             top: 0px;
           }
-          &[aria-selected=true] {
+          &[aria-checked=true] {
             color: #0078d4;
             cursor: default;
             font-weight: bold;
             text-decoration: underline;
           }
-          &:hover[aria-selected=true] {
+          &:hover[aria-checked=true] {
             background-color: transparent;
             color: #0078d4;
           }
@@ -835,13 +835,13 @@ exports[`Pagination render buttons Pagination correctly 1`] = `
             position: relative;
             top: 0px;
           }
-          &[aria-selected=true] {
+          &[aria-checked=true] {
             color: #0078d4;
             cursor: default;
             font-weight: bold;
             text-decoration: underline;
           }
-          &:hover[aria-selected=true] {
+          &:hover[aria-checked=true] {
             background-color: transparent;
             color: #0078d4;
           }
@@ -961,13 +961,13 @@ exports[`Pagination render buttons Pagination correctly 1`] = `
             position: relative;
             top: 0px;
           }
-          &[aria-selected=true] {
+          &[aria-checked=true] {
             color: #0078d4;
             cursor: default;
             font-weight: bold;
             text-decoration: underline;
           }
-          &:hover[aria-selected=true] {
+          &:hover[aria-checked=true] {
             background-color: transparent;
             color: #0078d4;
           }


### PR DESCRIPTION
- Adjust selection and hover styles for `Pagination` component to use `aria-checked` instead of `aria-selected`

<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

The `Pagination` component’s CSS for selection and hover states was still targeting `aria-selected`, even though it was changed `aria-checked` a long time ago.

This meant selection styling and hover effects were not applied as intended.

## New Behavior

Updated the CSS selectors to target `aria-checked` instead of `aria-selected`, ensuring selection and hover styles correctly apply to the current markup.

## Related Issue(s)

No related issue