### PR TITLE
feat(react-utilities): add focusgroup attribute to baseElementProperties

### DIFF
--- a/change/@fluentui-react-utilities-59bbb135-7f60-4972-b999-3b78f64f41b5.json
+++ b/change/@fluentui-react-utilities-59bbb135-7f60-4972-b999-3b78f64f41b5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: add focusgroup attribute to baseElementProperties",
+  "packageName": "@fluentui/react-utilities",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-utilities/src/utils/properties.ts
+++ b/packages/react-components/react-utilities/src/utils/properties.ts
@@ -119,6 +119,7 @@ export const baseElementProperties = toObjectMap([
   'id', // global
   'lang', // global
   'popover', // global
+  'focusgroup', // global
   'ref', // global
   'role', // global
   'style', // global


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

[`focusgroup`](https://open-ui.org/components/focusgroup.explainer/) attribute was filtered out by `getInstristicElementProps` helper

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

`focusgroup` attribute is added to a valid attributes whitelist and passed through to a component as a valid attribute.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
