### PR TITLE
ci(release): switch to manually triggered releases for v8 packages

### DIFF
--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -19,15 +19,16 @@ variables:
   - name: tags
     value: production,externalfacing
 
-schedules:
-  # minute 0, hour 7 in UTC (11pm in UTC-8), any day of month, any month, days 1-5 of week (M-F)
-  # https://docs.microsoft.com/en-us/azure/devops/pipelines/build/triggers?tabs=yaml&view=azure-devops#supported-cron-syntax
-  - cron: '0 7 * * 1-5'
-    # will be 12am during daylight savings time unless trigger is updated
-    displayName: 'Daily release (Sundary-Thursday at 11pm PST)'
-    branches:
-      include:
-        - master
+# Disabling automatic scheduled releases for more control
+# schedules:
+#   # minute 0, hour 7 in UTC (11pm in UTC-8), any day of month, any month, days 1-5 of week (M-F)
+#   # https://docs.microsoft.com/en-us/azure/devops/pipelines/build/triggers?tabs=yaml&view=azure-devops#supported-cron-syntax
+#   - cron: '0 7 * * 1-5'
+#     # will be 12am during daylight savings time unless trigger is updated
+#     displayName: 'Daily release (Sundary-Thursday at 11pm PST)'
+#     branches:
+#       include:
+#         - master
 
 resources:
   repositories:


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

Updates Azure release pipeline for v8 packages to improve control over release timing. 

The main change is disabling the automatic scheduled releases, which were previously set to run daily on weekdays.

**Why:**
- aligned with v9 approach
- more secure
- more control as we are adding R19 support to v8


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
