### PR TITLE
Fix: Resizable columns - make default column padding configurable

### DIFF
--- a/packages/react-components/react-table/library/src/components/DataGrid/DataGrid.types.ts
+++ b/packages/react-components/react-table/library/src/components/DataGrid/DataGrid.types.ts
@@ -102,6 +102,17 @@ export type DataGridProps = TableProps &
        * @default true
        * */
       autoFitColumns?: boolean;
+
+      /**
+       * In pixels. Default padding value used when calculating the total width of the columns.
+       * This is used when adjusting the column widths to fit the container.
+       *
+       * Change this value to total horizontal padding of your cells when you have
+       * custom padding set on the cells or set to 0 if the cells have box-sizing: border-box.
+       *
+       * Specify this value in columnSizingOptions for per-column padding.
+       * */
+      defaultColumnPadding?: number;
     };
   };
 

--- a/packages/react-components/react-table/library/src/components/DataGrid/useDataGrid.ts
+++ b/packages/react-components/react-table/library/src/components/DataGrid/useDataGrid.ts
@@ -77,6 +77,7 @@ export const useDataGrid_unstable = (props: DataGridProps, ref: React.Ref<HTMLEl
       // Disables automatic resizing of columns when the container overflows.
       // This allows the sum of the columns to be larger than the container.
       autoFitColumns: resizableColumnsOptions.autoFitColumns ?? true,
+      defaultColumnPadding: resizableColumnsOptions.defaultColumnPadding,
     }),
   ]);
 

--- a/packages/react-components/react-table/library/src/hooks/types.ts
+++ b/packages/react-components/react-table/library/src/hooks/types.ts
@@ -173,7 +173,7 @@ export interface ColumnWidthState {
   width: number;
   minWidth: number;
   idealWidth: number;
-  padding: number;
+  padding?: number;
 }
 
 export type ColumnSizingTableProps = TableProps;
@@ -219,6 +219,28 @@ export type UseTableColumnSizingParams = {
     e: KeyboardEvent | TouchEvent | MouseEvent | undefined,
     data: { columnId: TableColumnId; width: number },
   ) => void;
+
+  /**
+   * Allows for a container size to be adjusted by a number of pixels, to make
+   * sure the columns don't overflow the table.
+   * By default, this value is calculated internally based on other props, but can be overriden.
+   */
   containerWidthOffset?: number;
+
+  /**
+   * If true, columns will be auto-fitted to the container width.
+   * @default true
+   * */
   autoFitColumns?: boolean;
+
+  /**
+   * In pixels. Default padding value used when calculating the total width of the columns.
+   * This is used when adjusting the column widths to fit the container.
+   *
+   * Change this value to total horizontal padding of your cells when you have
+   * custom padding set on the cells or set to 0 if the cells have box-sizing: border-box.
+   *
+   * Specify this value in columnSizingOptions for per-column padding.
+   * */
+  defaultColumnPadding?: number;
 };

--- a/packages/react-components/react-table/library/src/utils/columnResizeUtils.ts
+++ b/packages/react-components/react-table/library/src/utils/columnResizeUtils.ts
@@ -62,7 +62,7 @@ export function columnDefinitionsToState<T>(
       width: Math.max(defaultWidth ?? idealWidth, minWidth),
       minWidth,
       idealWidth: Math.max(defaultWidth ?? idealWidth, minWidth),
-      padding: padding ?? 16,
+      padding,
     };
   });
 
@@ -90,8 +90,8 @@ export function getColumnByIndex(state: ColumnWidthState[], index: number): Colu
   return state[index];
 }
 
-export function getTotalWidth(state: ColumnWidthState[]): number {
-  return state.reduce((sum, column) => sum + column.width + column.padding, 0);
+export function getTotalWidth(state: ColumnWidthState[], defaultColumnPadding: number = 16): number {
+  return state.reduce((sum, column) => sum + column.width + (column.padding ?? defaultColumnPadding), 0);
 }
 
 export function getLength(state: ColumnWidthState[]): number {
@@ -151,9 +151,10 @@ export function setColumnProperty(
 export function adjustColumnWidthsToFitContainer(
   state: ColumnWidthState[],
   containerWidth: number,
+  defaultColumnPadding?: number,
 ): ColumnWidthState[] {
   let newState = state;
-  const totalWidth = getTotalWidth(newState);
+  const totalWidth = getTotalWidth(newState, defaultColumnPadding);
 
   // The total width is smaller, we are expanding columns
   if (totalWidth < containerWidth) {


### PR DESCRIPTION
## Feature: Configurable Default Column Padding for DataGrid Resizable Columns

### Overview

This PR introduces a new option to configure the default column padding for resizable columns in the DataGrid component. This enhancement gives consumers the option to update the value used for resizable columns calculation for their custom designs or use cases.

### Changes

- Adds a `defaultColumnPadding` option to DataGrid and related types, allowing consumers to specify the amount of padding applied to columns when resizable columns are enabled.
- Updates internal logic and type definitions to support the new configuration.
- Maintains backward compatibility: if no value is provided, the previous default padding is used.

### Usage

```tsx
<DataGrid
  columns={columns}
  items={items}
  resizableColumns
  resizableColumnsOptions={{
      autoFitColumns: false,
      defaultColumnPadding: 0,
  }}
/>
```

### Additional Notes

- This option also enables a workaround for [#35234](https://github.com/microsoft/fluentui/issues/35234):  
  When using `box-sizing: border-box` on DataGrid cells, setting `defaultColumnPadding={0}` eliminates the extra padding involved in the calculation of column widths.
- No breaking changes; existing usage without the new prop will continue to work as before.