### PR TITLE
fix(workspace-plugin): add addSourceMappingUrl generation for build executor / covering both swc and babel transforms

### DIFF
--- a/tools/workspace-plugin/src/executors/build/executor.spec.ts
+++ b/tools/workspace-plugin/src/executors/build/executor.spec.ts
@@ -206,7 +206,8 @@ describe('Build Executor', () => {
           const styles = useStyles();
           return \`<h1 class=\\"\${styles}\\">\${greeting} \${user.name} from \${(_user_hometown = user.hometown) === null || _user_hometown === void 0 ? void 0 : _user_hometown.name}</h1>\`;
       }
-      "
+
+      //# sourceMappingURL=greeter.js.map"
     `);
     expect(readFileSync(join(workspaceRoot, 'libs/proj/lib/greeter.js.map'), 'utf-8')).toMatchInlineSnapshot(
       `"{\\"version\\":3,\\"sources\\":[\\"../src/greeter.ts\\"],\\"sourcesContent\\":[\\"import { useStyles } from './greeter.styles';\\\\nexport function greeter(greeting: string, user: User): string {\\\\n  const styles = useStyles();\\\\n  return \`<h1 class=\\\\\\"\${styles}\\\\\\">\${greeting} \${user.name} from \${user.hometown?.name}</h1>\`;\\\\n}\\\\n\\\\ntype User = {\\\\n  name: string;\\\\n  hometown?: {\\\\n    name: string;\\\\n  };\\\\n};\\\\n\\"],\\"names\\":[\\"useStyles\\",\\"greeter\\",\\"greeting\\",\\"user\\",\\"styles\\",\\"name\\",\\"hometown\\"],\\"mappings\\":\\"AAAA,SAASA,SAAS,QAAQ,mBAAmB;AAC7C,OAAO,SAASC,QAAQC,QAAgB,EAAEC,IAAU;QAEYA;IAD9D,MAAMC,SAASJ;IACf,OAAO,CAAC,WAAW,EAAEI,OAAO,EAAE,EAAEF,SAAS,CAAC,EAAEC,KAAKE,IAAI,CAAC,MAAM,GAAEF,iBAAAA,KAAKG,QAAQ,cAAbH,qCAAAA,eAAeE,IAAI,CAAC,KAAK,CAAC;AAC1F\\"}"`,
@@ -228,7 +229,7 @@ describe('Build Executor', () => {
           var _user_hometown;
           const styles = (0, _greeterstyles.useStyles)();
           return \`<h1 class=\\"\${styles}\\">\${greeting} \${user.name} from \${(_user_hometown = user.hometown) === null || _user_hometown === void 0 ? void 0 : _user_hometown.name}</h1>\`;
-      }
+      } //# sourceMappingURL=greeter.js.map
       "
     `);
 
@@ -243,7 +244,8 @@ describe('Build Executor', () => {
         }
       }, {
         d: [\\".fe3e8s9{color:red;}\\"]
-      });"
+      });
+      //# sourceMappingURL=greeter.styles.js.map"
     `);
     expect(readFileSync(join(workspaceRoot, 'libs/proj/lib-commonjs/greeter.styles.js'), 'utf-8'))
       .toMatchInlineSnapshot(`
@@ -266,7 +268,7 @@ describe('Build Executor', () => {
           d: [
               \\".fe3e8s9{color:red;}\\"
           ]
-      });
+      }); //# sourceMappingURL=greeter.styles.js.map
       "
     `);
 
@@ -319,34 +321,35 @@ describe('Build Executor', () => {
       // assert raw styles content matches the original SWC-compiled styles (before Griffel transformation)
       // =====================
       expect(readFileSync(join(workspaceRoot, 'libs/proj/lib/greeter.styles.raw.js'), 'utf-8')).toMatchInlineSnapshot(`
-      "import { makeStyles } from '@griffel/react';
-      export const useStyles = makeStyles({
-          root: {
-              color: 'red'
-          }
-      });
-      "
-    `);
+        "import { makeStyles } from '@griffel/react';
+        export const useStyles = makeStyles({
+            root: {
+                color: 'red'
+            }
+        });
+
+        //# sourceMappingURL=greeter.styles.js.map"
+      `);
       expect(readFileSync(join(workspaceRoot, 'libs/proj/lib-commonjs/greeter.styles.raw.js'), 'utf-8'))
         .toMatchInlineSnapshot(`
-      "\\"use strict\\";
-      Object.defineProperty(exports, \\"__esModule\\", {
-          value: true
-      });
-      Object.defineProperty(exports, \\"useStyles\\", {
-          enumerable: true,
-          get: function() {
-              return useStyles;
-          }
-      });
-      const _react = require(\\"@griffel/react\\");
-      const useStyles = (0, _react.makeStyles)({
-          root: {
-              color: 'red'
-          }
-      });
-      "
-    `);
+        "\\"use strict\\";
+        Object.defineProperty(exports, \\"__esModule\\", {
+            value: true
+        });
+        Object.defineProperty(exports, \\"useStyles\\", {
+            enumerable: true,
+            get: function() {
+                return useStyles;
+            }
+        });
+        const _react = require(\\"@griffel/react\\");
+        const useStyles = (0, _react.makeStyles)({
+            root: {
+                color: 'red'
+            }
+        }); //# sourceMappingURL=greeter.styles.js.map
+        "
+      `);
 
       // =====================
       // showcase that babel transformation creates invalid source map - which differs with raw styles source maps produced by SWC-compiled source maps (before Griffel transformation)

--- a/tools/workspace-plugin/src/executors/build/lib/babel.ts
+++ b/tools/workspace-plugin/src/executors/build/lib/babel.ts
@@ -104,14 +104,7 @@ async function babel(esmModuleOutput: NormalizedOptions['moduleOutput'][number],
       sourceFileName: basename(filename),
     })) /* Bad `transformAsync` types. it can be null only if 2nd param is null(config)*/ as NonNullableRecord<BabelFileResult>;
 
-    // FIXME:
-    // - NOTE: needs to be fixed primarily in {@link 'file://./swc.ts'} as well
-    // - swc does not add source mapping url when using @swc/core imperative APIs (unlike @swc/cli) (//# sourceMappingURL=) !
-    // - we ship transpiled files without proper source mapping since - Wed, 31 May 2023 (the swithc from swc/cli to programatic api useage)
-    // - @swc/cli does add source mapping because besides invoking swc/core programatically it also contains custom logic to add source mapping url https://github.com/swc-project/pkgs/blob/main/packages/cli/src/swc/compile.ts#L42-L44
-    // const resultCode = addSourceMappingUrl(result.code, basename(filename) + '.map');
-
-    const resultCode = result.code;
+    const resultCode = addSourceMappingUrl(result.code, basename(filename) + '.map');
 
     if (resultCode === sourceCode) {
       logger.verbose(`babel: skipped ${filePath}`);


### PR DESCRIPTION


<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
