### PR TITLE
feat(react-divider): expose base hook and types for Divider component

### DIFF
--- a/change/@fluentui-react-divider-0c7d2b0c-98c3-4c42-b98a-d07fc7db63a5.json
+++ b/change/@fluentui-react-divider-0c7d2b0c-98c3-4c42-b98a-d07fc7db63a5.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: expose base hook and types for Divider component",
+  "packageName": "@fluentui/react-divider",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-divider/library/etc/react-divider.api.md
+++ b/packages/react-components/react-divider/library/etc/react-divider.api.md
@@ -16,6 +16,12 @@ import type { SlotClassNames } from '@fluentui/react-utilities';
 export const Divider: ForwardRefComponent<DividerProps>;
 
 // @public (undocumented)
+export type DividerBaseProps = Omit<DividerProps, 'alignContent' | 'appearance' | 'inset'>;
+
+// @public (undocumented)
+export type DividerBaseState = Omit<DividerState, 'alignContent' | 'appearance' | 'inset'>;
+
+// @public (undocumented)
 export const dividerClassNames: SlotClassNames<DividerSlots>;
 
 // @public (undocumented)
@@ -36,10 +42,13 @@ export type DividerSlots = {
 export type DividerState = ComponentState<DividerSlots> & Required<Pick<DividerProps, 'alignContent' | 'appearance' | 'inset' | 'vertical'>>;
 
 // @public
-export const renderDivider_unstable: (state: DividerState) => JSXElement;
+export const renderDivider_unstable: (state: DividerBaseState) => JSXElement;
 
 // @public
 export const useDivider_unstable: (props: DividerProps, ref: React_2.Ref<HTMLElement>) => DividerState;
+
+// @public
+export const useDividerBase_unstable: (props: DividerBaseProps, ref?: React_2.Ref<HTMLElement>) => DividerBaseState;
 
 // @public (undocumented)
 export const useDividerStyles_unstable: (state: DividerState) => DividerState;

--- a/packages/react-components/react-divider/library/src/components/Divider/renderDivider.tsx
+++ b/packages/react-components/react-divider/library/src/components/Divider/renderDivider.tsx
@@ -3,12 +3,12 @@
 
 import { assertSlots } from '@fluentui/react-utilities';
 import type { JSXElement } from '@fluentui/react-utilities';
-import { DividerSlots, DividerState } from './Divider.types';
+import { DividerSlots, DividerBaseState } from './Divider.types';
 
 /**
  * Renders a Divider component by passing the slot props (defined in `state`) to the appropriate slots.
  */
-export const renderDivider_unstable = (state: DividerState): JSXElement => {
+export const renderDivider_unstable = (state: DividerBaseState): JSXElement => {
   assertSlots<DividerSlots>(state);
   return (
     <state.root>{state.root.children !== undefined && <state.wrapper>{state.root.children}</state.wrapper>}</state.root>

--- a/packages/react-components/react-divider/library/src/index.ts
+++ b/packages/react-components/react-divider/library/src/index.ts
@@ -4,9 +4,6 @@ export {
   renderDivider_unstable,
   useDividerStyles_unstable,
   useDivider_unstable,
+  useDividerBase_unstable,
 } from './Divider';
-export type { DividerProps, DividerSlots, DividerState } from './Divider';
-
-// Experimental APIs - will be uncommented in the experimental release branch
-// export { useDividerBase_unstable } from './Divider';
-// export type { DividerBaseProps, DividerBaseState } from './Divider';
+export type { DividerProps, DividerSlots, DividerState, DividerBaseProps, DividerBaseState } from './Divider';


### PR DESCRIPTION
Updated exports in `index.ts` to include the new Divider base hook and types, making them available for public use