### PR TITLE
fix(public-docsite-v9-headless): align fonts and heading styles 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -123,6 +123,7 @@ apps/vr-tests-web-components @microsoft/fui-wc
 apps/ssr-tests @microsoft/fluentui-react
 apps/pr-deploy-site @microsoft/fluentui-react-build
 apps/public-docsite-v9 @microsoft/cxe-red @microsoft/cxe-prg @microsoft/teams-prg @microsoft/fluentui-react-build
+apps/public-docsite-v9-headless @microsoft/cxe-prg @microsoft/fluentui-react-build
 apps/theming-designer @microsoft/fluentui-react
 apps/ssr-tests-v9 @microsoft/fluentui-react-build
 apps/rit-tests-v8 @microsoft/fluentui-react-build

--- a/apps/public-docsite-v9-headless/.storybook/main.js
+++ b/apps/public-docsite-v9-headless/.storybook/main.js
@@ -10,6 +10,7 @@ module.exports = /** @type {Omit<import('../../../.storybook/main'), 'typescript
     // headless package stories
     '../../../packages/react-components/react-headless-components-preview/stories/src/**/index.stories.@(ts|tsx)',
   ],
+  staticDirs: ['../public'],
   addons: [...rootMain.addons],
   build: {
     previewUrl: process.env.DEPLOY_PATH,

--- a/apps/public-docsite-v9-headless/.storybook/manager-head.html
+++ b/apps/public-docsite-v9-headless/.storybook/manager-head.html
@@ -1,0 +1,150 @@
+<!--
+  Override the default favicon used in the Storybook in the browser tab.
+ -->
+<link rel="shortcut icon" type="image/x-icon" href="https://react.fluentui.dev/favicon-192.ico" />
+<link href="/shell.css" rel="stylesheet" />
+
+<!--
+  Override the default styles used in the Storybook svg icons for the left tree panel.
+
+  @see https://storybook.js.org/docs/react/configure/theming#css-escape-hatches
+
+  > 💡 NOTE:
+  >
+  > This is brittle way for providing custom non thenable styles for manager UI
+  >
+  > Those selectors might change on any storybook version bump.
+ -->
+
+<style>
+  @font-face {
+    font-family: 'Segoe UI';
+    src: local('Segoe UI Light'),
+      url(https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/light/latest.woff2) format('woff2'),
+      url(https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/light/latest.woff) format('woff'),
+      url(https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/light/latest.ttf) format('truetype');
+    font-weight: 100;
+  }
+
+  @font-face {
+    font-family: 'Segoe UI';
+    src: local('Segoe UI Semilight'),
+      url(https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/semilight/latest.woff2) format('woff2'),
+      url(https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/semilight/latest.woff) format('woff'),
+      url(https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/semilight/latest.ttf) format('truetype');
+    font-weight: 200;
+  }
+
+  @font-face {
+    font-family: 'Segoe UI';
+    src: local('Segoe UI'),
+      url(https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/normal/latest.woff2) format('woff2'),
+      url(https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/normal/latest.woff) format('woff'),
+      url(https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/normal/latest.ttf) format('truetype');
+    font-weight: 400;
+  }
+
+  @font-face {
+    font-family: 'Segoe UI';
+    src: local('Segoe UI Semibold'),
+      url(https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/semibold/latest.woff2) format('woff2'),
+      url(https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/semibold/latest.woff) format('woff'),
+      url(https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/semibold/latest.ttf) format('truetype');
+    font-weight: 600;
+  }
+
+  @font-face {
+    font-family: 'Segoe UI';
+    src: local('Segoe UI Bold'),
+      url(https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/bold/latest.woff2) format('woff2'),
+      url(https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/bold/latest.woff) format('woff'),
+      url(https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/bold/latest.ttf) format('truetype');
+    font-weight: 700;
+  }
+
+  #storybook-preview-iframe {
+    background: transparent !important;
+  }
+
+  #storybook-explorer-searchfield {
+    font-weight: 400 !important;
+    font-size: 14px !important;
+    letter-spacing: -0.01em !important;
+    line-height: 14px !important;
+  }
+
+  .sidebar-item svg,
+  .sidebar-svg-icon {
+    color: #11100f !important;
+  }
+
+  .sidebar-item[data-selected='true'] svg,
+  .sidebar-item[data-selected='true'] .sidebar-svg-icon {
+    color: #ffffff !important;
+  }
+
+  /**
+    The `button[data-action='collapse-ref']` selector is used to ensure
+    that the "Storybook Composition" (https://storybook.js.org/docs/sharing/storybook-composition) menu items
+    align with the styling of the other sidebar menu items.
+  */
+  .sidebar-subheading,
+  button[data-action='collapse-ref'] {
+    font-weight: 600 !important;
+    font-size: 16px !important;
+    letter-spacing: 0px !important;
+    line-height: 24px !important;
+    text-transform: none !important;
+    color: #11100f !important;
+  }
+
+  .sidebar-subheading button,
+  button[data-action='collapse-ref'] {
+    display: flex !important;
+    align-items: center !important;
+  }
+
+  .sidebar-item {
+    align-items: center !important;
+    font-weight: 400 !important;
+    font-size: 14px !important;
+    letter-spacing: -0.01em !important;
+    line-height: 24px !important;
+    color: #11100f !important;
+  }
+
+  .sidebar-item a {
+    align-items: center !important;
+  }
+
+  .sidebar-item[data-selected='true'] {
+    font-weight: 600 !important;
+    font-size: 14px !important;
+    letter-spacing: -0.01em !important;
+    line-height: 24px !important;
+    color: #ffffff !important;
+  }
+
+  .sidebar-item > span:first-child,
+  button[data-action='collapse-ref'] > span:first-child,
+  .sidebar-item > svg {
+    margin-top: 0 !important;
+  }
+
+  /*
+  * Hides "Addons" button from mobile view nav.
+  */
+  nav > button:last-child {
+    display: none;
+  }
+
+  /*
+  Storybook has proposed a feature for this in https://github.com/storybookjs/storybook/issues/9209
+  which will configure stories to exist in deeplink URL format, but do not appear in the nav tree or the docs page
+  Using suggested temporary workaround until storybook gets proper support
+  See https://github.com/microsoft/fluentui/blob/master/docs/react-v9/contributing/rfcs/react-components/convergence/authoring-stories.md#10-internal-stories-for-testing
+  */
+  [id*='accessibility-stories'] {
+    display: none !important;
+  }
+</style>

--- a/apps/public-docsite-v9-headless/.storybook/preview-head.html
+++ b/apps/public-docsite-v9-headless/.storybook/preview-head.html
@@ -1,5 +1,13 @@
 <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+<!--
+  Tailwind's Preflight resets h1/h2/p/a to unstyled, which would override the
+  docs typography defined in `react-storybook-addon/src/styles.css`. Import
+  only theme tokens and utilities so stories can still use Tailwind classes,
+  but MDX docs keep their Segoe UI headings.
+-->
 <style type="text/tailwindcss">
+  @import 'tailwindcss/theme' layer(theme);
+  @import 'tailwindcss/utilities' layer(utilities);
   :root {
     interpolate-size: allow-keywords;
   }

--- a/apps/public-docsite-v9-headless/.storybook/preview-head.html
+++ b/apps/public-docsite-v9-headless/.storybook/preview-head.html
@@ -1,10 +1,4 @@
 <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
-<!--
-  Tailwind's Preflight resets h1/h2/p/a to unstyled, which would override the
-  docs typography defined in `react-storybook-addon/src/styles.css`. Import
-  only theme tokens and utilities so stories can still use Tailwind classes,
-  but MDX docs keep their Segoe UI headings.
--->
 <style type="text/tailwindcss">
   @import 'tailwindcss/theme' layer(theme);
   @import 'tailwindcss/utilities' layer(utilities);

--- a/apps/public-docsite-v9-headless/.storybook/preview.js
+++ b/apps/public-docsite-v9-headless/.storybook/preview.js
@@ -1,4 +1,8 @@
+import { polyfillBodyAndObserve } from '@microsoft/focusgroup-polyfill/shadowless';
+
 import * as rootPreview from '../../../.storybook/preview';
+
+polyfillBodyAndObserve();
 
 /** @type {typeof rootPreview.decorators} */
 export const decorators = [...rootPreview.decorators];

--- a/apps/public-docsite-v9-headless/public/shell.css
+++ b/apps/public-docsite-v9-headless/public/shell.css
@@ -1,0 +1,72 @@
+/* remove margin from sidebar logo  */
+.sidebar-header > div:first-of-type {
+  margin-right: 0;
+}
+
+/* remove sidebar shortcuts menu */
+.sidebar-header > div:last-child {
+  display: none;
+}
+
+/* Add left side background color splash */
+/* colors become distracting in mobile layout so scoped to where sidebar is visible */
+@media (min-width: 600px) {
+  #root > div:before {
+    content: '';
+    position: absolute;
+    top: -200px;
+    left: -200px;
+    width: 400px;
+    height: 400px;
+    background: #c989e8;
+    opacity: 0.5;
+    filter: blur(150px);
+  }
+
+  /* Add right side background color splash */
+  #root > div:after {
+    content: '';
+    position: absolute;
+    top: -200px;
+    right: -200px;
+    width: 400px;
+    height: 400px;
+    background: #b3d4ff;
+    opacity: 0.5;
+    filter: blur(150px);
+  }
+}
+
+/* Give sidebar a transparent white background to match design */
+.sidebar-container {
+  background: rgba(255, 255, 255, 0.6);
+}
+
+/* remove background preventing color splash from showing */
+#storybook-preview-wrapper {
+  background: transparent;
+}
+
+/*
+ * Set position fixed to create a layer and prevent iframe from jumping when content is
+ * larger than the viewport and the iframe itself
+ */
+[role='main'] {
+  position: fixed;
+}
+
+/* remove box shadow style from storybooks wrapper div */
+[role='main'] > div {
+  box-shadow: none;
+}
+
+/* permanently hide toolbar so animation never appears on page load */
+[role='main'] .os-host {
+  display: none;
+}
+
+/* stop offset from changing page dimensions when 't' is pressed and toolbar opened */
+[role='main'] > div > div > div {
+  top: 0 !important;
+  height: 100% !important;
+}


### PR DESCRIPTION
Port the manager-head.html font-faces and sidebar overrides plus the shell.css color-splash from public-docsite-v9, and scope Tailwind in preview-head.html to theme+utilities layers, so MDX h1/h2/p aren't reset.

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<img width="2115" height="953" alt="Screenshot 2026-04-20 at 13 41 52" src="https://github.com/user-attachments/assets/a5b69836-2749-414b-987c-9175553a7d47" />

## New Behavior

<img width="1728" height="994" alt="Screenshot 2026-04-20 at 13 41 12" src="https://github.com/user-attachments/assets/906eb457-bac4-4522-b210-c0748c699683" />
