### PR TITLE
fix(v0): backport the second part of Portal fix

### DIFF
--- a/packages/fluentui/react-northstar/src/components/Portal/PortalInner.tsx
+++ b/packages/fluentui/react-northstar/src/components/Portal/PortalInner.tsx
@@ -56,7 +56,20 @@ export const PortalInner: React.FC<PortalInnerProps> = props => {
     return () => _.invoke(props, 'onUnmount', props);
   }, []);
 
-  return container && ReactDOM.createPortal(children, container);
+  return (
+    container &&
+    ReactDOM.createPortal(
+      <>
+        {children}
+        {/* Heads up!
+         *  This node exists only to ensure that the portal is not empty as we rely on that in `usePortalBox`
+         *  hook for React 18+.
+         */}
+        <span hidden />
+      </>,
+      container,
+    )
+  );
 };
 
 PortalInner.propTypes = {

--- a/packages/fluentui/react-northstar/test/specs/components/Portal/PortalInner-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Portal/PortalInner-test.tsx
@@ -17,10 +17,12 @@ const mountPortalInner = (props: PortalInnerProps) =>
 describe('PortalInner', () => {
   describe('render', () => {
     it('calls react createPortal', () => {
-      const mountNode = document.createElement('div');
-      const comp = mountPortalInner({ mountNode });
+      const mountNodeEl = document.createElement('div');
+      const componentElements = mountPortalInner({ mountNode: mountNodeEl })
+        // A fragment is being used in PortalInner, there are multiple elements returned
+        .getDOMNode() as unknown as HTMLElement[];
 
-      expect(mountNode.contains(comp.getDOMNode())).toBeTruthy();
+      expect(mountNodeEl.contains(componentElements.pop())).toBeTruthy();
     });
   });
 


### PR DESCRIPTION
## New Behavior

Follow up for #35272.

Ports the second part of changes in v9. A `Portal` should always have a child otherwise it might cause unexpected breaks with the new approach.
