### PR TITLE
fix(react-storybook-addon): fix arg type transformation for slot shorthand in FluentDocsPage

### DIFF
--- a/packages/react-components/react-storybook-addon/src/docs/FluentDocsPage.tsx
+++ b/packages/react-components/react-storybook-addon/src/docs/FluentDocsPage.tsx
@@ -180,17 +180,17 @@ function withSlotEnhancer(story: PreparedStory, options: { slotsApi?: boolean; n
 
   const transformArgTypeNameWithSlotShorthand = (typeName: string) => {
     const match = typeName.match(slotRegex);
-    
+
     if (match) {
       hasArgAsSlot = true;
       return `Slot<\"${match[1]}\">`;
     }
-    
+
     if (typeName.includes('WithSlotShorthandValue')) {
       hasArgAsSlot = true;
       return `Slot`;
     }
-    
+
     return typeName;
   };
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

After migrating to Storybook v8, the Slots type enhancement fix from #35375 broke again, but this time it only affects components, not subcomponents.

Steps to reproduce:
- Visit the SB website
- Open the `AvatarGroup` component docs, then check the `Avatar` subcomponent's slot props – these display correctly.
- Next, go to the `Avatar` component page and check its props – these are not displaying properly.

https://github.com/user-attachments/assets/3503570c-190a-4cf8-8841-ab848550eda3


## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

Update `story.argTypes` as well as `story.moduleExports` and `story.subcomponents` to make sure all places with `argTypes/__docgenInfo.props` are replaced

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
