### PR TITLE
feat(react-button): expose button base hooks and types

### DIFF
--- a/change/@fluentui-react-button-fcb6154c-d0ed-4f2f-8e4a-19d591664e5c.json
+++ b/change/@fluentui-react-button-fcb6154c-d0ed-4f2f-8e4a-19d591664e5c.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: expose button base hooks and types",
+  "packageName": "@fluentui/react-button",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-button/library/etc/react-button.api.md
+++ b/packages/react-components/react-button/library/etc/react-button.api.md
@@ -7,6 +7,7 @@
 import type { ARIAButtonSlotProps } from '@fluentui/react-aria';
 import type { ComponentProps } from '@fluentui/react-utilities';
 import type { ComponentState } from '@fluentui/react-utilities';
+import type { DistributiveOmit } from '@fluentui/react-utilities';
 import { ForwardRefComponent } from '@fluentui/react-utilities';
 import type { JSXElement } from '@fluentui/react-utilities';
 import * as React_2 from 'react';
@@ -15,6 +16,12 @@ import type { SlotClassNames } from '@fluentui/react-utilities';
 
 // @public
 export const Button: ForwardRefComponent<ButtonProps>;
+
+// @public (undocumented)
+export type ButtonBaseProps = DistributiveOmit<ButtonProps, 'appearance' | 'size' | 'shape'>;
+
+// @public (undocumented)
+export type ButtonBaseState = DistributiveOmit<ButtonState, 'appearance' | 'size' | 'shape'>;
 
 // @public (undocumented)
 export const buttonClassNames: SlotClassNames<ButtonSlots>;
@@ -121,6 +128,12 @@ export type SplitButtonState = ComponentState<SplitButtonSlots> & Omit<ButtonSta
 export const ToggleButton: ForwardRefComponent<ToggleButtonProps>;
 
 // @public (undocumented)
+export type ToggleButtonBaseProps = ButtonBaseProps & Pick<ToggleButtonProps, 'defaultChecked' | 'checked' | 'isAccessible'>;
+
+// @public (undocumented)
+export type ToggleButtonBaseState = ButtonBaseState & Required<Pick<ToggleButtonProps, 'checked' | 'isAccessible'>>;
+
+// @public (undocumented)
 export const toggleButtonClassNames: SlotClassNames<ButtonSlots>;
 
 // @public (undocumented)
@@ -135,6 +148,9 @@ export type ToggleButtonState = ButtonState & Required<Pick<ToggleButtonProps, '
 
 // @public
 export const useButton_unstable: (props: ButtonProps, ref: React_2.Ref<HTMLButtonElement | HTMLAnchorElement>) => ButtonState;
+
+// @public
+export const useButtonBase_unstable: (props: ButtonBaseProps, ref?: React_2.Ref<HTMLButtonElement | HTMLAnchorElement>) => ButtonBaseState;
 
 // @internal
 export const useButtonContext: () => ButtonContextValue;
@@ -162,6 +178,9 @@ export const useSplitButtonStyles_unstable: (state: SplitButtonState) => SplitBu
 
 // @public
 export const useToggleButton_unstable: (props: ToggleButtonProps, ref: React_2.Ref<HTMLButtonElement | HTMLAnchorElement>) => ToggleButtonState;
+
+// @public
+export const useToggleButtonBase_unstable: (props: ToggleButtonProps, ref?: React_2.Ref<HTMLButtonElement | HTMLAnchorElement>) => ToggleButtonBaseState;
 
 // @public (undocumented)
 export const useToggleButtonStyles_unstable: (state: ToggleButtonState) => ToggleButtonState;

--- a/packages/react-components/react-button/library/src/index.ts
+++ b/packages/react-components/react-button/library/src/index.ts
@@ -4,8 +4,9 @@ export {
   renderButton_unstable,
   useButtonStyles_unstable,
   useButton_unstable,
+  useButtonBase_unstable,
 } from './Button';
-export type { ButtonProps, ButtonSlots, ButtonState } from './Button';
+export type { ButtonProps, ButtonSlots, ButtonState, ButtonBaseProps, ButtonBaseState } from './Button';
 export {
   CompoundButton,
   compoundButtonClassNames,
@@ -36,16 +37,16 @@ export {
   toggleButtonClassNames,
   useToggleButtonStyles_unstable,
   useToggleButton_unstable,
+  useToggleButtonBase_unstable,
 } from './ToggleButton';
-export type { ToggleButtonProps, ToggleButtonState } from './ToggleButton';
+export type {
+  ToggleButtonProps,
+  ToggleButtonState,
+  ToggleButtonBaseProps,
+  ToggleButtonBaseState,
+} from './ToggleButton';
 
 export { useToggleState } from './utils/index';
 
 export { ButtonContextProvider, useButtonContext } from './contexts/index';
 export type { ButtonContextValue } from './contexts/index';
-
-// Experimental APIs - will be uncommented in the experimental release branch
-// export { useButtonBase_unstable } from './Button';
-// export type { ButtonBaseProps, ButtonBaseState } from './Button';
-// export { useToggleButtonBase_unstable } from './ToggleButton';
-// export type { ToggleButtonBaseProps, ToggleButtonBaseState } from './ToggleButton';


### PR DESCRIPTION
Expose new base hooks and types for buttons and toggle buttons. These changes make it easier for developers to build on top of the button components by providing more granular access to their underlying logic and state