### PR TITLE
fix(scripts-monorepo): prevent command injection for getAffected helper

### DIFF
--- a/scripts/monorepo/src/getAffectedPackages.js
+++ b/scripts/monorepo/src/getAffectedPackages.js
@@ -14,14 +14,16 @@ function getAffectedPackages(base = 'origin/master') {
     'show',
     'projects',
     '--affected',
-    `--base=${base}`,
+    '--base',
+    base,
     '--json',
     // override NX_VERBOSE_LOGGING in order to emit valid JSON
-    `--verbose=false`,
+    '--verbose=false',
   ];
-  const res = spawnSync('nx', cmdArgs, {
+  const nx = process.platform === 'win32' ? 'nx.cmd' : 'nx';
+  const res = spawnSync(nx, cmdArgs, {
     cwd: workspaceRoot,
-    shell: true,
+    shell: false,
   });
 
   if (res.status !== 0) {


### PR DESCRIPTION
## Description

Fixes a command injection vulnerability in `getAffectedPackages.js` by:

- Passing `base` as a separate argument instead of interpolating it into the command string
- Disabling `shell: true` in `spawnSync` to prevent shell interpretation of arguments
- Using platform-aware binary resolution (`nx.cmd` on Windows) since `shell: false` requires it

These changes ensure that user-controlled input (the `base` parameter) cannot be used to inject arbitrary shell commands.