### PR TITLE
feat(react-progress): add useProgressBarBase_unstable hook

### DIFF
--- a/change/@fluentui-react-progress-58adfb89-e975-4924-a0aa-3b68033e956f.json
+++ b/change/@fluentui-react-progress-58adfb89-e975-4924-a0aa-3b68033e956f.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add base hooks for ProgressBar",
+  "packageName": "@fluentui/react-progress",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-progress/library/etc/react-progress.api.md
+++ b/packages/react-components/react-progress/library/etc/react-progress.api.md
@@ -17,10 +17,10 @@ import type { SlotClassNames } from '@fluentui/react-utilities';
 export const ProgressBar: ForwardRefComponent<ProgressBarProps>;
 
 // @public
-export type ProgressBarBaseProps = Omit<ProgressBarProps, 'shape' | 'thickness' | 'color'>;
+export type ProgressBarBaseProps = Omit<ProgressBarProps, 'shape' | 'thickness' | 'color' | 'indeterminateMotion'>;
 
 // @public
-export type ProgressBarBaseState = Omit<ProgressBarState, 'shape' | 'thickness' | 'color'>;
+export type ProgressBarBaseState = Omit<ProgressBarState, 'shape' | 'thickness' | 'color' | 'indeterminateMotion'>;
 
 // @public (undocumented)
 export const progressBarClassNames: SlotClassNames<Omit<ProgressBarSlots, 'indeterminateMotion'>>;

--- a/packages/react-components/react-progress/library/etc/react-progress.api.md
+++ b/packages/react-components/react-progress/library/etc/react-progress.api.md
@@ -16,6 +16,12 @@ import type { SlotClassNames } from '@fluentui/react-utilities';
 // @public
 export const ProgressBar: ForwardRefComponent<ProgressBarProps>;
 
+// @public
+export type ProgressBarBaseProps = Omit<ProgressBarProps, 'shape' | 'thickness' | 'color'>;
+
+// @public
+export type ProgressBarBaseState = Omit<ProgressBarState, 'shape' | 'thickness' | 'color'>;
+
 // @public (undocumented)
 export const progressBarClassNames: SlotClassNames<Omit<ProgressBarSlots, 'indeterminateMotion'>>;
 
@@ -39,10 +45,13 @@ export type ProgressBarSlots = {
 export type ProgressBarState = ComponentState<Required<ProgressBarSlots>> & Required<Pick<ProgressBarProps, 'max' | 'shape' | 'thickness'>> & Pick<ProgressBarProps, 'value' | 'color'>;
 
 // @public
-export const renderProgressBar_unstable: (state: ProgressBarState) => JSXElement;
+export const renderProgressBar_unstable: (state: ProgressBarBaseState) => JSXElement;
 
 // @public
 export const useProgressBar_unstable: (props: ProgressBarProps, ref: React_2.Ref<HTMLElement>) => ProgressBarState;
+
+// @public
+export const useProgressBarBase_unstable: (props: ProgressBarBaseProps, ref: React_2.Ref<HTMLElement>) => ProgressBarBaseState;
 
 // @public
 export const useProgressBarStyles_unstable: (state: ProgressBarState) => ProgressBarState;

--- a/packages/react-components/react-progress/library/src/ProgressBar.ts
+++ b/packages/react-components/react-progress/library/src/ProgressBar.ts
@@ -1,8 +1,15 @@
-export type { ProgressBarProps, ProgressBarSlots, ProgressBarState } from './components/ProgressBar/index';
+export type {
+  ProgressBarProps,
+  ProgressBarBaseProps,
+  ProgressBarSlots,
+  ProgressBarState,
+  ProgressBarBaseState,
+} from './components/ProgressBar/index';
 export {
   ProgressBar,
   progressBarClassNames,
   renderProgressBar_unstable,
   useProgressBarStyles_unstable,
   useProgressBar_unstable,
+  useProgressBarBase_unstable,
 } from './components/ProgressBar/index';

--- a/packages/react-components/react-progress/library/src/components/ProgressBar/ProgressBar.types.ts
+++ b/packages/react-components/react-progress/library/src/components/ProgressBar/ProgressBar.types.ts
@@ -54,7 +54,7 @@ export type ProgressBarProps = Omit<ComponentProps<ProgressBarSlots>, 'size'> & 
 /**
  * ProgressBar base props — excludes design props (shape, thickness, color).
  */
-export type ProgressBarBaseProps = DistributiveOmit<ProgressBarProps, 'shape' | 'thickness' | 'color'>;
+export type ProgressBarBaseProps = Omit<ProgressBarProps, 'shape' | 'thickness' | 'color'>;
 
 /**
  * State used in rendering ProgressBar

--- a/packages/react-components/react-progress/library/src/components/ProgressBar/ProgressBar.types.ts
+++ b/packages/react-components/react-progress/library/src/components/ProgressBar/ProgressBar.types.ts
@@ -54,7 +54,7 @@ export type ProgressBarProps = Omit<ComponentProps<ProgressBarSlots>, 'size'> & 
 /**
  * ProgressBar base props — excludes design props (shape, thickness, color).
  */
-export type ProgressBarBaseProps = Omit<ProgressBarProps, 'shape' | 'thickness' | 'color'>;
+export type ProgressBarBaseProps = Omit<ProgressBarProps, 'shape' | 'thickness' | 'color' | 'indeterminateMotion'>;
 
 /**
  * State used in rendering ProgressBar
@@ -66,4 +66,4 @@ export type ProgressBarState = ComponentState<Required<ProgressBarSlots>> &
 /**
  * ProgressBar base state — excludes design props (shape, thickness, color).
  */
-export type ProgressBarBaseState = Omit<ProgressBarState, 'shape' | 'thickness' | 'color'>;
+export type ProgressBarBaseState = Omit<ProgressBarState, 'shape' | 'thickness' | 'color' | 'indeterminateMotion'>;

--- a/packages/react-components/react-progress/library/src/components/ProgressBar/ProgressBar.types.ts
+++ b/packages/react-components/react-progress/library/src/components/ProgressBar/ProgressBar.types.ts
@@ -52,8 +52,18 @@ export type ProgressBarProps = Omit<ComponentProps<ProgressBarSlots>, 'size'> & 
 };
 
 /**
+ * ProgressBar base props — excludes design props (shape, thickness, color).
+ */
+export type ProgressBarBaseProps = DistributiveOmit<ProgressBarProps, 'shape' | 'thickness' | 'color'>;
+
+/**
  * State used in rendering ProgressBar
  */
 export type ProgressBarState = ComponentState<Required<ProgressBarSlots>> &
   Required<Pick<ProgressBarProps, 'max' | 'shape' | 'thickness'>> &
   Pick<ProgressBarProps, 'value' | 'color'>;
+
+/**
+ * ProgressBar base state — excludes design props (shape, thickness, color).
+ */
+export type ProgressBarBaseState = Omit<ProgressBarState, 'shape' | 'thickness' | 'color'>;

--- a/packages/react-components/react-progress/library/src/components/ProgressBar/index.ts
+++ b/packages/react-components/react-progress/library/src/components/ProgressBar/index.ts
@@ -1,5 +1,11 @@
 export { ProgressBar } from './ProgressBar';
-export type { ProgressBarProps, ProgressBarSlots, ProgressBarState } from './ProgressBar.types';
+export type {
+  ProgressBarProps,
+  ProgressBarBaseProps,
+  ProgressBarSlots,
+  ProgressBarState,
+  ProgressBarBaseState,
+} from './ProgressBar.types';
 export { renderProgressBar_unstable } from './renderProgressBar';
-export { useProgressBar_unstable } from './useProgressBar';
+export { useProgressBar_unstable, useProgressBarBase_unstable } from './useProgressBar';
 export { progressBarClassNames, useProgressBarStyles_unstable } from './useProgressBarStyles.styles';

--- a/packages/react-components/react-progress/library/src/components/ProgressBar/renderProgressBar.tsx
+++ b/packages/react-components/react-progress/library/src/components/ProgressBar/renderProgressBar.tsx
@@ -3,12 +3,12 @@
 
 import { assertSlots } from '@fluentui/react-utilities';
 import type { JSXElement } from '@fluentui/react-utilities';
-import type { ProgressBarState, ProgressBarSlots } from './ProgressBar.types';
+import type { ProgressBarBaseState, ProgressBarSlots } from './ProgressBar.types';
 
 /**
  * Render the final JSX of ProgressBar
  */
-export const renderProgressBar_unstable = (state: ProgressBarState): JSXElement => {
+export const renderProgressBar_unstable = (state: ProgressBarBaseState): JSXElement => {
   assertSlots<ProgressBarSlots>(state);
   return (
     <state.root>

--- a/packages/react-components/react-progress/library/src/components/ProgressBar/useProgressBar.tsx
+++ b/packages/react-components/react-progress/library/src/components/ProgressBar/useProgressBar.tsx
@@ -30,9 +30,11 @@ export const useProgressBar_unstable = (props: ProgressBarProps, ref: React.Ref<
     color = fieldState === 'error' || fieldState === 'warning' || fieldState === 'success' ? fieldState : 'brand',
     shape = 'rounded',
     thickness = 'medium',
+    indeterminateMotion,
+    ...baseProps
   } = props;
 
-  const state = useProgressBarBase_unstable(props, ref);
+  const state = useProgressBarBase_unstable(baseProps, ref);
 
   return {
     ...state,
@@ -41,7 +43,7 @@ export const useProgressBar_unstable = (props: ProgressBarProps, ref: React.Ref<
     thickness,
     indeterminateMotion:
       state.value === undefined
-        ? motionSlot(props.indeterminateMotion, {
+        ? motionSlot(indeterminateMotion, {
             elementType: ProgressBarIndeterminateMotion,
             defaultProps: {},
           })

--- a/packages/react-components/react-progress/library/src/components/ProgressBar/useProgressBar.tsx
+++ b/packages/react-components/react-progress/library/src/components/ProgressBar/useProgressBar.tsx
@@ -5,7 +5,12 @@ import { useFieldContext_unstable } from '@fluentui/react-field';
 import { motionSlot } from '@fluentui/react-motion';
 import { getIntrinsicElementProps, slot } from '@fluentui/react-utilities';
 import { clampValue, clampMax } from '../../utils/index';
-import type { ProgressBarProps, ProgressBarState } from './ProgressBar.types';
+import type {
+  ProgressBarProps,
+  ProgressBarState,
+  ProgressBarBaseProps,
+  ProgressBarBaseState,
+} from './ProgressBar.types';
 import { ProgressBarIndeterminateMotion } from './progressBarMotions';
 
 /**
@@ -26,6 +31,38 @@ export const useProgressBar_unstable = (props: ProgressBarProps, ref: React.Ref<
     shape = 'rounded',
     thickness = 'medium',
   } = props;
+
+  const state = useProgressBarBase_unstable(props, ref);
+
+  return {
+    ...state,
+    color,
+    shape,
+    thickness,
+    indeterminateMotion:
+      state.value === undefined
+        ? motionSlot(props.indeterminateMotion, {
+            elementType: ProgressBarIndeterminateMotion,
+            defaultProps: {},
+          })
+        : undefined,
+  };
+};
+
+/**
+ * Base hook for ProgressBar component. Manages state related to ARIA progressbar attributes
+ * (role, aria-valuemin, aria-valuemax, aria-valuenow) and field context integration —
+ * without design props (shape, thickness, color).
+ *
+ * @param props - props from this instance of ProgressBar (without shape, thickness, color)
+ * @param ref - reference to root HTMLElement of ProgressBar
+ */
+export const useProgressBarBase_unstable = (
+  props: ProgressBarBaseProps,
+  ref: React.Ref<HTMLElement>,
+): ProgressBarBaseState => {
+  const field = useFieldContext_unstable();
+
   const max = clampMax(props.max ?? 1);
   const value = clampValue(props.value, max);
 
@@ -51,23 +88,12 @@ export const useProgressBar_unstable = (props: ProgressBarProps, ref: React.Ref<
       .join(' ');
   }
   const bar = slot.always(props.bar, { elementType: 'div' });
-  const state: ProgressBarState = {
-    color,
+
+  return {
     max,
-    shape,
-    thickness,
     value,
     components: { root: 'div', bar: 'div', indeterminateMotion: ProgressBarIndeterminateMotion },
     root,
     bar,
-    indeterminateMotion:
-      value === undefined
-        ? motionSlot(props.indeterminateMotion, {
-            elementType: ProgressBarIndeterminateMotion,
-            defaultProps: {},
-          })
-        : undefined,
   };
-
-  return state;
 };

--- a/packages/react-components/react-progress/library/src/index.ts
+++ b/packages/react-components/react-progress/library/src/index.ts
@@ -4,13 +4,12 @@ export {
   renderProgressBar_unstable,
   useProgressBar_unstable,
   useProgressBarStyles_unstable,
+  useProgressBarBase_unstable,
 } from './ProgressBar';
 export type {
   ProgressBarProps,
   ProgressBarSlots,
   ProgressBarState,
+  ProgressBarBaseProps,
+  ProgressBarBaseState,
 } from './ProgressBar';
-
-// Experimental APIs - will be uncommented in the experimental release branch
-// export { useProgressBarBase_unstable } from './ProgressBar';
-// export type { ProgressBarBaseProps, ProgressBarBaseState } from './ProgressBar';

--- a/packages/react-components/react-progress/library/src/index.ts
+++ b/packages/react-components/react-progress/library/src/index.ts
@@ -5,4 +5,12 @@ export {
   useProgressBar_unstable,
   useProgressBarStyles_unstable,
 } from './ProgressBar';
-export type { ProgressBarProps, ProgressBarSlots, ProgressBarState } from './ProgressBar';
+export type {
+  ProgressBarProps,
+  ProgressBarSlots,
+  ProgressBarState,
+} from './ProgressBar';
+
+// Experimental APIs - will be uncommented in the experimental release branch
+// export { useProgressBarBase_unstable } from './ProgressBar';
+// export type { ProgressBarBaseProps, ProgressBarBaseState } from './ProgressBar';


### PR DESCRIPTION
## Summary

- Adds `useProgressBarBase_unstable` hook that extracts pure ProgressBar logic: ARIA `role=progressbar`, `aria-valuemin`, `aria-valuemax`, `aria-valuenow`, field context integration (`aria-labelledby`, `aria-describedby`), value clamping
- Adds `ProgressBarBaseProps` and `ProgressBarBaseState` types using `DistributiveOmit`
- Refactors `useProgressBar_unstable` to delegate to the base hook, then add design props
- Exports new types and hook from both the component `index.ts` and package `index.ts`

## Design props excluded from base hook

| Prop | Description |
|---|---|
| `shape` | `'rounded'` or `'square'` bar shape |
| `thickness` | `'medium'` or `'large'` bar thickness |
| `color` | `'brand'` / `'success'` / `'warning'` / `'error'` status color |

## Functional props retained in base hook

- `value` — current progress value (used for ARIA attributes)
- `max` — maximum progress value (used for ARIA attributes, defaults to 1)
- `bar` slot — filled portion of the track
- Field context integration (labelId, validationMessageId, hintId)

🤖 Generated with [Claude Code](https://claude.com/claude-code)