### PR TITLE
feat: DataGrid header cells can contain interactive controls

### DIFF
--- a/change/@fluentui-react-table-3104ff6a-619f-46a0-8313-2fa905c419cf.json
+++ b/change/@fluentui-react-table-3104ff6a-619f-46a0-8313-2fa905c419cf.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: DataGrid header cells can contain interactive controls",
+  "packageName": "@fluentui/react-table",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-table/library/etc/react-table.api.md
+++ b/packages/react-components/react-table/library/etc/react-table.api.md
@@ -121,7 +121,7 @@ export const DataGridHeaderCell: ForwardRefComponent<DataGridHeaderCellProps>;
 export const dataGridHeaderCellClassNames: SlotClassNames<DataGridHeaderCellSlots>;
 
 // @public
-export type DataGridHeaderCellProps = Omit<TableHeaderCellProps, 'sortable'>;
+export type DataGridHeaderCellProps = Omit<TableHeaderCellProps, 'sortable'> & Pick<DataGridCellProps, 'focusMode'>;
 
 // @public (undocumented)
 export type DataGridHeaderCellSlots = TableHeaderCellSlots;

--- a/packages/react-components/react-table/library/src/components/DataGridHeaderCell/DataGridHeaderCell.test.tsx
+++ b/packages/react-components/react-table/library/src/components/DataGridHeaderCell/DataGridHeaderCell.test.tsx
@@ -170,4 +170,44 @@ describe('DataGridHeaderCell', () => {
       expect(columnHeader.hasAttribute('tabindex')).toBe(false);
     });
   });
+
+  it('should not set tabindex when focusMode is none', () => {
+    const dataGridCtx = mockSortableDataGridContext();
+    const { getAllByRole } = render(
+      <TableContextProvider value={{ noNativeElements: true, size: 'medium', sortable: false }}>
+        <DataGridContextProvider value={dataGridCtx}>
+          <ColumnIdContextProvider value={dataGridCtx.columns[0].columnId}>
+            <DataGridHeaderCell focusMode="none">Header cell</DataGridHeaderCell>
+          </ColumnIdContextProvider>
+        </DataGridContextProvider>
+      </TableContextProvider>,
+    );
+
+    const columnHeaders = getAllByRole('columnheader');
+
+    columnHeaders.forEach(columnHeader => {
+      expect(columnHeader.tabIndex).toBe(-1);
+      expect(columnHeader.hasAttribute('tabindex')).toBe(false);
+    });
+  });
+
+  it('should override sortable and set tabindex when focusMode is group', () => {
+    const dataGridCtx = mockSortableDataGridContext();
+    const { getAllByRole } = render(
+      <TableContextProvider value={{ noNativeElements: true, size: 'medium', sortable: true }}>
+        <DataGridContextProvider value={dataGridCtx}>
+          <ColumnIdContextProvider value={dataGridCtx.columns[0].columnId}>
+            <DataGridHeaderCell focusMode="group">Header cell</DataGridHeaderCell>
+          </ColumnIdContextProvider>
+        </DataGridContextProvider>
+      </TableContextProvider>,
+    );
+
+    const columnHeaders = getAllByRole('columnheader');
+
+    columnHeaders.forEach(columnHeader => {
+      expect(columnHeader.tabIndex).toBe(0);
+      expect(columnHeader.getAttribute('tabindex')).toBe('0');
+    });
+  });
 });

--- a/packages/react-components/react-table/library/src/components/DataGridHeaderCell/DataGridHeaderCell.types.ts
+++ b/packages/react-components/react-table/library/src/components/DataGridHeaderCell/DataGridHeaderCell.types.ts
@@ -4,12 +4,14 @@ import {
   TableHeaderCellState,
 } from '../TableHeaderCell/TableHeaderCell.types';
 
+import { DataGridCellProps } from '../DataGridCell/DataGridCell.types';
+
 export type DataGridHeaderCellSlots = TableHeaderCellSlots;
 
 /**
  * DataGridHeaderCell Props
  */
-export type DataGridHeaderCellProps = Omit<TableHeaderCellProps, 'sortable'>;
+export type DataGridHeaderCellProps = Omit<TableHeaderCellProps, 'sortable'> & Pick<DataGridCellProps, 'focusMode'>;
 
 /**
  * State used in rendering DataGridHeaderCell

--- a/packages/react-components/react-table/library/src/components/DataGridHeaderCell/__snapshots__/DataGridHeaderCell.test.tsx.snap
+++ b/packages/react-components/react-table/library/src/components/DataGridHeaderCell/__snapshots__/DataGridHeaderCell.test.tsx.snap
@@ -9,7 +9,6 @@ exports[`DataGridHeaderCell renders a default state 1`] = `
   >
     <div
       class="fui-DataGridHeaderCell__button fui-TableHeaderCell__button"
-      role="presentation"
     >
       Default DataGridHeaderCell
     </div>

--- a/packages/react-components/react-table/library/src/components/DataGridHeaderCell/useDataGridHeaderCell.ts
+++ b/packages/react-components/react-table/library/src/components/DataGridHeaderCell/useDataGridHeaderCell.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useFocusableGroup } from '@fluentui/react-tabster';
 import { useEventCallback } from '@fluentui/react-utilities';
 import type { DataGridHeaderCellProps, DataGridHeaderCellState } from './DataGridHeaderCell.types';
 import { useTableHeaderCell_unstable } from '../TableHeaderCell/useTableHeaderCell';
@@ -42,6 +43,9 @@ export const useDataGridHeaderCell_unstable = (
     return ctx.columnSizing_unstable.getTableHeaderCellProps;
   });
 
+  const { focusMode = sortable ? 'none' : 'cell' } = props;
+  const focusableGroupAttr = useFocusableGroup({ tabBehavior: 'limited-trap-focus' });
+
   // eslint-disable-next-line @typescript-eslint/no-deprecated -- prefer HTMLTableCellElement
   const onClick = useEventCallback((e: React.MouseEvent<HTMLTableHeaderCellElement>) => {
     if (sortable) {
@@ -55,7 +59,8 @@ export const useDataGridHeaderCell_unstable = (
       sortable,
       sortDirection,
       as: 'div',
-      tabIndex: sortable ? undefined : 0,
+      tabIndex: focusMode !== 'none' ? 0 : undefined,
+      ...(focusMode === 'group' && focusableGroupAttr),
       ...(resizableColumns ? getTableHeaderCellProps(columnId) : {}),
       ...props,
       onClick,

--- a/packages/react-components/react-table/library/src/components/TableHeaderCell/__snapshots__/TableHeaderCell.test.tsx.snap
+++ b/packages/react-components/react-table/library/src/components/TableHeaderCell/__snapshots__/TableHeaderCell.test.tsx.snap
@@ -7,7 +7,6 @@ exports[`TableHeaderCell renders a default state 1`] = `
   >
     <div
       class="fui-TableHeaderCell__button"
-      role="presentation"
     >
       Default TableHeaderCell
     </div>

--- a/packages/react-components/react-table/library/src/components/TableHeaderCell/useTableHeaderCell.tsx
+++ b/packages/react-components/react-table/library/src/components/TableHeaderCell/useTableHeaderCell.tsx
@@ -29,16 +29,14 @@ export const useTableHeaderCell_unstable = (
 
   const rootComponent = props.as ?? noNativeElements ? 'div' : 'th';
 
+  // The sort button is rendered as a div when not sortable, and as an ARIA button when sortable.
   const buttonSlot = slot.always<ARIAButtonSlotProps>(props.button, {
     elementType: 'div',
     defaultProps: {
       as: 'div',
-      ...(!sortable && {
-        role: 'presentation',
-        tabIndex: undefined,
-      }),
     },
   });
+  const ariaButtonProps = useARIAButtonProps(buttonSlot.as, buttonSlot);
 
   return {
     components: {
@@ -65,7 +63,7 @@ export const useTableHeaderCell_unstable = (
       defaultProps: { children: props.sortDirection ? sortIcons[props.sortDirection] : undefined },
       elementType: 'span',
     }),
-    button: useARIAButtonProps(buttonSlot.as, buttonSlot),
+    button: sortable ? ariaButtonProps : buttonSlot,
     sortable,
     noNativeElements,
   };

--- a/packages/react-components/react-table/stories/src/DataGrid/FocusableElementsInCells.stories.tsx
+++ b/packages/react-components/react-table/stories/src/DataGrid/FocusableElementsInCells.stories.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import {
   FolderRegular,
   EditRegular,
+  MoreHorizontalRegular,
   OpenRegular,
   DocumentRegular,
   DocumentPdfRegular,
@@ -22,6 +23,11 @@ import {
   TableColumnDefinition,
   createTableColumn,
   Button,
+  Menu,
+  MenuTrigger,
+  MenuList,
+  MenuItem,
+  MenuPopover,
   TableColumnId,
   DataGridCellFocusMode,
 } from '@fluentui/react-components';
@@ -87,11 +93,25 @@ const columns: TableColumnDefinition<Item>[] = [
   }),
   createTableColumn<Item>({
     columnId: 'author',
-    compare: (a, b) => {
-      return a.author.label.localeCompare(b.author.label);
-    },
     renderHeaderCell: () => {
-      return 'Author';
+      return (
+        <>
+          Author
+          <Button appearance="transparent" aria-label="Edit" icon={<EditRegular />} />
+          <Menu positioning={{ autoSize: true }}>
+            <MenuTrigger disableButtonEnhancement>
+              <Button appearance="transparent" icon={<MoreHorizontalRegular />} aria-label="More options" />
+            </MenuTrigger>
+
+            <MenuPopover>
+              <MenuList>
+                <MenuItem>Delete column</MenuItem>
+                <MenuItem>Create new author</MenuItem>
+              </MenuList>
+            </MenuPopover>
+          </Menu>
+        </>
+      );
     },
     renderCell: item => {
       return (
@@ -154,7 +174,11 @@ export const FocusableElementsInCells = (): JSXElement => {
     >
       <DataGridHeader>
         <DataGridRow selectionCell={{ checkboxIndicator: { 'aria-label': 'Select all rows' } }}>
-          {({ renderHeaderCell }) => <DataGridHeaderCell>{renderHeaderCell()}</DataGridHeaderCell>}
+          {({ columnId, renderHeaderCell }) => (
+            <DataGridHeaderCell focusMode={columnId === 'author' ? 'group' : undefined}>
+              {renderHeaderCell()}
+            </DataGridHeaderCell>
+          )}
         </DataGridRow>
       </DataGridHeader>
       <DataGridBody<Item>>
@@ -174,7 +198,7 @@ FocusableElementsInCells.parameters = {
   docs: {
     description: {
       story: [
-        'When cells contain focusable elements, set the `focusMode` prop on the `DataGridCell` component.',
+        'When cells contain focusable elements, set the `focusMode` prop on the `DataGridCell` or `DataGridHeaderCell` components.',
         '',
         'Use `group` when there are multiple focusable elements in cell,',
         '`group` will enable the following behaviour:',
@@ -183,7 +207,9 @@ FocusableElementsInCells.parameters = {
         '- Escape will move focus back to the cell',
         '',
         'Use `none` when there is one single focusable element in cell,',
-        '`none` will make the cell non-focusable',
+        '`none` will make the cell non-focusable.',
+        '',
+        'Do not add nested focusable elements to a sortable `DataGridHeaderCell`, since they will be rendered within the sort button.',
       ].join('\n'),
     },
   },


### PR DESCRIPTION
## Previous Behavior

There were two issues preventing authors from adding their own buttons to DataGrid header cells:
1. It broke arrow key navigation through cells in the grid, as well as not allowing keyboard users to access the inner buttons
2. The `useARIAButtonProps` hook messes with default enter/space key > click behavior, making it impossible to activate the buttons with the keyboard even if you can focus them

We've had a few requests for being able to add custom buttons to header cells (e.g. a menu button and info button / InfoLabel most recently), and it's a pretty common pattern. While we can't currently support that together with the sortable column button behavior, we can support it for non-sortable columns.

## New Behavior

Adds `focusMode` as a prop to `DataGridHeaderCell` following the pattern of `DataGridCell`. When set, the keyboard behavior works for header cells in the same way it does for body cells.

This PR also updates the TableHeaderCell to only conditionally apply `useARIAButtonProps` when `sortable` is true (i.e. when the slot is rendered as a button).

## Related Issue(s)

- Fixes #31265, and also two partner ADO issues
