### PR TITLE
feat(react-teaching-popover): add base hooks for TeachingPopover components

### DIFF
--- a/change/@fluentui-react-teaching-popover-base-hooks.json
+++ b/change/@fluentui-react-teaching-popover-base-hooks.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add base hooks for TeachingPopover components",
+  "packageName": "@fluentui/react-teaching-popover",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-teaching-popover/library/src/TeachingPopoverCarousel.ts
+++ b/packages/react-components/react-teaching-popover/library/src/TeachingPopoverCarousel.ts
@@ -1,4 +1,6 @@
 export type {
+  TeachingPopoverCarouselBaseProps,
+  TeachingPopoverCarouselBaseState,
   TeachingPopoverCarouselContextValues,
   TeachingPopoverCarouselProps,
   TeachingPopoverCarouselSlots,
@@ -11,4 +13,5 @@ export {
   useTeachingPopoverCarouselContextValues_unstable,
   useTeachingPopoverCarouselStyles_unstable,
   useTeachingPopoverCarousel_unstable,
+  useTeachingPopoverCarouselBase_unstable,
 } from './components/TeachingPopoverCarousel/index';

--- a/packages/react-components/react-teaching-popover/library/src/TeachingPopoverCarouselFooter.ts
+++ b/packages/react-components/react-teaching-popover/library/src/TeachingPopoverCarouselFooter.ts
@@ -1,4 +1,6 @@
 export type {
+  TeachingPopoverCarouselFooterBaseProps,
+  TeachingPopoverCarouselFooterBaseState,
   TeachingPopoverCarouselFooterLayout,
   TeachingPopoverCarouselFooterProps,
   TeachingPopoverCarouselFooterSlots,
@@ -11,4 +13,5 @@ export {
   teachingPopoverCarouselFooterClassNames,
   useTeachingPopoverCarouselFooterStyles_unstable,
   useTeachingPopoverCarouselFooter_unstable,
+  useTeachingPopoverCarouselFooterBase_unstable,
 } from './components/TeachingPopoverCarouselFooter/index';

--- a/packages/react-components/react-teaching-popover/library/src/TeachingPopoverCarouselFooterButton.ts
+++ b/packages/react-components/react-teaching-popover/library/src/TeachingPopoverCarouselFooterButton.ts
@@ -1,4 +1,6 @@
 export type {
+  TeachingPopoverCarouselFooterButtonBaseProps,
+  TeachingPopoverCarouselFooterButtonBaseState,
   TeachingPopoverCarouselFooterButtonProps,
   TeachingPopoverCarouselFooterButtonSlots,
   TeachingPopoverCarouselFooterButtonState,
@@ -9,4 +11,5 @@ export {
   teachingPopoverCarouselFooterButtonClassNames,
   useTeachingPopoverCarouselFooterButtonStyles_unstable,
   useTeachingPopoverCarouselFooterButton_unstable,
+  useTeachingPopoverCarouselFooterButtonBase_unstable,
 } from './components/TeachingPopoverCarouselFooterButton/index';

--- a/packages/react-components/react-teaching-popover/library/src/TeachingPopoverCarouselNavButton.ts
+++ b/packages/react-components/react-teaching-popover/library/src/TeachingPopoverCarouselNavButton.ts
@@ -1,4 +1,6 @@
 export type {
+  TeachingPopoverCarouselNavButtonBaseProps,
+  TeachingPopoverCarouselNavButtonBaseState,
   TeachingPopoverCarouselNavButtonProps,
   TeachingPopoverCarouselNavButtonSlots,
   TeachingPopoverCarouselNavButtonState,
@@ -9,4 +11,5 @@ export {
   teachingPopoverCarouselNavButtonClassNames,
   useTeachingPopoverCarouselNavButtonStyles_unstable,
   useTeachingPopoverCarouselNavButton_unstable,
+  useTeachingPopoverCarouselNavButtonBase_unstable,
 } from './components/TeachingPopoverCarouselNavButton/index';

--- a/packages/react-components/react-teaching-popover/library/src/TeachingPopoverFooter.ts
+++ b/packages/react-components/react-teaching-popover/library/src/TeachingPopoverFooter.ts
@@ -1,4 +1,6 @@
 export type {
+  TeachingPopoverFooterBaseProps,
+  TeachingPopoverFooterBaseState,
   TeachingPopoverFooterProps,
   TeachingPopoverFooterSlots,
   TeachingPopoverFooterState,
@@ -9,4 +11,5 @@ export {
   teachingPopoverFooterClassNames,
   useTeachingPopoverFooterStyles_unstable,
   useTeachingPopoverFooter_unstable,
+  useTeachingPopoverFooterBase_unstable,
 } from './components/TeachingPopoverFooter';

--- a/packages/react-components/react-teaching-popover/library/src/TeachingPopoverHeader.ts
+++ b/packages/react-components/react-teaching-popover/library/src/TeachingPopoverHeader.ts
@@ -1,4 +1,6 @@
 export type {
+  TeachingPopoverHeaderBaseProps,
+  TeachingPopoverHeaderBaseState,
   TeachingPopoverHeaderProps,
   TeachingPopoverHeaderSlots,
   TeachingPopoverHeaderState,
@@ -9,4 +11,5 @@ export {
   teachingPopoverHeaderClassNames,
   useTeachingPopoverHeaderStyles_unstable,
   useTeachingPopoverHeader_unstable,
+  useTeachingPopoverHeaderBase_unstable,
 } from './components/TeachingPopoverHeader/index';

--- a/packages/react-components/react-teaching-popover/library/src/TeachingPopoverTitle.ts
+++ b/packages/react-components/react-teaching-popover/library/src/TeachingPopoverTitle.ts
@@ -1,4 +1,6 @@
 export type {
+  TeachingPopoverTitleBaseProps,
+  TeachingPopoverTitleBaseState,
   TeachingPopoverTitleProps,
   TeachingPopoverTitleSlots,
   TeachingPopoverTitleState,
@@ -9,4 +11,5 @@ export {
   teachingPopoverTitleClassNames,
   useTeachingPopoverTitleStyles_unstable,
   useTeachingPopoverTitle_unstable,
+  useTeachingPopoverTitleBase_unstable,
 } from './components/TeachingPopoverTitle/index';

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarousel/TeachingPopoverCarousel.types.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarousel/TeachingPopoverCarousel.types.ts
@@ -1,4 +1,4 @@
-import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+import type { ComponentProps, ComponentState, DistributiveOmit, Slot } from '@fluentui/react-utilities';
 import { type PopoverContextValue } from '@fluentui/react-popover';
 
 import { type CarouselContextValue } from './Carousel/CarouselContext';
@@ -29,3 +29,7 @@ export type TeachingPopoverCarouselState = ComponentState<Required<TeachingPopov
 export type TeachingPopoverCarouselContextValues = {
   carousel: CarouselContextValue;
 };
+
+export type TeachingPopoverCarouselBaseProps = TeachingPopoverCarouselProps;
+
+export type TeachingPopoverCarouselBaseState = DistributiveOmit<TeachingPopoverCarouselState, 'appearance'>;

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarousel/index.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarousel/index.ts
@@ -1,12 +1,17 @@
 export { TeachingPopoverCarousel } from './TeachingPopoverCarousel';
 export type {
+  TeachingPopoverCarouselBaseProps,
+  TeachingPopoverCarouselBaseState,
   TeachingPopoverCarouselContextValues,
   TeachingPopoverCarouselProps,
   TeachingPopoverCarouselSlots,
   TeachingPopoverCarouselState,
 } from './TeachingPopoverCarousel.types';
 export { renderTeachingPopoverCarousel_unstable } from './renderTeachingPopoverCarousel';
-export { useTeachingPopoverCarousel_unstable } from './useTeachingPopoverCarousel';
+export {
+  useTeachingPopoverCarousel_unstable,
+  useTeachingPopoverCarouselBase_unstable,
+} from './useTeachingPopoverCarousel';
 export {
   teachingPopoverCarouselClassNames,
   useTeachingPopoverCarouselStyles_unstable,

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarousel/useTeachingPopoverCarousel.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarousel/useTeachingPopoverCarousel.ts
@@ -2,14 +2,19 @@
 
 import * as React from 'react';
 import { getIntrinsicElementProps, slot, useEventCallback, useMergedRefs } from '@fluentui/react-utilities';
-import type { TeachingPopoverCarouselProps, TeachingPopoverCarouselState } from './TeachingPopoverCarousel.types';
+import type {
+  TeachingPopoverCarouselBaseProps,
+  TeachingPopoverCarouselBaseState,
+  TeachingPopoverCarouselProps,
+  TeachingPopoverCarouselState,
+} from './TeachingPopoverCarousel.types';
 import { usePopoverContext_unstable } from '@fluentui/react-popover';
 import { useCarousel_unstable } from './Carousel/Carousel';
 
-export const useTeachingPopoverCarousel_unstable = (
-  props: TeachingPopoverCarouselProps,
+export const useTeachingPopoverCarouselBase_unstable = (
+  props: TeachingPopoverCarouselBaseProps,
   ref: React.Ref<HTMLDivElement>,
-): TeachingPopoverCarouselState => {
+): TeachingPopoverCarouselBaseState => {
   const toggleOpen = usePopoverContext_unstable(c => c.toggleOpen);
   const handleFinish: TeachingPopoverCarouselProps['onFinish'] = useEventCallback((event, data) => {
     props.onFinish?.(event, data);
@@ -24,9 +29,7 @@ export const useTeachingPopoverCarousel_unstable = (
     onFinish: handleFinish,
   });
 
-  const appearance = usePopoverContext_unstable(context => context.appearance);
   return {
-    appearance,
     components: {
       root: 'div',
     },
@@ -38,5 +41,18 @@ export const useTeachingPopoverCarousel_unstable = (
       { elementType: 'div' },
     ),
     ...carousel,
+  };
+};
+
+export const useTeachingPopoverCarousel_unstable = (
+  props: TeachingPopoverCarouselProps,
+  ref: React.Ref<HTMLDivElement>,
+): TeachingPopoverCarouselState => {
+  const appearance = usePopoverContext_unstable(context => context.appearance);
+  const baseState = useTeachingPopoverCarouselBase_unstable(props, ref);
+
+  return {
+    ...baseState,
+    appearance,
   };
 };

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselFooter/TeachingPopoverCarouselFooter.types.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselFooter/TeachingPopoverCarouselFooter.types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+import type { ComponentProps, ComponentState, DistributiveOmit, Slot } from '@fluentui/react-utilities';
 import type { TeachingPopoverCarouselFooterButtonProps } from '../TeachingPopoverCarouselFooterButton/TeachingPopoverCarouselFooterButton.types';
 
 export type TeachingPopoverCarouselFooterSlots = {
@@ -50,3 +50,7 @@ export type TeachingPopoverCarouselFooterProps = ComponentProps<TeachingPopoverC
  */
 export type TeachingPopoverCarouselFooterState = ComponentState<Required<TeachingPopoverCarouselFooterSlots>> &
   Pick<TeachingPopoverCarouselFooterProps, 'layout'>;
+
+export type TeachingPopoverCarouselFooterBaseProps = DistributiveOmit<TeachingPopoverCarouselFooterProps, 'layout'>;
+
+export type TeachingPopoverCarouselFooterBaseState = DistributiveOmit<TeachingPopoverCarouselFooterState, 'layout'>;

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselFooter/index.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselFooter/index.ts
@@ -1,5 +1,7 @@
 export { TeachingPopoverCarouselFooter } from './TeachingPopoverCarouselFooter';
 export type {
+  TeachingPopoverCarouselFooterBaseProps,
+  TeachingPopoverCarouselFooterBaseState,
   TeachingPopoverCarouselFooterLayout,
   TeachingPopoverCarouselFooterProps,
   TeachingPopoverCarouselFooterSlots,
@@ -7,7 +9,10 @@ export type {
   TeachingPopoverPageCountChildRenderFunction,
 } from './TeachingPopoverCarouselFooter.types';
 export { renderTeachingPopoverCarouselFooter_unstable } from './renderTeachingPopoverCarouselFooter';
-export { useTeachingPopoverCarouselFooter_unstable } from './useTeachingPopoverCarouselFooter';
+export {
+  useTeachingPopoverCarouselFooter_unstable,
+  useTeachingPopoverCarouselFooterBase_unstable,
+} from './useTeachingPopoverCarouselFooter';
 export {
   teachingPopoverCarouselFooterClassNames,
   useTeachingPopoverCarouselFooterStyles_unstable,

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselFooter/useTeachingPopoverCarouselFooter.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselFooter/useTeachingPopoverCarouselFooter.ts
@@ -2,16 +2,18 @@ import { getIntrinsicElementProps, slot } from '@fluentui/react-utilities';
 import * as React from 'react';
 
 import type {
+  TeachingPopoverCarouselFooterBaseProps,
+  TeachingPopoverCarouselFooterBaseState,
   TeachingPopoverCarouselFooterProps,
   TeachingPopoverCarouselFooterState,
 } from './TeachingPopoverCarouselFooter.types';
 import { TeachingPopoverCarouselFooterButton } from '../TeachingPopoverCarouselFooterButton/TeachingPopoverCarouselFooterButton';
 
-export const useTeachingPopoverCarouselFooter_unstable = (
-  props: TeachingPopoverCarouselFooterProps,
+export const useTeachingPopoverCarouselFooterBase_unstable = (
+  props: TeachingPopoverCarouselFooterBaseProps,
   ref: React.Ref<HTMLDivElement>,
-): TeachingPopoverCarouselFooterState => {
-  const { layout = 'centered', initialStepText, finalStepText } = props;
+): TeachingPopoverCarouselFooterBaseState => {
+  const { initialStepText, finalStepText } = props;
 
   const previous = slot.optional(props.previous, {
     defaultProps: {
@@ -31,7 +33,6 @@ export const useTeachingPopoverCarouselFooter_unstable = (
   });
 
   return {
-    layout,
     components: {
       root: 'div',
       next: TeachingPopoverCarouselFooterButton,
@@ -46,5 +47,18 @@ export const useTeachingPopoverCarouselFooter_unstable = (
     ),
     previous,
     next,
+  };
+};
+
+export const useTeachingPopoverCarouselFooter_unstable = (
+  props: TeachingPopoverCarouselFooterProps,
+  ref: React.Ref<HTMLDivElement>,
+): TeachingPopoverCarouselFooterState => {
+  const layout = props.layout ?? 'centered';
+  const baseState = useTeachingPopoverCarouselFooterBase_unstable(props, ref);
+
+  return {
+    ...baseState,
+    layout,
   };
 };

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselFooterButton/TeachingPopoverCarouselFooterButton.types.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselFooterButton/TeachingPopoverCarouselFooterButton.types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+import type { ComponentProps, ComponentState, DistributiveOmit, Slot } from '@fluentui/react-utilities';
 import { PopoverContextValue } from '@fluentui/react-popover';
 import { ButtonProps, ButtonState } from '@fluentui/react-button';
 import { ARIAButtonSlotProps } from '@fluentui/react-aria';
@@ -33,3 +33,10 @@ export type TeachingPopoverCarouselFooterButtonState = ButtonState &
     /* Rename popover appearance to prevent conflict with button appearance */
     popoverAppearance: PopoverContextValue['appearance'];
   };
+
+export type TeachingPopoverCarouselFooterButtonBaseProps = TeachingPopoverCarouselFooterButtonProps;
+
+export type TeachingPopoverCarouselFooterButtonBaseState = DistributiveOmit<
+  TeachingPopoverCarouselFooterButtonState,
+  'popoverAppearance'
+>;

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselFooterButton/index.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselFooterButton/index.ts
@@ -1,11 +1,16 @@
 export { TeachingPopoverCarouselFooterButton } from './TeachingPopoverCarouselFooterButton';
 export type {
+  TeachingPopoverCarouselFooterButtonBaseProps,
+  TeachingPopoverCarouselFooterButtonBaseState,
   TeachingPopoverCarouselFooterButtonProps,
   TeachingPopoverCarouselFooterButtonSlots,
   TeachingPopoverCarouselFooterButtonState,
 } from './TeachingPopoverCarouselFooterButton.types';
 export { renderTeachingPopoverCarouselFooterButton_unstable } from './renderTeachingPopoverCarouselFooterButton';
-export { useTeachingPopoverCarouselFooterButton_unstable } from './useTeachingPopoverCarouselFooterButton';
+export {
+  useTeachingPopoverCarouselFooterButton_unstable,
+  useTeachingPopoverCarouselFooterButtonBase_unstable,
+} from './useTeachingPopoverCarouselFooterButton';
 export {
   teachingPopoverCarouselFooterButtonClassNames,
   useTeachingPopoverCarouselFooterButtonStyles_unstable,

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselFooterButton/useTeachingPopoverCarouselFooterButton.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselFooterButton/useTeachingPopoverCarouselFooterButton.ts
@@ -3,6 +3,8 @@
 import * as React from 'react';
 import { getIntrinsicElementProps, mergeCallbacks, slot } from '@fluentui/react-utilities';
 import type {
+  TeachingPopoverCarouselFooterButtonBaseProps,
+  TeachingPopoverCarouselFooterButtonBaseState,
   TeachingPopoverCarouselFooterButtonProps,
   TeachingPopoverCarouselFooterButtonState,
 } from './TeachingPopoverCarouselFooterButton.types';
@@ -13,21 +15,17 @@ import { useButton_unstable } from '@fluentui/react-button';
 import { useCarouselValues_unstable } from '../TeachingPopoverCarousel/Carousel/useCarouselValues';
 
 /**
- * Create the state required to render TeachingPopoverCarouselFooterButton.
- *
- * The returned state can be modified with hooks such as useTeachingPopoverCarouselFooterButtonStyles_unstable,
- * before being passed to renderTeachingPopoverCarouselFooterButton_unstable.
+ * Create the base state required to render TeachingPopoverCarouselFooterButton, without design-specific props.
  *
  * @param props - props from this instance of TeachingPopoverCarouselFooterButton
  * @param ref - reference to root HTMLDivElement of TeachingPopoverCarouselFooterButton
  */
-export const useTeachingPopoverCarouselFooterButton_unstable = (
-  props: TeachingPopoverCarouselFooterButtonProps,
+export const useTeachingPopoverCarouselFooterButtonBase_unstable = (
+  props: TeachingPopoverCarouselFooterButtonBaseProps,
   ref: React.Ref<HTMLButtonElement | HTMLAnchorElement>,
-): TeachingPopoverCarouselFooterButtonState => {
+): TeachingPopoverCarouselFooterButtonBaseState => {
   const { navType, altText } = props;
 
-  const popoverAppearance = usePopoverContext_unstable(context => context.appearance);
   const selectPageByDirection = useCarouselContext_unstable(c => c.selectPageByDirection);
   const values = useCarouselValues_unstable(snapshot => snapshot);
   const activeValue = useCarouselContext_unstable(c => c.value);
@@ -54,6 +52,46 @@ export const useTeachingPopoverCarouselFooterButton_unstable = (
     return values.indexOf(activeValue) === values.length - 1;
   }, [navType, activeValue, values]);
 
+  /* Handle altText on trailing step */
+  let buttonChild = props.children;
+  if (isTrailing) {
+    buttonChild = altText;
+  }
+
+  return {
+    ...useButton_unstable({ ...props }, ref),
+    navType,
+    altText,
+    // Override useButton root slot
+    root: slot.always(
+      getIntrinsicElementProps('button', {
+        ref,
+        ...props,
+        onClick: handleButtonClick,
+        children: buttonChild,
+      }),
+      { elementType: 'button' },
+    ),
+  };
+};
+
+/**
+ * Create the state required to render TeachingPopoverCarouselFooterButton.
+ *
+ * The returned state can be modified with hooks such as useTeachingPopoverCarouselFooterButtonStyles_unstable,
+ * before being passed to renderTeachingPopoverCarouselFooterButton_unstable.
+ *
+ * @param props - props from this instance of TeachingPopoverCarouselFooterButton
+ * @param ref - reference to root HTMLDivElement of TeachingPopoverCarouselFooterButton
+ */
+export const useTeachingPopoverCarouselFooterButton_unstable = (
+  props: TeachingPopoverCarouselFooterButtonProps,
+  ref: React.Ref<HTMLButtonElement | HTMLAnchorElement>,
+): TeachingPopoverCarouselFooterButtonState => {
+  const { navType } = props;
+
+  const popoverAppearance = usePopoverContext_unstable(context => context.appearance);
+
   let buttonAppearanceType: 'primary' | 'outline' | undefined;
 
   if (navType === 'next') {
@@ -62,27 +100,13 @@ export const useTeachingPopoverCarouselFooterButton_unstable = (
     buttonAppearanceType = popoverAppearance === 'brand' ? 'outline' : undefined;
   }
 
-  /* Handle altText on trailing step */
-  let buttonChild = props.children;
-  if (isTrailing) {
-    buttonChild = altText;
-  }
+  const baseState = useTeachingPopoverCarouselFooterButtonBase_unstable(
+    { appearance: buttonAppearanceType, ...props },
+    ref,
+  );
 
   return {
-    ...useButton_unstable({ appearance: buttonAppearanceType, ...props }, ref),
-    navType,
+    ...baseState,
     popoverAppearance,
-    altText,
-    // Override useButton root slot
-    root: slot.always(
-      getIntrinsicElementProps('button', {
-        ref,
-        appearance: buttonAppearanceType,
-        ...props,
-        onClick: handleButtonClick,
-        children: buttonChild,
-      }),
-      { elementType: 'button' },
-    ),
   };
 };

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselNavButton/TeachingPopoverCarouselNavButton.types.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselNavButton/TeachingPopoverCarouselNavButton.types.ts
@@ -1,6 +1,6 @@
 import { ARIAButtonSlotProps } from '@fluentui/react-aria';
 import { PopoverContextValue } from '@fluentui/react-popover';
-import type { ComponentState, ComponentProps, Slot } from '@fluentui/react-utilities';
+import type { ComponentState, ComponentProps, DistributiveOmit, Slot } from '@fluentui/react-utilities';
 
 export type TeachingPopoverCarouselNavButtonSlots = {
   /**
@@ -23,3 +23,10 @@ export type TeachingPopoverCarouselNavButtonState = ComponentState<TeachingPopov
    */
   isSelected?: boolean;
 } & Pick<PopoverContextValue, 'appearance'>;
+
+export type TeachingPopoverCarouselNavButtonBaseProps = TeachingPopoverCarouselNavButtonProps;
+
+export type TeachingPopoverCarouselNavButtonBaseState = DistributiveOmit<
+  TeachingPopoverCarouselNavButtonState,
+  'appearance'
+>;

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselNavButton/index.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselNavButton/index.ts
@@ -1,11 +1,16 @@
 export { TeachingPopoverCarouselNavButton } from './TeachingPopoverCarouselNavButton';
 export type {
+  TeachingPopoverCarouselNavButtonBaseProps,
+  TeachingPopoverCarouselNavButtonBaseState,
   TeachingPopoverCarouselNavButtonProps,
   TeachingPopoverCarouselNavButtonSlots,
   TeachingPopoverCarouselNavButtonState,
 } from './TeachingPopoverCarouselNavButton.types';
 export { renderTeachingPopoverCarouselNavButton_unstable } from './renderTeachingPopoverCarouselNavButton';
-export { useTeachingPopoverCarouselNavButton_unstable } from './useTeachingPopoverCarouselNavButton';
+export {
+  useTeachingPopoverCarouselNavButton_unstable,
+  useTeachingPopoverCarouselNavButtonBase_unstable,
+} from './useTeachingPopoverCarouselNavButton';
 export {
   teachingPopoverCarouselNavButtonClassNames,
   useTeachingPopoverCarouselNavButtonStyles_unstable,

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselNavButton/useTeachingPopoverCarouselNavButton.tsx
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselNavButton/useTeachingPopoverCarouselNavButton.tsx
@@ -7,6 +7,8 @@ import { useTabsterAttributes } from '@fluentui/react-tabster';
 import { getIntrinsicElementProps, isHTMLElement, slot, useEventCallback } from '@fluentui/react-utilities';
 
 import type {
+  TeachingPopoverCarouselNavButtonBaseProps,
+  TeachingPopoverCarouselNavButtonBaseState,
   TeachingPopoverCarouselNavButtonProps,
   TeachingPopoverCarouselNavButtonState,
 } from './TeachingPopoverCarouselNavButton.types';
@@ -14,23 +16,19 @@ import { useCarouselContext_unstable } from '../TeachingPopoverCarousel/Carousel
 import { useValueIdContext } from '../TeachingPopoverCarouselNav/valueIdContext';
 
 /**
- * Create the state required to render TeachingPopoverCarouselNavButton.
- *
- * The returned state can be modified with hooks such as useTeachingPopoverCarouselNavButtonStyles_unstable,
- * before being passed to renderTeachingPopoverCarouselNavButton_unstable.
+ * Create the base state required to render TeachingPopoverCarouselNavButton, without design-specific props.
  *
  * @param props - props from this instance of TeachingPopoverCarouselNavButton
  * @param ref - reference to root HTMLElement of TeachingPopoverCarouselNavButton
  */
-export const useTeachingPopoverCarouselNavButton_unstable = (
-  props: TeachingPopoverCarouselNavButtonProps,
+export const useTeachingPopoverCarouselNavButtonBase_unstable = (
+  props: TeachingPopoverCarouselNavButtonBaseProps,
   ref: React.Ref<HTMLButtonElement | HTMLAnchorElement>,
-): TeachingPopoverCarouselNavButtonState => {
+): TeachingPopoverCarouselNavButtonBaseState => {
   const { onClick, as = 'a' } = props;
 
   const value = useValueIdContext();
 
-  const appearance = usePopoverContext_unstable(context => context.appearance);
   const selectPageByValue = useCarouselContext_unstable(c => c.selectPageByValue);
   const isSelected = useCarouselContext_unstable(c => c.value === value);
 
@@ -62,9 +60,8 @@ export const useTeachingPopoverCarouselNavButton_unstable = (
 
   _carouselButton.onClick = handleClick;
 
-  const state: TeachingPopoverCarouselNavButtonState = {
+  const state: TeachingPopoverCarouselNavButtonBaseState = {
     isSelected,
-    appearance,
     components: {
       root: 'button',
     },
@@ -72,4 +69,26 @@ export const useTeachingPopoverCarouselNavButton_unstable = (
   };
 
   return state;
+};
+
+/**
+ * Create the state required to render TeachingPopoverCarouselNavButton.
+ *
+ * The returned state can be modified with hooks such as useTeachingPopoverCarouselNavButtonStyles_unstable,
+ * before being passed to renderTeachingPopoverCarouselNavButton_unstable.
+ *
+ * @param props - props from this instance of TeachingPopoverCarouselNavButton
+ * @param ref - reference to root HTMLElement of TeachingPopoverCarouselNavButton
+ */
+export const useTeachingPopoverCarouselNavButton_unstable = (
+  props: TeachingPopoverCarouselNavButtonProps,
+  ref: React.Ref<HTMLButtonElement | HTMLAnchorElement>,
+): TeachingPopoverCarouselNavButtonState => {
+  const appearance = usePopoverContext_unstable(context => context.appearance);
+  const baseState = useTeachingPopoverCarouselNavButtonBase_unstable(props, ref);
+
+  return {
+    ...baseState,
+    appearance,
+  };
 };

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverFooter/TeachingPopoverFooter.types.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverFooter/TeachingPopoverFooter.types.ts
@@ -1,5 +1,5 @@
 import { Button } from '@fluentui/react-button';
-import { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+import { ComponentProps, ComponentState, DistributiveOmit, Slot } from '@fluentui/react-utilities';
 import { PopoverContextValue } from '@fluentui/react-popover';
 
 export type TeachingPopoverFooterSlots = {
@@ -30,3 +30,10 @@ export type TeachingPopoverFooterState = ComponentState<TeachingPopoverFooterSlo
 
 export type TeachingPopoverFooterProps = ComponentProps<TeachingPopoverFooterSlots> &
   Pick<TeachingPopoverFooterState, 'footerLayout'>;
+
+export type TeachingPopoverFooterBaseProps = DistributiveOmit<TeachingPopoverFooterProps, 'footerLayout'>;
+
+export type TeachingPopoverFooterBaseState = DistributiveOmit<
+  TeachingPopoverFooterState,
+  'appearance' | 'footerLayout'
+>;

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverFooter/index.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverFooter/index.ts
@@ -1,11 +1,13 @@
 export { TeachingPopoverFooter } from './TeachingPopoverFooter';
 export type {
+  TeachingPopoverFooterBaseProps,
+  TeachingPopoverFooterBaseState,
   TeachingPopoverFooterProps,
   TeachingPopoverFooterSlots,
   TeachingPopoverFooterState,
 } from './TeachingPopoverFooter.types';
 export { renderTeachingPopoverFooter_unstable } from './renderTeachingPopoverFooter';
-export { useTeachingPopoverFooter_unstable } from './useTeachingPopoverFooter';
+export { useTeachingPopoverFooter_unstable, useTeachingPopoverFooterBase_unstable } from './useTeachingPopoverFooter';
 export {
   teachingPopoverFooterClassNames,
   useTeachingPopoverFooterStyles_unstable,

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverFooter/useTeachingPopoverFooter.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverFooter/useTeachingPopoverFooter.ts
@@ -2,20 +2,24 @@
 
 import * as React from 'react';
 import { getIntrinsicElementProps, mergeCallbacks, slot, useEventCallback } from '@fluentui/react-utilities';
-import type { TeachingPopoverFooterProps, TeachingPopoverFooterState } from './TeachingPopoverFooter.types';
+import type {
+  TeachingPopoverFooterBaseProps,
+  TeachingPopoverFooterBaseState,
+  TeachingPopoverFooterProps,
+  TeachingPopoverFooterState,
+} from './TeachingPopoverFooter.types';
 import { Button } from '@fluentui/react-button';
 import { usePopoverContext_unstable } from '@fluentui/react-popover';
 
 /**
- * Returns the props and state required to render the component
+ * Returns the base props and state required to render the component, without design-specific props.
  * @param props - TeachingPopoverFooter properties
  * @param ref - reference to root HTMLElement of TeachingPopoverFooter
  */
-export const useTeachingPopoverFooter_unstable = (
-  props: TeachingPopoverFooterProps,
+export const useTeachingPopoverFooterBase_unstable = (
+  props: TeachingPopoverFooterBaseProps,
   ref: React.Ref<HTMLDivElement>,
-): TeachingPopoverFooterState => {
-  const appearance = usePopoverContext_unstable(context => context.appearance);
+): TeachingPopoverFooterBaseState => {
   const toggleOpen = usePopoverContext_unstable(context => context.toggleOpen);
 
   const handleButtonClick = useEventCallback(
@@ -30,7 +34,7 @@ export const useTeachingPopoverFooter_unstable = (
 
   const secondary = slot.optional(props.secondary, {
     defaultProps: {
-      appearance: appearance === 'brand' ? 'primary' : undefined,
+      appearance: undefined,
     },
     renderByDefault: props.secondary !== undefined,
     elementType: Button,
@@ -43,7 +47,7 @@ export const useTeachingPopoverFooter_unstable = (
 
   const primary = slot.always(props.primary, {
     defaultProps: {
-      appearance: appearance === 'brand' ? undefined : 'primary',
+      appearance: undefined,
     },
     elementType: Button,
   });
@@ -54,8 +58,6 @@ export const useTeachingPopoverFooter_unstable = (
   }
 
   return {
-    footerLayout: props.footerLayout ?? 'horizontal',
-    appearance,
     components: {
       root: 'div',
       primary: Button,
@@ -70,5 +72,31 @@ export const useTeachingPopoverFooter_unstable = (
     ),
     secondary,
     primary,
+  };
+};
+
+/**
+ * Returns the props and state required to render the component
+ * @param props - TeachingPopoverFooter properties
+ * @param ref - reference to root HTMLElement of TeachingPopoverFooter
+ */
+export const useTeachingPopoverFooter_unstable = (
+  props: TeachingPopoverFooterProps,
+  ref: React.Ref<HTMLDivElement>,
+): TeachingPopoverFooterState => {
+  const appearance = usePopoverContext_unstable(context => context.appearance);
+  const footerLayout = props.footerLayout ?? 'horizontal';
+  const baseState = useTeachingPopoverFooterBase_unstable(props, ref);
+
+  // Override button appearance based on popover appearance
+  if (baseState.secondary) {
+    baseState.secondary.appearance = appearance === 'brand' ? 'primary' : undefined;
+  }
+  baseState.primary.appearance = appearance === 'brand' ? undefined : 'primary';
+
+  return {
+    ...baseState,
+    footerLayout,
+    appearance,
   };
 };

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverHeader/TeachingPopoverHeader.types.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverHeader/TeachingPopoverHeader.types.ts
@@ -1,4 +1,4 @@
-import { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+import { ComponentProps, ComponentState, DistributiveOmit, Slot } from '@fluentui/react-utilities';
 import { PopoverContextValue } from '@fluentui/react-popover';
 
 export type TeachingPopoverHeaderSlots = {
@@ -22,3 +22,7 @@ export type TeachingPopoverHeaderState = ComponentState<TeachingPopoverHeaderSlo
   Pick<PopoverContextValue, 'appearance'>;
 
 export type TeachingPopoverHeaderProps = ComponentProps<TeachingPopoverHeaderSlots>;
+
+export type TeachingPopoverHeaderBaseProps = TeachingPopoverHeaderProps;
+
+export type TeachingPopoverHeaderBaseState = DistributiveOmit<TeachingPopoverHeaderState, 'appearance'>;

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverHeader/index.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverHeader/index.ts
@@ -1,11 +1,13 @@
 export { TeachingPopoverHeader } from './TeachingPopoverHeader';
 export type {
+  TeachingPopoverHeaderBaseProps,
+  TeachingPopoverHeaderBaseState,
   TeachingPopoverHeaderProps,
   TeachingPopoverHeaderSlots,
   TeachingPopoverHeaderState,
 } from './TeachingPopoverHeader.types';
 export { renderTeachingPopoverHeader_unstable } from './renderTeachingPopoverHeader';
-export { useTeachingPopoverHeader_unstable } from './useTeachingPopoverHeader';
+export { useTeachingPopoverHeader_unstable, useTeachingPopoverHeaderBase_unstable } from './useTeachingPopoverHeader';
 export {
   teachingPopoverHeaderClassNames,
   useTeachingPopoverHeaderStyles_unstable,

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverHeader/useTeachingPopoverHeader.tsx
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverHeader/useTeachingPopoverHeader.tsx
@@ -2,25 +2,29 @@
 
 import * as React from 'react';
 import { getIntrinsicElementProps, useEventCallback, slot } from '@fluentui/react-utilities';
-import type { TeachingPopoverHeaderProps, TeachingPopoverHeaderState } from './TeachingPopoverHeader.types';
+import type {
+  TeachingPopoverHeaderBaseProps,
+  TeachingPopoverHeaderBaseState,
+  TeachingPopoverHeaderProps,
+  TeachingPopoverHeaderState,
+} from './TeachingPopoverHeader.types';
 
 import { Dismiss12Regular, Lightbulb16Regular } from '@fluentui/react-icons';
 import { usePopoverContext_unstable } from '@fluentui/react-popover';
 
 /**
- * Returns the props and state required to render the component
+ * Returns the base props and state required to render the component, without design-specific props.
  * @param props - TeachingPopoverHeader properties
  * @param ref - reference to root HTMLElement of TeachingPopoverHeader
  */
-export const useTeachingPopoverHeader_unstable = (
-  props: TeachingPopoverHeaderProps,
+export const useTeachingPopoverHeaderBase_unstable = (
+  props: TeachingPopoverHeaderBaseProps,
   ref: React.Ref<HTMLDivElement>,
-): TeachingPopoverHeaderState => {
+): TeachingPopoverHeaderBaseState => {
   const { dismissButton, icon } = props;
 
   const setOpen = usePopoverContext_unstable(context => context.setOpen);
   const triggerRef = usePopoverContext_unstable(context => context.triggerRef);
-  const appearance = usePopoverContext_unstable(context => context.appearance);
 
   const onDismissButtonClick = useEventCallback((ev: React.MouseEvent<HTMLButtonElement>) => {
     if (!ev.defaultPrevented) {
@@ -33,7 +37,6 @@ export const useTeachingPopoverHeader_unstable = (
   });
 
   return {
-    appearance,
     components: {
       root: 'div',
       dismissButton: 'button',
@@ -64,5 +67,23 @@ export const useTeachingPopoverHeader_unstable = (
       },
       elementType: 'button',
     }),
+  };
+};
+
+/**
+ * Returns the props and state required to render the component
+ * @param props - TeachingPopoverHeader properties
+ * @param ref - reference to root HTMLElement of TeachingPopoverHeader
+ */
+export const useTeachingPopoverHeader_unstable = (
+  props: TeachingPopoverHeaderProps,
+  ref: React.Ref<HTMLDivElement>,
+): TeachingPopoverHeaderState => {
+  const appearance = usePopoverContext_unstable(context => context.appearance);
+  const baseState = useTeachingPopoverHeaderBase_unstable(props, ref);
+
+  return {
+    ...baseState,
+    appearance,
   };
 };

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverTitle/TeachingPopoverTitle.types.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverTitle/TeachingPopoverTitle.types.ts
@@ -1,5 +1,5 @@
 import { PopoverContextValue } from '@fluentui/react-popover';
-import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+import type { ComponentProps, ComponentState, DistributiveOmit, Slot } from '@fluentui/react-utilities';
 
 export type TeachingPopoverTitleSlots = {
   /**
@@ -22,3 +22,7 @@ export type TeachingPopoverTitleProps = ComponentProps<TeachingPopoverTitleSlots
  */
 export type TeachingPopoverTitleState = ComponentState<TeachingPopoverTitleSlots> &
   Pick<PopoverContextValue, 'appearance'>;
+
+export type TeachingPopoverTitleBaseProps = TeachingPopoverTitleProps;
+
+export type TeachingPopoverTitleBaseState = DistributiveOmit<TeachingPopoverTitleState, 'appearance'>;

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverTitle/index.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverTitle/index.ts
@@ -1,11 +1,13 @@
 export { TeachingPopoverTitle } from './TeachingPopoverTitle';
 export type {
+  TeachingPopoverTitleBaseProps,
+  TeachingPopoverTitleBaseState,
   TeachingPopoverTitleProps,
   TeachingPopoverTitleSlots,
   TeachingPopoverTitleState,
 } from './TeachingPopoverTitle.types';
 export { renderTeachingPopoverTitle_unstable } from './renderTeachingPopoverTitle';
-export { useTeachingPopoverTitle_unstable } from './useTeachingPopoverTitle';
+export { useTeachingPopoverTitle_unstable, useTeachingPopoverTitleBase_unstable } from './useTeachingPopoverTitle';
 export {
   teachingPopoverTitleClassNames,
   useTeachingPopoverTitleStyles_unstable,

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverTitle/useTeachingPopoverTitle.tsx
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverTitle/useTeachingPopoverTitle.tsx
@@ -2,25 +2,29 @@
 
 import * as React from 'react';
 import { getIntrinsicElementProps, useEventCallback, slot } from '@fluentui/react-utilities';
-import type { TeachingPopoverTitleProps, TeachingPopoverTitleState } from './TeachingPopoverTitle.types';
+import type {
+  TeachingPopoverTitleBaseProps,
+  TeachingPopoverTitleBaseState,
+  TeachingPopoverTitleProps,
+  TeachingPopoverTitleState,
+} from './TeachingPopoverTitle.types';
 import { DismissFilled, DismissRegular, bundleIcon } from '@fluentui/react-icons';
 import { usePopoverContext_unstable } from '@fluentui/react-popover';
 
 const DismissIcon = bundleIcon(DismissFilled, DismissRegular);
 /**
- * Returns the props and state required to render the component
+ * Returns the base props and state required to render the component, without design-specific props.
  * @param props - TeachingPopoverTitle properties
  * @param ref - reference to root HTMLElement of TeachingPopoverTitle
  */
-export const useTeachingPopoverTitle_unstable = (
-  props: TeachingPopoverTitleProps,
+export const useTeachingPopoverTitleBase_unstable = (
+  props: TeachingPopoverTitleBaseProps,
   ref: React.Ref<HTMLDivElement>,
-): TeachingPopoverTitleState => {
+): TeachingPopoverTitleBaseState => {
   const { dismissButton } = props;
 
   const setOpen = usePopoverContext_unstable(context => context.setOpen);
   const triggerRef = usePopoverContext_unstable(context => context.triggerRef);
-  const appearance = usePopoverContext_unstable(context => context.appearance);
 
   const onDismissButtonClick = useEventCallback((ev: React.MouseEvent<HTMLButtonElement>) => {
     if (!ev.defaultPrevented) {
@@ -33,7 +37,6 @@ export const useTeachingPopoverTitle_unstable = (
   });
 
   return {
-    appearance,
     components: {
       root: 'h2',
       dismissButton: 'button',
@@ -55,5 +58,23 @@ export const useTeachingPopoverTitle_unstable = (
       },
       elementType: 'button',
     }),
+  };
+};
+
+/**
+ * Returns the props and state required to render the component
+ * @param props - TeachingPopoverTitle properties
+ * @param ref - reference to root HTMLElement of TeachingPopoverTitle
+ */
+export const useTeachingPopoverTitle_unstable = (
+  props: TeachingPopoverTitleProps,
+  ref: React.Ref<HTMLDivElement>,
+): TeachingPopoverTitleState => {
+  const appearance = usePopoverContext_unstable(context => context.appearance);
+  const baseState = useTeachingPopoverTitleBase_unstable(props, ref);
+
+  return {
+    ...baseState,
+    appearance,
   };
 };

--- a/packages/react-components/react-teaching-popover/library/src/index.ts
+++ b/packages/react-components/react-teaching-popover/library/src/index.ts
@@ -4,8 +4,11 @@ export {
   renderTeachingPopoverHeader_unstable,
   useTeachingPopoverHeaderStyles_unstable,
   useTeachingPopoverHeader_unstable,
+  useTeachingPopoverHeaderBase_unstable,
 } from './TeachingPopoverHeader';
 export type {
+  TeachingPopoverHeaderBaseProps,
+  TeachingPopoverHeaderBaseState,
   TeachingPopoverHeaderProps,
   TeachingPopoverHeaderSlots,
   TeachingPopoverHeaderState,
@@ -40,9 +43,12 @@ export {
   renderTeachingPopoverCarousel_unstable,
   useTeachingPopoverCarouselStyles_unstable,
   useTeachingPopoverCarousel_unstable,
+  useTeachingPopoverCarouselBase_unstable,
   useTeachingPopoverCarouselContextValues_unstable,
 } from './TeachingPopoverCarousel';
 export type {
+  TeachingPopoverCarouselBaseProps,
+  TeachingPopoverCarouselBaseState,
   TeachingPopoverCarouselProps,
   TeachingPopoverCarouselSlots,
   TeachingPopoverCarouselState,
@@ -53,8 +59,11 @@ export {
   renderTeachingPopoverCarouselFooter_unstable,
   useTeachingPopoverCarouselFooterStyles_unstable,
   useTeachingPopoverCarouselFooter_unstable,
+  useTeachingPopoverCarouselFooterBase_unstable,
 } from './TeachingPopoverCarouselFooter';
 export type {
+  TeachingPopoverCarouselFooterBaseProps,
+  TeachingPopoverCarouselFooterBaseState,
   TeachingPopoverCarouselFooterProps,
   TeachingPopoverCarouselFooterSlots,
   TeachingPopoverCarouselFooterState,
@@ -77,8 +86,11 @@ export {
   renderTeachingPopoverCarouselNavButton_unstable,
   useTeachingPopoverCarouselNavButtonStyles_unstable,
   useTeachingPopoverCarouselNavButton_unstable,
+  useTeachingPopoverCarouselNavButtonBase_unstable,
 } from './TeachingPopoverCarouselNavButton';
 export type {
+  TeachingPopoverCarouselNavButtonBaseProps,
+  TeachingPopoverCarouselNavButtonBaseState,
   TeachingPopoverCarouselNavButtonProps,
   TeachingPopoverCarouselNavButtonSlots,
   TeachingPopoverCarouselNavButtonState,
@@ -101,8 +113,11 @@ export {
   renderTeachingPopoverTitle_unstable,
   useTeachingPopoverTitleStyles_unstable,
   useTeachingPopoverTitle_unstable,
+  useTeachingPopoverTitleBase_unstable,
 } from './TeachingPopoverTitle';
 export type {
+  TeachingPopoverTitleBaseProps,
+  TeachingPopoverTitleBaseState,
   TeachingPopoverTitleProps,
   TeachingPopoverTitleSlots,
   TeachingPopoverTitleState,
@@ -124,8 +139,14 @@ export {
   teachingPopoverFooterClassNames,
   renderTeachingPopoverFooter_unstable,
   useTeachingPopoverFooter_unstable,
+  useTeachingPopoverFooterBase_unstable,
 } from './TeachingPopoverFooter';
-export type { TeachingPopoverFooterProps, TeachingPopoverFooterState } from './TeachingPopoverFooter';
+export type {
+  TeachingPopoverFooterBaseProps,
+  TeachingPopoverFooterBaseState,
+  TeachingPopoverFooterProps,
+  TeachingPopoverFooterState,
+} from './TeachingPopoverFooter';
 export {
   TeachingPopoverCarouselPageCount,
   renderTeachingPopoverCarouselPageCount_unstable,
@@ -145,8 +166,11 @@ export {
   teachingPopoverCarouselFooterButtonClassNames,
   useTeachingPopoverCarouselFooterButtonStyles_unstable,
   useTeachingPopoverCarouselFooterButton_unstable,
+  useTeachingPopoverCarouselFooterButtonBase_unstable,
 } from './TeachingPopoverCarouselFooterButton';
 export type {
+  TeachingPopoverCarouselFooterButtonBaseProps,
+  TeachingPopoverCarouselFooterButtonBaseState,
   TeachingPopoverCarouselFooterButtonProps,
   TeachingPopoverCarouselFooterButtonSlots,
   TeachingPopoverCarouselFooterButtonState,


### PR DESCRIPTION
## Summary

- Add `use*Base_unstable` hooks and `*BaseProps`/`*BaseState` types for 7 TeachingPopover components
- Base hooks contain all behavioral logic without design-specific props (appearance, layout, footerLayout)
- Styled hooks refactored to call base hook + add design props back
- All new exports propagated through component index.ts, intermediate re-export files, and library/src/index.ts

## Components with base hooks

- `TeachingPopoverHeader`: `useTeachingPopoverHeaderBase_unstable`
- `TeachingPopoverTitle`: `useTeachingPopoverTitleBase_unstable`
- `TeachingPopoverFooter`: `useTeachingPopoverFooterBase_unstable` (omits `appearance`, `footerLayout`)
- `TeachingPopoverCarousel`: `useTeachingPopoverCarouselBase_unstable`
- `TeachingPopoverCarouselFooter`: `useTeachingPopoverCarouselFooterBase_unstable` (omits `layout`)
- `TeachingPopoverCarouselNavButton`: `useTeachingPopoverCarouselNavButtonBase_unstable`
- `TeachingPopoverCarouselFooterButton`: `useTeachingPopoverCarouselFooterButtonBase_unstable` (omits `popoverAppearance`)

## Test plan

- [ ] TypeScript compiles without new errors (`yarn tsc -p packages/react-components/react-teaching-popover/library/tsconfig.lib.json --noEmit`)
- [ ] Pre-existing TS errors in `renderPopoverSurface.tsx` and `renderTeachingPopoverCarouselNav.tsx` are unchanged
- [ ] Verify base hooks export correctly from package index

🤖 Generated with [Claude Code](https://claude.com/claude-code)