### PR TITLE
fix(react-aria): handle position fixed in getTotalOffsetTop to prevent scroll jump

### DIFF
--- a/packages/react-components/react-aria/library/src/activedescendant/scrollIntoView.ts
+++ b/packages/react-components/react-aria/library/src/activedescendant/scrollIntoView.ts
@@ -49,6 +49,14 @@ const getTotalOffsetTop = (element: HTMLElement, scrollParent: HTMLElement): num
     return scrollParent.offsetTop * -1;
   }
 
+  // Handle position: fixed elements where offsetTop is unreliable
+  const win = element.ownerDocument?.defaultView;
+  const isFixed = win && win.getComputedStyle(element).position === 'fixed';
+
+  if (isFixed) {
+    return element.getBoundingClientRect().top + getTotalOffsetTop(element.offsetParent as HTMLElement, scrollParent);
+  }
+
   return element.offsetTop + getTotalOffsetTop(element.offsetParent as HTMLElement, scrollParent);
 };
 


### PR DESCRIPTION
Fixes: #35921

When a `Dropdown `with `inlinePopup `is opened inside a scrollable container (like a `Dialog`), a race condition between `createPositionManager `and `useActiveDescendant `causes the parent container to violently scroll to the top.

This occurs because the active descendant controller fires `scrollIntoView `while the listbox is still temporarily pinned with` position: fixed`. Because fixed elements report an `offsetTop `of `0`, the `getTotalOffsetTop `function calculates a negative distance, triggering the browser to scroll to the top of the container.

**The Solution:**
Updated the `getTotalOffsetTop `utility in `react-aria` to account for elements removed from the normal document flow.

Added a check for `position: fixed` using `getComputedStyle`.

If the element is fixed, it bypasses the unreliable `offsetTop `property and instead uses `getBoundingClientRect().top` to accurately calculate the visual distance to the scroll parent.

Fallbacks to standard `offsetTop `math for all standard relative/absolute elements.

**Testing:**

Verified the math fix resolves the `-111px` scroll jump in the provided reproduction environment without breaking standard relative scroll calculations.