### PR TITLE
chore: update react-radio code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -233,8 +233,8 @@ packages/react-components/react-portal/library @microsoft/teams-prg
 packages/react-components/react-portal/stories @microsoft/teams-prg
 packages/react-components/react-provider/library @microsoft/teams-prg
 packages/react-components/react-provider/stories @microsoft/teams-prg
-packages/react-components/react-radio/library @microsoft/cxe-red  @spmonahan
-packages/react-components/react-radio/stories @microsoft/cxe-red  @spmonahan
+packages/react-components/react-radio/library @microsoft/cxe-prg  @dmytrokirpa
+packages/react-components/react-radio/stories @microsoft/cxe-prg  @dmytrokirpa
 packages/react-components/react-select/library @microsoft/cxe-prg @mainframev
 packages/react-components/react-select/stories @microsoft/cxe-prg @mainframev
 packages/react-components/react-slider/library @microsoft/cxe-prg @dmytrokirpa
@@ -373,7 +373,7 @@ packages/react/src/components/Overlay @microsoft/cxe-red @khmakoto
 packages/react/src/components/Panel @microsoft/cxe-red @khmakoto
 packages/react/src/components/Persona @microsoft/cxe-red
 packages/react/src/components/PersonaCoin @microsoft/cxe-red
-packages/react/src/components/Pivot @microsoft/cxe-red 
+packages/react/src/components/Pivot @microsoft/cxe-red
 packages/react/src/components/SearchBox @microsoft/cxe-red
 packages/react/src/components/Shimmer @microsoft/cxe-red
 packages/react/src/components/SpinButton @microsoft/cxe-red
@@ -387,7 +387,7 @@ packages/react/src/components/WeeklyDayPicker @microsoft/cxe-red
 
 ## Theming and styling
 packages/react/src/utilities/ThemeProvider @microsoft/cxe-red @dzearing
-packages/fluent2-theme @microsoft/cxe-red 
+packages/fluent2-theme @microsoft/cxe-red
 ## Experiments
 packages/react-experiments @microsoft/cxe-red
 packages/react-experiments/src/components/Signals @ThomasMichon


### PR DESCRIPTION
 Updated `.github/CODEOWNERS` to assign `packages/react-components/react-radio/library` and `packages/react-components/react-radio/stories` to `@microsoft/cxe-prg` and `@dmytrokirpa`, replacing the previous owners.