### PR TITLE
fix(rit-tests-v8): make sure dependencies are build before running tests

### DIFF
--- a/apps/rit-tests-v8/project.json
+++ b/apps/rit-tests-v8/project.json
@@ -4,5 +4,9 @@
   "projectType": "application",
   "implicitDependencies": [],
   "tags": ["v8"],
-  "targets": {}
+  "targets": {
+    "test": {
+      "dependsOn": ["^build"]
+    }
+  }
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

`test` target is failing on 

```
 Validation Error:

  Module @fluentui/jest-serializer-merge-styles in the snapshotSerializers option was not found.
         <rootDir> is: /Users/martinhochel/Projects/msft/fluentui/apps/rit-tests-v8
```

## New Behavior

see pr title

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
