### PR TITLE
fix(v0): useAccessibility v2

### DIFF
--- a/packages/fluentui/react-bindings/src/utils/mergeCallbacks.ts
+++ b/packages/fluentui/react-bindings/src/utils/mergeCallbacks.ts
@@ -1,0 +1,32 @@
+/**
+ * @internal
+ * Combine two event callbacks into a single callback function that calls each one in order.
+ *
+ * Usage example:
+ * ```ts
+ * state.slot.onChange = mergeCallbacks(state.slot.onChange, ev => {
+ *   // Handle onChange
+ * });
+ * ```
+ *
+ * The primary use is to avoid the need to capture an existing callback (`state.slot.onChange` in the example) to a
+ * local variable before replacing with a new listener that calls the existing one. This helps avoid bugs like:
+ * * Infinite recursion by calling the re-assigned state.slot.onChange if it's not captured to a local variable.
+ * * Missing a call to the original onChange due to an early return or other conditional.
+ *
+ * If you need a callback that is stable between renders, wrap the result in {@link useEventCallback}.
+ *
+ * @param callback1 - The first callback to be called, or undefined
+ * @param callback2 - The second callback to be called, or undefined
+ *
+ * @returns A function that that calls the provided functions in order
+ */
+export function mergeCallbacks<Args extends unknown[]>(
+  callback1: ((...args: Args) => void) | undefined,
+  callback2: ((...args: Args) => void) | undefined,
+) {
+  return (...args: Args) => {
+    callback1?.(...args);
+    callback2?.(...args);
+  };
+}


### PR DESCRIPTION
## New Behavior

PR updates `useAccessibility()` to be safe in Concurrent & Strict Modes. After multiple iterations I came to this one as the most simple and straightforward.

The most complexity was around keeping `onKeyDown` handler referentially stable. The previous approach won't work. As `getA11yProps` is a function, hooks can't called there. The current approach:
- If there is only behavior key handler, we use it directly (stable ✅ )
- If there is only user key handler, we use it directly  (stable if a passed handler is stable ✅ )
- If both are defined, we create a new function that calls them both ( ⚠️ unstable reference )

The approach is a compromise between complex refactors (get type safety & split to hooks & functions) & performance problems (if `getA11yProps` would be a hook, it will be simple, but hooks can't be called conditionally).

Tests were updated to use RTL.