### PR TITLE
chore(v0): fix `variables` in Embed

### DIFF
--- a/packages/fluentui/react-northstar/src/components/Embed/Embed.tsx
+++ b/packages/fluentui/react-northstar/src/components/Embed/Embed.tsx
@@ -165,7 +165,7 @@ export const Embed = React.forwardRef<HTMLSpanElement, EmbedProps>((props, ref) 
     <Image
       src={placeholder}
       styles={resolvedStyles.image}
-      variables={{ width: variables.width, height: variables.height }}
+      variables={{ width: variables?.width, height: variables?.height }}
     />
   ) : null;
 
@@ -195,8 +195,8 @@ export const Embed = React.forwardRef<HTMLSpanElement, EmbedProps>((props, ref) 
                 poster: placeholder,
                 styles: resolvedStyles.video,
                 variables: {
-                  width: variables.width,
-                  height: variables.height,
+                  width: variables?.width,
+                  height: variables?.height,
                 },
               }),
           })}


### PR DESCRIPTION
## New Behavior

Follow up for `defaultProps` changes. `defaultProps.variables = {}` was removed, so `variables` could be `undefined`. PR updates `variables` access to be safe.
