### PR TITLE
fix(react-19-tests-v9): run r19 integration tests (jest) against react 19 and fix majority of newly exposed issues

### DIFF
--- a/apps/react-19-tests-v9/jest-react-19.config.js
+++ b/apps/react-19-tests-v9/jest-react-19.config.js
@@ -15,7 +15,7 @@ const jestConfig = require('./jest.config');
  */
 const config = {
   ...jestConfig,
-  moduleNameMapper: { ...tsPathAliases },
+  moduleNameMapper: { ...tsPathAliases, ...jestConfig.moduleNameMapper },
   displayName: 'react-19-tests-v9-integration',
   roots: createRoots(),
   // Keeps Jest from using too much memory as GC gets invokes more often, makes tests slower

--- a/apps/react-19-tests-v9/jest.config.js
+++ b/apps/react-19-tests-v9/jest.config.js
@@ -7,6 +7,8 @@ const { join } = require('node:path');
 const { getNodeModulesPath } = require('./config/utils');
 
 const usedNodeModulesPath = getNodeModulesPath();
+const workspaceRootNodeModulesPath = join(__dirname, '../../node_modules');
+
 // Reading the SWC compilation config and remove the "exclude"
 // for the test files to be compiled by SWC
 const { exclude: _, ...swcJestConfig } = JSON.parse(readFileSync(join(__dirname, '.swcrc'), 'utf-8'));
@@ -32,10 +34,12 @@ module.exports = {
   // Forces React to be resolved from the root node_modules to ensure the same instance is used across all packages
   moduleNameMapper: {
     '^react$': join(usedNodeModulesPath, './react'),
+    '^react/jsx-runtime$': join(usedNodeModulesPath, 'react/jsx-runtime'),
     '^react-dom$': join(usedNodeModulesPath, './react-dom'),
-    '^react-dom/(test-utils|client)$': join(usedNodeModulesPath, './react-dom/$1'),
+    '^react-dom/(.+)$': join(usedNodeModulesPath, 'react-dom/$1'),
     '^react-test-renderer$': join(usedNodeModulesPath, './react-test-renderer'),
-    '^@testing-library/(react|dom)$': join(usedNodeModulesPath, './@testing-library/$1'),
+    '^@testing-library/(react|dom)$': join(workspaceRootNodeModulesPath, './@testing-library/$1'),
+    '^@testing-library/react-hooks$': join(workspaceRootNodeModulesPath, './@testing-library/react'),
   },
   transform: {
     '^.+\\.tsx?$': ['@swc/jest', swcJestConfig],

--- a/change/@fluentui-react-utilities-8724a56d-8250-4a42-90c8-fae51b4bb32f.json
+++ b/change/@fluentui-react-utilities-8724a56d-8250-4a42-90c8-fae51b4bb32f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "refactor: switch to defensive appraoch for getReactElementRef func instead of relying on React.version for ref acquisition",
+  "packageName": "@fluentui/react-utilities",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-utilities-8724a56d-8250-4a42-90c8-fae51b4bb32f.json
+++ b/change/@fluentui-react-utilities-8724a56d-8250-4a42-90c8-fae51b4bb32f.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "refactor: switch to defensive appraoch for getReactElementRef func instead of relying on React.version for ref acquisition",
-  "packageName": "@fluentui/react-utilities",
-  "email": "martinhochel@microsoft.com",
-  "dependentChangeType": "none"
-}

--- a/jest.preset.js
+++ b/jest.preset.js
@@ -14,8 +14,11 @@ const tsPathAliases = pathsToModuleNameMapper(tsConfig.compilerOptions.paths, {
  */
 const testingLibraryPaths = {
   '^@testing-library/(.*)$': [path.join(__dirname, 'node_modules/@testing-library/$1')],
+  // without this React 17 will be used instead of React 18
+  '^@testing-library/react-hooks$': path.join(__dirname, 'node_modules/@testing-library/react-hooks'),
   '^react-is$': path.join(__dirname, 'node_modules/react-is'),
   '^react$': path.join(__dirname, 'node_modules/react'),
+  '^react/jsx-runtime$': path.join(__dirname, 'node_modules/react/jsx-runtime'),
   '^react-dom$': path.join(__dirname, 'node_modules/react-dom'),
   '^react-dom/(.*)$': path.join(__dirname, 'node_modules/react-dom/$1'),
   '^react-test-renderer$': path.join(__dirname, 'node_modules/react-test-renderer'),

--- a/jest.preset.js
+++ b/jest.preset.js
@@ -15,7 +15,7 @@ const tsPathAliases = pathsToModuleNameMapper(tsConfig.compilerOptions.paths, {
 const testingLibraryPaths = {
   '^@testing-library/(.*)$': [path.join(__dirname, 'node_modules/@testing-library/$1')],
   // without this React 17 will be used instead of React 18
-  '^@testing-library/react-hooks$': path.join(__dirname, 'node_modules/@testing-library/react-hooks'),
+  '^@testing-library/react-hooks$': path.join(__dirname, 'node_modules/@testing-library/react'),
   '^react-is$': path.join(__dirname, 'node_modules/react-is'),
   '^react$': path.join(__dirname, 'node_modules/react'),
   '^react/jsx-runtime$': path.join(__dirname, 'node_modules/react/jsx-runtime'),

--- a/packages/react-components/react-accordion/library/src/components/Accordion/Accordion.test.tsx
+++ b/packages/react-components/react-accordion/library/src/components/Accordion/Accordion.test.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { Accordion } from './Accordion';
-import * as renderer from 'react-test-renderer';
+import { render } from '@testing-library/react';
+
 import { isConformant } from '../../testing/isConformant';
+import { Accordion } from './Accordion';
 
 describe('Accordion', () => {
   isConformant({
@@ -15,9 +16,7 @@ describe('Accordion', () => {
    * Note: see more visual regression tests for Accordion in /apps/vr-tests.
    */
   it('renders a default state', () => {
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const component = renderer.create(<Accordion>Default Accordion</Accordion>);
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    const { container } = render(<Accordion>Default Accordion</Accordion>);
+    expect(container).toMatchSnapshot();
   });
 });

--- a/packages/react-components/react-accordion/library/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/packages/react-components/react-accordion/library/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
@@ -1,9 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Accordion renders a default state 1`] = `
-<div
-  className="fui-Accordion"
->
-  Default Accordion
+<div>
+  <div
+    class="fui-Accordion"
+  >
+    Default Accordion
+  </div>
 </div>
 `;

--- a/packages/react-components/react-accordion/library/src/components/AccordionHeader/AccordionHeader.test.tsx
+++ b/packages/react-components/react-accordion/library/src/components/AccordionHeader/AccordionHeader.test.tsx
@@ -2,7 +2,7 @@ import { resetIdsForTests } from '@fluentui/react-utilities';
 import * as React from 'react';
 import { AccordionHeader } from './AccordionHeader';
 import { AccordionHeaderProps } from './AccordionHeader.types';
-import * as renderer from 'react-test-renderer';
+import { render, fireEvent, screen } from '@testing-library/react';
 import { isConformant } from '../../testing/isConformant';
 import { Accordion } from '../Accordion/Accordion';
 import { AccordionItem } from '../AccordionItem';
@@ -31,26 +31,21 @@ describe('AccordionHeader', () => {
    * Note: see more visual regression tests for AccordionHeader in /apps/vr-tests.
    */
   it('renders a default state', () => {
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const component = renderer.create(<AccordionHeader>Default AccordionHeader</AccordionHeader>);
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    const { container } = render(<AccordionHeader>Default AccordionHeader</AccordionHeader>);
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   /**
    * Note: see more visual regression tests for AccordionHeader in /apps/vr-tests.
    */
   it('renders when expandIcon is null', () => {
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const component = renderer.create(<AccordionHeader expandIcon={null}>Default AccordionHeader</AccordionHeader>);
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    const { container } = render(<AccordionHeader expandIcon={null}>Default AccordionHeader</AccordionHeader>);
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   it('should invoke click and toggle', () => {
     const mockClick = jest.fn();
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const component = renderer.create(
+    render(
       <Accordion collapsible openItems={0} onToggle={mockClick}>
         <AccordionItem value={0}>
           <AccordionHeader button={{ onClick: mockClick }}>Header</AccordionHeader>
@@ -58,17 +53,14 @@ describe('AccordionHeader', () => {
         </AccordionItem>
       </Accordion>,
     );
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    renderer.act(() => {
-      component.root.findAllByType('button')[0].props.onClick({ defaultPrevented: false });
-    });
+    const button = screen.getByRole('button');
+    fireEvent.click(button, { defaultPrevented: false });
     expect(mockClick).toHaveBeenCalledTimes(2);
   });
 
   it('should invoke click and prevent toggle', () => {
     const mockClick = jest.fn();
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const component = renderer.create(
+    render(
       <Accordion collapsible openItems={0} onToggle={mockClick}>
         <AccordionItem value={0}>
           <AccordionHeader button={{ onClick: mockClick }}>Header</AccordionHeader>
@@ -76,10 +68,10 @@ describe('AccordionHeader', () => {
         </AccordionItem>
       </Accordion>,
     );
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    renderer.act(() => {
-      component.root.findAllByType('button')[0].props.onClick({ defaultPrevented: true });
-    });
+    const button = screen.getByRole('button');
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+    Object.defineProperty(event, 'defaultPrevented', { value: true });
+    button.dispatchEvent(event);
     expect(mockClick).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/react-components/react-accordion/library/src/components/AccordionHeader/__snapshots__/AccordionHeader.test.tsx.snap
+++ b/packages/react-components/react-accordion/library/src/components/AccordionHeader/__snapshots__/AccordionHeader.test.tsx.snap
@@ -2,30 +2,23 @@
 
 exports[`AccordionHeader renders a default state 1`] = `
 <div
-  className="fui-AccordionHeader"
+  class="fui-AccordionHeader"
 >
   <button
-    aria-expanded={false}
-    className="fui-AccordionHeader__button"
-    disabled={false}
-    onClick={[Function]}
+    aria-expanded="false"
+    class="fui-AccordionHeader__button"
     type="button"
   >
     <span
-      aria-hidden={true}
-      className="fui-AccordionHeader__expandIcon"
+      aria-hidden="true"
+      class="fui-AccordionHeader__expandIcon"
     >
       <svg
-        aria-hidden={true}
-        className=""
+        aria-hidden="true"
+        class=""
         fill="currentColor"
         height="1em"
-        style={
-          Object {
-            "transform": "rotate(0deg)",
-            "transition": "transform 200ms ease-out",
-          }
-        }
+        style="transform: rotate(0deg); transition: transform 200ms ease-out;"
         viewBox="0 0 20 20"
         width="1em"
         xmlns="http://www.w3.org/2000/svg"
@@ -43,13 +36,11 @@ exports[`AccordionHeader renders a default state 1`] = `
 
 exports[`AccordionHeader renders when expandIcon is null 1`] = `
 <div
-  className="fui-AccordionHeader"
+  class="fui-AccordionHeader"
 >
   <button
-    aria-expanded={false}
-    className="fui-AccordionHeader__button"
-    disabled={false}
-    onClick={[Function]}
+    aria-expanded="false"
+    class="fui-AccordionHeader__button"
     type="button"
   >
     Default AccordionHeader

--- a/packages/react-components/react-accordion/library/src/components/AccordionItem/AccordionItem.test.tsx
+++ b/packages/react-components/react-accordion/library/src/components/AccordionItem/AccordionItem.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
+import { render } from '@testing-library/react';
+
 import { AccordionItem } from './AccordionItem';
-import * as renderer from 'react-test-renderer';
 import { isConformant } from '../../testing/isConformant';
 
 describe('AccordionItem', () => {
@@ -15,9 +16,7 @@ describe('AccordionItem', () => {
    * Note: see more visual regression tests for AccordionItem in /apps/vr-tests.
    */
   it('renders a default state', () => {
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const component = renderer.create(<AccordionItem value={0}>Default AccordionItem</AccordionItem>);
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    const { container } = render(<AccordionItem value={0}>Default AccordionItem</AccordionItem>);
+    expect(container).toMatchSnapshot();
   });
 });

--- a/packages/react-components/react-accordion/library/src/components/AccordionItem/__snapshots__/AccordionItem.test.tsx.snap
+++ b/packages/react-components/react-accordion/library/src/components/AccordionItem/__snapshots__/AccordionItem.test.tsx.snap
@@ -1,9 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AccordionItem renders a default state 1`] = `
-<div
-  className="fui-AccordionItem"
->
-  Default AccordionItem
+<div>
+  <div
+    class="fui-AccordionItem"
+  >
+    Default AccordionItem
+  </div>
 </div>
 `;

--- a/packages/react-components/react-accordion/library/src/components/AccordionPanel/AccordionPanel.test.tsx
+++ b/packages/react-components/react-accordion/library/src/components/AccordionPanel/AccordionPanel.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
+import { render } from '@testing-library/react';
 import { AccordionPanel } from './AccordionPanel';
-import * as renderer from 'react-test-renderer';
 import { isConformant } from '../../testing/isConformant';
 import { AccordionItemProvider } from '../../contexts/accordionItem';
 import { mockAccordionItemContextValue } from '../../testing/mockContextValue';
@@ -26,9 +26,7 @@ describe('AccordionPanel', () => {
    * Note: see more visual regression tests for AccordionPanel in /apps/vr-tests.
    */
   it('renders a default state', () => {
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const component = renderer.create(<AccordionPanel>Default AccordionPanel</AccordionPanel>);
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    const { container } = render(<AccordionPanel>Default AccordionPanel</AccordionPanel>);
+    expect(container).toMatchSnapshot();
   });
 });

--- a/packages/react-components/react-accordion/library/src/components/AccordionPanel/__snapshots__/AccordionPanel.test.tsx.snap
+++ b/packages/react-components/react-accordion/library/src/components/AccordionPanel/__snapshots__/AccordionPanel.test.tsx.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AccordionPanel renders a default state 1`] = `null`;
+exports[`AccordionPanel renders a default state 1`] = `<div />`;

--- a/packages/react-components/react-badge/library/src/components/Badge/Badge.test.tsx
+++ b/packages/react-components/react-badge/library/src/components/Badge/Badge.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Badge } from './Badge';
-import * as renderer from 'react-test-renderer';
+import { render } from '@testing-library/react';
 
 import { isConformant } from '../../testing/isConformant';
 
@@ -21,9 +21,7 @@ describe('Badge', () => {
    * Note: see more visual regression tests for Badge in /apps/vr-tests.
    */
   it('renders a default state', () => {
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const component = renderer.create(<Badge>Default Badge</Badge>);
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    const { container } = render(<Badge>Default Badge</Badge>);
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/packages/react-components/react-badge/library/src/components/Badge/__snapshots__/Badge.test.tsx.snap
+++ b/packages/react-components/react-badge/library/src/components/Badge/__snapshots__/Badge.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Badge renders a default state 1`] = `
 <div
-  className="fui-Badge"
+  class="fui-Badge"
 >
   Default Badge
 </div>

--- a/packages/react-components/react-badge/library/src/components/CounterBadge/CounterBadge.test.tsx
+++ b/packages/react-components/react-badge/library/src/components/CounterBadge/CounterBadge.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { CounterBadge } from './CounterBadge';
-import * as renderer from 'react-test-renderer';
+import { render } from '@testing-library/react';
 import { isConformant } from '../../testing/isConformant';
 
 describe('CounterBadge', () => {
@@ -17,9 +17,7 @@ describe('CounterBadge', () => {
   });
 
   it('renders a default state', () => {
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const component = renderer.create(<CounterBadge />);
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    const { container } = render(<CounterBadge />);
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/packages/react-components/react-badge/library/src/components/CounterBadge/__snapshots__/CounterBadge.test.tsx.snap
+++ b/packages/react-components/react-badge/library/src/components/CounterBadge/__snapshots__/CounterBadge.test.tsx.snap
@@ -2,6 +2,6 @@
 
 exports[`CounterBadge renders a default state 1`] = `
 <div
-  className="fui-Badge fui-CounterBadge"
+  class="fui-Badge fui-CounterBadge"
 />
 `;

--- a/packages/react-components/react-badge/library/src/components/PresenceBadge/PresenceBadge.test.tsx
+++ b/packages/react-components/react-badge/library/src/components/PresenceBadge/PresenceBadge.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { PresenceBadge } from './PresenceBadge';
-import * as renderer from 'react-test-renderer';
+import { render } from '@testing-library/react';
 import { isConformant } from '../../testing/isConformant';
 
 describe('PresenceBadge', () => {
@@ -10,9 +10,7 @@ describe('PresenceBadge', () => {
   });
 
   it('renders a default state', () => {
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const component = renderer.create(<PresenceBadge />);
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    const { container } = render(<PresenceBadge />);
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/packages/react-components/react-badge/library/src/components/PresenceBadge/__snapshots__/PresenceBadge.test.tsx.snap
+++ b/packages/react-components/react-badge/library/src/components/PresenceBadge/__snapshots__/PresenceBadge.test.tsx.snap
@@ -3,15 +3,15 @@
 exports[`PresenceBadge renders a default state 1`] = `
 <div
   aria-label="available"
-  className="fui-PresenceBadge"
+  class="fui-PresenceBadge"
   role="img"
 >
   <span
-    className="fui-PresenceBadge__icon"
+    class="fui-PresenceBadge__icon"
   >
     <svg
-      aria-hidden={true}
-      className=""
+      aria-hidden="true"
+      class=""
       fill="currentColor"
       height="16"
       viewBox="0 0 16 16"

--- a/packages/react-components/react-dialog/library/src/components/DialogTrigger/DialogTrigger.test.tsx
+++ b/packages/react-components/react-dialog/library/src/components/DialogTrigger/DialogTrigger.test.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { DialogTrigger } from './DialogTrigger';
-import * as renderer from 'react-test-renderer';
 import { createEvent, fireEvent, render } from '@testing-library/react';
 import { isConformant } from '../../testing/isConformant';
 import { mockUseDialogContext } from '../../testing/mockUseDialogContext';
@@ -33,14 +32,12 @@ describe('DialogTrigger', () => {
    * Note: see more visual regression tests for DialogTrigger in /apps/vr-tests.
    */
   it('renders a default state', () => {
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const component = renderer.create(
+    const { container } = render(
       <DialogTrigger disableButtonEnhancement>
         <button>Dialog trigger</button>
       </DialogTrigger>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   it('should retain original child callback ref', () => {

--- a/packages/react-components/react-dialog/library/src/components/DialogTrigger/__snapshots__/DialogTrigger.test.tsx.snap
+++ b/packages/react-components/react-dialog/library/src/components/DialogTrigger/__snapshots__/DialogTrigger.test.tsx.snap
@@ -3,7 +3,6 @@
 exports[`DialogTrigger renders a default state 1`] = `
 <button
   data-tabster="{\\"restorer\\":{\\"type\\":1}}"
-  onClick={[Function]}
 >
   Dialog trigger
 </button>

--- a/packages/react-components/react-divider/library/src/components/Divider/Divider.test.tsx
+++ b/packages/react-components/react-divider/library/src/components/Divider/Divider.test.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import * as renderer from 'react-test-renderer';
 import { resetIdsForTests } from '@fluentui/react-utilities';
 import { isConformant } from '../../testing/isConformant';
 import { Divider } from './Divider';
+import { render } from '@testing-library/react';
 
 describe('Divider', () => {
   afterEach(() => {
@@ -22,104 +22,76 @@ describe('Divider', () => {
   });
 
   it('renders a default divider', () => {
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const component = renderer.create(<Divider />);
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    const { container } = render(<Divider />);
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   it('renders a divider with content', () => {
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const component = renderer.create(<Divider>Default Divider</Divider>);
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    const { container } = render(<Divider>Default Divider</Divider>);
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   it('renders a divider with inset', () => {
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const component = renderer.create(<Divider inset>Inset</Divider>);
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    const { container } = render(<Divider inset>Inset</Divider>);
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   it('renders a subtle appearance', () => {
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const component = renderer.create(<Divider appearance="subtle">Subtle</Divider>);
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    const { container } = render(<Divider appearance="subtle">Subtle</Divider>);
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   it('renders a brand appearance', () => {
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const component = renderer.create(<Divider appearance="brand">Brand</Divider>);
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    const { container } = render(<Divider appearance="brand">Brand</Divider>);
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   it('renders a strong appearance', () => {
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const component = renderer.create(<Divider appearance="strong">Strong</Divider>);
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    const { container } = render(<Divider appearance="strong">Strong</Divider>);
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   it('renders content start aligned', () => {
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const component = renderer.create(<Divider alignContent="start">Start</Divider>);
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    const { container } = render(<Divider alignContent="start">Start</Divider>);
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   it('renders content center aligned', () => {
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const component = renderer.create(<Divider alignContent="center">Center</Divider>);
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    const { container } = render(<Divider alignContent="center">Center</Divider>);
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   it('renders content end aligned', () => {
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const component = renderer.create(<Divider alignContent="end">End</Divider>);
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    const { container } = render(<Divider alignContent="end">End</Divider>);
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   it('renders a divider with a different color', () => {
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const component = renderer.create(<Divider color="#FF00FF" />);
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    const { container } = render(<Divider color="#FF00FF" />);
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   it('renders a vertical divider', () => {
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const component = renderer.create(<Divider vertical />);
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    const { container } = render(<Divider vertical />);
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   it('renders a vertical divider with content', () => {
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const component = renderer.create(<Divider vertical>Vertical</Divider>);
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    const { container } = render(<Divider vertical>Vertical</Divider>);
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   it('renders a vertical divider with a fixed height', () => {
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const component = renderer.create(
+    const { container } = render(
       <Divider style={{ height: 100 }} vertical>
         fixed 100px height
       </Divider>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   it('renders a horizontal divider with a fixed width', () => {
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const component = renderer.create(<Divider style={{ width: 100 }}>fixed 100px width</Divider>);
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    const { container } = render(<Divider style={{ width: 100 }}>fixed 100px width</Divider>);
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/packages/react-components/react-divider/library/src/components/Divider/__snapshots__/Divider.test.tsx.snap
+++ b/packages/react-components/react-divider/library/src/components/Divider/__snapshots__/Divider.test.tsx.snap
@@ -2,14 +2,14 @@
 
 exports[`Divider renders a brand appearance 1`] = `
 <div
-  aria-labelledby="divider-r4"
+  aria-labelledby="divider-rb"
   aria-orientation="horizontal"
-  className="fui-Divider"
+  class="fui-Divider"
   role="separator"
 >
   <div
-    className="fui-Divider__wrapper"
-    id="divider-r4"
+    class="fui-Divider__wrapper"
+    id="divider-rb"
   >
     Brand
   </div>
@@ -19,7 +19,7 @@ exports[`Divider renders a brand appearance 1`] = `
 exports[`Divider renders a default divider 1`] = `
 <div
   aria-orientation="horizontal"
-  className="fui-Divider"
+  class="fui-Divider"
   role="separator"
 />
 `;
@@ -27,21 +27,21 @@ exports[`Divider renders a default divider 1`] = `
 exports[`Divider renders a divider with a different color 1`] = `
 <div
   aria-orientation="horizontal"
-  className="fui-Divider"
+  class="fui-Divider"
   role="separator"
 />
 `;
 
 exports[`Divider renders a divider with content 1`] = `
 <div
-  aria-labelledby="divider-r1"
+  aria-labelledby="divider-r8"
   aria-orientation="horizontal"
-  className="fui-Divider"
+  class="fui-Divider"
   role="separator"
 >
   <div
-    className="fui-Divider__wrapper"
-    id="divider-r1"
+    class="fui-Divider__wrapper"
+    id="divider-r8"
   >
     Default Divider
   </div>
@@ -50,14 +50,14 @@ exports[`Divider renders a divider with content 1`] = `
 
 exports[`Divider renders a divider with inset 1`] = `
 <div
-  aria-labelledby="divider-r2"
+  aria-labelledby="divider-r9"
   aria-orientation="horizontal"
-  className="fui-Divider"
+  class="fui-Divider"
   role="separator"
 >
   <div
-    className="fui-Divider__wrapper"
-    id="divider-r2"
+    class="fui-Divider__wrapper"
+    id="divider-r9"
   >
     Inset
   </div>
@@ -66,19 +66,15 @@ exports[`Divider renders a divider with inset 1`] = `
 
 exports[`Divider renders a horizontal divider with a fixed width 1`] = `
 <div
-  aria-labelledby="divider-rd"
+  aria-labelledby="divider-rk"
   aria-orientation="horizontal"
-  className="fui-Divider"
+  class="fui-Divider"
   role="separator"
-  style={
-    Object {
-      "width": 100,
-    }
-  }
+  style="width: 100px;"
 >
   <div
-    className="fui-Divider__wrapper"
-    id="divider-rd"
+    class="fui-Divider__wrapper"
+    id="divider-rk"
   >
     fixed 100px width
   </div>
@@ -87,14 +83,14 @@ exports[`Divider renders a horizontal divider with a fixed width 1`] = `
 
 exports[`Divider renders a strong appearance 1`] = `
 <div
-  aria-labelledby="divider-r5"
+  aria-labelledby="divider-rc"
   aria-orientation="horizontal"
-  className="fui-Divider"
+  class="fui-Divider"
   role="separator"
 >
   <div
-    className="fui-Divider__wrapper"
-    id="divider-r5"
+    class="fui-Divider__wrapper"
+    id="divider-rc"
   >
     Strong
   </div>
@@ -103,14 +99,14 @@ exports[`Divider renders a strong appearance 1`] = `
 
 exports[`Divider renders a subtle appearance 1`] = `
 <div
-  aria-labelledby="divider-r3"
+  aria-labelledby="divider-ra"
   aria-orientation="horizontal"
-  className="fui-Divider"
+  class="fui-Divider"
   role="separator"
 >
   <div
-    className="fui-Divider__wrapper"
-    id="divider-r3"
+    class="fui-Divider__wrapper"
+    id="divider-ra"
   >
     Subtle
   </div>
@@ -120,26 +116,22 @@ exports[`Divider renders a subtle appearance 1`] = `
 exports[`Divider renders a vertical divider 1`] = `
 <div
   aria-orientation="vertical"
-  className="fui-Divider"
+  class="fui-Divider"
   role="separator"
 />
 `;
 
 exports[`Divider renders a vertical divider with a fixed height 1`] = `
 <div
-  aria-labelledby="divider-rc"
+  aria-labelledby="divider-rj"
   aria-orientation="vertical"
-  className="fui-Divider"
+  class="fui-Divider"
   role="separator"
-  style={
-    Object {
-      "height": 100,
-    }
-  }
+  style="height: 100px;"
 >
   <div
-    className="fui-Divider__wrapper"
-    id="divider-rc"
+    class="fui-Divider__wrapper"
+    id="divider-rj"
   >
     fixed 100px height
   </div>
@@ -148,14 +140,14 @@ exports[`Divider renders a vertical divider with a fixed height 1`] = `
 
 exports[`Divider renders a vertical divider with content 1`] = `
 <div
-  aria-labelledby="divider-rb"
+  aria-labelledby="divider-ri"
   aria-orientation="vertical"
-  className="fui-Divider"
+  class="fui-Divider"
   role="separator"
 >
   <div
-    className="fui-Divider__wrapper"
-    id="divider-rb"
+    class="fui-Divider__wrapper"
+    id="divider-ri"
   >
     Vertical
   </div>
@@ -164,14 +156,14 @@ exports[`Divider renders a vertical divider with content 1`] = `
 
 exports[`Divider renders content center aligned 1`] = `
 <div
-  aria-labelledby="divider-r7"
+  aria-labelledby="divider-re"
   aria-orientation="horizontal"
-  className="fui-Divider"
+  class="fui-Divider"
   role="separator"
 >
   <div
-    className="fui-Divider__wrapper"
-    id="divider-r7"
+    class="fui-Divider__wrapper"
+    id="divider-re"
   >
     Center
   </div>
@@ -180,14 +172,14 @@ exports[`Divider renders content center aligned 1`] = `
 
 exports[`Divider renders content end aligned 1`] = `
 <div
-  aria-labelledby="divider-r8"
+  aria-labelledby="divider-rf"
   aria-orientation="horizontal"
-  className="fui-Divider"
+  class="fui-Divider"
   role="separator"
 >
   <div
-    className="fui-Divider__wrapper"
-    id="divider-r8"
+    class="fui-Divider__wrapper"
+    id="divider-rf"
   >
     End
   </div>
@@ -196,14 +188,14 @@ exports[`Divider renders content end aligned 1`] = `
 
 exports[`Divider renders content start aligned 1`] = `
 <div
-  aria-labelledby="divider-r6"
+  aria-labelledby="divider-rd"
   aria-orientation="horizontal"
-  className="fui-Divider"
+  class="fui-Divider"
   role="separator"
 >
   <div
-    className="fui-Divider__wrapper"
-    id="divider-r6"
+    class="fui-Divider__wrapper"
+    id="divider-rd"
   >
     Start
   </div>

--- a/packages/react-components/react-menu/library/src/components/MenuDivider/MenuDivider.test.tsx
+++ b/packages/react-components/react-menu/library/src/components/MenuDivider/MenuDivider.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { MenuDivider } from './MenuDivider';
-import * as renderer from 'react-test-renderer';
+import { render } from '@testing-library/react';
 import { isConformant } from '../../testing/isConformant';
 
 describe('MenuDivider', () => {
@@ -13,9 +13,7 @@ describe('MenuDivider', () => {
    * Note: see more visual regression tests for MenuDivider in /apps/vr-tests.
    */
   it('renders a default state', () => {
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const component = renderer.create(<MenuDivider>Default MenuDivider</MenuDivider>);
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    const { container } = render(<MenuDivider>Default MenuDivider</MenuDivider>);
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/packages/react-components/react-menu/library/src/components/MenuDivider/__snapshots__/MenuDivider.test.tsx.snap
+++ b/packages/react-components/react-menu/library/src/components/MenuDivider/__snapshots__/MenuDivider.test.tsx.snap
@@ -2,8 +2,8 @@
 
 exports[`MenuDivider renders a default state 1`] = `
 <div
-  aria-hidden={true}
-  className="fui-MenuDivider"
+  aria-hidden="true"
+  class="fui-MenuDivider"
   role="presentation"
 >
   Default MenuDivider

--- a/packages/react-components/react-menu/library/src/components/MenuGroup/MenuGroup.test.tsx
+++ b/packages/react-components/react-menu/library/src/components/MenuGroup/MenuGroup.test.tsx
@@ -1,7 +1,6 @@
 import { resetIdsForTests } from '@fluentui/react-utilities';
 import * as React from 'react';
 import { MenuGroup } from './MenuGroup';
-import * as renderer from 'react-test-renderer';
 import { render } from '@testing-library/react';
 import { isConformant } from '../../testing/isConformant';
 
@@ -23,10 +22,8 @@ describe('MenuGroup', () => {
    * Note: see more visual regression tests for MenuGroup in /apps/vr-tests.
    */
   it('renders a default state', () => {
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const component = renderer.create(<MenuGroup>Default MenuGroup</MenuGroup>);
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    const { container } = render(<MenuGroup>Default MenuGroup</MenuGroup>);
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   it('should allow user to specify their own aria-labelledby attribute', () => {

--- a/packages/react-components/react-menu/library/src/components/MenuGroup/__snapshots__/MenuGroup.test.tsx.snap
+++ b/packages/react-components/react-menu/library/src/components/MenuGroup/__snapshots__/MenuGroup.test.tsx.snap
@@ -2,8 +2,8 @@
 
 exports[`MenuGroup renders a default state 1`] = `
 <div
-  aria-labelledby="menu-groupr0"
-  className="fui-MenuGroup"
+  aria-labelledby="menu-groupr7"
+  class="fui-MenuGroup"
   role="group"
 >
   Default MenuGroup

--- a/packages/react-components/react-menu/library/src/components/MenuGroupHeader/MenuGroupHeader.test.tsx
+++ b/packages/react-components/react-menu/library/src/components/MenuGroupHeader/MenuGroupHeader.test.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { MenuGroupHeader } from './MenuGroupHeader';
-import * as renderer from 'react-test-renderer';
 import { render } from '@testing-library/react';
 import { isConformant } from '../../testing/isConformant';
 import { MenuGroupContextProvider } from '../../contexts/menuGroupContext';
@@ -15,10 +14,8 @@ describe('MenuGroupHeader', () => {
    * Note: see more visual regression tests for MenuGroupHeader in /apps/vr-tests.
    */
   it('renders a default state', () => {
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const component = renderer.create(<MenuGroupHeader>Default MenuGroupHeader</MenuGroupHeader>);
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    const { container } = render(<MenuGroupHeader>Default MenuGroupHeader</MenuGroupHeader>);
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   it('should allow user to specify their own id', () => {

--- a/packages/react-components/react-menu/library/src/components/MenuGroupHeader/__snapshots__/MenuGroupHeader.test.tsx.snap
+++ b/packages/react-components/react-menu/library/src/components/MenuGroupHeader/__snapshots__/MenuGroupHeader.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`MenuGroupHeader renders a default state 1`] = `
 <div
-  className="fui-MenuGroupHeader"
+  class="fui-MenuGroupHeader"
   id=""
 >
   Default MenuGroupHeader

--- a/packages/react-components/react-menu/library/src/components/MenuItem/MenuItem.test.tsx
+++ b/packages/react-components/react-menu/library/src/components/MenuItem/MenuItem.test.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { render, fireEvent, createEvent } from '@testing-library/react';
 import { Enter, Space } from '@fluentui/keyboard-keys';
 import { MenuItem } from './MenuItem';
-import * as renderer from 'react-test-renderer';
 import { isConformant } from '../../testing/isConformant';
 import { MenuTriggerContextProvider } from '../../contexts/menuTriggerContext';
 import { MenuListProvider } from '../../contexts/menuListContext';
@@ -35,10 +34,8 @@ describe('MenuItem', () => {
    * Note: see more visual regression tests for MenuItem in /apps/vr-tests.
    */
   it('renders a default state', () => {
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const component = renderer.create(<MenuItem>Default MenuItem</MenuItem>);
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    const { container } = render(<MenuItem>Default MenuItem</MenuItem>);
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   it('should focus the item on mousemove', () => {

--- a/packages/react-components/react-menu/library/src/components/MenuItem/__snapshots__/MenuItem.test.tsx.snap
+++ b/packages/react-components/react-menu/library/src/components/MenuItem/__snapshots__/MenuItem.test.tsx.snap
@@ -2,16 +2,12 @@
 
 exports[`MenuItem renders a default state 1`] = `
 <div
-  className="fui-MenuItem"
-  onClick={[Function]}
-  onKeyDown={[Function]}
-  onKeyUp={[Function]}
-  onMouseMove={[Function]}
+  class="fui-MenuItem"
   role="menuitem"
-  tabIndex={0}
+  tabindex="0"
 >
   <span
-    className="fui-MenuItem__content"
+    class="fui-MenuItem__content"
   >
     Default MenuItem
   </span>

--- a/packages/react-components/react-menu/library/src/components/MenuItemCheckbox/MenuItemCheckbox.test.tsx
+++ b/packages/react-components/react-menu/library/src/components/MenuItemCheckbox/MenuItemCheckbox.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as renderer from 'react-test-renderer';
 import { Enter, Space } from '@fluentui/keyboard-keys';
 import { render, fireEvent } from '@testing-library/react';
 import { isConformant } from '../../testing/isConformant';
@@ -39,14 +38,12 @@ describe('MenuItemCheckbox conformance', () => {
    * Note: see more visual regression tests for MenuItemCheckbox in /apps/vr-tests.
    */
   it('renders a default state', () => {
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const component = renderer.create(
+    const { container } = render(
       <MenuItemCheckbox name="checkbox" value="1">
         Default MenuItemCheckbox
       </MenuItemCheckbox>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 });
 

--- a/packages/react-components/react-menu/library/src/components/MenuItemCheckbox/__snapshots__/MenuItemCheckbox.test.tsx.snap
+++ b/packages/react-components/react-menu/library/src/components/MenuItemCheckbox/__snapshots__/MenuItemCheckbox.test.tsx.snap
@@ -2,22 +2,18 @@
 
 exports[`MenuItemCheckbox conformance renders a default state 1`] = `
 <div
-  aria-checked={false}
-  className="fui-MenuItem fui-MenuItemCheckbox"
+  aria-checked="false"
+  class="fui-MenuItem fui-MenuItemCheckbox"
   name="checkbox"
-  onClick={[Function]}
-  onKeyDown={[Function]}
-  onKeyUp={[Function]}
-  onMouseMove={[Function]}
   role="menuitemcheckbox"
-  tabIndex={0}
+  tabindex="0"
 >
   <span
-    className="fui-MenuItem__checkmark fui-MenuItemCheckbox__checkmark"
+    class="fui-MenuItem__checkmark fui-MenuItemCheckbox__checkmark"
   >
     <svg
-      aria-hidden={true}
-      className=""
+      aria-hidden="true"
+      class=""
       fill="currentColor"
       height="16"
       viewBox="0 0 16 16"
@@ -31,7 +27,7 @@ exports[`MenuItemCheckbox conformance renders a default state 1`] = `
     </svg>
   </span>
   <span
-    className="fui-MenuItem__content fui-MenuItemCheckbox__content"
+    class="fui-MenuItem__content fui-MenuItemCheckbox__content"
   >
     Default MenuItemCheckbox
   </span>

--- a/packages/react-components/react-menu/library/src/components/MenuItemRadio/MenuItemRadio.test.tsx
+++ b/packages/react-components/react-menu/library/src/components/MenuItemRadio/MenuItemRadio.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as renderer from 'react-test-renderer';
 import { Enter, Space } from '@fluentui/keyboard-keys';
 import { render, fireEvent } from '@testing-library/react';
 import { MenuItemRadio } from './MenuItemRadio';
@@ -36,14 +35,12 @@ describe('MenuItemRadio', () => {
    * Note: see more visual regression tests for MenuItemRadio in /apps/vr-tests.
    */
   it('renders a default state', () => {
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const component = renderer.create(
+    const { container } = render(
       <MenuItemRadio name="radio" value="1">
         Default MenuItemRadio
       </MenuItemRadio>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 });
 

--- a/packages/react-components/react-menu/library/src/components/MenuItemRadio/__snapshots__/MenuItemRadio.test.tsx.snap
+++ b/packages/react-components/react-menu/library/src/components/MenuItemRadio/__snapshots__/MenuItemRadio.test.tsx.snap
@@ -2,22 +2,18 @@
 
 exports[`MenuItemRadio renders a default state 1`] = `
 <div
-  aria-checked={false}
-  className="fui-MenuItem fui-MenuItemRadio"
+  aria-checked="false"
+  class="fui-MenuItem fui-MenuItemRadio"
   name="radio"
-  onClick={[Function]}
-  onKeyDown={[Function]}
-  onKeyUp={[Function]}
-  onMouseMove={[Function]}
   role="menuitemradio"
-  tabIndex={0}
+  tabindex="0"
 >
   <span
-    className="fui-MenuItem__checkmark fui-MenuItemRadio__checkmark"
+    class="fui-MenuItem__checkmark fui-MenuItemRadio__checkmark"
   >
     <svg
-      aria-hidden={true}
-      className=""
+      aria-hidden="true"
+      class=""
       fill="currentColor"
       height="16"
       viewBox="0 0 16 16"
@@ -31,7 +27,7 @@ exports[`MenuItemRadio renders a default state 1`] = `
     </svg>
   </span>
   <span
-    className="fui-MenuItem__content fui-MenuItemRadio__content"
+    class="fui-MenuItem__content fui-MenuItemRadio__content"
   >
     Default MenuItemRadio
   </span>

--- a/packages/react-components/react-menu/library/src/components/MenuList/MenuList.test.tsx
+++ b/packages/react-components/react-menu/library/src/components/MenuList/MenuList.test.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { MenuList } from './MenuList';
-import * as renderer from 'react-test-renderer';
 import { render } from '@testing-library/react';
 import { useHasParentContext } from '@fluentui/react-context-selector';
 import { isConformant } from '../../testing/isConformant';
@@ -25,10 +24,8 @@ describe('MenuList', () => {
    * Note: see more visual regression tests for MenuList in /apps/vr-tests.
    */
   it('renders a default state', () => {
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const component = renderer.create(<MenuList>Default MenuList</MenuList>);
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    const { container } = render(<MenuList>Default MenuList</MenuList>);
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   it('set hasMenuListContext to true', () => {

--- a/packages/react-components/react-menu/library/src/components/MenuList/__snapshots__/MenuList.test.tsx.snap
+++ b/packages/react-components/react-menu/library/src/components/MenuList/__snapshots__/MenuList.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`MenuList renders a default state 1`] = `
 <div
   aria-labelledby=""
-  className="fui-MenuList"
+  class="fui-MenuList"
   data-tabster="{\\"mover\\":{\\"cyclic\\":true,\\"direction\\":1,\\"memorizeCurrent\\":true}}"
   role="menu"
 >

--- a/packages/react-components/react-menu/library/src/components/MenuTrigger/MenuTrigger.test.tsx
+++ b/packages/react-components/react-menu/library/src/components/MenuTrigger/MenuTrigger.test.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { MenuTrigger } from './MenuTrigger';
-import * as renderer from 'react-test-renderer';
 import { createEvent, fireEvent, render } from '@testing-library/react';
 import { isConformant } from '../../testing/isConformant';
 import { mockUseMenuContext } from '../../testing/mockUseMenuContext';
@@ -33,14 +32,12 @@ describe('MenuTrigger', () => {
    * Note: see more visual regression tests for MenuTrigger in /apps/vr-tests.
    */
   it('renders a default state', () => {
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const component = renderer.create(
+    const { container } = render(
       <MenuTrigger disableButtonEnhancement>
         <button>Menu trigger</button>
       </MenuTrigger>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   it('should retain original child callback ref', () => {

--- a/packages/react-components/react-menu/library/src/components/MenuTrigger/__snapshots__/MenuTrigger.test.tsx.snap
+++ b/packages/react-components/react-menu/library/src/components/MenuTrigger/__snapshots__/MenuTrigger.test.tsx.snap
@@ -4,13 +4,6 @@ exports[`MenuTrigger renders a default state 1`] = `
 <button
   aria-haspopup="menu"
   id="id"
-  onClick={[Function]}
-  onContextMenu={[Function]}
-  onKeyDown={[Function]}
-  onMouseEnter={[Function]}
-  onMouseLeave={[Function]}
-  onMouseMove={[Function]}
-  onMouseOver={[Function]}
 >
   Menu trigger
 </button>

--- a/packages/react-components/react-motion/library/src/hooks/useAnimateAtoms-node.test.tsx
+++ b/packages/react-components/react-motion/library/src/hooks/useAnimateAtoms-node.test.tsx
@@ -4,15 +4,39 @@
 
 // 👆 this is intentionally to test in SSR like environment
 
-import { renderHook } from '@testing-library/react-hooks';
+import * as React from 'react';
+import { renderToString } from 'react-dom/server';
 import { useAnimateAtoms } from './useAnimateAtoms';
 
 describe('useAnimateAtoms (node)', () => {
   it('handles node/server environments', () => {
-    const { result } = renderHook(() => useAnimateAtoms());
+    const { result } = renderHookSSR(() => useAnimateAtoms());
 
     expect(result.current).toBeInstanceOf(Function);
   });
 });
 
-export {};
+// Minimal SSR-only renderHook replacement using react-dom/server
+function renderHookSSR<T>(
+  callback: () => T,
+  options?: { wrapper?: React.ComponentType<{ children: React.ReactNode }> },
+) {
+  const result: { current: T | undefined } = { current: undefined };
+
+  const Probe: React.FC = () => {
+    result.current = callback();
+    return null;
+  };
+
+  const element = options?.wrapper ? (
+    <options.wrapper>
+      <Probe />
+    </options.wrapper>
+  ) : (
+    <Probe />
+  );
+
+  renderToString(element);
+
+  return { result };
+}

--- a/packages/react-components/react-motion/library/src/slots/presenceMotionSlot.test.tsx
+++ b/packages/react-components/react-motion/library/src/slots/presenceMotionSlot.test.tsx
@@ -57,6 +57,9 @@ describe('presenceMotionSlot', () => {
     expect(queryByTestId('root')).not.toBeNull();
     expect(queryByTestId('content')).not.toBeNull();
 
+    expect(TestMotion).toHaveBeenCalledTimes(1);
+
+    // TODO: these fail in React 19
     expect(TestMotion).toHaveBeenCalledWith(
       expect.objectContaining({ visible: true, unmountOnExit: true }),
       expect.any(Object),
@@ -69,6 +72,8 @@ describe('presenceMotionSlot', () => {
     expect(queryByTestId('root')).not.toBeNull();
     expect(queryByTestId('content')).toBeNull();
 
+    expect(TestMotion).toHaveBeenCalledTimes(4);
+    // TODO: these fail in React 19
     expect(TestMotion).toHaveBeenLastCalledWith(
       expect.objectContaining({ visible: false, unmountOnExit: true }),
       expect.any(Object),

--- a/packages/react-components/react-motion/library/src/slots/presenceMotionSlot.test.tsx
+++ b/packages/react-components/react-motion/library/src/slots/presenceMotionSlot.test.tsx
@@ -59,11 +59,8 @@ describe('presenceMotionSlot', () => {
 
     expect(TestMotion).toHaveBeenCalledTimes(1);
 
-    // TODO: these fail in React 19
-    expect(TestMotion).toHaveBeenCalledWith(
-      expect.objectContaining({ visible: true, unmountOnExit: true }),
-      expect.any(Object),
-    );
+    const firstCall = TestMotion.mock.calls[0];
+    expect(firstCall[0]).toEqual(expect.objectContaining({ visible: true, unmountOnExit: true }));
 
     // ---
 
@@ -73,11 +70,9 @@ describe('presenceMotionSlot', () => {
     expect(queryByTestId('content')).toBeNull();
 
     expect(TestMotion).toHaveBeenCalledTimes(4);
-    // TODO: these fail in React 19
-    expect(TestMotion).toHaveBeenLastCalledWith(
-      expect.objectContaining({ visible: false, unmountOnExit: true }),
-      expect.any(Object),
-    );
+
+    const lastCall = TestMotion.mock.calls[3];
+    expect(lastCall[0]).toEqual(expect.objectContaining({ visible: false, unmountOnExit: true }));
   });
 
   it('handles object as value', () => {

--- a/packages/react-components/react-overflow/library/src/useOverflowContainer.test.ts
+++ b/packages/react-components/react-overflow/library/src/useOverflowContainer.test.ts
@@ -98,25 +98,29 @@ describe('useOverflowContainer', () => {
 
   it('should not re-render on first mount', () => {
     mockOverflowManager();
-    const { result } = renderHook(() =>
-      useOverflowContainer(() => undefined, { onUpdateItemVisibility: () => undefined }),
-    );
+    let renderCount = 0;
+    renderHook(() => {
+      renderCount++;
+      return useOverflowContainer(() => undefined, { onUpdateItemVisibility: () => undefined });
+    });
 
-    expect(result.all.length).toEqual(1);
+    expect(renderCount).toEqual(1);
   });
 
   it('should re-render when option changes', () => {
     let overflowAxis: OverflowAxis = 'horizontal';
     mockOverflowManager();
-    const { result, rerender } = renderHook(() =>
-      useOverflowContainer(() => undefined, { onUpdateItemVisibility: () => undefined, overflowAxis }),
-    );
+    let renderCount = 0;
+    const { rerender } = renderHook(() => {
+      renderCount++;
+      return useOverflowContainer(() => undefined, { onUpdateItemVisibility: () => undefined, overflowAxis });
+    });
 
-    expect(result.all.length).toEqual(1);
+    expect(renderCount).toEqual(1);
 
     overflowAxis = 'vertical';
     rerender();
 
-    expect(result.all.length).toEqual(2);
+    expect(renderCount).toEqual(2);
   });
 });

--- a/packages/react-components/react-popover/library/src/components/PopoverTrigger/PopoverTrigger.test.tsx
+++ b/packages/react-components/react-popover/library/src/components/PopoverTrigger/PopoverTrigger.test.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import { PopoverTrigger } from './PopoverTrigger';
-import * as renderer from 'react-test-renderer';
 import { mockPopoverContext } from '../../testing/mockUsePopoverContext';
 import { isConformant } from '../../testing/isConformant';
 
@@ -31,14 +30,12 @@ describe('PopoverTrigger', () => {
    * Note: see more visual regression tests for PopoverTrigger in /apps/vr-tests.
    */
   it('renders a default state', () => {
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const component = renderer.create(
+    const { container } = render(
       <PopoverTrigger disableButtonEnhancement>
         <button>Popover trigger</button>
       </PopoverTrigger>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   it.each([

--- a/packages/react-components/react-popover/library/src/components/PopoverTrigger/__snapshots__/PopoverTrigger.test.tsx.snap
+++ b/packages/react-components/react-popover/library/src/components/PopoverTrigger/__snapshots__/PopoverTrigger.test.tsx.snap
@@ -4,11 +4,6 @@ exports[`PopoverTrigger renders a default state 1`] = `
 <button
   aria-expanded="false"
   data-tabster="{\\"restorer\\":{\\"type\\":1}}"
-  onClick={[Function]}
-  onContextMenu={[Function]}
-  onKeyDown={[Function]}
-  onMouseEnter={[Function]}
-  onMouseLeave={[Function]}
 >
   Popover trigger
 </button>

--- a/packages/react-components/react-portal/library/src/components/Portal/Portal-node.test.tsx
+++ b/packages/react-components/react-portal/library/src/components/Portal/Portal-node.test.tsx
@@ -6,22 +6,18 @@
 
 import { SSRProvider } from '@fluentui/react-utilities';
 import * as React from 'react';
-import * as renderer from 'react-test-renderer';
+import { renderToString } from 'react-dom/server';
 import { Portal } from './Portal';
 
 describe('Portal (node)', () => {
   it('renders hidden span as virtual parent in SSR', () => {
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const component = renderer.create(
+    const html = renderToString(
       <SSRProvider>
         <Portal>portals content</Portal>
       </SSRProvider>,
     );
 
-    expect(component.toJSON()).toMatchInlineSnapshot(`
-      <span
-        hidden={true}
-      />
-    `);
+    // Portal renders nothing on the server
+    expect(html).toMatchInlineSnapshot(`"<span hidden=\\"\\"></span>"`);
   });
 });

--- a/packages/react-components/react-provider/library/src/components/FluentProvider/FluentProvider.test.tsx
+++ b/packages/react-components/react-provider/library/src/components/FluentProvider/FluentProvider.test.tsx
@@ -2,7 +2,6 @@ import { teamsLightTheme } from '@fluentui/react-theme';
 import { resetIdsForTests } from '@fluentui/react-utilities';
 import { render } from '@testing-library/react';
 import * as React from 'react';
-import * as reactTestRenderer from 'react-test-renderer';
 
 import { FluentProvider } from './FluentProvider';
 import { fluentProviderClassNames } from './useFluentProviderStyles.styles';
@@ -37,12 +36,10 @@ describe('FluentProvider', () => {
    * Note: see more visual regression tests for FluentProvider in /apps/vr-tests.
    */
   it('renders a default state', () => {
-    // eslint-disable-next-line @typescript-eslint/no-deprecated -- FIXME
-    const component = reactTestRenderer.create(
+    const { container } = render(
       <FluentProvider theme={{ colorBrandBackground2: '#fff' }}>Default FluentProvider</FluentProvider>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   it(`should emit an error on duplicated IDs`, () => {

--- a/packages/react-components/react-provider/library/src/components/FluentProvider/__snapshots__/FluentProvider.test.tsx.snap
+++ b/packages/react-components/react-provider/library/src/components/FluentProvider/__snapshots__/FluentProvider.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`FluentProvider renders a default state 1`] = `
 <div
-  className="fui-FluentProvider fui-FluentProvider1"
+  class="fui-FluentProvider fui-FluentProvider1"
   dir="ltr"
 >
   Default FluentProvider

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverTrigger/TeachingPopoverTrigger.test.tsx
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverTrigger/TeachingPopoverTrigger.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { isConformant } from '../../testing/isConformant';
-import * as renderer from 'react-test-renderer';
 import { TeachingPopoverTrigger } from './TeachingPopoverTrigger';
+import { render } from '@testing-library/react';
 
 describe('TeachingPopoverTrigger', () => {
   isConformant({
@@ -21,13 +21,11 @@ describe('TeachingPopoverTrigger', () => {
 
   // TODO add more tests here, and create visual regression tests in /apps/vr-tests
   it('renders a default state', () => {
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const component = renderer.create(
+    const { container } = render(
       <TeachingPopoverTrigger disableButtonEnhancement>
         <button>Popover trigger</button>
       </TeachingPopoverTrigger>,
     );
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverTrigger/__snapshots__/TeachingPopoverTrigger.test.tsx.snap
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverTrigger/__snapshots__/TeachingPopoverTrigger.test.tsx.snap
@@ -4,11 +4,6 @@ exports[`TeachingPopoverTrigger renders a default state 1`] = `
 <button
   aria-expanded="false"
   data-tabster="{\\"restorer\\":{\\"type\\":1}}"
-  onClick={[Function]}
-  onContextMenu={[Function]}
-  onKeyDown={[Function]}
-  onMouseEnter={[Function]}
-  onMouseLeave={[Function]}
 >
   Popover trigger
 </button>

--- a/packages/react-components/react-utilities/src/compose/types.test.ts
+++ b/packages/react-components/react-utilities/src/compose/types.test.ts
@@ -41,13 +41,13 @@ describe(`types`, () => {
 
       type ChildrenLessIntrinsicElement = Types.Slot<'input'>;
       // @ts-expect-error - particular elements cannot have any children
-      const noChildrenEl: ChildrenLessIntrinsicElement = { children: React.createElement('div', 'hello') };
+      const noChildrenEl: ChildrenLessIntrinsicElement = { children: React.createElement('div', null, 'hello') };
 
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore - FIX THE API / this doesn't work ATM and should be fixed
       type NoChildrenComponent = Types.Slot<typeof NoChildrenAllowedComponent>;
       // @ts-expect-error - component doesn't allow any children
-      const noChildrenComponentEl: NoChildrenComponent = { children: React.createElement('div', 'hello') };
+      const noChildrenComponentEl: NoChildrenComponent = { children: React.createElement('div', null, 'hello') };
 
       type ComponentDeclaration = Types.Slot<typeof GreeterComponent>;
       let componentEl: ComponentDeclaration = { greeting: 'hello', who: 'world' };

--- a/packages/react-components/react-utilities/src/ssr/SSRContext-node.test.tsx
+++ b/packages/react-components/react-utilities/src/ssr/SSRContext-node.test.tsx
@@ -4,7 +4,8 @@
 
 // 👆 this is intentionally to test in SSR like environment
 
-import { renderHook } from '@testing-library/react-hooks';
+import * as React from 'react';
+import { renderToString } from 'react-dom/server';
 import { SSRProvider, useIsSSR } from './SSRContext';
 
 describe('useIsSSR (node)', () => {
@@ -15,15 +16,40 @@ describe('useIsSSR (node)', () => {
   it('returns "false" and logs an error if is used outside of SSRProvider', () => {
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     const error = jest.spyOn(console, 'error').mockImplementationOnce(() => {});
-    const { result } = renderHook(() => useIsSSR());
+    const { result } = renderHookSSR(() => useIsSSR());
 
     expect(error).toHaveBeenCalledWith(expect.stringMatching(/When server rendering, you must wrap your application/));
     expect(result.current).toBe(false);
   });
 
   it('returns "true" if is inside SSRProvider', () => {
-    const { result } = renderHook(() => useIsSSR(), { wrapper: SSRProvider });
+    const { result } = renderHookSSR(() => useIsSSR(), { wrapper: SSRProvider });
 
     expect(result.current).toBe(true);
   });
 });
+
+// Minimal SSR-only renderHook replacement using react-dom/server
+function renderHookSSR<T>(
+  callback: () => T,
+  options?: { wrapper?: React.ComponentType<{ children: React.ReactNode }> },
+) {
+  const result: { current: T | undefined } = { current: undefined };
+
+  const Probe: React.FC = () => {
+    result.current = callback();
+    return null;
+  };
+
+  const element = options?.wrapper ? (
+    <options.wrapper>
+      <Probe />
+    </options.wrapper>
+  ) : (
+    <Probe />
+  );
+
+  renderToString(element);
+
+  return { result };
+}

--- a/packages/react-components/react-utilities/src/utils/getReactElementRef.test.ts
+++ b/packages/react-components/react-utilities/src/utils/getReactElementRef.test.ts
@@ -2,79 +2,70 @@ import * as React from 'react';
 
 import { getReactElementRef } from './getReactElementRef';
 
+const reactVersion = parseInt(React.version, 10);
+
 describe('getReactElementRef', () => {
-  let versionReplacer: jest.ReplaceProperty<string>;
+  if (reactVersion >= 19) {
+    describe('React 19 behavior', () => {
+      it('returns ref from element.props.ref', () => {
+        const ref = React.createRef<HTMLDivElement>();
+        const element = React.createElement('div', { ref });
 
-  afterEach(() => {
-    // Restore original React version
-    versionReplacer?.restore();
-  });
+        expect(getReactElementRef(element)).toBe(ref);
+      });
 
-  describe('React 19 behavior', () => {
-    beforeEach(() => {
-      versionReplacer = jest.replaceProperty(React, 'version', '19.0.0');
+      it('returns null when no ref is provided', () => {
+        const element = React.createElement('div');
+
+        expect(getReactElementRef(element)).toBeNull();
+      });
+
+      it('handles function refs', () => {
+        const mockFunctionRef = jest.fn();
+        const element = React.createElement('div', { ref: mockFunctionRef });
+
+        expect(getReactElementRef(element)).toBe(mockFunctionRef);
+      });
+
+      it('handles null refs', () => {
+        const element = React.createElement('div', { ref: null });
+
+        expect(getReactElementRef(element)).toBeNull();
+      });
     });
+  }
 
-    it('returns ref from element.props.ref', () => {
-      const ref = React.createRef<HTMLDivElement>();
-      const element = React.createElement('div', { ref });
+  if (reactVersion < 19) {
+    describe('Pre-React 19 behavior', () => {
+      function createReactElementWithRef<T>(ref?: React.Ref<T>): React.ReactElement & { ref?: React.Ref<T> } {
+        return { ...React.createElement('div'), ref };
+      }
 
-      expect(getReactElementRef(element)).toBe(ref);
+      it('returns ref from element.ref', () => {
+        const ref = React.createRef<HTMLDivElement>();
+        const element = createReactElementWithRef(ref);
+
+        expect(getReactElementRef(element)).toBe(ref);
+      });
+
+      it('returns undefined when no ref is provided', () => {
+        const element = createReactElementWithRef();
+
+        expect(getReactElementRef(element)).toBeUndefined();
+      });
+
+      it('handles function refs in pre-React 19', () => {
+        const mockFunctionRef = jest.fn(() => null) as React.RefCallback<HTMLDivElement>;
+        const element = createReactElementWithRef(mockFunctionRef);
+
+        expect(getReactElementRef(element)).toBe(mockFunctionRef);
+      });
+
+      it('handles null refs', () => {
+        const element = createReactElementWithRef(null);
+
+        expect(getReactElementRef(element)).toBeNull();
+      });
     });
-
-    it('returns null when no ref is provided', () => {
-      const element = React.createElement('div');
-
-      expect(getReactElementRef(element)).toBeNull();
-    });
-
-    it('handles function refs', () => {
-      const mockFunctionRef = jest.fn();
-      const element = React.createElement('div', { ref: mockFunctionRef });
-
-      expect(getReactElementRef(element)).toBe(mockFunctionRef);
-    });
-
-    it('handles null refs', () => {
-      const element = React.createElement('div', { ref: null });
-
-      expect(getReactElementRef(element)).toBeNull();
-    });
-  });
-
-  describe('Pre-React 19 behavior', () => {
-    function createReactElementWithRef<T>(ref?: React.Ref<T>): React.ReactElement & { ref?: React.Ref<T> } {
-      return { ...React.createElement('div'), ref };
-    }
-
-    beforeEach(() => {
-      versionReplacer = jest.replaceProperty(React, 'version', '18.3.1');
-    });
-
-    it('returns ref from element.ref', () => {
-      const ref = React.createRef<HTMLDivElement>();
-      const element = createReactElementWithRef(ref);
-
-      expect(getReactElementRef(element)).toBe(ref);
-    });
-
-    it('returns undefined when no ref is provided', () => {
-      const element = createReactElementWithRef();
-
-      expect(getReactElementRef(element)).toBeUndefined();
-    });
-
-    it('handles function refs in pre-React 19', () => {
-      const mockFunctionRef = jest.fn(() => null) as React.RefCallback<HTMLDivElement>;
-      const element = createReactElementWithRef(mockFunctionRef);
-
-      expect(getReactElementRef(element)).toBe(mockFunctionRef);
-    });
-
-    it('handles null refs', () => {
-      const element = createReactElementWithRef(null);
-
-      expect(getReactElementRef(element)).toBeNull();
-    });
-  });
+  }
 });

--- a/packages/react-components/react-utilities/src/utils/getReactElementRef.test.ts
+++ b/packages/react-components/react-utilities/src/utils/getReactElementRef.test.ts
@@ -14,10 +14,10 @@ describe('getReactElementRef', () => {
         expect(getReactElementRef(element)).toBe(ref);
       });
 
-      it('returns null when no ref is provided', () => {
+      it('returns undefined when no ref is provided', () => {
         const element = React.createElement('div');
 
-        expect(getReactElementRef(element)).toBeNull();
+        expect(getReactElementRef(element)).toBeUndefined();
       });
 
       it('handles function refs', () => {

--- a/packages/react-components/react-utilities/src/utils/getReactElementRef.ts
+++ b/packages/react-components/react-utilities/src/utils/getReactElementRef.ts
@@ -16,7 +16,10 @@ export function getReactElementRef<T>(element: React.ReactElement | null | undef
     return element.props.ref;
   }
 
-  type ReactElementLegacy = React.ReactElement & { ref?: React.Ref<any> };
+  type ReactElementLegacy = React.ReactElement & {
+    ref?: // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    React.Ref<any>;
+  };
   // React < 19
   if (typeof (element as ReactElementLegacy).ref !== 'undefined') {
     return (element as ReactElementLegacy).ref;

--- a/packages/react-components/react-utilities/src/utils/getReactElementRef.ts
+++ b/packages/react-components/react-utilities/src/utils/getReactElementRef.ts
@@ -14,7 +14,7 @@ export function getReactElementRef<T>(element: React.ReactElement | null | undef
   }
 
   if (IS_REACT_19_OR_HIGHER) {
-    return element.props?.ref;
+    return element.props.ref;
   }
 
   return (element as React.ReactElement & { ref: React.Ref<T> | undefined }).ref;

--- a/packages/react-components/react-utilities/src/utils/getReactElementRef.ts
+++ b/packages/react-components/react-utilities/src/utils/getReactElementRef.ts
@@ -1,5 +1,7 @@
 import * as React from 'react';
 
+const IS_REACT_19_OR_HIGHER = parseInt(React.version, 10) >= 19;
+
 /**
  * Returns a ref for the React element in a backwards-compatible way.
  *
@@ -11,17 +13,9 @@ export function getReactElementRef<T>(element: React.ReactElement | null | undef
     return undefined;
   }
 
-  // React 19+
-  if (typeof element.props.ref !== 'undefined') {
-    return element.props.ref;
+  if (IS_REACT_19_OR_HIGHER) {
+    return element.props?.ref;
   }
 
-  type ReactElementLegacy = React.ReactElement & {
-    ref?: // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    React.Ref<any>;
-  };
-  // React < 19
-  if (typeof (element as ReactElementLegacy).ref !== 'undefined') {
-    return (element as ReactElementLegacy).ref;
-  }
+  return (element as React.ReactElement & { ref: React.Ref<T> | undefined }).ref;
 }

--- a/packages/react-components/react-utilities/src/utils/getReactElementRef.ts
+++ b/packages/react-components/react-utilities/src/utils/getReactElementRef.ts
@@ -1,7 +1,5 @@
 import * as React from 'react';
 
-const IS_REACT_19_OR_HIGHER = parseInt(React.version, 10) >= 19;
-
 /**
  * Returns a ref for the React element in a backwards-compatible way.
  *
@@ -13,9 +11,14 @@ export function getReactElementRef<T>(element: React.ReactElement | null | undef
     return undefined;
   }
 
-  if (IS_REACT_19_OR_HIGHER) {
+  // React 19+
+  if (typeof element.props.ref !== 'undefined') {
     return element.props.ref;
   }
 
-  return (element as React.ReactElement & { ref: React.Ref<T> | undefined }).ref;
+  type ReactElementLegacy = React.ReactElement & { ref?: React.Ref<any> };
+  // React < 19
+  if (typeof (element as ReactElementLegacy).ref !== 'undefined') {
+    return (element as ReactElementLegacy).ref;
+  }
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

R19 integration `jest` tests were running React 18 under the hood. this was caused by `@testing-library/react-hooks` usage.

> NOTE: exposed during RIT implementation https://github.com/microsoft/fluentui/pull/35022

## New Behavior

R19 integration `jest` tests run against React 19 - exposing failing tests that need to be fixed

### Refactors

- `getReactElementRef`: changes testing to execute specs on real React being used - this started to fail with proper jest setup fixes 
- migrates all v9 tests from react-test-renderer to RTL for R19+ compatibility

### Fixes

Resolves some of the failing tests (against React 19)

**Before:**

```
Test Suites: 8 failed, 380 passed, 388 total
Tests:       14 failed, 13 skipped, 5963 passed, 5990 total
```

**After:**

```
Test Suites: 3 failed, 385 passed, 388 total
Tests:       4 failed, 13 skipped, 5969 passed, 5986 total
```

### Remaining failing projects

- react-tabster / 2 suites
  - src/hooks/useFocusVisible.test.tsx
  - src/hooks/useTabster.test.ts
- react-list / 1 suite
  - src/components/List/List.test.tsx 

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
