### PR TITLE
feat(cli): add skill instalation hint/detection to migrate cmd

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,57 @@
+# Fluent UI Agent Skills
+
+This directory contains [agent skills](https://agentskills.io) — reusable instruction sets that extend AI coding agents with Fluent UI-specific capabilities. Skills are installed into your project (or globally) and automatically loaded by supported agents.
+
+## Available skills
+
+| Skill                                                               | Description                                                                                                                    |
+| ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| [`fluentui-migrate-v8-to-v9`](./fluentui-migrate-v8-to-v9/SKILL.md) | Guides AI agents through migrating a codebase from Fluent UI React v8 (`@fluentui/react`) to v9 (`@fluentui/react-components`) |
+
+## Installation
+
+Skills are installed via the [`npx skills`](https://github.com/vercel-labs/skills) CLI, which supports 40+ coding agents including Claude Code, GitHub Copilot, Cursor, Codex, and more.
+
+### Install the migration skill
+
+```bash
+# Interactive — choose which agents and skills to install
+npx skills add microsoft/fluentui
+
+# Install a specific skill
+npx skills add microsoft/fluentui --skill fluentui-migrate-v8-to-v9
+
+# Install to a specific agent
+npx skills add microsoft/fluentui --skill fluentui-migrate-v8-to-v9 -a claude-code
+
+# Install globally (available across all projects)
+npx skills add microsoft/fluentui --skill fluentui-migrate-v8-to-v9 -g
+```
+
+### List available skills
+
+```bash
+npx skills add microsoft/fluentui --list
+```
+
+## Managing installed skills
+
+```bash
+# List installed skills
+npx skills list
+
+# Check for updates
+npx skills check
+
+# Update to latest
+npx skills update
+
+# Remove a skill
+npx skills remove fluentui-migrate-v8-to-v9
+```
+
+## Further reading
+
+- [Agent Skills specification](https://agentskills.io)
+- [Skills directory](https://skills.sh)
+- [`@fluentui/cli` migrate command](../tools/cli/src/commands/migrate/README.md)

--- a/tools/cli/src/commands/migrate/README.md
+++ b/tools/cli/src/commands/migrate/README.md
@@ -1,0 +1,272 @@
+# `migrate` command
+
+The `migrate` command performs static analysis on a codebase and inserts structured migration annotations into source files. These annotations serve as a deterministic work queue for human developers or AI agents to execute the actual migration.
+
+## Usage
+
+```bash
+fluentui migrate [migration] [--list]
+```
+
+| Flag     | Alias | Description                   |
+| -------- | ----- | ----------------------------- |
+| `--list` | `-l`  | List all available migrations |
+
+### `migrate v8-to-v9`
+
+Analyzes a directory for Fluent UI v8 (`@fluentui/react`) usage and annotates each migration site with the appropriate action and target.
+
+```bash
+fluentui migrate v8-to-v9 --path <dir> [--dryRun]
+```
+
+| Flag       | Default | Description                                   |
+| ---------- | ------- | --------------------------------------------- |
+| `--path`   | —       | **Required.** Source root to analyze          |
+| `--dryRun` | `false` | Preview annotations without writing any files |
+
+> **Note**: The package must have a `package.json` reachable from `--path` so the analyzer can determine which v9 dependencies are already installed.
+
+## Two-phase migration model
+
+The command implements **phase 1** of a two-phase migration:
+
+1. **Annotate** (this command) — statically detects v8 usage, classifies each finding, and inserts `@fluent-migrate:` comments into source files.
+2. **Execute** (human or AI agent) — consumes annotations as a work queue, applies changes in priority order, removes comments after each fix, and validates the result.
+
+The companion skill at `skills/fluentui-migrate-v8-to-v9/SKILL.md` defines the agent workflow for phase 2.
+
+### Installing the migration skill
+
+After running annotations, install the companion AI agent skill to guide phase 2:
+
+```bash
+npx skills add microsoft/fluentui --skill fluentui-migrate-v8-to-v9
+```
+
+The CLI automatically checks whether the skill is installed and prints this hint when it is missing. See [`skills/README.md`](../../../../../skills/README.md) for full installation options and the supported agent list.
+
+## Annotation format
+
+Annotations are inserted as comments directly above the detected usage site:
+
+```ts
+// @fluent-migrate:<action> | <codemod> | <payload> | <note>
+```
+
+Inside JSX children, block comments are used instead:
+
+```tsx
+{
+  /* @fluent-migrate:<action> | <codemod> | <payload> | <note> */
+}
+```
+
+### Actions
+
+| Action          | Meaning                                                           |
+| --------------- | ----------------------------------------------------------------- |
+| `auto`          | Safe to apply mechanically — a 1:1 rename or straightforward swap |
+| `scaffold`      | Boilerplate structure needed — e.g. wrapping in `<Field>`         |
+| `manual`        | Requires human judgment — multiple valid approaches exist         |
+| `no-equivalent` | No v9 replacement — requires a custom solution or removal         |
+
+## Rules
+
+The analyzer applies a set of rules to each source file. A rule detects a specific v8 pattern and emits one or more annotations.
+
+### `import-paths`
+
+Rewrites `@fluentui/react` imports to their v9 targets.
+
+- Standard specifiers → `auto` to `@fluentui/react-components`
+- Compat components (`Calendar`, `DatePicker`, `TimePicker`) → `manual` to their compat packages
+- Deprecated components with no equivalent → `no-equivalent`
+- Side-effect imports → `auto`
+
+### `component-rename`
+
+Maps v8 component names to their v9 equivalents. Covers three tiers:
+
+- **Auto 1:1 renames** — `Separator→Divider`, `Toggle→Switch`, `Shimmer→Skeleton`, `Fabric→FluentProvider`, `Layer→Portal`, `ProgressIndicator→ProgressBar`, `ChoiceGroup→RadioGroup`, and others
+- **Structural renames** (`manual`) — `Panel→OverlayDrawer`, `Callout→Popover`, `ContextualMenu→Menu`, `Pivot→TabList`, `Modal→Dialog`, and others requiring API restructuring
+- **No equivalent** — handled by the `no-equivalent` rule instead
+
+### `button-variants`
+
+Maps v8 button types to v9 `Button` with the appropriate `appearance`:
+
+| v8               | v9                                                  | Action |
+| ---------------- | --------------------------------------------------- | ------ |
+| `PrimaryButton`  | `Button appearance="primary"`                       | `auto` |
+| `DefaultButton`  | `Button`                                            | `auto` |
+| `ActionButton`   | `Button appearance="transparent"`                   | `auto` |
+| `IconButton`     | `Button` (icon-only, ensure `aria-label`)           | `auto` |
+| `CompoundButton` | `CompoundButton` (`secondaryText→secondaryContent`) | `auto` |
+
+### `prop-rename`
+
+Renames props mechanically:
+
+| v8 prop           | v9 prop            |
+| ----------------- | ------------------ |
+| `ariaLabel`       | `aria-label`       |
+| `ariaHidden`      | `aria-hidden`      |
+| `ariaDescribedBy` | `aria-describedby` |
+| `ariaLabelledBy`  | `aria-labelledby`  |
+| `componentRef`    | `ref`              |
+
+### `icon-props`
+
+Converts `iconProps={{ iconName: 'X' }}` to `icon={<XRegular />}`.
+
+- Known icon names → `auto` (requires `@fluentui/react-icons`)
+- Unknown or dynamic icon names → `manual`
+
+### `dialog-props`
+
+Maps `Dialog`/`Modal` props:
+
+- `hidden` → `open={!expr}` (`auto`)
+- `isOpen` → `open` (`auto`)
+- `onDismiss` → `onOpenChange` (`auto`)
+- `isBlocking` → `modalType="alert"` (`auto`)
+- `dialogContentProps` → `DialogTitle + DialogBody` structure (`scaffold`)
+
+### `enum-to-string`
+
+Replaces v8 enum members with v9 string literals for `MessageBarType`, `SpinnerSize`, `DialogType`, and `CheckboxVisibility`.
+
+### `toggle-props`
+
+Maps `Toggle`-specific props: `inlineLabel→labelPosition`, `onChange` signature rewrite, and marks `onText`/`offText` as `no-equivalent`.
+
+### `progress-bar-props`
+
+Maps `ProgressIndicator` props: `percentComplete→value`, `label→Field wrapper`.
+
+### `label-extraction`
+
+For components whose `label` prop moves to a `<Field>` wrapper (`TextField`, `SpinButton`, `Slider`, `ChoiceGroup`, `Spinner`, `ProgressIndicator`):
+
+- `label` → `scaffold` (wrap in `<Field label="...">`)
+- `onRenderLabel` → `manual`
+
+### `styles-prop`
+
+Detects any `styles` prop on Fluent components and emits `scaffold` — suggests replacing with `makeStyles` and design tokens.
+
+### `remove-theme-prop`
+
+Detects `theme` prop usage and emits `auto`. Adds a note about nested `FluentProvider` if the value is non-trivial.
+
+### `use-boolean`
+
+Detects `useBoolean` from v8 and suggests replacing with `useState`. Emits `auto` inside function components, `manual` otherwise.
+
+### `keycodes`
+
+Detects `KeyCodes` enum usage and maps known members to `event.key` string values (e.g. `KeyCodes.enter→'Enter'`). Unknown members are `manual`.
+
+### `get-id`
+
+Detects `getId` from v8 and suggests replacing with `useId` from v9. Emits `auto` inside function components, `manual` otherwise.
+
+### `no-equivalent`
+
+Flags deprecated components with no v9 replacement: `ActivityItem`, `MarqueeSelection`, `HoverCard`, `ResizeGroup`, `ScrollablePane`, `Announced`, `Stack`, `StackItem`. Each annotation includes a recommended alternative in the note.
+
+## Output
+
+### Summary (write mode)
+
+After annotating, the command prints:
+
+```
+Annotated 12 files
+  auto             34  (safe to apply mechanically)
+  scaffold          8  (boilerplate needed)
+  manual            5  (requires judgment)
+  no-equivalent     2  (no v9 replacement)
+
+Required packages (not in package.json):
+  @fluentui/react-components          — v9 component library
+  @fluentui/react-icons               — icon replacements
+```
+
+### Dry-run mode
+
+With `--dryRun`, no files are modified. The command prints the same counts plus a list of files that would be annotated.
+
+### Metadata file
+
+After writing annotations, the command creates `.fluent-migrate/metadata.json` in the project root:
+
+```json
+{
+  "version": 1,
+  "annotatedFiles": ["src/App.tsx", "src/components/Header.tsx"]
+}
+```
+
+This file is consumed by the migration skill as the deterministic work queue.
+
+## Architecture
+
+```
+migrate/
+├── index.ts                          # Parent command — registers subcommands, --list flag
+├── v8-to-v9/
+│   ├── index.ts                      # Yargs subcommand definition (--path, --dryRun)
+│   ├── handler.ts                    # Orchestrates analyze → write → summary
+│   ├── utils/annotator/
+│   │   ├── index.ts                  # Public API (analyzeFiles, writeAnnotations)
+│   │   ├── types.ts                  # AnnotationAction, Annotation, FileAnalysis types
+│   │   ├── analyzer.ts              # File discovery, ts-morph parsing, rule execution
+│   │   ├── writer.ts                # Comment insertion, idempotency, metadata.json output
+│   │   └── rules/
+│   │       ├── utils.ts             # Shared helpers (getFluentImportNames, isJsxChild)
+│   │       ├── import-paths.ts
+│   │       ├── component-rename.ts
+│   │       ├── button-variants.ts
+│   │       ├── prop-rename.ts
+│   │       ├── icon-props.ts
+│   │       ├── dialog-props.ts
+│   │       ├── enum-to-string.ts
+│   │       ├── toggle-props.ts
+│   │       ├── progress-bar-props.ts
+│   │       ├── label-extraction.ts
+│   │       ├── styles-prop.ts
+│   │       ├── remove-theme-prop.ts
+│   │       ├── use-boolean.ts
+│   │       ├── keycodes.ts
+│   │       ├── get-id.ts
+│   │       └── no-equivalent.ts
+│   └── __tests__/
+│       ├── handler.spec.ts           # Unit tests (mocked analyzer/writer)
+│       ├── handler.integration.spec.ts # Integration tests (real files + temp dirs)
+│       └── fixtures/                 # Sample .tsx files exercising each rule
+└── README.md                         # This file
+```
+
+### How it works
+
+1. **Package detection** — walks up from `--path` to find the nearest `package.json` and reads installed dependencies
+2. **File discovery** — scans `**/*.ts` and `**/*.tsx` under `--path`, skipping `node_modules` and `.d.ts` files
+3. **Import extraction** — uses ts-morph to find all names imported from `@fluentui/react`
+4. **Rule execution** — each rule inspects the AST for specific v8 patterns and emits typed annotations with line numbers
+5. **Annotation writing** — inserts comments above each target node, preserving indentation and handling JSX context; sorts annotations by line descending to avoid offset drift
+6. **Idempotency** — re-running the command on already-annotated files skips duplicate annotations
+7. **Metadata output** — writes `.fluent-migrate/metadata.json` listing all annotated files
+
+## Testing
+
+```bash
+# Run all migrate tests
+yarn nx run cli:test -- --testPathPatterns=migrate
+
+# Run full CLI test suite
+yarn nx run cli:test
+```
+
+Tests use a fixture-based approach with sample `.tsx` files in `__tests__/fixtures/` covering each rule. Integration tests create temporary directories, run the real analyzer and writer, and verify annotation content, idempotency, indentation, and metadata output.

--- a/tools/cli/src/commands/migrate/v8-to-v9/__tests__/handler.spec.ts
+++ b/tools/cli/src/commands/migrate/v8-to-v9/__tests__/handler.spec.ts
@@ -1,13 +1,17 @@
 import { handler } from '../handler';
 import * as annotator from '../utils/annotator';
+import * as skillCheck from '../utils/skill-check';
 import * as fs from 'fs/promises';
 
 jest.mock('../utils/annotator');
+jest.mock('../utils/skill-check');
 jest.mock('fs/promises');
 
 const mockAnalyzeFiles = annotator.analyzeFiles as jest.MockedFunction<typeof annotator.analyzeFiles>;
 const mockWriteAnnotations = annotator.writeAnnotations as jest.MockedFunction<typeof annotator.writeAnnotations>;
 const mockStat = fs.stat as jest.MockedFunction<typeof fs.stat>;
+const mockIsSkillInstalled = skillCheck.isSkillInstalled as jest.MockedFunction<typeof skillCheck.isSkillInstalled>;
+const mockPrintSkillHint = skillCheck.printSkillHint as jest.MockedFunction<typeof skillCheck.printSkillHint>;
 
 describe('migrate v8-to-v9 handler', () => {
   let logSpy: jest.SpyInstance;
@@ -17,6 +21,8 @@ describe('migrate v8-to-v9 handler', () => {
     logSpy = jest.spyOn(console, 'log').mockImplementation();
     // Default: path exists and is a directory
     mockStat.mockResolvedValue({ isDirectory: () => true } as Awaited<ReturnType<typeof fs.stat>>);
+    // Default: skill is installed (suppress hint)
+    mockIsSkillInstalled.mockReturnValue(true);
   });
 
   afterEach(() => {
@@ -97,5 +103,36 @@ describe('migrate v8-to-v9 handler', () => {
     );
 
     expect(mockAnalyzeFiles).not.toHaveBeenCalled();
+  });
+
+  it('prints skill install hint when skill is not found', async () => {
+    mockAnalyzeFiles.mockResolvedValue([]);
+    mockWriteAnnotations.mockResolvedValue({ filesChanged: 0 });
+    mockIsSkillInstalled.mockReturnValue(false);
+
+    await handler({ path: 'src/', dryRun: false, _: [], $0: 'fluentui-cli' });
+
+    expect(mockIsSkillInstalled).toHaveBeenCalled();
+    expect(mockPrintSkillHint).toHaveBeenCalled();
+  });
+
+  it('does not print skill hint when skill is already installed', async () => {
+    mockAnalyzeFiles.mockResolvedValue([]);
+    mockWriteAnnotations.mockResolvedValue({ filesChanged: 0 });
+    mockIsSkillInstalled.mockReturnValue(true);
+
+    await handler({ path: 'src/', dryRun: false, _: [], $0: 'fluentui-cli' });
+
+    expect(mockPrintSkillHint).not.toHaveBeenCalled();
+  });
+
+  it('prints skill install hint in dryRun mode when skill is not found', async () => {
+    mockAnalyzeFiles.mockResolvedValue([]);
+    mockIsSkillInstalled.mockReturnValue(false);
+
+    await handler({ path: 'src/', dryRun: true, _: [], $0: 'fluentui-cli' });
+
+    expect(mockPrintSkillHint).toHaveBeenCalled();
+    expect(mockWriteAnnotations).not.toHaveBeenCalled();
   });
 });

--- a/tools/cli/src/commands/migrate/v8-to-v9/__tests__/skill-check.spec.ts
+++ b/tools/cli/src/commands/migrate/v8-to-v9/__tests__/skill-check.spec.ts
@@ -1,0 +1,55 @@
+import { execFileSync } from 'child_process';
+import { isSkillInstalled, printSkillHint } from '../utils/skill-check';
+
+jest.mock('child_process');
+
+const mockExecFileSync = execFileSync as jest.MockedFunction<typeof execFileSync>;
+
+describe('skill-check', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('isSkillInstalled', () => {
+    it('returns true when skills list output contains the skill name', () => {
+      mockExecFileSync.mockReturnValue(
+        'Project Skills\n\nfluentui-migrate-v8-to-v9 ~/project/skills/fluentui-migrate-v8-to-v9\n  Agents: Claude Code\n',
+      );
+
+      expect(isSkillInstalled()).toBe(true);
+    });
+
+    it('returns false when skills list output does not contain the skill name', () => {
+      mockExecFileSync.mockReturnValue('No project skills found.\nTry listing global skills with -g\n');
+
+      expect(isSkillInstalled()).toBe(false);
+    });
+
+    it('returns false when npx skills command fails', () => {
+      mockExecFileSync.mockImplementation(() => {
+        throw new Error('command not found');
+      });
+
+      expect(isSkillInstalled()).toBe(false);
+    });
+  });
+
+  describe('printSkillHint', () => {
+    let logSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      logSpy = jest.spyOn(console, 'log').mockImplementation();
+    });
+
+    afterEach(() => {
+      logSpy.mockRestore();
+    });
+
+    it('prints npx skills add command', () => {
+      printSkillHint();
+
+      const output = logSpy.mock.calls.map((args: unknown[]) => args[0]).join('\n');
+      expect(output).toContain('npx skills add microsoft/fluentui --skill fluentui-migrate-v8-to-v9');
+    });
+  });
+});

--- a/tools/cli/src/commands/migrate/v8-to-v9/handler.ts
+++ b/tools/cli/src/commands/migrate/v8-to-v9/handler.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs/promises';
 import type { CommandHandler } from '../../../utils/types';
 import { analyzeFiles, writeAnnotations } from './utils/annotator';
 import type { FileAnalysis } from './utils/annotator';
+import { isSkillInstalled, printSkillHint } from './utils/skill-check';
 
 interface V8ToV9Args {
   path: string;
@@ -24,11 +25,13 @@ export const handler: CommandHandler<V8ToV9Args> = async argv => {
 
   if (argv.dryRun) {
     printDryRunReport(results);
+    printSkillHintIfNeeded();
     return;
   }
 
   const { filesChanged } = await writeAnnotations(results, argv.path);
   printSummary(results, filesChanged);
+  printSkillHintIfNeeded();
 };
 
 function countByAction(results: FileAnalysis[]) {
@@ -104,5 +107,11 @@ function printDryRunReport(results: FileAnalysis[]): void {
     for (const file of results) {
       console.log(`  ${file.filePath}  (${file.annotations.length} annotations)`);
     }
+  }
+}
+
+function printSkillHintIfNeeded(): void {
+  if (!isSkillInstalled()) {
+    printSkillHint();
   }
 }

--- a/tools/cli/src/commands/migrate/v8-to-v9/utils/skill-check.ts
+++ b/tools/cli/src/commands/migrate/v8-to-v9/utils/skill-check.ts
@@ -1,0 +1,26 @@
+import { execFileSync } from 'child_process';
+
+const SKILL_NAME = 'fluentui-migrate-v8-to-v9';
+
+/**
+ * Check whether the `fluentui-migrate-v8-to-v9` skill is installed
+ * by delegating to `npx skills list`.
+ */
+export function isSkillInstalled(): boolean {
+  try {
+    const output = execFileSync('npx', ['--no-install', 'skills', 'list'], {
+      timeout: 15_000,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    return output.includes(SKILL_NAME);
+  } catch {
+    return false;
+  }
+}
+
+export function printSkillHint(): void {
+  console.log('\nNext step — install the migration skill for your coding agent:');
+  console.log('  npx skills add microsoft/fluentui --skill fluentui-migrate-v8-to-v9');
+  console.log('\nThe skill guides AI agents through the annotation-driven migration process.');
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

## New Behavior

 **`migrate` command Skill install detection**
 - New `isSkillInstalled()` helper — runs `npx --no-install skills list` and checks for the skill in the output
 - `printSkillHint()` prints the install command when the skill is not found
 - The `migrate v8-to-v9` handler now prints the hint after both write and dry-run paths
 
 **Documentation**
 - `skills/README.md` — primary docs listing available skills, install commands, two-phase migration workflow, prerequisites, and skill management
 - `tools/cli/src/commands/migrate/README.md` — full command reference (usage, annotation format, all 16 rules,architecture, testing) with a cross-link to the skill install instructions


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
