### PR TITLE
fix(react-menu-grid-preview): ArrowRight should not open submenus inside MenuGrid

### DIFF
--- a/change/@fluentui-react-menu-fix-arrow-right-submenu-in-grid.json
+++ b/change/@fluentui-react-menu-fix-arrow-right-submenu-in-grid.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add shouldOpenOnArrowRight to MenuListContextValue to allow grid containers to opt out of ArrowRight opening submenus",
+  "packageName": "@fluentui/react-menu",
+  "email": "bsunderhus@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-menu-grid-preview-fix-arrow-right-submenu.json
+++ b/change/@fluentui-react-menu-grid-preview-fix-arrow-right-submenu.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: ArrowRight no longer opens submenus inside MenuGrid (reserved for column navigation)",
+  "packageName": "@fluentui/react-menu-grid-preview",
+  "email": "bsunderhus@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-menu-grid-preview/library/src/components/MenuGrid/MenuGrid.cy.tsx
+++ b/packages/react-components/react-menu-grid-preview/library/src/components/MenuGrid/MenuGrid.cy.tsx
@@ -242,6 +242,12 @@ describe('With MenuList submenus', () => {
     cy.get(menuGridItemSelector).eq(1).should('be.focused');
   });
 
+  it('should not open a submenu trigger with ArrowRight', () => {
+    mount(<WithSubmenuExample />);
+    cy.get(menuGridItemSelector).first().focus().realPress('ArrowRight').realPress('ArrowRight');
+    cy.get(menuSelector).should('have.length', 0);
+  });
+
   it('should open a submenu trigger with Enter', () => {
     mount(<WithSubmenuExample />);
     cy.get(menuGridItemSelector).first().focus().realPress('ArrowRight').realPress('Enter');

--- a/packages/react-components/react-menu-grid-preview/library/src/components/MenuGrid/useMenuGridContextValues.ts
+++ b/packages/react-components/react-menu-grid-preview/library/src/components/MenuGrid/useMenuGridContextValues.ts
@@ -7,6 +7,7 @@ const menuList = {
   checkedValues: {},
   hasIcons: false,
   hasCheckmarks: false,
+  shouldOpenOnArrowRight: false,
 };
 
 export function useMenuGridContextValues_unstable(state: MenuGridState): MenuGridContextValues {

--- a/packages/react-components/react-menu/library/etc/react-menu.api.md
+++ b/packages/react-components/react-menu/library/etc/react-menu.api.md
@@ -230,6 +230,7 @@ export type MenuListContextValue = Pick<MenuListProps, 'checkedValues' | 'hasIco
     toggleCheckbox?: SelectableHandler;
     selectRadio?: SelectableHandler;
     onCheckedValueChange?: (e: MenuCheckedValueChangeEvent, data: MenuCheckedValueChangeData) => void;
+    shouldOpenOnArrowRight?: boolean;
 };
 
 // @public (undocumented)

--- a/packages/react-components/react-menu/library/src/components/MenuTrigger/useMenuTrigger.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuTrigger/useMenuTrigger.ts
@@ -17,6 +17,7 @@ import * as React from 'react';
 
 import type { MenuTriggerProps, MenuTriggerState } from './MenuTrigger.types';
 import { useMenuContext_unstable } from '../../contexts/menuContext';
+import { useMenuListContext_unstable } from '../../contexts/menuListContext';
 import { useIsSubmenu, useOnMenuSafeZoneTimeout } from '../../utils';
 
 function noop() {
@@ -41,6 +42,7 @@ export const useMenuTrigger_unstable = (props: MenuTriggerProps): MenuTriggerSta
   const openOnContext = useMenuContext_unstable(context => context.openOnContext);
 
   const isSubmenu = useIsSubmenu();
+  const shouldOpenOnArrowRight = useMenuListContext_unstable(ctx => ctx.shouldOpenOnArrowRight ?? true);
 
   const { findFirstFocusable } = useFocusFinders();
   const focusFirst = React.useCallback(() => {
@@ -98,7 +100,10 @@ export const useMenuTrigger_unstable = (props: MenuTriggerProps): MenuTriggerSta
 
     const key = event.key;
 
-    if (!openOnContext && ((isSubmenu && key === OpenArrowKey) || (!isSubmenu && key === ArrowDown))) {
+    if (
+      !openOnContext &&
+      ((isSubmenu && shouldOpenOnArrowRight && key === OpenArrowKey) || (!isSubmenu && key === ArrowDown))
+    ) {
       setOpen(event, { open: true, keyboard: true, type: 'menuTriggerKeyDown', event });
     }
 
@@ -107,7 +112,7 @@ export const useMenuTrigger_unstable = (props: MenuTriggerProps): MenuTriggerSta
     }
 
     // if menu is already open, can't rely on effects to focus
-    if (open && key === OpenArrowKey && isSubmenu) {
+    if (open && key === OpenArrowKey && isSubmenu && shouldOpenOnArrowRight) {
       focusFirst();
     }
   };

--- a/packages/react-components/react-menu/library/src/contexts/menuListContext.tsx
+++ b/packages/react-components/react-menu/library/src/contexts/menuListContext.tsx
@@ -36,6 +36,14 @@ export type MenuListContextValue = Pick<MenuListProps, 'checkedValues' | 'hasIco
    * the signature remains just to avoid breaking changes
    */
   onCheckedValueChange?: (e: MenuCheckedValueChangeEvent, data: MenuCheckedValueChangeData) => void;
+  /**
+   * Whether child menus (submenus) should open when the user presses the ArrowRight key on their trigger.
+   * Set to `false` when the list context is provided by a grid-like container (e.g. MenuGrid) where
+   * ArrowRight is reserved for column navigation.
+   *
+   * @default true
+   */
+  shouldOpenOnArrowRight?: boolean;
 };
 
 export const MenuListProvider = MenuListContext.Provider;


### PR DESCRIPTION
## Summary

- Adds `shouldOpenOnArrowRight?: boolean` to `MenuListContextValue` in `@fluentui/react-menu` — allows list-like containers to opt out of the ArrowRight-opens-submenu keyboard behavior
- `MenuGrid` sets `shouldOpenOnArrowRight: false`, preserving ArrowRight for grid column navigation while hover-open behavior remains correct
- `useMenuTrigger` gates both the open-on-keydown and focus-first-on-keydown behaviors behind this flag
- Adds e2e test: `should not open a submenu trigger with ArrowRight`

## Test plan

- [x] `yarn nx run react-menu-grid-preview:e2e` — all 9 tests pass
- [x] `yarn nx run react-menu:build` — API md updated, build succeeds
- [x] ArrowRight navigates grid columns, does not open submenu
- [x] Enter still opens the submenu
- [x] Hover still opens the submenu (existing tests cover this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)