### PR TITLE
feat(react-headless-components-preview): add Toolbar component

### DIFF
--- a/packages/react-components/react-headless-components-preview/library/etc/react-headless-components-preview.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/react-headless-components-preview.api.md
@@ -986,9 +986,7 @@ export type ToolbarState = ToolbarState_2 & {
 export const ToolbarToggleButton: ForwardRefComponent<ToolbarToggleButtonProps>;
 
 // @public (undocumented)
-export type ToolbarToggleButtonProps = ToolbarToggleButtonBaseProps & {
-    vertical?: boolean;
-};
+export type ToolbarToggleButtonProps = ToolbarToggleButtonBaseProps;
 
 // @public (undocumented)
 export type ToolbarToggleButtonState = ToolbarToggleButtonBaseState & {

--- a/packages/react-components/react-headless-components-preview/library/etc/react-headless-components-preview.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/react-headless-components-preview.api.md
@@ -142,6 +142,20 @@ import { TextareaBaseState } from '@fluentui/react-textarea';
 import type { TextareaSlots as TextareaSlots_2 } from '@fluentui/react-textarea';
 import type { ToggleButtonBaseProps } from '@fluentui/react-button';
 import type { ToggleButtonBaseState } from '@fluentui/react-button';
+import { ToolbarBaseState } from '@fluentui/react-toolbar';
+import type { ToolbarButtonProps as ToolbarButtonProps_2 } from '@fluentui/react-toolbar';
+import type { ToolbarButtonState as ToolbarButtonState_2 } from '@fluentui/react-toolbar';
+import { ToolbarContextValue } from '@fluentui/react-toolbar';
+import { ToolbarContextValues as ToolbarContextValues_2 } from '@fluentui/react-toolbar';
+import type { ToolbarDividerProps as ToolbarDividerProps_2 } from '@fluentui/react-toolbar';
+import type { ToolbarDividerState as ToolbarDividerState_2 } from '@fluentui/react-toolbar';
+import type { ToolbarGroupProps as ToolbarGroupProps_2 } from '@fluentui/react-toolbar';
+import { ToolbarGroupState as ToolbarGroupState_2 } from '@fluentui/react-toolbar';
+import type { ToolbarProps as ToolbarProps_2 } from '@fluentui/react-toolbar';
+import type { ToolbarRadioGroupProps as ToolbarRadioGroupProps_2 } from '@fluentui/react-toolbar';
+import type { ToolbarRadioGroupState as ToolbarRadioGroupState_2 } from '@fluentui/react-toolbar';
+import type { ToolbarSlots as ToolbarSlots_2 } from '@fluentui/react-toolbar';
+import type { ToolbarState as ToolbarState_2 } from '@fluentui/react-toolbar';
 import { useMessageBarBodyContextValues_unstable } from '@fluentui/react-message-bar';
 import { useFluent_unstable as useProviderContext } from '@fluentui/react-shared-contexts';
 
@@ -680,6 +694,21 @@ export const renderTextarea: (state: TextareaBaseState) => JSXElement;
 export const renderToggleButton: (state: ButtonBaseState) => JSXElement;
 
 // @public
+export const renderToolbar: (state: ToolbarBaseState, contextValues: ToolbarContextValues_2) => JSXElement;
+
+// @public
+export const renderToolbarButton: (state: ButtonBaseState) => JSXElement;
+
+// @public
+export const renderToolbarDivider: (state: DividerBaseState) => JSXElement;
+
+// @public
+export const renderToolbarGroup: (state: ToolbarGroupState_2) => JSXElement;
+
+// @public
+export const renderToolbarRadioGroup: (state: ToolbarGroupState_2) => JSXElement;
+
+// @public
 export const SearchBox: ForwardRefComponent<SearchBoxProps>;
 
 // @public
@@ -873,6 +902,82 @@ export type ToggleButtonState = ToggleButtonBaseState & {
 };
 
 // @public
+export const Toolbar: ForwardRefComponent<ToolbarProps>;
+
+// @public
+export const ToolbarButton: ForwardRefComponent<ToolbarButtonProps>;
+
+// @public (undocumented)
+export type ToolbarButtonProps = ToolbarButtonProps_2;
+
+// @public (undocumented)
+export type ToolbarButtonState = ToolbarButtonState_2 & {
+    root: {
+        'data-vertical'?: string;
+        'data-disabled'?: string;
+        'data-disabled-focusable'?: string;
+        'data-icon-only'?: string;
+    };
+};
+
+// @public (undocumented)
+export type ToolbarContextValues = ToolbarContextValues_2;
+
+// @public
+export const ToolbarDivider: ForwardRefComponent<ToolbarDividerProps>;
+
+// @public (undocumented)
+export type ToolbarDividerProps = ToolbarDividerProps_2;
+
+// @public (undocumented)
+export type ToolbarDividerState = ToolbarDividerState_2 & {
+    root: {
+        'data-vertical'?: string;
+    };
+};
+
+// @public
+export const ToolbarGroup: ForwardRefComponent<ToolbarGroupProps>;
+
+// @public (undocumented)
+export type ToolbarGroupProps = ToolbarGroupProps_2;
+
+// @public (undocumented)
+export type ToolbarGroupState = ToolbarGroupState_2 & {
+    root: {
+        'data-vertical'?: string;
+    };
+};
+
+// @public (undocumented)
+export type ToolbarProps = ToolbarProps_2;
+
+// @public
+export const ToolbarRadioGroup: ForwardRefComponent<ToolbarRadioGroupProps>;
+
+// @public (undocumented)
+export type ToolbarRadioGroupProps = ToolbarRadioGroupProps_2;
+
+// @public (undocumented)
+export type ToolbarRadioGroupState = ToolbarRadioGroupState_2 & {
+    vertical?: boolean;
+    root: {
+        'data-vertical'?: string;
+    };
+};
+
+// @public (undocumented)
+export type ToolbarSlots = ToolbarSlots_2;
+
+// @public (undocumented)
+export type ToolbarState = ToolbarState_2 & {
+    root: {
+        'data-vertical'?: string;
+        'data-size'?: string;
+    };
+};
+
+// @public
 export const useAccordion: (props: AccordionProps, ref: React_2.Ref<HTMLElement>) => AccordionState;
 
 // @public
@@ -1014,6 +1119,27 @@ export const useTextarea: (props: TextareaProps, ref: React_2.Ref<HTMLTextAreaEl
 
 // @public
 export const useToggleButton: (props: ToggleButtonProps, ref: React_2.Ref<HTMLButtonElement | HTMLAnchorElement>) => ToggleButtonState;
+
+// @public
+export const useToolbar: (props: ToolbarProps, ref: React_2.Ref<HTMLElement>) => ToolbarState;
+
+// @public
+export const useToolbarButton: (props: ToolbarButtonProps, ref: React_2.Ref<HTMLButtonElement | HTMLAnchorElement>) => ToolbarButtonState;
+
+// @public
+export const useToolbarContext: <T>(selector: ContextSelector<ToolbarContextValue, T>) => T;
+
+// @public
+export const useToolbarContextValues: (state: ToolbarState) => ToolbarContextValues;
+
+// @public
+export const useToolbarDivider: (props: ToolbarDividerProps, ref: React_2.Ref<HTMLElement>) => ToolbarDividerState;
+
+// @public
+export const useToolbarGroup: (props: ToolbarGroupProps, ref: React_2.Ref<HTMLDivElement>) => ToolbarGroupState;
+
+// @public
+export const useToolbarRadioGroup: (props: ToolbarRadioGroupProps, ref: React_2.Ref<HTMLDivElement>) => ToolbarRadioGroupState;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react-components/react-headless-components-preview/library/etc/react-headless-components-preview.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/react-headless-components-preview.api.md
@@ -142,20 +142,19 @@ import { TextareaBaseState } from '@fluentui/react-textarea';
 import type { TextareaSlots as TextareaSlots_2 } from '@fluentui/react-textarea';
 import type { ToggleButtonBaseProps } from '@fluentui/react-button';
 import type { ToggleButtonBaseState } from '@fluentui/react-button';
+import type { ToolbarBaseProps } from '@fluentui/react-toolbar';
 import { ToolbarBaseState } from '@fluentui/react-toolbar';
-import type { ToolbarButtonProps as ToolbarButtonProps_2 } from '@fluentui/react-toolbar';
-import type { ToolbarButtonState as ToolbarButtonState_2 } from '@fluentui/react-toolbar';
+import type { ToolbarButtonBaseProps } from '@fluentui/react-toolbar';
+import type { ToolbarButtonBaseState } from '@fluentui/react-toolbar';
 import { ToolbarContextValue } from '@fluentui/react-toolbar';
 import { ToolbarContextValues as ToolbarContextValues_2 } from '@fluentui/react-toolbar';
-import type { ToolbarDividerProps as ToolbarDividerProps_2 } from '@fluentui/react-toolbar';
-import type { ToolbarDividerState as ToolbarDividerState_2 } from '@fluentui/react-toolbar';
+import type { ToolbarDividerBaseProps } from '@fluentui/react-toolbar';
+import type { ToolbarDividerBaseState } from '@fluentui/react-toolbar';
 import type { ToolbarGroupProps as ToolbarGroupProps_2 } from '@fluentui/react-toolbar';
 import { ToolbarGroupState as ToolbarGroupState_2 } from '@fluentui/react-toolbar';
-import type { ToolbarProps as ToolbarProps_2 } from '@fluentui/react-toolbar';
 import type { ToolbarRadioGroupProps as ToolbarRadioGroupProps_2 } from '@fluentui/react-toolbar';
 import type { ToolbarRadioGroupState as ToolbarRadioGroupState_2 } from '@fluentui/react-toolbar';
 import type { ToolbarSlots as ToolbarSlots_2 } from '@fluentui/react-toolbar';
-import type { ToolbarState as ToolbarState_2 } from '@fluentui/react-toolbar';
 import type { ToolbarToggleButtonBaseProps } from '@fluentui/react-toolbar';
 import type { ToolbarToggleButtonBaseState } from '@fluentui/react-toolbar';
 import { useMessageBarBodyContextValues_unstable } from '@fluentui/react-message-bar';
@@ -913,10 +912,10 @@ export const Toolbar: ForwardRefComponent<ToolbarProps>;
 export const ToolbarButton: ForwardRefComponent<ToolbarButtonProps>;
 
 // @public (undocumented)
-export type ToolbarButtonProps = ToolbarButtonProps_2;
+export type ToolbarButtonProps = ToolbarButtonBaseProps;
 
 // @public (undocumented)
-export type ToolbarButtonState = ToolbarButtonState_2 & {
+export type ToolbarButtonState = ToolbarButtonBaseState & {
     root: {
         'data-vertical'?: string;
         'data-disabled'?: string;
@@ -932,10 +931,10 @@ export type ToolbarContextValues = ToolbarContextValues_2;
 export const ToolbarDivider: ForwardRefComponent<ToolbarDividerProps>;
 
 // @public (undocumented)
-export type ToolbarDividerProps = ToolbarDividerProps_2;
+export type ToolbarDividerProps = ToolbarDividerBaseProps;
 
 // @public (undocumented)
-export type ToolbarDividerState = ToolbarDividerState_2 & {
+export type ToolbarDividerState = ToolbarDividerBaseState & {
     root: {
         'data-vertical'?: string;
     };
@@ -955,7 +954,7 @@ export type ToolbarGroupState = ToolbarGroupState_2 & {
 };
 
 // @public (undocumented)
-export type ToolbarProps = ToolbarProps_2;
+export type ToolbarProps = ToolbarBaseProps;
 
 // @public
 export const ToolbarRadioGroup: ForwardRefComponent<ToolbarRadioGroupProps>;
@@ -975,10 +974,10 @@ export type ToolbarRadioGroupState = ToolbarRadioGroupState_2 & {
 export type ToolbarSlots = ToolbarSlots_2;
 
 // @public (undocumented)
-export type ToolbarState = ToolbarState_2 & {
+export type ToolbarState = ToolbarBaseState & {
     root: {
         'data-vertical'?: string;
-        'data-size'?: string;
+        focusgroup?: string;
     };
 };
 

--- a/packages/react-components/react-headless-components-preview/library/etc/react-headless-components-preview.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/react-headless-components-preview.api.md
@@ -156,6 +156,8 @@ import type { ToolbarRadioGroupProps as ToolbarRadioGroupProps_2 } from '@fluent
 import type { ToolbarRadioGroupState as ToolbarRadioGroupState_2 } from '@fluentui/react-toolbar';
 import type { ToolbarSlots as ToolbarSlots_2 } from '@fluentui/react-toolbar';
 import type { ToolbarState as ToolbarState_2 } from '@fluentui/react-toolbar';
+import type { ToolbarToggleButtonBaseProps } from '@fluentui/react-toolbar';
+import type { ToolbarToggleButtonBaseState } from '@fluentui/react-toolbar';
 import { useMessageBarBodyContextValues_unstable } from '@fluentui/react-message-bar';
 import { useFluent_unstable as useProviderContext } from '@fluentui/react-shared-contexts';
 
@@ -709,6 +711,9 @@ export const renderToolbarGroup: (state: ToolbarGroupState_2) => JSXElement;
 export const renderToolbarRadioGroup: (state: ToolbarGroupState_2) => JSXElement;
 
 // @public
+export const renderToolbarToggleButton: (state: ButtonBaseState) => JSXElement;
+
+// @public
 export const SearchBox: ForwardRefComponent<SearchBoxProps>;
 
 // @public
@@ -978,6 +983,24 @@ export type ToolbarState = ToolbarState_2 & {
 };
 
 // @public
+export const ToolbarToggleButton: ForwardRefComponent<ToolbarToggleButtonProps>;
+
+// @public (undocumented)
+export type ToolbarToggleButtonProps = ToolbarToggleButtonBaseProps & {
+    vertical?: boolean;
+};
+
+// @public (undocumented)
+export type ToolbarToggleButtonState = ToolbarToggleButtonBaseState & {
+    root: {
+        'data-disabled'?: string;
+        'data-disabled-focusable'?: string;
+        'data-icon-only'?: string;
+        'data-checked'?: string;
+    };
+};
+
+// @public
 export const useAccordion: (props: AccordionProps, ref: React_2.Ref<HTMLElement>) => AccordionState;
 
 // @public
@@ -1140,6 +1163,9 @@ export const useToolbarGroup: (props: ToolbarGroupProps, ref: React_2.Ref<HTMLDi
 
 // @public
 export const useToolbarRadioGroup: (props: ToolbarRadioGroupProps, ref: React_2.Ref<HTMLDivElement>) => ToolbarRadioGroupState;
+
+// @public
+export const useToolbarToggleButton: (props: ToolbarToggleButtonProps, ref: React_2.Ref<HTMLButtonElement | HTMLAnchorElement>) => ToolbarToggleButtonState;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react-components/react-headless-components-preview/library/package.json
+++ b/packages/react-components/react-headless-components-preview/library/package.json
@@ -49,6 +49,7 @@
     "@fluentui/react-tabs": "^9.11.2",
     "@fluentui/react-tags": "^9.7.19",
     "@fluentui/react-textarea": "^9.7.0",
+    "@fluentui/react-toolbar": "^9.7.7",
     "@fluentui/react-utilities": "^9.26.2",
     "@swc/helpers": "^0.5.1"
   },

--- a/packages/react-components/react-headless-components-preview/library/src/Toolbar.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/Toolbar.ts
@@ -12,3 +12,6 @@ export type { ToolbarGroupProps, ToolbarGroupState } from './components/Toolbar'
 
 export { ToolbarRadioGroup, renderToolbarRadioGroup, useToolbarRadioGroup } from './components/Toolbar';
 export type { ToolbarRadioGroupProps, ToolbarRadioGroupState } from './components/Toolbar';
+
+export { ToolbarToggleButton, renderToolbarToggleButton, useToolbarToggleButton } from './components/Toolbar';
+export type { ToolbarToggleButtonProps, ToolbarToggleButtonState } from './components/Toolbar';

--- a/packages/react-components/react-headless-components-preview/library/src/Toolbar.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/Toolbar.ts
@@ -1,0 +1,14 @@
+export { Toolbar, renderToolbar, useToolbar, useToolbarContext, useToolbarContextValues } from './components/Toolbar';
+export type { ToolbarSlots, ToolbarProps, ToolbarState, ToolbarContextValues } from './components/Toolbar';
+
+export { ToolbarButton, renderToolbarButton, useToolbarButton } from './components/Toolbar';
+export type { ToolbarButtonProps, ToolbarButtonState } from './components/Toolbar';
+
+export { ToolbarDivider, renderToolbarDivider, useToolbarDivider } from './components/Toolbar';
+export type { ToolbarDividerProps, ToolbarDividerState } from './components/Toolbar';
+
+export { ToolbarGroup, renderToolbarGroup, useToolbarGroup } from './components/Toolbar';
+export type { ToolbarGroupProps, ToolbarGroupState } from './components/Toolbar';
+
+export { ToolbarRadioGroup, renderToolbarRadioGroup, useToolbarRadioGroup } from './components/Toolbar';
+export type { ToolbarRadioGroupProps, ToolbarRadioGroupState } from './components/Toolbar';

--- a/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/Toolbar.test.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/Toolbar.test.tsx
@@ -17,7 +17,7 @@ describe('Toolbar', () => {
       </Toolbar>,
     );
 
-    expect(getByRole('toolbar')).toHaveAttribute('focusgroup', 'toolbar inline');
+    expect(getByRole('toolbar')).toHaveAttribute('focusgroup', 'toolbar inline wrap');
     expect(getByRole('toolbar')).not.toHaveAttribute('data-vertical');
 
     expect(getAllByRole('button')).toHaveLength(2);
@@ -36,7 +36,7 @@ describe('Toolbar', () => {
       </Toolbar>,
     );
 
-    expect(getByRole('toolbar')).toHaveAttribute('focusgroup', 'toolbar block');
+    expect(getByRole('toolbar')).toHaveAttribute('focusgroup', 'toolbar block wrap');
     expect(getByRole('toolbar')).toHaveAttribute('data-vertical');
 
     const button1 = getByRole('button', { name: 'Bold' });

--- a/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/Toolbar.test.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/Toolbar.test.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { Toolbar } from '.';
+import { ToolbarButton } from './ToolbarButton';
+import { ToolbarToggleButton } from './ToolbarToggleButton';
+
+describe('Toolbar', () => {
+  it('renders unchecked by default', () => {
+    const { getByRole, getAllByRole } = render(
+      <Toolbar>
+        <ToolbarButton name="format" value="bold">
+          Bold
+        </ToolbarButton>
+        <ToolbarToggleButton name="format" value="italic">
+          Italic
+        </ToolbarToggleButton>
+      </Toolbar>,
+    );
+
+    expect(getByRole('toolbar')).toHaveAttribute('focusgroup', 'toolbar inline');
+    expect(getByRole('toolbar')).not.toHaveAttribute('data-vertical');
+
+    expect(getAllByRole('button')).toHaveLength(2);
+  });
+
+  it('renders checked when value is in toolbar checkedValues', () => {
+    const { getByRole } = render(
+      <Toolbar defaultCheckedValues={{ format: ['bold'] }} vertical>
+        <ToolbarToggleButton name="format" value="bold">
+          Bold
+        </ToolbarToggleButton>
+        <ToolbarToggleButton name="format" value="italic" disabled>
+          Italic
+        </ToolbarToggleButton>
+        <ToolbarToggleButton name="format" value="underline" icon="U" aria-label="Underline" />
+      </Toolbar>,
+    );
+
+    expect(getByRole('toolbar')).toHaveAttribute('focusgroup', 'toolbar block');
+    expect(getByRole('toolbar')).toHaveAttribute('data-vertical');
+
+    const button1 = getByRole('button', { name: 'Bold' });
+    expect(button1).toHaveAttribute('aria-pressed', 'true');
+    expect(button1).toHaveAttribute('data-checked');
+
+    const button2 = getByRole('button', { name: 'Italic' });
+    expect(button2).toHaveAttribute('aria-pressed', 'false');
+    expect(button2).not.toHaveAttribute('data-checked');
+    expect(button2).toBeDisabled();
+    expect(button2).toHaveAttribute('data-disabled');
+
+    const button3 = getByRole('button', { name: 'Underline' });
+    expect(button3).toHaveAttribute('aria-pressed', 'false');
+    expect(button3).not.toHaveAttribute('data-checked');
+    expect(button3).not.toBeDisabled();
+    expect(button3).toHaveAttribute('data-icon-only');
+  });
+});

--- a/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/Toolbar.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/Toolbar.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import * as React from 'react';
+import type { ForwardRefComponent } from '@fluentui/react-utilities';
+import type { ToolbarProps } from './Toolbar.types';
+import { useToolbar, useToolbarContextValues } from './useToolbar';
+import { renderToolbar } from './renderToolbar';
+
+/**
+ * A toolbar component that provides a container for grouping a set of controls such as buttons and menu items.
+ */
+export const Toolbar: ForwardRefComponent<ToolbarProps> = React.forwardRef((props, ref) => {
+  const state = useToolbar(props, ref);
+  const contextValues = useToolbarContextValues(state);
+
+  return renderToolbar(state, contextValues);
+});
+
+Toolbar.displayName = 'Toolbar';

--- a/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/Toolbar.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/Toolbar.types.ts
@@ -1,8 +1,8 @@
 import type {
   ToolbarSlots as ToolbarBaseSlots,
-  ToolbarProps as ToolbarBaseProps,
+  ToolbarBaseProps,
   ToolbarContextValues as ToolbarBaseContextValues,
-  ToolbarState as ToolbarBaseState,
+  ToolbarBaseState,
 } from '@fluentui/react-toolbar';
 
 export type ToolbarSlots = ToolbarBaseSlots;
@@ -15,10 +15,11 @@ export type ToolbarState = ToolbarBaseState & {
      * Data attribute set when the toolbar is vertically oriented.
      */
     'data-vertical'?: string;
+
     /**
-     * Data attribute reflecting the current size of the toolbar. Value is 'small', 'medium', or 'large'.
+     * Data attribute to define the focus behavior of the toolbar's children
      */
-    'data-size'?: string;
+    focusgroup?: string;
   };
 };
 

--- a/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/Toolbar.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/Toolbar.types.ts
@@ -1,0 +1,25 @@
+import type {
+  ToolbarSlots as ToolbarBaseSlots,
+  ToolbarProps as ToolbarBaseProps,
+  ToolbarContextValues as ToolbarBaseContextValues,
+  ToolbarState as ToolbarBaseState,
+} from '@fluentui/react-toolbar';
+
+export type ToolbarSlots = ToolbarBaseSlots;
+
+export type ToolbarProps = ToolbarBaseProps;
+
+export type ToolbarState = ToolbarBaseState & {
+  root: {
+    /**
+     * Data attribute set when the toolbar is vertically oriented.
+     */
+    'data-vertical'?: string;
+    /**
+     * Data attribute reflecting the current size of the toolbar. Value is 'small', 'medium', or 'large'.
+     */
+    'data-size'?: string;
+  };
+};
+
+export type ToolbarContextValues = ToolbarBaseContextValues;

--- a/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarButton/ToolbarButton.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarButton/ToolbarButton.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import * as React from 'react';
+import type { ForwardRefComponent } from '@fluentui/react-utilities';
+import type { ToolbarButtonProps } from './ToolbarButton.types';
+import { useToolbarButton } from './useToolbarButton';
+import { renderToolbarButton } from './renderToolbarButton';
+
+/**
+ * A button component designed to be used inside a Toolbar, inheriting toolbar context such as size.
+ */
+export const ToolbarButton: ForwardRefComponent<ToolbarButtonProps> = React.forwardRef((props, ref) => {
+  const state = useToolbarButton(props, ref);
+
+  return renderToolbarButton(state);
+  // Casting is required due to lack of distributive union to support unions on @types/react
+}) as ForwardRefComponent<ToolbarButtonProps>;
+
+ToolbarButton.displayName = 'ToolbarButton';

--- a/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarButton/ToolbarButton.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarButton/ToolbarButton.types.ts
@@ -1,0 +1,30 @@
+import type {
+  ToolbarButtonProps as ToolbarButtonBaseProps,
+  ToolbarButtonState as ToolbarButtonBaseState,
+} from '@fluentui/react-toolbar';
+
+export type ToolbarButtonProps = ToolbarButtonBaseProps;
+
+export type ToolbarButtonState = ToolbarButtonBaseState & {
+  root: {
+    /**
+     * Data attribute set when the button is in a vertically oriented toolbar.
+     */
+    'data-vertical'?: string;
+
+    /**
+     * Data attribute set when the button is disabled.
+     */
+    'data-disabled'?: string;
+
+    /**
+     * Data attribute set when the button is disabled but still focusable.
+     */
+    'data-disabled-focusable'?: string;
+
+    /**
+     * Data attribute set when the button renders only an icon.
+     */
+    'data-icon-only'?: string;
+  };
+};

--- a/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarButton/ToolbarButton.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarButton/ToolbarButton.types.ts
@@ -1,7 +1,4 @@
-import type {
-  ToolbarButtonProps as ToolbarButtonBaseProps,
-  ToolbarButtonState as ToolbarButtonBaseState,
-} from '@fluentui/react-toolbar';
+import type { ToolbarButtonBaseProps, ToolbarButtonBaseState } from '@fluentui/react-toolbar';
 
 export type ToolbarButtonProps = ToolbarButtonBaseProps;
 

--- a/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarButton/index.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarButton/index.ts
@@ -1,0 +1,4 @@
+export { ToolbarButton } from './ToolbarButton';
+export { renderToolbarButton } from './renderToolbarButton';
+export { useToolbarButton } from './useToolbarButton';
+export type { ToolbarButtonProps, ToolbarButtonState } from './ToolbarButton.types';

--- a/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarButton/renderToolbarButton.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarButton/renderToolbarButton.ts
@@ -1,0 +1,6 @@
+import { renderButton_unstable } from '@fluentui/react-button';
+
+/**
+ * Renders the final JSX of the ToolbarButton component, given the state.
+ */
+export const renderToolbarButton = renderButton_unstable;

--- a/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarButton/useToolbarButton.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarButton/useToolbarButton.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import type * as React from 'react';
-import { useToolbarButton_unstable } from '@fluentui/react-toolbar';
+import { useToolbarButtonBase_unstable } from '@fluentui/react-toolbar';
 
 import type { ToolbarButtonProps, ToolbarButtonState } from './ToolbarButton.types';
 import { stringifyDataAttribute } from '../../../utils';
@@ -16,7 +16,7 @@ export const useToolbarButton = (
 ): ToolbarButtonState => {
   'use no memo';
 
-  const state: ToolbarButtonState = useToolbarButton_unstable(props, ref);
+  const state: ToolbarButtonState = useToolbarButtonBase_unstable(props, ref);
 
   // Set data attributes for vertical, disabled, disabledFocusable, and iconOnly states to simplify styling.
   state.root['data-vertical'] = stringifyDataAttribute(state.vertical);

--- a/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarButton/useToolbarButton.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarButton/useToolbarButton.ts
@@ -1,0 +1,28 @@
+'use client';
+
+import type * as React from 'react';
+import { useToolbarButton_unstable } from '@fluentui/react-toolbar';
+
+import type { ToolbarButtonProps, ToolbarButtonState } from './ToolbarButton.types';
+import { stringifyDataAttribute } from '../../../utils';
+
+/**
+ * Returns the state for a ToolbarButton component, given its props and ref.
+ * The returned state can be modified with hooks before being passed to `renderToolbarButton`.
+ */
+export const useToolbarButton = (
+  props: ToolbarButtonProps,
+  ref: React.Ref<HTMLButtonElement | HTMLAnchorElement>,
+): ToolbarButtonState => {
+  'use no memo';
+
+  const state: ToolbarButtonState = useToolbarButton_unstable(props, ref);
+
+  // Set data attributes for vertical, disabled, disabledFocusable, and iconOnly states to simplify styling.
+  state.root['data-vertical'] = stringifyDataAttribute(state.vertical);
+  state.root['data-disabled'] = stringifyDataAttribute(state.disabled);
+  state.root['data-disabled-focusable'] = stringifyDataAttribute(state.disabledFocusable);
+  state.root['data-icon-only'] = stringifyDataAttribute(state.iconOnly);
+
+  return state;
+};

--- a/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarDivider/ToolbarDivider.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarDivider/ToolbarDivider.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import * as React from 'react';
+import type { ForwardRefComponent } from '@fluentui/react-utilities';
+import type { ToolbarDividerProps } from './ToolbarDivider.types';
+import { useToolbarDivider } from './useToolbarDivider';
+import { renderToolbarDivider } from './renderToolbarDivider';
+
+/**
+ * A divider component designed to be used inside a Toolbar to visually separate groups of controls.
+ * Its orientation is automatically inverted relative to the toolbar's orientation.
+ */
+export const ToolbarDivider: ForwardRefComponent<ToolbarDividerProps> = React.forwardRef((props, ref) => {
+  const state = useToolbarDivider(props, ref);
+
+  return renderToolbarDivider(state);
+});
+
+ToolbarDivider.displayName = 'ToolbarDivider';

--- a/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarDivider/ToolbarDivider.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarDivider/ToolbarDivider.types.ts
@@ -1,7 +1,4 @@
-import type {
-  ToolbarDividerProps as ToolbarDividerBaseProps,
-  ToolbarDividerState as ToolbarDividerBaseState,
-} from '@fluentui/react-toolbar';
+import type { ToolbarDividerBaseProps, ToolbarDividerBaseState } from '@fluentui/react-toolbar';
 
 export type ToolbarDividerProps = ToolbarDividerBaseProps;
 

--- a/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarDivider/ToolbarDivider.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarDivider/ToolbarDivider.types.ts
@@ -1,0 +1,16 @@
+import type {
+  ToolbarDividerProps as ToolbarDividerBaseProps,
+  ToolbarDividerState as ToolbarDividerBaseState,
+} from '@fluentui/react-toolbar';
+
+export type ToolbarDividerProps = ToolbarDividerBaseProps;
+
+export type ToolbarDividerState = ToolbarDividerBaseState & {
+  root: {
+    /**
+     * Data attribute reflecting the actual orientation of the divider element.
+     * Note: the toolbar divider's orientation is inverted relative to the toolbar's orientation.
+     */
+    'data-vertical'?: string;
+  };
+};

--- a/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarDivider/index.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarDivider/index.ts
@@ -1,0 +1,4 @@
+export { ToolbarDivider } from './ToolbarDivider';
+export { renderToolbarDivider } from './renderToolbarDivider';
+export { useToolbarDivider } from './useToolbarDivider';
+export type { ToolbarDividerProps, ToolbarDividerState } from './ToolbarDivider.types';

--- a/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarDivider/renderToolbarDivider.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarDivider/renderToolbarDivider.ts
@@ -1,0 +1,6 @@
+import { renderDivider_unstable } from '@fluentui/react-divider';
+
+/**
+ * Renders the final JSX of the ToolbarDivider component, given the state.
+ */
+export const renderToolbarDivider = renderDivider_unstable;

--- a/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarDivider/useToolbarDivider.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarDivider/useToolbarDivider.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import type * as React from 'react';
-import { useToolbarDivider_unstable } from '@fluentui/react-toolbar';
+import { useToolbarDividerBase_unstable } from '@fluentui/react-toolbar';
 
 import type { ToolbarDividerProps, ToolbarDividerState } from './ToolbarDivider.types';
 import { stringifyDataAttribute } from '../../../utils';
@@ -13,7 +13,7 @@ import { stringifyDataAttribute } from '../../../utils';
 export const useToolbarDivider = (props: ToolbarDividerProps, ref: React.Ref<HTMLElement>): ToolbarDividerState => {
   'use no memo';
 
-  const state: ToolbarDividerState = useToolbarDivider_unstable(props, ref);
+  const state: ToolbarDividerState = useToolbarDividerBase_unstable(props, ref);
 
   // Set data-vertical based on the resolved orientation of the divider (already inverted relative to the toolbar).
   state.root['data-vertical'] = stringifyDataAttribute(state.vertical);

--- a/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarDivider/useToolbarDivider.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarDivider/useToolbarDivider.ts
@@ -1,0 +1,22 @@
+'use client';
+
+import type * as React from 'react';
+import { useToolbarDivider_unstable } from '@fluentui/react-toolbar';
+
+import type { ToolbarDividerProps, ToolbarDividerState } from './ToolbarDivider.types';
+import { stringifyDataAttribute } from '../../../utils';
+
+/**
+ * Returns the state for a ToolbarDivider component, given its props and ref.
+ * The returned state can be modified with hooks before being passed to `renderToolbarDivider`.
+ */
+export const useToolbarDivider = (props: ToolbarDividerProps, ref: React.Ref<HTMLElement>): ToolbarDividerState => {
+  'use no memo';
+
+  const state: ToolbarDividerState = useToolbarDivider_unstable(props, ref);
+
+  // Set data-vertical based on the resolved orientation of the divider (already inverted relative to the toolbar).
+  state.root['data-vertical'] = stringifyDataAttribute(state.vertical);
+
+  return state;
+};

--- a/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarGroup/ToolbarGroup.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarGroup/ToolbarGroup.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import * as React from 'react';
+import type { ForwardRefComponent } from '@fluentui/react-utilities';
+import type { ToolbarGroupProps } from './ToolbarGroup.types';
+import { useToolbarGroup } from './useToolbarGroup';
+import { renderToolbarGroup } from './renderToolbarGroup';
+
+/**
+ * A group component used inside a Toolbar to visually and semantically group related controls.
+ */
+export const ToolbarGroup: ForwardRefComponent<ToolbarGroupProps> = React.forwardRef((props, ref) => {
+  const state = useToolbarGroup(props, ref);
+
+  return renderToolbarGroup(state);
+  // Casting is required due to lack of distributive union to support unions on @types/react
+}) as ForwardRefComponent<ToolbarGroupProps>;
+
+ToolbarGroup.displayName = 'ToolbarGroup';

--- a/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarGroup/ToolbarGroup.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarGroup/ToolbarGroup.types.ts
@@ -1,0 +1,15 @@
+import type {
+  ToolbarGroupProps as ToolbarGroupBaseProps,
+  ToolbarGroupState as ToolbarGroupBaseState,
+} from '@fluentui/react-toolbar';
+
+export type ToolbarGroupProps = ToolbarGroupBaseProps;
+
+export type ToolbarGroupState = ToolbarGroupBaseState & {
+  root: {
+    /**
+     * Data attribute set when the toolbar group is in a vertically oriented toolbar.
+     */
+    'data-vertical'?: string;
+  };
+};

--- a/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarGroup/index.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarGroup/index.ts
@@ -1,0 +1,4 @@
+export { ToolbarGroup } from './ToolbarGroup';
+export { renderToolbarGroup } from './renderToolbarGroup';
+export { useToolbarGroup } from './useToolbarGroup';
+export type { ToolbarGroupProps, ToolbarGroupState } from './ToolbarGroup.types';

--- a/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarGroup/renderToolbarGroup.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarGroup/renderToolbarGroup.ts
@@ -1,0 +1,6 @@
+import { renderToolbarGroup_unstable } from '@fluentui/react-toolbar';
+
+/**
+ * Renders the final JSX of the ToolbarGroup component, given the state.
+ */
+export const renderToolbarGroup = renderToolbarGroup_unstable;

--- a/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarGroup/useToolbarGroup.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarGroup/useToolbarGroup.ts
@@ -1,0 +1,22 @@
+'use client';
+
+import type * as React from 'react';
+import { useToolbarGroup_unstable } from '@fluentui/react-toolbar';
+
+import type { ToolbarGroupProps, ToolbarGroupState } from './ToolbarGroup.types';
+import { stringifyDataAttribute } from '../../../utils';
+
+/**
+ * Returns the state for a ToolbarGroup component, given its props and ref.
+ * The returned state can be modified with hooks before being passed to `renderToolbarGroup`.
+ */
+export const useToolbarGroup = (props: ToolbarGroupProps, ref: React.Ref<HTMLDivElement>): ToolbarGroupState => {
+  'use no memo';
+
+  const state: ToolbarGroupState = useToolbarGroup_unstable(props, ref);
+
+  // Set data-vertical based on the toolbar context orientation.
+  state.root['data-vertical'] = stringifyDataAttribute(state.vertical);
+
+  return state;
+};

--- a/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarRadioGroup/ToolbarRadioGroup.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarRadioGroup/ToolbarRadioGroup.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import * as React from 'react';
+import type { ForwardRefComponent } from '@fluentui/react-utilities';
+import type { ToolbarRadioGroupProps } from './ToolbarRadioGroup.types';
+import { useToolbarRadioGroup } from './useToolbarRadioGroup';
+import { renderToolbarRadioGroup } from './renderToolbarRadioGroup';
+
+/**
+ * A radio group component used inside a Toolbar to group mutually exclusive toggle controls.
+ */
+export const ToolbarRadioGroup: ForwardRefComponent<ToolbarRadioGroupProps> = React.forwardRef((props, ref) => {
+  const state = useToolbarRadioGroup(props, ref);
+
+  return renderToolbarRadioGroup(state);
+  // Casting is required due to lack of distributive union to support unions on @types/react
+}) as ForwardRefComponent<ToolbarRadioGroupProps>;
+
+ToolbarRadioGroup.displayName = 'ToolbarRadioGroup';

--- a/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarRadioGroup/ToolbarRadioGroup.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarRadioGroup/ToolbarRadioGroup.types.ts
@@ -1,0 +1,19 @@
+import type {
+  ToolbarRadioGroupProps as ToolbarRadioGroupBaseProps,
+  ToolbarRadioGroupState as ToolbarRadioGroupBaseState,
+} from '@fluentui/react-toolbar';
+
+export type ToolbarRadioGroupProps = ToolbarRadioGroupBaseProps;
+
+export type ToolbarRadioGroupState = ToolbarRadioGroupBaseState & {
+  /**
+   * Whether the toolbar group is in a vertically oriented toolbar.
+   */
+  vertical?: boolean;
+  root: {
+    /**
+     * Data attribute set when the toolbar radio group is in a vertically oriented toolbar.
+     */
+    'data-vertical'?: string;
+  };
+};

--- a/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarRadioGroup/index.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarRadioGroup/index.ts
@@ -1,0 +1,4 @@
+export { ToolbarRadioGroup } from './ToolbarRadioGroup';
+export { renderToolbarRadioGroup } from './renderToolbarRadioGroup';
+export { useToolbarRadioGroup } from './useToolbarRadioGroup';
+export type { ToolbarRadioGroupProps, ToolbarRadioGroupState } from './ToolbarRadioGroup.types';

--- a/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarRadioGroup/renderToolbarRadioGroup.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarRadioGroup/renderToolbarRadioGroup.ts
@@ -1,0 +1,6 @@
+import { renderToolbarGroup_unstable } from '@fluentui/react-toolbar';
+
+/**
+ * Renders the final JSX of the ToolbarRadioGroup component, given the state.
+ */
+export const renderToolbarRadioGroup = renderToolbarGroup_unstable;

--- a/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarRadioGroup/useToolbarRadioGroup.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarRadioGroup/useToolbarRadioGroup.ts
@@ -1,0 +1,20 @@
+'use client';
+
+import type * as React from 'react';
+import { useToolbarGroup } from '../ToolbarGroup/useToolbarGroup';
+
+import type { ToolbarRadioGroupProps, ToolbarRadioGroupState } from './ToolbarRadioGroup.types';
+
+/**
+ * Returns the state for a ToolbarRadioGroup component, given its props and ref.
+ * The returned state can be modified with hooks before being passed to `renderToolbarRadioGroup`.
+ */
+export const useToolbarRadioGroup = (
+  props: ToolbarRadioGroupProps,
+  ref: React.Ref<HTMLDivElement>,
+): ToolbarRadioGroupState => {
+  'use no memo';
+
+  // ToolbarRadioGroup reuses ToolbarGroup logic with role='radiogroup'.
+  return useToolbarGroup({ role: 'radiogroup', ...props }, ref) as unknown as ToolbarRadioGroupState;
+};

--- a/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarToggleButton/ToolbarToggleButton.test.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarToggleButton/ToolbarToggleButton.test.tsx
@@ -5,17 +5,21 @@ import { ToolbarToggleButton } from './ToolbarToggleButton';
 
 describe('ToolbarToggleButton', () => {
   it('renders unchecked by default', () => {
-    const { getByRole } = render(
+    const { getAllByRole } = render(
       <Toolbar>
         <ToolbarToggleButton name="format" value="bold">
           Bold
         </ToolbarToggleButton>
+        <ToolbarToggleButton name="format" value="italic">
+          Italic
+        </ToolbarToggleButton>
       </Toolbar>,
     );
 
-    const button = getByRole('button', { name: 'Bold' });
-    expect(button).toHaveAttribute('aria-pressed', 'false');
-    expect(button).not.toHaveAttribute('data-checked');
+    getAllByRole('button').forEach(button => {
+      expect(button).toHaveAttribute('aria-pressed', 'false');
+      expect(button).not.toHaveAttribute('data-checked');
+    });
   });
 
   it('renders checked when value is in toolbar checkedValues', () => {
@@ -24,11 +28,27 @@ describe('ToolbarToggleButton', () => {
         <ToolbarToggleButton name="format" value="bold">
           Bold
         </ToolbarToggleButton>
+        <ToolbarToggleButton name="format" value="italic" disabled>
+          Italic
+        </ToolbarToggleButton>
+        <ToolbarToggleButton name="format" value="underline" icon="U" aria-label="Underline" />
       </Toolbar>,
     );
 
-    const button = getByRole('button', { name: 'Bold' });
-    expect(button).toHaveAttribute('aria-pressed', 'true');
-    expect(button).toHaveAttribute('data-checked');
+    const button1 = getByRole('button', { name: 'Bold' });
+    expect(button1).toHaveAttribute('aria-pressed', 'true');
+    expect(button1).toHaveAttribute('data-checked');
+
+    const button2 = getByRole('button', { name: 'Italic' });
+    expect(button2).toHaveAttribute('aria-pressed', 'false');
+    expect(button2).not.toHaveAttribute('data-checked');
+    expect(button2).toBeDisabled();
+    expect(button2).toHaveAttribute('data-disabled');
+
+    const button3 = getByRole('button', { name: 'Underline' });
+    expect(button3).toHaveAttribute('aria-pressed', 'false');
+    expect(button3).not.toHaveAttribute('data-checked');
+    expect(button3).not.toBeDisabled();
+    expect(button3).toHaveAttribute('data-icon-only');
   });
 });

--- a/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarToggleButton/ToolbarToggleButton.test.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarToggleButton/ToolbarToggleButton.test.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { Toolbar } from '../Toolbar';
+import { ToolbarToggleButton } from './ToolbarToggleButton';
+
+describe('ToolbarToggleButton', () => {
+  it('renders unchecked by default', () => {
+    const { getByRole } = render(
+      <Toolbar>
+        <ToolbarToggleButton name="format" value="bold">
+          Bold
+        </ToolbarToggleButton>
+      </Toolbar>,
+    );
+
+    const button = getByRole('button', { name: 'Bold' });
+    expect(button).toHaveAttribute('aria-pressed', 'false');
+    expect(button).not.toHaveAttribute('data-checked');
+  });
+
+  it('renders checked when value is in toolbar checkedValues', () => {
+    const { getByRole } = render(
+      <Toolbar defaultCheckedValues={{ format: ['bold'] }}>
+        <ToolbarToggleButton name="format" value="bold">
+          Bold
+        </ToolbarToggleButton>
+      </Toolbar>,
+    );
+
+    const button = getByRole('button', { name: 'Bold' });
+    expect(button).toHaveAttribute('aria-pressed', 'true');
+    expect(button).toHaveAttribute('data-checked');
+  });
+});

--- a/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarToggleButton/ToolbarToggleButton.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarToggleButton/ToolbarToggleButton.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import * as React from 'react';
+import type { ForwardRefComponent } from '@fluentui/react-utilities';
+import type { ToolbarToggleButtonProps } from './ToolbarToggleButton.types';
+import { useToolbarToggleButton } from './useToolbarToggleButton';
+import { renderToolbarToggleButton } from './renderToolbarToggleButton';
+
+/**
+ * A toggle button designed to be used inside a Toolbar with toolbar toggle-group behavior.
+ */
+export const ToolbarToggleButton: ForwardRefComponent<ToolbarToggleButtonProps> = React.forwardRef((props, ref) => {
+  const state = useToolbarToggleButton(props, ref);
+
+  return renderToolbarToggleButton(state);
+});
+
+ToolbarToggleButton.displayName = 'ToolbarToggleButton';

--- a/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarToggleButton/ToolbarToggleButton.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarToggleButton/ToolbarToggleButton.types.ts
@@ -1,11 +1,6 @@
 import type { ToolbarToggleButtonBaseProps, ToolbarToggleButtonBaseState } from '@fluentui/react-toolbar';
 
-export type ToolbarToggleButtonProps = ToolbarToggleButtonBaseProps & {
-  /**
-   * Whether the toolbar toggle button is in a vertically oriented toolbar.
-   */
-  vertical?: boolean;
-};
+export type ToolbarToggleButtonProps = ToolbarToggleButtonBaseProps;
 
 export type ToolbarToggleButtonState = ToolbarToggleButtonBaseState & {
   root: {

--- a/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarToggleButton/ToolbarToggleButton.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarToggleButton/ToolbarToggleButton.types.ts
@@ -1,0 +1,32 @@
+import type { ToolbarToggleButtonBaseProps, ToolbarToggleButtonBaseState } from '@fluentui/react-toolbar';
+
+export type ToolbarToggleButtonProps = ToolbarToggleButtonBaseProps & {
+  /**
+   * Whether the toolbar toggle button is in a vertically oriented toolbar.
+   */
+  vertical?: boolean;
+};
+
+export type ToolbarToggleButtonState = ToolbarToggleButtonBaseState & {
+  root: {
+    /**
+     * Data attribute set when the button is disabled.
+     */
+    'data-disabled'?: string;
+
+    /**
+     * Data attribute set when the button is disabled but still focusable.
+     */
+    'data-disabled-focusable'?: string;
+
+    /**
+     * Data attribute set when the button renders only an icon.
+     */
+    'data-icon-only'?: string;
+
+    /**
+     * Data attribute set when the button is in a checked (pressed) state.
+     */
+    'data-checked'?: string;
+  };
+};

--- a/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarToggleButton/index.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarToggleButton/index.ts
@@ -1,0 +1,4 @@
+export { ToolbarToggleButton } from './ToolbarToggleButton';
+export { renderToolbarToggleButton } from './renderToolbarToggleButton';
+export { useToolbarToggleButton } from './useToolbarToggleButton';
+export type { ToolbarToggleButtonProps, ToolbarToggleButtonState } from './ToolbarToggleButton.types';

--- a/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarToggleButton/renderToolbarToggleButton.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarToggleButton/renderToolbarToggleButton.ts
@@ -1,0 +1,6 @@
+import { renderToggleButton_unstable } from '@fluentui/react-button';
+
+/**
+ * Renders the final JSX of the ToolbarToggleButton component, given the state.
+ */
+export const renderToolbarToggleButton = renderToggleButton_unstable;

--- a/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarToggleButton/useToolbarToggleButton.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarToggleButton/useToolbarToggleButton.ts
@@ -1,0 +1,27 @@
+'use client';
+
+import type * as React from 'react';
+import { useToolbarToggleButtonBase_unstable } from '@fluentui/react-toolbar';
+
+import type { ToolbarToggleButtonProps, ToolbarToggleButtonState } from './ToolbarToggleButton.types';
+import { stringifyDataAttribute } from '../../../utils';
+
+/**
+ * Returns the state for a ToolbarToggleButton component, given its props and ref.
+ * The returned state can be modified with hooks before being passed to `renderToolbarToggleButton`.
+ */
+export const useToolbarToggleButton = (
+  props: ToolbarToggleButtonProps,
+  ref: React.Ref<HTMLButtonElement | HTMLAnchorElement>,
+): ToolbarToggleButtonState => {
+  'use no memo';
+
+  const state: ToolbarToggleButtonState = useToolbarToggleButtonBase_unstable(props, ref);
+
+  state.root['data-disabled'] = stringifyDataAttribute(state.disabled);
+  state.root['data-disabled-focusable'] = stringifyDataAttribute(state.disabledFocusable);
+  state.root['data-icon-only'] = stringifyDataAttribute(state.iconOnly);
+  state.root['data-checked'] = stringifyDataAttribute(state.checked);
+
+  return state;
+};

--- a/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/index.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/index.ts
@@ -1,0 +1,24 @@
+export { Toolbar } from './Toolbar';
+export { renderToolbar } from './renderToolbar';
+export { useToolbar, useToolbarContext, useToolbarContextValues } from './useToolbar';
+export type { ToolbarSlots, ToolbarProps, ToolbarState, ToolbarContextValues } from './Toolbar.types';
+
+export { ToolbarButton } from './ToolbarButton';
+export { renderToolbarButton } from './ToolbarButton';
+export { useToolbarButton } from './ToolbarButton';
+export type { ToolbarButtonProps, ToolbarButtonState } from './ToolbarButton';
+
+export { ToolbarDivider } from './ToolbarDivider';
+export { renderToolbarDivider } from './ToolbarDivider';
+export { useToolbarDivider } from './ToolbarDivider';
+export type { ToolbarDividerProps, ToolbarDividerState } from './ToolbarDivider';
+
+export { ToolbarGroup } from './ToolbarGroup';
+export { renderToolbarGroup } from './ToolbarGroup';
+export { useToolbarGroup } from './ToolbarGroup';
+export type { ToolbarGroupProps, ToolbarGroupState } from './ToolbarGroup';
+
+export { ToolbarRadioGroup } from './ToolbarRadioGroup';
+export { renderToolbarRadioGroup } from './ToolbarRadioGroup';
+export { useToolbarRadioGroup } from './ToolbarRadioGroup';
+export type { ToolbarRadioGroupProps, ToolbarRadioGroupState } from './ToolbarRadioGroup';

--- a/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/index.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/index.ts
@@ -22,3 +22,8 @@ export { ToolbarRadioGroup } from './ToolbarRadioGroup';
 export { renderToolbarRadioGroup } from './ToolbarRadioGroup';
 export { useToolbarRadioGroup } from './ToolbarRadioGroup';
 export type { ToolbarRadioGroupProps, ToolbarRadioGroupState } from './ToolbarRadioGroup';
+
+export { ToolbarToggleButton } from './ToolbarToggleButton';
+export { renderToolbarToggleButton } from './ToolbarToggleButton';
+export { useToolbarToggleButton } from './ToolbarToggleButton';
+export type { ToolbarToggleButtonProps, ToolbarToggleButtonState } from './ToolbarToggleButton';

--- a/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/renderToolbar.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/renderToolbar.ts
@@ -1,0 +1,6 @@
+import { renderToolbar_unstable } from '@fluentui/react-toolbar';
+
+/**
+ * Renders the final JSX of the Toolbar component, given the state and context values.
+ */
+export const renderToolbar = renderToolbar_unstable;

--- a/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/useToolbar.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/useToolbar.ts
@@ -19,7 +19,7 @@ export const useToolbar = (props: ToolbarProps, ref: React.Ref<HTMLElement>): To
 
   const state: ToolbarState = useToolbarBase_unstable(props, ref);
 
-  state.root.focusgroup = `toolbar ${state.vertical ? 'block' : 'inline'}`;
+  state.root.focusgroup = `toolbar ${state.vertical ? 'block' : 'inline'} wrap`;
   state.root['data-vertical'] = stringifyDataAttribute(state.vertical);
 
   return state;

--- a/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/useToolbar.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/useToolbar.ts
@@ -1,0 +1,39 @@
+'use client';
+
+import type * as React from 'react';
+import {
+  useToolbar_unstable,
+  useToolbarContext_unstable,
+  useToolbarContextValues_unstable,
+} from '@fluentui/react-toolbar';
+
+import type { ToolbarProps, ToolbarState, ToolbarContextValues } from './Toolbar.types';
+import { stringifyDataAttribute } from '../../utils';
+
+/**
+ * Returns the state for a Toolbar component, given its props and ref.
+ * The returned state can be modified with hooks before being passed to `renderToolbar`.
+ */
+export const useToolbar = (props: ToolbarProps, ref: React.Ref<HTMLElement>): ToolbarState => {
+  'use no memo';
+
+  const state: ToolbarState = useToolbar_unstable(props, ref);
+
+  // Set data attributes for vertical and size states to simplify styling of these states.
+  state.root['data-vertical'] = stringifyDataAttribute(state.vertical);
+  state.root['data-size'] = state.size;
+
+  return state;
+};
+
+/**
+ * Returns the context of the toolbar, which is used to pass information about the toolbar to its children.
+ */
+export const useToolbarContext = useToolbarContext_unstable;
+
+/**
+ * Maps the state of the toolbar to the values that are passed through context to its children.
+ */
+export const useToolbarContextValues = useToolbarContextValues_unstable as (
+  state: ToolbarState,
+) => ToolbarContextValues;

--- a/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/useToolbar.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/useToolbar.ts
@@ -2,7 +2,7 @@
 
 import type * as React from 'react';
 import {
-  useToolbar_unstable,
+  useToolbarBase_unstable,
   useToolbarContext_unstable,
   useToolbarContextValues_unstable,
 } from '@fluentui/react-toolbar';
@@ -17,11 +17,10 @@ import { stringifyDataAttribute } from '../../utils';
 export const useToolbar = (props: ToolbarProps, ref: React.Ref<HTMLElement>): ToolbarState => {
   'use no memo';
 
-  const state: ToolbarState = useToolbar_unstable(props, ref);
+  const state: ToolbarState = useToolbarBase_unstable(props, ref);
 
-  // Set data attributes for vertical and size states to simplify styling of these states.
+  state.root.focusgroup = `toolbar ${state.vertical ? 'block' : 'inline'}`;
   state.root['data-vertical'] = stringifyDataAttribute(state.vertical);
-  state.root['data-size'] = state.size;
 
   return state;
 };

--- a/packages/react-components/react-headless-components-preview/library/src/index.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/index.ts
@@ -207,6 +207,9 @@ export {
   ToolbarRadioGroup,
   renderToolbarRadioGroup,
   useToolbarRadioGroup,
+  ToolbarToggleButton,
+  renderToolbarToggleButton,
+  useToolbarToggleButton,
 } from './Toolbar';
 export type {
   ToolbarSlots,
@@ -221,4 +224,6 @@ export type {
   ToolbarGroupState,
   ToolbarRadioGroupProps,
   ToolbarRadioGroupState,
+  ToolbarToggleButtonProps,
+  ToolbarToggleButtonState,
 } from './Toolbar';

--- a/packages/react-components/react-headless-components-preview/library/src/index.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/index.ts
@@ -188,3 +188,37 @@ export type { TextareaSlots, TextareaProps, TextareaState } from './Textarea';
 
 export { ToggleButton, renderToggleButton, useToggleButton } from './ToggleButton';
 export type { ToggleButtonSlots, ToggleButtonProps, ToggleButtonState } from './ToggleButton';
+
+export {
+  Toolbar,
+  renderToolbar,
+  useToolbar,
+  useToolbarContext,
+  useToolbarContextValues,
+  ToolbarButton,
+  renderToolbarButton,
+  useToolbarButton,
+  ToolbarDivider,
+  renderToolbarDivider,
+  useToolbarDivider,
+  ToolbarGroup,
+  renderToolbarGroup,
+  useToolbarGroup,
+  ToolbarRadioGroup,
+  renderToolbarRadioGroup,
+  useToolbarRadioGroup,
+} from './Toolbar';
+export type {
+  ToolbarSlots,
+  ToolbarProps,
+  ToolbarState,
+  ToolbarContextValues,
+  ToolbarButtonProps,
+  ToolbarButtonState,
+  ToolbarDividerProps,
+  ToolbarDividerState,
+  ToolbarGroupProps,
+  ToolbarGroupState,
+  ToolbarRadioGroupProps,
+  ToolbarRadioGroupState,
+} from './Toolbar';

--- a/packages/react-components/react-headless-components-preview/stories/src/Toolbar/ToolbarDefault.stories.tsx
+++ b/packages/react-components/react-headless-components-preview/stories/src/Toolbar/ToolbarDefault.stories.tsx
@@ -1,0 +1,83 @@
+import * as React from 'react';
+import {
+  Toolbar,
+  ToolbarButton,
+  ToolbarDivider,
+  ToolbarGroup,
+  ToolbarRadioGroup,
+} from '@fluentui/react-headless-components-preview';
+import {
+  CutRegular,
+  CopyRegular,
+  ClipboardPasteRegular,
+  TextBoldRegular,
+  TextItalicRegular,
+  TextUnderlineRegular,
+  TextAlignLeftRegular,
+  TextAlignCenterRegular,
+  TextAlignRightRegular,
+} from '@fluentui/react-icons';
+
+const classes = {
+  toolbar:
+    'inline-flex items-center gap-0.5 rounded-lg border border-gray-200 bg-white p-1 shadow-sm data-[vertical]:flex-col',
+  button:
+    'flex items-center justify-center size-8 rounded border-none bg-transparent p-0 text-gray-700 cursor-pointer ' +
+    'hover:bg-gray-100 active:bg-gray-200 ' +
+    'focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 ' +
+    'data-[disabled]:opacity-40 data-[disabled]:cursor-not-allowed data-[disabled]:pointer-events-none',
+  activeButton:
+    'flex items-center justify-center size-8 rounded border-none p-0 text-blue-700 bg-blue-50 cursor-pointer ' +
+    'hover:bg-blue-100 active:bg-blue-200 ' +
+    'focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1',
+  divider: 'mx-0.5 w-px self-stretch bg-gray-200 data-[vertical]:h-px data-[vertical]:w-auto data-[vertical]:my-0.5',
+  group: 'flex items-center gap-0.5 data-[vertical]:flex-col',
+};
+
+const alignOptions = ['left', 'center', 'right'] as const;
+type AlignOption = (typeof alignOptions)[number];
+
+const alignIcons: Record<AlignOption, React.FC<React.SVGProps<SVGSVGElement>>> = {
+  left: TextAlignLeftRegular,
+  center: TextAlignCenterRegular,
+  right: TextAlignRightRegular,
+};
+
+export const Default = (): React.ReactNode => {
+  const [align, setAlign] = React.useState<AlignOption>('left');
+
+  return (
+    <Toolbar className={classes.toolbar} aria-label="Text formatting">
+      <ToolbarButton className={classes.button} aria-label="Cut" icon={<CutRegular />} />
+      <ToolbarButton className={classes.button} aria-label="Copy" icon={<CopyRegular />} />
+      <ToolbarButton className={classes.button} aria-label="Paste" icon={<ClipboardPasteRegular />} />
+
+      <ToolbarDivider className={classes.divider} />
+
+      <ToolbarGroup className={classes.group}>
+        <ToolbarButton className={classes.button} aria-label="Bold" icon={<TextBoldRegular />} />
+        <ToolbarButton className={classes.button} aria-label="Italic" icon={<TextItalicRegular />} />
+        <ToolbarButton className={classes.button} aria-label="Underline" icon={<TextUnderlineRegular />} />
+        <ToolbarButton className={classes.button} aria-label="Underline" disabled icon={<TextUnderlineRegular />} />
+      </ToolbarGroup>
+
+      <ToolbarDivider className={classes.divider} />
+
+      <ToolbarRadioGroup className={classes.group} aria-label="Text alignment">
+        {alignOptions.map(option => {
+          const Icon = alignIcons[option];
+          return (
+            <ToolbarButton
+              key={option}
+              className={align === option ? classes.activeButton : classes.button}
+              aria-label={`Align ${option}`}
+              aria-pressed={align === option}
+              icon={<Icon />}
+              onClick={() => setAlign(option)}
+            />
+          );
+        })}
+      </ToolbarRadioGroup>
+    </Toolbar>
+  );
+};

--- a/packages/react-components/react-headless-components-preview/stories/src/Toolbar/ToolbarDefault.stories.tsx
+++ b/packages/react-components/react-headless-components-preview/stories/src/Toolbar/ToolbarDefault.stories.tsx
@@ -5,6 +5,7 @@ import {
   ToolbarDivider,
   ToolbarGroup,
   ToolbarRadioGroup,
+  ToolbarToggleButton,
 } from '@fluentui/react-headless-components-preview';
 import {
   CutRegular,
@@ -29,22 +30,25 @@ const classes = {
   activeButton:
     'flex items-center justify-center size-8 rounded border-none p-0 text-blue-700 bg-blue-50 cursor-pointer ' +
     'hover:bg-blue-100 active:bg-blue-200 ' +
-    'focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1',
+    'focus:outline-none focus-visible:ring-2 focus-visible:ring-black focus-visible:ring-offset-1',
+  toggleButton:
+    'flex items-center justify-center size-8 rounded border-none bg-transparent p-0 text-gray-700 cursor-pointer ' +
+    'hover:bg-gray-100 active:bg-gray-200 ' +
+    'focus:outline-none focus-visible:ring-2 focus-visible:ring-black focus-visible:ring-offset-1 ' +
+    'data-[checked]:text-blue-700 data-[checked]:bg-blue-50 ' +
+    'data-[disabled]:opacity-40 data-[disabled]:cursor-not-allowed data-[disabled]:pointer-events-none',
   divider: 'mx-0.5 w-px self-stretch bg-gray-200 data-[vertical]:h-px data-[vertical]:w-auto data-[vertical]:my-0.5',
   group: 'flex items-center gap-0.5 data-[vertical]:flex-col',
 };
 
-const alignOptions = ['left', 'center', 'right'] as const;
-type AlignOption = (typeof alignOptions)[number];
-
-const alignIcons: Record<AlignOption, React.FC<React.SVGProps<SVGSVGElement>>> = {
+const alignIcons = {
   left: TextAlignLeftRegular,
   center: TextAlignCenterRegular,
   right: TextAlignRightRegular,
 };
 
 export const Default = (): React.ReactNode => {
-  const [align, setAlign] = React.useState<AlignOption>('left');
+  const [align, setAlign] = React.useState('left');
 
   return (
     <Toolbar className={classes.toolbar} aria-label="Text formatting">
@@ -54,18 +58,45 @@ export const Default = (): React.ReactNode => {
 
       <ToolbarDivider className={classes.divider} />
 
-      <ToolbarGroup className={classes.group}>
-        <ToolbarButton className={classes.button} aria-label="Bold" icon={<TextBoldRegular />} />
-        <ToolbarButton className={classes.button} aria-label="Italic" icon={<TextItalicRegular />} />
-        <ToolbarButton className={classes.button} aria-label="Underline" icon={<TextUnderlineRegular />} />
-        <ToolbarButton className={classes.button} aria-label="Underline" disabled icon={<TextUnderlineRegular />} />
+      <ToolbarGroup className={classes.group} aria-label="Text formatting">
+        <ToolbarToggleButton
+          name="format"
+          value="bold"
+          className={classes.toggleButton}
+          aria-label="Bold"
+          icon={<TextBoldRegular />}
+          onClick={() => undefined}
+        />
+        <ToolbarToggleButton
+          name="format"
+          value="italic"
+          className={classes.toggleButton}
+          aria-label="Italic"
+          icon={<TextItalicRegular />}
+          onClick={() => undefined}
+        />
+        <ToolbarToggleButton
+          name="format"
+          value="underline"
+          className={classes.toggleButton}
+          aria-label="Underline"
+          icon={<TextUnderlineRegular />}
+          onClick={() => undefined}
+        />
+        <ToolbarToggleButton
+          name="format"
+          value="strikethrough"
+          disabled
+          className={classes.toggleButton}
+          aria-label="Strikethrough"
+          icon={<TextUnderlineRegular />}
+        />
       </ToolbarGroup>
 
       <ToolbarDivider className={classes.divider} />
 
       <ToolbarRadioGroup className={classes.group} aria-label="Text alignment">
-        {alignOptions.map(option => {
-          const Icon = alignIcons[option];
+        {Object.entries(alignIcons).map(([option, Icon]) => {
           return (
             <ToolbarButton
               key={option}

--- a/packages/react-components/react-headless-components-preview/stories/src/Toolbar/ToolbarDescription.md
+++ b/packages/react-components/react-headless-components-preview/stories/src/Toolbar/ToolbarDescription.md
@@ -1,0 +1,3 @@
+A toolbar provides a container for grouping a set of controls such as buttons, menu buttons, or checkboxes.
+
+Toolbar exposes semantic data attributes on all its sub-components to simplify headless styling:

--- a/packages/react-components/react-headless-components-preview/stories/src/Toolbar/ToolbarToggleButton.stories.tsx
+++ b/packages/react-components/react-headless-components-preview/stories/src/Toolbar/ToolbarToggleButton.stories.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import { Toolbar, ToolbarGroup, ToolbarToggleButton } from '@fluentui/react-headless-components-preview';
+import { TextBoldRegular, TextItalicRegular, TextUnderlineRegular } from '@fluentui/react-icons';
+
+const classes = {
+  toolbar:
+    'inline-flex items-center gap-0.5 rounded-lg border border-gray-200 bg-white p-1 shadow-sm data-[vertical]:flex-col',
+  toggleButton:
+    'flex items-center justify-center size-8 rounded border-none bg-transparent p-0 text-gray-700 cursor-pointer ' +
+    'hover:bg-gray-100 active:bg-gray-200 ' +
+    'focus:outline-none focus-visible:ring-2 focus-visible:ring-black focus-visible:ring-offset-1 ' +
+    'data-[checked]:text-blue-700 data-[checked]:bg-blue-50 ' +
+    'data-[disabled]:opacity-40 data-[disabled]:cursor-not-allowed data-[disabled]:pointer-events-none',
+  divider: 'mx-0.5 w-px self-stretch bg-gray-200 data-[vertical]:h-px data-[vertical]:w-auto data-[vertical]:my-0.5',
+  group: 'flex items-center gap-0.5 data-[vertical]:flex-col',
+};
+
+export const Toggle = (): React.ReactNode => {
+  return (
+    <Toolbar className={classes.toolbar} aria-label="Multiple formatting states">
+      <ToolbarGroup className={classes.group} aria-label="Pre-selected formatting">
+        <ToolbarToggleButton
+          name="format"
+          value="bold"
+          className={classes.toggleButton}
+          aria-label="Bold (checked)"
+          icon={<TextBoldRegular />}
+        />
+        <ToolbarToggleButton
+          name="format"
+          value="italic"
+          className={classes.toggleButton}
+          aria-label="Italic"
+          icon={<TextItalicRegular />}
+        />
+        <ToolbarToggleButton
+          name="format"
+          value="underline"
+          className={classes.toggleButton}
+          aria-label="Underline"
+          icon={<TextUnderlineRegular />}
+        />
+      </ToolbarGroup>
+    </Toolbar>
+  );
+};

--- a/packages/react-components/react-headless-components-preview/stories/src/Toolbar/ToolbarVertical.stories.tsx
+++ b/packages/react-components/react-headless-components-preview/stories/src/Toolbar/ToolbarVertical.stories.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import { Toolbar, ToolbarButton, ToolbarDivider, ToolbarGroup } from '@fluentui/react-headless-components-preview';
+import {
+  CutRegular,
+  CopyRegular,
+  ClipboardPasteRegular,
+  TextBoldRegular,
+  TextItalicRegular,
+  TextUnderlineRegular,
+} from '@fluentui/react-icons';
+
+const classes = {
+  toolbar:
+    'inline-flex items-center gap-0.5 rounded-lg border border-gray-200 bg-white p-1 shadow-sm data-[vertical]:flex-col',
+  button:
+    'flex items-center justify-center size-8 rounded border-none bg-transparent p-0 text-gray-700 cursor-pointer ' +
+    'hover:bg-gray-100 active:bg-gray-200 ' +
+    'focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 ' +
+    'data-[disabled]:opacity-40 data-[disabled]:cursor-not-allowed data-[disabled]:pointer-events-none',
+  divider: 'mx-0.5 w-px self-stretch bg-gray-200 data-[vertical]:h-px data-[vertical]:w-auto data-[vertical]:my-0.5',
+  group: 'flex items-center gap-0.5 data-[vertical]:flex-col',
+};
+
+export const Vertical = (): React.ReactNode => (
+  <Toolbar className={classes.toolbar} vertical aria-label="Text formatting">
+    <ToolbarButton className={classes.button} aria-label="Cut" icon={<CutRegular />} />
+    <ToolbarButton className={classes.button} aria-label="Copy" icon={<CopyRegular />} />
+    <ToolbarButton className={classes.button} aria-label="Paste" icon={<ClipboardPasteRegular />} />
+
+    <ToolbarDivider className={classes.divider} />
+
+    <ToolbarGroup className={classes.group} aria-label="Text formatting">
+      <ToolbarButton className={classes.button} aria-label="Bold" icon={<TextBoldRegular />} />
+      <ToolbarButton className={classes.button} aria-label="Italic" icon={<TextItalicRegular />} />
+      <ToolbarButton className={classes.button} aria-label="Underline" icon={<TextUnderlineRegular />} />
+    </ToolbarGroup>
+  </Toolbar>
+);

--- a/packages/react-components/react-headless-components-preview/stories/src/Toolbar/index.stories.tsx
+++ b/packages/react-components/react-headless-components-preview/stories/src/Toolbar/index.stories.tsx
@@ -4,17 +4,19 @@ import {
   ToolbarDivider,
   ToolbarGroup,
   ToolbarRadioGroup,
+  ToolbarToggleButton,
 } from '@fluentui/react-headless-components-preview';
 
 import descriptionMd from './ToolbarDescription.md';
 
 export { Default } from './ToolbarDefault.stories';
 export { Vertical } from './ToolbarVertical.stories';
+export { Toggle } from './ToolbarToggleButton.stories';
 
 export default {
   title: 'Headless Components/Toolbar',
   component: Toolbar,
-  subcomponents: { ToolbarButton, ToolbarDivider, ToolbarGroup, ToolbarRadioGroup },
+  subcomponents: { ToolbarButton, ToolbarDivider, ToolbarGroup, ToolbarRadioGroup, ToolbarToggleButton },
   parameters: {
     docs: {
       description: {

--- a/packages/react-components/react-headless-components-preview/stories/src/Toolbar/index.stories.tsx
+++ b/packages/react-components/react-headless-components-preview/stories/src/Toolbar/index.stories.tsx
@@ -1,0 +1,25 @@
+import {
+  Toolbar,
+  ToolbarButton,
+  ToolbarDivider,
+  ToolbarGroup,
+  ToolbarRadioGroup,
+} from '@fluentui/react-headless-components-preview';
+
+import descriptionMd from './ToolbarDescription.md';
+
+export { Default } from './ToolbarDefault.stories';
+export { Vertical } from './ToolbarVertical.stories';
+
+export default {
+  title: 'Headless Components/Toolbar',
+  component: Toolbar,
+  subcomponents: { ToolbarButton, ToolbarDivider, ToolbarGroup, ToolbarRadioGroup },
+  parameters: {
+    docs: {
+      description: {
+        component: descriptionMd,
+      },
+    },
+  },
+};


### PR DESCRIPTION
This pull request introduces a new headless `Toolbar` component suite to the `@fluentui/react-headless-components-preview` package. It adds the core `Toolbar` component and related subcomponents (such as `ToolbarButton`, `ToolbarDivider`, `ToolbarGroup`, and `ToolbarRadioGroup`), along with their hooks, types, and renderers. These components are built on top of the primitives from `@fluentui/react-toolbar`, exposing a headless API for advanced composition and styling. The PR also adds tests and updates package dependencies.

**New Toolbar suite integration:**

- Added `Toolbar`, `ToolbarButton`, `ToolbarDivider`, `ToolbarGroup`, and `ToolbarRadioGroup` components, each with corresponding hooks (`useToolbar`, `useToolbarButton`, etc.), types, and render functions, providing a headless API for building toolbars. [[1]](diffhunk://#diff-412406a0293a3ae1d733579f6e11105f251cb9fd1183ec794e0474d23cd84609R1-R14) [[2]](diffhunk://#diff-fdbabdeb876bdbf9a8a972053ac8c712d8fba8add238d05c4cb7a4fc43e7ff7dR1-R20) [[3]](diffhunk://#diff-6967435ec9f1dd20767b7535ff0ba9657456c882fc5707b5707252db23470c6bR1-R19) [[4]](diffhunk://#diff-1fac14bbcd742b2b4a2ee459640f24d01e49625fd65c9566f165df592623e252R1-R19) [[5]](diffhunk://#diff-51aac3b6fe26c481157f6af9f4423064b54af48f75609d51ccd5299166253c82R1-R18)
- Extended the public API and type definitions to include all new Toolbar-related components, props, states, slots, and context values, ensuring they are documented and available for consumers. [[1]](diffhunk://#diff-62ca89fa1c6eb955d2f1258b784f6a54818a1c7969fc47babac28b754891f258R124-R136) [[2]](diffhunk://#diff-62ca89fa1c6eb955d2f1258b784f6a54818a1c7969fc47babac28b754891f258R579-R593) [[3]](diffhunk://#diff-62ca89fa1c6eb955d2f1258b784f6a54818a1c7969fc47babac28b754891f258R787-R862) [[4]](diffhunk://#diff-62ca89fa1c6eb955d2f1258b784f6a54818a1c7969fc47babac28b754891f258R977-R997)
- Integrated the new `@fluentui/react-toolbar` dependency to provide base implementations for the Toolbar primitives.

**Component implementation details:**

- Each Toolbar subcomponent sets appropriate data attributes (e.g., `data-vertical`, `data-disabled`, `data-icon-only`) on the root element to facilitate styling and state indication. [[1]](diffhunk://#diff-f06d82020f7537ca1291fe68447a44fc37a862d33c5a186a9cf800b6228d49ddR1-R28) [[2]](diffhunk://#diff-d3d4173e1471a91136df60c8a9d75978ea65fa4c98e1a723d3515adfdf113646R1-R22) [[3]](diffhunk://#diff-feca54a24faa0cfc11e30cdf8380b29795464945744edd5ee62012e10a5ea76bR1-R27) [[4]](diffhunk://#diff-f7f78b4eaee8ddfc3c20d9d6c64a75a12a8dc3fd08a5dafc8ddb035f9db81853R1-R13) [[5]](diffhunk://#diff-dcbd4a7ee040af11005bf1cb663181091806f9a41d1ffdc663f36952a49dac02R1-R15)
- Render functions for Toolbar subcomponents delegate rendering to the corresponding base component renderers from Fluent UI (e.g., `renderButton_unstable`, `renderDivider_unstable`). [[1]](diffhunk://#diff-1cb9bed002677c05ced171a17b2bad7ec791015874297a34c1b00e9dfb75706bR1-R6) [[2]](diffhunk://#diff-f1c19e611bb4ee9670997a0ac656b1f2ffc588ed329b4586afb7c3093c5fcdf8R1-R6)

**Testing:**

- Added conformance and rendering tests for the `Toolbar` component to ensure correct behavior and accessibility attributes.

This update enables advanced headless composition of toolbars and related controls using Fluent UI primitives in the preview package.