### PR TITLE
fix(workspace-plugin): make react lib and component generators pass linting after generation

### DIFF
--- a/tools/workspace-plugin/src/generators/react-component/files/component/render__componentName__.tsx__tmpl__
+++ b/tools/workspace-plugin/src/generators/react-component/files/component/render__componentName__.tsx__tmpl__
@@ -2,12 +2,13 @@
 /** @jsxImportSource @fluentui/react-jsx-runtime */
 
 import { assertSlots } from '@fluentui/react-utilities';
+import type { JSXElement } from '@fluentui/react-utilities';
 import type { <%= componentName %>State, <%= componentName %>Slots } from './<%= componentName %>.types';
 
 /**
  * Render the final JSX of <%= componentName %>
  */
-export const render<%= componentName %>_unstable = (state: <%= componentName %>State) => {
+export const render<%= componentName %>_unstable = (state: <%= componentName %>State): JSXElement => {
   assertSlots<<%= componentName %>Slots>(state);
 
   // TODO Add additional slots in the appropriate place

--- a/tools/workspace-plugin/src/generators/react-library/files/src/testing/isConformant.ts__tmpl__
+++ b/tools/workspace-plugin/src/generators/react-library/files/src/testing/isConformant.ts__tmpl__
@@ -4,7 +4,7 @@ import griffelTests from '@fluentui/react-conformance-griffel';
 
 export function isConformant<TProps = {}>(
   testInfo: Omit<IsConformantOptions<TProps>, 'componentPath'> & { componentPath?: string },
-) {
+): void {
   const defaultOptions: Partial<IsConformantOptions<TProps>> = {
     tsConfig: { configName: 'tsconfig.spec.json' },
     componentPath: require.main?.filename.replace('.test', ''),


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

See PR title / failing tooling integration pipeline https://github.com/microsoft/fluentui/actions/runs/17486104036/job/49665320004?pr=35022


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Follows  https://github.com/microsoft/fluentui/pull/35080
