### PR TITLE
[Fix]: DetailsList group “Unselect All” checkbox does not clear selection when group contains unselectable items (canSelectItem returns false)

### DIFF
--- a/change/@fluentui-utilities-63124421-3d96-4247-af3a-2b945b207050.json
+++ b/change/@fluentui-utilities-63124421-3d96-4247-af3a-2b945b207050.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[Fix]: DetailsList group “Unselect All” checkbox does not clear selection when group contains unselectable items (canSelectItem returns false)",
+  "packageName": "@fluentui/utilities",
+  "email": "sheetalsinghnew@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/utilities/src/selection/Selection.test.ts
+++ b/packages/utilities/src/selection/Selection.test.ts
@@ -243,4 +243,139 @@ describe('Selection', () => {
 
     expect(selection.getSelection()).toEqual([{ key: 'b' }, { key: 'a' }]);
   });
+
+  it('toggles range selection correctly when all items are selectable', () => {
+    const items: IObjectWithKey[] = [{ key: 'a' }, { key: 'b' }, { key: 'c' }];
+    const selection = new Selection({
+      items,
+      selectionMode: SelectionMode.multiple,
+      onSelectionChanged,
+    });
+
+    // First toggle should select all items in range
+    selection.toggleRangeSelected(0, 3);
+    expect(selection.getSelectedIndices()).toEqual([0, 1, 2]);
+    expect(onSelectionChanged).toHaveBeenCalledTimes(1);
+
+    // Second toggle should deselect all items in range
+    selection.toggleRangeSelected(0, 3);
+    expect(selection.getSelectedIndices()).toEqual([]);
+    expect(onSelectionChanged).toHaveBeenCalledTimes(2);
+  });
+
+  it('toggles range selection correctly when some items are not selectable', () => {
+    const items: IObjectWithKey[] = [{ key: 'a' }, { key: 'b' }, { key: 'c' }, { key: 'd' }];
+    const selection = new Selection({
+      items,
+      selectionMode: SelectionMode.multiple,
+      canSelectItem: item => item.key !== 'b', // Make 'b' unselectable
+      onSelectionChanged,
+    });
+
+    // First toggle should select only selectable items (a, c, d)
+    selection.toggleRangeSelected(0, 4);
+    expect(selection.getSelectedIndices()).toEqual([0, 2, 3]);
+    expect(selection.isIndexSelected(0)).toBe(true); // a - selected
+    expect(selection.isIndexSelected(1)).toBe(false); // b - not selectable
+    expect(selection.isIndexSelected(2)).toBe(true); // c - selected
+    expect(selection.isIndexSelected(3)).toBe(true); // d - selected
+    expect(onSelectionChanged).toHaveBeenCalledTimes(1);
+
+    // Second toggle should deselect all selectable items
+    // This is the fix: it should work even with unselectable items in the range
+    selection.toggleRangeSelected(0, 4);
+    expect(selection.getSelectedIndices()).toEqual([]);
+    expect(selection.isIndexSelected(0)).toBe(false);
+    expect(selection.isIndexSelected(1)).toBe(false);
+    expect(selection.isIndexSelected(2)).toBe(false);
+    expect(selection.isIndexSelected(3)).toBe(false);
+    expect(onSelectionChanged).toHaveBeenCalledTimes(2);
+  });
+
+  it('toggles partial range selection correctly with unselectable items', () => {
+    const items: IObjectWithKey[] = [{ key: 'a' }, { key: 'b' }, { key: 'c' }, { key: 'd' }];
+    const selection = new Selection({
+      items,
+      selectionMode: SelectionMode.multiple,
+      canSelectItem: item => item.key !== 'c', // Make 'c' unselectable
+      onSelectionChanged,
+    });
+
+    // Manually select only item 'a'
+    selection.setKeySelected('a', true, false);
+    expect(selection.getSelectedIndices()).toEqual([0]);
+    expect(onSelectionChanged).toHaveBeenCalledTimes(1);
+
+    // Toggle range: since not all selectable items (a, b, d) are selected, it should select them
+    selection.toggleRangeSelected(0, 4);
+    expect(selection.getSelectedIndices()).toEqual([0, 1, 3]);
+    expect(selection.isIndexSelected(2)).toBe(false); // c is not selectable
+    expect(onSelectionChanged).toHaveBeenCalledTimes(2);
+
+    // Toggle range again: all selectable items are selected, so deselect them
+    selection.toggleRangeSelected(0, 4);
+    expect(selection.getSelectedIndices()).toEqual([]);
+    expect(onSelectionChanged).toHaveBeenCalledTimes(3);
+  });
+
+  it('handles toggleRangeSelected with only unselectable items in range', () => {
+    const items: IObjectWithKey[] = [{ key: 'a' }, { key: 'b' }, { key: 'c' }, { key: 'd' }];
+    const selection = new Selection({
+      items,
+      selectionMode: SelectionMode.multiple,
+      canSelectItem: item => item.key !== 'b' && item.key !== 'c',
+      onSelectionChanged,
+    });
+
+    // Toggle a range containing only unselectable items (b, c)
+    selection.toggleRangeSelected(1, 2);
+    expect(selection.getSelectedIndices()).toEqual([]);
+    expect(onSelectionChanged).toHaveBeenCalledTimes(0);
+
+    // Toggle again - should still have no effect
+    selection.toggleRangeSelected(1, 2);
+    expect(selection.getSelectedIndices()).toEqual([]);
+    expect(onSelectionChanged).toHaveBeenCalledTimes(0);
+  });
+
+  it('handles grouped DetailsList scenario with unselectable item', () => {
+    // This test simulates the exact bug scenario from the issue
+    const items: IObjectWithKey[] = [
+      { key: 'a1' }, // Group A - selectable
+      { key: 'a2' }, // Group A - NOT selectable
+      { key: 'b1' }, // Group B - selectable
+      { key: 'b2' }, // Group B - selectable
+    ];
+
+    const selection = new Selection({
+      items,
+      selectionMode: SelectionMode.multiple,
+      canSelectItem: item => item.key !== 'a2',
+      onSelectionChanged,
+    });
+
+    // Simulate clicking Group A header checkbox (first time - select)
+    selection.toggleRangeSelected(0, 2); // Group A has items at index 0-1
+    expect(selection.getSelectedIndices()).toEqual([0]); // Only a1 selected
+    expect(selection.isIndexSelected(0)).toBe(true); // a1
+    expect(selection.isIndexSelected(1)).toBe(false); // a2 (unselectable)
+    expect(onSelectionChanged).toHaveBeenCalledTimes(1);
+
+    // Simulate clicking Group A header checkbox (second time - deselect)
+    // THIS IS THE BUG FIX: this should now work correctly
+    selection.toggleRangeSelected(0, 2);
+    expect(selection.getSelectedIndices()).toEqual([]); // All deselected
+    expect(selection.isIndexSelected(0)).toBe(false);
+    expect(selection.isIndexSelected(1)).toBe(false);
+    expect(onSelectionChanged).toHaveBeenCalledTimes(2);
+
+    // Verify Group B works correctly (all items selectable)
+    selection.toggleRangeSelected(2, 2);
+    expect(selection.getSelectedIndices()).toEqual([2, 3]);
+    expect(onSelectionChanged).toHaveBeenCalledTimes(3);
+
+    selection.toggleRangeSelected(2, 2);
+    expect(selection.getSelectedIndices()).toEqual([]);
+    expect(onSelectionChanged).toHaveBeenCalledTimes(4);
+  });
 });

--- a/packages/utilities/src/selection/Selection.ts
+++ b/packages/utilities/src/selection/Selection.ts
@@ -523,16 +523,35 @@ export class Selection<TItem = IObjectWithKey> implements ISelection<TItem> {
       return;
     }
 
-    const isRangeSelected = this.isRangeSelected(fromIndex, count);
     const endIndex = fromIndex + count;
 
     if (this.mode === SelectionMode.single && count > 1) {
       return;
     }
 
+    // FIX: Check if all SELECTABLE items in the range are selected
+    let selectableCount = 0;
+    let selectedCount = 0;
+
+    for (let i = fromIndex; i < endIndex; i++) {
+      if (!this._unselectableIndices[i]) {
+        selectableCount++;
+        if (this.isIndexSelected(i)) {
+          selectedCount++;
+        }
+      }
+    }
+
+    // If all selectable items are selected, we should deselect them
+    // Otherwise, we should select them
+    const shouldSelect = selectedCount < selectableCount;
+
     this.setChangeEvents(false);
     for (let i = fromIndex; i < endIndex; i++) {
-      this.setIndexSelected(i, !isRangeSelected, false);
+      // Only toggle selectable items
+      if (!this._unselectableIndices[i]) {
+        this.setIndexSelected(i, shouldSelect, false);
+      }
     }
     this.setChangeEvents(true);
   }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
