### PR TITLE
fix(react): allow Toggle to disable focus via data-is-focusable attri...

### DIFF
--- a/packages/react/src/components/Toggle/Toggle.base.tsx
+++ b/packages/react/src/components/Toggle/Toggle.base.tsx
@@ -126,7 +126,7 @@ export const ToggleBase: React.FunctionComponent<IToggleProps> = React.forwardRe
         'aria-label': ariaLabel ? ariaLabel : badAriaLabel,
         'aria-labelledby': labelledById,
         className: classNames.pill,
-        'data-is-focusable': true,
+        'data-is-focusable': toggleNativeProps['data-is-focusable'] ?? true,
         'data-ktp-target': true,
         disabled,
         id,

--- a/packages/react/src/components/Toggle/Toggle.test.tsx
+++ b/packages/react/src/components/Toggle/Toggle.test.tsx
@@ -87,6 +87,18 @@ describe('Toggle', () => {
     expect(screen.queryByText('label')).toBeNull();
   });
 
+  it('renders data-is-focusable true by default', () => {
+    const { container } = render(<Toggle label="Label" />);
+    const button = getBySelector(container, 'button') as HTMLButtonElement;
+    expect(button.getAttribute('data-is-focusable')).toEqual('true');
+  });
+
+  it('respects data-is-focusable false when passed', () => {
+    const { container } = render(<Toggle label="Label" data-is-focusable={false} />);
+    const button = getBySelector(container, 'button') as HTMLButtonElement;
+    expect(button.getAttribute('data-is-focusable')).toEqual('false');
+  });
+
   it(`doesn't trigger onSubmit when placed inside a form`, () => {
     const onSubmit = jest.fn();
 


### PR DESCRIPTION
Fixes #31935

## Previous Behavior

The Toggle component had a hardcoded `data-is-focusable="true"` attribute, which prevented users from disabling focus behavior. This was problematic in scenarios like DetailsList where arrow key navigation should skip certain interactive elements, similar to how Checkbox allows this via `inputProps={{ "data-is-focusable": false }}`.

## New Behavior

The Toggle component now respects the `data-is-focusable` attribute passed as a prop. Users can now disable focus by passing `data-is-focusable={false}` to the Toggle component, making it consistent with the Checkbox component's behavior. The default value remains `true` to maintain backward compatibility.

### Usage Example

```jsx
// Disable focus on Toggle (prevents arrow key navigation in DetailsList)
<Toggle data-is-focusable={false} label="My Toggle" />

// Default behavior (focusable)
<Toggle label="My Toggle" />
```

## Related Issue(s)

- Fixes #31935

## Changes

- Modified `Toggle.base.tsx` to check `toggleNativeProps['data-is-focusable']` and default to `true` if not provided
- Added two test cases to verify default behavior and ability to disable focus
- 2 files changed, 13 insertions(+), 1 deletion(-)