### PR TITLE
fix(DetailsList): DetailsRow correctly falls back to horizontal FocusZone

### DIFF
--- a/change/@fluentui-react-d23e2624-d5ec-4f8a-a317-1c7b9d11141e.json
+++ b/change/@fluentui-react-d23e2624-d5ec-4f8a-a317-1c7b9d11141e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(DetailsList): DetailsRow correctly falls back to horizontal FocusZone",
+  "packageName": "@fluentui/react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/DetailsList/DetailsRow.base.tsx
+++ b/packages/react/src/components/DetailsList/DetailsRow.base.tsx
@@ -226,7 +226,7 @@ export class DetailsRowBase extends React.Component<IDetailsRowBaseProps, IDetai
     const ariaSelected = selectionMode === SelectionMode.none ? undefined : isSelected;
     const ariaPositionInSet = group ? itemIndex - group.startIndex + 1 : undefined;
     const ariaSetSize = group ? group.count : undefined;
-    const focusZoneDirection = focusZoneProps ? focusZoneProps.direction : FocusZoneDirection.horizontal;
+    const focusZoneDirection = focusZoneProps?.direction ?? FocusZoneDirection.horizontal;
 
     this._classNames = {
       ...this._classNames,


### PR DESCRIPTION
## Previous Behavior

Arrowing up/down within a DetailsList row would move between items in the row instead of between rows (can only repro on examples with multiple focusable items in each row, such as the Advanced example).

This was caused by a mistake in the check for `focusZoneProps.direction`:
```js
focusZoneProps ? focusZoneProps.direction : FocusZoneDirection.horizontal
```

Since `focusZoneProps` is always defined in `DetailsRow` props even if only as an empty object, the check never actually used `FocusZoneDirection.horizontal` as the default / fallback value. This causes `FocusZone` to use both up/down and left/right arrows to move between items within the row.

## New Behavior

Fixed, up/down arrow keys in DetailsList always move between rows.

## Related Issue(s)

- Fixes [ADO issue](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/20797)
