### PR TITLE
Fix: Proper property name in MenuGridGroup context

### DIFF
--- a/change/@fluentui-react-menu-grid-preview-2806b09d-2d36-4e04-ab2e-194f397949bd.json
+++ b/change/@fluentui-react-menu-grid-preview-2806b09d-2d36-4e04-ab2e-194f397949bd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Use proper property name for MenuGridGroup context",
+  "packageName": "@fluentui/react-menu-grid-preview",
+  "email": "adam.samec@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-menu-grid-preview/library/etc/react-menu-grid-preview.api.md
+++ b/packages/react-components/react-menu-grid-preview/library/etc/react-menu-grid-preview.api.md
@@ -67,7 +67,7 @@ export type MenuGridGroupContextValue = {
 
 // @public (undocumented)
 export type MenuGridGroupContextValues = {
-    MenuGridGroup: MenuGridGroupContextValue;
+    menuGridGroup: MenuGridGroupContextValue;
 };
 
 // @public

--- a/packages/react-components/react-menu-grid-preview/library/src/components/MenuGridGroup/MenuGridGroup.types.ts
+++ b/packages/react-components/react-menu-grid-preview/library/src/components/MenuGridGroup/MenuGridGroup.types.ts
@@ -15,5 +15,5 @@ export type MenuGridGroupState = ComponentState<MenuGridGroupSlots> & {
 };
 
 export type MenuGridGroupContextValues = {
-  MenuGridGroup: MenuGridGroupContextValue;
+  menuGridGroup: MenuGridGroupContextValue;
 };

--- a/packages/react-components/react-menu-grid-preview/library/src/components/MenuGridGroup/renderMenuGridGroup.tsx
+++ b/packages/react-components/react-menu-grid-preview/library/src/components/MenuGridGroup/renderMenuGridGroup.tsx
@@ -15,7 +15,7 @@ export const renderMenuGridGroup_unstable = (
   assertSlots<MenuGridGroupSlots>(state);
 
   return (
-    <MenuGridGroupContextProvider value={contextValues.MenuGridGroup}>
+    <MenuGridGroupContextProvider value={contextValues.menuGridGroup}>
       <state.root />
     </MenuGridGroupContextProvider>
   );

--- a/packages/react-components/react-menu-grid-preview/library/src/components/MenuGridGroup/useMenuGridGroupContextValues.ts
+++ b/packages/react-components/react-menu-grid-preview/library/src/components/MenuGridGroup/useMenuGridGroupContextValues.ts
@@ -5,7 +5,7 @@ import type { MenuGridGroupContextValues, MenuGridGroupState } from './MenuGridG
 
 export function useMenuGridGroupContextValues_unstable(state: MenuGridGroupState): MenuGridGroupContextValues {
   const { headerId } = state;
-  const MenuGridGroup = React.useMemo(() => ({ headerId }), [headerId]);
+  const menuGridGroup = React.useMemo(() => ({ headerId }), [headerId]);
 
-  return { MenuGridGroup };
+  return { menuGridGroup };
 }


### PR DESCRIPTION
### Description of changes

This PR fixes the letter case for the `menuGridGroup` property name in the MenuGridGroup context values
