### PR TITLE
feat(cypress): make 'press' command work in cypress 13/react 17 and undo setup in r17-tests-v9

### DIFF
--- a/apps/react-17-tests-v9/config/support/commands.js
+++ b/apps/react-17-tests-v9/config/support/commands.js
@@ -1,7 +1,0 @@
-import { realPress } from 'cypress-real-events/commands/realPress';
-
-/**
- * Press command fallback for Cypress 13 compatibility.
- * The press command is available in Cypress 14+ but not in Cypress 13.
- */
-Cypress.Commands.add('press', realPress);

--- a/apps/react-17-tests-v9/config/support/component.js
+++ b/apps/react-17-tests-v9/config/support/component.js
@@ -1,5 +1,0 @@
-// base config support file
-import '../../../../scripts/cypress/src/support/component';
-
-// custom commands
-import './commands';

--- a/apps/react-17-tests-v9/cypress-react-17.config.ts
+++ b/apps/react-17-tests-v9/cypress-react-17.config.ts
@@ -13,13 +13,7 @@ const specs = [
   path.resolve('../../packages/react-components/react-tabster/src/**/*.cy.{tsx,ts}'),
   ...excludedSpecs,
 ];
-const config = {
-  ...baseConfig,
-  component: {
-    ...baseConfig.component,
-    supportFile: path.resolve(__dirname, 'config/support/component.js'),
-  },
-};
+const config = { ...baseConfig };
 
 config.component.specPattern = specs;
 config.component.devServer.webpackConfig.resolve ??= {};

--- a/scripts/cypress/src/support/commands.js
+++ b/scripts/cypress/src/support/commands.js
@@ -28,3 +28,14 @@
 /**
  * Navigates to storybook story URL based on component name and story name
  */
+
+/**
+ * Press command fallback for Cypress 13 compatibility.
+ * Registers only on Cypress v13, where `cy.press` is not built-in.
+ */
+const CYPRESS_MAJOR_VERSION =
+  typeof Cypress !== 'undefined' && Cypress.version ? Number(String(Cypress.version).split('.')[0]) : undefined;
+
+if (CYPRESS_MAJOR_VERSION === 13) {
+  Cypress.Commands.add('press', /** @type {any} */ (require('cypress-real-events/commands/realPress').realPress));
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

`scripts-cypress` includes conditional loading based of features based on Cypress versions in order to be able to keep 1 source of truth for integration and normal cypress testing

- reverts r17-tests-v9 cypress changes https://github.com/microsoft/fluentui/pull/34985 by encapsulation
- exposed during https://github.com/microsoft/fluentui/pull/35022

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
