### PR TITLE
fix(public-docsite-v9): resolve race condition when running build-storybook:docsite

### DIFF
--- a/apps/public-docsite-v9/project.json
+++ b/apps/public-docsite-v9/project.json
@@ -22,7 +22,8 @@
     },
     "build-storybook:react": {
       "inputs": ["default", "{workspaceRoot}/.storybook/**", "{projectRoot}/.storybook/**"],
-      "outputs": ["{projectRoot}/dist/react"]
+      "outputs": ["{projectRoot}/dist/react"],
+      "dependsOn": ["build-storybook"]
     },
     "build-storybook:docsite": {
       "executor": "nx:noop",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

`build-storybook:docsite` is failing during deploy after v9 deprecated packages have been re-added to monorepo

## New Behavior

make sure dependencies are ready for `build-storybook:react` and `build-storybook:docsite` targets

<img width="845" height="202" alt="targets tree of execution" src="https://github.com/user-attachments/assets/1020e910-c569-4210-b50d-60e92d8aae65" />


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
