### PR TITLE
Adding alias to support oneCDN URL updates (for when icons update)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -180,7 +180,7 @@ packages/react-components/react-theme/library @microsoft/teams-prg
 packages/react-components/react-theme/stories @microsoft/teams-prg
 packages/react-components/react-utilities @microsoft/teams-prg @microsoft/cxe-prg
 packages/storybook @microsoft/cxe-prg @microsoft/teams-prg
-packages/style-utilities @dzearing @bigbadcapers @microsoft/cxe-red
+packages/style-utilities @bigbadcapers @microsoft/cxe-red
 packages/style-utilities/src/interfaces @phkuo @dzearing @microsoft/cxe-red
 packages/style-utilities/src/styles @phkuo @dzearing @microsoft/cxe-red
 packages/theme @dzearing @microsoft/cxe-red


### PR DESCRIPTION
Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally (looks like it's not required for edits under .github based on previous PRs, but lmk if i got that wrong)

The OneCDN that hosts app and filetype icons used throughout FluentUI elements is versioned and the style-utilities package should get updated when we improve our filetype icon coverage or fix app icons. ( Example PR: #33966 ) 

These updates used to only require changes in the react-file-type-icons package but with that security change, the PRs require one more step after review/approval that I'm hoping to spare annoyance on other folks every time they're done and tested in branch and just need merge.