### PR TITLE
feat(react-popover): add base hooks for Popover component

### DIFF
--- a/change/@fluentui-react-popover-b2d909e1-d6a8-4100-bc7c-0f2f28238665.json
+++ b/change/@fluentui-react-popover-b2d909e1-d6a8-4100-bc7c-0f2f28238665.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add base hooks for Popover component",
+  "packageName": "@fluentui/react-popover",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-popover/library/src/Popover.ts
+++ b/packages/react-components/react-popover/library/src/Popover.ts
@@ -1,8 +1,15 @@
 export type {
   OnOpenChangeData,
   OpenPopoverEvents,
+  PopoverBaseProps,
   PopoverProps,
   PopoverSize,
+  PopoverBaseState,
   PopoverState,
 } from './components/Popover/index';
-export { Popover, renderPopover_unstable, usePopover_unstable } from './components/Popover/index';
+export {
+  Popover,
+  renderPopover_unstable,
+  usePopover_unstable,
+  usePopoverBase_unstable,
+} from './components/Popover/index';

--- a/packages/react-components/react-popover/library/src/PopoverSurface.ts
+++ b/packages/react-components/react-popover/library/src/PopoverSurface.ts
@@ -1,4 +1,10 @@
-export type { PopoverSurfaceProps, PopoverSurfaceSlots, PopoverSurfaceState } from './components/PopoverSurface/index';
+export type {
+  PopoverSurfaceBaseProps,
+  PopoverSurfaceProps,
+  PopoverSurfaceSlots,
+  PopoverSurfaceBaseState,
+  PopoverSurfaceState,
+} from './components/PopoverSurface/index';
 export {
   PopoverSurface,
   arrowHeights,
@@ -6,4 +12,5 @@ export {
   renderPopoverSurface_unstable,
   usePopoverSurfaceStyles_unstable,
   usePopoverSurface_unstable,
+  usePopoverSurfaceBase_unstable,
 } from './components/PopoverSurface/index';

--- a/packages/react-components/react-popover/library/src/components/Popover/Popover.types.ts
+++ b/packages/react-components/react-popover/library/src/components/Popover/Popover.types.ts
@@ -145,6 +145,8 @@ export type PopoverProps = Pick<PortalProps, 'mountNode'> & {
   unstable_disableAutoFocus?: boolean;
 };
 
+export type PopoverBaseProps = Omit<PopoverProps, 'appearance' | 'size'>;
+
 /**
  * Popover State
  */
@@ -205,6 +207,8 @@ export type PopoverState = Pick<
     // eslint-disable-next-line @typescript-eslint/no-deprecated
     triggerRef: React.MutableRefObject<HTMLElement | null>;
   };
+
+export type PopoverBaseState = Omit<PopoverState, 'appearance' | 'size'>;
 
 /**
  * Data attached to open/close events

--- a/packages/react-components/react-popover/library/src/components/Popover/index.ts
+++ b/packages/react-components/react-popover/library/src/components/Popover/index.ts
@@ -1,4 +1,12 @@
 export { Popover } from './Popover';
-export type { OnOpenChangeData, OpenPopoverEvents, PopoverProps, PopoverSize, PopoverState } from './Popover.types';
+export type {
+  OnOpenChangeData,
+  OpenPopoverEvents,
+  PopoverBaseProps,
+  PopoverProps,
+  PopoverSize,
+  PopoverBaseState,
+  PopoverState,
+} from './Popover.types';
 export { renderPopover_unstable } from './renderPopover';
-export { usePopover_unstable } from './usePopover';
+export { usePopover_unstable, usePopoverBase_unstable } from './usePopover';

--- a/packages/react-components/react-popover/library/src/components/PopoverSurface/PopoverSurface.types.ts
+++ b/packages/react-components/react-popover/library/src/components/PopoverSurface/PopoverSurface.types.ts
@@ -13,6 +13,8 @@ export type PopoverSurfaceSlots = {
   root: Slot<'div'>;
 };
 
+export type PopoverSurfaceBaseProps = PopoverSurfaceProps;
+
 /**
  * PopoverSurface State
  */
@@ -23,3 +25,5 @@ export type PopoverSurfaceState = ComponentState<PopoverSurfaceSlots> &
      */
     arrowClassName?: string;
   };
+
+export type PopoverSurfaceBaseState = Omit<PopoverSurfaceState, 'appearance' | 'size'>;

--- a/packages/react-components/react-popover/library/src/components/PopoverSurface/index.ts
+++ b/packages/react-components/react-popover/library/src/components/PopoverSurface/index.ts
@@ -1,7 +1,13 @@
 export { PopoverSurface } from './PopoverSurface';
-export type { PopoverSurfaceProps, PopoverSurfaceSlots, PopoverSurfaceState } from './PopoverSurface.types';
+export type {
+  PopoverSurfaceBaseProps,
+  PopoverSurfaceProps,
+  PopoverSurfaceSlots,
+  PopoverSurfaceBaseState,
+  PopoverSurfaceState,
+} from './PopoverSurface.types';
 export { renderPopoverSurface_unstable } from './renderPopoverSurface';
-export { usePopoverSurface_unstable } from './usePopoverSurface';
+export { usePopoverSurface_unstable, usePopoverSurfaceBase_unstable } from './usePopoverSurface';
 export {
   arrowHeights,
   popoverSurfaceClassNames,

--- a/packages/react-components/react-popover/library/src/components/PopoverSurface/usePopoverSurface.ts
+++ b/packages/react-components/react-popover/library/src/components/PopoverSurface/usePopoverSurface.ts
@@ -1,10 +1,15 @@
 'use client';
 
 import * as React from 'react';
-import { getIntrinsicElementProps, useMergedRefs, slot } from '@fluentui/react-utilities';
+import { useMergedRefs, slot } from '@fluentui/react-utilities';
 import { useModalAttributes } from '@fluentui/react-tabster';
 import { usePopoverContext_unstable } from '../../popoverContext';
-import type { PopoverSurfaceProps, PopoverSurfaceState } from './PopoverSurface.types';
+import type {
+  PopoverSurfaceProps,
+  PopoverSurfaceState,
+  PopoverSurfaceBaseProps,
+  PopoverSurfaceBaseState,
+} from './PopoverSurface.types';
 
 /**
  * Create the state required to render PopoverSurface.
@@ -19,14 +24,34 @@ export const usePopoverSurface_unstable = (
   props: PopoverSurfaceProps,
   ref: React.Ref<HTMLDivElement>,
 ): PopoverSurfaceState => {
+  const size = usePopoverContext_unstable(context => context.size);
+  const appearance = usePopoverContext_unstable(context => context.appearance);
+  const state = usePopoverSurfaceBase_unstable(props, ref);
+
+  return {
+    appearance,
+    size,
+    ...state,
+  };
+};
+
+/**
+ * Base hook that builds PopoverSurface state for behavior and structure only.
+ *
+ * @internal
+ * @param props - User provided props to the PopoverSurface component.
+ * @param ref - User provided ref to be passed to the PopoverSurface component.
+ */
+export const usePopoverSurfaceBase_unstable = (
+  props: PopoverSurfaceBaseProps,
+  ref: React.Ref<HTMLDivElement>,
+): PopoverSurfaceBaseState => {
   const contentRef = usePopoverContext_unstable(context => context.contentRef);
   const openOnHover = usePopoverContext_unstable(context => context.openOnHover);
   const setOpen = usePopoverContext_unstable(context => context.setOpen);
   const mountNode = usePopoverContext_unstable(context => context.mountNode);
   const arrowRef = usePopoverContext_unstable(context => context.arrowRef);
-  const size = usePopoverContext_unstable(context => context.size);
   const withArrow = usePopoverContext_unstable(context => context.withArrow);
-  const appearance = usePopoverContext_unstable(context => context.appearance);
   const trapFocus = usePopoverContext_unstable(context => context.trapFocus);
   const inertTrapFocus = usePopoverContext_unstable(context => context.inertTrapFocus);
   const inline = usePopoverContext_unstable(context => context.inline);
@@ -36,27 +61,22 @@ export const usePopoverSurface_unstable = (
     alwaysFocusable: !trapFocus,
   });
 
-  const state: PopoverSurfaceState = {
+  const state: PopoverSurfaceBaseState = {
     inline,
-    appearance,
     withArrow,
-    size,
     arrowRef,
     mountNode,
     components: {
       root: 'div',
     },
     root: slot.always(
-      getIntrinsicElementProps('div', {
-        // FIXME:
-        // `contentRef` is wrongly assigned to be `HTMLElement` instead of `HTMLDivElement`
-        // but since it would be a breaking change to fix it, we are casting ref to it's proper type
+      {
         ref: useMergedRefs(ref, contentRef) as React.Ref<HTMLDivElement>,
         role: trapFocus ? 'dialog' : 'group',
         'aria-modal': trapFocus ? true : undefined,
         ...modalAttributes,
         ...props,
-      }),
+      },
       { elementType: 'div' },
     ),
   };

--- a/packages/react-components/react-popover/library/src/index.ts
+++ b/packages/react-components/react-popover/library/src/index.ts
@@ -13,3 +13,9 @@ export { PopoverProvider, usePopoverContext_unstable } from './popoverContext';
 export type { PopoverContextValue } from './popoverContext';
 export { PopoverTrigger, renderPopoverTrigger_unstable, usePopoverTrigger_unstable } from './PopoverTrigger';
 export type { PopoverTriggerChildProps, PopoverTriggerProps, PopoverTriggerState } from './PopoverTrigger';
+
+// Experimental APIs
+// export type { PopoverBaseProps, PopoverBaseState } from './Popover';
+// export { usePopoverBase_unstable } from './Popover';
+// export type { PopoverSurfaceBaseProps, PopoverSurfaceBaseState } from './PopoverSurface';
+// export { usePopoverSurfaceBase_unstable } from './PopoverSurface';


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

Added `use${Component}Base__unstable` hook for every component that contains state for logic, slots (but not default implementations), but not design-related props as per #35623. Exports are commented out intentionally, as we'll uncomment them in `experimental` branch for experimental release. 

Example how to compose a custom Popover component: 

```tsx
import * as React from 'react';
import type { 
  PopoverBaseProps, 
  PopoverState,  
  PopoverSurfaceBaseProps,
  PopoverSurfaceState, 
} from '@fluentui/react-popover';
import { 
  PopoverTrigger,
  renderPopover_unstable, 
  usePopoverBase_unstable,
  renderPopoverSurface_unstable,
  usePopoverSurfaceBase_unstable,
} from '@fluentui/react-popover';

export const CustomPopover = React.forwardRef<HTMLDivElement, PopoverBaseProps>((props, ref) => {
  const state = usePopoverBase_unstable(props);
  return renderPopover_unstable(state as PopoverState);
});

export const CustomPopoverSurface = React.forwardRef<HTMLDivElement, PopoverSurfaceBaseProps>((props, ref) => {
  const state = usePopoverSurfaceBase_unstable(props, ref);
   
// Add custom class names to slots
  state.root.className = ['popover-surface', state.root.className].filter(Boolean).join(' ');
  state.arrowClassName = ['popover-surface__arrow', state.arrowClassName].filter(Boolean).join(' ');

  return renderPopoverSurface_unstable(state as PopoverSurfaceState);
});

export const CustomPopoverTrigger = PopoverTrigger;

const Example = () => {
  return (
    <CustomPopover defaultOpen positioning={{ position: 'after' }}>
      <CustomPopoverTrigger>
        <button>Open Popover</button>
      </CustomPopoverTrigger>
      <CustomPopoverSurface>This is the popover content.</CustomPopoverSurface>
    </CustomPopover>
  );
};

```

**Note:** No public API or behavior changes to existing components, all unit/VR tests are passing. 


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Partially implements #35562
