### PR TITLE
fix(react-tabs): tabster attributes should be overridable on Tabs

### DIFF
--- a/change/@fluentui-react-tabs-6295d8e4-1cd2-4574-8138-808dab54f3cf.json
+++ b/change/@fluentui-react-tabs-6295d8e4-1cd2-4574-8138-808dab54f3cf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: tabster attributes should be overridable on Tabs",
+  "packageName": "@fluentui/react-tabs",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tabs/library/src/components/Tab/Tab.test.tsx
+++ b/packages/react-components/react-tabs/library/src/components/Tab/Tab.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { fireEvent, render } from '@testing-library/react';
+import { useTabsterAttributes } from '@fluentui/react-tabster';
 import { Tab } from './Tab';
 import { isConformant } from '../../testing/isConformant';
 import { TabListContext } from '../TabList/TabListContext';
@@ -129,5 +130,48 @@ describe('Tab', () => {
     );
 
     expect(ref).toHaveBeenCalledTimes(1);
+  });
+
+  it('tabster attributes can be overridden', () => {
+    const AttrProvider: React.FC<{
+      children: (attributes: ReturnType<typeof useTabsterAttributes>) => React.ReactNode;
+    }> = props => {
+      const attributes = useTabsterAttributes({
+        observed: { names: ['foo'] },
+      });
+
+      return props.children(attributes);
+    };
+
+    const { getAllByRole } = render(
+      <>
+        <AttrProvider>
+          {attributes => (
+            <Tab value="1" {...attributes}>
+              Tab 1
+            </Tab>
+          )}
+        </AttrProvider>
+        <Tab value="2">Tab 2</Tab>
+      </>,
+    );
+
+    const tabs = getAllByRole('tab');
+
+    expect(tabs).toHaveLength(2);
+
+    const tab1 = tabs[0];
+    const tab2 = tabs[1];
+
+    expect(tab1.dataset).toMatchInlineSnapshot(`
+      DOMStringMap {
+        "tabster": "{\\"observed\\":{\\"names\\":[\\"foo\\"]}}",
+      }
+    `);
+    expect(tab2.dataset).toMatchInlineSnapshot(`
+      DOMStringMap {
+        "tabster": "{\\"focusable\\":{\\"isDefault\\":false}}",
+      }
+    `);
   });
 });

--- a/packages/react-components/react-tabs/library/src/components/Tab/useTab.ts
+++ b/packages/react-components/react-tabs/library/src/components/Tab/useTab.ts
@@ -34,8 +34,8 @@ export const useTab_unstable = (props: TabProps, ref: React.Ref<HTMLElement>): T
     // eslint-disable-next-line @typescript-eslint/no-deprecated
     components: { ...state.components, contentReservedSpace: 'span' },
     root: {
-      ...state.root,
       ...focusAttributes,
+      ...state.root,
     },
     contentReservedSpace: slot.optional(contentReservedSpace, {
       renderByDefault: !state.selected && !state.iconOnly && reserveSelectedTabSpace,


### PR DESCRIPTION
## New Behavior

### 9.10.8

<img width="483" height="206" alt="image" src="https://github.com/user-attachments/assets/38d3cef1-0ddd-4838-919f-ab0017f07bba" />

https://stackblitz.com/edit/nyoum7bs-m1pdfcgm

### 9.11.1

<img width="515" height="210" alt="image" src="https://github.com/user-attachments/assets/8861afd0-30de-44e9-b54c-3b815451e95e" />

https://stackblitz.com/edit/nyoum7bs

---

Fixes regression introduced by https://github.com/microsoft/fluentui/pull/35638. Restores the previous behavior when Tabster attributes could be overriden.
