### PR TITLE
Fix(react-menu-grid-preview): Allow navigation in MenuGrid submenu of MenuList

### DIFF
--- a/change/@fluentui-react-menu-grid-preview-9ac68dd6-389b-4ee4-8b63-9a26d47f1f73.json
+++ b/change/@fluentui-react-menu-grid-preview-9ac68dd6-389b-4ee4-8b63-9a26d47f1f73.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Allow navigation in MenuGrid submenu of MenuList",
+  "packageName": "@fluentui/react-menu-grid-preview",
+  "email": "adam.samec@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-menu-grid-preview/library/package.json
+++ b/packages/react-components/react-menu-grid-preview/library/package.json
@@ -24,6 +24,7 @@
     "@fluentui/scripts-api-extractor": "*"
   },
   "dependencies": {
+    "@fluentui/keyboard-keys": "^9.0.8",
     "@fluentui/react-menu": "^9.19.6",
     "@fluentui/react-table": "^9.18.6",
     "@fluentui/react-tabster": "^9.26.5",

--- a/packages/react-components/react-menu-grid-preview/library/src/components/MenuGridCell/useMenuGridCell.ts
+++ b/packages/react-components/react-menu-grid-preview/library/src/components/MenuGridCell/useMenuGridCell.ts
@@ -1,5 +1,13 @@
 import * as React from 'react';
-import { useMergedRefs, getIntrinsicElementProps, slot } from '@fluentui/react-utilities';
+import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
+import { ArrowLeft, ArrowRight } from '@fluentui/keyboard-keys';
+import {
+  useMergedRefs,
+  useEventCallback,
+  mergeCallbacks,
+  getIntrinsicElementProps,
+  slot,
+} from '@fluentui/react-utilities';
 import { MenuGridCellProps, MenuGridCellState } from './MenuGridCell.types';
 import { useValidateNesting } from '../../utils/useValidateNesting';
 
@@ -7,8 +15,17 @@ import { useValidateNesting } from '../../utils/useValidateNesting';
  * Given user props, returns state and render function for a MenuGridCell.
  */
 export function useMenuGridCell_unstable(props: MenuGridCellProps, ref: React.Ref<HTMLDivElement>): MenuGridCellState {
-  const validateNestingRef = useValidateNesting('MenuGridCell');
   const { visuallyHidden } = props;
+  const validateNestingRef = useValidateNesting('MenuGridCell');
+  const { dir } = useFluent();
+
+  const CloseArrowKey = dir === 'ltr' ? ArrowLeft : ArrowRight;
+  const onKeyDownWithPrevent = useEventCallback((event: React.KeyboardEvent<HTMLElement>) => {
+    if (event.key === CloseArrowKey) {
+      event.preventDefault();
+    }
+  });
+  const onKeyDown = useEventCallback(mergeCallbacks(props.onKeyDown, onKeyDownWithPrevent));
 
   return {
     visuallyHidden,
@@ -20,6 +37,7 @@ export function useMenuGridCell_unstable(props: MenuGridCellProps, ref: React.Re
         ref: useMergedRefs(ref, validateNestingRef),
         role: 'gridcell',
         ...props,
+        onKeyDown,
       }),
       { elementType: 'div' },
     ),


### PR DESCRIPTION
### Description of changes

This PR adds changes so that MenuGrid submenu of MenuList enables navigation using Left or Right arrow key between MenuGrid cell action and MenuGrid row. This fixes the previous incorrect behavior where this arrow key navigation caused closing of the MenuGrid submenu.