### PR TITLE
fix(DataGrid): single-select radio input should be fully hidden, not disabled

### DIFF
--- a/change/@fluentui-react-table-6820f12e-0e91-48c5-8c1e-d1a171333a45.json
+++ b/change/@fluentui-react-table-6820f12e-0e91-48c5-8c1e-d1a171333a45.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: single-select radio input should be fully hidden, not disabled",
+  "packageName": "@fluentui/react-table",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-table/library/src/components/DataGridRow/DataGridRow.test.tsx
+++ b/packages/react-components/react-table/library/src/components/DataGridRow/DataGridRow.test.tsx
@@ -183,20 +183,6 @@ describe('DataGridRow', () => {
       expect(toggleRow).toHaveBeenCalledTimes(0);
     });
 
-    it('should disable selection cell input if the row is in a header and the selection mode is singe', () => {
-      const toggleRow = jest.fn();
-      const ctx = mockDataGridContext({ selectableRows: true }, { selection: { toggleRow, selectionMode: 'single' } });
-      const { container } = render(
-        <DataGridHeader>
-          <DataGridContextProvider value={ctx}>
-            <DataGridRow>{() => <div />}</DataGridRow>
-          </DataGridContextProvider>
-        </DataGridHeader>,
-      );
-
-      expect(container.querySelector("input[type='radio']")?.hasAttribute('disabled')).toBe(true);
-    });
-
     it('should render aria-selected=true if row is selected', () => {
       const isRowSelected = () => true;
       const ctx = mockDataGridContext({ selectableRows: true }, { selection: { isRowSelected } });

--- a/packages/react-components/react-table/library/src/components/DataGridRow/useDataGridRow.tsx
+++ b/packages/react-components/react-table/library/src/components/DataGridRow/useDataGridRow.tsx
@@ -79,11 +79,6 @@ export const useDataGridRow_unstable = (props: DataGridRowProps, ref: React.Ref<
     selectionCell: slot.optional(props.selectionCell, {
       renderByDefault: selectable,
       elementType: DataGridSelectionCell,
-      defaultProps: {
-        radioIndicator: {
-          disabled: isHeader,
-        },
-      },
     }),
     renderCell: props.children,
     columnDefs,

--- a/packages/react-components/react-table/library/src/components/DataGridRow/useDataGridRowStyles.styles.ts
+++ b/packages/react-components/react-table/library/src/components/DataGridRow/useDataGridRowStyles.styles.ts
@@ -3,7 +3,6 @@ import { createCustomFocusIndicatorStyle } from '@fluentui/react-tabster';
 import type { DataGridRowSlots, DataGridRowState } from './DataGridRow.types';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import { useTableRowStyles_unstable } from '../TableRow/useTableRowStyles.styles';
-import { useIsInTableHeader } from '../../contexts/tableHeaderContext';
 import { useDataGridContext_unstable } from '../../contexts/dataGridContext';
 import { tableSelectionCellClassNames } from '../TableSelectionCell/useTableSelectionCellStyles.styles';
 
@@ -13,13 +12,6 @@ export const dataGridRowClassNames: SlotClassNames<DataGridRowSlots> = {
 };
 
 const useStyles = makeStyles({
-  singleSelectHeader: {
-    // the selection cell's radio indicator should not be exposed in a single-select header row
-    ['& .fui-Radio']: {
-      display: 'none',
-    },
-  },
-
   subtleSelection: {
     ...createCustomFocusIndicatorStyle(
       {
@@ -44,8 +36,6 @@ const useStyles = makeStyles({
 export const useDataGridRowStyles_unstable = (state: DataGridRowState): DataGridRowState => {
   'use no memo';
 
-  const isHeader = useIsInTableHeader();
-  const isSingleSelect = useDataGridContext_unstable(ctx => ctx.selection.selectionMode === 'single');
   const isSubtle = useDataGridContext_unstable(ctx => ctx.subtleSelection);
   const styles = useStyles();
 
@@ -54,7 +44,6 @@ export const useDataGridRowStyles_unstable = (state: DataGridRowState): DataGrid
     dataGridRowClassNames.root,
     state.root.className,
     isSubtle && styles.subtleSelection,
-    isHeader && isSingleSelect && styles.singleSelectHeader,
   );
   if (state.selectionCell) {
     state.selectionCell.className = mergeClasses(dataGridRowClassNames.selectionCell, state.selectionCell.className);

--- a/packages/react-components/react-table/library/src/components/DataGridRow/useDataGridRowStyles.styles.ts
+++ b/packages/react-components/react-table/library/src/components/DataGridRow/useDataGridRowStyles.styles.ts
@@ -14,19 +14,9 @@ export const dataGridRowClassNames: SlotClassNames<DataGridRowSlots> = {
 
 const useStyles = makeStyles({
   singleSelectHeader: {
-    ...createCustomFocusIndicatorStyle(
-      {
-        [`& .${tableSelectionCellClassNames.root}`]: {
-          opacity: 0,
-        },
-      },
-      { selector: 'focus-within' },
-    ),
-
-    ':hover': {
-      [`& .${tableSelectionCellClassNames.root}`]: {
-        opacity: 0,
-      },
+    // the selection cell's radio indicator should not be exposed in a single-select header row
+    ['& .fui-Radio']: {
+      display: 'none',
     },
   },
 

--- a/packages/react-components/react-table/library/src/components/DataGridSelectionCell/DataGridSelectionCell.test.tsx
+++ b/packages/react-components/react-table/library/src/components/DataGridSelectionCell/DataGridSelectionCell.test.tsx
@@ -139,6 +139,23 @@ describe('DataGridSelectionCell', () => {
       expect((getByRole('checkbox') as HTMLInputElement).checked).toBe(true);
     });
 
+    it('should not render a radio in the header in single-select mode', () => {
+      const allRowsSelected = true;
+      const ctx = mockDataGridContext(
+        { selectableRows: true },
+        { selection: { allRowsSelected, selectionMode: 'single' } },
+      );
+      const { queryByRole } = render(
+        <DataGridHeader>
+          <DataGridContextProvider value={ctx}>
+            <DataGridSelectionCell />
+          </DataGridContextProvider>
+        </DataGridHeader>,
+      );
+
+      expect(queryByRole('radio') as HTMLInputElement).toBeFalsy();
+    });
+
     it('should toggle all rows in multiselect mode', () => {
       const toggleAllRows = jest.fn();
       const ctx = mockDataGridContext(

--- a/packages/react-components/react-table/library/src/components/DataGridSelectionCell/useDataGridSelectionCell.ts
+++ b/packages/react-components/react-table/library/src/components/DataGridSelectionCell/useDataGridSelectionCell.ts
@@ -52,6 +52,7 @@ export const useDataGridSelectionCell_unstable = (
       invisible: isHeader && type === 'radio',
       'aria-selected': checked === 'mixed' ? undefined : checked,
       subtle,
+      radioIndicator: isHeader ? null : undefined,
       ...props,
       onClick,
     },


### PR DESCRIPTION
## Previous Behavior

The radio was visually hidden but had a `disabled` prop added. The `disabled` state was semantically incorrect, and the radio also lacked an accessible name (and wasn't visually present) despite being exposed in the a11y tree. Since the radio is both invisible and not interactable, it should not be in the a11y tree at all.

## New Behavior

The radio has `display: none`, removing it from the a11y tree.

## Related Issue(s)

- Fixes #34583 and an [ADO issue](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/24838)
