### PR TITLE
chore: bump floating-ui/devtools to 0.2.3

### DIFF
--- a/change/@fluentui-react-positioning-baea89b5-496c-4cff-90cd-c1d34b305be6.json
+++ b/change/@fluentui-react-positioning-baea89b5-496c-4cff-90cd-c1d34b305be6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bumps @floating-ui/devtools ver to latest",
+  "packageName": "@fluentui/react-positioning",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-positioning/library/package.json
+++ b/packages/react-components/react-positioning/library/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@floating-ui/dom": "^1.6.12",
-    "@floating-ui/devtools": "0.2.1",
+    "@floating-ui/devtools": "^0.2.3",
     "@fluentui/react-shared-contexts": "^9.24.1",
     "@fluentui/react-theme": "^9.2.0",
     "@fluentui/react-utilities": "^9.23.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1862,10 +1862,10 @@
   dependencies:
     "@floating-ui/utils" "^0.2.8"
 
-"@floating-ui/devtools@0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@floating-ui/devtools/-/devtools-0.2.1.tgz#3e8023e09ede273a7aa426e7911f3dac630024c5"
-  integrity sha512-8PHJLbD6VhBh+LJ1uty/Bz30qs02NXCE5u8WpOhSewlYXUWl03GNXknr9AS2yaAWJEQaY27x7eByJs44gODBcw==
+"@floating-ui/devtools@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@floating-ui/devtools/-/devtools-0.2.3.tgz#071f069e5a25e6f2a63ed68584a11ff7c9298947"
+  integrity sha512-ZTcxTvgo9CRlP7vJV62yCxdqmahHTGpSTi5QaTDgGoyQq0OyjaVZhUhXv/qdkQFOI3Sxlfmz0XGG4HaZMsDf8Q==
 
 "@floating-ui/dom@1.6.12", "@floating-ui/dom@^1.0.0", "@floating-ui/dom@^1.6.12":
   version "1.6.12"


### PR DESCRIPTION
Bumps up to two patch versions from [0.2.1 to 0.2.3](https://github.com/floating-ui/floating-ui/blob/master/packages/devtools/CHANGELOG.md#023) 

- Fixes #35043 
