### PR TITLE
fix(react-motion): cleanup animation handle on unmounted component

### DIFF
--- a/change/@fluentui-react-motion-7b660839-76c7-41b2-a48e-6261139bca99.json
+++ b/change/@fluentui-react-motion-7b660839-76c7-41b2-a48e-6261139bca99.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: cleanup animation handle on unmounted component",
+  "packageName": "@fluentui/react-motion",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-motion/library/src/factories/createPresenceComponent.ts
+++ b/packages/react-components/react-motion/library/src/factories/createPresenceComponent.ts
@@ -241,6 +241,17 @@ export function createPresenceComponent<MotionParams extends Record<string, Moti
         ],
       );
 
+      React.useEffect(() => {
+        // Heads up!
+        //
+        // Dispose the handle when unmounting the component to clean up retained references. Doing it in a separate
+        // effect to ensure that the component is unmounted.
+
+        if (unmountOnExit && !mounted) {
+          handleRef.current?.dispose();
+        }
+      }, [handleRef, unmountOnExit, mounted]);
+
       if (mounted) {
         return child;
       }

--- a/packages/react-components/react-motion/library/src/types.ts
+++ b/packages/react-components/react-motion/library/src/types.ts
@@ -34,6 +34,7 @@ export type PresenceMotionFn<MotionParams extends Record<string, MotionParam> = 
 export type AnimationHandle = Pick<Animation, 'cancel' | 'finish' | 'pause' | 'play' | 'playbackRate' | 'reverse'> & {
   setMotionEndCallbacks: (onfinish: () => void, oncancel: () => void) => void;
   isRunning: () => boolean;
+  dispose: () => void;
 };
 
 export type MotionImperativeRef = {


### PR DESCRIPTION
## Previous Behavior

Components that are created via `createPresenceComponent()` and using `unmountOnExit` will be retained till a host component will be unmounted.

<img width="579" height="224" alt="image" src="https://github.com/user-attachments/assets/153e8f2c-e17f-47b8-9348-b2f3d912dfe0" />

https://github.com/user-attachments/assets/a334048e-10bc-422b-beae-28b8f6b6c331

### Typical scenario

- Open a `Dialog`
- Close a `Dialog`
- Call GC, capture snapshot, notice a recent instance on a `AnimationHandle` being retained even when an element is removed from DOM

## New Behavior

If an element is removed from DOM, it's safe to cleanup references. The problem is that `AnimationHandle` is created by a `React.useCallback` in `useAnimateAtomsInSupportedEnvironment()` that references `element`, it's an actual retainer:

<img width="1138" height="322" alt="image" src="https://github.com/user-attachments/assets/af531f22-3ed2-46c1-9190-9b7fc69940ff" />

```tsx
  return React.useCallback(
    (
      element: HTMLElement, // 👈 here is a context reference
      // ...
    ): AnimationHandle => {

      return {
        set playbackRate(rate: number) {},
        setMotionEndCallbacks(onfinish: () => void, oncancel: () => void) {}
        // ...
      }
  }, []);
```

I moved creation of objects to `createHandle()`, so closures don't have a reference to an element anymore and only keep references to `animations`. `dispose()` method introduces to clear references to animations.

`.dispose()` is called in `React.useEffect()` once a DOM element is gone, this fixes the issue:

<img width="630" height="166" alt="image" src="https://github.com/user-attachments/assets/97e72566-fa96-4c04-8c1a-e0034de7ba17" />

P.S. Unit test is not added as it required hijacking internals deeply.

## Related Issue(s)

Fixes #35534
