### PR TITLE
Fix: Use proper slots for MenuGridItem in MenuGrid stories

### DIFF
--- a/packages/react-components/react-menu-grid-preview/stories/src/MenuGrid/MenuGridDefault.stories.tsx
+++ b/packages/react-components/react-menu-grid-preview/stories/src/MenuGrid/MenuGridDefault.stories.tsx
@@ -26,7 +26,7 @@ export const Default = (): JSXElement => {
                   aria-label={`Profile card for ${name}`}
                 />
               }
-              secondSubAction={
+              firstSubAction={
                 <Button size="small" appearance="transparent" icon={<DeleteRegular />} aria-label={`Remove ${name}`} />
               }
             >

--- a/packages/react-components/react-menu-grid-preview/stories/src/MenuGrid/MenuGridWithSubmenu.stories.tsx
+++ b/packages/react-components/react-menu-grid-preview/stories/src/MenuGrid/MenuGridWithSubmenu.stories.tsx
@@ -44,7 +44,7 @@ export const WithSubmenu = (): JSXElement => {
       <MenuPopover>
         <MenuGrid>
           {items.map(name => (
-            <MenuGridItem key={name} secondSubAction={<Submenu />} aria-label={name}>
+            <MenuGridItem key={name} firstSubAction={<Submenu />} aria-label={name}>
               {name}
             </MenuGridItem>
           ))}


### PR DESCRIPTION
### Description of changes

This PR provides a fix to use the secondSubAction slot instead of the firstSubAction slot for the MenuGridItem component within the stories of the MenuGrid component.