### PR TITLE
test(react-charts,react-charting): mock Date in correctYearMonth tests to ensure consistent year handling

### DIFF
--- a/change/@fluentui-react-portal-f36862f7-4589-4ff2-9d92-a33071c391a4.json
+++ b/change/@fluentui-react-portal-f36862f7-4589-4ff2-9d92-a33071c391a4.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "fix: replace Node.ELEMENT_NODE with hardcoded value for SSR compatibility",
-  "packageName": "@fluentui/react-portal",
-  "email": "dmytrokirpa@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/packages/charts/react-charting/src/components/DeclarativeChart/PlotlySchemaAdapterUT.test.tsx
+++ b/packages/charts/react-charting/src/components/DeclarativeChart/PlotlySchemaAdapterUT.test.tsx
@@ -154,6 +154,16 @@ describe('isMonthArray', () => {
 });
 
 describe('correctYearMonth', () => {
+  beforeEach(() => {
+    // Mock Date to always return 2025 as the current year
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2025-01-01'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   test('Should return dates array when input array contains months data', () => {
     expect(correctYearMonth([10, 11, 1])).toStrictEqual(['10 01, 2025', '11 01, 2025', '1 01, 2026']);
   });

--- a/packages/charts/react-charts/library/src/components/DeclarativeChart/PlotlySchemaAdapterUT.test.tsx
+++ b/packages/charts/react-charts/library/src/components/DeclarativeChart/PlotlySchemaAdapterUT.test.tsx
@@ -145,6 +145,16 @@ describe('isMonthArray', () => {
 });
 
 describe('correctYearMonth', () => {
+  beforeEach(() => {
+    // Mock Date to always return 2025 as the current year
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2025-01-01'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   test('Should return dates array when input array contains months data', () => {
     expect(correctYearMonth([10, 11, 1])).toStrictEqual(['10 01, 2025', '11 01, 2025', '1 01, 2026']);
   });


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

`correctYearMonth` tests were failing because they relied on the non-deterministic `new Date().getFullYear()`.

<img width="1460" height="720" alt="image" src="https://github.com/user-attachments/assets/c0a63a94-c45b-4a66-b699-707a8c1b971b" />


## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

Mock year for the `correctYearMonth` tests 

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
