### PR TITLE
fix(charts): modify isSafeUrl utility

### DIFF
--- a/change/@fluentui-react-charting-f3b97d35-d40a-4e05-ab50-3a1d6d34a0ce.json
+++ b/change/@fluentui-react-charting-f3b97d35-d40a-4e05-ab50-3a1d6d34a0ce.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: isSafeUrl utility",
+  "packageName": "@fluentui/react-charting",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-charts-81c5619a-02e7-4074-9355-e7565f999790.json
+++ b/change/@fluentui-react-charts-81c5619a-02e7-4074-9355-e7565f999790.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: isSafeUrl utility",
+  "packageName": "@fluentui/react-charts",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charts/react-charting/src/utilities/UtilityUnitTests.test.ts
+++ b/packages/charts/react-charting/src/utilities/UtilityUnitTests.test.ts
@@ -1564,8 +1564,16 @@ describe('isSafeUrl', () => {
     expect(utils.isSafeUrl('file:///etc/passwd')).toBe(false);
   });
 
-  test('Should block ftp: protocol', () => {
-    expect(utils.isSafeUrl('ftp://example.com/file')).toBe(false);
+  test('Should allow ftp: protocol', () => {
+    expect(utils.isSafeUrl('ftp://example.com/file')).toBe(true);
+  });
+
+  test('Should allow mailto: protocol', () => {
+    expect(utils.isSafeUrl('mailto:user@example.com')).toBe(true);
+  });
+
+  test('Should allow tel: protocol', () => {
+    expect(utils.isSafeUrl('tel:+1234567890')).toBe(true);
   });
 
   test('Should block custom: protocol', () => {

--- a/packages/charts/react-charting/src/utilities/utilities.ts
+++ b/packages/charts/react-charting/src/utilities/utilities.ts
@@ -2557,7 +2557,7 @@ const truncateTextToFitWidth = (text: string, maxWidth: number, measure: (s: str
 
 export function isSafeUrl(href: string): boolean {
   if (/^[a-z][a-z0-9+.-]*:/i.test(href)) {
-    return /^https?:/i.test(href);
+    return /^(https?|mailto|tel|ftp):/i.test(href);
   }
 
   return true;

--- a/packages/charts/react-charts/library/src/utilities/UtilityUnitTests.test.ts
+++ b/packages/charts/react-charts/library/src/utilities/UtilityUnitTests.test.ts
@@ -1569,8 +1569,16 @@ describe('isSafeUrl', () => {
     expect(utils.isSafeUrl('file:///etc/passwd')).toBe(false);
   });
 
-  test('Should block ftp: protocol', () => {
-    expect(utils.isSafeUrl('ftp://example.com/file')).toBe(false);
+  test('Should allow ftp: protocol', () => {
+    expect(utils.isSafeUrl('ftp://example.com/file')).toBe(true);
+  });
+
+  test('Should allow mailto: protocol', () => {
+    expect(utils.isSafeUrl('mailto:user@example.com')).toBe(true);
+  });
+
+  test('Should allow tel: protocol', () => {
+    expect(utils.isSafeUrl('tel:+1234567890')).toBe(true);
   });
 
   test('Should block custom: protocol', () => {

--- a/packages/charts/react-charts/library/src/utilities/utilities.ts
+++ b/packages/charts/react-charts/library/src/utilities/utilities.ts
@@ -2713,7 +2713,7 @@ const truncateTextToFitWidth = (text: string, maxWidth: number, measure: (s: str
 
 export function isSafeUrl(href: string): boolean {
   if (/^[a-z][a-z0-9+.-]*:/i.test(href)) {
-    return /^https?:/i.test(href);
+    return /^(https?|mailto|tel|ftp):/i.test(href);
   }
   return true;
 }


### PR DESCRIPTION
Updates the `isSafeUrl` utility function in both the `react-charting` and `react-charts/library` packages to allow additional URL protocols (`mailto:`, `tel:`, and `ftp:`), and updates the related unit tests to reflect these changes.