### PR TITLE
fix(react-charts): Fixing annotations opacity issue

### DIFF
--- a/change/@fluentui-react-charts-99f19c12-517b-470e-be58-f781f19efbed.json
+++ b/change/@fluentui-react-charts-99f19c12-517b-470e-be58-f781f19efbed.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(react-charts):Fixing annotations opacity issue",
+  "packageName": "@fluentui/react-charts",
+  "email": "120183316+srmukher@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charts/react-charts/library/src/components/CommonComponents/Annotations/ChartAnnotationLayer.tsx
+++ b/packages/charts/react-charts/library/src/components/CommonComponents/Annotations/ChartAnnotationLayer.tsx
@@ -441,7 +441,9 @@ export const ChartAnnotationLayer: React.FC<ChartAnnotationLayerProps> = React.m
       maxWidth: layout?.maxWidth,
       ...(hasCustomBackground
         ? {
-            backgroundColor: applyOpacityToColor(baseBackgroundColor, backgroundOpacity),
+            backgroundColor: applyOpacityToColor(baseBackgroundColor, backgroundOpacity, {
+              preserveOriginalOpacity: annotation.style?.opacity === undefined,
+            }),
           }
         : {
             backgroundColor: applyOpacityToColor(tokens.colorNeutralBackground1, DEFAULT_ANNOTATION_BACKGROUND_OPACITY),

--- a/packages/charts/react-charts/library/src/components/CommonComponents/Annotations/useChartAnnotationLayer.styles.ts
+++ b/packages/charts/react-charts/library/src/components/CommonComponents/Annotations/useChartAnnotationLayer.styles.ts
@@ -30,7 +30,13 @@ export const DEFAULT_CONNECTOR_END_PADDING = 0;
 export const DEFAULT_CONNECTOR_STROKE_WIDTH = 2;
 export const DEFAULT_CONNECTOR_ARROW: ChartAnnotationArrowHead = 'end';
 
-export const applyOpacityToColor = (color: string | undefined, opacity: number): string | undefined => {
+export const applyOpacityToColor = (
+  color: string | undefined,
+  opacity: number,
+  options?: {
+    preserveOriginalOpacity?: boolean;
+  },
+): string | undefined => {
   if (!color) {
     return undefined;
   }
@@ -38,6 +44,13 @@ export const applyOpacityToColor = (color: string | undefined, opacity: number):
   const parsed = d3Color(color);
   if (!parsed) {
     return color;
+  }
+
+  const originalOpacity = typeof parsed.opacity === 'number' ? parsed.opacity : 1;
+  const preserveOriginalOpacity = options?.preserveOriginalOpacity ?? true;
+
+  if (preserveOriginalOpacity && originalOpacity < 1) {
+    return parsed.toString();
   }
 
   parsed.opacity = Math.max(0, Math.min(1, opacity));


### PR DESCRIPTION
Before:

<img width="1180" height="845" alt="image" src="https://github.com/user-attachments/assets/0ce8dd62-908b-417a-9a33-8517189fffc1" />

After:

<img width="1244" height="470" alt="image" src="https://github.com/user-attachments/assets/b595f1d2-26b0-48b4-a883-51a7b46b0f16" />
