### PR TITLE
test(react-portal-compat): fix race build and type-check issue

### DIFF
--- a/packages/react-components/react-portal-compat/src/PortalCompat.cy.tsx
+++ b/packages/react-components/react-portal-compat/src/PortalCompat.cy.tsx
@@ -3,7 +3,7 @@ import { mount as mountBase } from '@fluentui/scripts-cypress';
 import { FluentProvider } from '@fluentui/react-provider';
 import { teamsLightTheme } from '@fluentui/react-theme';
 import type { JSXElement } from '@fluentui/react-utilities/';
-import { PortalCompatProvider } from '@fluentui/react-portal-compat';
+import { PortalCompatProvider } from './PortalCompatProvider';
 import { usePortalCompat } from '@fluentui/react-portal-compat-context';
 
 const mount = (element: JSXElement) => {


### PR DESCRIPTION
This change fixes a CI [race condition](https://github.com/microsoft/fluentui/actions/runs/19676236495/job/56370309621) where type-checking on self-referenced import can run before the build step for this package. The issue is probably caused by the package's legacy structure, other compat packages (react-timepicker-compat) do not have this problem

<img width="839" height="446" alt="Screenshot 2025-11-25 at 19 52 43" src="https://github.com/user-attachments/assets/b2de86e8-501f-4b8c-933a-6b5391efc4ba" />

<img width="820" height="854" alt="Screenshot 2025-11-25 at 19 54 29" src="https://github.com/user-attachments/assets/195f07aa-bf1e-4f4c-9b44-53bc89feb092" />

