### PR TITLE
fix(react-toolbar): ToolbarRadioButton should respect "size" prop

### DIFF
--- a/change/@fluentui-react-toolbar-bf51238a-5c69-41cd-9cdf-32e82f044fb0.json
+++ b/change/@fluentui-react-toolbar-bf51238a-5c69-41cd-9cdf-32e82f044fb0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: ToolbarRadioButton should respect \"size\" prop",
+  "packageName": "@fluentui/react-toolbar",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarRadioButton/ToolbarRadioButton.types.ts
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarRadioButton/ToolbarRadioButton.types.ts
@@ -21,4 +21,4 @@ export type ToolbarRadioButtonState = ComponentState<Partial<ButtonSlots>> &
   Required<Pick<ToggleButtonProps, 'checked'>> &
   Pick<ToolbarRadioButtonProps, 'name' | 'value'>;
 
-export type ToolbarRadioButtonBaseState = DistributiveOmit<ToolbarRadioButtonState, 'appearance'>;
+export type ToolbarRadioButtonBaseState = DistributiveOmit<ToolbarRadioButtonState, 'appearance' | 'size'>;

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarRadioButton/useToolbarRadioButton.test.tsx
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarRadioButton/useToolbarRadioButton.test.tsx
@@ -1,0 +1,46 @@
+import { renderHook } from '@testing-library/react-hooks';
+import * as React from 'react';
+
+import { ToolbarContext } from '../Toolbar/ToolbarContext';
+import { useToolbarRadioButton_unstable } from './useToolbarRadioButton';
+import type { ToolbarRadioButtonProps } from './ToolbarRadioButton.types';
+
+const refMock = React.createRef<HTMLButtonElement>();
+const propsMock: ToolbarRadioButtonProps = {
+  name: 'test-radio',
+  value: 'test-value',
+};
+
+const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  return (
+    <ToolbarContext.Provider value={{ size: 'large', vertical: false, checkedValues: {} }}>
+      {children}
+    </ToolbarContext.Provider>
+  );
+};
+
+describe('useToolbarRadioButton', () => {
+  describe('size', () => {
+    it('applies the medium size by default', () => {
+      const { result } = renderHook(() => useToolbarRadioButton_unstable(propsMock, refMock));
+
+      expect(result.current.size).toBe('medium');
+    });
+
+    it('applies the size from a context', () => {
+      const { result } = renderHook(() => useToolbarRadioButton_unstable(propsMock, refMock), {
+        wrapper: Wrapper,
+      });
+
+      expect(result.current.size).toBe('large');
+    });
+
+    it('applies the size from props over context', () => {
+      const { result } = renderHook(() => useToolbarRadioButton_unstable({ ...propsMock, size: 'small' }, refMock), {
+        wrapper: Wrapper,
+      });
+
+      expect(result.current.size).toBe('small');
+    });
+  });
+});

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarRadioButton/useToolbarRadioButton.ts
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarRadioButton/useToolbarRadioButton.ts
@@ -24,10 +24,12 @@ export const useToolbarRadioButton_unstable = (
   const { appearance = 'secondary' } = props;
   const size = useToolbarContext_unstable(ctx => ctx.size);
   const state = useToolbarRadioButtonBase_unstable(props, ref);
+
   return {
     ...state,
+
     appearance,
-    size,
+    size: props.size || size,
   };
 };
 


### PR DESCRIPTION
## Previous Behavior

#35658 broke `size` prop on `ToolbarRadioButton`:
- @fluentui/react-toolbar: 9.7.0 https://stackblitz.com/edit/ffbbjvjy?file=src%2Fexample.tsx
- @fluentui/react-toolbar: 9.6.11 https://stackblitz.com/edit/ffbbjvjy-g7m8enjw?

### 9.7.0

<img width="1801" height="579" alt="image" src="https://github.com/user-attachments/assets/6441f533-11f2-4969-af44-29e5e044a483" />

### 9.6.1

<img width="1799" height="592" alt="image" src="https://github.com/user-attachments/assets/181196a8-312a-4b1a-80fe-d8df1ccdd162" />


## New Behavior

- Logic is fixed
- UTs are added

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
