### PR TITLE
fix(react-charts): prevent XSS via new Function() in VegaLiteSchemaAdapter

### DIFF
--- a/packages/charts/react-charts/library/src/components/VegaDeclarativeChart/VegaLiteSchemaAdapter.ts
+++ b/packages/charts/react-charts/library/src/components/VegaDeclarativeChart/VegaLiteSchemaAdapter.ts
@@ -11,6 +11,7 @@ import type {
   VegaLiteSort,
   VegaLiteTitleParams,
 } from './VegaLiteTypes';
+import { safeEvaluateExpression } from './safeExpressionEvaluator';
 import type { LineChartProps } from '../LineChart/index';
 import type { VerticalBarChartProps } from '../VerticalBarChart/index';
 import type { VerticalStackedBarChartProps } from '../VerticalStackedBarChart/index';
@@ -234,9 +235,7 @@ function applyTransforms(
       if (typeof filterExpr === 'string') {
         result = result.filter(row => {
           try {
-            const datum = row;
-            // eslint-disable-next-line no-new-func
-            return new Function('datum', `return ${filterExpr}`)(datum);
+            return safeEvaluateExpression(filterExpr, row as Record<string, unknown>);
           } catch {
             return true;
           }
@@ -250,9 +249,7 @@ function applyTransforms(
       const asField = transform.as as string;
       result = result.map(row => {
         try {
-          const datum = row;
-          // eslint-disable-next-line no-new-func
-          const value = new Function('datum', `return ${expr}`)(datum);
+          const value = safeEvaluateExpression(expr, row as Record<string, unknown>);
           return { ...row, [asField]: value };
         } catch {
           return row;
@@ -1185,9 +1182,7 @@ function initializeTransformContext(spec: VegaLiteSpec) {
 
     dataValues.forEach(row => {
       try {
-        const datum = row;
-        // eslint-disable-next-line no-new-func
-        const result = new Function('datum', `return ${condition.test}`)(datum);
+        const result = safeEvaluateExpression(condition.test, row as Record<string, unknown>);
         row[colorField] = result ? condition.value : elseValue;
       } catch {
         row[colorField] = elseValue;

--- a/packages/charts/react-charts/library/src/components/VegaDeclarativeChart/safeExpressionEvaluator.test.ts
+++ b/packages/charts/react-charts/library/src/components/VegaDeclarativeChart/safeExpressionEvaluator.test.ts
@@ -1,0 +1,98 @@
+import { safeEvaluateExpression } from './safeExpressionEvaluator';
+
+describe('safeEvaluateExpression', () => {
+  const datum = { x: 10, y: 55, category: 'A', label: 'hello world', nested: { a: 1 }, year: 2020, value: 100 };
+
+  // -- Property access -------------------------------------------------------
+  it('reads datum properties via dot notation', () => {
+    expect(safeEvaluateExpression('datum.x', datum)).toBe(10);
+    expect(safeEvaluateExpression('datum.category', datum)).toBe('A');
+  });
+
+  it('reads datum properties via bracket notation', () => {
+    expect(safeEvaluateExpression("datum['label']", datum)).toBe('hello world');
+  });
+
+  it('reads nested datum properties', () => {
+    expect(safeEvaluateExpression('datum.nested.a', datum)).toBe(1);
+  });
+
+  // -- Comparisons -----------------------------------------------------------
+  it('evaluates > comparison', () => {
+    expect(safeEvaluateExpression('datum.y > 30', datum)).toBe(true);
+    expect(safeEvaluateExpression('datum.x > 30', datum)).toBe(false);
+  });
+
+  it('evaluates === strict equality', () => {
+    expect(safeEvaluateExpression("datum.category === 'A'", datum)).toBe(true);
+    expect(safeEvaluateExpression("datum.category === 'B'", datum)).toBe(false);
+  });
+
+  // -- Logical ---------------------------------------------------------------
+  it('evaluates && and ||', () => {
+    expect(safeEvaluateExpression('datum.x > 5 && datum.y > 50', datum)).toBe(true);
+    expect(safeEvaluateExpression('datum.x > 100 || datum.y > 50', datum)).toBe(true);
+  });
+
+  // -- Arithmetic ------------------------------------------------------------
+  it('evaluates arithmetic', () => {
+    expect(safeEvaluateExpression('datum.x + datum.y', datum)).toBe(65);
+    expect(safeEvaluateExpression('datum.x * 2', datum)).toBe(20);
+  });
+
+  // -- Ternary ---------------------------------------------------------------
+  it('evaluates ternary expression', () => {
+    expect(safeEvaluateExpression("datum.x > 5 ? 'big' : 'small'", datum)).toBe('big');
+  });
+
+  // -- Realistic Vega-Lite expressions ---------------------------------------
+  it('evaluates typical filter expression: datum.y > 30', () => {
+    expect(safeEvaluateExpression('datum.y > 30', { y: 28 })).toBe(false);
+    expect(safeEvaluateExpression('datum.y > 30', { y: 55 })).toBe(true);
+  });
+
+  it('evaluates compound conditional', () => {
+    expect(safeEvaluateExpression('datum.year === 2020 && datum.value > 50', datum)).toBe(true);
+  });
+
+  // -- Security: rejected patterns -------------------------------------------
+  it('rejects unknown identifiers (prevents access to globals)', () => {
+    expect(() => safeEvaluateExpression('window', datum)).toThrow(/disallowed identifier/);
+    expect(() => safeEvaluateExpression('document', datum)).toThrow(/disallowed identifier/);
+    expect(() => safeEvaluateExpression('globalThis', datum)).toThrow(/disallowed identifier/);
+    expect(() => safeEvaluateExpression('process', datum)).toThrow(/disallowed identifier/);
+    expect(() => safeEvaluateExpression('this', datum)).toThrow(/disallowed identifier/);
+  });
+
+  it('rejects function call attempts via disallowed identifiers', () => {
+    expect(() => safeEvaluateExpression('alert(1)', datum)).toThrow(/disallowed identifier/);
+    expect(() => safeEvaluateExpression('eval("code")', datum)).toThrow(/disallowed identifier/);
+    expect(() => safeEvaluateExpression('fetch("url")', datum)).toThrow(/disallowed identifier/);
+  });
+
+  it('rejects prototype chain traversal', () => {
+    expect(() => safeEvaluateExpression('datum.constructor', datum)).toThrow(/disallowed property/);
+    expect(() => safeEvaluateExpression('datum.__proto__', datum)).toThrow(/disallowed property/);
+    expect(() => safeEvaluateExpression('datum.prototype', datum)).toThrow(/disallowed property/);
+  });
+
+  it('rejects assignment operators', () => {
+    expect(() => safeEvaluateExpression('datum.x = 42', datum)).toThrow(/assignment/);
+  });
+
+  it('rejects dangerous syntax', () => {
+    expect(() => safeEvaluateExpression('`${datum.x}`', datum)).toThrow(/disallowed syntax/);
+    expect(() => safeEvaluateExpression('datum.x; datum.y', datum)).toThrow(/disallowed syntax/);
+  });
+
+  it('rejects empty expression', () => {
+    expect(() => safeEvaluateExpression('', datum)).toThrow();
+    expect(() => safeEvaluateExpression('   ', datum)).toThrow();
+  });
+
+  // -- String literals containing blocked words should be allowed ------------
+  it('allows blocked words inside string literals', () => {
+    expect(safeEvaluateExpression("datum.category === 'constructor'", datum)).toBe(false);
+    expect(safeEvaluateExpression("datum.category === 'window'", datum)).toBe(false);
+  });
+});

--- a/packages/charts/react-charts/library/src/components/VegaDeclarativeChart/safeExpressionEvaluator.ts
+++ b/packages/charts/react-charts/library/src/components/VegaDeclarativeChart/safeExpressionEvaluator.ts
@@ -1,0 +1,66 @@
+/**
+ * Safe expression evaluator for Vega-Lite expressions.
+ *
+ * Validates expressions against an allowlist before evaluation to prevent
+ * XSS / arbitrary code execution via `new Function()`.
+ *
+ * Allowed: `datum` property access, comparisons, arithmetic, logical ops,
+ * ternary, literals, and parenthesized grouping.
+ *
+ * Blocked: global access, prototype traversal, assignments, and dangerous syntax.
+ */
+
+const ALLOWED_IDENTS = /^(datum|true|false|null|undefined|NaN|Infinity)$/;
+const DANGEROUS_PROPS = /\b(constructor|__proto__|prototype)\b/;
+const DANGEROUS_SYNTAX = /[`{}\\;]/;
+const ASSIGNMENT = /(?<![!=<>])=(?!=)/;
+const SINGLE_QUOTED_STRING = /'[^'\\]*(?:\\.[^'\\]*)*'/g;
+const DOUBLE_QUOTED_STRING = /"[^"\\]*(?:\\.[^"\\]*)*"/g;
+const STANDALONE_IDENT = /(?<!\.)\b([a-zA-Z_$]\w*)\b/g;
+
+/**
+ * Validates that a Vega-Lite expression only contains safe operations.
+ * Throws if the expression could lead to code injection.
+ */
+function validateExpression(expr: string): void {
+  if (!expr.trim()) {
+    throw new Error('Empty expression');
+  }
+
+  // Strip string literals to avoid false positives on identifier checks
+  const stripped = expr.replace(SINGLE_QUOTED_STRING, '""').replace(DOUBLE_QUOTED_STRING, '""');
+
+  if (DANGEROUS_SYNTAX.test(stripped)) {
+    throw new Error('Unsafe expression: disallowed syntax');
+  }
+  if (ASSIGNMENT.test(stripped)) {
+    throw new Error('Unsafe expression: assignment not allowed');
+  }
+  if (DANGEROUS_PROPS.test(stripped)) {
+    throw new Error('Unsafe expression: disallowed property access');
+  }
+
+  // Check all standalone identifiers (not preceded by a dot)
+  STANDALONE_IDENT.lastIndex = 0;
+  const identifiers = stripped.match(STANDALONE_IDENT) || [];
+  for (const id of identifiers) {
+    if (!ALLOWED_IDENTS.test(id)) {
+      throw new Error(`Unsafe expression: disallowed identifier '${id}'`);
+    }
+  }
+}
+
+/**
+ * Safely evaluates a Vega-Lite expression string against a `datum` object.
+ * Validates the expression against an allowlist before evaluation.
+ *
+ * @param expr - Vega-Lite expression string (e.g. `"datum.y > 30"`)
+ * @param datum - The data row to evaluate against
+ * @returns The result of the expression evaluation
+ * @throws If the expression contains disallowed syntax
+ */
+export function safeEvaluateExpression(expr: string, datum: Record<string, unknown>): unknown {
+  validateExpression(expr);
+  // eslint-disable-next-line no-new-func
+  return new Function('datum', `'use strict'; return (${expr})`)(datum);
+}


### PR DESCRIPTION
## Description

Fixes an XSS / code injection vulnerability in `VegaLiteSchemaAdapter.ts` where three `new Function()` calls (equivalent to `eval()`) executed arbitrary expression strings from Vega-Lite specs without validation.

## Changes

- **New:** `safeExpressionEvaluator.ts` — lightweight allowlist-based validator (~60 lines) that checks expressions before `new Function()` evaluation:
  - Blocks dangerous syntax (backticks, braces, semicolons)
  - Blocks assignment operators
  - Blocks prototype chain traversal (`constructor`, `__proto__`, `prototype`)
  - Allowlists standalone identifiers (`datum`, `true`, `false`, `null`, etc.)
  - Runs in strict mode to prevent global object leaks via `this`
- **New:** `safeExpressionEvaluator.test.ts` — 17 tests covering valid expressions and security rejection cases
- **Modified:** `VegaLiteSchemaAdapter.ts` — replaced 3 unguarded `new Function()` calls with `safeEvaluateExpression()`

## Validation

- ✅ `nx run react-charts:type-check`
- ✅ `nx run react-charts:lint` (0 errors)
- ✅ `nx run react-charts:test` (all tests pass)
