### PR TITLE
docs: remove old storybook dist output for GHP

### DIFF
--- a/.github/workflows/docsite-publish-ghpages.yml
+++ b/.github/workflows/docsite-publish-ghpages.yml
@@ -51,7 +51,6 @@ jobs:
           rm -rf _pages
           mkdir -p _pages/react _pages/charts _pages/web-components
 
-          cp -R apps/public-docsite-v9/dist/storybook/* _pages/
           cp -R apps/public-docsite-v9/dist/react/* _pages/react/
           cp -R apps/chart-docsite/dist/storybook/* _pages/charts/
           cp -R packages/web-components/dist/storybook/* _pages/web-components

--- a/apps/public-docsite-v9/package.json
+++ b/apps/public-docsite-v9/package.json
@@ -4,10 +4,9 @@
   "private": true,
   "description": "Fluent UI React v9 documentation",
   "scripts": {
-    "build-storybook": "cross-env NODE_OPTIONS=--max_old_space_size=3072 storybook build -o ./dist/storybook --docs",
-    "build-storybook:react": "cross-env NODE_OPTIONS=--max_old_space_size=3072 DEPLOY_PATH=/react/ storybook build -o ./dist/react --docs",
+    "build-storybook": "cross-env NODE_OPTIONS=--max_old_space_size=3072 DEPLOY_PATH=/react/ storybook build -o ./dist/react --docs",
     "postbuild-storybook": "yarn rewrite-title && yarn generate-llms-docs",
-    "rewrite-title": "node -r ../../scripts/ts-node/src/register ../../scripts/storybook/src/scripts/rewrite-title.ts --title 'Fluent UI React v9' --distPath ./dist/storybook",
+    "rewrite-title": "node -r ../../scripts/ts-node/src/register ../../scripts/storybook/src/scripts/rewrite-title.ts --title 'Fluent UI React v9' --distPath ./dist/react",
     "generate-llms-docs": "yarn storybook-llms-extractor --config storybook-llms.config.js",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",

--- a/apps/public-docsite-v9/project.json
+++ b/apps/public-docsite-v9/project.json
@@ -20,12 +20,9 @@
         }
       ]
     },
-    "build-storybook:react": {
+    "build-storybook:docsite": {
       "inputs": ["default", "{workspaceRoot}/.storybook/**", "{projectRoot}/.storybook/**"],
       "outputs": ["{projectRoot}/dist/react"],
-      "dependsOn": ["build-storybook"]
-    },
-    "build-storybook:docsite": {
       "executor": "nx:noop",
       "dependsOn": [
         "build-storybook",

--- a/apps/public-docsite-v9/storybook-llms.config.js
+++ b/apps/public-docsite-v9/storybook-llms.config.js
@@ -9,8 +9,8 @@ const storybookConfig = require('./.storybook/main');
  * @type {import('@fluentui/storybook-llms-extractor').Config}
  */
 module.exports = {
-  distPath: './dist/storybook',
-  summaryBaseUrl: 'https://react.fluentui.dev',
+  distPath: './dist/react',
+  summaryBaseUrl: 'https://storybooks.fluentui.dev/react/',
   summaryTitle: 'Fluent UI React v9',
   summaryDescription:
     "Fluent UI React is a library of React components that implement Microsoft's [Fluent Design System](https://fluent2.microsoft.design).",


### PR DESCRIPTION
## Previous Behavior

Two different builds for docsite: for `react.fluentui.dev` and `react.fluentui.dev/react` 

## New Behavior

We have a redirect to `storybooks.fluentui.dev/react` from `react.fluentui.dev`, so we do not need to keep old build output for GHP anymore

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

-  Implements #35061
