### PR TITLE
ci: add missing GITHUB_PAT env variable for release-vnext-experimental AZP

### DIFF
--- a/azure-pipelines.release-vnext-experimental.yml
+++ b/azure-pipelines.release-vnext-experimental.yml
@@ -116,6 +116,8 @@ extends:
               - script: |
                   yarn publish:beachball -b origin/$(Build.SourceBranchName) -n $(npmToken) --no-push --tag experimental --config scripts/beachball/src/release-vNext.config.js
                   git reset --hard origin/$(Build.SourceBranchName)
+                env:
+                  GITHUB_PAT: $(githubPAT)
                 displayName: Publish changes and bump versions
                 condition: and(succeeded(), not(${{ parameters.dryRun }}))
 


### PR DESCRIPTION
`GITHUB_PAT` is missing for the experimental pipeline:

- `nightly` - https://github.com/microsoft/fluentui/blob/master/azure-pipelines.release-vnext.yml#L101C34-L101C38
- `experimental` - https://github.com/microsoft/fluentui/blob/master/azure-pipelines.release-vnext-experimental.yml#L117