### PR TITLE
docs: fix TypeScript and JavaScript capitalization

### DIFF
--- a/apps/public-docsite-v9/src/Concepts/BuildTimeStyles.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/BuildTimeStyles.stories.mdx
@@ -69,9 +69,9 @@ module.exports = {
 > ℹ️ **Note**: A chain of webpack loaders is executed in reverse order
 > [https://webpack.js.org/concepts/loaders/#loader-features](https://webpack.js.org/concepts/loaders/#loader-features)
 
-#### Typescript (and additional compilation) support
+#### TypeScript (and additional compilation) support
 
-The Webpack loader [evaluate styles at runtime](#build-time-style-evaluation). For typescript
+The Webpack loader [evaluate styles at runtime](#build-time-style-evaluation). For TypeScript
 it's necessary to install `@babel/preset-typescript` and configure it in the [babelOptions](https://github.com/microsoft/griffel/tree/main/packages/webpack-loader#configuring-babel-settings) of the loader. Similarly
 any other language features that might be required can also be configured here. While the order of loaders will
 ensure that the webpack loader will run on transpiled code (for a specific module), runtime evaluation can potentially require other
@@ -106,7 +106,7 @@ Simply create a Babel configuration file such as `.babelrc.json` and add the pre
 };
 ```
 
-#### Typescript (and additional transpilation) support
+#### TypeScript (and additional transpilation) support
 
 [Similar to above](#typescript-and-additional-transpilation-support)
 
@@ -235,4 +235,4 @@ The build-time evaluation happens as a part of the Babel transforms in Griffel. 
 batched and done in single evaluation context. **Linaria's Babel config is separate to any config used by the application**.
 Therefore, additional language features
 may require extra configuration. How to do this configuration is described in the sections above. One common
-language feature that will require extra configuration is Typescript.
+language feature that will require extra configuration is TypeScript.

--- a/docs/react-v9/contributing/implementation-best-practices.md
+++ b/docs/react-v9/contributing/implementation-best-practices.md
@@ -14,7 +14,7 @@ If a property applies to the component or to the logical element of the componen
 
 If a property applies to a part or slot of a component, prefix/suffix with the part name (e.g. prefer `iconPosition` over `position`). Prefer to prefix the part name except where the property is acting as a verb (e.g. `alignContent` over `contentAlign`).
 
-Avoid any hungarian notation of properties. While they can appear helpful when writing the props in Typescript, they are not idiomatic when calling from TSX.
+Avoid any hungarian notation of properties. While they can appear helpful when writing the props in TypeScript, they are not idiomatic when calling from TSX.
 
 ### List properties in alphabetical order
 
@@ -32,9 +32,9 @@ Part of the design specification process for a component is to identify and name
 
 ### Prefer types over interfaces
 
-v9+ components are built using React Hooks and Typescript. Hooks is a functional programming approach that replaces the the object-oriented approach of React component classes. While Typescript supports object-oriented programming through interfaces and classes, it also fully supports functional programming through type declarations, type intersections, and discriminated unions. Because Typescript transpiles to JavaScript, a prototype-based language, it provides type inference and [duck typing](https://en.wikipedia.org/wiki/Duck_typing).
+v9+ components are built using React Hooks and TypeScript. Hooks is a functional programming approach that replaces the the object-oriented approach of React component classes. While TypeScript supports object-oriented programming through interfaces and classes, it also fully supports functional programming through type declarations, type intersections, and discriminated unions. Because TypeScript transpiles to JavaScript, a prototype-based language, it provides type inference and [duck typing](https://en.wikipedia.org/wiki/Duck_typing).
 
-Types and interfaces can often be used [interchangeably](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#differences-between-type-aliases-and-interfaces) in Typescript. There are a few differences that make types the preferred choice:
+Types and interfaces can often be used [interchangeably](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#differences-between-type-aliases-and-interfaces) in TypeScript. There are a few differences that make types the preferred choice:
 
 - Interfaces can be re-opened to add new properties through declaration merging.
 

--- a/docs/react-v9/contributing/rfcs/react-components/convergence/event-handlers-event-type.md
+++ b/docs/react-v9/contributing/rfcs/react-components/convergence/event-handlers-event-type.md
@@ -136,7 +136,7 @@ import * as React from 'react';
            });
        const onOpenChange = (_e: Event, data: OnSomeEventData) => {
          console.log(data.event.currentTarget); // ✅ base event data can be used without checking data.type
-         console.log(data.event.clientX); // ❌ Typescript will give an error here as expected
+         console.log(data.event.clientX); // ❌ TypeScript will give an error here as expected
          if (data.type === 'click') {
            console.log(data.event.clientX); // ✅ this won't blow as `data.type` verification will ensure `data.event` is a mouse event
          }

--- a/docs/react-v9/contributing/rfcs/react-components/convergence/prop-string-union-naming.md
+++ b/docs/react-v9/contributing/rfcs/react-components/convergence/prop-string-union-naming.md
@@ -10,7 +10,7 @@
 
 Standardize the naming conventions for string union prop values across the library so users and contributors get a consistent experience.
 
-A "string union prop value" is a React component prop where the value is a Typescript string union:
+A "string union prop value" is a React component prop where the value is a TypeScript string union:
 
 ```ts
 myProp: 'a' | 'b';

--- a/docs/react-v9/contributing/rfcs/react-components/convergence/theme-shape.md
+++ b/docs/react-v9/contributing/rfcs/react-components/convergence/theme-shape.md
@@ -13,7 +13,7 @@ However, 1200 CSS variables in DOM affects browser performance. This RFC propose
 
 ## <a name="performance-analysis"></a>Performance analysis
 
-The current theme consists of ~1200 tokens which are injected into DOM as CSS variables. It impacts not only Javascript performance but also browser performance in styles computation phase.
+The current theme consists of ~1200 tokens which are injected into DOM as CSS variables. It impacts not only JavaScript performance but also browser performance in styles computation phase.
 
 To see the performance impact we render 20 `FluentProvider` components side by side (**each** injecting a class with 1200 CSS variables) - mount and unmount 10 times and measure the performance in Chrome profiler with 6x CPU slowdown. After each mount, a CSS attribute is accessed to force reflow in order to be able to measure the rendering performance.
 
@@ -178,7 +178,7 @@ Current design token spec also calls out `fontWeights` and `alignment` tokens ar
 
 ### <a name="flatten-tokens"></a>Flatten the tokens object
 
-In Typescript the theme is represented by a deep object:
+In TypeScript the theme is represented by a deep object:
 
 ```js
 /* Before */

--- a/docs/react-wiki-archive/Guidelines/React-Guidelines.md
+++ b/docs/react-wiki-archive/Guidelines/React-Guidelines.md
@@ -1,6 +1,6 @@
 ## Favor composition over inheritance
 
-Even as the ES6 Javascript standard is giving us the "class" keyword, we should stay away from inheritance as a model for extending functionality. Inheritance forces a single linear path within which to extend functionality. Functionality from different aspects or domains are added in arbitrary nodes along this path. Eventually, the functionality of the subclasses is muddied with multiple responsibilities. Rather, given a composition model, each composed type can focus on its own purpose without compromising on flexibility. Further, it is easier to test each of these composed units rather than subclasses that are mixed in purpose.
+Even as the ES6 JavaScript standard is giving us the "class" keyword, we should stay away from inheritance as a model for extending functionality. Inheritance forces a single linear path within which to extend functionality. Functionality from different aspects or domains are added in arbitrary nodes along this path. Eventually, the functionality of the subclasses is muddied with multiple responsibilities. Rather, given a composition model, each composed type can focus on its own purpose without compromising on flexibility. Further, it is easier to test each of these composed units rather than subclasses that are mixed in purpose.
 
 Inheritance also doesn't work with the new hooks-based function components.
 

--- a/docs/react-wiki-archive/Guidelines/TypeScript-Guidelines.md
+++ b/docs/react-wiki-archive/Guidelines/TypeScript-Guidelines.md
@@ -249,4 +249,4 @@ export default function foo() {}
 
 ## Acknowledgements
 
-Many of these rules were inspired by the guidelines of Outlook Web, [Typescript](https://github.com/Microsoft/TypeScript/wiki/Coding-guidelines), [Pillar Studio](https://github.com/pillarstudio/standards/blob/master/reactjs-guidelines.md) and [AirBnb](https://github.com/airbnb/javascript)
+Many of these rules were inspired by the guidelines of Outlook Web, [TypeScript](https://github.com/Microsoft/TypeScript/wiki/Coding-guidelines), [Pillar Studio](https://github.com/pillarstudio/standards/blob/master/reactjs-guidelines.md) and [AirBnb](https://github.com/airbnb/javascript)

--- a/docs/react-wiki-archive/Implementation-Best-Practices.md
+++ b/docs/react-wiki-archive/Implementation-Best-Practices.md
@@ -16,7 +16,7 @@ If a property applies to the component or to the logical element of the componen
 
 If a property applies to a part or slot of a component, prefix/suffix with the part name (e.g. prefer `iconPosition` over `position`). Prefer to prefix the part name except where the property is acting as a verb (e.g. `alignContent` over `contentAlign`).
 
-Avoid any hungarian notation of properties. While they can appear helpful when writing the props in Typescript, they are not idiomatic when calling from TSX.
+Avoid any hungarian notation of properties. While they can appear helpful when writing the props in TypeScript, they are not idiomatic when calling from TSX.
 
 ### List properties in alphabetical order
 
@@ -34,9 +34,9 @@ Part of the design specification process for a component is to identify and name
 
 ### Prefer types over interfaces
 
-v9+ components are built using React Hooks and Typescript. Hooks is a functional programming approach that replaces the the object-oriented approach of React component classes. While Typescript supports object-oriented programming through interfaces and classes, it also fully supports functional programming through type declarations, type intersections, and discriminated unions. Because Typescript transpiles to JavaScript, a prototype-based language, it provide type inference and [duck typing](https://en.wikipedia.org/wiki/Duck_typing).
+v9+ components are built using React Hooks and TypeScript. Hooks is a functional programming approach that replaces the the object-oriented approach of React component classes. While TypeScript supports object-oriented programming through interfaces and classes, it also fully supports functional programming through type declarations, type intersections, and discriminated unions. Because TypeScript transpiles to JavaScript, a prototype-based language, it provide type inference and [duck typing](https://en.wikipedia.org/wiki/Duck_typing).
 
-Types and interfaces can often be used [interchangeably](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#differences-between-type-aliases-and-interfaces) in Typescript. There are a few differences that make types the preferred choice:
+Types and interfaces can often be used [interchangeably](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#differences-between-type-aliases-and-interfaces) in TypeScript. There are a few differences that make types the preferred choice:
 
 - Interfaces can be re-opened to add new properties through declaration merging.
 

--- a/packages/charts/react-charting/docs/TechnicalDetails.md
+++ b/packages/charts/react-charting/docs/TechnicalDetails.md
@@ -45,7 +45,7 @@ The charting components are built using following building blocks.
   - Axis localization
     The axes support 2 ways of localization.
 
-    1. Javascript provided inbuilt localization for numeric and date axis. Specify the culture and dateLocalizeOptions for date axis to define target localization. Refer the [javascript localization guide](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString) for usage.
+    1. JavaScript provided inbuilt localization for numeric and date axis. Specify the culture and dateLocalizeOptions for date axis to define target localization. Refer the [JavaScript localization guide](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString) for usage.
     2. Custom locale definition: The consumer of the library can specify a custom locale definition as supported by d3 (like [this](https://github.com/d3/d3-time-format/blob/main/locale/en-US.json)). The date axis will use the date range and the multiformat specified in the definition to determine the correct format to show in the ticks. For example - If the date range is in days then the axis will show hourly ticks. If the date range spans across months then the axis will show months in tick labels and so on.
        Specify the custom locale definition in the timeFormatLocale prop.
        Refer to the Custom Locale Date Axis example in line chart for sample usage.

--- a/packages/charts/react-charts/stories/src/AreaChart/AreaChartBestPractices.md
+++ b/packages/charts/react-charts/stories/src/AreaChart/AreaChartBestPractices.md
@@ -29,7 +29,7 @@ The area chart is a highly performant visual. It uses a path-based rendering mec
 
 The chart axes support 2 ways of localization.
 
-1. JavaScript provided inbuilt localization for numeric and date axis. Specify the culture and `dateLocalizeOptions` for date axis to define target localization. Refer the Javascript localization guide for usage.
+1. JavaScript provided inbuilt localization for numeric and date axis. Specify the culture and `dateLocalizeOptions` for date axis to define target localization. Refer the JavaScript localization guide for usage.
 2. Custom locale definition: The consumer of the library can specify a custom locale definition as supported by d3 like this. The date axis will use the date range and the multiformat specified in the definition to determine the correct labels to show in the ticks. For example - If the date range is in days, then the axis will show hourly ticks. If the date range spans across months, then the axis will show months in tick labels and so on. Specify the custom locale definition in the `timeFormatLocale` prop. Refer to the Custom Locale Date Axis example in line chart for sample usage.
 
 ### Creating Date Objects For Chart Data

--- a/packages/charts/react-charts/stories/src/HeatMapChart/docs/HeatMapChartBestPractices.md
+++ b/packages/charts/react-charts/stories/src/HeatMapChart/docs/HeatMapChartBestPractices.md
@@ -27,7 +27,7 @@ Use the following formatters based on the type of axis.
 
 The chart axes support 2 ways of localization.
 
-1. JavaScript provided inbuilt localization for numeric and date axis. Specify the culture and `dateLocalizeOptions` for date axis to define target localization. Refer the [Javascript localization guide](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString) for usage.
+1. JavaScript provided inbuilt localization for numeric and date axis. Specify the culture and `dateLocalizeOptions` for date axis to define target localization. Refer the [JavaScript localization guide](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString) for usage.
 2. Custom locale definition: The consumer of the library can specify a custom locale definition as supported by d3 [like this](https://github.com/d3/d3-time-format/blob/main/locale/en-US.json). The date axis will use the date range and the multiformat specified in the definition to determine the correct labels to show in the ticks. For example - If the date range is in days, then the axis will show hourly ticks. If the date range spans across months, then the axis will show months in tick labels and so on. Specify the custom locale definition in the `timeFormatLocale` prop. Refer to the Custom Locale Date Axis example in line chart for sample usage.
 
 ### Creating Date Objects For Chart Data

--- a/packages/charts/react-charts/stories/src/LineChart/LineChartBestPractices.md
+++ b/packages/charts/react-charts/stories/src/LineChart/LineChartBestPractices.md
@@ -43,7 +43,7 @@ Line chart provides a bunch of props to enable custom accessibility messages. Us
 
 The chart axes support 2 ways of localization.
 
-1. JavaScript provided inbuilt localization for numeric and date axis. Specify the culture and `dateLocalizeOptions` for date axis to define target localization. Refer the [Javascript localization guide](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString) for usage.
+1. JavaScript provided inbuilt localization for numeric and date axis. Specify the culture and `dateLocalizeOptions` for date axis to define target localization. Refer the [JavaScript localization guide](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString) for usage.
 2. Custom locale definition: The consumer of the library can specify a custom locale definition as supported by d3 [like this](https://github.com/d3/d3-time-format/blob/main/locale/en-US.json). The date axis will use the date range and the multiformat specified in the definition to determine the correct labels to show in the ticks. For example - If the date range is in days, then the axis will show hourly ticks. If the date range spans across months, then the axis will show months in tick labels and so on. Specify the custom locale definition in the `timeFormatLocale` prop. Refer to the Custom Locale Date Axis example in line chart for sample usage.
 
 ### Creating Date Objects For Chart Data

--- a/packages/merge-styles/CHANGELOG.md
+++ b/packages/merge-styles/CHANGELOG.md
@@ -874,7 +874,7 @@ Thu, 15 Nov 2018 13:36:22 GMT
 
 ### Minor changes
 
-- DevExp: get rid of const enum so the library is compatible with Typescript's isolatedModule compilation mode
+- DevExp: get rid of const enum so the library is compatible with TypeScript's isolatedModule compilation mode
 
 ## 6.14.0
 Tue, 13 Nov 2018 13:30:53 GMT

--- a/packages/react-components/react-components/CHANGELOG.md
+++ b/packages/react-components/react-components/CHANGELOG.md
@@ -8452,7 +8452,7 @@ Thu, 26 Jan 2023 13:30:51 GMT
 - `@fluentui/react-textarea`
   - Deprecate TextareaField_unstable in favor of Field with Textarea as its child. ([PR #26430](https://github.com/microsoft/fluentui/pull/26430) by behowell@microsoft.com)
 - `@fluentui/react-toolbar`
-  - fix: export toolbar hooks as functions, not Typescript types ([PR #26462](https://github.com/microsoft/fluentui/pull/26462) by seanmonahan@microsoft.com)
+  - fix: export toolbar hooks as functions, not TypeScript types ([PR #26462](https://github.com/microsoft/fluentui/pull/26462) by seanmonahan@microsoft.com)
 - `@fluentui/react-utilities`
   - fix: Leverage React.useId when available for our useId hook. ([PR #26465](https://github.com/microsoft/fluentui/pull/26465) by esteban.230@hotmail.com)
 

--- a/packages/react-components/react-theme-sass/README.md
+++ b/packages/react-components/react-theme-sass/README.md
@@ -33,4 +33,4 @@ ReactDOM.render(
 }
 ```
 
-> ⚠ Note: This package does not export any Javascript code.️
+> ⚠ Note: This package does not export any JavaScript code.️

--- a/packages/react-components/react-toolbar/library/CHANGELOG.md
+++ b/packages/react-components/react-toolbar/library/CHANGELOG.md
@@ -1958,7 +1958,7 @@ Thu, 26 Jan 2023 13:31:02 GMT
 
 ### Patches
 
-- fix: export toolbar hooks as functions, not Typescript types ([PR #26462](https://github.com/microsoft/fluentui/pull/26462) by seanmonahan@microsoft.com)
+- fix: export toolbar hooks as functions, not TypeScript types ([PR #26462](https://github.com/microsoft/fluentui/pull/26462) by seanmonahan@microsoft.com)
 - Bump @fluentui/react-button to v9.2.0 ([PR #26496](https://github.com/microsoft/fluentui/pull/26496) by beachball)
 - Bump @fluentui/react-divider to v9.1.12 ([PR #26496](https://github.com/microsoft/fluentui/pull/26496) by beachball)
 - Bump @fluentui/react-utilities to v9.5.0 ([PR #26496](https://github.com/microsoft/fluentui/pull/26496) by beachball)

--- a/packages/react-examples/src/react-charting/AreaChart/docs/AreaChartBestPractices.md
+++ b/packages/react-examples/src/react-charting/AreaChart/docs/AreaChartBestPractices.md
@@ -32,7 +32,7 @@ The area chart is a highly performant visual. It uses a path-based rendering mec
 
 The chart axes support 2 ways of localization.
 
-1. JavaScript provided inbuilt localization for numeric and date axis. Specify the culture and `dateLocalizeOptions` for date axis to define target localization. Refer the [Javascript localization guide](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString) for usage.
+1. JavaScript provided inbuilt localization for numeric and date axis. Specify the culture and `dateLocalizeOptions` for date axis to define target localization. Refer the [JavaScript localization guide](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString) for usage.
 2. Custom locale definition: The consumer of the library can specify a custom locale definition as supported by d3 [like this](https://github.com/d3/d3-time-format/blob/main/locale/en-US.json). The date axis will use the date range and the multiformat specified in the definition to determine the correct labels to show in the ticks. For example - If the date range is in days, then the axis will show hourly ticks. If the date range spans across months, then the axis will show months in tick labels and so on. Specify the custom locale definition in the `timeFormatLocale` prop. Refer to the Custom Locale Date Axis example in line chart for sample usage.
 
 ### Creating Date Objects For Chart Data

--- a/packages/react-examples/src/react-charting/HeatMapChart/docs/HeatMapChartBestPractices.md
+++ b/packages/react-examples/src/react-charting/HeatMapChart/docs/HeatMapChartBestPractices.md
@@ -27,7 +27,7 @@ Use the following formatters based on the type of axis.
 
 The chart axes support 2 ways of localization.
 
-1. JavaScript provided inbuilt localization for numeric and date axis. Specify the culture and `dateLocalizeOptions` for date axis to define target localization. Refer the [Javascript localization guide](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString) for usage.
+1. JavaScript provided inbuilt localization for numeric and date axis. Specify the culture and `dateLocalizeOptions` for date axis to define target localization. Refer the [JavaScript localization guide](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString) for usage.
 2. Custom locale definition: The consumer of the library can specify a custom locale definition as supported by d3 [like this](https://github.com/d3/d3-time-format/blob/main/locale/en-US.json). The date axis will use the date range and the multiformat specified in the definition to determine the correct labels to show in the ticks. For example - If the date range is in days, then the axis will show hourly ticks. If the date range spans across months, then the axis will show months in tick labels and so on. Specify the custom locale definition in the `timeFormatLocale` prop. Refer to the Custom Locale Date Axis example in line chart for sample usage.
 
 ### Creating Date Objects For Chart Data

--- a/packages/react-examples/src/react-charting/LineChart/docs/LineChartBestPractices.md
+++ b/packages/react-examples/src/react-charting/LineChart/docs/LineChartBestPractices.md
@@ -43,7 +43,7 @@ Line chart provides a bunch of props to enable custom accessibility messages. Us
 
 The chart axes support 2 ways of localization.
 
-1. JavaScript provided inbuilt localization for numeric and date axis. Specify the culture and `dateLocalizeOptions` for date axis to define target localization. Refer the [Javascript localization guide](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString) for usage.
+1. JavaScript provided inbuilt localization for numeric and date axis. Specify the culture and `dateLocalizeOptions` for date axis to define target localization. Refer the [JavaScript localization guide](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString) for usage.
 2. Custom locale definition: The consumer of the library can specify a custom locale definition as supported by d3 [like this](https://github.com/d3/d3-time-format/blob/main/locale/en-US.json). The date axis will use the date range and the multiformat specified in the definition to determine the correct labels to show in the ticks. For example - If the date range is in days, then the axis will show hourly ticks. If the date range spans across months, then the axis will show months in tick labels and so on. Specify the custom locale definition in the `timeFormatLocale` prop. Refer to the Custom Locale Date Axis example in line chart for sample usage.
 
 ### Creating Date Objects For Chart Data

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -10915,7 +10915,7 @@ Thu, 15 Nov 2018 13:36:22 GMT
 
 ### Minor changes
 
-- DevExp: get rid of const enum so the library is compatible with Typescript's isolatedModule compilation mode
+- DevExp: get rid of const enum so the library is compatible with TypeScript's isolatedModule compilation mode
 - ScrollablePane and Sticky: Fix placeholder height, Sticky sorting, and stickyClassName
 - Slider: replace button with div so vertical Sliders render on Safari
 
@@ -11283,7 +11283,7 @@ Mon, 08 Oct 2018 12:24:16 GMT
 
 ### Minor changes
 
-- Typescript 3.1 type fixes.
+- TypeScript 3.1 type fixes.
 
 ### Patches
 

--- a/packages/style-utilities/CHANGELOG.md
+++ b/packages/style-utilities/CHANGELOG.md
@@ -1831,7 +1831,7 @@ Thu, 15 Nov 2018 13:36:22 GMT
 
 ### Minor changes
 
-- DevExp: get rid of const enum so the library is compatible with Typescript's isolatedModule compilation mode
+- DevExp: get rid of const enum so the library is compatible with TypeScript's isolatedModule compilation mode
 
 ## 6.34.1
 Fri, 09 Nov 2018 13:32:57 GMT

--- a/packages/utilities/CHANGELOG.md
+++ b/packages/utilities/CHANGELOG.md
@@ -1924,7 +1924,7 @@ Thu, 15 Nov 2018 13:36:22 GMT
 
 ### Minor changes
 
-- DevExp: get rid of const enum so the library is compatible with Typescript's isolatedModule compilation mode
+- DevExp: get rid of const enum so the library is compatible with TypeScript's isolatedModule compilation mode
 - Styled: now reacts to loadTheme changes even when not wrapped in a Customizer.
 
 ## 6.26.0


### PR DESCRIPTION
## Summary
This PR fixes incorrect capitalizations of "TypeScript" and "JavaScript" throughout the FluentUI documentation and comments.

## Changes made
- Fixed **22 files** with incorrect capitalizations
- Changed "Typescript" → "TypeScript" 
- Changed "Javascript" → "JavaScript"

## Files updated
### Documentation
- Contributing guides and best practices
- RFC documents  
- Component documentation for charts (HeatMapChart, LineChart, AreaChart)
- README files

### Historical records
- CHANGELOG entries (preserved as documentation of past releases)

## Impact
- ✅ Documentation only changes
- ✅ No functional code changes
- ✅ No breaking changes
- ✅ Improves consistency across the codebase

## Test plan
All changes are in markdown files and comments only. No code changes require testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)