### PR TITLE
chore: compile for IE11

### DIFF
--- a/scripts/babel/src/index.js
+++ b/scripts/babel/src/index.js
@@ -26,7 +26,11 @@ module.exports = (/** @type {import('@babel/core').ConfigAPI} */ api) => {
       {
         loose: true,
         modules: useESModules ? false : 'cjs',
-        targets: isNode ? { node: '10' } : undefined,
+        targets: isNode
+          ? { node: '10' }
+          : {
+              browsers: ['last 2 versions', 'ie 11'],
+            },
         exclude: [
           // https://github.com/microsoft/fluent-ui-react/pull/1895
           'proposal-object-rest-spread',


### PR DESCRIPTION
## Previous Behavior

Default targets for Babel have been changed in meantime, so the last two releases started to be compile for more modern JS.

The issue is that there are multiple circular references that started to break once the output started to use `const` over `var`:

<img width="2142" height="924" alt="image" src="https://github.com/user-attachments/assets/b54d2015-f7f1-46c1-9863-22902f740ad1" />

## New Behavior

Switches `targets` to compile to older JS i.e. use `var`.