### PR TITLE
fix(pr-docsite-url): fix broken staging docsite PR builds

### DIFF
--- a/apps/pr-deploy-site/pr-deploy-site.js
+++ b/apps/pr-deploy-site/pr-deploy-site.js
@@ -26,7 +26,7 @@ var siteInfo = [
   },
   {
     package: '@fluentui/public-docsite-v9',
-    link: './public-docsite-v9/storybook/index.html',
+    link: './public-docsite-v9/react/index.html',
     icon: 'Teamwork',
     title: 'Converged (@fluentui/public-docsite-v9)',
   },


### PR DESCRIPTION
This should fix broken staging PR builds for docsite, we forgot to update path to new `dist` path for `pr-deploy-site`  after removal of old one in #35352 
