### PR TITLE
ci: run publish-website template conditionally

### DIFF
--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -157,10 +157,10 @@ extends:
                   node ./packages/public-docsite-setup/scripts/generateHomepage ./homepage
                 displayName: 'Generate homepage.htm'
 
-              - template: .devops/templates/publish-website.yml@self
-                parameters:
-                  version: 8
-                condition: not(${{ parameters.dryRun }})
+              - ${{ if eq(parameters.dryRun, false) }}:
+                  - template: .devops/templates/publish-website.yml@self
+                    parameters:
+                      version: 8
 
               # Run this near the end because it's more likely to fail than the artifact upload tasks, and its
               # failure doesn't need to block anything else


### PR DESCRIPTION
```shell
Azure Pipelines doesn't allow the "condition" property on a template reference step. 
Only "template" and "parameters" are valid at that level. 
To conditionally include a template step, use a compile-time template expression instead.
```