### PR TITLE
fix(public-docsite-v9): update react-router ssr guide with missing step for setting providers in client entry

### DIFF
--- a/apps/public-docsite-v9/src/Concepts/SSR/Remix.stories.mdx
+++ b/apps/public-docsite-v9/src/Concepts/SSR/Remix.stories.mdx
@@ -93,6 +93,28 @@ npx react-router reveal
 npx remix reveal
 ```
 
+- Update the `entry.client.tsx` to wrap the router with both `<RendererProvider>` and `<SSRProvider>`:
+
+```tsx
+import { createDOMRenderer, RendererProvider, SSRProvider } from '@fluentui/react-components';
+import { startTransition, StrictMode } from 'react';
+import { hydrateRoot } from 'react-dom/client';
+import { HydratedRouter } from 'react-router/dom';
+
+startTransition(() => {
+  hydrateRoot(
+    document,
+    <StrictMode>
+      <RendererProvider renderer={createDOMRenderer()}>
+        <SSRProvider>
+          <HydratedRouter />
+        </SSRProvider>
+      </RendererProvider>
+    </StrictMode>,
+  );
+});
+```
+
 - and then update the `entry.server.tsx`:
 
 ```tsx


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

[The React Router SSR guide on the docsite](https://storybooks.fluentui.dev/react/?path=/docs/concepts-developer-server-side-rendering-react-router-7-and-remix-setup--docs) was  missing the step to update the `entry.client.tsx` which led to issues like https://github.com/microsoft/fluentui/issues/35329#issuecomment-3406826588

## New Behavior

The React Router SSR guide on the documentation site has been updated to include the step for updating `entry.client.tsx`.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes ##35329
