### PR TITLE
fix(react-tags): set default button type if dismissible 

### DIFF
--- a/change/@fluentui-react-tags-ed80a9a9-6af8-429d-858e-89dbb0133796.json
+++ b/change/@fluentui-react-tags-ed80a9a9-6af8-429d-858e-89dbb0133796.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: set default button type for dismissible",
+  "packageName": "@fluentui/react-tags",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tags/library/src/components/Tag/useTag.tsx
+++ b/packages/react-components/react-tags/library/src/components/Tag/useTag.tsx
@@ -94,7 +94,12 @@ export const useTag_unstable = (props: TagProps, ref: React.Ref<HTMLSpanElement 
         id,
         ...(dismissible && { onClick: dismissOnClick, onKeyDown: dismissOnKeyDown }),
       }),
-      { elementType },
+      {
+        defaultProps: {
+          type: elementType === 'button' ? 'button' : undefined,
+        },
+        elementType,
+      },
     ),
 
     media: slot.optional(props.media, { elementType: 'span' }),


### PR DESCRIPTION
## Previous Behavior

The default button type was submit, which could cause unexpected behavior when TagPicker was used inside a form

![ezgif-192e9212c346dc](https://github.com/user-attachments/assets/f2bbfb19-3e4f-4f26-8867-de8f058ce24e)

## New Behavior

![ezgif-1f9f38a89f5722](https://github.com/user-attachments/assets/e01ecc57-3318-455f-80a1-3933ffbfe1c6)


The default button type is now button 


