### PR TITLE
fix(vr-tests-web-components): update test scripts and fix story errors

### DIFF
--- a/apps/vr-tests-web-components/package.json
+++ b/apps/vr-tests-web-components/package.json
@@ -10,7 +10,7 @@
     "lint": "ESLINT_USE_FLAT_CONFIG=false eslint src --ext .ts,.tsx",
     "start": "storybook dev",
     "type-check": "tsc -p . --baseUrl . --noEmit",
-    "test-vr": "storywright --browsers chromium --url dist/storybook --destpath dist/screenshots --waitTimeScreenshot 500 --concurrency 4 --headless true --stepsApi parameters"
+    "test-vr": "storywright --browsers chromium --url dist/storybook --destpath dist/screenshots --waitTimeScreenshot 500 --concurrency 4 --headless true --stepsApi parameters --bailOnStoriesError"
   },
   "dependencies": {
     "react": "19.2.0",

--- a/apps/vr-tests-web-components/src/stories/checkbox/checkbox-indeterminate.stories.tsx
+++ b/apps/vr-tests-web-components/src/stories/checkbox/checkbox-indeterminate.stories.tsx
@@ -22,7 +22,7 @@ export default {
       steps: new Steps()
         .snapshot('normal', { cropTo: '.testWrapper' })
         .executeScript(
-          'document.getElementsByTagName("fluent-checkbox").forEach(checkbox => checkbox.indeterminate = true)',
+          'Array.from(document.getElementsByTagName("fluent-checkbox")).forEach(checkbox => checkbox.indeterminate = true)',
         )
         .snapshot('indeterminate', { cropTo: '.testWrapper' })
         .end(),

--- a/apps/vr-tests-web-components/src/stories/link/link.stories.tsx
+++ b/apps/vr-tests-web-components/src/stories/link/link.stories.tsx
@@ -46,7 +46,7 @@ export const WithLongText = () =>
     </style>
     <p class="max-width">
     This paragraph contains a link which is very long.
-    <fluent-link href="#">Fluent links wrap correctly between lines when they are very long.</fluent-link> This is
+    <fluent-link id="${linkId}" href="#">Fluent links wrap correctly between lines when they are very long.</fluent-link> This is
     because they are inline elements.
     </p>
 `);

--- a/apps/vr-tests-web-components/src/stories/menu-list/menu-list.stories.tsx
+++ b/apps/vr-tests-web-components/src/stories/menu-list/menu-list.stories.tsx
@@ -175,14 +175,14 @@ export const RadioWithIconsRTL = getStoryVariant(RadioWithIcons, RTL);
 export const WithSubmenu = () =>
   parse(`
     <fluent-menu-list>
-      <fluent-menu-item>
+      <fluent-menu-item aria-haspopup="menu">
         Item 1
         <fluent-menu-list slot="submenu">
           <fluent-menu-item> Subitem 1.1 </fluent-menu-item>
           <fluent-menu-item> Subitem 1.2 </fluent-menu-item>
         </fluent-menu-list>
       </fluent-menu-item>
-      <fluent-menu-item>
+      <fluent-menu-item aria-haspopup="menu">
         Item 2
         <fluent-menu-list slot="submenu">
           <fluent-menu-item> Subitem 2.1 </fluent-menu-item>

--- a/apps/vr-tests-web-components/src/stories/radio-group/radio-group.stories.tsx
+++ b/apps/vr-tests-web-components/src/stories/radio-group/radio-group.stories.tsx
@@ -22,9 +22,9 @@ export default {
     storyWright: {
       steps: new Steps()
         .snapshot('normal', { cropTo: '.testWrapper' })
-        .click('[role="radio"]:first-child')
+        .click('fluent-radio:first-child')
         .snapshot('1st selected', { cropTo: '.testWrapper' })
-        .click('[role="radio"]:nth-child(2)')
+        .click('fluent-radio:nth-child(2)')
         .snapshot('2nd selected', { cropTo: '.testWrapper' })
         .end(),
     },

--- a/apps/vr-tests-web-components/src/stories/slider/slider.stories.tsx
+++ b/apps/vr-tests-web-components/src/stories/slider/slider.stories.tsx
@@ -19,8 +19,8 @@ export default {
     storyWright: {
       steps: new Steps()
         .snapshot('normal', { cropTo: '.testWrapper' })
-        .focus('[role="slider"]')
-        .keys('[role="slider"]', Keys.rightArrow)
+        .focus('fluent-slider')
+        .keys('fluent-slider', Keys.rightArrow)
         .snapshot('rightArrow', { cropTo: '.testWrapper' })
         .end(),
     },


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

We found in https://github.com/microsoft/fluentui/pull/35346#discussion_r2477740780 that some WebComponents VR tests were logging errors quietly without causing the pipeline to fail.

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

- Added `--bailOnStoriesError` flag to the `test-vr` script in package.json for improved error handling.
- Updated checkbox story to use `Array.from` as `HTMLCollection` doesn't have `forEach` method
- Added missing `id` attribute to the long text link story for proper element targeting.
- Fixed submenu items targeting in the menu list story by adding `aria-haspopup` attributes.
- Updated radio group story to use `fluent-radio` selectors for as there are no elements with the `[role=radio]` attribute
- Changed slider story to focus on `fluent-slider` instead of `[role="slider"]` as there are no elements such elements 

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Partially implements #35430
