### PR TITLE
docs(Stagger): Add outY prop to Slide components in Stagger stories

### DIFF
--- a/packages/react-components/react-motion-components-preview/stories/src/choreography/Stagger/StaggerExpandableContainer.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/choreography/Stagger/StaggerExpandableContainer.stories.tsx
@@ -211,7 +211,7 @@ export const ExpandableContainer = (): JSXElement => {
               reversed={!staggerVisible}
             >
               {staggerItems.map(item => (
-                <Slide key={item.id} delay={COLLAPSE_EXPAND_DELAY}>
+                <Slide key={item.id} delay={COLLAPSE_EXPAND_DELAY} outY="20px">
                   <div className={classes.item}>
                     <Persona
                       name={item.name}

--- a/packages/react-components/react-motion-components-preview/stories/src/choreography/Stagger/StaggerItemDelay.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/choreography/Stagger/StaggerItemDelay.stories.tsx
@@ -70,7 +70,7 @@ export const ItemDelay = (): JSXElement => {
         <Stagger visible={visible} itemDelay={itemDelay}>
           {/* Create a list of items, each wrapped with a presence transition */}
           {Array.from({ length: 8 }, (_, i) => (
-            <Slide key={`stagger-item-${i}`}>
+            <Slide key={`stagger-item-${i}`} outY="20px">
               {/* Outer div protects the inner div from Slide's opacity animation */}
               <div>
                 <div className={classes.item} style={{ opacity: 1 - 0.1 * i }}>

--- a/packages/react-components/react-motion-components-preview/stories/src/choreography/Stagger/StaggerPresence.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/choreography/Stagger/StaggerPresence.stories.tsx
@@ -58,7 +58,7 @@ export const Presence = (): JSXElement => {
         <Stagger visible={visible}>
           {/* Create a list of items, each wrapped with a presence transition */}
           {Array.from({ length: 8 }, (_, i) => (
-            <Slide key={`stagger-item-${i}`}>
+            <Slide key={`stagger-item-${i}`} outY="20px">
               {/* Outer div protects the inner div from Slide's opacity animation */}
               <div>
                 <div className={classes.item} style={{ opacity: 1 - 0.1 * i }}>

--- a/packages/react-components/react-motion-components-preview/stories/src/choreography/Stagger/StaggerReversed.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/choreography/Stagger/StaggerReversed.stories.tsx
@@ -58,7 +58,7 @@ export const Reversed = (): JSXElement => {
         <Stagger visible={visible} reversed>
           {/* Create a list of items, each wrapped with a presence transition */}
           {Array.from({ length: 8 }, (_, i) => (
-            <Slide key={`stagger-item-${i}`}>
+            <Slide key={`stagger-item-${i}`} outY="20px">
               {/* Outer div protects the inner div from Slide's opacity animation */}
               <div>
                 <div className={classes.item} style={{ opacity: 1 - 0.1 * i }}>


### PR DESCRIPTION
## Summary

Updates Stagger story examples to explicitly set `outY="20px"` on Slide components after the Slide component's default changed from 20px to 0px.

## Changes

- Added `outY="20px"` prop to Slide components in the following stories:
  - StaggerItemDelay.stories.tsx
  - StaggerPresence.stories.tsx
  - StaggerReversed.stories.tsx
  - StaggerExpandableContainer.stories.tsx

## Background

The Slide motion component previously had a default of 20 pixels in the Y direction. It was recently updated to have defaults of 0 pixels for both X and Y. These Stagger stories relied on that default behavior, so they need to explicitly specify the Y offset to maintain the expected animation.