### PR TITLE
feat(react-color-picker): add useColorPickerBase_unstable, useColorAreaBase_unstable, useColorSliderBase_unstable, useAlphaSliderBase_unstable hooks

### DIFF
--- a/change/@fluentui-react-color-picker-base-hooks.json
+++ b/change/@fluentui-react-color-picker-base-hooks.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add useColorPickerBase_unstable, useColorAreaBase_unstable, useColorSliderBase_unstable, and useAlphaSliderBase_unstable hooks",
+  "packageName": "@fluentui/react-color-picker",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-color-picker/library/src/AlphaSlider.ts
+++ b/packages/react-components/react-color-picker/library/src/AlphaSlider.ts
@@ -1,9 +1,16 @@
-export type { AlphaSliderProps, AlphaSliderSlots, AlphaSliderState } from './components/AlphaSlider/index';
+export type {
+  AlphaSliderBaseProps,
+  AlphaSliderBaseState,
+  AlphaSliderProps,
+  AlphaSliderSlots,
+  AlphaSliderState,
+} from './components/AlphaSlider/index';
 export {
   AlphaSlider,
   alphaSliderCSSVars,
   alphaSliderClassNames,
   renderAlphaSlider_unstable,
+  useAlphaSliderBase_unstable,
   useAlphaSliderStyles_unstable,
   useAlphaSlider_unstable,
 } from './components/AlphaSlider/index';

--- a/packages/react-components/react-color-picker/library/src/ColorArea.ts
+++ b/packages/react-components/react-color-picker/library/src/ColorArea.ts
@@ -1,4 +1,6 @@
 export type {
+  ColorAreaBaseProps,
+  ColorAreaBaseState,
   ColorAreaOnColorChangeData,
   ColorAreaProps,
   ColorAreaSlots,
@@ -9,6 +11,7 @@ export {
   colorAreaCSSVars,
   colorAreaClassNames,
   renderColorArea_unstable,
+  useColorAreaBase_unstable,
   useColorAreaStyles_unstable,
   useColorArea_unstable,
 } from './components/ColorArea/index';

--- a/packages/react-components/react-color-picker/library/src/ColorPicker.ts
+++ b/packages/react-components/react-color-picker/library/src/ColorPicker.ts
@@ -1,4 +1,6 @@
 export type {
+  ColorPickerBaseProps,
+  ColorPickerBaseState,
   ColorPickerOnChangeData,
   ColorPickerProps,
   ColorPickerSlots,
@@ -8,6 +10,7 @@ export {
   ColorPicker,
   colorPickerClassNames,
   renderColorPicker_unstable,
+  useColorPickerBase_unstable,
   useColorPickerStyles_unstable,
   useColorPicker_unstable,
 } from './components/ColorPicker/index';

--- a/packages/react-components/react-color-picker/library/src/ColorSlider.ts
+++ b/packages/react-components/react-color-picker/library/src/ColorSlider.ts
@@ -1,4 +1,7 @@
 export type {
+  ColorChannel,
+  ColorSliderBaseProps,
+  ColorSliderBaseState,
   ColorSliderProps,
   ColorSliderSlots,
   ColorSliderState,
@@ -9,6 +12,7 @@ export {
   colorSliderCSSVars,
   colorSliderClassNames,
   renderColorSlider_unstable,
+  useColorSliderBase_unstable,
   useColorSliderStyles_unstable,
   useColorSlider_unstable,
 } from './components/ColorSlider/index';

--- a/packages/react-components/react-color-picker/library/src/components/AlphaSlider/AlphaSlider.types.ts
+++ b/packages/react-components/react-color-picker/library/src/components/AlphaSlider/AlphaSlider.types.ts
@@ -1,4 +1,4 @@
-import type { ComponentState } from '@fluentui/react-utilities';
+import type { ComponentState, DistributiveOmit } from '@fluentui/react-utilities';
 import type { ColorSliderSlots, ColorSliderProps, ColorSliderState } from '../ColorSlider/ColorSlider.types';
 
 export type AlphaSliderSlots = ColorSliderSlots;
@@ -24,3 +24,13 @@ export type AlphaSliderProps = Omit<ColorSliderProps, 'channel'> & {
 export type AlphaSliderState = ComponentState<AlphaSliderSlots> &
   Pick<AlphaSliderProps, 'vertical'> &
   Omit<ColorSliderState, keyof ColorSliderSlots | 'components'>;
+
+/**
+ * AlphaSlider Props without design-only props.
+ */
+export type AlphaSliderBaseProps = DistributiveOmit<AlphaSliderProps, 'shape'>;
+
+/**
+ * State used in rendering AlphaSlider, without design-only state.
+ */
+export type AlphaSliderBaseState = DistributiveOmit<AlphaSliderState, 'shape'>;

--- a/packages/react-components/react-color-picker/library/src/components/AlphaSlider/index.ts
+++ b/packages/react-components/react-color-picker/library/src/components/AlphaSlider/index.ts
@@ -1,7 +1,13 @@
 export { AlphaSlider } from './AlphaSlider';
-export type { AlphaSliderProps, AlphaSliderSlots, AlphaSliderState } from './AlphaSlider.types';
+export type {
+  AlphaSliderBaseProps,
+  AlphaSliderBaseState,
+  AlphaSliderProps,
+  AlphaSliderSlots,
+  AlphaSliderState,
+} from './AlphaSlider.types';
 export { renderAlphaSlider_unstable } from './renderAlphaSlider';
-export { useAlphaSlider_unstable } from './useAlphaSlider';
+export { useAlphaSliderBase_unstable, useAlphaSlider_unstable } from './useAlphaSlider';
 export {
   alphaSliderCSSVars,
   alphaSliderClassNames,

--- a/packages/react-components/react-color-picker/library/src/components/AlphaSlider/useAlphaSlider.ts
+++ b/packages/react-components/react-color-picker/library/src/components/AlphaSlider/useAlphaSlider.ts
@@ -2,24 +2,25 @@
 
 import * as React from 'react';
 import { getPartitionedNativeProps, useId, slot } from '@fluentui/react-utilities';
-import type { AlphaSliderProps, AlphaSliderState } from './AlphaSlider.types';
+import type {
+  AlphaSliderBaseProps,
+  AlphaSliderBaseState,
+  AlphaSliderProps,
+  AlphaSliderState,
+} from './AlphaSlider.types';
 import { useAlphaSliderState_unstable } from './useAlphaSliderState';
 import { useColorPickerContextValue_unstable } from '../../contexts/colorPicker';
 
 /**
- * Create the state required to render AlphaSlider.
+ * Create the base state required to render AlphaSlider, without design-only props.
  *
- * The returned state can be modified with hooks such as useAlphaSliderStyles_unstable,
- * before being passed to renderAlphaSlider_unstable.
- *
- * @param props - props from this instance of AlphaSlider
+ * @param props - props from this instance of AlphaSlider (without shape)
  * @param ref - reference to root HTMLInputElement of AlphaSlider
  */
-export const useAlphaSlider_unstable = (
-  props: AlphaSliderProps,
+export const useAlphaSliderBase_unstable = (
+  props: AlphaSliderBaseProps,
   ref: React.Ref<HTMLInputElement>,
-): AlphaSliderState => {
-  const shapeFromContext = useColorPickerContextValue_unstable(ctx => ctx.shape);
+): AlphaSliderBaseState => {
   const nativeProps = getPartitionedNativeProps({
     props,
     primarySlotTagName: 'input',
@@ -27,7 +28,6 @@ export const useAlphaSlider_unstable = (
   });
 
   const {
-    shape = shapeFromContext,
     vertical,
     // Slots
     root,
@@ -36,8 +36,7 @@ export const useAlphaSlider_unstable = (
     thumb,
   } = props;
 
-  const state: AlphaSliderState = {
-    shape,
+  const state: AlphaSliderBaseState = {
     vertical,
     components: {
       input: 'input',
@@ -62,7 +61,29 @@ export const useAlphaSlider_unstable = (
     thumb: slot.always(thumb, { elementType: 'div' }),
   };
 
-  useAlphaSliderState_unstable(state, props);
+  useAlphaSliderState_unstable(state as AlphaSliderState, props as AlphaSliderProps);
 
   return state;
+};
+
+/**
+ * Create the state required to render AlphaSlider.
+ *
+ * The returned state can be modified with hooks such as useAlphaSliderStyles_unstable,
+ * before being passed to renderAlphaSlider_unstable.
+ *
+ * @param props - props from this instance of AlphaSlider
+ * @param ref - reference to root HTMLInputElement of AlphaSlider
+ */
+export const useAlphaSlider_unstable = (
+  props: AlphaSliderProps,
+  ref: React.Ref<HTMLInputElement>,
+): AlphaSliderState => {
+  const shapeFromContext = useColorPickerContextValue_unstable(ctx => ctx.shape);
+  const { shape = shapeFromContext } = props;
+
+  return {
+    ...useAlphaSliderBase_unstable(props, ref),
+    shape,
+  };
 };

--- a/packages/react-components/react-color-picker/library/src/components/ColorArea/ColorArea.types.ts
+++ b/packages/react-components/react-color-picker/library/src/components/ColorArea/ColorArea.types.ts
@@ -1,5 +1,12 @@
 import * as React from 'react';
-import type { ComponentState, Slot, EventHandler, EventData, ComponentProps } from '@fluentui/react-utilities';
+import type {
+  ComponentState,
+  DistributiveOmit,
+  Slot,
+  EventHandler,
+  EventData,
+  ComponentProps,
+} from '@fluentui/react-utilities';
 import type { HsvColor } from '../../types/color';
 import type { ColorPickerProps } from '../ColorPicker/ColorPicker.types';
 
@@ -39,3 +46,13 @@ export type ColorAreaProps = Omit<ComponentProps<Partial<ColorAreaSlots>>, 'colo
  * State used in rendering ColorArea
  */
 export type ColorAreaState = ComponentState<Required<ColorAreaSlots>> & Pick<ColorAreaProps, 'color' | 'shape'>;
+
+/**
+ * ColorArea Props without design-only props.
+ */
+export type ColorAreaBaseProps = DistributiveOmit<ColorAreaProps, 'shape'>;
+
+/**
+ * State used in rendering ColorArea, without design-only state.
+ */
+export type ColorAreaBaseState = DistributiveOmit<ColorAreaState, 'shape'>;

--- a/packages/react-components/react-color-picker/library/src/components/ColorArea/index.ts
+++ b/packages/react-components/react-color-picker/library/src/components/ColorArea/index.ts
@@ -1,5 +1,12 @@
 export { ColorArea } from './ColorArea';
-export type { ColorAreaOnColorChangeData, ColorAreaProps, ColorAreaSlots, ColorAreaState } from './ColorArea.types';
+export type {
+  ColorAreaBaseProps,
+  ColorAreaBaseState,
+  ColorAreaOnColorChangeData,
+  ColorAreaProps,
+  ColorAreaSlots,
+  ColorAreaState,
+} from './ColorArea.types';
 export { renderColorArea_unstable } from './renderColorArea';
-export { useColorArea_unstable } from './useColorArea';
+export { useColorAreaBase_unstable, useColorArea_unstable } from './useColorArea';
 export { colorAreaCSSVars, colorAreaClassNames, useColorAreaStyles_unstable } from './useColorAreaStyles.styles';

--- a/packages/react-components/react-color-picker/library/src/components/ColorArea/useColorArea.ts
+++ b/packages/react-components/react-color-picker/library/src/components/ColorArea/useColorArea.ts
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import { tinycolor } from '@ctrl/tinycolor';
 import { useId, slot, useMergedRefs, mergeCallbacks, getIntrinsicElementProps } from '@fluentui/react-utilities';
-import type { ColorAreaProps, ColorAreaState } from './ColorArea.types';
+import type { ColorAreaBaseProps, ColorAreaBaseState, ColorAreaProps, ColorAreaState } from './ColorArea.types';
 import type { HsvColor } from '../../types/color';
 import { colorAreaCSSVars } from './useColorAreaStyles.styles';
 import { useEventCallback, useControllableState } from '@fluentui/react-utilities';
@@ -14,15 +14,15 @@ import { getCoordinates } from '../../utils/getCoordinates';
 import { useColorPickerContextValue_unstable } from '../../contexts/colorPicker';
 
 /**
- * Create the state required to render ColorArea.
+ * Create the base state required to render ColorArea, without design-only props.
  *
- * The returned state can be modified with hooks such as useColorAreaStyles_unstable,
- * before being passed to renderColorArea_unstable.
- *
- * @param props - props from this instance of ColorArea
+ * @param props - props from this instance of ColorArea (without shape)
  * @param ref - reference to root HTMLDivElement of ColorArea
  */
-export const useColorArea_unstable = (props: ColorAreaProps, ref: React.Ref<HTMLDivElement>): ColorAreaState => {
+export const useColorAreaBase_unstable = (
+  props: ColorAreaBaseProps,
+  ref: React.Ref<HTMLDivElement>,
+): ColorAreaBaseState => {
   const { targetDocument } = useFluent();
   const rootRef = React.useRef<HTMLDivElement>(null);
   const xRef = React.useRef<HTMLInputElement>(null);
@@ -30,11 +30,9 @@ export const useColorArea_unstable = (props: ColorAreaProps, ref: React.Ref<HTML
   const focusWithinRef = useFocusWithin();
   const onChangeFromContext = useColorPickerContextValue_unstable(ctx => ctx.requestChange);
   const colorFromContext = useColorPickerContextValue_unstable(ctx => ctx.color);
-  const shapeFromContext = useColorPickerContextValue_unstable(ctx => ctx.shape);
 
   const {
     onChange = onChangeFromContext as unknown as ColorAreaProps['onChange'],
-    shape = shapeFromContext,
     // Slots
     inputX,
     inputY,
@@ -164,8 +162,7 @@ export const useColorArea_unstable = (props: ColorAreaProps, ref: React.Ref<HTML
     [colorAreaCSSVars.thumbColorVar]: tinycolor(hsvColor).toRgbString(),
     [colorAreaCSSVars.mainColorVar]: `hsl(${hsvColor.h}, 100%, 50%)`,
   };
-  const state: ColorAreaState = {
-    shape,
+  const state: ColorAreaBaseState = {
     components: {
       inputX: 'input',
       inputY: 'input',
@@ -217,4 +214,23 @@ export const useColorArea_unstable = (props: ColorAreaProps, ref: React.Ref<HTML
   state.inputY.value = value;
 
   return state;
+};
+
+/**
+ * Create the state required to render ColorArea.
+ *
+ * The returned state can be modified with hooks such as useColorAreaStyles_unstable,
+ * before being passed to renderColorArea_unstable.
+ *
+ * @param props - props from this instance of ColorArea
+ * @param ref - reference to root HTMLDivElement of ColorArea
+ */
+export const useColorArea_unstable = (props: ColorAreaProps, ref: React.Ref<HTMLDivElement>): ColorAreaState => {
+  const shapeFromContext = useColorPickerContextValue_unstable(ctx => ctx.shape);
+  const { shape = shapeFromContext } = props;
+
+  return {
+    ...useColorAreaBase_unstable(props, ref),
+    shape,
+  };
 };

--- a/packages/react-components/react-color-picker/library/src/components/ColorPicker/ColorPicker.types.ts
+++ b/packages/react-components/react-color-picker/library/src/components/ColorPicker/ColorPicker.types.ts
@@ -1,5 +1,12 @@
 import * as React from 'react';
-import type { ComponentProps, ComponentState, Slot, EventHandler, EventData } from '@fluentui/react-utilities';
+import type {
+  ComponentProps,
+  ComponentState,
+  DistributiveOmit,
+  Slot,
+  EventHandler,
+  EventData,
+} from '@fluentui/react-utilities';
 import { ColorPickerContextValue } from '../../contexts/colorPicker';
 import type { HsvColor } from '../../types/color';
 
@@ -36,3 +43,13 @@ export type ColorPickerProps = Omit<ComponentProps<Partial<ColorPickerSlots>>, '
  * State used in rendering ColorPicker
  */
 export type ColorPickerState = ComponentState<ColorPickerSlots> & ColorPickerContextValue;
+
+/**
+ * ColorPicker Props without design-only props.
+ */
+export type ColorPickerBaseProps = DistributiveOmit<ColorPickerProps, 'shape'>;
+
+/**
+ * State used in rendering ColorPicker, without design-only state.
+ */
+export type ColorPickerBaseState = DistributiveOmit<ColorPickerState, 'shape'>;

--- a/packages/react-components/react-color-picker/library/src/components/ColorPicker/index.ts
+++ b/packages/react-components/react-color-picker/library/src/components/ColorPicker/index.ts
@@ -1,10 +1,12 @@
 export { ColorPicker } from './ColorPicker';
 export type {
+  ColorPickerBaseProps,
+  ColorPickerBaseState,
   ColorPickerOnChangeData,
   ColorPickerProps,
   ColorPickerSlots,
   ColorPickerState,
 } from './ColorPicker.types';
 export { renderColorPicker_unstable } from './renderColorPicker';
-export { useColorPicker_unstable } from './useColorPicker';
+export { useColorPickerBase_unstable, useColorPicker_unstable } from './useColorPicker';
 export { colorPickerClassNames, useColorPickerStyles_unstable } from './useColorPickerStyles.styles';

--- a/packages/react-components/react-color-picker/library/src/components/ColorPicker/useColorPicker.ts
+++ b/packages/react-components/react-color-picker/library/src/components/ColorPicker/useColorPicker.ts
@@ -2,18 +2,24 @@
 
 import * as React from 'react';
 import { getIntrinsicElementProps, slot, useEventCallback } from '@fluentui/react-utilities';
-import type { ColorPickerProps, ColorPickerState } from './ColorPicker.types';
+import type {
+  ColorPickerBaseProps,
+  ColorPickerBaseState,
+  ColorPickerProps,
+  ColorPickerState,
+} from './ColorPicker.types';
+
 /**
- * Create the state required to render ColorPicker.
+ * Create the base state required to render ColorPicker, without design-only props.
  *
- * The returned state can be modified with hooks such as useColorPickerStyles_unstable,
- * before being passed to renderColorPicker_unstable.
- *
- * @param props - props from this instance of ColorPicker
+ * @param props - props from this instance of ColorPicker (without shape)
  * @param ref - reference to root HTMLDivElement of ColorPicker
  */
-export const useColorPicker_unstable = (props: ColorPickerProps, ref: React.Ref<HTMLDivElement>): ColorPickerState => {
-  const { color, onColorChange, shape, ...rest } = props;
+export const useColorPickerBase_unstable = (
+  props: ColorPickerBaseProps,
+  ref: React.Ref<HTMLDivElement>,
+): ColorPickerBaseState => {
+  const { color, onColorChange, ...rest } = props;
 
   const requestChange: ColorPickerState['requestChange'] = useEventCallback((event, data) => {
     onColorChange?.(event, {
@@ -36,6 +42,23 @@ export const useColorPicker_unstable = (props: ColorPickerProps, ref: React.Ref<
     ),
     color,
     requestChange,
+  };
+};
+
+/**
+ * Create the state required to render ColorPicker.
+ *
+ * The returned state can be modified with hooks such as useColorPickerStyles_unstable,
+ * before being passed to renderColorPicker_unstable.
+ *
+ * @param props - props from this instance of ColorPicker
+ * @param ref - reference to root HTMLDivElement of ColorPicker
+ */
+export const useColorPicker_unstable = (props: ColorPickerProps, ref: React.Ref<HTMLDivElement>): ColorPickerState => {
+  const { shape } = props;
+
+  return {
+    ...useColorPickerBase_unstable(props, ref),
     shape,
   };
 };

--- a/packages/react-components/react-color-picker/library/src/components/ColorSlider/ColorSlider.types.ts
+++ b/packages/react-components/react-color-picker/library/src/components/ColorSlider/ColorSlider.types.ts
@@ -1,5 +1,12 @@
 import * as React from 'react';
-import type { ComponentProps, ComponentState, Slot, EventHandler, EventData } from '@fluentui/react-utilities';
+import type {
+  ComponentProps,
+  ComponentState,
+  DistributiveOmit,
+  Slot,
+  EventHandler,
+  EventData,
+} from '@fluentui/react-utilities';
 import type { HsvColor } from '../../types/color';
 import type { ColorPickerProps } from '../ColorPicker/ColorPicker.types';
 
@@ -57,3 +64,13 @@ export type ColorSliderProps = Omit<
  */
 export type ColorSliderState = ComponentState<ColorSliderSlots> &
   Pick<ColorSliderProps, 'vertical' | 'shape' | 'channel'>;
+
+/**
+ * ColorSlider Props without design-only props.
+ */
+export type ColorSliderBaseProps = DistributiveOmit<ColorSliderProps, 'shape'>;
+
+/**
+ * State used in rendering ColorSlider, without design-only state.
+ */
+export type ColorSliderBaseState = DistributiveOmit<ColorSliderState, 'shape'>;

--- a/packages/react-components/react-color-picker/library/src/components/ColorSlider/index.ts
+++ b/packages/react-components/react-color-picker/library/src/components/ColorSlider/index.ts
@@ -1,7 +1,15 @@
 export { ColorSlider } from './ColorSlider';
-export type { ColorSliderProps, ColorSliderSlots, ColorSliderState, SliderOnChangeData } from './ColorSlider.types';
+export type {
+  ColorChannel,
+  ColorSliderBaseProps,
+  ColorSliderBaseState,
+  ColorSliderProps,
+  ColorSliderSlots,
+  ColorSliderState,
+  SliderOnChangeData,
+} from './ColorSlider.types';
 export { renderColorSlider_unstable } from './renderColorSlider';
-export { useColorSlider_unstable } from './useColorSlider';
+export { useColorSliderBase_unstable, useColorSlider_unstable } from './useColorSlider';
 export {
   colorSliderCSSVars,
   colorSliderClassNames,

--- a/packages/react-components/react-color-picker/library/src/components/ColorSlider/useColorSlider.ts
+++ b/packages/react-components/react-color-picker/library/src/components/ColorSlider/useColorSlider.ts
@@ -11,7 +11,12 @@ import {
 } from '@fluentui/react-utilities';
 import { colorSliderCSSVars } from './useColorSliderStyles.styles';
 import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
-import type { ColorSliderProps, ColorSliderState } from './ColorSlider.types';
+import type {
+  ColorSliderBaseProps,
+  ColorSliderBaseState,
+  ColorSliderProps,
+  ColorSliderState,
+} from './ColorSlider.types';
 import { useColorPickerContextValue_unstable } from '../../contexts/colorPicker';
 import { MIN, HUE_MAX, MAX as COLOR_MAX } from '../../utils/constants';
 import { getPercent } from '../../utils/getPercent';
@@ -21,24 +26,20 @@ import { HsvColor } from '../../types/color';
 import { INITIAL_COLOR_HSV } from '../../utils/constants';
 
 /**
- * Create the state required to render ColorSlider.
+ * Create the base state required to render ColorSlider, without design-only props.
  *
- * The returned state can be modified with hooks such as useColorSliderStyles_unstable,
- * before being passed to renderColorSlider_unstable.
- *
- * @param props - props from this instance of ColorSlider
+ * @param props - props from this instance of ColorSlider (without shape)
  * @param ref - reference to root HTMLInputElement of ColorSlider
  */
-export const useColorSlider_unstable = (
-  props: ColorSliderProps,
+export const useColorSliderBase_unstable = (
+  props: ColorSliderBaseProps,
   ref: React.Ref<HTMLInputElement>,
-): ColorSliderState => {
+): ColorSliderBaseState => {
   'use no memo';
 
   const { dir } = useFluent();
   const onChangeFromContext = useColorPickerContextValue_unstable(ctx => ctx.requestChange);
   const colorFromContext = useColorPickerContextValue_unstable(ctx => ctx.color);
-  const shapeFromContext = useColorPickerContextValue_unstable(ctx => ctx.shape);
   const nativeProps = getPartitionedNativeProps({
     props,
     primarySlotTagName: 'input',
@@ -49,7 +50,6 @@ export const useColorSlider_unstable = (
     color,
     channel = 'hue',
     onChange = onChangeFromContext,
-    shape = shapeFromContext,
     vertical,
     // Slots
     root,
@@ -110,8 +110,7 @@ export const useColorSlider_unstable = (
         : `hsl(${hslColor.h} 100%, 50%)`,
   };
 
-  const state: ColorSliderState = {
-    shape,
+  const state: ColorSliderBaseState = {
     vertical,
     channel,
     components: {
@@ -154,4 +153,28 @@ export const useColorSlider_unstable = (
   state.input.value = clampedValue;
   state.input.onChange = _onChange;
   return state;
+};
+
+/**
+ * Create the state required to render ColorSlider.
+ *
+ * The returned state can be modified with hooks such as useColorSliderStyles_unstable,
+ * before being passed to renderColorSlider_unstable.
+ *
+ * @param props - props from this instance of ColorSlider
+ * @param ref - reference to root HTMLInputElement of ColorSlider
+ */
+export const useColorSlider_unstable = (
+  props: ColorSliderProps,
+  ref: React.Ref<HTMLInputElement>,
+): ColorSliderState => {
+  'use no memo';
+
+  const shapeFromContext = useColorPickerContextValue_unstable(ctx => ctx.shape);
+  const { shape = shapeFromContext } = props;
+
+  return {
+    ...useColorSliderBase_unstable(props, ref),
+    shape,
+  };
 };

--- a/packages/react-components/react-color-picker/library/src/index.ts
+++ b/packages/react-components/react-color-picker/library/src/index.ts
@@ -1,32 +1,61 @@
-export type { ColorSliderProps, ColorSliderSlots, ColorSliderState } from './ColorSlider';
+export type {
+  ColorChannel,
+  ColorSliderBaseProps,
+  ColorSliderBaseState,
+  ColorSliderProps,
+  ColorSliderSlots,
+  ColorSliderState,
+} from './ColorSlider';
 export {
   ColorSlider,
   colorSliderClassNames,
   renderColorSlider_unstable,
+  useColorSliderBase_unstable,
   useColorSliderStyles_unstable,
   useColorSlider_unstable,
 } from './ColorSlider';
-export type { ColorPickerProps, ColorPickerSlots, ColorPickerState } from './ColorPicker';
+export type {
+  ColorPickerBaseProps,
+  ColorPickerBaseState,
+  ColorPickerProps,
+  ColorPickerSlots,
+  ColorPickerState,
+} from './ColorPicker';
 export {
   ColorPicker,
   colorPickerClassNames,
   renderColorPicker_unstable,
+  useColorPickerBase_unstable,
   useColorPickerStyles_unstable,
   useColorPicker_unstable,
 } from './ColorPicker';
-export type { ColorAreaProps, ColorAreaSlots, ColorAreaState } from './ColorArea';
+export type {
+  ColorAreaBaseProps,
+  ColorAreaBaseState,
+  ColorAreaProps,
+  ColorAreaSlots,
+  ColorAreaState,
+} from './ColorArea';
 export {
   ColorArea,
   colorAreaClassNames,
   renderColorArea_unstable,
+  useColorAreaBase_unstable,
   useColorAreaStyles_unstable,
   useColorArea_unstable,
 } from './ColorArea';
-export type { AlphaSliderProps, AlphaSliderSlots, AlphaSliderState } from './AlphaSlider';
+export type {
+  AlphaSliderBaseProps,
+  AlphaSliderBaseState,
+  AlphaSliderProps,
+  AlphaSliderSlots,
+  AlphaSliderState,
+} from './AlphaSlider';
 export {
   AlphaSlider,
   alphaSliderClassNames,
   renderAlphaSlider_unstable,
+  useAlphaSliderBase_unstable,
   useAlphaSliderStyles_unstable,
   useAlphaSlider_unstable,
 } from './AlphaSlider';


### PR DESCRIPTION
## Summary

- Adds `useColorPickerBase_unstable` hook and `ColorPickerBaseProps`/`ColorPickerBaseState` types to `@fluentui/react-color-picker`
- Adds `useColorAreaBase_unstable` hook and `ColorAreaBaseProps`/`ColorAreaBaseState` types
- Adds `useColorSliderBase_unstable` hook and `ColorSliderBaseProps`/`ColorSliderBaseState` types
- Adds `useAlphaSliderBase_unstable` hook and `AlphaSliderBaseProps`/`AlphaSliderBaseState` types
- Refactors styled hooks to compose from base hooks, adding design-only `shape` prop

## Test plan

- [ ] TypeScript compiles without new errors (verified: `tsc --noEmit` passes cleanly)
- [ ] Existing ColorPicker stories/tests pass
- [ ] Base hooks export correctly from package index

🤖 Generated with [Claude Code](https://claude.com/claude-code)