### PR TITLE
feat(react-accordion): [CAP] use bundleIcon for AccordionHeader expand icon

### DIFF
--- a/packages/react-components/react-accordion/library/src/components/AccordionHeader/useAccordionHeader.tsx
+++ b/packages/react-components/react-accordion/library/src/components/AccordionHeader/useAccordionHeader.tsx
@@ -10,10 +10,12 @@ import type {
   AccordionHeaderState,
 } from './AccordionHeader.types';
 import { useAccordionContext_unstable } from '../../contexts/accordion';
-import { ChevronRightRegular } from '@fluentui/react-icons';
+import { bundleIcon, ChevronRightFilled, ChevronRightRegular } from '@fluentui/react-icons';
 import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
 import { useAccordionItemContext_unstable } from '../../contexts/accordionItem';
 import { motionTokens } from '@fluentui/react-motion';
+
+const ChevronRightIcon = bundleIcon(ChevronRightFilled, ChevronRightRegular);
 
 /**
  * Returns the props and state required to render the component
@@ -41,7 +43,7 @@ export const useAccordionHeader_unstable = (
 
   if (state.expandIcon) {
     state.expandIcon.children ??= (
-      <ChevronRightRegular
+      <ChevronRightIcon
         style={{
           transform: `rotate(${expandIconRotation}deg)`,
           transition: `transform ${motionTokens.durationNormal}ms ease-out`,

--- a/packages/react-components/react-accordion/library/src/components/AccordionHeader/useAccordionHeaderStyles.styles.ts
+++ b/packages/react-components/react-accordion/library/src/components/AccordionHeader/useAccordionHeaderStyles.styles.ts
@@ -5,6 +5,7 @@ import { createFocusOutlineStyle } from '@fluentui/react-tabster';
 import { tokens, typographyStyles } from '@fluentui/react-theme';
 import type { AccordionHeaderSlots, AccordionHeaderState } from './AccordionHeader.types';
 import type { SlotClassNames } from '@fluentui/react-utilities';
+import { iconFilledClassName, iconRegularClassName } from '@fluentui/react-icons';
 
 export const accordionHeaderClassNames: SlotClassNames<AccordionHeaderSlots> = {
   root: 'fui-AccordionHeader',
@@ -83,6 +84,8 @@ const useStyles = makeStyles({
     alignItems: 'center',
     lineHeight: tokens.lineHeightBase500,
     fontSize: tokens.fontSizeBase500,
+    [`:hover .${iconFilledClassName}`]: { display: 'inline' },
+    [`:hover .${iconRegularClassName}`]: { display: 'none' },
   },
   expandIconStart: {
     paddingRight: tokens.spacingHorizontalS,


### PR DESCRIPTION
# Overview 
Updates AccordionHeader to use bundleIcon for the expand/collapse chevron icon, replacing the standalone ChevronRightRegular with a bundled ChevronRightFilled/ChevronRightRegular

## Changes
- Replaced ChevronRightRegular with bundleIcon(ChevronRightFilled, ChevronRightRegular) in useAccordionHeader.tsx
- Added hover styles in useAccordionHeaderStyles.styles.ts to toggle between regular and filled icon variants using iconFilledClassName / iconRegularClassName