### PR TITLE
fix: update drawer scroll state when content change

### DIFF
--- a/packages/react-components/react-drawer/library/src/components/DrawerBody/DrawerBody.cy.tsx
+++ b/packages/react-components/react-drawer/library/src/components/DrawerBody/DrawerBody.cy.tsx
@@ -5,6 +5,7 @@ import { webLightTheme } from '@fluentui/react-theme';
 
 import { DrawerBody } from './DrawerBody';
 import type { JSXElement } from '@fluentui/react-utilities';
+import { DrawerProvider, useDrawerContextValue } from '../../contexts';
 
 const mountFluent = (element: JSXElement) => {
   mount(<FluentProvider theme={webLightTheme}>{element}</FluentProvider>);
@@ -38,5 +39,49 @@ describe('DrawerBody', () => {
     cy.get('#drawer-body')
       .scrollTo('top')
       .should($e => assertScrollPosition($e[0], 0));
+  });
+
+  it('updates scrollState when children change from short to long', () => {
+    const shortContent = 'Short content';
+    const longContent = Array(50)
+      .fill(
+        'lorem ipsum dolor sit amet consectetur, adipisicing elit. Corrupti, animi? Quos, eum pariatur. Labore magni vel doloremque reiciendis, consequatur porro explicabo similique harum illo, ad hic, earum nobis accusantium quasi?',
+      )
+      .join(' ');
+
+    const Example = () => {
+      const context = useDrawerContextValue();
+      const [showLong, setShowLong] = React.useState(false);
+
+      return (
+        <DrawerProvider value={context}>
+          <div id="scroll-state">{context.scrollState}</div>
+
+          <DrawerBody id="drawer-body" style={{ height: '200px' }}>
+            {showLong ? longContent : shortContent}
+          </DrawerBody>
+
+          <button id="toggle-content" onClick={() => setShowLong(s => !s)}>
+            Toggle
+          </button>
+        </DrawerProvider>
+      );
+    };
+
+    mountFluent(<Example />);
+
+    // Initially short content should result in 'none'
+    cy.get('#drawer-body').should('exist');
+    cy.get('#scroll-state').should('have.text', 'none');
+
+    // Toggle to long content and assert context scroll state updates to 'top'
+    cy.get('#toggle-content').click();
+    cy.get('#scroll-state').should('have.text', 'top');
+
+    // Scroll to bottom and assert it becomes 'bottom'
+    cy.get('#drawer-body')
+      .scrollTo('bottom')
+      // wait for any rAF-based updates and then assert the scrollState
+      .then(() => cy.get('#scroll-state').should('have.text', 'bottom'));
   });
 });

--- a/packages/react-components/react-drawer/library/src/components/DrawerBody/useDrawerBody.ts
+++ b/packages/react-components/react-drawer/library/src/components/DrawerBody/useDrawerBody.ts
@@ -12,6 +12,7 @@ import { useDrawerContext_unstable } from '../../contexts/drawerContext';
 import { DrawerScrollState } from '../../shared/DrawerBase.types';
 
 import type { DrawerBodyProps, DrawerBodyState } from './DrawerBody.types';
+import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
 
 /**
  * @internal
@@ -47,9 +48,14 @@ const getScrollState = ({ scrollTop, scrollHeight, clientHeight }: HTMLElement):
  */
 export const useDrawerBody_unstable = (props: DrawerBodyProps, ref: React.Ref<HTMLElement>): DrawerBodyState => {
   const { setScrollState } = useDrawerContext_unstable();
+  const { targetDocument } = useFluent();
+  const win = targetDocument?.defaultView;
 
   const scrollRef = React.useRef<HTMLDivElement | null>(null);
-  const [setAnimationFrame, cancelAnimationFrame] = useAnimationFrame();
+  const mergedRef = useMergedRefs(ref, scrollRef);
+
+  const [setScrollAnimationFrame, cancelScrollAnimationFrame] = useAnimationFrame();
+  const [setResizeAnimationFrame, cancelResizeAnimationFrame] = useAnimationFrame();
 
   const updateScrollState = React.useCallback(() => {
     if (!scrollRef.current) {
@@ -60,23 +66,28 @@ export const useDrawerBody_unstable = (props: DrawerBodyProps, ref: React.Ref<HT
   }, [setScrollState]);
 
   const onScroll = React.useCallback(() => {
-    cancelAnimationFrame();
-    setAnimationFrame(() => updateScrollState());
-  }, [cancelAnimationFrame, setAnimationFrame, updateScrollState]);
+    cancelScrollAnimationFrame();
+    setScrollAnimationFrame(() => updateScrollState());
+  }, [cancelScrollAnimationFrame, setScrollAnimationFrame, updateScrollState]);
 
+  // Update scroll state on children change
+  useIsomorphicLayoutEffect(() => updateScrollState(), [props.children]);
+
+  // Update scroll state on mount and when resize occurs
   useIsomorphicLayoutEffect(() => {
-    cancelAnimationFrame();
-    setAnimationFrame(() => updateScrollState());
-    /* update scroll state when children changes */
-    return () => cancelAnimationFrame();
-  }, [props.children, cancelAnimationFrame, updateScrollState, setAnimationFrame]);
+    if (!scrollRef.current || !win) {
+      return;
+    }
 
-  useIsomorphicLayoutEffect(() => {
-    cancelAnimationFrame();
-    setAnimationFrame(() => updateScrollState());
+    const observer = new win.ResizeObserver(() => setResizeAnimationFrame(() => updateScrollState()));
 
-    return () => cancelAnimationFrame();
-  }, [cancelAnimationFrame, updateScrollState, setAnimationFrame]);
+    observer.observe(scrollRef.current);
+
+    return () => {
+      observer.disconnect();
+      cancelResizeAnimationFrame();
+    };
+  }, [cancelResizeAnimationFrame, setResizeAnimationFrame, updateScrollState, win]);
 
   return {
     components: {
@@ -85,10 +96,7 @@ export const useDrawerBody_unstable = (props: DrawerBodyProps, ref: React.Ref<HT
 
     root: slot.always(
       getIntrinsicElementProps<DrawerBodyProps>('div', {
-        // FIXME:
-        // `ref` is wrongly assigned to be `HTMLElement` instead of `HTMLDivElement`
-        // but since it would be a breaking change to fix it, we are casting ref to it's proper type
-        ref: useMergedRefs<HTMLDivElement>(ref as React.Ref<HTMLDivElement>, scrollRef),
+        ref: mergedRef,
         ...props,
         onScroll: mergeCallbacks(props.onScroll, onScroll),
       }),

--- a/packages/react-components/react-drawer/stories/src/Drawer/DrawerDefault.stories.tsx
+++ b/packages/react-components/react-drawer/stories/src/Drawer/DrawerDefault.stories.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import type { JSXElement } from '@fluentui/react-components';
 import {
   DrawerBody,
   DrawerHeader,
@@ -16,6 +15,11 @@ import {
   useRestoreFocusSource,
   useRestoreFocusTarget,
   ToggleButton,
+  Accordion,
+  AccordionItem,
+  AccordionPanel,
+  AccordionHeader,
+  DrawerFooter,
 } from '@fluentui/react-components';
 import { Dismiss24Regular } from '@fluentui/react-icons';
 
@@ -48,12 +52,12 @@ const useStyles = makeStyles({
 
 type DrawerType = Required<DrawerProps>['type'];
 
-export const Default = (): JSXElement => {
+export const Default = () => {
   const styles = useStyles();
   const labelId = useId('type-label');
 
-  const [isOpen, setIsOpen] = React.useState(false);
-  const [type, setType] = React.useState<DrawerType>('overlay');
+  const [isOpen, setIsOpen] = React.useState(true);
+  const [type, setType] = React.useState<DrawerType>('inline');
 
   // all Drawers need manual focus restoration attributes
   // unless (as in the case of some inline drawers, you do not want automatic focus restoration)
@@ -85,8 +89,38 @@ export const Default = (): JSXElement => {
         </DrawerHeader>
 
         <DrawerBody>
-          <p>Drawer content</p>
+          <Accordion collapsible>
+            <AccordionItem value="1">
+              <AccordionHeader>Accordion Header 1</AccordionHeader>
+              <AccordionPanel>
+                <div>Accordion Panel 1</div>
+                <div>Accordion Panel 1</div>
+                <div>Accordion Panel 1</div>
+                <div>Accordion Panel 1</div>
+                <div>Accordion Panel 1</div>
+                <div>Accordion Panel 1</div>
+                <div>Accordion Panel 1</div>
+                <div>Accordion Panel 1</div>
+                <div>Accordion Panel 1</div>
+                <div>Accordion Panel 1</div>
+                <div>Accordion Panel 1</div>
+                <div>Accordion Panel 1</div>
+                <div>Accordion Panel 1</div>
+                <div>Accordion Panel 1</div>
+                <div>Accordion Panel 1</div>
+                <div>Accordion Panel 1</div>
+                <div>Accordion Panel 1</div>
+                <div>Accordion Panel 1</div>
+                <div>Accordion Panel 1</div>
+                <div>Accordion Panel 1</div>
+                <div>Accordion Panel 1</div>
+                <div>Accordion Panel 1</div>
+                <div>Accordion Panel 1</div>
+              </AccordionPanel>
+            </AccordionItem>
+          </Accordion>
         </DrawerBody>
+        <DrawerFooter>A drawer footer.</DrawerFooter>
       </Drawer>
 
       <div className={styles.content}>


### PR DESCRIPTION
## Previous Behavior

DrawerBody was not accounting for content change to calculate the scroll state, that is responsible to define the separator.

## New Behavior

DrawerBody now has a ResizeObserver to detect when the content changes, at least for when the height changes.

## Related Issue(s)

- Fixes #34324
