### PR TITLE
feat(react-tag-picker): add base hooks for TagPicker components

### DIFF
--- a/change/@fluentui-react-tag-picker-c97b0cc0-e48a-4e22-986f-464ccc9476d3.json
+++ b/change/@fluentui-react-tag-picker-c97b0cc0-e48a-4e22-986f-464ccc9476d3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: add base hooks for TagPicker components",
+  "packageName": "@fluentui/react-tag-picker",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tag-picker/library/etc/react-tag-picker.api.md
+++ b/packages/react-components/react-tag-picker/library/etc/react-tag-picker.api.md
@@ -28,6 +28,7 @@ import type { OptionState } from '@fluentui/react-combobox';
 import * as React_2 from 'react';
 import type { Slot } from '@fluentui/react-utilities';
 import type { SlotClassNames } from '@fluentui/react-utilities';
+import type { TagGroupBaseState } from '@fluentui/react-tags';
 import { TagGroupContextValues } from '@fluentui/react-tags';
 import type { TagGroupSlots } from '@fluentui/react-tags';
 import type { TagGroupState } from '@fluentui/react-tags';
@@ -60,7 +61,19 @@ export const renderTagPickerOptionGroup: (state: TagPickerOptionGroupState) => J
 export const TagPicker: React_2.FC<TagPickerProps>;
 
 // @public
+export type TagPickerBaseProps = Omit<TagPickerProps, 'size' | 'appearance'>;
+
+// @public
+export type TagPickerBaseState = Omit<TagPickerState, 'size' | 'appearance'>;
+
+// @public
 export const TagPickerButton: ForwardRefComponent<TagPickerButtonProps>;
+
+// @public
+export type TagPickerButtonBaseProps = Omit<TagPickerButtonProps, 'size' | 'appearance'>;
+
+// @public
+export type TagPickerButtonBaseState = Omit<TagPickerButtonState, 'size'>;
 
 // @public (undocumented)
 export const tagPickerButtonClassNames: SlotClassNames<TagPickerButtonSlots>;
@@ -110,6 +123,12 @@ export type TagPickerContextValues = {
 // @public
 export const TagPickerControl: ForwardRefComponent<TagPickerControlProps>;
 
+// @public
+export type TagPickerControlBaseProps = TagPickerControlProps;
+
+// @public
+export type TagPickerControlBaseState = Omit<TagPickerControlState, 'size' | 'appearance'>;
+
 // @public (undocumented)
 export const tagPickerControlClassNames: SlotClassNames<TagPickerControlSlots & TagPickerControlInternalSlots>;
 
@@ -132,6 +151,14 @@ export type TagPickerControlState = ComponentState<TagPickerControlSlots & TagPi
 // @public
 export const TagPickerGroup: ForwardRefComponent<TagPickerGroupProps>;
 
+// @public
+export type TagPickerGroupBaseProps = TagPickerGroupProps;
+
+// @public
+export type TagPickerGroupBaseState = TagGroupBaseState & {
+    hasSelectedOptions: boolean;
+};
+
 // @public (undocumented)
 export const tagPickerGroupClassNames: SlotClassNames<TagPickerGroupSlots>;
 
@@ -148,6 +175,12 @@ export type TagPickerGroupState = TagGroupState & {
 
 // @public
 export const TagPickerInput: ForwardRefComponent<TagPickerInputProps>;
+
+// @public
+export type TagPickerInputBaseProps = Omit<TagPickerInputProps, 'appearance'>;
+
+// @public
+export type TagPickerInputBaseState = Omit<TagPickerInputState, 'size'>;
 
 // @public (undocumented)
 export const tagPickerInputClassNames: SlotClassNames<TagPickerInputSlots>;
@@ -263,7 +296,13 @@ export type TagPickerState = ComponentState<TagPickerSlots> & Pick<ComboboxState
 export const useTagPicker_unstable: (props: TagPickerProps) => TagPickerState;
 
 // @public
+export const useTagPickerBase_unstable: (props: TagPickerBaseProps) => TagPickerBaseState;
+
+// @public
 export const useTagPickerButton_unstable: (props: TagPickerButtonProps, ref: React_2.Ref<HTMLButtonElement>) => TagPickerButtonState;
+
+// @public
+export const useTagPickerButtonBase_unstable: (props: TagPickerButtonBaseProps, ref: React_2.Ref<HTMLButtonElement>) => TagPickerButtonBaseState;
 
 // @public
 export const useTagPickerButtonStyles_unstable: (state: TagPickerButtonState) => TagPickerButtonState;
@@ -275,6 +314,9 @@ export const useTagPickerContext_unstable: <T>(selector: ContextSelector<TagPick
 export const useTagPickerControl_unstable: (props: TagPickerControlProps, ref: React_2.Ref<HTMLDivElement>) => TagPickerControlState;
 
 // @public
+export const useTagPickerControlBase_unstable: (props: TagPickerControlBaseProps, ref: React_2.Ref<HTMLDivElement>) => TagPickerControlBaseState;
+
+// @public
 export const useTagPickerControlStyles_unstable: (state: TagPickerControlState) => TagPickerControlState;
 
 // @public (undocumented)
@@ -284,10 +326,16 @@ export function useTagPickerFilter({ filter: filterOverride, noOptionsElement, r
 export const useTagPickerGroup_unstable: (props: TagPickerGroupProps, ref: React_2.Ref<HTMLDivElement>) => TagPickerGroupState;
 
 // @public
+export const useTagPickerGroupBase_unstable: (props: TagPickerGroupBaseProps, ref: React_2.Ref<HTMLDivElement>) => TagPickerGroupBaseState;
+
+// @public
 export const useTagPickerGroupStyles_unstable: (state: TagPickerGroupState) => TagPickerGroupState;
 
 // @public
 export const useTagPickerInput_unstable: (propsArg: TagPickerInputProps, ref: React_2.Ref<HTMLInputElement>) => TagPickerInputState;
+
+// @public
+export const useTagPickerInputBase_unstable: (propsArg: TagPickerInputBaseProps, ref: React_2.Ref<HTMLInputElement>) => TagPickerInputBaseState;
 
 // @public
 export const useTagPickerInputStyles_unstable: (state: TagPickerInputState) => TagPickerInputState;

--- a/packages/react-components/react-tag-picker/library/src/TagPicker.ts
+++ b/packages/react-components/react-tag-picker/library/src/TagPicker.ts
@@ -1,4 +1,6 @@
 export type {
+  TagPickerBaseProps,
+  TagPickerBaseState,
   TagPickerContextValues,
   TagPickerOnOpenChangeData,
   TagPickerOnOptionSelectData,
@@ -7,4 +9,9 @@ export type {
   TagPickerSlots,
   TagPickerState,
 } from './components/TagPicker/index';
-export { TagPicker, renderTagPicker_unstable, useTagPicker_unstable } from './components/TagPicker/index';
+export {
+  TagPicker,
+  renderTagPicker_unstable,
+  useTagPickerBase_unstable,
+  useTagPicker_unstable,
+} from './components/TagPicker/index';

--- a/packages/react-components/react-tag-picker/library/src/TagPickerButton.ts
+++ b/packages/react-components/react-tag-picker/library/src/TagPickerButton.ts
@@ -1,4 +1,6 @@
 export type {
+  TagPickerButtonBaseProps,
+  TagPickerButtonBaseState,
   TagPickerButtonProps,
   TagPickerButtonSlots,
   TagPickerButtonState,
@@ -8,5 +10,6 @@ export {
   renderTagPickerButton_unstable,
   tagPickerButtonClassNames,
   useTagPickerButtonStyles_unstable,
+  useTagPickerButtonBase_unstable,
   useTagPickerButton_unstable,
 } from './components/TagPickerButton/index';

--- a/packages/react-components/react-tag-picker/library/src/TagPickerControl.ts
+++ b/packages/react-components/react-tag-picker/library/src/TagPickerControl.ts
@@ -1,4 +1,6 @@
 export type {
+  TagPickerControlBaseProps,
+  TagPickerControlBaseState,
   TagPickerControlCSSProperties,
   TagPickerControlInternalSlots,
   TagPickerControlProps,
@@ -12,5 +14,6 @@ export {
   tagPickerControlAsideWidthToken,
   tagPickerControlClassNames,
   useTagPickerControlStyles_unstable,
+  useTagPickerControlBase_unstable,
   useTagPickerControl_unstable,
 } from './components/TagPickerControl/index';

--- a/packages/react-components/react-tag-picker/library/src/TagPickerGroup.ts
+++ b/packages/react-components/react-tag-picker/library/src/TagPickerGroup.ts
@@ -1,8 +1,15 @@
-export type { TagPickerGroupProps, TagPickerGroupSlots, TagPickerGroupState } from './components/TagPickerGroup/index';
+export type {
+  TagPickerGroupBaseProps,
+  TagPickerGroupBaseState,
+  TagPickerGroupProps,
+  TagPickerGroupSlots,
+  TagPickerGroupState,
+} from './components/TagPickerGroup/index';
 export {
   TagPickerGroup,
   renderTagPickerGroup_unstable,
   tagPickerGroupClassNames,
   useTagPickerGroupStyles_unstable,
+  useTagPickerGroupBase_unstable,
   useTagPickerGroup_unstable,
 } from './components/TagPickerGroup/index';

--- a/packages/react-components/react-tag-picker/library/src/TagPickerInput.ts
+++ b/packages/react-components/react-tag-picker/library/src/TagPickerInput.ts
@@ -1,8 +1,15 @@
-export type { TagPickerInputProps, TagPickerInputSlots, TagPickerInputState } from './components/TagPickerInput/index';
+export type {
+  TagPickerInputBaseProps,
+  TagPickerInputBaseState,
+  TagPickerInputProps,
+  TagPickerInputSlots,
+  TagPickerInputState,
+} from './components/TagPickerInput/index';
 export {
   TagPickerInput,
   renderTagPickerInput_unstable,
   tagPickerInputClassNames,
   useTagPickerInputStyles_unstable,
+  useTagPickerInputBase_unstable,
   useTagPickerInput_unstable,
 } from './components/TagPickerInput/index';

--- a/packages/react-components/react-tag-picker/library/src/components/TagPicker/TagPicker.types.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPicker/TagPicker.types.ts
@@ -106,3 +106,13 @@ export type TagPickerContextValues = {
   activeDescendant: ActiveDescendantContextValue;
   listbox: ListboxContextValue;
 };
+
+/**
+ * TagPicker Base Props - omits design-only props
+ */
+export type TagPickerBaseProps = Omit<TagPickerProps, 'size' | 'appearance'>;
+
+/**
+ * TagPicker Base State - omits design-only state
+ */
+export type TagPickerBaseState = Omit<TagPickerState, 'size' | 'appearance'>;

--- a/packages/react-components/react-tag-picker/library/src/components/TagPicker/index.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPicker/index.ts
@@ -1,5 +1,7 @@
 export { TagPicker } from './TagPicker';
 export type {
+  TagPickerBaseProps,
+  TagPickerBaseState,
   TagPickerContextValues,
   TagPickerOnOpenChangeData,
   TagPickerOnOptionSelectData,
@@ -9,4 +11,4 @@ export type {
   TagPickerState,
 } from './TagPicker.types';
 export { renderTagPicker_unstable } from './renderTagPicker';
-export { useTagPicker_unstable } from './useTagPicker';
+export { useTagPickerBase_unstable, useTagPicker_unstable } from './useTagPicker';

--- a/packages/react-components/react-tag-picker/library/src/components/TagPicker/useTagPicker.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPicker/useTagPicker.ts
@@ -3,14 +3,19 @@
 import * as React from 'react';
 import { elementContains, useEventCallback, useId, useMergedRefs } from '@fluentui/react-utilities';
 import type {
+  TagPickerBaseProps,
+  TagPickerBaseState,
   TagPickerOnOpenChangeData,
   TagPickerOnOptionSelectData,
   TagPickerProps,
   TagPickerState,
 } from './TagPicker.types';
 import { optionClassNames } from '@fluentui/react-combobox';
-import type { PositioningShorthandValue } from '@fluentui/react-positioning';
-import { resolvePositioningShorthand, usePositioning } from '@fluentui/react-positioning';
+import {
+  type PositioningShorthandValue,
+  resolvePositioningShorthand,
+  usePositioning,
+} from '@fluentui/react-positioning';
 import { useActiveDescendant } from '@fluentui/react-aria';
 import { useComboboxBaseState } from '@fluentui/react-combobox';
 
@@ -26,11 +31,27 @@ const fallbackPositions: PositioningShorthandValue[] = ['above', 'after', 'after
  * @param props - props from this instance of Picker
  */
 export const useTagPicker_unstable = (props: TagPickerProps): TagPickerState => {
+  const { size = 'medium', appearance = 'outline', ...baseProps } = props;
+  const state = useTagPickerBase_unstable(baseProps);
+
+  return {
+    ...state,
+    size,
+    appearance,
+  };
+};
+
+/**
+ * Create the base state required to render TagPicker, without design-only props.
+ *
+ * @param props - props from this instance of TagPicker (without size, appearance)
+ */
+export const useTagPickerBase_unstable = (props: TagPickerBaseProps): TagPickerBaseState => {
   const popoverId = useId('picker-listbox');
   const triggerInnerRef = React.useRef<HTMLInputElement | HTMLButtonElement>(null);
   const secondaryActionRef = React.useRef<HTMLSpanElement>(null);
   const tagPickerGroupRef = React.useRef<HTMLDivElement>(null);
-  const { positioning, size = 'medium', inline = false, noPopover = false, disableAutoFocus } = props;
+  const { positioning, inline = false, noPopover = false, disableAutoFocus } = props;
 
   const { targetRef, containerRef } = usePositioning({
     position: 'below' as const,
@@ -87,7 +108,6 @@ export const useTagPicker_unstable = (props: TagPickerProps): TagPickerState => 
     secondaryActionRef,
     tagPickerGroupRef,
     targetRef,
-    size,
     inline,
     open: comboboxState.open,
     mountNode: comboboxState.mountNode,
@@ -95,7 +115,6 @@ export const useTagPicker_unstable = (props: TagPickerProps): TagPickerState => 
       comboboxState.onOptionClick(event);
       comboboxState.setOpen(event, false);
     }),
-    appearance: comboboxState.appearance,
     clearSelection: comboboxState.clearSelection,
     getOptionById: comboboxState.getOptionById,
     getOptionsMatchingValue: comboboxState.getOptionsMatchingValue,

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerButton/TagPickerButton.types.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerButton/TagPickerButton.types.ts
@@ -21,3 +21,13 @@ export type TagPickerButtonState = ComponentState<TagPickerButtonSlots> &
   Pick<TagPickerContextValue, 'size'> & {
     hasSelectedOption: boolean;
   };
+
+/**
+ * TagPickerButton Base Props - omits design-only props
+ */
+export type TagPickerButtonBaseProps = Omit<TagPickerButtonProps, 'size' | 'appearance'>;
+
+/**
+ * TagPickerButton Base State - omits design-only state
+ */
+export type TagPickerButtonBaseState = Omit<TagPickerButtonState, 'size'>;

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerButton/index.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerButton/index.ts
@@ -1,5 +1,11 @@
 export { TagPickerButton } from './TagPickerButton';
-export type { TagPickerButtonProps, TagPickerButtonSlots, TagPickerButtonState } from './TagPickerButton.types';
+export type {
+  TagPickerButtonBaseProps,
+  TagPickerButtonBaseState,
+  TagPickerButtonProps,
+  TagPickerButtonSlots,
+  TagPickerButtonState,
+} from './TagPickerButton.types';
 export { renderTagPickerButton_unstable } from './renderTagPickerButton';
-export { useTagPickerButton_unstable } from './useTagPickerButton';
+export { useTagPickerButtonBase_unstable, useTagPickerButton_unstable } from './useTagPickerButton';
 export { tagPickerButtonClassNames, useTagPickerButtonStyles_unstable } from './useTagPickerButtonStyles.styles';

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerButton/useTagPickerButton.tsx
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerButton/useTagPickerButton.tsx
@@ -2,7 +2,12 @@
 
 import type * as React from 'react';
 import { useActiveDescendantContext } from '@fluentui/react-aria';
-import type { TagPickerButtonProps, TagPickerButtonState } from './TagPickerButton.types';
+import type {
+  TagPickerButtonBaseProps,
+  TagPickerButtonBaseState,
+  TagPickerButtonProps,
+  TagPickerButtonState,
+} from './TagPickerButton.types';
 import { useTagPickerContext_unstable } from '../../contexts/TagPickerContext';
 import { useButtonTriggerSlot } from '@fluentui/react-combobox';
 
@@ -19,6 +24,23 @@ export const useTagPickerButton_unstable = (
   props: TagPickerButtonProps,
   ref: React.Ref<HTMLButtonElement>,
 ): TagPickerButtonState => {
+  const size = useTagPickerContext_unstable(ctx => ctx.size);
+  return {
+    ...useTagPickerButtonBase_unstable(props, ref),
+    size,
+  };
+};
+
+/**
+ * Create the base state required to render TagPickerButton, without design-only props.
+ *
+ * @param props - props from this instance of PickerButton (without size, appearance)
+ * @param ref - reference to root HTMLButtonElement of PickerButton
+ */
+export const useTagPickerButtonBase_unstable = (
+  props: TagPickerButtonBaseProps,
+  ref: React.Ref<HTMLButtonElement>,
+): TagPickerButtonBaseState => {
   const { controller: activeDescendantController } = useActiveDescendantContext();
   const triggerRef = useTagPickerContext_unstable(ctx => ctx.triggerRef);
   const open = useTagPickerContext_unstable(ctx => ctx.open);
@@ -39,7 +61,7 @@ export const useTagPickerButton_unstable = (
       tabIndex: 0,
       children:
         value ||
-        // @ts-expect-error - FIXME: TS2339: Property 'placeholder' does not exist on type 'TagPickerButtonProps'
+        // @ts-expect-error - FIXME: TS2339: Property 'placeholder' does not exist on type 'TagPickerButtonBaseProps'
         props.placeholder,
       'aria-controls': open ? popoverId : undefined,
       ref,
@@ -54,16 +76,11 @@ export const useTagPickerButton_unstable = (
     },
   });
 
-  const size = useTagPickerContext_unstable(ctx => ctx.size);
-
-  const state: TagPickerButtonState = {
+  return {
     components: {
       root: 'button',
     },
     root,
-    size,
     hasSelectedOption,
   };
-
-  return state;
 };

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerControl/TagPickerControl.types.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerControl/TagPickerControl.types.ts
@@ -32,3 +32,13 @@ export type TagPickerControlState = ComponentState<TagPickerControlSlots & TagPi
   Pick<TagPickerContextValue, 'size' | 'appearance' | 'disabled'> & {
     invalid: boolean;
   };
+
+/**
+ * TagPickerControl Base Props - same as TagPickerControlProps (no design-only own props)
+ */
+export type TagPickerControlBaseProps = TagPickerControlProps;
+
+/**
+ * TagPickerControl Base State - omits design-only state sourced from context
+ */
+export type TagPickerControlBaseState = Omit<TagPickerControlState, 'size' | 'appearance'>;

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerControl/index.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerControl/index.ts
@@ -1,5 +1,7 @@
 export { TagPickerControl } from './TagPickerControl';
 export type {
+  TagPickerControlBaseProps,
+  TagPickerControlBaseState,
   TagPickerControlCSSProperties,
   TagPickerControlInternalSlots,
   TagPickerControlProps,
@@ -7,7 +9,7 @@ export type {
   TagPickerControlState,
 } from './TagPickerControl.types';
 export { renderTagPickerControl_unstable } from './renderTagPickerControl';
-export { useTagPickerControl_unstable } from './useTagPickerControl';
+export { useTagPickerControlBase_unstable, useTagPickerControl_unstable } from './useTagPickerControl';
 export {
   iconSizes,
   tagPickerControlAsideWidthToken,

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerControl/useTagPickerControl.tsx
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerControl/useTagPickerControl.tsx
@@ -11,7 +11,12 @@ import {
   useMergedRefs,
 } from '@fluentui/react-utilities';
 import { useFluent_unstable } from '@fluentui/react-shared-contexts';
-import type { TagPickerControlProps, TagPickerControlState } from './TagPickerControl.types';
+import type {
+  TagPickerControlBaseProps,
+  TagPickerControlBaseState,
+  TagPickerControlProps,
+  TagPickerControlState,
+} from './TagPickerControl.types';
 import { useTagPickerContext_unstable } from '../../contexts/TagPickerContext';
 import { ChevronDownRegular } from '@fluentui/react-icons';
 import { useResizeObserverRef } from '../../utils/useResizeObserverRef';
@@ -20,18 +25,15 @@ import { useFieldContext_unstable } from '@fluentui/react-field';
 import { useExpandLabel } from '../../utils/useExpandLabel';
 
 /**
- * Create the state required to render PickerControl.
- *
- * The returned state can be modified with hooks such as usePickerControlStyles_unstable,
- * before being passed to renderPickerControl_unstable.
+ * Create the base state required to render TagPickerControl, without design-only props.
  *
  * @param props - props from this instance of PickerControl
  * @param ref - reference to root HTMLDivElement of PickerControl
  */
-export const useTagPickerControl_unstable = (
-  props: TagPickerControlProps,
+export const useTagPickerControlBase_unstable = (
+  props: TagPickerControlBaseProps,
   ref: React.Ref<HTMLDivElement>,
-): TagPickerControlState => {
+): TagPickerControlBaseState => {
   const targetRef = useTagPickerContext_unstable(ctx => ctx.targetRef);
   const triggerRef = useTagPickerContext_unstable(ctx => ctx.triggerRef);
   const tagPickerGroupRef = useTagPickerContext_unstable(ctx => ctx.tagPickerGroupRef);
@@ -39,8 +41,6 @@ export const useTagPickerControl_unstable = (
   const popoverId = useTagPickerContext_unstable(ctx => ctx.popoverId);
   const setOpen = useTagPickerContext_unstable(ctx => ctx.setOpen);
   const secondaryInnerActionRef = useTagPickerContext_unstable(ctx => ctx.secondaryActionRef);
-  const size = useTagPickerContext_unstable(ctx => ctx.size);
-  const appearance = useTagPickerContext_unstable(ctx => ctx.appearance);
   const disabled = useTagPickerContext_unstable(ctx => ctx.disabled);
   const invalid = useFieldContext_unstable()?.validationState === 'error';
   const noPopover = useTagPickerContext_unstable(ctx => ctx.noPopover ?? false);
@@ -66,7 +66,6 @@ export const useTagPickerControl_unstable = (
     defaultProps: {
       'aria-expanded': open,
       'aria-disabled': disabled ? 'true' : undefined,
-      children: <ChevronDownRegular />,
       role: 'button',
     },
     elementType: 'span',
@@ -114,7 +113,7 @@ export const useTagPickerControl_unstable = (
     }
   });
 
-  const state: TagPickerControlState = {
+  const state: TagPickerControlBaseState = {
     components: {
       root: 'div',
       expandIcon: 'span',
@@ -133,8 +132,6 @@ export const useTagPickerControl_unstable = (
     aside,
     expandIcon,
     secondaryAction,
-    size,
-    appearance,
     disabled,
     invalid,
   };
@@ -153,4 +150,32 @@ export const useTagPickerControl_unstable = (
   }, [targetDocument]);
 
   return state;
+};
+
+/**
+ * Create the state required to render PickerControl.
+ *
+ * The returned state can be modified with hooks such as usePickerControlStyles_unstable,
+ * before being passed to renderPickerControl_unstable.
+ *
+ * @param props - props from this instance of PickerControl
+ * @param ref - reference to root HTMLDivElement of PickerControl
+ */
+export const useTagPickerControl_unstable = (
+  props: TagPickerControlProps,
+  ref: React.Ref<HTMLDivElement>,
+): TagPickerControlState => {
+  const size = useTagPickerContext_unstable(ctx => ctx.size);
+  const appearance = useTagPickerContext_unstable(ctx => ctx.appearance);
+  const baseState = useTagPickerControlBase_unstable(props, ref);
+
+  return {
+    ...baseState,
+    size,
+    appearance,
+    // Add design default icon for expandIcon
+    expandIcon: baseState.expandIcon
+      ? { ...baseState.expandIcon, children: baseState.expandIcon.children ?? <ChevronDownRegular /> }
+      : baseState.expandIcon,
+  };
 };

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerGroup/TagPickerGroup.types.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerGroup/TagPickerGroup.types.ts
@@ -1,4 +1,4 @@
-import type { TagGroupSlots, TagGroupState } from '@fluentui/react-tags';
+import type { TagGroupBaseState, TagGroupSlots, TagGroupState } from '@fluentui/react-tags';
 import type { ComponentProps } from '@fluentui/react-utilities';
 
 export type TagPickerGroupSlots = TagGroupSlots;
@@ -12,5 +12,17 @@ export type TagPickerGroupProps = ComponentProps<TagPickerGroupSlots>;
  * State used in rendering TagPickerGroup
  */
 export type TagPickerGroupState = TagGroupState & {
+  hasSelectedOptions: boolean;
+};
+
+/**
+ * TagPickerGroup Base Props - same as TagPickerGroupProps (no design-only own props)
+ */
+export type TagPickerGroupBaseProps = TagPickerGroupProps;
+
+/**
+ * TagPickerGroup Base State - omits design-only state sourced from TagPicker context
+ */
+export type TagPickerGroupBaseState = TagGroupBaseState & {
   hasSelectedOptions: boolean;
 };

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerGroup/index.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerGroup/index.ts
@@ -1,5 +1,11 @@
 export { TagPickerGroup } from './TagPickerGroup';
-export type { TagPickerGroupProps, TagPickerGroupSlots, TagPickerGroupState } from './TagPickerGroup.types';
+export type {
+  TagPickerGroupBaseProps,
+  TagPickerGroupBaseState,
+  TagPickerGroupProps,
+  TagPickerGroupSlots,
+  TagPickerGroupState,
+} from './TagPickerGroup.types';
 export { renderTagPickerGroup_unstable } from './renderTagPickerGroup';
-export { useTagPickerGroup_unstable } from './useTagPickerGroup';
+export { useTagPickerGroupBase_unstable, useTagPickerGroup_unstable } from './useTagPickerGroup';
 export { tagPickerGroupClassNames, useTagPickerGroupStyles_unstable } from './useTagPickerGroupStyles.styles';

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerGroup/useTagPickerGroup.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerGroup/useTagPickerGroup.ts
@@ -1,8 +1,13 @@
 'use client';
 
-import type * as React from 'react';
-import type { TagPickerGroupProps, TagPickerGroupState } from './TagPickerGroup.types';
-import { useTagGroup_unstable } from '@fluentui/react-tags';
+import * as React from 'react';
+import type {
+  TagPickerGroupBaseProps,
+  TagPickerGroupBaseState,
+  TagPickerGroupProps,
+  TagPickerGroupState,
+} from './TagPickerGroup.types';
+import { useTagGroupBase_unstable } from '@fluentui/react-tags';
 import { useTagPickerContext_unstable } from '../../contexts/TagPickerContext';
 import { isHTMLElement, useEventCallback, useMergedRefs } from '@fluentui/react-utilities';
 import { tagPickerAppearanceToTagAppearance, tagPickerSizeToTagSize } from '../../utils/tagPicker2Tag';
@@ -10,25 +15,20 @@ import { useArrowNavigationGroup } from '@fluentui/react-tabster';
 import { ArrowRight } from '@fluentui/keyboard-keys';
 
 /**
- * Create the state required to render TagPickerGroup.
- *
- * The returned state can be modified with hooks such as usePickerTagGroupStyles_unstable,
- * before being passed to renderPickerTagGroup_unstable.
+ * Create the base state required to render TagPickerGroup, without design-only props.
  *
  * @param props - props from this instance of TagPickerGroup
  * @param ref - reference to root HTMLDivElement of TagPickerGroup
  */
-export const useTagPickerGroup_unstable = (
-  props: TagPickerGroupProps,
+export const useTagPickerGroupBase_unstable = (
+  props: TagPickerGroupBaseProps,
   ref: React.Ref<HTMLDivElement>,
-): TagPickerGroupState => {
+): TagPickerGroupBaseState => {
   const hasSelectedOptions = useTagPickerContext_unstable(ctx => ctx.selectedOptions.length > 0);
   const hasOneSelectedOption = useTagPickerContext_unstable(ctx => ctx.selectedOptions.length === 1);
   const triggerRef = useTagPickerContext_unstable(ctx => ctx.triggerRef);
   const tagPickerGroupRef = useTagPickerContext_unstable(ctx => ctx.tagPickerGroupRef);
   const selectOption = useTagPickerContext_unstable(ctx => ctx.selectOption);
-  const size = useTagPickerContext_unstable(ctx => tagPickerSizeToTagSize(ctx.size));
-  const appearance = useTagPickerContext_unstable(ctx => ctx.appearance);
   const disabled = useTagPickerContext_unstable(ctx => ctx.disabled);
 
   const arrowNavigationProps = useArrowNavigationGroup({
@@ -37,14 +37,12 @@ export const useTagPickerGroup_unstable = (
     memorizeCurrent: true,
   });
 
-  const state = useTagGroup_unstable(
+  const state = useTagGroupBase_unstable(
     {
       role: 'listbox',
       disabled,
       ...props,
       ...arrowNavigationProps,
-      size,
-      appearance: tagPickerAppearanceToTagAppearance(appearance),
       dismissible: true,
       onKeyDown: useEventCallback(event => {
         props.onKeyDown?.(event);
@@ -71,5 +69,28 @@ export const useTagPickerGroup_unstable = (
   return {
     ...state,
     hasSelectedOptions,
+  };
+};
+
+/**
+ * Create the state required to render TagPickerGroup.
+ *
+ * The returned state can be modified with hooks such as usePickerTagGroupStyles_unstable,
+ * before being passed to renderPickerTagGroup_unstable.
+ *
+ * @param props - props from this instance of TagPickerGroup
+ * @param ref - reference to root HTMLDivElement of TagPickerGroup
+ */
+export const useTagPickerGroup_unstable = (
+  props: TagPickerGroupProps,
+  ref: React.Ref<HTMLDivElement>,
+): TagPickerGroupState => {
+  const size = useTagPickerContext_unstable(ctx => tagPickerSizeToTagSize(ctx.size));
+  const appearance = useTagPickerContext_unstable(ctx => ctx.appearance);
+
+  return {
+    ...useTagPickerGroupBase_unstable(props, ref),
+    size,
+    appearance: tagPickerAppearanceToTagAppearance(appearance),
   };
 };

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerGroup/useTagPickerGroup.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerGroup/useTagPickerGroup.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import * as React from 'react';
+import type * as React from 'react';
 import type {
   TagPickerGroupBaseProps,
   TagPickerGroupBaseState,

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerInput/TagPickerInput.types.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerInput/TagPickerInput.types.ts
@@ -23,3 +23,13 @@ export type TagPickerInputProps = Omit<
  */
 export type TagPickerInputState = ComponentState<TagPickerInputSlots> &
   Pick<TagPickerContextValue, 'size' | 'disabled'>;
+
+/**
+ * TagPickerInput Base Props - omits design-only props
+ */
+export type TagPickerInputBaseProps = Omit<TagPickerInputProps, 'appearance'>;
+
+/**
+ * TagPickerInput Base State - omits design-only state
+ */
+export type TagPickerInputBaseState = Omit<TagPickerInputState, 'size'>;

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerInput/index.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerInput/index.ts
@@ -1,5 +1,11 @@
 export { TagPickerInput } from './TagPickerInput';
-export type { TagPickerInputProps, TagPickerInputSlots, TagPickerInputState } from './TagPickerInput.types';
+export type {
+  TagPickerInputBaseProps,
+  TagPickerInputBaseState,
+  TagPickerInputProps,
+  TagPickerInputSlots,
+  TagPickerInputState,
+} from './TagPickerInput.types';
 export { renderTagPickerInput_unstable } from './renderTagPickerInput';
-export { useTagPickerInput_unstable } from './useTagPickerInput';
+export { useTagPickerInputBase_unstable, useTagPickerInput_unstable } from './useTagPickerInput';
 export { tagPickerInputClassNames, useTagPickerInputStyles_unstable } from './useTagPickerInputStyles.styles';

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerInput/useTagPickerInput.tsx
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerInput/useTagPickerInput.tsx
@@ -2,7 +2,12 @@
 
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import type { TagPickerInputProps, TagPickerInputState } from './TagPickerInput.types';
+import type {
+  TagPickerInputBaseProps,
+  TagPickerInputBaseState,
+  TagPickerInputProps,
+  TagPickerInputState,
+} from './TagPickerInput.types';
 import { useActiveDescendantContext } from '@fluentui/react-aria';
 import { useTagPickerContext_unstable } from '../../contexts/TagPickerContext';
 import {
@@ -18,25 +23,21 @@ import { tagPickerInputCSSRules } from '../../utils/tokens';
 import { useFocusFinders } from '@fluentui/react-tabster';
 
 /**
- * Create the state required to render TagPickerInput.
+ * Create the base state required to render TagPickerInput, without design-only props.
  *
- * The returned state can be modified with hooks such as useTagPickerInputStyles_unstable,
- * before being passed to renderTagPickerInput_unstable.
- *
- * @param props - props from this instance of TagPickerInput
- * @param ref - reference to root HTMLDivElement of TagPickerInput
+ * @param propsArg - props from this instance of TagPickerInput (without appearance)
+ * @param ref - reference to root HTMLInputElement of TagPickerInput
  */
-export const useTagPickerInput_unstable = (
-  propsArg: TagPickerInputProps,
+export const useTagPickerInputBase_unstable = (
+  propsArg: TagPickerInputBaseProps,
   ref: React.Ref<HTMLInputElement>,
-): TagPickerInputState => {
+): TagPickerInputBaseState => {
   const props = useFieldControlProps_unstable(propsArg, {
     supportsLabelFor: true,
     supportsRequired: true,
     supportsSize: true,
   });
   const { controller: activeDescendantController } = useActiveDescendantContext();
-  const size = useTagPickerContext_unstable(ctx => ctx.size);
   const contextDisabled = useTagPickerContext_unstable(ctx => ctx.disabled);
   const tagPickerGroupRef = useTagPickerContext_unstable(ctx => ctx.tagPickerGroupRef);
 
@@ -128,16 +129,33 @@ export const useTagPickerInput_unstable = (
     },
   );
 
-  const state: TagPickerInputState = {
+  return {
     components: {
       root: 'input',
     },
     root,
     disabled,
+  };
+};
+
+/**
+ * Create the state required to render TagPickerInput.
+ *
+ * The returned state can be modified with hooks such as useTagPickerInputStyles_unstable,
+ * before being passed to renderTagPickerInput_unstable.
+ *
+ * @param propsArg - props from this instance of TagPickerInput
+ * @param ref - reference to root HTMLInputElement of TagPickerInput
+ */
+export const useTagPickerInput_unstable = (
+  propsArg: TagPickerInputProps,
+  ref: React.Ref<HTMLInputElement>,
+): TagPickerInputState => {
+  const size = useTagPickerContext_unstable(ctx => ctx.size);
+  return {
+    ...useTagPickerInputBase_unstable(propsArg, ref),
     size,
   };
-
-  return state;
 };
 
 /**

--- a/packages/react-components/react-tag-picker/library/src/index.ts
+++ b/packages/react-components/react-tag-picker/library/src/index.ts
@@ -1,5 +1,7 @@
-export { TagPicker, renderTagPicker_unstable, useTagPicker_unstable } from './TagPicker';
+export { TagPicker, renderTagPicker_unstable, useTagPickerBase_unstable, useTagPicker_unstable } from './TagPicker';
 export type {
+  TagPickerBaseProps,
+  TagPickerBaseState,
   TagPickerContextValues,
   TagPickerProps,
   TagPickerSlots,
@@ -13,9 +15,16 @@ export {
   tagPickerInputClassNames,
   renderTagPickerInput_unstable,
   useTagPickerInputStyles_unstable,
+  useTagPickerInputBase_unstable,
   useTagPickerInput_unstable,
 } from './TagPickerInput';
-export type { TagPickerInputProps, TagPickerInputSlots, TagPickerInputState } from './TagPickerInput';
+export type {
+  TagPickerInputBaseProps,
+  TagPickerInputBaseState,
+  TagPickerInputProps,
+  TagPickerInputSlots,
+  TagPickerInputState,
+} from './TagPickerInput';
 export {
   TagPickerList,
   tagPickerListClassNames,
@@ -29,17 +38,31 @@ export {
   tagPickerButtonClassNames,
   renderTagPickerButton_unstable,
   useTagPickerButtonStyles_unstable,
+  useTagPickerButtonBase_unstable,
   useTagPickerButton_unstable,
 } from './TagPickerButton';
-export type { TagPickerButtonProps, TagPickerButtonSlots, TagPickerButtonState } from './TagPickerButton';
+export type {
+  TagPickerButtonBaseProps,
+  TagPickerButtonBaseState,
+  TagPickerButtonProps,
+  TagPickerButtonSlots,
+  TagPickerButtonState,
+} from './TagPickerButton';
 export {
   TagPickerControl,
   tagPickerControlClassNames,
   renderTagPickerControl_unstable,
   useTagPickerControlStyles_unstable,
+  useTagPickerControlBase_unstable,
   useTagPickerControl_unstable,
 } from './TagPickerControl';
-export type { TagPickerControlProps, TagPickerControlSlots, TagPickerControlState } from './TagPickerControl';
+export type {
+  TagPickerControlBaseProps,
+  TagPickerControlBaseState,
+  TagPickerControlProps,
+  TagPickerControlSlots,
+  TagPickerControlState,
+} from './TagPickerControl';
 export {
   TagPickerOption,
   tagPickerOptionClassNames,
@@ -53,9 +76,16 @@ export {
   tagPickerGroupClassNames,
   renderTagPickerGroup_unstable,
   useTagPickerGroupStyles_unstable,
+  useTagPickerGroupBase_unstable,
   useTagPickerGroup_unstable,
 } from './TagPickerGroup';
-export type { TagPickerGroupProps, TagPickerGroupSlots, TagPickerGroupState } from './TagPickerGroup';
+export type {
+  TagPickerGroupBaseProps,
+  TagPickerGroupBaseState,
+  TagPickerGroupProps,
+  TagPickerGroupSlots,
+  TagPickerGroupState,
+} from './TagPickerGroup';
 
 export {
   TagPickerOptionGroup,


### PR DESCRIPTION
## Summary

- Adds `useTagPickerBase_unstable` for `TagPicker` (omits `size`, `appearance`)
- Adds `useTagPickerButtonBase_unstable` for `TagPickerButton` (omits `size`)
- Adds `useTagPickerControlBase_unstable` for `TagPickerControl` (omits `size`, `appearance`; `expandIcon` without default icon children)
- Adds `useTagPickerGroupBase_unstable` for `TagPickerGroup` (calls `useTagGroupBase_unstable`, omits `size`/`appearance` from context)
- Adds `useTagPickerInputBase_unstable` for `TagPickerInput` (omits `size`)
- Exports new hooks and `Base*Props`/`Base*State` types from package index
- `TagPickerList`, `TagPickerOption`, `TagPickerOptionGroup` skipped (no design-only state props)

Part of the base state hooks RFC: [docs/react-v9/contributing/rfcs/react-components/convergence/base-state-hooks.md](docs/react-v9/contributing/rfcs/react-components/convergence/base-state-hooks.md)

## Test plan

- [x] Existing tests pass (`yarn jest react-tag-picker`)
- [x] Build passes (`yarn build --to @fluentui/react-tag-picker`)
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)