### PR TITLE
docs(motion): home pages for motion system & motion components

### DIFF
--- a/change/@fluentui-react-motion-44d5d8fd-6710-49df-8937-48b7e73075a4.json
+++ b/change/@fluentui-react-motion-44d5d8fd-6710-49df-8937-48b7e73075a4.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "docs(motion): add motion system docs",
+  "packageName": "@fluentui/react-motion",
+  "email": "robertpenner@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-motion-components-preview-643db992-5d5b-4a0a-adbb-b8bf361f41c3.json
+++ b/change/@fluentui-react-motion-components-preview-643db992-5d5b-4a0a-adbb-b8bf361f41c3.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "docs(motion): add motion components docs",
+  "packageName": "@fluentui/react-motion-components-preview",
+  "email": "robertpenner@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-motion-components-preview/library/README.md
+++ b/packages/react-components/react-motion-components-preview/library/README.md
@@ -1,5 +1,93 @@
 # @fluentui/react-motion-components-preview
 
-**React Motion Components for [Fluent UI React](https://react.fluentui.dev/)**
+**Pre-built Motion Components for [Fluent UI React](https://react.fluentui.dev/)**
 
-These are not production-ready components and **should never be used in product**. This space is useful for testing new components whose APIs might change before final release.
+> ⚠️ **Preview Package**: These components are in beta and APIs may change before stable release.
+
+Ready-to-use presence components for common UI animation patterns, built on top of `@fluentui/react-motion`.
+
+## Components
+
+| Component    | Description                                                |
+| ------------ | ---------------------------------------------------------- |
+| **Fade**     | Opacity transitions for tooltips, notifications, overlays  |
+| **Scale**    | Size animations for popovers, menus, emphasis              |
+| **Collapse** | Height/width expansion for accordions, expandable sections |
+| **Slide**    | Directional movement for drawers, panels, carousels        |
+| **Blur**     | Focus/defocus effects for backgrounds, depth               |
+| **Rotate**   | 3D rotation for card flips, reveals                        |
+| **Stagger**  | Choreography for sequential list animations                |
+
+Each component (except Blur and Rotate) comes with **Snappy** (150ms) and **Relaxed** (250ms) timing variants.
+
+## Installation
+
+```bash
+npm install @fluentui/react-motion-components-preview
+# or
+yarn add @fluentui/react-motion-components-preview
+```
+
+## Quick Start
+
+```tsx
+import { Fade, Scale, Slide, Collapse } from '@fluentui/react-motion-components-preview';
+
+// Simple fade
+function Tooltip({ visible, children }) {
+  return (
+    <Fade visible={visible}>
+      {children}
+    </Fade>
+  );
+}
+
+// Slide from the right
+function Drawer({ open, children }) {
+  return (
+    <Slide visible={open} outX="20px">
+      {children}
+    </Slide>
+  );
+}
+
+// Use timing variants
+import { FadeSnappy, ScaleRelaxed } from '@fluentui/react-motion-components-preview';
+
+<FadeSnappy visible={show}>Quick feedback</FadeSnappy>
+<ScaleRelaxed visible={show}>Smooth entrance</ScaleRelaxed>
+```
+
+### The `.In` and `.Out` Pattern
+
+Every presence component includes one-way sub-components:
+
+```tsx
+// One-way enter animation (plays on mount)
+<Fade.In>
+  <div>Fades in once</div>
+</Fade.In>
+
+// One-way exit animation (plays on mount)
+<Fade.Out>
+  <div>Fades out once</div>
+</Fade.Out>
+```
+
+## Documentation
+
+📚 **[Full documentation](https://react.fluentui.dev/?path=/docs/motion-components-preview-introduction--docs)**
+
+- [Introduction](https://react.fluentui.dev/?path=/docs/motion-components-preview-introduction--docs) — Overview of all components
+- [Fade](https://react.fluentui.dev/?path=/docs/motion-components-preview-fade--docs)
+- [Scale](https://react.fluentui.dev/?path=/docs/motion-components-preview-scale--docs)
+- [Collapse](https://react.fluentui.dev/?path=/docs/motion-components-preview-collapse--docs)
+- [Slide](https://react.fluentui.dev/?path=/docs/motion-components-preview-slide--docs)
+- [Blur](https://react.fluentui.dev/?path=/docs/motion-components-preview-blur--docs)
+- [Rotate](https://react.fluentui.dev/?path=/docs/motion-components-preview-rotate--docs)
+- [Stagger](https://react.fluentui.dev/?path=/docs/motion-choreography-preview-stagger--docs)
+- [Motion Atoms](https://react.fluentui.dev/?path=/docs/motion-components-preview-atoms--docs) — Building blocks for custom components
+
+## Related
+
+- **[@fluentui/react-motion](https://www.npmjs.com/package/@fluentui/react-motion)** — Core motion APIs for creating custom animations

--- a/packages/react-components/react-motion-components-preview/stories/package.json
+++ b/packages/react-components/react-motion-components-preview/stories/package.json
@@ -1,5 +1,12 @@
 {
   "name": "@fluentui/react-motion-components-preview-stories",
   "version": "0.0.0",
-  "private": true
+  "private": true,
+  "devDependencies": {
+    "@fluentui/react-components": "*",
+    "@fluentui/react-icons": "*",
+    "@fluentui/react-motion": "*",
+    "@fluentui/react-motion-components-preview": "*",
+    "@fluentui/react-shared-contexts": "*"
+  }
 }

--- a/packages/react-components/react-motion-components-preview/stories/package.json
+++ b/packages/react-components/react-motion-components-preview/stories/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "devDependencies": {
     "@fluentui/react-components": "*",
-    "@fluentui/react-icons": "*",
+    "@fluentui/react-icons": "^2.0.245",
     "@fluentui/react-motion": "*",
     "@fluentui/react-motion-components-preview": "*",
     "@fluentui/react-shared-contexts": "*"

--- a/packages/react-components/react-motion-components-preview/stories/package.json
+++ b/packages/react-components/react-motion-components-preview/stories/package.json
@@ -2,11 +2,12 @@
   "name": "@fluentui/react-motion-components-preview-stories",
   "version": "0.0.0",
   "private": true,
-  "devDependencies": {
+  "dependencies": {
     "@fluentui/react-components": "*",
     "@fluentui/react-icons": "^2.0.245",
     "@fluentui/react-motion": "*",
     "@fluentui/react-motion-components-preview": "*",
-    "@fluentui/react-shared-contexts": "*"
+    "@fluentui/react-shared-contexts": "*",
+    "react": "*"
   }
 }

--- a/packages/react-components/react-motion-components-preview/stories/package.json
+++ b/packages/react-components/react-motion-components-preview/stories/package.json
@@ -7,7 +7,6 @@
     "@fluentui/react-icons": "^2.0.245",
     "@fluentui/react-motion": "*",
     "@fluentui/react-motion-components-preview": "*",
-    "@fluentui/react-shared-contexts": "*",
-    "react": "*"
+    "@fluentui/react-shared-contexts": "*"
   }
 }

--- a/packages/react-components/react-motion-components-preview/stories/package.json
+++ b/packages/react-components/react-motion-components-preview/stories/package.json
@@ -7,6 +7,7 @@
     "@fluentui/react-icons": "^2.0.245",
     "@fluentui/react-motion": "*",
     "@fluentui/react-motion-components-preview": "*",
-    "@fluentui/react-shared-contexts": "*"
+    "@fluentui/react-shared-contexts": "*",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   }
 }

--- a/packages/react-components/react-motion-components-preview/stories/src/Atoms/AtomsDemo.styles.ts
+++ b/packages/react-components/react-motion-components-preview/stories/src/Atoms/AtomsDemo.styles.ts
@@ -1,0 +1,68 @@
+'use client';
+
+import { makeStyles, tokens } from '@fluentui/react-components';
+
+export const useClasses = makeStyles({
+  container: {
+    display: 'flex',
+    flexDirection: 'column',
+    border: `${tokens.strokeWidthThin} solid ${tokens.colorNeutralStroke1}`,
+    borderRadius: tokens.borderRadiusMedium,
+    marginTop: tokens.spacingVerticalXXL,
+    marginBottom: tokens.spacingVerticalXXL,
+    overflow: 'hidden',
+  },
+  controls: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: tokens.spacingHorizontalL,
+    flexWrap: 'wrap',
+    padding: `${tokens.spacingVerticalL} ${tokens.spacingHorizontalXL}`,
+    backgroundColor: tokens.colorNeutralBackground2,
+    borderBottom: `${tokens.strokeWidthThin} solid ${tokens.colorNeutralStroke1}`,
+  },
+  body: {
+    display: 'flex',
+    '@media (max-width: 600px)': {
+      flexDirection: 'column',
+    },
+  },
+  demoArea: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: '120px',
+    flex: '0 0 200px',
+    backgroundColor: tokens.colorNeutralBackground1,
+    padding: tokens.spacingVerticalXL,
+  },
+  demoBox: {
+    width: '100px',
+    height: '80px',
+    backgroundColor: tokens.colorNeutralBackground3,
+    border: `${tokens.strokeWidthThin} solid ${tokens.colorNeutralStroke1}`,
+    borderRadius: tokens.borderRadiusMedium,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    color: tokens.colorNeutralForeground1,
+    fontWeight: tokens.fontWeightSemibold,
+  },
+  codeArea: {
+    flex: '1 1 auto',
+    minWidth: 0,
+    margin: 0,
+    padding: `${tokens.spacingVerticalL} ${tokens.spacingHorizontalXL}`,
+    backgroundColor: tokens.colorNeutralBackground3,
+    borderLeft: `${tokens.strokeWidthThin} solid ${tokens.colorNeutralStroke1}`,
+    overflow: 'auto',
+    fontFamily: tokens.fontFamilyMonospace,
+    fontSize: tokens.fontSizeBase100,
+    lineHeight: tokens.lineHeightBase200,
+    color: tokens.colorNeutralForeground1,
+    '@media (max-width: 600px)': {
+      borderLeft: 'none',
+      borderTop: `${tokens.strokeWidthThin} solid ${tokens.colorNeutralStroke1}`,
+    },
+  },
+});

--- a/packages/react-components/react-motion-components-preview/stories/src/Atoms/AtomsDemo.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Atoms/AtomsDemo.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import * as React from 'react';
+import { Button, Select } from '@fluentui/react-components';
+import { createMotionComponent, motionTokens } from '@fluentui/react-motion';
+import { fadeAtom, scaleAtom, slideAtom, rotateAtom, blurAtom } from '@fluentui/react-motion-components-preview';
+import { useClasses } from './AtomsDemo.styles';
+
+type AtomType = 'fade' | 'scale' | 'slide' | 'rotate' | 'blur';
+
+const demoDuration = 600;
+
+const createAtomMotion = (type: AtomType) => {
+  const easing = motionTokens.curveDecelerateMid;
+
+  switch (type) {
+    case 'fade':
+      return createMotionComponent(fadeAtom({ direction: 'enter', duration: demoDuration, easing }));
+    case 'scale':
+      return createMotionComponent(scaleAtom({ direction: 'enter', duration: demoDuration, easing, outScale: 0.5 }));
+    case 'slide':
+      return createMotionComponent(slideAtom({ direction: 'enter', duration: demoDuration, easing, outY: '30px' }));
+    case 'rotate':
+      return createMotionComponent(
+        rotateAtom({ direction: 'enter', duration: demoDuration, easing, axis: 'z', outAngle: -90 }),
+      );
+    case 'blur':
+      return createMotionComponent(blurAtom({ direction: 'enter', duration: demoDuration, easing, outRadius: '10px' }));
+    default: {
+      const _exhaustive: never = type;
+      throw new Error(`Unhandled atom type: ${_exhaustive}`);
+    }
+  }
+};
+
+const atomLabels: Record<AtomType, string> = {
+  fade: 'fadeAtom',
+  scale: 'scaleAtom',
+  slide: 'slideAtom',
+  rotate: 'rotateAtom',
+  blur: 'blurAtom',
+};
+
+const atomCodeSnippets: Record<AtomType, string> = {
+  fade: `fadeAtom({
+  direction: 'enter',
+  duration: 600,
+  outOpacity: 0,
+  inOpacity: 1,
+})`,
+  scale: `scaleAtom({
+  direction: 'enter',
+  duration: 600,
+  outScale: 0.5,
+  inScale: 1,
+})`,
+  slide: `slideAtom({
+  direction: 'enter',
+  duration: 600,
+  outY: '30px',
+  inY: '0px',
+})`,
+  rotate: `rotateAtom({
+  direction: 'enter',
+  duration: 600,
+  axis: 'z',
+  outAngle: -90,
+  inAngle: 0,
+})`,
+  blur: `blurAtom({
+  direction: 'enter',
+  duration: 600,
+  outRadius: '10px',
+  inRadius: '0px',
+})`,
+};
+
+export const AtomsDemo: React.FC = () => {
+  const classes = useClasses();
+  const [atomType, setAtomType] = React.useState<AtomType>('fade');
+  const [key, setKey] = React.useState(0);
+
+  const MotionComponent = React.useMemo(() => createAtomMotion(atomType), [atomType]);
+
+  const handleAtomChange = React.useCallback((event: React.ChangeEvent<HTMLSelectElement>) => {
+    setAtomType(event.target.value as AtomType);
+    setKey(k => k + 1);
+  }, []);
+  const handleReplay = React.useCallback(() => setKey(k => k + 1), []);
+
+  return (
+    <div className={classes.container}>
+      <div className={classes.controls}>
+        <Select value={atomType} onChange={handleAtomChange}>
+          <option value="fade">fadeAtom</option>
+          <option value="scale">scaleAtom</option>
+          <option value="slide">slideAtom</option>
+          <option value="rotate">rotateAtom</option>
+          <option value="blur">blurAtom</option>
+        </Select>
+        <Button appearance="primary" onClick={handleReplay}>
+          Replay
+        </Button>
+      </div>
+      <div className={classes.body}>
+        <div className={classes.demoArea}>
+          <MotionComponent key={key}>
+            <div className={classes.demoBox}>{atomLabels[atomType]}</div>
+          </MotionComponent>
+        </div>
+        <pre className={classes.codeArea}>{atomCodeSnippets[atomType]}</pre>
+      </div>
+    </div>
+  );
+};

--- a/packages/react-components/react-motion-components-preview/stories/src/Atoms/ComposingAtomsDemo.styles.ts
+++ b/packages/react-components/react-motion-components-preview/stories/src/Atoms/ComposingAtomsDemo.styles.ts
@@ -1,0 +1,83 @@
+'use client';
+
+import { makeStyles, tokens } from '@fluentui/react-components';
+
+export const useClasses = makeStyles({
+  wrapper: {
+    border: `${tokens.strokeWidthThin} solid ${tokens.colorNeutralStroke1}`,
+    borderRadius: tokens.borderRadiusMedium,
+    overflow: 'hidden',
+    marginTop: tokens.spacingVerticalXXL,
+    marginBottom: tokens.spacingVerticalXXL,
+  },
+  header: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: `${tokens.spacingVerticalM} ${tokens.spacingHorizontalXL}`,
+    backgroundColor: tokens.colorNeutralBackground2,
+    borderBottom: `${tokens.strokeWidthThin} solid ${tokens.colorNeutralStroke1}`,
+  },
+  title: {
+    margin: 0,
+    fontWeight: tokens.fontWeightSemibold,
+    fontSize: tokens.fontSizeBase300,
+  },
+  body: {
+    display: 'flex',
+    '@media (max-width: 600px)': {
+      flexDirection: 'column',
+    },
+  },
+  demoArea: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flex: '1 1 auto',
+    minHeight: '120px',
+    padding: tokens.spacingVerticalXL,
+    backgroundColor: tokens.colorNeutralBackground1,
+  },
+  demoPane: {
+    display: 'flex',
+    flexDirection: 'column',
+    flex: '0 0 220px',
+  },
+  buttonRow: {
+    display: 'flex',
+    justifyContent: 'center',
+    padding: `${tokens.spacingVerticalM} ${tokens.spacingHorizontalXL} ${tokens.spacingVerticalL}`,
+    backgroundColor: tokens.colorNeutralBackground1,
+  },
+  demoBox: {
+    padding: `${tokens.spacingVerticalL} ${tokens.spacingHorizontalXXL}`,
+    backgroundColor: tokens.colorNeutralBackground3,
+    border: `${tokens.strokeWidthThin} solid ${tokens.colorNeutralStroke1}`,
+    borderRadius: tokens.borderRadiusMedium,
+    color: tokens.colorNeutralForeground1,
+    fontSize: tokens.fontSizeBase300,
+    fontWeight: tokens.fontWeightSemibold,
+    textAlign: 'center',
+  },
+  codeArea: {
+    flex: '1 1 auto',
+    minWidth: 0,
+    padding: `${tokens.spacingVerticalL} ${tokens.spacingHorizontalXL}`,
+    backgroundColor: tokens.colorNeutralBackground1,
+    borderLeft: `${tokens.strokeWidthThin} solid ${tokens.colorNeutralStroke1}`,
+    overflow: 'auto',
+    '@media (max-width: 600px)': {
+      borderLeft: 'none',
+      borderTop: `${tokens.strokeWidthThin} solid ${tokens.colorNeutralStroke1}`,
+    },
+  },
+  code: {
+    fontFamily: tokens.fontFamilyMonospace,
+    fontSize: tokens.fontSizeBase100,
+    lineHeight: tokens.lineHeightBase200,
+    color: tokens.colorNeutralForeground1,
+    whiteSpace: 'pre',
+    margin: 0,
+    display: 'block',
+  },
+});

--- a/packages/react-components/react-motion-components-preview/stories/src/Atoms/ComposingAtomsDemo.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Atoms/ComposingAtomsDemo.tsx
@@ -1,0 +1,259 @@
+'use client';
+
+import * as React from 'react';
+import { Button } from '@fluentui/react-components';
+import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
+import { OpenRegular } from '@fluentui/react-icons';
+import { createPresenceComponent, motionTokens } from '@fluentui/react-motion';
+import { rotateAtom, blurAtom, scaleAtom } from '@fluentui/react-motion-components-preview';
+import { useClasses } from './ComposingAtomsDemo.styles';
+
+const duration = 1000;
+const exitDuration = 1000;
+const easing = motionTokens.curveDecelerateMid;
+
+// Custom "SpinBlur" — combines rotate + blur + scale
+const SpinBlur = createPresenceComponent({
+  enter: [
+    rotateAtom({ direction: 'enter', duration, easing, axis: 'z', outAngle: -20, inAngle: 0 }),
+    blurAtom({ direction: 'enter', duration, easing, outRadius: '8px', inRadius: '0px' }),
+    scaleAtom({ direction: 'enter', duration, easing, outScale: 2 }),
+  ],
+  exit: [
+    rotateAtom({
+      direction: 'exit',
+      duration: exitDuration,
+      easing: motionTokens.curveAccelerateMid,
+      axis: 'z',
+      outAngle: 90,
+      inAngle: 0,
+    }),
+    blurAtom({
+      direction: 'exit',
+      duration: exitDuration,
+      easing: motionTokens.curveLinear,
+      outRadius: '8px',
+      inRadius: '0px',
+    }),
+    scaleAtom({ direction: 'exit', duration: exitDuration, easing: motionTokens.curveLinear, outScale: 0 }),
+  ],
+});
+
+const codeSnippet = `const SpinBlur = createPresenceComponent({
+  enter: [
+    rotateAtom({ direction: 'enter', duration: 800, axis: 'z', outAngle: -20 }),
+    blurAtom({ direction: 'enter', duration: 800, outRadius: '8px' }),
+    scaleAtom({ direction: 'enter', duration: 800, outScale: 0.8 }),
+  ],
+  exit: [
+    rotateAtom({ direction: 'exit', duration: 600, axis: 'z', outAngle: -20 }),
+    blurAtom({ direction: 'exit', duration: 600, outRadius: '8px' }),
+    scaleAtom({ direction: 'exit', duration: 600, outScale: 0.8 }),
+  ],
+});
+
+// Usage — just like any presence component
+<SpinBlur visible={isVisible}>
+  <div>Your content</div>
+</SpinBlur>`;
+
+const stackblitzExampleCode = `import * as React from 'react';
+import { makeStyles, tokens, Button, FluentProvider, webLightTheme } from '@fluentui/react-components';
+import { createPresenceComponent } from '@fluentui/react-motion';
+import { rotateAtom, blurAtom, scaleAtom } from '@fluentui/react-motion-components-preview';
+
+const useClasses = makeStyles({
+  container: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: '16px',
+    padding: '40px',
+  },
+  box: {
+    padding: '24px 32px',
+    backgroundColor: tokens.colorNeutralBackground3,
+    border: \`1px solid \${tokens.colorNeutralStroke1}\`,
+    borderRadius: '8px',
+    fontSize: '18px',
+    fontWeight: 600,
+    textAlign: 'center',
+  },
+});
+
+const SpinBlur = createPresenceComponent({
+  enter: [
+    rotateAtom({ direction: 'enter', duration: 800, axis: 'z', outAngle: -20 }),
+    blurAtom({ direction: 'enter', duration: 800, outRadius: '8px' }),
+    scaleAtom({ direction: 'enter', duration: 800, outScale: 0.8 }),
+  ],
+  exit: [
+    rotateAtom({ direction: 'exit', duration: 600, axis: 'z', outAngle: -20 }),
+    blurAtom({ direction: 'exit', duration: 600, outRadius: '8px' }),
+    scaleAtom({ direction: 'exit', duration: 600, outScale: 0.8 }),
+  ],
+});
+
+export default function Example() {
+  const classes = useClasses();
+  const [visible, setVisible] = React.useState(true);
+
+  return (
+    <div className={classes.container}>
+      <SpinBlur visible={visible}>
+        <div className={classes.box}>SpinBlur ✨</div>
+      </SpinBlur>
+      <Button appearance="primary" onClick={() => setVisible(v => !v)}>
+        {visible ? 'Hide' : 'Show'}
+      </Button>
+    </div>
+  );
+}`;
+
+const stackblitzFiles: Record<string, string> = {
+  '.stackblitzrc': JSON.stringify({}),
+  'index.html': `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SpinBlur — Composing Motion Atoms</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/index.tsx"></script>
+  </body>
+</html>`,
+  'src/index.tsx': `import * as React from 'react';
+import { createRoot } from 'react-dom/client';
+import { FluentProvider, webLightTheme } from '@fluentui/react-components';
+import Example from './example';
+
+createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <FluentProvider theme={webLightTheme}>
+      <Example />
+    </FluentProvider>
+  </React.StrictMode>,
+);`,
+  'src/example.tsx': stackblitzExampleCode,
+  'tsconfig.json': JSON.stringify(
+    {
+      compilerOptions: {
+        target: 'ES2020',
+        useDefineForClassFields: true,
+        lib: ['ES2020', 'DOM', 'DOM.Iterable'],
+        module: 'ESNext',
+        skipLibCheck: true,
+        moduleResolution: 'node',
+        resolveJsonModule: true,
+        isolatedModules: true,
+        noEmit: true,
+        jsx: 'react-jsx',
+        strict: true,
+      },
+      include: ['src'],
+    },
+    null,
+    2,
+  ),
+  'vite.config.ts': `import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+export default defineConfig({ plugins: [react()] })`,
+  'package.json': JSON.stringify(
+    {
+      name: 'fluent-motion-spinblur-example',
+      private: true,
+      version: '0.0.0',
+      type: 'module',
+      scripts: { dev: 'vite', build: 'tsc && vite build', preview: 'vite preview' },
+      dependencies: {
+        react: '^18',
+        'react-dom': '^18',
+        '@fluentui/react-components': '^9.0.0',
+        '@fluentui/react-motion': 'latest',
+        '@fluentui/react-motion-components-preview': 'latest',
+      },
+      devDependencies: {
+        '@types/react': '^18',
+        '@types/react-dom': '^18',
+        '@vitejs/plugin-react': '^4.2.0',
+        typescript: '~5.0.0',
+        vite: '^5.0.0',
+      },
+    },
+    null,
+    2,
+  ),
+};
+
+function openInStackBlitz(doc: Document) {
+  const form = doc.createElement('form');
+  form.method = 'post';
+  form.target = '_blank';
+  form.action = `https://stackblitz.com/run?file=${encodeURIComponent('src/example.tsx')}`;
+
+  const addField = (name: string, value: string) => {
+    const input = doc.createElement('input');
+    input.type = 'hidden';
+    input.name = name;
+    input.value = value;
+    form.appendChild(input);
+  };
+
+  addField('project[template]', 'node');
+  addField('project[title]', 'SpinBlur — Composing Motion Atoms');
+  addField('project[description]', '# Custom presence component composed from rotateAtom + blurAtom + scaleAtom');
+
+  Object.entries(stackblitzFiles).forEach(([path, content]) => {
+    addField(`project[files][${path}]`, content);
+  });
+
+  doc.body.appendChild(form);
+  form.submit();
+  doc.body.removeChild(form);
+}
+
+export const ComposingAtomsDemo: React.FC = () => {
+  const classes = useClasses();
+  const { targetDocument } = useFluent();
+  const [visible, setVisible] = React.useState(true);
+
+  const handleToggle = React.useCallback(() => {
+    setVisible(v => !v);
+  }, []);
+
+  const handleOpenStackBlitz = React.useCallback(() => {
+    if (targetDocument) {
+      openInStackBlitz(targetDocument);
+    }
+  }, [targetDocument]);
+
+  return (
+    <div className={classes.wrapper}>
+      <div className={classes.header}>
+        <h4 className={classes.title}>Custom "SpinBlur" — rotate + blur + scale</h4>
+        <Button appearance="subtle" icon={<OpenRegular />} size="small" onClick={handleOpenStackBlitz}>
+          Try in StackBlitz
+        </Button>
+      </div>
+      <div className={classes.body}>
+        <div className={classes.demoPane}>
+          <div className={classes.demoArea}>
+            <SpinBlur visible={visible}>
+              <div className={classes.demoBox}>SpinBlur</div>
+            </SpinBlur>
+          </div>
+          <div className={classes.buttonRow}>
+            <Button appearance="primary" onClick={handleToggle}>
+              {visible ? 'Hide' : 'Show'}
+            </Button>
+          </div>
+        </div>
+        <div className={classes.codeArea}>
+          <code className={classes.code}>{codeSnippet}</code>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/packages/react-components/react-motion-components-preview/stories/src/Atoms/index.mdx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Atoms/index.mdx
@@ -1,0 +1,183 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import { tokens } from '@fluentui/react-components';
+import { AtomsDemo } from './AtomsDemo';
+import { ComposingAtomsDemo } from './ComposingAtomsDemo';
+
+<Meta title="Motion/Components (preview)/Atoms" />
+
+<style>
+  {`
+  .atoms-hero {
+    text-align: center;
+    padding: 32px 20px;
+    background: linear-gradient(135deg, ${tokens.colorPaletteGreenBackground2} 0%, ${tokens.colorNeutralBackground1} 100%);
+    border-radius: 12px;
+    margin-bottom: 32px;
+  }
+  .atoms-hero h1 {
+    margin: 0 0 12px 0;
+    font-size: 1.8rem;
+  }
+  .atoms-hero .hero-subtitle {
+    font-size: 1rem;
+    color: ${tokens.colorNeutralForeground2};
+    max-width: 600px;
+    margin: 0 auto;
+  }
+  .warning-banner {
+    padding: 16px 20px;
+    background: ${tokens.colorPaletteYellowBackground1};
+    border: 1px solid ${tokens.colorPaletteYellowBorder1};
+    border-radius: 8px;
+    margin-bottom: 24px;
+  }
+  .warning-banner strong {
+    color: ${tokens.colorPaletteYellowForeground2};
+  }
+  .atom-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 16px 0;
+  }
+  .atom-table th,
+  .atom-table td {
+    padding: 12px;
+    text-align: left;
+    border-bottom: 1px solid ${tokens.colorNeutralStroke1};
+  }
+  .atom-table th {
+    background: ${tokens.colorNeutralBackground3};
+    font-weight: 600;
+  }
+  .atom-table code {
+    background: ${tokens.colorNeutralBackground4};
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-size: 0.9em;
+  }
+  .info-box {
+    padding: 16px 20px;
+    background: ${tokens.colorNeutralBackground3};
+    border-radius: 8px;
+    margin: 16px 0;
+  }
+`}
+</style>
+
+<div className="atoms-hero">
+  <h1>Motion Atoms</h1>
+  <div className="hero-subtitle">
+    The smallest building blocks in the <a href="?path=/docs/motion-introduction--docs">Fluent Motion System</a>. Each
+    atom produces a single animation effect that can be composed into richer motion.
+  </div>
+</div>
+
+<div className="warning-banner">
+  <strong>⚠️ Advanced API:</strong> Atoms are for developers creating custom motion components. For most use cases, use
+  the pre-built <a href="?path=/docs/motion-components-preview-introduction--docs">Motion Components</a> like{' '}
+  <code>Fade</code>, <code>Scale</code>, etc.
+</div>
+
+## What are Motion Atoms?
+
+In the Fluent Motion System's <a href="?path=/docs/motion-introduction--docs#an-atomic-motion-system">atomic model</a>, **atoms** are single one-way animations — keyframes changing one property over time. They're the foundation that <a href="?path=/docs/motion-components-preview-introduction--docs">Motion Components</a> (molecules) are built from.
+
+Each atom is a factory function that returns an `AtomMotion` object — a plain description of keyframes, duration, and easing that the browser can execute directly.
+
+```ts
+import { fadeAtom } from '@fluentui/react-motion-components-preview';
+
+const fadeIn = fadeAtom({
+  direction: 'enter',
+  duration: 500,
+  outOpacity: 0,
+  inOpacity: 1,
+});
+// Returns: { keyframes: [{ opacity: 0 }, { opacity: 1 }], duration: 500, easing: '...', ... }
+```
+
+## Available Atoms
+
+| Atom         | Effect               | CSS Property             | Key Parameters                |
+| ------------ | -------------------- | ------------------------ | ----------------------------- |
+| `fadeAtom`   | Opacity transition   | `opacity`                | `outOpacity`, `inOpacity`     |
+| `scaleAtom`  | Size scaling         | `transform: scale()`     | `outScale`, `inScale`         |
+| `slideAtom`  | Position translation | `transform: translate()` | `outX`, `outY`, `inX`, `inY`  |
+| `rotateAtom` | 3D rotation          | `transform: rotate3d()`  | `axis`, `outAngle`, `inAngle` |
+| `blurAtom`   | Blur filter          | `filter: blur()`         | `outRadius`, `inRadius`       |
+
+<AtomsDemo />
+
+## Atom API Reference
+
+### Common Parameters
+
+All atoms accept these base parameters:
+
+| Parameter   | Type                | Default       | Description                             |
+| ----------- | ------------------- | ------------- | --------------------------------------- |
+| `direction` | `'enter' \| 'exit'` | —             | **Required.** Determines keyframe order |
+| `duration`  | `number`            | —             | **Required.** Animation duration in ms  |
+| `easing`    | `string`            | `curveLinear` | CSS easing function                     |
+| `delay`     | `number`            | `0`           | Delay before animation starts           |
+
+### Per-Atom Parameters
+
+In addition to the common parameters above, each atom has specific properties:
+
+```ts
+import { fadeAtom, scaleAtom, slideAtom, rotateAtom, blurAtom } from '@fluentui/react-motion-components-preview';
+
+// fadeAtom — opacity transition
+fadeAtom({ direction: 'enter', duration: 500, outOpacity: 0, inOpacity: 1 });
+
+// scaleAtom — size scaling
+scaleAtom({ direction: 'enter', duration: 500, outScale: 0.9, inScale: 1 });
+
+// slideAtom — position translation
+slideAtom({ direction: 'enter', duration: 500, outX: '0px', outY: '20px', inX: '0px', inY: '0px' });
+
+// rotateAtom — rotation (axis: 'x' | 'y' | 'z')
+rotateAtom({ direction: 'enter', duration: 600, axis: 'z', outAngle: -90, inAngle: 0 });
+
+// blurAtom — blur filter
+blurAtom({ direction: 'enter', duration: 500, outRadius: '10px', inRadius: '0px' });
+```
+
+## Creating Custom Presence Components
+
+The real power of atoms is **composing** them. Pass an array of atoms to `createPresenceComponent` and they run in parallel — creating richer effects from simple building blocks:
+
+<ComposingAtomsDemo />
+
+Multiple atoms in an array animate simultaneously. Use the same duration for a cohesive feel, or intentionally vary them for more complex choreography.
+
+### Dynamic Parameters
+
+Use the function form to access runtime values like element dimensions:
+
+```tsx
+const DynamicSlide = createPresenceComponent(({ element }) => {
+  const width = element.offsetWidth;
+  return {
+    enter: slideAtom({ direction: 'enter', duration: 500, outX: `-${width}px` }),
+    exit: slideAtom({ direction: 'exit', duration: 500, outX: `-${width}px` }),
+  };
+});
+```
+
+## When to Use Atoms
+
+| Use Case                                       | Recommendation                                                  |
+| ---------------------------------------------- | --------------------------------------------------------------- |
+| Standard fade, scale, slide                    | Use pre-built components (`Fade`, `Scale`, etc.)                |
+| Custom combination of effects                  | Compose atoms into a new presence component                     |
+| Unique animation not covered by existing atoms | Create custom keyframes directly with `createPresenceComponent` |
+| Dynamic animations based on element size       | Use atoms with the function form                                |
+
+## See Also
+
+- [Motion Components](?path=/docs/motion-components-preview-introduction--docs) — Pre-built presence animations (molecules)
+- [createPresenceComponent](?path=/docs/motion-apis-createpresencecomponent--docs) — Factory for presence components
+- [createMotionComponent](?path=/docs/motion-apis-createmotioncomponent--docs) — Factory for one-way motion
+- [Motion Tokens](?path=/docs/motion-tokens--docs) — Duration and easing values

--- a/packages/react-components/react-motion-components-preview/stories/src/Introduction/ComponentsGrid.styles.ts
+++ b/packages/react-components/react-motion-components-preview/stories/src/Introduction/ComponentsGrid.styles.ts
@@ -1,0 +1,48 @@
+'use client';
+
+import { makeStyles, tokens } from '@fluentui/react-components';
+
+export const useClasses = makeStyles({
+  grid: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))',
+    gap: tokens.spacingHorizontalL,
+    marginTop: tokens.spacingVerticalXXL,
+    marginBottom: tokens.spacingVerticalXXL,
+  },
+  card: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: tokens.spacingVerticalM,
+    padding: tokens.spacingVerticalXL,
+    border: `${tokens.strokeWidthThin} solid ${tokens.colorNeutralStroke1}`,
+    borderRadius: tokens.borderRadiusMedium,
+    backgroundColor: tokens.colorNeutralBackground1,
+  },
+  name: {
+    margin: 0,
+    fontWeight: tokens.fontWeightSemibold,
+    fontSize: tokens.fontSizeBase400,
+  },
+  demoArea: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '100%',
+    height: '60px',
+  },
+  demoBox: {
+    width: '50px',
+    height: '50px',
+    backgroundColor: tokens.colorNeutralBackground3,
+    border: `${tokens.strokeWidthThin} solid ${tokens.colorNeutralStroke1}`,
+    borderRadius: tokens.borderRadiusSmall,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    color: tokens.colorNeutralForeground1,
+    fontSize: tokens.fontSizeBase200,
+    fontWeight: tokens.fontWeightSemibold,
+  },
+});

--- a/packages/react-components/react-motion-components-preview/stories/src/Introduction/ComponentsGrid.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Introduction/ComponentsGrid.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import * as React from 'react';
+import { Button } from '@fluentui/react-components';
+import {
+  FadeRelaxed,
+  ScaleRelaxed,
+  CollapseRelaxed,
+  SlideRelaxed,
+  Blur,
+  Rotate,
+} from '@fluentui/react-motion-components-preview';
+import { useClasses } from './ComponentsGrid.styles';
+
+interface ComponentCardProps {
+  name: string;
+  children: (visible: boolean) => React.ReactNode;
+}
+
+const ComponentCard: React.FC<ComponentCardProps> = ({ name, children }) => {
+  const classes = useClasses();
+  const [visible, setVisible] = React.useState(true);
+  const toggleVisible = React.useCallback(() => setVisible(v => !v), []);
+
+  return (
+    <div className={classes.card}>
+      <h4 className={classes.name}>{name}</h4>
+      <div className={classes.demoArea}>{children(visible)}</div>
+      <Button appearance="primary" size="small" onClick={toggleVisible}>
+        {visible ? 'Hide' : 'Show'}
+      </Button>
+    </div>
+  );
+};
+
+export const ComponentsGrid: React.FC = () => {
+  const classes = useClasses();
+
+  return (
+    <div className={classes.grid}>
+      <ComponentCard name="Fade">
+        {visible => (
+          <FadeRelaxed visible={visible}>
+            <div className={classes.demoBox}>Fade</div>
+          </FadeRelaxed>
+        )}
+      </ComponentCard>
+
+      <ComponentCard name="Scale">
+        {visible => (
+          <ScaleRelaxed visible={visible}>
+            <div className={classes.demoBox}>Scale</div>
+          </ScaleRelaxed>
+        )}
+      </ComponentCard>
+
+      <ComponentCard name="Collapse">
+        {visible => (
+          <CollapseRelaxed visible={visible}>
+            <div className={classes.demoBox}>Collapse</div>
+          </CollapseRelaxed>
+        )}
+      </ComponentCard>
+
+      <ComponentCard name="Slide">
+        {visible => (
+          <SlideRelaxed visible={visible}>
+            <div className={classes.demoBox}>Slide</div>
+          </SlideRelaxed>
+        )}
+      </ComponentCard>
+
+      <ComponentCard name="Blur">
+        {visible => (
+          <Blur visible={visible}>
+            <div className={classes.demoBox}>Blur</div>
+          </Blur>
+        )}
+      </ComponentCard>
+
+      <ComponentCard name="Rotate">
+        {visible => (
+          <Rotate visible={visible} outAngle={-90} inAngle={0} axis="z">
+            <div className={classes.demoBox}>Rotate</div>
+          </Rotate>
+        )}
+      </ComponentCard>
+    </div>
+  );
+};

--- a/packages/react-components/react-motion-components-preview/stories/src/Introduction/InOutDemo.styles.ts
+++ b/packages/react-components/react-motion-components-preview/stories/src/Introduction/InOutDemo.styles.ts
@@ -1,0 +1,69 @@
+'use client';
+
+import { makeStyles, tokens } from '@fluentui/react-components';
+
+export const useClasses = makeStyles({
+  container: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(3, 1fr)',
+    gap: tokens.spacingHorizontalL,
+    marginTop: tokens.spacingVerticalXXL,
+    marginBottom: tokens.spacingVerticalXXL,
+
+    '@media (max-width: 600px)': {
+      gridTemplateColumns: '1fr',
+    },
+  },
+  panel: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: tokens.spacingVerticalM,
+    padding: tokens.spacingVerticalXL,
+    border: `${tokens.strokeWidthThin} solid ${tokens.colorNeutralStroke1}`,
+    borderRadius: tokens.borderRadiusMedium,
+    backgroundColor: tokens.colorNeutralBackground1,
+  },
+  title: {
+    margin: 0,
+    fontWeight: tokens.fontWeightSemibold,
+    fontSize: tokens.fontSizeBase300,
+  },
+  subtitle: {
+    margin: 0,
+    fontSize: tokens.fontSizeBase200,
+    color: tokens.colorNeutralForeground3,
+    textAlign: 'center',
+  },
+  code: {
+    fontFamily: tokens.fontFamilyMonospace,
+    fontSize: tokens.fontSizeBase200,
+    backgroundColor: tokens.colorNeutralBackground4,
+    padding: `${tokens.spacingVerticalXXS} ${tokens.spacingHorizontalSNudge}`,
+    borderRadius: tokens.borderRadiusSmall,
+  },
+  demoArea: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '100%',
+    height: '60px',
+  },
+  demoBox: {
+    width: '80px',
+    height: '50px',
+    backgroundColor: tokens.colorBrandBackground,
+    borderRadius: tokens.borderRadiusSmall,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    color: tokens.colorNeutralForegroundOnBrand,
+    fontSize: tokens.fontSizeBase200,
+    fontWeight: tokens.fontWeightSemibold,
+  },
+  button: {
+    minWidth: 'auto',
+    padding: `${tokens.spacingVerticalXS} ${tokens.spacingHorizontalM}`,
+    fontSize: tokens.fontSizeBase200,
+  },
+});

--- a/packages/react-components/react-motion-components-preview/stories/src/Introduction/InOutDemo.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Introduction/InOutDemo.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import * as React from 'react';
+import { Button } from '@fluentui/react-components';
+import { Fade } from '@fluentui/react-motion-components-preview';
+import { useClasses } from './InOutDemo.styles';
+
+export const InOutDemo: React.FC = () => {
+  const classes = useClasses();
+  const [visible, setVisible] = React.useState(true);
+  const [inKey, setInKey] = React.useState(0);
+  const [outKey, setOutKey] = React.useState(0);
+
+  const replayIn = React.useCallback(() => setInKey(k => k + 1), []);
+  const toggleVisible = React.useCallback(() => setVisible(v => !v), []);
+  const replayOut = React.useCallback(() => setOutKey(k => k + 1), []);
+
+  return (
+    <div className={classes.container}>
+      <div className={classes.panel}>
+        <h4 className={classes.title}>Fade.In</h4>
+        <span className={classes.code}>&lt;Fade.In&gt;</span>
+        <p className={classes.subtitle}>One-way enter</p>
+        <div className={classes.demoArea}>
+          <Fade.In key={inKey}>
+            <div className={classes.demoBox}>Enter</div>
+          </Fade.In>
+        </div>
+        <Button className={classes.button} size="small" onClick={replayIn}>
+          Replay
+        </Button>
+      </div>
+
+      <div className={classes.panel}>
+        <h4 className={classes.title}>Fade</h4>
+        <span className={classes.code}>&lt;Fade visible&gt;</span>
+        <p className={classes.subtitle}>Two-way presence</p>
+        <div className={classes.demoArea}>
+          <Fade visible={visible}>
+            <div className={classes.demoBox}>Toggle</div>
+          </Fade>
+        </div>
+        <Button className={classes.button} size="small" onClick={toggleVisible}>
+          {visible ? 'Hide' : 'Show'}
+        </Button>
+      </div>
+
+      <div className={classes.panel}>
+        <h4 className={classes.title}>Fade.Out</h4>
+        <span className={classes.code}>&lt;Fade.Out&gt;</span>
+        <p className={classes.subtitle}>One-way exit</p>
+        <div className={classes.demoArea}>
+          <Fade.Out key={outKey}>
+            <div className={classes.demoBox}>Exit</div>
+          </Fade.Out>
+        </div>
+        <Button className={classes.button} size="small" onClick={replayOut}>
+          Replay
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/packages/react-components/react-motion-components-preview/stories/src/Introduction/VariantsDemo.styles.ts
+++ b/packages/react-components/react-motion-components-preview/stories/src/Introduction/VariantsDemo.styles.ts
@@ -1,0 +1,66 @@
+'use client';
+
+import { makeStyles, tokens } from '@fluentui/react-components';
+
+export const useClasses = makeStyles({
+  toolbar: {
+    textAlign: 'center',
+    marginBottom: tokens.spacingVerticalL,
+  },
+  container: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(3, 1fr)',
+    gap: tokens.spacingHorizontalL,
+    marginTop: tokens.spacingVerticalXXL,
+    marginBottom: tokens.spacingVerticalXXL,
+
+    '@media (max-width: 600px)': {
+      gridTemplateColumns: '1fr',
+    },
+  },
+  panel: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: tokens.spacingVerticalM,
+    padding: tokens.spacingVerticalXL,
+    border: `${tokens.strokeWidthThin} solid ${tokens.colorNeutralStroke1}`,
+    borderRadius: tokens.borderRadiusMedium,
+    backgroundColor: tokens.colorNeutralBackground1,
+  },
+  title: {
+    margin: 0,
+    fontWeight: tokens.fontWeightSemibold,
+    fontSize: tokens.fontSizeBase300,
+  },
+  duration: {
+    margin: 0,
+    fontSize: tokens.fontSizeBase200,
+    color: tokens.colorNeutralForeground3,
+    fontFamily: tokens.fontFamilyMonospace,
+  },
+  demoArea: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '100%',
+    height: '60px',
+  },
+  demoBox: {
+    width: '80px',
+    height: '50px',
+    backgroundColor: tokens.colorBrandBackground,
+    borderRadius: tokens.borderRadiusSmall,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    color: tokens.colorNeutralForegroundOnBrand,
+    fontSize: tokens.fontSizeBase200,
+    fontWeight: tokens.fontWeightSemibold,
+  },
+  button: {
+    minWidth: 'auto',
+    padding: `${tokens.spacingVerticalXS} ${tokens.spacingHorizontalM}`,
+    fontSize: tokens.fontSizeBase200,
+  },
+});

--- a/packages/react-components/react-motion-components-preview/stories/src/Introduction/VariantsDemo.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Introduction/VariantsDemo.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import * as React from 'react';
+import { Button } from '@fluentui/react-components';
+import { Fade, FadeSnappy, FadeRelaxed } from '@fluentui/react-motion-components-preview';
+import { useClasses } from './VariantsDemo.styles';
+
+export const VariantsDemo: React.FC = () => {
+  const classes = useClasses();
+  const [visibleSnappy, setVisibleSnappy] = React.useState(true);
+  const [visibleDefault, setVisibleDefault] = React.useState(true);
+  const [visibleRelaxed, setVisibleRelaxed] = React.useState(true);
+
+  const toggleAll = React.useCallback(() => {
+    setVisibleSnappy(v => !v);
+    setVisibleDefault(v => !v);
+    setVisibleRelaxed(v => !v);
+  }, []);
+  const toggleSnappy = React.useCallback(() => setVisibleSnappy(v => !v), []);
+  const toggleDefault = React.useCallback(() => setVisibleDefault(v => !v), []);
+  const toggleRelaxed = React.useCallback(() => setVisibleRelaxed(v => !v), []);
+
+  return (
+    <>
+      <div className={classes.toolbar}>
+        <Button onClick={toggleAll}>Toggle All</Button>
+      </div>
+      <div className={classes.container}>
+        <div className={classes.panel}>
+          <h4 className={classes.title}>FadeSnappy</h4>
+          <p className={classes.duration}>150ms</p>
+          <div className={classes.demoArea}>
+            <FadeSnappy visible={visibleSnappy}>
+              <div className={classes.demoBox}>Snappy</div>
+            </FadeSnappy>
+          </div>
+          <Button className={classes.button} size="small" onClick={toggleSnappy}>
+            {visibleSnappy ? 'Hide' : 'Show'}
+          </Button>
+        </div>
+
+        <div className={classes.panel}>
+          <h4 className={classes.title}>Fade</h4>
+          <p className={classes.duration}>200ms</p>
+          <div className={classes.demoArea}>
+            <Fade visible={visibleDefault}>
+              <div className={classes.demoBox}>Default</div>
+            </Fade>
+          </div>
+          <Button className={classes.button} size="small" onClick={toggleDefault}>
+            {visibleDefault ? 'Hide' : 'Show'}
+          </Button>
+        </div>
+
+        <div className={classes.panel}>
+          <h4 className={classes.title}>FadeRelaxed</h4>
+          <p className={classes.duration}>250ms</p>
+          <div className={classes.demoArea}>
+            <FadeRelaxed visible={visibleRelaxed}>
+              <div className={classes.demoBox}>Relaxed</div>
+            </FadeRelaxed>
+          </div>
+          <Button className={classes.button} size="small" onClick={toggleRelaxed}>
+            {visibleRelaxed ? 'Hide' : 'Show'}
+          </Button>
+        </div>
+      </div>
+    </>
+  );
+};

--- a/packages/react-components/react-motion-components-preview/stories/src/Introduction/index.mdx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Introduction/index.mdx
@@ -1,0 +1,289 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import { tokens } from '@fluentui/react-components';
+import { ComponentsGrid } from './ComponentsGrid';
+import { InOutDemo } from './InOutDemo';
+import { VariantsDemo } from './VariantsDemo';
+
+<Meta title="Motion/Components (preview)/Introduction" />
+
+<style>
+  {`
+  .components-hero {
+    text-align: center;
+    padding: 40px 20px;
+    background: linear-gradient(135deg, ${tokens.colorPalettePurpleBackground2} 0%, ${tokens.colorNeutralBackground1} 100%);
+    border-radius: 12px;
+    margin-bottom: 32px;
+  }
+  .components-hero h1 {
+    margin: 0 0 16px 0;
+    font-size: 2rem;
+  }
+  .components-hero .hero-subtitle {
+    font-size: 1.1rem;
+    color: ${tokens.colorNeutralForeground2};
+    max-width: 600px;
+    margin: 0 auto;
+  }
+  .warning-banner {
+    padding: 16px 20px;
+    background: ${tokens.colorPaletteYellowBackground1};
+    border: 1px solid ${tokens.colorPaletteYellowBorder1};
+    border-radius: 8px;
+    margin-bottom: 24px;
+  }
+  .warning-banner strong {
+    color: ${tokens.colorPaletteYellowForeground2};
+  }
+  .audience-section {
+    margin: 32px 0;
+    padding: 24px;
+    border-radius: 8px;
+    border: 1px solid ${tokens.colorNeutralStroke1};
+  }
+  .audience-section h2 {
+    margin-top: 0;
+  }
+  .designer-section {
+    border-left: 4px solid ${tokens.colorPalettePurpleBorder2};
+  }
+  .developer-section {
+    border-left: 4px solid ${tokens.colorPaletteBlueBorder2};
+  }
+  .component-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 16px 0;
+  }
+  .component-table th,
+  .component-table td {
+    padding: 12px;
+    text-align: left;
+    border-bottom: 1px solid ${tokens.colorNeutralStroke1};
+  }
+  .component-table th {
+    background: ${tokens.colorNeutralBackground3};
+    font-weight: 600;
+  }
+  .component-table code {
+    background: ${tokens.colorNeutralBackground4};
+    padding: 2px 6px;
+    border-radius: 4px;
+  }
+`}
+</style>
+
+<div className="components-hero">
+  <h1>Motion Components</h1>
+  <div className="hero-subtitle">
+    Pre-built presence animations for common UI patterns — ready to use with intelligent defaults. Part of the{' '}
+    <a href="?path=/docs/motion-introduction--docs">Fluent Motion System</a>.
+  </div>
+</div>
+
+<div className="warning-banner">
+  <strong>⚠️ Preview Package:</strong> These components are in beta and APIs may change before stable release. Import
+  from <code>@fluentui/react-motion-components-preview</code>
+</div>
+
+## Overview
+
+The Motion Components package provides six **presence components** that handle the most common UI animation needs. Each component manages visibility state and plays appropriate enter/exit animations.
+
+<ComponentsGrid />
+
+---
+
+<div className="audience-section designer-section">
+
+## For Motion Designers
+
+### Available Components
+
+| Component    | Animation              | Best For                                  |
+| ------------ | ---------------------- | ----------------------------------------- |
+| **Fade**     | Opacity transition     | Tooltips, notifications, overlays, modals |
+| **Scale**    | Size grow/shrink       | Popovers, menus, buttons, emphasis        |
+| **Collapse** | Height/width expansion | Accordions, expandable sections           |
+| **Slide**    | Directional movement   | Drawers, panels, carousels                |
+| **Blur**     | Focus/defocus effect   | Background dimming, depth                 |
+| **Rotate**   | 3D rotation            | Card flips, reveals, playful interactions |
+
+### Timing Variants
+
+Each component (except Blur and Rotate) comes with pre-configured timing variants:
+
+| Variant     | Duration                 | Feel              | Use Case                           |
+| ----------- | ------------------------ | ----------------- | ---------------------------------- |
+| **Default** | 200ms (`durationNormal`) | Balanced          | General purpose                    |
+| **Snappy**  | 150ms (`durationFast`)   | Quick, responsive | Small elements, micro-interactions |
+| **Relaxed** | 250ms (`durationGentle`) | Smooth, calm      | Large elements, important content  |
+
+**Collapse** also has a **Delayed** variant that adds a delay before the collapse begins, useful for accordions where you want the content to be readable briefly before collapsing.
+
+### Direction Support
+
+**Slide** can move content in any direction — left, right, up, or down. This makes it versatile for drawers that slide in from the edge of the screen, panels that reveal from a specific side, or page transitions that move content horizontally.
+
+### Choreography with Stagger
+
+**Stagger** coordinates multiple animations in sequence, creating a cascading ripple effect — like items in a list appearing one after another instead of all at once. It's ideal for lists, grids, card layouts, and any group of elements that should animate in sequence.
+
+</div>
+
+---
+
+<div className="audience-section developer-section">
+
+## For Developers
+
+### Installation
+
+```bash
+npm install @fluentui/react-motion-components-preview
+# or
+yarn add @fluentui/react-motion-components-preview
+```
+
+### Basic Usage
+
+```tsx
+import { Fade, Scale, Slide, Collapse } from '@fluentui/react-motion-components-preview';
+
+function MyComponent() {
+  const [showTooltip, setShowTooltip] = useState(false);
+
+  return (
+    <Fade visible={showTooltip}>
+      <div className="tooltip">Hello!</div>
+    </Fade>
+  );
+}
+```
+
+### The `.In` and `.Out` Pattern
+
+Every presence component includes **one-way motion sub-components** that play just the enter or exit animation:
+
+<InOutDemo />
+
+```tsx
+import { Fade, Scale, Slide } from '@fluentui/react-motion-components-preview';
+
+// Full presence (two-way, controlled by visible prop)
+<Fade visible={isVisible}>
+  <Content />
+</Fade>
+
+// Just the enter animation (one-way, plays on mount)
+<Fade.In>
+  <Content />
+</Fade.In>
+
+// Just the exit animation (one-way, plays on mount)
+<Fade.Out>
+  <Content />
+</Fade.Out>
+```
+
+**Use cases for `.In` and `.Out`:**
+
+- Page load animations (use `.In` for entrance-only)
+- Exit transitions before navigation (use `.Out`)
+- Choreographing different enter/exit from different components
+- Looping or staggered animations
+
+### Using Variants
+
+Variants are separate exports with pre-configured timing:
+
+```tsx
+import {
+  Fade, FadeSnappy, FadeRelaxed,
+  Scale, ScaleSnappy, ScaleRelaxed,
+  Collapse, CollapseSnappy, CollapseRelaxed, CollapseDelayed,
+  Slide, SlideSnappy, SlideRelaxed
+} from '@fluentui/react-motion-components-preview';
+
+// Quick feedback for small UI
+<ScaleSnappy visible={showMenu}>
+  <Menu />
+</ScaleSnappy>
+
+// Relaxed feel for important content
+<FadeRelaxed visible={showModal}>
+  <Modal />
+</FadeRelaxed>
+```
+
+<VariantsDemo />
+
+### Customization with Parameters
+
+All components accept parameters to customize their behavior:
+
+```tsx
+// Custom opacity range (e.g. fade to semi-transparent instead of invisible)
+<Fade visible={isVisible} outOpacity={0.5} inOpacity={1}>
+  <Content />
+</Fade>
+
+// Slide from a specific direction
+<Slide visible={isVisible} outX="100px">
+  <Content />
+</Slide>
+
+// Horizontal collapse (instead of default vertical)
+<Collapse visible={isVisible} orientation="horizontal">
+  <Content />
+</Collapse>
+```
+
+See the Component Reference table below for all available parameters.
+
+### Choreography with Stagger
+
+Animate lists of items in sequence:
+
+```tsx
+import { Stagger, Fade } from '@fluentui/react-motion-components-preview';
+
+function List({ items, visible }) {
+  return (
+    <Stagger>
+      {items.map(item => (
+        <Fade key={item.id} visible={visible}>
+          <ListItem>{item.name}</ListItem>
+        </Fade>
+      ))}
+    </Stagger>
+  );
+}
+```
+
+### Component Reference
+
+| Component  | Variants                                               | Key Parameters                                      |
+| ---------- | ------------------------------------------------------ | --------------------------------------------------- |
+| `Fade`     | `FadeSnappy`, `FadeRelaxed`                            | `outOpacity`, `inOpacity`, `duration`, `easing`     |
+| `Scale`    | `ScaleSnappy`, `ScaleRelaxed`                          | `outScale`, `inScale`, `duration`, `easing`         |
+| `Collapse` | `CollapseSnappy`, `CollapseRelaxed`, `CollapseDelayed` | `orientation`, `outSize`, `duration`, `easing`      |
+| `Slide`    | `SlideSnappy`, `SlideRelaxed`                          | `outX`, `outY`, `inX`, `inY`, `duration`, `easing`  |
+| `Blur`     | —                                                      | `outRadius`, `inRadius`, `duration`, `easing`       |
+| `Rotate`   | —                                                      | `axis`, `outAngle`, `inAngle`, `duration`, `easing` |
+| `Stagger`  | —                                                      | `itemDelay`, `itemDuration`, `reversed`, `hideMode` |
+
+</div>
+
+---
+
+## Next Steps
+
+- **[Fade](?path=/docs/motion-components-preview-fade--docs)** — Simple opacity transitions
+- **[Scale](?path=/docs/motion-components-preview-scale--docs)** — Grow and shrink animations
+- **[Collapse](?path=/docs/motion-components-preview-collapse--docs)** — Expandable height/width
+- **[Slide](?path=/docs/motion-components-preview-slide--docs)** — Directional slide animations
+- **[Blur](?path=/docs/motion-components-preview-blur--docs)** — Focus/blur effects
+- **[Rotate](?path=/docs/motion-components-preview-rotate--docs)** — 3D rotation effects
+- **[Stagger](?path=/docs/motion-choreography-preview-stagger--docs)** — Sequential animation choreography
+- **[Motion Atoms](?path=/docs/motion-components-preview-atoms--docs)** — Building blocks for custom components

--- a/packages/react-components/react-motion/library/README.md
+++ b/packages/react-components/react-motion/library/README.md
@@ -1,5 +1,63 @@
 # @fluentui/react-motion
 
-**React Motions components for [Fluent UI React](https://react.fluentui.dev/)**
+**React Motion components for [Fluent UI React](https://react.fluentui.dev/)**
 
-These are not production-ready components and **should never be used in product**. This space is useful for testing new components whose APIs might change before final release.
+A lightweight, performant animation library for React that brings Fluent UI experiences to life using the Web Animations API (WAAPI).
+
+## Features
+
+- ⚡ **Performance** — Animations run on the compositor thread for smooth 60fps motion
+- 📦 **Lightweight** — ~3KB gzipped, leverages native browser capabilities
+- 🎯 **Simple by default** — Common UI animations with minimal code
+- 🔧 **Powerful on demand** — Full customization with keyframes, timing, and callbacks
+
+## Installation
+
+```bash
+npm install @fluentui/react-motion
+# or
+yarn add @fluentui/react-motion
+```
+
+## Quick Start
+
+```tsx
+import { createPresenceComponent, motionTokens } from '@fluentui/react-motion';
+
+// Create a custom fade presence component
+const Fade = createPresenceComponent({
+  enter: {
+    keyframes: [{ opacity: 0 }, { opacity: 1 }],
+    duration: motionTokens.durationNormal,
+  },
+  exit: {
+    keyframes: [{ opacity: 1 }, { opacity: 0 }],
+    duration: motionTokens.durationFast,
+  },
+});
+
+// Use it in your app
+function App() {
+  const [visible, setVisible] = useState(true);
+
+  return (
+    <Fade visible={visible}>
+      <div>Animated content</div>
+    </Fade>
+  );
+}
+```
+
+## Documentation
+
+📚 **[Full documentation](https://react.fluentui.dev/?path=/docs/motion-introduction--docs)**
+
+- [Introduction](https://react.fluentui.dev/?path=/docs/motion-introduction--docs) — Overview and key concepts
+- [createPresenceComponent](https://react.fluentui.dev/?path=/docs/motion-apis-createpresencecomponent--docs) — Two-way enter/exit animations
+- [createMotionComponent](https://react.fluentui.dev/?path=/docs/motion-apis-createmotioncomponent--docs) — One-way animations
+- [Motion Tokens](https://react.fluentui.dev/?path=/docs/motion-tokens--docs) — Duration and easing values
+- [Migration Guide](https://react.fluentui.dev/?path=/docs/motion-migration--docs) — Coming from Framer Motion, GSAP, etc.
+
+## Pre-built Components
+
+For ready-to-use motion components (Fade, Scale, Slide, Collapse, etc.), see **[@fluentui/react-motion-components-preview](https://www.npmjs.com/package/@fluentui/react-motion-components-preview)**.

--- a/packages/react-components/react-motion/stories/src/Introduction/MotionIntroDemo.styles.ts
+++ b/packages/react-components/react-motion/stories/src/Introduction/MotionIntroDemo.styles.ts
@@ -1,0 +1,19 @@
+'use client';
+
+import { makeStyles, tokens } from '@fluentui/react-components';
+
+export const useClasses = makeStyles({
+  demo: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: tokens.spacingVerticalM,
+    padding: tokens.spacingVerticalXL,
+  },
+  card: {
+    padding: `${tokens.spacingVerticalL} ${tokens.spacingHorizontalXXL}`,
+    fontWeight: tokens.fontWeightSemibold,
+    fontSize: tokens.fontSizeBase300,
+    textAlign: 'center',
+  },
+});

--- a/packages/react-components/react-motion/stories/src/Introduction/MotionIntroDemo.tsx
+++ b/packages/react-components/react-motion/stories/src/Introduction/MotionIntroDemo.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import * as React from 'react';
+import { Button, Card } from '@fluentui/react-components';
+import { Fade } from '@fluentui/react-motion-components-preview';
+import { useClasses } from './MotionIntroDemo.styles';
+
+export const MotionIntroDemo: React.FC = () => {
+  const classes = useClasses();
+  const [visible, setVisible] = React.useState(true);
+
+  const handleToggle = React.useCallback(() => {
+    setVisible(v => !v);
+  }, []);
+
+  return (
+    <div className={classes.demo}>
+      <Fade visible={visible}>
+        <Card appearance="filled" className={classes.card}>
+          Hello, Motion! ✨
+        </Card>
+      </Fade>
+      <Button appearance="primary" onClick={handleToggle}>
+        {visible ? 'Hide' : 'Show'}
+      </Button>
+    </div>
+  );
+};

--- a/packages/react-components/react-motion/stories/src/Introduction/MotionVsPresenceDemo.styles.ts
+++ b/packages/react-components/react-motion/stories/src/Introduction/MotionVsPresenceDemo.styles.ts
@@ -1,0 +1,78 @@
+'use client';
+
+import { makeStyles, tokens } from '@fluentui/react-components';
+
+export const useClasses = makeStyles({
+  container: {
+    display: 'grid',
+    gridTemplateColumns: '1fr 1fr',
+    gap: tokens.spacingHorizontalXXL,
+    marginTop: tokens.spacingVerticalXXL,
+    marginBottom: tokens.spacingVerticalXXL,
+
+    '@media (max-width: 600px)': {
+      gridTemplateColumns: '1fr',
+    },
+  },
+  panel: {
+    display: 'flex',
+    flexDirection: 'column',
+    border: `${tokens.strokeWidthThin} solid ${tokens.colorNeutralStroke1}`,
+    borderRadius: tokens.borderRadiusMedium,
+    overflow: 'hidden',
+  },
+  panelHeader: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: tokens.spacingVerticalXS,
+    padding: `${tokens.spacingVerticalL} ${tokens.spacingHorizontalXL} ${tokens.spacingVerticalM}`,
+    backgroundColor: tokens.colorNeutralBackground2,
+  },
+  title: {
+    margin: 0,
+    fontSize: tokens.fontSizeBase400,
+    fontWeight: tokens.fontWeightSemibold,
+  },
+  subtitle: {
+    margin: 0,
+    fontSize: tokens.fontSizeBase200,
+    color: tokens.colorNeutralForeground3,
+    textAlign: 'center',
+  },
+  demoArea: {
+    display: 'grid',
+    alignItems: 'center',
+    justifyItems: 'center',
+    height: '80px',
+    padding: tokens.spacingVerticalL,
+    backgroundColor: tokens.colorNeutralBackground1,
+  },
+  motionWrapper: {
+    width: 'fit-content',
+  },
+  card: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: `${tokens.spacingVerticalM} ${tokens.spacingHorizontalXL}`,
+    fontWeight: tokens.fontWeightSemibold,
+    fontSize: tokens.fontSizeBase300,
+  },
+  codeArea: {
+    margin: 0,
+    padding: `${tokens.spacingVerticalM} ${tokens.spacingHorizontalL}`,
+    backgroundColor: tokens.colorNeutralBackground3,
+    borderTop: `${tokens.strokeWidthThin} solid ${tokens.colorNeutralStroke1}`,
+    overflow: 'auto',
+    fontFamily: tokens.fontFamilyMonospace,
+    fontSize: tokens.fontSizeBase100,
+    lineHeight: tokens.lineHeightBase200,
+    color: tokens.colorNeutralForeground1,
+  },
+  buttonRow: {
+    display: 'flex',
+    justifyContent: 'center',
+    padding: `${tokens.spacingVerticalM} ${tokens.spacingHorizontalXL} ${tokens.spacingVerticalL}`,
+    backgroundColor: tokens.colorNeutralBackground2,
+  },
+});

--- a/packages/react-components/react-motion/stories/src/Introduction/MotionVsPresenceDemo.tsx
+++ b/packages/react-components/react-motion/stories/src/Introduction/MotionVsPresenceDemo.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import * as React from 'react';
+import { Button, Card } from '@fluentui/react-components';
+import { createMotionComponent, createPresenceComponent, motionTokens } from '@fluentui/react-motion';
+import { useClasses } from './MotionVsPresenceDemo.styles';
+
+// One-way motion: plays on mount
+const SlideIn = createMotionComponent({
+  keyframes: [
+    { transform: 'translateX(-50px)', opacity: 0 },
+    { transform: 'translateX(0)', opacity: 1 },
+  ],
+  duration: motionTokens.durationUltraSlow,
+  easing: motionTokens.curveDecelerateMin,
+});
+
+// Two-way presence: controlled by visible prop
+const FadePresence = createPresenceComponent({
+  enter: {
+    keyframes: [{ opacity: 0 }, { opacity: 1 }],
+    duration: motionTokens.durationUltraSlow,
+    easing: motionTokens.curveDecelerateMid,
+  },
+  exit: {
+    keyframes: [{ opacity: 1 }, { opacity: 0 }],
+    duration: motionTokens.durationSlow,
+    easing: motionTokens.curveAccelerateMid,
+  },
+});
+
+const motionCode = `const SlideIn = createMotionComponent({
+  keyframes: [
+    { transform: 'translateX(-50px)', opacity: 0 },
+    { transform: 'translateX(0)', opacity: 1 },
+  ],
+  duration: motionTokens.durationUltraSlow,
+  easing: motionTokens.curveDecelerateMin,
+});`;
+
+const presenceCode = `const Fade = createPresenceComponent({
+  enter: {
+    keyframes: [{ opacity: 0 }, { opacity: 1 }],
+    duration: 500,
+  },
+  exit: {
+    keyframes: [{ opacity: 1 }, { opacity: 0 }],
+    duration: 300,
+  },
+});`;
+
+export const MotionVsPresenceDemo: React.FC = () => {
+  const classes = useClasses();
+  const [motionKey, setMotionKey] = React.useState(0);
+  const [presenceVisible, setPresenceVisible] = React.useState(true);
+
+  const handleReplay = React.useCallback(() => {
+    setMotionKey(k => k + 1);
+  }, []);
+
+  const handleTogglePresence = React.useCallback(() => {
+    setPresenceVisible(v => !v);
+  }, []);
+
+  return (
+    <div className={classes.container}>
+      <div className={classes.panel}>
+        <div className={classes.panelHeader}>
+          <h4 className={classes.title}>One-Way Motion</h4>
+          <p className={classes.subtitle}>Plays once on mount</p>
+        </div>
+        <div className={classes.demoArea}>
+          <div className={classes.motionWrapper}>
+            <SlideIn key={motionKey}>
+              <Card appearance="filled" className={classes.card}>
+                Slide In
+              </Card>
+            </SlideIn>
+          </div>
+        </div>
+        <div className={classes.buttonRow}>
+          <Button appearance="primary" onClick={handleReplay}>
+            Replay
+          </Button>
+        </div>
+        <pre className={classes.codeArea}>{motionCode}</pre>
+      </div>
+
+      <div className={classes.panel}>
+        <div className={classes.panelHeader}>
+          <h4 className={classes.title}>Two-Way Presence</h4>
+          <p className={classes.subtitle}>Toggles with enter/exit</p>
+        </div>
+        <div className={classes.demoArea}>
+          <div className={classes.motionWrapper}>
+            <FadePresence visible={presenceVisible}>
+              <Card appearance="filled" className={classes.card}>
+                Fade
+              </Card>
+            </FadePresence>
+          </div>
+        </div>
+        <div className={classes.buttonRow}>
+          <Button appearance="primary" onClick={handleTogglePresence}>
+            {presenceVisible ? 'Hide' : 'Show'}
+          </Button>
+        </div>
+        <pre className={classes.codeArea}>{presenceCode}</pre>
+      </div>
+    </div>
+  );
+};

--- a/packages/react-components/react-motion/stories/src/Introduction/index.mdx
+++ b/packages/react-components/react-motion/stories/src/Introduction/index.mdx
@@ -1,0 +1,238 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import { Card, CardHeader, tokens } from '@fluentui/react-components';
+import { MotionIntroDemo } from './MotionIntroDemo';
+import { MotionVsPresenceDemo } from './MotionVsPresenceDemo';
+
+<Meta title="Motion/Introduction" />
+
+<style>
+  {`
+  .motion-hero {
+    text-align: center;
+    padding: 40px 20px;
+    background: linear-gradient(135deg, ${tokens.colorBrandBackground2} 0%, ${tokens.colorNeutralBackground1} 100%);
+    border-radius: 12px;
+    margin-bottom: 32px;
+  }
+  .motion-hero h1 {
+    margin: 0 0 16px 0;
+    font-size: clamp(1.8rem, 5vw, 2.5rem);
+  }
+  .motion-hero .hero-subtitle {
+    font-size: 1.1rem;
+    color: ${tokens.colorNeutralForeground2};
+    max-width: 600px;
+    margin: 0 auto;
+  }
+  .principles-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 24px;
+    margin: 32px 0;
+  }
+  .principles-grid h3 {
+    margin: 0;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .audience-card {
+    margin: 32px 0;
+    padding: 24px;
+  }
+  .audience-card h2 {
+    margin-top: 0;
+  }
+  .designer-card {
+    border-left: 4px solid ${tokens.colorPalettePurpleBorder2};
+  }
+  .developer-card {
+    border-left: 4px solid ${tokens.colorPaletteBlueBorder2};
+  }
+  .a11y-callout {
+    margin: 24px 0;
+    padding: 20px 24px;
+    border-radius: 8px;
+    border: 1px solid ${tokens.colorPaletteGreenBorder1};
+    background: ${tokens.colorNeutralBackground1};
+  }
+  .a11y-callout h3 {
+    margin-top: 0;
+  }
+`}
+</style>
+
+<div className="motion-hero">
+  <h1>Fluent Motion System</h1>
+  <div className="hero-subtitle">
+    Add smooth, polished animations to your UI with just a few lines of code. Built on the browser's native animation
+    engine for great performance out of the box.
+  </div>
+</div>
+
+## What is Fluent Motion?
+
+Fluent Motion is a set of React components that make it easy to animate elements in your UI — showing, hiding, sliding, fading, and more. You describe _what_ you want to animate, and the system handles the _how_.
+
+Under the hood it uses the browser's [Web Animations API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Animations_API), so animations are fast and smooth without extra JavaScript overhead.
+
+<MotionIntroDemo />
+
+## An Atomic Motion System
+
+Inspired by [atomic design](https://bradfrost.com/blog/post/atomic-web-design/), Fluent Motion is built in composable layers:
+
+| Layer         | What it is                                                                                         | Example                        |
+| ------------- | -------------------------------------------------------------------------------------------------- | ------------------------------ |
+| **Atoms**     | A single one-way animation — keyframes changing one property over time                             | `fadeAtom()`, `scaleAtom()`    |
+| **Molecules** | Combinations of atoms, e.g. pairing an enter atom with an exit atom to create a presence animation | `<Fade>`, `<Scale>`, `<Slide>` |
+| **Organisms** | Higher-order choreography that coordinates multiple molecules                                      | `<Stagger>`, `<PresenceGroup>` |
+
+**Factories** (`createMotionComponent`, `createPresenceComponent`) are the tools you use to assemble atoms into molecules — they turn raw keyframe definitions into React components.
+
+**Most users start with Molecules** — the pre-built components like `<Fade>` and `<Scale>` that work out of the box. When you need a custom effect, you can compose atoms together using the factories. See <a href="?path=/docs/motion-components-preview-atoms--docs">Motion Atoms</a> for the full API.
+
+## Key Principles
+
+<div className="principles-grid">
+  <Card appearance="filled">
+    <CardHeader header={<h3>⚡ Performance</h3>} />
+    <div>
+      Animations run on the browser's compositor thread where possible, ensuring smooth motion at 60fps, 120fps —
+      whatever your device can handle.
+    </div>
+  </Card>
+  <Card appearance="filled">
+    <CardHeader header={<h3>📦 Lightweight</h3>} />
+    <div>
+      Small bundle size — the browser does the heavy lifting. No JavaScript animation engine is shipped to your users.
+    </div>
+  </Card>
+  <Card appearance="filled">
+    <CardHeader header={<h3>🎯 Simple by Default</h3>} />
+    <div>
+      Common animations work with minimal code. Pre-built components like <code>Fade</code>, <code>Scale</code>, and{' '}
+      <code>Slide</code> work out of the box.
+    </div>
+  </Card>
+  <Card appearance="filled">
+    <CardHeader header={<h3>🔧 Powerful on Demand</h3>} />
+    <div>
+      Full customization available when needed — custom keyframes, timing, easing curves, and lifecycle callbacks.
+    </div>
+  </Card>
+</div>
+
+<div className="a11y-callout">
+
+### ♿ Built-in Accessibility
+
+Fluent Motion automatically respects the user's **prefers-reduced-motion** operating system setting.
+When a user has requested reduced motion, animations are scaled down or disabled — you don't need to write any extra code. This ensures your UI is inclusive by default.
+
+</div>
+
+<Card appearance="filled" className="audience-card designer-card">
+
+## For Motion Designers
+
+The Fluent Motion System uses **design tokens** — named values that keep animation timing consistent across all Microsoft products. Instead of picking arbitrary millisecond values, you choose a token that communicates the _intent_ of the motion.
+
+### Duration Tokens (examples)
+
+A few commonly used durations to give you a feel for the scale:
+
+| Token               | Duration | When to Use                    |
+| ------------------- | -------- | ------------------------------ |
+| `durationFaster`    | 100ms    | Button presses, toggles        |
+| `durationNormal`    | 200ms    | Default for most UI animations |
+| `durationSlow`      | 300ms    | Large elements, emphasis       |
+| `durationUltraSlow` | 500ms    | Dramatic reveals, onboarding   |
+
+The full set of duration and easing tokens is available on the <a href="?path=/docs/motion-tokens--docs">Motion Tokens</a> page.
+
+### Easing Curves (examples)
+
+Easing curves control how an animation accelerates and decelerates. Fluent defines three families:
+
+| Curve Family   | Feel                        | When to Use                           |
+| -------------- | --------------------------- | ------------------------------------- |
+| **Decelerate** | Starts fast, settles gently | Elements **entering** the screen      |
+| **Accelerate** | Starts slow, speeds away    | Elements **leaving** the screen       |
+| **Easy-ease**  | Smooth start and end        | Elements **moving** within the screen |
+
+Each family has variants (e.g. `curveDecelerateMid`, `curveDecelerateMax`) for different intensities.
+See all curves with interactive previews on the <a href="?path=/docs/motion-tokens--docs">Motion Tokens</a> page.
+
+### Pre-built Components
+
+Six presence components — **Fade**, **Scale**, **Collapse**, **Slide**, **Blur**, and **Rotate** — handle the most common UI motion patterns. Each comes in **Snappy** and **Relaxed** timing variants.
+
+See all components with interactive demos on the <a href="?path=/docs/motion-components-preview-introduction--docs">Motion Components</a> page.
+
+</Card>
+
+<Card appearance="filled" className="audience-card developer-card">
+
+## For Developers
+
+### Two Types of Motion
+
+The Fluent Motion System distinguishes between two fundamental patterns:
+
+<MotionVsPresenceDemo />
+
+**One-Way Motion** — Created with `createMotionComponent()`, plays a single animation on mount. Good for page-load entrances or one-off effects.
+
+**Two-Way Presence** — Created with `createPresenceComponent()`, manages enter/exit animations controlled by a `visible` prop. This is what the pre-built components (`Fade`, `Scale`, etc.) use under the hood.
+
+For most use cases, you don't need the factories — use the <a href="?path=/docs/motion-components-preview-introduction--docs">pre-built Motion Components</a> instead.
+
+### Two Packages to Know
+
+| Package                                     | Status | What's Inside                                                                                                              |
+| ------------------------------------------- | ------ | -------------------------------------------------------------------------------------------------------------------------- |
+| `@fluentui/react-motion`                    | Stable | Core factories (`createMotionComponent`, `createPresenceComponent`), `PresenceGroup`, `motionTokens`, `presenceMotionSlot` |
+| `@fluentui/react-motion-components-preview` | Beta   | Ready-to-use components: `Fade`, `Scale`, `Collapse`, `Slide`, `Blur`, `Rotate`, `Stagger`, plus Snappy/Relaxed variants   |
+
+</Card>
+
+## Next Steps
+
+<div className="principles-grid">
+  <Card appearance="filled">
+    <CardHeader header={<h3>📚 Learn the APIs</h3>} />
+    <div>
+      Dive into <a href="?path=/docs/motion-apis-createpresencecomponent--docs">createPresenceComponent</a> and{' '}
+      <a href="?path=/docs/motion-apis-createmotioncomponent--docs">createMotionComponent</a> for full API
+      documentation.
+    </div>
+  </Card>
+  <Card appearance="filled">
+    <CardHeader header={<h3>🧩 Use Pre-built Components</h3>} />
+    <div>
+      Explore the <a href="?path=/docs/motion-components-preview-introduction--docs">Motion Components</a> for
+      ready-to-use animations.
+    </div>
+  </Card>
+  <Card appearance="filled">
+    <CardHeader header={<h3>🎨 Explore Tokens</h3>} />
+    <div>
+      See all available <a href="?path=/docs/motion-tokens--docs">Motion Tokens</a> for durations and easing curves.
+    </div>
+  </Card>
+  <Card appearance="filled">
+    <CardHeader header={<h3>🔄 Migrate from Other Libraries</h3>} />
+    <div>
+      Coming from Framer Motion or GSAP? Check our <a href="?path=/docs/motion-migration--docs">Migration Guide</a>.
+    </div>
+  </Card>
+  <Card appearance="filled">
+    <CardHeader header={<h3>⚛️ Motion Atoms</h3>} />
+    <div>
+      Build custom animations by composing{' '}
+      <a href="?path=/docs/motion-components-preview-atoms--docs">low-level atoms</a> like <code>fadeAtom</code> and{' '}
+      <code>scaleAtom</code>.
+    </div>
+  </Card>
+</div>

--- a/packages/react-components/react-motion/stories/src/Introduction/index.stories.tsx
+++ b/packages/react-components/react-motion/stories/src/Introduction/index.stories.tsx
@@ -1,0 +1,9 @@
+import type { Meta } from '@storybook/react-webpack5';
+import { MotionIntroDemo } from './MotionIntroDemo';
+
+const meta: Meta<typeof MotionIntroDemo> = {
+  title: 'Motion/Introduction',
+  component: MotionIntroDemo,
+};
+
+export default meta;

--- a/packages/react-components/react-motion/stories/src/Migration/index.mdx
+++ b/packages/react-components/react-motion/stories/src/Migration/index.mdx
@@ -1,0 +1,643 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import { tokens } from '@fluentui/react-components';
+
+<Meta title="Motion/Migration" />
+
+<style>
+  {`
+  .migration-hero {
+    text-align: center;
+    padding: 32px 20px;
+    background: linear-gradient(135deg, ${tokens.colorBrandBackground2} 0%, ${tokens.colorNeutralBackground1} 100%);
+    border-radius: 12px;
+    margin-bottom: 32px;
+  }
+  .migration-hero h1 {
+    margin: 0 0 12px 0;
+    font-size: 1.8rem;
+  }
+  .migration-hero p {
+    font-size: 1rem;
+    color: ${tokens.colorNeutralForeground2};
+    max-width: 600px;
+    margin: 0 auto;
+  }
+  .comparison-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 16px 0;
+    font-size: 0.9em;
+  }
+  .comparison-table th,
+  .comparison-table td {
+    padding: 12px;
+    text-align: left;
+    border-bottom: 1px solid ${tokens.colorNeutralStroke1};
+  }
+  .comparison-table th {
+    background: ${tokens.colorNeutralBackground3};
+    font-weight: 600;
+  }
+  .comparison-table code {
+    background: ${tokens.colorNeutralBackground4};
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-size: 0.9em;
+  }
+  .section-card {
+    padding: 24px;
+    border: 1px solid ${tokens.colorNeutralStroke1};
+    border-radius: 8px;
+    margin: 24px 0;
+  }
+  .section-card h2 {
+    margin-top: 0;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+  .pro-con-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(min(280px, 100%), 1fr));
+    gap: 16px;
+    margin: 16px 0;
+  }
+  .pro-box, .con-box {
+    padding: 16px;
+    border-radius: 8px;
+  }
+  .pro-box {
+    background: ${tokens.colorPaletteGreenBackground1};
+    border: 1px solid ${tokens.colorPaletteGreenBorder1};
+  }
+  .con-box {
+    background: ${tokens.colorPaletteRedBackground1};
+    border: 1px solid ${tokens.colorPaletteRedBorder1};
+  }
+  .pro-box h4, .con-box h4 {
+    margin: 0 0 8px 0;
+  }
+  .migration-example {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(min(320px, 100%), 1fr));
+    gap: 16px;
+    margin: 16px 0;
+  }
+  .migration-example > div {
+    padding: 16px;
+    border-radius: 8px;
+    min-width: 0;
+  }
+  .migration-example pre {
+    overflow-x: auto;
+    white-space: pre;
+  }
+  .before {
+    background: ${tokens.colorPaletteRedBackground1};
+    border: 1px solid ${tokens.colorPaletteRedBorder1};
+  }
+  .after {
+    background: ${tokens.colorPaletteGreenBackground1};
+    border: 1px solid ${tokens.colorPaletteGreenBorder1};
+  }
+  .before h4, .after h4 {
+    margin: 0 0 12px 0;
+    font-size: 0.85em;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+  @media (max-width: 640px) {
+    .migration-example, .pro-con-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+`}
+</style>
+
+<div className="migration-hero">
+  <h1>Migration & Comparison</h1>
+  <p>
+    Coming from another animation library? This guide helps you understand how Fluent Motion compares and how to
+    migrate.
+  </p>
+</div>
+
+## Why Fluent Motion?
+
+Fluent Motion is purpose-built for Microsoft's design system with specific goals:
+
+<div className="pro-con-grid">
+  <div className="pro-box">
+    <h4>✅ Strengths</h4>
+    <ul>
+      <li>Tiny bundle size — ~3KB gzipped</li>
+      <li>Native performance — Uses browser's WAAPI</li>
+      <li>Design token integration — Fluent durations & curves</li>
+      <li>Simple API — Declarative React components</li>
+      <li>Reduced motion support — Built-in accessibility</li>
+    </ul>
+  </div>
+  <div className="con-box">
+    <h4>⚠️ Limitations</h4>
+    <ul>
+      <li>No spring physics (use CSS/keyframes instead)</li>
+      <li>No scroll-driven animations (yet)</li>
+      <li>No gesture-based animations</li>
+      <li>No complex orchestration (use Stagger for basic needs)</li>
+      <li>No shared element transitions</li>
+    </ul>
+  </div>
+</div>
+
+---
+
+## Library Comparison
+
+<table className="comparison-table">
+  <thead>
+    <tr>
+      <th>Feature</th>
+      <th>Fluent Motion</th>
+      <th>Framer Motion</th>
+      <th>React Spring</th>
+      <th>GSAP</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <strong>Bundle Size</strong>
+      </td>
+      <td>~3KB</td>
+      <td>~50KB</td>
+      <td>~25KB</td>
+      <td>~60KB</td>
+    </tr>
+    <tr>
+      <td>
+        <strong>Animation Engine</strong>
+      </td>
+      <td>WAAPI (native)</td>
+      <td>JS runtime</td>
+      <td>JS runtime (springs)</td>
+      <td>JS runtime</td>
+    </tr>
+    <tr>
+      <td>
+        <strong>Spring Physics</strong>
+      </td>
+      <td>❌ No</td>
+      <td>✅ Yes</td>
+      <td>✅ Yes (primary)</td>
+      <td>✅ Yes (plugin)</td>
+    </tr>
+    <tr>
+      <td>
+        <strong>Keyframe Animations</strong>
+      </td>
+      <td>✅ Yes (primary)</td>
+      <td>✅ Yes</td>
+      <td>⚠️ Limited</td>
+      <td>✅ Yes</td>
+    </tr>
+    <tr>
+      <td>
+        <strong>Enter/Exit (Presence)</strong>
+      </td>
+      <td>✅ Yes</td>
+      <td>✅ Yes (AnimatePresence)</td>
+      <td>✅ Yes (useTransition)</td>
+      <td>⚠️ Manual</td>
+    </tr>
+    <tr>
+      <td>
+        <strong>Layout Animations</strong>
+      </td>
+      <td>❌ No</td>
+      <td>✅ Yes</td>
+      <td>❌ No</td>
+      <td>⚠️ Plugin</td>
+    </tr>
+    <tr>
+      <td>
+        <strong>Gesture Support</strong>
+      </td>
+      <td>❌ No</td>
+      <td>✅ Yes</td>
+      <td>⚠️ Limited</td>
+      <td>⚠️ Plugin</td>
+    </tr>
+    <tr>
+      <td>
+        <strong>Scroll Animations</strong>
+      </td>
+      <td>❌ No</td>
+      <td>✅ Yes</td>
+      <td>❌ No</td>
+      <td>✅ Yes</td>
+    </tr>
+    <tr>
+      <td>
+        <strong>SSR Support</strong>
+      </td>
+      <td>✅ Yes</td>
+      <td>✅ Yes</td>
+      <td>✅ Yes</td>
+      <td>⚠️ Requires setup</td>
+    </tr>
+    <tr>
+      <td>
+        <strong>Design Tokens</strong>
+      </td>
+      <td>✅ Fluent integrated</td>
+      <td>❌ Manual</td>
+      <td>❌ Manual</td>
+      <td>❌ Manual</td>
+    </tr>
+  </tbody>
+</table>
+
+---
+
+<div className="section-card">
+
+## Migrating from Framer Motion
+
+Framer Motion is a popular choice for React animations. Here's how common patterns translate to Fluent Motion.
+
+### Basic Animation
+
+<div className="migration-example">
+  <div className="before">
+    <h4>Framer Motion</h4>
+
+```tsx
+import { motion } from 'framer-motion';
+
+<motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.2 }}>
+  Content
+</motion.div>;
+```
+
+  </div>
+  <div className="after">
+    <h4>Fluent Motion</h4>
+
+```tsx
+import { Fade } from '@fluentui/react-motion-components-preview';
+
+<Fade.In>
+  <div>Content</div>
+</Fade.In>;
+```
+
+  </div>
+</div>
+
+### Enter/Exit Presence
+
+<div className="migration-example">
+  <div className="before">
+    <h4>Framer Motion</h4>
+
+```tsx
+import { AnimatePresence, motion } from 'framer-motion';
+
+<AnimatePresence>
+  {isVisible && (
+    <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
+      Content
+    </motion.div>
+  )}
+</AnimatePresence>;
+```
+
+  </div>
+  <div className="after">
+    <h4>Fluent Motion</h4>
+
+```tsx
+import { Fade } from '@fluentui/react-motion-components-preview';
+
+<Fade visible={isVisible}>
+  <div>Content</div>
+</Fade>;
+```
+
+  </div>
+</div>
+
+### Scale + Fade Combo
+
+<div className="migration-example">
+  <div className="before">
+    <h4>Framer Motion</h4>
+
+```tsx
+<motion.div
+  initial={{ opacity: 0, scale: 0.9 }}
+  animate={{ opacity: 1, scale: 1 }}
+  exit={{ opacity: 0, scale: 0.9 }}
+  transition={{ duration: 0.2 }}
+>
+  Content
+</motion.div>
+```
+
+  </div>
+  <div className="after">
+    <h4>Fluent Motion</h4>
+
+```tsx
+import { createPresenceComponent, motionTokens } from '@fluentui/react-motion';
+import { fadeAtom, scaleAtom } from '@fluentui/react-motion-components-preview';
+
+const FadeScale = createPresenceComponent({
+  enter: [
+    fadeAtom({ direction: 'enter', duration: motionTokens.durationNormal }),
+    scaleAtom({
+      direction: 'enter',
+      duration: motionTokens.durationNormal,
+      outScale: 0.9,
+    }),
+  ],
+  exit: [
+    fadeAtom({ direction: 'exit', duration: motionTokens.durationNormal }),
+    scaleAtom({
+      direction: 'exit',
+      duration: motionTokens.durationNormal,
+      outScale: 0.9,
+    }),
+  ],
+});
+
+<FadeScale visible={isVisible}>
+  <div>Content</div>
+</FadeScale>;
+```
+
+  </div>
+</div>
+
+### List Stagger
+
+<div className="migration-example">
+  <div className="before">
+    <h4>Framer Motion</h4>
+
+```tsx
+<motion.ul
+  initial="hidden"
+  animate="visible"
+  variants={{
+    visible: { transition: { staggerChildren: 0.05 } },
+  }}
+>
+  {items.map(item => (
+    <motion.li
+      key={item.id}
+      variants={{
+        hidden: { opacity: 0 },
+        visible: { opacity: 1 },
+      }}
+    >
+      {item.name}
+    </motion.li>
+  ))}
+</motion.ul>
+```
+
+  </div>
+  <div className="after">
+    <h4>Fluent Motion</h4>
+
+```tsx
+import { Stagger, Fade } from '@fluentui/react-motion-components-preview';
+
+<Stagger itemDelay={50}>
+  {items.map(item => (
+    <Fade key={item.id} visible={true}>
+      <li>{item.name}</li>
+    </Fade>
+  ))}
+</Stagger>;
+```
+
+  </div>
+</div>
+
+### What Doesn't Migrate Directly
+
+| Framer Motion Feature | Fluent Motion Alternative                            |
+| --------------------- | ---------------------------------------------------- |
+| `spring` physics      | Use CSS easing curves (`curveDecelerateMid`, etc.)   |
+| `layout` animations   | Not supported; consider CSS transitions              |
+| `drag` gestures       | Use native drag APIs or a gesture library            |
+| `useScroll`           | Not supported; use Intersection Observer             |
+| `useMotionValue`      | Not supported; use CSS custom properties             |
+| Variants system       | Use component variants (`FadeSnappy`, `FadeRelaxed`) |
+
+</div>
+
+---
+
+<div className="section-card">
+
+## Migrating from React Spring
+
+React Spring focuses on spring physics. Fluent Motion uses keyframe-based animations instead.
+
+### Basic Spring → Keyframe
+
+<div className="migration-example">
+  <div className="before">
+    <h4>React Spring</h4>
+
+```tsx
+import { useSpring, animated } from '@react-spring/web';
+
+const props = useSpring({
+  opacity: isVisible ? 1 : 0,
+  config: { tension: 300, friction: 20 },
+});
+
+<animated.div style={props}>Content</animated.div>;
+```
+
+  </div>
+  <div className="after">
+    <h4>Fluent Motion</h4>
+
+```tsx
+import { Fade } from '@fluentui/react-motion-components-preview';
+
+// Note: Spring physics are replaced with easing curves
+<Fade visible={isVisible}>
+  <div>Content</div>
+</Fade>;
+```
+
+  </div>
+</div>
+
+### useTransition → Presence
+
+<div className="migration-example">
+  <div className="before">
+    <h4>React Spring</h4>
+
+```tsx
+import { useTransition, animated } from '@react-spring/web';
+
+const transitions = useTransition(isVisible, {
+  from: { opacity: 0 },
+  enter: { opacity: 1 },
+  leave: { opacity: 0 },
+});
+
+{
+  transitions((style, item) => item && <animated.div style={style}>Content</animated.div>);
+}
+```
+
+  </div>
+  <div className="after">
+    <h4>Fluent Motion</h4>
+
+```tsx
+import { Fade } from '@fluentui/react-motion-components-preview';
+
+<Fade visible={isVisible} unmountOnExit>
+  <div>Content</div>
+</Fade>;
+```
+
+  </div>
+</div>
+
+### Key Differences
+
+- **No spring physics**: Fluent Motion uses CSS easing curves. For a spring-like feel, use `curveDecelerateMid` or `curveDecelerateMax`.
+- **Simpler API**: No hooks required for basic animations—just components with props.
+- **Predictable timing**: Keyframe animations have fixed durations, making them easier to coordinate.
+
+</div>
+
+---
+
+<div className="section-card">
+
+## Migrating from GSAP
+
+GSAP is a powerful timeline-based animation library. Fluent Motion is simpler but covers most UI animation needs.
+
+### Basic Tween → Presence
+
+<div className="migration-example">
+  <div className="before">
+    <h4>GSAP</h4>
+
+```tsx
+import { gsap } from 'gsap';
+import { useRef, useEffect } from 'react';
+
+const ref = useRef();
+
+useEffect(() => {
+  if (isVisible) {
+    gsap.to(ref.current, { opacity: 1, duration: 0.2 });
+  } else {
+    gsap.to(ref.current, { opacity: 0, duration: 0.2 });
+  }
+}, [isVisible]);
+
+<div ref={ref} style={{ opacity: 0 }}>
+  Content
+</div>;
+```
+
+  </div>
+  <div className="after">
+    <h4>Fluent Motion</h4>
+
+```tsx
+import { Fade } from '@fluentui/react-motion-components-preview';
+
+<Fade visible={isVisible}>
+  <div>Content</div>
+</Fade>;
+```
+
+  </div>
+</div>
+
+### Timeline → Stagger
+
+<div className="migration-example">
+  <div className="before">
+    <h4>GSAP</h4>
+
+```tsx
+const tl = gsap.timeline();
+tl.to('.item', {
+  opacity: 1,
+  stagger: 0.1,
+  duration: 0.3,
+});
+```
+
+  </div>
+  <div className="after">
+    <h4>Fluent Motion</h4>
+
+```tsx
+import { Stagger, Fade } from '@fluentui/react-motion-components-preview';
+
+<Stagger itemDelay={100}>
+  {items.map(item => (
+    <Fade key={item.id} visible duration={300}>
+      <div className="item">{item}</div>
+    </Fade>
+  ))}
+</Stagger>;
+```
+
+  </div>
+</div>
+
+### What GSAP Does That Fluent Motion Doesn't
+
+- Complex timelines with labels and control
+- ScrollTrigger for scroll-based animations
+- MorphSVG for shape morphing
+- Physics-based motion
+- Draggable plugin
+
+For these advanced use cases, GSAP may still be the right choice. Fluent Motion is optimized for common UI transitions.
+
+</div>
+
+---
+
+## Concept Mapping
+
+| Concept            | Framer Motion               | React Spring      | GSAP             | Fluent Motion                                    |
+| ------------------ | --------------------------- | ----------------- | ---------------- | ------------------------------------------------ |
+| One-shot animation | `motion.div` with `animate` | `useSpring`       | `gsap.to()`      | `createMotionComponent` or `.In`/`.Out`          |
+| Enter/exit         | `AnimatePresence`           | `useTransition`   | Manual           | `createPresenceComponent` or built-in components |
+| Staggered list     | `staggerChildren` variant   | `useTrail`        | `stagger` option | `<Stagger>` component                            |
+| Duration           | `transition.duration`       | `config.duration` | `duration`       | `duration` prop or tokens                        |
+| Easing             | `transition.ease`           | `config.easing`   | `ease`           | `easing` prop or tokens                          |
+
+---
+
+## When to Use What
+
+| Use Case                              | Recommendation    |
+| ------------------------------------- | ----------------- |
+| Fluent UI app, simple transitions     | **Fluent Motion** |
+| Complex gesture interactions          | Framer Motion     |
+| Spring physics feel                   | React Spring      |
+| Complex timelines, scroll-driven      | GSAP              |
+| Performance-critical, minimal bundle  | **Fluent Motion** |
+| Design system consistency (Microsoft) | **Fluent Motion** |

--- a/yarn.lock
+++ b/yarn.lock
@@ -1874,12 +1874,12 @@
     "@fluentui/styles" "^0.66.5"
     classnames "^2.2.6"
 
-"@fluentui/react-icons@^2.0.237", "@fluentui/react-icons@^2.0.239", "@fluentui/react-icons@^2.0.245", "@fluentui/react-icons@^2.0.306":
-  version "2.0.311"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-icons/-/react-icons-2.0.311.tgz#c617312703525f2170fc1f163dca7667831340e4"
-  integrity sha512-njTCiHki4gxtB0ebFFIy8jC+9xFqIbnqzFGO+3mixSjUIn/wl0NKUVzXiXcaYUx6d0okEAiYgciuT7eQjJhW8Q==
+"@fluentui/react-icons@*", "@fluentui/react-icons@^2.0.237", "@fluentui/react-icons@^2.0.239", "@fluentui/react-icons@^2.0.245", "@fluentui/react-icons@^2.0.306":
+  version "2.0.325"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-icons/-/react-icons-2.0.325.tgz#ab46787c3a044466f77b3ad50a5f6641f0799c9b"
+  integrity sha512-dbmpGMwyCFfkFdMSTEFnbNMXKDomPpqbzXVKRKM0EEQrcwOoQvm08d+SV+WWH11kni26SrgEtB9ycldD+fr92w==
   dependencies:
-    "@griffel/react" "^1.0.0"
+    "@griffel/react" "^1.6.1"
     tslib "^2.1.0"
 
 "@fluentui/react-northstar-fela-renderer@^0.66.5":
@@ -1986,16 +1986,16 @@
     stylis "^4.2.0"
     tslib "^2.1.0"
 
-"@griffel/core@^1.16.0", "@griffel/core@^1.19.2":
-  version "1.19.2"
-  resolved "https://registry.yarnpkg.com/@griffel/core/-/core-1.19.2.tgz#994070585bb49795d882355fc0787eb9878db71c"
-  integrity sha512-WkB/QQkjy9dE4vrNYGhQvRRUHFkYVOuaznVOMNTDT4pS9aTJ9XPrMTXXlkpcwaf0D3vNKoerj4zAwnU2lBzbOg==
+"@griffel/core@^1.16.0", "@griffel/core@^1.21.0":
+  version "1.21.0"
+  resolved "https://registry.yarnpkg.com/@griffel/core/-/core-1.21.0.tgz#2d2fa4ddd1d7ddfe853d2598527b956cb4506142"
+  integrity sha512-QqMoewiNTT0DmLM7OY607c7yhg18SuKfzovTO3hPXGQvtdu/StnjvuBAs+1B1kYSVGReAo6s/dJVeLnPuHjE7Q==
   dependencies:
     "@emotion/hash" "^0.9.0"
-    "@griffel/style-types" "^1.3.0"
+    "@griffel/style-types" "^1.4.0"
     csstype "^3.1.3"
     rtl-css-js "^1.16.1"
-    stylis "^4.2.0"
+    stylis "^4.4.0"
     tslib "^2.1.0"
 
 "@griffel/eslint-plugin@^2.0.0":
@@ -2015,12 +2015,12 @@
     "@griffel/core" "^1.16.0"
     tslib "^2.1.0"
 
-"@griffel/react@^1.0.0", "@griffel/react@^1.5.32":
-  version "1.5.32"
-  resolved "https://registry.yarnpkg.com/@griffel/react/-/react-1.5.32.tgz#cfe034476aa7fbd25507a83b74d85ca06082b03d"
-  integrity sha512-jN3SmSwAUcWFUQuQ9jlhqZ5ELtKY21foaUR0q1mJtiAeSErVgjkpKJyMLRYpvaFGWrDql0Uz23nXUogXbsS2wQ==
+"@griffel/react@^1.5.32", "@griffel/react@^1.6.1":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@griffel/react/-/react-1.7.2.tgz#5c3589b128fd3a0654f589bb25055487fb06e677"
+  integrity sha512-/+N+81e9ibNsh2wNlhGf2PcimEFrx8VbtWiLCmI6lsrTV5eBcQrIIDVQq737KPIJFtD4v6Txu9n0PXbN3hedNg==
   dependencies:
-    "@griffel/core" "^1.19.2"
+    "@griffel/core" "^1.21.0"
     tslib "^2.1.0"
 
 "@griffel/shadow-dom@0.2.2":
@@ -2031,10 +2031,10 @@
     "@griffel/core" "^1.16.0"
     tslib "^2.1.0"
 
-"@griffel/style-types@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@griffel/style-types/-/style-types-1.3.0.tgz#42b4f1902a0221a9a8334fda12a2fe88f13d65ee"
-  integrity sha512-bHwD3sUE84Xwv4dH011gOKe1jul77M1S6ZFN9Tnq8pvZ48UMdY//vtES6fv7GRS5wXYT4iqxQPBluAiYAfkpmw==
+"@griffel/style-types@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@griffel/style-types/-/style-types-1.4.0.tgz#58eb5538506e8602188a8b17ba9f0b48d703cf4b"
+  integrity sha512-vNDfOGV7RN/XkA7vxgf7Z5HgW8eiBm5cHT9wQPhsKB4pxWom5u6eQ9CkYE5mCCTSPl9H6Nd1NBai04d4P6BD7Q==
   dependencies:
     csstype "^3.1.3"
 
@@ -18821,10 +18821,10 @@ stylis@^3.5.4:
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.4.tgz#f665f25f5e299cf3d64654ab949a57c768b73fbe"
   integrity sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==
 
-stylis@^4.2.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.3.0.tgz#abe305a669fc3d8777e10eefcfc73ad861c5588c"
-  integrity sha512-E87pIogpwUsUwXw7dNyU4QDjdgVMy52m+XEOPEKUn161cCzWjjhPSQhByfd1CcNvrOLnXQ6OnnZDwnJrz/Z4YQ==
+stylis@^4.2.0, stylis@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.4.0.tgz#c5846c9345f4bfc51bd0cbd7ca35a0744f485a5d"
+  integrity sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==
 
 supports-color@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1874,12 +1874,12 @@
     "@fluentui/styles" "^0.66.5"
     classnames "^2.2.6"
 
-"@fluentui/react-icons@*", "@fluentui/react-icons@^2.0.237", "@fluentui/react-icons@^2.0.239", "@fluentui/react-icons@^2.0.245", "@fluentui/react-icons@^2.0.306":
-  version "2.0.325"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-icons/-/react-icons-2.0.325.tgz#ab46787c3a044466f77b3ad50a5f6641f0799c9b"
-  integrity sha512-dbmpGMwyCFfkFdMSTEFnbNMXKDomPpqbzXVKRKM0EEQrcwOoQvm08d+SV+WWH11kni26SrgEtB9ycldD+fr92w==
+"@fluentui/react-icons@^2.0.237", "@fluentui/react-icons@^2.0.239", "@fluentui/react-icons@^2.0.245", "@fluentui/react-icons@^2.0.306":
+  version "2.0.311"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-icons/-/react-icons-2.0.311.tgz#c617312703525f2170fc1f163dca7667831340e4"
+  integrity sha512-njTCiHki4gxtB0ebFFIy8jC+9xFqIbnqzFGO+3mixSjUIn/wl0NKUVzXiXcaYUx6d0okEAiYgciuT7eQjJhW8Q==
   dependencies:
-    "@griffel/react" "^1.6.1"
+    "@griffel/react" "^1.0.0"
     tslib "^2.1.0"
 
 "@fluentui/react-northstar-fela-renderer@^0.66.5":
@@ -1986,16 +1986,16 @@
     stylis "^4.2.0"
     tslib "^2.1.0"
 
-"@griffel/core@^1.16.0", "@griffel/core@^1.21.0":
-  version "1.21.0"
-  resolved "https://registry.yarnpkg.com/@griffel/core/-/core-1.21.0.tgz#2d2fa4ddd1d7ddfe853d2598527b956cb4506142"
-  integrity sha512-QqMoewiNTT0DmLM7OY607c7yhg18SuKfzovTO3hPXGQvtdu/StnjvuBAs+1B1kYSVGReAo6s/dJVeLnPuHjE7Q==
+"@griffel/core@^1.16.0", "@griffel/core@^1.19.2":
+  version "1.19.2"
+  resolved "https://registry.yarnpkg.com/@griffel/core/-/core-1.19.2.tgz#994070585bb49795d882355fc0787eb9878db71c"
+  integrity sha512-WkB/QQkjy9dE4vrNYGhQvRRUHFkYVOuaznVOMNTDT4pS9aTJ9XPrMTXXlkpcwaf0D3vNKoerj4zAwnU2lBzbOg==
   dependencies:
     "@emotion/hash" "^0.9.0"
-    "@griffel/style-types" "^1.4.0"
+    "@griffel/style-types" "^1.3.0"
     csstype "^3.1.3"
     rtl-css-js "^1.16.1"
-    stylis "^4.4.0"
+    stylis "^4.2.0"
     tslib "^2.1.0"
 
 "@griffel/eslint-plugin@^2.0.0":
@@ -2015,12 +2015,12 @@
     "@griffel/core" "^1.16.0"
     tslib "^2.1.0"
 
-"@griffel/react@^1.5.32", "@griffel/react@^1.6.1":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@griffel/react/-/react-1.7.2.tgz#5c3589b128fd3a0654f589bb25055487fb06e677"
-  integrity sha512-/+N+81e9ibNsh2wNlhGf2PcimEFrx8VbtWiLCmI6lsrTV5eBcQrIIDVQq737KPIJFtD4v6Txu9n0PXbN3hedNg==
+"@griffel/react@^1.0.0", "@griffel/react@^1.5.32":
+  version "1.5.32"
+  resolved "https://registry.yarnpkg.com/@griffel/react/-/react-1.5.32.tgz#cfe034476aa7fbd25507a83b74d85ca06082b03d"
+  integrity sha512-jN3SmSwAUcWFUQuQ9jlhqZ5ELtKY21foaUR0q1mJtiAeSErVgjkpKJyMLRYpvaFGWrDql0Uz23nXUogXbsS2wQ==
   dependencies:
-    "@griffel/core" "^1.21.0"
+    "@griffel/core" "^1.19.2"
     tslib "^2.1.0"
 
 "@griffel/shadow-dom@0.2.2":
@@ -2031,10 +2031,10 @@
     "@griffel/core" "^1.16.0"
     tslib "^2.1.0"
 
-"@griffel/style-types@^1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@griffel/style-types/-/style-types-1.4.0.tgz#58eb5538506e8602188a8b17ba9f0b48d703cf4b"
-  integrity sha512-vNDfOGV7RN/XkA7vxgf7Z5HgW8eiBm5cHT9wQPhsKB4pxWom5u6eQ9CkYE5mCCTSPl9H6Nd1NBai04d4P6BD7Q==
+"@griffel/style-types@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@griffel/style-types/-/style-types-1.3.0.tgz#42b4f1902a0221a9a8334fda12a2fe88f13d65ee"
+  integrity sha512-bHwD3sUE84Xwv4dH011gOKe1jul77M1S6ZFN9Tnq8pvZ48UMdY//vtES6fv7GRS5wXYT4iqxQPBluAiYAfkpmw==
   dependencies:
     csstype "^3.1.3"
 
@@ -18821,10 +18821,10 @@ stylis@^3.5.4:
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.4.tgz#f665f25f5e299cf3d64654ab949a57c768b73fbe"
   integrity sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==
 
-stylis@^4.2.0, stylis@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.4.0.tgz#c5846c9345f4bfc51bd0cbd7ca35a0744f485a5d"
-  integrity sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==
+stylis@^4.2.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.3.0.tgz#abe305a669fc3d8777e10eefcfc73ad861c5588c"
+  integrity sha512-E87pIogpwUsUwXw7dNyU4QDjdgVMy52m+XEOPEKUn161cCzWjjhPSQhByfd1CcNvrOLnXQ6OnnZDwnJrz/Z4YQ==
 
 supports-color@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16988,12 +16988,7 @@ react-window@^1.8.6:
     "@babel/runtime" "^7.0.0"
     memoize-one ">=3.1.1 <6"
 
-react@*:
-  version "19.2.6"
-  resolved "https://registry.yarnpkg.com/react/-/react-19.2.6.tgz#3dadb8e12b2a7934c1d5317973e5dce1301f9a4d"
-  integrity sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==
-
-react@19.2.0, "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0":
+react@*, react@19.2.0, "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0":
   version "19.2.0"
   resolved "https://registry.yarnpkg.com/react/-/react-19.2.0.tgz#d33dd1721698f4376ae57a54098cb47fc75d93a5"
   integrity sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -16988,7 +16988,7 @@ react-window@^1.8.6:
     "@babel/runtime" "^7.0.0"
     memoize-one ">=3.1.1 <6"
 
-react@*, react@19.2.0, "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0":
+react@19.2.0, "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0":
   version "19.2.0"
   resolved "https://registry.yarnpkg.com/react/-/react-19.2.0.tgz#d33dd1721698f4376ae57a54098cb47fc75d93a5"
   integrity sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -16988,6 +16988,11 @@ react-window@^1.8.6:
     "@babel/runtime" "^7.0.0"
     memoize-one ">=3.1.1 <6"
 
+react@*:
+  version "19.2.6"
+  resolved "https://registry.yarnpkg.com/react/-/react-19.2.6.tgz#3dadb8e12b2a7934c1d5317973e5dce1301f9a4d"
+  integrity sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==
+
 react@19.2.0, "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0":
   version "19.2.0"
   resolved "https://registry.yarnpkg.com/react/-/react-19.2.0.tgz#d33dd1721698f4376ae57a54098cb47fc75d93a5"


### PR DESCRIPTION
## Summary

This PR adds **Storybook documentation and interactive demos** for the Fluent UI motion system and motion components.

---

## `@fluentui/react-motion` — [new docs](https://fluentuipr.z22.web.core.windows.net/pull/35737/public-docsite-v9/react/index.html?path=/docs/motion-introduction--docs)

<img width="1920" height="1400" alt="image" src="https://github.com/user-attachments/assets/ab3ca911-87ba-48fd-a9e3-7e086aabd4ba" />

### Introduction page (`Motion/Introduction`)
- [Hero landing page](https://fluentuipr.z22.web.core.windows.net/pull/35737/public-docsite-v9/react/index.html?path=/docs/motion-introduction--docs) explaining the atomic motion system (compose animations from primitives: fade, scale, slide, rotate, blur)
- **`MotionIntroDemo`** — live interactive demo of the motion primitives
- **`MotionVsPresenceDemo`** — side-by-side panels showing `useMotion` vs `createPresenceComponent` with inline code snippets
- Design principles section (purposeful, accessible, performant, consistent)

### Migration guide (`Motion/Migration`)
- 656-line guide covering migration from **Framer Motion**, **React Spring**, and **CSS transitions** to the Fluent motion system
- Comparison tables, pros/cons grids, and before/after code examples

### Motion Slot API stories (`Motion/MotionSlotAPI`, `Motion/PresenceMotionSlotAPI`)
- `MotionSlotDefault`, `MotionSlotCustomize`, `MotionSlotDisable` story sets
- `PresenceMotionSlotDefault`, `PresenceMotionSlotCustomize`, `PresenceMotionSlotDisable` story sets
- Each with `.md` descriptions and `.tsx` implementations

### Updated README
- Overhauled `react-motion` README with usage patterns, API overview, and links to Storybook docs

---

## `@fluentui/react-motion-components-preview` — [new docs](https://fluentuipr.z22.web.core.windows.net/pull/35737/public-docsite-v9/react/index.html?path=/docs/motion-components-preview-introduction--docs)

<img width="1409" height="1710" alt="image" src="https://github.com/user-attachments/assets/17c61b7a-7a31-4d6f-be0a-4d88973ba40b" />


### Introduction page (`Motion/Components (preview)/Introduction`)
- **`ComponentsGrid`** — visual overview of all pre-built components (Collapse, Fade, Scale, etc.) using Relaxed variants
- **`InOutDemo`** — live in/out toggle demo
- **`VariantsDemo`** — interactive variant explorer

### Motion Atoms page (`Motion/Components (preview)/Atoms`)
- **`AtomsDemo`** — interactive playground for individual atoms (fade, scale, slide, rotate, blur) with live preview and code snippets
- **`ComposingAtomsDemo`** — demonstrates composing multiple atoms into custom presence components, including a SpinBlur example

### Updated README
- Comprehensive rewrite of `react-motion-components-preview` README with installation, usage patterns, and API reference

---

## `@fluentui/react-drawer` — API additions

- Added `InlineDrawerBaseProps`, `InlineDrawerBaseState`, `InlineDrawerBaseSlots` types to support composing `InlineDrawer` without the `surfaceMotion` slot
- Extracted `useInlineDrawerBase_unstable` hook from `useInlineDrawer_unstable` for reuse by consumers building custom drawer variants
- Exported the new base hook and types from the package public API

## `@fluentui/react-dialog` — new story

- Added `DialogMotionCustom` story demonstrating how to customize Dialog's enter/exit animation duration and easing via `motionTokens` and a Slider/Switch control panel

## Change files

- `@fluentui/react-motion` — patch (docs)
- `@fluentui/react-motion-components-preview` — patch (docs)
- `@fluentui/react-drawer` — minor (new exported types and hook)
- `@fluentui/react-components` — minor (re-exports `InlineDrawerBaseProps`)