### PR TITLE
chore(v0): remove .defaultProps usage [part 1]

### DIFF
--- a/packages/fluentui/react-bindings/src/utils/getElementType.ts
+++ b/packages/fluentui/react-bindings/src/utils/getElementType.ts
@@ -5,11 +5,15 @@ import * as React from 'react';
  * Useful for calculating what type a component should render as.
  *
  * @param props - A ReactElement props object
+ * @param defaultAs - Default createElement() type
  * @returns A ReactElement type
  */
-export function getElementType<P extends Record<string, any>>(props: P): React.ElementType {
+export function getElementType<P extends Record<string, any>>(
+  props: P,
+  defaultAs: React.ElementType = 'div',
+): React.ElementType {
   // ----------------------------------------
   // use defaultProp or 'div'
 
-  return props.as || 'div';
+  return props.as || defaultAs;
 }

--- a/packages/fluentui/react-northstar/src/components/Accordion/Accordion.tsx
+++ b/packages/fluentui/react-northstar/src/components/Accordion/Accordion.tsx
@@ -115,7 +115,7 @@ export const Accordion = React.forwardRef<HTMLDListElement, AccordionProps>((pro
   const {
     expanded,
     exclusive,
-    accessibility,
+    accessibility = accordionBehavior,
     children,
     className,
     design,
@@ -178,7 +178,7 @@ export const Accordion = React.forwardRef<HTMLDListElement, AccordionProps>((pro
 
   const getNavigationItemsSize = () => props.panels.length;
   const unhandledProps = useUnhandledProps(Accordion.handledProps, props);
-  const ElementType = getElementType(props);
+  const ElementType = getElementType(props, 'dl');
 
   const focusHandler: ContainerFocusHandler = new ContainerFocusHandler(
     getNavigationItemsSize,
@@ -344,11 +344,6 @@ Accordion.propTypes = {
 
   renderPanelTitle: PropTypes.func,
   renderPanelContent: PropTypes.func,
-};
-
-Accordion.defaultProps = {
-  accessibility: accordionBehavior,
-  as: 'dl',
 };
 
 Accordion.handledProps = Object.keys(Accordion.propTypes) as any;

--- a/packages/fluentui/react-northstar/src/components/Accordion/AccordionContent.tsx
+++ b/packages/fluentui/react-northstar/src/components/Accordion/AccordionContent.tsx
@@ -54,11 +54,21 @@ export type AccordionContentStylesProps = Required<Pick<AccordionContentProps, '
 export const AccordionContent = React.forwardRef<HTMLDListElement, AccordionContentProps>((props, ref) => {
   const context = useFluentContext();
 
-  const { children, content, accordionTitleId, active, className, design, styles, variables } = props;
+  const {
+    accessibility = accordionContentBehavior,
+    children,
+    content,
+    accordionTitleId,
+    active,
+    className,
+    design,
+    styles,
+    variables,
+  } = props;
   const ElementType = getElementType(props);
   const unhandledProps = useUnhandledProps(AccordionContent.handledProps, props);
 
-  const getA11yProps = useAccessibility(props.accessibility, {
+  const getA11yProps = useAccessibility(accessibility, {
     debugName: AccordionContent.displayName,
     mapPropsToBehavior: () => ({
       accordionTitleId,
@@ -112,11 +122,6 @@ AccordionContent.propTypes = {
   accordionTitleId: PropTypes.string,
   active: PropTypes.bool,
   onClick: PropTypes.func,
-};
-
-AccordionContent.defaultProps = {
-  accessibility: accordionContentBehavior,
-  as: 'div',
 };
 
 AccordionContent.handledProps = Object.keys(AccordionContent.propTypes) as any;

--- a/packages/fluentui/react-northstar/src/components/Accordion/AccordionTitle.tsx
+++ b/packages/fluentui/react-northstar/src/components/Accordion/AccordionTitle.tsx
@@ -95,13 +95,13 @@ export const AccordionTitle = React.forwardRef<HTMLDListElement, AccordionTitleP
     const context = useFluentContext();
 
     const {
-      contentRef,
+      contentRef = _.noop,
       children,
       content,
-      indicator,
-      contentWrapper,
+      indicator = {},
+      contentWrapper = {},
       disabled,
-      accessibility,
+      accessibility = accordionTitleBehavior,
       canBeCollapsed,
       as,
       active,
@@ -240,13 +240,5 @@ AccordionTitle.propTypes = {
 };
 
 AccordionTitle.handledProps = Object.keys(AccordionTitle.propTypes) as any;
-
-AccordionTitle.defaultProps = {
-  accessibility: accordionTitleBehavior,
-  as: 'div',
-  contentRef: _.noop,
-  indicator: {},
-  contentWrapper: {},
-};
 
 AccordionTitle.create = createShorthandFactory({ Component: AccordionTitle, mappedProp: 'content' });

--- a/packages/fluentui/react-northstar/src/components/Alert/Alert.tsx
+++ b/packages/fluentui/react-northstar/src/components/Alert/Alert.tsx
@@ -126,6 +126,7 @@ export const Alert = React.forwardRef<HTMLDivElement, AlertProps>((props, ref) =
   const context = useFluentContext();
 
   const {
+    accessibility = alertBehavior,
     warning,
     danger,
     info,
@@ -139,11 +140,11 @@ export const Alert = React.forwardRef<HTMLDivElement, AlertProps>((props, ref) =
     styles,
     children,
     actions,
-    dismissAction,
+    dismissAction = {},
     content,
     icon,
     header,
-    body,
+    body = {},
   } = props;
 
   const [visible, setVisible] = useControllableState({
@@ -156,7 +157,7 @@ export const Alert = React.forwardRef<HTMLDivElement, AlertProps>((props, ref) =
   const ElementType = getElementType(props);
   const unhandledProps = useUnhandledProps(Alert.handledProps, props);
 
-  const getA11yProps = useAccessibility(props.accessibility, {
+  const getA11yProps = useAccessibility(accessibility, {
     debugName: Alert.displayName,
     mapPropsToBehavior: () => ({
       warning,
@@ -282,12 +283,6 @@ export const Alert = React.forwardRef<HTMLDivElement, AlertProps>((props, ref) =
   FluentComponentStaticProps<AlertProps> & {
     DismissAction: typeof AlertDismissAction;
   };
-
-Alert.defaultProps = {
-  accessibility: alertBehavior,
-  dismissAction: {},
-  body: {},
-};
 
 Alert.propTypes = {
   ...commonPropTypes.createCommon({ content: 'shorthand' }),

--- a/packages/fluentui/react-northstar/src/components/Alert/AlertDismissAction.tsx
+++ b/packages/fluentui/react-northstar/src/components/Alert/AlertDismissAction.tsx
@@ -83,11 +83,11 @@ export const AlertDismissAction = React.forwardRef<
   const context = useFluentContext();
 
   const {
-    accessibility,
-    as,
+    accessibility = buttonBehavior,
+    as = 'button',
     children,
     className,
-    content,
+    content = {},
     disabled,
     design,
     styles,
@@ -173,12 +173,6 @@ export const AlertDismissAction = React.forwardRef<
   return result;
 }) as unknown as ForwardRefWithAs<'button', HTMLButtonElement, AlertDismissActionProps> &
   FluentComponentStaticProps<AlertDismissActionProps>;
-
-AlertDismissAction.defaultProps = {
-  as: 'button',
-  accessibility: buttonBehavior,
-  content: {},
-};
 
 AlertDismissAction.displayName = 'AlertDismissAction';
 

--- a/packages/fluentui/react-northstar/src/components/Avatar/Avatar.tsx
+++ b/packages/fluentui/react-northstar/src/components/Avatar/Avatar.tsx
@@ -18,6 +18,7 @@ import { AvatarStatusProps, AvatarStatus } from './AvatarStatus';
 import { AvatarImage, AvatarImageProps } from './AvatarImage';
 import { AvatarIcon, AvatarIconProps } from './AvatarIcon';
 import { AvatarLabel, AvatarLabelProps } from './AvatarLabel';
+import { getDefaultInitials } from './getDefaultInitials';
 
 export interface AvatarProps extends UIComponentProps {
   /**
@@ -64,13 +65,13 @@ export const Avatar = React.forwardRef<HTMLDivElement, AvatarProps>((props, ref)
     accessibility,
     className,
     design,
-    getInitials,
+    getInitials = getDefaultInitials,
     label,
     icon,
     image,
     name,
     square,
-    size,
+    size = 'medium',
     status,
     styles,
     variables,
@@ -146,32 +147,6 @@ export const Avatar = React.forwardRef<HTMLDivElement, AvatarProps>((props, ref)
 }) as unknown as ForwardRefWithAs<'div', HTMLDivElement, AvatarProps> & FluentComponentStaticProps<AvatarProps>;
 
 Avatar.displayName = 'Avatar';
-
-Avatar.defaultProps = {
-  size: 'medium',
-  getInitials(name: string) {
-    if (!name) {
-      return '';
-    }
-
-    const reducedName = name
-      .replace(/\s+/g, ' ')
-      .replace(/\s*\(.*?\)\s*/g, ' ')
-      .replace(/\s*{.*?}\s*/g, ' ')
-      .replace(/\s*\[.*?]\s*/g, ' ');
-
-    const initials = reducedName
-      .split(' ')
-      .filter(item => item !== '')
-      .map(item => item.charAt(0))
-      .reduce((accumulator, currentValue) => accumulator + currentValue, '');
-
-    if (initials.length > 2) {
-      return initials.charAt(0) + initials.charAt(initials.length - 1);
-    }
-    return initials;
-  },
-};
 
 Avatar.propTypes = {
   ...commonPropTypes.createCommon({

--- a/packages/fluentui/react-northstar/src/components/Avatar/AvatarIcon.tsx
+++ b/packages/fluentui/react-northstar/src/components/Avatar/AvatarIcon.tsx
@@ -40,7 +40,7 @@ export const avatarIconClassName = 'ui-avatar__icon';
 export const AvatarIcon = React.forwardRef<HTMLSpanElement, AvatarIconProps>((props, ref) => {
   const context = useFluentContext();
 
-  const { className, children, design, styles, variables, size, square, content } = props;
+  const { accessibility, className, children, design, styles, variables, size, square, content } = props;
 
   const { classes } = useStyles<AvatarIconStylesProps>(AvatarIcon.displayName, {
     className: avatarIconClassName,
@@ -57,12 +57,12 @@ export const AvatarIcon = React.forwardRef<HTMLSpanElement, AvatarIconProps>((pr
     rtl: context.rtl,
   });
 
-  const getA11Props = useAccessibility(props.accessibility, {
+  const getA11Props = useAccessibility(accessibility, {
     debugName: AvatarIcon.displayName,
     rtl: context.rtl,
   });
 
-  const ElementType = getElementType(props);
+  const ElementType = getElementType(props, 'span');
   const unhandledProps = useUnhandledProps(AvatarIcon.handledProps, props);
 
   const element = (
@@ -82,9 +82,6 @@ AvatarIcon.propTypes = {
   size: customPropTypes.size,
 };
 AvatarIcon.handledProps = Object.keys(AvatarIcon.propTypes) as any;
-AvatarIcon.defaultProps = {
-  as: 'span',
-};
 
 AvatarIcon.shorthandConfig = {
   mappedProp: 'content',

--- a/packages/fluentui/react-northstar/src/components/Avatar/AvatarImage.tsx
+++ b/packages/fluentui/react-northstar/src/components/Avatar/AvatarImage.tsx
@@ -50,7 +50,7 @@ export const AvatarImage = React.forwardRef<HTMLImageElement, AvatarImageProps>(
   const context = useFluentContext();
 
   const {
-    accessibility,
+    accessibility = imageBehavior,
     alt,
     'aria-label': ariaLabel,
     avatar,
@@ -88,7 +88,7 @@ export const AvatarImage = React.forwardRef<HTMLImageElement, AvatarImageProps>(
     rtl: context.rtl,
   });
 
-  const ElementType = getElementType(props);
+  const ElementType = getElementType(props, 'img');
   const unhandledProps = useUnhandledProps(AvatarImage.handledProps, props);
 
   const result = <ElementType {...getA11Props('root', { className: classes.root, ref, ...unhandledProps })} />;
@@ -98,10 +98,6 @@ export const AvatarImage = React.forwardRef<HTMLImageElement, AvatarImageProps>(
   FluentComponentStaticProps<AvatarImageProps>;
 
 AvatarImage.displayName = 'AvatarImage';
-AvatarImage.defaultProps = {
-  as: 'img',
-  accessibility: imageBehavior,
-};
 
 AvatarImage.propTypes = {
   ...commonPropTypes.createCommon({

--- a/packages/fluentui/react-northstar/src/components/Avatar/AvatarLabel.tsx
+++ b/packages/fluentui/react-northstar/src/components/Avatar/AvatarLabel.tsx
@@ -67,7 +67,7 @@ export const AvatarLabel = React.forwardRef<HTMLSpanElement, AvatarLabelProps>((
     rtl: context.rtl,
   });
 
-  const ElementType = getElementType(props);
+  const ElementType = getElementType(props, 'span');
   const unhandledProps = useUnhandledProps(AvatarLabel.handledProps, props);
 
   const element = (
@@ -96,10 +96,6 @@ AvatarLabel.propTypes = {
   circular: PropTypes.bool,
 };
 AvatarLabel.handledProps = Object.keys(AvatarLabel.propTypes) as any;
-
-AvatarLabel.defaultProps = {
-  as: 'span',
-};
 
 AvatarLabel.shorthandConfig = {
   mappedProp: 'content',

--- a/packages/fluentui/react-northstar/src/components/Avatar/AvatarStatus.tsx
+++ b/packages/fluentui/react-northstar/src/components/Avatar/AvatarStatus.tsx
@@ -47,7 +47,19 @@ export const avatarStatusClassName = statusClassName;
 export const AvatarStatus = React.forwardRef<HTMLSpanElement, AvatarStatusProps>((props, ref) => {
   const context = useFluentContext();
 
-  const { className, color, design, icon, image, size, state, styles, variables } = props;
+  const {
+    accessibility = avatarStatusBehavior,
+    className,
+    color,
+    design,
+    icon,
+    image,
+    size = 'medium',
+    state = 'unknown',
+    styles,
+    variables,
+  } = props;
+
   const { classes } = useStyles<AvatarStatusStylesProps>(AvatarStatus.displayName, {
     className: avatarStatusClassName,
     mapPropsToStyles: () => ({
@@ -63,11 +75,11 @@ export const AvatarStatus = React.forwardRef<HTMLSpanElement, AvatarStatusProps>
     }),
     rtl: context.rtl,
   });
-  const getA11Props = useAccessibility(props.accessibility, {
+  const getA11Props = useAccessibility(accessibility, {
     debugName: AvatarStatus.displayName,
     rtl: context.rtl,
   });
-  const ElementType = getElementType(props);
+  const ElementType = getElementType(props, 'span');
   const unhandledProps = useUnhandledProps(AvatarStatus.handledProps, props);
 
   const iconElement = createShorthand<React.FC<AvatarStatusIconProps>>(AvatarStatusIcon, icon, {
@@ -106,11 +118,5 @@ AvatarStatus.propTypes = {
   state: PropTypes.oneOf(['success', 'info', 'warning', 'error', 'unknown']),
 };
 AvatarStatus.handledProps = Object.keys(AvatarStatus.propTypes) as any;
-AvatarStatus.defaultProps = {
-  accessibility: avatarStatusBehavior,
-  as: 'span',
-  size: 'medium',
-  state: 'unknown',
-};
 
 AvatarStatus.create = createShorthandFactory({ Component: AvatarStatus, mappedProp: 'state' });

--- a/packages/fluentui/react-northstar/src/components/Avatar/AvatarStatusIcon.tsx
+++ b/packages/fluentui/react-northstar/src/components/Avatar/AvatarStatusIcon.tsx
@@ -34,7 +34,7 @@ export const avatarStatusIconClassName = 'ui-avatar__statusicon';
 export const AvatarStatusIcon = React.forwardRef<HTMLSpanElement, AvatarStatusIconProps>((props, ref) => {
   const context = useFluentContext();
 
-  const { children, className, design, size, state, styles, variables } = props;
+  const { accessibility, children, className, design, size, state, styles, variables } = props;
 
   const { classes } = useStyles<AvatarStatusIconStylesProps>(AvatarStatusIcon.displayName, {
     className: avatarStatusIconClassName,
@@ -51,12 +51,12 @@ export const AvatarStatusIcon = React.forwardRef<HTMLSpanElement, AvatarStatusIc
     rtl: context.rtl,
   });
 
-  const getA11Props = useAccessibility(props.accessibility, {
+  const getA11Props = useAccessibility(accessibility, {
     debugName: AvatarStatusIcon.displayName,
     rtl: context.rtl,
   });
 
-  const ElementType = getElementType(props);
+  const ElementType = getElementType(props, 'span');
   const unhandledProps = useUnhandledProps(AvatarStatusIcon.handledProps, props);
 
   const element = (
@@ -73,8 +73,5 @@ AvatarStatusIcon.propTypes = {
   state: PropTypes.oneOf(['success', 'info', 'warning', 'error', 'unknown']),
 };
 AvatarStatusIcon.handledProps = Object.keys(AvatarStatusIcon.propTypes) as any;
-AvatarStatusIcon.defaultProps = {
-  as: 'span',
-};
 
 AvatarStatusIcon.create = createShorthandFactory({ Component: AvatarStatusIcon });

--- a/packages/fluentui/react-northstar/src/components/Avatar/AvatarStatusImage.tsx
+++ b/packages/fluentui/react-northstar/src/components/Avatar/AvatarStatusImage.tsx
@@ -35,7 +35,7 @@ export const avatarStatusImageClassName = 'ui-avatar__statusimage';
 export const AvatarStatusImage = React.forwardRef<HTMLImageElement, AvatarStatusImageProps>((props, ref) => {
   const context = useFluentContext();
 
-  const { children, className, design, size, styles, variables } = props;
+  const { accessibility = imageBehavior, children, className, design, size, styles, variables } = props;
 
   const { classes } = useStyles<AvatarStatusImageStylesProps>(AvatarStatusImage.displayName, {
     className: avatarStatusImageClassName,
@@ -51,12 +51,12 @@ export const AvatarStatusImage = React.forwardRef<HTMLImageElement, AvatarStatus
     rtl: context.rtl,
   });
 
-  const getA11Props = useAccessibility(props.accessibility, {
+  const getA11Props = useAccessibility(accessibility, {
     debugName: AvatarStatusImage.displayName,
     rtl: context.rtl,
   });
 
-  const ElementType = getElementType(props);
+  const ElementType = getElementType(props, 'img');
   const unhandledProps = useUnhandledProps(AvatarStatusImage.handledProps, props);
 
   const element = (
@@ -74,10 +74,6 @@ AvatarStatusImage.propTypes = {
   size: customPropTypes.size,
 };
 AvatarStatusImage.handledProps = Object.keys(AvatarStatusImage.propTypes) as any;
-AvatarStatusImage.defaultProps = {
-  accessibility: imageBehavior,
-  as: 'img',
-};
 
 AvatarStatusImage.shorthandConfig = {
   allowsJSX: false,

--- a/packages/fluentui/react-northstar/src/components/Avatar/getDefaultInitials.ts
+++ b/packages/fluentui/react-northstar/src/components/Avatar/getDefaultInitials.ts
@@ -1,0 +1,22 @@
+export function getDefaultInitials(name: string): string {
+  if (!name) {
+    return '';
+  }
+
+  const reducedName = name
+    .replace(/\s+/g, ' ')
+    .replace(/\s*\(.*?\)\s*/g, ' ')
+    .replace(/\s*{.*?}\s*/g, ' ')
+    .replace(/\s*\[.*?]\s*/g, ' ');
+
+  const initials = reducedName
+    .split(' ')
+    .filter(item => item !== '')
+    .map(item => item.charAt(0))
+    .reduce((accumulator, currentValue) => accumulator + currentValue, '');
+
+  if (initials.length > 2) {
+    return initials.charAt(0) + initials.charAt(initials.length - 1);
+  }
+  return initials;
+}

--- a/packages/fluentui/react-northstar/src/components/Button/ButtonGroup.tsx
+++ b/packages/fluentui/react-northstar/src/components/Button/ButtonGroup.tsx
@@ -48,7 +48,17 @@ export const buttonGroupClassName = 'ui-buttons';
 export const ButtonGroup = React.forwardRef<HTMLDivElement, ButtonGroupProps>((props, ref) => {
   const context = useFluentContext();
 
-  const { children, buttons, circular, content, className, design, styles, variables } = props;
+  const {
+    accessibility = buttonGroupBehavior,
+    children,
+    buttons,
+    circular,
+    content,
+    className,
+    design,
+    styles,
+    variables,
+  } = props;
   const ElementType = getElementType(props);
   const unhandledProps = useUnhandledProps(ButtonGroup.handledProps, props);
   const { classes, styles: resolvedStyles } = useStyles<ButtonGroupStylesProps>(ButtonGroup.displayName, {
@@ -65,7 +75,7 @@ export const ButtonGroup = React.forwardRef<HTMLDivElement, ButtonGroupProps>((p
     rtl: context.rtl,
   });
 
-  const getA11yProps = useAccessibility<ButtonGroupBehaviorProps>(props.accessibility, {
+  const getA11yProps = useAccessibility<ButtonGroupBehaviorProps>(accessibility, {
     debugName: ButtonGroup.displayName,
     rtl: context.rtl,
   });
@@ -122,10 +132,6 @@ ButtonGroup.propTypes = {
   ...commonPropTypes.createCommon(),
   buttons: customPropTypes.collectionShorthand,
   circular: PropTypes.bool,
-};
-
-ButtonGroup.defaultProps = {
-  accessibility: buttonGroupBehavior,
 };
 
 ButtonGroup.handledProps = Object.keys(ButtonGroup.propTypes) as any;

--- a/packages/fluentui/react-northstar/src/components/Card/Card.tsx
+++ b/packages/fluentui/react-northstar/src/components/Card/Card.tsx
@@ -106,6 +106,7 @@ export const Card = React.forwardRef<HTMLDivElement, CardProps>((props, ref) => 
   const cardRef = React.useRef<HTMLElement>();
 
   const {
+    accessibility = cardBehavior,
     className,
     design,
     styles,
@@ -114,7 +115,7 @@ export const Card = React.forwardRef<HTMLDivElement, CardProps>((props, ref) => 
     compact,
     horizontal,
     centered,
-    size,
+    size = 'medium',
     fluid,
     onClick,
     disabled,
@@ -125,8 +126,9 @@ export const Card = React.forwardRef<HTMLDivElement, CardProps>((props, ref) => 
     selected,
   } = props;
   const ElementType = getElementType(props);
+
   const unhandledProps = useUnhandledProps(Card.handledProps, props);
-  const getA11yProps = useAccessibility(props.accessibility, {
+  const getA11yProps = useAccessibility(accessibility, {
     debugName: Card.displayName,
     actionHandlers: {
       performClick: e => {
@@ -223,11 +225,6 @@ Card.propTypes = {
   ghost: PropTypes.bool,
   inverted: PropTypes.bool,
   selected: PropTypes.bool,
-};
-
-Card.defaultProps = {
-  accessibility: cardBehavior,
-  size: 'medium',
 };
 
 Card.handledProps = Object.keys(Card.propTypes) as any;

--- a/packages/fluentui/react-northstar/src/components/Card/CardBody.tsx
+++ b/packages/fluentui/react-northstar/src/components/Card/CardBody.tsx
@@ -31,10 +31,10 @@ export const cardBodyClassName = 'ui-card__body';
 export const CardBody = React.forwardRef<HTMLDivElement, CardBodyProps>((props, ref) => {
   const context = useFluentContext();
 
-  const { className, design, styles, variables, children, fitted } = props;
+  const { accessibility, className, design, styles, variables, children, fitted } = props;
   const ElementType = getElementType(props);
   const unhandledProps = useUnhandledProps(CardBody.handledProps, props);
-  const getA11yProps = useAccessibility(props.accessibility, {
+  const getA11yProps = useAccessibility(accessibility, {
     debugName: CardBody.displayName,
     rtl: context.rtl,
   });

--- a/packages/fluentui/react-northstar/src/components/Card/CardColumn.tsx
+++ b/packages/fluentui/react-northstar/src/components/Card/CardColumn.tsx
@@ -27,10 +27,11 @@ export const cardColumnClassName = 'ui-card__column';
 export const CardColumn = React.forwardRef<HTMLDivElement, CardColumnProps>((props, ref) => {
   const context = useFluentContext();
 
-  const { className, design, styles, variables, children } = props;
+  const { accessibility, className, design, styles, variables, children } = props;
+
   const ElementType = getElementType(props);
   const unhandledProps = useUnhandledProps(CardColumn.handledProps, props);
-  const getA11yProps = useAccessibility(props.accessibility, {
+  const getA11yProps = useAccessibility(accessibility, {
     debugName: CardColumn.displayName,
     rtl: context.rtl,
   });

--- a/packages/fluentui/react-northstar/src/components/Card/CardFooter.tsx
+++ b/packages/fluentui/react-northstar/src/components/Card/CardFooter.tsx
@@ -31,10 +31,10 @@ export const cardFooterClassName = 'ui-card__footer';
 export const CardFooter = React.forwardRef<HTMLDivElement, CardFooterProps>((props, ref) => {
   const context = useFluentContext();
 
-  const { className, design, styles, variables, children, fitted } = props;
+  const { accessibility, className, design, styles, variables, children, fitted } = props;
   const ElementType = getElementType(props);
   const unhandledProps = useUnhandledProps(CardFooter.handledProps, props);
-  const getA11yProps = useAccessibility(props.accessibility, {
+  const getA11yProps = useAccessibility(accessibility, {
     debugName: CardFooter.displayName,
     rtl: context.rtl,
   });

--- a/packages/fluentui/react-northstar/src/components/Card/CardHeader.tsx
+++ b/packages/fluentui/react-northstar/src/components/Card/CardHeader.tsx
@@ -32,10 +32,10 @@ export const cardHeaderClassName = 'ui-card__header';
 export const CardHeader = React.forwardRef<HTMLDivElement, CardHeaderProps>((props, ref) => {
   const context = useFluentContext();
 
-  const { className, design, styles, variables, children, fitted } = props;
+  const { accessibility, className, design, styles, variables, children, fitted } = props;
   const ElementType = getElementType(props);
   const unhandledProps = useUnhandledProps(CardHeader.handledProps, props);
-  const getA11yProps = useAccessibility(props.accessibility, {
+  const getA11yProps = useAccessibility(accessibility, {
     debugName: CardHeader.displayName,
     rtl: context.rtl,
   });

--- a/packages/fluentui/react-northstar/src/components/Card/CardPreview.tsx
+++ b/packages/fluentui/react-northstar/src/components/Card/CardPreview.tsx
@@ -35,10 +35,10 @@ export const cardPreviewClassName = 'ui-card__preview';
 export const CardPreview = React.forwardRef<HTMLDivElement, CardPreviewProps>((props, ref) => {
   const context = useFluentContext();
 
-  const { className, design, styles, variables, children, horizontal, fitted } = props;
+  const { accessibility, className, design, styles, variables, children, horizontal, fitted } = props;
   const ElementType = getElementType(props);
   const unhandledProps = useUnhandledProps(CardPreview.handledProps, props);
-  const getA11yProps = useAccessibility(props.accessibility, {
+  const getA11yProps = useAccessibility(accessibility, {
     debugName: CardPreview.displayName,
     rtl: context.rtl,
   });

--- a/packages/fluentui/react-northstar/src/components/Card/CardTopControls.tsx
+++ b/packages/fluentui/react-northstar/src/components/Card/CardTopControls.tsx
@@ -28,10 +28,10 @@ export const cardTopControlsClassName = 'ui-card__topcontrols';
 export const CardTopControls = React.forwardRef<HTMLDivElement, CardTopControlsProps>((props, ref) => {
   const context = useFluentContext();
 
-  const { className, design, styles, variables, children } = props;
+  const { accessibility, className, design, styles, variables, children } = props;
   const ElementType = getElementType(props);
   const unhandledProps = useUnhandledProps(CardTopControls.handledProps, props);
-  const getA11yProps = useAccessibility(props.accessibility, {
+  const getA11yProps = useAccessibility(accessibility, {
     debugName: CardTopControls.displayName,
     rtl: context.rtl,
   });

--- a/packages/fluentui/react-northstar/src/components/Carousel/CarouselNavigation.tsx
+++ b/packages/fluentui/react-northstar/src/components/Carousel/CarouselNavigation.tsx
@@ -76,7 +76,7 @@ export const CarouselNavigation = React.forwardRef<HTMLUListElement, CarouselNav
   const context = useFluentContext();
 
   const {
-    accessibility,
+    accessibility = tabListBehavior,
     variables,
     children,
     className,
@@ -91,7 +91,7 @@ export const CarouselNavigation = React.forwardRef<HTMLUListElement, CarouselNav
     styles,
     disableClickableNav,
   } = props;
-  const ElementType = getElementType(props);
+  const ElementType = getElementType(props, 'ul');
   const unhandledProps = useUnhandledProps(CarouselNavigation.handledProps, props);
 
   const getA11yProps = useAccessibility(accessibility, {
@@ -176,11 +176,6 @@ CarouselNavigation.propTypes = {
   secondary: customPropTypes.every([customPropTypes.disallow(['primary']), PropTypes.bool]),
   vertical: PropTypes.bool,
   disableClickableNav: PropTypes.bool,
-};
-
-CarouselNavigation.defaultProps = {
-  accessibility: tabListBehavior,
-  as: 'ul',
 };
 
 CarouselNavigation.handledProps = Object.keys(CarouselNavigation.propTypes) as any;

--- a/packages/fluentui/react-northstar/src/components/Carousel/CarouselNavigationItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Carousel/CarouselNavigationItem.tsx
@@ -94,6 +94,7 @@ export const CarouselNavigationItem = React.forwardRef<HTMLLIElement, CarouselNa
   const context = useFluentContext();
 
   const {
+    accessibility = tabBehavior,
     children,
     thumbnails,
     vertical,
@@ -101,17 +102,17 @@ export const CarouselNavigationItem = React.forwardRef<HTMLLIElement, CarouselNa
     content,
     iconOnly,
     primary,
-    indicator,
+    indicator = {},
     className,
     design,
     styles,
     variables,
     disableClickableNav,
   } = props;
-  const ElementType = getElementType(props);
+  const ElementType = getElementType(props, 'li');
   const unhandledProps = useUnhandledProps(CarouselNavigationItem.handledProps, props);
 
-  const getA11yProps = useAccessibility(props.accessibility, {
+  const getA11yProps = useAccessibility(accessibility, {
     debugName: CarouselNavigationItem.displayName,
     actionHandlers: {
       performClick: event => !event.defaultPrevented && handleClick(event),
@@ -210,12 +211,6 @@ CarouselNavigationItem.propTypes = {
 };
 
 CarouselNavigationItem.handledProps = Object.keys(CarouselNavigationItem.propTypes) as any;
-
-CarouselNavigationItem.defaultProps = {
-  accessibility: tabBehavior,
-  as: 'li',
-  indicator: {},
-};
 
 CarouselNavigationItem.create = createShorthandFactory({
   Component: CarouselNavigationItem,

--- a/packages/fluentui/react-northstar/src/components/Carousel/CarouselPaddlesContainer.tsx
+++ b/packages/fluentui/react-northstar/src/components/Carousel/CarouselPaddlesContainer.tsx
@@ -32,7 +32,7 @@ export const CarouselPaddlesContainer = React.forwardRef<HTMLDivElement, Carouse
   (props, ref) => {
     const context = useFluentContext();
 
-    const { className, children, design, styles, variables, content } = props;
+    const { accessibility, className, children, design, styles, variables, content } = props;
 
     const { classes } = useStyles<CarouselPaddlesContainerStylesProps>(CarouselPaddlesContainer.displayName, {
       className: carouselPaddlesContainerClassName,
@@ -45,7 +45,7 @@ export const CarouselPaddlesContainer = React.forwardRef<HTMLDivElement, Carouse
       rtl: context.rtl,
     });
 
-    const getA11Props = useAccessibility(props.accessibility, {
+    const getA11Props = useAccessibility(accessibility, {
       debugName: CarouselPaddlesContainer.displayName,
       rtl: context.rtl,
     });

--- a/packages/fluentui/react-northstar/src/components/Checkbox/Checkbox.tsx
+++ b/packages/fluentui/react-northstar/src/components/Checkbox/Checkbox.tsx
@@ -80,7 +80,8 @@ export const checkboxSlotClassNames: CheckboxSlotClassNames = {
 export const Checkbox = React.forwardRef<HTMLDivElement, CheckboxProps>((props, ref) => {
   const context = useFluentContext();
 
-  const { className, design, disabled, label, labelPosition, indicator, styles, toggle, variables } = props;
+  const { accessibility, className, design, disabled, label, labelPosition, indicator, styles, toggle, variables } =
+    props;
 
   const [checked, setChecked] = useControllableState({
     defaultState: props.defaultChecked,
@@ -88,7 +89,7 @@ export const Checkbox = React.forwardRef<HTMLDivElement, CheckboxProps>((props, 
     initialState: false,
   });
 
-  const getA11Props = useAccessibility(props.accessibility, {
+  const getA11Props = useAccessibility(accessibility, {
     debugName: Checkbox.displayName,
     mapPropsToBehavior: () => ({
       checked,

--- a/packages/fluentui/react-northstar/src/components/Divider/Divider.tsx
+++ b/packages/fluentui/react-northstar/src/components/Divider/Divider.tsx
@@ -62,8 +62,19 @@ export const dividerClassName = 'ui-divider';
 export const Divider = React.forwardRef<HTMLDivElement, DividerProps>((props, ref) => {
   const context = useFluentContext();
 
-  const { children, color, fitted, size, important, vertical, className, design, styles, variables, accessibility } =
-    props;
+  const {
+    children,
+    color,
+    fitted,
+    size = 0,
+    important,
+    vertical,
+    className,
+    design,
+    styles,
+    variables,
+    accessibility,
+  } = props;
   const ElementType = getElementType(props);
   const unhandledProps = useUnhandledProps(Divider.handledProps, props);
   const getA11yProps = useAccessibility<never>(accessibility, {
@@ -118,10 +129,6 @@ Divider.propTypes = {
   size: PropTypes.number,
   important: PropTypes.bool,
   vertical: PropTypes.bool,
-};
-
-Divider.defaultProps = {
-  size: 0,
 };
 
 Divider.Content = DividerContent;

--- a/packages/fluentui/react-northstar/src/components/Dropdown/DropdownItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dropdown/DropdownItem.tsx
@@ -94,7 +94,7 @@ export const DropdownItem = React.forwardRef<HTMLLIElement, DropdownItemProps>((
     isFromKeyboard,
     styles,
     checkable,
-    checkableIndicator,
+    checkableIndicator = {},
     selected,
     variables,
   } = props;
@@ -112,7 +112,7 @@ export const DropdownItem = React.forwardRef<HTMLLIElement, DropdownItemProps>((
     rtl: context.rtl,
   });
 
-  const ElementType = getElementType(props);
+  const ElementType = getElementType(props, 'li');
   const unhandledProps = useUnhandledProps(DropdownItem.handledProps, props);
 
   const handleClick = (e: React.MouseEvent | React.KeyboardEvent) => {
@@ -181,11 +181,6 @@ export const DropdownItem = React.forwardRef<HTMLLIElement, DropdownItemProps>((
   FluentComponentStaticProps<DropdownItemProps>;
 
 DropdownItem.displayName = 'DropdownItem';
-
-DropdownItem.defaultProps = {
-  as: 'li',
-  checkableIndicator: {},
-};
 
 DropdownItem.propTypes = {
   ...commonPropTypes.createCommon({

--- a/packages/fluentui/react-northstar/src/components/Dropdown/DropdownSelectedItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dropdown/DropdownSelectedItem.tsx
@@ -91,26 +91,31 @@ export const dropdownSelectedItemSlotClassNames: DropdownSelectedItemSlotClassNa
 
 export type DropdownSelectedItemStylesProps = { hasImage: boolean };
 
+const DEFAULT_ICON = <CloseIcon />;
+
 /**
  * A DropdownSelectedItem represents a selected item of 'multiple-selection' Dropdown.
  */
 export const DropdownSelectedItem = React.forwardRef<HTMLSpanElement, DropdownSelectedItemProps>((props, ref) => {
   const context = useFluentContext();
 
-  const { active, header, icon, image, className, design, styles, variables, disabled } = props;
+  const { active, header, icon = DEFAULT_ICON, image, className, design, styles, variables, disabled } = props;
 
   const itemRef = React.useRef<HTMLElement>();
-  const ElementType = getElementType(props);
+  const ElementType = getElementType(props, 'span');
   const unhandledProps = useUnhandledProps(DropdownSelectedItem.handledProps, props);
 
-  const getA11yProps = useAccessibility<DropdownSelectedItemBehaviorProps>(props.accessibility, {
-    debugName: DropdownSelectedItem.displayName,
-    mapPropsToBehavior: () => ({
-      header: header as string,
-      active,
-    }),
-    rtl: context.rtl,
-  });
+  const getA11yProps = useAccessibility<DropdownSelectedItemBehaviorProps>(
+    props.accessibility ?? dropdownSelectedItemBehavior,
+    {
+      debugName: DropdownSelectedItem.displayName,
+      mapPropsToBehavior: () => ({
+        header: header as string,
+        active,
+      }),
+      rtl: context.rtl,
+    },
+  );
 
   React.useEffect(() => {
     if (active) {
@@ -228,12 +233,6 @@ DropdownSelectedItem.propTypes = {
 };
 
 DropdownSelectedItem.handledProps = Object.keys(DropdownSelectedItem.propTypes) as any;
-
-DropdownSelectedItem.defaultProps = {
-  accessibility: dropdownSelectedItemBehavior,
-  as: 'span',
-  icon: <CloseIcon />,
-};
 
 DropdownSelectedItem.create = createShorthandFactory({
   Component: DropdownSelectedItem,

--- a/packages/fluentui/react-northstar/src/components/Embed/Embed.tsx
+++ b/packages/fluentui/react-northstar/src/components/Embed/Embed.tsx
@@ -85,11 +85,24 @@ export type EmbedStylesProps = Required<Pick<EmbedProps, 'active'>> & { iframeLo
 export const Embed = React.forwardRef<HTMLSpanElement, EmbedProps>((props, ref) => {
   const context = useFluentContext();
 
-  const { alt, title, control, iframe, placeholder, video, variables, styles, className, design } = props;
-  const ElementType = getElementType(props);
+  const {
+    accessibility = embedBehavior,
+    alt,
+    title,
+    control = {},
+    iframe,
+    placeholder,
+    video,
+    variables,
+    styles,
+    className,
+    design,
+  } = props;
+
+  const ElementType = getElementType(props, 'span');
   const unhandledProps = useUnhandledProps(Embed.handledProps, props);
 
-  const getA11yProps = useAccessibility<EmbedBehaviorProps>(props.accessibility, {
+  const getA11yProps = useAccessibility<EmbedBehaviorProps>(accessibility, {
     debugName: Embed.displayName,
     actionHandlers: {
       performClick: event => handleClick(event),
@@ -232,13 +245,6 @@ Embed.propTypes = {
   onClick: PropTypes.func,
   placeholder: PropTypes.string,
   video: customPropTypes.every([customPropTypes.disallow(['iframe']), customPropTypes.itemShorthand]),
-};
-
-Embed.defaultProps = {
-  as: 'span' as const,
-  accessibility: embedBehavior,
-  control: {},
-  variables: {},
 };
 
 Embed.handledProps = Object.keys(Embed.propTypes) as any;

--- a/packages/fluentui/react-northstar/src/components/Form/Form.tsx
+++ b/packages/fluentui/react-northstar/src/components/Form/Form.tsx
@@ -57,7 +57,7 @@ export const Form = React.forwardRef<HTMLFormElement, FormProps>((props, ref) =>
   const context = useFluentContext();
 
   const { className, design, styles, variables, action, children, accessibility } = props;
-  const ElementType = getElementType(props);
+  const ElementType = getElementType(props, 'form');
   const unhandledProps = useUnhandledProps(Form.handledProps, props);
 
   const { classes } = useStyles<FormStylesProps>(Form.displayName, {
@@ -118,11 +118,6 @@ Form.propTypes = {
   fields: customPropTypes.collectionShorthand,
   onSubmit: PropTypes.func,
 };
-
-Form.defaultProps = {
-  as: 'form' as const,
-};
-
 Form.handledProps = Object.keys(Form.propTypes) as any;
 
 Form.create = createShorthandFactory({

--- a/packages/fluentui/react-northstar/src/components/Form/FormField.tsx
+++ b/packages/fluentui/react-northstar/src/components/Form/FormField.tsx
@@ -67,6 +67,8 @@ export type FormFieldStylesProps = Required<Pick<FormFieldProps, 'type' | 'inlin
   hasErrorMessage: boolean;
 };
 
+const DEFAULT_CONTROL = { as: Input };
+
 /**
  * A FormField represents a Form element containing a label and an input.
  */
@@ -75,7 +77,7 @@ export const FormField = React.forwardRef<HTMLDivElement, FormFieldProps>((props
 
   const {
     children,
-    control,
+    control = DEFAULT_CONTROL,
     id,
     label,
     message,
@@ -97,7 +99,7 @@ export const FormField = React.forwardRef<HTMLDivElement, FormFieldProps>((props
   const labelId = React.useRef<string>();
   labelId.current = getOrGenerateIdFromShorthand('form-label-', id, labelId.current);
 
-  const getA11yProps = useAccessibility<FormFieldBehaviorProps>(props.accessibility, {
+  const getA11yProps = useAccessibility<FormFieldBehaviorProps>(props.accessibility ?? formFieldBehavior, {
     debugName: FormField.displayName,
     mapPropsToBehavior: () => ({
       hasErrorMessage: !!errorMessage,
@@ -201,10 +203,5 @@ FormField.propTypes = {
 };
 
 FormField.handledProps = Object.keys(FormField.propTypes) as any;
-
-FormField.defaultProps = {
-  accessibility: formFieldBehavior,
-  control: { as: Input },
-};
 
 FormField.create = createShorthandFactory({ Component: FormField, mappedProp: 'label' });

--- a/packages/fluentui/react-northstar/src/components/Form/FormFieldCustom.tsx
+++ b/packages/fluentui/react-northstar/src/components/Form/FormFieldCustom.tsx
@@ -48,7 +48,7 @@ export const FormFieldCustom = React.forwardRef<HTMLDivElement, FormFieldCustomP
   const ElementType = getElementType(props);
   const unhandledProps = useUnhandledProps(FormFieldCustom.handledProps, props);
 
-  const getA11yProps = useAccessibility<FormFieldBehaviorProps>(props.accessibility, {
+  const getA11yProps = useAccessibility<FormFieldBehaviorProps>(props.accessibility ?? formFieldBehavior, {
     debugName: FormFieldCustom.displayName,
     rtl: context.rtl,
   });
@@ -99,7 +99,3 @@ FormFieldCustom.propTypes = {
 };
 
 FormFieldCustom.handledProps = Object.keys(FormFieldCustom.propTypes) as any;
-
-FormFieldCustom.defaultProps = {
-  accessibility: formFieldBehavior,
-};

--- a/packages/fluentui/react-northstar/src/components/Header/Header.tsx
+++ b/packages/fluentui/react-northstar/src/components/Header/Header.tsx
@@ -60,7 +60,7 @@ export const Header = React.forwardRef<HTMLHeadingElement, HeaderProps>((props, 
   const context = useFluentContext();
 
   const { children, content, variables, align, className, design, styles, description, color } = props;
-  const ElementType = getElementType(props);
+  const ElementType = getElementType(props, 'h1');
   const unhandledProps = useUnhandledProps(Header.handledProps, props);
   const hasChildren = childrenExist(children);
   const contentElement = hasChildren ? children : content;
@@ -118,10 +118,6 @@ Header.propTypes = {
   ...commonPropTypes.createCommon({ color: true }),
   description: customPropTypes.itemShorthand,
   align: customPropTypes.align,
-};
-
-Header.defaultProps = {
-  as: 'h1',
 };
 
 Header.handledProps = Object.keys(Header.propTypes) as any;

--- a/packages/fluentui/react-northstar/src/components/Header/HeaderDescription.tsx
+++ b/packages/fluentui/react-northstar/src/components/Header/HeaderDescription.tsx
@@ -43,7 +43,7 @@ export const HeaderDescription = React.forwardRef<HTMLParagraphElement, HeaderDe
   const context = useFluentContext();
 
   const { children, content, color, className, design, styles, variables } = props;
-  const ElementType = getElementType(props);
+  const ElementType = getElementType(props, 'p');
   const unhandledProps = useUnhandledProps(HeaderDescription.handledProps, props);
 
   const getA11yProps = useAccessibility<never>(props.accessibility, {
@@ -86,10 +86,6 @@ HeaderDescription.displayName = 'HeaderDescription';
 
 HeaderDescription.propTypes = {
   ...commonPropTypes.createCommon({ color: true }),
-};
-
-HeaderDescription.defaultProps = {
-  as: 'p',
 };
 
 HeaderDescription.handledProps = Object.keys(HeaderDescription.propTypes) as any;

--- a/packages/fluentui/react-northstar/src/components/Image/Image.tsx
+++ b/packages/fluentui/react-northstar/src/components/Image/Image.tsx
@@ -53,7 +53,7 @@ export const Image = React.forwardRef<HTMLImageElement, ImageProps>((props, ref)
   const context = useFluentContext();
 
   const {
-    accessibility,
+    accessibility = imageBehavior,
     alt,
     'aria-label': ariaLabel,
     avatar,
@@ -89,7 +89,7 @@ export const Image = React.forwardRef<HTMLImageElement, ImageProps>((props, ref)
     rtl: context.rtl,
   });
 
-  const ElementType = getElementType(props);
+  const ElementType = getElementType(props, 'img');
   const unhandledProps = useUnhandledProps(Image.handledProps, props);
 
   const result = <ElementType {...getA11Props('root', { className: classes.root, ref, ...unhandledProps })} />;
@@ -98,10 +98,6 @@ export const Image = React.forwardRef<HTMLImageElement, ImageProps>((props, ref)
 }) as unknown as ForwardRefWithAs<'img', HTMLImageElement, ImageProps> & FluentComponentStaticProps<ImageProps>;
 
 Image.displayName = 'Image';
-Image.defaultProps = {
-  as: 'img' as const,
-  accessibility: imageBehavior,
-};
 
 Image.propTypes = {
   ...commonPropTypes.createCommon({

--- a/packages/fluentui/react-northstar/src/components/Label/Label.tsx
+++ b/packages/fluentui/react-northstar/src/components/Label/Label.tsx
@@ -78,12 +78,12 @@ export const Label = React.forwardRef<HTMLSpanElement, LabelProps>((props, ref) 
     color,
     content,
     icon,
-    iconPosition,
+    iconPosition = 'end',
     design,
     styles,
     variables,
     image,
-    imagePosition,
+    imagePosition = 'start',
   } = props;
 
   const getA11Props = useAccessibility(accessibility, {
@@ -105,7 +105,7 @@ export const Label = React.forwardRef<HTMLSpanElement, LabelProps>((props, ref) 
     rtl: context.rtl,
   });
 
-  const ElementType = getElementType(props);
+  const ElementType = getElementType(props, 'span');
   const unhandledProps = useUnhandledProps(Label.handledProps, props);
 
   if (childrenExist(children)) {
@@ -177,11 +177,5 @@ Label.propTypes = {
   fluid: PropTypes.bool,
 };
 Label.handledProps = Object.keys(Label.propTypes) as any;
-
-Label.defaultProps = {
-  as: 'span',
-  imagePosition: 'start',
-  iconPosition: 'end',
-};
 
 Label.create = createShorthandFactory({ Component: Label, mappedProp: 'content' });

--- a/packages/fluentui/react-northstar/src/components/List/List.tsx
+++ b/packages/fluentui/react-northstar/src/components/List/List.tsx
@@ -76,6 +76,8 @@ export interface ListProps extends UIComponentProps, ChildrenComponentProps {
 export type ListStylesProps = Pick<ListProps, 'debug' | 'horizontal'> & { isListTag: boolean };
 export const listClassName = 'ui-list';
 
+const DEFAULT_WRAP = (children: ReactChildren) => <>{children}</>;
+
 /**
  * A List displays a group of related sequential items.
  *
@@ -92,7 +94,7 @@ export const List = React.forwardRef<HTMLUListElement, ListProps & { as: React.R
   const context = useFluentContext();
 
   const {
-    accessibility,
+    accessibility = listBehavior,
     as,
     children,
     className,
@@ -106,7 +108,7 @@ export const List = React.forwardRef<HTMLUListElement, ListProps & { as: React.R
     truncateContent,
     truncateHeader,
     variables,
-    wrap,
+    wrap = DEFAULT_WRAP,
   } = props;
 
   const [selectedIndex, setSelectedIndex] = useControllableState({
@@ -133,7 +135,7 @@ export const List = React.forwardRef<HTMLUListElement, ListProps & { as: React.R
   const latestProps = React.useRef<ListProps>(props);
   latestProps.current = props;
 
-  const ElementType = getElementType(props);
+  const ElementType = getElementType(props, 'ul');
   const unhandledProps = useUnhandledProps(List.handledProps, props);
 
   const hasContent = childrenExist(children) || (items && items.length > 0);
@@ -191,11 +193,6 @@ export const List = React.forwardRef<HTMLUListElement, ListProps & { as: React.R
 
 List.displayName = 'List';
 
-List.defaultProps = {
-  as: 'ul',
-  accessibility: listBehavior,
-  wrap: children => children,
-};
 List.propTypes = {
   ...commonPropTypes.createCommon({
     content: false,

--- a/packages/fluentui/react-northstar/src/components/List/ListItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/List/ListItem.tsx
@@ -85,7 +85,7 @@ export const ListItem = React.forwardRef<HTMLLIElement, ListItemProps>((props, r
   const context = useFluentContext();
 
   const {
-    accessibility,
+    accessibility = listItemBehavior,
     className,
     content,
     contentMedia,
@@ -146,7 +146,7 @@ export const ListItem = React.forwardRef<HTMLLIElement, ListItemProps>((props, r
     rtl: context.rtl,
   });
 
-  const ElementType = getElementType(props);
+  const ElementType = getElementType(props, 'li');
   const unhandledProps = useUnhandledProps(ListItem.handledProps, props);
 
   const handleClick = (e: React.MouseEvent | React.KeyboardEvent) => {
@@ -219,11 +219,6 @@ export const ListItem = React.forwardRef<HTMLLIElement, ListItemProps>((props, r
   FluentComponentStaticProps<ListItemProps>;
 
 ListItem.displayName = 'ListItem';
-
-ListItem.defaultProps = {
-  as: 'li',
-  accessibility: listItemBehavior,
-};
 
 ListItem.propTypes = {
   ...commonPropTypes.createCommon({

--- a/packages/fluentui/react-northstar/src/components/Loader/Loader.tsx
+++ b/packages/fluentui/react-northstar/src/components/Loader/Loader.tsx
@@ -49,16 +49,8 @@ export interface LoaderProps extends UIComponentProps {
   /** A size of the loader. */
   size?: SizeValue;
 
-  /** A loader can contain a custom svg element. */
-  svg?: ShorthandValue<BoxProps>;
-
   /** A loader can be secondary */
   secondary?: boolean;
-}
-
-export interface LoaderState {
-  visible: boolean;
-  labelId: string;
 }
 
 export const loaderClassName = 'ui-loader';
@@ -78,14 +70,26 @@ export type LoaderStylesProps = Pick<LoaderProps, 'inline' | 'labelPosition' | '
 export const Loader = React.forwardRef<HTMLDivElement, LoaderProps>((props, ref) => {
   const context = useFluentContext();
 
-  const { delay, secondary, label, indicator, inline, labelPosition, className, design, styles, variables, size } =
-    props;
+  const {
+    accessibility = loaderBehavior,
+    delay = 0,
+    secondary,
+    label,
+    indicator = {},
+    inline,
+    labelPosition = 'below',
+    className,
+    design,
+    styles,
+    variables,
+    size = 'medium',
+  } = props;
 
   const ElementType = getElementType(props);
   const unhandledProps = useUnhandledProps(Loader.handledProps, props);
 
   const delayTimer = React.useRef<number>();
-  const [visible, setVisible] = React.useState(props.delay === 0);
+  const [visible, setVisible] = React.useState(delay === 0);
 
   const labelId = React.useRef<string>();
   labelId.current = getOrGenerateIdFromShorthand('loader-label-', label, labelId.current);
@@ -107,7 +111,7 @@ export const Loader = React.forwardRef<HTMLDivElement, LoaderProps>((props, ref)
     rtl: context.rtl,
   });
 
-  const getA11yProps = useAccessibility<LoaderBehaviorProps>(props.accessibility, {
+  const getA11yProps = useAccessibility<LoaderBehaviorProps>(accessibility, {
     debugName: Loader.displayName,
     mapPropsToBehavior: () => ({
       labelId: labelId.current,
@@ -179,17 +183,7 @@ Loader.propTypes = {
   label: customPropTypes.itemShorthand,
   labelPosition: PropTypes.oneOf(['above', 'below', 'start', 'end']),
   size: customPropTypes.size,
-  svg: customPropTypes.itemShorthand,
   secondary: PropTypes.bool,
-};
-
-Loader.defaultProps = {
-  accessibility: loaderBehavior,
-  delay: 0,
-  indicator: {},
-  labelPosition: 'below',
-  svg: '',
-  size: 'medium',
 };
 
 Loader.handledProps = Object.keys(Loader.propTypes) as any;

--- a/packages/fluentui/react-northstar/src/components/Menu/Menu.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/Menu.tsx
@@ -170,10 +170,10 @@ export const Menu = React.forwardRef<HTMLUListElement, MenuProps>((props, ref) =
     className,
     design,
     secondary,
-    accessibility,
+    accessibility = menuBehavior,
   } = props;
 
-  const ElementType = getElementType(props);
+  const ElementType = getElementType(props, 'ul');
 
   const slotProps = {
     divider: {
@@ -202,7 +202,7 @@ export const Menu = React.forwardRef<HTMLUListElement, MenuProps>((props, ref) =
 
   const unhandledProps = useUnhandledProps(Menu.handledProps, props);
 
-  const getA11yProps = useAccessibility<MenuBehaviorProps>(props.accessibility, {
+  const getA11yProps = useAccessibility<MenuBehaviorProps>(accessibility, {
     debugName: Menu.displayName,
     mapPropsToBehavior: () => ({
       vertical,
@@ -381,11 +381,6 @@ Menu.propTypes = {
 };
 
 Menu.handledProps = Object.keys(Menu.propTypes) as any;
-
-Menu.defaultProps = {
-  as: 'ul',
-  accessibility: menuBehavior,
-};
 
 Menu.Item = MenuItem;
 Menu.ItemIcon = MenuItemIcon;

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuDivider.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuDivider.tsx
@@ -105,7 +105,7 @@ export const MenuDivider = React.forwardRef<HTMLLIElement, MenuDividerProps>((in
     unstable_props: props,
   });
 
-  const ElementType = getElementType(props);
+  const ElementType = getElementType(props, 'li');
   const unhandledProps = useUnhandledProps(MenuDivider.handledProps, props);
 
   const element = (
@@ -123,10 +123,6 @@ export const MenuDivider = React.forwardRef<HTMLLIElement, MenuDividerProps>((in
 
   return element;
 }) as unknown as ForwardRefWithAs<'li', HTMLLIElement, MenuDividerProps> & FluentComponentStaticProps<MenuDividerProps>;
-
-MenuDivider.defaultProps = {
-  as: 'li',
-};
 
 MenuDivider.displayName = 'MenuDivider';
 

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
@@ -176,6 +176,8 @@ export const menuItemSlotClassNames: MenuItemSlotClassNames = {
   submenu: `${menuItemClassName}__submenu`,
 };
 
+const DEFAULT_INDICATOR = <ChevronEndIcon outline />;
+
 /**
  * A MenuItem is an actionable item within a Menu.
  */
@@ -204,12 +206,12 @@ export const MenuItem = React.forwardRef<HTMLAnchorElement, MenuItemProps>((inpu
     children,
     content,
     icon,
-    wrapper,
+    wrapper = {},
     primary,
     secondary,
     active,
     vertical,
-    indicator,
+    indicator = DEFAULT_INDICATOR,
     disabled,
     underlined,
     iconOnly,
@@ -241,7 +243,7 @@ export const MenuItem = React.forwardRef<HTMLAnchorElement, MenuItemProps>((inpu
 
   const [isFromKeyboard, setIsFromKeyboard] = React.useState(false);
 
-  const ElementType = getElementType(props);
+  const ElementType = getElementType(props, 'a');
   const unhandledProps = useUnhandledProps(MenuItem.handledProps, props);
 
   const getA11yProps = useAccessibility<MenuItemBehaviorProps>(accessibility, {
@@ -619,10 +621,4 @@ MenuItem.handledProps = Object.keys(MenuItem.propTypes) as any;
 
 MenuItem.shorthandConfig = {
   mappedProp: 'content',
-};
-
-MenuItem.defaultProps = {
-  as: 'a',
-  wrapper: {},
-  indicator: <ChevronEndIcon outline />,
 };

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItemContent.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItemContent.tsx
@@ -54,7 +54,19 @@ export const MenuItemContent = React.forwardRef<HTMLSpanElement, MenuItemContent
     vertical: v => v.vertical,
   }) as unknown as MenuItemSubscribedValue; // TODO: we should improve typings for the useContextSelectors
 
-  const { className, children, design, styles, variables, content, hasMenu, hasIcon, vertical, inSubmenu } = props;
+  const {
+    accessibility,
+    className,
+    children,
+    design,
+    styles,
+    variables,
+    content,
+    hasMenu,
+    hasIcon,
+    vertical,
+    inSubmenu,
+  } = props;
 
   const { classes } = useStyles<MenuItemContentStylesProps>(MenuItemContent.displayName, {
     className: menuItemContentClassName,
@@ -73,12 +85,12 @@ export const MenuItemContent = React.forwardRef<HTMLSpanElement, MenuItemContent
     rtl: context.rtl,
   });
 
-  const getA11Props = useAccessibility(props.accessibility, {
+  const getA11Props = useAccessibility(accessibility, {
     debugName: MenuItemContent.displayName,
     rtl: context.rtl,
   });
 
-  const ElementType = getElementType(props);
+  const ElementType = getElementType(props, 'span');
   const unhandledProps = useUnhandledProps(MenuItemContent.handledProps, props);
 
   const element = (
@@ -99,10 +111,6 @@ export const MenuItemContent = React.forwardRef<HTMLSpanElement, MenuItemContent
   FluentComponentStaticProps<MenuItemContentProps>;
 
 MenuItemContent.displayName = 'MenuItemContent';
-
-MenuItemContent.defaultProps = {
-  as: 'span',
-};
 
 MenuItemContent.propTypes = {
   ...commonPropTypes.createCommon(),

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItemIcon.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItemIcon.tsx
@@ -36,7 +36,7 @@ export const menuItemIconClassName = 'ui-menu__itemicon';
 export const MenuItemIcon = React.forwardRef<HTMLSpanElement, MenuItemIconProps>((props, ref) => {
   const context = useFluentContext();
 
-  const { className, children, design, styles, variables, content, hasContent, iconOnly } = props;
+  const { accessibility, className, children, design, styles, variables, content, hasContent, iconOnly } = props;
 
   const { classes } = useStyles<MenuItemIconStylesProps>(MenuItemIcon.displayName, {
     className: menuItemIconClassName,
@@ -53,12 +53,12 @@ export const MenuItemIcon = React.forwardRef<HTMLSpanElement, MenuItemIconProps>
     rtl: context.rtl,
   });
 
-  const getA11Props = useAccessibility(props.accessibility, {
+  const getA11Props = useAccessibility(accessibility, {
     debugName: MenuItemIcon.displayName,
     rtl: context.rtl,
   });
 
-  const ElementType = getElementType(props);
+  const ElementType = getElementType(props, 'span');
   const unhandledProps = useUnhandledProps(MenuItemIcon.handledProps, props);
 
   const element = (
@@ -72,10 +72,6 @@ export const MenuItemIcon = React.forwardRef<HTMLSpanElement, MenuItemIconProps>
   FluentComponentStaticProps<MenuItemIconProps>;
 
 MenuItemIcon.displayName = 'MenuItemIcon';
-
-MenuItemIcon.defaultProps = {
-  as: 'span',
-};
 
 MenuItemIcon.propTypes = {
   ...commonPropTypes.createCommon(),

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItemIndicator.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItemIndicator.tsx
@@ -50,6 +50,7 @@ export const MenuItemIndicator = React.forwardRef<HTMLSpanElement, MenuItemIndic
   const context = useFluentContext();
 
   const {
+    accessibility = indicatorBehavior,
     className,
     children,
     design,
@@ -83,12 +84,12 @@ export const MenuItemIndicator = React.forwardRef<HTMLSpanElement, MenuItemIndic
     rtl: context.rtl,
   });
 
-  const getA11Props = useAccessibility(props.accessibility, {
+  const getA11Props = useAccessibility(accessibility, {
     debugName: MenuItemIndicator.displayName,
     rtl: context.rtl,
   });
 
-  const ElementType = getElementType(props);
+  const ElementType = getElementType(props, 'span');
   const unhandledProps = useUnhandledProps(MenuItemIndicator.handledProps, props);
 
   const element = (
@@ -102,11 +103,6 @@ export const MenuItemIndicator = React.forwardRef<HTMLSpanElement, MenuItemIndic
   FluentComponentStaticProps<MenuItemIndicatorProps>;
 
 MenuItemIndicator.displayName = 'MenuItemIndicator';
-
-MenuItemIndicator.defaultProps = {
-  as: 'span',
-  accessibility: indicatorBehavior,
-};
 
 MenuItemIndicator.propTypes = {
   ...commonPropTypes.createCommon(),

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItemWrapper.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItemWrapper.tsx
@@ -83,6 +83,7 @@ export const MenuItemWrapper = React.forwardRef<HTMLLIElement, MenuItemWrapperPr
   const context = useFluentContext();
 
   const {
+    accessibility,
     className,
     children,
     design,
@@ -126,12 +127,12 @@ export const MenuItemWrapper = React.forwardRef<HTMLLIElement, MenuItemWrapperPr
     rtl: context.rtl,
   });
 
-  const getA11Props = useAccessibility(props.accessibility, {
+  const getA11Props = useAccessibility(accessibility, {
     debugName: MenuItemWrapper.displayName,
     rtl: context.rtl,
   });
 
-  const ElementType = getElementType(props);
+  const ElementType = getElementType(props, 'li');
   const unhandledProps = useUnhandledProps(MenuItemWrapper.handledProps, props);
 
   const element = (
@@ -145,10 +146,6 @@ export const MenuItemWrapper = React.forwardRef<HTMLLIElement, MenuItemWrapperPr
   FluentComponentStaticProps<MenuItemWrapperProps>;
 
 MenuItemWrapper.displayName = 'MenuItemWrapper';
-
-MenuItemWrapper.defaultProps = {
-  as: 'li',
-};
 
 MenuItemWrapper.propTypes = {
   ...commonPropTypes.createCommon(),

--- a/packages/fluentui/react-northstar/src/components/MenuButton/MenuButton.tsx
+++ b/packages/fluentui/react-northstar/src/components/MenuButton/MenuButton.tsx
@@ -115,8 +115,8 @@ export const MenuButton = React.forwardRef<HTMLDivElement, MenuButtonProps>((pro
     contextMenu,
     menu,
     // Popup props:
-    accessibility,
-    align,
+    accessibility = menuButtonBehavior,
+    align = 'start',
     className,
     defaultOpen,
     flipBoundary,
@@ -128,7 +128,7 @@ export const MenuButton = React.forwardRef<HTMLDivElement, MenuButtonProps>((pro
     overflowBoundary,
     pointing,
     popperRef,
-    position,
+    position = 'below',
     positionFixed,
     tabbableTrigger,
     target,
@@ -347,12 +347,6 @@ MenuButton.propTypes = {
     PropTypes.arrayOf(customPropTypes.itemShorthandWithoutJSX),
   ]),
   contextMenu: PropTypes.bool,
-};
-
-MenuButton.defaultProps = {
-  accessibility: menuButtonBehavior,
-  align: 'start',
-  position: 'below',
 };
 
 MenuButton.handledProps = Object.keys(MenuButton.propTypes) as any;

--- a/packages/fluentui/react-northstar/src/components/Pill/Pill.tsx
+++ b/packages/fluentui/react-northstar/src/components/Pill/Pill.tsx
@@ -124,6 +124,7 @@ export const Pill = React.forwardRef<HTMLSpanElement, PillProps>((props, ref) =>
   const parentProps = usePillContext();
 
   const {
+    accessibility,
     className,
     design,
     styles,
@@ -150,7 +151,7 @@ export const Pill = React.forwardRef<HTMLSpanElement, PillProps>((props, ref) =>
     initialState: false,
   });
 
-  const ElementType = getElementType(props);
+  const ElementType = getElementType(props, 'span');
   const unhandledProps = useUnhandledProps(Pill.handledProps, props);
 
   const handleDismiss = e => {
@@ -165,7 +166,7 @@ export const Pill = React.forwardRef<HTMLSpanElement, PillProps>((props, ref) =>
     _.invoke(props, 'onClick', e, props);
   };
 
-  const getA11yProps = useAccessibility(props.accessibility || parentProps.pillBehavior || pillBehavior, {
+  const getA11yProps = useAccessibility(accessibility || parentProps.pillBehavior || pillBehavior, {
     debugName: Pill.displayName,
     actionHandlers: {
       performDismiss: handleDismiss,
@@ -256,11 +257,6 @@ export const Pill = React.forwardRef<HTMLSpanElement, PillProps>((props, ref) =>
 
   return element;
 }) as unknown as ForwardRefWithAs<'span', HTMLSpanElement, PillProps> & FluentComponentStaticProps<PillProps>;
-
-Pill.defaultProps = {
-  as: 'span' as const,
-  accessibility: pillBehavior,
-};
 
 Pill.propTypes = {
   ...commonPropTypes.createCommon(),

--- a/packages/fluentui/react-northstar/src/components/Pill/PillAction.tsx
+++ b/packages/fluentui/react-northstar/src/components/Pill/PillAction.tsx
@@ -35,13 +35,24 @@ export interface PillActionProps extends UIComponentProps, ChildrenComponentProp
 export type PillActionStylesProps = Required<Pick<PillActionProps, 'size'>>;
 export const pillActionClassName = 'ui-pill__action';
 
+const DEFAULT_CONTENT = <CloseIcon />;
+
 /**
  * A PillAction allows user to execute an action.
  */
 export const PillAction = React.forwardRef<HTMLDivElement, PillActionProps>((props, ref) => {
   const context = useFluentContext();
 
-  const { accessibility, children, className, content, design, styles, variables, size } = props;
+  const {
+    accessibility = pillActionBehavior,
+    children,
+    className,
+    content = DEFAULT_CONTENT,
+    design,
+    styles,
+    variables,
+    size,
+  } = props;
 
   const getA11Props = useAccessibility(accessibility, {
     debugName: PillAction.displayName,
@@ -81,11 +92,6 @@ PillAction.propTypes = {
 };
 
 PillAction.handledProps = Object.keys(PillAction.propTypes) as any;
-
-PillAction.defaultProps = {
-  accessibility: pillActionBehavior,
-  content: <CloseIcon />,
-};
 
 PillAction.shorthandConfig = {
   mappedProp: 'content',

--- a/packages/fluentui/react-northstar/src/components/Pill/PillContent.tsx
+++ b/packages/fluentui/react-northstar/src/components/Pill/PillContent.tsx
@@ -61,7 +61,7 @@ export const PillContent = React.forwardRef<HTMLSpanElement, PillContentProps>((
     rtl: context.rtl,
   });
 
-  const ElementType = getElementType(props);
+  const ElementType = getElementType(props, 'span');
   const unhandledProps = useUnhandledProps(PillContent.handledProps, props);
 
   const element = (
@@ -89,10 +89,6 @@ PillContent.propTypes = {
 };
 
 PillContent.handledProps = Object.keys(PillContent.propTypes) as any;
-
-PillContent.defaultProps = {
-  as: 'span',
-};
 
 PillContent.shorthandConfig = {
   mappedProp: 'content',

--- a/packages/fluentui/react-northstar/src/components/Pill/PillGroup.tsx
+++ b/packages/fluentui/react-northstar/src/components/Pill/PillGroup.tsx
@@ -35,7 +35,7 @@ export const pillGroupClassName = 'ui-pills';
 export const PillGroup = React.forwardRef<HTMLDivElement, PillGroupProps>((props, ref) => {
   const context = useFluentContext();
 
-  const { accessibility, children, className, design, styles, variables } = props;
+  const { accessibility = PillGroupBehavior, children, className, design, styles, variables } = props;
 
   const getA11Props = useAccessibility(accessibility, {
     debugName: PillGroup.displayName,
@@ -78,10 +78,6 @@ export const PillGroup = React.forwardRef<HTMLDivElement, PillGroupProps>((props
 PillGroup.displayName = 'PillGroup';
 
 PillGroup.propTypes = commonPropTypes.createCommon();
-
-PillGroup.defaultProps = {
-  accessibility: PillGroupBehavior,
-};
 
 PillGroup.handledProps = Object.keys(PillGroup.propTypes) as any;
 

--- a/packages/fluentui/react-northstar/src/components/Pill/PillIcon.tsx
+++ b/packages/fluentui/react-northstar/src/components/Pill/PillIcon.tsx
@@ -55,7 +55,18 @@ export const pillIconClassName = 'ui-pill__icon';
 export const PillIcon = React.forwardRef<HTMLSpanElement, PillIconProps>((props, ref) => {
   const context = useFluentContext();
 
-  const { accessibility, children, className, content, design, styles, variables, size, selectable, image } = props;
+  const {
+    accessibility = pillIconBehavior,
+    children,
+    className,
+    content,
+    design,
+    styles,
+    variables,
+    size,
+    selectable,
+    image,
+  } = props;
 
   const getA11Props = useAccessibility(accessibility, {
     debugName: PillIcon.displayName,
@@ -69,7 +80,7 @@ export const PillIcon = React.forwardRef<HTMLSpanElement, PillIconProps>((props,
     rtl: context.rtl,
   });
 
-  const ElementType = getElementType(props);
+  const ElementType = getElementType(props, 'span');
   const unhandledProps = useUnhandledProps(PillIcon.handledProps, props);
 
   const element = (
@@ -86,11 +97,6 @@ export const PillIcon = React.forwardRef<HTMLSpanElement, PillIconProps>((props,
 
   return element;
 }) as unknown as ForwardRefWithAs<'span', HTMLSpanElement, PillIconProps> & FluentComponentStaticProps<PillIconProps>;
-
-PillIcon.defaultProps = {
-  accessibility: pillIconBehavior,
-  as: 'span' as const,
-};
 
 PillIcon.displayName = 'PillIcon';
 

--- a/packages/fluentui/react-northstar/src/components/Pill/PillImage.tsx
+++ b/packages/fluentui/react-northstar/src/components/Pill/PillImage.tsx
@@ -35,7 +35,7 @@ export const pillImageClassName = 'ui-pill__image';
 export const PillImage = React.forwardRef<HTMLImageElement, PillImageProps>((props, ref) => {
   const context = useFluentContext();
 
-  const { accessibility, className, design, styles, variables, size } = props;
+  const { accessibility = pillImageBehavior, className, design, styles, variables, size } = props;
 
   const getA11Props = useAccessibility(accessibility, {
     debugName: PillImage.displayName,
@@ -56,7 +56,7 @@ export const PillImage = React.forwardRef<HTMLImageElement, PillImageProps>((pro
     rtl: context.rtl,
   });
 
-  const ElementType = getElementType(props);
+  const ElementType = getElementType(props, 'img');
   const unhandledProps = useUnhandledProps(PillImage.handledProps, props);
 
   const result = <ElementType {...getA11Props('root', { className: classes.root, ref, ...unhandledProps })} />;
@@ -65,11 +65,6 @@ export const PillImage = React.forwardRef<HTMLImageElement, PillImageProps>((pro
 }) as unknown as ForwardRefWithAs<'img', HTMLImageElement, PillImageProps> & FluentComponentStaticProps<PillImageProps>;
 
 PillImage.displayName = 'PillImage';
-
-PillImage.defaultProps = {
-  accessibility: pillImageBehavior,
-  as: 'img',
-};
 
 PillImage.propTypes = {
   ...commonPropTypes.createCommon({

--- a/packages/fluentui/react-northstar/src/components/Provider/Provider.tsx
+++ b/packages/fluentui/react-northstar/src/components/Provider/Provider.tsx
@@ -149,9 +149,6 @@ export const Provider: ComponentWithAs<'div', ProviderProps> & {
 
 Provider.displayName = 'Provider';
 
-Provider.defaultProps = {
-  theme: {},
-};
 Provider.propTypes = {
   as: PropTypes.elementType,
   design: PropTypes.object,

--- a/packages/fluentui/react-northstar/src/components/RadioGroup/RadioGroup.tsx
+++ b/packages/fluentui/react-northstar/src/components/RadioGroup/RadioGroup.tsx
@@ -64,11 +64,11 @@ export type RadioGroupStylesProps = Required<Pick<RadioGroupProps, 'vertical'>>;
 export const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>((props, ref) => {
   const context = useFluentContext();
 
-  const { children, vertical, items, className, design, styles, variables } = props;
+  const { accessibility = radioGroupBehavior, children, vertical, items, className, design, styles, variables } = props;
   const ElementType = getElementType(props);
   const unhandledProps = useUnhandledProps(RadioGroup.handledProps, props);
 
-  const getA11yProps = useAccessibility<RadioGroupBehaviorProps>(props.accessibility, {
+  const getA11yProps = useAccessibility<RadioGroupBehaviorProps>(accessibility, {
     debugName: RadioGroup.displayName,
     actionHandlers: {
       nextItem: event => setCheckedItem(event, 1),
@@ -217,10 +217,6 @@ RadioGroup.propTypes = {
   items: customPropTypes.collectionShorthand,
   onCheckedValueChange: PropTypes.func,
   vertical: PropTypes.bool,
-};
-
-RadioGroup.defaultProps = {
-  accessibility: radioGroupBehavior,
 };
 
 RadioGroup.handledProps = Object.keys(RadioGroup.propTypes) as any;

--- a/packages/fluentui/react-northstar/src/components/RadioGroup/RadioGroupItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/RadioGroup/RadioGroupItem.tsx
@@ -86,6 +86,9 @@ export const radioGroupItemSlotClassNames: RadioGroupItemSlotClassNames = {
 
 export type RadioGroupItemStylesProps = Required<Pick<RadioGroupItemProps, 'disabled' | 'vertical' | 'checked'>>;
 
+const DEFAULT_INDICATOR = <RadioButtonIcon outline />;
+const DEFAULT_CHECKED_INDICATOR = <RadioButtonIcon />;
+
 /**
  * A RadioGroupItem represents single input element within a RadioGroup.
  *
@@ -95,8 +98,19 @@ export type RadioGroupItemStylesProps = Required<Pick<RadioGroupItemProps, 'disa
 export const RadioGroupItem = React.forwardRef<HTMLDivElement, RadioGroupItemProps>((props, ref) => {
   const context = useFluentContext();
 
-  const { label, checkedIndicator, indicator, disabled, vertical, className, design, styles, variables, shouldFocus } =
-    props;
+  const {
+    accessibility = radioGroupItemBehavior,
+    label,
+    checkedIndicator = DEFAULT_CHECKED_INDICATOR,
+    indicator = DEFAULT_INDICATOR,
+    disabled,
+    vertical,
+    className,
+    design,
+    styles,
+    variables,
+    shouldFocus,
+  } = props;
   const elementRef = React.useRef<HTMLElement>();
   const ElementType = getElementType(props);
   const unhandledProps = useUnhandledProps(RadioGroupItem.handledProps, props);
@@ -145,7 +159,7 @@ export const RadioGroupItem = React.forwardRef<HTMLDivElement, RadioGroupItemPro
     rtl: context.rtl,
   });
 
-  const getA11yProps = useAccessibility<RadioGroupItemBehaviorProps>(props.accessibility, {
+  const getA11yProps = useAccessibility<RadioGroupItemBehaviorProps>(accessibility, {
     debugName: RadioGroupItem.displayName,
     actionHandlers: {
       performClick: e => {
@@ -218,12 +232,6 @@ RadioGroupItem.propTypes = {
   shouldFocus: PropTypes.bool,
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   vertical: PropTypes.bool,
-};
-
-RadioGroupItem.defaultProps = {
-  accessibility: radioGroupItemBehavior,
-  indicator: <RadioButtonIcon outline />,
-  checkedIndicator: <RadioButtonIcon />,
 };
 
 RadioGroupItem.handledProps = Object.keys(RadioGroupItem.propTypes) as any;

--- a/packages/fluentui/react-northstar/src/components/Reaction/Reaction.tsx
+++ b/packages/fluentui/react-northstar/src/components/Reaction/Reaction.tsx
@@ -60,7 +60,7 @@ export const Reaction = React.forwardRef<HTMLSpanElement, ReactionProps>((props,
   const context = useFluentContext();
 
   const { children, icon, content, className, design, styles, variables } = props;
-  const ElementType = getElementType(props);
+  const ElementType = getElementType(props, 'span');
   const unhandledProps = useUnhandledProps(Reaction.handledProps, props);
 
   const getA11yProps = useAccessibility<never>(props.accessibility, {
@@ -127,10 +127,6 @@ Reaction.propTypes = {
     content: 'shorthand',
   }),
   icon: customPropTypes.shorthandAllowingChildren,
-};
-
-Reaction.defaultProps = {
-  as: 'span',
 };
 
 Reaction.handledProps = Object.keys(Reaction.propTypes) as any;

--- a/packages/fluentui/react-northstar/src/components/SplitButton/SplitButton.tsx
+++ b/packages/fluentui/react-northstar/src/components/SplitButton/SplitButton.tsx
@@ -118,10 +118,10 @@ export const SplitButton = React.forwardRef<HTMLDivElement, SplitButtonProps>((p
     menu,
     primary,
     secondary,
-    toggleButton,
+    toggleButton = {},
     size,
-    position,
-    align,
+    position = 'below',
+    align = 'start',
     flipBoundary,
     flat,
     overflowBoundary,
@@ -134,7 +134,7 @@ export const SplitButton = React.forwardRef<HTMLDivElement, SplitButtonProps>((p
     className,
     design,
     styles,
-    accessibility,
+    accessibility = splitButtonBehavior,
     variables,
   } = props;
 
@@ -326,13 +326,6 @@ SplitButton.propTypes = {
   unstable_disableTether: PropTypes.oneOf([true, false, 'all']),
   unstable_pinned: PropTypes.bool,
   autoSize: PropTypes.oneOf<AutoSize>(AUTOSIZES),
-};
-
-SplitButton.defaultProps = {
-  accessibility: splitButtonBehavior,
-  toggleButton: {},
-  position: 'below',
-  align: 'start',
 };
 
 SplitButton.handledProps = Object.keys(SplitButton.propTypes) as any;

--- a/packages/fluentui/react-northstar/src/components/SplitButton/SplitButtonToggle.tsx
+++ b/packages/fluentui/react-northstar/src/components/SplitButton/SplitButtonToggle.tsx
@@ -67,7 +67,7 @@ export const SplitButtonToggle = React.forwardRef<HTMLButtonElement, SplitButton
     const context = useFluentContext();
 
     const {
-      accessibility,
+      accessibility = buttonBehavior,
       as,
       children,
       content,
@@ -115,7 +115,7 @@ export const SplitButtonToggle = React.forwardRef<HTMLButtonElement, SplitButton
     });
 
     const unhandledProps = useUnhandledProps(SplitButtonToggle.handledProps, props);
-    const ElementType = getElementType(props);
+    const ElementType = getElementType(props, 'button');
 
     const handleClick = (e: React.SyntheticEvent) => {
       if (disabled) {
@@ -145,11 +145,6 @@ export const SplitButtonToggle = React.forwardRef<HTMLButtonElement, SplitButton
   },
 ) as unknown as ForwardRefWithAs<'button', HTMLButtonElement, SplitButtonToggleProps> &
   FluentComponentStaticProps<SplitButtonToggleProps>;
-
-SplitButtonToggle.defaultProps = {
-  as: 'button',
-  accessibility: buttonBehavior,
-};
 
 SplitButtonToggle.displayName = 'SplitButtonToggle';
 

--- a/packages/fluentui/react-northstar/src/components/Status/Status.tsx
+++ b/packages/fluentui/react-northstar/src/components/Status/Status.tsx
@@ -44,7 +44,17 @@ export const statusClassName = 'ui-status';
 export const Status = React.forwardRef<HTMLSpanElement, StatusProps>((props, ref) => {
   const context = useFluentContext();
 
-  const { className, color, icon, size, state, design, styles, variables } = props;
+  const {
+    accessibility = statusBehavior,
+    className,
+    color,
+    icon,
+    size = 'medium',
+    state = 'unknown',
+    design,
+    styles,
+    variables,
+  } = props;
   const { classes, styles: resolvedStyles } = useStyles<StatusStylesProps>(Status.displayName, {
     className: statusClassName,
     mapPropsToStyles: () => ({
@@ -60,11 +70,11 @@ export const Status = React.forwardRef<HTMLSpanElement, StatusProps>((props, ref
     }),
     rtl: context.rtl,
   });
-  const getA11Props = useAccessibility(props.accessibility, {
+  const getA11Props = useAccessibility(accessibility, {
     debugName: Status.displayName,
     rtl: context.rtl,
   });
-  const ElementType = getElementType(props);
+  const ElementType = getElementType(props, 'span');
   const unhandledProps = useUnhandledProps(Status.handledProps, props);
 
   const iconElement = Box.create(icon, {
@@ -102,11 +112,5 @@ Status.propTypes = {
   ]),
 };
 Status.handledProps = Object.keys(Status.propTypes) as any;
-Status.defaultProps = {
-  accessibility: statusBehavior,
-  as: 'span' as const,
-  size: 'medium',
-  state: 'unknown',
-};
 
 Status.create = createShorthandFactory({ Component: Status, mappedProp: 'state' });

--- a/packages/fluentui/react-northstar/src/components/SvgIcon/SvgIcon.tsx
+++ b/packages/fluentui/react-northstar/src/components/SvgIcon/SvgIcon.tsx
@@ -37,8 +37,8 @@ export const SvgIcon: ComponentWithAs<'span', SvgIconProps & { children: SvgIcon
     disabled,
     children,
     outline,
-    rotate,
-    size,
+    rotate = 0,
+    size = 'medium',
     styles,
     variables,
     xSpacing,
@@ -59,7 +59,7 @@ export const SvgIcon: ComponentWithAs<'span', SvgIconProps & { children: SvgIcon
     rtl: context.rtl,
   });
 
-  const ElementType = getElementType(props);
+  const ElementType = getElementType(props, 'span');
   const unhandledProps = getUnhandledProps(SvgIcon.handledProps, props);
 
   const element = (
@@ -79,8 +79,3 @@ export const SvgIcon: ComponentWithAs<'span', SvgIconProps & { children: SvgIcon
 
 SvgIcon.displayName = svgIconDisplayName;
 SvgIcon.handledProps = [...svgIconHandledProps, 'children'];
-SvgIcon.defaultProps = {
-  as: 'span',
-  size: 'medium',
-  rotate: 0,
-};

--- a/packages/fluentui/react-northstar/src/components/Table/Table.tsx
+++ b/packages/fluentui/react-northstar/src/components/Table/Table.tsx
@@ -77,7 +77,17 @@ export type TableStylesProps = never;
 export const Table = React.forwardRef<HTMLDivElement, TableProps>((props, ref) => {
   const context = useFluentContext();
 
-  const { children, rows, header, compact, accessibility, className, design, styles, variables } = props;
+  const {
+    children,
+    rows,
+    header,
+    compact,
+    accessibility = tableBehavior,
+    className,
+    design,
+    styles,
+    variables,
+  } = props;
   const hasChildren = childrenExist(children);
   const ElementType = getElementType(props);
   const unhandledProps = useUnhandledProps(Table.handledProps, props);
@@ -174,7 +184,3 @@ Table.propTypes = {
 };
 
 Table.handledProps = Object.keys(Table.propTypes) as any;
-
-Table.defaultProps = {
-  accessibility: tableBehavior,
-};

--- a/packages/fluentui/react-northstar/src/components/Table/TableCell.tsx
+++ b/packages/fluentui/react-northstar/src/components/Table/TableCell.tsx
@@ -59,11 +59,21 @@ export const TableCell = React.forwardRef<HTMLDivElement, TableCellProps>((props
 
   const cellRef = React.useRef<HTMLElement>();
 
-  const { children, content, truncateContent, className, design, styles, variables } = props;
+  const {
+    accessibility = tableCellBehavior,
+    children,
+    content,
+    truncateContent,
+    className,
+    design,
+    styles,
+    variables,
+  } = props;
+
   const hasChildren = childrenExist(children);
   const ElementType = getElementType(props);
   const unhandledProps = useUnhandledProps(TableCell.handledProps, props);
-  const getA11yProps = useAccessibility(props.accessibility, {
+  const getA11yProps = useAccessibility(accessibility, {
     debugName: TableCell.displayName,
     actionHandlers: {
       focusCell: e => {
@@ -131,9 +141,5 @@ TableCell.propTypes = {
 };
 
 TableCell.handledProps = Object.keys(TableCell.propTypes) as any;
-
-TableCell.defaultProps = {
-  accessibility: tableCellBehavior,
-};
 
 TableCell.create = createShorthandFactory({ Component: TableCell, mappedProp: 'content' });

--- a/packages/fluentui/react-northstar/src/components/Table/TableRow.tsx
+++ b/packages/fluentui/react-northstar/src/components/Table/TableRow.tsx
@@ -56,7 +56,18 @@ export const TableRow = React.forwardRef<HTMLDivElement, TableRowProps>((props, 
   const context = useFluentContext();
 
   const rowRef = React.useRef<HTMLElement>();
-  const { className, design, styles, items, header, compact, children, accessibility, variables, selected } = props;
+  const {
+    className,
+    design,
+    styles,
+    items,
+    header,
+    compact,
+    children,
+    accessibility = tableRowBehavior,
+    variables,
+    selected,
+  } = props;
 
   const hasChildren = childrenExist(children);
   const ElementType = getElementType(props);
@@ -141,9 +152,5 @@ TableRow.propTypes = {
 };
 
 TableRow.handledProps = Object.keys(TableRow.propTypes) as any;
-
-TableRow.defaultProps = {
-  accessibility: tableRowBehavior,
-};
 
 TableRow.create = createShorthandFactory({ Component: TableRow, mappedArrayProp: 'items' });

--- a/packages/fluentui/react-northstar/src/components/Text/Text.tsx
+++ b/packages/fluentui/react-northstar/src/components/Text/Text.tsx
@@ -146,7 +146,7 @@ export const Text = React.forwardRef<HTMLSpanElement, TextProps>((props, ref) =>
   });
 
   const unhandledProps = useUnhandledProps(Text.handledProps, props);
-  const ElementType = getElementType(props);
+  const ElementType = getElementType(props, 'span');
 
   const element = (
     <ElementType
@@ -166,9 +166,6 @@ export const Text = React.forwardRef<HTMLSpanElement, TextProps>((props, ref) =>
 
 Text.displayName = 'Text';
 
-Text.defaultProps = {
-  as: 'span' as const,
-};
 Text.propTypes = {
   ...commonPropTypes.createCommon({ color: true }),
   atMention: PropTypes.oneOfType<any>([PropTypes.bool, PropTypes.oneOf(['me'])]),

--- a/packages/fluentui/react-northstar/src/components/TextArea/TextArea.tsx
+++ b/packages/fluentui/react-northstar/src/components/TextArea/TextArea.tsx
@@ -68,7 +68,18 @@ export const textAreaClassName = 'ui-textarea';
 export const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>((props, ref) => {
   const context = useFluentContext();
 
-  const { disabled, accessibility, inverted, resize, fluid, className, design, styles, variables, error } = props;
+  const {
+    disabled,
+    accessibility = textAreaBehavior,
+    inverted,
+    resize,
+    fluid,
+    className,
+    design,
+    styles,
+    variables,
+    error,
+  } = props;
 
   const [value, setValue] = useControllableState({
     defaultState: props.defaultValue,
@@ -104,7 +115,7 @@ export const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>((pr
     rtl: context.rtl,
   });
 
-  const ElementType = getElementType(props);
+  const ElementType = getElementType(props, 'textarea');
 
   const handleChange = (e: React.ChangeEvent | React.FormEvent) => {
     const newValue = _.get(e, 'target.value');
@@ -144,11 +155,6 @@ TextArea.propTypes = {
   fluid: PropTypes.bool,
   error: PropTypes.bool,
   resize: PropTypes.oneOf(['none', 'both', 'horizontal', 'vertical']),
-};
-
-TextArea.defaultProps = {
-  as: 'textarea',
-  accessibility: textAreaBehavior,
 };
 
 TextArea.handledProps = Object.keys(TextArea.propTypes) as any;

--- a/packages/fluentui/react-northstar/src/components/Tooltip/Tooltip.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tooltip/Tooltip.tsx
@@ -34,6 +34,7 @@ import {
   Position,
   AutoSize,
   AUTOSIZES,
+  Offset,
 } from '../../utils/positioner';
 import { PortalInner } from '../Portal/PortalInner';
 import { TooltipContent, TooltipContentProps } from './TooltipContent';
@@ -95,6 +96,8 @@ export interface TooltipProps
 
 export const tooltipClassName = 'ui-tooltip';
 
+const DEFAULT_OFFSET: Offset = [4, 4];
+
 /**
  * A Tooltip displays additional non-modal information on top of its target element.
  * Tooltip doesn't receive focus and cannot contain focusable elements.
@@ -109,26 +112,26 @@ export const Tooltip: React.FC<TooltipProps> &
   const context = useFluentContext();
 
   const {
-    accessibility,
-    align,
+    accessibility = tooltipAsLabelBehavior,
+    align = 'center',
     content,
     flipBoundary,
     mountNode,
-    mouseLeaveDelay,
-    offset,
+    mouseLeaveDelay = 10,
+    offset = DEFAULT_OFFSET,
     overflowBoundary,
     pointing,
     popperRef,
-    position,
+    position = 'above',
     positionFixed,
     target,
     trigger,
     unstable_disableTether,
     unstable_pinned,
     autoSize,
-    subtle,
+    subtle = true,
     dismissOnContentMouseEnter,
-    mouseEnterDelay,
+    mouseEnterDelay = 0,
   } = props;
 
   const [open, setOpen] = useControllableState({
@@ -296,15 +299,6 @@ export const Tooltip: React.FC<TooltipProps> &
 
 Tooltip.displayName = 'Tooltip';
 
-Tooltip.defaultProps = {
-  align: 'center',
-  position: 'above',
-  mouseLeaveDelay: 10,
-  mouseEnterDelay: 0,
-  subtle: true,
-  accessibility: tooltipAsLabelBehavior,
-  offset: [4, 4],
-};
 Tooltip.propTypes = {
   ...commonPropTypes.createCommon({
     as: false,

--- a/packages/fluentui/react-northstar/src/components/Tree/Tree.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tree/Tree.tsx
@@ -111,12 +111,21 @@ export type TreeStylesProps = never;
 export const Tree = React.forwardRef<HTMLDivElement, TreeProps>((props, ref) => {
   const context = useFluentContext();
 
-  const { selectable, children, renderedItems, className, design, styles, variables } = props;
+  const {
+    accessibility = treeBehavior,
+    selectable,
+    children,
+    renderedItems,
+    className,
+    design,
+    styles,
+    variables,
+  } = props;
 
   const ElementType = getElementType(props);
   const unhandledProps = useUnhandledProps(Tree.handledProps, props);
 
-  const getA11yProps = useAccessibility(props.accessibility, {
+  const getA11yProps = useAccessibility(accessibility, {
     debugName: Tree.displayName,
     rtl: context.rtl,
     mapPropsToBehavior: () => ({
@@ -236,10 +245,6 @@ Tree.propTypes = {
 
 Tree.Item = TreeItem;
 Tree.Title = TreeTitle;
-
-Tree.defaultProps = {
-  accessibility: treeBehavior,
-};
 
 Tree.handledProps = Object.keys(Tree.propTypes) as any;
 

--- a/packages/fluentui/react-northstar/src/components/Tree/TreeItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tree/TreeItem.tsx
@@ -127,7 +127,7 @@ export const TreeItem = React.forwardRef<HTMLDivElement, TreeItemProps>((props, 
   const context = useFluentContext();
 
   const {
-    accessibility,
+    accessibility = treeItemBehavior,
     children,
     className,
     contentRef,
@@ -141,7 +141,7 @@ export const TreeItem = React.forwardRef<HTMLDivElement, TreeItemProps>((props, 
     variables,
     treeSize,
     selectionIndicator,
-    selectable,
+    selectable = true,
     id,
     parent,
   } = props;
@@ -355,11 +355,6 @@ TreeItem.propTypes = {
   selectable: PropTypes.bool,
   unstyled: PropTypes.bool,
   onKeyDown: PropTypes.func,
-};
-
-TreeItem.defaultProps = {
-  accessibility: treeItemBehavior,
-  selectable: true,
 };
 
 TreeItem.handledProps = Object.keys(TreeItem.propTypes) as any;

--- a/packages/fluentui/react-northstar/src/components/Tree/TreeTitle.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tree/TreeTitle.tsx
@@ -103,7 +103,7 @@ export const TreeTitle = React.forwardRef<HTMLAnchorElement, TreeTitleProps>((pr
 
   const { focusItemById, toggleItemActive, toggleItemSelect } = React.useContext(TreeContext);
   const {
-    accessibility,
+    accessibility = treeTitleBehavior,
     id,
     children,
     className,
@@ -115,7 +115,7 @@ export const TreeTitle = React.forwardRef<HTMLAnchorElement, TreeTitleProps>((pr
     styles,
     treeSize,
     variables,
-    selectionIndicator,
+    selectionIndicator = {},
     disabled,
     selected,
     selectable,
@@ -169,7 +169,7 @@ export const TreeTitle = React.forwardRef<HTMLAnchorElement, TreeTitleProps>((pr
     unstyled: props.unstyled,
   });
 
-  const ElementType = getElementType(props);
+  const ElementType = getElementType(props, 'a');
   const unhandledProps = useUnhandledProps(TreeTitle.handledProps, props);
 
   const handleClick = e => {
@@ -242,11 +242,6 @@ TreeTitle.propTypes = {
   unstyled: PropTypes.bool,
   indeterminate: PropTypes.bool,
   parent: PropTypes.string,
-};
-TreeTitle.defaultProps = {
-  as: 'a' as const,
-  selectionIndicator: {},
-  accessibility: treeTitleBehavior,
 };
 TreeTitle.handledProps = Object.keys(TreeTitle.propTypes) as any;
 

--- a/packages/fluentui/react-northstar/src/components/Video/Video.tsx
+++ b/packages/fluentui/react-northstar/src/components/Video/Video.tsx
@@ -46,13 +46,25 @@ export type VideoStylesProps = Required<Pick<VideoProps, 'variables'>>;
  * A Video provides ability to embed video content.
  */
 export const Video = React.forwardRef<HTMLVideoElement, VideoProps>((props, ref) => {
-  const { controls, autoPlay, loop, poster, src, muted, variables, className, design, styles } = props;
+  const {
+    accessibility = videoBehavior,
+    controls = true,
+    autoPlay = false,
+    loop,
+    poster,
+    src,
+    muted = false,
+    variables,
+    className,
+    design,
+    styles,
+  } = props;
   const videoRef = React.useRef<HTMLVideoElement>();
 
-  const ElementType = getElementType(props);
+  const ElementType = getElementType(props, 'video');
   const unhandledProps = useUnhandledProps(Video.handledProps, props);
 
-  const getA11yProps = useAccessibility(props.accessibility, {
+  const getA11yProps = useAccessibility(accessibility, {
     debugName: Video.displayName,
   });
 
@@ -116,14 +128,6 @@ Video.propTypes = {
   muted: PropTypes.bool,
   poster: PropTypes.string,
   src: PropTypes.string,
-};
-
-Video.defaultProps = {
-  as: 'video' as const,
-  accessibility: videoBehavior,
-  controls: true,
-  autoPlay: false,
-  muted: false,
 };
 
 Video.handledProps = Object.keys(Video.propTypes) as any;

--- a/packages/fluentui/react-northstar/src/utils/positioner/Popper.tsx
+++ b/packages/fluentui/react-northstar/src/utils/positioner/Popper.tsx
@@ -7,6 +7,9 @@ import { getPlacement } from './positioningHelper';
 import { PopperChildrenFn, PopperProps, PopperRefHandle } from './types';
 import { usePopper } from './usePopper';
 
+const DEFAULT_MODIFIERS = [];
+const DEFAULT_POSITIONING_DEPENDENCIES = [];
+
 /**
  * Popper relies on the 3rd party library [Popper.js](https://github.com/FezVrasta/popper.js) for positioning.
  *
@@ -21,6 +24,11 @@ export const Popper: React.FunctionComponent<PopperProps> = props => {
 
   const popperRef = React.useRef<PopperRefHandle | null>(null);
   const { targetRef, containerRef, arrowRef } = usePopper({
+    enabled: true,
+    modifiers: DEFAULT_MODIFIERS,
+    positionFixed: false,
+    positioningDependencies: DEFAULT_POSITIONING_DEPENDENCIES,
+
     ...props,
 
     popperRef: useMergedRefs(props.popperRef, popperRef),
@@ -59,11 +67,4 @@ export const Popper: React.FunctionComponent<PopperProps> = props => {
     : (props.children as React.ReactElement);
 
   return child ? <Ref innerRef={containerRef}>{React.Children.only(child)}</Ref> : null;
-};
-
-Popper.defaultProps = {
-  enabled: true,
-  modifiers: [],
-  positionFixed: false,
-  positioningDependencies: [],
 };

--- a/packages/fluentui/react-northstar/test/specs/components/Avatar/Avatar-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Avatar/Avatar-test.tsx
@@ -3,9 +3,9 @@ import { implementsShorthandProp, isConformant } from 'test/specs/commonTests';
 import { Avatar } from 'src/components/Avatar/Avatar';
 import { AvatarImage } from 'src/components/Avatar/AvatarImage';
 import { AvatarLabel } from 'src/components/Avatar/AvatarLabel';
+import { getDefaultInitials } from 'src/components/Avatar/getDefaultInitials';
 
 const avatarImplementsShorthandProp = implementsShorthandProp(Avatar);
-const { getInitials } = (Avatar as any).defaultProps;
 
 describe('Avatar', () => {
   isConformant(Avatar, {
@@ -17,103 +17,103 @@ describe('Avatar', () => {
 
   describe('generateInitials', () => {
     it('generateInitials should show just the initials of the first and last words in the name', () => {
-      expect(getInitials('Cecil MiddleName Folk')).toEqual('CF');
+      expect(getDefaultInitials('Cecil MiddleName Folk')).toEqual('CF');
     });
 
     it('generateInitials removes the text inside brackets', () => {
-      expect(getInitials('Cecil Folk (Working position)')).toEqual('CF');
-      expect(getInitials('Cecil Folk {Working position}')).toEqual('CF');
-      expect(getInitials('Cecil Folk [Working position]')).toEqual('CF');
+      expect(getDefaultInitials('Cecil Folk (Working position)')).toEqual('CF');
+      expect(getDefaultInitials('Cecil Folk {Working position}')).toEqual('CF');
+      expect(getDefaultInitials('Cecil Folk [Working position]')).toEqual('CF');
     });
 
     it('handles null inputs', () => {
-      let result = getInitials(null);
+      let result = getDefaultInitials(null);
       expect(result).toEqual('');
 
-      result = getInitials(undefined);
+      result = getDefaultInitials(undefined);
       expect(result).toEqual('');
     });
 
     it('handles whitespace input', () => {
-      let result = getInitials('    ');
+      let result = getDefaultInitials('    ');
       expect(result).toEqual('');
 
-      result = getInitials('\t\n');
+      result = getDefaultInitials('\t\n');
       expect(result).toEqual('');
     });
 
     it('calculates an expected initials for non-ASCII characters', () => {
-      let result = getInitials('Írissa Þórðardóttir');
+      let result = getDefaultInitials('Írissa Þórðardóttir');
       expect(result).toEqual('ÍÞ');
 
-      result = getInitials('Øyvind Åsen');
+      result = getDefaultInitials('Øyvind Åsen');
       expect(result).toEqual('ØÅ');
     });
 
     it('calculates an expected initials with a hypen', () => {
-      const result = getInitials('David Zearing-Goff');
+      const result = getDefaultInitials('David Zearing-Goff');
       expect(result).toEqual('DZ');
     });
 
     it('calculates an expected initials with numbers', () => {
-      const result = getInitials('4lex 5loo');
+      const result = getDefaultInitials('4lex 5loo');
       expect(result).toEqual('45');
     });
 
     it('calculates an expected initials with multiple parentheses, extra spaces, and unwanted characters', () => {
-      const result = getInitials(' !@#$%^&*()=+ (Alpha) David   (The man) `~<>,./?[]{}|   Goff   (Gamma)    ');
+      const result = getDefaultInitials(' !@#$%^&*()=+ (Alpha) David   (The man) `~<>,./?[]{}|   Goff   (Gamma)    ');
       expect(result).toEqual('!G');
     });
 
     it('calculates an expected initials for names with multiple components', () => {
-      let result = getInitials('A');
+      let result = getDefaultInitials('A');
       expect(result).toEqual('A');
 
-      result = getInitials('A B');
+      result = getDefaultInitials('A B');
       expect(result).toEqual('AB');
 
-      result = getInitials('A B C');
+      result = getDefaultInitials('A B C');
       expect(result).toEqual('AC');
 
-      result = getInitials('A B C D');
+      result = getDefaultInitials('A B C D');
       expect(result).toEqual('AD');
     });
 
     it('calculates an expected initials for Arabic names', () => {
-      const result = getInitials('خسرو رحیمی');
+      const result = getDefaultInitials('خسرو رحیمی');
       expect(result).toEqual('خر');
     });
 
     it('calculates an expected initials for Chinese names', () => {
-      let result = getInitials('桂英');
+      let result = getDefaultInitials('桂英');
       expect(result).toEqual('桂');
 
-      result = getInitials('佳');
+      result = getDefaultInitials('佳');
       expect(result).toEqual('佳');
 
-      result = getInitials('宋智洋');
+      result = getDefaultInitials('宋智洋');
       expect(result).toEqual('宋');
     });
 
     it('calculates an expected initials for Korean names', () => {
-      let result = getInitials('강현');
+      let result = getDefaultInitials('강현');
       expect(result).toEqual('강');
 
-      result = getInitials('최종래');
+      result = getDefaultInitials('최종래');
       expect(result).toEqual('최');
 
-      result = getInitials('남궁 성종');
+      result = getDefaultInitials('남궁 성종');
       expect(result).toEqual('남성');
     });
 
     it('calculates an expected initials for Japanese names', () => {
-      let result = getInitials('松田');
+      let result = getDefaultInitials('松田');
       expect(result).toEqual('松');
 
-      result = getInitials('海野');
+      result = getDefaultInitials('海野');
       expect(result).toEqual('海');
 
-      result = getInitials('かり');
+      result = getDefaultInitials('かり');
       expect(result).toEqual('か');
     });
   });

--- a/packages/fluentui/react-northstar/test/specs/components/Embed/Embed-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Embed/Embed-test.tsx
@@ -44,11 +44,4 @@ describe('Embed', () => {
       );
     });
   });
-
-  describe('variables', () => {
-    it('should be set by default', () => {
-      const variables = mountWithProviderAndGetComponent(Embed, <Embed />).prop('variables');
-      expect(variables).toEqual({});
-    });
-  });
 });

--- a/packages/fluentui/react-northstar/test/specs/components/Loader/Loader-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Loader/Loader-test.tsx
@@ -9,10 +9,11 @@ describe('Loader', () => {
   isConformant(Loader, { testPath: __filename, constructorName: 'Loader' });
 
   describe('delay', () => {
-    it('is "0" by default', () => {
+    it('is "0" by default, renders child instantly', () => {
+      const selector = `.${loaderClassName}`;
       const wrapper = mountWithProvider(<Loader />);
 
-      expect(wrapper.find(Loader).prop('delay')).toBe(0);
+      expect(wrapper.find(selector).exists()).toBe(true);
     });
 
     it('renders children only when "delay" is passed', () => {


### PR DESCRIPTION
## New Behavior

Inlines `.defaultProps` on components that don't use `compose()` to avoid errors in StrictMode.