### PR TITLE
docs(motion): motion component Storybook improvements

### DIFF
--- a/change/@fluentui-eslint-plugin-react-components-e021e189-a41c-499b-9128-8c61ec392c3c.json
+++ b/change/@fluentui-eslint-plugin-react-components-e021e189-a41c-499b-9128-8c61ec392c3c.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "fix: use require for package.json to prevent API Extractor from failing on unresolved types",
-  "packageName": "@fluentui/eslint-plugin-react-components",
-  "email": "robertpenner@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@fluentui-eslint-plugin-react-components-e021e189-a41c-499b-9128-8c61ec392c3c.json
+++ b/change/@fluentui-eslint-plugin-react-components-e021e189-a41c-499b-9128-8c61ec392c3c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: use require for package.json to prevent API Extractor from failing on unresolved types",
+  "packageName": "@fluentui/eslint-plugin-react-components",
+  "email": "robertpenner@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/eslint-plugin-react-components/etc/eslint-plugin-react-components.api.md
+++ b/packages/react-components/eslint-plugin-react-components/etc/eslint-plugin-react-components.api.md
@@ -15,9 +15,7 @@ export const configs: {
         rules: {};
     };
     'flat/recommended': {
-        plugins: {
-            [x: string]: ESLint.Plugin;
-        };
+        plugins: Record<string, ESLint.Plugin>;
         rules: {};
     };
 };

--- a/packages/react-components/eslint-plugin-react-components/etc/eslint-plugin-react-components.api.md
+++ b/packages/react-components/eslint-plugin-react-components/etc/eslint-plugin-react-components.api.md
@@ -15,7 +15,9 @@ export const configs: {
         rules: {};
     };
     'flat/recommended': {
-        plugins: Record<string, ESLint.Plugin>;
+        plugins: {
+            [x: string]: ESLint.Plugin;
+        };
         rules: {};
     };
 };

--- a/packages/react-components/eslint-plugin-react-components/src/index.ts
+++ b/packages/react-components/eslint-plugin-react-components/src/index.ts
@@ -1,6 +1,8 @@
 import type { ESLint } from 'eslint';
 
-import { name, version } from '../package.json';
+// Use require to avoid leaking package.json types into declarations,
+// which causes API Extractor to fail resolving '../package.json'.
+const { name, version } = require('../package.json') as { name: string; version: string };
 import { RULE_NAME as enforceUseClientName, rule as enforceUseClient } from './rules/enforce-use-client';
 import { RULE_NAME as preferFluentUIV9Name, rule as preferFluentUIV9 } from './rules/prefer-fluentui-v9';
 
@@ -17,7 +19,10 @@ const recommendedRules = {
   // Add rules to the recommended config here in the future
 };
 
-export const configs = {
+export const configs: {
+  recommended: { plugins: string[]; rules: {} };
+  'flat/recommended': { plugins: Record<string, ESLint.Plugin>; rules: {} };
+} = {
   recommended: {
     plugins: [name],
     rules: recommendedRules,

--- a/packages/react-components/eslint-plugin-react-components/src/index.ts
+++ b/packages/react-components/eslint-plugin-react-components/src/index.ts
@@ -1,8 +1,6 @@
 import type { ESLint } from 'eslint';
 
-// Use require to avoid leaking package.json types into declarations,
-// which causes API Extractor to fail resolving '../package.json'.
-const { name, version } = require('../package.json') as { name: string; version: string };
+import { name, version } from '../package.json';
 import { RULE_NAME as enforceUseClientName, rule as enforceUseClient } from './rules/enforce-use-client';
 import { RULE_NAME as preferFluentUIV9Name, rule as preferFluentUIV9 } from './rules/prefer-fluentui-v9';
 
@@ -19,10 +17,7 @@ const recommendedRules = {
   // Add rules to the recommended config here in the future
 };
 
-export const configs: {
-  recommended: { plugins: string[]; rules: {} };
-  'flat/recommended': { plugins: Record<string, ESLint.Plugin>; rules: {} };
-} = {
+export const configs = {
   recommended: {
     plugins: [name],
     rules: recommendedRules,

--- a/packages/react-components/react-motion-components-preview/stories/src/Blur/Blur.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Blur/Blur.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import type { JSXElement } from '@fluentui/react-components';
 import type { PresenceComponentProps } from '@fluentui/react-components';
-import { Scale, type ScaleParams } from '@fluentui/react-motion-components-preview';
+import { Blur, type BlurParams } from '@fluentui/react-motion-components-preview';
 
 const LoremIpsum = React.forwardRef<HTMLDivElement, React.HTMLProps<HTMLDivElement>>((props, ref) => (
   <div ref={ref} {...props}>
@@ -11,10 +11,10 @@ const LoremIpsum = React.forwardRef<HTMLDivElement, React.HTMLProps<HTMLDivEleme
   </div>
 ));
 
-export const DefaultScale = (props: PresenceComponentProps & ScaleParams): JSXElement => {
+export const DefaultBlur = (props: PresenceComponentProps & BlurParams): JSXElement => {
   return (
-    <Scale {...props}>
+    <Blur {...props}>
       <LoremIpsum />
-    </Scale>
+    </Blur>
   );
 };

--- a/packages/react-components/react-motion-components-preview/stories/src/Blur/Blur.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Blur/Blur.stories.tsx
@@ -1,7 +1,13 @@
 import * as React from 'react';
 import type { JSXElement } from '@fluentui/react-components';
-import type { PresenceComponentProps } from '@fluentui/react-components';
+import { makeStyles, tokens, type PresenceComponentProps } from '@fluentui/react-components';
 import { Blur, type BlurParams } from '@fluentui/react-motion-components-preview';
+
+const useClasses = makeStyles({
+  wrapper: {
+    padding: tokens.spacingVerticalXL,
+  },
+});
 
 const LoremIpsum = React.forwardRef<HTMLDivElement, React.HTMLProps<HTMLDivElement>>((props, ref) => (
   <div ref={ref} {...props}>
@@ -12,9 +18,12 @@ const LoremIpsum = React.forwardRef<HTMLDivElement, React.HTMLProps<HTMLDivEleme
 ));
 
 export const DefaultBlur = (props: PresenceComponentProps & BlurParams): JSXElement => {
+  const classes = useClasses();
   return (
-    <Blur {...props}>
-      <LoremIpsum />
-    </Blur>
+    <div className={classes.wrapper}>
+      <Blur {...props}>
+        <LoremIpsum />
+      </Blur>
+    </div>
   );
 };

--- a/packages/react-components/react-motion-components-preview/stories/src/Blur/BlurDefault.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Blur/BlurDefault.stories.tsx
@@ -7,11 +7,11 @@ const useClasses = makeStyles({
   container: {
     display: 'grid',
     gridTemplate: `"controls ." "card card" / 1fr 1fr`,
-    gap: '20px 10px',
+    gap: `${tokens.spacingVerticalXL} ${tokens.spacingHorizontalMNudge}`,
   },
   card: {
     gridArea: 'card',
-    padding: '20px',
+    padding: tokens.spacingVerticalXL,
     maxHeight: '300px',
     overflow: 'hidden',
   },
@@ -23,7 +23,7 @@ const useClasses = makeStyles({
     border: `${tokens.strokeWidthThicker} solid ${tokens.colorNeutralForeground3}`,
     borderRadius: tokens.borderRadiusMedium,
     boxShadow: tokens.shadow16,
-    padding: '10px',
+    padding: tokens.spacingVerticalMNudge,
   },
   field: {
     flex: 1,

--- a/packages/react-components/react-motion-components-preview/stories/src/Blur/BlurDefault.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Blur/BlurDefault.stories.tsx
@@ -28,6 +28,9 @@ const useClasses = makeStyles({
   field: {
     flex: 1,
   },
+  cardHeaderText: {
+    margin: 0,
+  },
 });
 
 const LoremIpsum = () => (
@@ -54,7 +57,7 @@ export const Default = (): JSXElement => {
         <Card className={classes.card}>
           <CardHeader
             header={
-              <Text as="h3" style={{ margin: 0 }} weight="semibold">
+              <Text as="h3" className={classes.cardHeaderText} weight="semibold">
                 Lorem Ipsum
               </Text>
             }

--- a/packages/react-components/react-motion-components-preview/stories/src/Blur/BlurDefault.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Blur/BlurDefault.stories.tsx
@@ -1,36 +1,29 @@
 import * as React from 'react';
 import type { JSXElement } from '@fluentui/react-components';
-import { Field, makeStyles, tokens, Switch } from '@fluentui/react-components';
+import { Card, CardHeader, Field, makeStyles, tokens, Switch, Text } from '@fluentui/react-components';
 import { Blur } from '@fluentui/react-motion-components-preview';
 
 const useClasses = makeStyles({
   container: {
     display: 'grid',
-    gridTemplateColumns: 'minmax(200px, 1fr) 2fr',
-    gridTemplateAreas: '"controls content"',
-    gap: '20px',
-    padding: '20px',
-  },
-  content: {
-    gridArea: 'content',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
+    gridTemplate: `"controls ." "card card" / 1fr 1fr`,
+    gap: '20px 10px',
   },
   card: {
+    gridArea: 'card',
     padding: '20px',
-    border: `${tokens.strokeWidthThin} solid ${tokens.colorNeutralStroke1}`,
-    borderRadius: tokens.borderRadiusMedium,
-    backgroundColor: tokens.colorNeutralBackground1,
-    maxWidth: '400px',
+    maxHeight: '300px',
+    overflow: 'hidden',
   },
   controls: {
-    gridArea: 'controls',
     display: 'flex',
     flexDirection: 'column',
+    gridArea: 'controls',
+
+    border: `${tokens.strokeWidthThicker} solid ${tokens.colorNeutralForeground3}`,
     borderRadius: tokens.borderRadiusMedium,
     boxShadow: tokens.shadow16,
-    padding: '20px',
+    padding: '10px',
   },
   field: {
     flex: 1,
@@ -57,13 +50,18 @@ export const Default = (): JSXElement => {
         </Field>
       </div>
 
-      <div className={classes.content}>
-        <Blur visible={visible}>
-          <div className={classes.card}>
-            <LoremIpsum />
-          </div>
-        </Blur>
-      </div>
+      <Blur visible={visible}>
+        <Card className={classes.card}>
+          <CardHeader
+            header={
+              <Text as="h3" style={{ margin: 0 }} weight="semibold">
+                Lorem Ipsum
+              </Text>
+            }
+          />
+          <LoremIpsum />
+        </Card>
+      </Blur>
     </div>
   );
 };

--- a/packages/react-components/react-motion-components-preview/stories/src/Blur/BlurRadius.stories.md
+++ b/packages/react-components/react-motion-components-preview/stories/src/Blur/BlurRadius.stories.md
@@ -1,1 +1,6 @@
-Compare different `outRadius` values to control the spread of the blur effect.
+The `Blur` component accepts two radius props:
+
+- **`outRadius`** — blur amount when the element is hidden
+- **`inRadius`** — blur amount when the element is visible (defaults to `0px`)
+
+Each card shows a different combination. The active radius value is **bolded** in the header. `animateOpacity` is disabled to isolate the blur effect.

--- a/packages/react-components/react-motion-components-preview/stories/src/Blur/BlurRadius.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Blur/BlurRadius.stories.tsx
@@ -1,48 +1,43 @@
 import * as React from 'react';
 import type { JSXElement } from '@fluentui/react-components';
-import { Card, CardHeader, makeStyles, Button, Text } from '@fluentui/react-components';
+import { Card, CardFooter, CardHeader, makeStyles, Button, Text } from '@fluentui/react-components';
 import { Blur } from '@fluentui/react-motion-components-preview';
 import BlurRadiusDescription from './BlurRadius.stories.md';
 
 const useClasses = makeStyles({
   container: {
     display: 'grid',
-    gridTemplateColumns: 'repeat(auto-fit, minmax(250px, 1fr))',
-    gap: '20px',
-    padding: '20px',
-  },
-  example: {
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'center',
-    gap: '10px',
+    gridTemplateColumns: '1fr 1fr',
+    gap: '40px',
+    padding: '10px',
   },
   card: {
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',
-    width: '200px',
-    height: '100px',
+    // width: '200px',
+    // height: '100px',
     padding: '20px',
   },
   controls: {
     display: 'flex',
     justifyContent: 'center',
-    // gap: '20px',
-    // marginBottom: '20px',
+    marginTop: '20px',
   },
 });
 
-const blurRadiusOptions = [
-  { label: 'Small (5px)', value: '5px' },
-  { label: 'Medium (20px)', value: '20px' },
-  { label: 'Large (50px)', value: '50px' },
-  { label: 'Extra Large (100px)', value: '100px' },
+const blurRadiusCombinations = [
+  // Top row: outRadius 5px, inRadius 0px (default)
+  { outRadius: '5px', inRadius: '0px' },
+  { outRadius: '10px', inRadius: '0px' },
+  // Bottom row: outRadius 20px, with inRadius values
+  { outRadius: '10px', inRadius: '1px' },
+  { outRadius: '10px', inRadius: '2px' },
 ];
 
 export const Radius = (): JSXElement => {
   const classes = useClasses();
-  const [visibleStates, setVisibleStates] = React.useState<boolean[]>(blurRadiusOptions.map(() => true));
+  const [visibleStates, setVisibleStates] = React.useState<boolean[]>(blurRadiusCombinations.map(() => true));
 
   const toggleAll = () => {
     setVisibleStates(prev => prev.map(state => !state));
@@ -55,21 +50,51 @@ export const Radius = (): JSXElement => {
   return (
     <>
       <div className={classes.container}>
-        {blurRadiusOptions.map((option, index) => (
-          <div key={option.value} className={classes.example}>
-            {/* <h4>{option.label}</h4> */}
-            <Button onClick={() => toggleSingle(index)}>{visibleStates[index] ? 'Hide' : 'Show'}</Button>
-            <Blur visible={visibleStates[index]} outRadius={option.value}>
-              <Card className={classes.card}>
-                <CardHeader header={<Text weight="semibold">Blur radius: {option.value}</Text>} />
-              </Card>
-            </Blur>
-          </div>
-        ))}
+        {blurRadiusCombinations.map((option, index) => {
+          const isVisible = visibleStates[index];
+          const outRadiusCell = <td style={{ fontWeight: isVisible ? 'normal' : 'bold' }}>{option.outRadius}</td>;
+          const inRadiusCell = <td style={{ fontWeight: isVisible ? 'bold' : 'normal' }}>{option.inRadius}</td>;
+          const cardHeader = (
+            <table>
+              <thead>
+                <tr>
+                  <th scope="col">outRadius</th>
+                  <th scope="col">inRadius</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  {outRadiusCell}
+                  {inRadiusCell}
+                </tr>
+              </tbody>
+            </table>
+          );
+          return (
+            <Card key={index} className={classes.card}>
+              <CardHeader header={cardHeader} />
+              <Blur
+                visible={visibleStates[index]}
+                outRadius={option.outRadius}
+                inRadius={option.inRadius}
+                animateOpacity={false}
+              >
+                <div>Lorem ipsum dolor sit amet</div>
+              </Blur>
+              <CardFooter>
+                <Button appearance="primary" onClick={() => toggleSingle(index)}>
+                  {visibleStates[index] ? 'Hide' : 'Show'}
+                </Button>
+              </CardFooter>
+            </Card>
+          );
+        })}
       </div>
 
       <div className={classes.controls}>
-        <Button onClick={toggleAll}>Toggle All</Button>
+        <Button appearance="secondary" onClick={toggleAll}>
+          Toggle All
+        </Button>
       </div>
     </>
   );

--- a/packages/react-components/react-motion-components-preview/stories/src/Blur/BlurRadius.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Blur/BlurRadius.stories.tsx
@@ -1,6 +1,18 @@
 import * as React from 'react';
 import type { JSXElement } from '@fluentui/react-components';
-import { Card, CardFooter, CardHeader, makeStyles, tokens, Button } from '@fluentui/react-components';
+import {
+  Button,
+  Card,
+  CardFooter,
+  Table,
+  TableBody,
+  TableCell,
+  TableHeader,
+  TableHeaderCell,
+  TableRow,
+  makeStyles,
+  tokens,
+} from '@fluentui/react-components';
 import { Blur } from '@fluentui/react-motion-components-preview';
 import BlurRadiusDescription from './BlurRadius.stories.md';
 
@@ -13,9 +25,17 @@ const useClasses = makeStyles({
   },
   card: {
     display: 'flex',
+    flexDirection: 'column',
     justifyContent: 'center',
     alignItems: 'center',
     padding: tokens.spacingVerticalXL,
+    gap: tokens.spacingVerticalM,
+  },
+  cellNormal: {
+    fontWeight: tokens.fontWeightRegular,
+  },
+  cellBold: {
+    fontWeight: tokens.fontWeightBold,
   },
   controls: {
     display: 'flex',
@@ -35,7 +55,7 @@ const blurRadiusCombinations = [
 
 export const Radius = (): JSXElement => {
   const classes = useClasses();
-  const [visibleStates, setVisibleStates] = React.useState<boolean[]>(blurRadiusCombinations.map(() => true));
+  const [visibleStates, setVisibleStates] = React.useState<boolean[]>(() => blurRadiusCombinations.map(() => true));
 
   const toggleAll = () => {
     setVisibleStates(prev => prev.map(state => !state));
@@ -50,38 +70,32 @@ export const Radius = (): JSXElement => {
       <div className={classes.container}>
         {blurRadiusCombinations.map((option, index) => {
           const isVisible = visibleStates[index];
-          const outRadiusCell = <td style={{ fontWeight: isVisible ? 'normal' : 'bold' }}>{option.outRadius}</td>;
-          const inRadiusCell = <td style={{ fontWeight: isVisible ? 'bold' : 'normal' }}>{option.inRadius}</td>;
-          const cardHeader = (
-            <table>
-              <thead>
-                <tr>
-                  <th scope="col">outRadius</th>
-                  <th scope="col">inRadius</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  {outRadiusCell}
-                  {inRadiusCell}
-                </tr>
-              </tbody>
-            </table>
-          );
           return (
             <Card key={index} className={classes.card}>
-              <CardHeader header={cardHeader} />
-              <Blur
-                visible={visibleStates[index]}
-                outRadius={option.outRadius}
-                inRadius={option.inRadius}
-                animateOpacity={false}
-              >
+              <Table size="small" noNativeElements aria-label="Blur radius values">
+                <TableHeader>
+                  <TableRow>
+                    <TableHeaderCell>outRadius</TableHeaderCell>
+                    <TableHeaderCell>inRadius</TableHeaderCell>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  <TableRow>
+                    <TableCell className={isVisible ? classes.cellNormal : classes.cellBold}>
+                      {option.outRadius}
+                    </TableCell>
+                    <TableCell className={isVisible ? classes.cellBold : classes.cellNormal}>
+                      {option.inRadius}
+                    </TableCell>
+                  </TableRow>
+                </TableBody>
+              </Table>
+              <Blur visible={isVisible} outRadius={option.outRadius} inRadius={option.inRadius} animateOpacity={false}>
                 <div>Lorem ipsum dolor sit amet</div>
               </Blur>
               <CardFooter>
                 <Button appearance="primary" onClick={() => toggleSingle(index)}>
-                  {visibleStates[index] ? 'Hide' : 'Show'}
+                  {isVisible ? 'Hide' : 'Show'}
                 </Button>
               </CardFooter>
             </Card>

--- a/packages/react-components/react-motion-components-preview/stories/src/Blur/BlurRadius.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Blur/BlurRadius.stories.tsx
@@ -32,8 +32,9 @@ const useClasses = makeStyles({
   },
   controls: {
     display: 'flex',
-    gap: '10px',
-    marginBottom: '20px',
+    justifyContent: 'center',
+    // gap: '20px',
+    // marginBottom: '20px',
   },
 });
 
@@ -58,10 +59,6 @@ export const Radius = (): JSXElement => {
 
   return (
     <>
-      <div className={classes.controls}>
-        <Button onClick={toggleAll}>Toggle All</Button>
-      </div>
-
       <div className={classes.container}>
         {blurRadiusOptions.map((option, index) => (
           <div key={option.value} className={classes.example}>
@@ -78,6 +75,10 @@ export const Radius = (): JSXElement => {
             </Blur>
           </div>
         ))}
+      </div>
+
+      <div className={classes.controls}>
+        <Button onClick={toggleAll}>Toggle All</Button>
       </div>
     </>
   );

--- a/packages/react-components/react-motion-components-preview/stories/src/Blur/BlurRadius.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Blur/BlurRadius.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import type { JSXElement } from '@fluentui/react-components';
-import { Card, CardFooter, CardHeader, makeStyles, tokens, Button, Text } from '@fluentui/react-components';
+import { Card, CardFooter, CardHeader, makeStyles, tokens, Button } from '@fluentui/react-components';
 import { Blur } from '@fluentui/react-motion-components-preview';
 import BlurRadiusDescription from './BlurRadius.stories.md';
 

--- a/packages/react-components/react-motion-components-preview/stories/src/Blur/BlurRadius.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Blur/BlurRadius.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import type { JSXElement } from '@fluentui/react-components';
-import { makeStyles, tokens, Button } from '@fluentui/react-components';
+import { Card, CardHeader, makeStyles, Button, Text } from '@fluentui/react-components';
 import { Blur } from '@fluentui/react-motion-components-preview';
 import BlurRadiusDescription from './BlurRadius.stories.md';
 
@@ -18,17 +18,12 @@ const useClasses = makeStyles({
     gap: '10px',
   },
   card: {
-    width: '200px',
-    height: '150px',
-    padding: '20px',
-    border: `${tokens.strokeWidthThin} solid ${tokens.colorNeutralStroke1}`,
-    borderRadius: tokens.borderRadiusMedium,
-    backgroundColor: tokens.colorNeutralBackground1,
     display: 'flex',
-    alignItems: 'center',
     justifyContent: 'center',
-    fontSize: tokens.fontSizeBase300,
-    textAlign: 'center',
+    alignItems: 'center',
+    width: '200px',
+    height: '100px',
+    padding: '20px',
   },
   controls: {
     display: 'flex',
@@ -62,16 +57,12 @@ export const Radius = (): JSXElement => {
       <div className={classes.container}>
         {blurRadiusOptions.map((option, index) => (
           <div key={option.value} className={classes.example}>
-            <h4>{option.label}</h4>
+            {/* <h4>{option.label}</h4> */}
             <Button onClick={() => toggleSingle(index)}>{visibleStates[index] ? 'Hide' : 'Show'}</Button>
             <Blur visible={visibleStates[index]} outRadius={option.value}>
-              <div className={classes.card}>
-                <div>
-                  Blur radius: {option.value}
-                  <br />
-                  Sample content with various text and elements.
-                </div>
-              </div>
+              <Card className={classes.card}>
+                <CardHeader header={<Text weight="semibold">Blur radius: {option.value}</Text>} />
+              </Card>
             </Blur>
           </div>
         ))}

--- a/packages/react-components/react-motion-components-preview/stories/src/Blur/BlurRadius.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Blur/BlurRadius.stories.tsx
@@ -15,8 +15,6 @@ const useClasses = makeStyles({
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',
-    // width: '200px',
-    // height: '100px',
     padding: tokens.spacingVerticalXL,
   },
   controls: {

--- a/packages/react-components/react-motion-components-preview/stories/src/Blur/BlurRadius.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Blur/BlurRadius.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import type { JSXElement } from '@fluentui/react-components';
-import { Card, CardFooter, CardHeader, makeStyles, Button, Text } from '@fluentui/react-components';
+import { Card, CardFooter, CardHeader, makeStyles, tokens, Button, Text } from '@fluentui/react-components';
 import { Blur } from '@fluentui/react-motion-components-preview';
 import BlurRadiusDescription from './BlurRadius.stories.md';
 
@@ -8,8 +8,8 @@ const useClasses = makeStyles({
   container: {
     display: 'grid',
     gridTemplateColumns: '1fr 1fr',
-    gap: '40px',
-    padding: '10px',
+    gap: tokens.spacingVerticalXXXL,
+    padding: tokens.spacingVerticalMNudge,
   },
   card: {
     display: 'flex',
@@ -17,12 +17,12 @@ const useClasses = makeStyles({
     alignItems: 'center',
     // width: '200px',
     // height: '100px',
-    padding: '20px',
+    padding: tokens.spacingVerticalXL,
   },
   controls: {
     display: 'flex',
     justifyContent: 'center',
-    marginTop: '20px',
+    marginTop: tokens.spacingVerticalXL,
   },
 });
 

--- a/packages/react-components/react-motion-components-preview/stories/src/Blur/index.stories.ts
+++ b/packages/react-components/react-motion-components-preview/stories/src/Blur/index.stories.ts
@@ -1,4 +1,4 @@
-import { Blur } from '@fluentui/react-motion-components-preview';
+import { DefaultBlur as Blur } from './Blur.stories';
 import BlurDescription from './BlurDescription.md';
 
 export { Default } from './BlurDefault.stories';

--- a/packages/react-components/react-motion-components-preview/stories/src/Collapse/Collapse.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Collapse/Collapse.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import type { JSXElement } from '@fluentui/react-components';
 import type { PresenceComponentProps } from '@fluentui/react-components';
-import { Collapse, CollapseParams } from '@fluentui/react-motion-components-preview';
+import { Collapse, type CollapseParams } from '@fluentui/react-motion-components-preview';
 
 const LoremIpsum = React.forwardRef<HTMLDivElement, React.HTMLProps<HTMLDivElement>>((props, ref) => (
   <div ref={ref} {...props}>

--- a/packages/react-components/react-motion-components-preview/stories/src/Collapse/Collapse.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Collapse/Collapse.stories.tsx
@@ -1,7 +1,13 @@
 import * as React from 'react';
 import type { JSXElement } from '@fluentui/react-components';
-import type { PresenceComponentProps } from '@fluentui/react-components';
+import { makeStyles, tokens, type PresenceComponentProps } from '@fluentui/react-components';
 import { Collapse, type CollapseParams } from '@fluentui/react-motion-components-preview';
+
+const useClasses = makeStyles({
+  wrapper: {
+    padding: tokens.spacingVerticalXL,
+  },
+});
 
 const LoremIpsum = React.forwardRef<HTMLDivElement, React.HTMLProps<HTMLDivElement>>((props, ref) => (
   <div ref={ref} {...props}>
@@ -12,9 +18,12 @@ const LoremIpsum = React.forwardRef<HTMLDivElement, React.HTMLProps<HTMLDivEleme
 ));
 
 export const DefaultCollapse = (props: PresenceComponentProps & CollapseParams): JSXElement => {
+  const classes = useClasses();
   return (
-    <Collapse {...props}>
-      <LoremIpsum />
-    </Collapse>
+    <div className={classes.wrapper}>
+      <Collapse {...props}>
+        <LoremIpsum />
+      </Collapse>
+    </div>
   );
 };

--- a/packages/react-components/react-motion-components-preview/stories/src/Collapse/Collapse.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Collapse/Collapse.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import type { JSXElement } from '@fluentui/react-components';
 import type { PresenceComponentProps } from '@fluentui/react-components';
-import { Collapse } from '@fluentui/react-motion-components-preview';
+import { Collapse, CollapseParams } from '@fluentui/react-motion-components-preview';
 
 const LoremIpsum = React.forwardRef<HTMLDivElement, React.HTMLProps<HTMLDivElement>>((props, ref) => (
   <div ref={ref} {...props}>
@@ -11,7 +11,7 @@ const LoremIpsum = React.forwardRef<HTMLDivElement, React.HTMLProps<HTMLDivEleme
   </div>
 ));
 
-export const DefaultCollapse = (props: PresenceComponentProps): JSXElement => {
+export const DefaultCollapse = (props: PresenceComponentProps & CollapseParams): JSXElement => {
   return (
     <Collapse {...props}>
       <LoremIpsum />

--- a/packages/react-components/react-motion-components-preview/stories/src/Collapse/CollapseCustomization.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Collapse/CollapseCustomization.stories.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import type { JSXElement } from '@fluentui/react-components';
 import {
+  Card,
+  CardHeader,
   createPresenceComponentVariant,
   Field,
   makeStyles,
@@ -9,6 +11,7 @@ import {
   motionTokens,
   Slider,
   Switch,
+  Text,
   tokens,
 } from '@fluentui/react-components';
 import { Collapse } from '@fluentui/react-motion-components-preview';
@@ -19,11 +22,18 @@ const useClasses = makeStyles({
   container: {
     display: 'grid',
     gridTemplate: `"controls ." "card card" / 1fr 1fr`,
-    gap: '20px 10px',
+    gap: `${tokens.spacingVerticalXL} ${tokens.spacingHorizontalMNudge}`,
   },
   card: {
     gridArea: 'card',
-    padding: '10px',
+    padding: tokens.spacingVerticalXL,
+  },
+  cardContent: {
+    maxHeight: '300px',
+    overflow: 'hidden',
+  },
+  cardHeaderText: {
+    margin: 0,
   },
   controls: {
     display: 'flex',
@@ -33,7 +43,7 @@ const useClasses = makeStyles({
     border: `${tokens.strokeWidthThicker} solid ${tokens.colorNeutralForeground3}`,
     borderRadius: tokens.borderRadiusMedium,
     boxShadow: tokens.shadow16,
-    padding: '10px',
+    padding: tokens.spacingVerticalMNudge,
   },
   field: {
     flex: 1,
@@ -135,9 +145,19 @@ export const Customization = (): JSXElement => {
         visible={visible}
         unmountOnExit={unmountOnExit}
       >
-        <div className={classes.card}>
-          <LoremIpsum />
-        </div>
+        <Card className={classes.card}>
+          <CardHeader
+            header={
+              <Text as="h3" className={classes.cardHeaderText} weight="semibold">
+                Lorem Ipsum
+              </Text>
+            }
+          />
+          {/* Wrapper div needed because Collapse controls maxHeight on its child to animate height */}
+          <div className={classes.cardContent}>
+            <LoremIpsum />
+          </div>
+        </Card>
       </CustomCollapseVariant>
     </div>
   );

--- a/packages/react-components/react-motion-components-preview/stories/src/Collapse/CollapseDefault.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Collapse/CollapseDefault.stories.tsx
@@ -1,4 +1,4 @@
-import { Field, makeStyles, tokens, Switch } from '@fluentui/react-components';
+import { Card, CardHeader, Field, makeStyles, tokens, Switch, Text } from '@fluentui/react-components';
 import { Collapse } from '@fluentui/react-motion-components-preview';
 import * as React from 'react';
 import type { JSXElement, PresenceComponentProps } from '@fluentui/react-components';
@@ -11,7 +11,11 @@ const useClasses = makeStyles({
   },
   card: {
     gridArea: 'card',
-    padding: '10px',
+    padding: '20px',
+  },
+  cardContent: {
+    maxHeight: '300px',
+    overflow: 'hidden',
   },
   controls: {
     display: 'flex',
@@ -49,9 +53,19 @@ export const Default = (props: PresenceComponentProps): JSXElement => {
       </div>
 
       <Collapse visible={visible}>
-        <div className={classes.card}>
-          <LoremIpsum />
-        </div>
+        <Card className={classes.card}>
+          <CardHeader
+            header={
+              <Text as="h3" style={{ margin: 0 }} weight="semibold">
+                Lorem Ipsum
+              </Text>
+            }
+          />
+          {/* Wrapper div needed because Collapse controls maxHeight on its child to animate height */}
+          <div className={classes.cardContent}>
+            <LoremIpsum />
+          </div>
+        </Card>
       </Collapse>
     </div>
   );

--- a/packages/react-components/react-motion-components-preview/stories/src/Collapse/CollapseDefault.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Collapse/CollapseDefault.stories.tsx
@@ -1,17 +1,17 @@
 import { Card, CardHeader, Field, makeStyles, tokens, Switch, Text } from '@fluentui/react-components';
 import { Collapse } from '@fluentui/react-motion-components-preview';
 import * as React from 'react';
-import type { JSXElement, PresenceComponentProps } from '@fluentui/react-components';
+import type { JSXElement } from '@fluentui/react-components';
 
 const useClasses = makeStyles({
   container: {
     display: 'grid',
     gridTemplate: `"controls ." "card card" / 1fr 1fr`,
-    gap: '20px 10px',
+    gap: `${tokens.spacingVerticalXL} ${tokens.spacingHorizontalMNudge}`,
   },
   card: {
     gridArea: 'card',
-    padding: '20px',
+    padding: tokens.spacingVerticalXL,
   },
   cardContent: {
     maxHeight: '300px',
@@ -25,7 +25,7 @@ const useClasses = makeStyles({
     border: `${tokens.strokeWidthThicker} solid ${tokens.colorNeutralForeground3}`,
     borderRadius: tokens.borderRadiusMedium,
     boxShadow: tokens.shadow16,
-    padding: '10px',
+    padding: tokens.spacingVerticalMNudge,
   },
   field: {
     flex: 1,
@@ -40,9 +40,9 @@ const LoremIpsum = () => (
   </>
 );
 
-export const Default = (props: PresenceComponentProps): JSXElement => {
+export const Default = (): JSXElement => {
   const classes = useClasses();
-  const [visible, setVisible] = React.useState<boolean>(false);
+  const [visible, setVisible] = React.useState<boolean>(true);
 
   return (
     <div className={classes.container}>

--- a/packages/react-components/react-motion-components-preview/stories/src/Collapse/CollapseDefault.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Collapse/CollapseDefault.stories.tsx
@@ -30,6 +30,9 @@ const useClasses = makeStyles({
   field: {
     flex: 1,
   },
+  cardHeaderText: {
+    margin: 0,
+  },
 });
 
 const LoremIpsum = () => (
@@ -56,7 +59,7 @@ export const Default = (): JSXElement => {
         <Card className={classes.card}>
           <CardHeader
             header={
-              <Text as="h3" style={{ margin: 0 }} weight="semibold">
+              <Text as="h3" className={classes.cardHeaderText} weight="semibold">
                 Lorem Ipsum
               </Text>
             }

--- a/packages/react-components/react-motion-components-preview/stories/src/Collapse/CollapseDelayed.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Collapse/CollapseDelayed.stories.tsx
@@ -9,11 +9,11 @@ const useClasses = makeStyles({
   container: {
     display: 'grid',
     gridTemplate: `"controls ." "card card" / 1fr 1fr`,
-    gap: '20px 10px',
+    gap: `${tokens.spacingVerticalXL} ${tokens.spacingHorizontalMNudge}`,
   },
   card: {
     gridArea: 'card',
-    padding: '20px',
+    padding: tokens.spacingVerticalXL,
   },
   cardContent: {
     maxHeight: '300px',
@@ -27,7 +27,7 @@ const useClasses = makeStyles({
     border: `${tokens.strokeWidthThicker} solid ${tokens.colorNeutralForeground3}`,
     borderRadius: tokens.borderRadiusMedium,
     boxShadow: tokens.shadow16,
-    padding: '10px',
+    padding: tokens.spacingVerticalMNudge,
   },
   field: {
     flex: 1,
@@ -44,7 +44,7 @@ const LoremIpsum = () => (
 
 export const Delayed = (): JSXElement => {
   const classes = useClasses();
-  const [visible, setVisible] = React.useState<boolean>(false);
+  const [visible, setVisible] = React.useState<boolean>(true);
 
   return (
     <div className={classes.container}>

--- a/packages/react-components/react-motion-components-preview/stories/src/Collapse/CollapseDelayed.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Collapse/CollapseDelayed.stories.tsx
@@ -32,6 +32,9 @@ const useClasses = makeStyles({
   field: {
     flex: 1,
   },
+  cardHeaderText: {
+    margin: 0,
+  },
 });
 
 const LoremIpsum = () => (
@@ -58,7 +61,7 @@ export const Delayed = (): JSXElement => {
         <Card className={classes.card}>
           <CardHeader
             header={
-              <Text as="h3" style={{ margin: 0 }} weight="semibold">
+              <Text as="h3" className={classes.cardHeaderText} weight="semibold">
                 Lorem Ipsum
               </Text>
             }

--- a/packages/react-components/react-motion-components-preview/stories/src/Collapse/CollapseDelayed.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Collapse/CollapseDelayed.stories.tsx
@@ -1,4 +1,4 @@
-import { Field, makeStyles, tokens, Switch } from '@fluentui/react-components';
+import { Card, CardHeader, Field, makeStyles, tokens, Switch, Text } from '@fluentui/react-components';
 import { CollapseDelayed } from '@fluentui/react-motion-components-preview';
 import * as React from 'react';
 import type { JSXElement } from '@fluentui/react-components';
@@ -13,7 +13,11 @@ const useClasses = makeStyles({
   },
   card: {
     gridArea: 'card',
-    padding: '10px',
+    padding: '20px',
+  },
+  cardContent: {
+    maxHeight: '300px',
+    overflow: 'hidden',
   },
   controls: {
     display: 'flex',
@@ -51,9 +55,19 @@ export const Delayed = (): JSXElement => {
       </div>
 
       <CollapseDelayed visible={visible}>
-        <div className={classes.card}>
-          <LoremIpsum />
-        </div>
+        <Card className={classes.card}>
+          <CardHeader
+            header={
+              <Text as="h3" style={{ margin: 0 }} weight="semibold">
+                Lorem Ipsum
+              </Text>
+            }
+          />
+          {/* Wrapper div needed because Collapse controls maxHeight on its child to animate height */}
+          <div className={classes.cardContent}>
+            <LoremIpsum />
+          </div>
+        </Card>
       </CollapseDelayed>
     </div>
   );

--- a/packages/react-components/react-motion-components-preview/stories/src/Collapse/CollapseHorizontal.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Collapse/CollapseHorizontal.stories.tsx
@@ -6,7 +6,7 @@ import type { JSXElement } from '@fluentui/react-components';
 import description from './CollapseHorizontal.stories.md';
 
 const useClasses = makeStyles({
-  container: {},
+  container: { display: 'flex', flexDirection: 'column', gap: '10px' },
   sideContent: {
     background: 'lightgrey',
     padding: '50px',
@@ -20,14 +20,14 @@ const useClasses = makeStyles({
     width: '300px',
   },
   controls: {
-    display: 'grid',
-    gridTemplateColumns: '1fr 3fr',
-    justifyContent: 'start',
+    display: 'flex',
+    flexDirection: 'column',
     gridArea: 'controls',
+
     border: `${tokens.strokeWidthThicker} solid ${tokens.colorNeutralForeground3}`,
     borderRadius: tokens.borderRadiusMedium,
     boxShadow: tokens.shadow16,
-    padding: '10px',
+    padding: tokens.spacingVerticalMNudge,
   },
   field: {
     flex: 1,

--- a/packages/react-components/react-motion-components-preview/stories/src/Collapse/CollapseRelaxed.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Collapse/CollapseRelaxed.stories.tsx
@@ -32,6 +32,9 @@ const useClasses = makeStyles({
   field: {
     flex: 1,
   },
+  cardHeaderText: {
+    margin: 0,
+  },
 });
 
 const LoremIpsum = () => (
@@ -58,7 +61,7 @@ export const Relaxed = (): JSXElement => {
         <Card className={classes.card}>
           <CardHeader
             header={
-              <Text as="h3" style={{ margin: 0 }} weight="semibold">
+              <Text as="h3" className={classes.cardHeaderText} weight="semibold">
                 Lorem Ipsum
               </Text>
             }

--- a/packages/react-components/react-motion-components-preview/stories/src/Collapse/CollapseRelaxed.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Collapse/CollapseRelaxed.stories.tsx
@@ -9,11 +9,11 @@ const useClasses = makeStyles({
   container: {
     display: 'grid',
     gridTemplate: `"controls ." "card card" / 1fr 1fr`,
-    gap: '20px 10px',
+    gap: `${tokens.spacingVerticalXL} ${tokens.spacingHorizontalMNudge}`,
   },
   card: {
     gridArea: 'card',
-    padding: '20px',
+    padding: tokens.spacingVerticalXL,
   },
   cardContent: {
     maxHeight: '300px',
@@ -27,7 +27,7 @@ const useClasses = makeStyles({
     border: `${tokens.strokeWidthThicker} solid ${tokens.colorNeutralForeground3}`,
     borderRadius: tokens.borderRadiusMedium,
     boxShadow: tokens.shadow16,
-    padding: '10px',
+    padding: tokens.spacingVerticalMNudge,
   },
   field: {
     flex: 1,
@@ -44,7 +44,7 @@ const LoremIpsum = () => (
 
 export const Relaxed = (): JSXElement => {
   const classes = useClasses();
-  const [visible, setVisible] = React.useState<boolean>(false);
+  const [visible, setVisible] = React.useState<boolean>(true);
 
   return (
     <div className={classes.container}>

--- a/packages/react-components/react-motion-components-preview/stories/src/Collapse/CollapseRelaxed.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Collapse/CollapseRelaxed.stories.tsx
@@ -1,4 +1,4 @@
-import { Field, makeStyles, tokens, Switch } from '@fluentui/react-components';
+import { Card, CardHeader, Field, makeStyles, tokens, Switch, Text } from '@fluentui/react-components';
 import { CollapseRelaxed } from '@fluentui/react-motion-components-preview';
 import * as React from 'react';
 import type { JSXElement } from '@fluentui/react-components';
@@ -13,7 +13,11 @@ const useClasses = makeStyles({
   },
   card: {
     gridArea: 'card',
-    padding: '10px',
+    padding: '20px',
+  },
+  cardContent: {
+    maxHeight: '300px',
+    overflow: 'hidden',
   },
   controls: {
     display: 'flex',
@@ -51,9 +55,19 @@ export const Relaxed = (): JSXElement => {
       </div>
 
       <CollapseRelaxed visible={visible}>
-        <div className={classes.card}>
-          <LoremIpsum />
-        </div>
+        <Card className={classes.card}>
+          <CardHeader
+            header={
+              <Text as="h3" style={{ margin: 0 }} weight="semibold">
+                Lorem Ipsum
+              </Text>
+            }
+          />
+          {/* Wrapper div needed because Collapse controls maxHeight on its child to animate height */}
+          <div className={classes.cardContent}>
+            <LoremIpsum />
+          </div>
+        </Card>
       </CollapseRelaxed>
     </div>
   );

--- a/packages/react-components/react-motion-components-preview/stories/src/Collapse/CollapseSnappy.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Collapse/CollapseSnappy.stories.tsx
@@ -9,11 +9,11 @@ const useClasses = makeStyles({
   container: {
     display: 'grid',
     gridTemplate: `"controls ." "card card" / 1fr 1fr`,
-    gap: '20px 10px',
+    gap: `${tokens.spacingVerticalXL} ${tokens.spacingHorizontalMNudge}`,
   },
   card: {
     gridArea: 'card',
-    padding: '20px',
+    padding: tokens.spacingVerticalXL,
   },
   cardContent: {
     maxHeight: '300px',
@@ -27,7 +27,7 @@ const useClasses = makeStyles({
     border: `${tokens.strokeWidthThicker} solid ${tokens.colorNeutralForeground3}`,
     borderRadius: tokens.borderRadiusMedium,
     boxShadow: tokens.shadow16,
-    padding: '10px',
+    padding: tokens.spacingVerticalMNudge,
   },
   field: {
     flex: 1,
@@ -44,7 +44,7 @@ const LoremIpsum = () => (
 
 export const Snappy = (): JSXElement => {
   const classes = useClasses();
-  const [visible, setVisible] = React.useState<boolean>(false);
+  const [visible, setVisible] = React.useState<boolean>(true);
 
   return (
     <div className={classes.container}>

--- a/packages/react-components/react-motion-components-preview/stories/src/Collapse/CollapseSnappy.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Collapse/CollapseSnappy.stories.tsx
@@ -1,4 +1,4 @@
-import { Field, makeStyles, tokens, Switch } from '@fluentui/react-components';
+import { Card, CardHeader, Field, makeStyles, tokens, Switch, Text } from '@fluentui/react-components';
 import { CollapseSnappy } from '@fluentui/react-motion-components-preview';
 import * as React from 'react';
 import type { JSXElement } from '@fluentui/react-components';
@@ -13,7 +13,11 @@ const useClasses = makeStyles({
   },
   card: {
     gridArea: 'card',
-    padding: '10px',
+    padding: '20px',
+  },
+  cardContent: {
+    maxHeight: '300px',
+    overflow: 'hidden',
   },
   controls: {
     display: 'flex',
@@ -51,9 +55,19 @@ export const Snappy = (): JSXElement => {
       </div>
 
       <CollapseSnappy visible={visible}>
-        <div className={classes.card}>
-          <LoremIpsum />
-        </div>
+        <Card className={classes.card}>
+          <CardHeader
+            header={
+              <Text as="h3" style={{ margin: 0 }} weight="semibold">
+                Lorem Ipsum
+              </Text>
+            }
+          />
+          {/* Wrapper div needed because Collapse controls maxHeight on its child to animate height */}
+          <div className={classes.cardContent}>
+            <LoremIpsum />
+          </div>
+        </Card>
       </CollapseSnappy>
     </div>
   );

--- a/packages/react-components/react-motion-components-preview/stories/src/Collapse/CollapseSnappy.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Collapse/CollapseSnappy.stories.tsx
@@ -32,6 +32,9 @@ const useClasses = makeStyles({
   field: {
     flex: 1,
   },
+  cardHeaderText: {
+    margin: 0,
+  },
 });
 
 const LoremIpsum = () => (
@@ -58,7 +61,7 @@ export const Snappy = (): JSXElement => {
         <Card className={classes.card}>
           <CardHeader
             header={
-              <Text as="h3" style={{ margin: 0 }} weight="semibold">
+              <Text as="h3" className={classes.cardHeaderText} weight="semibold">
                 Lorem Ipsum
               </Text>
             }

--- a/packages/react-components/react-motion-components-preview/stories/src/Fade/Fade.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Fade/Fade.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import type { JSXElement } from '@fluentui/react-components';
 import type { PresenceComponentProps } from '@fluentui/react-components';
-import { Fade } from '@fluentui/react-motion-components-preview';
+import { Fade, type FadeParams } from '@fluentui/react-motion-components-preview';
 
 const LoremIpsum = React.forwardRef<HTMLDivElement, React.HTMLProps<HTMLDivElement>>((props, ref) => (
   <div ref={ref} {...props}>
@@ -11,7 +11,7 @@ const LoremIpsum = React.forwardRef<HTMLDivElement, React.HTMLProps<HTMLDivEleme
   </div>
 ));
 
-export const DefaultFade = (props: PresenceComponentProps): JSXElement => {
+export const DefaultFade = (props: PresenceComponentProps & FadeParams): JSXElement => {
   return (
     <Fade {...props}>
       <LoremIpsum />

--- a/packages/react-components/react-motion-components-preview/stories/src/Fade/Fade.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Fade/Fade.stories.tsx
@@ -1,7 +1,13 @@
 import * as React from 'react';
 import type { JSXElement } from '@fluentui/react-components';
-import type { PresenceComponentProps } from '@fluentui/react-components';
+import { makeStyles, tokens, type PresenceComponentProps } from '@fluentui/react-components';
 import { Fade, type FadeParams } from '@fluentui/react-motion-components-preview';
+
+const useClasses = makeStyles({
+  wrapper: {
+    padding: tokens.spacingVerticalXL,
+  },
+});
 
 const LoremIpsum = React.forwardRef<HTMLDivElement, React.HTMLProps<HTMLDivElement>>((props, ref) => (
   <div ref={ref} {...props}>
@@ -12,9 +18,12 @@ const LoremIpsum = React.forwardRef<HTMLDivElement, React.HTMLProps<HTMLDivEleme
 ));
 
 export const DefaultFade = (props: PresenceComponentProps & FadeParams): JSXElement => {
+  const classes = useClasses();
   return (
-    <Fade {...props}>
-      <LoremIpsum />
-    </Fade>
+    <div className={classes.wrapper}>
+      <Fade {...props}>
+        <LoremIpsum />
+      </Fade>
+    </div>
   );
 };

--- a/packages/react-components/react-motion-components-preview/stories/src/Fade/FadeCustomization.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Fade/FadeCustomization.stories.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import type { JSXElement } from '@fluentui/react-components';
 import {
+  Card,
+  CardHeader,
   createPresenceComponentVariant,
   Field,
   makeStyles,
@@ -9,6 +11,7 @@ import {
   motionTokens,
   Slider,
   Switch,
+  Text,
   tokens,
 } from '@fluentui/react-components';
 import { Fade } from '@fluentui/react-motion-components-preview';
@@ -19,11 +22,16 @@ const useClasses = makeStyles({
   container: {
     display: 'grid',
     gridTemplate: `"controls ." "card card" / 1fr 1fr`,
-    gap: '20px 10px',
+    gap: `${tokens.spacingVerticalXL} ${tokens.spacingHorizontalMNudge}`,
   },
   card: {
     gridArea: 'card',
-    padding: '10px',
+    padding: tokens.spacingVerticalXL,
+    maxHeight: '300px',
+    overflow: 'hidden',
+  },
+  cardHeaderText: {
+    margin: 0,
   },
   controls: {
     display: 'flex',
@@ -33,7 +41,7 @@ const useClasses = makeStyles({
     border: `${tokens.strokeWidthThicker} solid ${tokens.colorNeutralForeground3}`,
     borderRadius: tokens.borderRadiusMedium,
     boxShadow: tokens.shadow16,
-    padding: '10px',
+    padding: tokens.spacingVerticalMNudge,
   },
   field: {
     flex: 1,
@@ -120,9 +128,16 @@ export const Customization = (): JSXElement => {
       </div>
 
       <CustomFadeVariant imperativeRef={motionRef} visible={visible} unmountOnExit={unmountOnExit}>
-        <div className={classes.card}>
+        <Card className={classes.card}>
+          <CardHeader
+            header={
+              <Text as="h3" className={classes.cardHeaderText} weight="semibold">
+                Lorem Ipsum
+              </Text>
+            }
+          />
           <LoremIpsum />
-        </div>
+        </Card>
       </CustomFadeVariant>
     </div>
   );

--- a/packages/react-components/react-motion-components-preview/stories/src/Fade/FadeDefault.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Fade/FadeDefault.stories.tsx
@@ -7,11 +7,11 @@ const useClasses = makeStyles({
   container: {
     display: 'grid',
     gridTemplate: `"controls ." "card card" / 1fr 1fr`,
-    gap: '20px 10px',
+    gap: `${tokens.spacingVerticalXL} ${tokens.spacingHorizontalMNudge}`,
   },
   card: {
     gridArea: 'card',
-    padding: '20px',
+    padding: tokens.spacingVerticalXL,
     maxHeight: '300px',
     overflow: 'hidden',
   },
@@ -23,7 +23,7 @@ const useClasses = makeStyles({
     border: `${tokens.strokeWidthThicker} solid ${tokens.colorNeutralForeground3}`,
     borderRadius: tokens.borderRadiusMedium,
     boxShadow: tokens.shadow16,
-    padding: '10px',
+    padding: tokens.spacingVerticalMNudge,
   },
   field: {
     flex: 1,
@@ -40,7 +40,7 @@ const LoremIpsum = () => (
 
 export const Default = (): JSXElement => {
   const classes = useClasses();
-  const [visible, setVisible] = React.useState<boolean>(false);
+  const [visible, setVisible] = React.useState<boolean>(true);
 
   return (
     <div className={classes.container}>

--- a/packages/react-components/react-motion-components-preview/stories/src/Fade/FadeDefault.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Fade/FadeDefault.stories.tsx
@@ -28,6 +28,9 @@ const useClasses = makeStyles({
   field: {
     flex: 1,
   },
+  cardHeaderText: {
+    margin: 0,
+  },
 });
 
 const LoremIpsum = () => (
@@ -54,7 +57,7 @@ export const Default = (): JSXElement => {
         <Card className={classes.card}>
           <CardHeader
             header={
-              <Text as="h3" style={{ margin: 0 }} weight="semibold">
+              <Text as="h3" className={classes.cardHeaderText} weight="semibold">
                 Lorem Ipsum
               </Text>
             }

--- a/packages/react-components/react-motion-components-preview/stories/src/Fade/FadeDefault.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Fade/FadeDefault.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import type { JSXElement } from '@fluentui/react-components';
-import { Field, makeStyles, tokens, Switch } from '@fluentui/react-components';
+import { Card, CardHeader, Field, makeStyles, tokens, Switch, Text } from '@fluentui/react-components';
 import { Fade } from '@fluentui/react-motion-components-preview';
 
 const useClasses = makeStyles({
@@ -11,7 +11,9 @@ const useClasses = makeStyles({
   },
   card: {
     gridArea: 'card',
-    padding: '10px',
+    padding: '20px',
+    maxHeight: '300px',
+    overflow: 'hidden',
   },
   controls: {
     display: 'flex',
@@ -49,9 +51,16 @@ export const Default = (): JSXElement => {
       </div>
 
       <Fade visible={visible}>
-        <div className={classes.card}>
+        <Card className={classes.card}>
+          <CardHeader
+            header={
+              <Text as="h3" style={{ margin: 0 }} weight="semibold">
+                Lorem Ipsum
+              </Text>
+            }
+          />
           <LoremIpsum />
-        </div>
+        </Card>
       </Fade>
     </div>
   );

--- a/packages/react-components/react-motion-components-preview/stories/src/Fade/FadeRelaxed.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Fade/FadeRelaxed.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import type { JSXElement } from '@fluentui/react-components';
-import { Field, makeStyles, tokens, Switch } from '@fluentui/react-components';
+import { Card, CardHeader, Field, makeStyles, tokens, Switch, Text } from '@fluentui/react-components';
 import { FadeRelaxed } from '@fluentui/react-motion-components-preview';
 
 import description from './FadeRelaxed.stories.md';
@@ -13,7 +13,9 @@ const useClasses = makeStyles({
   },
   card: {
     gridArea: 'card',
-    padding: '10px',
+    padding: '20px',
+    maxHeight: '300px',
+    overflow: 'hidden',
   },
   controls: {
     display: 'flex',
@@ -51,9 +53,16 @@ export const Relaxed = (): JSXElement => {
       </div>
 
       <FadeRelaxed visible={visible}>
-        <div className={classes.card}>
+        <Card className={classes.card}>
+          <CardHeader
+            header={
+              <Text as="h3" style={{ margin: 0 }} weight="semibold">
+                Lorem Ipsum
+              </Text>
+            }
+          />
           <LoremIpsum />
-        </div>
+        </Card>
       </FadeRelaxed>
     </div>
   );

--- a/packages/react-components/react-motion-components-preview/stories/src/Fade/FadeRelaxed.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Fade/FadeRelaxed.stories.tsx
@@ -9,11 +9,11 @@ const useClasses = makeStyles({
   container: {
     display: 'grid',
     gridTemplate: `"controls ." "card card" / 1fr 1fr`,
-    gap: '20px 10px',
+    gap: `${tokens.spacingVerticalXL} ${tokens.spacingHorizontalMNudge}`,
   },
   card: {
     gridArea: 'card',
-    padding: '20px',
+    padding: tokens.spacingVerticalXL,
     maxHeight: '300px',
     overflow: 'hidden',
   },
@@ -25,7 +25,7 @@ const useClasses = makeStyles({
     border: `${tokens.strokeWidthThicker} solid ${tokens.colorNeutralForeground3}`,
     borderRadius: tokens.borderRadiusMedium,
     boxShadow: tokens.shadow16,
-    padding: '10px',
+    padding: tokens.spacingVerticalMNudge,
   },
   field: {
     flex: 1,
@@ -42,7 +42,7 @@ const LoremIpsum = () => (
 
 export const Relaxed = (): JSXElement => {
   const classes = useClasses();
-  const [visible, setVisible] = React.useState<boolean>(false);
+  const [visible, setVisible] = React.useState<boolean>(true);
 
   return (
     <div className={classes.container}>

--- a/packages/react-components/react-motion-components-preview/stories/src/Fade/FadeRelaxed.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Fade/FadeRelaxed.stories.tsx
@@ -30,6 +30,9 @@ const useClasses = makeStyles({
   field: {
     flex: 1,
   },
+  cardHeaderText: {
+    margin: 0,
+  },
 });
 
 const LoremIpsum = () => (
@@ -56,7 +59,7 @@ export const Relaxed = (): JSXElement => {
         <Card className={classes.card}>
           <CardHeader
             header={
-              <Text as="h3" style={{ margin: 0 }} weight="semibold">
+              <Text as="h3" className={classes.cardHeaderText} weight="semibold">
                 Lorem Ipsum
               </Text>
             }

--- a/packages/react-components/react-motion-components-preview/stories/src/Fade/FadeSnappy.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Fade/FadeSnappy.stories.tsx
@@ -9,11 +9,11 @@ const useClasses = makeStyles({
   container: {
     display: 'grid',
     gridTemplate: `"controls ." "card card" / 1fr 1fr`,
-    gap: '20px 10px',
+    gap: `${tokens.spacingVerticalXL} ${tokens.spacingHorizontalMNudge}`,
   },
   card: {
     gridArea: 'card',
-    padding: '20px',
+    padding: tokens.spacingVerticalXL,
     maxHeight: '300px',
     overflow: 'hidden',
   },
@@ -25,7 +25,7 @@ const useClasses = makeStyles({
     border: `${tokens.strokeWidthThicker} solid ${tokens.colorNeutralForeground3}`,
     borderRadius: tokens.borderRadiusMedium,
     boxShadow: tokens.shadow16,
-    padding: '10px',
+    padding: tokens.spacingVerticalMNudge,
   },
   field: {
     flex: 1,
@@ -42,7 +42,7 @@ const LoremIpsum = () => (
 
 export const Snappy = (): JSXElement => {
   const classes = useClasses();
-  const [visible, setVisible] = React.useState<boolean>(false);
+  const [visible, setVisible] = React.useState<boolean>(true);
 
   return (
     <div className={classes.container}>

--- a/packages/react-components/react-motion-components-preview/stories/src/Fade/FadeSnappy.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Fade/FadeSnappy.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import type { JSXElement } from '@fluentui/react-components';
-import { Field, makeStyles, tokens, Switch } from '@fluentui/react-components';
+import { Card, CardHeader, Field, makeStyles, tokens, Switch, Text } from '@fluentui/react-components';
 import { FadeSnappy } from '@fluentui/react-motion-components-preview';
 
 import description from './FadeSnappy.stories.md';
@@ -13,7 +13,9 @@ const useClasses = makeStyles({
   },
   card: {
     gridArea: 'card',
-    padding: '10px',
+    padding: '20px',
+    maxHeight: '300px',
+    overflow: 'hidden',
   },
   controls: {
     display: 'flex',
@@ -51,9 +53,16 @@ export const Snappy = (): JSXElement => {
       </div>
 
       <FadeSnappy visible={visible}>
-        <div className={classes.card}>
+        <Card className={classes.card}>
+          <CardHeader
+            header={
+              <Text as="h3" style={{ margin: 0 }} weight="semibold">
+                Lorem Ipsum
+              </Text>
+            }
+          />
           <LoremIpsum />
-        </div>
+        </Card>
       </FadeSnappy>
     </div>
   );

--- a/packages/react-components/react-motion-components-preview/stories/src/Fade/FadeSnappy.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Fade/FadeSnappy.stories.tsx
@@ -30,6 +30,9 @@ const useClasses = makeStyles({
   field: {
     flex: 1,
   },
+  cardHeaderText: {
+    margin: 0,
+  },
 });
 
 const LoremIpsum = () => (
@@ -56,7 +59,7 @@ export const Snappy = (): JSXElement => {
         <Card className={classes.card}>
           <CardHeader
             header={
-              <Text as="h3" style={{ margin: 0 }} weight="semibold">
+              <Text as="h3" className={classes.cardHeaderText} weight="semibold">
                 Lorem Ipsum
               </Text>
             }

--- a/packages/react-components/react-motion-components-preview/stories/src/Rotate/Rotate.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Rotate/Rotate.stories.tsx
@@ -1,7 +1,13 @@
 import * as React from 'react';
 import type { JSXElement } from '@fluentui/react-components';
-import type { PresenceComponentProps } from '@fluentui/react-components';
+import { makeStyles, tokens, type PresenceComponentProps } from '@fluentui/react-components';
 import { Rotate, type RotateParams } from '@fluentui/react-motion-components-preview';
+
+const useClasses = makeStyles({
+  wrapper: {
+    padding: tokens.spacingVerticalXL,
+  },
+});
 
 const LoremIpsum = React.forwardRef<HTMLDivElement, React.HTMLProps<HTMLDivElement>>((props, ref) => (
   <div ref={ref} {...props}>
@@ -12,9 +18,12 @@ const LoremIpsum = React.forwardRef<HTMLDivElement, React.HTMLProps<HTMLDivEleme
 ));
 
 export const DefaultRotate = (props: PresenceComponentProps & RotateParams): JSXElement => {
+  const classes = useClasses();
   return (
-    <Rotate {...props}>
-      <LoremIpsum />
-    </Rotate>
+    <div className={classes.wrapper}>
+      <Rotate {...props}>
+        <LoremIpsum />
+      </Rotate>
+    </div>
   );
 };

--- a/packages/react-components/react-motion-components-preview/stories/src/Rotate/Rotate.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Rotate/Rotate.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import type { JSXElement } from '@fluentui/react-components';
 import type { PresenceComponentProps } from '@fluentui/react-components';
-import { Scale, type ScaleParams } from '@fluentui/react-motion-components-preview';
+import { Rotate, type RotateParams } from '@fluentui/react-motion-components-preview';
 
 const LoremIpsum = React.forwardRef<HTMLDivElement, React.HTMLProps<HTMLDivElement>>((props, ref) => (
   <div ref={ref} {...props}>
@@ -11,10 +11,10 @@ const LoremIpsum = React.forwardRef<HTMLDivElement, React.HTMLProps<HTMLDivEleme
   </div>
 ));
 
-export const DefaultScale = (props: PresenceComponentProps & ScaleParams): JSXElement => {
+export const DefaultRotate = (props: PresenceComponentProps & RotateParams): JSXElement => {
   return (
-    <Scale {...props}>
+    <Rotate {...props}>
       <LoremIpsum />
-    </Scale>
+    </Rotate>
   );
 };

--- a/packages/react-components/react-motion-components-preview/stories/src/Rotate/RotateDefault.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Rotate/RotateDefault.stories.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import type { JSXElement } from '@fluentui/react-components';
 import {
+  Card,
+  CardHeader,
   Field,
   makeStyles,
   tokens,
@@ -11,6 +13,7 @@ import {
   Radio,
   motionTokens,
   Button,
+  Text,
 } from '@fluentui/react-components';
 import { Rotate, type RotateParams } from '@fluentui/react-motion-components-preview';
 
@@ -47,7 +50,7 @@ const useClasses = makeStyles({
     fontWeight: tokens.fontWeightSemibold,
     color: tokens.colorNeutralForeground2,
     marginBottom: tokens.spacingVerticalXS,
-    borderBottom: `1px solid ${tokens.colorNeutralStroke2}`,
+    borderBottom: `${tokens.strokeWidthThin} solid ${tokens.colorNeutralStroke2}`,
     paddingBottom: tokens.spacingVerticalXS,
   },
   toggleGroup: {
@@ -199,9 +202,16 @@ export const Default = (props: React.ComponentProps<typeof Rotate>): JSXElement 
       </div>
 
       <Rotate visible={visible} axis={axis} outAngle={outAngle} duration={duration}>
-        <div className={classes.card}>
+        <Card className={classes.card}>
+          <CardHeader
+            header={
+              <Text as="h3" style={{ margin: 0 }} weight="semibold">
+                Lorem Ipsum
+              </Text>
+            }
+          />
           <LoremIpsum />
-        </div>
+        </Card>
       </Rotate>
     </div>
   );

--- a/packages/react-components/react-motion-components-preview/stories/src/Rotate/RotateDefault.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Rotate/RotateDefault.stories.tsx
@@ -24,11 +24,13 @@ const useClasses = makeStyles({
     display: 'grid',
     gridTemplate: `"controls ." "card card" / 1fr 1fr`,
     gap: `${tokens.spacingVerticalXL} ${tokens.spacingHorizontalMNudge}`,
-    overflow: 'clip',
   },
   card: {
     gridArea: 'card',
     padding: tokens.spacingHorizontalMNudge,
+  },
+  cardHeaderText: {
+    margin: 0,
   },
   controls: {
     display: 'flex',
@@ -205,7 +207,7 @@ export const Default = (props: React.ComponentProps<typeof Rotate>): JSXElement 
         <Card className={classes.card}>
           <CardHeader
             header={
-              <Text as="h3" style={{ margin: 0 }} weight="semibold">
+              <Text as="h3" className={classes.cardHeaderText} weight="semibold">
                 Lorem Ipsum
               </Text>
             }

--- a/packages/react-components/react-motion-components-preview/stories/src/Rotate/index.stories.ts
+++ b/packages/react-components/react-motion-components-preview/stories/src/Rotate/index.stories.ts
@@ -1,4 +1,4 @@
-import { Default as Rotate } from './RotateDefault.stories';
+import { DefaultRotate as Rotate } from './Rotate.stories';
 import RotateDescription from './RotateDescription.md';
 
 export { Default } from './RotateDefault.stories';

--- a/packages/react-components/react-motion-components-preview/stories/src/Scale/Scale.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Scale/Scale.stories.tsx
@@ -1,7 +1,13 @@
 import * as React from 'react';
 import type { JSXElement } from '@fluentui/react-components';
-import type { PresenceComponentProps } from '@fluentui/react-components';
+import { makeStyles, tokens, type PresenceComponentProps } from '@fluentui/react-components';
 import { Scale, type ScaleParams } from '@fluentui/react-motion-components-preview';
+
+const useClasses = makeStyles({
+  wrapper: {
+    padding: tokens.spacingVerticalXL,
+  },
+});
 
 const LoremIpsum = React.forwardRef<HTMLDivElement, React.HTMLProps<HTMLDivElement>>((props, ref) => (
   <div ref={ref} {...props}>
@@ -12,9 +18,12 @@ const LoremIpsum = React.forwardRef<HTMLDivElement, React.HTMLProps<HTMLDivEleme
 ));
 
 export const DefaultScale = (props: PresenceComponentProps & ScaleParams): JSXElement => {
+  const classes = useClasses();
   return (
-    <Scale {...props}>
-      <LoremIpsum />
-    </Scale>
+    <div className={classes.wrapper}>
+      <Scale {...props}>
+        <LoremIpsum />
+      </Scale>
+    </div>
   );
 };

--- a/packages/react-components/react-motion-components-preview/stories/src/Scale/ScaleCustomization.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Scale/ScaleCustomization.stories.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import type { JSXElement } from '@fluentui/react-components';
 import {
+  Card,
+  CardHeader,
   createPresenceComponentVariant,
   Field,
   makeStyles,
@@ -9,6 +11,7 @@ import {
   motionTokens,
   Slider,
   Switch,
+  Text,
   tokens,
 } from '@fluentui/react-components';
 
@@ -19,11 +22,16 @@ const useClasses = makeStyles({
   container: {
     display: 'grid',
     gridTemplate: `"controls ." "card card" / 1fr 1fr`,
-    gap: '20px 10px',
+    gap: `${tokens.spacingVerticalXL} ${tokens.spacingHorizontalMNudge}`,
   },
   card: {
     gridArea: 'card',
-    padding: '10px',
+    padding: tokens.spacingVerticalXL,
+    maxHeight: '300px',
+    overflow: 'hidden',
+  },
+  cardHeaderText: {
+    margin: 0,
   },
   controls: {
     display: 'flex',
@@ -33,7 +41,7 @@ const useClasses = makeStyles({
     border: `${tokens.strokeWidthThicker} solid ${tokens.colorNeutralForeground3}`,
     borderRadius: tokens.borderRadiusMedium,
     boxShadow: tokens.shadow16,
-    padding: '10px',
+    padding: tokens.spacingVerticalMNudge,
   },
   field: {
     flex: 1,
@@ -143,9 +151,16 @@ export const Customization = (): JSXElement => {
         visible={visible}
         unmountOnExit={unmountOnExit}
       >
-        <div className={classes.card}>
+        <Card className={classes.card}>
+          <CardHeader
+            header={
+              <Text as="h3" className={classes.cardHeaderText} weight="semibold">
+                Lorem Ipsum
+              </Text>
+            }
+          />
           <LoremIpsum />
-        </div>
+        </Card>
       </CustomScaleVariant>
     </div>
   );

--- a/packages/react-components/react-motion-components-preview/stories/src/Scale/ScaleDefault.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Scale/ScaleDefault.stories.tsx
@@ -7,11 +7,11 @@ const useClasses = makeStyles({
   container: {
     display: 'grid',
     gridTemplate: `"controls ." "card card" / 1fr 1fr`,
-    gap: '20px 10px',
+    gap: `${tokens.spacingVerticalXL} ${tokens.spacingHorizontalMNudge}`,
   },
   card: {
     gridArea: 'card',
-    padding: '20px',
+    padding: tokens.spacingVerticalXL,
     maxHeight: '300px',
     overflow: 'hidden',
   },
@@ -23,7 +23,7 @@ const useClasses = makeStyles({
     border: `${tokens.strokeWidthThicker} solid ${tokens.colorNeutralForeground3}`,
     borderRadius: tokens.borderRadiusMedium,
     boxShadow: tokens.shadow16,
-    padding: '10px',
+    padding: tokens.spacingVerticalMNudge,
   },
   field: {
     flex: 1,

--- a/packages/react-components/react-motion-components-preview/stories/src/Scale/ScaleDefault.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Scale/ScaleDefault.stories.tsx
@@ -28,6 +28,9 @@ const useClasses = makeStyles({
   field: {
     flex: 1,
   },
+  cardHeaderText: {
+    margin: 0,
+  },
 });
 
 const LoremIpsum = () => (
@@ -54,7 +57,7 @@ export const Default = (): JSXElement => {
         <Card className={classes.card}>
           <CardHeader
             header={
-              <Text as="h3" style={{ margin: 0 }} weight="semibold">
+              <Text as="h3" className={classes.cardHeaderText} weight="semibold">
                 Lorem Ipsum
               </Text>
             }

--- a/packages/react-components/react-motion-components-preview/stories/src/Scale/ScaleDefault.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Scale/ScaleDefault.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import type { JSXElement } from '@fluentui/react-components';
-import { Field, makeStyles, tokens, Switch } from '@fluentui/react-components';
+import { Card, CardHeader, Field, makeStyles, tokens, Switch, Text } from '@fluentui/react-components';
 import { Scale } from '@fluentui/react-motion-components-preview';
 
 const useClasses = makeStyles({
@@ -11,7 +11,9 @@ const useClasses = makeStyles({
   },
   card: {
     gridArea: 'card',
-    padding: '10px',
+    padding: '20px',
+    maxHeight: '300px',
+    overflow: 'hidden',
   },
   controls: {
     display: 'flex',
@@ -49,9 +51,16 @@ export const Default = (): JSXElement => {
       </div>
 
       <Scale visible={visible}>
-        <div className={classes.card}>
+        <Card className={classes.card}>
+          <CardHeader
+            header={
+              <Text as="h3" style={{ margin: 0 }} weight="semibold">
+                Lorem Ipsum
+              </Text>
+            }
+          />
           <LoremIpsum />
-        </div>
+        </Card>
       </Scale>
     </div>
   );

--- a/packages/react-components/react-motion-components-preview/stories/src/Scale/ScaleRelaxed.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Scale/ScaleRelaxed.stories.tsx
@@ -9,11 +9,11 @@ const useClasses = makeStyles({
   container: {
     display: 'grid',
     gridTemplate: `"controls ." "card card" / 1fr 1fr`,
-    gap: '20px 10px',
+    gap: `${tokens.spacingVerticalXL} ${tokens.spacingHorizontalMNudge}`,
   },
   card: {
     gridArea: 'card',
-    padding: '20px',
+    padding: tokens.spacingVerticalXL,
     maxHeight: '300px',
     overflow: 'hidden',
   },
@@ -25,7 +25,7 @@ const useClasses = makeStyles({
     border: `${tokens.strokeWidthThicker} solid ${tokens.colorNeutralForeground3}`,
     borderRadius: tokens.borderRadiusMedium,
     boxShadow: tokens.shadow16,
-    padding: '10px',
+    padding: tokens.spacingVerticalMNudge,
   },
   field: {
     flex: 1,

--- a/packages/react-components/react-motion-components-preview/stories/src/Scale/ScaleRelaxed.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Scale/ScaleRelaxed.stories.tsx
@@ -30,6 +30,9 @@ const useClasses = makeStyles({
   field: {
     flex: 1,
   },
+  cardHeaderText: {
+    margin: 0,
+  },
 });
 
 const LoremIpsum = () => (
@@ -56,7 +59,7 @@ export const Relaxed = (): JSXElement => {
         <Card className={classes.card}>
           <CardHeader
             header={
-              <Text as="h3" style={{ margin: 0 }} weight="semibold">
+              <Text as="h3" className={classes.cardHeaderText} weight="semibold">
                 Lorem Ipsum
               </Text>
             }

--- a/packages/react-components/react-motion-components-preview/stories/src/Scale/ScaleRelaxed.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Scale/ScaleRelaxed.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import type { JSXElement } from '@fluentui/react-components';
-import { Field, makeStyles, tokens, Switch } from '@fluentui/react-components';
+import { Card, CardHeader, Field, makeStyles, tokens, Switch, Text } from '@fluentui/react-components';
 import { ScaleRelaxed } from '@fluentui/react-motion-components-preview';
 
 import description from './ScaleRelaxed.stories.md';
@@ -13,7 +13,9 @@ const useClasses = makeStyles({
   },
   card: {
     gridArea: 'card',
-    padding: '10px',
+    padding: '20px',
+    maxHeight: '300px',
+    overflow: 'hidden',
   },
   controls: {
     display: 'flex',
@@ -51,9 +53,16 @@ export const Relaxed = (): JSXElement => {
       </div>
 
       <ScaleRelaxed visible={visible}>
-        <div className={classes.card}>
+        <Card className={classes.card}>
+          <CardHeader
+            header={
+              <Text as="h3" style={{ margin: 0 }} weight="semibold">
+                Lorem Ipsum
+              </Text>
+            }
+          />
           <LoremIpsum />
-        </div>
+        </Card>
       </ScaleRelaxed>
     </div>
   );

--- a/packages/react-components/react-motion-components-preview/stories/src/Scale/ScaleSnappy.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Scale/ScaleSnappy.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import type { JSXElement } from '@fluentui/react-components';
-import { Field, makeStyles, tokens, Switch } from '@fluentui/react-components';
+import { Card, CardHeader, Field, makeStyles, Switch, Text } from '@fluentui/react-components';
 import { ScaleSnappy } from '@fluentui/react-motion-components-preview';
 
 import description from './ScaleSnappy.stories.md';
@@ -13,16 +13,12 @@ const useClasses = makeStyles({
   },
   card: {
     gridArea: 'card',
-    padding: '10px',
+    padding: '20px',
   },
   controls: {
     display: 'flex',
     flexDirection: 'column',
     gridArea: 'controls',
-
-    border: `${tokens.strokeWidthThicker} solid ${tokens.colorNeutralForeground3}`,
-    borderRadius: tokens.borderRadiusMedium,
-    boxShadow: tokens.shadow16,
     padding: '10px',
   },
   field: {
@@ -44,16 +40,23 @@ export const Snappy = (): JSXElement => {
 
   return (
     <div className={classes.container}>
-      <div className={classes.controls}>
+      <Card className={classes.controls}>
         <Field className={classes.field}>
           <Switch label="Visible" checked={visible} onChange={() => setVisible(v => !v)} />
         </Field>
-      </div>
+      </Card>
 
       <ScaleSnappy visible={visible}>
-        <div className={classes.card}>
+        <Card className={classes.card}>
+          <CardHeader
+            header={
+              <Text as="h3" style={{ margin: 0 }} weight="semibold">
+                Lorem Ipsum
+              </Text>
+            }
+          />
           <LoremIpsum />
-        </div>
+        </Card>
       </ScaleSnappy>
     </div>
   );

--- a/packages/react-components/react-motion-components-preview/stories/src/Scale/ScaleSnappy.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Scale/ScaleSnappy.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import type { JSXElement } from '@fluentui/react-components';
-import { Card, CardHeader, Field, makeStyles, Switch, Text } from '@fluentui/react-components';
+import { Card, CardHeader, Field, makeStyles, tokens, Switch, Text } from '@fluentui/react-components';
 import { ScaleSnappy } from '@fluentui/react-motion-components-preview';
 
 import description from './ScaleSnappy.stories.md';
@@ -9,17 +9,23 @@ const useClasses = makeStyles({
   container: {
     display: 'grid',
     gridTemplate: `"controls ." "card card" / 1fr 1fr`,
-    gap: '20px 10px',
+    gap: `${tokens.spacingVerticalXL} ${tokens.spacingHorizontalMNudge}`,
   },
   card: {
     gridArea: 'card',
-    padding: '20px',
+    padding: tokens.spacingVerticalXL,
+    maxHeight: '300px',
+    overflow: 'hidden',
   },
   controls: {
     display: 'flex',
     flexDirection: 'column',
     gridArea: 'controls',
-    padding: '10px',
+
+    border: `${tokens.strokeWidthThicker} solid ${tokens.colorNeutralForeground3}`,
+    borderRadius: tokens.borderRadiusMedium,
+    boxShadow: tokens.shadow16,
+    padding: tokens.spacingVerticalMNudge,
   },
   field: {
     flex: 1,
@@ -40,11 +46,11 @@ export const Snappy = (): JSXElement => {
 
   return (
     <div className={classes.container}>
-      <Card className={classes.controls}>
+      <div className={classes.controls}>
         <Field className={classes.field}>
           <Switch label="Visible" checked={visible} onChange={() => setVisible(v => !v)} />
         </Field>
-      </Card>
+      </div>
 
       <ScaleSnappy visible={visible}>
         <Card className={classes.card}>

--- a/packages/react-components/react-motion-components-preview/stories/src/Scale/ScaleSnappy.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Scale/ScaleSnappy.stories.tsx
@@ -30,6 +30,9 @@ const useClasses = makeStyles({
   field: {
     flex: 1,
   },
+  cardHeaderText: {
+    margin: 0,
+  },
 });
 
 const LoremIpsum = () => (
@@ -56,7 +59,7 @@ export const Snappy = (): JSXElement => {
         <Card className={classes.card}>
           <CardHeader
             header={
-              <Text as="h3" style={{ margin: 0 }} weight="semibold">
+              <Text as="h3" className={classes.cardHeaderText} weight="semibold">
                 Lorem Ipsum
               </Text>
             }

--- a/packages/react-components/react-motion-components-preview/stories/src/Slide/Slide.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Slide/Slide.stories.tsx
@@ -1,7 +1,13 @@
 import * as React from 'react';
 import type { JSXElement } from '@fluentui/react-components';
-import type { PresenceComponentProps } from '@fluentui/react-components';
+import { makeStyles, tokens, type PresenceComponentProps } from '@fluentui/react-components';
 import { Slide, type SlideParams } from '@fluentui/react-motion-components-preview';
+
+const useClasses = makeStyles({
+  wrapper: {
+    padding: tokens.spacingVerticalXL,
+  },
+});
 
 const LoremIpsum = React.forwardRef<HTMLDivElement, React.HTMLProps<HTMLDivElement>>((props, ref) => (
   <div ref={ref} {...props}>
@@ -12,9 +18,12 @@ const LoremIpsum = React.forwardRef<HTMLDivElement, React.HTMLProps<HTMLDivEleme
 ));
 
 export const DefaultSlide = (props: PresenceComponentProps & SlideParams): JSXElement => {
+  const classes = useClasses();
   return (
-    <Slide {...props}>
-      <LoremIpsum />
-    </Slide>
+    <div className={classes.wrapper}>
+      <Slide {...props}>
+        <LoremIpsum />
+      </Slide>
+    </div>
   );
 };

--- a/packages/react-components/react-motion-components-preview/stories/src/Slide/Slide.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Slide/Slide.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import type { JSXElement } from '@fluentui/react-components';
 import type { PresenceComponentProps } from '@fluentui/react-components';
-import { Scale, type ScaleParams } from '@fluentui/react-motion-components-preview';
+import { Slide, type SlideParams } from '@fluentui/react-motion-components-preview';
 
 const LoremIpsum = React.forwardRef<HTMLDivElement, React.HTMLProps<HTMLDivElement>>((props, ref) => (
   <div ref={ref} {...props}>
@@ -11,10 +11,10 @@ const LoremIpsum = React.forwardRef<HTMLDivElement, React.HTMLProps<HTMLDivEleme
   </div>
 ));
 
-export const DefaultScale = (props: PresenceComponentProps & ScaleParams): JSXElement => {
+export const DefaultSlide = (props: PresenceComponentProps & SlideParams): JSXElement => {
   return (
-    <Scale {...props}>
+    <Slide {...props}>
       <LoremIpsum />
-    </Scale>
+    </Slide>
   );
 };

--- a/packages/react-components/react-motion-components-preview/stories/src/Slide/SlideCardsDemo.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Slide/SlideCardsDemo.stories.tsx
@@ -108,19 +108,16 @@ export const CardsDemo = (): JSXElement => {
     });
   };
 
-  const showAll = () => {
-    setVisibleCards(new Set(cardData.map(card => card.id)));
-  };
+  const allVisible = cardData.every(card => visibleCards.has(card.id));
 
-  const hideAll = () => {
-    setVisibleCards(new Set());
+  const toggleAll = () => {
+    setVisibleCards(allVisible ? new Set() : new Set(cardData.map(card => card.id)));
   };
 
   return (
     <div className={classes.container}>
       <div className={classes.controls}>
-        <Button onClick={showAll}>Show All</Button>
-        <Button onClick={hideAll}>Hide All</Button>
+        <Button onClick={toggleAll}>{allVisible ? 'Hide All' : 'Show All'}</Button>
         {cardData.map(card => (
           <Button
             key={card.id}

--- a/packages/react-components/react-motion-components-preview/stories/src/Slide/SlideDefault.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Slide/SlideDefault.stories.tsx
@@ -1,17 +1,19 @@
 import * as React from 'react';
 import type { JSXElement } from '@fluentui/react-components';
-import { Field, makeStyles, tokens, Switch } from '@fluentui/react-components';
+import { Card, CardHeader, Field, makeStyles, tokens, Switch, Text } from '@fluentui/react-components';
 import { Slide } from '@fluentui/react-motion-components-preview';
 
 const useClasses = makeStyles({
   container: {
     display: 'grid',
     gridTemplate: `"controls ." "card card" / 1fr 1fr`,
-    gap: '20px 10px',
+    gap: `${tokens.spacingVerticalXL} ${tokens.spacingHorizontalMNudge}`,
   },
   card: {
     gridArea: 'card',
-    padding: '10px',
+    padding: tokens.spacingVerticalXL,
+    maxHeight: '300px',
+    overflow: 'hidden',
   },
   controls: {
     display: 'flex',
@@ -21,7 +23,7 @@ const useClasses = makeStyles({
     border: `${tokens.strokeWidthThicker} solid ${tokens.colorNeutralForeground3}`,
     borderRadius: tokens.borderRadiusMedium,
     boxShadow: tokens.shadow16,
-    padding: '10px',
+    padding: tokens.spacingVerticalMNudge,
   },
   field: {
     flex: 1,
@@ -49,9 +51,16 @@ export const Default = (): JSXElement => {
       </div>
 
       <Slide visible={visible} outY="20px">
-        <div className={classes.card}>
+        <Card className={classes.card}>
+          <CardHeader
+            header={
+              <Text as="h3" style={{ margin: 0 }} weight="semibold">
+                Lorem Ipsum
+              </Text>
+            }
+          />
           <LoremIpsum />
-        </div>
+        </Card>
       </Slide>
     </div>
   );

--- a/packages/react-components/react-motion-components-preview/stories/src/Slide/SlideDefault.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Slide/SlideDefault.stories.tsx
@@ -28,6 +28,9 @@ const useClasses = makeStyles({
   field: {
     flex: 1,
   },
+  cardHeaderText: {
+    margin: 0,
+  },
 });
 
 const LoremIpsum = () => (
@@ -54,7 +57,7 @@ export const Default = (): JSXElement => {
         <Card className={classes.card}>
           <CardHeader
             header={
-              <Text as="h3" style={{ margin: 0 }} weight="semibold">
+              <Text as="h3" className={classes.cardHeaderText} weight="semibold">
                 Lorem Ipsum
               </Text>
             }

--- a/packages/react-components/react-motion-components-preview/stories/src/Slide/SlideRelaxed.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Slide/SlideRelaxed.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import type { JSXElement } from '@fluentui/react-components';
-import { Field, makeStyles, tokens, Switch } from '@fluentui/react-components';
+import { Card, CardHeader, Field, makeStyles, tokens, Switch, Text } from '@fluentui/react-components';
 import { SlideRelaxed } from '@fluentui/react-motion-components-preview';
 
 import description from './SlideRelaxed.stories.md';
@@ -9,11 +9,16 @@ const useClasses = makeStyles({
   container: {
     display: 'grid',
     gridTemplate: `"controls ." "card card" / 1fr 1fr`,
-    gap: '20px 10px',
+    gap: `${tokens.spacingVerticalXL} ${tokens.spacingHorizontalMNudge}`,
   },
   card: {
     gridArea: 'card',
-    padding: '10px',
+    padding: tokens.spacingVerticalXL,
+    maxHeight: '300px',
+    overflow: 'hidden',
+  },
+  cardHeaderText: {
+    margin: 0,
   },
   controls: {
     display: 'flex',
@@ -23,7 +28,7 @@ const useClasses = makeStyles({
     border: `${tokens.strokeWidthThicker} solid ${tokens.colorNeutralForeground3}`,
     borderRadius: tokens.borderRadiusMedium,
     boxShadow: tokens.shadow16,
-    padding: '10px',
+    padding: tokens.spacingVerticalMNudge,
   },
   field: {
     flex: 1,
@@ -51,9 +56,16 @@ export const Relaxed = (): JSXElement => {
       </div>
 
       <SlideRelaxed visible={visible} outY="20px">
-        <div className={classes.card}>
+        <Card className={classes.card}>
+          <CardHeader
+            header={
+              <Text as="h3" className={classes.cardHeaderText} weight="semibold">
+                Lorem Ipsum
+              </Text>
+            }
+          />
           <LoremIpsum />
-        </div>
+        </Card>
       </SlideRelaxed>
     </div>
   );

--- a/packages/react-components/react-motion-components-preview/stories/src/Slide/SlideRelaxed.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Slide/SlideRelaxed.stories.tsx
@@ -50,7 +50,7 @@ export const Relaxed = (): JSXElement => {
         </Field>
       </div>
 
-      <SlideRelaxed visible={visible}>
+      <SlideRelaxed visible={visible} outY="20px">
         <div className={classes.card}>
           <LoremIpsum />
         </div>

--- a/packages/react-components/react-motion-components-preview/stories/src/Slide/SlideSnappy.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Slide/SlideSnappy.stories.tsx
@@ -50,7 +50,7 @@ export const Snappy = (): JSXElement => {
         </Field>
       </div>
 
-      <SlideSnappy visible={visible}>
+      <SlideSnappy visible={visible} outY="20px">
         <div className={classes.card}>
           <LoremIpsum />
         </div>

--- a/packages/react-components/react-motion-components-preview/stories/src/Slide/SlideSnappy.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Slide/SlideSnappy.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import type { JSXElement } from '@fluentui/react-components';
-import { Field, makeStyles, tokens, Switch } from '@fluentui/react-components';
+import { Card, CardHeader, Field, makeStyles, tokens, Switch, Text } from '@fluentui/react-components';
 import { SlideSnappy } from '@fluentui/react-motion-components-preview';
 
 import description from './SlideSnappy.stories.md';
@@ -9,11 +9,16 @@ const useClasses = makeStyles({
   container: {
     display: 'grid',
     gridTemplate: `"controls ." "card card" / 1fr 1fr`,
-    gap: '20px 10px',
+    gap: `${tokens.spacingVerticalXL} ${tokens.spacingHorizontalMNudge}`,
   },
   card: {
     gridArea: 'card',
-    padding: '10px',
+    padding: tokens.spacingVerticalXL,
+    maxHeight: '300px',
+    overflow: 'hidden',
+  },
+  cardHeaderText: {
+    margin: 0,
   },
   controls: {
     display: 'flex',
@@ -23,7 +28,7 @@ const useClasses = makeStyles({
     border: `${tokens.strokeWidthThicker} solid ${tokens.colorNeutralForeground3}`,
     borderRadius: tokens.borderRadiusMedium,
     boxShadow: tokens.shadow16,
-    padding: '10px',
+    padding: tokens.spacingVerticalMNudge,
   },
   field: {
     flex: 1,
@@ -51,9 +56,16 @@ export const Snappy = (): JSXElement => {
       </div>
 
       <SlideSnappy visible={visible} outY="20px">
-        <div className={classes.card}>
+        <Card className={classes.card}>
+          <CardHeader
+            header={
+              <Text as="h3" className={classes.cardHeaderText} weight="semibold">
+                Lorem Ipsum
+              </Text>
+            }
+          />
           <LoremIpsum />
-        </div>
+        </Card>
       </SlideSnappy>
     </div>
   );

--- a/packages/react-components/react-motion-components-preview/stories/src/Slide/index.stories.ts
+++ b/packages/react-components/react-motion-components-preview/stories/src/Slide/index.stories.ts
@@ -1,4 +1,4 @@
-import { Slide } from '@fluentui/react-motion-components-preview';
+import { DefaultSlide as Slide } from './Slide.stories';
 import SlideDescription from './SlideDescription.md';
 
 export { Default } from './SlideDefault.stories';


### PR DESCRIPTION
Standardize `react-motion-components-preview` Storybook stories so that all six motion components (Blur, Collapse, Fade, Rotate, Scale, Slide) share a consistent layout, a working args table, etc.

<img width="1303" height="972" alt="image" src="https://github.com/user-attachments/assets/8a21a147-ff84-445b-8c43-a87e6884b123" />


## Previous Behavior

- Default stories used inconsistent layouts: some had a side-by-side grid, some used `gridTemplateColumns`, and spacing was a mix of hardcoded pixel values and tokens.
- Many stories were hard to navigate on mobile, as the text blocks became quite long with the narrower viewport. 
- Default stories for Blur, Collapse, Fade, and Scale used a plain `<div>` as the animated content instead of a `Card`.
- The Storybook args table was missing or incomplete for most components.
- `SlideSnappy` and `SlideRelaxed` had no `outX`/`outY` prop, so the slide had no visible direction.

## New Behavior

- All six Default stories use the same two-row grid layout (`"controls ." "card card" / 1fr 1fr`) with design tokens for spacing throughout.
- Stories have a better mobile-responsive layout by enforcing a maximum height.
- The animated content in each Default story is a `Card` with a `CardHeader`, matching the established pattern.
- Every component now has a thin story wrapper typed as `PresenceComponentProps & *Params` (e.g. `PresenceComponentProps & BlurParams`), which causes Storybook to render a full JSDoc args table for all props.
- `SlideSnappy` and `SlideRelaxed` now set `outY="20px"`, consistent with `SlideDefault`.
- `SlideCardsDemo` has a single **Show All / Hide All** toggle button instead of two.
