### PR TITLE
test(scripts-monorepo): udpate snapshot diff that changed re-ordering after switching to nx graph resolution for devDeps

### DIFF
--- a/scripts/monorepo/src/getDependencies.spec.js
+++ b/scripts/monorepo/src/getDependencies.spec.js
@@ -50,17 +50,17 @@ describe(`#getDependencies`, () => {
         Object {
           "dependencyType": "devDependencies",
           "isTopLevel": true,
-          "name": "eslint-plugin",
-        },
-        Object {
-          "dependencyType": "devDependencies",
-          "isTopLevel": true,
           "name": "react-conformance",
         },
         Object {
           "dependencyType": "devDependencies",
           "isTopLevel": true,
           "name": "react-conformance-griffel",
+        },
+        Object {
+          "dependencyType": "devDependencies",
+          "isTopLevel": false,
+          "name": "eslint-plugin",
         },
         Object {
           "dependencyType": "devDependencies",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

- master is failing https://github.com/microsoft/fluentui/actions/runs/20787291068/job/59700243708
- bug introduced by https://github.com/microsoft/fluentui/pull/35611 

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
- master is unblocked / see PR title

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
