### PR TITLE
feat(react-skeleton): add useSkeletonBase_unstable hook

### DIFF
--- a/change/@fluentui-react-skeleton-10530e19-dafd-40ac-a870-5e62801499ad.json
+++ b/change/@fluentui-react-skeleton-10530e19-dafd-40ac-a870-5e62801499ad.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add base hooks for Skeleton",
+  "packageName": "@fluentui/react-skeleton",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-skeleton/library/etc/react-skeleton.api.md
+++ b/packages/react-components/react-skeleton/library/etc/react-skeleton.api.md
@@ -16,10 +16,16 @@ import type { SlotClassNames } from '@fluentui/react-utilities';
 export const renderSkeleton_unstable: (state: SkeletonState, contextValues: SkeletonContextValues) => JSXElement;
 
 // @public
-export const renderSkeletonItem_unstable: (state: SkeletonItemState) => JSXElement;
+export const renderSkeletonItem_unstable: (state: SkeletonItemBaseState) => JSXElement;
 
 // @public
 export const Skeleton: ForwardRefComponent<SkeletonProps>;
+
+// @public
+export type SkeletonBaseProps = Omit<SkeletonProps, 'animation' | 'appearance'>;
+
+// @public
+export type SkeletonBaseState = Omit<SkeletonState, 'animation' | 'appearance' | 'size' | 'shape'>;
 
 // @public (undocumented)
 export const skeletonClassNames: SlotClassNames<SkeletonSlots>;
@@ -41,6 +47,12 @@ export interface SkeletonContextValue {
 
 // @public (undocumented)
 export const SkeletonItem: ForwardRefComponent<SkeletonItemProps>;
+
+// @public
+export type SkeletonItemBaseProps = Omit<SkeletonItemProps, 'animation' | 'appearance' | 'size' | 'shape'>;
+
+// @public
+export type SkeletonItemBaseState = Omit<SkeletonItemState, 'animation' | 'appearance' | 'size' | 'shape'>;
 
 // @public (undocumented)
 export const skeletonItemClassNames: SlotClassNames<SkeletonItemSlots>;
@@ -79,11 +91,17 @@ export type SkeletonState = ComponentState<SkeletonSlots> & Required<Pick<Skelet
 // @public
 export const useSkeleton_unstable: (props: SkeletonProps, ref: React_2.Ref<HTMLElement>) => SkeletonState;
 
+// @public
+export const useSkeletonBase_unstable: (props: SkeletonBaseProps, ref: React_2.Ref<HTMLDivElement>) => SkeletonBaseState;
+
 // @public (undocumented)
 export const useSkeletonContext: () => SkeletonContextValue;
 
 // @public
 export const useSkeletonItem_unstable: (props: SkeletonItemProps, ref: React_2.Ref<HTMLElement>) => SkeletonItemState;
+
+// @public
+export const useSkeletonItemBase_unstable: (props: SkeletonItemBaseProps, ref?: React_2.Ref<HTMLDivElement>) => SkeletonItemBaseState;
 
 // @public
 export const useSkeletonItemStyles_unstable: (state: SkeletonItemState) => SkeletonItemState;

--- a/packages/react-components/react-skeleton/library/etc/react-skeleton.api.md
+++ b/packages/react-components/react-skeleton/library/etc/react-skeleton.api.md
@@ -101,7 +101,7 @@ export const useSkeletonContext: () => SkeletonContextValue;
 export const useSkeletonItem_unstable: (props: SkeletonItemProps, ref: React_2.Ref<HTMLElement>) => SkeletonItemState;
 
 // @public
-export const useSkeletonItemBase_unstable: (props: SkeletonItemBaseProps, ref?: React_2.Ref<HTMLDivElement>) => SkeletonItemBaseState;
+export const useSkeletonItemBase_unstable: (props: SkeletonItemBaseProps, ref: React_2.Ref<HTMLDivElement>) => SkeletonItemBaseState;
 
 // @public
 export const useSkeletonItemStyles_unstable: (state: SkeletonItemState) => SkeletonItemState;

--- a/packages/react-components/react-skeleton/library/src/Skeleton.ts
+++ b/packages/react-components/react-skeleton/library/src/Skeleton.ts
@@ -1,4 +1,6 @@
 export type {
+  SkeletonBaseProps,
+  SkeletonBaseState,
   SkeletonContextValues,
   SkeletonItemSize,
   SkeletonProps,
@@ -12,4 +14,5 @@ export {
   useSkeletonContextValues,
   useSkeletonStyles_unstable,
   useSkeleton_unstable,
+  useSkeletonBase_unstable,
 } from './components/Skeleton/index';

--- a/packages/react-components/react-skeleton/library/src/SkeletonItem.ts
+++ b/packages/react-components/react-skeleton/library/src/SkeletonItem.ts
@@ -1,8 +1,15 @@
-export type { SkeletonItemProps, SkeletonItemSlots, SkeletonItemState } from './components/SkeletonItem/index';
+export type {
+  SkeletonItemBaseProps,
+  SkeletonItemBaseState,
+  SkeletonItemProps,
+  SkeletonItemSlots,
+  SkeletonItemState,
+} from './components/SkeletonItem/index';
 export {
   SkeletonItem,
   renderSkeletonItem_unstable,
   skeletonItemClassNames,
   useSkeletonItemStyles_unstable,
   useSkeletonItem_unstable,
+  useSkeletonItemBase_unstable,
 } from './components/SkeletonItem/index';

--- a/packages/react-components/react-skeleton/library/src/components/Skeleton/Skeleton.types.ts
+++ b/packages/react-components/react-skeleton/library/src/components/Skeleton/Skeleton.types.ts
@@ -1,4 +1,4 @@
-import type { ComponentProps, ComponentState, DistributiveOmit, Slot } from '@fluentui/react-utilities';
+import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
 import { SkeletonContextValue } from '../../contexts/index';
 
 export type SkeletonSlots = {
@@ -54,7 +54,7 @@ export type SkeletonProps = Omit<ComponentProps<Partial<SkeletonSlots>>, 'width'
 /**
  * Skeleton base props, excluding design-related props like animation and appearance.
  */
-export type SkeletonBaseProps = DistributiveOmit<SkeletonProps, 'animation' | 'appearance'>;
+export type SkeletonBaseProps = Omit<SkeletonProps, 'animation' | 'appearance'>;
 
 export type SkeletonContextValues = {
   skeletonGroup: SkeletonContextValue;
@@ -70,4 +70,4 @@ export type SkeletonState = ComponentState<SkeletonSlots> &
 /**
  * Skeleton base state, excluding design-related state like animation and appearance.
  */
-export type SkeletonBaseState = DistributiveOmit<SkeletonState, 'animation' | 'appearance' | 'size' | 'shape'>;
+export type SkeletonBaseState = Omit<SkeletonState, 'animation' | 'appearance' | 'size' | 'shape'>;

--- a/packages/react-components/react-skeleton/library/src/components/Skeleton/Skeleton.types.ts
+++ b/packages/react-components/react-skeleton/library/src/components/Skeleton/Skeleton.types.ts
@@ -1,4 +1,4 @@
-import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+import type { ComponentProps, ComponentState, DistributiveOmit, Slot } from '@fluentui/react-utilities';
 import { SkeletonContextValue } from '../../contexts/index';
 
 export type SkeletonSlots = {
@@ -51,6 +51,11 @@ export type SkeletonProps = Omit<ComponentProps<Partial<SkeletonSlots>>, 'width'
   shape?: 'circle' | 'square' | 'rectangle';
 };
 
+/**
+ * Skeleton base props, excluding design-related props like animation and appearance.
+ */
+export type SkeletonBaseProps = DistributiveOmit<SkeletonProps, 'animation' | 'appearance'>;
+
 export type SkeletonContextValues = {
   skeletonGroup: SkeletonContextValue;
 };
@@ -61,3 +66,8 @@ export type SkeletonContextValues = {
 export type SkeletonState = ComponentState<SkeletonSlots> &
   Required<Pick<SkeletonProps, 'animation' | 'appearance'>> &
   Pick<SkeletonProps, 'size' | 'shape'>;
+
+/**
+ * Skeleton base state, excluding design-related state like animation and appearance.
+ */
+export type SkeletonBaseState = DistributiveOmit<SkeletonState, 'animation' | 'appearance' | 'size' | 'shape'>;

--- a/packages/react-components/react-skeleton/library/src/components/Skeleton/index.ts
+++ b/packages/react-components/react-skeleton/library/src/components/Skeleton/index.ts
@@ -1,5 +1,7 @@
 export { Skeleton } from './Skeleton';
 export type {
+  SkeletonBaseProps,
+  SkeletonBaseState,
   SkeletonContextValues,
   SkeletonItemSize,
   SkeletonProps,
@@ -7,6 +9,6 @@ export type {
   SkeletonState,
 } from './Skeleton.types';
 export { renderSkeleton_unstable } from './renderSkeleton';
-export { useSkeleton_unstable } from './useSkeleton';
+export { useSkeleton_unstable, useSkeletonBase_unstable } from './useSkeleton';
 export { useSkeletonContextValues } from './useSkeletonContextValues';
 export { skeletonClassNames, useSkeletonStyles_unstable } from './useSkeletonStyles.styles';

--- a/packages/react-components/react-skeleton/library/src/components/Skeleton/useSkeleton.ts
+++ b/packages/react-components/react-skeleton/library/src/components/Skeleton/useSkeleton.ts
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { getIntrinsicElementProps, slot } from '@fluentui/react-utilities';
-import type { SkeletonProps, SkeletonState } from './Skeleton.types';
+import type { SkeletonBaseProps, SkeletonBaseState, SkeletonProps, SkeletonState } from './Skeleton.types';
 import { useSkeletonContext } from '../../contexts/SkeletonContext';
 
 /**
@@ -16,8 +16,32 @@ import { useSkeletonContext } from '../../contexts/SkeletonContext';
  */
 export const useSkeleton_unstable = (props: SkeletonProps, ref: React.Ref<HTMLElement>): SkeletonState => {
   const { animation: contextAnimation, appearance: contextAppearance } = useSkeletonContext();
-  const { animation = contextAnimation ?? 'wave', appearance = contextAppearance ?? 'opaque', size, shape } = props;
+  const {
+    animation = contextAnimation ?? 'wave',
+    appearance = contextAppearance ?? 'opaque',
+    size,
+    shape,
+    ...baseProps
+  } = props;
 
+  const baseState = useSkeletonBase_unstable(baseProps, ref);
+
+  return {
+    ...baseState,
+    animation,
+    appearance,
+    size,
+    shape,
+  };
+};
+
+/**
+ * Base hook for Skeleton component, which manages state related to slots structure and ARIA attributes.
+ *
+ * @param props - User provided props to the Skeleton component.
+ * @param ref - User provided ref to be passed to the Skeleton component.
+ */
+export const useSkeletonBase_unstable = (props: SkeletonBaseProps, ref?: React.Ref<HTMLElement>): SkeletonBaseState => {
   const root = slot.always(
     getIntrinsicElementProps('div', {
       // FIXME:
@@ -30,5 +54,5 @@ export const useSkeleton_unstable = (props: SkeletonProps, ref: React.Ref<HTMLEl
     }),
     { elementType: 'div' },
   );
-  return { animation, appearance, size, shape, components: { root: 'div' }, root };
+  return { components: { root: 'div' }, root };
 };

--- a/packages/react-components/react-skeleton/library/src/components/Skeleton/useSkeleton.ts
+++ b/packages/react-components/react-skeleton/library/src/components/Skeleton/useSkeleton.ts
@@ -24,7 +24,7 @@ export const useSkeleton_unstable = (props: SkeletonProps, ref: React.Ref<HTMLEl
     ...baseProps
   } = props;
 
-  const baseState = useSkeletonBase_unstable(baseProps, ref);
+  const baseState = useSkeletonBase_unstable(baseProps, ref as React.Ref<HTMLDivElement>);
 
   return {
     ...baseState,
@@ -41,13 +41,13 @@ export const useSkeleton_unstable = (props: SkeletonProps, ref: React.Ref<HTMLEl
  * @param props - User provided props to the Skeleton component.
  * @param ref - User provided ref to be passed to the Skeleton component.
  */
-export const useSkeletonBase_unstable = (props: SkeletonBaseProps, ref?: React.Ref<HTMLElement>): SkeletonBaseState => {
+export const useSkeletonBase_unstable = (
+  props: SkeletonBaseProps,
+  ref: React.Ref<HTMLDivElement>,
+): SkeletonBaseState => {
   const root = slot.always(
     getIntrinsicElementProps('div', {
-      // FIXME:
-      // `ref` is wrongly assigned to be `HTMLElement` instead of `HTMLDivElement`
-      // but since it would be a breaking change to fix it, we are casting ref to it's proper type
-      ref: ref as React.Ref<HTMLDivElement>,
+      ref,
       role: 'progressbar',
       'aria-busy': true,
       ...props,

--- a/packages/react-components/react-skeleton/library/src/components/SkeletonItem/SkeletonItem.types.ts
+++ b/packages/react-components/react-skeleton/library/src/components/SkeletonItem/SkeletonItem.types.ts
@@ -1,4 +1,4 @@
-import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+import type { ComponentProps, ComponentState, DistributiveOmit, Slot } from '@fluentui/react-utilities';
 import type { SkeletonProps } from '../Skeleton/Skeleton.types';
 
 export type SkeletonItemSlots = {
@@ -24,7 +24,17 @@ export type SkeletonItemProps = ComponentProps<SkeletonItemSlots> &
   };
 
 /**
+ * SkeletonItem base props, excluding design-related props like animation, appearance, size, and shape.
+ */
+export type SkeletonItemBaseProps = DistributiveOmit<SkeletonItemProps, 'animation' | 'appearance' | 'size' | 'shape'>;
+
+/**
  * State used in rendering SkeletonItem
  */
 export type SkeletonItemState = ComponentState<SkeletonItemSlots> &
   Required<Pick<SkeletonItemProps, 'animation' | 'appearance' | 'size' | 'shape'>>;
+
+/**
+ * SkeletonItem base state, excluding design-related state like animation, appearance, size, and shape.
+ */
+export type SkeletonItemBaseState = DistributiveOmit<SkeletonItemState, 'animation' | 'appearance' | 'size' | 'shape'>;

--- a/packages/react-components/react-skeleton/library/src/components/SkeletonItem/SkeletonItem.types.ts
+++ b/packages/react-components/react-skeleton/library/src/components/SkeletonItem/SkeletonItem.types.ts
@@ -1,4 +1,4 @@
-import type { ComponentProps, ComponentState, DistributiveOmit, Slot } from '@fluentui/react-utilities';
+import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
 import type { SkeletonProps } from '../Skeleton/Skeleton.types';
 
 export type SkeletonItemSlots = {
@@ -26,7 +26,7 @@ export type SkeletonItemProps = ComponentProps<SkeletonItemSlots> &
 /**
  * SkeletonItem base props, excluding design-related props like animation, appearance, size, and shape.
  */
-export type SkeletonItemBaseProps = DistributiveOmit<SkeletonItemProps, 'animation' | 'appearance' | 'size' | 'shape'>;
+export type SkeletonItemBaseProps = Omit<SkeletonItemProps, 'animation' | 'appearance' | 'size' | 'shape'>;
 
 /**
  * State used in rendering SkeletonItem
@@ -37,4 +37,4 @@ export type SkeletonItemState = ComponentState<SkeletonItemSlots> &
 /**
  * SkeletonItem base state, excluding design-related state like animation, appearance, size, and shape.
  */
-export type SkeletonItemBaseState = DistributiveOmit<SkeletonItemState, 'animation' | 'appearance' | 'size' | 'shape'>;
+export type SkeletonItemBaseState = Omit<SkeletonItemState, 'animation' | 'appearance' | 'size' | 'shape'>;

--- a/packages/react-components/react-skeleton/library/src/components/SkeletonItem/index.ts
+++ b/packages/react-components/react-skeleton/library/src/components/SkeletonItem/index.ts
@@ -1,5 +1,11 @@
 export { SkeletonItem } from './SkeletonItem';
-export type { SkeletonItemProps, SkeletonItemSlots, SkeletonItemState } from './SkeletonItem.types';
+export type {
+  SkeletonItemBaseProps,
+  SkeletonItemBaseState,
+  SkeletonItemProps,
+  SkeletonItemSlots,
+  SkeletonItemState,
+} from './SkeletonItem.types';
 export { renderSkeletonItem_unstable } from './renderSkeletonItem';
-export { useSkeletonItem_unstable } from './useSkeletonItem';
+export { useSkeletonItem_unstable, useSkeletonItemBase_unstable } from './useSkeletonItem';
 export { skeletonItemClassNames, useSkeletonItemStyles_unstable } from './useSkeletonItemStyles.styles';

--- a/packages/react-components/react-skeleton/library/src/components/SkeletonItem/renderSkeletonItem.tsx
+++ b/packages/react-components/react-skeleton/library/src/components/SkeletonItem/renderSkeletonItem.tsx
@@ -3,12 +3,12 @@
 
 import { assertSlots } from '@fluentui/react-utilities';
 import type { JSXElement } from '@fluentui/react-utilities';
-import type { SkeletonItemState, SkeletonItemSlots } from './SkeletonItem.types';
+import type { SkeletonItemBaseState, SkeletonItemSlots } from './SkeletonItem.types';
 
 /**
  * Render the final JSX of SkeletonItem
  */
-export const renderSkeletonItem_unstable = (state: SkeletonItemState): JSXElement => {
+export const renderSkeletonItem_unstable = (state: SkeletonItemBaseState): JSXElement => {
   assertSlots<SkeletonItemSlots>(state);
 
   return <state.root />;

--- a/packages/react-components/react-skeleton/library/src/components/SkeletonItem/useSkeletonItem.tsx
+++ b/packages/react-components/react-skeleton/library/src/components/SkeletonItem/useSkeletonItem.tsx
@@ -53,7 +53,7 @@ export const useSkeletonItem_unstable = (props: SkeletonItemProps, ref: React.Re
  */
 export const useSkeletonItemBase_unstable = (
   props: SkeletonItemBaseProps,
-  ref?: React.Ref<HTMLDivElement>,
+  ref: React.Ref<HTMLDivElement>,
 ): SkeletonItemBaseState => {
   const root = slot.always(
     getIntrinsicElementProps('div', {

--- a/packages/react-components/react-skeleton/library/src/components/SkeletonItem/useSkeletonItem.tsx
+++ b/packages/react-components/react-skeleton/library/src/components/SkeletonItem/useSkeletonItem.tsx
@@ -3,7 +3,12 @@
 import * as React from 'react';
 import { getIntrinsicElementProps, slot } from '@fluentui/react-utilities';
 import { useSkeletonContext } from '../../contexts/SkeletonContext';
-import type { SkeletonItemProps, SkeletonItemState } from './SkeletonItem.types';
+import type {
+  SkeletonItemBaseProps,
+  SkeletonItemBaseState,
+  SkeletonItemProps,
+  SkeletonItemState,
+} from './SkeletonItem.types';
 
 /**
  * Create the state required to render SkeletonItem.
@@ -26,8 +31,30 @@ export const useSkeletonItem_unstable = (props: SkeletonItemProps, ref: React.Re
     appearance = contextAppearance ?? 'opaque',
     size = contextSize ?? 16,
     shape = contextShape ?? 'rectangle',
+    ...baseProps
   } = props;
 
+  const baseState = useSkeletonItemBase_unstable(baseProps, ref);
+
+  return {
+    ...baseState,
+    animation,
+    appearance,
+    size,
+    shape,
+  };
+};
+
+/**
+ * Base hook for SkeletonItem component, which manages state related to slots structure.
+ *
+ * @param props - User provided props to the SkeletonItem component.
+ * @param ref - User provided ref to be passed to the SkeletonItem component.
+ */
+export const useSkeletonItemBase_unstable = (
+  props: SkeletonItemBaseProps,
+  ref?: React.Ref<HTMLElement>,
+): SkeletonItemBaseState => {
   const root = slot.always(
     getIntrinsicElementProps('div', {
       // FIXME:
@@ -38,5 +65,5 @@ export const useSkeletonItem_unstable = (props: SkeletonItemProps, ref: React.Re
     }),
     { elementType: 'div' },
   );
-  return { appearance, animation, size, shape, components: { root: 'div' }, root };
+  return { components: { root: 'div' }, root };
 };

--- a/packages/react-components/react-skeleton/library/src/components/SkeletonItem/useSkeletonItem.tsx
+++ b/packages/react-components/react-skeleton/library/src/components/SkeletonItem/useSkeletonItem.tsx
@@ -34,7 +34,7 @@ export const useSkeletonItem_unstable = (props: SkeletonItemProps, ref: React.Re
     ...baseProps
   } = props;
 
-  const baseState = useSkeletonItemBase_unstable(baseProps, ref);
+  const baseState = useSkeletonItemBase_unstable(baseProps, ref as React.Ref<HTMLDivElement>);
 
   return {
     ...baseState,
@@ -53,14 +53,11 @@ export const useSkeletonItem_unstable = (props: SkeletonItemProps, ref: React.Re
  */
 export const useSkeletonItemBase_unstable = (
   props: SkeletonItemBaseProps,
-  ref?: React.Ref<HTMLElement>,
+  ref?: React.Ref<HTMLDivElement>,
 ): SkeletonItemBaseState => {
   const root = slot.always(
     getIntrinsicElementProps('div', {
-      // FIXME:
-      // `ref` is wrongly assigned to be `HTMLElement` instead of `HTMLDivElement`
-      // but since it would be a breaking change to fix it, we are casting ref to it's proper type
-      ref: ref as React.Ref<HTMLDivElement>,
+      ref,
       ...props,
     }),
     { elementType: 'div' },

--- a/packages/react-components/react-skeleton/library/src/index.ts
+++ b/packages/react-components/react-skeleton/library/src/index.ts
@@ -16,3 +16,9 @@ export {
 export type { SkeletonItemProps, SkeletonItemSlots, SkeletonItemState } from './SkeletonItem';
 export { SkeletonContextProvider, useSkeletonContext } from './contexts/index';
 export type { SkeletonContextValue } from './contexts/index';
+
+// Experimental APIs - will be uncommented in the experimental release branch
+// export { useSkeletonBase_unstable } from './Skeleton';
+// export type { SkeletonBaseProps, SkeletonBaseState } from './Skeleton';
+// export { useSkeletonItemBase_unstable } from './SkeletonItem';
+// export type { SkeletonItemBaseProps, SkeletonItemBaseState } from './SkeletonItem';

--- a/packages/react-components/react-skeleton/library/src/index.ts
+++ b/packages/react-components/react-skeleton/library/src/index.ts
@@ -4,21 +4,23 @@ export {
   skeletonClassNames,
   useSkeletonStyles_unstable,
   useSkeleton_unstable,
+  useSkeletonBase_unstable,
 } from './Skeleton';
-export type { SkeletonProps, SkeletonSlots, SkeletonState } from './Skeleton';
+export type { SkeletonBaseProps, SkeletonProps, SkeletonSlots, SkeletonBaseState, SkeletonState } from './Skeleton';
 export {
   SkeletonItem,
   renderSkeletonItem_unstable,
   skeletonItemClassNames,
   useSkeletonItemStyles_unstable,
   useSkeletonItem_unstable,
+  useSkeletonItemBase_unstable,
 } from './SkeletonItem';
-export type { SkeletonItemProps, SkeletonItemSlots, SkeletonItemState } from './SkeletonItem';
+export type {
+  SkeletonItemBaseProps,
+  SkeletonItemProps,
+  SkeletonItemSlots,
+  SkeletonItemBaseState,
+  SkeletonItemState,
+} from './SkeletonItem';
 export { SkeletonContextProvider, useSkeletonContext } from './contexts/index';
 export type { SkeletonContextValue } from './contexts/index';
-
-// Experimental APIs - will be uncommented in the experimental release branch
-// export { useSkeletonBase_unstable } from './Skeleton';
-// export type { SkeletonBaseProps, SkeletonBaseState } from './Skeleton';
-// export { useSkeletonItemBase_unstable } from './SkeletonItem';
-// export type { SkeletonItemBaseProps, SkeletonItemBaseState } from './SkeletonItem';


### PR DESCRIPTION
## Summary

- Adds `useSkeletonBase_unstable` hook to `react-skeleton` that extracts pure component logic without design props
- Adds `useSkeletonItemBase_unstable` hook to `react-skeleton` for SkeletonItem component
- Adds `SkeletonBaseProps` / `SkeletonBaseState` types (omitting `animation` and `appearance` as design-related props)
- Adds `SkeletonItemBaseProps` / `SkeletonItemBaseState` types (omitting `animation`, `appearance`, `size`, `shape`)
- Refactors `useSkeleton_unstable` to call `useSkeletonBase_unstable` internally
- Refactors `useSkeletonItem_unstable` to call `useSkeletonItemBase_unstable` internally
- Exports all new types and hooks from the package `index.ts`

## What base hooks include

The base hooks preserve:
- `role="progressbar"` and `aria-busy={true}` ARIA attributes on Skeleton
- Slot structure (`root` slot with intrinsic element props)

The base hooks exclude:
- `animation` prop (wave/pulse visual animation - design concern)
- `appearance` prop (opaque/translucent - design concern)
- `size` prop on SkeletonItem (design concern)
- `shape` prop on SkeletonItem (circle/square/rectangle - design concern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)