### PR TITLE
Fix typo in TeachingBubble documentation

### DIFF
--- a/packages/react-examples/src/react/TeachingBubble/TeachingBubble.doc.tsx
+++ b/packages/react-examples/src/react/TeachingBubble/TeachingBubble.doc.tsx
@@ -42,7 +42,7 @@ export const TeachingBubblePageProps: IDocPageProps = {
       view: <TeachingBubbleWideExample />,
     },
     {
-      title: 'TeachingBubble with custon button order',
+      title: 'TeachingBubble with custom button order',
       code: TeachingBubbleButtonOrderExampleCode,
       view: <TeachingBubbleButtonOrderExample />,
     },


### PR DESCRIPTION
Fixes #34819

Fixed typo in TeachingBubble example title on the documentation page. Changed 'custon' to 'custom' in the button order example title.

The typo was in: `packages/react-examples/src/react/TeachingBubble/TeachingBubble.doc.tsx`

Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=105917501