### PR TITLE
fix: remove unnecessary type check for better ssr compatibility

### DIFF
--- a/change/@fluentui-web-components-c0d84950-9afe-4f89-a10c-8706d3533f8f.json
+++ b/change/@fluentui-web-components-c0d84950-9afe-4f89-a10c-8706d3533f8f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: remove unnecessary type check for better ssr compatibility",
+  "packageName": "@fluentui/web-components",
+  "email": "machi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/accordion/accordion.ts
+++ b/packages/web-components/src/accordion/accordion.ts
@@ -119,11 +119,9 @@ export class Accordion extends FASTElement {
     // Add event listeners to each non-disabled AccordionItem
     this.accordionItems = children.filter(child => !child.hasAttribute('disabled'));
     this.accordionItems.forEach((item: Element, index: number) => {
-      if (item instanceof BaseAccordionItem) {
-        item.addEventListener('click', this.expandedChangedHandler);
-        // Subscribe to the expanded attribute of the item
-        Observable.getNotifier(item).subscribe(this, 'expanded');
-      }
+      item.addEventListener('click', this.expandedChangedHandler);
+      // Subscribe to the expanded attribute of the item
+      Observable.getNotifier(item).subscribe(this, 'expanded');
     });
 
     if (this.isSingleExpandMode()) {


### PR DESCRIPTION
## Previous Behavior

When Accordion binds click event listeners to AccordionItems, it checks if the child is `instanceof AccordionItem`. This is not very necessary since the event handler itself also does this check. And checking the type when binding event listener is not SSR/BTR compatible because the children may not have been ready.

## New Behavior

Type check is removed from event listener binding time.
