### PR TITLE
Fix(react-menu-grid-preview): Correct MenuGrid components displayName and comments

### DIFF
--- a/packages/react-components/react-menu-grid-preview/library/src/components/MenuGridCell/MenuGridCell.tsx
+++ b/packages/react-components/react-menu-grid-preview/library/src/components/MenuGridCell/MenuGridCell.tsx
@@ -19,4 +19,4 @@ export const MenuGridCell: ForwardRefComponent<MenuGridCellProps> = React.forwar
   return renderMenuGridCell_unstable(state);
 });
 
-MenuGridCell.displayName = 'MenuGroup';
+MenuGridCell.displayName = 'MenuGridCell';

--- a/packages/react-components/react-menu-grid-preview/library/src/components/MenuGridCell/renderMenuGridCell.tsx
+++ b/packages/react-components/react-menu-grid-preview/library/src/components/MenuGridCell/renderMenuGridCell.tsx
@@ -4,8 +4,7 @@ import { assertSlots } from '@fluentui/react-utilities';
 import { MenuGridCellSlots, MenuGridCellState } from './MenuGridCell.types';
 
 /**
- * Redefine the render function to add slots. Reuse the menugroup structure but add
- * slots to children.
+ * Function that renders the final JSX of the component
  */
 export const renderMenuGridCell_unstable = (state: MenuGridCellState) => {
   assertSlots<MenuGridCellSlots>(state);

--- a/packages/react-components/react-menu-grid-preview/library/src/components/MenuGridRow/MenuGridRow.tsx
+++ b/packages/react-components/react-menu-grid-preview/library/src/components/MenuGridRow/MenuGridRow.tsx
@@ -19,4 +19,4 @@ export const MenuGridRow: ForwardRefComponent<MenuGridRowProps> = React.forwardR
   return renderMenuGridRow_unstable(state);
 });
 
-MenuGridRow.displayName = 'MenuGroup';
+MenuGridRow.displayName = 'MenuGridRow';

--- a/packages/react-components/react-menu-grid-preview/library/src/components/MenuGridRowGroup/MenuGridRowGroup.tsx
+++ b/packages/react-components/react-menu-grid-preview/library/src/components/MenuGridRowGroup/MenuGridRowGroup.tsx
@@ -21,4 +21,4 @@ export const MenuGridRowGroup: ForwardRefComponent<MenuGridRowGroupProps> = Reac
   return renderMenuGridRowGroup_unstable(state, contextValues);
 });
 
-MenuGridRowGroup.displayName = 'MenuGroup';
+MenuGridRowGroup.displayName = 'MenuGridRowGroup';

--- a/packages/react-components/react-menu-grid-preview/library/src/components/MenuGridRowGroup/renderMenuGridRowGroup.tsx
+++ b/packages/react-components/react-menu-grid-preview/library/src/components/MenuGridRowGroup/renderMenuGridRowGroup.tsx
@@ -5,8 +5,7 @@ import { MenuGridRowGroupContextValues, MenuGridRowGroupSlots, MenuGridRowGroupS
 import { MenuGridRowGroupContextProvider } from '../../contexts/menuGridRowGroupContext';
 
 /**
- * Redefine the render function to add slots. Reuse the menugroup structure but add
- * slots to children.
+ * Function that renders the final JSX of the component
  */
 export const renderMenuGridRowGroup_unstable = (
   state: MenuGridRowGroupState,

--- a/packages/react-components/react-menu-grid-preview/library/src/components/MenuGridRowGroupHeader/MenuGridRowGroupHeader.tsx
+++ b/packages/react-components/react-menu-grid-preview/library/src/components/MenuGridRowGroupHeader/MenuGridRowGroupHeader.tsx
@@ -21,4 +21,4 @@ export const MenuGridRowGroupHeader: ForwardRefComponent<MenuGridRowGroupHeaderP
   },
 );
 
-MenuGridRowGroupHeader.displayName = 'MenuGroup';
+MenuGridRowGroupHeader.displayName = 'MenuGridRowGroupHeader';

--- a/packages/react-components/react-menu-grid-preview/library/src/components/MenuGridRowGroupHeader/renderMenuGridRowGroupHeader.tsx
+++ b/packages/react-components/react-menu-grid-preview/library/src/components/MenuGridRowGroupHeader/renderMenuGridRowGroupHeader.tsx
@@ -4,8 +4,7 @@ import { assertSlots } from '@fluentui/react-utilities';
 import { MenuGridRowGroupHeaderSlots, MenuGridRowGroupHeaderState } from './MenuGridRowGroupHeader.types';
 
 /**
- * Redefine the render function to add slots. Reuse the menugroup structure but add
- * slots to children.
+ * Function that renders the final JSX of the component
  */
 export const renderMenuGridRowGroupHeader_unstable = (state: MenuGridRowGroupHeaderState) => {
   assertSlots<MenuGridRowGroupHeaderSlots>(state);


### PR DESCRIPTION
### Description of changes

This PR corrects the displayName of MenuGrid components and improves some render function comments.