### PR TITLE
ci: migrate PR website deploy from Azure Blob Storage to GitHub Pages

### DIFF
--- a/.github/workflows/docsite-publish-ghpages.yml
+++ b/.github/workflows/docsite-publish-ghpages.yml
@@ -7,11 +7,15 @@ on:
       - master
   workflow_dispatch:
 
+concurrency:
+  group: gh-pages-production
+  cancel-in-progress: false
+
 jobs:
-  build:
+  build-and-deploy:
     runs-on: ubuntu-latest
-    outputs:
-      artifact_id: ${{ steps.artifact_upload.outputs.artifact_id }}
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v6
@@ -55,28 +59,28 @@ jobs:
           cp -R apps/chart-docsite/dist/storybook/* _pages/charts/
           cp -R packages/web-components/dist/storybook/* _pages/web-components
 
-      - name: Upload Pages Artifact
+      - name: Deploy to gh-pages branch
         if: steps.affected_storybooks_count.outputs.value > 0
-        id: artifact_upload
-        uses: actions/upload-pages-artifact@v4
-        with:
-          path: _pages
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
 
-  deploy:
-    runs-on: ubuntu-latest
-    needs: build
-    if: needs.build.outputs.artifact_id
-    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
-    permissions:
-      pages: write # to deploy to Pages
-      id-token: write # to verify the deployment originates from an appropriate source
+          # Fetch gh-pages branch or create orphan if it doesn't exist
+          if git fetch origin gh-pages:gh-pages 2>/dev/null; then
+            git checkout gh-pages
+          else
+            git checkout --orphan gh-pages
+            git rm -rf . 2>/dev/null || true
+          fi
 
-    # Deploy to the github-pages environment
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+          # Remove production files but preserve pr-preview/ and .git/
+          find . -maxdepth 1 ! -name '.git' ! -name 'pr-preview' ! -name '.' -exec rm -rf {} +
 
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+          # Copy new production files
+          git checkout ${{ github.sha }} -- _pages/
+          cp -R _pages/* .
+          rm -rf _pages
+
+          git add -A
+          git diff --staged --quiet || git commit -m "Deploy docsite from ${GITHUB_SHA::7}"
+          git push origin gh-pages

--- a/.github/workflows/pr-website-cleanup.yml
+++ b/.github/workflows/pr-website-cleanup.yml
@@ -1,0 +1,34 @@
+name: PR Website Cleanup
+on:
+  pull_request_target:
+    types: [closed]
+
+concurrency:
+  group: gh-pages-pr-${{ github.event.number }}
+  cancel-in-progress: true
+
+jobs:
+  cleanup:
+    if: ${{ github.repository_owner == 'microsoft' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: gh-pages
+          fetch-depth: 1
+
+      - name: Remove PR preview
+        run: |
+          PREVIEW_DIR="pr-preview/pr-${{ github.event.number }}"
+          if [ -d "$PREVIEW_DIR" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            rm -rf "$PREVIEW_DIR"
+            git add -A
+            git commit -m "Remove preview for PR #${{ github.event.number }}"
+            git push origin gh-pages
+          else
+            echo "No preview directory found for PR #${{ github.event.number }}, skipping cleanup"
+          fi

--- a/.github/workflows/pr-website-deploy-comment.yml
+++ b/.github/workflows/pr-website-deploy-comment.yml
@@ -11,8 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DEPLOY_HOST_URL: https://fluentuipr.z22.web.core.windows.net/
-  AZURE_STORAGE: fluentuipr
+  DEPLOY_HOST_URL: https://microsoft.github.io/fluentui/
 
 jobs:
   deploy:
@@ -22,13 +21,10 @@ jobs:
       pr_number: ${{ steps.pr_number.outputs.result }}
       website_url: ${{ steps.website_url.outputs.id }}
     permissions:
-      id-token: write
+      contents: write
 
     steps:
       - uses: actions/checkout@v6
-        with:
-          sparse-checkout: |
-            .github
 
       - uses: actions/download-artifact@v7
         with:
@@ -56,29 +52,27 @@ jobs:
 
       - name: Load WEBSITE URL
         id: website_url
-        run: echo "id=${{env.DEPLOY_HOST_URL}}pull/${{steps.pr_number.outputs.result}}/" >> $GITHUB_OUTPUT
+        run: echo "id=${{env.DEPLOY_HOST_URL}}pr-preview/pr-${{steps.pr_number.outputs.result}}/" >> $GITHUB_OUTPUT
 
-      - name: Login via Azure CLI
-        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - name: Deploy PR preview to gh-pages
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Upload PR WebSite
-        uses: azure/cli@089eac9d8cc39f5d003e94f8b65efc51076c9cbd # v2.1.0
-        env:
-          AZCOPY_AUTO_LOGIN_TYPE: 'AZCLI'
-        with:
-          azcliversion: latest
-          inlineScript: |
-            az storage blob upload-batch \
-              --destination '$web' \
-              --source ./website \
-              --account-name ${{ env.AZURE_STORAGE }} \
-              --destination-path pull/${{steps.pr_number.outputs.result}} \
-              --auth-mode login \
-              --overwrite
+          # Move website files to temp location before switching branches
+          PREVIEW_DIR="pr-preview/pr-${{ steps.pr_number.outputs.result }}"
+          cp -R ./website /tmp/pr-website
+
+          git fetch origin gh-pages:gh-pages
+          git checkout gh-pages
+
+          rm -rf "$PREVIEW_DIR"
+          mkdir -p "$PREVIEW_DIR"
+          cp -R /tmp/pr-website/* "$PREVIEW_DIR/"
+
+          git add -A
+          git diff --staged --quiet || git commit -m "Deploy preview for PR #${{ steps.pr_number.outputs.result }}"
+          git push origin gh-pages
 
   comment:
     runs-on: ubuntu-latest

--- a/apps/pr-deploy-site/pr-deploy-site.js
+++ b/apps/pr-deploy-site/pr-deploy-site.js
@@ -110,8 +110,8 @@ function main() {
  * @param {string} urlPath
  */
 function updatePrOrBranchLink(urlPath) {
-  // location.pathname will be like /pull/17568/ or /heads/master/
-  var hrefMatch = urlPath.match(/^\/(pull|heads)\/([^/]+)/);
+  // location.pathname will be like /pr-preview/pr-17568/ or /pull/17568/ or /heads/master/
+  var hrefMatch = urlPath.match(/^\/(pull|heads)\/([^/]+)/) || urlPath.match(/\/pr-preview\/pr-(\d+)/);
   if (!hrefMatch) {
     return;
   }
@@ -122,6 +122,15 @@ function updatePrOrBranchLink(urlPath) {
   }
 
   var repoUrl = 'https://github.com/microsoft/fluentui';
+
+  // Match from /pr-preview/pr-NUMBER/ pattern (only capture group is the PR number)
+  if (hrefMatch.length === 2) {
+    var prNumber = hrefMatch[1];
+    link.textContent = 'PR #' + prNumber;
+    link.href = repoUrl + '/pull/' + prNumber;
+    return;
+  }
+
   var type = hrefMatch[1];
   var value = hrefMatch[2];
 


### PR DESCRIPTION
> ## NOTE:
>
> Initial plan was to migrate to https://github.com/actions/upload-artifact/releases/tag/v7.0.0 but unfortunately they support only single file for now. will revisit once their support expands to multi file upload

## Description

Migrates the PR preview website deployment infrastructure from Azure Blob Storage to GitHub Pages, eliminating the Azure dependency and using only GitHub-native infrastructure.

### Changes

- **`docsite-publish-ghpages.yml`** — Replaced `actions/upload-pages-artifact` + `actions/deploy-pages` with direct git push to `gh-pages` branch. Uses `clean-exclude` pattern to preserve `pr-preview/` directory during production deploys.
- **`pr-website-deploy-comment.yml`** — Removed `azure/login`, `azure/cli` actions and Azure env vars. Deploys PR preview to `gh-pages` branch under `pr-preview/pr-NUMBER/` via git CLI.
- **`pr-website-cleanup.yml`** *(new)* — Cleans up PR preview directory from `gh-pages` branch on `pull_request_target: closed`.
- **`pr-deploy-site.js`** — Updated `updatePrOrBranchLink()` URL parsing to recognize the new `/pr-preview/pr-NUMBER/` path format.

### URL Change

| | URL |
|---|---|
| **Before** | `https://fluentuipr.z22.web.core.windows.net/pull/NUMBER/` |
| **After** | `https://microsoft.github.io/fluentui/pr-preview/pr-NUMBER/` |

### Security

- Zero third-party actions for deployment — uses only `actions/checkout` + git CLI
- Azure secrets (`AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`) can be removed after merge
- Fork PR support maintained via `workflow_run` + `pull_request_target` triggers

### Manual prerequisite (repo admin)

> **Settings → Pages → Source** must be changed from "GitHub Actions" to **"Deploy from branch"** (`gh-pages` / `/ (root)`) before the new workflows will work.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>