### PR TITLE
test(v0): fix tests for publish utils

### DIFF
--- a/scripts/fluentui-publish/src/publish.spec.ts
+++ b/scripts/fluentui-publish/src/publish.spec.ts
@@ -21,8 +21,9 @@ jest.mock('./utils', () => {
     ...originalModule,
     gitPush: jest.fn(async () => {}),
     gitTag: jest.fn(async () => {}),
-    getLatestTag: jest.fn(async arg => {
-      return originalModule.getLatestTag(arg);
+    getLatestTag: jest.fn().mockReturnValue({
+      tag: '@fluentui/react-northstar_v0.68.0',
+      extractedVersion: '0.68.0',
     }),
   };
 });

--- a/scripts/fluentui-publish/src/version.spec.ts
+++ b/scripts/fluentui-publish/src/version.spec.ts
@@ -3,6 +3,14 @@ import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 
 import { changelog } from './version';
 
+jest.mock('./utils', () => ({
+  ...jest.requireActual('./utils'),
+  getLatestTag: jest.fn().mockReturnValue({
+    tag: '@fluentui/react-northstar_v0.68.0',
+    extractedVersion: '0.68.0',
+  }),
+}));
+
 describe(`version`, () => {
   it.todo('not sure if this is good idea to test on jest level');
 });


### PR DESCRIPTION
## Previous Behavior

Tests are fetching latest tag from Git and fail after every release.

## New Behavior

Tests are mocked and don't depend on the actual information from Git.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
