### PR TITLE
chore(workspace-plugin): update generators to generate eslint flat co…

### DIFF
--- a/tools/workspace-plugin/src/generators/react-library/files/.eslintrc.json__tmpl__
+++ b/tools/workspace-plugin/src/generators/react-library/files/.eslintrc.json__tmpl__
@@ -1,4 +1,0 @@
-{
-  "extends": ["plugin:@fluentui/eslint-plugin/react"],
-  "root": true
-}

--- a/tools/workspace-plugin/src/generators/react-library/files/eslint.config.js__tmpl__
+++ b/tools/workspace-plugin/src/generators/react-library/files/eslint.config.js__tmpl__
@@ -1,0 +1,5 @@
+// @ts-check
+
+const fluentPlugin = require('@fluentui/eslint-plugin');
+
+module.exports = [...fluentPlugin.configs['flat/react']];

--- a/tools/workspace-plugin/src/generators/react-library/index.spec.ts
+++ b/tools/workspace-plugin/src/generators/react-library/index.spec.ts
@@ -54,12 +54,12 @@ describe('react-library generator', () => {
       Array [
         "project.json",
         ".babelrc.json",
-        ".eslintrc.json",
         ".swcrc",
         "LICENSE",
         "README.md",
         "config",
         "docs",
+        "eslint.config.js",
         "etc",
         "jest.config.js",
         "package.json",
@@ -172,7 +172,7 @@ describe('react-library generator', () => {
         "src",
         ".storybook",
         "README.md",
-        ".eslintrc.json",
+        "eslint.config.js",
         "tsconfig.json",
         "tsconfig.lib.json",
         "package.json",
@@ -213,24 +213,24 @@ describe('react-library generator', () => {
       "
     `);
 
-    expect(readJson(tree, `${stories.root}/.eslintrc.json`)).toMatchInlineSnapshot(`
-      Object {
-        "extends": Array [
-          "plugin:@fluentui/eslint-plugin/react",
-        ],
-        "root": true,
-        "rules": Object {
-          "import/no-extraneous-dependencies": Array [
-            "error",
-            Object {
-              "packageDir": Array [
-                ".",
-                "../../../../",
-              ],
-            },
-          ],
+    const eslintConfig = tree.read(`${stories.root}/eslint.config.js`, 'utf-8');
+    expect(eslintConfig).toMatchInlineSnapshot(`
+      "// @ts-check
+
+      const fluentPlugin = require('@fluentui/eslint-plugin');
+
+      module.exports = [
+        ...fluentPlugin.configs['flat/react'],
+        {
+          rules: {
+            'import/no-extraneous-dependencies': [
+              'error',
+              { packageDir: ['.', '../../../../'] },
+            ],
+          },
         },
-      }
+      ];
+      "
     `);
 
     // global updates
@@ -264,12 +264,12 @@ describe('react-library generator', () => {
       Array [
         "project.json",
         ".babelrc.json",
-        ".eslintrc.json",
         ".swcrc",
         "LICENSE",
         "README.md",
         "config",
         "docs",
+        "eslint.config.js",
         "etc",
         "jest.config.js",
         "package.json",
@@ -294,7 +294,7 @@ describe('react-library generator', () => {
         "src",
         ".storybook",
         "README.md",
-        ".eslintrc.json",
+        "eslint.config.js",
         "tsconfig.json",
         "tsconfig.lib.json",
         "package.json",

--- a/tools/workspace-plugin/src/generators/split-library-in-two/generator.spec.ts
+++ b/tools/workspace-plugin/src/generators/split-library-in-two/generator.spec.ts
@@ -233,25 +233,25 @@ describe('split-library-in-two generator', () => {
         ],
       }
     `);
-    expect(readJson(tree, `${storiesConfig.root}/.eslintrc.json`)).toMatchInlineSnapshot(`
-      Object {
-        "extends": Array [
-          "plugin:@fluentui/eslint-plugin/react",
-        ],
-        "root": true,
-        "rules": Object {
-          "import/no-extraneous-dependencies": Array [
-            "error",
-            Object {
-              "packageDir": Array [
-                ".",
-                "../../../../",
-              ],
-            },
-          ],
+    expect(tree.read(`${storiesConfig.root}/eslint.config.js`, 'utf-8')).toMatchInlineSnapshot(`
+      "// @ts-check
+
+      const fluentPlugin = require('@fluentui/eslint-plugin');
+
+      module.exports = [
+        ...fluentPlugin.configs['flat/react'],
+        {
+          rules: {
+            'import/no-extraneous-dependencies': [
+              'error',
+              { packageDir: ['.', '../../../../'] },
+            ],
+          },
         },
-      }
+      ];
+      "
     `);
+
     expect(tree.read(`${storiesConfig.root}/README.md`, 'utf-8')).toMatchInlineSnapshot(`
       "# @proj/react-hello-stories
 

--- a/tools/workspace-plugin/src/generators/split-library-in-two/generator.ts
+++ b/tools/workspace-plugin/src/generators/split-library-in-two/generator.ts
@@ -324,13 +324,22 @@ function makeStoriesLibrary(tree: Tree, options: Options, logger: CLIOutput) {
       },
     },
     publicApi: stripIndents`export {}`,
-    eslintrc: {
-      extends: ['plugin:@fluentui/eslint-plugin/react'],
-      root: true,
-      rules: {
-        'import/no-extraneous-dependencies': ['error', { packageDir: ['.', options.projectOffsetFromRoot.updated] }],
-      },
+    eslintConfig: `// @ts-check
+
+const fluentPlugin = require('@fluentui/eslint-plugin');
+
+module.exports = [
+  ...fluentPlugin.configs['flat/react'],
+  {
+    rules: {
+      'import/no-extraneous-dependencies': [
+        'error',
+        { packageDir: ['.', '${options.projectOffsetFromRoot.updated}'] },
+      ],
     },
+  },
+];
+`,
     tsconfig: {
       root: {
         ...options.oldContent.tsConfig,
@@ -361,7 +370,7 @@ function makeStoriesLibrary(tree: Tree, options: Options, logger: CLIOutput) {
 
   tree.write(joinPathFragments(newProjectRoot, 'README.md'), templates.readme);
   tree.write(joinPathFragments(newProjectSourceRoot, 'index.ts'), templates.publicApi);
-  writeJson(tree, joinPathFragments(newProjectRoot, '.eslintrc.json'), templates.eslintrc);
+  tree.write(joinPathFragments(newProjectRoot, 'eslint.config.js'), templates.eslintConfig);
   writeJson(tree, joinPathFragments(newProjectRoot, 'tsconfig.json'), templates.tsconfig.root);
   writeJson(tree, joinPathFragments(newProjectRoot, 'tsconfig.lib.json'), templates.tsconfig.lib);
   writeJson(tree, joinPathFragments(newProjectRoot, 'package.json'), templates.packageJson);


### PR DESCRIPTION
This pull request updates the ESLint configuration for generated React libraries to use the new flat config format with `eslint.config.js` instead of the old `.eslintrc.json` format. It also updates the generator logic and associated tests to reflect this change.
