### PR TITLE
fix(react-charting): Fixing donut colors and segment orders

### DIFF
--- a/change/@fluentui-react-charting-43e9af9f-0688-4320-bb12-7fa920daebf0.json
+++ b/change/@fluentui-react-charting-43e9af9f-0688-4320-bb12-7fa920daebf0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(react-charting): Fixing donut colors and segment orders",
+  "packageName": "@fluentui/react-charting",
+  "email": "120183316+srmukher@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charts/react-charting/etc/react-charting.api.md
+++ b/packages/charts/react-charting/etc/react-charting.api.md
@@ -608,6 +608,7 @@ export interface IDonutChartProps extends ICartesianChartProps {
     hideLabels?: boolean;
     innerRadius?: number;
     onRenderCalloutPerDataPoint?: IRenderFunction<IChartDataPoint>;
+    order?: 'default' | 'sorted';
     roundCorners?: boolean;
     showLabelsInPercent?: boolean;
     styles?: IStyleFunctionOrObject<IDonutChartStyleProps, IDonutChartStyles>;

--- a/packages/charts/react-charting/src/components/DeclarativeChart/DeclarativeChart.tsx
+++ b/packages/charts/react-charting/src/components/DeclarativeChart/DeclarativeChart.tsx
@@ -455,6 +455,7 @@ export const DeclarativeChart: React.FunctionComponent<DeclarativeChartProps> = 
     gridProperties.templateColumns === SINGLE_REPEAT
   ) {
     if (chart.type === 'donut') {
+      // If there are multiple data traces for donut/pie, picking the last one similar to plotly
       const keys = Object.keys(groupedTraces);
       keys.forEach((key, index) => {
         if (index < keys.length - 1) {

--- a/packages/charts/react-charting/src/components/DeclarativeChart/DeclarativeChart.tsx
+++ b/packages/charts/react-charting/src/components/DeclarativeChart/DeclarativeChart.tsx
@@ -454,11 +454,20 @@ export const DeclarativeChart: React.FunctionComponent<DeclarativeChartProps> = 
     gridProperties.templateRows === SINGLE_REPEAT &&
     gridProperties.templateColumns === SINGLE_REPEAT
   ) {
-    Object.keys(groupedTraces).forEach((key, index) => {
-      if (index > 0) {
-        delete groupedTraces[key];
-      }
-    });
+    if (chart.type === 'donut') {
+      const keys = Object.keys(groupedTraces);
+      keys.forEach((key, index) => {
+        if (index < keys.length - 1) {
+          delete groupedTraces[key];
+        }
+      });
+    } else {
+      Object.keys(groupedTraces).forEach((key, index) => {
+        if (index > 0) {
+          delete groupedTraces[key];
+        }
+      });
+    }
     isMultiPlot.current = false;
   }
 

--- a/packages/charts/react-charting/src/components/DeclarativeChart/DeclarativeChart.tsx
+++ b/packages/charts/react-charting/src/components/DeclarativeChart/DeclarativeChart.tsx
@@ -516,7 +516,6 @@ export const DeclarativeChart: React.FunctionComponent<DeclarativeChartProps> = 
             if (donutIdxs.length > 1 && donutIdxs.length === index.length) {
               groupIdxs = [donutIdxs[donutIdxs.length - 1]];
               filteredTracesInfo = validTracesFilteredIndex.filter(trace => groupIdxs.includes(trace.index));
-              // chartType = 'donut';
             }
           }
 

--- a/packages/charts/react-charting/src/components/DeclarativeChart/DeclarativeChart.tsx
+++ b/packages/charts/react-charting/src/components/DeclarativeChart/DeclarativeChart.tsx
@@ -454,8 +454,15 @@ export const DeclarativeChart: React.FunctionComponent<DeclarativeChartProps> = 
     gridProperties.templateRows === SINGLE_REPEAT &&
     gridProperties.templateColumns === SINGLE_REPEAT
   ) {
-    Object.keys(groupedTraces).forEach((key, index) => {
-      if (index > 0) {
+    const groupKeys = Object.keys(groupedTraces);
+    // If all traces are pie/donut-like, keep the LAST one; otherwise keep the FIRST
+    const allPieLike = plotlyInputWithValidData.data.every(d => {
+      const pd = d as Partial<PlotData> & { labels?: unknown; values?: unknown };
+      return pd?.type === 'pie' || pd?.hole !== undefined || (pd?.labels && pd?.values);
+    });
+    groupKeys.forEach((key, index) => {
+      const keepIndex = allPieLike ? groupKeys.length - 1 : 0;
+      if (index !== keepIndex) {
         delete groupedTraces[key];
       }
     });
@@ -482,12 +489,8 @@ export const DeclarativeChart: React.FunctionComponent<DeclarativeChartProps> = 
         }}
       >
         {Object.entries(groupedTraces).map(([xAxisKey, index]) => {
-          const plotlyInputForGroup: PlotlySchema = {
-            ...plotlyInputWithValidData,
-            data: index.map(idx => plotlyInputWithValidData.data[idx]),
-          };
-
-          const filteredTracesInfo = validTracesFilteredIndex.filter(trace => index.includes(trace.index));
+          // Determine chart type for this group first
+          let filteredTracesInfo = validTracesFilteredIndex.filter(trace => index.includes(trace.index));
           let chartType =
             validTracesFilteredIndex.some(trace => trace.type === FALLBACK_TYPE) || chart.type === FALLBACK_TYPE
               ? FALLBACK_TYPE
@@ -499,6 +502,28 @@ export const DeclarativeChart: React.FunctionComponent<DeclarativeChartProps> = 
           ) {
             chartType = 'line';
           }
+
+          // In single-plot mode, if multiple donut/pie traces are present in this group, pass only the last one
+          let groupIdxs = index;
+          if (!isMultiPlot.current && index.length > 1) {
+            const donutIdxs = index.filter(idx => {
+              const d = plotlyInputWithValidData.data[idx] as Partial<PlotData> & {
+                labels?: unknown;
+                values?: unknown;
+              };
+              return d?.type === 'pie' || d?.hole !== undefined || (d?.labels && d?.values);
+            });
+            if (donutIdxs.length > 1 && donutIdxs.length === index.length) {
+              groupIdxs = [donutIdxs[donutIdxs.length - 1]];
+              filteredTracesInfo = validTracesFilteredIndex.filter(trace => groupIdxs.includes(trace.index));
+              // chartType = 'donut';
+            }
+          }
+
+          const plotlyInputForGroup: PlotlySchema = {
+            ...plotlyInputWithValidData,
+            data: groupIdxs.map(idx => plotlyInputWithValidData.data[idx]),
+          };
 
           const chartEntry = chartMap[chartType as ChartType];
           if (chartEntry) {

--- a/packages/charts/react-charting/src/components/DeclarativeChart/PlotlyColorAdapter.ts
+++ b/packages/charts/react-charting/src/components/DeclarativeChart/PlotlyColorAdapter.ts
@@ -92,11 +92,11 @@ function tryMapFluentDataViz(
     return hexColor;
   }
   if (isDonut) {
-    const idx =
-      templateColorway === 'plotly'
-        ? DEFAULT_PLOTLY_COLORWAY.indexOf(hexColor.toLowerCase())
-        : DEFAULT_D3_COLORWAY.indexOf(hexColor.toLowerCase());
-    return idx !== -1 ? getColorFromToken(D3_FLUENTVIZ_COLORWAY_MAPPING[idx], !!isDarkTheme) : hexColor;
+    const defaultColorway = templateColorway === 'plotly' ? DEFAULT_PLOTLY_COLORWAY : DEFAULT_D3_COLORWAY;
+    const defaultMapping =
+      templateColorway === 'plotly' ? PLOTLY_FLUENTVIZ_COLORWAY_MAPPING : D3_FLUENTVIZ_COLORWAY_MAPPING;
+    const idx = defaultColorway.indexOf(hexColor.toLowerCase());
+    return idx !== -1 ? getColorFromToken(defaultMapping[idx], !!isDarkTheme) : hexColor;
   } else {
     const index = DEFAULT_PLOTLY_COLORWAY.indexOf(hexColor.toLowerCase());
     if (index !== -1) {
@@ -115,8 +115,11 @@ export const getColor = (
 ): string => {
   if (!colorMap.current.has(legendLabel)) {
     let nextColor: string;
-    const defaultColorMapping =
-      isDonut && templateColorway === 'plotly' ? PLOTLY_FLUENTVIZ_COLORWAY_MAPPING : D3_FLUENTVIZ_COLORWAY_MAPPING;
+    const defaultColorMapping = isDonut
+      ? templateColorway === 'plotly'
+        ? PLOTLY_FLUENTVIZ_COLORWAY_MAPPING
+        : D3_FLUENTVIZ_COLORWAY_MAPPING
+      : PLOTLY_FLUENTVIZ_COLORWAY_MAPPING;
     if (colorMap.current.size < defaultColorMapping.length) {
       // Get first 10 colors from plotly-fluentviz colorway mapping
       nextColor = getColorFromToken(defaultColorMapping[colorMap.current.size], isDarkTheme);

--- a/packages/charts/react-charting/src/components/DeclarativeChart/PlotlyColorAdapter.ts
+++ b/packages/charts/react-charting/src/components/DeclarativeChart/PlotlyColorAdapter.ts
@@ -91,17 +91,15 @@ function tryMapFluentDataViz(
   if (templateColorway !== 'plotly') {
     return hexColor;
   }
+  let defaultColorway: string[] = DEFAULT_PLOTLY_COLORWAY;
+  let defaultMapping: string[] = PLOTLY_FLUENTVIZ_COLORWAY_MAPPING;
   if (isDonut) {
-    const defaultColorway = templateColorway === 'plotly' ? DEFAULT_PLOTLY_COLORWAY : DEFAULT_D3_COLORWAY;
-    const defaultMapping =
-      templateColorway === 'plotly' ? PLOTLY_FLUENTVIZ_COLORWAY_MAPPING : D3_FLUENTVIZ_COLORWAY_MAPPING;
-    const idx = defaultColorway.indexOf(hexColor.toLowerCase());
-    return idx !== -1 ? getColorFromToken(defaultMapping[idx], !!isDarkTheme) : hexColor;
-  } else {
-    const index = DEFAULT_PLOTLY_COLORWAY.indexOf(hexColor.toLowerCase());
-    if (index !== -1) {
-      return getColorFromToken(PLOTLY_FLUENTVIZ_COLORWAY_MAPPING[index], isDarkTheme);
-    }
+    defaultColorway = templateColorway === 'plotly' ? DEFAULT_PLOTLY_COLORWAY : DEFAULT_D3_COLORWAY;
+    defaultMapping = templateColorway === 'plotly' ? PLOTLY_FLUENTVIZ_COLORWAY_MAPPING : D3_FLUENTVIZ_COLORWAY_MAPPING;
+  }
+  const idx = defaultColorway.indexOf(hexColor.toLowerCase());
+  if (idx !== -1) {
+    return getColorFromToken(defaultMapping[idx], !!isDarkTheme);
   }
   return hexColor;
 }

--- a/packages/charts/react-charting/src/components/DeclarativeChart/PlotlyColorAdapter.ts
+++ b/packages/charts/react-charting/src/components/DeclarativeChart/PlotlyColorAdapter.ts
@@ -68,11 +68,6 @@ export const D3_FLUENTVIZ_COLORWAY_MAPPING: string[] = [
   DataVizPalette.color3, // cyan/teal -> teal.tint20
 ];
 
-// Quick lookup from D3 hex to Fluent token
-export const D3_TO_FLUENT_TOKEN_BY_HEX: Record<string, string> = Object.fromEntries(
-  DEFAULT_D3_COLORWAY.map((hex, i) => [hex.toLowerCase(), D3_FLUENTVIZ_COLORWAY_MAPPING[i]]),
-);
-
 function getPlotlyColorway(colorway: string[] | undefined, isDonut: boolean = false): PlotlyColorway {
   const isPlotlyColorway =
     isArrayOrTypedArray(colorway) &&
@@ -94,8 +89,8 @@ function tryMapFluentDataViz(
     return hexColor;
   }
   if (isDonut) {
-    const idx = DEFAULT_PLOTLY_COLORWAY.indexOf(hexColor.toLowerCase());
-    return idx !== -1 ? getColorFromToken(DEFAULT_PLOTLY_COLORWAY[idx], !!isDarkTheme) : hexColor;
+    const idx = DEFAULT_D3_COLORWAY.indexOf(hexColor.toLowerCase());
+    return idx !== -1 ? getColorFromToken(D3_FLUENTVIZ_COLORWAY_MAPPING[idx], !!isDarkTheme) : hexColor;
   } else {
     const index = DEFAULT_PLOTLY_COLORWAY.indexOf(hexColor.toLowerCase());
     if (index !== -1) {

--- a/packages/charts/react-charting/src/components/DeclarativeChart/PlotlySchemaAdapter.ts
+++ b/packages/charts/react-charting/src/components/DeclarativeChart/PlotlySchemaAdapter.ts
@@ -495,7 +495,7 @@ export const transformPlotlyJsonToDonutProps = (
   const colors: string[] | string | null | undefined = extractColor(
     input.layout?.piecolorway ?? input.layout?.template?.layout?.colorway,
     colorwayType,
-    input.layout?.piecolorway ?? input.layout?.template?.layout?.colorway ?? firstData?.marker?.colors,
+    input.layout?.piecolorway ?? firstData?.marker?.colors,
     colorMap,
     isDarkTheme,
     true,

--- a/packages/charts/react-charting/src/components/DeclarativeChart/PlotlySchemaAdapter.ts
+++ b/packages/charts/react-charting/src/components/DeclarativeChart/PlotlySchemaAdapter.ts
@@ -558,7 +558,16 @@ export const transformPlotlyJsonToDonutProps = (
   const { chartTitle } = getTitles(input.layout);
   // Build anticlockwise order by keeping the first item, reversing the rest
   const legends = Object.keys(mapLegendToDataPoint);
-  const reorderedEntries = legends.map(key => [key, mapLegendToDataPoint[key]] as const);
+  const reorderedEntries =
+    legends.length > 1
+      ? ([
+          [legends[0], mapLegendToDataPoint[legends[0]]],
+          ...legends
+            .slice(1)
+            .reverse()
+            .map(key => [key, mapLegendToDataPoint[key]] as const),
+        ] as ReadonlyArray<readonly [string, IChartDataPoint]>)
+      : legends.map(key => [key, mapLegendToDataPoint[key]] as const);
   return {
     data: {
       chartTitle,
@@ -571,6 +580,7 @@ export const transformPlotlyJsonToDonutProps = (
     hideLabels,
     showLabelsInPercent: firstData.textinfo ? ['percent', 'label+percent'].includes(firstData.textinfo) : true,
     roundCorners: true,
+    order: 'sorted',
   };
 };
 

--- a/packages/charts/react-charting/src/components/DeclarativeChart/PlotlySchemaAdapter.ts
+++ b/packages/charts/react-charting/src/components/DeclarativeChart/PlotlySchemaAdapter.ts
@@ -488,7 +488,7 @@ export const transformPlotlyJsonToDonutProps = (
   colorwayType: ColorwayType,
   isDarkTheme?: boolean,
 ): IDonutChartProps => {
-  const firstData = input.data[input.data.length - 1] as Partial<PieData>;
+  const firstData = input.data[0] as Partial<PieData>;
   // extract colors for each series only once
   // use piecolorway if available
   // otherwise, default to colorway from template

--- a/packages/charts/react-charting/src/components/DeclarativeChart/PlotlySchemaAdapter.ts
+++ b/packages/charts/react-charting/src/components/DeclarativeChart/PlotlySchemaAdapter.ts
@@ -558,16 +558,7 @@ export const transformPlotlyJsonToDonutProps = (
   const { chartTitle } = getTitles(input.layout);
   // Build anticlockwise order by keeping the first item, reversing the rest
   const legends = Object.keys(mapLegendToDataPoint);
-  const reorderedEntries =
-    legends.length > 1
-      ? ([
-          [legends[0], mapLegendToDataPoint[legends[0]]],
-          ...legends
-            .slice(1)
-            .reverse()
-            .map(key => [key, mapLegendToDataPoint[key]] as const),
-        ] as ReadonlyArray<readonly [string, IChartDataPoint]>)
-      : legends.map(key => [key, mapLegendToDataPoint[key]] as const);
+  const reorderedEntries = legends.map(key => [key, mapLegendToDataPoint[key]] as const);
   return {
     data: {
       chartTitle,

--- a/packages/charts/react-charting/src/components/DeclarativeChart/PlotlySchemaAdapter.ts
+++ b/packages/charts/react-charting/src/components/DeclarativeChart/PlotlySchemaAdapter.ts
@@ -319,7 +319,7 @@ export const _getGaugeAxisColor = (
   isDarkTheme?: boolean,
 ): string => {
   const extractedColors = extractColor(colorway, colorwayType, color, colorMap, isDarkTheme);
-  return resolveColor(extractedColors, 0, '', colorMap, isDarkTheme);
+  return resolveColor(extractedColors, 0, '', colorMap, colorway, isDarkTheme);
 };
 
 export const resolveXAxisPoint = (
@@ -522,7 +522,17 @@ export const transformPlotlyJsonToDonutProps = (
     validPairs.sort((a, b) => (b.value as number) - (a.value as number));
     validPairs.forEach((pair, sortedIdx) => {
       const legend = `${pair.label}`;
-      const color: string = pair.color ?? resolveColor(colors, sortedIdx, legend, colorMap, isDarkTheme, true);
+      const color: string =
+        pair.color ??
+        resolveColor(
+          colors,
+          sortedIdx,
+          legend,
+          colorMap,
+          input.layout?.piecolorway ?? input.layout?.template?.layout?.colorway,
+          isDarkTheme,
+          true,
+        );
       if (!mapLegendToDataPoint[legend]) {
         mapLegendToDataPoint[legend] = {
           legend,
@@ -634,7 +644,14 @@ export const transformPlotlyJsonToVSBCProps = (
                 ? ((series.marker?.color as Color[])?.[index2 % (series.marker?.color as Color[]).length] as number)
                 : 0,
             )
-          : resolveColor(extractedBarColors, index2, legend, colorMap, isDarkTheme);
+          : resolveColor(
+              extractedBarColors,
+              index2,
+              legend,
+              colorMap,
+              input.layout?.template?.layout?.colorway,
+              isDarkTheme,
+            );
         const opacity = getOpacity(series, index2);
         const yVal: number | string = rangeYValues[index2] as number | string;
         const yAxisCalloutData = getFormattedCalloutYData(yVal, yAxisTickFormat);
@@ -649,7 +666,14 @@ export const transformPlotlyJsonToVSBCProps = (
             yMaxValue = Math.max(yMaxValue, yVal);
           }
         } else if (series.type === 'scatter' || !!fallbackVSBC) {
-          const lineColor = resolveColor(extractedLineColors, index1, legend, colorMap, isDarkTheme);
+          const lineColor = resolveColor(
+            extractedLineColors,
+            index1,
+            legend,
+            colorMap,
+            input.layout?.template?.layout?.colorway,
+            isDarkTheme,
+          );
           const lineOptions = getLineOptions(series.line);
           const legendShape = getLegendShape(series);
 
@@ -781,7 +805,14 @@ export const transformPlotlyJsonToGVBCProps = (
                 ? ((series.marker?.color as Color[])?.[xIndex % (series.marker?.color as Color[]).length] as number)
                 : 0,
             )
-          : resolveColor(extractedColors, xIndex, legend, colorMap, isDarkTheme);
+          : resolveColor(
+              extractedColors,
+              xIndex,
+              legend,
+              colorMap,
+              processedInput.layout?.template?.layout?.colorway,
+              isDarkTheme,
+            );
         const opacity = getOpacity(series, xIndex);
 
         const yVal: number = series.y![xIndex] as number;
@@ -890,7 +921,7 @@ export const transformPlotlyJsonToVBCProps = (
               ? ((series.marker?.color as Color[])?.[index % (series.marker?.color as Color[]).length] as number)
               : 0,
           )
-        : resolveColor(extractedColors, index, legend, colorMap, isDarkTheme);
+        : resolveColor(extractedColors, index, legend, colorMap, input.layout?.template?.layout?.colorway, isDarkTheme);
       const opacity = getOpacity(series, index);
       const yVal = calculateHistNorm(
         series.histnorm,
@@ -1030,7 +1061,14 @@ const transformPlotlyJsonToScatterTraceProps = (
       const isXYearCategory = isYearArray(series.x); // Consider year as categorical not numeric continuous axis
       const legend: string = legends[index];
       // resolve color for each legend's lines from the extracted colors
-      const seriesColor = resolveColor(extractedColors, index, legend, colorMap, isDarkTheme);
+      const seriesColor = resolveColor(
+        extractedColors,
+        index,
+        legend,
+        colorMap,
+        input.layout?.template?.layout?.colorway,
+        isDarkTheme,
+      );
       const seriesOpacity = getOpacity(series, index);
       mode = series.fill === 'tozeroy' ? 'tozeroy' : 'tonexty';
       // if mode contains 'text', we prioritize showing the text over curving the line
@@ -1175,7 +1213,7 @@ export const transformPlotlyJsonToHorizontalBarWithAxisProps = (
                   ? ((series.marker?.color as Color[])?.[i % (series.marker?.color as Color[]).length] as number)
                   : 0,
               )
-            : resolveColor(extractedColors, i, legend, colorMap, isDarkTheme);
+            : resolveColor(extractedColors, i, legend, colorMap, input.layout?.template?.layout?.colorway, isDarkTheme);
           const opacity = getOpacity(series, i);
 
           return {
@@ -1260,7 +1298,7 @@ export const transformPlotlyJsonToGanttChartProps = (
                   ? ((series.marker?.color as Color[])?.[i % (series.marker?.color as Color[]).length] as number)
                   : 0,
               )
-            : resolveColor(extractedColors, i, legend, colorMap, isDarkTheme);
+            : resolveColor(extractedColors, i, legend, colorMap, input.layout?.template?.layout?.colorway, isDarkTheme);
           const opacity = getOpacity(series, i);
           const base = convertXValueToNumber(series.base?.[i]);
           const xVal = convertXValueToNumber(series.x?.[i]);
@@ -1490,7 +1528,14 @@ export const transformPlotlyJsonToSankeyProps = (
   );
   const sankeyChartData = {
     nodes: node.label?.map((label: string, index: number) => {
-      const color = resolveColor(extractedNodeColors, index, label, colorMap, isDarkTheme);
+      const color = resolveColor(
+        extractedNodeColors,
+        index,
+        label,
+        colorMap,
+        input.layout?.template?.layout?.colorway,
+        isDarkTheme,
+      );
 
       return {
         nodeId: index,
@@ -1546,7 +1591,14 @@ export const transformPlotlyJsonToGaugeProps = (
     ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
       firstData.gauge.steps.map((step: any, index: number): IGaugeChartSegment => {
         const legend = step.name || `Segment ${index + 1}`;
-        const color = resolveColor(extractedColors, index, legend, colorMap, isDarkTheme);
+        const color = resolveColor(
+          extractedColors,
+          index,
+          legend,
+          colorMap,
+          input.layout?.template?.layout?.colorway,
+          isDarkTheme,
+        );
         return {
           legend,
           size: step.range?.[1] - step.range?.[0],
@@ -1585,7 +1637,14 @@ export const transformPlotlyJsonToGaugeProps = (
         colorMap,
         isDarkTheme,
       );
-      const color = resolveColor(extractedIncreasingDeltaColors, 0, '', colorMap, isDarkTheme);
+      const color = resolveColor(
+        extractedIncreasingDeltaColors,
+        0,
+        '',
+        colorMap,
+        input.layout?.template?.layout?.colorway,
+        isDarkTheme,
+      );
       sublabelColor = color;
     } else {
       sublabel = `\u25BC ${Math.abs(diff)}`;
@@ -1596,7 +1655,14 @@ export const transformPlotlyJsonToGaugeProps = (
         colorMap,
         isDarkTheme,
       );
-      const color = resolveColor(extractedDecreasingDeltaColors, 0, '', colorMap, isDarkTheme);
+      const color = resolveColor(
+        extractedDecreasingDeltaColors,
+        0,
+        '',
+        colorMap,
+        input.layout?.template?.layout?.colorway,
+        isDarkTheme,
+      );
       sublabelColor = color;
     }
   }
@@ -1888,7 +1954,14 @@ export const transformPlotlyJsonToFunnelChartProps = (
         isDarkTheme,
       );
       // Always use the first color for the series/category
-      const color = resolveColor(extractedColors, 0, category, colorMap, isDarkTheme);
+      const color = resolveColor(
+        extractedColors,
+        0,
+        category,
+        colorMap,
+        input.layout?.template?.layout?.colorway,
+        isDarkTheme,
+      );
       seriesColors[category] = color;
 
       const labels = series.labels ?? series.y ?? series.stage;
@@ -1933,7 +2006,14 @@ export const transformPlotlyJsonToFunnelChartProps = (
       );
 
       categories.forEach((label: string, i: number) => {
-        const color = resolveColor(extractedColors, i, label, colorMap, isDarkTheme);
+        const color = resolveColor(
+          extractedColors,
+          i,
+          label,
+          colorMap,
+          input.layout?.template?.layout?.colorway,
+          isDarkTheme,
+        );
         const valueNum = Number(values[i]);
         if (isNaN(valueNum)) {
           return;
@@ -2349,7 +2429,15 @@ export const getAllupLegendsProps = (
         pieSeries.labels?.forEach((label, labelIndex: number) => {
           const legend = `${label}`;
           // resolve color for each legend from the extracted colors
-          const color: string = resolveColor(colors, labelIndex, legend, colorMap, isDarkTheme, true);
+          const color: string = resolveColor(
+            colors,
+            labelIndex,
+            legend,
+            colorMap,
+            input.layout?.piecolorway ?? input.layout?.template?.layout?.colorway,
+            isDarkTheme,
+            true,
+          );
           if (legend !== '' && allupLegends.some(group => group.title === legend) === false) {
             allupLegends.push({
               title: legend,

--- a/packages/charts/react-charting/src/components/DeclarativeChart/PlotlySchemaAdapterUT.test.tsx
+++ b/packages/charts/react-charting/src/components/DeclarativeChart/PlotlySchemaAdapterUT.test.tsx
@@ -175,11 +175,11 @@ describe('correctYearMonth', () => {
 
 describe('getColor', () => {
   test('Should return color code when we had legend title', () => {
-    expect(getColor('test', { current: colorMap }, 'plotly', true)).toBe('#3487c7');
+    expect(getColor('test', { current: colorMap }, 'plotly', true)).toBe('#637cef');
   });
 
   test('Should return color code when we had legend title', () => {
-    expect(getColor('test', { current: colorMap }, 'plotly', false)).toBe('#3487c7');
+    expect(getColor('test', { current: colorMap }, 'plotly', false)).toBe('#637cef');
   });
 
   test('Should return color code when we had legend title is empty', () => {

--- a/packages/charts/react-charting/src/components/DeclarativeChart/PlotlySchemaAdapterUT.test.tsx
+++ b/packages/charts/react-charting/src/components/DeclarativeChart/PlotlySchemaAdapterUT.test.tsx
@@ -202,7 +202,7 @@ describe('transform Plotly Json To chart Props', () => {
         transformPlotlyJsonToDonutProps(plotlySchema, false, { current: colorMap }, 'default', true),
       ).toMatchSnapshot();
     } catch (e) {
-      expect(e).toStrictEqual(TypeError("Cannot read properties of undefined (reading 'length')"));
+      expect(e).toStrictEqual(TypeError("Cannot read properties of undefined (reading '0')"));
     }
   });
 

--- a/packages/charts/react-charting/src/components/DeclarativeChart/PlotlySchemaAdapterUT.test.tsx
+++ b/packages/charts/react-charting/src/components/DeclarativeChart/PlotlySchemaAdapterUT.test.tsx
@@ -202,7 +202,7 @@ describe('transform Plotly Json To chart Props', () => {
         transformPlotlyJsonToDonutProps(plotlySchema, false, { current: colorMap }, 'default', true),
       ).toMatchSnapshot();
     } catch (e) {
-      expect(e).toStrictEqual(TypeError("Cannot read properties of undefined (reading '0')"));
+      expect(e).toStrictEqual(TypeError("Cannot read properties of undefined (reading 'length')"));
     }
   });
 

--- a/packages/charts/react-charting/src/components/DeclarativeChart/PlotlySchemaAdapterUT.test.tsx
+++ b/packages/charts/react-charting/src/components/DeclarativeChart/PlotlySchemaAdapterUT.test.tsx
@@ -175,15 +175,15 @@ describe('correctYearMonth', () => {
 
 describe('getColor', () => {
   test('Should return color code when we had legend title', () => {
-    expect(getColor('test', { current: colorMap }, true)).toBe('#637cef');
+    expect(getColor('test', { current: colorMap }, 'plotly', true)).toBe('#3487c7');
   });
 
   test('Should return color code when we had legend title', () => {
-    expect(getColor('test', { current: colorMap }, false)).toBe('#637cef');
+    expect(getColor('test', { current: colorMap }, 'plotly', false)).toBe('#3487c7');
   });
 
   test('Should return color code when we had legend title is empty', () => {
-    expect(getColor('', { current: colorMap }, false)).toBe('#f7630c');
+    expect(getColor('', { current: colorMap }, 'plotly', false)).toBe('#f7630c');
   });
 });
 

--- a/packages/charts/react-charting/src/components/DeclarativeChart/__snapshots__/DeclarativeChartRTL.test.tsx.snap
+++ b/packages/charts/react-charting/src/components/DeclarativeChart/__snapshots__/DeclarativeChartRTL.test.tsx.snap
@@ -1544,7 +1544,7 @@ exports[`DeclarativeChart Should render donutchart in DeclarativeChart 1`] = `
 
                         {
                           cursor: default;
-                          fill: #9a3d0c;
+                          fill: #3487c7;
                           opacity: 0.1;
                           outline: transparent;
                           stroke: #ffffff;
@@ -1555,446 +1555,6 @@ exports[`DeclarativeChart Should render donutchart in DeclarativeChart 1`] = `
                     d="M0.58,-38.835A3,3,0,0,1,3.855,-41.823A42,42,0,0,1,39.24,-14.973A3,3,0,0,1,37.245,-11.014L-38.675,10.21Z"
                     data-is-focusable="false"
                     id="_Pie_1Merc7"
-                    role="img"
-                    tabindex="-1"
-                  />
-                </g>
-                <g>
-                  <path
-                    aria-label="Fiat, 2."
-                    class=
-
-                        {
-                          cursor: default;
-                          fill: #b146c2;
-                          opacity: 0.1;
-                          outline: transparent;
-                          stroke: #ffffff;
-                        }
-                        &::-moz-focus-inner {
-                          border: 0;
-                        }
-                    d="M37.557,-9.897A3,3,0,0,1,41.316,-7.547A42,42,0,0,1,41.991,0.868A3,3,0,0,1,38.655,3.787L-39.677,-5.07Z"
-                    data-is-focusable="false"
-                    id="_Pie_1Fiat2"
-                    role="img"
-                    tabindex="-1"
-                  />
-                </g>
-                <g>
-                  <path
-                    aria-label="Hornet, 2."
-                    class=
-
-                        {
-                          cursor: default;
-                          fill: #ad006a;
-                          opacity: 0.1;
-                          outline: transparent;
-                          stroke: #ffffff;
-                        }
-                        &::-moz-focus-inner {
-                          border: 0;
-                        }
-                    d="M38.524,4.94A3,3,0,0,1,41.125,8.53A42,42,0,0,1,38.588,16.583A3,3,0,0,1,34.399,18.034L-34.865,-19.607Z"
-                    data-is-focusable="false"
-                    id="_Pie_1Hornet2"
-                    role="img"
-                    tabindex="-1"
-                  />
-                </g>
-                <g>
-                  <path
-                    aria-label="Mazda, 2."
-                    class=
-
-                        {
-                          cursor: default;
-                          fill: #2c72a8;
-                          opacity: 0.1;
-                          outline: transparent;
-                          stroke: #ffffff;
-                        }
-                        &::-moz-focus-inner {
-                          border: 0;
-                        }
-                    d="M33.845,19.053A3,3,0,0,1,34.906,23.357A42,42,0,0,1,29.529,29.867A3,3,0,0,1,25.102,29.638L-24.943,-31.271Z"
-                    data-is-focusable="false"
-                    id="_Pie_1Mazda2"
-                    role="img"
-                    tabindex="-1"
-                  />
-                </g>
-                <g>
-                  <path
-                    aria-label="Toyota, 2."
-                    class=
-
-                        {
-                          cursor: default;
-                          fill: #6d5700;
-                          opacity: 0.1;
-                          outline: transparent;
-                          stroke: #ffffff;
-                        }
-                        &::-moz-focus-inner {
-                          border: 0;
-                        }
-                    d="M24.206,30.374A3,3,0,0,1,23.572,34.762A42,42,0,0,1,16.143,38.774A3,3,0,0,1,12.127,36.898L-11.365,-38.351Z"
-                    data-is-focusable="false"
-                    id="_Pie_1Toyota2"
-                    role="img"
-                    tabindex="-1"
-                  />
-                </g>
-                <g>
-                  <path
-                    aria-label="AMC, 1."
-                    class=
-
-                        {
-                          cursor: default;
-                          fill: #637cef;
-                          opacity: 0.1;
-                          outline: transparent;
-                          stroke: #ffffff;
-                        }
-                        &::-moz-focus-inner {
-                          border: 0;
-                        }
-                    d="M11.019,37.244A3,3,0,0,1,8.783,41.071A42,42,0,0,1,8.011,41.229A3,3,0,0,1,4.454,38.583L-3.416,-39.854Z"
-                    data-is-focusable="false"
-                    id="_Pie_1AMC1"
-                    role="img"
-                    tabindex="-1"
-                  />
-                </g>
-                <g>
-                  <path
-                    aria-label="Cadillac, 1."
-                    class=
-
-                        {
-                          cursor: default;
-                          fill: #f7630c;
-                          opacity: 1;
-                          outline: transparent;
-                          stroke: #ffffff;
-                        }
-                        &::-moz-focus-inner {
-                          border: 0;
-                        }
-                    d="M3.3,38.699A3,3,0,0,1,0.339,41.999A42,42,0,0,1,-0.448,41.998A3,3,0,0,1,-3.401,38.691L4.673,-39.726Z"
-                    data-is-focusable="true"
-                    id="_Pie_1Cadillac1"
-                    role="img"
-                    tabindex="0"
-                  />
-                </g>
-                <g>
-                  <path
-                    aria-label="Camaro, 1."
-                    class=
-
-                        {
-                          cursor: default;
-                          fill: #57811b;
-                          opacity: 0.1;
-                          outline: transparent;
-                          stroke: #ffffff;
-                        }
-                        &::-moz-focus-inner {
-                          border: 0;
-                        }
-                    d="M-4.554,38.572A3,3,0,0,1,-8.119,41.208A42,42,0,0,1,-8.89,41.048A3,3,0,0,1,-11.116,37.215L12.571,-37.973Z"
-                    data-is-focusable="false"
-                    id="_Pie_1Camaro1"
-                    role="img"
-                    tabindex="-1"
-                  />
-                </g>
-                <g>
-                  <path
-                    aria-label="Chrysler, 1."
-                    class=
-
-                        {
-                          cursor: default;
-                          fill: #9373c0;
-                          opacity: 0.1;
-                          outline: transparent;
-                          stroke: #ffffff;
-                        }
-                        &::-moz-focus-inner {
-                          border: 0;
-                        }
-                    d="M-12.223,36.866A3,3,0,0,1,-16.244,38.731A42,42,0,0,1,-16.968,38.42A3,3,0,0,1,-18.377,34.217L19.955,-34.667Z"
-                    data-is-focusable="false"
-                    id="_Pie_1Chrysler1"
-                    role="img"
-                    tabindex="-1"
-                  />
-                </g>
-                <g>
-                  <path
-                    aria-label="Datsun, 1."
-                    class=
-
-                        {
-                          cursor: default;
-                          fill: #ca5010;
-                          opacity: 0.1;
-                          outline: transparent;
-                          stroke: #ffffff;
-                        }
-                        &::-moz-focus-inner {
-                          border: 0;
-                        }
-                    d="M-19.391,33.653A3,3,0,0,1,-23.705,34.671A42,42,0,0,1,-24.351,34.22A3,3,0,0,1,-24.886,29.819L26.522,-29.943Z"
-                    data-is-focusable="false"
-                    id="_Pie_1Datsun1"
-                    role="img"
-                    tabindex="-1"
-                  />
-                </g>
-                <g>
-                  <path
-                    aria-label="Dodge, 1."
-                    class=
-
-                        {
-                          cursor: default;
-                          fill: #3a96dd;
-                          opacity: 0.1;
-                          outline: transparent;
-                          stroke: #ffffff;
-                        }
-                        &::-moz-focus-inner {
-                          border: 0;
-                        }
-                    d="M-25.766,29.063A3,3,0,0,1,-30.197,29.192A42,42,0,0,1,-30.739,28.62A3,3,0,0,1,-30.377,24.202L32.005,-23.994Z"
-                    data-is-focusable="false"
-                    id="_Pie_1Dodge1"
-                    role="img"
-                    tabindex="-1"
-                  />
-                </g>
-                <g>
-                  <path
-                    aria-label="Duster, 1."
-                    class=
-
-                        {
-                          cursor: default;
-                          fill: #e3008c;
-                          opacity: 0.1;
-                          outline: transparent;
-                          stroke: #ffffff;
-                        }
-                        &::-moz-focus-inner {
-                          border: 0;
-                        }
-                    d="M-31.087,23.284A3,3,0,0,1,-35.453,22.518A42,42,0,0,1,-35.869,21.85A3,3,0,0,1,-34.626,17.595L36.178,-17.063Z"
-                    data-is-focusable="false"
-                    id="_Pie_1Duster1"
-                    role="img"
-                    tabindex="-1"
-                  />
-                </g>
-                <g>
-                  <path
-                    aria-label="Ferrari, 1."
-                    class=
-
-                        {
-                          cursor: default;
-                          fill: #13a10e;
-                          opacity: 0.1;
-                          outline: transparent;
-                          stroke: #ffffff;
-                        }
-                        &::-moz-focus-inner {
-                          border: 0;
-                        }
-                    d="M-35.136,16.553A3,3,0,0,1,-39.259,14.924A42,42,0,0,1,-39.532,14.185A3,3,0,0,1,-37.458,10.267L38.872,-9.434Z"
-                    data-is-focusable="false"
-                    id="_Pie_1Ferrari1"
-                    role="img"
-                    tabindex="-1"
-                  />
-                </g>
-                <g>
-                  <path
-                    aria-label="Ford, 1."
-                    class=
-
-                        {
-                          cursor: default;
-                          fill: #ae8c00;
-                          opacity: 0.1;
-                          outline: transparent;
-                          stroke: #ffffff;
-                        }
-                        &::-moz-focus-inner {
-                          border: 0;
-                        }
-                    d="M-37.748,9.144A3,3,0,0,1,-41.459,6.719A42,42,0,0,1,-41.578,5.941A3,3,0,0,1,-38.758,2.52L39.975,-1.42Z"
-                    data-is-focusable="false"
-                    id="_Pie_1Ford1"
-                    role="img"
-                    tabindex="-1"
-                  />
-                </g>
-                <g>
-                  <path
-                    aria-label="Honda, 1."
-                    class=
-
-                        {
-                          cursor: default;
-                          fill: #3c51b4;
-                          opacity: 0.1;
-                          outline: transparent;
-                          stroke: #ffffff;
-                        }
-                        &::-moz-focus-inner {
-                          border: 0;
-                        }
-                    d="M-38.816,1.362A3,3,0,0,1,-41.963,-1.76A42,42,0,0,1,-41.923,-2.547A3,3,0,0,1,-38.472,-5.33L39.443,6.653Z"
-                    data-is-focusable="false"
-                    id="_Pie_1Honda1"
-                    role="img"
-                    tabindex="-1"
-                  />
-                </g>
-                <g>
-                  <path
-                    aria-label="Lincoln, 1."
-                    class=
-
-                        {
-                          cursor: default;
-                          fill: #026467;
-                          opacity: 0.1;
-                          outline: transparent;
-                          stroke: #ffffff;
-                        }
-                        &::-moz-focus-inner {
-                          border: 0;
-                        }
-                    d="M-38.296,-6.477A3,3,0,0,1,-40.751,-10.168A42,42,0,0,1,-40.553,-10.93A3,3,0,0,1,-36.613,-12.962L37.297,14.453Z"
-                    data-is-focusable="false"
-                    id="_Pie_1Lincoln1"
-                    role="img"
-                    tabindex="-1"
-                  />
-                </g>
-                <g>
-                  <path
-                    aria-label="Lotus, 1."
-                    class=
-
-                        {
-                          cursor: default;
-                          fill: #674c8c;
-                          opacity: 0.1;
-                          outline: transparent;
-                          stroke: #ffffff;
-                        }
-                        &::-moz-focus-inner {
-                          border: 0;
-                        }
-                    d="M-36.209,-14.05A3,3,0,0,1,-37.871,-18.16A42,42,0,0,1,-37.524,-18.867A3,3,0,0,1,-33.256,-20.064L33.626,21.663Z"
-                    data-is-focusable="false"
-                    id="_Pie_1Lotus1"
-                    role="img"
-                    tabindex="-1"
-                  />
-                </g>
-                <g>
-                  <path
-                    aria-label="Maserati, 1."
-                    class=
-
-                        {
-                          cursor: default;
-                          fill: #0e7a0b;
-                          opacity: 0.1;
-                          outline: transparent;
-                          stroke: #ffffff;
-                        }
-                        &::-moz-focus-inner {
-                          border: 0;
-                        }
-                    d="M-32.642,-21.048A3,3,0,0,1,-33.443,-25.409A42,42,0,0,1,-32.96,-26.031A3,3,0,0,1,-28.538,-26.345L28.58,27.986Z"
-                    data-is-focusable="false"
-                    id="_Pie_1Maserati1"
-                    role="img"
-                    tabindex="-1"
-                  />
-                </g>
-                <g>
-                  <path
-                    aria-label="Pontiac, 1."
-                    class=
-
-                        {
-                          cursor: default;
-                          fill: #405f14;
-                          opacity: 0.1;
-                          outline: transparent;
-                          stroke: #ffffff;
-                        }
-                        &::-moz-focus-inner {
-                          border: 0;
-                        }
-                    d="M-27.739,-27.186A3,3,0,0,1,-27.646,-31.618A42,42,0,0,1,-27.048,-32.131A3,3,0,0,1,-22.653,-31.549L22.364,33.164Z"
-                    data-is-focusable="false"
-                    id="_Pie_1Pontiac1"
-                    role="img"
-                    tabindex="-1"
-                  />
-                </g>
-                <g>
-                  <path
-                    aria-label="Porsche, 1."
-                    class=
-
-                        {
-                          cursor: default;
-                          fill: #863593;
-                          opacity: 0.1;
-                          outline: transparent;
-                          stroke: #ffffff;
-                        }
-                        &::-moz-focus-inner {
-                          border: 0;
-                        }
-                    d="M-21.701,-32.211A3,3,0,0,1,-20.718,-36.534A42,42,0,0,1,-20.03,-36.916A3,3,0,0,1,-15.842,-35.462L15.233,36.986Z"
-                    data-is-focusable="false"
-                    id="_Pie_1Porsche1"
-                    role="img"
-                    tabindex="-1"
-                  />
-                </g>
-                <g>
-                  <path
-                    aria-label="Valiant, 1."
-                    class=
-
-                        {
-                          cursor: default;
-                          fill: #4f6bed;
-                          opacity: 0.1;
-                          outline: transparent;
-                          stroke: #ffffff;
-                        }
-                        &::-moz-focus-inner {
-                          border: 0;
-                        }
-                    d="M-14.776,-35.919A3,3,0,0,1,-12.943,-39.956A42,42,0,0,1,-12.192,-40.192A3,3,0,0,1,-8.382,-37.924L7.48,39.294Z"
-                    data-is-focusable="false"
-                    id="_Pie_1Valiant1"
                     role="img"
                     tabindex="-1"
                   />
@@ -2014,9 +1574,449 @@ exports[`DeclarativeChart Should render donutchart in DeclarativeChart 1`] = `
                         &::-moz-focus-inner {
                           border: 0;
                         }
-                    d="M-7.246,-38.158A3,3,0,0,1,-4.639,-41.743A42,42,0,0,1,-3.855,-41.823A3,3,0,0,1,-0.58,-38.835L-0.58,39.996Z"
+                    d="M37.557,-9.897A3,3,0,0,1,41.316,-7.547A42,42,0,0,1,41.451,-6.771A3,3,0,0,1,38.7,-3.295L-39.938,2.219Z"
                     data-is-focusable="false"
                     id="_Pie_1Volvo1"
+                    role="img"
+                    tabindex="-1"
+                  />
+                </g>
+                <g>
+                  <path
+                    aria-label="Valiant, 1."
+                    class=
+
+                        {
+                          cursor: default;
+                          fill: #4f6bed;
+                          opacity: 0.1;
+                          outline: transparent;
+                          stroke: #ffffff;
+                        }
+                        &::-moz-focus-inner {
+                          border: 0;
+                        }
+                    d="M38.781,-2.138A3,3,0,0,1,41.99,0.921A42,42,0,0,1,41.965,1.708A3,3,0,0,1,38.571,4.56L-39.568,-5.863Z"
+                    data-is-focusable="false"
+                    id="_Pie_1Valiant1"
+                    role="img"
+                    tabindex="-1"
+                  />
+                </g>
+                <g>
+                  <path
+                    aria-label="Porsche, 1."
+                    class=
+
+                        {
+                          cursor: default;
+                          fill: #6d5700;
+                          opacity: 0.1;
+                          outline: transparent;
+                          stroke: #ffffff;
+                        }
+                        &::-moz-focus-inner {
+                          border: 0;
+                        }
+                    d="M38.418,5.709A3,3,0,0,1,40.946,9.351A42,42,0,0,1,40.763,10.117A3,3,0,0,1,36.865,12.227L-37.579,-13.705Z"
+                    data-is-focusable="false"
+                    id="_Pie_1Porsche1"
+                    role="img"
+                    tabindex="-1"
+                  />
+                </g>
+                <g>
+                  <path
+                    aria-label="Pontiac, 1."
+                    class=
+
+                        {
+                          cursor: default;
+                          fill: #863593;
+                          opacity: 0.1;
+                          outline: transparent;
+                          stroke: #ffffff;
+                        }
+                        &::-moz-focus-inner {
+                          border: 0;
+                        }
+                    d="M36.483,13.323A3,3,0,0,1,38.227,17.399A42,42,0,0,1,37.894,18.112A3,3,0,0,1,33.65,19.395L-34.053,-20.986Z"
+                    data-is-focusable="false"
+                    id="_Pie_1Pontiac1"
+                    role="img"
+                    tabindex="-1"
+                  />
+                </g>
+                <g>
+                  <path
+                    aria-label="Maserati, 1."
+                    class=
+
+                        {
+                          cursor: default;
+                          fill: #405f14;
+                          opacity: 0.1;
+                          outline: transparent;
+                          stroke: #ffffff;
+                        }
+                        &::-moz-focus-inner {
+                          border: 0;
+                        }
+                    d="M33.056,20.391A3,3,0,0,1,33.944,24.735A42,42,0,0,1,33.474,25.367A3,3,0,0,1,29.06,25.769L-29.134,-27.409Z"
+                    data-is-focusable="false"
+                    id="_Pie_1Maserati1"
+                    role="img"
+                    tabindex="-1"
+                  />
+                </g>
+                <g>
+                  <path
+                    aria-label="Lotus, 1."
+                    class=
+
+                        {
+                          cursor: default;
+                          fill: #9a3d0c;
+                          opacity: 0.1;
+                          outline: transparent;
+                          stroke: #ffffff;
+                        }
+                        &::-moz-focus-inner {
+                          border: 0;
+                        }
+                    d="M28.277,26.626A3,3,0,0,1,28.273,31.059A42,42,0,0,1,27.685,31.584A3,3,0,0,1,23.28,31.09L-23.023,-32.71Z"
+                    data-is-focusable="false"
+                    id="_Pie_1Lotus1"
+                    role="img"
+                    tabindex="-1"
+                  />
+                </g>
+                <g>
+                  <path
+                    aria-label="Lincoln, 1."
+                    class=
+
+                        {
+                          cursor: default;
+                          fill: #2c72a8;
+                          opacity: 0.1;
+                          outline: transparent;
+                          stroke: #ffffff;
+                        }
+                        &::-moz-focus-inner {
+                          border: 0;
+                        }
+                    d="M22.341,31.771A3,3,0,0,1,21.445,36.113A42,42,0,0,1,20.764,36.508A3,3,0,0,1,16.548,35.138L-15.97,-36.674Z"
+                    data-is-focusable="false"
+                    id="_Pie_1Lincoln1"
+                    role="img"
+                    tabindex="-1"
+                  />
+                </g>
+                <g>
+                  <path
+                    aria-label="Honda, 1."
+                    class=
+
+                        {
+                          cursor: default;
+                          fill: #0e7a0b;
+                          opacity: 0.1;
+                          outline: transparent;
+                          stroke: #ffffff;
+                        }
+                        &::-moz-focus-inner {
+                          border: 0;
+                        }
+                    d="M15.491,35.617A3,3,0,0,1,13.74,39.689A42,42,0,0,1,12.993,39.94A3,3,0,0,1,9.139,37.749L-8.264,-39.137Z"
+                    data-is-focusable="false"
+                    id="_Pie_1Honda1"
+                    role="img"
+                    tabindex="-1"
+                  />
+                </g>
+                <g>
+                  <path
+                    aria-label="Ford, 1."
+                    class=
+
+                        {
+                          cursor: default;
+                          fill: #674c8c;
+                          opacity: 0.1;
+                          outline: transparent;
+                          stroke: #ffffff;
+                        }
+                        &::-moz-focus-inner {
+                          border: 0;
+                        }
+                    d="M8.008,38.005A3,3,0,0,1,5.473,41.642A42,42,0,0,1,4.691,41.737A3,3,0,0,1,1.357,38.816L-0.22,-39.999Z"
+                    data-is-focusable="false"
+                    id="_Pie_1Ford1"
+                    role="img"
+                    tabindex="-1"
+                  />
+                </g>
+                <g>
+                  <path
+                    aria-label="Ferrari, 1."
+                    class=
+
+                        {
+                          cursor: default;
+                          fill: #026467;
+                          opacity: 0.1;
+                          outline: transparent;
+                          stroke: #ffffff;
+                        }
+                        &::-moz-focus-inner {
+                          border: 0;
+                        }
+                    d="M0.197,38.839A3,3,0,0,1,-3.018,41.891A42,42,0,0,1,-3.803,41.827A3,3,0,0,1,-6.482,38.295L7.833,-39.226Z"
+                    data-is-focusable="false"
+                    id="_Pie_1Ferrari1"
+                    role="img"
+                    tabindex="-1"
+                  />
+                </g>
+                <g>
+                  <path
+                    aria-label="Duster, 1."
+                    class=
+
+                        {
+                          cursor: default;
+                          fill: #ad006a;
+                          opacity: 0.1;
+                          outline: transparent;
+                          stroke: #ffffff;
+                        }
+                        &::-moz-focus-inner {
+                          border: 0;
+                        }
+                    d="M-7.622,38.084A3,3,0,0,1,-11.386,40.427A42,42,0,0,1,-12.142,40.207A3,3,0,0,1,-14.055,36.208L15.566,-36.847Z"
+                    data-is-focusable="false"
+                    id="_Pie_1Duster1"
+                    role="img"
+                    tabindex="-1"
+                  />
+                </g>
+                <g>
+                  <path
+                    aria-label="Dodge, 1."
+                    class=
+
+                        {
+                          cursor: default;
+                          fill: #3c51b4;
+                          opacity: 0.1;
+                          outline: transparent;
+                          stroke: #ffffff;
+                        }
+                        &::-moz-focus-inner {
+                          border: 0;
+                        }
+                    d="M-15.13,35.772A3,3,0,0,1,-19.287,37.309A42,42,0,0,1,-19.984,36.941A3,3,0,0,1,-21.053,32.639L22.662,-32.961Z"
+                    data-is-focusable="false"
+                    id="_Pie_1Dodge1"
+                    role="img"
+                    tabindex="-1"
+                  />
+                </g>
+                <g>
+                  <path
+                    aria-label="Datsun, 1."
+                    class=
+
+                        {
+                          cursor: default;
+                          fill: #2aa0a4;
+                          opacity: 0.1;
+                          outline: transparent;
+                          stroke: #ffffff;
+                        }
+                        &::-moz-focus-inner {
+                          border: 0;
+                        }
+                    d="M-22.018,31.996A3,3,0,0,1,-26.4,32.665A42,42,0,0,1,-27.008,32.165A3,3,0,0,1,-27.19,27.735L28.83,-27.727Z"
+                    data-is-focusable="false"
+                    id="_Pie_1Datsun1"
+                    role="img"
+                    tabindex="-1"
+                  />
+                </g>
+                <g>
+                  <path
+                    aria-label="Chrysler, 1."
+                    class=
+
+                        {
+                          cursor: default;
+                          fill: #ae8c00;
+                          opacity: 0.1;
+                          outline: transparent;
+                          stroke: #ffffff;
+                        }
+                        &::-moz-focus-inner {
+                          border: 0;
+                        }
+                    d="M-28.006,26.911A3,3,0,0,1,-32.433,26.685A42,42,0,0,1,-32.928,26.072A3,3,0,0,1,-32.214,21.697L33.82,-21.359Z"
+                    data-is-focusable="false"
+                    id="_Pie_1Chrysler1"
+                    role="img"
+                    tabindex="-1"
+                  />
+                </g>
+                <g>
+                  <path
+                    aria-label="Camaro, 1."
+                    class=
+
+                        {
+                          cursor: default;
+                          fill: #dbdbdb;
+                          opacity: 0.1;
+                          outline: transparent;
+                          stroke: #ffffff;
+                        }
+                        &::-moz-focus-inner {
+                          border: 0;
+                        }
+                    d="M-32.848,20.725A3,3,0,0,1,-37.139,19.613A42,42,0,0,1,-37.5,18.913A3,3,0,0,1,-35.921,14.771L37.426,-14.117Z"
+                    data-is-focusable="false"
+                    id="_Pie_1Camaro1"
+                    role="img"
+                    tabindex="-1"
+                  />
+                </g>
+                <g>
+                  <path
+                    aria-label="Cadillac, 1."
+                    class=
+
+                        {
+                          cursor: default;
+                          fill: #ea38a6;
+                          opacity: 1;
+                          outline: transparent;
+                          stroke: #ffffff;
+                        }
+                        &::-moz-focus-inner {
+                          border: 0;
+                        }
+                    d="M-36.346,13.692A3,3,0,0,1,-40.326,11.739A42,42,0,0,1,-40.539,10.981A3,3,0,0,1,-38.159,7.241L39.501,-6.298Z"
+                    data-is-focusable="true"
+                    id="_Pie_1Cadillac1"
+                    role="img"
+                    tabindex="0"
+                  />
+                </g>
+                <g>
+                  <path
+                    aria-label="AMC, 1."
+                    class=
+
+                        {
+                          cursor: default;
+                          fill: #9a3d0c;
+                          opacity: 0.1;
+                          outline: transparent;
+                          stroke: #ffffff;
+                        }
+                        &::-moz-focus-inner {
+                          border: 0;
+                        }
+                    d="M-38.358,6.098A3,3,0,0,1,-41.863,3.385A42,42,0,0,1,-41.919,2.599A3,3,0,0,1,-38.835,-0.585L39.96,1.779Z"
+                    data-is-focusable="false"
+                    id="_Pie_1AMC1"
+                    role="img"
+                    tabindex="-1"
+                  />
+                </g>
+                <g>
+                  <path
+                    aria-label="Toyota, 2."
+                    class=
+
+                        {
+                          cursor: default;
+                          fill: #9373c0;
+                          opacity: 0.1;
+                          outline: transparent;
+                          stroke: #ffffff;
+                        }
+                        &::-moz-focus-inner {
+                          border: 0;
+                        }
+                    d="M-38.8,-1.745A3,3,0,0,1,-41.688,-5.108A42,42,0,0,1,-39.824,-13.342A3,3,0,0,1,-35.77,-15.134L36.364,16.664Z"
+                    data-is-focusable="false"
+                    id="_Pie_1Toyota2"
+                    role="img"
+                    tabindex="-1"
+                  />
+                </g>
+                <g>
+                  <path
+                    aria-label="Mazda, 2."
+                    class=
+
+                        {
+                          cursor: default;
+                          fill: #c50f1f;
+                          opacity: 0.1;
+                          outline: transparent;
+                          stroke: #ffffff;
+                        }
+                        &::-moz-focus-inner {
+                          border: 0;
+                        }
+                    d="M-35.302,-16.196A3,3,0,0,1,-36.714,-20.398A42,42,0,0,1,-31.893,-27.328A3,3,0,0,1,-27.462,-27.466L27.438,29.106Z"
+                    data-is-focusable="false"
+                    id="_Pie_1Mazda2"
+                    role="img"
+                    tabindex="-1"
+                  />
+                </g>
+                <g>
+                  <path
+                    aria-label="Hornet, 2."
+                    class=
+
+                        {
+                          cursor: default;
+                          fill: #13a10e;
+                          opacity: 0.1;
+                          outline: transparent;
+                          stroke: #ffffff;
+                        }
+                        &::-moz-focus-inner {
+                          border: 0;
+                        }
+                    d="M-26.63,-28.273A3,3,0,0,1,-26.359,-32.698A42,42,0,0,1,-19.287,-37.309A3,3,0,0,1,-15.13,-35.772L14.491,37.283Z"
+                    data-is-focusable="false"
+                    id="_Pie_1Hornet2"
+                    role="img"
+                    tabindex="-1"
+                  />
+                </g>
+                <g>
+                  <path
+                    aria-label="Fiat, 2."
+                    class=
+
+                        {
+                          cursor: default;
+                          fill: #f7630c;
+                          opacity: 0.1;
+                          outline: transparent;
+                          stroke: #ffffff;
+                        }
+                        &::-moz-focus-inner {
+                          border: 0;
+                        }
+                    d="M-14.055,-36.208A3,3,0,0,1,-12.142,-40.207A42,42,0,0,1,-3.855,-41.823A3,3,0,0,1,-0.58,-38.835L-0.58,39.996Z"
+                    data-is-focusable="false"
+                    id="_Pie_1Fiat2"
                     role="img"
                     tabindex="-1"
                   />
@@ -2173,7 +2173,7 @@ exports[`DeclarativeChart Should render donutchart in DeclarativeChart 1`] = `
 
                                   {
                                     background-color: #ffffff;
-                                    border-color: #9a3d0c;
+                                    border-color: #3487c7;
                                     border: 1px solid;
                                     content: ;
                                     height: 12px;
@@ -2213,7 +2213,7 @@ exports[`DeclarativeChart Should render donutchart in DeclarativeChart 1`] = `
                           role="none"
                         >
                           <button
-                            aria-label="Fiat"
+                            aria-label="Volvo"
                             aria-posinset="2"
                             aria-selected="false"
                             aria-setsize="22"
@@ -2273,7 +2273,7 @@ exports[`DeclarativeChart Should render donutchart in DeclarativeChart 1`] = `
 
                                   {
                                     background-color: #ffffff;
-                                    border-color: #b146c2;
+                                    border-color: #ea38a6;
                                     border: 1px solid;
                                     content: ;
                                     height: 12px;
@@ -2299,1807 +2299,7 @@ exports[`DeclarativeChart Should render donutchart in DeclarativeChart 1`] = `
                                     opacity: 0.67;
                                   }
                             >
-                              Fiat
-                            </div>
-                          </button>
-                        </div>
-                        <div
-                          class=
-                              ms-OverflowSet-item
-                              {
-                                display: inherit;
-                                flex-shrink: 0;
-                              }
-                          role="none"
-                        >
-                          <button
-                            aria-label="Hornet"
-                            aria-posinset="3"
-                            aria-selected="false"
-                            aria-setsize="22"
-                            class=
-
-                                {
-                                  align-items: center;
-                                  background: none;
-                                  border: none;
-                                  cursor: pointer;
-                                  display: flex;
-                                  outline: transparent;
-                                  padding-bottom: 8px;
-                                  padding-left: 8px;
-                                  padding-right: 8px;
-                                  padding-top: 8px;
-                                  position: relative;
-                                  text-transform: capitalize;
-                                }
-                                &::-moz-focus-inner {
-                                  border: 0;
-                                }
-                                .ms-Fabric--isFocusVisible &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                            data-is-focusable="true"
-                            role="option"
-                            tabindex="-1"
-                          >
-                            <div
-                              class=
-
-                                  {
-                                    background-color: #ffffff;
-                                    border-color: #ad006a;
-                                    border: 1px solid;
-                                    content: ;
-                                    height: 12px;
-                                    margin-right: 8px;
-                                    width: 12px;
-                                  }
-                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
-                                    content: linear-gradient(to right, #ffffff, #ffffff);
-                                    opacity: 0.6;
-                                  }
-                            />
-                            <div
-                              class=
-
-                                  {
-                                    -moz-osx-font-smoothing: grayscale;
-                                    -webkit-font-smoothing: antialiased;
-                                    color: #323130;
-                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                    font-size: 12px;
-                                    font-weight: 400;
-                                    line-height: 16px;
-                                    opacity: 0.67;
-                                  }
-                            >
-                              Hornet
-                            </div>
-                          </button>
-                        </div>
-                        <div
-                          class=
-                              ms-OverflowSet-item
-                              {
-                                display: inherit;
-                                flex-shrink: 0;
-                              }
-                          role="none"
-                        >
-                          <button
-                            aria-label="Mazda"
-                            aria-posinset="4"
-                            aria-selected="false"
-                            aria-setsize="22"
-                            class=
-
-                                {
-                                  align-items: center;
-                                  background: none;
-                                  border: none;
-                                  cursor: pointer;
-                                  display: flex;
-                                  outline: transparent;
-                                  padding-bottom: 8px;
-                                  padding-left: 8px;
-                                  padding-right: 8px;
-                                  padding-top: 8px;
-                                  position: relative;
-                                  text-transform: capitalize;
-                                }
-                                &::-moz-focus-inner {
-                                  border: 0;
-                                }
-                                .ms-Fabric--isFocusVisible &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                            data-is-focusable="true"
-                            role="option"
-                            tabindex="-1"
-                          >
-                            <div
-                              class=
-
-                                  {
-                                    background-color: #ffffff;
-                                    border-color: #2c72a8;
-                                    border: 1px solid;
-                                    content: ;
-                                    height: 12px;
-                                    margin-right: 8px;
-                                    width: 12px;
-                                  }
-                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
-                                    content: linear-gradient(to right, #ffffff, #ffffff);
-                                    opacity: 0.6;
-                                  }
-                            />
-                            <div
-                              class=
-
-                                  {
-                                    -moz-osx-font-smoothing: grayscale;
-                                    -webkit-font-smoothing: antialiased;
-                                    color: #323130;
-                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                    font-size: 12px;
-                                    font-weight: 400;
-                                    line-height: 16px;
-                                    opacity: 0.67;
-                                  }
-                            >
-                              Mazda
-                            </div>
-                          </button>
-                        </div>
-                        <div
-                          class=
-                              ms-OverflowSet-item
-                              {
-                                display: inherit;
-                                flex-shrink: 0;
-                              }
-                          role="none"
-                        >
-                          <button
-                            aria-label="Toyota"
-                            aria-posinset="5"
-                            aria-selected="false"
-                            aria-setsize="22"
-                            class=
-
-                                {
-                                  align-items: center;
-                                  background: none;
-                                  border: none;
-                                  cursor: pointer;
-                                  display: flex;
-                                  outline: transparent;
-                                  padding-bottom: 8px;
-                                  padding-left: 8px;
-                                  padding-right: 8px;
-                                  padding-top: 8px;
-                                  position: relative;
-                                  text-transform: capitalize;
-                                }
-                                &::-moz-focus-inner {
-                                  border: 0;
-                                }
-                                .ms-Fabric--isFocusVisible &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                            data-is-focusable="true"
-                            role="option"
-                            tabindex="-1"
-                          >
-                            <div
-                              class=
-
-                                  {
-                                    background-color: #ffffff;
-                                    border-color: #6d5700;
-                                    border: 1px solid;
-                                    content: ;
-                                    height: 12px;
-                                    margin-right: 8px;
-                                    width: 12px;
-                                  }
-                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
-                                    content: linear-gradient(to right, #ffffff, #ffffff);
-                                    opacity: 0.6;
-                                  }
-                            />
-                            <div
-                              class=
-
-                                  {
-                                    -moz-osx-font-smoothing: grayscale;
-                                    -webkit-font-smoothing: antialiased;
-                                    color: #323130;
-                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                    font-size: 12px;
-                                    font-weight: 400;
-                                    line-height: 16px;
-                                    opacity: 0.67;
-                                  }
-                            >
-                              Toyota
-                            </div>
-                          </button>
-                        </div>
-                        <div
-                          class=
-                              ms-OverflowSet-item
-                              {
-                                display: inherit;
-                                flex-shrink: 0;
-                              }
-                          role="none"
-                        >
-                          <button
-                            aria-label="AMC"
-                            aria-posinset="6"
-                            aria-selected="false"
-                            aria-setsize="22"
-                            class=
-
-                                {
-                                  align-items: center;
-                                  background: none;
-                                  border: none;
-                                  cursor: pointer;
-                                  display: flex;
-                                  outline: transparent;
-                                  padding-bottom: 8px;
-                                  padding-left: 8px;
-                                  padding-right: 8px;
-                                  padding-top: 8px;
-                                  position: relative;
-                                  text-transform: capitalize;
-                                }
-                                &::-moz-focus-inner {
-                                  border: 0;
-                                }
-                                .ms-Fabric--isFocusVisible &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                            data-is-focusable="true"
-                            role="option"
-                            tabindex="-1"
-                          >
-                            <div
-                              class=
-
-                                  {
-                                    background-color: #ffffff;
-                                    border-color: #637cef;
-                                    border: 1px solid;
-                                    content: ;
-                                    height: 12px;
-                                    margin-right: 8px;
-                                    width: 12px;
-                                  }
-                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
-                                    content: linear-gradient(to right, #ffffff, #ffffff);
-                                    opacity: 0.6;
-                                  }
-                            />
-                            <div
-                              class=
-
-                                  {
-                                    -moz-osx-font-smoothing: grayscale;
-                                    -webkit-font-smoothing: antialiased;
-                                    color: #323130;
-                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                    font-size: 12px;
-                                    font-weight: 400;
-                                    line-height: 16px;
-                                    opacity: 0.67;
-                                  }
-                            >
-                              AMC
-                            </div>
-                          </button>
-                        </div>
-                        <div
-                          class=
-                              ms-OverflowSet-item
-                              {
-                                display: inherit;
-                                flex-shrink: 0;
-                              }
-                          role="none"
-                        >
-                          <button
-                            aria-label="Cadillac"
-                            aria-posinset="7"
-                            aria-selected="true"
-                            aria-setsize="22"
-                            class=
-
-                                {
-                                  align-items: center;
-                                  background: none;
-                                  border: none;
-                                  cursor: pointer;
-                                  display: flex;
-                                  outline: transparent;
-                                  padding-bottom: 8px;
-                                  padding-left: 8px;
-                                  padding-right: 8px;
-                                  padding-top: 8px;
-                                  position: relative;
-                                  text-transform: capitalize;
-                                }
-                                &::-moz-focus-inner {
-                                  border: 0;
-                                }
-                                .ms-Fabric--isFocusVisible &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                            data-is-focusable="true"
-                            role="option"
-                            tabindex="-1"
-                          >
-                            <div
-                              class=
-
-                                  {
-                                    background-color: #f7630c;
-                                    border-color: #f7630c;
-                                    border: 1px solid;
-                                    content: ;
-                                    height: 12px;
-                                    margin-right: 8px;
-                                    width: 12px;
-                                  }
-                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
-                                    content: linear-gradient(to right, #f7630c, #f7630c);
-                                    opacity: ;
-                                  }
-                            />
-                            <div
-                              class=
-
-                                  {
-                                    -moz-osx-font-smoothing: grayscale;
-                                    -webkit-font-smoothing: antialiased;
-                                    color: #323130;
-                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                    font-size: 12px;
-                                    font-weight: 400;
-                                    line-height: 16px;
-                                    opacity: ;
-                                  }
-                            >
-                              Cadillac
-                            </div>
-                          </button>
-                        </div>
-                        <div
-                          class=
-                              ms-OverflowSet-item
-                              {
-                                display: inherit;
-                                flex-shrink: 0;
-                              }
-                          role="none"
-                        >
-                          <button
-                            aria-label="Camaro"
-                            aria-posinset="8"
-                            aria-selected="false"
-                            aria-setsize="22"
-                            class=
-
-                                {
-                                  align-items: center;
-                                  background: none;
-                                  border: none;
-                                  cursor: pointer;
-                                  display: flex;
-                                  outline: transparent;
-                                  padding-bottom: 8px;
-                                  padding-left: 8px;
-                                  padding-right: 8px;
-                                  padding-top: 8px;
-                                  position: relative;
-                                  text-transform: capitalize;
-                                }
-                                &::-moz-focus-inner {
-                                  border: 0;
-                                }
-                                .ms-Fabric--isFocusVisible &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                            data-is-focusable="true"
-                            role="option"
-                            tabindex="-1"
-                          >
-                            <div
-                              class=
-
-                                  {
-                                    background-color: #ffffff;
-                                    border-color: #57811b;
-                                    border: 1px solid;
-                                    content: ;
-                                    height: 12px;
-                                    margin-right: 8px;
-                                    width: 12px;
-                                  }
-                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
-                                    content: linear-gradient(to right, #ffffff, #ffffff);
-                                    opacity: 0.6;
-                                  }
-                            />
-                            <div
-                              class=
-
-                                  {
-                                    -moz-osx-font-smoothing: grayscale;
-                                    -webkit-font-smoothing: antialiased;
-                                    color: #323130;
-                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                    font-size: 12px;
-                                    font-weight: 400;
-                                    line-height: 16px;
-                                    opacity: 0.67;
-                                  }
-                            >
-                              Camaro
-                            </div>
-                          </button>
-                        </div>
-                        <div
-                          class=
-                              ms-OverflowSet-item
-                              {
-                                display: inherit;
-                                flex-shrink: 0;
-                              }
-                          role="none"
-                        >
-                          <button
-                            aria-label="Chrysler"
-                            aria-posinset="9"
-                            aria-selected="false"
-                            aria-setsize="22"
-                            class=
-
-                                {
-                                  align-items: center;
-                                  background: none;
-                                  border: none;
-                                  cursor: pointer;
-                                  display: flex;
-                                  outline: transparent;
-                                  padding-bottom: 8px;
-                                  padding-left: 8px;
-                                  padding-right: 8px;
-                                  padding-top: 8px;
-                                  position: relative;
-                                  text-transform: capitalize;
-                                }
-                                &::-moz-focus-inner {
-                                  border: 0;
-                                }
-                                .ms-Fabric--isFocusVisible &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                            data-is-focusable="true"
-                            role="option"
-                            tabindex="-1"
-                          >
-                            <div
-                              class=
-
-                                  {
-                                    background-color: #ffffff;
-                                    border-color: #9373c0;
-                                    border: 1px solid;
-                                    content: ;
-                                    height: 12px;
-                                    margin-right: 8px;
-                                    width: 12px;
-                                  }
-                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
-                                    content: linear-gradient(to right, #ffffff, #ffffff);
-                                    opacity: 0.6;
-                                  }
-                            />
-                            <div
-                              class=
-
-                                  {
-                                    -moz-osx-font-smoothing: grayscale;
-                                    -webkit-font-smoothing: antialiased;
-                                    color: #323130;
-                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                    font-size: 12px;
-                                    font-weight: 400;
-                                    line-height: 16px;
-                                    opacity: 0.67;
-                                  }
-                            >
-                              Chrysler
-                            </div>
-                          </button>
-                        </div>
-                        <div
-                          class=
-                              ms-OverflowSet-item
-                              {
-                                display: inherit;
-                                flex-shrink: 0;
-                              }
-                          role="none"
-                        >
-                          <button
-                            aria-label="Datsun"
-                            aria-posinset="10"
-                            aria-selected="false"
-                            aria-setsize="22"
-                            class=
-
-                                {
-                                  align-items: center;
-                                  background: none;
-                                  border: none;
-                                  cursor: pointer;
-                                  display: flex;
-                                  outline: transparent;
-                                  padding-bottom: 8px;
-                                  padding-left: 8px;
-                                  padding-right: 8px;
-                                  padding-top: 8px;
-                                  position: relative;
-                                  text-transform: capitalize;
-                                }
-                                &::-moz-focus-inner {
-                                  border: 0;
-                                }
-                                .ms-Fabric--isFocusVisible &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                            data-is-focusable="true"
-                            role="option"
-                            tabindex="-1"
-                          >
-                            <div
-                              class=
-
-                                  {
-                                    background-color: #ffffff;
-                                    border-color: #ca5010;
-                                    border: 1px solid;
-                                    content: ;
-                                    height: 12px;
-                                    margin-right: 8px;
-                                    width: 12px;
-                                  }
-                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
-                                    content: linear-gradient(to right, #ffffff, #ffffff);
-                                    opacity: 0.6;
-                                  }
-                            />
-                            <div
-                              class=
-
-                                  {
-                                    -moz-osx-font-smoothing: grayscale;
-                                    -webkit-font-smoothing: antialiased;
-                                    color: #323130;
-                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                    font-size: 12px;
-                                    font-weight: 400;
-                                    line-height: 16px;
-                                    opacity: 0.67;
-                                  }
-                            >
-                              Datsun
-                            </div>
-                          </button>
-                        </div>
-                        <div
-                          class=
-                              ms-OverflowSet-item
-                              {
-                                display: inherit;
-                                flex-shrink: 0;
-                              }
-                          role="none"
-                        >
-                          <button
-                            aria-label="Dodge"
-                            aria-posinset="11"
-                            aria-selected="false"
-                            aria-setsize="22"
-                            class=
-
-                                {
-                                  align-items: center;
-                                  background: none;
-                                  border: none;
-                                  cursor: pointer;
-                                  display: flex;
-                                  outline: transparent;
-                                  padding-bottom: 8px;
-                                  padding-left: 8px;
-                                  padding-right: 8px;
-                                  padding-top: 8px;
-                                  position: relative;
-                                  text-transform: capitalize;
-                                }
-                                &::-moz-focus-inner {
-                                  border: 0;
-                                }
-                                .ms-Fabric--isFocusVisible &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                            data-is-focusable="true"
-                            role="option"
-                            tabindex="-1"
-                          >
-                            <div
-                              class=
-
-                                  {
-                                    background-color: #ffffff;
-                                    border-color: #3a96dd;
-                                    border: 1px solid;
-                                    content: ;
-                                    height: 12px;
-                                    margin-right: 8px;
-                                    width: 12px;
-                                  }
-                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
-                                    content: linear-gradient(to right, #ffffff, #ffffff);
-                                    opacity: 0.6;
-                                  }
-                            />
-                            <div
-                              class=
-
-                                  {
-                                    -moz-osx-font-smoothing: grayscale;
-                                    -webkit-font-smoothing: antialiased;
-                                    color: #323130;
-                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                    font-size: 12px;
-                                    font-weight: 400;
-                                    line-height: 16px;
-                                    opacity: 0.67;
-                                  }
-                            >
-                              Dodge
-                            </div>
-                          </button>
-                        </div>
-                        <div
-                          class=
-                              ms-OverflowSet-item
-                              {
-                                display: inherit;
-                                flex-shrink: 0;
-                              }
-                          role="none"
-                        >
-                          <button
-                            aria-label="Duster"
-                            aria-posinset="12"
-                            aria-selected="false"
-                            aria-setsize="22"
-                            class=
-
-                                {
-                                  align-items: center;
-                                  background: none;
-                                  border: none;
-                                  cursor: pointer;
-                                  display: flex;
-                                  outline: transparent;
-                                  padding-bottom: 8px;
-                                  padding-left: 8px;
-                                  padding-right: 8px;
-                                  padding-top: 8px;
-                                  position: relative;
-                                  text-transform: capitalize;
-                                }
-                                &::-moz-focus-inner {
-                                  border: 0;
-                                }
-                                .ms-Fabric--isFocusVisible &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                            data-is-focusable="true"
-                            role="option"
-                            tabindex="-1"
-                          >
-                            <div
-                              class=
-
-                                  {
-                                    background-color: #ffffff;
-                                    border-color: #e3008c;
-                                    border: 1px solid;
-                                    content: ;
-                                    height: 12px;
-                                    margin-right: 8px;
-                                    width: 12px;
-                                  }
-                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
-                                    content: linear-gradient(to right, #ffffff, #ffffff);
-                                    opacity: 0.6;
-                                  }
-                            />
-                            <div
-                              class=
-
-                                  {
-                                    -moz-osx-font-smoothing: grayscale;
-                                    -webkit-font-smoothing: antialiased;
-                                    color: #323130;
-                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                    font-size: 12px;
-                                    font-weight: 400;
-                                    line-height: 16px;
-                                    opacity: 0.67;
-                                  }
-                            >
-                              Duster
-                            </div>
-                          </button>
-                        </div>
-                        <div
-                          class=
-                              ms-OverflowSet-item
-                              {
-                                display: inherit;
-                                flex-shrink: 0;
-                              }
-                          role="none"
-                        >
-                          <button
-                            aria-label="Ferrari"
-                            aria-posinset="13"
-                            aria-selected="false"
-                            aria-setsize="22"
-                            class=
-
-                                {
-                                  align-items: center;
-                                  background: none;
-                                  border: none;
-                                  cursor: pointer;
-                                  display: flex;
-                                  outline: transparent;
-                                  padding-bottom: 8px;
-                                  padding-left: 8px;
-                                  padding-right: 8px;
-                                  padding-top: 8px;
-                                  position: relative;
-                                  text-transform: capitalize;
-                                }
-                                &::-moz-focus-inner {
-                                  border: 0;
-                                }
-                                .ms-Fabric--isFocusVisible &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                            data-is-focusable="true"
-                            role="option"
-                            tabindex="-1"
-                          >
-                            <div
-                              class=
-
-                                  {
-                                    background-color: #ffffff;
-                                    border-color: #13a10e;
-                                    border: 1px solid;
-                                    content: ;
-                                    height: 12px;
-                                    margin-right: 8px;
-                                    width: 12px;
-                                  }
-                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
-                                    content: linear-gradient(to right, #ffffff, #ffffff);
-                                    opacity: 0.6;
-                                  }
-                            />
-                            <div
-                              class=
-
-                                  {
-                                    -moz-osx-font-smoothing: grayscale;
-                                    -webkit-font-smoothing: antialiased;
-                                    color: #323130;
-                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                    font-size: 12px;
-                                    font-weight: 400;
-                                    line-height: 16px;
-                                    opacity: 0.67;
-                                  }
-                            >
-                              Ferrari
-                            </div>
-                          </button>
-                        </div>
-                        <div
-                          class=
-                              ms-OverflowSet-item
-                              {
-                                display: inherit;
-                                flex-shrink: 0;
-                              }
-                          role="none"
-                        >
-                          <button
-                            aria-label="Ford"
-                            aria-posinset="14"
-                            aria-selected="false"
-                            aria-setsize="22"
-                            class=
-
-                                {
-                                  align-items: center;
-                                  background: none;
-                                  border: none;
-                                  cursor: pointer;
-                                  display: flex;
-                                  outline: transparent;
-                                  padding-bottom: 8px;
-                                  padding-left: 8px;
-                                  padding-right: 8px;
-                                  padding-top: 8px;
-                                  position: relative;
-                                  text-transform: capitalize;
-                                }
-                                &::-moz-focus-inner {
-                                  border: 0;
-                                }
-                                .ms-Fabric--isFocusVisible &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                            data-is-focusable="true"
-                            role="option"
-                            tabindex="-1"
-                          >
-                            <div
-                              class=
-
-                                  {
-                                    background-color: #ffffff;
-                                    border-color: #ae8c00;
-                                    border: 1px solid;
-                                    content: ;
-                                    height: 12px;
-                                    margin-right: 8px;
-                                    width: 12px;
-                                  }
-                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
-                                    content: linear-gradient(to right, #ffffff, #ffffff);
-                                    opacity: 0.6;
-                                  }
-                            />
-                            <div
-                              class=
-
-                                  {
-                                    -moz-osx-font-smoothing: grayscale;
-                                    -webkit-font-smoothing: antialiased;
-                                    color: #323130;
-                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                    font-size: 12px;
-                                    font-weight: 400;
-                                    line-height: 16px;
-                                    opacity: 0.67;
-                                  }
-                            >
-                              Ford
-                            </div>
-                          </button>
-                        </div>
-                        <div
-                          class=
-                              ms-OverflowSet-item
-                              {
-                                display: inherit;
-                                flex-shrink: 0;
-                              }
-                          role="none"
-                        >
-                          <button
-                            aria-label="Honda"
-                            aria-posinset="15"
-                            aria-selected="false"
-                            aria-setsize="22"
-                            class=
-
-                                {
-                                  align-items: center;
-                                  background: none;
-                                  border: none;
-                                  cursor: pointer;
-                                  display: flex;
-                                  outline: transparent;
-                                  padding-bottom: 8px;
-                                  padding-left: 8px;
-                                  padding-right: 8px;
-                                  padding-top: 8px;
-                                  position: relative;
-                                  text-transform: capitalize;
-                                }
-                                &::-moz-focus-inner {
-                                  border: 0;
-                                }
-                                .ms-Fabric--isFocusVisible &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                            data-is-focusable="true"
-                            role="option"
-                            tabindex="-1"
-                          >
-                            <div
-                              class=
-
-                                  {
-                                    background-color: #ffffff;
-                                    border-color: #3c51b4;
-                                    border: 1px solid;
-                                    content: ;
-                                    height: 12px;
-                                    margin-right: 8px;
-                                    width: 12px;
-                                  }
-                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
-                                    content: linear-gradient(to right, #ffffff, #ffffff);
-                                    opacity: 0.6;
-                                  }
-                            />
-                            <div
-                              class=
-
-                                  {
-                                    -moz-osx-font-smoothing: grayscale;
-                                    -webkit-font-smoothing: antialiased;
-                                    color: #323130;
-                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                    font-size: 12px;
-                                    font-weight: 400;
-                                    line-height: 16px;
-                                    opacity: 0.67;
-                                  }
-                            >
-                              Honda
-                            </div>
-                          </button>
-                        </div>
-                        <div
-                          class=
-                              ms-OverflowSet-item
-                              {
-                                display: inherit;
-                                flex-shrink: 0;
-                              }
-                          role="none"
-                        >
-                          <button
-                            aria-label="Lincoln"
-                            aria-posinset="16"
-                            aria-selected="false"
-                            aria-setsize="22"
-                            class=
-
-                                {
-                                  align-items: center;
-                                  background: none;
-                                  border: none;
-                                  cursor: pointer;
-                                  display: flex;
-                                  outline: transparent;
-                                  padding-bottom: 8px;
-                                  padding-left: 8px;
-                                  padding-right: 8px;
-                                  padding-top: 8px;
-                                  position: relative;
-                                  text-transform: capitalize;
-                                }
-                                &::-moz-focus-inner {
-                                  border: 0;
-                                }
-                                .ms-Fabric--isFocusVisible &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                            data-is-focusable="true"
-                            role="option"
-                            tabindex="-1"
-                          >
-                            <div
-                              class=
-
-                                  {
-                                    background-color: #ffffff;
-                                    border-color: #026467;
-                                    border: 1px solid;
-                                    content: ;
-                                    height: 12px;
-                                    margin-right: 8px;
-                                    width: 12px;
-                                  }
-                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
-                                    content: linear-gradient(to right, #ffffff, #ffffff);
-                                    opacity: 0.6;
-                                  }
-                            />
-                            <div
-                              class=
-
-                                  {
-                                    -moz-osx-font-smoothing: grayscale;
-                                    -webkit-font-smoothing: antialiased;
-                                    color: #323130;
-                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                    font-size: 12px;
-                                    font-weight: 400;
-                                    line-height: 16px;
-                                    opacity: 0.67;
-                                  }
-                            >
-                              Lincoln
-                            </div>
-                          </button>
-                        </div>
-                        <div
-                          class=
-                              ms-OverflowSet-item
-                              {
-                                display: inherit;
-                                flex-shrink: 0;
-                              }
-                          role="none"
-                        >
-                          <button
-                            aria-label="Lotus"
-                            aria-posinset="17"
-                            aria-selected="false"
-                            aria-setsize="22"
-                            class=
-
-                                {
-                                  align-items: center;
-                                  background: none;
-                                  border: none;
-                                  cursor: pointer;
-                                  display: flex;
-                                  outline: transparent;
-                                  padding-bottom: 8px;
-                                  padding-left: 8px;
-                                  padding-right: 8px;
-                                  padding-top: 8px;
-                                  position: relative;
-                                  text-transform: capitalize;
-                                }
-                                &::-moz-focus-inner {
-                                  border: 0;
-                                }
-                                .ms-Fabric--isFocusVisible &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                            data-is-focusable="true"
-                            role="option"
-                            tabindex="-1"
-                          >
-                            <div
-                              class=
-
-                                  {
-                                    background-color: #ffffff;
-                                    border-color: #674c8c;
-                                    border: 1px solid;
-                                    content: ;
-                                    height: 12px;
-                                    margin-right: 8px;
-                                    width: 12px;
-                                  }
-                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
-                                    content: linear-gradient(to right, #ffffff, #ffffff);
-                                    opacity: 0.6;
-                                  }
-                            />
-                            <div
-                              class=
-
-                                  {
-                                    -moz-osx-font-smoothing: grayscale;
-                                    -webkit-font-smoothing: antialiased;
-                                    color: #323130;
-                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                    font-size: 12px;
-                                    font-weight: 400;
-                                    line-height: 16px;
-                                    opacity: 0.67;
-                                  }
-                            >
-                              Lotus
-                            </div>
-                          </button>
-                        </div>
-                        <div
-                          class=
-                              ms-OverflowSet-item
-                              {
-                                display: inherit;
-                                flex-shrink: 0;
-                              }
-                          role="none"
-                        >
-                          <button
-                            aria-label="Maserati"
-                            aria-posinset="18"
-                            aria-selected="false"
-                            aria-setsize="22"
-                            class=
-
-                                {
-                                  align-items: center;
-                                  background: none;
-                                  border: none;
-                                  cursor: pointer;
-                                  display: flex;
-                                  outline: transparent;
-                                  padding-bottom: 8px;
-                                  padding-left: 8px;
-                                  padding-right: 8px;
-                                  padding-top: 8px;
-                                  position: relative;
-                                  text-transform: capitalize;
-                                }
-                                &::-moz-focus-inner {
-                                  border: 0;
-                                }
-                                .ms-Fabric--isFocusVisible &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                            data-is-focusable="true"
-                            role="option"
-                            tabindex="-1"
-                          >
-                            <div
-                              class=
-
-                                  {
-                                    background-color: #ffffff;
-                                    border-color: #0e7a0b;
-                                    border: 1px solid;
-                                    content: ;
-                                    height: 12px;
-                                    margin-right: 8px;
-                                    width: 12px;
-                                  }
-                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
-                                    content: linear-gradient(to right, #ffffff, #ffffff);
-                                    opacity: 0.6;
-                                  }
-                            />
-                            <div
-                              class=
-
-                                  {
-                                    -moz-osx-font-smoothing: grayscale;
-                                    -webkit-font-smoothing: antialiased;
-                                    color: #323130;
-                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                    font-size: 12px;
-                                    font-weight: 400;
-                                    line-height: 16px;
-                                    opacity: 0.67;
-                                  }
-                            >
-                              Maserati
-                            </div>
-                          </button>
-                        </div>
-                        <div
-                          class=
-                              ms-OverflowSet-item
-                              {
-                                display: inherit;
-                                flex-shrink: 0;
-                              }
-                          role="none"
-                        >
-                          <button
-                            aria-label="Pontiac"
-                            aria-posinset="19"
-                            aria-selected="false"
-                            aria-setsize="22"
-                            class=
-
-                                {
-                                  align-items: center;
-                                  background: none;
-                                  border: none;
-                                  cursor: pointer;
-                                  display: flex;
-                                  outline: transparent;
-                                  padding-bottom: 8px;
-                                  padding-left: 8px;
-                                  padding-right: 8px;
-                                  padding-top: 8px;
-                                  position: relative;
-                                  text-transform: capitalize;
-                                }
-                                &::-moz-focus-inner {
-                                  border: 0;
-                                }
-                                .ms-Fabric--isFocusVisible &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                            data-is-focusable="true"
-                            role="option"
-                            tabindex="-1"
-                          >
-                            <div
-                              class=
-
-                                  {
-                                    background-color: #ffffff;
-                                    border-color: #405f14;
-                                    border: 1px solid;
-                                    content: ;
-                                    height: 12px;
-                                    margin-right: 8px;
-                                    width: 12px;
-                                  }
-                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
-                                    content: linear-gradient(to right, #ffffff, #ffffff);
-                                    opacity: 0.6;
-                                  }
-                            />
-                            <div
-                              class=
-
-                                  {
-                                    -moz-osx-font-smoothing: grayscale;
-                                    -webkit-font-smoothing: antialiased;
-                                    color: #323130;
-                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                    font-size: 12px;
-                                    font-weight: 400;
-                                    line-height: 16px;
-                                    opacity: 0.67;
-                                  }
-                            >
-                              Pontiac
-                            </div>
-                          </button>
-                        </div>
-                        <div
-                          class=
-                              ms-OverflowSet-item
-                              {
-                                display: inherit;
-                                flex-shrink: 0;
-                              }
-                          role="none"
-                        >
-                          <button
-                            aria-label="Porsche"
-                            aria-posinset="20"
-                            aria-selected="false"
-                            aria-setsize="22"
-                            class=
-
-                                {
-                                  align-items: center;
-                                  background: none;
-                                  border: none;
-                                  cursor: pointer;
-                                  display: flex;
-                                  outline: transparent;
-                                  padding-bottom: 8px;
-                                  padding-left: 8px;
-                                  padding-right: 8px;
-                                  padding-top: 8px;
-                                  position: relative;
-                                  text-transform: capitalize;
-                                }
-                                &::-moz-focus-inner {
-                                  border: 0;
-                                }
-                                .ms-Fabric--isFocusVisible &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                            data-is-focusable="true"
-                            role="option"
-                            tabindex="-1"
-                          >
-                            <div
-                              class=
-
-                                  {
-                                    background-color: #ffffff;
-                                    border-color: #863593;
-                                    border: 1px solid;
-                                    content: ;
-                                    height: 12px;
-                                    margin-right: 8px;
-                                    width: 12px;
-                                  }
-                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
-                                    content: linear-gradient(to right, #ffffff, #ffffff);
-                                    opacity: 0.6;
-                                  }
-                            />
-                            <div
-                              class=
-
-                                  {
-                                    -moz-osx-font-smoothing: grayscale;
-                                    -webkit-font-smoothing: antialiased;
-                                    color: #323130;
-                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                    font-size: 12px;
-                                    font-weight: 400;
-                                    line-height: 16px;
-                                    opacity: 0.67;
-                                  }
-                            >
-                              Porsche
+                              Volvo
                             </div>
                           </button>
                         </div>
@@ -4114,7 +2314,7 @@ exports[`DeclarativeChart Should render donutchart in DeclarativeChart 1`] = `
                         >
                           <button
                             aria-label="Valiant"
-                            aria-posinset="21"
+                            aria-posinset="3"
                             aria-selected="false"
                             aria-setsize="22"
                             class=
@@ -4213,7 +2413,1807 @@ exports[`DeclarativeChart Should render donutchart in DeclarativeChart 1`] = `
                           role="none"
                         >
                           <button
-                            aria-label="Volvo"
+                            aria-label="Porsche"
+                            aria-posinset="4"
+                            aria-selected="false"
+                            aria-setsize="22"
+                            class=
+
+                                {
+                                  align-items: center;
+                                  background: none;
+                                  border: none;
+                                  cursor: pointer;
+                                  display: flex;
+                                  outline: transparent;
+                                  padding-bottom: 8px;
+                                  padding-left: 8px;
+                                  padding-right: 8px;
+                                  padding-top: 8px;
+                                  position: relative;
+                                  text-transform: capitalize;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                            data-is-focusable="true"
+                            role="option"
+                            tabindex="-1"
+                          >
+                            <div
+                              class=
+
+                                  {
+                                    background-color: #ffffff;
+                                    border-color: #6d5700;
+                                    border: 1px solid;
+                                    content: ;
+                                    height: 12px;
+                                    margin-right: 8px;
+                                    width: 12px;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
+                                    content: linear-gradient(to right, #ffffff, #ffffff);
+                                    opacity: 0.6;
+                                  }
+                            />
+                            <div
+                              class=
+
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    color: #323130;
+                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                    font-size: 12px;
+                                    font-weight: 400;
+                                    line-height: 16px;
+                                    opacity: 0.67;
+                                  }
+                            >
+                              Porsche
+                            </div>
+                          </button>
+                        </div>
+                        <div
+                          class=
+                              ms-OverflowSet-item
+                              {
+                                display: inherit;
+                                flex-shrink: 0;
+                              }
+                          role="none"
+                        >
+                          <button
+                            aria-label="Pontiac"
+                            aria-posinset="5"
+                            aria-selected="false"
+                            aria-setsize="22"
+                            class=
+
+                                {
+                                  align-items: center;
+                                  background: none;
+                                  border: none;
+                                  cursor: pointer;
+                                  display: flex;
+                                  outline: transparent;
+                                  padding-bottom: 8px;
+                                  padding-left: 8px;
+                                  padding-right: 8px;
+                                  padding-top: 8px;
+                                  position: relative;
+                                  text-transform: capitalize;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                            data-is-focusable="true"
+                            role="option"
+                            tabindex="-1"
+                          >
+                            <div
+                              class=
+
+                                  {
+                                    background-color: #ffffff;
+                                    border-color: #863593;
+                                    border: 1px solid;
+                                    content: ;
+                                    height: 12px;
+                                    margin-right: 8px;
+                                    width: 12px;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
+                                    content: linear-gradient(to right, #ffffff, #ffffff);
+                                    opacity: 0.6;
+                                  }
+                            />
+                            <div
+                              class=
+
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    color: #323130;
+                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                    font-size: 12px;
+                                    font-weight: 400;
+                                    line-height: 16px;
+                                    opacity: 0.67;
+                                  }
+                            >
+                              Pontiac
+                            </div>
+                          </button>
+                        </div>
+                        <div
+                          class=
+                              ms-OverflowSet-item
+                              {
+                                display: inherit;
+                                flex-shrink: 0;
+                              }
+                          role="none"
+                        >
+                          <button
+                            aria-label="Maserati"
+                            aria-posinset="6"
+                            aria-selected="false"
+                            aria-setsize="22"
+                            class=
+
+                                {
+                                  align-items: center;
+                                  background: none;
+                                  border: none;
+                                  cursor: pointer;
+                                  display: flex;
+                                  outline: transparent;
+                                  padding-bottom: 8px;
+                                  padding-left: 8px;
+                                  padding-right: 8px;
+                                  padding-top: 8px;
+                                  position: relative;
+                                  text-transform: capitalize;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                            data-is-focusable="true"
+                            role="option"
+                            tabindex="-1"
+                          >
+                            <div
+                              class=
+
+                                  {
+                                    background-color: #ffffff;
+                                    border-color: #405f14;
+                                    border: 1px solid;
+                                    content: ;
+                                    height: 12px;
+                                    margin-right: 8px;
+                                    width: 12px;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
+                                    content: linear-gradient(to right, #ffffff, #ffffff);
+                                    opacity: 0.6;
+                                  }
+                            />
+                            <div
+                              class=
+
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    color: #323130;
+                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                    font-size: 12px;
+                                    font-weight: 400;
+                                    line-height: 16px;
+                                    opacity: 0.67;
+                                  }
+                            >
+                              Maserati
+                            </div>
+                          </button>
+                        </div>
+                        <div
+                          class=
+                              ms-OverflowSet-item
+                              {
+                                display: inherit;
+                                flex-shrink: 0;
+                              }
+                          role="none"
+                        >
+                          <button
+                            aria-label="Lotus"
+                            aria-posinset="7"
+                            aria-selected="false"
+                            aria-setsize="22"
+                            class=
+
+                                {
+                                  align-items: center;
+                                  background: none;
+                                  border: none;
+                                  cursor: pointer;
+                                  display: flex;
+                                  outline: transparent;
+                                  padding-bottom: 8px;
+                                  padding-left: 8px;
+                                  padding-right: 8px;
+                                  padding-top: 8px;
+                                  position: relative;
+                                  text-transform: capitalize;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                            data-is-focusable="true"
+                            role="option"
+                            tabindex="-1"
+                          >
+                            <div
+                              class=
+
+                                  {
+                                    background-color: #ffffff;
+                                    border-color: #9a3d0c;
+                                    border: 1px solid;
+                                    content: ;
+                                    height: 12px;
+                                    margin-right: 8px;
+                                    width: 12px;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
+                                    content: linear-gradient(to right, #ffffff, #ffffff);
+                                    opacity: 0.6;
+                                  }
+                            />
+                            <div
+                              class=
+
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    color: #323130;
+                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                    font-size: 12px;
+                                    font-weight: 400;
+                                    line-height: 16px;
+                                    opacity: 0.67;
+                                  }
+                            >
+                              Lotus
+                            </div>
+                          </button>
+                        </div>
+                        <div
+                          class=
+                              ms-OverflowSet-item
+                              {
+                                display: inherit;
+                                flex-shrink: 0;
+                              }
+                          role="none"
+                        >
+                          <button
+                            aria-label="Lincoln"
+                            aria-posinset="8"
+                            aria-selected="false"
+                            aria-setsize="22"
+                            class=
+
+                                {
+                                  align-items: center;
+                                  background: none;
+                                  border: none;
+                                  cursor: pointer;
+                                  display: flex;
+                                  outline: transparent;
+                                  padding-bottom: 8px;
+                                  padding-left: 8px;
+                                  padding-right: 8px;
+                                  padding-top: 8px;
+                                  position: relative;
+                                  text-transform: capitalize;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                            data-is-focusable="true"
+                            role="option"
+                            tabindex="-1"
+                          >
+                            <div
+                              class=
+
+                                  {
+                                    background-color: #ffffff;
+                                    border-color: #2c72a8;
+                                    border: 1px solid;
+                                    content: ;
+                                    height: 12px;
+                                    margin-right: 8px;
+                                    width: 12px;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
+                                    content: linear-gradient(to right, #ffffff, #ffffff);
+                                    opacity: 0.6;
+                                  }
+                            />
+                            <div
+                              class=
+
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    color: #323130;
+                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                    font-size: 12px;
+                                    font-weight: 400;
+                                    line-height: 16px;
+                                    opacity: 0.67;
+                                  }
+                            >
+                              Lincoln
+                            </div>
+                          </button>
+                        </div>
+                        <div
+                          class=
+                              ms-OverflowSet-item
+                              {
+                                display: inherit;
+                                flex-shrink: 0;
+                              }
+                          role="none"
+                        >
+                          <button
+                            aria-label="Honda"
+                            aria-posinset="9"
+                            aria-selected="false"
+                            aria-setsize="22"
+                            class=
+
+                                {
+                                  align-items: center;
+                                  background: none;
+                                  border: none;
+                                  cursor: pointer;
+                                  display: flex;
+                                  outline: transparent;
+                                  padding-bottom: 8px;
+                                  padding-left: 8px;
+                                  padding-right: 8px;
+                                  padding-top: 8px;
+                                  position: relative;
+                                  text-transform: capitalize;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                            data-is-focusable="true"
+                            role="option"
+                            tabindex="-1"
+                          >
+                            <div
+                              class=
+
+                                  {
+                                    background-color: #ffffff;
+                                    border-color: #0e7a0b;
+                                    border: 1px solid;
+                                    content: ;
+                                    height: 12px;
+                                    margin-right: 8px;
+                                    width: 12px;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
+                                    content: linear-gradient(to right, #ffffff, #ffffff);
+                                    opacity: 0.6;
+                                  }
+                            />
+                            <div
+                              class=
+
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    color: #323130;
+                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                    font-size: 12px;
+                                    font-weight: 400;
+                                    line-height: 16px;
+                                    opacity: 0.67;
+                                  }
+                            >
+                              Honda
+                            </div>
+                          </button>
+                        </div>
+                        <div
+                          class=
+                              ms-OverflowSet-item
+                              {
+                                display: inherit;
+                                flex-shrink: 0;
+                              }
+                          role="none"
+                        >
+                          <button
+                            aria-label="Ford"
+                            aria-posinset="10"
+                            aria-selected="false"
+                            aria-setsize="22"
+                            class=
+
+                                {
+                                  align-items: center;
+                                  background: none;
+                                  border: none;
+                                  cursor: pointer;
+                                  display: flex;
+                                  outline: transparent;
+                                  padding-bottom: 8px;
+                                  padding-left: 8px;
+                                  padding-right: 8px;
+                                  padding-top: 8px;
+                                  position: relative;
+                                  text-transform: capitalize;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                            data-is-focusable="true"
+                            role="option"
+                            tabindex="-1"
+                          >
+                            <div
+                              class=
+
+                                  {
+                                    background-color: #ffffff;
+                                    border-color: #674c8c;
+                                    border: 1px solid;
+                                    content: ;
+                                    height: 12px;
+                                    margin-right: 8px;
+                                    width: 12px;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
+                                    content: linear-gradient(to right, #ffffff, #ffffff);
+                                    opacity: 0.6;
+                                  }
+                            />
+                            <div
+                              class=
+
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    color: #323130;
+                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                    font-size: 12px;
+                                    font-weight: 400;
+                                    line-height: 16px;
+                                    opacity: 0.67;
+                                  }
+                            >
+                              Ford
+                            </div>
+                          </button>
+                        </div>
+                        <div
+                          class=
+                              ms-OverflowSet-item
+                              {
+                                display: inherit;
+                                flex-shrink: 0;
+                              }
+                          role="none"
+                        >
+                          <button
+                            aria-label="Ferrari"
+                            aria-posinset="11"
+                            aria-selected="false"
+                            aria-setsize="22"
+                            class=
+
+                                {
+                                  align-items: center;
+                                  background: none;
+                                  border: none;
+                                  cursor: pointer;
+                                  display: flex;
+                                  outline: transparent;
+                                  padding-bottom: 8px;
+                                  padding-left: 8px;
+                                  padding-right: 8px;
+                                  padding-top: 8px;
+                                  position: relative;
+                                  text-transform: capitalize;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                            data-is-focusable="true"
+                            role="option"
+                            tabindex="-1"
+                          >
+                            <div
+                              class=
+
+                                  {
+                                    background-color: #ffffff;
+                                    border-color: #026467;
+                                    border: 1px solid;
+                                    content: ;
+                                    height: 12px;
+                                    margin-right: 8px;
+                                    width: 12px;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
+                                    content: linear-gradient(to right, #ffffff, #ffffff);
+                                    opacity: 0.6;
+                                  }
+                            />
+                            <div
+                              class=
+
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    color: #323130;
+                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                    font-size: 12px;
+                                    font-weight: 400;
+                                    line-height: 16px;
+                                    opacity: 0.67;
+                                  }
+                            >
+                              Ferrari
+                            </div>
+                          </button>
+                        </div>
+                        <div
+                          class=
+                              ms-OverflowSet-item
+                              {
+                                display: inherit;
+                                flex-shrink: 0;
+                              }
+                          role="none"
+                        >
+                          <button
+                            aria-label="Duster"
+                            aria-posinset="12"
+                            aria-selected="false"
+                            aria-setsize="22"
+                            class=
+
+                                {
+                                  align-items: center;
+                                  background: none;
+                                  border: none;
+                                  cursor: pointer;
+                                  display: flex;
+                                  outline: transparent;
+                                  padding-bottom: 8px;
+                                  padding-left: 8px;
+                                  padding-right: 8px;
+                                  padding-top: 8px;
+                                  position: relative;
+                                  text-transform: capitalize;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                            data-is-focusable="true"
+                            role="option"
+                            tabindex="-1"
+                          >
+                            <div
+                              class=
+
+                                  {
+                                    background-color: #ffffff;
+                                    border-color: #ad006a;
+                                    border: 1px solid;
+                                    content: ;
+                                    height: 12px;
+                                    margin-right: 8px;
+                                    width: 12px;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
+                                    content: linear-gradient(to right, #ffffff, #ffffff);
+                                    opacity: 0.6;
+                                  }
+                            />
+                            <div
+                              class=
+
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    color: #323130;
+                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                    font-size: 12px;
+                                    font-weight: 400;
+                                    line-height: 16px;
+                                    opacity: 0.67;
+                                  }
+                            >
+                              Duster
+                            </div>
+                          </button>
+                        </div>
+                        <div
+                          class=
+                              ms-OverflowSet-item
+                              {
+                                display: inherit;
+                                flex-shrink: 0;
+                              }
+                          role="none"
+                        >
+                          <button
+                            aria-label="Dodge"
+                            aria-posinset="13"
+                            aria-selected="false"
+                            aria-setsize="22"
+                            class=
+
+                                {
+                                  align-items: center;
+                                  background: none;
+                                  border: none;
+                                  cursor: pointer;
+                                  display: flex;
+                                  outline: transparent;
+                                  padding-bottom: 8px;
+                                  padding-left: 8px;
+                                  padding-right: 8px;
+                                  padding-top: 8px;
+                                  position: relative;
+                                  text-transform: capitalize;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                            data-is-focusable="true"
+                            role="option"
+                            tabindex="-1"
+                          >
+                            <div
+                              class=
+
+                                  {
+                                    background-color: #ffffff;
+                                    border-color: #3c51b4;
+                                    border: 1px solid;
+                                    content: ;
+                                    height: 12px;
+                                    margin-right: 8px;
+                                    width: 12px;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
+                                    content: linear-gradient(to right, #ffffff, #ffffff);
+                                    opacity: 0.6;
+                                  }
+                            />
+                            <div
+                              class=
+
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    color: #323130;
+                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                    font-size: 12px;
+                                    font-weight: 400;
+                                    line-height: 16px;
+                                    opacity: 0.67;
+                                  }
+                            >
+                              Dodge
+                            </div>
+                          </button>
+                        </div>
+                        <div
+                          class=
+                              ms-OverflowSet-item
+                              {
+                                display: inherit;
+                                flex-shrink: 0;
+                              }
+                          role="none"
+                        >
+                          <button
+                            aria-label="Datsun"
+                            aria-posinset="14"
+                            aria-selected="false"
+                            aria-setsize="22"
+                            class=
+
+                                {
+                                  align-items: center;
+                                  background: none;
+                                  border: none;
+                                  cursor: pointer;
+                                  display: flex;
+                                  outline: transparent;
+                                  padding-bottom: 8px;
+                                  padding-left: 8px;
+                                  padding-right: 8px;
+                                  padding-top: 8px;
+                                  position: relative;
+                                  text-transform: capitalize;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                            data-is-focusable="true"
+                            role="option"
+                            tabindex="-1"
+                          >
+                            <div
+                              class=
+
+                                  {
+                                    background-color: #ffffff;
+                                    border-color: #2aa0a4;
+                                    border: 1px solid;
+                                    content: ;
+                                    height: 12px;
+                                    margin-right: 8px;
+                                    width: 12px;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
+                                    content: linear-gradient(to right, #ffffff, #ffffff);
+                                    opacity: 0.6;
+                                  }
+                            />
+                            <div
+                              class=
+
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    color: #323130;
+                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                    font-size: 12px;
+                                    font-weight: 400;
+                                    line-height: 16px;
+                                    opacity: 0.67;
+                                  }
+                            >
+                              Datsun
+                            </div>
+                          </button>
+                        </div>
+                        <div
+                          class=
+                              ms-OverflowSet-item
+                              {
+                                display: inherit;
+                                flex-shrink: 0;
+                              }
+                          role="none"
+                        >
+                          <button
+                            aria-label="Chrysler"
+                            aria-posinset="15"
+                            aria-selected="false"
+                            aria-setsize="22"
+                            class=
+
+                                {
+                                  align-items: center;
+                                  background: none;
+                                  border: none;
+                                  cursor: pointer;
+                                  display: flex;
+                                  outline: transparent;
+                                  padding-bottom: 8px;
+                                  padding-left: 8px;
+                                  padding-right: 8px;
+                                  padding-top: 8px;
+                                  position: relative;
+                                  text-transform: capitalize;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                            data-is-focusable="true"
+                            role="option"
+                            tabindex="-1"
+                          >
+                            <div
+                              class=
+
+                                  {
+                                    background-color: #ffffff;
+                                    border-color: #ae8c00;
+                                    border: 1px solid;
+                                    content: ;
+                                    height: 12px;
+                                    margin-right: 8px;
+                                    width: 12px;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
+                                    content: linear-gradient(to right, #ffffff, #ffffff);
+                                    opacity: 0.6;
+                                  }
+                            />
+                            <div
+                              class=
+
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    color: #323130;
+                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                    font-size: 12px;
+                                    font-weight: 400;
+                                    line-height: 16px;
+                                    opacity: 0.67;
+                                  }
+                            >
+                              Chrysler
+                            </div>
+                          </button>
+                        </div>
+                        <div
+                          class=
+                              ms-OverflowSet-item
+                              {
+                                display: inherit;
+                                flex-shrink: 0;
+                              }
+                          role="none"
+                        >
+                          <button
+                            aria-label="Camaro"
+                            aria-posinset="16"
+                            aria-selected="false"
+                            aria-setsize="22"
+                            class=
+
+                                {
+                                  align-items: center;
+                                  background: none;
+                                  border: none;
+                                  cursor: pointer;
+                                  display: flex;
+                                  outline: transparent;
+                                  padding-bottom: 8px;
+                                  padding-left: 8px;
+                                  padding-right: 8px;
+                                  padding-top: 8px;
+                                  position: relative;
+                                  text-transform: capitalize;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                            data-is-focusable="true"
+                            role="option"
+                            tabindex="-1"
+                          >
+                            <div
+                              class=
+
+                                  {
+                                    background-color: #ffffff;
+                                    border-color: #dbdbdb;
+                                    border: 1px solid;
+                                    content: ;
+                                    height: 12px;
+                                    margin-right: 8px;
+                                    width: 12px;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
+                                    content: linear-gradient(to right, #ffffff, #ffffff);
+                                    opacity: 0.6;
+                                  }
+                            />
+                            <div
+                              class=
+
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    color: #323130;
+                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                    font-size: 12px;
+                                    font-weight: 400;
+                                    line-height: 16px;
+                                    opacity: 0.67;
+                                  }
+                            >
+                              Camaro
+                            </div>
+                          </button>
+                        </div>
+                        <div
+                          class=
+                              ms-OverflowSet-item
+                              {
+                                display: inherit;
+                                flex-shrink: 0;
+                              }
+                          role="none"
+                        >
+                          <button
+                            aria-label="Cadillac"
+                            aria-posinset="17"
+                            aria-selected="true"
+                            aria-setsize="22"
+                            class=
+
+                                {
+                                  align-items: center;
+                                  background: none;
+                                  border: none;
+                                  cursor: pointer;
+                                  display: flex;
+                                  outline: transparent;
+                                  padding-bottom: 8px;
+                                  padding-left: 8px;
+                                  padding-right: 8px;
+                                  padding-top: 8px;
+                                  position: relative;
+                                  text-transform: capitalize;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                            data-is-focusable="true"
+                            role="option"
+                            tabindex="-1"
+                          >
+                            <div
+                              class=
+
+                                  {
+                                    background-color: #ea38a6;
+                                    border-color: #ea38a6;
+                                    border: 1px solid;
+                                    content: ;
+                                    height: 12px;
+                                    margin-right: 8px;
+                                    width: 12px;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
+                                    content: linear-gradient(to right, #ea38a6, #ea38a6);
+                                    opacity: ;
+                                  }
+                            />
+                            <div
+                              class=
+
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    color: #323130;
+                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                    font-size: 12px;
+                                    font-weight: 400;
+                                    line-height: 16px;
+                                    opacity: ;
+                                  }
+                            >
+                              Cadillac
+                            </div>
+                          </button>
+                        </div>
+                        <div
+                          class=
+                              ms-OverflowSet-item
+                              {
+                                display: inherit;
+                                flex-shrink: 0;
+                              }
+                          role="none"
+                        >
+                          <button
+                            aria-label="AMC"
+                            aria-posinset="18"
+                            aria-selected="false"
+                            aria-setsize="22"
+                            class=
+
+                                {
+                                  align-items: center;
+                                  background: none;
+                                  border: none;
+                                  cursor: pointer;
+                                  display: flex;
+                                  outline: transparent;
+                                  padding-bottom: 8px;
+                                  padding-left: 8px;
+                                  padding-right: 8px;
+                                  padding-top: 8px;
+                                  position: relative;
+                                  text-transform: capitalize;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                            data-is-focusable="true"
+                            role="option"
+                            tabindex="-1"
+                          >
+                            <div
+                              class=
+
+                                  {
+                                    background-color: #ffffff;
+                                    border-color: #9a3d0c;
+                                    border: 1px solid;
+                                    content: ;
+                                    height: 12px;
+                                    margin-right: 8px;
+                                    width: 12px;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
+                                    content: linear-gradient(to right, #ffffff, #ffffff);
+                                    opacity: 0.6;
+                                  }
+                            />
+                            <div
+                              class=
+
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    color: #323130;
+                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                    font-size: 12px;
+                                    font-weight: 400;
+                                    line-height: 16px;
+                                    opacity: 0.67;
+                                  }
+                            >
+                              AMC
+                            </div>
+                          </button>
+                        </div>
+                        <div
+                          class=
+                              ms-OverflowSet-item
+                              {
+                                display: inherit;
+                                flex-shrink: 0;
+                              }
+                          role="none"
+                        >
+                          <button
+                            aria-label="Toyota"
+                            aria-posinset="19"
+                            aria-selected="false"
+                            aria-setsize="22"
+                            class=
+
+                                {
+                                  align-items: center;
+                                  background: none;
+                                  border: none;
+                                  cursor: pointer;
+                                  display: flex;
+                                  outline: transparent;
+                                  padding-bottom: 8px;
+                                  padding-left: 8px;
+                                  padding-right: 8px;
+                                  padding-top: 8px;
+                                  position: relative;
+                                  text-transform: capitalize;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                            data-is-focusable="true"
+                            role="option"
+                            tabindex="-1"
+                          >
+                            <div
+                              class=
+
+                                  {
+                                    background-color: #ffffff;
+                                    border-color: #9373c0;
+                                    border: 1px solid;
+                                    content: ;
+                                    height: 12px;
+                                    margin-right: 8px;
+                                    width: 12px;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
+                                    content: linear-gradient(to right, #ffffff, #ffffff);
+                                    opacity: 0.6;
+                                  }
+                            />
+                            <div
+                              class=
+
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    color: #323130;
+                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                    font-size: 12px;
+                                    font-weight: 400;
+                                    line-height: 16px;
+                                    opacity: 0.67;
+                                  }
+                            >
+                              Toyota
+                            </div>
+                          </button>
+                        </div>
+                        <div
+                          class=
+                              ms-OverflowSet-item
+                              {
+                                display: inherit;
+                                flex-shrink: 0;
+                              }
+                          role="none"
+                        >
+                          <button
+                            aria-label="Mazda"
+                            aria-posinset="20"
+                            aria-selected="false"
+                            aria-setsize="22"
+                            class=
+
+                                {
+                                  align-items: center;
+                                  background: none;
+                                  border: none;
+                                  cursor: pointer;
+                                  display: flex;
+                                  outline: transparent;
+                                  padding-bottom: 8px;
+                                  padding-left: 8px;
+                                  padding-right: 8px;
+                                  padding-top: 8px;
+                                  position: relative;
+                                  text-transform: capitalize;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                            data-is-focusable="true"
+                            role="option"
+                            tabindex="-1"
+                          >
+                            <div
+                              class=
+
+                                  {
+                                    background-color: #ffffff;
+                                    border-color: #c50f1f;
+                                    border: 1px solid;
+                                    content: ;
+                                    height: 12px;
+                                    margin-right: 8px;
+                                    width: 12px;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
+                                    content: linear-gradient(to right, #ffffff, #ffffff);
+                                    opacity: 0.6;
+                                  }
+                            />
+                            <div
+                              class=
+
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    color: #323130;
+                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                    font-size: 12px;
+                                    font-weight: 400;
+                                    line-height: 16px;
+                                    opacity: 0.67;
+                                  }
+                            >
+                              Mazda
+                            </div>
+                          </button>
+                        </div>
+                        <div
+                          class=
+                              ms-OverflowSet-item
+                              {
+                                display: inherit;
+                                flex-shrink: 0;
+                              }
+                          role="none"
+                        >
+                          <button
+                            aria-label="Hornet"
+                            aria-posinset="21"
+                            aria-selected="false"
+                            aria-setsize="22"
+                            class=
+
+                                {
+                                  align-items: center;
+                                  background: none;
+                                  border: none;
+                                  cursor: pointer;
+                                  display: flex;
+                                  outline: transparent;
+                                  padding-bottom: 8px;
+                                  padding-left: 8px;
+                                  padding-right: 8px;
+                                  padding-top: 8px;
+                                  position: relative;
+                                  text-transform: capitalize;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                            data-is-focusable="true"
+                            role="option"
+                            tabindex="-1"
+                          >
+                            <div
+                              class=
+
+                                  {
+                                    background-color: #ffffff;
+                                    border-color: #13a10e;
+                                    border: 1px solid;
+                                    content: ;
+                                    height: 12px;
+                                    margin-right: 8px;
+                                    width: 12px;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
+                                    content: linear-gradient(to right, #ffffff, #ffffff);
+                                    opacity: 0.6;
+                                  }
+                            />
+                            <div
+                              class=
+
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    color: #323130;
+                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                    font-size: 12px;
+                                    font-weight: 400;
+                                    line-height: 16px;
+                                    opacity: 0.67;
+                                  }
+                            >
+                              Hornet
+                            </div>
+                          </button>
+                        </div>
+                        <div
+                          class=
+                              ms-OverflowSet-item
+                              {
+                                display: inherit;
+                                flex-shrink: 0;
+                              }
+                          role="none"
+                        >
+                          <button
+                            aria-label="Fiat"
                             aria-posinset="22"
                             aria-selected="false"
                             aria-setsize="22"
@@ -4273,7 +4273,7 @@ exports[`DeclarativeChart Should render donutchart in DeclarativeChart 1`] = `
 
                                   {
                                     background-color: #ffffff;
-                                    border-color: #ea38a6;
+                                    border-color: #f7630c;
                                     border: 1px solid;
                                     content: ;
                                     height: 12px;
@@ -4299,7 +4299,7 @@ exports[`DeclarativeChart Should render donutchart in DeclarativeChart 1`] = `
                                     opacity: 0.67;
                                   }
                             >
-                              Volvo
+                              Fiat
                             </div>
                           </button>
                         </div>
@@ -19731,7 +19731,7 @@ exports[`DeclarativeChart Should render piechart in DeclarativeChart 1`] = `
 
                         {
                           cursor: default;
-                          fill: #febfb3;
+                          fill: #FEBFB3;
                           opacity: 1;
                           outline: transparent;
                           stroke: #ffffff;
@@ -19767,94 +19767,12 @@ exports[`DeclarativeChart Should render piechart in DeclarativeChart 1`] = `
                 </g>
                 <g>
                   <path
-                    aria-label="Hydrogen, 2500."
-                    class=
-
-                        {
-                          cursor: default;
-                          fill: #e1396c;
-                          opacity: 1;
-                          outline: transparent;
-                          stroke: #ffffff;
-                        }
-                        &::-moz-focus-inner {
-                          border: 0;
-                        }
-                    d="M-0.329,-0.527A0.219,0.219,0,1,1,-0.46,-0.76L36.613,16.108Z"
-                    data-is-focusable="true"
-                    id="_Pie_1Hydrogen2500"
-                    role="img"
-                    tabindex="-1"
-                  />
-                  <text
-                    aria-hidden="true"
-                    class=
-
-                        {
-                          fill: #323130;
-                          font-size: 12px;
-                          font-weight: 600;
-                        }
-                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
-                          fill: CanvasText;
-                        }
-                    dominant-baseline="hanging"
-                    text-anchor="end"
-                    x="2.615123681135871"
-                    y="-1.4700775939937216"
-                  >
-                    2.5k
-                  </text>
-                </g>
-                <g>
-                  <path
-                    aria-label="Carbon_Dioxide, 1053."
-                    class=
-
-                        {
-                          cursor: default;
-                          fill: #96d38c;
-                          opacity: 1;
-                          outline: transparent;
-                          stroke: #ffffff;
-                        }
-                        &::-moz-focus-inner {
-                          border: 0;
-                        }
-                    d="M-0.699,-0.715L14.563,37.255Z"
-                    data-is-focusable="true"
-                    id="_Pie_1Carbon_Dioxide1053"
-                    role="img"
-                    tabindex="-1"
-                  />
-                  <text
-                    aria-hidden="true"
-                    class=
-
-                        {
-                          fill: #323130;
-                          font-size: 12px;
-                          font-weight: 600;
-                        }
-                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
-                          fill: CanvasText;
-                        }
-                    dominant-baseline="auto"
-                    text-anchor="end"
-                    x="2.0980415379491326"
-                    y="2.1443464517283672"
-                  >
-                    1.1k
-                  </text>
-                </g>
-                <g>
-                  <path
                     aria-label="Nitrogen, 500."
                     class=
 
                         {
                           cursor: default;
-                          fill: #d0f9b1;
+                          fill: #D0F9B1;
                           opacity: 1;
                           outline: transparent;
                           stroke: #ffffff;
@@ -19862,7 +19780,7 @@ exports[`DeclarativeChart Should render piechart in DeclarativeChart 1`] = `
                         &::-moz-focus-inner {
                           border: 0;
                         }
-                    d="M-0.19,-0.982L-0.4,39.998Z"
+                    d="M-0.327,0.945L20.384,-34.416Z"
                     data-is-focusable="true"
                     id="_Pie_1Nitrogen500"
                     role="img"
@@ -19880,12 +19798,94 @@ exports[`DeclarativeChart Should render piechart in DeclarativeChart 1`] = `
                         @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
                           fill: CanvasText;
                         }
-                    dominant-baseline="auto"
+                    dominant-baseline="hanging"
                     text-anchor="end"
-                    x="0.5704533452268108"
-                    y="2.9452645010116734"
+                    x="0.9818088892614404"
+                    y="-2.8347929915546244"
                   >
                     500
+                  </text>
+                </g>
+                <g>
+                  <path
+                    aria-label="Carbon_Dioxide, 1053."
+                    class=
+
+                        {
+                          cursor: default;
+                          fill: #96D38C;
+                          opacity: 1;
+                          outline: transparent;
+                          stroke: #ffffff;
+                        }
+                        &::-moz-focus-inner {
+                          border: 0;
+                        }
+                    d="M-0.794,0.609L38.733,-9.988Z"
+                    data-is-focusable="true"
+                    id="_Pie_1Carbon_Dioxide1053"
+                    role="img"
+                    tabindex="-1"
+                  />
+                  <text
+                    aria-hidden="true"
+                    class=
+
+                        {
+                          fill: #323130;
+                          font-size: 12px;
+                          font-weight: 600;
+                        }
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
+                          fill: CanvasText;
+                        }
+                    dominant-baseline="hanging"
+                    text-anchor="end"
+                    x="2.380575816630471"
+                    y="-1.8256118922909557"
+                  >
+                    1.1k
+                  </text>
+                </g>
+                <g>
+                  <path
+                    aria-label="Hydrogen, 2500."
+                    class=
+
+                        {
+                          cursor: default;
+                          fill: #E1396C;
+                          opacity: 1;
+                          outline: transparent;
+                          stroke: #ffffff;
+                        }
+                        &::-moz-focus-inner {
+                          border: 0;
+                        }
+                    d="M0.355,-0.51A0.219,0.219,0,1,1,0.517,-0.721L-0.4,39.998Z"
+                    data-is-focusable="true"
+                    id="_Pie_1Hydrogen2500"
+                    role="img"
+                    tabindex="-1"
+                  />
+                  <text
+                    aria-hidden="true"
+                    class=
+
+                        {
+                          fill: #323130;
+                          font-size: 12px;
+                          font-weight: 600;
+                        }
+                        @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
+                          fill: CanvasText;
+                        }
+                    dominant-baseline="auto"
+                    text-anchor="end"
+                    x="2.380575816630475"
+                    y="1.8256118922909508"
+                  >
+                    2.5k
                   </text>
                 </g>
               </g>
@@ -20015,8 +20015,8 @@ exports[`DeclarativeChart Should render piechart in DeclarativeChart 1`] = `
                               class=
 
                                   {
-                                    background-color: #febfb3;
-                                    border-color: #febfb3;
+                                    background-color: #FEBFB3;
+                                    border-color: #FEBFB3;
                                     border: 1px solid;
                                     content: ;
                                     height: 12px;
@@ -20024,7 +20024,7 @@ exports[`DeclarativeChart Should render piechart in DeclarativeChart 1`] = `
                                     width: 12px;
                                   }
                                   @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
-                                    content: linear-gradient(to right, #febfb3, #febfb3);
+                                    content: linear-gradient(to right, #FEBFB3, #FEBFB3);
                                     opacity: ;
                                   }
                             />
@@ -20056,7 +20056,7 @@ exports[`DeclarativeChart Should render piechart in DeclarativeChart 1`] = `
                           role="none"
                         >
                           <button
-                            aria-label="Hydrogen"
+                            aria-label="Nitrogen"
                             aria-posinset="2"
                             aria-selected="false"
                             aria-setsize="4"
@@ -20115,8 +20115,8 @@ exports[`DeclarativeChart Should render piechart in DeclarativeChart 1`] = `
                               class=
 
                                   {
-                                    background-color: #e1396c;
-                                    border-color: #e1396c;
+                                    background-color: #D0F9B1;
+                                    border-color: #D0F9B1;
                                     border: 1px solid;
                                     content: ;
                                     height: 12px;
@@ -20124,7 +20124,7 @@ exports[`DeclarativeChart Should render piechart in DeclarativeChart 1`] = `
                                     width: 12px;
                                   }
                                   @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
-                                    content: linear-gradient(to right, #e1396c, #e1396c);
+                                    content: linear-gradient(to right, #D0F9B1, #D0F9B1);
                                     opacity: ;
                                   }
                             />
@@ -20142,7 +20142,7 @@ exports[`DeclarativeChart Should render piechart in DeclarativeChart 1`] = `
                                     opacity: ;
                                   }
                             >
-                              Hydrogen
+                              Nitrogen
                             </div>
                           </button>
                         </div>
@@ -20215,8 +20215,8 @@ exports[`DeclarativeChart Should render piechart in DeclarativeChart 1`] = `
                               class=
 
                                   {
-                                    background-color: #96d38c;
-                                    border-color: #96d38c;
+                                    background-color: #96D38C;
+                                    border-color: #96D38C;
                                     border: 1px solid;
                                     content: ;
                                     height: 12px;
@@ -20224,7 +20224,7 @@ exports[`DeclarativeChart Should render piechart in DeclarativeChart 1`] = `
                                     width: 12px;
                                   }
                                   @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
-                                    content: linear-gradient(to right, #96d38c, #96d38c);
+                                    content: linear-gradient(to right, #96D38C, #96D38C);
                                     opacity: ;
                                   }
                             />
@@ -20256,7 +20256,7 @@ exports[`DeclarativeChart Should render piechart in DeclarativeChart 1`] = `
                           role="none"
                         >
                           <button
-                            aria-label="Nitrogen"
+                            aria-label="Hydrogen"
                             aria-posinset="4"
                             aria-selected="false"
                             aria-setsize="4"
@@ -20315,8 +20315,8 @@ exports[`DeclarativeChart Should render piechart in DeclarativeChart 1`] = `
                               class=
 
                                   {
-                                    background-color: #d0f9b1;
-                                    border-color: #d0f9b1;
+                                    background-color: #E1396C;
+                                    border-color: #E1396C;
                                     border: 1px solid;
                                     content: ;
                                     height: 12px;
@@ -20324,7 +20324,7 @@ exports[`DeclarativeChart Should render piechart in DeclarativeChart 1`] = `
                                     width: 12px;
                                   }
                                   @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
-                                    content: linear-gradient(to right, #d0f9b1, #d0f9b1);
+                                    content: linear-gradient(to right, #E1396C, #E1396C);
                                     opacity: ;
                                   }
                             />
@@ -20342,7 +20342,7 @@ exports[`DeclarativeChart Should render piechart in DeclarativeChart 1`] = `
                                     opacity: ;
                                   }
                             >
-                              Nitrogen
+                              Hydrogen
                             </div>
                           </button>
                         </div>

--- a/packages/charts/react-charting/src/components/DeclarativeChart/__snapshots__/DeclarativeChartRTL.test.tsx.snap
+++ b/packages/charts/react-charting/src/components/DeclarativeChart/__snapshots__/DeclarativeChartRTL.test.tsx.snap
@@ -2213,1708 +2213,8 @@ exports[`DeclarativeChart Should render donutchart in DeclarativeChart 1`] = `
                           role="none"
                         >
                           <button
-                            aria-label="Volvo"
-                            aria-posinset="2"
-                            aria-selected="false"
-                            aria-setsize="22"
-                            class=
-
-                                {
-                                  align-items: center;
-                                  background: none;
-                                  border: none;
-                                  cursor: pointer;
-                                  display: flex;
-                                  outline: transparent;
-                                  padding-bottom: 8px;
-                                  padding-left: 8px;
-                                  padding-right: 8px;
-                                  padding-top: 8px;
-                                  position: relative;
-                                  text-transform: capitalize;
-                                }
-                                &::-moz-focus-inner {
-                                  border: 0;
-                                }
-                                .ms-Fabric--isFocusVisible &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                            data-is-focusable="true"
-                            role="option"
-                            tabindex="-1"
-                          >
-                            <div
-                              class=
-
-                                  {
-                                    background-color: #ffffff;
-                                    border-color: #ea38a6;
-                                    border: 1px solid;
-                                    content: ;
-                                    height: 12px;
-                                    margin-right: 8px;
-                                    width: 12px;
-                                  }
-                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
-                                    content: linear-gradient(to right, #ffffff, #ffffff);
-                                    opacity: 0.6;
-                                  }
-                            />
-                            <div
-                              class=
-
-                                  {
-                                    -moz-osx-font-smoothing: grayscale;
-                                    -webkit-font-smoothing: antialiased;
-                                    color: #323130;
-                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                    font-size: 12px;
-                                    font-weight: 400;
-                                    line-height: 16px;
-                                    opacity: 0.67;
-                                  }
-                            >
-                              Volvo
-                            </div>
-                          </button>
-                        </div>
-                        <div
-                          class=
-                              ms-OverflowSet-item
-                              {
-                                display: inherit;
-                                flex-shrink: 0;
-                              }
-                          role="none"
-                        >
-                          <button
-                            aria-label="Valiant"
-                            aria-posinset="3"
-                            aria-selected="false"
-                            aria-setsize="22"
-                            class=
-
-                                {
-                                  align-items: center;
-                                  background: none;
-                                  border: none;
-                                  cursor: pointer;
-                                  display: flex;
-                                  outline: transparent;
-                                  padding-bottom: 8px;
-                                  padding-left: 8px;
-                                  padding-right: 8px;
-                                  padding-top: 8px;
-                                  position: relative;
-                                  text-transform: capitalize;
-                                }
-                                &::-moz-focus-inner {
-                                  border: 0;
-                                }
-                                .ms-Fabric--isFocusVisible &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                            data-is-focusable="true"
-                            role="option"
-                            tabindex="-1"
-                          >
-                            <div
-                              class=
-
-                                  {
-                                    background-color: #ffffff;
-                                    border-color: #4f6bed;
-                                    border: 1px solid;
-                                    content: ;
-                                    height: 12px;
-                                    margin-right: 8px;
-                                    width: 12px;
-                                  }
-                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
-                                    content: linear-gradient(to right, #ffffff, #ffffff);
-                                    opacity: 0.6;
-                                  }
-                            />
-                            <div
-                              class=
-
-                                  {
-                                    -moz-osx-font-smoothing: grayscale;
-                                    -webkit-font-smoothing: antialiased;
-                                    color: #323130;
-                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                    font-size: 12px;
-                                    font-weight: 400;
-                                    line-height: 16px;
-                                    opacity: 0.67;
-                                  }
-                            >
-                              Valiant
-                            </div>
-                          </button>
-                        </div>
-                        <div
-                          class=
-                              ms-OverflowSet-item
-                              {
-                                display: inherit;
-                                flex-shrink: 0;
-                              }
-                          role="none"
-                        >
-                          <button
-                            aria-label="Porsche"
-                            aria-posinset="4"
-                            aria-selected="false"
-                            aria-setsize="22"
-                            class=
-
-                                {
-                                  align-items: center;
-                                  background: none;
-                                  border: none;
-                                  cursor: pointer;
-                                  display: flex;
-                                  outline: transparent;
-                                  padding-bottom: 8px;
-                                  padding-left: 8px;
-                                  padding-right: 8px;
-                                  padding-top: 8px;
-                                  position: relative;
-                                  text-transform: capitalize;
-                                }
-                                &::-moz-focus-inner {
-                                  border: 0;
-                                }
-                                .ms-Fabric--isFocusVisible &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                            data-is-focusable="true"
-                            role="option"
-                            tabindex="-1"
-                          >
-                            <div
-                              class=
-
-                                  {
-                                    background-color: #ffffff;
-                                    border-color: #6d5700;
-                                    border: 1px solid;
-                                    content: ;
-                                    height: 12px;
-                                    margin-right: 8px;
-                                    width: 12px;
-                                  }
-                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
-                                    content: linear-gradient(to right, #ffffff, #ffffff);
-                                    opacity: 0.6;
-                                  }
-                            />
-                            <div
-                              class=
-
-                                  {
-                                    -moz-osx-font-smoothing: grayscale;
-                                    -webkit-font-smoothing: antialiased;
-                                    color: #323130;
-                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                    font-size: 12px;
-                                    font-weight: 400;
-                                    line-height: 16px;
-                                    opacity: 0.67;
-                                  }
-                            >
-                              Porsche
-                            </div>
-                          </button>
-                        </div>
-                        <div
-                          class=
-                              ms-OverflowSet-item
-                              {
-                                display: inherit;
-                                flex-shrink: 0;
-                              }
-                          role="none"
-                        >
-                          <button
-                            aria-label="Pontiac"
-                            aria-posinset="5"
-                            aria-selected="false"
-                            aria-setsize="22"
-                            class=
-
-                                {
-                                  align-items: center;
-                                  background: none;
-                                  border: none;
-                                  cursor: pointer;
-                                  display: flex;
-                                  outline: transparent;
-                                  padding-bottom: 8px;
-                                  padding-left: 8px;
-                                  padding-right: 8px;
-                                  padding-top: 8px;
-                                  position: relative;
-                                  text-transform: capitalize;
-                                }
-                                &::-moz-focus-inner {
-                                  border: 0;
-                                }
-                                .ms-Fabric--isFocusVisible &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                            data-is-focusable="true"
-                            role="option"
-                            tabindex="-1"
-                          >
-                            <div
-                              class=
-
-                                  {
-                                    background-color: #ffffff;
-                                    border-color: #863593;
-                                    border: 1px solid;
-                                    content: ;
-                                    height: 12px;
-                                    margin-right: 8px;
-                                    width: 12px;
-                                  }
-                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
-                                    content: linear-gradient(to right, #ffffff, #ffffff);
-                                    opacity: 0.6;
-                                  }
-                            />
-                            <div
-                              class=
-
-                                  {
-                                    -moz-osx-font-smoothing: grayscale;
-                                    -webkit-font-smoothing: antialiased;
-                                    color: #323130;
-                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                    font-size: 12px;
-                                    font-weight: 400;
-                                    line-height: 16px;
-                                    opacity: 0.67;
-                                  }
-                            >
-                              Pontiac
-                            </div>
-                          </button>
-                        </div>
-                        <div
-                          class=
-                              ms-OverflowSet-item
-                              {
-                                display: inherit;
-                                flex-shrink: 0;
-                              }
-                          role="none"
-                        >
-                          <button
-                            aria-label="Maserati"
-                            aria-posinset="6"
-                            aria-selected="false"
-                            aria-setsize="22"
-                            class=
-
-                                {
-                                  align-items: center;
-                                  background: none;
-                                  border: none;
-                                  cursor: pointer;
-                                  display: flex;
-                                  outline: transparent;
-                                  padding-bottom: 8px;
-                                  padding-left: 8px;
-                                  padding-right: 8px;
-                                  padding-top: 8px;
-                                  position: relative;
-                                  text-transform: capitalize;
-                                }
-                                &::-moz-focus-inner {
-                                  border: 0;
-                                }
-                                .ms-Fabric--isFocusVisible &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                            data-is-focusable="true"
-                            role="option"
-                            tabindex="-1"
-                          >
-                            <div
-                              class=
-
-                                  {
-                                    background-color: #ffffff;
-                                    border-color: #405f14;
-                                    border: 1px solid;
-                                    content: ;
-                                    height: 12px;
-                                    margin-right: 8px;
-                                    width: 12px;
-                                  }
-                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
-                                    content: linear-gradient(to right, #ffffff, #ffffff);
-                                    opacity: 0.6;
-                                  }
-                            />
-                            <div
-                              class=
-
-                                  {
-                                    -moz-osx-font-smoothing: grayscale;
-                                    -webkit-font-smoothing: antialiased;
-                                    color: #323130;
-                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                    font-size: 12px;
-                                    font-weight: 400;
-                                    line-height: 16px;
-                                    opacity: 0.67;
-                                  }
-                            >
-                              Maserati
-                            </div>
-                          </button>
-                        </div>
-                        <div
-                          class=
-                              ms-OverflowSet-item
-                              {
-                                display: inherit;
-                                flex-shrink: 0;
-                              }
-                          role="none"
-                        >
-                          <button
-                            aria-label="Lotus"
-                            aria-posinset="7"
-                            aria-selected="false"
-                            aria-setsize="22"
-                            class=
-
-                                {
-                                  align-items: center;
-                                  background: none;
-                                  border: none;
-                                  cursor: pointer;
-                                  display: flex;
-                                  outline: transparent;
-                                  padding-bottom: 8px;
-                                  padding-left: 8px;
-                                  padding-right: 8px;
-                                  padding-top: 8px;
-                                  position: relative;
-                                  text-transform: capitalize;
-                                }
-                                &::-moz-focus-inner {
-                                  border: 0;
-                                }
-                                .ms-Fabric--isFocusVisible &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                            data-is-focusable="true"
-                            role="option"
-                            tabindex="-1"
-                          >
-                            <div
-                              class=
-
-                                  {
-                                    background-color: #ffffff;
-                                    border-color: #9a3d0c;
-                                    border: 1px solid;
-                                    content: ;
-                                    height: 12px;
-                                    margin-right: 8px;
-                                    width: 12px;
-                                  }
-                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
-                                    content: linear-gradient(to right, #ffffff, #ffffff);
-                                    opacity: 0.6;
-                                  }
-                            />
-                            <div
-                              class=
-
-                                  {
-                                    -moz-osx-font-smoothing: grayscale;
-                                    -webkit-font-smoothing: antialiased;
-                                    color: #323130;
-                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                    font-size: 12px;
-                                    font-weight: 400;
-                                    line-height: 16px;
-                                    opacity: 0.67;
-                                  }
-                            >
-                              Lotus
-                            </div>
-                          </button>
-                        </div>
-                        <div
-                          class=
-                              ms-OverflowSet-item
-                              {
-                                display: inherit;
-                                flex-shrink: 0;
-                              }
-                          role="none"
-                        >
-                          <button
-                            aria-label="Lincoln"
-                            aria-posinset="8"
-                            aria-selected="false"
-                            aria-setsize="22"
-                            class=
-
-                                {
-                                  align-items: center;
-                                  background: none;
-                                  border: none;
-                                  cursor: pointer;
-                                  display: flex;
-                                  outline: transparent;
-                                  padding-bottom: 8px;
-                                  padding-left: 8px;
-                                  padding-right: 8px;
-                                  padding-top: 8px;
-                                  position: relative;
-                                  text-transform: capitalize;
-                                }
-                                &::-moz-focus-inner {
-                                  border: 0;
-                                }
-                                .ms-Fabric--isFocusVisible &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                            data-is-focusable="true"
-                            role="option"
-                            tabindex="-1"
-                          >
-                            <div
-                              class=
-
-                                  {
-                                    background-color: #ffffff;
-                                    border-color: #2c72a8;
-                                    border: 1px solid;
-                                    content: ;
-                                    height: 12px;
-                                    margin-right: 8px;
-                                    width: 12px;
-                                  }
-                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
-                                    content: linear-gradient(to right, #ffffff, #ffffff);
-                                    opacity: 0.6;
-                                  }
-                            />
-                            <div
-                              class=
-
-                                  {
-                                    -moz-osx-font-smoothing: grayscale;
-                                    -webkit-font-smoothing: antialiased;
-                                    color: #323130;
-                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                    font-size: 12px;
-                                    font-weight: 400;
-                                    line-height: 16px;
-                                    opacity: 0.67;
-                                  }
-                            >
-                              Lincoln
-                            </div>
-                          </button>
-                        </div>
-                        <div
-                          class=
-                              ms-OverflowSet-item
-                              {
-                                display: inherit;
-                                flex-shrink: 0;
-                              }
-                          role="none"
-                        >
-                          <button
-                            aria-label="Honda"
-                            aria-posinset="9"
-                            aria-selected="false"
-                            aria-setsize="22"
-                            class=
-
-                                {
-                                  align-items: center;
-                                  background: none;
-                                  border: none;
-                                  cursor: pointer;
-                                  display: flex;
-                                  outline: transparent;
-                                  padding-bottom: 8px;
-                                  padding-left: 8px;
-                                  padding-right: 8px;
-                                  padding-top: 8px;
-                                  position: relative;
-                                  text-transform: capitalize;
-                                }
-                                &::-moz-focus-inner {
-                                  border: 0;
-                                }
-                                .ms-Fabric--isFocusVisible &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                            data-is-focusable="true"
-                            role="option"
-                            tabindex="-1"
-                          >
-                            <div
-                              class=
-
-                                  {
-                                    background-color: #ffffff;
-                                    border-color: #0e7a0b;
-                                    border: 1px solid;
-                                    content: ;
-                                    height: 12px;
-                                    margin-right: 8px;
-                                    width: 12px;
-                                  }
-                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
-                                    content: linear-gradient(to right, #ffffff, #ffffff);
-                                    opacity: 0.6;
-                                  }
-                            />
-                            <div
-                              class=
-
-                                  {
-                                    -moz-osx-font-smoothing: grayscale;
-                                    -webkit-font-smoothing: antialiased;
-                                    color: #323130;
-                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                    font-size: 12px;
-                                    font-weight: 400;
-                                    line-height: 16px;
-                                    opacity: 0.67;
-                                  }
-                            >
-                              Honda
-                            </div>
-                          </button>
-                        </div>
-                        <div
-                          class=
-                              ms-OverflowSet-item
-                              {
-                                display: inherit;
-                                flex-shrink: 0;
-                              }
-                          role="none"
-                        >
-                          <button
-                            aria-label="Ford"
-                            aria-posinset="10"
-                            aria-selected="false"
-                            aria-setsize="22"
-                            class=
-
-                                {
-                                  align-items: center;
-                                  background: none;
-                                  border: none;
-                                  cursor: pointer;
-                                  display: flex;
-                                  outline: transparent;
-                                  padding-bottom: 8px;
-                                  padding-left: 8px;
-                                  padding-right: 8px;
-                                  padding-top: 8px;
-                                  position: relative;
-                                  text-transform: capitalize;
-                                }
-                                &::-moz-focus-inner {
-                                  border: 0;
-                                }
-                                .ms-Fabric--isFocusVisible &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                            data-is-focusable="true"
-                            role="option"
-                            tabindex="-1"
-                          >
-                            <div
-                              class=
-
-                                  {
-                                    background-color: #ffffff;
-                                    border-color: #674c8c;
-                                    border: 1px solid;
-                                    content: ;
-                                    height: 12px;
-                                    margin-right: 8px;
-                                    width: 12px;
-                                  }
-                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
-                                    content: linear-gradient(to right, #ffffff, #ffffff);
-                                    opacity: 0.6;
-                                  }
-                            />
-                            <div
-                              class=
-
-                                  {
-                                    -moz-osx-font-smoothing: grayscale;
-                                    -webkit-font-smoothing: antialiased;
-                                    color: #323130;
-                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                    font-size: 12px;
-                                    font-weight: 400;
-                                    line-height: 16px;
-                                    opacity: 0.67;
-                                  }
-                            >
-                              Ford
-                            </div>
-                          </button>
-                        </div>
-                        <div
-                          class=
-                              ms-OverflowSet-item
-                              {
-                                display: inherit;
-                                flex-shrink: 0;
-                              }
-                          role="none"
-                        >
-                          <button
-                            aria-label="Ferrari"
-                            aria-posinset="11"
-                            aria-selected="false"
-                            aria-setsize="22"
-                            class=
-
-                                {
-                                  align-items: center;
-                                  background: none;
-                                  border: none;
-                                  cursor: pointer;
-                                  display: flex;
-                                  outline: transparent;
-                                  padding-bottom: 8px;
-                                  padding-left: 8px;
-                                  padding-right: 8px;
-                                  padding-top: 8px;
-                                  position: relative;
-                                  text-transform: capitalize;
-                                }
-                                &::-moz-focus-inner {
-                                  border: 0;
-                                }
-                                .ms-Fabric--isFocusVisible &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                            data-is-focusable="true"
-                            role="option"
-                            tabindex="-1"
-                          >
-                            <div
-                              class=
-
-                                  {
-                                    background-color: #ffffff;
-                                    border-color: #026467;
-                                    border: 1px solid;
-                                    content: ;
-                                    height: 12px;
-                                    margin-right: 8px;
-                                    width: 12px;
-                                  }
-                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
-                                    content: linear-gradient(to right, #ffffff, #ffffff);
-                                    opacity: 0.6;
-                                  }
-                            />
-                            <div
-                              class=
-
-                                  {
-                                    -moz-osx-font-smoothing: grayscale;
-                                    -webkit-font-smoothing: antialiased;
-                                    color: #323130;
-                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                    font-size: 12px;
-                                    font-weight: 400;
-                                    line-height: 16px;
-                                    opacity: 0.67;
-                                  }
-                            >
-                              Ferrari
-                            </div>
-                          </button>
-                        </div>
-                        <div
-                          class=
-                              ms-OverflowSet-item
-                              {
-                                display: inherit;
-                                flex-shrink: 0;
-                              }
-                          role="none"
-                        >
-                          <button
-                            aria-label="Duster"
-                            aria-posinset="12"
-                            aria-selected="false"
-                            aria-setsize="22"
-                            class=
-
-                                {
-                                  align-items: center;
-                                  background: none;
-                                  border: none;
-                                  cursor: pointer;
-                                  display: flex;
-                                  outline: transparent;
-                                  padding-bottom: 8px;
-                                  padding-left: 8px;
-                                  padding-right: 8px;
-                                  padding-top: 8px;
-                                  position: relative;
-                                  text-transform: capitalize;
-                                }
-                                &::-moz-focus-inner {
-                                  border: 0;
-                                }
-                                .ms-Fabric--isFocusVisible &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                            data-is-focusable="true"
-                            role="option"
-                            tabindex="-1"
-                          >
-                            <div
-                              class=
-
-                                  {
-                                    background-color: #ffffff;
-                                    border-color: #ad006a;
-                                    border: 1px solid;
-                                    content: ;
-                                    height: 12px;
-                                    margin-right: 8px;
-                                    width: 12px;
-                                  }
-                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
-                                    content: linear-gradient(to right, #ffffff, #ffffff);
-                                    opacity: 0.6;
-                                  }
-                            />
-                            <div
-                              class=
-
-                                  {
-                                    -moz-osx-font-smoothing: grayscale;
-                                    -webkit-font-smoothing: antialiased;
-                                    color: #323130;
-                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                    font-size: 12px;
-                                    font-weight: 400;
-                                    line-height: 16px;
-                                    opacity: 0.67;
-                                  }
-                            >
-                              Duster
-                            </div>
-                          </button>
-                        </div>
-                        <div
-                          class=
-                              ms-OverflowSet-item
-                              {
-                                display: inherit;
-                                flex-shrink: 0;
-                              }
-                          role="none"
-                        >
-                          <button
-                            aria-label="Dodge"
-                            aria-posinset="13"
-                            aria-selected="false"
-                            aria-setsize="22"
-                            class=
-
-                                {
-                                  align-items: center;
-                                  background: none;
-                                  border: none;
-                                  cursor: pointer;
-                                  display: flex;
-                                  outline: transparent;
-                                  padding-bottom: 8px;
-                                  padding-left: 8px;
-                                  padding-right: 8px;
-                                  padding-top: 8px;
-                                  position: relative;
-                                  text-transform: capitalize;
-                                }
-                                &::-moz-focus-inner {
-                                  border: 0;
-                                }
-                                .ms-Fabric--isFocusVisible &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                            data-is-focusable="true"
-                            role="option"
-                            tabindex="-1"
-                          >
-                            <div
-                              class=
-
-                                  {
-                                    background-color: #ffffff;
-                                    border-color: #3c51b4;
-                                    border: 1px solid;
-                                    content: ;
-                                    height: 12px;
-                                    margin-right: 8px;
-                                    width: 12px;
-                                  }
-                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
-                                    content: linear-gradient(to right, #ffffff, #ffffff);
-                                    opacity: 0.6;
-                                  }
-                            />
-                            <div
-                              class=
-
-                                  {
-                                    -moz-osx-font-smoothing: grayscale;
-                                    -webkit-font-smoothing: antialiased;
-                                    color: #323130;
-                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                    font-size: 12px;
-                                    font-weight: 400;
-                                    line-height: 16px;
-                                    opacity: 0.67;
-                                  }
-                            >
-                              Dodge
-                            </div>
-                          </button>
-                        </div>
-                        <div
-                          class=
-                              ms-OverflowSet-item
-                              {
-                                display: inherit;
-                                flex-shrink: 0;
-                              }
-                          role="none"
-                        >
-                          <button
-                            aria-label="Datsun"
-                            aria-posinset="14"
-                            aria-selected="false"
-                            aria-setsize="22"
-                            class=
-
-                                {
-                                  align-items: center;
-                                  background: none;
-                                  border: none;
-                                  cursor: pointer;
-                                  display: flex;
-                                  outline: transparent;
-                                  padding-bottom: 8px;
-                                  padding-left: 8px;
-                                  padding-right: 8px;
-                                  padding-top: 8px;
-                                  position: relative;
-                                  text-transform: capitalize;
-                                }
-                                &::-moz-focus-inner {
-                                  border: 0;
-                                }
-                                .ms-Fabric--isFocusVisible &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                            data-is-focusable="true"
-                            role="option"
-                            tabindex="-1"
-                          >
-                            <div
-                              class=
-
-                                  {
-                                    background-color: #ffffff;
-                                    border-color: #2aa0a4;
-                                    border: 1px solid;
-                                    content: ;
-                                    height: 12px;
-                                    margin-right: 8px;
-                                    width: 12px;
-                                  }
-                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
-                                    content: linear-gradient(to right, #ffffff, #ffffff);
-                                    opacity: 0.6;
-                                  }
-                            />
-                            <div
-                              class=
-
-                                  {
-                                    -moz-osx-font-smoothing: grayscale;
-                                    -webkit-font-smoothing: antialiased;
-                                    color: #323130;
-                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                    font-size: 12px;
-                                    font-weight: 400;
-                                    line-height: 16px;
-                                    opacity: 0.67;
-                                  }
-                            >
-                              Datsun
-                            </div>
-                          </button>
-                        </div>
-                        <div
-                          class=
-                              ms-OverflowSet-item
-                              {
-                                display: inherit;
-                                flex-shrink: 0;
-                              }
-                          role="none"
-                        >
-                          <button
-                            aria-label="Chrysler"
-                            aria-posinset="15"
-                            aria-selected="false"
-                            aria-setsize="22"
-                            class=
-
-                                {
-                                  align-items: center;
-                                  background: none;
-                                  border: none;
-                                  cursor: pointer;
-                                  display: flex;
-                                  outline: transparent;
-                                  padding-bottom: 8px;
-                                  padding-left: 8px;
-                                  padding-right: 8px;
-                                  padding-top: 8px;
-                                  position: relative;
-                                  text-transform: capitalize;
-                                }
-                                &::-moz-focus-inner {
-                                  border: 0;
-                                }
-                                .ms-Fabric--isFocusVisible &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                            data-is-focusable="true"
-                            role="option"
-                            tabindex="-1"
-                          >
-                            <div
-                              class=
-
-                                  {
-                                    background-color: #ffffff;
-                                    border-color: #ae8c00;
-                                    border: 1px solid;
-                                    content: ;
-                                    height: 12px;
-                                    margin-right: 8px;
-                                    width: 12px;
-                                  }
-                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
-                                    content: linear-gradient(to right, #ffffff, #ffffff);
-                                    opacity: 0.6;
-                                  }
-                            />
-                            <div
-                              class=
-
-                                  {
-                                    -moz-osx-font-smoothing: grayscale;
-                                    -webkit-font-smoothing: antialiased;
-                                    color: #323130;
-                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                    font-size: 12px;
-                                    font-weight: 400;
-                                    line-height: 16px;
-                                    opacity: 0.67;
-                                  }
-                            >
-                              Chrysler
-                            </div>
-                          </button>
-                        </div>
-                        <div
-                          class=
-                              ms-OverflowSet-item
-                              {
-                                display: inherit;
-                                flex-shrink: 0;
-                              }
-                          role="none"
-                        >
-                          <button
-                            aria-label="Camaro"
-                            aria-posinset="16"
-                            aria-selected="false"
-                            aria-setsize="22"
-                            class=
-
-                                {
-                                  align-items: center;
-                                  background: none;
-                                  border: none;
-                                  cursor: pointer;
-                                  display: flex;
-                                  outline: transparent;
-                                  padding-bottom: 8px;
-                                  padding-left: 8px;
-                                  padding-right: 8px;
-                                  padding-top: 8px;
-                                  position: relative;
-                                  text-transform: capitalize;
-                                }
-                                &::-moz-focus-inner {
-                                  border: 0;
-                                }
-                                .ms-Fabric--isFocusVisible &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                            data-is-focusable="true"
-                            role="option"
-                            tabindex="-1"
-                          >
-                            <div
-                              class=
-
-                                  {
-                                    background-color: #ffffff;
-                                    border-color: #dbdbdb;
-                                    border: 1px solid;
-                                    content: ;
-                                    height: 12px;
-                                    margin-right: 8px;
-                                    width: 12px;
-                                  }
-                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
-                                    content: linear-gradient(to right, #ffffff, #ffffff);
-                                    opacity: 0.6;
-                                  }
-                            />
-                            <div
-                              class=
-
-                                  {
-                                    -moz-osx-font-smoothing: grayscale;
-                                    -webkit-font-smoothing: antialiased;
-                                    color: #323130;
-                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                    font-size: 12px;
-                                    font-weight: 400;
-                                    line-height: 16px;
-                                    opacity: 0.67;
-                                  }
-                            >
-                              Camaro
-                            </div>
-                          </button>
-                        </div>
-                        <div
-                          class=
-                              ms-OverflowSet-item
-                              {
-                                display: inherit;
-                                flex-shrink: 0;
-                              }
-                          role="none"
-                        >
-                          <button
-                            aria-label="Cadillac"
-                            aria-posinset="17"
-                            aria-selected="true"
-                            aria-setsize="22"
-                            class=
-
-                                {
-                                  align-items: center;
-                                  background: none;
-                                  border: none;
-                                  cursor: pointer;
-                                  display: flex;
-                                  outline: transparent;
-                                  padding-bottom: 8px;
-                                  padding-left: 8px;
-                                  padding-right: 8px;
-                                  padding-top: 8px;
-                                  position: relative;
-                                  text-transform: capitalize;
-                                }
-                                &::-moz-focus-inner {
-                                  border: 0;
-                                }
-                                .ms-Fabric--isFocusVisible &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                            data-is-focusable="true"
-                            role="option"
-                            tabindex="-1"
-                          >
-                            <div
-                              class=
-
-                                  {
-                                    background-color: #ea38a6;
-                                    border-color: #ea38a6;
-                                    border: 1px solid;
-                                    content: ;
-                                    height: 12px;
-                                    margin-right: 8px;
-                                    width: 12px;
-                                  }
-                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
-                                    content: linear-gradient(to right, #ea38a6, #ea38a6);
-                                    opacity: ;
-                                  }
-                            />
-                            <div
-                              class=
-
-                                  {
-                                    -moz-osx-font-smoothing: grayscale;
-                                    -webkit-font-smoothing: antialiased;
-                                    color: #323130;
-                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                    font-size: 12px;
-                                    font-weight: 400;
-                                    line-height: 16px;
-                                    opacity: ;
-                                  }
-                            >
-                              Cadillac
-                            </div>
-                          </button>
-                        </div>
-                        <div
-                          class=
-                              ms-OverflowSet-item
-                              {
-                                display: inherit;
-                                flex-shrink: 0;
-                              }
-                          role="none"
-                        >
-                          <button
-                            aria-label="AMC"
-                            aria-posinset="18"
-                            aria-selected="false"
-                            aria-setsize="22"
-                            class=
-
-                                {
-                                  align-items: center;
-                                  background: none;
-                                  border: none;
-                                  cursor: pointer;
-                                  display: flex;
-                                  outline: transparent;
-                                  padding-bottom: 8px;
-                                  padding-left: 8px;
-                                  padding-right: 8px;
-                                  padding-top: 8px;
-                                  position: relative;
-                                  text-transform: capitalize;
-                                }
-                                &::-moz-focus-inner {
-                                  border: 0;
-                                }
-                                .ms-Fabric--isFocusVisible &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  border: 1px solid transparent;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
-                                  outline-color: #605e5c;
-                                }
-                            data-is-focusable="true"
-                            role="option"
-                            tabindex="-1"
-                          >
-                            <div
-                              class=
-
-                                  {
-                                    background-color: #ffffff;
-                                    border-color: #9a3d0c;
-                                    border: 1px solid;
-                                    content: ;
-                                    height: 12px;
-                                    margin-right: 8px;
-                                    width: 12px;
-                                  }
-                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
-                                    content: linear-gradient(to right, #ffffff, #ffffff);
-                                    opacity: 0.6;
-                                  }
-                            />
-                            <div
-                              class=
-
-                                  {
-                                    -moz-osx-font-smoothing: grayscale;
-                                    -webkit-font-smoothing: antialiased;
-                                    color: #323130;
-                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                    font-size: 12px;
-                                    font-weight: 400;
-                                    line-height: 16px;
-                                    opacity: 0.67;
-                                  }
-                            >
-                              AMC
-                            </div>
-                          </button>
-                        </div>
-                        <div
-                          class=
-                              ms-OverflowSet-item
-                              {
-                                display: inherit;
-                                flex-shrink: 0;
-                              }
-                          role="none"
-                        >
-                          <button
                             aria-label="Toyota"
-                            aria-posinset="19"
+                            aria-posinset="2"
                             aria-selected="false"
                             aria-setsize="22"
                             class=
@@ -4014,7 +2314,7 @@ exports[`DeclarativeChart Should render donutchart in DeclarativeChart 1`] = `
                         >
                           <button
                             aria-label="Mazda"
-                            aria-posinset="20"
+                            aria-posinset="3"
                             aria-selected="false"
                             aria-setsize="22"
                             class=
@@ -4114,7 +2414,7 @@ exports[`DeclarativeChart Should render donutchart in DeclarativeChart 1`] = `
                         >
                           <button
                             aria-label="Hornet"
-                            aria-posinset="21"
+                            aria-posinset="4"
                             aria-selected="false"
                             aria-setsize="22"
                             class=
@@ -4214,7 +2514,7 @@ exports[`DeclarativeChart Should render donutchart in DeclarativeChart 1`] = `
                         >
                           <button
                             aria-label="Fiat"
-                            aria-posinset="22"
+                            aria-posinset="5"
                             aria-selected="false"
                             aria-setsize="22"
                             class=
@@ -4300,6 +2600,1706 @@ exports[`DeclarativeChart Should render donutchart in DeclarativeChart 1`] = `
                                   }
                             >
                               Fiat
+                            </div>
+                          </button>
+                        </div>
+                        <div
+                          class=
+                              ms-OverflowSet-item
+                              {
+                                display: inherit;
+                                flex-shrink: 0;
+                              }
+                          role="none"
+                        >
+                          <button
+                            aria-label="Volvo"
+                            aria-posinset="6"
+                            aria-selected="false"
+                            aria-setsize="22"
+                            class=
+
+                                {
+                                  align-items: center;
+                                  background: none;
+                                  border: none;
+                                  cursor: pointer;
+                                  display: flex;
+                                  outline: transparent;
+                                  padding-bottom: 8px;
+                                  padding-left: 8px;
+                                  padding-right: 8px;
+                                  padding-top: 8px;
+                                  position: relative;
+                                  text-transform: capitalize;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                            data-is-focusable="true"
+                            role="option"
+                            tabindex="-1"
+                          >
+                            <div
+                              class=
+
+                                  {
+                                    background-color: #ffffff;
+                                    border-color: #ea38a6;
+                                    border: 1px solid;
+                                    content: ;
+                                    height: 12px;
+                                    margin-right: 8px;
+                                    width: 12px;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
+                                    content: linear-gradient(to right, #ffffff, #ffffff);
+                                    opacity: 0.6;
+                                  }
+                            />
+                            <div
+                              class=
+
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    color: #323130;
+                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                    font-size: 12px;
+                                    font-weight: 400;
+                                    line-height: 16px;
+                                    opacity: 0.67;
+                                  }
+                            >
+                              Volvo
+                            </div>
+                          </button>
+                        </div>
+                        <div
+                          class=
+                              ms-OverflowSet-item
+                              {
+                                display: inherit;
+                                flex-shrink: 0;
+                              }
+                          role="none"
+                        >
+                          <button
+                            aria-label="Valiant"
+                            aria-posinset="7"
+                            aria-selected="false"
+                            aria-setsize="22"
+                            class=
+
+                                {
+                                  align-items: center;
+                                  background: none;
+                                  border: none;
+                                  cursor: pointer;
+                                  display: flex;
+                                  outline: transparent;
+                                  padding-bottom: 8px;
+                                  padding-left: 8px;
+                                  padding-right: 8px;
+                                  padding-top: 8px;
+                                  position: relative;
+                                  text-transform: capitalize;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                            data-is-focusable="true"
+                            role="option"
+                            tabindex="-1"
+                          >
+                            <div
+                              class=
+
+                                  {
+                                    background-color: #ffffff;
+                                    border-color: #4f6bed;
+                                    border: 1px solid;
+                                    content: ;
+                                    height: 12px;
+                                    margin-right: 8px;
+                                    width: 12px;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
+                                    content: linear-gradient(to right, #ffffff, #ffffff);
+                                    opacity: 0.6;
+                                  }
+                            />
+                            <div
+                              class=
+
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    color: #323130;
+                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                    font-size: 12px;
+                                    font-weight: 400;
+                                    line-height: 16px;
+                                    opacity: 0.67;
+                                  }
+                            >
+                              Valiant
+                            </div>
+                          </button>
+                        </div>
+                        <div
+                          class=
+                              ms-OverflowSet-item
+                              {
+                                display: inherit;
+                                flex-shrink: 0;
+                              }
+                          role="none"
+                        >
+                          <button
+                            aria-label="Porsche"
+                            aria-posinset="8"
+                            aria-selected="false"
+                            aria-setsize="22"
+                            class=
+
+                                {
+                                  align-items: center;
+                                  background: none;
+                                  border: none;
+                                  cursor: pointer;
+                                  display: flex;
+                                  outline: transparent;
+                                  padding-bottom: 8px;
+                                  padding-left: 8px;
+                                  padding-right: 8px;
+                                  padding-top: 8px;
+                                  position: relative;
+                                  text-transform: capitalize;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                            data-is-focusable="true"
+                            role="option"
+                            tabindex="-1"
+                          >
+                            <div
+                              class=
+
+                                  {
+                                    background-color: #ffffff;
+                                    border-color: #6d5700;
+                                    border: 1px solid;
+                                    content: ;
+                                    height: 12px;
+                                    margin-right: 8px;
+                                    width: 12px;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
+                                    content: linear-gradient(to right, #ffffff, #ffffff);
+                                    opacity: 0.6;
+                                  }
+                            />
+                            <div
+                              class=
+
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    color: #323130;
+                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                    font-size: 12px;
+                                    font-weight: 400;
+                                    line-height: 16px;
+                                    opacity: 0.67;
+                                  }
+                            >
+                              Porsche
+                            </div>
+                          </button>
+                        </div>
+                        <div
+                          class=
+                              ms-OverflowSet-item
+                              {
+                                display: inherit;
+                                flex-shrink: 0;
+                              }
+                          role="none"
+                        >
+                          <button
+                            aria-label="Pontiac"
+                            aria-posinset="9"
+                            aria-selected="false"
+                            aria-setsize="22"
+                            class=
+
+                                {
+                                  align-items: center;
+                                  background: none;
+                                  border: none;
+                                  cursor: pointer;
+                                  display: flex;
+                                  outline: transparent;
+                                  padding-bottom: 8px;
+                                  padding-left: 8px;
+                                  padding-right: 8px;
+                                  padding-top: 8px;
+                                  position: relative;
+                                  text-transform: capitalize;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                            data-is-focusable="true"
+                            role="option"
+                            tabindex="-1"
+                          >
+                            <div
+                              class=
+
+                                  {
+                                    background-color: #ffffff;
+                                    border-color: #863593;
+                                    border: 1px solid;
+                                    content: ;
+                                    height: 12px;
+                                    margin-right: 8px;
+                                    width: 12px;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
+                                    content: linear-gradient(to right, #ffffff, #ffffff);
+                                    opacity: 0.6;
+                                  }
+                            />
+                            <div
+                              class=
+
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    color: #323130;
+                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                    font-size: 12px;
+                                    font-weight: 400;
+                                    line-height: 16px;
+                                    opacity: 0.67;
+                                  }
+                            >
+                              Pontiac
+                            </div>
+                          </button>
+                        </div>
+                        <div
+                          class=
+                              ms-OverflowSet-item
+                              {
+                                display: inherit;
+                                flex-shrink: 0;
+                              }
+                          role="none"
+                        >
+                          <button
+                            aria-label="Maserati"
+                            aria-posinset="10"
+                            aria-selected="false"
+                            aria-setsize="22"
+                            class=
+
+                                {
+                                  align-items: center;
+                                  background: none;
+                                  border: none;
+                                  cursor: pointer;
+                                  display: flex;
+                                  outline: transparent;
+                                  padding-bottom: 8px;
+                                  padding-left: 8px;
+                                  padding-right: 8px;
+                                  padding-top: 8px;
+                                  position: relative;
+                                  text-transform: capitalize;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                            data-is-focusable="true"
+                            role="option"
+                            tabindex="-1"
+                          >
+                            <div
+                              class=
+
+                                  {
+                                    background-color: #ffffff;
+                                    border-color: #405f14;
+                                    border: 1px solid;
+                                    content: ;
+                                    height: 12px;
+                                    margin-right: 8px;
+                                    width: 12px;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
+                                    content: linear-gradient(to right, #ffffff, #ffffff);
+                                    opacity: 0.6;
+                                  }
+                            />
+                            <div
+                              class=
+
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    color: #323130;
+                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                    font-size: 12px;
+                                    font-weight: 400;
+                                    line-height: 16px;
+                                    opacity: 0.67;
+                                  }
+                            >
+                              Maserati
+                            </div>
+                          </button>
+                        </div>
+                        <div
+                          class=
+                              ms-OverflowSet-item
+                              {
+                                display: inherit;
+                                flex-shrink: 0;
+                              }
+                          role="none"
+                        >
+                          <button
+                            aria-label="Lotus"
+                            aria-posinset="11"
+                            aria-selected="false"
+                            aria-setsize="22"
+                            class=
+
+                                {
+                                  align-items: center;
+                                  background: none;
+                                  border: none;
+                                  cursor: pointer;
+                                  display: flex;
+                                  outline: transparent;
+                                  padding-bottom: 8px;
+                                  padding-left: 8px;
+                                  padding-right: 8px;
+                                  padding-top: 8px;
+                                  position: relative;
+                                  text-transform: capitalize;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                            data-is-focusable="true"
+                            role="option"
+                            tabindex="-1"
+                          >
+                            <div
+                              class=
+
+                                  {
+                                    background-color: #ffffff;
+                                    border-color: #9a3d0c;
+                                    border: 1px solid;
+                                    content: ;
+                                    height: 12px;
+                                    margin-right: 8px;
+                                    width: 12px;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
+                                    content: linear-gradient(to right, #ffffff, #ffffff);
+                                    opacity: 0.6;
+                                  }
+                            />
+                            <div
+                              class=
+
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    color: #323130;
+                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                    font-size: 12px;
+                                    font-weight: 400;
+                                    line-height: 16px;
+                                    opacity: 0.67;
+                                  }
+                            >
+                              Lotus
+                            </div>
+                          </button>
+                        </div>
+                        <div
+                          class=
+                              ms-OverflowSet-item
+                              {
+                                display: inherit;
+                                flex-shrink: 0;
+                              }
+                          role="none"
+                        >
+                          <button
+                            aria-label="Lincoln"
+                            aria-posinset="12"
+                            aria-selected="false"
+                            aria-setsize="22"
+                            class=
+
+                                {
+                                  align-items: center;
+                                  background: none;
+                                  border: none;
+                                  cursor: pointer;
+                                  display: flex;
+                                  outline: transparent;
+                                  padding-bottom: 8px;
+                                  padding-left: 8px;
+                                  padding-right: 8px;
+                                  padding-top: 8px;
+                                  position: relative;
+                                  text-transform: capitalize;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                            data-is-focusable="true"
+                            role="option"
+                            tabindex="-1"
+                          >
+                            <div
+                              class=
+
+                                  {
+                                    background-color: #ffffff;
+                                    border-color: #2c72a8;
+                                    border: 1px solid;
+                                    content: ;
+                                    height: 12px;
+                                    margin-right: 8px;
+                                    width: 12px;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
+                                    content: linear-gradient(to right, #ffffff, #ffffff);
+                                    opacity: 0.6;
+                                  }
+                            />
+                            <div
+                              class=
+
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    color: #323130;
+                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                    font-size: 12px;
+                                    font-weight: 400;
+                                    line-height: 16px;
+                                    opacity: 0.67;
+                                  }
+                            >
+                              Lincoln
+                            </div>
+                          </button>
+                        </div>
+                        <div
+                          class=
+                              ms-OverflowSet-item
+                              {
+                                display: inherit;
+                                flex-shrink: 0;
+                              }
+                          role="none"
+                        >
+                          <button
+                            aria-label="Honda"
+                            aria-posinset="13"
+                            aria-selected="false"
+                            aria-setsize="22"
+                            class=
+
+                                {
+                                  align-items: center;
+                                  background: none;
+                                  border: none;
+                                  cursor: pointer;
+                                  display: flex;
+                                  outline: transparent;
+                                  padding-bottom: 8px;
+                                  padding-left: 8px;
+                                  padding-right: 8px;
+                                  padding-top: 8px;
+                                  position: relative;
+                                  text-transform: capitalize;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                            data-is-focusable="true"
+                            role="option"
+                            tabindex="-1"
+                          >
+                            <div
+                              class=
+
+                                  {
+                                    background-color: #ffffff;
+                                    border-color: #0e7a0b;
+                                    border: 1px solid;
+                                    content: ;
+                                    height: 12px;
+                                    margin-right: 8px;
+                                    width: 12px;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
+                                    content: linear-gradient(to right, #ffffff, #ffffff);
+                                    opacity: 0.6;
+                                  }
+                            />
+                            <div
+                              class=
+
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    color: #323130;
+                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                    font-size: 12px;
+                                    font-weight: 400;
+                                    line-height: 16px;
+                                    opacity: 0.67;
+                                  }
+                            >
+                              Honda
+                            </div>
+                          </button>
+                        </div>
+                        <div
+                          class=
+                              ms-OverflowSet-item
+                              {
+                                display: inherit;
+                                flex-shrink: 0;
+                              }
+                          role="none"
+                        >
+                          <button
+                            aria-label="Ford"
+                            aria-posinset="14"
+                            aria-selected="false"
+                            aria-setsize="22"
+                            class=
+
+                                {
+                                  align-items: center;
+                                  background: none;
+                                  border: none;
+                                  cursor: pointer;
+                                  display: flex;
+                                  outline: transparent;
+                                  padding-bottom: 8px;
+                                  padding-left: 8px;
+                                  padding-right: 8px;
+                                  padding-top: 8px;
+                                  position: relative;
+                                  text-transform: capitalize;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                            data-is-focusable="true"
+                            role="option"
+                            tabindex="-1"
+                          >
+                            <div
+                              class=
+
+                                  {
+                                    background-color: #ffffff;
+                                    border-color: #674c8c;
+                                    border: 1px solid;
+                                    content: ;
+                                    height: 12px;
+                                    margin-right: 8px;
+                                    width: 12px;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
+                                    content: linear-gradient(to right, #ffffff, #ffffff);
+                                    opacity: 0.6;
+                                  }
+                            />
+                            <div
+                              class=
+
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    color: #323130;
+                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                    font-size: 12px;
+                                    font-weight: 400;
+                                    line-height: 16px;
+                                    opacity: 0.67;
+                                  }
+                            >
+                              Ford
+                            </div>
+                          </button>
+                        </div>
+                        <div
+                          class=
+                              ms-OverflowSet-item
+                              {
+                                display: inherit;
+                                flex-shrink: 0;
+                              }
+                          role="none"
+                        >
+                          <button
+                            aria-label="Ferrari"
+                            aria-posinset="15"
+                            aria-selected="false"
+                            aria-setsize="22"
+                            class=
+
+                                {
+                                  align-items: center;
+                                  background: none;
+                                  border: none;
+                                  cursor: pointer;
+                                  display: flex;
+                                  outline: transparent;
+                                  padding-bottom: 8px;
+                                  padding-left: 8px;
+                                  padding-right: 8px;
+                                  padding-top: 8px;
+                                  position: relative;
+                                  text-transform: capitalize;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                            data-is-focusable="true"
+                            role="option"
+                            tabindex="-1"
+                          >
+                            <div
+                              class=
+
+                                  {
+                                    background-color: #ffffff;
+                                    border-color: #026467;
+                                    border: 1px solid;
+                                    content: ;
+                                    height: 12px;
+                                    margin-right: 8px;
+                                    width: 12px;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
+                                    content: linear-gradient(to right, #ffffff, #ffffff);
+                                    opacity: 0.6;
+                                  }
+                            />
+                            <div
+                              class=
+
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    color: #323130;
+                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                    font-size: 12px;
+                                    font-weight: 400;
+                                    line-height: 16px;
+                                    opacity: 0.67;
+                                  }
+                            >
+                              Ferrari
+                            </div>
+                          </button>
+                        </div>
+                        <div
+                          class=
+                              ms-OverflowSet-item
+                              {
+                                display: inherit;
+                                flex-shrink: 0;
+                              }
+                          role="none"
+                        >
+                          <button
+                            aria-label="Duster"
+                            aria-posinset="16"
+                            aria-selected="false"
+                            aria-setsize="22"
+                            class=
+
+                                {
+                                  align-items: center;
+                                  background: none;
+                                  border: none;
+                                  cursor: pointer;
+                                  display: flex;
+                                  outline: transparent;
+                                  padding-bottom: 8px;
+                                  padding-left: 8px;
+                                  padding-right: 8px;
+                                  padding-top: 8px;
+                                  position: relative;
+                                  text-transform: capitalize;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                            data-is-focusable="true"
+                            role="option"
+                            tabindex="-1"
+                          >
+                            <div
+                              class=
+
+                                  {
+                                    background-color: #ffffff;
+                                    border-color: #ad006a;
+                                    border: 1px solid;
+                                    content: ;
+                                    height: 12px;
+                                    margin-right: 8px;
+                                    width: 12px;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
+                                    content: linear-gradient(to right, #ffffff, #ffffff);
+                                    opacity: 0.6;
+                                  }
+                            />
+                            <div
+                              class=
+
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    color: #323130;
+                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                    font-size: 12px;
+                                    font-weight: 400;
+                                    line-height: 16px;
+                                    opacity: 0.67;
+                                  }
+                            >
+                              Duster
+                            </div>
+                          </button>
+                        </div>
+                        <div
+                          class=
+                              ms-OverflowSet-item
+                              {
+                                display: inherit;
+                                flex-shrink: 0;
+                              }
+                          role="none"
+                        >
+                          <button
+                            aria-label="Dodge"
+                            aria-posinset="17"
+                            aria-selected="false"
+                            aria-setsize="22"
+                            class=
+
+                                {
+                                  align-items: center;
+                                  background: none;
+                                  border: none;
+                                  cursor: pointer;
+                                  display: flex;
+                                  outline: transparent;
+                                  padding-bottom: 8px;
+                                  padding-left: 8px;
+                                  padding-right: 8px;
+                                  padding-top: 8px;
+                                  position: relative;
+                                  text-transform: capitalize;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                            data-is-focusable="true"
+                            role="option"
+                            tabindex="-1"
+                          >
+                            <div
+                              class=
+
+                                  {
+                                    background-color: #ffffff;
+                                    border-color: #3c51b4;
+                                    border: 1px solid;
+                                    content: ;
+                                    height: 12px;
+                                    margin-right: 8px;
+                                    width: 12px;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
+                                    content: linear-gradient(to right, #ffffff, #ffffff);
+                                    opacity: 0.6;
+                                  }
+                            />
+                            <div
+                              class=
+
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    color: #323130;
+                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                    font-size: 12px;
+                                    font-weight: 400;
+                                    line-height: 16px;
+                                    opacity: 0.67;
+                                  }
+                            >
+                              Dodge
+                            </div>
+                          </button>
+                        </div>
+                        <div
+                          class=
+                              ms-OverflowSet-item
+                              {
+                                display: inherit;
+                                flex-shrink: 0;
+                              }
+                          role="none"
+                        >
+                          <button
+                            aria-label="Datsun"
+                            aria-posinset="18"
+                            aria-selected="false"
+                            aria-setsize="22"
+                            class=
+
+                                {
+                                  align-items: center;
+                                  background: none;
+                                  border: none;
+                                  cursor: pointer;
+                                  display: flex;
+                                  outline: transparent;
+                                  padding-bottom: 8px;
+                                  padding-left: 8px;
+                                  padding-right: 8px;
+                                  padding-top: 8px;
+                                  position: relative;
+                                  text-transform: capitalize;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                            data-is-focusable="true"
+                            role="option"
+                            tabindex="-1"
+                          >
+                            <div
+                              class=
+
+                                  {
+                                    background-color: #ffffff;
+                                    border-color: #2aa0a4;
+                                    border: 1px solid;
+                                    content: ;
+                                    height: 12px;
+                                    margin-right: 8px;
+                                    width: 12px;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
+                                    content: linear-gradient(to right, #ffffff, #ffffff);
+                                    opacity: 0.6;
+                                  }
+                            />
+                            <div
+                              class=
+
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    color: #323130;
+                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                    font-size: 12px;
+                                    font-weight: 400;
+                                    line-height: 16px;
+                                    opacity: 0.67;
+                                  }
+                            >
+                              Datsun
+                            </div>
+                          </button>
+                        </div>
+                        <div
+                          class=
+                              ms-OverflowSet-item
+                              {
+                                display: inherit;
+                                flex-shrink: 0;
+                              }
+                          role="none"
+                        >
+                          <button
+                            aria-label="Chrysler"
+                            aria-posinset="19"
+                            aria-selected="false"
+                            aria-setsize="22"
+                            class=
+
+                                {
+                                  align-items: center;
+                                  background: none;
+                                  border: none;
+                                  cursor: pointer;
+                                  display: flex;
+                                  outline: transparent;
+                                  padding-bottom: 8px;
+                                  padding-left: 8px;
+                                  padding-right: 8px;
+                                  padding-top: 8px;
+                                  position: relative;
+                                  text-transform: capitalize;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                            data-is-focusable="true"
+                            role="option"
+                            tabindex="-1"
+                          >
+                            <div
+                              class=
+
+                                  {
+                                    background-color: #ffffff;
+                                    border-color: #ae8c00;
+                                    border: 1px solid;
+                                    content: ;
+                                    height: 12px;
+                                    margin-right: 8px;
+                                    width: 12px;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
+                                    content: linear-gradient(to right, #ffffff, #ffffff);
+                                    opacity: 0.6;
+                                  }
+                            />
+                            <div
+                              class=
+
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    color: #323130;
+                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                    font-size: 12px;
+                                    font-weight: 400;
+                                    line-height: 16px;
+                                    opacity: 0.67;
+                                  }
+                            >
+                              Chrysler
+                            </div>
+                          </button>
+                        </div>
+                        <div
+                          class=
+                              ms-OverflowSet-item
+                              {
+                                display: inherit;
+                                flex-shrink: 0;
+                              }
+                          role="none"
+                        >
+                          <button
+                            aria-label="Camaro"
+                            aria-posinset="20"
+                            aria-selected="false"
+                            aria-setsize="22"
+                            class=
+
+                                {
+                                  align-items: center;
+                                  background: none;
+                                  border: none;
+                                  cursor: pointer;
+                                  display: flex;
+                                  outline: transparent;
+                                  padding-bottom: 8px;
+                                  padding-left: 8px;
+                                  padding-right: 8px;
+                                  padding-top: 8px;
+                                  position: relative;
+                                  text-transform: capitalize;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                            data-is-focusable="true"
+                            role="option"
+                            tabindex="-1"
+                          >
+                            <div
+                              class=
+
+                                  {
+                                    background-color: #ffffff;
+                                    border-color: #dbdbdb;
+                                    border: 1px solid;
+                                    content: ;
+                                    height: 12px;
+                                    margin-right: 8px;
+                                    width: 12px;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
+                                    content: linear-gradient(to right, #ffffff, #ffffff);
+                                    opacity: 0.6;
+                                  }
+                            />
+                            <div
+                              class=
+
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    color: #323130;
+                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                    font-size: 12px;
+                                    font-weight: 400;
+                                    line-height: 16px;
+                                    opacity: 0.67;
+                                  }
+                            >
+                              Camaro
+                            </div>
+                          </button>
+                        </div>
+                        <div
+                          class=
+                              ms-OverflowSet-item
+                              {
+                                display: inherit;
+                                flex-shrink: 0;
+                              }
+                          role="none"
+                        >
+                          <button
+                            aria-label="Cadillac"
+                            aria-posinset="21"
+                            aria-selected="true"
+                            aria-setsize="22"
+                            class=
+
+                                {
+                                  align-items: center;
+                                  background: none;
+                                  border: none;
+                                  cursor: pointer;
+                                  display: flex;
+                                  outline: transparent;
+                                  padding-bottom: 8px;
+                                  padding-left: 8px;
+                                  padding-right: 8px;
+                                  padding-top: 8px;
+                                  position: relative;
+                                  text-transform: capitalize;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                            data-is-focusable="true"
+                            role="option"
+                            tabindex="-1"
+                          >
+                            <div
+                              class=
+
+                                  {
+                                    background-color: #ea38a6;
+                                    border-color: #ea38a6;
+                                    border: 1px solid;
+                                    content: ;
+                                    height: 12px;
+                                    margin-right: 8px;
+                                    width: 12px;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
+                                    content: linear-gradient(to right, #ea38a6, #ea38a6);
+                                    opacity: ;
+                                  }
+                            />
+                            <div
+                              class=
+
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    color: #323130;
+                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                    font-size: 12px;
+                                    font-weight: 400;
+                                    line-height: 16px;
+                                    opacity: ;
+                                  }
+                            >
+                              Cadillac
+                            </div>
+                          </button>
+                        </div>
+                        <div
+                          class=
+                              ms-OverflowSet-item
+                              {
+                                display: inherit;
+                                flex-shrink: 0;
+                              }
+                          role="none"
+                        >
+                          <button
+                            aria-label="AMC"
+                            aria-posinset="22"
+                            aria-selected="false"
+                            aria-setsize="22"
+                            class=
+
+                                {
+                                  align-items: center;
+                                  background: none;
+                                  border: none;
+                                  cursor: pointer;
+                                  display: flex;
+                                  outline: transparent;
+                                  padding-bottom: 8px;
+                                  padding-left: 8px;
+                                  padding-right: 8px;
+                                  padding-top: 8px;
+                                  position: relative;
+                                  text-transform: capitalize;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                                :host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  border: 1px solid transparent;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){:host(.ms-Fabric--isFocusVisible) &:focus:after {
+                                  outline-color: #605e5c;
+                                }
+                            data-is-focusable="true"
+                            role="option"
+                            tabindex="-1"
+                          >
+                            <div
+                              class=
+
+                                  {
+                                    background-color: #ffffff;
+                                    border-color: #9a3d0c;
+                                    border: 1px solid;
+                                    content: ;
+                                    height: 12px;
+                                    margin-right: 8px;
+                                    width: 12px;
+                                  }
+                                  @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
+                                    content: linear-gradient(to right, #ffffff, #ffffff);
+                                    opacity: 0.6;
+                                  }
+                            />
+                            <div
+                              class=
+
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    color: #323130;
+                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                    font-size: 12px;
+                                    font-weight: 400;
+                                    line-height: 16px;
+                                    opacity: 0.67;
+                                  }
+                            >
+                              AMC
                             </div>
                           </button>
                         </div>
@@ -20056,7 +20056,7 @@ exports[`DeclarativeChart Should render piechart in DeclarativeChart 1`] = `
                           role="none"
                         >
                           <button
-                            aria-label="Nitrogen"
+                            aria-label="Hydrogen"
                             aria-posinset="2"
                             aria-selected="false"
                             aria-setsize="4"
@@ -20115,8 +20115,8 @@ exports[`DeclarativeChart Should render piechart in DeclarativeChart 1`] = `
                               class=
 
                                   {
-                                    background-color: #D0F9B1;
-                                    border-color: #D0F9B1;
+                                    background-color: #E1396C;
+                                    border-color: #E1396C;
                                     border: 1px solid;
                                     content: ;
                                     height: 12px;
@@ -20124,7 +20124,7 @@ exports[`DeclarativeChart Should render piechart in DeclarativeChart 1`] = `
                                     width: 12px;
                                   }
                                   @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
-                                    content: linear-gradient(to right, #D0F9B1, #D0F9B1);
+                                    content: linear-gradient(to right, #E1396C, #E1396C);
                                     opacity: ;
                                   }
                             />
@@ -20142,7 +20142,7 @@ exports[`DeclarativeChart Should render piechart in DeclarativeChart 1`] = `
                                     opacity: ;
                                   }
                             >
-                              Nitrogen
+                              Hydrogen
                             </div>
                           </button>
                         </div>
@@ -20256,7 +20256,7 @@ exports[`DeclarativeChart Should render piechart in DeclarativeChart 1`] = `
                           role="none"
                         >
                           <button
-                            aria-label="Hydrogen"
+                            aria-label="Nitrogen"
                             aria-posinset="4"
                             aria-selected="false"
                             aria-setsize="4"
@@ -20315,8 +20315,8 @@ exports[`DeclarativeChart Should render piechart in DeclarativeChart 1`] = `
                               class=
 
                                   {
-                                    background-color: #E1396C;
-                                    border-color: #E1396C;
+                                    background-color: #D0F9B1;
+                                    border-color: #D0F9B1;
                                     border: 1px solid;
                                     content: ;
                                     height: 12px;
@@ -20324,7 +20324,7 @@ exports[`DeclarativeChart Should render piechart in DeclarativeChart 1`] = `
                                     width: 12px;
                                   }
                                   @media screen and (-ms-high-contrast: active), screen and (forced-colors: active){& {
-                                    content: linear-gradient(to right, #E1396C, #E1396C);
+                                    content: linear-gradient(to right, #D0F9B1, #D0F9B1);
                                     opacity: ;
                                   }
                             />
@@ -20342,7 +20342,7 @@ exports[`DeclarativeChart Should render piechart in DeclarativeChart 1`] = `
                                     opacity: ;
                                   }
                             >
-                              Hydrogen
+                              Nitrogen
                             </div>
                           </button>
                         </div>

--- a/packages/charts/react-charting/src/components/DeclarativeChart/__snapshots__/PlotlySchemaAdapterUT.test.tsx.snap
+++ b/packages/charts/react-charting/src/components/DeclarativeChart/__snapshots__/PlotlySchemaAdapterUT.test.tsx.snap
@@ -522,7 +522,7 @@ Object {
       "name": "Jan",
       "series": Array [
         Object {
-          "color": "#637cefff",
+          "color": "#3487c7ff",
           "data": 2000,
           "key": "Category A",
           "legend": "Category A",
@@ -545,7 +545,7 @@ Object {
       "name": "Feb",
       "series": Array [
         Object {
-          "color": "#637cefff",
+          "color": "#3487c7ff",
           "data": 2100,
           "key": "Category A",
           "legend": "Category A",
@@ -568,7 +568,7 @@ Object {
       "name": "Mar",
       "series": Array [
         Object {
-          "color": "#637cefff",
+          "color": "#3487c7ff",
           "data": 2200,
           "key": "Category A",
           "legend": "Category A",
@@ -591,7 +591,7 @@ Object {
       "name": "Apr",
       "series": Array [
         Object {
-          "color": "#637cefff",
+          "color": "#3487c7ff",
           "data": 2300,
           "key": "Category A",
           "legend": "Category A",
@@ -614,7 +614,7 @@ Object {
       "name": "May",
       "series": Array [
         Object {
-          "color": "#637cefff",
+          "color": "#3487c7ff",
           "data": 2400,
           "key": "Category A",
           "legend": "Category A",
@@ -3200,139 +3200,139 @@ Object {
   "chartTitle": "PHP Framework Popularity at Work - SitePoint, 2015",
   "data": Array [
     Object {
-      "color": "#3a96ddff",
+      "color": "#d77440ff",
       "legend": "Votes",
       "x": 1659,
       "y": "Laravel",
     },
     Object {
-      "color": "#3a96ddff",
+      "color": "#d77440ff",
       "legend": "Votes",
       "x": 1067,
       "y": "Symfony2",
     },
     Object {
-      "color": "#3a96ddff",
+      "color": "#d77440ff",
       "legend": "Votes",
       "x": 671,
       "y": "Nette",
     },
     Object {
-      "color": "#3a96ddff",
+      "color": "#d77440ff",
       "legend": "Votes",
       "x": 597,
       "y": "CodeIgniter",
     },
     Object {
-      "color": "#3a96ddff",
+      "color": "#d77440ff",
       "legend": "Votes",
       "x": 504,
       "y": "Yii 2",
     },
     Object {
-      "color": "#3a96ddff",
+      "color": "#d77440ff",
       "legend": "Votes",
       "x": 418,
       "y": "PHPixie",
     },
     Object {
-      "color": "#3a96ddff",
+      "color": "#d77440ff",
       "legend": "Votes",
       "x": 407,
       "y": "Yii 1",
     },
     Object {
-      "color": "#3a96ddff",
+      "color": "#d77440ff",
       "legend": "Votes",
       "x": 390,
       "y": "Zend Framework 2",
     },
     Object {
-      "color": "#3a96ddff",
+      "color": "#d77440ff",
       "legend": "Votes",
       "x": 378,
       "y": "Company Internal Framework",
     },
     Object {
-      "color": "#3a96ddff",
+      "color": "#d77440ff",
       "legend": "Votes",
       "x": 274,
       "y": "Zend Framework 1",
     },
     Object {
-      "color": "#3a96ddff",
+      "color": "#d77440ff",
       "legend": "Votes",
       "x": 255,
       "y": "CakePHP",
     },
     Object {
-      "color": "#3a96ddff",
+      "color": "#d77440ff",
       "legend": "Votes",
       "x": 243,
       "y": "No Framework",
     },
     Object {
-      "color": "#3a96ddff",
+      "color": "#d77440ff",
       "legend": "Votes",
       "x": 203,
       "y": "We use a CMS for everything",
     },
     Object {
-      "color": "#3a96ddff",
+      "color": "#d77440ff",
       "legend": "Votes",
       "x": 169,
       "y": "Phalcon",
     },
     Object {
-      "color": "#3a96ddff",
+      "color": "#d77440ff",
       "legend": "Votes",
       "x": 79,
       "y": "Slim",
     },
     Object {
-      "color": "#3a96ddff",
+      "color": "#d77440ff",
       "legend": "Votes",
       "x": 65,
       "y": "Silex",
     },
     Object {
-      "color": "#3a96ddff",
+      "color": "#d77440ff",
       "legend": "Votes",
       "x": 42,
       "y": "Simple MVC Framework",
     },
     Object {
-      "color": "#3a96ddff",
+      "color": "#d77440ff",
       "legend": "Votes",
       "x": 35,
       "y": "Typo 3",
     },
     Object {
-      "color": "#3a96ddff",
+      "color": "#d77440ff",
       "legend": "Votes",
       "x": 35,
       "y": "Kohana",
     },
     Object {
-      "color": "#3a96ddff",
+      "color": "#d77440ff",
       "legend": "Votes",
       "x": 25,
       "y": "FuelPHP",
     },
     Object {
-      "color": "#3a96ddff",
+      "color": "#d77440ff",
       "legend": "Votes",
       "x": 17,
       "y": "TYPO3 Flow",
     },
     Object {
-      "color": "#3a96ddff",
+      "color": "#d77440ff",
       "legend": "Votes",
       "x": 11,
       "y": "Drupal",
     },
     Object {
-      "color": "#3a96ddff",
+      "color": "#d77440ff",
       "legend": "Votes",
       "x": 10,
       "y": "Aura",
@@ -5080,7 +5080,7 @@ Object {
   "data": Object {
     "scatterChartData": Array [
       Object {
-        "color": "#57811bff",
+        "color": "#13a10eff",
         "data": Array [
           Object {
             "x": 2015-01-01T00:00:00.000Z,
@@ -5592,7 +5592,7 @@ Object {
         "useSecondaryYScale": false,
       },
       Object {
-        "color": "#9373c0ff",
+        "color": "#dc626dff",
         "data": Array [
           Object {
             "x": 2015-01-01T00:00:00.000Z,
@@ -6104,7 +6104,7 @@ Object {
         "useSecondaryYScale": false,
       },
       Object {
-        "color": "#ca5010ff",
+        "color": "#9373c0ff",
         "data": Array [
           Object {
             "x": 2015-01-01T00:00:00.000Z,

--- a/packages/charts/react-charting/src/components/DeclarativeChart/__snapshots__/PlotlySchemaAdapterUT.test.tsx.snap
+++ b/packages/charts/react-charting/src/components/DeclarativeChart/__snapshots__/PlotlySchemaAdapterUT.test.tsx.snap
@@ -470,6 +470,7 @@ Object {
   "hideLabels": false,
   "hideLegend": false,
   "innerRadius": 42,
+  "order": "sorted",
   "roundCorners": true,
   "showLabelsInPercent": true,
   "width": undefined,
@@ -507,6 +508,7 @@ Object {
   "hideLabels": false,
   "hideLegend": false,
   "innerRadius": 1,
+  "order": "sorted",
   "roundCorners": true,
   "showLabelsInPercent": false,
   "width": undefined,
@@ -522,7 +524,7 @@ Object {
       "name": "Jan",
       "series": Array [
         Object {
-          "color": "#3487c7ff",
+          "color": "#637cefff",
           "data": 2000,
           "key": "Category A",
           "legend": "Category A",
@@ -545,7 +547,7 @@ Object {
       "name": "Feb",
       "series": Array [
         Object {
-          "color": "#3487c7ff",
+          "color": "#637cefff",
           "data": 2100,
           "key": "Category A",
           "legend": "Category A",
@@ -568,7 +570,7 @@ Object {
       "name": "Mar",
       "series": Array [
         Object {
-          "color": "#3487c7ff",
+          "color": "#637cefff",
           "data": 2200,
           "key": "Category A",
           "legend": "Category A",
@@ -591,7 +593,7 @@ Object {
       "name": "Apr",
       "series": Array [
         Object {
-          "color": "#3487c7ff",
+          "color": "#637cefff",
           "data": 2300,
           "key": "Category A",
           "legend": "Category A",
@@ -614,7 +616,7 @@ Object {
       "name": "May",
       "series": Array [
         Object {
-          "color": "#3487c7ff",
+          "color": "#637cefff",
           "data": 2400,
           "key": "Category A",
           "legend": "Category A",
@@ -3200,139 +3202,139 @@ Object {
   "chartTitle": "PHP Framework Popularity at Work - SitePoint, 2015",
   "data": Array [
     Object {
-      "color": "#d77440ff",
+      "color": "#3a96ddff",
       "legend": "Votes",
       "x": 1659,
       "y": "Laravel",
     },
     Object {
-      "color": "#d77440ff",
+      "color": "#3a96ddff",
       "legend": "Votes",
       "x": 1067,
       "y": "Symfony2",
     },
     Object {
-      "color": "#d77440ff",
+      "color": "#3a96ddff",
       "legend": "Votes",
       "x": 671,
       "y": "Nette",
     },
     Object {
-      "color": "#d77440ff",
+      "color": "#3a96ddff",
       "legend": "Votes",
       "x": 597,
       "y": "CodeIgniter",
     },
     Object {
-      "color": "#d77440ff",
+      "color": "#3a96ddff",
       "legend": "Votes",
       "x": 504,
       "y": "Yii 2",
     },
     Object {
-      "color": "#d77440ff",
+      "color": "#3a96ddff",
       "legend": "Votes",
       "x": 418,
       "y": "PHPixie",
     },
     Object {
-      "color": "#d77440ff",
+      "color": "#3a96ddff",
       "legend": "Votes",
       "x": 407,
       "y": "Yii 1",
     },
     Object {
-      "color": "#d77440ff",
+      "color": "#3a96ddff",
       "legend": "Votes",
       "x": 390,
       "y": "Zend Framework 2",
     },
     Object {
-      "color": "#d77440ff",
+      "color": "#3a96ddff",
       "legend": "Votes",
       "x": 378,
       "y": "Company Internal Framework",
     },
     Object {
-      "color": "#d77440ff",
+      "color": "#3a96ddff",
       "legend": "Votes",
       "x": 274,
       "y": "Zend Framework 1",
     },
     Object {
-      "color": "#d77440ff",
+      "color": "#3a96ddff",
       "legend": "Votes",
       "x": 255,
       "y": "CakePHP",
     },
     Object {
-      "color": "#d77440ff",
+      "color": "#3a96ddff",
       "legend": "Votes",
       "x": 243,
       "y": "No Framework",
     },
     Object {
-      "color": "#d77440ff",
+      "color": "#3a96ddff",
       "legend": "Votes",
       "x": 203,
       "y": "We use a CMS for everything",
     },
     Object {
-      "color": "#d77440ff",
+      "color": "#3a96ddff",
       "legend": "Votes",
       "x": 169,
       "y": "Phalcon",
     },
     Object {
-      "color": "#d77440ff",
+      "color": "#3a96ddff",
       "legend": "Votes",
       "x": 79,
       "y": "Slim",
     },
     Object {
-      "color": "#d77440ff",
+      "color": "#3a96ddff",
       "legend": "Votes",
       "x": 65,
       "y": "Silex",
     },
     Object {
-      "color": "#d77440ff",
+      "color": "#3a96ddff",
       "legend": "Votes",
       "x": 42,
       "y": "Simple MVC Framework",
     },
     Object {
-      "color": "#d77440ff",
+      "color": "#3a96ddff",
       "legend": "Votes",
       "x": 35,
       "y": "Typo 3",
     },
     Object {
-      "color": "#d77440ff",
+      "color": "#3a96ddff",
       "legend": "Votes",
       "x": 35,
       "y": "Kohana",
     },
     Object {
-      "color": "#d77440ff",
+      "color": "#3a96ddff",
       "legend": "Votes",
       "x": 25,
       "y": "FuelPHP",
     },
     Object {
-      "color": "#d77440ff",
+      "color": "#3a96ddff",
       "legend": "Votes",
       "x": 17,
       "y": "TYPO3 Flow",
     },
     Object {
-      "color": "#d77440ff",
+      "color": "#3a96ddff",
       "legend": "Votes",
       "x": 11,
       "y": "Drupal",
     },
     Object {
-      "color": "#d77440ff",
+      "color": "#3a96ddff",
       "legend": "Votes",
       "x": 10,
       "y": "Aura",
@@ -5080,7 +5082,7 @@ Object {
   "data": Object {
     "scatterChartData": Array [
       Object {
-        "color": "#13a10eff",
+        "color": "#57811bff",
         "data": Array [
           Object {
             "x": 2015-01-01T00:00:00.000Z,
@@ -5592,7 +5594,7 @@ Object {
         "useSecondaryYScale": false,
       },
       Object {
-        "color": "#dc626dff",
+        "color": "#9373c0ff",
         "data": Array [
           Object {
             "x": 2015-01-01T00:00:00.000Z,
@@ -6104,7 +6106,7 @@ Object {
         "useSecondaryYScale": false,
       },
       Object {
-        "color": "#9373c0ff",
+        "color": "#ca5010ff",
         "data": Array [
           Object {
             "x": 2015-01-01T00:00:00.000Z,

--- a/packages/charts/react-charting/src/components/DeclarativeChart/__snapshots__/PlotlySchemaAdapterUT.test.tsx.snap
+++ b/packages/charts/react-charting/src/components/DeclarativeChart/__snapshots__/PlotlySchemaAdapterUT.test.tsx.snap
@@ -354,114 +354,114 @@ Object {
   "data": Object {
     "chartData": Array [
       Object {
-        "color": "#57811b",
+        "color": "#3487c7",
         "data": 7,
         "legend": "Merc",
       },
       Object {
-        "color": "#9373c0",
-        "data": 2,
-        "legend": "Fiat",
-      },
-      Object {
-        "color": "#ca5010",
-        "data": 2,
-        "legend": "Hornet",
-      },
-      Object {
-        "color": "#3a96dd",
-        "data": 2,
-        "legend": "Mazda",
-      },
-      Object {
-        "color": "#e3008c",
-        "data": 2,
-        "legend": "Toyota",
-      },
-      Object {
-        "color": "#13a10e",
+        "color": "#ea38a6",
         "data": 1,
-        "legend": "AMC",
-      },
-      Object {
-        "color": "#b146c2",
-        "data": 1,
-        "legend": "Cadillac",
-      },
-      Object {
-        "color": "#ae8c00",
-        "data": 1,
-        "legend": "Camaro",
-      },
-      Object {
-        "color": "#93a4f4",
-        "data": 1,
-        "legend": "Chrysler",
-      },
-      Object {
-        "color": "#ee5fb7",
-        "data": 1,
-        "legend": "Datsun",
-      },
-      Object {
-        "color": "#4cb4b7",
-        "data": 1,
-        "legend": "Dodge",
-      },
-      Object {
-        "color": "#a083c9",
-        "data": 1,
-        "legend": "Duster",
-      },
-      Object {
-        "color": "#27ac22",
-        "data": 1,
-        "legend": "Ferrari",
-      },
-      Object {
-        "color": "#4fa1e1",
-        "data": 1,
-        "legend": "Ford",
-      },
-      Object {
-        "color": "#d77440",
-        "data": 1,
-        "legend": "Honda",
-      },
-      Object {
-        "color": "#73aa24",
-        "data": 1,
-        "legend": "Lincoln",
-      },
-      Object {
-        "color": "#c36bd1",
-        "data": 1,
-        "legend": "Lotus",
-      },
-      Object {
-        "color": "#d0b232",
-        "data": 1,
-        "legend": "Maserati",
+        "legend": "Volvo",
       },
       Object {
         "color": "#4f6bed",
         "data": 1,
-        "legend": "Pontiac",
+        "legend": "Valiant",
       },
       Object {
-        "color": "#ea38a6",
+        "color": "#d0b232",
         "data": 1,
         "legend": "Porsche",
       },
       Object {
-        "color": "#038387",
+        "color": "#c36bd1",
         "data": 1,
-        "legend": "Valiant",
+        "legend": "Pontiac",
       },
       Object {
-        "color": "#8764b8",
+        "color": "#73aa24",
         "data": 1,
-        "legend": "Volvo",
+        "legend": "Maserati",
+      },
+      Object {
+        "color": "#d77440",
+        "data": 1,
+        "legend": "Lotus",
+      },
+      Object {
+        "color": "#4fa1e1",
+        "data": 1,
+        "legend": "Lincoln",
+      },
+      Object {
+        "color": "#27ac22",
+        "data": 1,
+        "legend": "Honda",
+      },
+      Object {
+        "color": "#a083c9",
+        "data": 1,
+        "legend": "Ford",
+      },
+      Object {
+        "color": "#4cb4b7",
+        "data": 1,
+        "legend": "Ferrari",
+      },
+      Object {
+        "color": "#ee5fb7",
+        "data": 1,
+        "legend": "Duster",
+      },
+      Object {
+        "color": "#93a4f4",
+        "data": 1,
+        "legend": "Dodge",
+      },
+      Object {
+        "color": "#2aa0a4",
+        "data": 1,
+        "legend": "Datsun",
+      },
+      Object {
+        "color": "#ae8c00",
+        "data": 1,
+        "legend": "Chrysler",
+      },
+      Object {
+        "color": "#4d4d4d",
+        "data": 1,
+        "legend": "Camaro",
+      },
+      Object {
+        "color": "#ea38a6",
+        "data": 1,
+        "legend": "Cadillac",
+      },
+      Object {
+        "color": "#d77440",
+        "data": 1,
+        "legend": "AMC",
+      },
+      Object {
+        "color": "#9373c0",
+        "data": 2,
+        "legend": "Toyota",
+      },
+      Object {
+        "color": "#dc626d",
+        "data": 2,
+        "legend": "Mazda",
+      },
+      Object {
+        "color": "#13a10e",
+        "data": 2,
+        "legend": "Hornet",
+      },
+      Object {
+        "color": "#f87528",
+        "data": 2,
+        "legend": "Fiat",
       },
     ],
     "chartTitle": "Donut charts using Plotly",
@@ -481,24 +481,24 @@ Object {
   "data": Object {
     "chartData": Array [
       Object {
-        "color": "#febfb3",
+        "color": "#FEBFB3",
         "data": 4500,
         "legend": "Oxygen",
       },
       Object {
-        "color": "#e1396c",
-        "data": 2500,
-        "legend": "Hydrogen",
+        "color": "#D0F9B1",
+        "data": 500,
+        "legend": "Nitrogen",
       },
       Object {
-        "color": "#96d38c",
+        "color": "#96D38C",
         "data": 1053,
         "legend": "Carbon_Dioxide",
       },
       Object {
-        "color": "#d0f9b1",
-        "data": 500,
-        "legend": "Nitrogen",
+        "color": "#E1396C",
+        "data": 2500,
+        "legend": "Hydrogen",
       },
     ],
     "chartTitle": "",
@@ -522,7 +522,7 @@ Object {
       "name": "Jan",
       "series": Array [
         Object {
-          "color": "#ba58c9ff",
+          "color": "#637cefff",
           "data": 2000,
           "key": "Category A",
           "legend": "Category A",
@@ -531,7 +531,7 @@ Object {
           "yAxisCalloutData": "2000",
         },
         Object {
-          "color": "#c19c00ff",
+          "color": "#f87528ff",
           "data": 3000,
           "key": "Category B",
           "legend": "Category B",
@@ -545,7 +545,7 @@ Object {
       "name": "Feb",
       "series": Array [
         Object {
-          "color": "#ba58c9ff",
+          "color": "#637cefff",
           "data": 2100,
           "key": "Category A",
           "legend": "Category A",
@@ -554,7 +554,7 @@ Object {
           "yAxisCalloutData": "2100",
         },
         Object {
-          "color": "#c19c00ff",
+          "color": "#f87528ff",
           "data": 3100,
           "key": "Category B",
           "legend": "Category B",
@@ -568,7 +568,7 @@ Object {
       "name": "Mar",
       "series": Array [
         Object {
-          "color": "#ba58c9ff",
+          "color": "#637cefff",
           "data": 2200,
           "key": "Category A",
           "legend": "Category A",
@@ -577,7 +577,7 @@ Object {
           "yAxisCalloutData": "2200",
         },
         Object {
-          "color": "#c19c00ff",
+          "color": "#f87528ff",
           "data": 3200,
           "key": "Category B",
           "legend": "Category B",
@@ -591,7 +591,7 @@ Object {
       "name": "Apr",
       "series": Array [
         Object {
-          "color": "#ba58c9ff",
+          "color": "#637cefff",
           "data": 2300,
           "key": "Category A",
           "legend": "Category A",
@@ -600,7 +600,7 @@ Object {
           "yAxisCalloutData": "2300",
         },
         Object {
-          "color": "#c19c00ff",
+          "color": "#f87528ff",
           "data": 3300,
           "key": "Category B",
           "legend": "Category B",
@@ -614,7 +614,7 @@ Object {
       "name": "May",
       "series": Array [
         Object {
-          "color": "#ba58c9ff",
+          "color": "#637cefff",
           "data": 2400,
           "key": "Category A",
           "legend": "Category A",
@@ -623,7 +623,7 @@ Object {
           "yAxisCalloutData": "2400",
         },
         Object {
-          "color": "#c19c00ff",
+          "color": "#f87528ff",
           "data": 3400,
           "key": "Category B",
           "legend": "Category B",
@@ -3200,139 +3200,139 @@ Object {
   "chartTitle": "PHP Framework Popularity at Work - SitePoint, 2015",
   "data": Array [
     Object {
-      "color": "#b29ad4ff",
+      "color": "#3a96ddff",
       "legend": "Votes",
       "x": 1659,
       "y": "Laravel",
     },
     Object {
-      "color": "#b29ad4ff",
+      "color": "#3a96ddff",
       "legend": "Votes",
       "x": 1067,
       "y": "Symfony2",
     },
     Object {
-      "color": "#b29ad4ff",
+      "color": "#3a96ddff",
       "legend": "Votes",
       "x": 671,
       "y": "Nette",
     },
     Object {
-      "color": "#b29ad4ff",
+      "color": "#3a96ddff",
       "legend": "Votes",
       "x": 597,
       "y": "CodeIgniter",
     },
     Object {
-      "color": "#b29ad4ff",
+      "color": "#3a96ddff",
       "legend": "Votes",
       "x": 504,
       "y": "Yii 2",
     },
     Object {
-      "color": "#b29ad4ff",
+      "color": "#3a96ddff",
       "legend": "Votes",
       "x": 418,
       "y": "PHPixie",
     },
     Object {
-      "color": "#b29ad4ff",
+      "color": "#3a96ddff",
       "legend": "Votes",
       "x": 407,
       "y": "Yii 1",
     },
     Object {
-      "color": "#b29ad4ff",
+      "color": "#3a96ddff",
       "legend": "Votes",
       "x": 390,
       "y": "Zend Framework 2",
     },
     Object {
-      "color": "#b29ad4ff",
+      "color": "#3a96ddff",
       "legend": "Votes",
       "x": 378,
       "y": "Company Internal Framework",
     },
     Object {
-      "color": "#b29ad4ff",
+      "color": "#3a96ddff",
       "legend": "Votes",
       "x": 274,
       "y": "Zend Framework 1",
     },
     Object {
-      "color": "#b29ad4ff",
+      "color": "#3a96ddff",
       "legend": "Votes",
       "x": 255,
       "y": "CakePHP",
     },
     Object {
-      "color": "#b29ad4ff",
+      "color": "#3a96ddff",
       "legend": "Votes",
       "x": 243,
       "y": "No Framework",
     },
     Object {
-      "color": "#b29ad4ff",
+      "color": "#3a96ddff",
       "legend": "Votes",
       "x": 203,
       "y": "We use a CMS for everything",
     },
     Object {
-      "color": "#b29ad4ff",
+      "color": "#3a96ddff",
       "legend": "Votes",
       "x": 169,
       "y": "Phalcon",
     },
     Object {
-      "color": "#b29ad4ff",
+      "color": "#3a96ddff",
       "legend": "Votes",
       "x": 79,
       "y": "Slim",
     },
     Object {
-      "color": "#b29ad4ff",
+      "color": "#3a96ddff",
       "legend": "Votes",
       "x": 65,
       "y": "Silex",
     },
     Object {
-      "color": "#b29ad4ff",
+      "color": "#3a96ddff",
       "legend": "Votes",
       "x": 42,
       "y": "Simple MVC Framework",
     },
     Object {
-      "color": "#b29ad4ff",
+      "color": "#3a96ddff",
       "legend": "Votes",
       "x": 35,
       "y": "Typo 3",
     },
     Object {
-      "color": "#b29ad4ff",
+      "color": "#3a96ddff",
       "legend": "Votes",
       "x": 35,
       "y": "Kohana",
     },
     Object {
-      "color": "#b29ad4ff",
+      "color": "#3a96ddff",
       "legend": "Votes",
       "x": 25,
       "y": "FuelPHP",
     },
     Object {
-      "color": "#b29ad4ff",
+      "color": "#3a96ddff",
       "legend": "Votes",
       "x": 17,
       "y": "TYPO3 Flow",
     },
     Object {
-      "color": "#b29ad4ff",
+      "color": "#3a96ddff",
       "legend": "Votes",
       "x": 11,
       "y": "Drupal",
     },
     Object {
-      "color": "#b29ad4ff",
+      "color": "#3a96ddff",
       "legend": "Votes",
       "x": 10,
       "y": "Aura",
@@ -5080,7 +5080,7 @@ Object {
   "data": Object {
     "scatterChartData": Array [
       Object {
-        "color": "#c8d1faff",
+        "color": "#57811bff",
         "data": Array [
           Object {
             "x": 2015-01-01T00:00:00.000Z,
@@ -5592,7 +5592,7 @@ Object {
         "useSecondaryYScale": false,
       },
       Object {
-        "color": "#f7addaff",
+        "color": "#9373c0ff",
         "data": Array [
           Object {
             "x": 2015-01-01T00:00:00.000Z,
@@ -6104,7 +6104,7 @@ Object {
         "useSecondaryYScale": false,
       },
       Object {
-        "color": "#9bd9dbff",
+        "color": "#ca5010ff",
         "data": Array [
           Object {
             "x": 2015-01-01T00:00:00.000Z,

--- a/packages/charts/react-charting/src/components/DonutChart/DonutChart.base.tsx
+++ b/packages/charts/react-charting/src/components/DonutChart/DonutChart.base.tsx
@@ -127,12 +127,12 @@ export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChar
       className: this.props.className!,
     });
 
-    const legendBars = this._createLegends(points);
+    const legendBars = this._createLegends(points.filter(d => d.data! >= 0));
     const donutMarginHorizontal = this.props.hideLabels ? 0 : 80;
     const donutMarginVertical = this.props.hideLabels ? 0 : 40;
     const outerRadius =
       Math.min(this.state._width! - donutMarginHorizontal, this.state._height! - donutMarginVertical) / 2;
-    const chartData = this._elevateToMinimums(points.filter((d: IChartDataPoint) => d.data! >= 0));
+    const chartData = this._elevateToMinimums(points);
     const valueInsideDonut =
       this.props.innerRadius! > MIN_DONUT_RADIUS
         ? this._valueInsideDonut(this.props.valueInsideDonut!, chartData!)

--- a/packages/charts/react-charting/src/components/DonutChart/DonutChart.base.tsx
+++ b/packages/charts/react-charting/src/components/DonutChart/DonutChart.base.tsx
@@ -280,6 +280,11 @@ export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChar
 
   // eslint-disable-next-line @typescript-eslint/no-deprecated
   private _createLegends(chartData: IChartDataPoint[]): JSX.Element {
+    if (this.props.order === 'sorted') {
+      chartData.sort((a: IChartDataPoint, b: IChartDataPoint) => {
+        return b.data! - a.data!;
+      });
+    }
     const legendDataItems = chartData.map((point: IChartDataPoint, index: number) => {
       const color: string = this.props.enableGradient
         ? point.gradient?.[0] || getNextGradient(index, 0, this.props.theme?.isInverted)[0]

--- a/packages/charts/react-charting/src/components/DonutChart/DonutChart.types.ts
+++ b/packages/charts/react-charting/src/components/DonutChart/DonutChart.types.ts
@@ -75,6 +75,14 @@ export interface IDonutChartProps extends ICartesianChartProps {
    * the public methods and properties of the component.
    */
   componentRef?: IRefObject<IChart>;
+
+  /**
+   * Rendering order of the legend
+   * @default 'default'
+   * 'default' - as per data provided
+   * 'sorted' - in descending order of value
+   */
+  order?: 'default' | 'sorted';
 }
 
 /**


### PR DESCRIPTION
Work item https://uifabric.visualstudio.com/iss/_workitems/edit/13444/
fix(react-charting): Fixing donut colors and segment orders

Fixed all below test app examples:
261, 306, 392, 393, 395, 396, 575, 576, 577, 578, 585, 588, 750, 816, 831

Fixes the following:
1. Sorting by value and assigning colors in that order
2. Changing the direction of rendering from clockwise to anticlockwise
3. Picking the last item from array of data for single plot from the schema for rendering
4. Considering negative numbers in total value calculation while calculating segment percentages

