### PR TITLE
[web-components][fix] fix missing focus state in forced colors on checked switch

### DIFF
--- a/change/@fluentui-web-components-287ac194-c9c2-4cc2-8a00-d30740e0eff6.json
+++ b/change/@fluentui-web-components-287ac194-c9c2-4cc2-8a00-d30740e0eff6.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: bug in switch checked story in forced-colors mode",
+  "packageName": "@fluentui/web-components",
+  "email": "rupertdavid@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/switch/switch.stories.ts
+++ b/packages/web-components/src/switch/switch.stories.ts
@@ -12,7 +12,7 @@ const storyTemplate = html<StoryArgs<FluentSwitch>>`
     id="${story => story.id}"
     name="${story => story.name}"
     ?required="${story => story.required}"
-    slot="${story => story.slot}"
+    ?slot="${story => story.slot}"
     ${ref('switch')}
   ></fluent-switch>
 `;
@@ -56,7 +56,6 @@ export const Default: Story = {};
 
 export const Checked: Story = {
   args: {
-    slot: 'input',
     checked: true,
   },
 };

--- a/packages/web-components/src/switch/switch.stories.ts
+++ b/packages/web-components/src/switch/switch.stories.ts
@@ -12,7 +12,7 @@ const storyTemplate = html<StoryArgs<FluentSwitch>>`
     id="${story => story.id}"
     name="${story => story.name}"
     ?required="${story => story.required}"
-    ?slot="${story => story.slot}"
+    slot="${story => story.slot}"
     ${ref('switch')}
   ></fluent-switch>
 `;

--- a/packages/web-components/src/switch/switch.styles.ts
+++ b/packages/web-components/src/switch/switch.styles.ts
@@ -121,6 +121,7 @@ export const styles = css`
   :host(:not([slot='input']):focus-visible) {
     border-color: ${colorTransparentStroke};
     outline: ${strokeWidthThick} solid ${colorTransparentStroke};
+    outline-offset: 1px;
     box-shadow: ${shadow4}, 0 0 0 2px ${colorStrokeFocus2};
   }
 `.withBehaviors(


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<img width="399" height="206" alt="image" src="https://github.com/user-attachments/assets/8281a263-76bb-44ab-911e-b8f3be04eb83" />

Switch Checked in forced-colors mode didn't show focus ring due to a bug in the story but where it has `slot="input"` which disables the focus ring and yields the behavior to `<fluent-field>` when slotted.

## New Behavior

<img width="734" height="216" alt="image" src="https://github.com/user-attachments/assets/18e878b5-0c00-40dd-954f-81d756dc7794" />

- Remove `slot="input"` to restore focus state
- Improve focus ring style by adding `outline-offset: 1px` (it was blending into the Highlight colro

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
