### PR TITLE
chore: extend packages peer dependencies versions to support React 19

### DIFF
--- a/change/@fluentui-global-context-3d949c74-2431-41ab-80b8-c9c5bc4bf054.json
+++ b/change/@fluentui-global-context-3d949c74-2431-41ab-80b8-c9c5bc4bf054.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/global-context",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-accordion-8f092d9b-2fd3-406e-9e2c-13dba50b594a.json
+++ b/change/@fluentui-react-accordion-8f092d9b-2fd3-406e-9e2c-13dba50b594a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-accordion",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-aria-1ed1ade4-9b5d-4327-8c36-c5c396e6d075.json
+++ b/change/@fluentui-react-aria-1ed1ade4-9b5d-4327-8c36-c5c396e6d075.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-aria",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-avatar-fb2cd0b0-9648-4e32-a4b9-bb59be5ab02d.json
+++ b/change/@fluentui-react-avatar-fb2cd0b0-9648-4e32-a4b9-bb59be5ab02d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-avatar",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-badge-1bc9f085-71e1-4e16-9752-b79fedf2382e.json
+++ b/change/@fluentui-react-badge-1bc9f085-71e1-4e16-9752-b79fedf2382e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-badge",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-breadcrumb-7847ddf4-12f8-4ab4-b42a-4770a49e856a.json
+++ b/change/@fluentui-react-breadcrumb-7847ddf4-12f8-4ab4-b42a-4770a49e856a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-breadcrumb",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-button-0f976cc9-b2b7-474c-9c25-95ab84a89dde.json
+++ b/change/@fluentui-react-button-0f976cc9-b2b7-474c-9c25-95ab84a89dde.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-button",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-calendar-compat-1a01e814-37a0-4d6d-9b66-94ab41f77980.json
+++ b/change/@fluentui-react-calendar-compat-1a01e814-37a0-4d6d-9b66-94ab41f77980.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-calendar-compat",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-card-50f7796c-72ea-4923-82c3-194156b61fef.json
+++ b/change/@fluentui-react-card-50f7796c-72ea-4923-82c3-194156b61fef.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-card",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-carousel-23554ff4-3453-4a06-abc9-401305ac16d4.json
+++ b/change/@fluentui-react-carousel-23554ff4-3453-4a06-abc9-401305ac16d4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-carousel",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-checkbox-8cd291e5-d6ed-4ff6-aa93-b40077e06fd3.json
+++ b/change/@fluentui-react-checkbox-8cd291e5-d6ed-4ff6-aa93-b40077e06fd3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-color-picker-74307406-7912-4307-b111-bdb93a31c472.json
+++ b/change/@fluentui-react-color-picker-74307406-7912-4307-b111-bdb93a31c472.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-color-picker",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-combobox-923a5c38-e59a-4c8a-a206-d3c3278f7617.json
+++ b/change/@fluentui-react-combobox-923a5c38-e59a-4c8a-a206-d3c3278f7617.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-combobox",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-components-8e72aba9-86f5-4e42-a85b-9d180a7cbbf9.json
+++ b/change/@fluentui-react-components-8e72aba9-86f5-4e42-a85b-9d180a7cbbf9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-components",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-conformance-griffel-d75f3aba-2abd-4e79-98ea-f119b527668a.json
+++ b/change/@fluentui-react-conformance-griffel-d75f3aba-2abd-4e79-98ea-f119b527668a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-conformance-griffel",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-context-selector-ae9590bd-5f87-4849-80a1-fc2673f71fc8.json
+++ b/change/@fluentui-react-context-selector-ae9590bd-5f87-4849-80a1-fc2673f71fc8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-context-selector",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-datepicker-compat-38f0b2d9-115e-454e-9e27-3a92fcb86a99.json
+++ b/change/@fluentui-react-datepicker-compat-38f0b2d9-115e-454e-9e27-3a92fcb86a99.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-datepicker-compat",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-dialog-b0437732-058d-4f96-8f45-bf872c645a3d.json
+++ b/change/@fluentui-react-dialog-b0437732-058d-4f96-8f45-bf872c645a3d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-dialog",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-divider-787f0410-39b2-44d3-ab2d-420ad089628b.json
+++ b/change/@fluentui-react-divider-787f0410-39b2-44d3-ab2d-420ad089628b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-divider",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-drawer-cca8820e-1495-44dc-aab5-990e214ce98d.json
+++ b/change/@fluentui-react-drawer-cca8820e-1495-44dc-aab5-990e214ce98d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-drawer",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-field-4a0231d7-271c-40b6-adbc-5d016c6349f2.json
+++ b/change/@fluentui-react-field-4a0231d7-271c-40b6-adbc-5d016c6349f2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-field",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-icons-compat-8c5683d8-5352-41d2-aee6-0e555f0b92c7.json
+++ b/change/@fluentui-react-icons-compat-8c5683d8-5352-41d2-aee6-0e555f0b92c7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-icons-compat",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-image-a0e77198-db63-45a3-9659-e4eb51db34da.json
+++ b/change/@fluentui-react-image-a0e77198-db63-45a3-9659-e4eb51db34da.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-image",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-infolabel-6aad8606-d6c9-45cc-82d3-ce41f7da6489.json
+++ b/change/@fluentui-react-infolabel-6aad8606-d6c9-45cc-82d3-ce41f7da6489.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-infolabel",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-input-e87cc035-081d-4690-8d1d-35d1d2d8820f.json
+++ b/change/@fluentui-react-input-e87cc035-081d-4690-8d1d-35d1d2d8820f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-input",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-jsx-runtime-080a13c8-37db-47fa-bd67-9c21d4cddfb2.json
+++ b/change/@fluentui-react-jsx-runtime-080a13c8-37db-47fa-bd67-9c21d4cddfb2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-jsx-runtime",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-label-9434a9f8-525d-4843-9924-ad3cfa2a96c9.json
+++ b/change/@fluentui-react-label-9434a9f8-525d-4843-9924-ad3cfa2a96c9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-label",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-link-6eda204f-4a36-4c25-bdf3-4b20bb78d94f.json
+++ b/change/@fluentui-react-link-6eda204f-4a36-4c25-bdf3-4b20bb78d94f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-link",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-list-60908799-9f26-406a-b277-4d800e5a861a.json
+++ b/change/@fluentui-react-list-60908799-9f26-406a-b277-4d800e5a861a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-list",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-menu-6679bf03-ec3c-422d-8036-fa3c9c205543.json
+++ b/change/@fluentui-react-menu-6679bf03-ec3c-422d-8036-fa3c9c205543.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-menu",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-menu-grid-preview-73c3473b-89d9-42de-9a8c-4932e6d09e97.json
+++ b/change/@fluentui-react-menu-grid-preview-73c3473b-89d9-42de-9a8c-4932e6d09e97.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-menu-grid-preview",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-message-bar-6adf328a-8e89-45b5-846e-07d2187843c1.json
+++ b/change/@fluentui-react-message-bar-6adf328a-8e89-45b5-846e-07d2187843c1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-message-bar",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-migration-v0-v9-276b38a5-441e-4bcc-a9f4-35cce6d643de.json
+++ b/change/@fluentui-react-migration-v0-v9-276b38a5-441e-4bcc-a9f4-35cce6d643de.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-migration-v0-v9",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-migration-v8-v9-fc611cb3-b933-4371-ae6a-0fd5269f69d7.json
+++ b/change/@fluentui-react-migration-v8-v9-fc611cb3-b933-4371-ae6a-0fd5269f69d7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-migration-v8-v9",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-motion-66f19263-a475-498a-8747-11974f7e3a44.json
+++ b/change/@fluentui-react-motion-66f19263-a475-498a-8747-11974f7e3a44.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-motion",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-motion-components-preview-db31028a-d50f-468b-a3ca-29b786c216f9.json
+++ b/change/@fluentui-react-motion-components-preview-db31028a-d50f-468b-a3ca-29b786c216f9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-motion-components-preview",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-nav-4c792725-7e57-4df8-b0b4-3a8d12b50ace.json
+++ b/change/@fluentui-react-nav-4c792725-7e57-4df8-b0b4-3a8d12b50ace.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-nav",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-overflow-f0160949-2b10-498a-bf37-439898d0406b.json
+++ b/change/@fluentui-react-overflow-f0160949-2b10-498a-bf37-439898d0406b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-overflow",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-persona-d8e129cd-9974-4fdd-8b5b-f253c6535573.json
+++ b/change/@fluentui-react-persona-d8e129cd-9974-4fdd-8b5b-f253c6535573.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-persona",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-popover-a82f99df-1135-44f0-a923-9cdca7296229.json
+++ b/change/@fluentui-react-popover-a82f99df-1135-44f0-a923-9cdca7296229.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-popover",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-portal-c93113eb-3eed-4582-a779-b831a58a1bc1.json
+++ b/change/@fluentui-react-portal-c93113eb-3eed-4582-a779-b831a58a1bc1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-portal",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-portal-compat-36d46524-5484-468e-be47-e66a85dc74ee.json
+++ b/change/@fluentui-react-portal-compat-36d46524-5484-468e-be47-e66a85dc74ee.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-portal-compat",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-portal-compat-context-1527e745-d291-4d71-ae79-28e92b0efaed.json
+++ b/change/@fluentui-react-portal-compat-context-1527e745-d291-4d71-ae79-28e92b0efaed.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-portal-compat-context",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-positioning-49d668ee-0905-4b36-ad62-934efa6c85ff.json
+++ b/change/@fluentui-react-positioning-49d668ee-0905-4b36-ad62-934efa6c85ff.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-positioning",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-progress-e58643ad-851b-4c7f-a7f6-52b9e912734c.json
+++ b/change/@fluentui-react-progress-e58643ad-851b-4c7f-a7f6-52b9e912734c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-progress",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-provider-0941b5b5-cd2d-46f8-a2fa-b55445af357b.json
+++ b/change/@fluentui-react-provider-0941b5b5-cd2d-46f8-a2fa-b55445af357b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-provider",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-radio-93614e95-36e9-469b-b72b-978123552b6a.json
+++ b/change/@fluentui-react-radio-93614e95-36e9-469b-b72b-978123552b6a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-radio",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-rating-9bb92a6d-b460-4acd-96ee-1871c6c67ef1.json
+++ b/change/@fluentui-react-rating-9bb92a6d-b460-4acd-96ee-1871c6c67ef1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-rating",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-search-212be2ac-ad9a-4ce2-b10c-5771e286c534.json
+++ b/change/@fluentui-react-search-212be2ac-ad9a-4ce2-b10c-5771e286c534.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-search",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-select-2d4e8fd2-5074-4baa-8323-7e1cda7bec51.json
+++ b/change/@fluentui-react-select-2d4e8fd2-5074-4baa-8323-7e1cda7bec51.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-select",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-shared-contexts-0712c8bd-0e7d-4153-8b77-0f76a4d4ff9f.json
+++ b/change/@fluentui-react-shared-contexts-0712c8bd-0e7d-4153-8b77-0f76a4d4ff9f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-shared-contexts",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-skeleton-51beef4b-ea19-4d4e-81bd-29d20356603e.json
+++ b/change/@fluentui-react-skeleton-51beef4b-ea19-4d4e-81bd-29d20356603e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-skeleton",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-slider-410319a0-491c-4ade-810a-3be03cd571dd.json
+++ b/change/@fluentui-react-slider-410319a0-491c-4ade-810a-3be03cd571dd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-slider",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-spinbutton-44f13892-5950-4718-b747-5c4455481da3.json
+++ b/change/@fluentui-react-spinbutton-44f13892-5950-4718-b747-5c4455481da3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-spinbutton",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-spinner-15a00091-7fb7-43e0-b51d-4c4e480d5225.json
+++ b/change/@fluentui-react-spinner-15a00091-7fb7-43e0-b51d-4c4e480d5225.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-spinner",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-storybook-addon-e236f8d9-4e46-47a7-a369-7bc728eca3ed.json
+++ b/change/@fluentui-react-storybook-addon-e236f8d9-4e46-47a7-a369-7bc728eca3ed.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-storybook-addon",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-swatch-picker-e1ec4cb4-49ed-452f-8026-cc0000372db4.json
+++ b/change/@fluentui-react-swatch-picker-e1ec4cb4-49ed-452f-8026-cc0000372db4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-swatch-picker",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-switch-5caac092-8344-4b91-ab9d-cba878372b22.json
+++ b/change/@fluentui-react-switch-5caac092-8344-4b91-ab9d-cba878372b22.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-switch",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-table-3466d301-f60e-463b-82f9-3c762f7a5d8e.json
+++ b/change/@fluentui-react-table-3466d301-f60e-463b-82f9-3c762f7a5d8e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-table",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tabs-2f86c46a-67cb-43f9-aabb-2e0ce8d4de60.json
+++ b/change/@fluentui-react-tabs-2f86c46a-67cb-43f9-aabb-2e0ce8d4de60.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-tabs",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tabster-525f963c-5f79-46ac-880d-58088bfc55e4.json
+++ b/change/@fluentui-react-tabster-525f963c-5f79-46ac-880d-58088bfc55e4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-tabster",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tag-picker-0fc415b5-b84c-479a-abeb-e0c33c9c409e.json
+++ b/change/@fluentui-react-tag-picker-0fc415b5-b84c-479a-abeb-e0c33c9c409e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-tag-picker",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tags-c12c66c2-b654-4e8d-a8a6-903d1d7e1447.json
+++ b/change/@fluentui-react-tags-c12c66c2-b654-4e8d-a8a6-903d1d7e1447.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-tags",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-teaching-popover-8c9f8b5e-caea-482c-b620-49777c03c065.json
+++ b/change/@fluentui-react-teaching-popover-8c9f8b5e-caea-482c-b620-49777c03c065.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-teaching-popover",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-text-adc80954-7cfd-4b5e-bdb4-4cfba8271ec3.json
+++ b/change/@fluentui-react-text-adc80954-7cfd-4b5e-bdb4-4cfba8271ec3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-text",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-textarea-3afc797e-7e35-4393-ade5-8c021c913c11.json
+++ b/change/@fluentui-react-textarea-3afc797e-7e35-4393-ade5-8c021c913c11.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-textarea",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-timepicker-compat-dc822812-905f-4254-a866-ec99c144164a.json
+++ b/change/@fluentui-react-timepicker-compat-dc822812-905f-4254-a866-ec99c144164a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-timepicker-compat",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-toast-9b0654bd-9d4b-4be5-a678-92a96951711f.json
+++ b/change/@fluentui-react-toast-9b0654bd-9d4b-4be5-a678-92a96951711f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-toast",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-toolbar-3b1579ef-960d-4a7a-b5f4-f871e039636b.json
+++ b/change/@fluentui-react-toolbar-3b1579ef-960d-4a7a-b5f4-f871e039636b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-toolbar",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tooltip-cf9382e8-6566-4381-998b-ac98a135572b.json
+++ b/change/@fluentui-react-tooltip-cf9382e8-6566-4381-998b-ac98a135572b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tree-0d3333fa-8a9a-4b80-8609-76742d8d6d63.json
+++ b/change/@fluentui-react-tree-0d3333fa-8a9a-4b80-8609-76742d8d6d63.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-tree",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-utilities-073d9e43-e46b-4d82-bd50-80828d361dd7.json
+++ b/change/@fluentui-react-utilities-073d9e43-e46b-4d82-bd50-80828d361dd7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extend peer dependencies versions to support React 19",
+  "packageName": "@fluentui/react-utilities",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/component-selector-preview/library/package.json
+++ b/packages/react-components/component-selector-preview/library/package.json
@@ -33,10 +33,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "exports": {
     ".": {

--- a/packages/react-components/global-context/package.json
+++ b/packages/react-components/global-context/package.json
@@ -22,10 +22,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-accordion/library/package.json
+++ b/packages/react-components/react-accordion/library/package.json
@@ -32,10 +32,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-aria/library/package.json
+++ b/packages/react-components/react-aria/library/package.json
@@ -26,10 +26,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-avatar/library/package.json
+++ b/packages/react-components/react-avatar/library/package.json
@@ -35,10 +35,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-badge/library/package.json
+++ b/packages/react-components/react-badge/library/package.json
@@ -27,10 +27,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-breadcrumb/library/package.json
+++ b/packages/react-components/react-breadcrumb/library/package.json
@@ -35,10 +35,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-button/library/package.json
+++ b/packages/react-components/react-button/library/package.json
@@ -31,10 +31,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-calendar-compat/library/package.json
+++ b/packages/react-components/react-calendar-compat/library/package.json
@@ -29,10 +29,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.8.0 <19.0.0",
-    "@types/react-dom": ">=16.8.0 <19.0.0",
-    "react": ">=16.8.0 <19.0.0",
-    "react-dom": ">=16.8.0 <19.0.0"
+    "@types/react": ">=16.8.0 <20.0.0",
+    "@types/react-dom": ">=16.8.0 <20.0.0",
+    "react": ">=16.8.0 <20.0.0",
+    "react-dom": ">=16.8.0 <20.0.0"
   },
   "exports": {
     ".": {

--- a/packages/react-components/react-card/library/package.json
+++ b/packages/react-components/react-card/library/package.json
@@ -33,10 +33,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-carousel/library/package.json
+++ b/packages/react-components/react-carousel/library/package.json
@@ -42,10 +42,10 @@
     "embla-carousel-fade": "^8.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "exports": {
     ".": {

--- a/packages/react-components/react-checkbox/library/package.json
+++ b/packages/react-components/react-checkbox/library/package.json
@@ -30,10 +30,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-color-picker/library/package.json
+++ b/packages/react-components/react-color-picker/library/package.json
@@ -35,10 +35,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "exports": {
     ".": {

--- a/packages/react-components/react-colorpicker-compat/package.json
+++ b/packages/react-components/react-colorpicker-compat/package.json
@@ -26,10 +26,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-combobox/library/package.json
+++ b/packages/react-components/react-combobox/library/package.json
@@ -35,10 +35,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-components/package.json
+++ b/packages/react-components/react-components/package.json
@@ -80,10 +80,10 @@
     "@fluentui/react-nav": "^9.3.5"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-conformance-griffel/package.json
+++ b/packages/react-components/react-conformance-griffel/package.json
@@ -15,8 +15,8 @@
     "@fluentui/scripts-api-extractor": "*"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
     "typescript": "^4.3.0",
     "@fluentui/react-conformance": "^0.20.0"
   },

--- a/packages/react-components/react-context-selector/package.json
+++ b/packages/react-components/react-context-selector/package.json
@@ -20,10 +20,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0",
     "scheduler": ">=0.19.0 <=0.23.0"
   },
   "beachball": {

--- a/packages/react-components/react-datepicker-compat/library/package.json
+++ b/packages/react-components/react-datepicker-compat/library/package.json
@@ -37,10 +37,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.8.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.8.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-dialog/library/package.json
+++ b/packages/react-components/react-dialog/library/package.json
@@ -40,10 +40,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-divider/library/package.json
+++ b/packages/react-components/react-divider/library/package.json
@@ -26,10 +26,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-drawer/library/package.json
+++ b/packages/react-components/react-drawer/library/package.json
@@ -32,10 +32,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-field/library/package.json
+++ b/packages/react-components/react-field/library/package.json
@@ -30,10 +30,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-icons-compat/library/package.json
+++ b/packages/react-components/react-icons-compat/library/package.json
@@ -32,10 +32,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.8.0 <19.0.0",
-    "@types/react-dom": ">=16.8.0 <19.0.0",
-    "react": ">=16.8.0 <19.0.0",
-    "react-dom": ">=16.8.0 <19.0.0"
+    "@types/react": ">=16.8.0 <20.0.0",
+    "@types/react-dom": ">=16.8.0 <20.0.0",
+    "react": ">=16.8.0 <20.0.0",
+    "react-dom": ">=16.8.0 <20.0.0"
   },
   "exports": {
     ".": {

--- a/packages/react-components/react-image/library/package.json
+++ b/packages/react-components/react-image/library/package.json
@@ -26,10 +26,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-infolabel/library/package.json
+++ b/packages/react-components/react-infolabel/library/package.json
@@ -32,10 +32,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.8.0 <19.0.0",
-    "@types/react-dom": ">=16.8.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.8.0 <19.0.0"
+    "@types/react": ">=16.8.0 <20.0.0",
+    "@types/react-dom": ">=16.8.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.8.0 <20.0.0"
   },
   "exports": {
     ".": {

--- a/packages/react-components/react-input/library/package.json
+++ b/packages/react-components/react-input/library/package.json
@@ -28,10 +28,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-jsx-runtime/package.json
+++ b/packages/react-components/react-jsx-runtime/package.json
@@ -23,8 +23,8 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-label/library/package.json
+++ b/packages/react-components/react-label/library/package.json
@@ -26,10 +26,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-link/library/package.json
+++ b/packages/react-components/react-link/library/package.json
@@ -29,10 +29,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-list/library/package.json
+++ b/packages/react-components/react-list/library/package.json
@@ -38,10 +38,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.8.0 <19.0.0",
-    "@types/react-dom": ">=16.8.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.8.0 <19.0.0"
+    "@types/react": ">=16.8.0 <20.0.0",
+    "@types/react-dom": ">=16.8.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.8.0 <20.0.0"
   },
   "exports": {
     ".": {

--- a/packages/react-components/react-menu-grid-preview/library/package.json
+++ b/packages/react-components/react-menu-grid-preview/library/package.json
@@ -35,10 +35,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "exports": {
     ".": {

--- a/packages/react-components/react-menu/library/package.json
+++ b/packages/react-components/react-menu/library/package.json
@@ -35,10 +35,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-message-bar/library/package.json
+++ b/packages/react-components/react-message-bar/library/package.json
@@ -31,10 +31,10 @@
     "react-transition-group": "^4.4.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.8.0 <19.0.0",
-    "@types/react-dom": ">=16.8.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.8.0 <19.0.0"
+    "@types/react": ">=16.8.0 <20.0.0",
+    "@types/react-dom": ">=16.8.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.8.0 <20.0.0"
   },
   "exports": {
     ".": {

--- a/packages/react-components/react-migration-v0-v9/library/package.json
+++ b/packages/react-components/react-migration-v0-v9/library/package.json
@@ -33,10 +33,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0",
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0",
     "@fluentui/react-northstar": "^0.66.5"
   },
   "beachball": {

--- a/packages/react-components/react-migration-v8-v9/library/package.json
+++ b/packages/react-components/react-migration-v8-v9/library/package.json
@@ -28,10 +28,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.8.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.8.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-motion-components-preview/library/package.json
+++ b/packages/react-components/react-motion-components-preview/library/package.json
@@ -28,10 +28,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "exports": {
     ".": {

--- a/packages/react-components/react-motion/library/package.json
+++ b/packages/react-components/react-motion/library/package.json
@@ -30,10 +30,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.8.0 <19.0.0",
-    "@types/react-dom": ">=16.8.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.8.0 <19.0.0"
+    "@types/react": ">=16.8.0 <20.0.0",
+    "@types/react-dom": ">=16.8.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.8.0 <20.0.0"
   },
   "exports": {
     ".": {

--- a/packages/react-components/react-nav/library/package.json
+++ b/packages/react-components/react-nav/library/package.json
@@ -35,10 +35,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "exports": {
     ".": {

--- a/packages/react-components/react-overflow/library/package.json
+++ b/packages/react-components/react-overflow/library/package.json
@@ -27,10 +27,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-persona/library/package.json
+++ b/packages/react-components/react-persona/library/package.json
@@ -28,10 +28,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-popover/library/package.json
+++ b/packages/react-components/react-popover/library/package.json
@@ -35,10 +35,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-portal-compat-context/package.json
+++ b/packages/react-components/react-portal-compat-context/package.json
@@ -19,8 +19,8 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-portal-compat/package.json
+++ b/packages/react-components/react-portal-compat/package.json
@@ -28,8 +28,8 @@
   },
   "peerDependencies": {
     "@fluentui/react-components": "^9.69.0",
-    "@types/react": ">=16.14.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-portal/library/package.json
+++ b/packages/react-components/react-portal/library/package.json
@@ -25,10 +25,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-positioning/library/package.json
+++ b/packages/react-components/react-positioning/library/package.json
@@ -27,10 +27,10 @@
     "use-sync-external-store": "^1.2.0"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-progress/library/package.json
+++ b/packages/react-components/react-progress/library/package.json
@@ -27,10 +27,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-provider/library/package.json
+++ b/packages/react-components/react-provider/library/package.json
@@ -29,10 +29,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-radio/library/package.json
+++ b/packages/react-components/react-radio/library/package.json
@@ -29,10 +29,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-rating/library/package.json
+++ b/packages/react-components/react-rating/library/package.json
@@ -28,10 +28,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.8.0 <19.0.0",
-    "@types/react-dom": ">=16.8.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.8.0 <19.0.0"
+    "@types/react": ">=16.8.0 <20.0.0",
+    "@types/react-dom": ">=16.8.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.8.0 <20.0.0"
   },
   "exports": {
     ".": {

--- a/packages/react-components/react-search/library/package.json
+++ b/packages/react-components/react-search/library/package.json
@@ -28,10 +28,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-select/library/package.json
+++ b/packages/react-components/react-select/library/package.json
@@ -28,10 +28,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-shared-contexts/library/package.json
+++ b/packages/react-components/react-shared-contexts/library/package.json
@@ -20,8 +20,8 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-skeleton/library/package.json
+++ b/packages/react-components/react-skeleton/library/package.json
@@ -27,10 +27,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-slider/library/package.json
+++ b/packages/react-components/react-slider/library/package.json
@@ -29,10 +29,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-spinbutton/library/package.json
+++ b/packages/react-components/react-spinbutton/library/package.json
@@ -30,10 +30,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-spinner/library/package.json
+++ b/packages/react-components/react-spinner/library/package.json
@@ -27,10 +27,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-storybook-addon/package.json
+++ b/packages/react-components/react-storybook-addon/package.json
@@ -37,10 +37,10 @@
     "@storybook/manager-api": "^7.6.20",
     "@storybook/react": "^7.6.20",
     "@storybook/theming": "^7.6.20",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "@types/react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0"
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "@types/react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-swatch-picker/library/package.json
+++ b/packages/react-components/react-swatch-picker/library/package.json
@@ -32,10 +32,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.8.0 <19.0.0",
-    "@types/react-dom": ">=16.8.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.8.0 <19.0.0"
+    "@types/react": ">=16.8.0 <20.0.0",
+    "@types/react-dom": ">=16.8.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.8.0 <20.0.0"
   },
   "exports": {
     ".": {

--- a/packages/react-components/react-switch/library/package.json
+++ b/packages/react-components/react-switch/library/package.json
@@ -30,10 +30,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-table/library/package.json
+++ b/packages/react-components/react-table/library/package.json
@@ -36,10 +36,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-tabs/library/package.json
+++ b/packages/react-components/react-tabs/library/package.json
@@ -28,10 +28,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-tabster/package.json
+++ b/packages/react-components/react-tabster/package.json
@@ -26,10 +26,10 @@
     "tabster": "^8.5.5"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-tag-picker/library/package.json
+++ b/packages/react-components/react-tag-picker/library/package.json
@@ -46,10 +46,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "exports": {
     ".": {

--- a/packages/react-components/react-tags/library/package.json
+++ b/packages/react-components/react-tags/library/package.json
@@ -33,10 +33,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-teaching-popover/library/package.json
+++ b/packages/react-components/react-teaching-popover/library/package.json
@@ -39,10 +39,10 @@
     "use-sync-external-store": "^1.2.0"
   },
   "peerDependencies": {
-    "@types/react": ">=16.8.0 <19.0.0",
-    "@types/react-dom": ">=16.8.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.8.0 <19.0.0"
+    "@types/react": ">=16.8.0 <20.0.0",
+    "@types/react-dom": ">=16.8.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.8.0 <20.0.0"
   },
   "exports": {
     ".": {

--- a/packages/react-components/react-text/library/package.json
+++ b/packages/react-components/react-text/library/package.json
@@ -26,10 +26,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-textarea/library/package.json
+++ b/packages/react-components/react-textarea/library/package.json
@@ -27,10 +27,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-timepicker-compat/library/package.json
+++ b/packages/react-components/react-timepicker-compat/library/package.json
@@ -38,10 +38,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.8.0 <19.0.0",
-    "@types/react-dom": ">=16.8.0 <19.0.0",
-    "react": ">=16.8.0 <19.0.0",
-    "react-dom": ">=16.8.0 <19.0.0"
+    "@types/react": ">=16.8.0 <20.0.0",
+    "@types/react-dom": ">=16.8.0 <20.0.0",
+    "react": ">=16.8.0 <20.0.0",
+    "react-dom": ">=16.8.0 <20.0.0"
   },
   "exports": {
     ".": {

--- a/packages/react-components/react-toast/library/package.json
+++ b/packages/react-components/react-toast/library/package.json
@@ -35,10 +35,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-toolbar/library/package.json
+++ b/packages/react-components/react-toolbar/library/package.json
@@ -33,10 +33,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-tooltip/library/package.json
+++ b/packages/react-components/react-tooltip/library/package.json
@@ -30,10 +30,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-tree/library/package.json
+++ b/packages/react-components/react-tree/library/package.json
@@ -39,10 +39,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "exports": {
     ".": {

--- a/packages/react-components/react-utilities-compat/library/package.json
+++ b/packages/react-components/react-utilities-compat/library/package.json
@@ -33,10 +33,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.8.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.8.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "exports": {
     ".": {

--- a/packages/react-components/react-utilities/package.json
+++ b/packages/react-components/react-utilities/package.json
@@ -22,8 +22,8 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/recipes/package.json
+++ b/packages/react-components/recipes/package.json
@@ -36,10 +36,10 @@
     "@fluentui/react-icons": "^2.0.245"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "exports": {
     ".": {

--- a/packages/react-components/theme-designer/package.json
+++ b/packages/react-components/theme-designer/package.json
@@ -29,10 +29,10 @@
     "codesandbox-import-utils": "^2.2.3"
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [


### PR DESCRIPTION
This PR updates Fluent UI v9 packages to extend their peer dependency support for React 19