### PR TITLE
[web-components][message-bar] Remove max-width on message-bar

### DIFF
--- a/change/@fluentui-web-components-eb85d684-0459-406b-9c7d-1f0d50fb98ae.json
+++ b/change/@fluentui-web-components-eb85d684-0459-406b-9c7d-1f0d50fb98ae.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Removed max-width for message-bar content",
+  "packageName": "@fluentui/web-components",
+  "email": "support@marvinkleinmusic.de",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/message-bar/message-bar.styles.ts
+++ b/packages/web-components/src/message-bar/message-bar.styles.ts
@@ -74,7 +74,6 @@ export const styles: ElementStyles = css`
 
   .content {
     grid-area: body;
-    max-width: 520px;
     padding-block: ${spacingVerticalMNudge};
     padding-inline: 0;
   }


### PR DESCRIPTION
## Previous Behavior
The message within the message-bar component has maximum length of 520px. This results in a lot of space being wasted on large screens. This PR removes this limit as I cannot see any logical reason behind it. Feel free to educate me if this was actually on purpose.

Before:
<img width="933" height="191" alt="before" src="https://github.com/user-attachments/assets/7fdc8983-8bef-42e3-84b0-78f737a11326" />

## New Behavior
Now the message will take up all available space before it breaks into a new line.

After:
<img width="918" height="122" alt="after" src="https://github.com/user-attachments/assets/d8b0195a-95f6-4799-992a-3adaeafde795" />

