### PR TITLE
fix(react-table): make invisible selection cell non-interactive

### DIFF
--- a/change/@fluentui-react-table-8230dfe0-09bb-46ce-bbdd-211d4c8b5efb.json
+++ b/change/@fluentui-react-table-8230dfe0-09bb-46ce-bbdd-211d4c8b5efb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "make invisible selection cell non-interactive",
+  "packageName": "@fluentui/react-table",
+  "email": "nana.mochihara@axis.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-table/library/src/components/TableSelectionCell/useTableSelectionCellStyles.styles.ts
+++ b/packages/react-components/react-table/library/src/components/TableSelectionCell/useTableSelectionCellStyles.styles.ts
@@ -64,6 +64,7 @@ const useStyles = makeStyles({
 
   hidden: {
     opacity: 0,
+    pointerEvents: 'none',
   },
 });
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Adding the `invisible` prop to `TableSelectionCell` hide the checkbox in the selection cell, but it is still interactive. It means, when you hover over the selection cell, a cursor "pointer"  appears and you can still click on it to select the checkboxes.

![before-fix](https://github.com/user-attachments/assets/296440ae-eab9-461f-8dcf-852548174207)

## New Behavior

If the checkbox is not visible, the cursor "pointer" is not visible and you cannot click on it.

![after-fix](https://github.com/user-attachments/assets/1816be15-52e1-4e93-ba09-dd81631e1dff)

## Related Issue(s)

This issue https://github.com/microsoft/fluentui/issues/34770 is already closed but the problem is not resolved.

