### PR TITLE
chore: setup no-restricted-imports for cypress tess within react-legacy and resolve issues within apps/rit-tests-v*

### DIFF
--- a/apps/rit-tests-v8/src/shared/components/ContextualMenu/ContextualMenuExample.cy.tsx
+++ b/apps/rit-tests-v8/src/shared/components/ContextualMenu/ContextualMenuExample.cy.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { mount } from '@cypress/react';
+import { mount } from '@fluentui/scripts-cypress';
 
 import { ContextualMenuExample } from './ContextualMenuExample';
 
@@ -8,11 +8,7 @@ const menuSelector = '[role="menu"]';
 
 describe('ContextualMenu', () => {
   it('renders ContextualMenu when trigger button is clicked', () => {
-    mount(
-      <React.StrictMode>
-        <ContextualMenuExample />
-      </React.StrictMode>,
-    );
+    mount(<ContextualMenuExample />);
 
     cy.get(menuTriggerSelector).click().get(menuSelector).should('be.visible');
   });

--- a/apps/rit-tests-v8/tsconfig.lib.json
+++ b/apps/rit-tests-v8/tsconfig.lib.json
@@ -8,6 +8,15 @@
     "outDir": "dist",
     "types": []
   },
-  "exclude": ["node_modules", "dist", "**/*.spec.ts", "**/*.spec.tsx", "**/*.test.ts", "**/*.test.tsx"],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.cy.ts",
+    "**/*.cy.tsx"
+  ],
   "include": ["./src/index.ts", "./src/react-18/", "./src/shared/**/*.ts", "./src/shared/**/*.tsx"]
 }

--- a/apps/rit-tests-v9/tsconfig.lib.json
+++ b/apps/rit-tests-v9/tsconfig.lib.json
@@ -8,6 +8,15 @@
     "outDir": "dist",
     "types": []
   },
-  "exclude": ["node_modules", "dist", "**/*.spec.ts", "**/*.spec.tsx", "**/*.test.ts", "**/*.test.tsx"],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.cy.ts",
+    "**/*.cy.tsx"
+  ],
   "include": ["src/index.ts", "./src/react-18/", "./src/shared/**/*.ts", "./src/shared/**/*.tsx"]
 }

--- a/packages/eslint-plugin/src/configs/react-legacy.js
+++ b/packages/eslint-plugin/src/configs/react-legacy.js
@@ -22,5 +22,22 @@ module.exports = {
         '@typescript-eslint/no-deprecated': 'off',
       },
     },
+    {
+      files: ['**/*.e2e.{ts,tsx,js}', '**/*.cy.{ts,tsx,js}', 'isConformant.{ts,tsx,js}'],
+      rules: {
+        '@typescript-eslint/no-restricted-imports': [
+          'error',
+          {
+            patterns: [
+              {
+                group: ['@cypress/react'],
+                importNames: ['mount'],
+                message: "Use 'mount' from @fluentui/scripts-cypress instead.",
+              },
+            ],
+          },
+        ],
+      },
+    },
   ],
 };

--- a/packages/react-examples/cypress.config.ts
+++ b/packages/react-examples/cypress.config.ts
@@ -2,6 +2,24 @@ import { baseConfig, baseWebpackConfig } from '@fluentui/scripts-cypress';
 import { createStorybookWebpackConfig } from '@fluentui/scripts-webpack';
 
 const config = { ...baseConfig };
-config.component.devServer.webpackConfig = createStorybookWebpackConfig(baseWebpackConfig);
+const v8webpackConfig = createStorybookWebpackConfig(baseWebpackConfig);
+
+// we need to remove scripts-cypress from aliases as we wanna keep node_modules resolution to make browser path work for `import { mount } from '@fluentui/scripts-cypress';`
+config.component.devServer.webpackConfig = removeAliases(v8webpackConfig, [
+  '@fluentui/scripts-cypress/',
+  '@fluentui/scripts-cypress$',
+]);
 
 export default config;
+
+function removeAliases(webpackConfig: typeof v8webpackConfig, aliases: string[]) {
+  const alias = webpackConfig?.resolve?.alias ?? {};
+
+  for (const key of Object.keys(alias)) {
+    if (aliases.includes(key)) {
+      delete (alias as Record<string, unknown>)[key];
+    }
+  }
+
+  return webpackConfig;
+}

--- a/packages/react-examples/src/react/FocusTrapZone/e2e/FocusTrapZone.e2e.tsx
+++ b/packages/react-examples/src/react/FocusTrapZone/e2e/FocusTrapZone.e2e.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { mount } from '@cypress/react';
+import { mount } from '@fluentui/scripts-cypress';
 import { FocusTrapZone } from '@fluentui/react/lib/FocusTrapZone';
 import { FocusZone, FocusZoneDirection } from '@fluentui/react/lib/FocusZone';
 import type { IFocusTrapZoneProps, IFocusTrapZone } from '@fluentui/react/lib/FocusTrapZone';


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

- update `rit-tests-v8` and `rit-tests-v9` tsconfig.lib.json to ignore cypress tests when type-checking,
-  enforce `@fluentui/scripts-cypress` in Cypress tests for v8

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
