### PR TITLE
fix(react-nav): update NavSubItemGroup motion handling and fix styles

### DIFF
--- a/change/@fluentui-react-nav-81032254-8256-4072-b14d-b3abe2fae93a.json
+++ b/change/@fluentui-react-nav-81032254-8256-4072-b14d-b3abe2fae93a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: update NavSubItemGroup motion handling and fix styles",
+  "packageName": "@fluentui/react-nav",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-nav/library/etc/react-nav.api.md
+++ b/packages/react-components/react-nav/library/etc/react-nav.api.md
@@ -31,7 +31,7 @@ import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import type { InlineDrawerSlots } from '@fluentui/react-drawer';
 import type { JSXElement } from '@fluentui/react-utilities';
 import { MenuButtonProps } from '@fluentui/react-button';
-import { PresenceMotionSlotProps } from '@fluentui/react-motion';
+import type { PresenceMotionSlotProps } from '@fluentui/react-motion';
 import * as React_2 from 'react';
 import type { Slot } from '@fluentui/react-utilities';
 import { SlotClassNames } from '@fluentui/react-utilities';

--- a/packages/react-components/react-nav/library/src/components/NavSubItemGroup/NavSubItemGroup.types.ts
+++ b/packages/react-components/react-nav/library/src/components/NavSubItemGroup/NavSubItemGroup.types.ts
@@ -1,4 +1,4 @@
-import { PresenceMotionSlotProps } from '@fluentui/react-motion';
+import type { PresenceMotionSlotProps } from '@fluentui/react-motion';
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
 import { NavDensity } from '../Nav/Nav.types';
 

--- a/packages/react-components/react-nav/library/src/components/NavSubItemGroup/useNavSubItemGroup.ts
+++ b/packages/react-components/react-nav/library/src/components/NavSubItemGroup/useNavSubItemGroup.ts
@@ -2,52 +2,11 @@
 
 import * as React from 'react';
 import { getIntrinsicElementProps, slot } from '@fluentui/react-utilities';
-import { createPresenceComponent, motionTokens, presenceMotionSlot } from '@fluentui/react-motion';
+import { presenceMotionSlot } from '@fluentui/react-motion';
+import { Collapse } from '@fluentui/react-motion-components-preview';
 
-import type {
-  NavSubItemGroupCollapseMotionParams,
-  NavSubItemGroupProps,
-  NavSubItemGroupState,
-} from './NavSubItemGroup.types';
+import type { NavSubItemGroupProps, NavSubItemGroupState } from './NavSubItemGroup.types';
 import { useNavCategoryContext_unstable } from '../NavCategoryContext';
-import { useNavContext_unstable } from '../NavContext';
-
-const smallSize = 28; // 28px for small density
-const largeSize = 40; // 40px for large density
-
-const NavGroupMotion = createPresenceComponent(({ items, density }: NavSubItemGroupCollapseMotionParams) => {
-  const isSmallDensity = density === 'small';
-  const height = items ? (isSmallDensity ? items * smallSize : items * largeSize) : 0;
-  const durationPerItem = isSmallDensity ? 15 : 25; // 15ms per item for small, 25ms for large
-  const keyframes: Keyframe[] = [
-    {
-      opacity: 0,
-      minHeight: 0,
-      height: 0,
-    },
-    {
-      opacity: 1,
-      minHeight: `${height}px`,
-      height: `${height}px`,
-    },
-  ];
-  const baseDuration = motionTokens.durationFast + (items || 0) * durationPerItem;
-  const maxDuration = motionTokens.durationUltraSlow;
-  const duration = baseDuration > maxDuration ? maxDuration : baseDuration;
-
-  return {
-    enter: {
-      keyframes,
-      duration,
-      easing: motionTokens.curveDecelerateMid,
-    },
-    exit: {
-      keyframes: [...keyframes].reverse(),
-      duration,
-      easing: motionTokens.curveAccelerateMin,
-    },
-  };
-});
 
 /**
  * Create the state required to render NavSubItemGroup.
@@ -63,13 +22,12 @@ export const useNavSubItemGroup_unstable = (
   ref: React.Ref<HTMLDivElement>,
 ): NavSubItemGroupState => {
   const { open } = useNavCategoryContext_unstable();
-  const { density } = useNavContext_unstable();
 
   return {
     open,
     components: {
       root: 'div',
-      collapseMotion: NavGroupMotion,
+      collapseMotion: Collapse,
     },
 
     root: slot.always(
@@ -81,12 +39,10 @@ export const useNavSubItemGroup_unstable = (
     ),
 
     collapseMotion: presenceMotionSlot(props.collapseMotion, {
-      elementType: NavGroupMotion,
+      elementType: Collapse,
       defaultProps: {
         visible: open,
         unmountOnExit: true,
-        items: React.Children.count(props.children),
-        density,
       },
     }),
   };

--- a/packages/react-components/react-nav/library/src/components/NavSubItemGroup/useNavSubItemGroupStyles.styles.ts
+++ b/packages/react-components/react-nav/library/src/components/NavSubItemGroup/useNavSubItemGroupStyles.styles.ts
@@ -13,6 +13,7 @@ export const navSubItemGroupClassNames: SlotClassNames<Omit<NavSubItemGroupSlots
  */
 const useStyles = makeStyles({
   root: {
+    flexShrink: 0,
     transform: 'translateZ(0)',
     overflow: 'hidden',
   },

--- a/packages/react-components/react-nav/stories/src/Nav/Basic.stories.tsx
+++ b/packages/react-components/react-nav/stories/src/Nav/Basic.stories.tsx
@@ -155,10 +155,10 @@ export const Basic = (): JSXElement => {
             <NavCategoryItem icon={<JobPostings />}>Job Postings</NavCategoryItem>
             <NavSubItemGroup>
               <NavSubItem href={linkDestination} value="7">
-                Openings
+                Lorem ipsum dolor sit amet, consectetuer adipiscing elit
               </NavSubItem>
               <NavSubItem href={linkDestination} value="8">
-                Submissions
+                Lorem ipsum dolor sit amet, consectetuer adipiscing elit
               </NavSubItem>
             </NavSubItemGroup>
           </NavCategory>


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

When you have items in the navigation that wrap their text it breaks the height calculation of submenus.

For example in the reproduction you can see that one item is cut off in the middle and the next item is not even show at all:

https://github.com/user-attachments/assets/b3ccd40f-a18d-47df-8d0a-c2ec1ade27b3



## New Behavior

Navigation items with a long text should be handled correctly

https://github.com/user-attachments/assets/0bfbb3aa-28f9-4db3-a483-90e59dd34bad


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #35541
