### PR TITLE
chore: add nx-set-shas to ghp deploy action

### DIFF
--- a/.github/workflows/docsite-publish-ghpages.yml
+++ b/.github/workflows/docsite-publish-ghpages.yml
@@ -18,6 +18,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Derive appropriate SHAs for base and head for `nx affected` commands
+        uses: nrwl/nx-set-shas@826660b82addbef3abff5fa871492ebad618c9e1 # v4.3.3
+        with:
+          main-branch-name: 'master'
+
       - uses: actions/setup-node@v4
         with:
           node-version: 20


### PR DESCRIPTION
GHP action is missing nx SHAs