### PR TITLE
docs: add agent skills for v9 base hooks creation and usage

### DIFF
--- a/.agents/skills/fluentui-react-v9-base-hooks/SKILL.md
+++ b/.agents/skills/fluentui-react-v9-base-hooks/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: fluentui-react-v9-base-hooks
+description: 'Guide for implementing base state hooks (use{Component}Base_unstable) in the Fluent UI v9 react-components codebase. Use when asked to implement a base state hook for a FluentUI component, extract headless logic from an existing use{Component}_unstable hook, add useXxxBase_unstable to a component package, or follow the base-state-hooks RFC at docs/react-v9/contributing/rfcs/react-components/convergence/base-state-hooks.md.'
+---
+
+# FluentUI v9 Base State Hooks — Implementation Guide
+
+Base state hooks (`use{Component}Base_unstable`) extract pure component logic — ARIA, keyboard handling, slot structure — without styling, design props, or default slot implementations.
+
+Full RFC: `docs/react-v9/contributing/rfcs/react-components/convergence/base-state-hooks.md`
+
+## What to Include vs. Exclude
+
+| Include                                               | Exclude                                      |
+| ----------------------------------------------------- | -------------------------------------------- |
+| ARIA attributes, keyboard handling                    | Design props (`appearance`, `size`, `shape`) |
+| Slot structure, focus management                      | Griffel styles, design tokens                |
+| Layout semantics affecting ARIA (e.g. `iconPosition`) | Motion/animation logic                       |
+| Refs, controlled/uncontrolled state                   | Default slot implementations (icons, etc.)   |
+
+Exception: apply minimum inline styles only when required for accessibility (e.g., visually-hidden elements, portal positioning). Document the rationale inline.
+
+## Naming
+
+- Hook: `use{Component}Base_unstable` — lives in same file as `use{Component}_unstable`
+- Props type: `{Component}BaseProps`
+- State type: `{Component}BaseState`
+- Exported from the component package `index.ts`, NOT re-exported from `@fluentui/react-components`
+
+## Types
+
+Derive base types using `DistributiveOmit` (preferred) or explicit composition. See `references/type-patterns.md` for full examples.
+
+```typescript
+// Preferred: derive by omitting design props
+type ButtonBaseProps = DistributiveOmit<ButtonProps, 'appearance' | 'size' | 'shape'>;
+type ButtonBaseState = DistributiveOmit<ButtonState, 'appearance' | 'size' | 'shape'>;
+```
+
+## Implementation Workflow
+
+### 1. Extract base logic
+
+Move all non-design logic from `use{Component}_unstable` into `use{Component}Base_unstable` in the same file:
+
+```typescript
+// packages/react-components/react-button/library/src/components/Button/useButton.ts
+export const useButtonBase_unstable = (
+  props: ButtonBaseProps,
+  ref?: React.Ref<HTMLButtonElement | HTMLAnchorElement>,
+): ButtonBaseState => {
+  const { icon, iconPosition = 'before', ...buttonProps } = props;
+  const iconShorthand = slot.optional(icon, { elementType: 'span' });
+
+  return {
+    disabled: props.disabled ?? false,
+    disabledFocusable: props.disabledFocusable ?? false,
+    iconPosition,
+    iconOnly: Boolean(iconShorthand?.children && !props.children),
+    components: { root: 'button', icon: 'span' },
+    root: slot.always<ARIAButtonSlotProps<'a'>>(useARIAButtonProps(buttonProps.as, buttonProps), {
+      elementType: 'button',
+      defaultProps: {
+        ref: ref as React.Ref<HTMLButtonElement & HTMLAnchorElement>,
+        type: props.as !== 'a' ? 'button' : undefined,
+      },
+    }),
+    icon: iconShorthand,
+  };
+};
+```
+
+### 2. Compose into styled hook
+
+```typescript
+export const useButton_unstable = (props: ButtonProps, ref): ButtonState => {
+  const { appearance = 'secondary', size = 'medium', shape = 'rounded' } = props;
+  return {
+    ...useButtonBase_unstable(props, ref),
+    appearance,
+    size,
+    shape,
+  };
+};
+```
+
+### 3. Export from package index
+
+In `packages/react-components/{package}/library/src/index.ts`:
+
+```typescript
+export { useButtonBase_unstable } from './components/Button/useButton';
+export type { ButtonBaseProps, ButtonBaseState } from './components/Button/Button.types';
+```
+
+## Testing
+
+Write dedicated tests for the base hook that verify structure, ARIA attributes, and slot behavior independently of design state. See `references/testing.md` for the pattern.

--- a/.agents/skills/fluentui-react-v9-base-hooks/references/testing.md
+++ b/.agents/skills/fluentui-react-v9-base-hooks/references/testing.md
@@ -1,0 +1,107 @@
+# Testing Base State Hooks
+
+## What to test
+
+| Category      | Verification                                                                |
+| ------------- | --------------------------------------------------------------------------- |
+| Structure     | Returns correct state with all required slots and `components` map          |
+| Accessibility | ARIA attributes present (`role`, `aria-selected`, `aria-orientation`, etc.) |
+| Purity        | No Griffel, design tokens, or motion utilities imported                     |
+| Slots         | Optional slots absent when not provided; present when provided              |
+| Refs          | Refs forwarded correctly to root element                                    |
+| States        | `disabled`, `disabledFocusable`, controlled/uncontrolled selection          |
+
+## Pattern: compound component (TabList + Tab)
+
+The TabList test demonstrates the canonical pattern for compound components with context:
+
+```tsx
+// useTabList.test.tsx
+import { useTabListBase_unstable } from './useTabList';
+import { renderTabList_unstable } from './renderTabList';
+import { renderTab_unstable, TabState, useTabBase_unstable } from '../Tab';
+import { useTabListContextValues_unstable } from './useTabListContextValues';
+import { useTabListContext_unstable } from './TabListContext';
+
+describe('useTabListBase', () => {
+  type CustomTabListProps = Parameters<typeof useTabListBase_unstable>[0] & {
+    appearance?: 'filled' | 'outline';
+  };
+
+  const CustomTabList = React.forwardRef<HTMLDivElement, CustomTabListProps>(
+    ({ appearance = 'filled', ...props }, ref) => {
+      const state = useTabListBase_unstable(props, ref);
+      // Assign custom design props needed by context consumers
+      Object.assign(state, { appearance, size: 'medium', reserveSelectedTabSpace: true });
+      const contextValues = useTabListContextValues_unstable(state as TabListState);
+
+      state.root.className = `tab-list tab-list--${appearance}`;
+      return renderTabList_unstable(state as TabListState, contextValues);
+    },
+  );
+
+  it('renders with correct ARIA attributes', () => {
+    const { getByRole } = render(
+      <CustomTabList defaultSelectedValue="1">
+        <CustomTab value="1">First</CustomTab>
+        <CustomTab value="2">Second</CustomTab>
+      </CustomTabList>,
+    );
+
+    expect(getByRole('tablist')).toHaveAttribute('aria-orientation', 'horizontal');
+  });
+
+  it('updates selection on click', async () => {
+    const { getByRole } = render(
+      <CustomTabList defaultSelectedValue="1">
+        <CustomTab value="1">First</CustomTab>
+        <CustomTab value="2">Second</CustomTab>
+      </CustomTabList>,
+    );
+
+    await userEvent.click(getByRole('tab', { name: 'Second' }));
+    expect(getByRole('tab', { name: 'Second' })).toHaveAttribute('aria-selected', 'true');
+    expect(getByRole('tab', { name: 'First' })).toHaveAttribute('aria-selected', 'false');
+  });
+});
+```
+
+## Pattern: simple component (Button)
+
+```tsx
+import { useButtonBase_unstable } from './useButton';
+import { renderButton_unstable } from './renderButton';
+
+const TestButton = React.forwardRef<HTMLButtonElement, ButtonBaseProps>((props, ref) => {
+  const state = useButtonBase_unstable(props, ref);
+  return renderButton_unstable(state as ButtonState);
+});
+
+describe('useButtonBase', () => {
+  it('renders as button with type="button"', () => {
+    const { getByRole } = render(<TestButton>Click me</TestButton>);
+    expect(getByRole('button')).toHaveAttribute('type', 'button');
+  });
+
+  it('applies aria-disabled when disabledFocusable', () => {
+    const { getByRole } = render(<TestButton disabledFocusable>Click me</TestButton>);
+    expect(getByRole('button')).toHaveAttribute('aria-disabled', 'true');
+    expect(getByRole('button')).not.toBeDisabled();
+  });
+
+  it('does not render icon slot when not provided', () => {
+    const { container } = render(<TestButton>Click me</TestButton>);
+    expect(container.querySelector('span')).toBeNull();
+  });
+});
+```
+
+## Purity check
+
+Add an import-level check to ensure no Griffel or design tokens are used:
+
+```typescript
+// In the test file or via lint rule
+// Verify no Griffel imports: grep for @griffel/react in the base hook file
+// Verify no design tokens: grep for tokens. usage
+```

--- a/.agents/skills/fluentui-react-v9-base-hooks/references/type-patterns.md
+++ b/.agents/skills/fluentui-react-v9-base-hooks/references/type-patterns.md
@@ -1,0 +1,121 @@
+# Type Patterns for Base State Hooks
+
+## Table of Contents
+
+- [Type Patterns for Base State Hooks](#type-patterns-for-base-state-hooks)
+  - [Table of Contents](#table-of-contents)
+  - [Derivation strategies](#derivation-strategies)
+  - [Button — DistributiveOmit pattern](#button--distributiveomit-pattern)
+  - [TabList — Omit pattern](#tablist--omit-pattern)
+  - [Design props hierarchy](#design-props-hierarchy)
+
+---
+
+## Derivation strategies
+
+**Option A: `DistributiveOmit`** — preferred when base props are a clean subset of full props:
+
+```typescript
+type ButtonBaseProps = DistributiveOmit<ButtonProps, 'appearance' | 'size' | 'shape'>;
+type ButtonBaseState = DistributiveOmit<ButtonState, 'appearance' | 'size' | 'shape'>;
+```
+
+**Option B: `Omit`** — works for non-union types:
+
+```typescript
+type TabListBaseProps = Omit<TabListProps, 'appearance' | 'size' | 'reserveSelectedTabSpace'>;
+type TabListBaseState = Omit<TabListState, 'appearance' | 'size' | 'reserveSelectedTabSpace'>;
+```
+
+**Option C: Explicit composition** — when the base type diverges significantly from the full type:
+
+```typescript
+type ButtonBaseProps = ComponentProps<ButtonSlots> & {
+  disabled?: boolean;
+  disabledFocusable?: boolean;
+  iconPosition?: 'before' | 'after';
+};
+type ButtonBaseState = ComponentState<ButtonSlots> & {
+  disabled: boolean;
+  disabledFocusable: boolean;
+  iconPosition: 'before' | 'after';
+  iconOnly: boolean;
+};
+```
+
+## Button — DistributiveOmit pattern
+
+```typescript
+// Button.types.ts
+
+export type ButtonSlots = {
+  root: NonNullable<Slot<ARIAButtonSlotProps<'a'>>>;
+  icon?: Slot<'span'>;
+};
+
+export type ButtonProps = ComponentProps<ButtonSlots> & {
+  appearance?: 'primary' | 'secondary' | 'outline' | 'subtle' | 'transparent';
+  disabled?: boolean;
+  disabledFocusable?: boolean;
+  iconPosition?: 'before' | 'after';
+  shape?: 'rounded' | 'circular' | 'square';
+  size?: 'small' | 'medium' | 'large';
+};
+
+export type ButtonBaseProps = DistributiveOmit<ButtonProps, 'appearance' | 'size' | 'shape'>;
+
+export type ButtonState = ComponentState<ButtonSlots> & {
+  appearance: NonNullable<ButtonProps['appearance']>;
+  disabled: boolean;
+  disabledFocusable: boolean;
+  iconOnly: boolean;
+  iconPosition: NonNullable<ButtonProps['iconPosition']>;
+  shape: NonNullable<ButtonProps['shape']>;
+  size: NonNullable<ButtonProps['size']>;
+};
+
+export type ButtonBaseState = DistributiveOmit<ButtonState, 'appearance' | 'size' | 'shape'>;
+```
+
+## TabList — Omit pattern
+
+```typescript
+// TabList.types.ts
+
+export type TabListSlots = { root: Slot<'div'> };
+
+export type TabListProps = ComponentProps<TabListSlots> & {
+  appearance?: 'transparent' | 'subtle';
+  disabled?: boolean;
+  defaultSelectedValue?: TabValue;
+  onTabSelect?: EventHandler<SelectTabData>;
+  reserveSelectedTabSpace?: boolean;
+  selectTabOnFocus?: boolean;
+  selectedValue?: TabValue;
+  size?: 'small' | 'medium' | 'large';
+  vertical?: boolean;
+};
+
+// Base props: omit all design/layout props that don't affect ARIA/structure
+export type TabListBaseProps = Omit<TabListProps, 'appearance' | 'size' | 'reserveSelectedTabSpace'>;
+
+export type TabListState = ComponentState<Required<TabListSlots>> &
+  TabListContextValue & {
+    appearance: NonNullable<TabListProps['appearance']>;
+    reserveSelectedTabSpace: boolean;
+    size: NonNullable<TabListProps['size']>;
+  };
+
+export type TabListBaseState = Omit<TabListState, 'appearance' | 'size' | 'reserveSelectedTabSpace'>;
+```
+
+## Design props hierarchy
+
+Base props/state can retain props that affect **slot structure or ARIA behavior**, even if they sound layout-related:
+
+- `iconPosition` — affects slot order AND ARIA description → **keep in base**
+- `vertical` — affects `aria-orientation` → **keep in base**
+- `appearance` — purely visual → **omit from base**
+- `size` — purely visual → **omit from base**
+- `shape` — purely visual → **omit from base**
+- `reserveSelectedTabSpace` — visual layout only → **omit from base**

--- a/.claude/skills/fluentui-react-v9-base-hooks
+++ b/.claude/skills/fluentui-react-v9-base-hooks
@@ -1,0 +1,1 @@
+../../.agents/skills/fluentui-react-v9-base-hooks

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "skills": {
+    "fluentui-react-v9-base-hooks": {
+      "source": "/Users/dmytrokirpa/Projects/fluentui/skills/fluentui-react-v9-base-hooks",
+      "sourceType": "local",
+      "computedHash": "144e6af2169b602ec714fa99fb7128904f4b5b04d44e9c4cf4d1e8a879664487"
+    }
+  }
+}

--- a/skills/fluentui-react-v9-base-hooks/SKILL.md
+++ b/skills/fluentui-react-v9-base-hooks/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: fluentui-react-v9-base-hooks
+description: 'Guide for implementing base state hooks (use{Component}Base_unstable) in the Fluent UI v9 react-components codebase. Use when asked to implement a base state hook for a FluentUI component, extract headless logic from an existing use{Component}_unstable hook, add useXxxBase_unstable to a component package, or follow the base-state-hooks RFC at docs/react-v9/contributing/rfcs/react-components/convergence/base-state-hooks.md.'
+---
+
+# FluentUI v9 Base State Hooks — Implementation Guide
+
+Base state hooks (`use{Component}Base_unstable`) extract pure component logic — ARIA, keyboard handling, slot structure — without styling, design props, or default slot implementations.
+
+Full RFC: `docs/react-v9/contributing/rfcs/react-components/convergence/base-state-hooks.md`
+
+## What to Include vs. Exclude
+
+| Include                                               | Exclude                                      |
+| ----------------------------------------------------- | -------------------------------------------- |
+| ARIA attributes, keyboard handling                    | Design props (`appearance`, `size`, `shape`) |
+| Slot structure, focus management                      | Griffel styles, design tokens                |
+| Layout semantics affecting ARIA (e.g. `iconPosition`) | Motion/animation logic                       |
+| Refs, controlled/uncontrolled state                   | Default slot implementations (icons, etc.)   |
+
+Exception: apply minimum inline styles only when required for accessibility (e.g., visually-hidden elements, portal positioning). Document the rationale inline.
+
+## Naming
+
+- Hook: `use{Component}Base_unstable` — lives in same file as `use{Component}_unstable`
+- Props type: `{Component}BaseProps`
+- State type: `{Component}BaseState`
+- Exported from the component package `index.ts`, NOT re-exported from `@fluentui/react-components`
+
+## Types
+
+Derive base types using `DistributiveOmit` (preferred) or explicit composition. See `references/type-patterns.md` for full examples.
+
+```typescript
+// Preferred: derive by omitting design props
+type ButtonBaseProps = DistributiveOmit<ButtonProps, 'appearance' | 'size' | 'shape'>;
+type ButtonBaseState = DistributiveOmit<ButtonState, 'appearance' | 'size' | 'shape'>;
+```
+
+## Implementation Workflow
+
+### 1. Extract base logic
+
+Move all non-design logic from `use{Component}_unstable` into `use{Component}Base_unstable` in the same file:
+
+```typescript
+// packages/react-components/react-button/library/src/components/Button/useButton.ts
+export const useButtonBase_unstable = (
+  props: ButtonBaseProps,
+  ref?: React.Ref<HTMLButtonElement | HTMLAnchorElement>,
+): ButtonBaseState => {
+  const { icon, iconPosition = 'before', ...buttonProps } = props;
+  const iconShorthand = slot.optional(icon, { elementType: 'span' });
+
+  return {
+    disabled: props.disabled ?? false,
+    disabledFocusable: props.disabledFocusable ?? false,
+    iconPosition,
+    iconOnly: Boolean(iconShorthand?.children && !props.children),
+    components: { root: 'button', icon: 'span' },
+    root: slot.always<ARIAButtonSlotProps<'a'>>(useARIAButtonProps(buttonProps.as, buttonProps), {
+      elementType: 'button',
+      defaultProps: {
+        ref: ref as React.Ref<HTMLButtonElement & HTMLAnchorElement>,
+        type: props.as !== 'a' ? 'button' : undefined,
+      },
+    }),
+    icon: iconShorthand,
+  };
+};
+```
+
+### 2. Compose into styled hook
+
+```typescript
+export const useButton_unstable = (props: ButtonProps, ref): ButtonState => {
+  const { appearance = 'secondary', size = 'medium', shape = 'rounded' } = props;
+  return {
+    ...useButtonBase_unstable(props, ref),
+    appearance,
+    size,
+    shape,
+  };
+};
+```
+
+### 3. Export from package index
+
+In `packages/react-components/{package}/library/src/index.ts`:
+
+```typescript
+export { useButtonBase_unstable } from './components/Button/useButton';
+export type { ButtonBaseProps, ButtonBaseState } from './components/Button/Button.types';
+```
+
+## Testing
+
+Write dedicated tests for the base hook that verify structure, ARIA attributes, and slot behavior independently of design state. See `references/testing.md` for the pattern.

--- a/skills/fluentui-react-v9-base-hooks/references/testing.md
+++ b/skills/fluentui-react-v9-base-hooks/references/testing.md
@@ -1,0 +1,107 @@
+# Testing Base State Hooks
+
+## What to test
+
+| Category      | Verification                                                                |
+| ------------- | --------------------------------------------------------------------------- |
+| Structure     | Returns correct state with all required slots and `components` map          |
+| Accessibility | ARIA attributes present (`role`, `aria-selected`, `aria-orientation`, etc.) |
+| Purity        | No Griffel, design tokens, or motion utilities imported                     |
+| Slots         | Optional slots absent when not provided; present when provided              |
+| Refs          | Refs forwarded correctly to root element                                    |
+| States        | `disabled`, `disabledFocusable`, controlled/uncontrolled selection          |
+
+## Pattern: compound component (TabList + Tab)
+
+The TabList test demonstrates the canonical pattern for compound components with context:
+
+```tsx
+// useTabList.test.tsx
+import { useTabListBase_unstable } from './useTabList';
+import { renderTabList_unstable } from './renderTabList';
+import { renderTab_unstable, TabState, useTabBase_unstable } from '../Tab';
+import { useTabListContextValues_unstable } from './useTabListContextValues';
+import { useTabListContext_unstable } from './TabListContext';
+
+describe('useTabListBase', () => {
+  type CustomTabListProps = Parameters<typeof useTabListBase_unstable>[0] & {
+    appearance?: 'filled' | 'outline';
+  };
+
+  const CustomTabList = React.forwardRef<HTMLDivElement, CustomTabListProps>(
+    ({ appearance = 'filled', ...props }, ref) => {
+      const state = useTabListBase_unstable(props, ref);
+      // Assign custom design props needed by context consumers
+      Object.assign(state, { appearance, size: 'medium', reserveSelectedTabSpace: true });
+      const contextValues = useTabListContextValues_unstable(state as TabListState);
+
+      state.root.className = `tab-list tab-list--${appearance}`;
+      return renderTabList_unstable(state as TabListState, contextValues);
+    },
+  );
+
+  it('renders with correct ARIA attributes', () => {
+    const { getByRole } = render(
+      <CustomTabList defaultSelectedValue="1">
+        <CustomTab value="1">First</CustomTab>
+        <CustomTab value="2">Second</CustomTab>
+      </CustomTabList>,
+    );
+
+    expect(getByRole('tablist')).toHaveAttribute('aria-orientation', 'horizontal');
+  });
+
+  it('updates selection on click', async () => {
+    const { getByRole } = render(
+      <CustomTabList defaultSelectedValue="1">
+        <CustomTab value="1">First</CustomTab>
+        <CustomTab value="2">Second</CustomTab>
+      </CustomTabList>,
+    );
+
+    await userEvent.click(getByRole('tab', { name: 'Second' }));
+    expect(getByRole('tab', { name: 'Second' })).toHaveAttribute('aria-selected', 'true');
+    expect(getByRole('tab', { name: 'First' })).toHaveAttribute('aria-selected', 'false');
+  });
+});
+```
+
+## Pattern: simple component (Button)
+
+```tsx
+import { useButtonBase_unstable } from './useButton';
+import { renderButton_unstable } from './renderButton';
+
+const TestButton = React.forwardRef<HTMLButtonElement, ButtonBaseProps>((props, ref) => {
+  const state = useButtonBase_unstable(props, ref);
+  return renderButton_unstable(state as ButtonState);
+});
+
+describe('useButtonBase', () => {
+  it('renders as button with type="button"', () => {
+    const { getByRole } = render(<TestButton>Click me</TestButton>);
+    expect(getByRole('button')).toHaveAttribute('type', 'button');
+  });
+
+  it('applies aria-disabled when disabledFocusable', () => {
+    const { getByRole } = render(<TestButton disabledFocusable>Click me</TestButton>);
+    expect(getByRole('button')).toHaveAttribute('aria-disabled', 'true');
+    expect(getByRole('button')).not.toBeDisabled();
+  });
+
+  it('does not render icon slot when not provided', () => {
+    const { container } = render(<TestButton>Click me</TestButton>);
+    expect(container.querySelector('span')).toBeNull();
+  });
+});
+```
+
+## Purity check
+
+Add an import-level check to ensure no Griffel or design tokens are used:
+
+```typescript
+// In the test file or via lint rule
+// Verify no Griffel imports: grep for @griffel/react in the base hook file
+// Verify no design tokens: grep for tokens. usage
+```

--- a/skills/fluentui-react-v9-base-hooks/references/type-patterns.md
+++ b/skills/fluentui-react-v9-base-hooks/references/type-patterns.md
@@ -1,0 +1,121 @@
+# Type Patterns for Base State Hooks
+
+## Table of Contents
+
+- [Type Patterns for Base State Hooks](#type-patterns-for-base-state-hooks)
+  - [Table of Contents](#table-of-contents)
+  - [Derivation strategies](#derivation-strategies)
+  - [Button — DistributiveOmit pattern](#button--distributiveomit-pattern)
+  - [TabList — Omit pattern](#tablist--omit-pattern)
+  - [Design props hierarchy](#design-props-hierarchy)
+
+---
+
+## Derivation strategies
+
+**Option A: `DistributiveOmit`** — preferred when base props are a clean subset of full props:
+
+```typescript
+type ButtonBaseProps = DistributiveOmit<ButtonProps, 'appearance' | 'size' | 'shape'>;
+type ButtonBaseState = DistributiveOmit<ButtonState, 'appearance' | 'size' | 'shape'>;
+```
+
+**Option B: `Omit`** — works for non-union types:
+
+```typescript
+type TabListBaseProps = Omit<TabListProps, 'appearance' | 'size' | 'reserveSelectedTabSpace'>;
+type TabListBaseState = Omit<TabListState, 'appearance' | 'size' | 'reserveSelectedTabSpace'>;
+```
+
+**Option C: Explicit composition** — when the base type diverges significantly from the full type:
+
+```typescript
+type ButtonBaseProps = ComponentProps<ButtonSlots> & {
+  disabled?: boolean;
+  disabledFocusable?: boolean;
+  iconPosition?: 'before' | 'after';
+};
+type ButtonBaseState = ComponentState<ButtonSlots> & {
+  disabled: boolean;
+  disabledFocusable: boolean;
+  iconPosition: 'before' | 'after';
+  iconOnly: boolean;
+};
+```
+
+## Button — DistributiveOmit pattern
+
+```typescript
+// Button.types.ts
+
+export type ButtonSlots = {
+  root: NonNullable<Slot<ARIAButtonSlotProps<'a'>>>;
+  icon?: Slot<'span'>;
+};
+
+export type ButtonProps = ComponentProps<ButtonSlots> & {
+  appearance?: 'primary' | 'secondary' | 'outline' | 'subtle' | 'transparent';
+  disabled?: boolean;
+  disabledFocusable?: boolean;
+  iconPosition?: 'before' | 'after';
+  shape?: 'rounded' | 'circular' | 'square';
+  size?: 'small' | 'medium' | 'large';
+};
+
+export type ButtonBaseProps = DistributiveOmit<ButtonProps, 'appearance' | 'size' | 'shape'>;
+
+export type ButtonState = ComponentState<ButtonSlots> & {
+  appearance: NonNullable<ButtonProps['appearance']>;
+  disabled: boolean;
+  disabledFocusable: boolean;
+  iconOnly: boolean;
+  iconPosition: NonNullable<ButtonProps['iconPosition']>;
+  shape: NonNullable<ButtonProps['shape']>;
+  size: NonNullable<ButtonProps['size']>;
+};
+
+export type ButtonBaseState = DistributiveOmit<ButtonState, 'appearance' | 'size' | 'shape'>;
+```
+
+## TabList — Omit pattern
+
+```typescript
+// TabList.types.ts
+
+export type TabListSlots = { root: Slot<'div'> };
+
+export type TabListProps = ComponentProps<TabListSlots> & {
+  appearance?: 'transparent' | 'subtle';
+  disabled?: boolean;
+  defaultSelectedValue?: TabValue;
+  onTabSelect?: EventHandler<SelectTabData>;
+  reserveSelectedTabSpace?: boolean;
+  selectTabOnFocus?: boolean;
+  selectedValue?: TabValue;
+  size?: 'small' | 'medium' | 'large';
+  vertical?: boolean;
+};
+
+// Base props: omit all design/layout props that don't affect ARIA/structure
+export type TabListBaseProps = Omit<TabListProps, 'appearance' | 'size' | 'reserveSelectedTabSpace'>;
+
+export type TabListState = ComponentState<Required<TabListSlots>> &
+  TabListContextValue & {
+    appearance: NonNullable<TabListProps['appearance']>;
+    reserveSelectedTabSpace: boolean;
+    size: NonNullable<TabListProps['size']>;
+  };
+
+export type TabListBaseState = Omit<TabListState, 'appearance' | 'size' | 'reserveSelectedTabSpace'>;
+```
+
+## Design props hierarchy
+
+Base props/state can retain props that affect **slot structure or ARIA behavior**, even if they sound layout-related:
+
+- `iconPosition` — affects slot order AND ARIA description → **keep in base**
+- `vertical` — affects `aria-orientation` → **keep in base**
+- `appearance` — purely visual → **omit from base**
+- `size` — purely visual → **omit from base**
+- `shape` — purely visual → **omit from base**
+- `reserveSelectedTabSpace` — visual layout only → **omit from base**

--- a/skills/fluentui-react-v9-custom-components/SKILL.md
+++ b/skills/fluentui-react-v9-custom-components/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: fluentui-react-v9-custom-components
+description: 'Guide for building custom React components using Fluent UI v9 base state hooks and render functions. Use when asked to: create a component based on FluentUI headless hooks, build a custom component using Fluent UI base state hooks, create a component with custom styling that reuses Fluent UI accessibility behavior, implement a component using render{Component}_unstable and use{Component}Base_unstable, or consume @fluentui/react-button/@fluentui/react-tabs/etc. without Fluent 2 visual design.'
+---
+
+# Building Custom Components with FluentUI v9 Base Hooks
+
+Base state hooks + render functions let you reuse Fluent's ARIA behavior, keyboard handling, and slot structure with completely custom styling. Imports come from individual component packages (e.g. `@fluentui/react-button`), not from `@fluentui/react-components`.
+
+> **Your responsibility:** custom styling, visible focus indicators, sufficient color contrast, and all visual accessibility. Base hooks provide ARIA structure but not visual a11y.
+
+## The Pattern
+
+```tsx
+import * as React from 'react';
+import { useButtonBase_unstable, renderButton_unstable } from '@fluentui/react-button';
+import type { ButtonBaseProps, ButtonState } from '@fluentui/react-button';
+
+type CustomButtonProps = ButtonBaseProps & {
+  variant?: 'primary' | 'secondary' | 'tertiary';
+  tone?: 'neutral' | 'success' | 'warning' | 'danger';
+};
+
+export const CustomButton = React.forwardRef<HTMLButtonElement, CustomButtonProps>(
+  ({ variant = 'primary', tone = 'neutral', ...props }, ref) => {
+    // 1. Get state: ARIA, keyboard handling, slot structure
+    const state = useButtonBase_unstable(props, ref);
+
+    // 2. Mutate state: apply your classes/styles
+    state.root.className = ['btn', `btn--${variant}`, `btn--${tone}`].filter(Boolean).join(' ');
+    if (state.icon) {
+      state.icon.className = 'btn__icon';
+    }
+
+    // 3. Render using Fluent's render function
+    return renderButton_unstable(state as ButtonState);
+  },
+);
+```
+
+## Available Hooks
+
+See `references/available-hooks.md` for the full inventory with import paths, prop/state types, and notes.
+
+**Quick reference:**
+
+| Component      | Hook                             | Render function                 | Package                     |
+| -------------- | -------------------------------- | ------------------------------- | --------------------------- |
+| Button         | `useButtonBase_unstable`         | `renderButton_unstable`         | `@fluentui/react-button`    |
+| ToggleButton   | `useToggleButtonBase_unstable`   | `renderToggleButton_unstable`   | `@fluentui/react-button`    |
+| TabList        | `useTabListBase_unstable`        | `renderTabList_unstable`        | `@fluentui/react-tabs`      |
+| Tab            | `useTabBase_unstable`            | `renderTab_unstable`            | `@fluentui/react-tabs`      |
+| Divider        | `useDividerBase_unstable`        | `renderDivider_unstable`        | `@fluentui/react-divider`   |
+| Accordion      | `useAccordionBase_unstable`      | `renderAccordion_unstable`      | `@fluentui/react-accordion` |
+| AccordionPanel | `useAccordionPanelBase_unstable` | `renderAccordionPanel_unstable` | `@fluentui/react-accordion` |
+| Toolbar        | `useToolbarBase_unstable`        | `renderToolbar_unstable`        | `@fluentui/react-toolbar`   |
+| ToolbarButton  | `useToolbarButtonBase_unstable`  | `renderToolbarButton_unstable`  | `@fluentui/react-toolbar`   |
+| Popover        | `usePopoverBase_unstable`        | `renderPopover_unstable`        | `@fluentui/react-popover`   |
+| Persona        | `usePersonaBase_unstable`        | `renderPersona_unstable`        | `@fluentui/react-persona`   |
+| Card           | `useCardBase_unstable`           | `renderCard_unstable`           | `@fluentui/react-card`      |
+
+## Compound Components (TabList, Accordion)
+
+Compound components require context values passed to the render function. Use `use{Component}ContextValues_unstable` and inject any design props needed by child components before calling it:
+
+```tsx
+import {
+  useTabListBase_unstable,
+  useTabListContextValues_unstable,
+  renderTabList_unstable,
+  useTabListA11yBehavior_unstable,
+} from '@fluentui/react-tabs';
+import type { TabListBaseProps, TabListState } from '@fluentui/react-tabs';
+
+type CustomTabListProps = TabListBaseProps & { appearance?: 'filled' | 'outline' };
+
+export const CustomTabList = React.forwardRef<HTMLDivElement, CustomTabListProps>(
+  ({ appearance = 'filled', ...props }, ref) => {
+    const state = useTabListBase_unstable(props, ref);
+
+    // Inject design props consumed by child Tab components via context
+    Object.assign(state, { appearance, size: 'medium', reserveSelectedTabSpace: true });
+    const contextValues = useTabListContextValues_unstable(state as TabListState);
+
+    // Apply custom classes
+    state.root.className = `tab-list tab-list--${appearance}`;
+
+    // Keyboard navigation: choose one approach
+    // Option A — Tabster (recommended for accessibility)
+    const focusProps = useTabListA11yBehavior_unstable({ vertical: state.vertical });
+    state.root = { ...state.root, ...focusProps };
+    // Option B — focusgroup proposal
+    // (state.root as any).focusgroup = `tablist ${state.vertical ? 'block' : 'inline'} no-memory wrap`;
+
+    return renderTabList_unstable(state as TabListState, contextValues);
+  },
+);
+```
+
+## TypeScript tips
+
+- Use `{Component}BaseProps` for the component's props type
+- Cast state to `{Component}State` when passing to render: `renderButton_unstable(state as ButtonState)`
+- Child components (e.g. `CustomTab`) read design values from context via `useTabListContext_unstable`

--- a/skills/fluentui-react-v9-custom-components/references/available-hooks.md
+++ b/skills/fluentui-react-v9-custom-components/references/available-hooks.md
@@ -1,0 +1,221 @@
+# Available Base Hooks & Render Functions
+
+## Table of Contents
+
+- [Available Base Hooks \& Render Functions](#available-base-hooks--render-functions)
+  - [Table of Contents](#table-of-contents)
+  - [Button — `@fluentui/react-button`](#button--fluentuireact-button)
+  - [ToggleButton — `@fluentui/react-button`](#togglebutton--fluentuireact-button)
+  - [TabList + Tab — `@fluentui/react-tabs`](#tablist--tab--fluentuireact-tabs)
+    - [TabList](#tablist)
+    - [Tab](#tab)
+  - [Divider — `@fluentui/react-divider`](#divider--fluentuireact-divider)
+  - [Accordion + AccordionPanel — `@fluentui/react-accordion`](#accordion--accordionpanel--fluentuireact-accordion)
+    - [Accordion](#accordion)
+    - [AccordionPanel](#accordionpanel)
+  - [Toolbar family — `@fluentui/react-toolbar`](#toolbar-family--fluentuireact-toolbar)
+  - [Popover + PopoverSurface — `@fluentui/react-popover`](#popover--popoversurface--fluentuireact-popover)
+  - [Persona — `@fluentui/react-persona`](#persona--fluentuireact-persona)
+  - [Card — `@fluentui/react-card`](#card--fluentuireact-card)
+
+---
+
+## Button — `@fluentui/react-button`
+
+```typescript
+import { useButtonBase_unstable, renderButton_unstable } from '@fluentui/react-button';
+import type { ButtonBaseProps, ButtonBaseState, ButtonState } from '@fluentui/react-button';
+```
+
+**Props (`ButtonBaseProps`):** `disabled?`, `disabledFocusable?`, `iconPosition?: 'before' | 'after'`, `icon?`, plus all HTML button/anchor props via `as` prop.
+
+**State (`ButtonBaseState`):** `disabled`, `disabledFocusable`, `iconPosition`, `iconOnly`, `root` (slot), `icon` (slot), `components`.
+
+**Notes:**
+
+- `renderButton_unstable(state as ButtonState)` — cast required
+- Handles `aria-disabled` for `disabledFocusable` case automatically
+- `iconOnly` is computed from `icon.children` + absence of `children`
+
+---
+
+## ToggleButton — `@fluentui/react-button`
+
+```typescript
+import { useToggleButtonBase_unstable, renderToggleButton_unstable } from '@fluentui/react-button';
+import type { ToggleButtonBaseProps, ToggleButtonState } from '@fluentui/react-button';
+```
+
+**Additional props:** `checked?`, `defaultChecked?` — controlled/uncontrolled toggle state.
+
+**Additional state:** `checked: boolean`.
+
+---
+
+## TabList + Tab — `@fluentui/react-tabs`
+
+### TabList
+
+```typescript
+import {
+  useTabListBase_unstable,
+  useTabListContextValues_unstable,
+  useTabListA11yBehavior_unstable,
+  renderTabList_unstable,
+} from '@fluentui/react-tabs';
+import type { TabListBaseProps, TabListBaseState, TabListState } from '@fluentui/react-tabs';
+```
+
+**Props (`TabListBaseProps`):** `disabled?`, `vertical?`, `selectTabOnFocus?`, `selectedValue?`, `defaultSelectedValue?`, `onTabSelect?`.
+
+**State (`TabListBaseState`):** `disabled`, `vertical`, `selectTabOnFocus`, `selectedValue`, `onSelect`, `onRegister`, `onUnregister`, `getRegisteredTabs`, `root` (slot), `components`.
+
+**Context injection required:** Before calling `useTabListContextValues_unstable`, assign design props that child Tab components expect via context:
+
+```typescript
+Object.assign(state, {
+  appearance: 'filled', // consumed by child Tab via context
+  size: 'medium', // consumed by child Tab via context
+  reserveSelectedTabSpace: true, // consumed by child Tab via context
+});
+const contextValues = useTabListContextValues_unstable(state as TabListState);
+```
+
+**Keyboard navigation:** `useTabListA11yBehavior_unstable({ vertical })` returns Tabster DOM attributes for arrow key navigation. Apply to `state.root`.
+
+### Tab
+
+```typescript
+import { useTabBase_unstable, renderTab_unstable } from '@fluentui/react-tabs';
+import type { TabBaseProps, TabBaseState, TabState } from '@fluentui/react-tabs';
+```
+
+**Props (`TabBaseProps`):** `value` (required, serializable), `disabled?`, `icon?`, `contentReservedSpace?`.
+
+**State:** `selected` (boolean, from TabList context), `value`, `disabled`, `root` (slot), `icon` (slot), `content` (slot).
+
+**Accessing context in custom Tab:**
+
+```typescript
+import { useTabListContext_unstable } from '@fluentui/react-tabs';
+
+const appearance = useTabListContext_unstable(ctx => ctx.appearance as CustomAppearance);
+```
+
+---
+
+## Divider — `@fluentui/react-divider`
+
+```typescript
+import { useDividerBase_unstable, renderDivider_unstable } from '@fluentui/react-divider';
+import type { DividerBaseProps, DividerBaseState, DividerState } from '@fluentui/react-divider';
+```
+
+**Props:** `vertical?`, `inset?`, `alignContent?: 'start' | 'center' | 'end'`, `children?`.
+
+**Notes:** `alignContent` affects ARIA role (`separator` vs. `presentation`) — kept in base.
+
+---
+
+## Accordion + AccordionPanel — `@fluentui/react-accordion`
+
+### Accordion
+
+```typescript
+import {
+  useAccordionBase_unstable,
+  useAccordionContextValues_unstable,
+  renderAccordion_unstable,
+} from '@fluentui/react-accordion';
+import type { AccordionBaseProps, AccordionState } from '@fluentui/react-accordion';
+```
+
+**Props:** `multiple?`, `collapsible?`, `openItems?`, `defaultOpenItems?`, `onToggle?`.
+
+**Context injection:** Similar to TabList — assign design props before calling `useAccordionContextValues_unstable`.
+
+### AccordionPanel
+
+```typescript
+import { useAccordionPanelBase_unstable, renderAccordionPanel_unstable } from '@fluentui/react-accordion';
+import type { AccordionPanelBaseProps, AccordionPanelState } from '@fluentui/react-accordion';
+```
+
+---
+
+## Toolbar family — `@fluentui/react-toolbar`
+
+```typescript
+import {
+  useToolbarBase_unstable,
+  useToolbarButtonBase_unstable,
+  useToolbarToggleButtonBase_unstable,
+  useToolbarRadioButtonBase_unstable,
+  useToolbarDividerBase_unstable,
+  useToolbarGroupBase_unstable,
+  renderToolbar_unstable,
+  renderToolbarButton_unstable,
+  // etc.
+} from '@fluentui/react-toolbar';
+```
+
+**Notes:**
+
+- `useToolbarBase_unstable` manages context for child toolbar items
+- `useToolbarButtonBase_unstable` extends `useButtonBase_unstable` with toolbar context awareness
+- All toolbar item hooks read toolbar context (disabled state propagation)
+
+---
+
+## Popover + PopoverSurface — `@fluentui/react-popover`
+
+```typescript
+import {
+  usePopoverBase_unstable,
+  usePopoverSurfaceBase_unstable,
+  renderPopover_unstable,
+  renderPopoverSurface_unstable,
+} from '@fluentui/react-popover';
+import type { PopoverBaseProps, PopoverSurfaceBaseProps } from '@fluentui/react-popover';
+```
+
+**Notes:**
+
+- `usePopoverBase_unstable` is a headless hook (no DOM element, manages open/close state)
+- `usePopoverSurfaceBase_unstable` renders the surface with positioning
+- Popover uses React portals — may require additional inline styles for positioning (accessibility exception)
+
+---
+
+## Persona — `@fluentui/react-persona`
+
+```typescript
+import { usePersonaBase_unstable, renderPersona_unstable } from '@fluentui/react-persona';
+import type { PersonaBaseProps, PersonaBaseState, PersonaState } from '@fluentui/react-persona';
+```
+
+**Props:** `name?`, `avatar?`, `presence?`, `primaryText?`, `secondaryText?`, `tertiaryText?`, `quaternaryText?`.
+
+**Notes:** Persona is a layout component — all text/avatar slots available, no design props in base.
+
+---
+
+## Card — `@fluentui/react-card`
+
+```typescript
+import { useCardBase_unstable, renderCard_unstable } from '@fluentui/react-card';
+import type { CardBaseProps, CardBaseState, CardState } from '@fluentui/react-card';
+```
+
+**Props (`CardBaseProps`):** `focusMode?: 'off' | 'no-tab' | 'tab-exit' | 'tab-only'`, `selected?`, `defaultSelected?`, `onSelectionChange?`, `disabled?`, plus all HTML div props.
+
+**State (`CardBaseState`):** `interactive`, `selectable`, `selected`, `selectFocused`, `disabled`, `root` (slot), `floatingAction` (slot), `checkbox` (slot), `components`.
+
+**Excluded design props:** `appearance`, `orientation`, `size` — assign these directly to state before rendering.
+
+**Notes:**
+
+- Card manages an internal checkbox slot for selectable cards and an ARIA reference link between the checkbox and card label
+- `renderCard_unstable(state as CardState)` — cast required
+- Child components (`CardHeader`, `CardFooter`, `CardPreview`) do not yet have base hooks; use them as-is from `@fluentui/react-card`
+- For selectable cards, `onSelectionChange` fires on mouse click, keyboard activation, and checkbox change events


### PR DESCRIPTION
This PR introduces two new skills:
- `fluentui-react-v9-base-hooks`, which provides comprehensive documentation and guidance for implementing "base/headless state hooks" in the Fluent UI v9 React components codebase. The skill includes an implementation guide, detailed type patterns, and recommended testing strategies to ensure consistency and best practices when extracting headless logic from component hooks. (this skill is also integrated into the repo, so you can use it in ClaudeCode via `/fluentui-react-v9-base-hooks`)
- `fluentui-react-v9-custom-components`, guidance for Agents on how to compose custom components on to of base/headless hooks

