### PR TITLE
fix(workspace-plugin): update version-bump generator to remove beachballChangetypes when using explicitVersion argument

### DIFF
--- a/tools/workspace-plugin/src/generators/version-bump/index.ts
+++ b/tools/workspace-plugin/src/generators/version-bump/index.ts
@@ -41,9 +41,9 @@ function runMigrationOnProject(tree: Tree, schema: ValidatedSchema, userLog: Use
   updateJson(tree, packageJsonPath, (packageJson: PackageJson) => {
     nextVersion = bumpVersion(packageJson, schema.bumpType, schema.prereleaseTag, schema.explicitVersion);
 
-    // nightly releases should bypass beachball disallowed changetypes
+    // explicitVersion or nightly releases should bypass beachball disallowed changetypes
     if (
-      schema.bumpType === 'nightly' &&
+      (schema.explicitVersion || schema.bumpType === 'nightly') &&
       packageJsonHasBeachballConfig(packageJson) &&
       packageJson.beachball?.disallowedChangeTypes
     ) {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

see pr title

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
