### PR TITLE
fix(react-checkbox): preserve slot onChange handler using mergeCallbacks

### DIFF
--- a/change/@fluentui-react-checkbox-2b88fe40-6584-40c8-b307-c4c8d0991dab.json
+++ b/change/@fluentui-react-checkbox-2b88fe40-6584-40c8-b307-c4c8d0991dab.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: preserve slot onChange handler using mergeCallbacks instead of direct assignment",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "karesansui.u@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-checkbox/library/src/components/Checkbox/Checkbox.test.tsx
+++ b/packages/react-components/react-checkbox/library/src/components/Checkbox/Checkbox.test.tsx
@@ -159,6 +159,17 @@ describe('Checkbox', () => {
     expect(onChange.mock.calls[2][1]).toEqual({ checked: true });
   });
 
+  it('calls custom onChange passed via input slot prop', () => {
+    const onChange = jest.fn();
+    const slotOnChange = jest.fn();
+
+    const renderedComponent = render(<Checkbox onChange={onChange} input={{ onChange: slotOnChange }} />);
+    fireEvent.click(renderedComponent.getByRole('checkbox'));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(slotOnChange).toHaveBeenCalledTimes(1);
+  });
+
   it("doesn't remove controlled mixed when no onChange provided", () => {
     const renderedComponent = render(<Checkbox checked="mixed" />);
     const input = renderedComponent.getByRole('checkbox') as HTMLInputElement;

--- a/packages/react-components/react-checkbox/library/src/components/Checkbox/useCheckbox.tsx
+++ b/packages/react-components/react-checkbox/library/src/components/Checkbox/useCheckbox.tsx
@@ -5,7 +5,7 @@ import { useFieldControlProps_unstable } from '@fluentui/react-field';
 import {
   getPartitionedNativeProps,
   useControllableState,
-  useEventCallback,
+  mergeCallbacks,
   useId,
   useIsomorphicLayoutEffect,
   useMergedRefs,
@@ -113,7 +113,7 @@ export const useCheckbox_unstable = (props: CheckboxProps, ref: React.Ref<HTMLIn
     }),
   };
 
-  state.input.onChange = useEventCallback(ev => {
+  state.input.onChange = mergeCallbacks(state.input.onChange, ev => {
     const val = ev.currentTarget.indeterminate ? 'mixed' : ev.currentTarget.checked;
     onChange?.(ev, { checked: val });
     setChecked(val);


### PR DESCRIPTION
## Previous Behavior

`useCheckbox_unstable` uses direct assignment (`state.input.onChange = useEventCallback(...)`) which silently drops any custom `onChange` passed via the `input` slot prop.

For example, `<Checkbox input={{ onChange: customHandler }} />` — `customHandler` is never called.

## New Behavior

Uses `mergeCallbacks(state.input.onChange, ...)` to preserve custom slot handlers, matching the pattern used by sibling components:

- **Radio** (`useRadio.tsx:61`): `input.onChange = mergeCallbacks(input.onChange, ev => ...)`
- **Switch** (`useSwitch.tsx:81`): `input.onChange = mergeCallbacks(input.onChange, ev => ...)`

## Related Issue(s)

None found — this is a previously unreported inconsistency.