### PR TITLE
fix(eslint-plugin-react-components): use require for package.json to fix API Extractor build

### DIFF
--- a/change/@fluentui-eslint-plugin-react-components-18e84cf8-8da7-41fa-8744-8a2195ab569e.json
+++ b/change/@fluentui-eslint-plugin-react-components-18e84cf8-8da7-41fa-8744-8a2195ab569e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: use require for package.json to fix API Extractor build",
+  "packageName": "@fluentui/eslint-plugin-react-components",
+  "email": "robertpenner@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/eslint-plugin-react-components/etc/eslint-plugin-react-components.api.md
+++ b/packages/react-components/eslint-plugin-react-components/etc/eslint-plugin-react-components.api.md
@@ -15,9 +15,7 @@ export const configs: {
         rules: {};
     };
     'flat/recommended': {
-        plugins: {
-            [x: string]: ESLint.Plugin;
-        };
+        plugins: Record<string, ESLint.Plugin>;
         rules: {};
     };
 };

--- a/packages/react-components/eslint-plugin-react-components/src/index.ts
+++ b/packages/react-components/eslint-plugin-react-components/src/index.ts
@@ -1,6 +1,8 @@
 import type { ESLint } from 'eslint';
 
-import { name, version } from '../package.json';
+// Use require to avoid leaking package.json types into declarations,
+// which causes API Extractor to fail resolving '../package.json'.
+const { name, version } = require('../package.json') as { name: string; version: string };
 import { RULE_NAME as enforceUseClientName, rule as enforceUseClient } from './rules/enforce-use-client';
 import { RULE_NAME as preferFluentUIV9Name, rule as preferFluentUIV9 } from './rules/prefer-fluentui-v9';
 
@@ -17,7 +19,10 @@ const recommendedRules = {
   // Add rules to the recommended config here in the future
 };
 
-export const configs = {
+export const configs: {
+  recommended: { plugins: string[]; rules: {} };
+  'flat/recommended': { plugins: Record<string, ESLint.Plugin>; rules: {} };
+} = {
   recommended: {
     plugins: [name],
     rules: recommendedRules,


### PR DESCRIPTION
The ES import of ../package.json leaked into declaration files, causing API Extractor to fail with TS2307 and TS1170 errors since it cannot resolve the path from the output directory.

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #35865
