### PR TITLE
feat(react-overflow): add pinned items

### DIFF
--- a/change/@fluentui-priority-overflow-9ca4f61b-1794-4d68-8b93-deca372b9b36.json
+++ b/change/@fluentui-priority-overflow-9ca4f61b-1794-4d68-8b93-deca372b9b36.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add support for pinned items",
+  "packageName": "@fluentui/priority-overflow",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-overflow-8d7da751-066b-4177-b647-265908b5fa70.json
+++ b/change/@fluentui-react-overflow-8d7da751-066b-4177-b647-265908b5fa70.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add support for pinned items",
+  "packageName": "@fluentui/react-overflow",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/priority-overflow/etc/priority-overflow.api.md
+++ b/packages/react-components/priority-overflow/etc/priority-overflow.api.md
@@ -64,6 +64,7 @@ export interface OverflowItemEntry {
     // (undocumented)
     groupId?: string;
     id: string;
+    pinned?: boolean;
     priority: number;
 }
 

--- a/packages/react-components/priority-overflow/src/overflowManager.ts
+++ b/packages/react-components/priority-overflow/src/overflowManager.ts
@@ -61,6 +61,11 @@ export function createOverflowManager(): OverflowManager {
       return lte ? 1 : -1;
     }
 
+    // Pinned items have "infinite" priority - they should never be hidden
+    if (lte.pinned !== rte.pinned) {
+      return lte.pinned ? 1 : -1;
+    }
+
     if (lte.priority !== rte.priority) {
       return lte.priority > rte.priority ? 1 : -1;
     }
@@ -175,6 +180,13 @@ export function createOverflowManager(): OverflowManager {
 
       // Remove items until there's no more overflow
       while (occupiedSize() > availableSize && visibleItemQueue.size() > options.minimumVisible) {
+        const nextItemId = visibleItemQueue.peek();
+
+        // Never hide pinned items - they should always remain visible
+        if (nextItemId && overflowItems[nextItemId]?.pinned) {
+          break;
+        }
+
         hideItem();
       }
     }

--- a/packages/react-components/priority-overflow/src/types.ts
+++ b/packages/react-components/priority-overflow/src/types.ts
@@ -17,11 +17,18 @@ export interface OverflowItemEntry {
   id: string;
 
   groupId?: string;
+
+  /**
+   * If true, the item will never overflow and will always be visible.
+   * Pinned items are excluded from the overflow count.
+   * @default false
+   */
+  pinned?: boolean;
 }
 
 export interface OverflowDividerEntry {
   /**
-   * HTML element that will be disappear when overflowed
+   * HTML element that will disappear when overflowed
    */
   element: HTMLElement;
 

--- a/packages/react-components/react-overflow/library/etc/react-overflow.api.md
+++ b/packages/react-components/react-overflow/library/etc/react-overflow.api.md
@@ -44,9 +44,14 @@ export const OverflowItem: React_2.ForwardRefExoticComponent<OverflowItemProps &
 export type OverflowItemProps = {
     id: string;
     groupId?: string;
-    priority?: number;
     children: React_2.ReactElement;
-};
+} & ({
+    pinned?: boolean;
+    priority?: never;
+} | {
+    pinned?: never;
+    priority?: number;
+});
 
 // @public
 export type OverflowProps = Partial<Pick<ObserveOptions, 'overflowAxis' | 'overflowDirection' | 'padding' | 'minimumVisible' | 'hasHiddenItems'>> & {
@@ -78,7 +83,7 @@ export const useOverflowCount: () => number;
 export function useOverflowDivider<TElement extends HTMLElement>(groupId?: string): React_2.RefObject<TElement | null>;
 
 // @internal
-export function useOverflowItem<TElement extends HTMLElement>(id: string, priority?: number, groupId?: string): React_2.RefObject<TElement | null>;
+export function useOverflowItem<TElement extends HTMLElement>(id: string, priority?: number, groupId?: string, pinned?: boolean): React_2.RefObject<TElement | null>;
 
 // @public (undocumented)
 export function useOverflowMenu<TElement extends HTMLElement>(id?: string): {

--- a/packages/react-components/react-overflow/library/src/components/OverflowItem/OverflowItem.tsx
+++ b/packages/react-components/react-overflow/library/src/components/OverflowItem/OverflowItem.tsx
@@ -18,9 +18,9 @@ import { OverflowItemProps } from './OverflowItem.types';
  * Behaves similarly to other `*Trigger` components in Fluent UI React.
  */
 export const OverflowItem = React.forwardRef((props: OverflowItemProps, ref) => {
-  const { id, groupId, priority, children } = props;
+  const { id, groupId, priority, pinned, children } = props;
 
-  const containerRef = useOverflowItem(id, priority, groupId);
+  const containerRef = useOverflowItem(id, priority, groupId, pinned);
   const child = getTriggerChild(children);
 
   return applyTriggerPropsToChildren(children, {

--- a/packages/react-components/react-overflow/library/src/components/OverflowItem/OverflowItem.types.ts
+++ b/packages/react-components/react-overflow/library/src/components/OverflowItem/OverflowItem.types.ts
@@ -13,11 +13,24 @@ export type OverflowItemProps = {
    */
   groupId?: string;
   /**
-   * A higher priority means the item overflows later.
-   */
-  priority?: number;
-  /**
    * The single child that has overflow item behavior attached.
    */
   children: React.ReactElement;
-};
+} & (
+  | {
+      /**
+       * If true, the item will never overflow and will always be visible.
+       * Mutually exclusive with `priority`.
+       */
+      pinned?: boolean;
+      priority?: never;
+    }
+  | {
+      pinned?: never;
+      /**
+       * A higher priority means the item overflows later.
+       * Mutually exclusive with `pinned`.
+       */
+      priority?: number;
+    }
+);

--- a/packages/react-components/react-overflow/library/src/useOverflowItem.test.tsx
+++ b/packages/react-components/react-overflow/library/src/useOverflowItem.test.tsx
@@ -37,6 +37,7 @@ describe('useOverflowItem', () => {
           "element": <div />,
           "groupId": "0",
           "id": "test",
+          "pinned": undefined,
           "priority": 0,
         },
       ]

--- a/packages/react-components/react-overflow/library/src/useOverflowItem.ts
+++ b/packages/react-components/react-overflow/library/src/useOverflowItem.ts
@@ -10,26 +10,39 @@ import { useOverflowContext } from './overflowContext';
  * @param id - unique identifier for the item used by the overflow manager
  * @param priority - higher priority means the item overflows later
  * @param groupId - assigns the item to a group, group visibility can be watched
+ * @param pinned - if true, the item will never overflow and will always be visible
  * @returns ref to assign to an intrinsic HTML element
  */
 export function useOverflowItem<TElement extends HTMLElement>(
   id: string,
   priority?: number,
   groupId?: string,
+  pinned?: boolean,
 ): React.RefObject<TElement | null> {
   const ref = React.useRef<TElement | null>(null);
   const registerItem = useOverflowContext(v => v.registerItem);
 
   useIsomorphicLayoutEffect(() => {
+    if (process.env.NODE_ENV !== 'production') {
+      if (typeof pinned !== 'undefined' && typeof priority !== 'undefined' && pinned) {
+        // eslint-disable-next-line no-console
+        console.error(
+          `useOverflowItem: Overflow item with id "${id}" has pinned=true and priority<0. ` +
+            `Pinned items are always visible and should not have defined priority.`,
+        );
+      }
+    }
+
     if (ref.current) {
       return registerItem({
         element: ref.current,
         id,
         priority: priority ?? 0,
         groupId,
+        pinned,
       });
     }
-  }, [id, priority, registerItem, groupId]);
+  }, [id, priority, registerItem, groupId, pinned]);
 
   return ref;
 }

--- a/packages/react-components/react-overflow/stories/src/Overflow/Pinned.stories.tsx
+++ b/packages/react-components/react-overflow/stories/src/Overflow/Pinned.stories.tsx
@@ -52,11 +52,18 @@ const useStyles = makeStyles({
 
 export const Pinned = (): JSXElement => {
   const styles = useStyles();
-
-  const [selected, setSelected] = React.useState<string>('6');
+  const [selected, setSelected] = React.useState<Set<string>>(() => new Set(['6']));
 
   const onSelect = (itemId: string) => {
-    setSelected(itemId);
+    setSelected(prev => {
+      const next = new Set(prev);
+      if (next.has(itemId)) {
+        next.delete(itemId);
+      } else {
+        next.add(itemId);
+      }
+      return next;
+    });
   };
 
   const itemIds = new Array(8).fill(0).map((_, i) => i.toString());
@@ -65,7 +72,7 @@ export const Pinned = (): JSXElement => {
     <Overflow>
       <div className={mergeClasses(styles.container, styles.resizableArea)}>
         {itemIds.map(i => (
-          <OverflowSelectionItem onSelectItem={onSelect} key={i} id={i} selected={selected === i} />
+          <OverflowSelectionItem onSelectItem={onSelect} key={i} id={i} selected={selected.has(i)} />
         ))}
         <OverflowMenu itemIds={itemIds} onSelect={onSelect} />
       </div>
@@ -83,7 +90,7 @@ const OverflowSelectionItem: React.FC<{
   };
 
   return (
-    <OverflowItem id={props.id} priority={props.selected ? 1000 : undefined}>
+    <OverflowItem id={props.id} pinned={props.selected}>
       <Button
         aria-pressed={props.selected ? 'true' : 'false'}
         appearance={props.selected ? 'primary' : 'secondary'}
@@ -137,10 +144,11 @@ Pinned.parameters = {
   docs: {
     description: {
       story: [
-        'An item can be pinned (always visible) by setting it to be a higher priority that all other overflow items.',
-        'This can be useful when implementing selection scenarios where the selected item must always be visible.',
-        'Try selecting different items below to observe this effect. The pinned item will be overflowed if there',
-        'is no space left for any overflow item.',
+        'An item can be pinned (always visible) by setting the `pinned` prop on `OverflowItem`.',
+        'Pinned items will never overflow regardless of container size.',
+        'Multiple items can be pinned at the same time.',
+        'This is useful when implementing selection scenarios where selected items must always be visible.',
+        'Try selecting different items below to observe this effect.',
       ].join('\n'),
     },
   },


### PR DESCRIPTION
## Previous Behavior

- Functionality of `pinned` items was implemented with `priority`
- Items with high priority could still overflow

## New Behavior

- New `pinned` prop is added. Pinned items can't have priority and don't overflow even if it results in broken layout
- New E2E tests added, the matching story was modified
- Changes confirmed to work as expected by an engineer on product side