### PR TITLE
feat(react-tooltip): expose base hook and types for Tooltip

### DIFF
--- a/change/@fluentui-react-tooltip-d5e6f7a8-b9c0-4d1e-2f3a-4b5c6d7e8f9a.json
+++ b/change/@fluentui-react-tooltip-d5e6f7a8-b9c0-4d1e-2f3a-4b5c6d7e8f9a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: expose base hooks for Tooltip",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tooltip/library/etc/react-tooltip.api.md
+++ b/packages/react-components/react-tooltip/library/etc/react-tooltip.api.md
@@ -21,10 +21,16 @@ export type OnVisibleChangeData = {
 };
 
 // @public
-export const renderTooltip_unstable: (state: TooltipState) => JSXElement;
+export const renderTooltip_unstable: (state: TooltipBaseState) => JSXElement;
 
 // @public
 export const Tooltip: React_2.FC<TooltipProps>;
+
+// @public (undocumented)
+export type TooltipBaseProps = Omit<TooltipProps, 'appearance'>;
+
+// @public (undocumented)
+export type TooltipBaseState = Omit<TooltipState, 'appearance'>;
 
 // @public (undocumented)
 export const tooltipClassNames: SlotClassNames<TooltipSlots>;
@@ -61,6 +67,9 @@ export type TooltipTriggerProps = {
 
 // @public
 export const useTooltip_unstable: (props: TooltipProps) => TooltipState;
+
+// @public
+export const useTooltipBase_unstable: (props: TooltipBaseProps) => TooltipBaseState;
 
 // @public
 export const useTooltipStyles_unstable: (state: TooltipState) => TooltipState;

--- a/packages/react-components/react-tooltip/library/src/components/Tooltip/renderTooltip.tsx
+++ b/packages/react-components/react-tooltip/library/src/components/Tooltip/renderTooltip.tsx
@@ -4,12 +4,12 @@
 import { Portal } from '@fluentui/react-portal';
 import { assertSlots } from '@fluentui/react-utilities';
 import type { JSXElement } from '@fluentui/react-utilities';
-import type { TooltipSlots, TooltipState } from './Tooltip.types';
+import type { TooltipBaseState, TooltipSlots } from './Tooltip.types';
 
 /**
  * Render the final JSX of Tooltip
  */
-export const renderTooltip_unstable = (state: TooltipState): JSXElement => {
+export const renderTooltip_unstable = (state: TooltipBaseState): JSXElement => {
   assertSlots<TooltipSlots>(state);
 
   return (

--- a/packages/react-components/react-tooltip/library/src/components/Tooltip/useTooltip.tsx
+++ b/packages/react-components/react-tooltip/library/src/components/Tooltip/useTooltip.tsx
@@ -14,9 +14,9 @@ import { useTooltipBase_unstable } from './useTooltipBase';
 export const useTooltip_unstable = (props: TooltipProps): TooltipState => {
   'use no memo';
 
-  const { appearance = 'normal' } = props;
+  const { appearance = 'normal', ...baseProps } = props;
 
-  const state = useTooltipBase_unstable(props);
+  const state = useTooltipBase_unstable(baseProps);
 
   return {
     appearance,

--- a/packages/react-components/react-tooltip/library/src/index.ts
+++ b/packages/react-components/react-tooltip/library/src/index.ts
@@ -4,6 +4,7 @@ export {
   tooltipClassNames,
   useTooltipStyles_unstable,
   useTooltip_unstable,
+  useTooltipBase_unstable,
 } from './Tooltip';
 export type {
   OnVisibleChangeData,
@@ -11,8 +12,6 @@ export type {
   TooltipSlots,
   TooltipState,
   TooltipChildProps as TooltipTriggerProps,
+  TooltipBaseProps,
+  TooltipBaseState,
 } from './Tooltip';
-
-// Experimental APIs - will be uncommented in experimental release
-// export { useTooltipBase_unstable } from './Tooltip';
-// export type { TooltipBaseProps, TooltipBaseState } from './Tooltip';


### PR DESCRIPTION
## Summary

- Exports `useTooltipBase_unstable`, `TooltipBaseProps`, and `TooltipBaseState` from `@fluentui/react-tooltip` public index
- Updates `renderTooltip_unstable` to accept `TooltipBaseState` instead of `TooltipState` — the render uses only structural/behavioral props (`shouldRenderTooltip`, `mountNode`, `content`, `withArrow`, `arrowRef`, `arrowClassName`, `children`) all of which are present in the base state

All hooks and types were already implemented in the component source files (added in PR #35637) but gated behind comments in `index.ts`.

Tracking: https://github.com/microsoft/fluentui/issues/35562

🤖 Generated with [Claude Code](https://claude.com/claude-code)