### PR TITLE
fix(react-charts): Use schema colorscale for gvbc

### DIFF
--- a/change/@fluentui-react-charts-e332a260-4741-4fac-af8d-ccadbc08ce92.json
+++ b/change/@fluentui-react-charts-e332a260-4741-4fac-af8d-ccadbc08ce92.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "use schema colorscale for gvbc",
+  "packageName": "@fluentui/react-charts",
+  "email": "anushgupta@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charts/react-charts/library/src/components/DeclarativeChart/PlotlySchemaAdapterUT.test.tsx
+++ b/packages/charts/react-charts/library/src/components/DeclarativeChart/PlotlySchemaAdapterUT.test.tsx
@@ -1,4 +1,4 @@
-import { isDateArray, isMonthArray, isNumberArray, sanitizeJson } from '@fluentui/chart-utilities';
+import { isDateArray, isMonthArray, isNumberArray, sanitizeJson, isInvalidValue } from '@fluentui/chart-utilities';
 
 import {
   correctYearMonth,
@@ -11,7 +11,6 @@ import {
   transformPlotlyJsonToHeatmapProps,
   transformPlotlyJsonToSankeyProps,
   transformPlotlyJsonToGaugeProps,
-  isInvalidValue,
   getNumberAtIndexOrDefault,
   getValidXYRanges,
 } from './PlotlySchemaAdapter';

--- a/packages/charts/react-charts/library/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.tsx
+++ b/packages/charts/react-charts/library/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.tsx
@@ -237,17 +237,17 @@ export const GroupedVerticalBarChart: React.FC<GroupedVerticalBarChartProps> = R
           ...point,
           series:
             point.series?.map(seriesPoint => {
+              // TODO: Add support for gradient colors
+              let startColor = seriesPoint.color ? seriesPoint.color : getNextColor(colorIndex, 0);
+              let endColor = startColor;
               if (!_legendColorMap[seriesPoint.legend]) {
-                let startColor = seriesPoint.color ? seriesPoint.color : getNextColor(colorIndex, 0);
-                let endColor = startColor;
-
                 _legendColorMap[seriesPoint.legend] = [startColor, endColor];
-                colorIndex += 1;
               }
+              colorIndex += 1;
 
               return {
                 ...seriesPoint,
-                color: _legendColorMap[seriesPoint.legend][0],
+                color: seriesPoint.color ?? _legendColorMap[seriesPoint.legend][0],
               };
             }) ?? [],
         };


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## New Behavior

Corresponding v8 PR: https://github.com/microsoft/fluentui/pull/34556
https://github.com/microsoft/fluentui/pull/34530
<img width="1538" height="453" alt="image" src="https://github.com/user-attachments/assets/02b0f8e7-7363-4500-9dee-6fb554e00d3a" />

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
