### PR TITLE
ci: run monosize compare only if target branch is master

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -44,13 +44,22 @@ jobs:
       - name: Build packages & create reports
         run: yarn nx affected -t bundle-size --nxBail
 
+      # NOTE: monosize-storage-azure only stores base reports for the default branch (master),
+      # so compare-reports will fail for PRs targeting other branches.
+      - name: Skip bundle size comparison notice
+        if: ${{ github.event.pull_request.base.ref != 'master' }}
+        run: echo "::warning::Bundle size comparison skipped — monosize-storage-azure only stores base reports for the default branch (master). PR targets '${{ github.event.pull_request.base.ref }}'."
+
       - name: Compare bundle size with base
+        if: ${{ github.event.pull_request.base.ref == 'master' }}
         run: npx monosize compare-reports --branch=${{ github.event.pull_request.base.ref }} --output=markdown --quiet > ./monosize-report.md
 
       - name: Save PR number
+        if: ${{ github.event.pull_request.base.ref == 'master' }}
         run: echo ${{ github.event.number }} > pr.txt
 
       - uses: actions/upload-artifact@v6
+        if: ${{ github.event.pull_request.base.ref == 'master' }}
         with:
           name: monosize-report
           retention-days: 1


### PR DESCRIPTION
## Description

The `bundle-size` workflow currently runs `monosize compare-reports` on every PR regardless of the target branch. Since `monosize-storage-azure` only stores base reports for the default branch (`master`), the comparison step fails for PRs targeting other branches (e.g. hotfix or release branches).

## Changes

- Added a condition (`github.event.pull_request.base.ref == 'master'`) to skip the **compare**, **save PR number**, and **upload artifact** steps when the PR does not target `master`.
- Added a warning annotation step so authors are informed that bundle size comparison was skipped and why.

## Why

This prevents false CI failures on PRs that target non-default branches while keeping the bundle size build step (which validates that packages still build correctly) intact for all PRs.