### PR TITLE
feat(react-toolbar): add base hooks for Toolbar components

### DIFF
--- a/change/@fluentui-react-toolbar-44df9417-6e42-4f3b-9afd-6055d04733a4.json
+++ b/change/@fluentui-react-toolbar-44df9417-6e42-4f3b-9afd-6055d04733a4.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add base hooks for Toolbar components",
+  "packageName": "@fluentui/react-toolbar",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-toolbar/library/etc/react-toolbar.api.md
+++ b/packages/react-components/react-toolbar/library/etc/react-toolbar.api.md
@@ -9,15 +9,16 @@ import { ButtonSlots } from '@fluentui/react-button';
 import { ButtonState } from '@fluentui/react-button';
 import type { ComponentProps } from '@fluentui/react-utilities';
 import type { ComponentState } from '@fluentui/react-utilities';
-import { DividerSlots } from '@fluentui/react-divider';
-import { DividerState } from '@fluentui/react-divider';
+import { ContextSelector } from '@fluentui/react-context-selector';
+import type { DividerSlots } from '@fluentui/react-divider';
+import type { DividerState } from '@fluentui/react-divider';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import type { JSXElement } from '@fluentui/react-utilities';
 import * as React_2 from 'react';
 import type { Slot } from '@fluentui/react-utilities';
 import { SlotClassNames } from '@fluentui/react-utilities';
-import { ToggleButtonProps } from '@fluentui/react-button';
-import { ToggleButtonState } from '@fluentui/react-button';
+import type { ToggleButtonProps } from '@fluentui/react-button';
+import type { ToggleButtonState } from '@fluentui/react-button';
 
 // @public
 export const renderToolbar_unstable: (state: ToolbarState, contextValues: ToolbarContextValues) => JSXElement;
@@ -143,6 +144,12 @@ export const useToolbarButton_unstable: (props: ToolbarButtonProps, ref: React_2
 
 // @public
 export const useToolbarButtonStyles_unstable: (state: ToolbarButtonState) => void;
+
+// @public (undocumented)
+export const useToolbarContext_unstable: <T>(selector: ContextSelector<ToolbarContextValue, T>) => T;
+
+// @public (undocumented)
+export function useToolbarContextValues_unstable(state: ToolbarState): ToolbarContextValues;
 
 // @public
 export const useToolbarDivider_unstable: (props: ToolbarDividerProps, ref: React_2.Ref<HTMLElement>) => ToolbarDividerState;

--- a/packages/react-components/react-toolbar/library/src/Toolbar.ts
+++ b/packages/react-components/react-toolbar/library/src/Toolbar.ts
@@ -4,8 +4,10 @@ export type {
   ToolbarCheckedValueChangeEvent,
   ToolbarContextValue,
   ToolbarContextValues,
+  ToolbarBaseProps,
   ToolbarProps,
   ToolbarSlots,
+  ToolbarBaseState,
   ToolbarState,
   UninitializedToolbarState,
 } from './components/Toolbar/index';
@@ -15,4 +17,7 @@ export {
   toolbarClassNames,
   useToolbarStyles_unstable,
   useToolbar_unstable,
+  useToolbarBase_unstable,
+  useToolbarContext_unstable,
+  useToolbarContextValues_unstable,
 } from './components/Toolbar/index';

--- a/packages/react-components/react-toolbar/library/src/ToolbarButton.ts
+++ b/packages/react-components/react-toolbar/library/src/ToolbarButton.ts
@@ -1,6 +1,12 @@
-export type { ToolbarButtonProps, ToolbarButtonState } from './components/ToolbarButton/index';
+export type {
+  ToolbarButtonBaseState,
+  ToolbarButtonProps,
+  ToolbarButtonBaseProps,
+  ToolbarButtonState,
+} from './components/ToolbarButton/index';
 export {
   ToolbarButton,
   useToolbarButtonStyles_unstable,
   useToolbarButton_unstable,
+  useToolbarButtonBase_unstable,
 } from './components/ToolbarButton/index';

--- a/packages/react-components/react-toolbar/library/src/ToolbarDivider.ts
+++ b/packages/react-components/react-toolbar/library/src/ToolbarDivider.ts
@@ -1,6 +1,12 @@
-export type { ToolbarDividerProps, ToolbarDividerState } from './components/ToolbarDivider/index';
+export type {
+  ToolbarDividerBaseState,
+  ToolbarDividerProps,
+  ToolbarDividerBaseProps,
+  ToolbarDividerState,
+} from './components/ToolbarDivider/index';
 export {
   ToolbarDivider,
   useToolbarDividerStyles_unstable,
   useToolbarDivider_unstable,
+  useToolbarDividerBase_unstable,
 } from './components/ToolbarDivider/index';

--- a/packages/react-components/react-toolbar/library/src/ToolbarRadioButton.ts
+++ b/packages/react-components/react-toolbar/library/src/ToolbarRadioButton.ts
@@ -1,6 +1,12 @@
-export type { ToolbarRadioButtonProps, ToolbarRadioButtonState } from './components/ToolbarRadioButton/index';
+export type {
+  ToolbarRadioButtonBaseProps,
+  ToolbarRadioButtonProps,
+  ToolbarRadioButtonBaseState,
+  ToolbarRadioButtonState,
+} from './components/ToolbarRadioButton/index';
 export {
   ToolbarRadioButton,
   useToolbarRadioButtonStyles_unstable,
   useToolbarRadioButton_unstable,
+  useToolbarRadioButtonBase_unstable,
 } from './components/ToolbarRadioButton/index';

--- a/packages/react-components/react-toolbar/library/src/ToolbarToggleButton.ts
+++ b/packages/react-components/react-toolbar/library/src/ToolbarToggleButton.ts
@@ -1,6 +1,12 @@
-export type { ToolbarToggleButtonProps, ToolbarToggleButtonState } from './components/ToolbarToggleButton/index';
+export type {
+  ToolbarToggleButtonBaseProps,
+  ToolbarToggleButtonProps,
+  ToolbarToggleButtonBaseState,
+  ToolbarToggleButtonState,
+} from './components/ToolbarToggleButton/index';
 export {
   ToolbarToggleButton,
   useToolbarToggleButtonStyles_unstable,
   useToolbarToggleButton_unstable,
+  useToolbarToggleButtonBase_unstable,
 } from './components/ToolbarToggleButton/index';

--- a/packages/react-components/react-toolbar/library/src/components/Toolbar/Toolbar.types.ts
+++ b/packages/react-components/react-toolbar/library/src/components/Toolbar/Toolbar.types.ts
@@ -51,6 +51,8 @@ export type ToolbarProps = ComponentProps<ToolbarSlots> & {
   onCheckedValueChange?: (e: ToolbarCheckedValueChangeEvent, data: ToolbarCheckedValueChangeData) => void;
 };
 
+export type ToolbarBaseProps = Omit<ToolbarProps, 'size'>;
+
 /**
  * State used in rendering Toolbar
  */
@@ -67,6 +69,8 @@ export type ToolbarState = ComponentState<ToolbarSlots> &
     handleRadio: ToggableHandler;
   };
 
+export type ToolbarBaseState = Omit<ToolbarState, 'size'>;
+
 export type ToolbarContextValue = Pick<ToolbarState, 'size' | 'vertical' | 'checkedValues'> & {
   handleToggleButton?: ToggableHandler;
   handleRadio?: ToggableHandler;
@@ -76,7 +80,7 @@ export type ToolbarContextValues = {
   toolbar: ToolbarContextValue;
 };
 
-export type UninitializedToolbarState = Omit<ToolbarState, 'checkedValues' | 'handleToggleButton' | 'handleRadio'> &
+export type UninitializedToolbarState = Omit<ToolbarBaseState, 'checkedValues' | 'handleToggleButton' | 'handleRadio'> &
   Partial<Pick<ToolbarState, 'checkedValues'>>;
 
 export type ToggableHandler = (

--- a/packages/react-components/react-toolbar/library/src/components/Toolbar/index.ts
+++ b/packages/react-components/react-toolbar/library/src/components/Toolbar/index.ts
@@ -1,3 +1,4 @@
+export { useToolbarContext_unstable } from './ToolbarContext';
 export { Toolbar } from './Toolbar';
 export type {
   ToggableHandler,
@@ -5,11 +6,14 @@ export type {
   ToolbarCheckedValueChangeEvent,
   ToolbarContextValue,
   ToolbarContextValues,
+  ToolbarBaseProps,
   ToolbarProps,
   ToolbarSlots,
+  ToolbarBaseState,
   ToolbarState,
   UninitializedToolbarState,
 } from './Toolbar.types';
 export { renderToolbar_unstable } from './renderToolbar';
-export { useToolbar_unstable } from './useToolbar';
+export { useToolbar_unstable, useToolbarBase_unstable } from './useToolbar';
+export { useToolbarContextValues_unstable } from './useToolbarContextValues';
 export { toolbarClassNames, useToolbarStyles_unstable } from './useToolbarStyles.styles';

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarButton/ToolbarButton.types.ts
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarButton/ToolbarButton.types.ts
@@ -1,4 +1,4 @@
-import type { ComponentProps, ComponentState } from '@fluentui/react-utilities';
+import type { ComponentProps, ComponentState, DistributiveOmit } from '@fluentui/react-utilities';
 import { ButtonProps, ButtonSlots, ButtonState } from '@fluentui/react-button';
 
 /**
@@ -11,9 +11,13 @@ export type ToolbarButtonProps = ComponentProps<ButtonSlots> &
     vertical?: boolean;
   };
 
+export type ToolbarButtonBaseProps = DistributiveOmit<ToolbarButtonProps, 'appearance'>;
+
 /**
  * State used in rendering ToolbarButton
  */
 export type ToolbarButtonState = ComponentState<Partial<ButtonSlots>> &
   ButtonState &
   Required<Pick<ToolbarButtonProps, 'vertical'>>;
+
+export type ToolbarButtonBaseState = DistributiveOmit<ToolbarButtonState, 'appearance' | 'size' | 'shape'>;

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarButton/index.ts
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarButton/index.ts
@@ -1,4 +1,9 @@
 export { ToolbarButton } from './ToolbarButton';
-export type { ToolbarButtonProps, ToolbarButtonState } from './ToolbarButton.types';
-export { useToolbarButton_unstable } from './useToolbarButton';
+export type {
+  ToolbarButtonBaseProps,
+  ToolbarButtonProps,
+  ToolbarButtonBaseState,
+  ToolbarButtonState,
+} from './ToolbarButton.types';
+export { useToolbarButton_unstable, useToolbarButtonBase_unstable } from './useToolbarButton';
 export { useToolbarButtonStyles_unstable } from './useToolbarButtonStyles.styles';

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarButton/useToolbarButton.ts
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarButton/useToolbarButton.ts
@@ -2,7 +2,12 @@
 
 import * as React from 'react';
 import { useButton_unstable } from '@fluentui/react-button';
-import { ToolbarButtonProps, ToolbarButtonState } from './ToolbarButton.types';
+import type {
+  ToolbarButtonBaseProps,
+  ToolbarButtonBaseState,
+  ToolbarButtonProps,
+  ToolbarButtonState,
+} from './ToolbarButton.types';
 
 /**
  * Given user props, defines default props for the Button, calls useButtonState and useChecked, and returns
@@ -14,6 +19,28 @@ export const useToolbarButton_unstable = (
   props: ToolbarButtonProps,
   ref: React.Ref<HTMLButtonElement | HTMLAnchorElement>,
 ): ToolbarButtonState => {
+  const state = useToolbarButtonBase_unstable(props, ref);
+
+  return {
+    appearance: 'subtle',
+    size: 'medium',
+    shape: 'rounded',
+    ...state,
+  };
+};
+
+/**
+ * Base hook that builds Toolbar Button state for behavior and structure only.
+ * It does not provide any design-related defaults.
+ *
+ * @internal
+ * @param props - User provided props to the Button component.
+ * @param ref - User provided ref to be passed to the Button component.
+ */
+export const useToolbarButtonBase_unstable = (
+  props: ToolbarButtonBaseProps,
+  ref: React.Ref<HTMLButtonElement | HTMLAnchorElement>,
+): ToolbarButtonBaseState => {
   const { vertical = false, ...buttonProps } = props;
   const state = useButton_unstable(
     {

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarDivider/ToolbarDivider.types.ts
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarDivider/ToolbarDivider.types.ts
@@ -1,5 +1,5 @@
 import type { ComponentProps, ComponentState } from '@fluentui/react-utilities';
-import { DividerSlots, DividerState } from '@fluentui/react-divider';
+import type { DividerSlots, DividerState } from '@fluentui/react-divider';
 
 /**
  * ToolbarDivider Props
@@ -13,7 +13,11 @@ export type ToolbarDividerProps = ComponentProps<Partial<DividerSlots>> & {
   vertical?: boolean;
 };
 
+export type ToolbarDividerBaseProps = ToolbarDividerProps;
+
 /**
  * State used in rendering ToolbarDivider
  */
 export type ToolbarDividerState = ComponentState<Partial<DividerSlots>> & DividerState;
+
+export type ToolbarDividerBaseState = Omit<ToolbarDividerState, 'appearance'>;

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarDivider/index.ts
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarDivider/index.ts
@@ -1,4 +1,9 @@
 export { ToolbarDivider } from './ToolbarDivider';
-export type { ToolbarDividerProps, ToolbarDividerState } from './ToolbarDivider.types';
+export type {
+  ToolbarDividerBaseProps,
+  ToolbarDividerProps,
+  ToolbarDividerBaseState,
+  ToolbarDividerState,
+} from './ToolbarDivider.types';
 export { useToolbarDividerStyles_unstable } from './useToolbarDividerStyles.styles';
-export { useToolbarDivider_unstable } from './useToolbarDivider';
+export { useToolbarDivider_unstable, useToolbarDividerBase_unstable } from './useToolbarDivider';

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarDivider/useToolbarDivider.ts
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarDivider/useToolbarDivider.ts
@@ -1,7 +1,12 @@
 'use client';
 
 import * as React from 'react';
-import { ToolbarDividerProps, ToolbarDividerState } from './ToolbarDivider.types';
+import type {
+  ToolbarDividerBaseProps,
+  ToolbarDividerBaseState,
+  ToolbarDividerProps,
+  ToolbarDividerState,
+} from './ToolbarDivider.types';
 import { useDivider_unstable } from '@fluentui/react-divider';
 import { useToolbarContext_unstable } from '../Toolbar/ToolbarContext';
 
@@ -18,6 +23,25 @@ export const useToolbarDivider_unstable = (
   props: ToolbarDividerProps,
   ref: React.Ref<HTMLElement>,
 ): ToolbarDividerState => {
+  const state = useToolbarDividerBase_unstable(props, ref);
+  return {
+    ...state,
+    appearance: 'default',
+  };
+};
+
+/**
+ * Base hook that builds ToolbarDivider state for behavior and structure only.
+ * It does not provide any design-related defaults.
+ *
+ * @internal
+ * @param props - props from this instance of ToolbarDivider
+ * @param ref - reference to root HTMLElement of ToolbarDivider
+ */
+export const useToolbarDividerBase_unstable = (
+  props: ToolbarDividerBaseProps,
+  ref: React.Ref<HTMLElement>,
+): ToolbarDividerBaseState => {
   const vertical = useToolbarContext_unstable(ctx => ctx.vertical);
   return useDivider_unstable({ vertical: !vertical, ...props }, ref);
 };

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarGroup/index.ts
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarGroup/index.ts
@@ -1,5 +1,5 @@
 export { ToolbarGroup } from './ToolbarGroup';
 export type { ToolbarGroupProps, ToolbarGroupSlots, ToolbarGroupState } from './ToolbarGroup.types';
-export { useToolbarGroup_unstable } from './useToolbarGroup';
+export { useToolbarGroup_unstable, useToolbarGroupBase_unstable } from './useToolbarGroup';
 export { toolbarGroupClassNames, useToolbarGroupStyles_unstable } from './useToolbarGroupStyles.styles';
 export { renderToolbarGroup_unstable } from './renderToolbarGroup';

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarGroup/useToolbarGroup.ts
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarGroup/useToolbarGroup.ts
@@ -1,10 +1,10 @@
 'use client';
 
-import { getIntrinsicElementProps, slot } from '@fluentui/react-utilities';
 import * as React from 'react';
 
-import { useToolbarContext_unstable } from '../Toolbar/ToolbarContext';
 import type { ToolbarGroupProps, ToolbarGroupState } from './ToolbarGroup.types';
+import { getIntrinsicElementProps, slot } from '@fluentui/react-utilities';
+import { useToolbarContext_unstable } from '../Toolbar/ToolbarContext';
 
 /**
  * Given user props, defines default props for the Group
@@ -12,6 +12,21 @@ import type { ToolbarGroupProps, ToolbarGroupState } from './ToolbarGroup.types'
  * @param ref - User provided ref to be passed to the Group component.
  */
 export const useToolbarGroup_unstable = (
+  props: ToolbarGroupProps,
+  ref: React.Ref<HTMLDivElement>,
+): ToolbarGroupState => {
+  return useToolbarGroupBase_unstable(props, ref);
+};
+
+/**
+ * Base hook that builds Toolbar Group state for behavior and structure only.
+ * It does not provide any design-related defaults.
+ *
+ * @internal
+ * @param props - User provided props to the Group component.
+ * @param ref - User provided ref to be passed to the Group component.
+ */
+export const useToolbarGroupBase_unstable = (
   props: ToolbarGroupProps,
   ref: React.Ref<HTMLDivElement>,
 ): ToolbarGroupState => {

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarRadioButton/ToolbarRadioButton.types.ts
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarRadioButton/ToolbarRadioButton.types.ts
@@ -1,5 +1,5 @@
-import type { ComponentProps, ComponentState } from '@fluentui/react-utilities';
-import { ToggleButtonProps, ButtonSlots, ToggleButtonState } from '@fluentui/react-button';
+import type { ComponentProps, ComponentState, DistributiveOmit } from '@fluentui/react-utilities';
+import type { ToggleButtonProps, ButtonSlots, ToggleButtonState } from '@fluentui/react-button';
 
 /**
  * ToolbarRadioButton Props
@@ -11,6 +11,8 @@ export type ToolbarRadioButtonProps = ComponentProps<ButtonSlots> &
     value: string;
   };
 
+export type ToolbarRadioButtonBaseProps = DistributiveOmit<ToolbarRadioButtonProps, 'appearance'>;
+
 /**
  * State used in rendering ToolbarRadioButton
  */
@@ -18,3 +20,5 @@ export type ToolbarRadioButtonState = ComponentState<Partial<ButtonSlots>> &
   ToggleButtonState &
   Required<Pick<ToggleButtonProps, 'checked'>> &
   Pick<ToolbarRadioButtonProps, 'name' | 'value'>;
+
+export type ToolbarRadioButtonBaseState = DistributiveOmit<ToolbarRadioButtonState, 'appearance'>;

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarRadioButton/index.ts
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarRadioButton/index.ts
@@ -1,4 +1,9 @@
 export { ToolbarRadioButton } from './ToolbarRadioButton';
-export type { ToolbarRadioButtonProps, ToolbarRadioButtonState } from './ToolbarRadioButton.types';
-export { useToolbarRadioButton_unstable } from './useToolbarRadioButton';
+export type {
+  ToolbarRadioButtonBaseProps,
+  ToolbarRadioButtonProps,
+  ToolbarRadioButtonBaseState,
+  ToolbarRadioButtonState,
+} from './ToolbarRadioButton.types';
+export { useToolbarRadioButton_unstable, useToolbarRadioButtonBase_unstable } from './useToolbarRadioButton';
 export { useToolbarRadioButtonStyles_unstable } from './useToolbarRadioButtonStyles.styles';

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarRadioButton/useToolbarRadioButton.ts
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarRadioButton/useToolbarRadioButton.ts
@@ -4,7 +4,12 @@ import * as React from 'react';
 import { useEventCallback } from '@fluentui/react-utilities';
 import { useToggleButton_unstable } from '@fluentui/react-button';
 import { useToolbarContext_unstable } from '../Toolbar/ToolbarContext';
-import { ToolbarRadioButtonProps, ToolbarRadioButtonState } from './ToolbarRadioButton.types';
+import type {
+  ToolbarRadioButtonProps,
+  ToolbarRadioButtonState,
+  ToolbarRadioButtonBaseProps,
+  ToolbarRadioButtonBaseState,
+} from './ToolbarRadioButton.types';
 
 /**
  * Given user props, defines default props for the RadioButton, calls useButtonState and useChecked, and returns
@@ -16,16 +21,37 @@ export const useToolbarRadioButton_unstable = (
   props: ToolbarRadioButtonProps,
   ref: React.Ref<HTMLButtonElement | HTMLAnchorElement>,
 ): ToolbarRadioButtonState => {
+  const { appearance = 'secondary' } = props;
+  const size = useToolbarContext_unstable(ctx => ctx.size);
+  const state = useToolbarRadioButtonBase_unstable(props, ref);
+  return {
+    ...state,
+    appearance,
+    size,
+  };
+};
+
+/**
+ * Base hook that builds Toolbar RadioButton state for behavior and structure only.
+ * It does not provide any design-related defaults.
+ *
+ * @internal
+ * @param props - User provided props to the RadioButton component.
+ * @param ref - User provided ref to be passed to the RadioButton component.
+ */
+export const useToolbarRadioButtonBase_unstable = (
+  props: ToolbarRadioButtonBaseProps,
+  ref: React.Ref<HTMLButtonElement | HTMLAnchorElement>,
+): ToolbarRadioButtonBaseState => {
   const handleRadio = useToolbarContext_unstable(ctx => ctx.handleRadio);
   const checked = useToolbarContext_unstable(ctx => !!ctx.checkedValues[props.name]?.includes(props.value));
-  const size = useToolbarContext_unstable(ctx => ctx.size);
 
   const { onClick: onClickOriginal } = props;
   const toggleButtonState = useToggleButton_unstable(
-    { size, checked, role: 'radio', 'aria-checked': checked, ...props },
+    { checked, role: 'radio', 'aria-checked': checked, ...props },
     ref,
   );
-  const state: ToolbarRadioButtonState = {
+  const state: ToolbarRadioButtonBaseState = {
     ...toggleButtonState,
     name: props.name,
     value: props.value,
@@ -39,5 +65,6 @@ export const useToolbarRadioButton_unstable = (
   );
   state.root['aria-pressed'] = undefined;
   state.root.onClick = handleOnClick;
+
   return state;
 };

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarToggleButton/ToolbarToggleButton.types.ts
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarToggleButton/ToolbarToggleButton.types.ts
@@ -1,5 +1,5 @@
-import type { ComponentProps, ComponentState } from '@fluentui/react-utilities';
-import { ToggleButtonProps, ButtonSlots, ToggleButtonState } from '@fluentui/react-button';
+import type { ComponentProps, ComponentState, DistributiveOmit } from '@fluentui/react-utilities';
+import type { ToggleButtonProps, ButtonSlots, ToggleButtonState } from '@fluentui/react-button';
 
 /**
  * ToolbarToggleButton Props
@@ -11,6 +11,8 @@ export type ToolbarToggleButtonProps = ComponentProps<ButtonSlots> &
     value: string;
   };
 
+export type ToolbarToggleButtonBaseProps = DistributiveOmit<ToolbarToggleButtonProps, 'appearance'>;
+
 /**
  * State used in rendering ToolbarToggleButton
  */
@@ -18,3 +20,5 @@ export type ToolbarToggleButtonState = ComponentState<Partial<ButtonSlots>> &
   ToggleButtonState &
   Required<Pick<ToggleButtonProps, 'checked'>> &
   Pick<ToolbarToggleButtonProps, 'name' | 'value'>;
+
+export type ToolbarToggleButtonBaseState = DistributiveOmit<ToolbarToggleButtonState, 'appearance'>;

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarToggleButton/index.ts
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarToggleButton/index.ts
@@ -1,4 +1,9 @@
 export { ToolbarToggleButton } from './ToolbarToggleButton';
-export type { ToolbarToggleButtonProps, ToolbarToggleButtonState } from './ToolbarToggleButton.types';
-export { useToolbarToggleButton_unstable } from './useToolbarToggleButton';
+export type {
+  ToolbarToggleButtonBaseState,
+  ToolbarToggleButtonProps,
+  ToolbarToggleButtonBaseProps,
+  ToolbarToggleButtonState,
+} from './ToolbarToggleButton.types';
+export { useToolbarToggleButton_unstable, useToolbarToggleButtonBase_unstable } from './useToolbarToggleButton';
 export { useToolbarToggleButtonStyles_unstable } from './useToolbarToggleButtonStyles.styles';

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarToggleButton/useToolbarToggleButton.ts
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarToggleButton/useToolbarToggleButton.ts
@@ -3,7 +3,12 @@
 import * as React from 'react';
 import { useToggleButton_unstable } from '@fluentui/react-button';
 import { useToolbarContext_unstable } from '../Toolbar/ToolbarContext';
-import { ToolbarToggleButtonProps, ToolbarToggleButtonState } from './ToolbarToggleButton.types';
+import type {
+  ToolbarToggleButtonProps,
+  ToolbarToggleButtonState,
+  ToolbarToggleButtonBaseProps,
+  ToolbarToggleButtonBaseState,
+} from './ToolbarToggleButton.types';
 
 /**
  * Given user props, defines default props for the ToggleButton, calls useButtonState and useChecked, and returns
@@ -15,12 +20,31 @@ export const useToolbarToggleButton_unstable = (
   props: ToolbarToggleButtonProps,
   ref: React.Ref<HTMLButtonElement | HTMLAnchorElement>,
 ): ToolbarToggleButtonState => {
+  const state = useToolbarToggleButtonBase_unstable(props, ref);
+  return {
+    appearance: 'subtle',
+    ...state,
+  };
+};
+
+/**
+ * Base hook that builds Toolbar ToggleButton state for behavior and structure only.
+ * It does not provide any design-related defaults.
+ *
+ * @internal
+ * @param props - User provided props to the ToggleButton component.
+ * @param ref - User provided ref to be passed to the ToggleButton component.
+ */
+export const useToolbarToggleButtonBase_unstable = (
+  props: ToolbarToggleButtonBaseProps,
+  ref: React.Ref<HTMLButtonElement | HTMLAnchorElement>,
+): ToolbarToggleButtonBaseState => {
   const handleToggleButton = useToolbarContext_unstable(ctx => ctx.handleToggleButton);
   const checked = useToolbarContext_unstable(ctx => !!ctx.checkedValues[props.name]?.includes(props.value));
 
   const { onClick: onClickOriginal } = props;
   const toggleButtonState = useToggleButton_unstable({ checked, ...props }, ref);
-  const state: ToolbarToggleButtonState = {
+  const state: ToolbarToggleButtonBaseState = {
     ...toggleButtonState,
     name: props.name,
     value: props.value,

--- a/packages/react-components/react-toolbar/library/src/index.ts
+++ b/packages/react-components/react-toolbar/library/src/index.ts
@@ -4,6 +4,8 @@ export {
   toolbarClassNames,
   useToolbarStyles_unstable,
   useToolbar_unstable,
+  useToolbarContextValues_unstable,
+  useToolbarContext_unstable,
 } from './Toolbar';
 export type { ToolbarContextValue, ToolbarContextValues, ToolbarProps, ToolbarSlots, ToolbarState } from './Toolbar';
 export { ToolbarButton, useToolbarButtonStyles_unstable, useToolbarButton_unstable } from './ToolbarButton';
@@ -32,3 +34,15 @@ export {
 export type { ToolbarGroupProps, ToolbarGroupState } from './ToolbarGroup';
 export { ToolbarRadioGroup } from './ToolbarRadioGroup';
 export type { ToolbarRadioGroupProps, ToolbarRadioGroupState } from './ToolbarRadioGroup';
+
+// Experimental APIs
+// export type { ToolbarBaseState, ToolbarBaseProps } from './Toolbar';
+// export { useToolbarBase_unstable } from './Toolbar';
+// export type { ToolbarButtonBaseState, ToolbarButtonBaseProps } from './ToolbarButton';
+// export { useToolbarButtonBase_unstable } from './ToolbarButton';
+// export type { ToolbarDividerBaseState, ToolbarDividerBaseProps } from './ToolbarDivider';
+// export { useToolbarDividerBase_unstable } from './ToolbarDivider';
+// export type { ToolbarRadioButtonBaseState, ToolbarRadioButtonBaseProps } from './ToolbarRadioButton';
+// export { useToolbarRadioButtonBase_unstable } from './ToolbarRadioButton';
+// export type { ToolbarToggleButtonBaseState, ToolbarToggleButtonBaseProps } from './ToolbarToggleButton';
+// export { useToolbarToggleButtonBase_unstable } from './ToolbarToggleButton';


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

Added `use${Component}Base__unstable` hook for every component that contains state for logic, slots (but not default implementations), but not design-related props as per #35623. Exports are commented out intentionally, as we'll uncomment them in `experimental` branch for experimental release. 

Example how to compose a custom Toolbar component: 

```tsx
import * as React from 'react';
import { renderButton_unstable } from '@fluentui/react-button';
import { renderDivider_unstable } from '@fluentui/react-divider';
import type {
  ToolbarBaseProps,
  ToolbarButtonBaseProps,
  ToolbarButtonState,
  ToolbarDividerBaseProps,
  ToolbarDividerState,
  ToolbarState,
} from '@fluentui/react-toolbar';
import {
  renderToolbar_unstable,
  useToolbarBase_unstable,
  useToolbarButtonBase_unstable,
  useToolbarContext_unstable,
  useToolbarContextValues_unstable,
  useToolbarDividerBase_unstable,
} from '@fluentui/react-toolbar';

type ToolbarSize = 'small' | 'large';

type ToolbarProps = ToolbarBaseProps & {
  size?: ToolbarSize;
};

const Toolbar = React.forwardRef<HTMLDivElement, ToolbarProps>(({ size = 'small', ...props }, ref) => {
  const state = useToolbarBase_unstable(props, ref);
  const contextValues = useToolbarContextValues_unstable({ size, ...state });

  state.root.className = ['toolbar', state.root.className].filter(Boolean).join(' ');

  return renderToolbar_unstable(state as ToolbarState, contextValues);
});

const ToolbarButton = React.forwardRef<HTMLButtonElement, ToolbarButtonBaseProps>((props, ref) => {
  const state = useToolbarButtonBase_unstable(props, ref);

  const size = useToolbarContext_unstable(ctx => ctx.size as ToolbarSize);

  state.root.className = ['toolbar__button', `toolbar__button--${size}`, state.root.className]
    .filter(Boolean)
    .join(' ');

  return renderButton_unstable(state as ToolbarButtonState);
});

const ToolbarDivider = React.forwardRef<HTMLElement, ToolbarDividerBaseProps>((props, ref) => {
  const state = useToolbarDividerBase_unstable(props, ref);

  state.root.className = ['toolbar__divider', state.root.className].filter(Boolean).join(' ');

  return renderDivider_unstable(state as ToolbarDividerState);
});

const Example = (): React.ReactNode => (
  <Toolbar size="small" aria-label="Toolbar example with buttons and divider">
    <ToolbarButton aria-label="First" icon={1} />
    <ToolbarButton aria-label="Second" icon={1} />
    <ToolbarDivider />
    <ToolbarButton aria-label="Third" icon={1}>
      3
    </ToolbarButton>
  </Toolbar>
);
```

**Note:** There are no public API changes or modifications to the behavior of existing components, and all unit and VR tests are passing. The two existing hooks, `useToolbarContextValues_unstable` and `useToolbarContext_unstable` now exported for composing custom components.


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Partially implements #35562
