### PR TITLE
feat(react-input): add useInputBase_unstable hook

### DIFF
--- a/change/@fluentui-react-input-e2a5a63e-40cf-40e8-a33f-b83b14c0058b.json
+++ b/change/@fluentui-react-input-e2a5a63e-40cf-40e8-a33f-b83b14c0058b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add base hooks for Input",
+  "packageName": "@fluentui/react-input",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-input/library/etc/react-input.api.md
+++ b/packages/react-components/react-input/library/etc/react-input.api.md
@@ -15,6 +15,12 @@ import type { SlotClassNames } from '@fluentui/react-utilities';
 // @public
 export const Input: ForwardRefComponent<InputProps>;
 
+// @public
+export type InputBaseProps = Omit<InputProps, 'appearance' | 'size'>;
+
+// @public
+export type InputBaseState = Omit<InputState, 'appearance' | 'size'>;
+
 // @public (undocumented)
 export const inputClassNames: SlotClassNames<InputSlots>;
 
@@ -46,10 +52,13 @@ export type InputSlots = {
 export type InputState = Required<Pick<InputProps, 'appearance' | 'size'>> & ComponentState<InputSlots>;
 
 // @public
-export const renderInput_unstable: (state: InputState) => JSXElement;
+export const renderInput_unstable: (state: InputBaseState) => JSXElement;
 
 // @public
 export const useInput_unstable: (props: InputProps, ref: React_2.Ref<HTMLInputElement>) => InputState;
+
+// @public
+export const useInputBase_unstable: (props: InputBaseProps, ref: React_2.Ref<HTMLInputElement>) => InputBaseState;
 
 // @public
 export const useInputStyles_unstable: (state: InputState) => InputState;

--- a/packages/react-components/react-input/library/src/Input.ts
+++ b/packages/react-components/react-input/library/src/Input.ts
@@ -1,8 +1,16 @@
-export type { InputOnChangeData, InputProps, InputSlots, InputState } from './components/Input/index';
+export type {
+  InputOnChangeData,
+  InputProps,
+  InputSlots,
+  InputState,
+  InputBaseProps,
+  InputBaseState,
+} from './components/Input/index';
 export {
   Input,
   inputClassNames,
   renderInput_unstable,
   useInputStyles_unstable,
   useInput_unstable,
+  useInputBase_unstable,
 } from './components/Input/index';

--- a/packages/react-components/react-input/library/src/components/Input/Input.types.ts
+++ b/packages/react-components/react-input/library/src/components/Input/Input.types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import type { ComponentProps, ComponentState, DistributiveOmit, Slot } from '@fluentui/react-utilities';
+import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
 
 export type InputSlots = {
   /**
@@ -110,7 +110,7 @@ export type InputProps = Omit<
  * Input props without design-specific props (appearance, size).
  * Use this when building a base input that is unstyled or uses a custom design system.
  */
-export type InputBaseProps = DistributiveOmit<InputProps, 'appearance' | 'size'>;
+export type InputBaseProps = Omit<InputProps, 'appearance' | 'size'>;
 
 /**
  * State used in rendering Input.
@@ -120,7 +120,7 @@ export type InputState = Required<Pick<InputProps, 'appearance' | 'size'>> & Com
 /**
  * Input state without design-specific state (appearance, size).
  */
-export type InputBaseState = DistributiveOmit<InputState, 'appearance' | 'size'>;
+export type InputBaseState = Omit<InputState, 'appearance' | 'size'>;
 
 /**
  * Data passed to the `onChange` callback when a user changes the input's value.

--- a/packages/react-components/react-input/library/src/components/Input/Input.types.ts
+++ b/packages/react-components/react-input/library/src/components/Input/Input.types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+import type { ComponentProps, ComponentState, DistributiveOmit, Slot } from '@fluentui/react-utilities';
 
 export type InputSlots = {
   /**
@@ -107,9 +107,20 @@ export type InputProps = Omit<
 };
 
 /**
+ * Input props without design-specific props (appearance, size).
+ * Use this when building a base input that is unstyled or uses a custom design system.
+ */
+export type InputBaseProps = DistributiveOmit<InputProps, 'appearance' | 'size'>;
+
+/**
  * State used in rendering Input.
  */
 export type InputState = Required<Pick<InputProps, 'appearance' | 'size'>> & ComponentState<InputSlots>;
+
+/**
+ * Input state without design-specific state (appearance, size).
+ */
+export type InputBaseState = DistributiveOmit<InputState, 'appearance' | 'size'>;
 
 /**
  * Data passed to the `onChange` callback when a user changes the input's value.

--- a/packages/react-components/react-input/library/src/components/Input/index.ts
+++ b/packages/react-components/react-input/library/src/components/Input/index.ts
@@ -1,5 +1,5 @@
 export { Input } from './Input';
-export type { InputOnChangeData, InputProps, InputSlots, InputState } from './Input.types';
+export type { InputBaseProps, InputBaseState, InputOnChangeData, InputProps, InputSlots, InputState } from './Input.types';
 export { renderInput_unstable } from './renderInput';
-export { useInput_unstable } from './useInput';
+export { useInput_unstable, useInputBase_unstable } from './useInput';
 export { inputClassNames, useInputStyles_unstable } from './useInputStyles.styles';

--- a/packages/react-components/react-input/library/src/components/Input/index.ts
+++ b/packages/react-components/react-input/library/src/components/Input/index.ts
@@ -1,5 +1,12 @@
 export { Input } from './Input';
-export type { InputBaseProps, InputBaseState, InputOnChangeData, InputProps, InputSlots, InputState } from './Input.types';
+export type {
+  InputBaseProps,
+  InputBaseState,
+  InputOnChangeData,
+  InputProps,
+  InputSlots,
+  InputState,
+} from './Input.types';
 export { renderInput_unstable } from './renderInput';
 export { useInput_unstable, useInputBase_unstable } from './useInput';
 export { inputClassNames, useInputStyles_unstable } from './useInputStyles.styles';

--- a/packages/react-components/react-input/library/src/components/Input/renderInput.tsx
+++ b/packages/react-components/react-input/library/src/components/Input/renderInput.tsx
@@ -3,12 +3,12 @@
 
 import { assertSlots } from '@fluentui/react-utilities';
 import type { JSXElement } from '@fluentui/react-utilities';
-import type { InputSlots, InputState } from './Input.types';
+import type { InputBaseState, InputSlots } from './Input.types';
 
 /**
  * Render the final JSX of Input
  */
-export const renderInput_unstable = (state: InputState): JSXElement => {
+export const renderInput_unstable = (state: InputBaseState): JSXElement => {
   assertSlots<InputSlots>(state);
   return (
     <state.root>

--- a/packages/react-components/react-input/library/src/components/Input/useInput.ts
+++ b/packages/react-components/react-input/library/src/components/Input/useInput.ts
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import { useFieldControlProps_unstable } from '@fluentui/react-field';
 import { getPartitionedNativeProps, useControllableState, useEventCallback, slot } from '@fluentui/react-utilities';
-import type { InputProps, InputState } from './Input.types';
+import type { InputBaseProps, InputBaseState, InputProps, InputState } from './Input.types';
 import { useOverrides_unstable as useOverrides } from '@fluentui/react-shared-contexts';
 
 /**
@@ -20,7 +20,7 @@ export const useInput_unstable = (props: InputProps, ref: React.Ref<HTMLInputEle
 
   const overrides = useOverrides();
 
-  const { size = 'medium', appearance = overrides.inputDefaultAppearance ?? 'outline', onChange } = props;
+  const { size = 'medium', appearance = overrides.inputDefaultAppearance ?? 'outline', ...baseProps } = props;
 
   if (
     process.env.NODE_ENV !== 'production' &&
@@ -33,6 +33,25 @@ export const useInput_unstable = (props: InputProps, ref: React.Ref<HTMLInputEle
     );
   }
 
+  const state = useInputBase_unstable(baseProps, ref);
+
+  return {
+    size,
+    appearance,
+    ...state,
+  };
+};
+
+/**
+ * Base hook for Input component, which manages state related to controlled/uncontrolled value,
+ * slot structure, and onChange handling. This hook excludes design-specific props (appearance, size).
+ *
+ * @param props - User provided props to the Input component.
+ * @param ref - User provided ref to be passed to the Input component.
+ */
+export const useInputBase_unstable = (props: InputBaseProps, ref: React.Ref<HTMLInputElement>): InputBaseState => {
+  const { onChange } = props;
+
   const [value, setValue] = useControllableState({
     state: props.value,
     defaultState: props.defaultValue,
@@ -42,12 +61,10 @@ export const useInput_unstable = (props: InputProps, ref: React.Ref<HTMLInputEle
   const nativeProps = getPartitionedNativeProps({
     props,
     primarySlotTagName: 'input',
-    excludedPropNames: ['size', 'onChange', 'value', 'defaultValue'],
+    excludedPropNames: ['onChange', 'value', 'defaultValue'],
   });
 
-  const state: InputState = {
-    size,
-    appearance,
+  const state: InputBaseState = {
     components: {
       root: 'span',
       input: 'input',

--- a/packages/react-components/react-input/library/src/index.ts
+++ b/packages/react-components/react-input/library/src/index.ts
@@ -4,9 +4,6 @@ export {
   renderInput_unstable,
   useInputStyles_unstable,
   useInput_unstable,
+  useInputBase_unstable,
 } from './Input';
-export type { InputOnChangeData, InputProps, InputSlots, InputState } from './Input';
-
-// Experimental APIs - will be uncommented in the experimental release branch
-// export { useInputBase_unstable } from './Input';
-// export type { InputBaseProps, InputBaseState } from './Input';
+export type { InputOnChangeData, InputProps, InputSlots, InputState, InputBaseProps, InputBaseState } from './Input';

--- a/packages/react-components/react-input/library/src/index.ts
+++ b/packages/react-components/react-input/library/src/index.ts
@@ -1,2 +1,12 @@
-export { Input, inputClassNames, renderInput_unstable, useInputStyles_unstable, useInput_unstable } from './Input';
+export {
+  Input,
+  inputClassNames,
+  renderInput_unstable,
+  useInputStyles_unstable,
+  useInput_unstable,
+} from './Input';
 export type { InputOnChangeData, InputProps, InputSlots, InputState } from './Input';
+
+// Experimental APIs - will be uncommented in the experimental release branch
+// export { useInputBase_unstable } from './Input';
+// export type { InputBaseProps, InputBaseState } from './Input';


### PR DESCRIPTION
## Summary

- Adds `InputBaseProps` type derived from `InputProps` by omitting design props (`appearance`, `size`)
- Adds `InputBaseState` type derived from `InputState` by omitting the same design props
- Adds `useInputBase_unstable` hook that handles:
  - Controlled/uncontrolled value state via `useControllableState`
  - `onChange` event handling with the `InputOnChangeData` callback signature
  - Slot structure: `root` (span wrapper), `input` (the actual input element), `contentBefore` and `contentAfter` optional slots
  - Native prop partitioning between root and input slots
- Refactors `useInput_unstable` to call `useInputBase_unstable` and spread its results, then add `appearance` and `size`
- Note: `contentBefore`/`contentAfter` are user-provided optional slots (not default implementations), so they remain in the base hook
- Exports new types and hook from `packages/react-components/react-input/library/src/index.ts`

## What base hooks do

Base hooks extract pure component logic — ARIA, keyboard handling, slot structure — WITHOUT styling, design props, or default slot implementations. This allows consumers to build custom-styled variants without taking on the full FluentUI design system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)