### PR TITLE
feat(react-persona): add base hook for Persona component

### DIFF
--- a/change/@fluentui-react-persona-ef5d4da9-a84d-43f5-8e69-bccb700679ab.json
+++ b/change/@fluentui-react-persona-ef5d4da9-a84d-43f5-8e69-bccb700679ab.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add base hook for Persona component",
+  "packageName": "@fluentui/react-persona",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-persona/library/src/Persona.ts
+++ b/packages/react-components/react-persona/library/src/Persona.ts
@@ -1,8 +1,15 @@
-export type { PersonaProps, PersonaSlots, PersonaState } from './components/Persona/index';
+export type {
+  PersonaBaseProps,
+  PersonaProps,
+  PersonaSlots,
+  PersonaBaseState,
+  PersonaState,
+} from './components/Persona/index';
 export {
   Persona,
   personaClassNames,
   renderPersona_unstable,
   usePersonaStyles_unstable,
   usePersona_unstable,
+  usePersonaBase_unstable,
 } from './components/Persona/index';

--- a/packages/react-components/react-persona/library/src/components/Persona/Persona.types.ts
+++ b/packages/react-components/react-persona/library/src/components/Persona/Persona.types.ts
@@ -83,6 +83,8 @@ export type PersonaProps = ComponentProps<PersonaSlots> & {
   textAlignment?: 'center' | 'start';
 };
 
+export type PersonaBaseProps = ComponentProps<Omit<PersonaSlots, 'avatar' | 'presence'>> & Pick<PersonaProps, 'name'>;
+
 /**
  * State used in rendering Persona
  */
@@ -93,3 +95,6 @@ export type PersonaState = ComponentState<PersonaSlots> &
      */
     numTextLines: number;
   };
+
+export type PersonaBaseState = ComponentState<Omit<PersonaSlots, 'avatar' | 'presence'>> &
+  Pick<PersonaState, 'numTextLines'>;

--- a/packages/react-components/react-persona/library/src/components/Persona/index.ts
+++ b/packages/react-components/react-persona/library/src/components/Persona/index.ts
@@ -1,5 +1,5 @@
 export { Persona } from './Persona';
-export type { PersonaProps, PersonaSlots, PersonaState } from './Persona.types';
+export type { PersonaBaseProps, PersonaProps, PersonaSlots, PersonaBaseState, PersonaState } from './Persona.types';
 export { renderPersona_unstable } from './renderPersona';
-export { usePersona_unstable } from './usePersona';
+export { usePersona_unstable, usePersonaBase_unstable } from './usePersona';
 export { personaClassNames, usePersonaStyles_unstable } from './usePersonaStyles.styles';

--- a/packages/react-components/react-persona/library/src/components/Persona/usePersona.ts
+++ b/packages/react-components/react-persona/library/src/components/Persona/usePersona.ts
@@ -1,8 +1,10 @@
+'use client';
+
 import * as React from 'react';
 import { Avatar } from '@fluentui/react-avatar';
-import { getIntrinsicElementProps, slot } from '@fluentui/react-utilities';
+import { slot } from '@fluentui/react-utilities';
 import { PresenceBadge } from '@fluentui/react-badge';
-import type { PersonaProps, PersonaState } from './Persona.types';
+import type { PersonaBaseProps, PersonaBaseState, PersonaProps, PersonaState } from './Persona.types';
 
 /**
  * Create the state required to render Persona.
@@ -14,68 +16,93 @@ import type { PersonaProps, PersonaState } from './Persona.types';
  * @param ref - reference to root HTMLElement of Persona
  */
 export const usePersona_unstable = (props: PersonaProps, ref: React.Ref<HTMLElement>): PersonaState => {
-  const { name, presenceOnly = false, size = 'medium', textAlignment = 'start', textPosition = 'after' } = props;
+  const {
+    avatar,
+    presenceOnly = false,
+    size = 'medium',
+    textAlignment = 'start',
+    textPosition = 'after',
+    presence,
+    ...baseProps
+  } = props;
 
-  const primaryText = slot.optional(props.primaryText, {
-    renderByDefault: true,
-    defaultProps: {
-      children: name,
-    },
-    elementType: 'span',
-  });
-  const secondaryText = slot.optional(props.secondaryText, { elementType: 'span' });
-  const tertiaryText = slot.optional(props.tertiaryText, { elementType: 'span' });
-  const quaternaryText = slot.optional(props.quaternaryText, { elementType: 'span' });
-  const numTextLines = [primaryText, secondaryText, tertiaryText, quaternaryText].filter(Boolean).length;
+  const state = usePersonaBase_unstable(baseProps, ref);
+
   return {
-    numTextLines,
+    ...state,
     presenceOnly,
     size,
     textAlignment,
     textPosition,
     components: {
-      root: 'div',
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
+      ...state.components,
       avatar: Avatar,
       presence: PresenceBadge,
-      primaryText: 'span',
-      secondaryText: 'span',
-      tertiaryText: 'span',
-      quaternaryText: 'span',
     },
-
-    root: slot.always(
-      getIntrinsicElementProps(
-        'div',
-        {
-          ...props,
-          // FIXME:
-          // `ref` is wrongly assigned to be `HTMLElement` instead of `HTMLDivElement`
-          // but since it would be a breaking change to fix it, we are casting ref to it's proper type
-          ref: ref as React.Ref<HTMLDivElement>,
-        },
-        /* excludedPropNames */ ['name'],
-      ),
-      { elementType: 'div' },
-    ),
     avatar: !presenceOnly
-      ? slot.optional(props.avatar, {
+      ? slot.optional(avatar, {
           renderByDefault: true,
           defaultProps: {
-            name,
-            badge: props.presence,
+            name: props.name,
+            badge: presence,
             size: avatarSizes[size],
           },
           elementType: Avatar,
         })
       : undefined,
     presence: presenceOnly
-      ? slot.optional(props.presence, {
+      ? slot.optional(presence, {
           defaultProps: {
             size: presenceSizes[size],
           },
           elementType: PresenceBadge,
         })
       : undefined,
+  };
+};
+
+/**
+ * Base hook for Persona component, manages state and structure common to all variants of Persona
+ */
+export const usePersonaBase_unstable = (props: PersonaBaseProps, ref?: React.Ref<HTMLElement>): PersonaBaseState => {
+  const {
+    name,
+    primaryText: primaryTextProp,
+    secondaryText: secondaryTextProp,
+    tertiaryText: tertiaryTextProp,
+    quaternaryText: quaternaryTextProp,
+    ...rest
+  } = props;
+
+  const primaryText = slot.optional(primaryTextProp, {
+    renderByDefault: true,
+    defaultProps: {
+      children: name,
+    },
+    elementType: 'span',
+  });
+  const secondaryText = slot.optional(secondaryTextProp, { elementType: 'span' });
+  const tertiaryText = slot.optional(tertiaryTextProp, { elementType: 'span' });
+  const quaternaryText = slot.optional(quaternaryTextProp, { elementType: 'span' });
+  const numTextLines = [primaryText, secondaryText, tertiaryText, quaternaryText].filter(Boolean).length;
+
+  return {
+    numTextLines,
+    components: {
+      root: 'div',
+      primaryText: 'span',
+      secondaryText: 'span',
+      tertiaryText: 'span',
+      quaternaryText: 'span',
+    },
+    root: slot.always(
+      {
+        ref: ref as React.Ref<HTMLDivElement>,
+        ...rest,
+      },
+      { elementType: 'div' },
+    ),
     primaryText,
     secondaryText,
     tertiaryText,

--- a/packages/react-components/react-persona/library/src/index.ts
+++ b/packages/react-components/react-persona/library/src/index.ts
@@ -6,3 +6,7 @@ export {
   usePersona_unstable,
 } from './Persona';
 export type { PersonaProps, PersonaSlots, PersonaState } from './Persona';
+
+// Experimental APIs - will be uncommented in experimental branch
+// export { usePersonaBase_unstable } from './components/Persona/usePersona';
+// export type { PersonaBaseProps, PersonaBaseState } from './components/Persona/Persona.types';


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

Added `usePersonaBase_unstable` hook that contains state for logic and slots (but excludes the avatar and presence slots to allow for custom avatar/presence implementations). Exports are commented out intentionally, as we'll uncomment them in experimental branch for experimental release.

Example how to compose a custom Persona component:

```tsx
import * as React from 'react';
import type { PersonaProps } from '@fluentui/react-persona';
import {
  usePersonaBase_unstable,
  renderPersona_unstable,
} from '@fluentui/react-persona';
import { Avatar } from '@fluentui/react-avatar';
import { PresenceBadge } from '@fluentui/react-badge';

const CustomPersona = React.forwardRef<HTMLDivElement, PersonaProps>((props, ref) => {
  const {
    avatar,
    presence,
    presenceOnly = false,
    size = 'medium',
    textAlignment = 'start',
    textPosition = 'after',
    ...baseProps
  } = props;

  const state = usePersonaBase_unstable(baseProps, ref);

  state.root.className = ['custom-persona', state.root.className].filter(Boolean).join(' ');

  return renderPersona_unstable({
    ...state,
    presenceOnly,
    size,
    textAlignment,
    textPosition,
    components: {
      ...state.components,
      avatar: Avatar,
      presence: PresenceBadge,
    },
    avatar: !presenceOnly ? {
      // Custom avatar configuration
      ...avatar,
      name: props.name,
      badge: presence,
    } : undefined,
    presence: presenceOnly ? {
      // Custom presence configuration
      ...presence,
    } : undefined,
  });
});

export const Example: React.FC = () => {
  return (
    <div>
      <CustomPersona 
        name="John Doe" 
        secondaryText="Software Engineer"
        tertiaryText="Available"
      />
    </div>
  );
};
```

**Note:** There are no public API changes or modifications to the behavior of existing components, and all unit and VR tests are passing. The new hook `usePersonaBase_unstable` and types (`PersonaBaseProps, PersonaBaseState`) are now exported for composing custom Persona components.

### Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->
Partially implements #35562
