### PR TITLE
refactor: replace slotted with slotchange

### DIFF
--- a/change/@fluentui-web-components-a63e0ca8-4de2-4db4-b527-89b8ffadc945.json
+++ b/change/@fluentui-web-components-a63e0ca8-4de2-4db4-b527-89b8ffadc945.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "refactor: replace slotted with slotchange for tree and tree-item",
+  "packageName": "@fluentui/web-components",
+  "email": "machi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/docs/web-components.api.md
+++ b/packages/web-components/docs/web-components.api.md
@@ -945,17 +945,21 @@ export class BaseTree extends FASTElement {
     changeHandler(e: Event): boolean | void;
     // Warning: (ae-forgotten-export) The symbol "BaseTreeItem" needs to be exported by the entry point index.d.ts
     //
-    // (undocumented)
+    // @internal (undocumented)
     childTreeItems: BaseTreeItem[];
-    // (undocumented)
+    // @internal (undocumented)
     childTreeItemsChanged(): void;
     // @internal
     clickHandler(e: Event): boolean | void;
     currentSelected: HTMLElement | null;
+    // @internal (undocumented)
+    defaultSlot: HTMLSlotElement;
     // @internal
     elementInternals: ElementInternals;
     // @internal
     focusHandler(e: FocusEvent): void;
+    // @internal (undocumented)
+    handleDefaultSlotChange(): void;
     // @internal
     keydownHandler(e: KeyboardEvent): boolean | void;
 }

--- a/packages/web-components/src/tree-item/tree-item.base.ts
+++ b/packages/web-components/src/tree-item/tree-item.base.ts
@@ -10,6 +10,10 @@ export class BaseTreeItem extends FASTElement {
    */
   public elementInternals: ElementInternals = this.attachInternals();
 
+  /** @internal */
+  @observable
+  public itemSlot!: HTMLSlotElement;
+
   constructor() {
     super();
     this.elementInternals.role = 'treeitem';
@@ -96,6 +100,7 @@ export class BaseTreeItem extends FASTElement {
     this.$fastController.addStyles(this.styles);
   }
 
+  /** @internal */
   @observable
   public childTreeItems: BaseTreeItem[] | undefined = [];
 
@@ -165,5 +170,10 @@ export class BaseTreeItem extends FASTElement {
     if (this.$fastController.isConnected) {
       this.tabIndex = this.selected ? 0 : -1;
     }
+  }
+
+  /** @internal */
+  public handleItemSlotChange() {
+    this.childTreeItems = this.itemSlot.assignedElements().filter(el => isTreeItem(el));
   }
 }

--- a/packages/web-components/src/tree-item/tree-item.template.ts
+++ b/packages/web-components/src/tree-item/tree-item.template.ts
@@ -1,5 +1,4 @@
-import { elements, html, slotted } from '@microsoft/fast-element';
-import { FluentDesignSystem } from '../fluent-design-system.js';
+import { html, ref } from '@microsoft/fast-element';
 import type { TreeItem } from './tree-item.js';
 
 const chevronIcon = html`
@@ -26,13 +25,7 @@ export const template = html<TreeItem>`
       </div>
     </div>
     <div role="group" class="items" part="items">
-      <slot
-        name="item"
-        ${slotted({
-          property: 'childTreeItems',
-          filter: elements(`${FluentDesignSystem.prefix}-tree-item`),
-        })}
-      ></slot>
+      <slot name="item" ${ref('itemSlot')} @slotchange="${x => x.handleItemSlotChange()}"></slot>
     </div>
   </template>
 `;

--- a/packages/web-components/src/tree/tree.base.ts
+++ b/packages/web-components/src/tree/tree.base.ts
@@ -35,13 +35,18 @@ export class BaseTree extends FASTElement {
    */
   public elementInternals: ElementInternals = this.attachInternals();
 
+  /** @internal */
+  public defaultSlot!: HTMLSlotElement;
+
   constructor() {
     super();
     this.elementInternals.role = 'tree';
   }
 
+  /** @internal */
   @observable
   childTreeItems: BaseTreeItem[] = [];
+  /** @internal */
   public childTreeItemsChanged() {
     this.updateCurrentSelected();
   }
@@ -260,5 +265,10 @@ export class BaseTree extends FASTElement {
     if (isHTMLElement(focusItem)) {
       focusItem.focus();
     }
+  }
+
+  /** @internal */
+  public handleDefaultSlotChange() {
+    this.childTreeItems = this.defaultSlot.assignedElements().filter(el => isTreeItem(el));
   }
 }

--- a/packages/web-components/src/tree/tree.template.ts
+++ b/packages/web-components/src/tree/tree.template.ts
@@ -1,5 +1,4 @@
-import { elements, html, slotted } from '@microsoft/fast-element';
-import { FluentDesignSystem } from '../fluent-design-system.js';
+import { html, ref } from '@microsoft/fast-element';
 import type { Tree } from './tree.js';
 
 export const template = html<Tree>`
@@ -12,10 +11,8 @@ export const template = html<Tree>`
     @change="${(x, c) => x.changeHandler(c.event)}"
   >
     <slot
-      ${slotted({
-        property: 'childTreeItems',
-        filter: elements(`${FluentDesignSystem.prefix}-tree-item`),
-      })}
+      ${ref('defaultSlot')}
+      @slotchange="${x => x.handleDefaultSlotChange()}"
     ></slot>
   </template>
 `;

--- a/packages/web-components/src/tree/tree.template.ts
+++ b/packages/web-components/src/tree/tree.template.ts
@@ -10,9 +10,6 @@ export const template = html<Tree>`
     @keydown="${(x, c) => x.keydownHandler(c.event as KeyboardEvent)}"
     @change="${(x, c) => x.changeHandler(c.event)}"
   >
-    <slot
-      ${ref('defaultSlot')}
-      @slotchange="${x => x.handleDefaultSlotChange()}"
-    ></slot>
+    <slot ${ref('defaultSlot')} @slotchange="${x => x.handleDefaultSlotChange()}"></slot>
   </template>
 `;


### PR DESCRIPTION
## Previous Behavior

In Tree and TreeItem templates, we use `slotted` directive with `elements()` filter to make sure the assigned elements are TreeItems, which also involved using `FluentDesignSysmte.prefix`. But using `FluentDesignSystem` makes it impossible for other libraries to reused the template since they may have different prefixes in their element names.

## New Behavior

Switching to using `slotchange` event and filter the assigned elements before assigning them to `childTreeItems` property. `slotchange` event is a browser built-in event, so more robust. This also eliminate the need of using `FluentDesignSystem.prefix`, which means libraries can reuse the template.