### PR TITLE
Adding aria-lables for Screen Readers

### DIFF
--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.tsx
@@ -85,6 +85,7 @@ export class GroupHeader extends BaseComponent<IGroupDividerProps, IGroupHeaderS
               className={ css('ms-GroupHeader-check', styles.check) }
               data-selection-toggle={ true }
               onClick={ this._onToggleSelectGroupClick }
+              aria-label={ currentlySelected ? 'Deselect All Rows' : 'Select All Rows' }
             >
               <Check checked={ currentlySelected } />
             </button>
@@ -100,6 +101,7 @@ export class GroupHeader extends BaseComponent<IGroupDividerProps, IGroupHeaderS
             type='button'
             className={ css('ms-GroupHeader-expand', styles.expand) }
             onClick={ this._onToggleCollapse }
+            aria-label={ isCollapsed ? 'Expand All Rows' : 'Collapse All Rows' }
           >
             <Icon
               className={ css(


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->
Discernible text was not available for two Ui components, resulting in accessibility issues for screen readers.

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
Discernible text has been added to ensure accessibility for screen readers.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes 2764254
Added Aria lables to the missing components to ensure accessibility.


Validation:
<img width="504" height="34" alt="Screenshot 2025-12-24 134006" src="https://github.com/user-attachments/assets/119f496f-81c6-4fbb-9777-e12da1985492" />
<img width="493" height="46" alt="image" src="https://github.com/user-attachments/assets/6f38974b-ed4d-4f9e-a8b9-3e9aab7a5ccc" />


