### PR TITLE
fix(react-toolbar): preserve user-defined appearance prop in useToolbarToggleButton

### DIFF
--- a/change/@fluentui-react-toolbar-35ee271f-7f08-400c-afe6-bb4b324be86a.json
+++ b/change/@fluentui-react-toolbar-35ee271f-7f08-400c-afe6-bb4b324be86a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: preserve user-defined appearance prop in useToolbarToggleButton",
+  "packageName": "@fluentui/react-toolbar",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarToggleButton/useToolbarToggleButton.ts
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarToggleButton/useToolbarToggleButton.ts
@@ -20,9 +20,10 @@ export const useToolbarToggleButton_unstable = (
   props: ToolbarToggleButtonProps,
   ref: React.Ref<HTMLButtonElement | HTMLAnchorElement>,
 ): ToolbarToggleButtonState => {
-  const state = useToolbarToggleButtonBase_unstable(props, ref);
+  const { appearance = 'subtle', ...baseProps } = props;
+  const state = useToolbarToggleButtonBase_unstable(baseProps, ref);
   return {
-    appearance: 'subtle',
+    appearance,
     ...state,
   };
 };


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Fixes a regression introduced in #35658

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #35892
