### PR TITLE
fix(react-storybook-addon): change FluentStory iframe URL to work with subpaths

### DIFF
--- a/packages/react-components/react-storybook-addon/src/docs/FluentStory.tsx
+++ b/packages/react-components/react-storybook-addon/src/docs/FluentStory.tsx
@@ -20,7 +20,7 @@ type FluentStoryProps = {
 export const FluentStory = ({ id, height }: FluentStoryProps): JSXElement => {
   return (
     <div className="sb-story sb-unstyled">
-      <iframe title={id} src={`/iframe.html?id=${id}&mode=story`} style={iframeStyle} height={height} />
+      <iframe title={id} src={`iframe.html?id=${id}&mode=story`} style={iframeStyle} height={height} />
     </div>
   );
 };


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

The storybook's stories iframe embededings were displayed as 404. For example

<img width="2484" height="784" alt="image" src="https://github.com/user-attachments/assets/55c64af4-da51-49f2-9c91-c7efeb4ed7c5" />

https://storybooks.fluentui.dev/react/?path=/docs/concepts-developer-accessibility-focus-indicator--docs

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

Change `/iframe.html` (absolute path) to `iframe.html` (relative path) to work with `/react/` subpaths.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #35493
