### PR TITLE
ci: move dryRun from variables to parameters

### DIFF
--- a/azure-pipelines.deprecate-package.yml
+++ b/azure-pipelines.deprecate-package.yml
@@ -12,6 +12,10 @@ parameters:
   - name: message
     type: string
     default: 'Deprecated in favor of stable release'
+  - name: dryRun
+    displayName: Dry Run Mode
+    type: boolean
+    default: false
 
 variables:
   - group: 'Github and NPM secrets'
@@ -52,4 +56,4 @@ extends:
               - script: |
                   npm deprecate ${{ parameters.packageSpec }} "${{ parameters.message }}" --registry https://registry.npmjs.org/ --//registry.npmjs.org/:_authToken=$(npmToken)
                 displayName: 'Deprecate package'
-                condition: eq(variables.dryRun, false)
+                condition: not(${{ parameters.dryRun }})

--- a/azure-pipelines.hotfix.yml
+++ b/azure-pipelines.hotfix.yml
@@ -4,6 +4,12 @@ trigger: none
 
 name: '$(targetNpmVersion) ($(Rev:r))'
 
+parameters:
+  - name: dryRun
+    displayName: Dry Run Mode
+    type: boolean
+    default: false
+
 variables:
   - template: .devops/templates/variables.yml
   - name: tags
@@ -76,7 +82,7 @@ extends:
               - script: |
                   npm publish packages/react/react-$(targetNpmVersion).tgz --tag hf8 --//registry.npmjs.org/:_authToken=$(npmToken)
                 displayName: Publish new version
-                condition: eq(variables.dryRun, false)
+                condition: not(${{ parameters.dryRun }})
 
               - template: .devops/templates/cleanup.yml@self
                 parameters:

--- a/azure-pipelines.release-vnext.yml
+++ b/azure-pipelines.release-vnext.yml
@@ -5,6 +5,12 @@ trigger: none
 # Example: v9_20201022.1
 name: 'v9_$(Date:yyyyMMdd)$(Rev:.r)'
 
+parameters:
+  - name: dryRun
+    displayName: Dry Run Mode
+    type: boolean
+    default: false
+
 variables:
   - group: 'Github and NPM secrets'
   - template: .devops/templates/variables.yml
@@ -84,7 +90,7 @@ extends:
               - script: |
                   node -r ./scripts/ts-node/src/register ./scripts/executors/src/deprecate-react-components-preview-packages.ts --token $(npmToken)
                 displayName: 'Deprecate preview packages'
-                condition: eq(variables.dryRun, false)
+                condition: not(${{ parameters.dryRun }})
 
               - script: |
                   yarn publish:beachball -n $(npmToken) --config scripts/beachball/src/release-vNext.config.js --message 'release: applying package updates - react-components'
@@ -92,13 +98,13 @@ extends:
                 env:
                   GITHUB_PAT: $(githubPAT)
                 displayName: Publish changes and bump versions
-                condition: eq(variables.dryRun, false)
+                condition: not(${{ parameters.dryRun }})
 
               - script: |
                   node -r ./scripts/ts-node/src/register scripts/executors/src/tag-react-components.ts --token $(npmToken)
                 displayName: Tag prelease packages with prerelease tag
                 continueOnError: true
-                condition: eq(variables.dryRun, false)
+                condition: not(${{ parameters.dryRun }})
 
               # Since releases are scoped, this should warn for any packages that were mistakenly not included in scoping
               - script: |

--- a/azure-pipelines.release.tools.yml
+++ b/azure-pipelines.release.tools.yml
@@ -5,6 +5,12 @@ trigger: none
 # Example: tools_20201022.1
 name: 'tools_$(Date:yyyyMMdd)$(Rev:.r)'
 
+parameters:
+  - name: dryRun
+    displayName: Dry Run Mode
+    type: boolean
+    default: false
+
 variables:
   - group: 'Github and NPM secrets'
   - template: .devops/templates/variables.yml
@@ -80,7 +86,7 @@ extends:
                 env:
                   GITHUB_PAT: $(githubPAT)
                 displayName: Publish changes and bump versions
-                condition: eq(variables.dryRun, false)
+                condition: not(${{ parameters.dryRun }})
 
               - template: .devops/templates/cleanup.yml@self
                 parameters:

--- a/azure-pipelines.release.web-components.yml
+++ b/azure-pipelines.release.web-components.yml
@@ -5,6 +5,12 @@ trigger: none
 # Example: web-components_20201022.1
 name: 'web-components_$(Date:yyyyMMdd)$(Rev:.r)'
 
+parameters:
+  - name: dryRun
+    displayName: Dry Run Mode
+    type: boolean
+    default: false
+
 variables:
   - group: 'Github and NPM secrets'
   - template: .devops/templates/variables.yml
@@ -78,7 +84,7 @@ extends:
                 env:
                   GITHUB_PAT: $(githubPAT)
                 displayName: Publish changes and bump versions
-                condition: eq(variables.dryRun, false)
+                condition: not(${{ parameters.dryRun }})
 
               - template: .devops/templates/cleanup.yml@self
                 parameters:

--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -5,6 +5,12 @@ trigger: none
 # Example: v8_20201022.1
 name: 'v8_$(Date:yyyyMMdd)$(Rev:.r)'
 
+parameters:
+  - name: dryRun
+    displayName: Dry Run Mode
+    type: boolean
+    default: false
+
 variables:
   - group: 'Github and NPM secrets'
   - template: .devops/templates/variables.yml
@@ -120,7 +126,7 @@ extends:
               - script: |
                   yarn publish:beachball -n $(npmToken) --config scripts/beachball/src/release-v8.config.js --message 'release: applying package updates - react v8'
                   git reset --hard origin/master
-                condition: and(succeeded(), eq(variables.dryRun, false))
+                condition: and(succeeded(), not(${{ parameters.dryRun }}))
                 env:
                   GITHUB_PAT: $(githubPAT)
                 displayName: Publish changes and bump versions
@@ -159,7 +165,7 @@ extends:
               # failure doesn't need to block anything else
               - script: |
                   node -r ./scripts/ts-node/src/register ./scripts/update-release-notes/src/index.ts --token=$(githubPAT) --apply --debug
-                condition: eq(variables.dryRun, false)
+                condition: not(${{ parameters.dryRun }})
                 displayName: 'Update github release notes'
 
               - template: .devops/templates/cleanup.yml@self

--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -160,6 +160,7 @@ extends:
               - template: .devops/templates/publish-website.yml@self
                 parameters:
                   version: 8
+                condition: not(${{ parameters.dryRun }})
 
               # Run this near the end because it's more likely to fail than the artifact upload tasks, and its
               # failure doesn't need to block anything else


### PR DESCRIPTION
Small improvement of moving from variables to parameters for dryMode, so checkbox is immediately visible during pipeline triggering process 

UPD: this should fix our dryMode as well, because of the conflict between YAML defined dryRun variable in devops /templates and Azure UI the variable is overwritten   

<img width="602" height="331" alt="image" src="https://github.com/user-attachments/assets/65194729-edf9-4e39-8a94-8441336aac07" />
