### PR TITLE
fix(react-link): use colorBrandForegroundInverted for inverted

### DIFF
--- a/change/@fluentui-react-link-fe54120e-3e12-4256-8781-1195cd2d87e0.json
+++ b/change/@fluentui-react-link-fe54120e-3e12-4256-8781-1195cd2d87e0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: use brand tokens for inverted variant",
+  "packageName": "@fluentui/react-link",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-link/library/src/components/Link/useLinkStyles.styles.ts
+++ b/packages/react-components/react-link/library/src/components/Link/useLinkStyles.styles.ts
@@ -94,10 +94,10 @@ const useStyles = makeStyles({
   inverted: {
     color: tokens.colorBrandForegroundInverted,
     ':hover': {
-      color: tokens.colorBrandForegroundInvertedHover,
+      color: tokens.colorBrandForegroundInverted,
     },
     ':active': {
-      color: tokens.colorBrandForegroundInvertedPressed,
+      color: tokens.colorBrandForegroundInverted,
     },
   },
   brand: {


### PR DESCRIPTION
In #35403, we aligned the Figma specs with the Link brand and inverted appearances. At the time, Figma was missing the inverted variant, while the code lacked the onBrand appearance. Although these gaps were aligned, the tokens proposed in the spec were incorrect, which introduced a regression in the Toast inverted appearance.

This change fixes that regression by ensuring Toast continues to use brand colors for its inverted appearance. At the same time, the problem spotted in #34911 should use "brand" value in `BackgroundAppearanceProvider`, so correct Link tokens applied. 

Link design spec inverted variant should be updated to reflect the code change

## Previous Behavior

<img width="341" height="156" alt="Screenshot 2026-01-20 at 19 08 27" src="https://github.com/user-attachments/assets/2349e604-e12d-451e-ad58-35018cee6f4e" />

<img width="342" height="158" alt="Screenshot 2026-01-20 at 19 09 15" src="https://github.com/user-attachments/assets/259d4bee-79f5-4f90-85cf-02eb3056e771" />

<img width="342" height="158" alt="Screenshot 2026-01-20 at 19 09 29" src="https://github.com/user-attachments/assets/aea1d737-6d24-4d5d-8919-131981b9b6c2" />

**Old issue with HC**

![toast-hc](https://github.com/user-attachments/assets/994f773e-c321-4e43-a080-7aa8d34852c7)

## New Behavior

Reverts Toast back to *9.66* before #34955 and #35403

<img width="310" height="139" alt="Screenshot 2026-01-20 at 19 40 59" src="https://github.com/user-attachments/assets/d0392ee9-15d7-4451-87ba-e3838fd48fd9" />

<img width="310" height="140" alt="Screenshot 2026-01-20 at 19 41 06" src="https://github.com/user-attachments/assets/f28bec2b-3cf5-4c28-9dab-3d2d245dd82f" />

<img width="310" height="140" alt="image" src="https://github.com/user-attachments/assets/c4086c66-5822-4a80-8ec4-1100d63d07e4" />

<img src="https://github.com/user-attachments/assets/cd3513e5-4f64-404b-9573-2fb7b4d96964" width="400" />


## Related Issue(s)

- Fixes #28400, #35341, #34911
