### PR TITLE
fix(Toolbar): apply styles for ToolbarGroup

### DIFF
--- a/change/@fluentui-react-toolbar-1a7ca97a-977c-45b8-9c84-a783f6428017.json
+++ b/change/@fluentui-react-toolbar-1a7ca97a-977c-45b8-9c84-a783f6428017.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: apply styles for ToolbarGroup",
+  "packageName": "@fluentui/react-toolbar",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-toolbar/library/etc/react-toolbar.api.md
+++ b/packages/react-components/react-toolbar/library/etc/react-toolbar.api.md
@@ -75,7 +75,9 @@ export const toolbarGroupClassNames: SlotClassNames<ToolbarGroupSlots>;
 export type ToolbarGroupProps = ComponentProps<ToolbarGroupSlots>;
 
 // @public
-export type ToolbarGroupState = ComponentState<ToolbarGroupSlots>;
+export type ToolbarGroupState = ComponentState<ToolbarGroupSlots> & {
+    vertical?: boolean;
+};
 
 // @public
 export type ToolbarProps = ComponentProps<ToolbarSlots> & {

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarGroup/ToolbarGroup.types.ts
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarGroup/ToolbarGroup.types.ts
@@ -12,4 +12,6 @@ export type ToolbarGroupProps = ComponentProps<ToolbarGroupSlots>;
 /**
  * State used in rendering ToolbarButton
  */
-export type ToolbarGroupState = ComponentState<ToolbarGroupSlots>;
+export type ToolbarGroupState = ComponentState<ToolbarGroupSlots> & {
+  vertical?: boolean;
+};

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarGroup/useToolbarGroup.ts
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarGroup/useToolbarGroup.ts
@@ -1,6 +1,8 @@
 import { getIntrinsicElementProps, slot } from '@fluentui/react-utilities';
 import * as React from 'react';
-import { ToolbarGroupProps, ToolbarGroupState } from './ToolbarGroup.types';
+
+import { useToolbarContext_unstable } from '../Toolbar/ToolbarContext';
+import type { ToolbarGroupProps, ToolbarGroupState } from './ToolbarGroup.types';
 
 /**
  * Given user props, defines default props for the Group
@@ -11,6 +13,8 @@ export const useToolbarGroup_unstable = (
   props: ToolbarGroupProps,
   ref: React.Ref<HTMLDivElement>,
 ): ToolbarGroupState => {
+  const vertical = useToolbarContext_unstable(ctx => ctx.vertical);
+
   return {
     components: {
       root: 'div',
@@ -23,5 +27,6 @@ export const useToolbarGroup_unstable = (
       }),
       { elementType: 'div' },
     ),
+    vertical,
   };
 };

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarGroup/useToolbarGroupStyles.styles.ts
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarGroup/useToolbarGroupStyles.styles.ts
@@ -1,10 +1,22 @@
 import { SlotClassNames } from '@fluentui/react-utilities';
-import { mergeClasses } from '@griffel/react';
+import { makeStyles, mergeClasses } from '@griffel/react';
+
 import type { ToolbarGroupSlots, ToolbarGroupState } from './ToolbarGroup.types';
 
 export const toolbarGroupClassNames: SlotClassNames<ToolbarGroupSlots> = {
   root: 'fui-ToolbarGroup',
 };
+
+const useStyles = makeStyles({
+  root: {
+    display: 'flex',
+    alignItems: 'center',
+  },
+  vertical: {
+    flexDirection: 'column',
+    width: 'fit-content',
+  },
+});
 
 /**
  * Apply styling to the Toolbar slots based on the state
@@ -12,7 +24,15 @@ export const toolbarGroupClassNames: SlotClassNames<ToolbarGroupSlots> = {
 export const useToolbarGroupStyles_unstable = (state: ToolbarGroupState): ToolbarGroupState => {
   'use no memo';
 
-  state.root.className = mergeClasses(toolbarGroupClassNames.root, state.root.className);
+  const { vertical } = state;
+  const styles = useStyles();
+
+  state.root.className = mergeClasses(
+    toolbarGroupClassNames.root,
+    styles.root,
+    vertical && styles.vertical,
+    state.root.className,
+  );
 
   return state;
 };


### PR DESCRIPTION
## Previous Behavior

`ToolbarGroup` does not have any styles, which breaks dividers inside.

<img width="216" height="177" alt="image" src="https://github.com/user-attachments/assets/2cfba139-091b-42eb-812c-8df43a17e619" />

## New Behavior

`ToolbarGroup` has the same styles as `Toolbar` now (except `padding`).

<img width="291" height="91" alt="image" src="https://github.com/user-attachments/assets/2c7f36da-7107-4d40-b1b5-028793257a78" />

## Related Issue(s)

Fixes #34738
