### PR TITLE
fix(react-tooltip): show tooltip correctly under strict mode

### DIFF
--- a/apps/rit-tests-v9/src/react-19/components/Tooltip.cy.tsx
+++ b/apps/rit-tests-v9/src/react-19/components/Tooltip.cy.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import { mount as mountBase } from '@fluentui/scripts-cypress';
+import {
+  Menu,
+  MenuItem,
+  MenuButton,
+  MenuList,
+  MenuTrigger,
+  MenuPopover,
+  webLightTheme,
+  Tooltip,
+  FluentProvider,
+  tooltipClassNames,
+} from '@fluentui/react-components';
+import type { JSXElement } from '@fluentui/react-utilities';
+
+const mount = (element: JSXElement) => {
+  mountBase(<FluentProvider theme={webLightTheme}>{element}</FluentProvider>);
+};
+
+// https://github.com/microsoft/fluentui/issues/34296
+describe('Tooltip visibility with strict mode', () => {
+  it('should show Tooltip inside a Menu when opened by keyboard', () => {
+    mount(
+      <Menu>
+        <MenuTrigger disableButtonEnhancement>
+          <MenuButton>Edit content</MenuButton>
+        </MenuTrigger>
+        <MenuPopover>
+          <MenuList>
+            <Tooltip content="Cut to clipboard" relationship="description">
+              <MenuItem>Menu Item</MenuItem>
+            </Tooltip>
+          </MenuList>
+        </MenuPopover>
+      </Menu>,
+    );
+
+    cy.realPress('Tab');
+    cy.get('button').focus().realPress('Enter');
+    cy.get('[role="menuitem"]').should('be.focused');
+    cy.get(`.${tooltipClassNames.content}`).should('be.visible');
+  });
+});

--- a/change/@fluentui-react-tooltip-61b2e251-ccc8-4eb9-83e4-fff3cb927190.json
+++ b/change/@fluentui-react-tooltip-61b2e251-ccc8-4eb9-83e4-fff3cb927190.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: In StrictMode, Tooltip now shows correctly on elements that are focused when created",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tooltip/library/src/components/Tooltip/private/useTooltipTimeout.ts
+++ b/packages/react-components/react-tooltip/library/src/components/Tooltip/private/useTooltipTimeout.ts
@@ -1,0 +1,61 @@
+'use client';
+
+import * as React from 'react';
+import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
+
+const setTimeoutNoop = (_callback: Function) => -1;
+const clearTimeoutNoop = (_handle: number) => undefined;
+
+type BrowserTimerSetter =
+  | ((fn: () => void, duration?: number, ...args: Record<string, unknown>[]) => number)
+  | ((fn: () => void) => number);
+
+/**
+ * @internal
+ * @param triggerElementRef - Reference to the trigger element
+ * @returns A pair of [setTimeout, clearTimeout] that are stable between renders.
+ */
+export function useTooltipTimeout(
+  triggerElementRef: React.MutableRefObject<HTMLElement>,
+): readonly [(fn: () => void, delay?: number) => number, () => void] {
+  const { targetDocument } = useFluent();
+  const win = targetDocument?.defaultView;
+
+  const setTimerFn: BrowserTimerSetter = win ? win.setTimeout : setTimeoutNoop;
+  const clearTimerFn: (id: number) => void = win ? win.clearTimeout : clearTimeoutNoop;
+
+  const id = React.useRef<number | undefined>(undefined);
+
+  const set = React.useCallback(
+    (fn: () => void, delay?: number) => {
+      if (id.current !== undefined) {
+        clearTimerFn(id.current);
+      }
+
+      id.current = setTimerFn(fn, delay ?? 0);
+      return id.current;
+    },
+    [clearTimerFn, setTimerFn],
+  );
+
+  const cancel = React.useCallback(() => {
+    if (id.current !== undefined) {
+      clearTimerFn(id.current);
+      id.current = undefined;
+    }
+  }, [clearTimerFn]);
+
+  // StrictMode-aware cleanup: only clear timeout if element has no parent (real unmount)
+  React.useEffect(() => {
+    const el = triggerElementRef.current;
+    return () => {
+      const isRealUnmount = !el || !el.isConnected;
+
+      if (isRealUnmount) {
+        cancel();
+      }
+    };
+  }, [cancel, triggerElementRef]);
+
+  return [set, cancel];
+}

--- a/packages/react-components/react-tooltip/library/src/components/Tooltip/useTooltip.tsx
+++ b/packages/react-components/react-tooltip/library/src/components/Tooltip/useTooltip.tsx
@@ -15,7 +15,6 @@ import {
   useIsomorphicLayoutEffect,
   useIsSSR,
   useMergedRefs,
-  useTimeout,
   getTriggerChild,
   mergeCallbacks,
   useEventCallback,
@@ -24,6 +23,7 @@ import {
 } from '@fluentui/react-utilities';
 import type { TooltipProps, TooltipState, TooltipChildProps, OnVisibleChangeData } from './Tooltip.types';
 import { arrowHeight, tooltipBorderRadius } from './private/constants';
+import { useTooltipTimeout } from './private/useTooltipTimeout';
 import { Escape } from '@fluentui/keyboard-keys';
 
 /**
@@ -40,7 +40,8 @@ export const useTooltip_unstable = (props: TooltipProps): TooltipState => {
   const context = useTooltipVisibility();
   const isServerSideRender = useIsSSR();
   const { targetDocument } = useFluent();
-  const [setDelayTimeout, clearDelayTimeout] = useTimeout();
+
+  const [visible, setVisibleInternal] = useControllableState({ state: props.visible, initialState: false });
 
   const {
     appearance = 'normal',
@@ -54,20 +55,6 @@ export const useTooltip_unstable = (props: TooltipProps): TooltipState => {
     hideDelay = 250,
     mountNode,
   } = props;
-
-  const [visible, setVisibleInternal] = useControllableState({ state: props.visible, initialState: false });
-  const setVisible = React.useCallback(
-    (ev: React.PointerEvent<HTMLElement> | React.FocusEvent<HTMLElement> | undefined, data: OnVisibleChangeData) => {
-      clearDelayTimeout();
-      setVisibleInternal(oldVisible => {
-        if (data.visible !== oldVisible) {
-          onVisibleChange?.(ev, data);
-        }
-        return data.visible;
-      });
-    },
-    [clearDelayTimeout, setVisibleInternal, onVisibleChange],
-  );
 
   const state: TooltipState = {
     withArrow,
@@ -115,6 +102,21 @@ export const useTooltip_unstable = (props: TooltipProps): TooltipState => {
     containerRef: React.MutableRefObject<HTMLDivElement>;
     arrowRef: React.MutableRefObject<HTMLDivElement>;
   } = usePositioning(positioningOptions);
+
+  const [setDelayTimeout, clearDelayTimeout] = useTooltipTimeout(containerRef);
+
+  const setVisible = React.useCallback(
+    (ev: React.PointerEvent<HTMLElement> | React.FocusEvent<HTMLElement> | undefined, data: OnVisibleChangeData) => {
+      clearDelayTimeout();
+      setVisibleInternal(oldVisible => {
+        if (data.visible !== oldVisible) {
+          onVisibleChange?.(ev, data);
+        }
+        return data.visible;
+      });
+    },
+    [clearDelayTimeout, setVisibleInternal, onVisibleChange],
+  );
 
   state.content.ref = useMergedRefs(state.content.ref, containerRef);
   state.arrowRef = arrowRef;


### PR DESCRIPTION
Alternative approach to #34331

## Previous Behavior

Tooltip uses a custom utilitiy useTimeout (useBrowserTimer) to manage the timer that delays showing the Tooltip. This utility creates the timer through an imperative function, but clears the timer in a useEffect cleanup function. This results in the tooltip never being shown if it is unmounted and remounted after the Tooltip was triggered but before it was shown. This can happen in StrictMode for a component that receives initial focus when it is created, such as a MenuItem.

## New Behavior

Tooltip uses it's inner `useTooltipTimeout` hook, which is based on previous `useTimeout` hook from `react-utilities` implementation with a additional check for a real unmount, making this hook StrictMode aware.

## Related Issue(s)

- Fixes #34296
