### PR TITLE
feat(react-table): add useTableBase_unstable, useTableCellBase_unstable, useTableRowBase_unstable, useTableCellLayoutBase_unstable, useDataGridBase_unstable, useDataGridRowBase_unstable

### DIFF
--- a/change/@fluentui-react-table-base-hooks.json
+++ b/change/@fluentui-react-table-base-hooks.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add base hooks for Table, TableCell, TableRow, TableCellLayout, DataGrid, DataGridRow",
+  "packageName": "@fluentui/react-table",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-table/library/src/DataGrid.ts
+++ b/packages/react-components/react-table/library/src/DataGrid.ts
@@ -1,4 +1,6 @@
 export type {
+  DataGridBaseProps,
+  DataGridBaseState,
   DataGridContextValue,
   DataGridContextValues,
   DataGridFocusMode,
@@ -12,5 +14,6 @@ export {
   renderDataGrid_unstable,
   useDataGridContextValues_unstable,
   useDataGridStyles_unstable,
+  useDataGridBase_unstable,
   useDataGrid_unstable,
 } from './components/DataGrid/index';

--- a/packages/react-components/react-table/library/src/DataGridRow.ts
+++ b/packages/react-components/react-table/library/src/DataGridRow.ts
@@ -1,5 +1,7 @@
 export type {
   CellRenderFunction,
+  DataGridRowBaseProps,
+  DataGridRowBaseState,
   DataGridRowProps,
   DataGridRowSlots,
   DataGridRowState,
@@ -9,5 +11,6 @@ export {
   dataGridRowClassNames,
   renderDataGridRow_unstable,
   useDataGridRowStyles_unstable,
+  useDataGridRowBase_unstable,
   useDataGridRow_unstable,
 } from './components/DataGridRow/index';

--- a/packages/react-components/react-table/library/src/Table.ts
+++ b/packages/react-components/react-table/library/src/Table.ts
@@ -1,5 +1,7 @@
 export type {
   SortDirection,
+  TableBaseProps,
+  TableBaseState,
   TableContextValue,
   TableContextValues,
   TableProps,
@@ -12,5 +14,6 @@ export {
   tableClassName,
   tableClassNames,
   useTableStyles_unstable,
+  useTableBase_unstable,
   useTable_unstable,
 } from './components/Table/index';

--- a/packages/react-components/react-table/library/src/TableCell.ts
+++ b/packages/react-components/react-table/library/src/TableCell.ts
@@ -1,9 +1,16 @@
-export type { TableCellProps, TableCellSlots, TableCellState } from './components/TableCell/index';
+export type {
+  TableCellBaseProps,
+  TableCellBaseState,
+  TableCellProps,
+  TableCellSlots,
+  TableCellState,
+} from './components/TableCell/index';
 export {
   TableCell,
   renderTableCell_unstable,
   tableCellClassName,
   tableCellClassNames,
   useTableCellStyles_unstable,
+  useTableCellBase_unstable,
   useTableCell_unstable,
 } from './components/TableCell/index';

--- a/packages/react-components/react-table/library/src/TableCellLayout.ts
+++ b/packages/react-components/react-table/library/src/TableCellLayout.ts
@@ -1,4 +1,6 @@
 export type {
+  TableCellLayoutBaseProps,
+  TableCellLayoutBaseState,
   TableCellLayoutContextValues,
   TableCellLayoutProps,
   TableCellLayoutSlots,
@@ -9,5 +11,6 @@ export {
   renderTableCellLayout_unstable,
   tableCellLayoutClassNames,
   useTableCellLayoutStyles_unstable,
+  useTableCellLayoutBase_unstable,
   useTableCellLayout_unstable,
 } from './components/TableCellLayout/index';

--- a/packages/react-components/react-table/library/src/TableRow.ts
+++ b/packages/react-components/react-table/library/src/TableRow.ts
@@ -1,9 +1,16 @@
-export type { TableRowProps, TableRowSlots, TableRowState } from './components/TableRow/index';
+export type {
+  TableRowBaseProps,
+  TableRowBaseState,
+  TableRowProps,
+  TableRowSlots,
+  TableRowState,
+} from './components/TableRow/index';
 export {
   TableRow,
   renderTableRow_unstable,
   tableRowClassName,
   tableRowClassNames,
   useTableRowStyles_unstable,
+  useTableRowBase_unstable,
   useTableRow_unstable,
 } from './components/TableRow/index';

--- a/packages/react-components/react-table/library/src/components/DataGrid/DataGrid.types.ts
+++ b/packages/react-components/react-table/library/src/components/DataGrid/DataGrid.types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { SelectionHookParams, SelectionMode } from '@fluentui/react-utilities';
+import { DistributiveOmit, SelectionHookParams, SelectionMode } from '@fluentui/react-utilities';
 import { TabsterDOMAttribute } from '@fluentui/react-tabster';
 import type { TableContextValues, TableProps, TableSlots, TableState } from '../Table/Table.types';
 import type {
@@ -118,3 +118,13 @@ export type DataGridState = TableState & { tableState: TableFeaturesState<unknow
     | 'resizableColumns'
     | 'compositeRowTabsterAttribute'
   >;
+
+/**
+ * DataGrid Props without design-only props.
+ */
+export type DataGridBaseProps = DistributiveOmit<DataGridProps, 'subtleSelection' | 'selectionAppearance' | 'size'>;
+
+/**
+ * State used in rendering DataGrid, without design-only state.
+ */
+export type DataGridBaseState = DistributiveOmit<DataGridState, 'subtleSelection' | 'selectionAppearance' | 'size'>;

--- a/packages/react-components/react-table/library/src/components/DataGrid/index.ts
+++ b/packages/react-components/react-table/library/src/components/DataGrid/index.ts
@@ -1,5 +1,7 @@
 export { DataGrid } from './DataGrid';
 export type {
+  DataGridBaseProps,
+  DataGridBaseState,
   DataGridContextValue,
   DataGridContextValues,
   DataGridFocusMode,
@@ -8,6 +10,6 @@ export type {
   DataGridState,
 } from './DataGrid.types';
 export { renderDataGrid_unstable } from './renderDataGrid';
-export { useDataGrid_unstable } from './useDataGrid';
+export { useDataGridBase_unstable, useDataGrid_unstable } from './useDataGrid';
 export { dataGridClassNames, useDataGridStyles_unstable } from './useDataGridStyles.styles';
 export { useDataGridContextValues_unstable } from './useDataGridContextValues';

--- a/packages/react-components/react-table/library/src/components/DataGrid/useDataGrid.ts
+++ b/packages/react-components/react-table/library/src/components/DataGrid/useDataGrid.ts
@@ -2,8 +2,8 @@
 
 import * as React from 'react';
 import { useArrowNavigationGroup, useFocusFinders } from '@fluentui/react-tabster';
-import type { DataGridProps, DataGridState } from './DataGrid.types';
-import { useTable_unstable } from '../Table/useTable';
+import type { DataGridBaseProps, DataGridBaseState, DataGridProps, DataGridState } from './DataGrid.types';
+import { useTableBase_unstable } from '../Table/useTable';
 import { useEventCallback, useMergedRefs } from '@fluentui/react-utilities';
 import { End, Home } from '@fluentui/keyboard-keys';
 import {
@@ -16,15 +16,12 @@ import {
 import { CELL_WIDTH } from '../TableSelectionCell';
 
 /**
- * Create the state required to render DataGrid.
+ * Create the base state required to render DataGrid, without design-only props.
  *
- * The returned state can be modified with hooks such as useDataGridStyles_unstable,
- * before being passed to renderDataGrid_unstable.
- *
- * @param props - props from this instance of DataGrid
+ * @param props - props from this instance of DataGrid (without subtleSelection, selectionAppearance, size)
  * @param ref - reference to root HTMLElement of DataGrid
  */
-export const useDataGrid_unstable = (props: DataGridProps, ref: React.Ref<HTMLElement>): DataGridState => {
+export const useDataGridBase_unstable = (props: DataGridBaseProps, ref: React.Ref<HTMLElement>): DataGridBaseState => {
   const {
     items,
     columns,
@@ -36,8 +33,6 @@ export const useDataGrid_unstable = (props: DataGridProps, ref: React.Ref<HTMLEl
     sortState,
     selectedItems,
     defaultSelectedItems,
-    subtleSelection = false,
-    selectionAppearance = 'brand',
     getRowId,
     resizableColumns,
     columnSizingOptions,
@@ -73,11 +68,7 @@ export const useDataGrid_unstable = (props: DataGridProps, ref: React.Ref<HTMLEl
     useTableColumnSizing_unstable({
       onColumnResize,
       columnSizingOptions,
-      // The selection cell is not part of the columns, therefore its width needs to be subtracted
-      // from the container to make sure the columns don't overflow the table.
       containerWidthOffset: widthOffset,
-      // Disables automatic resizing of columns when the container overflows.
-      // This allows the sum of the columns to be larger than the container.
       autoFitColumns: resizableColumnsOptions.autoFitColumns ?? true,
     }),
   ]);
@@ -88,7 +79,6 @@ export const useDataGrid_unstable = (props: DataGridProps, ref: React.Ref<HTMLEl
     props.onKeyDown?.(e);
     focusMode === 'composite' && onCompositeKeyDown(e);
 
-    // handle ctrl+home and ctrl+end
     if (!innerRef.current || !e.ctrlKey || e.defaultPrevented) {
       return;
     }
@@ -109,7 +99,7 @@ export const useDataGrid_unstable = (props: DataGridProps, ref: React.Ref<HTMLEl
     }
   });
 
-  const baseTableState = useTable_unstable(
+  const baseTableState = useTableBase_unstable(
     {
       role: 'grid',
       as: 'div',
@@ -128,9 +118,26 @@ export const useDataGrid_unstable = (props: DataGridProps, ref: React.Ref<HTMLEl
     focusMode,
     tableState,
     selectableRows: !!selectionMode,
-    subtleSelection,
-    selectionAppearance,
     resizableColumns,
     compositeRowTabsterAttribute,
+  };
+};
+
+/**
+ * Create the state required to render DataGrid.
+ *
+ * The returned state can be modified with hooks such as useDataGridStyles_unstable,
+ * before being passed to renderDataGrid_unstable.
+ *
+ * @param props - props from this instance of DataGrid
+ * @param ref - reference to root HTMLElement of DataGrid
+ */
+export const useDataGrid_unstable = (props: DataGridProps, ref: React.Ref<HTMLElement>): DataGridState => {
+  const { subtleSelection = false, selectionAppearance = 'brand' } = props;
+  return {
+    ...useDataGridBase_unstable(props, ref),
+    subtleSelection,
+    selectionAppearance,
+    size: props.size ?? 'medium',
   };
 };

--- a/packages/react-components/react-table/library/src/components/DataGridRow/DataGridRow.types.ts
+++ b/packages/react-components/react-table/library/src/components/DataGridRow/DataGridRow.types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+import type { ComponentProps, ComponentState, DistributiveOmit, Slot } from '@fluentui/react-utilities';
 import type { TableColumnDefinition } from '../../hooks';
 import { DataGridContextValue } from '../DataGrid/DataGrid.types';
 import type { TableRowProps, TableRowSlots, TableRowState } from '../TableRow/TableRow.types';
@@ -36,3 +36,13 @@ export type DataGridRowState = TableRowState &
     columnDefs: TableColumnDefinition<any>[];
     dataGridContextValue: DataGridContextValue;
   };
+
+/**
+ * DataGridRow Props without design-only props.
+ */
+export type DataGridRowBaseProps<TItem = unknown> = DistributiveOmit<DataGridRowProps<TItem>, 'appearance'>;
+
+/**
+ * State used in rendering DataGridRow, without design-only state.
+ */
+export type DataGridRowBaseState = DistributiveOmit<DataGridRowState, 'appearance' | 'size'>;

--- a/packages/react-components/react-table/library/src/components/DataGridRow/index.ts
+++ b/packages/react-components/react-table/library/src/components/DataGridRow/index.ts
@@ -1,5 +1,12 @@
 export { DataGridRow } from './DataGridRow';
-export type { CellRenderFunction, DataGridRowProps, DataGridRowSlots, DataGridRowState } from './DataGridRow.types';
+export type {
+  CellRenderFunction,
+  DataGridRowBaseProps,
+  DataGridRowBaseState,
+  DataGridRowProps,
+  DataGridRowSlots,
+  DataGridRowState,
+} from './DataGridRow.types';
 export { renderDataGridRow_unstable } from './renderDataGridRow';
-export { useDataGridRow_unstable } from './useDataGridRow';
+export { useDataGridRowBase_unstable, useDataGridRow_unstable } from './useDataGridRow';
 export { dataGridRowClassNames, useDataGridRowStyles_unstable } from './useDataGridRowStyles.styles';

--- a/packages/react-components/react-table/library/src/components/DataGridRow/useDataGridRow.tsx
+++ b/packages/react-components/react-table/library/src/components/DataGridRow/useDataGridRow.tsx
@@ -3,23 +3,29 @@
 import * as React from 'react';
 import { isInteractiveHTMLElement, useEventCallback, slot } from '@fluentui/react-utilities';
 import { Space } from '@fluentui/keyboard-keys';
-import type { DataGridRowProps, DataGridRowState } from './DataGridRow.types';
-import { useTableRow_unstable } from '../TableRow/useTableRow';
+import type {
+  DataGridRowBaseProps,
+  DataGridRowBaseState,
+  DataGridRowProps,
+  DataGridRowState,
+} from './DataGridRow.types';
+import { useTableRowBase_unstable } from '../TableRow/useTableRow';
 import { dataGridContextDefaultValue, useDataGridContext_unstable } from '../../contexts/dataGridContext';
+import { useTableContext } from '../../contexts/tableContext';
 import { DataGridSelectionCell } from '../DataGridSelectionCell/DataGridSelectionCell';
 import { useTableRowIdContext } from '../../contexts/rowIdContext';
 import { useIsInTableHeader } from '../../contexts/tableHeaderContext';
 
 /**
- * Create the state required to render DataGridRow.
+ * Create the base state required to render DataGridRow, without design-only props.
  *
- * The returned state can be modified with hooks such as useDataGridRowStyles_unstable,
- * before being passed to renderDataGridRow_unstable.
- *
- * @param props - props from this instance of DataGridRow
+ * @param props - props from this instance of DataGridRow (without appearance)
  * @param ref - reference to root HTMLElement of DataGridRow
  */
-export const useDataGridRow_unstable = (props: DataGridRowProps, ref: React.Ref<HTMLElement>): DataGridRowState => {
+export const useDataGridRowBase_unstable = (
+  props: DataGridRowBaseProps,
+  ref: React.Ref<HTMLElement>,
+): DataGridRowBaseState => {
   const rowId = useTableRowIdContext();
   const isHeader = useIsInTableHeader();
   const columnDefs = useDataGridContext_unstable(ctx => ctx.columns);
@@ -29,13 +35,7 @@ export const useDataGridRow_unstable = (props: DataGridRowProps, ref: React.Ref<
   const compositeRowTabsterAttribute = useDataGridContext_unstable(ctx => ctx.compositeRowTabsterAttribute);
 
   const tabbable = focusMode === 'row_unstable' || focusMode === 'composite';
-  const appearance = useDataGridContext_unstable(ctx => {
-    if (!isHeader && selectable && ctx.selection.isRowSelected(rowId)) {
-      return ctx.selectionAppearance;
-    }
 
-    return 'none';
-  });
   const toggleRow = useDataGridContext_unstable(ctx => ctx.selection.toggleRow);
 
   const onClick = useEventCallback((e: React.MouseEvent<HTMLTableRowElement>) => {
@@ -56,9 +56,8 @@ export const useDataGridRow_unstable = (props: DataGridRowProps, ref: React.Ref<
     props.onKeyDown?.(e);
   });
 
-  const baseState = useTableRow_unstable(
+  const baseState = useTableRowBase_unstable(
     {
-      appearance,
       'aria-selected': selectable ? selected : undefined,
       tabIndex: tabbable && !isHeader ? 0 : undefined,
       ...(focusMode === 'composite' && !isHeader && compositeRowTabsterAttribute),
@@ -84,9 +83,35 @@ export const useDataGridRow_unstable = (props: DataGridRowProps, ref: React.Ref<
     }),
     renderCell: props.children,
     columnDefs,
-    // This context value should not be used internally
-    // It's intended to help power user render functions
     dataGridContextValue: useStableDataGridContextValue(),
+  };
+};
+
+/**
+ * Create the state required to render DataGridRow.
+ *
+ * The returned state can be modified with hooks such as useDataGridRowStyles_unstable,
+ * before being passed to renderDataGridRow_unstable.
+ *
+ * @param props - props from this instance of DataGridRow
+ * @param ref - reference to root HTMLElement of DataGridRow
+ */
+export const useDataGridRow_unstable = (props: DataGridRowProps, ref: React.Ref<HTMLElement>): DataGridRowState => {
+  const rowId = useTableRowIdContext();
+  const isHeader = useIsInTableHeader();
+  const selectable = useDataGridContext_unstable(ctx => ctx.selectableRows);
+  const { size } = useTableContext();
+  const appearance = useDataGridContext_unstable(ctx => {
+    if (!isHeader && selectable && ctx.selection.isRowSelected(rowId)) {
+      return ctx.selectionAppearance ?? 'brand';
+    }
+
+    return 'none';
+  });
+  return {
+    ...useDataGridRowBase_unstable(props, ref),
+    appearance,
+    size,
   };
 };
 

--- a/packages/react-components/react-table/library/src/components/Table/Table.types.ts
+++ b/packages/react-components/react-table/library/src/components/Table/Table.types.ts
@@ -1,4 +1,4 @@
-import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+import type { ComponentProps, ComponentState, DistributiveOmit, Slot } from '@fluentui/react-utilities';
 
 export type TableSlots = {
   root: Slot<'table', 'div'>;
@@ -37,8 +37,18 @@ export type TableContextValues = {
 export type TableProps = ComponentProps<TableSlots> & Partial<TableContextValue>;
 
 /**
+ * Table Props without design-only props.
+ */
+export type TableBaseProps = DistributiveOmit<TableProps, 'size'>;
+
+/**
  * State used in rendering Table
  */
 export type TableState = ComponentState<TableSlots> &
   Pick<Required<TableProps>, 'size' | 'noNativeElements'> &
   TableContextValue;
+
+/**
+ * State used in rendering Table, without design-only state.
+ */
+export type TableBaseState = DistributiveOmit<TableState, 'size'>;

--- a/packages/react-components/react-table/library/src/components/Table/index.ts
+++ b/packages/react-components/react-table/library/src/components/Table/index.ts
@@ -1,6 +1,8 @@
 export { Table } from './Table';
 export type {
   SortDirection,
+  TableBaseProps,
+  TableBaseState,
   TableContextValue,
   TableContextValues,
   TableProps,
@@ -8,5 +10,5 @@ export type {
   TableState,
 } from './Table.types';
 export { renderTable_unstable } from './renderTable';
-export { useTable_unstable } from './useTable';
+export { useTableBase_unstable, useTable_unstable } from './useTable';
 export { tableClassName, tableClassNames, useTableStyles_unstable } from './useTableStyles.styles';

--- a/packages/react-components/react-table/library/src/components/Table/useTable.ts
+++ b/packages/react-components/react-table/library/src/components/Table/useTable.ts
@@ -1,17 +1,14 @@
 import * as React from 'react';
 import { getIntrinsicElementProps, slot } from '@fluentui/react-utilities';
-import type { TableProps, TableState } from './Table.types';
+import type { TableBaseProps, TableBaseState, TableProps, TableState } from './Table.types';
 
 /**
- * Create the state required to render Table.
+ * Create the base state required to render Table, without design-only props.
  *
- * The returned state can be modified with hooks such as useTableStyles_unstable,
- * before being passed to renderTable_unstable.
- *
- * @param props - props from this instance of Table
+ * @param props - props from this instance of Table (without size)
  * @param ref - reference to root HTMLElement of Table
  */
-export const useTable_unstable = (props: TableProps, ref: React.Ref<HTMLElement>): TableState => {
+export const useTableBase_unstable = (props: TableBaseProps, ref: React.Ref<HTMLElement>): TableBaseState => {
   const rootComponent = props.as ?? props.noNativeElements ? 'div' : 'table';
 
   return {
@@ -29,8 +26,23 @@ export const useTable_unstable = (props: TableProps, ref: React.Ref<HTMLElement>
       }),
       { elementType: rootComponent },
     ),
-    size: props.size ?? 'medium',
     noNativeElements: props.noNativeElements ?? false,
     sortable: props.sortable ?? false,
+  };
+};
+
+/**
+ * Create the state required to render Table.
+ *
+ * The returned state can be modified with hooks such as useTableStyles_unstable,
+ * before being passed to renderTable_unstable.
+ *
+ * @param props - props from this instance of Table
+ * @param ref - reference to root HTMLElement of Table
+ */
+export const useTable_unstable = (props: TableProps, ref: React.Ref<HTMLElement>): TableState => {
+  return {
+    ...useTableBase_unstable(props, ref),
+    size: props.size ?? 'medium',
   };
 };

--- a/packages/react-components/react-table/library/src/components/TableCell/TableCell.types.ts
+++ b/packages/react-components/react-table/library/src/components/TableCell/TableCell.types.ts
@@ -1,4 +1,4 @@
-import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+import type { ComponentProps, ComponentState, DistributiveOmit, Slot } from '@fluentui/react-utilities';
 import { TableContextValue } from '../Table/Table.types';
 
 export type TableCellSlots = {
@@ -11,6 +11,16 @@ export type TableCellSlots = {
 export type TableCellProps = ComponentProps<TableCellSlots> & {};
 
 /**
+ * TableCell Props without design-only props.
+ */
+export type TableCellBaseProps = TableCellProps;
+
+/**
  * State used in rendering TableCell
  */
 export type TableCellState = ComponentState<TableCellSlots> & Pick<TableContextValue, 'noNativeElements' | 'size'>;
+
+/**
+ * State used in rendering TableCell, without design-only state.
+ */
+export type TableCellBaseState = DistributiveOmit<TableCellState, 'size'>;

--- a/packages/react-components/react-table/library/src/components/TableCell/index.ts
+++ b/packages/react-components/react-table/library/src/components/TableCell/index.ts
@@ -1,5 +1,11 @@
 export { TableCell } from './TableCell';
-export type { TableCellProps, TableCellSlots, TableCellState } from './TableCell.types';
+export type {
+  TableCellBaseProps,
+  TableCellBaseState,
+  TableCellProps,
+  TableCellSlots,
+  TableCellState,
+} from './TableCell.types';
 export { renderTableCell_unstable } from './renderTableCell';
-export { useTableCell_unstable } from './useTableCell';
+export { useTableCellBase_unstable, useTableCell_unstable } from './useTableCell';
 export { tableCellClassName, tableCellClassNames, useTableCellStyles_unstable } from './useTableCellStyles.styles';

--- a/packages/react-components/react-table/library/src/components/TableCell/useTableCell.ts
+++ b/packages/react-components/react-table/library/src/components/TableCell/useTableCell.ts
@@ -2,20 +2,20 @@
 
 import * as React from 'react';
 import { getIntrinsicElementProps, slot } from '@fluentui/react-utilities';
-import type { TableCellProps, TableCellState } from './TableCell.types';
+import type { TableCellBaseProps, TableCellBaseState, TableCellProps, TableCellState } from './TableCell.types';
 import { useTableContext } from '../../contexts/tableContext';
 
 /**
- * Create the state required to render TableCell.
- *
- * The returned state can be modified with hooks such as useTableCellStyles_unstable,
- * before being passed to renderTableCell_unstable.
+ * Create the base state required to render TableCell, without design-only props.
  *
  * @param props - props from this instance of TableCell
  * @param ref - reference to root HTMLElement of TableCell
  */
-export const useTableCell_unstable = (props: TableCellProps, ref: React.Ref<HTMLElement>): TableCellState => {
-  const { noNativeElements, size } = useTableContext();
+export const useTableCellBase_unstable = (
+  props: TableCellBaseProps,
+  ref: React.Ref<HTMLElement>,
+): TableCellBaseState => {
+  const { noNativeElements } = useTableContext();
 
   const rootComponent = props.as ?? noNativeElements ? 'div' : 'td';
 
@@ -35,6 +35,22 @@ export const useTableCell_unstable = (props: TableCellProps, ref: React.Ref<HTML
       { elementType: rootComponent },
     ),
     noNativeElements,
+  };
+};
+
+/**
+ * Create the state required to render TableCell.
+ *
+ * The returned state can be modified with hooks such as useTableCellStyles_unstable,
+ * before being passed to renderTableCell_unstable.
+ *
+ * @param props - props from this instance of TableCell
+ * @param ref - reference to root HTMLElement of TableCell
+ */
+export const useTableCell_unstable = (props: TableCellProps, ref: React.Ref<HTMLElement>): TableCellState => {
+  const { size } = useTableContext();
+  return {
+    ...useTableCellBase_unstable(props, ref),
     size,
   };
 };

--- a/packages/react-components/react-table/library/src/components/TableCellLayout/TableCellLayout.types.ts
+++ b/packages/react-components/react-table/library/src/components/TableCellLayout/TableCellLayout.types.ts
@@ -1,4 +1,4 @@
-import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+import type { ComponentProps, ComponentState, DistributiveOmit, Slot } from '@fluentui/react-utilities';
 import type { AvatarSize } from '@fluentui/react-avatar';
 import { TableContextValue } from '../Table/Table.types';
 
@@ -50,6 +50,11 @@ export type TableCellLayoutProps = Omit<ComponentProps<Partial<TableCellLayoutSl
   };
 
 /**
+ * TableCellLayout Props without design-only props.
+ */
+export type TableCellLayoutBaseProps = DistributiveOmit<TableCellLayoutProps, 'appearance'>;
+
+/**
  * State used in rendering TableCellLayout
  */
 export type TableCellLayoutState = ComponentState<TableCellLayoutSlots> &
@@ -57,3 +62,8 @@ export type TableCellLayoutState = ComponentState<TableCellLayoutSlots> &
     TableContextValue,
     'size'
   >;
+
+/**
+ * State used in rendering TableCellLayout, without design-only state.
+ */
+export type TableCellLayoutBaseState = DistributiveOmit<TableCellLayoutState, 'appearance' | 'size' | 'avatarSize'>;

--- a/packages/react-components/react-table/library/src/components/TableCellLayout/index.ts
+++ b/packages/react-components/react-table/library/src/components/TableCellLayout/index.ts
@@ -1,10 +1,12 @@
 export { TableCellLayout } from './TableCellLayout';
 export type {
+  TableCellLayoutBaseProps,
+  TableCellLayoutBaseState,
   TableCellLayoutContextValues,
   TableCellLayoutProps,
   TableCellLayoutSlots,
   TableCellLayoutState,
 } from './TableCellLayout.types';
 export { renderTableCellLayout_unstable } from './renderTableCellLayout';
-export { useTableCellLayout_unstable } from './useTableCellLayout';
+export { useTableCellLayoutBase_unstable, useTableCellLayout_unstable } from './useTableCellLayout';
 export { tableCellLayoutClassNames, useTableCellLayoutStyles_unstable } from './useTableCellLayoutStyles.styles';

--- a/packages/react-components/react-table/library/src/components/TableCellLayout/useTableCellLayout.ts
+++ b/packages/react-components/react-table/library/src/components/TableCellLayout/useTableCellLayout.ts
@@ -2,7 +2,12 @@
 
 import * as React from 'react';
 import { getIntrinsicElementProps, slot } from '@fluentui/react-utilities';
-import type { TableCellLayoutProps, TableCellLayoutState } from './TableCellLayout.types';
+import type {
+  TableCellLayoutBaseProps,
+  TableCellLayoutBaseState,
+  TableCellLayoutProps,
+  TableCellLayoutState,
+} from './TableCellLayout.types';
 import { useTableContext } from '../../contexts/tableContext';
 
 const tableAvatarSizeMap = {
@@ -12,20 +17,15 @@ const tableAvatarSizeMap = {
 } as const;
 
 /**
- * Create the state required to render TableCellLayout.
+ * Create the base state required to render TableCellLayout, without design-only props.
  *
- * The returned state can be modified with hooks such as useTableCellLayoutStyles_unstable,
- * before being passed to renderTableCellLayout_unstable.
- *
- * @param props - props from this instance of TableCellLayout
+ * @param props - props from this instance of TableCellLayout (without appearance)
  * @param ref - reference to root HTMLElement of TableCellLayout
  */
-export const useTableCellLayout_unstable = (
-  props: TableCellLayoutProps,
+export const useTableCellLayoutBase_unstable = (
+  props: TableCellLayoutBaseProps,
   ref: React.Ref<HTMLElement>,
-): TableCellLayoutState => {
-  const { size } = useTableContext();
-
+): TableCellLayoutBaseState => {
   return {
     components: {
       root: 'div',
@@ -49,7 +49,6 @@ export const useTableCellLayout_unstable = (
       ),
       { elementType: 'div' },
     ),
-    appearance: props.appearance,
     truncate: props.truncate,
     main: slot.optional(props.main, { renderByDefault: true, elementType: 'span' }),
     media: slot.optional(props.media, { elementType: 'span' }),
@@ -58,6 +57,26 @@ export const useTableCellLayout_unstable = (
       renderByDefault: !!props.description || !!props.children,
       elementType: 'div',
     }),
+  };
+};
+
+/**
+ * Create the state required to render TableCellLayout.
+ *
+ * The returned state can be modified with hooks such as useTableCellLayoutStyles_unstable,
+ * before being passed to renderTableCellLayout_unstable.
+ *
+ * @param props - props from this instance of TableCellLayout
+ * @param ref - reference to root HTMLElement of TableCellLayout
+ */
+export const useTableCellLayout_unstable = (
+  props: TableCellLayoutProps,
+  ref: React.Ref<HTMLElement>,
+): TableCellLayoutState => {
+  const { size } = useTableContext();
+  return {
+    ...useTableCellLayoutBase_unstable(props, ref),
+    appearance: props.appearance,
     avatarSize: tableAvatarSizeMap[size],
     size,
   };

--- a/packages/react-components/react-table/library/src/components/TableRow/TableRow.types.ts
+++ b/packages/react-components/react-table/library/src/components/TableRow/TableRow.types.ts
@@ -1,4 +1,4 @@
-import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+import type { ComponentProps, ComponentState, DistributiveOmit, Slot } from '@fluentui/react-utilities';
 import { TableContextValue } from '../Table/Table.types';
 
 export type TableRowSlots = {
@@ -18,6 +18,11 @@ export type TableRowProps = ComponentProps<TableRowSlots> & {
 };
 
 /**
+ * TableRow Props without design-only props.
+ */
+export type TableRowBaseProps = DistributiveOmit<TableRowProps, 'appearance'>;
+
+/**
  * State used in rendering TableRow
  */
 export type TableRowState = ComponentState<TableRowSlots> &
@@ -25,3 +30,8 @@ export type TableRowState = ComponentState<TableRowSlots> &
   Pick<Required<TableRowProps>, 'appearance'> & {
     isHeaderRow: boolean;
   };
+
+/**
+ * State used in rendering TableRow, without design-only state.
+ */
+export type TableRowBaseState = DistributiveOmit<TableRowState, 'appearance' | 'size'>;

--- a/packages/react-components/react-table/library/src/components/TableRow/index.ts
+++ b/packages/react-components/react-table/library/src/components/TableRow/index.ts
@@ -1,5 +1,11 @@
 export { TableRow } from './TableRow';
-export type { TableRowProps, TableRowSlots, TableRowState } from './TableRow.types';
+export type {
+  TableRowBaseProps,
+  TableRowBaseState,
+  TableRowProps,
+  TableRowSlots,
+  TableRowState,
+} from './TableRow.types';
 export { renderTableRow_unstable } from './renderTableRow';
-export { useTableRow_unstable } from './useTableRow';
+export { useTableRowBase_unstable, useTableRow_unstable } from './useTableRow';
 export { tableRowClassName, tableRowClassNames, useTableRowStyles_unstable } from './useTableRowStyles.styles';

--- a/packages/react-components/react-table/library/src/components/TableRow/useTableRow.ts
+++ b/packages/react-components/react-table/library/src/components/TableRow/useTableRow.ts
@@ -3,21 +3,18 @@
 import * as React from 'react';
 import { getIntrinsicElementProps, useMergedRefs, slot } from '@fluentui/react-utilities';
 import { useFocusVisible, useFocusWithin } from '@fluentui/react-tabster';
-import type { TableRowProps, TableRowState } from './TableRow.types';
+import type { TableRowBaseProps, TableRowBaseState, TableRowProps, TableRowState } from './TableRow.types';
 import { useTableContext } from '../../contexts/tableContext';
 import { useIsInTableHeader } from '../../contexts/tableHeaderContext';
 
 /**
- * Create the state required to render TableRow.
+ * Create the base state required to render TableRow, without design-only props.
  *
- * The returned state can be modified with hooks such as useTableRowStyles_unstable,
- * before being passed to renderTableRow_unstable.
- *
- * @param props - props from this instance of TableRow
+ * @param props - props from this instance of TableRow (without appearance)
  * @param ref - reference to root HTMLElement of TableRow
  */
-export const useTableRow_unstable = (props: TableRowProps, ref: React.Ref<HTMLElement>): TableRowState => {
-  const { noNativeElements, size } = useTableContext();
+export const useTableRowBase_unstable = (props: TableRowBaseProps, ref: React.Ref<HTMLElement>): TableRowBaseState => {
+  const { noNativeElements } = useTableContext();
   const rootComponent = props.as ?? noNativeElements ? 'div' : 'tr';
   const focusVisibleRef = useFocusVisible();
   const focusWithinRef = useFocusWithin();
@@ -38,9 +35,25 @@ export const useTableRow_unstable = (props: TableRowProps, ref: React.Ref<HTMLEl
       }),
       { elementType: rootComponent },
     ),
-    size,
     noNativeElements,
-    appearance: props.appearance ?? 'none',
     isHeaderRow,
+  };
+};
+
+/**
+ * Create the state required to render TableRow.
+ *
+ * The returned state can be modified with hooks such as useTableRowStyles_unstable,
+ * before being passed to renderTableRow_unstable.
+ *
+ * @param props - props from this instance of TableRow
+ * @param ref - reference to root HTMLElement of TableRow
+ */
+export const useTableRow_unstable = (props: TableRowProps, ref: React.Ref<HTMLElement>): TableRowState => {
+  const { size } = useTableContext();
+  return {
+    ...useTableRowBase_unstable(props, ref),
+    size,
+    appearance: props.appearance ?? 'none',
   };
 };

--- a/packages/react-components/react-table/library/src/index.ts
+++ b/packages/react-components/react-table/library/src/index.ts
@@ -26,20 +26,28 @@ export {
   tableCellClassNames,
   tableCellClassName,
   useTableCellStyles_unstable,
+  useTableCellBase_unstable,
   useTableCell_unstable,
   renderTableCell_unstable,
 } from './TableCell';
-export type { TableCellProps, TableCellState, TableCellSlots } from './TableCell';
+export type {
+  TableCellBaseProps,
+  TableCellBaseState,
+  TableCellProps,
+  TableCellState,
+  TableCellSlots,
+} from './TableCell';
 
 export {
   TableRow,
   tableRowClassNames,
   tableRowClassName,
   useTableRowStyles_unstable,
+  useTableRowBase_unstable,
   useTableRow_unstable,
   renderTableRow_unstable,
 } from './TableRow';
-export type { TableRowProps, TableRowState, TableRowSlots } from './TableRow';
+export type { TableRowBaseProps, TableRowBaseState, TableRowProps, TableRowState, TableRowSlots } from './TableRow';
 
 export {
   TableBody,
@@ -56,10 +64,20 @@ export {
   tableClassName,
   tableClassNames,
   useTableStyles_unstable,
+  useTableBase_unstable,
   useTable_unstable,
   renderTable_unstable,
 } from './Table';
-export type { TableProps, TableSlots, TableState, TableContextValue, TableContextValues, SortDirection } from './Table';
+export type {
+  TableBaseProps,
+  TableBaseState,
+  TableProps,
+  TableSlots,
+  TableState,
+  TableContextValue,
+  TableContextValues,
+  SortDirection,
+} from './Table';
 
 export {
   TableHeader,
@@ -117,10 +135,17 @@ export {
   TableCellLayout,
   tableCellLayoutClassNames,
   useTableCellLayoutStyles_unstable,
+  useTableCellLayoutBase_unstable,
   useTableCellLayout_unstable,
   renderTableCellLayout_unstable,
 } from './TableCellLayout';
-export type { TableCellLayoutProps, TableCellLayoutSlots, TableCellLayoutState } from './TableCellLayout';
+export type {
+  TableCellLayoutBaseProps,
+  TableCellLayoutBaseState,
+  TableCellLayoutProps,
+  TableCellLayoutSlots,
+  TableCellLayoutState,
+} from './TableCellLayout';
 
 export {
   DataGridCell,
@@ -135,10 +160,18 @@ export {
   DataGridRow,
   dataGridRowClassNames,
   useDataGridRowStyles_unstable,
+  useDataGridRowBase_unstable,
   useDataGridRow_unstable,
   renderDataGridRow_unstable,
 } from './DataGridRow';
-export type { DataGridRowProps, DataGridRowState, DataGridRowSlots, CellRenderFunction } from './DataGridRow';
+export type {
+  DataGridRowBaseProps,
+  DataGridRowBaseState,
+  DataGridRowProps,
+  DataGridRowState,
+  DataGridRowSlots,
+  CellRenderFunction,
+} from './DataGridRow';
 
 export {
   DataGridBody,
@@ -153,11 +186,14 @@ export {
   DataGrid,
   dataGridClassNames,
   useDataGridStyles_unstable,
+  useDataGridBase_unstable,
   useDataGrid_unstable,
   renderDataGrid_unstable,
   useDataGridContextValues_unstable,
 } from './DataGrid';
 export type {
+  DataGridBaseProps,
+  DataGridBaseState,
   DataGridProps,
   DataGridSlots,
   DataGridState,


### PR DESCRIPTION
## Summary

Adds base state hooks to `@fluentui/react-table` following the base hooks RFC pattern. Each base hook extracts structural, ARIA, and behavioral logic while omitting design-only props (`appearance`, `size`, `selectionAppearance`, `subtleSelection`, `avatarSize`).

### New hooks and types

- `useTableBase_unstable` / `TableBaseProps` / `TableBaseState` — omits `size`
- `useTableCellBase_unstable` / `TableCellBaseProps` / `TableCellBaseState` — omits `size`
- `useTableRowBase_unstable` / `TableRowBaseProps` / `TableRowBaseState` — omits `appearance`, `size`
- `useTableCellLayoutBase_unstable` / `TableCellLayoutBaseProps` / `TableCellLayoutBaseState` — omits `appearance`, `size`, `avatarSize`
- `useDataGridBase_unstable` / `DataGridBaseProps` / `DataGridBaseState` — omits `subtleSelection`, `selectionAppearance`, `size`
- `useDataGridRowBase_unstable` / `DataGridRowBaseProps` / `DataGridRowBaseState` — omits `appearance`, `size`

### Architecture notes

- Base hooks call into each other: `useDataGridBase_unstable` → `useTableBase_unstable`, `useDataGridRowBase_unstable` → `useTableRowBase_unstable`
- Context-provided design props (`size`, `appearance`) are read in the styled hooks and excluded from base hooks
- `DataGridRow`'s `appearance` is computed from the DataGrid context's `selectionAppearance` (design prop) — moved to the styled hook

## Test plan

- [ ] TypeScript compiles without new errors in `@fluentui/react-table`
- [ ] Existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)