### PR TITLE
add HTML Popover API attributes

### DIFF
--- a/change/@fluentui-react-utilities-5342059a-8947-4c1a-92a5-9df2f306483a.json
+++ b/change/@fluentui-react-utilities-5342059a-8947-4c1a-92a5-9df2f306483a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "add HTML Popover API attributes",
+  "packageName": "@fluentui/react-utilities",
+  "email": "seanmonahan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-utilities/src/utils/properties.test.ts
+++ b/packages/react-components/react-utilities/src/utils/properties.test.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getNativeProps, divProperties, inputProperties, anchorProperties } from './properties';
+import { getNativeProps, divProperties, inputProperties, anchorProperties, buttonProperties } from './properties';
 
 describe('getNativeProps', () => {
   it('can pass through data tags', () => {
@@ -111,5 +111,32 @@ describe('getNativeProps', () => {
     });
 
     expect(result).not.toHaveProperty('foobar');
+  });
+
+  describe('popover', () => {
+    it('allows the popoverTarget attribute on button', () => {
+      const result = getNativeProps<React.HTMLAttributes<HTMLButtonElement>>(
+        {
+          popoverTarget: 'some-id',
+        },
+        buttonProperties,
+      );
+
+      expect(result.popoverTarget).toEqual('some-id');
+    });
+
+    it('allows the popover attribute on divs', () => {
+      const result = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(
+        {
+          popover: 'auto',
+          popoverTarget: 'some-id',
+        },
+        divProperties,
+      );
+
+      expect(result.popover).toEqual('auto');
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((result as any).popoverTarget).toEqual(undefined);
+    });
   });
 });

--- a/packages/react-components/react-utilities/src/utils/properties.ts
+++ b/packages/react-components/react-utilities/src/utils/properties.ts
@@ -118,6 +118,7 @@ export const baseElementProperties = toObjectMap([
   'htmlFor', // global
   'id', // global
   'lang', // global
+  'popover', // global
   'ref', // global
   'role', // global
   'style', // global
@@ -237,6 +238,8 @@ export const buttonProperties = toObjectMap(htmlElementProperties, [
   'formMethod', // input, button
   'formNoValidate', // input, button
   'formTarget', // input, button
+  'popoverTarget', // input, button
+  'popoverTargetAction', // input, button
   'type', // a, button, input, link, menu, object, script, source, style
   'value', // button, input, li, option, meter, progress, param,
 ]);


### PR DESCRIPTION
## Previous Behavior

`getNativeProps()` would strip attributes required for the [HTML Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API).

## New Behavior

Added `popover`, `popoverTarget` and `popoverTargetAction` so they are no longer filtered by `getNativeProps()`.