### PR TITLE
List: default cursor for items with disabled selection

### DIFF
--- a/change/@fluentui-react-list-ac029cf6-2a1e-4edb-a427-de93bbfad634.json
+++ b/change/@fluentui-react-list-ac029cf6-2a1e-4edb-a427-de93bbfad634.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Use default cursor when selection is disabled",
+  "packageName": "@fluentui/react-list",
+  "email": "jirivyhnalek@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-list/library/etc/react-list.api.md
+++ b/packages/react-components/react-list/library/etc/react-list.api.md
@@ -46,6 +46,7 @@ export type ListItemSlots = {
 export type ListItemState = ComponentState<ListItemSlots> & {
     selectable: boolean;
     navigable: boolean;
+    disabledSelection?: boolean;
 };
 
 // @public

--- a/packages/react-components/react-list/library/etc/react-list.api.md
+++ b/packages/react-components/react-list/library/etc/react-list.api.md
@@ -46,7 +46,7 @@ export type ListItemSlots = {
 export type ListItemState = ComponentState<ListItemSlots> & {
     selectable: boolean;
     navigable: boolean;
-    disabledSelection?: boolean;
+    disabled?: boolean;
 };
 
 // @public

--- a/packages/react-components/react-list/library/src/components/ListItem/ListItem.types.ts
+++ b/packages/react-components/react-list/library/src/components/ListItem/ListItem.types.ts
@@ -27,5 +27,5 @@ export type ListItemProps = ComponentProps<ListItemSlots> & {
 export type ListItemState = ComponentState<ListItemSlots> & {
   selectable: boolean;
   navigable: boolean;
-  disabledSelection?: boolean;
+  disabled?: boolean;
 };

--- a/packages/react-components/react-list/library/src/components/ListItem/ListItem.types.ts
+++ b/packages/react-components/react-list/library/src/components/ListItem/ListItem.types.ts
@@ -24,4 +24,8 @@ export type ListItemProps = ComponentProps<ListItemSlots> & {
 /**
  * State used in rendering ListItem
  */
-export type ListItemState = ComponentState<ListItemSlots> & { selectable: boolean; navigable: boolean };
+export type ListItemState = ComponentState<ListItemSlots> & {
+  selectable: boolean;
+  navigable: boolean;
+  disabledSelection?: boolean;
+};

--- a/packages/react-components/react-list/library/src/components/ListItem/useListItem.tsx
+++ b/packages/react-components/react-list/library/src/components/ListItem/useListItem.tsx
@@ -227,7 +227,7 @@ export const useListItem_unstable = (
     },
     root,
     checkmark,
-    disabledSelection,
+    disabled: disabledSelection && !onAction,
     selectable: isSelectionModeEnabled,
     navigable: focusableItems,
   };

--- a/packages/react-components/react-list/library/src/components/ListItem/useListItem.tsx
+++ b/packages/react-components/react-list/library/src/components/ListItem/useListItem.tsx
@@ -227,6 +227,7 @@ export const useListItem_unstable = (
     },
     root,
     checkmark,
+    disabledSelection,
     selectable: isSelectionModeEnabled,
     navigable: focusableItems,
   };

--- a/packages/react-components/react-list/library/src/components/ListItem/useListItemStyles.styles.ts
+++ b/packages/react-components/react-list/library/src/components/ListItem/useListItemStyles.styles.ts
@@ -38,6 +38,10 @@ const useStyles = makeStyles({
     display: 'flex',
     cursor: 'pointer',
   },
+
+  disabledSelection: {
+    cursor: 'default',
+  },
 });
 
 /**
@@ -54,6 +58,7 @@ export const useListItemStyles_unstable = (state: ListItemState): ListItemState 
     listItemClassNames.root,
     rootBaseStyles,
     (state.selectable || state.navigable) && styles.rootClickableOrSelectable,
+    state.disabledSelection && styles.disabledSelection,
     state.root.className,
   );
 

--- a/packages/react-components/react-list/library/src/components/ListItem/useListItemStyles.styles.ts
+++ b/packages/react-components/react-list/library/src/components/ListItem/useListItemStyles.styles.ts
@@ -39,7 +39,7 @@ const useStyles = makeStyles({
     cursor: 'pointer',
   },
 
-  disabledSelection: {
+  disabled: {
     cursor: 'default',
   },
 });
@@ -58,7 +58,7 @@ export const useListItemStyles_unstable = (state: ListItemState): ListItemState 
     listItemClassNames.root,
     rootBaseStyles,
     (state.selectable || state.navigable) && styles.rootClickableOrSelectable,
-    state.disabledSelection && styles.disabledSelection,
+    state.disabled && styles.disabled,
     state.root.className,
   );
 

--- a/packages/react-components/react-list/stories/src/List/SingleActionSelectionDifferentPrimary.stories.tsx
+++ b/packages/react-components/react-list/stories/src/List/SingleActionSelectionDifferentPrimary.stories.tsx
@@ -45,8 +45,15 @@ export const SingleActionSelectionDifferentPrimary = (): JSXElement => {
       selectedItems={selectedItems}
       onSelectionChange={(_, data) => setSelectedItems(data.selectedItems)}
     >
-      {items.map(({ name, avatar }) => (
-        <ListItem key={name} value={name} aria-label={name} onAction={onAction} checkmark={{ 'aria-label': name }}>
+      {items.map(({ name, avatar }, index) => (
+        <ListItem
+          key={name}
+          value={name}
+          aria-label={name}
+          onAction={onAction}
+          checkmark={{ 'aria-label': name }}
+          disabledSelection={index === 2}
+        >
           <Persona
             name={name}
             secondaryText="Available"


### PR DESCRIPTION
## Previous Behavior

Previously pointer would be used even if the selection was disabled and there was no other action passed.

## New Behavior

Currently pointer is set to "default" when selection is disabled for the item and no `onAction` callback is present.