### PR TITLE
ci: update react major versions integration job names

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -81,7 +81,7 @@ jobs:
           git status --porcelain
           git diff-index --quiet HEAD -- || exit 1
 
-  react_integration_tests_collocated:
+  react-major-versions-integration:
     if: ${{ github.repository_owner == 'microsoft' }}
     runs-on: macos-14-xlarge
     steps:
@@ -129,13 +129,13 @@ jobs:
         run: |
           FLUENT_JEST_WORKER=2 yarn nx affected -t test-rit--17--test,test-rit--17--type-check,test-rit--19--test,test-rit--19--type-check --exclude='react-19-tests-v9,react-charting,react,react-hooks,react-examples,react-experiments'
 
-  react_integration_tests:
+  react_19_v9_source_code_typecheck:
     if: ${{ github.repository_owner == 'microsoft' }}
     runs-on: ubuntu-latest
     permissions:
       contents: 'read'
       actions: 'read'
-    name: v9 source files type-check against React 19
+    name: v9 source code type-check against React 19
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

- see PR title
- once this lands the `react-major-versions-integration` job will be  set as "required" to be able to proceed with PR merges going forward

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
