### PR TITLE
chore(v0): remove .defaultProps usage [part 2]

### DIFF
--- a/packages/fluentui/react-bindings/src/compose/compose.ts
+++ b/packages/fluentui/react-bindings/src/compose/compose.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
+import * as _ from 'lodash';
 
-import { ComponentWithAs, ComposedComponent, ComposeOptions, Input, InputComposeComponent } from './consts';
+import { ComponentWithAs, ComposedComponent, ComposeOptions, Input } from './consts';
 import { wasComposedPreviously } from './wasComposedPreviously';
 import { mergeComposeOptions } from './mergeComposeOptions';
 
@@ -21,10 +22,12 @@ function compose<
   );
 
   const Component = React.forwardRef<HTMLElement, TInputProps & TParentProps & { as?: React.ElementType }>(
-    (props, ref) => {
-      return composeOptions.render(props, ref as React.Ref<HTMLDivElement>, {
+    (componentProps, ref) => {
+      const allProps = _.defaults({}, componentProps, composeOptions.defaultProps);
+
+      return composeOptions.render(allProps, ref as React.Ref<HTMLDivElement>, {
         ...composeOptions,
-        state: composeOptions.state(props, ref, composeOptions),
+        state: composeOptions.state(allProps, ref, composeOptions),
         slots: {
           ...composeOptions.slots,
           __self: Component,
@@ -34,10 +37,6 @@ function compose<
   ) as unknown as ComponentWithAs<TElementType, TInputProps & TParentProps>;
 
   Component.displayName = composeOptions.displayName;
-
-  if ((input as InputComposeComponent).defaultProps) {
-    Component.defaultProps = (input as InputComposeComponent).defaultProps;
-  }
 
   (Component as unknown as ComposedComponent).fluentComposeConfig = composeOptions;
 

--- a/packages/fluentui/react-bindings/src/compose/consts.ts
+++ b/packages/fluentui/react-bindings/src/compose/consts.ts
@@ -107,6 +107,8 @@ export type ComposeOptions<
 
   mapPropsToStylesProps?: (props: TParentStylesProps & TInputProps) => TInputStylesProps;
 
+  defaultProps?: Partial<TParentProps & TInputProps & { as: React.ElementType }>;
+
   handledProps?: (keyof TInputProps | 'as')[];
 
   overrideStyles?: boolean;
@@ -162,6 +164,7 @@ export type ComposePreparedOptions<TProps = {}, TInputState = any, TParentState 
   mapPropsToStylesPropsChain: ((props: object) => object)[];
   render: ComposeRenderFunction;
 
+  defaultProps: Partial<TProps & { as: React.ElementType }>;
   handledProps: (keyof TProps | 'as')[];
 
   overrideStyles: boolean;
@@ -226,6 +229,7 @@ export const defaultComposeOptions: Required<ComposePreparedOptions> = {
   displayNames: [],
   mapPropsToStylesPropsChain: [],
   render: () => null,
+  defaultProps: {},
   handledProps: [] as never[],
   overrideStyles: false,
   // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/packages/fluentui/react-bindings/src/compose/mergeComposeOptions.ts
+++ b/packages/fluentui/react-bindings/src/compose/mergeComposeOptions.ts
@@ -51,6 +51,11 @@ export function mergeComposeOptions(
 
     render: typeof input === 'function' ? input : parentOptions.render,
 
+    defaultProps: {
+      ...parentOptions.defaultProps,
+      ...inputOptions.defaultProps,
+    },
+
     handledProps: [...parentOptions.handledProps, ...((inputOptions.handledProps as never[]) || ([] as never[]))],
 
     overrideStyles: inputOptions.overrideStyles || false,

--- a/packages/fluentui/react-bindings/test/compose/compose-test.tsx
+++ b/packages/fluentui/react-bindings/test/compose/compose-test.tsx
@@ -7,6 +7,7 @@ describe('compose', () => {
     as?: string;
     defaultChecked?: boolean;
     checked?: boolean;
+    id?: string;
   }
 
   const useToggle = (props: ToggleProps) => props;
@@ -21,6 +22,10 @@ describe('compose', () => {
       slots: {},
       state: useToggle,
       handledProps: ['checked'],
+      defaultProps: {
+        id: 'default-id',
+        'aria-label': 'toggle',
+      },
       displayName: 'Toggle',
     },
   );
@@ -28,15 +33,26 @@ describe('compose', () => {
   it('can compose a component', () => {
     const wrapper = mount(<Toggle id="foo" checked />);
 
-    expect(wrapper.html()).toMatch('<div id="foo"></div>');
+    expect(wrapper.html()).toMatch('<div id="foo" aria-label="toggle"></div>');
     expect(Toggle.displayName).toEqual('Toggle');
   });
 
-  it('can recompose a component', () => {
-    const NewToggle = compose<'div', ToggleProps, {}, {}, {}>(Toggle, { displayName: 'NewToggle' });
-    const wrapper = mount(<NewToggle id="foo" />);
+  it('handles `defaultProps`', () => {
+    const wrapper = mount(<Toggle />);
 
-    expect(wrapper.html()).toMatch('<div id="foo"></div>');
+    expect(wrapper.html()).toMatch('<div id="default-id" aria-label="toggle"></div>');
+  });
+
+  it('can recompose a component', () => {
+    const NewToggle = compose<'div', ToggleProps, {}, {}, {}>(Toggle, {
+      displayName: 'NewToggle',
+      defaultProps: {
+        id: 'new-default-id',
+      },
+    });
+    const wrapper = mount(<NewToggle />);
+
+    expect(wrapper.html()).toMatch('<div id="new-default-id" aria-label="toggle"></div>');
     expect(NewToggle.displayName).toEqual('NewToggle');
   });
 
@@ -82,7 +98,7 @@ describe('compose', () => {
       state: useNewToggle,
     });
     const wrapper = mount(<NewToggle id="foo" />);
-    expect(wrapper.html()).toMatch('<div id="foo" data-new-state="NewToggle"></div>');
+    expect(wrapper.html()).toMatch('<div id="foo" aria-label="toggle" data-new-state="NewToggle"></div>');
     expect(NewToggle.displayName).toEqual('NewToggle');
   });
 });

--- a/packages/fluentui/react-northstar/src/components/Attachment/Attachment.tsx
+++ b/packages/fluentui/react-northstar/src/components/Attachment/Attachment.tsx
@@ -198,6 +198,11 @@ export const Attachment = compose<'div', AttachmentProps, AttachmentStylesProps,
       header: AttachmentHeader,
       icon: AttachmentIcon,
     },
+
+    defaultProps: {
+      accessibility: attachmentBehavior,
+      body: {},
+    },
     handledProps: [
       'accessibility',
       'action',
@@ -239,10 +244,6 @@ Attachment.propTypes = {
   icon: customPropTypes.shorthandAllowingChildren,
   onClick: PropTypes.func,
   progress: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-};
-Attachment.defaultProps = {
-  accessibility: attachmentBehavior,
-  body: {},
 };
 
 Attachment.Action = AttachmentAction;

--- a/packages/fluentui/react-northstar/src/components/Attachment/AttachmentAction.tsx
+++ b/packages/fluentui/react-northstar/src/components/Attachment/AttachmentAction.tsx
@@ -40,15 +40,15 @@ export const AttachmentAction = compose<
   displayName: 'AttachmentAction',
   overrideStyles: true,
 
+  defaultProps: {
+    accessibility: buttonBehavior,
+    as: 'button',
+  },
   shorthandConfig: {
     mappedProp: 'content',
   },
 });
 
-AttachmentAction.defaultProps = {
-  accessibility: buttonBehavior,
-  as: 'button',
-};
 AttachmentAction.propTypes = {
   ...commonPropTypes.createCommon({
     content: 'shorthand',

--- a/packages/fluentui/react-northstar/src/components/Attachment/AttachmentDescription.tsx
+++ b/packages/fluentui/react-northstar/src/components/Attachment/AttachmentDescription.tsx
@@ -21,13 +21,14 @@ export const AttachmentDescription = compose<
   className: attachmentDescriptionClassName,
   displayName: 'AttachmentDescription',
 
+  defaultProps: {
+    as: 'span',
+  },
+
   overrideStyles: true,
   shorthandConfig: {
     mappedProp: 'content',
   },
 });
 
-AttachmentDescription.defaultProps = {
-  as: 'span',
-};
 AttachmentDescription.propTypes = commonPropTypes.createCommon();

--- a/packages/fluentui/react-northstar/src/components/Attachment/AttachmentHeader.tsx
+++ b/packages/fluentui/react-northstar/src/components/Attachment/AttachmentHeader.tsx
@@ -21,13 +21,14 @@ export const AttachmentHeader = compose<
   className: attachmentHeaderClassName,
   displayName: 'AttachmentHeader',
 
+  defaultProps: {
+    as: 'span',
+  },
+
   overrideStyles: true,
   shorthandConfig: {
     mappedProp: 'content',
   },
 });
 
-AttachmentHeader.defaultProps = {
-  as: 'span',
-};
 AttachmentHeader.propTypes = commonPropTypes.createCommon();

--- a/packages/fluentui/react-northstar/src/components/Attachment/AttachmentIcon.tsx
+++ b/packages/fluentui/react-northstar/src/components/Attachment/AttachmentIcon.tsx
@@ -21,13 +21,14 @@ export const AttachmentIcon = compose<
   className: attachmentIconClassName,
   displayName: 'AttachmentIcon',
 
+  defaultProps: {
+    as: 'span',
+  },
+
   overrideStyles: true,
   shorthandConfig: {
     mappedProp: 'content',
   },
 });
 
-AttachmentIcon.defaultProps = {
-  as: 'span',
-};
 AttachmentIcon.propTypes = commonPropTypes.createCommon();

--- a/packages/fluentui/react-northstar/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/packages/fluentui/react-northstar/src/components/Breadcrumb/Breadcrumb.tsx
@@ -106,6 +106,11 @@ export const Breadcrumb = compose<'nav', BreadcrumbProps, BreadcrumbStylesProps,
     className: breadcrumbClassName,
     displayName: 'Breadcrumb',
     handledProps: ['accessibility', 'as', 'children', 'className', 'content', 'design', 'styles', 'variables', 'size'],
+    defaultProps: {
+      as: 'nav',
+      size: 'medium',
+      accessibility: breadcrumbBehavior,
+    },
     mapPropsToStylesProps: ({ size }) => ({
       size,
     }),
@@ -117,12 +122,6 @@ export const Breadcrumb = compose<'nav', BreadcrumbProps, BreadcrumbStylesProps,
   Item: typeof BreadcrumbItem;
   Divider: typeof BreadcrumbDivider;
   Link: typeof BreadcrumbLink;
-};
-
-Breadcrumb.defaultProps = {
-  as: 'nav',
-  size: 'medium',
-  accessibility: breadcrumbBehavior,
 };
 
 Breadcrumb.propTypes = {

--- a/packages/fluentui/react-northstar/src/components/Breadcrumb/BreadcrumbDivider.tsx
+++ b/packages/fluentui/react-northstar/src/components/Breadcrumb/BreadcrumbDivider.tsx
@@ -70,14 +70,13 @@ export const BreadcrumbDivider = compose<'span', BreadcrumbDividerProps, Breadcr
   {
     className: breadcrumbDividerClassName,
     displayName: 'BreadcrumbDivider',
+    defaultProps: {
+      as: 'span',
+      children: '/',
+      accessibility: breadcrumbDividerBehavior,
+    },
     handledProps: ['accessibility', 'as', 'children', 'className', 'content', 'design', 'styles', 'variables'],
   },
 );
-
-BreadcrumbDivider.defaultProps = {
-  as: 'span',
-  children: '/',
-  accessibility: breadcrumbDividerBehavior,
-};
 
 BreadcrumbDivider.propTypes = commonPropTypes.createCommon();

--- a/packages/fluentui/react-northstar/src/components/Breadcrumb/BreadcrumbItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Breadcrumb/BreadcrumbItem.tsx
@@ -85,6 +85,9 @@ export const BreadcrumbItem = compose<'div', BreadcrumbItemProps, BreadcrumbItem
   {
     className: breadcrumbItemClassName,
     displayName: 'BreadcrumbItem',
+    defaultProps: {
+      accessibility: breadcrumbItemBehavior,
+    },
     handledProps: [
       'accessibility',
       'as',
@@ -98,9 +101,5 @@ export const BreadcrumbItem = compose<'div', BreadcrumbItemProps, BreadcrumbItem
     ],
   },
 );
-
-BreadcrumbItem.defaultProps = {
-  accessibility: breadcrumbItemBehavior,
-};
 
 BreadcrumbItem.propTypes = commonPropTypes.createCommon();

--- a/packages/fluentui/react-northstar/src/components/Breadcrumb/BreadcrumbLink.tsx
+++ b/packages/fluentui/react-northstar/src/components/Breadcrumb/BreadcrumbLink.tsx
@@ -76,12 +76,11 @@ export const BreadcrumbLink = compose<'a', BreadcrumbLinkProps, BreadcrumbLinkSt
   {
     className: breadcrumbLinkClassName,
     displayName: 'BreadcrumbLink',
+    defaultProps: {
+      as: 'a',
+    },
     handledProps: ['accessibility', 'as', 'children', 'className', 'content', 'design', 'styles', 'variables'],
   },
 );
-
-BreadcrumbLink.defaultProps = {
-  as: 'a',
-};
 
 BreadcrumbLink.propTypes = commonPropTypes.createCommon();

--- a/packages/fluentui/react-northstar/src/components/Button/Button.tsx
+++ b/packages/fluentui/react-northstar/src/components/Button/Button.tsx
@@ -298,6 +298,11 @@ export const Button = compose<'button', ButtonProps, ButtonStylesProps, {}, {}>(
     shorthandConfig: {
       mappedProp: 'content',
     },
+    defaultProps: {
+      as: 'button',
+      accessibility: buttonBehavior,
+      size: 'medium',
+    },
     handledProps: [
       'accessibility',
       'as',
@@ -332,12 +337,6 @@ export const Button = compose<'button', ButtonProps, ButtonStylesProps, {}, {}>(
   shorthandConfig: ShorthandConfig<ButtonProps>;
   Content: typeof ButtonContent;
   Group: typeof ButtonGroup;
-};
-
-Button.defaultProps = {
-  as: 'button',
-  accessibility: buttonBehavior,
-  size: 'medium',
 };
 
 Button.propTypes = {

--- a/packages/fluentui/react-northstar/src/components/Button/ButtonContent.tsx
+++ b/packages/fluentui/react-northstar/src/components/Button/ButtonContent.tsx
@@ -22,14 +22,14 @@ export const ButtonContent = compose<'span', ButtonContentProps, ButtonContentSt
   handledProps: ['size'],
 
   overrideStyles: true,
+  defaultProps: {
+    as: 'span',
+  },
   shorthandConfig: {
     mappedProp: 'content',
   },
 });
 
-ButtonContent.defaultProps = {
-  as: 'span',
-};
 ButtonContent.propTypes = {
   ...commonPropTypes.createCommon(),
   size: customPropTypes.size,

--- a/packages/fluentui/react-northstar/src/components/Carousel/Carousel.tsx
+++ b/packages/fluentui/react-northstar/src/components/Carousel/Carousel.tsx
@@ -179,12 +179,12 @@ export const Carousel = React.forwardRef<HTMLDivElement, CarouselProps>((props, 
   const context = useFluentContext();
 
   const {
-    accessibility,
+    accessibility = carouselBehavior,
     items,
     circular,
     getItemPositionText,
-    paddlePrevious,
-    paddleNext,
+    paddlePrevious = {},
+    paddleNext = {},
     navigation,
     thumbnails,
     children,
@@ -195,10 +195,10 @@ export const Carousel = React.forwardRef<HTMLDivElement, CarouselProps>((props, 
     styles,
     variables,
     disableClickableNav,
-    animationEnterFromPrev,
-    animationEnterFromNext,
-    animationExitToPrev,
-    animationExitToNext,
+    animationEnterFromPrev = 'carousel-slide-to-previous-enter',
+    animationEnterFromNext = 'carousel-slide-to-next-enter',
+    animationExitToPrev = '',
+    animationExitToNext = '',
   } = props;
 
   const ElementType = getElementType(props);
@@ -554,16 +554,6 @@ Carousel.propTypes = {
   animationEnterFromNext: PropTypes.string,
   animationExitToPrev: PropTypes.string,
   animationExitToNext: PropTypes.string,
-};
-
-Carousel.defaultProps = {
-  accessibility: carouselBehavior,
-  paddlePrevious: {},
-  paddleNext: {},
-  animationEnterFromPrev: 'carousel-slide-to-previous-enter',
-  animationEnterFromNext: 'carousel-slide-to-next-enter',
-  animationExitToPrev: '',
-  animationExitToNext: '',
 };
 
 Carousel.Item = CarouselItem;

--- a/packages/fluentui/react-northstar/src/components/Carousel/CarouselItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Carousel/CarouselItem.tsx
@@ -63,7 +63,7 @@ export const CarouselItem = React.forwardRef<HTMLDivElement, CarouselItemProps>(
 
   const unhandledProps = useUnhandledProps(CarouselItem.handledProps, props);
   const {
-    accessibility,
+    accessibility = carouselItemBehavior,
     navigation,
     active,
     children,
@@ -128,10 +128,6 @@ CarouselItem.propTypes = {
   active: PropTypes.bool,
   navigation: PropTypes.bool,
   itemPositionText: PropTypes.string,
-};
-
-CarouselItem.defaultProps = {
-  accessibility: carouselItemBehavior,
 };
 
 CarouselItem.handledProps = Object.keys(CarouselItem.propTypes) as any;

--- a/packages/fluentui/react-northstar/src/components/Carousel/CarouselPaddle.tsx
+++ b/packages/fluentui/react-northstar/src/components/Carousel/CarouselPaddle.tsx
@@ -79,11 +79,11 @@ export const CarouselPaddle = React.forwardRef<HTMLButtonElement, CarouselPaddle
     const context = useFluentContext();
 
     const {
-      accessibility,
+      accessibility = buttonBehavior,
       as,
       children,
       className,
-      content,
+      content = {},
       disabled,
       design,
       hidden,
@@ -129,7 +129,7 @@ export const CarouselPaddle = React.forwardRef<HTMLButtonElement, CarouselPaddle
     });
 
     const unhandledProps = useUnhandledProps(CarouselPaddle.handledProps, props);
-    const ElementType = getElementType(props);
+    const ElementType = getElementType(props, 'button');
 
     const handleClick = (e: React.SyntheticEvent) => {
       if (disabled) {
@@ -168,12 +168,6 @@ export const CarouselPaddle = React.forwardRef<HTMLButtonElement, CarouselPaddle
   },
 ) as unknown as ForwardRefWithAs<'button', HTMLButtonElement, CarouselPaddleProps> &
   FluentComponentStaticProps<CarouselPaddleProps>;
-
-CarouselPaddle.defaultProps = {
-  as: 'button',
-  accessibility: buttonBehavior,
-  content: {},
-};
 
 CarouselPaddle.displayName = 'CarouselPaddle';
 

--- a/packages/fluentui/react-northstar/src/components/Chat/Chat.tsx
+++ b/packages/fluentui/react-northstar/src/components/Chat/Chat.tsx
@@ -55,7 +55,16 @@ export const chatSlotClassNames: ChatSlotClassNames = {
 export const Chat = React.forwardRef<HTMLUListElement, ChatProps>((props, ref) => {
   const context = useFluentContext();
 
-  const { accessibility, children, className, density, design, items, styles, variables } = props;
+  const {
+    accessibility = chatBehavior,
+    children,
+    className,
+    density = defaultChatDensity,
+    design,
+    items,
+    styles,
+    variables,
+  } = props;
 
   const getA11Props = useAccessibility(accessibility, {
     debugName: Chat.displayName,
@@ -73,7 +82,7 @@ export const Chat = React.forwardRef<HTMLUListElement, ChatProps>((props, ref) =
     rtl: context.rtl,
   });
 
-  const ElementType = getElementType(props);
+  const ElementType = getElementType(props, 'ul');
   const unhandledProps = useUnhandledProps(Chat.handledProps, props);
 
   const element = getA11Props.unstable_wrapWithFocusZone(
@@ -109,11 +118,6 @@ export const Chat = React.forwardRef<HTMLUListElement, ChatProps>((props, ref) =
 
 Chat.displayName = 'Chat';
 
-Chat.defaultProps = {
-  accessibility: chatBehavior,
-  as: 'ul',
-  density: defaultChatDensity,
-};
 Chat.propTypes = {
   ...commonPropTypes.createCommon({
     content: false,

--- a/packages/fluentui/react-northstar/src/components/Chat/ChatItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Chat/ChatItem.tsx
@@ -72,10 +72,10 @@ export const ChatItem = React.forwardRef<HTMLLIElement, ChatItemProps>((props, r
   const chatDensity = useChatDensityContext();
   const {
     accessibility,
-    attached,
+    attached = false,
     children,
     className,
-    contentPosition,
+    contentPosition = 'start',
     density = chatDensity,
     design,
     gutter,
@@ -131,7 +131,7 @@ export const ChatItem = React.forwardRef<HTMLLIElement, ChatItemProps>((props, r
     );
   };
 
-  const ElementType = getElementType(props);
+  const ElementType = getElementType(props, 'li');
   const unhandledProps = useUnhandledProps(ChatItem.handledProps, props);
 
   const element = (
@@ -152,11 +152,6 @@ export const ChatItem = React.forwardRef<HTMLLIElement, ChatItemProps>((props, r
 
 ChatItem.displayName = 'ChatItem';
 
-ChatItem.defaultProps = {
-  as: 'li',
-  contentPosition: 'start',
-  attached: false,
-};
 ChatItem.propTypes = {
   ...commonPropTypes.createCommon({ content: false }),
   attached: PropTypes.oneOfType([PropTypes.bool, PropTypes.oneOf<'top' | 'bottom'>(['top', 'bottom'])]),

--- a/packages/fluentui/react-northstar/src/components/Checkbox/Checkbox.tsx
+++ b/packages/fluentui/react-northstar/src/components/Checkbox/Checkbox.tsx
@@ -80,8 +80,18 @@ export const checkboxSlotClassNames: CheckboxSlotClassNames = {
 export const Checkbox = React.forwardRef<HTMLDivElement, CheckboxProps>((props, ref) => {
   const context = useFluentContext();
 
-  const { accessibility, className, design, disabled, label, labelPosition, indicator, styles, toggle, variables } =
-    props;
+  const {
+    accessibility = checkboxBehavior,
+    className,
+    design,
+    disabled,
+    label,
+    labelPosition = 'end',
+    indicator = {},
+    styles,
+    toggle,
+    variables,
+  } = props;
 
   const [checked, setChecked] = useControllableState({
     defaultState: props.defaultChecked,
@@ -180,11 +190,6 @@ export const Checkbox = React.forwardRef<HTMLDivElement, CheckboxProps>((props, 
 
 Checkbox.displayName = 'Checkbox';
 
-Checkbox.defaultProps = {
-  accessibility: checkboxBehavior,
-  indicator: {},
-  labelPosition: 'end',
-};
 Checkbox.propTypes = {
   ...commonPropTypes.createCommon({
     content: false,

--- a/packages/fluentui/react-northstar/src/components/Datepicker/Datepicker.tsx
+++ b/packages/fluentui/react-northstar/src/components/Datepicker/Datepicker.tsx
@@ -149,13 +149,34 @@ const formatRestrictedInput = (restrictedOptions: IRestrictedDatesOptions, local
   return formattedString;
 };
 
+const DEFAULT_PROPS: Partial<DatepickerProps> = {
+  accessibility: datepickerBehavior,
+
+  inputOnly: false,
+  buttonOnly: false,
+  calendar: {},
+  popup: {},
+  input: {},
+
+  firstDayOfWeek: DayOfWeek.Monday,
+  firstWeekOfYear: FirstWeekOfYear.FirstDay,
+  dateRangeType: DateRangeType.Day,
+
+  fallbackToLastCorrectDateOnBlur: true,
+  allowManualInput: true,
+  required: false,
+
+  ...DEFAULT_CALENDAR_STRINGS,
+};
+
 /**
  * A Datepicker is a control which is used to display dates grid and allow user to select them.
  *
  * @accessibilityIssues
  * [NVDA - Aria-selected is not narrated for the gridcell](https://github.com/nvaccess/nvda/issues/11986)
  */
-export const Datepicker = React.forwardRef<HTMLDivElement, DatepickerProps>((props, ref) => {
+export const Datepicker = React.forwardRef<HTMLDivElement, DatepickerProps>((_props, ref) => {
+  const props = _.defaults({}, _props, DEFAULT_PROPS);
   const context = useFluentContext();
 
   const inputRef = React.useRef<HTMLElement>();
@@ -197,6 +218,7 @@ export const Datepicker = React.forwardRef<HTMLDivElement, DatepickerProps>((pro
   };
 
   const {
+    accessibility,
     calendar,
     popup,
     input,
@@ -290,7 +312,7 @@ export const Datepicker = React.forwardRef<HTMLDivElement, DatepickerProps>((pro
   const ElementType = getElementType(props);
   const unhandledProps = useUnhandledProps(Datepicker.handledProps, props);
 
-  const getA11yProps = useAccessibility(props.accessibility, {
+  const getA11yProps = useAccessibility(accessibility, {
     debugName: Datepicker.displayName,
     actionHandlers: {
       open: e => {
@@ -532,26 +554,6 @@ Datepicker.propTypes = {
 
   'aria-labelledby': PropTypes.string,
   'aria-invalid': PropTypes.bool,
-};
-
-Datepicker.defaultProps = {
-  accessibility: datepickerBehavior,
-
-  inputOnly: false,
-  buttonOnly: false,
-  calendar: {},
-  popup: {},
-  input: {},
-
-  firstDayOfWeek: DayOfWeek.Monday,
-  firstWeekOfYear: FirstWeekOfYear.FirstDay,
-  dateRangeType: DateRangeType.Day,
-
-  fallbackToLastCorrectDateOnBlur: true,
-  allowManualInput: true,
-  required: false,
-
-  ...DEFAULT_CALENDAR_STRINGS,
 };
 
 Datepicker.handledProps = Object.keys(Datepicker.propTypes) as any;

--- a/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendar.tsx
+++ b/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendar.tsx
@@ -95,13 +95,29 @@ const normalizeDateInGrid = (date: Date): Date => {
   return result;
 };
 
+const DEFAULT_PROPS: Partial<DatepickerCalendarProps> = {
+  accessibility: datepickerCalendarBehavior,
+  firstDayOfWeek: DayOfWeek.Monday,
+  firstWeekOfYear: FirstWeekOfYear.FirstDay,
+  dateRangeType: DateRangeType.Day,
+  header: {},
+  calendarCell: {},
+  calendarCellButton: {},
+  calendarHeaderCell: {},
+  calendarGrid: {},
+  calendarGridRow: {},
+  ...DEFAULT_CALENDAR_STRINGS,
+};
+
 /**
  * A DatepickerCalendar is used to display dates in sematically grouped way.
  */
-export const DatepickerCalendar = React.forwardRef<HTMLDivElement, DatepickerCalendarProps>((props, ref) => {
+export const DatepickerCalendar = React.forwardRef<HTMLDivElement, DatepickerCalendarProps>((_props, ref) => {
+  const props = _.defaults({}, _props, DEFAULT_PROPS);
   const context = useFluentContext();
 
   const {
+    accessibility,
     className,
     design,
     styles,
@@ -142,7 +158,7 @@ export const DatepickerCalendar = React.forwardRef<HTMLDivElement, DatepickerCal
       setGridNavigatedDate(date);
     }
   };
-  const getA11yProps = useAccessibility(props.accessibility, {
+  const getA11yProps = useAccessibility(accessibility, {
     debugName: DatepickerCalendar.displayName,
     actionHandlers: {
       addWeek: e => {
@@ -492,20 +508,6 @@ DatepickerCalendar.propTypes = {
   inputBoundedFormatString: PropTypes.string,
   inputMinBoundedFormatString: PropTypes.string,
   inputMaxBoundedFormatString: PropTypes.string,
-};
-
-DatepickerCalendar.defaultProps = {
-  accessibility: datepickerCalendarBehavior,
-  firstDayOfWeek: DayOfWeek.Monday,
-  firstWeekOfYear: FirstWeekOfYear.FirstDay,
-  dateRangeType: DateRangeType.Day,
-  header: {},
-  calendarCell: {},
-  calendarCellButton: {},
-  calendarHeaderCell: {},
-  calendarGrid: {},
-  calendarGridRow: {},
-  ...DEFAULT_CALENDAR_STRINGS,
 };
 
 DatepickerCalendar.handledProps = Object.keys(DatepickerCalendar.propTypes) as any;

--- a/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarCell.tsx
+++ b/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarCell.tsx
@@ -53,10 +53,10 @@ export const DatepickerCalendarCell = compose<
   (props, ref, composeOptions) => {
     const context = useFluentContext();
 
-    const { className, design, styles, variables, disabled, selected, quiet, today, content } = props;
+    const { accessibility, className, design, styles, variables, disabled, selected, quiet, today, content } = props;
     const unhandledProps = useUnhandledProps(composeOptions.handledProps, props);
     const ElementType = getElementType(props);
-    const getA11yProps = useAccessibility(props.accessibility, {
+    const getA11yProps = useAccessibility(accessibility, {
       debugName: composeOptions.displayName,
       actionHandlers: {},
       mapPropsToBehavior: () => ({
@@ -104,7 +104,10 @@ export const DatepickerCalendarCell = compose<
   {
     className: datepickerCalendarCellClassName,
     displayName: 'DatepickerCalendarCell',
-
+    defaultProps: {
+      accessibility: datepickerCalendarCellBehavior,
+      as: 'td',
+    },
     handledProps: [
       'accessibility',
       'as',
@@ -127,9 +130,4 @@ DatepickerCalendarCell.propTypes = {
   selected: PropTypes.bool,
   quiet: PropTypes.bool,
   today: PropTypes.bool,
-};
-
-DatepickerCalendarCell.defaultProps = {
-  accessibility: datepickerCalendarCellBehavior,
-  as: 'td',
 };

--- a/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarCellButton.tsx
+++ b/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarCellButton.tsx
@@ -79,10 +79,10 @@ export const DatepickerCalendarCellButton = compose<
   (props, ref, composeOptions) => {
     const context = useFluentContext();
 
-    const { className, design, styles, variables, disabled, selected, quiet, today, content } = props;
+    const { accessibility, className, design, styles, variables, disabled, selected, quiet, today, content } = props;
     const unhandledProps = useUnhandledProps(composeOptions.handledProps, props);
     const ElementType = getElementType(props);
-    const getA11yProps = useAccessibility(props.accessibility, {
+    const getA11yProps = useAccessibility(accessibility, {
       debugName: composeOptions.displayName,
       actionHandlers: {
         performClick: e => {
@@ -145,7 +145,10 @@ export const DatepickerCalendarCellButton = compose<
   {
     className: datepickerCalendarCellButtonClassName,
     displayName: 'DatepickerCalendarCellButton',
-
+    defaultProps: {
+      accessibility: datepickerCalendarCellButtonBehavior,
+      as: 'button',
+    },
     handledProps: [
       'accessibility',
       'as',
@@ -170,9 +173,4 @@ DatepickerCalendarCellButton.propTypes = {
   selected: PropTypes.bool,
   quiet: PropTypes.bool,
   today: PropTypes.bool,
-};
-
-DatepickerCalendarCellButton.defaultProps = {
-  accessibility: datepickerCalendarCellButtonBehavior,
-  as: 'button',
 };

--- a/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarGrid.tsx
+++ b/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarGrid.tsx
@@ -20,13 +20,12 @@ export const DatepickerCalendarGrid = compose<
   className: datepickerCalendarGridClassName,
   displayName: 'DatepickerCalendarGrid',
   overrideStyles: true,
+  defaultProps: {
+    as: 'table',
+  },
   shorthandConfig: {
     mappedProp: 'content',
   },
 });
-
-DatepickerCalendarGrid.defaultProps = {
-  as: 'table',
-};
 
 DatepickerCalendarGrid.propTypes = commonPropTypes.createCommon();

--- a/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarGridRow.tsx
+++ b/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarGridRow.tsx
@@ -25,6 +25,9 @@ export const DatepickerCalendarGridRow = compose<
   displayName: 'DatepickerCalendarGridRow',
   handledProps: ['isRowSelectionActive'],
   overrideStyles: true,
+  defaultProps: {
+    as: 'tr',
+  },
   mapPropsToStylesProps: ({ isRowSelectionActive }) => ({
     isRowSelectionActive,
   }),
@@ -32,9 +35,5 @@ export const DatepickerCalendarGridRow = compose<
     mappedProp: 'content',
   },
 });
-
-DatepickerCalendarGridRow.defaultProps = {
-  as: 'tr',
-};
 
 DatepickerCalendarGridRow.propTypes = commonPropTypes.createCommon();

--- a/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarHeader.tsx
+++ b/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarHeader.tsx
@@ -68,11 +68,25 @@ export const DatepickerCalendarHeader = React.forwardRef<HTMLDivElement, Datepic
   (props, ref) => {
     const context = useFluentContext();
 
-    const { className, design, styles, variables, label, nextButton, previousButton, onPreviousClick, onNextClick } =
-      props;
+    const {
+      accessibility = datepickerCalendarHeaderBehavior,
+      className,
+      design,
+      styles,
+      variables,
+      label = {},
+      nextButton = {},
+      previousButton = {},
+      onPreviousClick,
+      onNextClick,
+      disabledPreviousButton,
+      disabledNextButton,
+      prevMonthAriaLabel = DEFAULT_CALENDAR_STRINGS.prevMonthAriaLabel,
+      nextMonthAriaLabel = DEFAULT_CALENDAR_STRINGS.nextMonthAriaLabel,
+    } = props;
     const ElementType = getElementType(props);
     const unhandledProps = useUnhandledProps(DatepickerCalendarHeader.handledProps, props);
-    const getA11yProps = useAccessibility(props.accessibility, {
+    const getA11yProps = useAccessibility(accessibility, {
       debugName: DatepickerCalendarHeader.displayName,
       actionHandlers: {},
       rtl: context.rtl,
@@ -107,16 +121,16 @@ export const DatepickerCalendarHeader = React.forwardRef<HTMLDivElement, Datepic
         {createShorthand(DatepickerCalendarHeaderAction, previousButton, {
           defaultProps: () =>
             getA11yProps('previousButton', {
-              title: props.prevMonthAriaLabel,
+              title: prevMonthAriaLabel,
               direction: 'previous' as const,
-              'aria-disabled': props.disabledPreviousButton,
-              disabledNavigatableButton: props.disabledPreviousButton,
+              'aria-disabled': disabledPreviousButton,
+              disabledNavigatableButton: disabledPreviousButton,
             }),
           overrideProps: (
             predefinedProps: DatepickerCalendarHeaderActionProps,
           ): DatepickerCalendarHeaderActionProps => ({
             onClick: (e, data) => {
-              if (!props.disabledPreviousButton) {
+              if (!disabledPreviousButton) {
                 onPreviousClick(e, data);
                 _.invoke(predefinedProps, 'onClick', e, data);
               }
@@ -126,16 +140,16 @@ export const DatepickerCalendarHeader = React.forwardRef<HTMLDivElement, Datepic
         {createShorthand(DatepickerCalendarHeaderAction, nextButton, {
           defaultProps: () =>
             getA11yProps('nextButton', {
-              title: props.nextMonthAriaLabel,
+              title: nextMonthAriaLabel,
               direction: 'next' as const,
-              'aria-disabled': props.disabledNextButton,
-              disabledNavigatableButton: props.disabledNextButton,
+              'aria-disabled': disabledNextButton,
+              disabledNavigatableButton: disabledNextButton,
             }),
           overrideProps: (
             predefinedProps: DatepickerCalendarHeaderActionProps,
           ): DatepickerCalendarHeaderActionProps => ({
             onClick: (e, data) => {
-              if (!props.disabledNextButton) {
+              if (!disabledNextButton) {
                 onNextClick(e, data);
                 _.invoke(predefinedProps, 'onClick', e, data);
               }
@@ -164,16 +178,6 @@ DatepickerCalendarHeader.propTypes = {
 
   prevMonthAriaLabel: PropTypes.string,
   nextMonthAriaLabel: PropTypes.string,
-};
-
-DatepickerCalendarHeader.defaultProps = {
-  accessibility: datepickerCalendarHeaderBehavior,
-  nextButton: {},
-  previousButton: {},
-  label: {},
-
-  prevMonthAriaLabel: DEFAULT_CALENDAR_STRINGS.prevMonthAriaLabel,
-  nextMonthAriaLabel: DEFAULT_CALENDAR_STRINGS.nextMonthAriaLabel,
 };
 
 DatepickerCalendarHeader.handledProps = Object.keys(DatepickerCalendarHeader.propTypes) as any;

--- a/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarHeaderAction.tsx
+++ b/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarHeaderAction.tsx
@@ -35,16 +35,15 @@ export const DatepickerCalendarHeaderAction = compose<
     text: true,
     disabled: p.disabledNavigatableButton,
   }),
+  defaultProps: {
+    as: 'button',
+    accessibility: buttonBehavior,
+    size: 'medium',
+    icon: {},
+  },
   slotProps: props => ({
     icon: {
       content: props.direction === 'next' ? <ChevronEndIcon /> : <ChevronStartIcon />,
     },
   }),
 });
-
-DatepickerCalendarHeaderAction.defaultProps = {
-  as: 'button',
-  accessibility: buttonBehavior,
-  size: 'medium',
-  icon: {},
-};

--- a/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarHeaderCell.tsx
+++ b/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarHeaderCell.tsx
@@ -20,13 +20,12 @@ export const DatepickerCalendarHeaderCell = compose<
   className: datepickerCalendarHeaderCellClassName,
   displayName: 'DatepickerCalendarHeaderCell',
   overrideStyles: true,
+  defaultProps: {
+    as: 'th',
+  },
   shorthandConfig: {
     mappedProp: 'content',
   },
 });
-
-DatepickerCalendarHeaderCell.defaultProps = {
-  as: 'th',
-};
 
 DatepickerCalendarHeaderCell.propTypes = commonPropTypes.createCommon();

--- a/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
@@ -376,6 +376,26 @@ const isEmpty = prop => {
   return typeof prop === 'object' && !prop.props && !_.get(prop, 'children') && !_.get(prop, 'content');
 };
 
+const DEFAULT_CLOSE_INDICATOR = <CloseIcon outline />;
+const DEFAULT_TOGGLE_INDICATOR = <ChevronDownIcon outline />;
+
+const DEFAULT_ITEM_TO_STRING = item => {
+  if (!item || React.isValidElement(item)) {
+    return '';
+  }
+
+  // targets DropdownItem shorthand objects
+  return (item as any).header || String(item);
+};
+const DEFAULT_ITEM_TO_VALUE = item => {
+  if (!item || React.isValidElement(item)) {
+    return '';
+  }
+
+  // targets DropdownItem shorthand objects
+  return (item as any).header || String(item);
+};
+
 /**
  * A Dropdown allows user to select one or more values from a list of options.
  * Can be created with search and multi-selection capabilities.
@@ -395,7 +415,7 @@ export const Dropdown = React.forwardRef<HTMLDivElement, DropdownProps>((props, 
     'aria-invalid': ariaInvalid,
     allowFreeform,
     clearable,
-    clearIndicator,
+    clearIndicator = DEFAULT_CLOSE_INDICATOR,
     checkable,
     checkableIndicator,
     className,
@@ -408,8 +428,8 @@ export const Dropdown = React.forwardRef<HTMLDivElement, DropdownProps>((props, 
     getA11yStatusMessage,
     inline,
     inverted,
-    itemToString,
-    itemToValue,
+    itemToString = DEFAULT_ITEM_TO_STRING,
+    itemToValue = DEFAULT_ITEM_TO_VALUE,
     items,
     highlightFirstItemOnOpen,
     multiple,
@@ -424,23 +444,24 @@ export const Dropdown = React.forwardRef<HTMLDivElement, DropdownProps>((props, 
     search,
     searchInput,
     styles,
-    toggleIndicator,
-    triggerButton,
+    toggleIndicator = DEFAULT_TOGGLE_INDICATOR,
+    triggerButton = {},
     variables,
+    list: listFromProps = {},
   } = props;
 
   const {
-    align,
+    align = 'start',
     flipBoundary,
     overflowBoundary,
-    position,
+    position = 'below',
     positionFixed,
     offset,
     unstable_disableTether,
     unstable_pinned,
     autoSize,
   } = props; // PositioningProps passed directly to Dropdown
-  const [list, positioningProps] = partitionPopperPropsFromShorthand(props.list); // PositioningProps passed to Dropdown `list` prop's `popper` key
+  const [list, positioningProps] = partitionPopperPropsFromShorthand(listFromProps); // PositioningProps passed to Dropdown `list` prop's `popper` key
 
   const buttonRef = React.useRef<HTMLElement>();
   const inputRef = React.useRef<HTMLInputElement | undefined>() as React.MutableRefObject<HTMLInputElement | undefined>;
@@ -1893,31 +1914,6 @@ Dropdown.propTypes = {
   autoSize: PropTypes.oneOf<AutoSize>(AUTOSIZES),
 };
 Dropdown.handledProps = Object.keys(Dropdown.propTypes) as any;
-
-Dropdown.defaultProps = {
-  align: 'start',
-  clearIndicator: <CloseIcon outline />,
-  itemToString: item => {
-    if (!item || React.isValidElement(item)) {
-      return '';
-    }
-
-    // targets DropdownItem shorthand objects
-    return (item as any).header || String(item);
-  },
-  itemToValue: item => {
-    if (!item || React.isValidElement(item)) {
-      return '';
-    }
-
-    // targets DropdownItem shorthand objects
-    return (item as any).header || String(item);
-  },
-  list: {},
-  position: 'below',
-  toggleIndicator: <ChevronDownIcon outline />,
-  triggerButton: {},
-};
 
 Dropdown.Item = DropdownItem;
 Dropdown.SearchInput = DropdownSearchInput;

--- a/packages/fluentui/react-northstar/src/components/Form/FormLabel.tsx
+++ b/packages/fluentui/react-northstar/src/components/Form/FormLabel.tsx
@@ -19,15 +19,14 @@ export const FormLabel = compose<'label', FormLabelProps, FormLabelStylesProps, 
   className: formLabelClassName,
   displayName: 'FormLabel',
   overrideStyles: true,
+  defaultProps: {
+    as: 'label',
+  },
   mapPropsToStylesProps: ({ inline, required }) => ({
     inline,
     required,
   }),
   handledProps: ['required', 'inline'],
 });
-
-FormLabel.defaultProps = {
-  as: 'label',
-};
 
 FormLabel.propTypes = commonPropTypes.createCommon();

--- a/packages/fluentui/react-northstar/src/components/Form/FormMessage.tsx
+++ b/packages/fluentui/react-northstar/src/components/Form/FormMessage.tsx
@@ -20,6 +20,9 @@ export const FormMessage = compose<'span', FormMessageProps, FormMessageStylesPr
   displayName: 'FormMessage',
 
   mapPropsToStylesProps: ({ error }) => ({ error }),
+  defaultProps: {
+    as: 'span',
+  },
   handledProps: ['error'],
 
   overrideStyles: true,
@@ -28,7 +31,4 @@ export const FormMessage = compose<'span', FormMessageProps, FormMessageStylesPr
   },
 });
 
-FormMessage.defaultProps = {
-  as: 'span',
-};
 FormMessage.propTypes = commonPropTypes.createCommon();

--- a/packages/fluentui/react-northstar/src/components/Form/utils/formFieldBase.tsx
+++ b/packages/fluentui/react-northstar/src/components/Form/utils/formFieldBase.tsx
@@ -141,6 +141,9 @@ export const _FormFieldBase = compose<'div', FormFieldBaseProps, {}, {}, {}>(
       message: FormMessage,
       control: Box,
     },
+    defaultProps: {
+      accessibility: formFieldBehavior,
+    },
     handledProps: [
       'as',
       'accessibility',
@@ -163,8 +166,4 @@ _FormFieldBase.propTypes = {
   inline: PropTypes.bool,
   message: customPropTypes.itemShorthand,
   errorMessage: customPropTypes.itemShorthand,
-};
-
-_FormFieldBase.defaultProps = {
-  accessibility: formFieldBehavior,
 };

--- a/packages/fluentui/react-northstar/src/components/Input/Input.tsx
+++ b/packages/fluentui/react-northstar/src/components/Input/Input.tsx
@@ -180,7 +180,6 @@ export const Input = compose<'input', InputProps, InputStylesProps, {}, {}>(
       initialState: '',
     });
     const hasValue: boolean = !!value && (value as string)?.length !== 0;
-
     const isShowSuccessIndicatorUndefined = typeof showSuccessIndicator === 'undefined';
 
     const requiredAndSuccessful = isShowSuccessIndicatorUndefined
@@ -393,6 +392,15 @@ export const Input = compose<'input', InputProps, InputStylesProps, {}, {}>(
       icon: Box,
       label: InputLabel,
     },
+
+    defaultProps: {
+      accessibility: inputBehavior,
+      type: 'text',
+      wrapper: {},
+      iconPosition: 'end',
+      errorIndicator: <ExclamationCircleIcon />,
+      successIndicator: <CheckmarkCircleIcon outline />,
+    },
     handledProps: [
       'accessibility',
       'as',
@@ -454,15 +462,6 @@ Input.propTypes = {
   error: PropTypes.bool,
   errorIndicator: customPropTypes.shorthandAllowingChildren,
   showSuccessIndicator: PropTypes.bool,
-};
-
-Input.defaultProps = {
-  accessibility: inputBehavior,
-  type: 'text',
-  wrapper: {},
-  iconPosition: 'end',
-  errorIndicator: <ExclamationCircleIcon />,
-  successIndicator: <CheckmarkCircleIcon outline />,
 };
 
 Input.Label = InputLabel;

--- a/packages/fluentui/react-northstar/src/components/Input/InputLabel.tsx
+++ b/packages/fluentui/react-northstar/src/components/Input/InputLabel.tsx
@@ -28,15 +28,14 @@ export const InputLabel = compose<'label', InputLabelProps, InputLabelStylesProp
     required,
     hasValue,
   }),
+  defaultProps: {
+    as: 'label',
+  },
   handledProps: ['required', 'labelPosition', 'hasValue'],
   shorthandConfig: {
     mappedProp: 'content',
   },
 });
-
-InputLabel.defaultProps = {
-  as: 'label',
-};
 
 InputLabel.propTypes = {
   ...commonPropTypes.createCommon(),

--- a/packages/fluentui/react-northstar/src/components/ItemLayout/ItemLayout.tsx
+++ b/packages/fluentui/react-northstar/src/components/ItemLayout/ItemLayout.tsx
@@ -71,6 +71,75 @@ export const itemLayoutSlotClassNames: ItemLayoutSlotClassNames = {
 
 export type ItemLayoutStylesProps = never;
 
+const DEFAULT_RENDER_MAIN_AREA: NonNullable<ItemLayoutProps['renderMainArea']> = (props, classes) => {
+  const { renderHeaderArea = DEFAULT_RENDER_HEADER_AREA, renderContentArea = DEFAULT_RENDER_CONTENT_AREA } = props;
+
+  const headerArea = renderHeaderArea(props, classes);
+  const contentArea = renderContentArea(props, classes);
+
+  return (
+    <div
+      className={itemLayoutSlotClassNames.main}
+      style={{
+        gridTemplateRows: '1fr 1fr',
+      }}
+    >
+      {headerArea}
+      {contentArea}
+    </div>
+  );
+};
+
+const DEFAULT_RENDER_HEADER_AREA: NonNullable<ItemLayoutProps['renderHeaderArea']> = (props, classes) => {
+  const { debug, header, headerMedia, headerCSS, headerMediaCSS } = props;
+
+  const mergedClasses = cx(itemLayoutSlotClassNames.header, classes.header);
+  const mediaClasses = cx(itemLayoutSlotClassNames.headerMedia, classes.headerMedia);
+
+  return !header && !headerMedia ? null : (
+    <Layout
+      className={mergedClasses}
+      alignItems="end"
+      gap={pxToRem(8)}
+      debug={debug}
+      main={rtlTextContainer.createFor({ element: header })}
+      rootCSS={headerCSS}
+      end={
+        headerMedia && (
+          <span style={headerMediaCSS} className={mediaClasses}>
+            {rtlTextContainer.createFor({ element: headerMedia })}
+          </span>
+        )
+      }
+    />
+  );
+};
+
+const DEFAULT_RENDER_CONTENT_AREA: NonNullable<ItemLayoutProps['renderContentArea']> = (props, classes) => {
+  const { debug, content, contentMedia, contentCSS, contentMediaCSS } = props;
+
+  const mergedClasses = cx(itemLayoutSlotClassNames.content, classes.content);
+  const mediaClasses = cx(itemLayoutSlotClassNames.contentMedia, classes.contentMedia);
+
+  return !content && !contentMedia ? null : (
+    <Layout
+      className={mergedClasses}
+      alignItems="start"
+      gap={pxToRem(8)}
+      debug={debug}
+      rootCSS={contentCSS}
+      main={rtlTextContainer.createFor({ element: content })}
+      end={
+        contentMedia && (
+          <span style={contentMediaCSS} className={mediaClasses}>
+            {rtlTextContainer.createFor({ element: contentMedia })}
+          </span>
+        )
+      }
+    />
+  );
+};
+
 /**
  * (DEPRECATED) The Item Layout handles layout styles for menu items, list items and other similar item templates.
  */
@@ -83,7 +152,7 @@ export const ItemLayout: ComponentWithAs<'div', ItemLayoutProps> &
     debug,
     endMedia,
     media,
-    renderMainArea,
+    renderMainArea = DEFAULT_RENDER_MAIN_AREA,
     rootCSS,
     mediaCSS,
     endMediaCSS,
@@ -170,77 +239,6 @@ ItemLayout.propTypes = {
   contentCSS: PropTypes.object,
   contentMediaCSS: PropTypes.object,
   endMediaCSS: PropTypes.object,
-};
-
-ItemLayout.defaultProps = {
-  renderMainArea: (props, classes) => {
-    const { renderHeaderArea, renderContentArea } = props;
-
-    const headerArea = renderHeaderArea(props, classes);
-    const contentArea = renderContentArea(props, classes);
-
-    return (
-      <div
-        className={itemLayoutSlotClassNames.main}
-        style={{
-          gridTemplateRows: '1fr 1fr',
-        }}
-      >
-        {headerArea}
-        {contentArea}
-      </div>
-    );
-  },
-
-  renderHeaderArea: (props, classes) => {
-    const { debug, header, headerMedia, headerCSS, headerMediaCSS } = props;
-
-    const mergedClasses = cx(itemLayoutSlotClassNames.header, classes.header);
-    const mediaClasses = cx(itemLayoutSlotClassNames.headerMedia, classes.headerMedia);
-
-    return !header && !headerMedia ? null : (
-      <Layout
-        className={mergedClasses}
-        alignItems="end"
-        gap={pxToRem(8)}
-        debug={debug}
-        main={rtlTextContainer.createFor({ element: header })}
-        rootCSS={headerCSS}
-        end={
-          headerMedia && (
-            <span style={headerMediaCSS} className={mediaClasses}>
-              {rtlTextContainer.createFor({ element: headerMedia })}
-            </span>
-          )
-        }
-      />
-    );
-  },
-
-  renderContentArea: (props, classes) => {
-    const { debug, content, contentMedia, contentCSS, contentMediaCSS } = props;
-
-    const mergedClasses = cx(itemLayoutSlotClassNames.content, classes.content);
-    const mediaClasses = cx(itemLayoutSlotClassNames.contentMedia, classes.contentMedia);
-
-    return !content && !contentMedia ? null : (
-      <Layout
-        className={mergedClasses}
-        alignItems="start"
-        gap={pxToRem(8)}
-        debug={debug}
-        rootCSS={contentCSS}
-        main={rtlTextContainer.createFor({ element: content })}
-        end={
-          contentMedia && (
-            <span style={contentMediaCSS} className={mediaClasses}>
-              {rtlTextContainer.createFor({ element: contentMedia })}
-            </span>
-          )
-        }
-      />
-    );
-  },
 };
 
 ItemLayout.handledProps = Object.keys(ItemLayout.propTypes) as any;

--- a/packages/fluentui/react-northstar/src/components/Layout/Layout.tsx
+++ b/packages/fluentui/react-northstar/src/components/Layout/Layout.tsx
@@ -69,6 +69,53 @@ export type LayoutStylesProps = Required<
   Pick<LayoutProps, 'alignItems' | 'debug' | 'gap' | 'justifyItems' | 'mainSize' | 'endSize' | 'startSize' | 'vertical'>
 > & { hasStart: boolean; hasMain: boolean; hasEnd: boolean };
 
+// TODO: when an area is another Layout, do not wrap them in an extra div
+// TODO: option 1) higher value layouts could use start={Layout.create(start)} to ensure Areas are layout root
+const DEFAULT_RENDER_START_AREA: NonNullable<LayoutProps['renderStartArea']> = ({ start, classes }) => {
+  return (
+    start && (
+      <div
+        className={cx(layoutSlotClassNames.start, classes.start)}
+        {...rtlTextContainer.getAttributes({ forElements: [start] })}
+      >
+        {start}
+      </div>
+    )
+  );
+};
+
+const DEFAULT_RENDER_MAIN_AREA: NonNullable<LayoutProps['renderMainArea']> = ({ main, classes }) => {
+  return (
+    main && (
+      <div
+        className={cx(layoutSlotClassNames.main, classes.main)}
+        {...rtlTextContainer.getAttributes({ forElements: [main] })}
+      >
+        {main}
+      </div>
+    )
+  );
+};
+
+const DEFAULT_RENDER_END_AREA: NonNullable<LayoutProps['renderEndArea']> = ({ end, classes }) => {
+  return (
+    end && (
+      <div
+        className={cx(layoutSlotClassNames.end, classes.end)}
+        {...rtlTextContainer.getAttributes({ forElements: [end] })}
+      >
+        {end}
+      </div>
+    )
+  );
+};
+
+// Heads up!
+// IE11 Doesn't support grid-gap, insert virtual columns instead
+const DEFAULT_RENDER_GAP: NonNullable<LayoutProps['renderGap']> = ({ gap, classes }) => {
+  return gap && <span className={cx(layoutSlotClassNames.gap, classes.gap)} />;
+};
+
 /**
  * (DEPRECATED) A layout is a utility for arranging the content of a component.
  */
@@ -78,20 +125,20 @@ export const Layout: ComponentWithAs<'div', LayoutProps> & FluentComponentStatic
   const {
     reducing,
     disappearing,
-    renderStartArea,
-    renderMainArea,
-    renderEndArea,
-    renderGap,
+    renderStartArea = DEFAULT_RENDER_START_AREA,
+    renderMainArea = DEFAULT_RENDER_MAIN_AREA,
+    renderEndArea = DEFAULT_RENDER_END_AREA,
+    renderGap = DEFAULT_RENDER_GAP,
     alignItems,
     debug,
     gap,
     justifyItems,
     main,
-    mainSize,
+    mainSize = '1fr',
     end,
-    endSize,
+    endSize = 'auto',
     start,
-    startSize,
+    startSize = 'auto',
     vertical,
     className,
     design,
@@ -228,59 +275,6 @@ Layout.propTypes = {
   disappearing: PropTypes.bool,
 
   vertical: PropTypes.bool,
-};
-
-Layout.defaultProps = {
-  startSize: 'auto',
-  mainSize: '1fr',
-  endSize: 'auto',
-
-  // TODO: when an area is another Layout, do not wrap them in an extra div
-  // TODO: option 1) higher value layouts could use start={Layout.create(start)} to ensure Areas are layout root
-  renderStartArea({ start, classes }) {
-    return (
-      start && (
-        <div
-          className={cx(layoutSlotClassNames.start, classes.start)}
-          {...rtlTextContainer.getAttributes({ forElements: [start] })}
-        >
-          {start}
-        </div>
-      )
-    );
-  },
-
-  renderMainArea({ main, classes }) {
-    return (
-      main && (
-        <div
-          className={cx(layoutSlotClassNames.main, classes.main)}
-          {...rtlTextContainer.getAttributes({ forElements: [main] })}
-        >
-          {main}
-        </div>
-      )
-    );
-  },
-
-  renderEndArea({ end, classes }) {
-    return (
-      end && (
-        <div
-          className={cx(layoutSlotClassNames.end, classes.end)}
-          {...rtlTextContainer.getAttributes({ forElements: [end] })}
-        >
-          {end}
-        </div>
-      )
-    );
-  },
-
-  // Heads up!
-  // IE11 Doesn't support grid-gap, insert virtual columns instead
-  renderGap({ gap, classes }) {
-    return gap && <span className={cx(layoutSlotClassNames.gap, classes.gap)} />;
-  },
 };
 
 Layout.handledProps = Object.keys(Layout.propTypes) as any;

--- a/packages/fluentui/react-northstar/src/components/List/List.tsx
+++ b/packages/fluentui/react-northstar/src/components/List/List.tsx
@@ -95,7 +95,6 @@ export const List = React.forwardRef<HTMLUListElement, ListProps & { as: React.R
 
   const {
     accessibility = listBehavior,
-    as,
     children,
     className,
     debug,
@@ -125,9 +124,11 @@ export const List = React.forwardRef<HTMLUListElement, ListProps & { as: React.R
     }),
     rtl: context.rtl,
   });
+
+  const ElementType = getElementType(props, 'ul');
   const { classes } = useStyles<ListStylesProps>(List.displayName, {
     className: listClassName,
-    mapPropsToStyles: () => ({ isListTag: as === 'ol' || as === 'ul', debug, horizontal }),
+    mapPropsToStyles: () => ({ isListTag: ElementType === 'ol' || ElementType === 'ul', debug, horizontal }),
     mapPropsToInlineStyles: () => ({ className, design, styles, variables }),
     rtl: context.rtl,
   });
@@ -135,7 +136,6 @@ export const List = React.forwardRef<HTMLUListElement, ListProps & { as: React.R
   const latestProps = React.useRef<ListProps>(props);
   latestProps.current = props;
 
-  const ElementType = getElementType(props, 'ul');
   const unhandledProps = useUnhandledProps(List.handledProps, props);
 
   const hasContent = childrenExist(children) || (items && items.length > 0);

--- a/packages/fluentui/react-northstar/src/components/Skeleton/SkeletonAvatar.tsx
+++ b/packages/fluentui/react-northstar/src/components/Skeleton/SkeletonAvatar.tsx
@@ -26,6 +26,10 @@ export const SkeletonAvatar = compose<
   displayName: 'SkeletonAvatar',
   overrideStyles: true,
   shorthandConfig: {},
+  defaultProps: {
+    as: 'span',
+    size: 'medium',
+  },
   handledProps: ['size'],
   mapPropsToStylesProps: ({ size }) => ({
     size,
@@ -35,9 +39,4 @@ export const SkeletonAvatar = compose<
 SkeletonAvatar.propTypes = {
   ...commonPropTypes.createCommon(),
   size: customPropTypes.size,
-};
-
-SkeletonAvatar.defaultProps = {
-  as: 'span',
-  size: 'medium',
 };

--- a/packages/fluentui/react-northstar/src/components/Skeleton/SkeletonButton.tsx
+++ b/packages/fluentui/react-northstar/src/components/Skeleton/SkeletonButton.tsx
@@ -38,6 +38,10 @@ export const SkeletonButton = compose<
   displayName: 'SkeletonButton',
   overrideStyles: true,
   shorthandConfig: {},
+  defaultProps: {
+    as: 'span',
+    size: 'medium',
+  },
   handledProps: ['size', 'circular', 'iconOnly', 'fluid'],
   mapPropsToStylesProps: ({ size, fluid, iconOnly, circular }) => ({
     size,
@@ -53,9 +57,4 @@ SkeletonButton.propTypes = {
   circular: PropTypes.bool,
   iconOnly: PropTypes.bool,
   fluid: PropTypes.bool,
-};
-
-SkeletonButton.defaultProps = {
-  as: 'span',
-  size: 'medium',
 };

--- a/packages/fluentui/react-northstar/src/components/Skeleton/SkeletonInput.tsx
+++ b/packages/fluentui/react-northstar/src/components/Skeleton/SkeletonInput.tsx
@@ -26,6 +26,9 @@ export const SkeletonInput = compose<
   displayName: 'SkeletonInput',
   overrideStyles: true,
   shorthandConfig: {},
+  defaultProps: {
+    as: 'span',
+  },
   handledProps: ['fluid'],
   mapPropsToStylesProps: ({ fluid }) => ({
     fluid,
@@ -35,8 +38,4 @@ export const SkeletonInput = compose<
 SkeletonInput.propTypes = {
   ...commonPropTypes.createCommon(),
   fluid: PropTypes.bool,
-};
-
-SkeletonInput.defaultProps = {
-  as: 'span',
 };

--- a/packages/fluentui/react-northstar/src/components/Skeleton/SkeletonLine.tsx
+++ b/packages/fluentui/react-northstar/src/components/Skeleton/SkeletonLine.tsx
@@ -22,6 +22,11 @@ export const SkeletonLine = compose<'span', SkeletonLineOwnProps, SkeletonLineSt
     displayName: 'SkeletonLine',
     overrideStyles: true,
     shorthandConfig: {},
+    defaultProps: {
+      as: 'span',
+      width: '100%',
+      height: '1rem',
+    },
     handledProps: ['width', 'height'],
     mapPropsToStylesProps: ({ width, height }) => ({ width, height }),
   },
@@ -31,10 +36,4 @@ SkeletonLine.propTypes = {
   ...commonPropTypes.createCommon(),
   width: PropTypes.string,
   height: PropTypes.string,
-};
-
-SkeletonLine.defaultProps = {
-  as: 'span',
-  width: '100%',
-  height: '1rem',
 };

--- a/packages/fluentui/react-northstar/src/components/Skeleton/SkeletonShape.tsx
+++ b/packages/fluentui/react-northstar/src/components/Skeleton/SkeletonShape.tsx
@@ -23,6 +23,12 @@ export const SkeletonShape = compose<'span', SkeletonShapeOwnProps, SkeletonShap
     displayName: 'SkeletonShape',
     overrideStyles: true,
     shorthandConfig: {},
+    defaultProps: {
+      as: 'span',
+      width: '100px',
+      height: '100px',
+      round: false,
+    },
     handledProps: ['round', 'width', 'height'],
     mapPropsToStylesProps: ({ width, height, round }) => ({ width, height, round }),
   },
@@ -33,11 +39,4 @@ SkeletonShape.propTypes = {
   width: PropTypes.string,
   height: PropTypes.string,
   round: PropTypes.bool,
-};
-
-SkeletonShape.defaultProps = {
-  as: 'span',
-  width: '100px',
-  height: '100px',
-  round: false,
 };

--- a/packages/fluentui/react-northstar/src/components/Skeleton/SkeletonText.tsx
+++ b/packages/fluentui/react-northstar/src/components/Skeleton/SkeletonText.tsx
@@ -26,6 +26,10 @@ export const SkeletonText = compose<
   displayName: 'SkeletonText',
   overrideStyles: true,
   shorthandConfig: {},
+  defaultProps: {
+    as: 'span',
+    size: 'medium',
+  },
   handledProps: ['size'],
   mapPropsToStylesProps: ({ size }) => ({
     size,
@@ -35,9 +39,4 @@ export const SkeletonText = compose<
 SkeletonText.propTypes = {
   ...commonPropTypes.createCommon(),
   size: customPropTypes.size,
-};
-
-SkeletonText.defaultProps = {
-  as: 'span',
-  size: 'medium',
 };

--- a/packages/fluentui/react-northstar/src/components/Slider/Slider.tsx
+++ b/packages/fluentui/react-northstar/src/components/Slider/Slider.tsx
@@ -115,6 +115,8 @@ export const sliderSlotClassNames: SliderSlotClassNames = {
   track: `${sliderClassName}__track`,
 };
 
+const DEFAULT_GET_A11Y_VALUE_MESSAGE_ON_CHANGE = ({ value }: SliderProps) => String(value);
+
 /**
  * A Slider represents an input that allows user to choose a value from within a specific range.
  *
@@ -128,13 +130,13 @@ export const Slider = React.forwardRef<HTMLInputElement, SliderProps>((props, re
   const context = useFluentContext();
 
   const {
-    accessibility,
-    min,
-    max,
-    getA11yValueMessageOnChange,
+    accessibility = sliderBehavior,
+    min = 0,
+    max = 100,
+    getA11yValueMessageOnChange = DEFAULT_GET_A11Y_VALUE_MESSAGE_ON_CHANGE,
     input,
     inputRef: userInputRef,
-    step,
+    step = 1,
     className,
     styles,
     variables,
@@ -258,13 +260,6 @@ export const Slider = React.forwardRef<HTMLInputElement, SliderProps>((props, re
 
 Slider.displayName = 'Slider';
 
-Slider.defaultProps = {
-  accessibility: sliderBehavior,
-  getA11yValueMessageOnChange: ({ value }) => String(value),
-  max: 100,
-  min: 0,
-  step: 1,
-};
 Slider.propTypes = {
   ...commonPropTypes.createCommon({ content: false }),
   defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),

--- a/packages/fluentui/react-northstar/src/components/Toolbar/Toolbar.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/Toolbar.tsx
@@ -613,6 +613,12 @@ export const Toolbar = compose<'div', ToolbarProps, ToolbarStylesProps, {}, {}>(
     }),
 
     shorthandConfig: { mappedProp: 'content' },
+
+    defaultProps: {
+      accessibility: toolbarBehavior,
+      overflowItem: {},
+      overflowSentinel: {},
+    },
     handledProps: [
       'accessibility',
       'as',
@@ -659,11 +665,6 @@ Toolbar.propTypes = {
   onOverflow: PropTypes.func,
   onOverflowOpenChange: PropTypes.func,
   getOverflowItems: PropTypes.func,
-};
-Toolbar.defaultProps = {
-  accessibility: toolbarBehavior,
-  overflowItem: {},
-  overflowSentinel: {},
 };
 
 Toolbar.CustomItem = ToolbarCustomItem;

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarItem.tsx
@@ -369,6 +369,12 @@ export const ToolbarItem = compose<'button', ToolbarItemProps, ToolbarItemStyles
     }),
 
     shorthandConfig: { mappedProp: 'content' },
+
+    defaultProps: {
+      as: 'button',
+      accessibility: toolbarItemBehavior,
+      wrapper: {},
+    },
     handledProps: [
       'accessibility',
       'as',
@@ -418,9 +424,4 @@ ToolbarItem.propTypes = {
     PropTypes.string,
   ]),
   wrapper: customPropTypes.shorthandAllowingChildren,
-};
-ToolbarItem.defaultProps = {
-  as: 'button',
-  accessibility: toolbarItemBehavior,
-  wrapper: {},
 };

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenu.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenu.tsx
@@ -194,6 +194,11 @@ export const ToolbarMenu = compose<'ul', ToolbarMenuProps, ToolbarMenuStylesProp
     shorthandConfig: {
       mappedArrayProp: 'items',
     },
+
+    defaultProps: {
+      accessibility: toolbarMenuBehavior,
+      as: 'ul',
+    },
     handledProps: [
       'accessibility',
       'as',
@@ -217,8 +222,4 @@ ToolbarMenu.propTypes = {
   onItemClick: PropTypes.func,
   submenu: PropTypes.bool,
   submenuIndicator: customPropTypes.shorthandAllowingChildren,
-};
-ToolbarMenu.defaultProps = {
-  accessibility: toolbarMenuBehavior,
-  as: 'ul',
 };

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuDivider.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuDivider.tsx
@@ -63,12 +63,13 @@ export const ToolbarMenuDivider = compose<'li', ToolbarMenuDividerProps, Toolbar
     displayName: 'ToolbarMenuDivider',
 
     shorthandConfig: { mappedProp: 'content' },
+
+    defaultProps: {
+      as: 'li',
+      accessibility: toolbarMenuDividerBehavior,
+    },
     handledProps: ['accessibility', 'as', 'children', 'className', 'content', 'design', 'styles', 'variables'],
   },
 ) as ComponentWithAs<'li', ToolbarMenuDividerProps>;
 
 ToolbarMenuDivider.propTypes = commonPropTypes.createCommon();
-ToolbarMenuDivider.defaultProps = {
-  as: 'li',
-  accessibility: toolbarMenuDividerBehavior,
-};

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuItem.tsx
@@ -143,6 +143,7 @@ export const ToolbarMenuItem = compose<'button', ToolbarMenuItemProps, ToolbarMe
     const {
       active,
       activeIndicator,
+      accessibility,
       children,
       content,
       disabled,
@@ -183,7 +184,7 @@ export const ToolbarMenuItem = compose<'button', ToolbarMenuItemProps, ToolbarMe
     const slotProps = composeOptions.resolveSlotProps<ToolbarMenuItemProps>(props);
     const unhandledProps = useUnhandledProps(composeOptions.handledProps, props);
 
-    const getA11yProps = useAccessibility(props.accessibility, {
+    const getA11yProps = useAccessibility(accessibility, {
       debugName: composeOptions.displayName,
       mapPropsToBehavior: () => ({
         hasMenu: !!menu,
@@ -479,6 +480,14 @@ export const ToolbarMenuItem = compose<'button', ToolbarMenuItemProps, ToolbarMe
     shorthandConfig: {
       mappedProp: 'content',
     },
+
+    defaultProps: {
+      as: 'button',
+      accessibility: toolbarMenuItemBehavior,
+      activeIndicator: {},
+      submenuIndicator: <ChevronEndIcon outline />,
+      wrapper: { as: 'li' },
+    },
     handledProps: [
       'accessibility',
       'as',
@@ -531,11 +540,4 @@ ToolbarMenuItem.propTypes = {
     PropTypes.string,
   ]),
   wrapper: customPropTypes.itemShorthand,
-};
-ToolbarMenuItem.defaultProps = {
-  as: 'button',
-  accessibility: toolbarMenuItemBehavior,
-  activeIndicator: {},
-  submenuIndicator: <ChevronEndIcon outline />,
-  wrapper: { as: 'li' },
 };

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuItemActiveIndicator.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuItemActiveIndicator.tsx
@@ -25,10 +25,11 @@ export const ToolbarMenuItemActiveIndicator = compose<
   shorthandConfig: {
     mappedProp: 'content',
   },
+
+  defaultProps: {
+    as: 'span',
+  },
   overrideStyles: true,
 });
 
-ToolbarMenuItemActiveIndicator.defaultProps = {
-  as: 'span',
-};
 ToolbarMenuItemActiveIndicator.propTypes = commonPropTypes.createCommon();

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuItemContent.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuItemContent.tsx
@@ -25,10 +25,10 @@ export const ToolbarMenuItemContent = compose<
   shorthandConfig: {
     mappedProp: 'content',
   },
+  defaultProps: {
+    as: 'span',
+  },
   overrideStyles: true,
 });
 
-ToolbarMenuItemContent.defaultProps = {
-  as: 'span',
-};
 ToolbarMenuItemContent.propTypes = commonPropTypes.createCommon();

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuItemIcon.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuItemIcon.tsx
@@ -27,14 +27,17 @@ export const ToolbarMenuItemIcon = compose<
   mapPropsToStylesProps: props => ({
     hasContent: props.hasContent,
   }),
+
   shorthandConfig: {
     mappedProp: 'content',
   },
+
+  defaultProps: {
+    as: 'span',
+  },
   handledProps: ['hasContent'],
+
   overrideStyles: true,
 });
 
-ToolbarMenuItemIcon.defaultProps = {
-  as: 'span',
-};
 ToolbarMenuItemIcon.propTypes = commonPropTypes.createCommon();

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuItemSubmenuIndicator.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuItemSubmenuIndicator.tsx
@@ -30,10 +30,11 @@ export const ToolbarMenuItemSubmenuIndicator = compose<
   shorthandConfig: {
     mappedProp: 'content',
   },
+
+  defaultProps: {
+    as: 'span',
+  },
   overrideStyles: true,
 });
 
-ToolbarMenuItemSubmenuIndicator.defaultProps = {
-  as: 'span',
-};
 ToolbarMenuItemSubmenuIndicator.propTypes = commonPropTypes.createCommon();

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuRadioGroup.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuRadioGroup.tsx
@@ -139,6 +139,11 @@ export const ToolbarMenuRadioGroup = compose<
       wrapper: ToolbarMenuRadioGroupWrapper,
     },
 
+    defaultProps: {
+      as: 'ul',
+      accessibility: toolbarMenuRadioGroupBehavior,
+      wrapper: {},
+    },
     handledProps: [
       'accessibility',
       'as',
@@ -163,9 +168,4 @@ ToolbarMenuRadioGroup.propTypes = {
   items: customPropTypes.collectionShorthand,
   onItemClick: PropTypes.func,
   wrapper: customPropTypes.itemShorthand,
-};
-ToolbarMenuRadioGroup.defaultProps = {
-  as: 'ul',
-  accessibility: toolbarMenuRadioGroupBehavior,
-  wrapper: {},
 };

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuRadioGroupWrapper.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuRadioGroupWrapper.tsx
@@ -23,11 +23,12 @@ export const ToolbarMenuRadioGroupWrapper = compose<
   displayName: 'ToolbarMenuRadioGroupWrapper',
 
   overrideStyles: true,
+
   shorthandConfig: { mappedProp: 'content' },
+  defaultProps: {
+    as: 'li',
+    accessibility: toolbarMenuRadioGroupWrapperBehavior,
+  },
 });
 
-ToolbarMenuRadioGroupWrapper.defaultProps = {
-  as: 'li',
-  accessibility: toolbarMenuRadioGroupWrapperBehavior,
-};
 ToolbarMenuRadioGroupWrapper.propTypes = commonPropTypes.createCommon();

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarRadioGroup.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarRadioGroup.tsx
@@ -184,6 +184,10 @@ export const ToolbarRadioGroup = compose<'div', ToolbarRadioGroupProps, ToolbarR
     }),
 
     shorthandConfig: { mappedProp: 'content' },
+
+    defaultProps: {
+      accessibility: toolbarRadioGroupBehavior,
+    },
     handledProps: [
       'accessibility',
       'as',
@@ -204,7 +208,4 @@ ToolbarRadioGroup.propTypes = {
   ...commonPropTypes.createCommon(),
   activeIndex: PropTypes.number,
   items: customPropTypes.collectionShorthandWithKindProp(['divider', 'item']),
-};
-ToolbarRadioGroup.defaultProps = {
-  accessibility: toolbarRadioGroupBehavior,
 };

--- a/packages/fluentui/react-northstar/test/specs/commonTests/isConformant.tsx
+++ b/packages/fluentui/react-northstar/test/specs/commonTests/isConformant.tsx
@@ -247,6 +247,16 @@ export function isConformant(
   });
 
   // ---------------------------------------
+  // Default props
+  // ---------------------------------------
+
+  describe('defaultProps (common)', () => {
+    test('should not be defined on components', () => {
+      expect(Component.hasOwnProperty('defaultProps')).toBe(false);
+    });
+  });
+
+  // ---------------------------------------
   // Handled props
   // ---------------------------------------
   describe('handles props', () => {
@@ -263,17 +273,13 @@ export function isConformant(
       expect(handledProps).toContain('variables');
     });
 
-    test('handledProps includes props defined in autoControlledProps, defaultProps or propTypes', () => {
-      const computedProps = _.union(
-        Component.autoControlledProps,
-        _.keys(Component.defaultProps),
-        _.keys(Component.propTypes),
-      );
+    test('handledProps includes props defined in autoControlledProps or propTypes', () => {
+      const computedProps = _.union(Component.autoControlledProps, _.keys(Component.propTypes));
       const expectedProps = _.uniq(computedProps).sort();
 
       const message =
         'Not all handled props were defined correctly. All props defined in handled props, must be defined' +
-        'either in static autoControlledProps, static defaultProps or static propTypes.';
+        'either in static autoControlledProps or static propTypes.';
 
       expect({
         message,


### PR DESCRIPTION
## New Behavior

- Inlines `.defaultProps` on all remaining components to avoid errors in StrictMode.
- Modifies `compose()` to handle `defaultProps` via configs
- Adds a test to ensure `.defaultProps` don't exist