### PR TITLE
fix(starter-templates): Add `@fluentui/react-components` and `@fluentui/react-icons` to `package.json`

### DIFF
--- a/starter-templates/src/react-components-vite/package.json
+++ b/starter-templates/src/react-components-vite/package.json
@@ -9,6 +9,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@fluentui/react-components": "^9.72.2",
+    "@fluentui/react-icons": "^2.0.311",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [✔️] Code is up-to-date with the `master` branch
* [❌] Your changes are covered by tests (if possible)
* [❌] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

The [react-components-vite](https://github.com/microsoft/fluentui/tree/02dce6867432d0d155d2366ebb73f95d8f539684/starter-templates/src/react-components-vite) starter project that is currently available on the `master` branch uses React Components v9 in the code but doesn't actually depend on the `@fluentui/react-components` and `@fluentui/react-icons` packages in `package.json`

As a result, when clicking on the [![Edit on StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/microsoft/fluentui/tree/02dce6867432d0d155d2366ebb73f95d8f539684/starter-templates/src/react-components-vite) or [![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/sandbox/github/microsoft/fluentui/tree/02dce6867432d0d155d2366ebb73f95d8f539684/starter-templates/src/react-components-vite) buttons, the project fails to run:

<img width="684" height="126" alt="image" src="https://github.com/user-attachments/assets/e2782703-45e0-47d5-ab0e-9569d670af89" />

## New Behavior

After adding `@fluentui/react-components` and `@fluentui/react-icons` packages to `package.json`, the project loads and runs properly:

[![Edit on StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/maddouri/fluentui/tree/fix.starter_project.add_fluentui_react_components_v9/starter-templates/src/react-components-vite)

[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/sandbox/github/maddouri/fluentui/tree/fix.starter_project.add_fluentui_react_components_v9/starter-templates/src/react-components-vite)

<img width="762" height="117" alt="image" src="https://github.com/user-attachments/assets/0af623ae-4367-466a-a859-aa718dd2aca4" />

<!--
## Related Issue(s)

 Please link the issue being fixed so it gets closed when this is merged.

- Fixes #
 -->