### PR TITLE
[fix]: menu-items programmatically added to menu-list do not  properl…

### DIFF
--- a/change/@fluentui-web-components-c44e3301-2ce6-40fc-9255-59b428cc9984.json
+++ b/change/@fluentui-web-components-c44e3301-2ce6-40fc-9255-59b428cc9984.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[fix]: menu-items programmatically added to menu-list do not  properly get assigned data indent.",
+  "packageName": "@fluentui/web-components",
+  "email": "jes@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/menu-list/menu-list.spec.ts
+++ b/packages/web-components/src/menu-list/menu-list.spec.ts
@@ -493,6 +493,99 @@ test.describe('Menu', () => {
     }
   });
 
+  test('should set the data-indent attribute correctly when menu items are dynamically appended', async ({
+    fastPage,
+  }) => {
+    const { element } = fastPage;
+
+    await fastPage.setTemplate({ innerHTML: '' });
+
+    await element.evaluate(node => {
+      const items = ['item 1', 'item 2', 'item 3'];
+
+      items.forEach(item => {
+        const menuItem = document.createElement('fluent-menu-item');
+        menuItem.role = 'menuitemradio';
+        menuItem.textContent = item;
+        node.append(menuItem);
+      });
+    });
+
+    const menuItems = element.locator('fluent-menu-item');
+    await expect(menuItems).toHaveCount(3);
+
+    for (const item of await menuItems.all()) {
+      await expect(item).toHaveAttribute('data-indent', '1');
+    }
+  });
+
+  test('should set the data-indent attribute correctly when menu items are appended via a DocumentFragment', async ({
+    fastPage,
+  }) => {
+    const { element } = fastPage;
+
+    await fastPage.setTemplate({ innerHTML: '' });
+
+    await element.evaluate(node => {
+      const fragment = document.createDocumentFragment();
+      const items = ['item 1', 'item 2', 'item 3'];
+
+      items.forEach(item => {
+        const menuItem = document.createElement('fluent-menu-item');
+        menuItem.role = 'menuitemradio';
+        menuItem.textContent = item;
+        fragment.append(menuItem);
+      });
+
+      node.append(fragment);
+    });
+
+    const menuItems = element.locator('fluent-menu-item');
+    await expect(menuItems).toHaveCount(3);
+
+    for (const item of await menuItems.all()) {
+      await expect(item).toHaveAttribute('data-indent', '1');
+    }
+  });
+
+  test('should update data-indent on existing items when a menuitemradio is appended and removed', async ({
+    fastPage,
+  }) => {
+    const { element } = fastPage;
+    const menuItems = element.locator('fluent-menu-item');
+
+    await test.step('all plain menuitems should start with data-indent 0', async () => {
+      for (const item of await menuItems.all()) {
+        await expect(item).toHaveAttribute('data-indent', '0');
+      }
+    });
+
+    await test.step('appending a menuitemradio should update all items to data-indent 1', async () => {
+      await element.evaluate(node => {
+        const menuItem = document.createElement('fluent-menu-item');
+        menuItem.role = 'menuitemradio';
+        menuItem.textContent = 'Radio item';
+        node.append(menuItem);
+      });
+
+      await expect(menuItems).toHaveCount(5);
+
+      for (const item of await menuItems.all()) {
+        await expect(item).toHaveAttribute('data-indent', '1');
+      }
+    });
+
+    await test.step('removing the menuitemradio should revert all items to data-indent 0', async () => {
+      await menuItems.last().evaluate(node => node.remove());
+
+      await expect(menuItems).toHaveCount(4);
+
+      for (const item of await menuItems.all()) {
+        await expect(item).toHaveAttribute('data-indent', '0');
+      }
+    });
+  });
+
   test.describe('`change` event', () => {
     test('should emit `change` event when `checked` property changed', async ({ fastPage }) => {
       const { element } = fastPage;

--- a/packages/web-components/src/menu-list/menu-list.ts
+++ b/packages/web-components/src/menu-list/menu-list.ts
@@ -161,7 +161,7 @@ export class MenuList extends FASTElement {
   }
 
   private static elementIndent(el: HTMLElement): MenuItemColumnCount {
-    const role = el.getAttribute('role');
+    const role = el.role;
     const startSlot = el.querySelector('[slot=start]');
 
     if (role && role !== MenuItemRole.menuitem) {
@@ -237,7 +237,7 @@ export class MenuList extends FASTElement {
     if (changedMenuItem.role === 'menuitemradio' && changedMenuItem.checked === true) {
       for (let i = changeItemIndex - 1; i >= 0; --i) {
         const item: Element = this.menuItems[i];
-        const role: string | null = item.getAttribute('role');
+        const role: string | null = (item as HTMLElement).role;
         if (role === MenuItemRole.menuitemradio) {
           (item as MenuItem).checked = false;
         }
@@ -248,7 +248,7 @@ export class MenuList extends FASTElement {
       const maxIndex: number = this.menuItems.length - 1;
       for (let i = changeItemIndex + 1; i <= maxIndex; ++i) {
         const item: Element = this.menuItems[i];
-        const role: string | null = item.getAttribute('role');
+        const role: string | null = (item as HTMLElement).role;
         if (role === MenuItemRole.menuitemradio) {
           (item as MenuItem).checked = false;
         }
@@ -263,9 +263,7 @@ export class MenuList extends FASTElement {
    * check if the item is a menu item
    */
   protected isMenuItemElement = (el: Element): el is HTMLElement => {
-    return (
-      isMenuItem(el) || (isHTMLElement(el) && (el.getAttribute('role') as string) in MenuList.focusableElementRoles)
-    );
+    return isMenuItem(el) || (isHTMLElement(el) && !!el.role && el.role in MenuList.focusableElementRoles);
   };
 
   /**


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

In the following example code, the `data-indent` attribute value is always `0`.


```js
const menuList = document.querySelector("fluent-menu-list");
const ITEMS = [
  "item 1",
  "item 2",
  "item 3",
];

ITEMS.forEach(item => {
  const menuItem = document.createElement("fluent-menu-item");
  menuItem.role = "menuitemradio";
  menuItem.textContent = item;
  menuList.append(menuItem);
});
```

The same issue also exist if you append the items to a `DocumentFragment` first then append the `DocumentFragment` to the menu list.

Current workaround is:

```js
const menuList = document.querySelector("fluent-menu-list");
const ITEMS = [
  "item 1",
  "item 2",
  "item 3",
];
const html = [];

ITEMS.forEach(item => {
  html.push(`
    <fluent-menu-item role="menuitemradio">
      ${item}
    </fluent-menu-item>
  `);
});

menuList.innerHTML = html.join("");
```
## New Behavior

Root cause: FAST's @attr decorator defers DOM attribute reflection via Updates.enqueue() (async microtask). When menu items are created programmatically with document.createElement() and the role property is set, the internal property value updates immediately but setAttribute('role', ...) is deferred. When setItems() runs in response to slotchange, el.getAttribute('role') returns stale/missing values, causing elementIndent() to always return 0.
With innerHTML, the HTML parser sets attributes directly before element upgrade, so getAttribute('role') works immediately.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
