### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/azure-static-web-apps-deploy.yml
+++ b/.github/workflows/azure-static-web-apps-deploy.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Build and Deploy Job
         id: builddeploy

--- a/.github/workflows/bundle-size-base.yml
+++ b/.github/workflows/bundle-size-base.yml
@@ -24,9 +24,9 @@ jobs:
       id-token: 'write'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           cache: 'yarn'
           node-version: '22'

--- a/.github/workflows/bundle-size-comment.yml
+++ b/.github/workflows/bundle-size-comment.yml
@@ -13,7 +13,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: monosize-report
           path: ./results

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -23,7 +23,7 @@ jobs:
       actions: 'read'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -32,7 +32,7 @@ jobs:
         with:
           main-branch-name: 'master'
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           cache: 'yarn'
           node-version: '22'
@@ -50,7 +50,7 @@ jobs:
       - name: Save PR number
         run: echo ${{ github.event.number }} > pr.txt
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: monosize-report
           retention-days: 1

--- a/.github/workflows/check-packages.yml
+++ b/.github/workflows/check-packages.yml
@@ -7,11 +7,11 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'microsoft' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'yarn'
@@ -40,15 +40,15 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'microsoft' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22.x
 
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v8
         with:
           script: |
             const syncpackVersion = require('./package.json').devDependencies.syncpack;
@@ -67,15 +67,15 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'microsoft' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22.x
 
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v8
         with:
           script: |
             const beachballVersion = require('./package.json').devDependencies.beachball;

--- a/.github/workflows/check-tooling.yml
+++ b/.github/workflows/check-tooling.yml
@@ -20,11 +20,11 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -19,12 +19,12 @@ jobs:
     # If you do not check out your code, Copilot will do this for you.
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           cache: 'yarn'
           node-version: '22'

--- a/.github/workflows/docsite-publish-ghpages.yml
+++ b/.github/workflows/docsite-publish-ghpages.yml
@@ -14,7 +14,7 @@ jobs:
       artifact_id: ${{ steps.artifact_upload.outputs.artifact_id }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -23,7 +23,7 @@ jobs:
         with:
           main-branch-name: 'master'
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'yarn'

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -12,8 +12,8 @@ jobs:
       issues: write
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/github-script@v7
+      - uses: actions/checkout@v6
+      - uses: actions/github-script@v8
         with:
           script: |
             const config = require('./.github/triage-bot.config.json');

--- a/.github/workflows/pr-housekeeping.yml
+++ b/.github/workflows/pr-housekeeping.yml
@@ -12,7 +12,7 @@ jobs:
     if: ${{ github.repository_owner == 'microsoft' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@v6
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
           sync-labels: true

--- a/.github/workflows/pr-vrt-comment.yml
+++ b/.github/workflows/pr-vrt-comment.yml
@@ -21,7 +21,7 @@ jobs:
       contents: read
       actions: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           sparse-checkout: |
             .github
@@ -30,7 +30,7 @@ jobs:
       # - see @{link file://./../scripts/prepare-vr-screenshots-for-upload.js#45}
       # - see @{link file://./pr-vrt.yml#56}
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: vrscreenshot
           path: ./screenshots
@@ -38,7 +38,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check if visual regression should be run (affected projects)
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         id: should_run_vrt
         with:
           script: |
@@ -56,7 +56,7 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         if: ${{ steps.should_run_vrt.outputs.result == 'true' }}
         with:
           name: pr-number
@@ -66,7 +66,7 @@ jobs:
 
       - name: Run VR Approval CLI
         if: ${{ steps.should_run_vrt.outputs.result == 'true' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           # this is explicity needed as github token is not available in CLI context
           GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-vrt-poc-comment.yml
+++ b/.github/workflows/pr-vrt-poc-comment.yml
@@ -27,7 +27,7 @@ jobs:
         env:
           W_RUN: ${{ toJSON(github.event.workflow_run) }}
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: pr-number
           path: ./results

--- a/.github/workflows/pr-vrt-poc.yml
+++ b/.github/workflows/pr-vrt-poc.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: Get Pull Request Details
         id: pr_details
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const response = await github.rest.pulls.get({
@@ -49,7 +49,7 @@ jobs:
           PR_DETAILS: ${{steps.pr_details.outputs.result}}
 
       - name: Checkout Forked Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ steps.pr_details.outputs.result.head.ref }}
           repository: ${{ steps.pr_details.outputs.result.repo.full_name }}
@@ -71,7 +71,7 @@ jobs:
         with:
           main-branch-name: 'master'
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           cache: 'yarn'
           node-version: '22'
@@ -129,7 +129,7 @@ jobs:
       contents: 'read'
       actions: 'read'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -138,7 +138,7 @@ jobs:
         with:
           main-branch-name: 'master'
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           cache: 'yarn'
           node-version: '22'
@@ -168,7 +168,7 @@ jobs:
 
       - name: Upload Report
         if: always() && github.event_name == 'pull_request' && steps.report.outputs.value == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: vrt_report
           retention-days: 1
@@ -180,7 +180,7 @@ jobs:
         if: always() && github.event_name == 'pull_request' && steps.report.outputs.value == 'true'
         run: echo ${{ github.event.number }} > pr.txt
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         if: always() && github.event_name == 'pull_request' && steps.report.outputs.value == 'true'
         with:
           name: pr-number

--- a/.github/workflows/pr-vrt.yml
+++ b/.github/workflows/pr-vrt.yml
@@ -26,7 +26,7 @@ jobs:
     name: Generate screenshots
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -35,7 +35,7 @@ jobs:
         with:
           main-branch-name: 'master'
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           cache: 'yarn'
           node-version: '22'
@@ -47,7 +47,7 @@ jobs:
         run: yarn nx affected -t test-vr --nxBail
 
       - name: Prepare VR screenshots for upload
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         id: screenshots_root
         with:
           script: |
@@ -60,7 +60,7 @@ jobs:
           result-encoding: string
 
       - name: Upload VR screenshots
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: vrscreenshot
           retention-days: 1
@@ -69,7 +69,7 @@ jobs:
       - name: Save PR number
         run: echo ${{ github.event.number }} > pr.txt
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: pr-number
           retention-days: 1

--- a/.github/workflows/pr-website-deploy-comment.yml
+++ b/.github/workflows/pr-website-deploy-comment.yml
@@ -25,19 +25,19 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           sparse-checkout: |
             .github
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: pr-website-artifacts
           path: ./website
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: pr-number
           path: ./results
@@ -45,7 +45,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Load PR number
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         id: pr_number
         with:
           script: |
@@ -88,7 +88,7 @@ jobs:
       pull-requests: write
       statuses: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: 'Comment on PR'
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
@@ -99,7 +99,7 @@ jobs:
             Pull request demo site: [URL](${{needs.deploy.outputs.website_url}})
 
       - name: Update PR deploy site GitHub status
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const run = require('./.github/scripts/deploy-pr-site-status');

--- a/.github/workflows/pr-website-deploy.yml
+++ b/.github/workflows/pr-website-deploy.yml
@@ -23,7 +23,7 @@ jobs:
       actions: 'read'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -32,7 +32,7 @@ jobs:
         with:
           main-branch-name: 'master'
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           cache: 'yarn'
           node-version: '22'
@@ -54,7 +54,7 @@ jobs:
 
       - name: Generate PR Deploy Site
         run: yarn nx run pr-deploy-site:generate:site
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: pr-website-artifacts
           retention-days: 1
@@ -64,7 +64,7 @@ jobs:
 
       - name: Save PR number
         run: echo ${{ github.event.number }} > pr.txt
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: pr-number
           retention-days: 1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -30,7 +30,7 @@ jobs:
       actions: 'read'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -39,7 +39,7 @@ jobs:
         with:
           main-branch-name: 'master'
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           cache: 'yarn'
           node-version: '22'
@@ -85,7 +85,7 @@ jobs:
     if: ${{ github.repository_owner == 'microsoft' }}
     runs-on: macos-14-xlarge
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -94,7 +94,7 @@ jobs:
         with:
           main-branch-name: 'master'
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           cache: 'yarn'
           node-version: '22'
@@ -117,7 +117,7 @@ jobs:
           yarn nx affected -t test-rit--17--e2e,test-rit--18--e2e --exclude='react-19-tests-v9,react-charting,react'
 
       - name: Upload Cypress screenshots if exist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always() && steps.e2e.outcome == 'failure'
         with:
           name: cypress-screenshots-react-test-rit
@@ -140,7 +140,7 @@ jobs:
       actions: 'read'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -149,7 +149,7 @@ jobs:
         with:
           main-branch-name: 'master'
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           cache: 'yarn'
           node-version: '22'
@@ -168,7 +168,7 @@ jobs:
         run: yarn nx affected -t e2e --exclude react-19-tests-v9 --nxBail --parallel 1
 
       - name: Upload Cypress screenshots if exist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: failure()
         with:
           name: cypress-screenshots

--- a/.github/workflows/vrt-baseline.yml
+++ b/.github/workflows/vrt-baseline.yml
@@ -21,11 +21,11 @@ jobs:
     name: Upload VRT Baseline
     runs-on: macos-14-xlarge
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           cache: 'yarn'
           node-version: '22'
@@ -37,7 +37,7 @@ jobs:
         run: yarn nx run-many -t test-vr --nxBail
 
       - name: Prepare VR screenshots for upload
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         id: screenshots_root
         with:
           script: |


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/checkout` | [``](https://github.com/actions/checkout/releases/tag/) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Release](https://github.com/actions/checkout/releases/tag/v6) |  |
| `actions/download-artifact` | [``](https://github.com/actions/download-artifact/releases/tag/) | [`v7`](https://github.com/actions/download-artifact/releases/tag/v7) | [Release](https://github.com/actions/download-artifact/releases/tag/v7) |  |
| `actions/github-script` | [``](https://github.com/actions/github-script/releases/tag/) | [`v8`](https://github.com/actions/github-script/releases/tag/v8) | [Release](https://github.com/actions/github-script/releases/tag/v8) |  |
| `actions/labeler` | [``](https://github.com/actions/labeler/releases/tag/) | [`v6`](https://github.com/actions/labeler/releases/tag/v6) | [Release](https://github.com/actions/labeler/releases/tag/v6) |  |
| `actions/setup-node` | [``](https://github.com/actions/setup-node/releases/tag/) | [`v6`](https://github.com/actions/setup-node/releases/tag/v6) | [Release](https://github.com/actions/setup-node/releases/tag/v6) |  |
| `actions/upload-artifact` | [``](https://github.com/actions/upload-artifact/releases/tag/) | [`v6`](https://github.com/actions/upload-artifact/releases/tag/v6) | [Release](https://github.com/actions/upload-artifact/releases/tag/v6) |  |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
