### PR TITLE
fix(ci): merge multiple `${{ }}` blocks into single expression in workflow conditionals

### DIFF
--- a/.github/workflows/bundle-size-comment.yml
+++ b/.github/workflows/bundle-size-comment.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   comment:
     runs-on: ubuntu-latest
-    if: ${{ github.repository_owner == 'microsoft' }} && ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.repository_owner == 'microsoft' && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/pr-vrt-comment.yml
+++ b/.github/workflows/pr-vrt-comment.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   run_vr_diff:
     runs-on: ubuntu-latest
-    if: ${{ github.repository_owner == 'microsoft' }} && ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.repository_owner == 'microsoft' && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
     permissions:
       # necessary to write comments to the PR from the vr-approval-cli
       pull-requests: write

--- a/.github/workflows/pr-website-deploy-comment.yml
+++ b/.github/workflows/pr-website-deploy-comment.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: ${{ github.repository_owner == 'microsoft' }} && ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.repository_owner == 'microsoft' && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
     outputs:
       pr_number: ${{ steps.pr_number.outputs.result }}
       website_url: ${{ steps.website_url.outputs.id }}


### PR DESCRIPTION
## Description

Fixes GitHub Actions warnings:

> Conditional expression contains literal text outside replacement tokens. This will cause the expression to always evaluate to truthy. Did you mean to put the entire expression inside ${{ }}?
> <img width="1842" height="183" alt="image" src="https://github.com/user-attachments/assets/8cd2532a-0889-4a7a-9724-87ff6ce01de7" />


### Problem

Three workflow files used `${{ A }} && ${{ B }}` in `if:` conditionals. The `&&` between the two expression blocks is **literal text**, so the entire condition becomes a non-empty string that always evaluates truthy — effectively bypassing the `repository_owner` guard.

### Fix

Merge into single expression blocks: `${{ A && B }}` so boolean logic is evaluated correctly.

### Affected files

- `.github/workflows/bundle-size-comment.yml`
- `.github/workflows/pr-vrt-comment.yml`
- `.github/workflows/pr-website-deploy-comment.yml`
