### PR TITLE
feat(react-motion): expose motion params as direct props on motion slot types

### DIFF
--- a/change/@fluentui-react-accordion-5af3cf85-7731-48c3-bab5-e9cab5a41726.json
+++ b/change/@fluentui-react-accordion-5af3cf85-7731-48c3-bab5-e9cab5a41726.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add CollapseParams to the motion slot type",
+  "packageName": "@fluentui/react-accordion",
+  "email": "robertpenner@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-dialog-99479e88-2ba2-44eb-bc12-a31d45848c86.json
+++ b/change/@fluentui-react-dialog-99479e88-2ba2-44eb-bc12-a31d45848c86.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add ScaleParams to the motion slot type",
+  "packageName": "@fluentui/react-dialog",
+  "email": "robertpenner@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-drawer-88aa353a-f04d-4124-8ccb-bded42fe2569.json
+++ b/change/@fluentui-react-drawer-88aa353a-f04d-4124-8ccb-bded42fe2569.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "fix: update type for drawerMotion slot",
+  "packageName": "@fluentui/react-drawer",
+  "email": "robertpenner@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-motion-fde65e2a-a820-4e69-80ac-b3b0a60f60de.json
+++ b/change/@fluentui-react-motion-fde65e2a-a820-4e69-80ac-b3b0a60f60de.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: expose motion params as direct props on motion slot types",
+  "packageName": "@fluentui/react-motion",
+  "email": "robertpenner@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tree-153f24ef-6509-418e-b50f-d9f8101fef7d.json
+++ b/change/@fluentui-react-tree-153f24ef-6509-418e-b50f-d9f8101fef7d.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add CollapseParams to the motion slot type",
+  "packageName": "@fluentui/react-tree",
+  "email": "robertpenner@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/eslint-plugin-react-components/etc/eslint-plugin-react-components.api.md
+++ b/packages/react-components/eslint-plugin-react-components/etc/eslint-plugin-react-components.api.md
@@ -5,7 +5,6 @@
 ```ts
 
 import type { ESLint } from 'eslint';
-import { name } from '../package.json';
 import { RuleListener } from '@typescript-eslint/utils/dist/ts-eslint';
 import { RuleModule } from '@typescript-eslint/utils/dist/ts-eslint';
 
@@ -17,7 +16,7 @@ export const configs: {
     };
     'flat/recommended': {
         plugins: {
-            [name]: ESLint.Plugin;
+            [x: string]: ESLint.Plugin;
         };
         rules: {};
     };

--- a/packages/react-components/eslint-plugin-react-components/etc/eslint-plugin-react-components.api.md
+++ b/packages/react-components/eslint-plugin-react-components/etc/eslint-plugin-react-components.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import type { ESLint } from 'eslint';
+import { name } from '../package.json';
 import { RuleListener } from '@typescript-eslint/utils/dist/ts-eslint';
 import { RuleModule } from '@typescript-eslint/utils/dist/ts-eslint';
 
@@ -16,7 +17,7 @@ export const configs: {
     };
     'flat/recommended': {
         plugins: {
-            [x: string]: ESLint.Plugin;
+            [name]: ESLint.Plugin;
         };
         rules: {};
     };

--- a/packages/react-components/react-accordion/library/etc/react-accordion.api.md
+++ b/packages/react-components/react-accordion/library/etc/react-accordion.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import type { ARIAButtonSlotProps } from '@fluentui/react-aria';
+import type { CollapseParams } from '@fluentui/react-motion-components-preview';
 import type { ComponentProps } from '@fluentui/react-utilities';
 import type { ComponentState } from '@fluentui/react-utilities';
 import type { ContextSelector } from '@fluentui/react-context-selector';
@@ -156,7 +157,7 @@ export type AccordionPanelProps = ComponentProps<AccordionPanelSlots>;
 // @public (undocumented)
 export type AccordionPanelSlots = {
     root: NonNullable<Slot<'div'>>;
-    collapseMotion?: Slot<PresenceMotionSlotProps>;
+    collapseMotion?: Slot<PresenceMotionSlotProps<CollapseParams>>;
 };
 
 // @public (undocumented)

--- a/packages/react-components/react-accordion/library/src/components/AccordionPanel/AccordionPanel.types.ts
+++ b/packages/react-components/react-accordion/library/src/components/AccordionPanel/AccordionPanel.types.ts
@@ -1,9 +1,10 @@
 import type { PresenceMotionSlotProps } from '@fluentui/react-motion';
+import type { CollapseParams } from '@fluentui/react-motion-components-preview';
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
 
 export type AccordionPanelSlots = {
   root: NonNullable<Slot<'div'>>;
-  collapseMotion?: Slot<PresenceMotionSlotProps>;
+  collapseMotion?: Slot<PresenceMotionSlotProps<CollapseParams>>;
 };
 
 export type AccordionPanelProps = ComponentProps<AccordionPanelSlots>;

--- a/packages/react-components/react-accordion/stories/src/Accordion/AccordionMotionCustom.stories.md
+++ b/packages/react-components/react-accordion/stories/src/Accordion/AccordionMotionCustom.stories.md
@@ -1,0 +1,7 @@
+`AccordionPanel`'s `collapseMotion` slot can directly take `Collapse` props, such as `duration`, `easing`, `animateOpacity` and others.
+
+The `collapseMotion` slot also supports the `children` render function, which allows replacing the default `Collapse` with a custom implementation. This story demonstrates the simpler direct prop approach:
+
+```tsx
+<AccordionPanel collapseMotion={{ duration, easing, animateOpacity }}>
+```

--- a/packages/react-components/react-accordion/stories/src/Accordion/AccordionMotionCustom.stories.tsx
+++ b/packages/react-components/react-accordion/stories/src/Accordion/AccordionMotionCustom.stories.tsx
@@ -1,0 +1,78 @@
+import * as React from 'react';
+import type { JSXElement } from '@fluentui/react-components';
+import {
+  Accordion,
+  AccordionHeader,
+  AccordionItem,
+  AccordionPanel,
+  Field,
+  makeStyles,
+  Slider,
+  Switch,
+  tokens,
+} from '@fluentui/react-components';
+
+const useStyles = makeStyles({
+  controls: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '8px',
+    marginBottom: '16px',
+    padding: '12px',
+    border: `${tokens.strokeWidthThicker} solid ${tokens.colorNeutralForeground3}`,
+    borderRadius: tokens.borderRadiusMedium,
+  },
+});
+
+export const MotionCustom = (): JSXElement => {
+  const classes = useStyles();
+  const [duration, setDuration] = React.useState(300);
+  const [animateOpacity, setAnimateOpacity] = React.useState(true);
+
+  return (
+    <>
+      <div className={classes.controls}>
+        <Field label={`Duration: ${duration}ms`}>
+          <Slider min={100} max={2000} step={50} value={duration} onChange={(_, data) => setDuration(data.value)} />
+        </Field>
+        <Switch
+          label="Animate opacity"
+          checked={animateOpacity}
+          onChange={(_, data) => setAnimateOpacity(data.checked)}
+        />
+      </div>
+
+      <Accordion collapsible>
+        <AccordionItem value="1">
+          <AccordionHeader>Accordion Header 1</AccordionHeader>
+          <AccordionPanel collapseMotion={{ duration, animateOpacity }}>
+            <div>Accordion Panel 1</div>
+          </AccordionPanel>
+        </AccordionItem>
+        <AccordionItem value="2">
+          <AccordionHeader>Accordion Header 2</AccordionHeader>
+          <AccordionPanel collapseMotion={{ duration, animateOpacity }}>
+            <div>Accordion Panel 2</div>
+          </AccordionPanel>
+        </AccordionItem>
+        <AccordionItem value="3">
+          <AccordionHeader>Accordion Header 3</AccordionHeader>
+          <AccordionPanel collapseMotion={{ duration, animateOpacity }}>
+            <div>Accordion Panel 3</div>
+          </AccordionPanel>
+        </AccordionItem>
+      </Accordion>
+    </>
+  );
+};
+
+MotionCustom.parameters = {
+  docs: {
+    description: {
+      story:
+        'The `collapseMotion` slot on `AccordionPanel` is typed with `CollapseParams`, so motion ' +
+        'parameters like `duration` and `animateOpacity` can be passed directly as props — ' +
+        'no `children` render function needed.',
+    },
+  },
+};

--- a/packages/react-components/react-accordion/stories/src/Accordion/AccordionMotionCustom.stories.tsx
+++ b/packages/react-components/react-accordion/stories/src/Accordion/AccordionMotionCustom.stories.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import type { JSXElement } from '@fluentui/react-components';
+import type { JSXElement, PersonaProps } from '@fluentui/react-components';
+import description from './AccordionMotionCustom.stories.md';
 import {
   Accordion,
   AccordionHeader,
@@ -7,27 +8,87 @@ import {
   AccordionPanel,
   Field,
   makeStyles,
+  motionTokens,
+  Persona,
   Slider,
   Switch,
   tokens,
 } from '@fluentui/react-components';
 
+const personaData = [
+  {
+    name: 'Kevin Sturgis',
+    image: 'persona-male.png',
+    status: 'available' as const,
+    useImage: true,
+    secondaryText: 'Available',
+  },
+  { name: 'Sarah Chen', status: 'busy' as const, useImage: false, secondaryText: 'In a meeting' },
+  {
+    name: 'Jessica Brown',
+    image: 'persona-female.png',
+    status: 'busy' as const,
+    useImage: true,
+    secondaryText: 'Do not disturb',
+  },
+  { name: 'Emily Johnson', status: 'available' as const, useImage: false, secondaryText: 'Available' },
+  { name: 'David Kim', status: 'offline' as const, useImage: false, secondaryText: 'Offline' },
+  {
+    name: 'Michael Rodriguez',
+    image: 'persona-male.png',
+    status: 'away' as const,
+    useImage: true,
+    secondaryText: 'Away',
+  },
+];
+
+const avatarFor = (useImage?: boolean, image?: string): PersonaProps['avatar'] =>
+  useImage
+    ? {
+        image: {
+          src: `https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-react-assets/${image}`,
+        },
+      }
+    : { color: 'colorful' };
+
 const useStyles = makeStyles({
   controls: {
     display: 'flex',
     flexDirection: 'column',
-    gap: '8px',
-    marginBottom: '16px',
-    padding: '12px',
+    gap: tokens.spacingVerticalS,
+    marginBottom: tokens.spacingVerticalL,
+    padding: tokens.spacingVerticalM,
     border: `${tokens.strokeWidthThicker} solid ${tokens.colorNeutralForeground3}`,
     borderRadius: tokens.borderRadiusMedium,
+  },
+  list: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: tokens.spacingVerticalM,
+    padding: `${tokens.spacingVerticalS} 0`,
   },
 });
 
 export const MotionCustom = (): JSXElement => {
   const classes = useStyles();
-  const [duration, setDuration] = React.useState(300);
+  const [duration, setDuration] = React.useState(1000);
   const [animateOpacity, setAnimateOpacity] = React.useState(true);
+
+  const renderList = (items: typeof personaData) => (
+    <div className={classes.list}>
+      {items.map(item => (
+        <Persona
+          key={item.name}
+          name={item.name}
+          secondaryText={item.secondaryText}
+          presence={{ status: item.status }}
+          avatar={avatarFor(item.useImage, item.image)}
+        />
+      ))}
+    </div>
+  );
+
+  const easing = motionTokens.curveDecelerateMid;
 
   return (
     <>
@@ -44,21 +105,21 @@ export const MotionCustom = (): JSXElement => {
 
       <Accordion collapsible>
         <AccordionItem value="1">
-          <AccordionHeader>Accordion Header 1</AccordionHeader>
-          <AccordionPanel collapseMotion={{ duration, animateOpacity }}>
-            <div>Accordion Panel 1</div>
+          <AccordionHeader>Team A</AccordionHeader>
+          <AccordionPanel collapseMotion={{ duration, easing, animateOpacity }}>
+            {renderList(personaData.slice(0, 3))}
           </AccordionPanel>
         </AccordionItem>
         <AccordionItem value="2">
-          <AccordionHeader>Accordion Header 2</AccordionHeader>
-          <AccordionPanel collapseMotion={{ duration, animateOpacity }}>
-            <div>Accordion Panel 2</div>
+          <AccordionHeader>Team B</AccordionHeader>
+          <AccordionPanel collapseMotion={{ duration, easing, animateOpacity }}>
+            {renderList(personaData.slice(3))}
           </AccordionPanel>
         </AccordionItem>
         <AccordionItem value="3">
-          <AccordionHeader>Accordion Header 3</AccordionHeader>
-          <AccordionPanel collapseMotion={{ duration, animateOpacity }}>
-            <div>Accordion Panel 3</div>
+          <AccordionHeader>Team C</AccordionHeader>
+          <AccordionPanel collapseMotion={{ duration, easing, animateOpacity }}>
+            {renderList(personaData)}
           </AccordionPanel>
         </AccordionItem>
       </Accordion>
@@ -69,10 +130,7 @@ export const MotionCustom = (): JSXElement => {
 MotionCustom.parameters = {
   docs: {
     description: {
-      story:
-        'The `collapseMotion` slot on `AccordionPanel` is typed with `CollapseParams`, so motion ' +
-        'parameters like `duration` and `animateOpacity` can be passed directly as props — ' +
-        'no `children` render function needed.',
+      story: description,
     },
   },
 };

--- a/packages/react-components/react-accordion/stories/src/Accordion/index.stories.tsx
+++ b/packages/react-components/react-accordion/stories/src/Accordion/index.stories.tsx
@@ -11,6 +11,7 @@ export { Disabled } from './AccordionDisabled.stories';
 export { ExpandIcon } from './AccordionExpandIcon.stories';
 export { ExpandIconPosition } from './AccordionExpandIconPosition.stories';
 export { WithIcon } from './AccordionWithIcon.stories';
+export { MotionCustom } from './AccordionMotionCustom.stories';
 import descriptionMd from './AccordionDescription.md';
 
 export default {

--- a/packages/react-components/react-dialog/library/etc/react-dialog.api.md
+++ b/packages/react-components/react-dialog/library/etc/react-dialog.api.md
@@ -10,11 +10,13 @@ import type { ComponentProps } from '@fluentui/react-utilities';
 import type { ComponentState } from '@fluentui/react-utilities';
 import type { ContextSelector } from '@fluentui/react-context-selector';
 import type { ExtractSlotProps } from '@fluentui/react-utilities';
+import type { FadeParams } from '@fluentui/react-motion-components-preview';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import type { JSXElement } from '@fluentui/react-utilities';
 import type { PortalProps } from '@fluentui/react-portal';
 import type { PresenceMotionSlotProps } from '@fluentui/react-motion';
 import * as React_2 from 'react';
+import type { ScaleParams } from '@fluentui/react-motion-components-preview';
 import type { Slot } from '@fluentui/react-utilities';
 import type { SlotClassNames } from '@fluentui/react-utilities';
 import type { TriggerProps } from '@fluentui/react-utilities';
@@ -158,7 +160,7 @@ export const DialogProvider: React_2.Provider<DialogContextValue | undefined> & 
 
 // @public (undocumented)
 export type DialogSlots = {
-    surfaceMotion: Slot<PresenceMotionSlotProps>;
+    surfaceMotion: Slot<PresenceMotionSlotProps<ScaleParams>>;
 };
 
 // @public (undocumented)
@@ -194,7 +196,7 @@ export const DialogSurfaceProvider: React_2.Provider<boolean | undefined>;
 export type DialogSurfaceSlots = {
     backdrop?: Slot<DialogBackdropSlotProps>;
     root: Slot<'div'>;
-    backdropMotion: Slot<PresenceMotionSlotProps>;
+    backdropMotion: Slot<PresenceMotionSlotProps<FadeParams>>;
 };
 
 // @public

--- a/packages/react-components/react-dialog/library/src/components/Dialog/Dialog.types.ts
+++ b/packages/react-components/react-dialog/library/src/components/Dialog/Dialog.types.ts
@@ -1,5 +1,6 @@
 import type * as React from 'react';
 import type { PresenceMotionSlotProps } from '@fluentui/react-motion';
+import type { ScaleParams } from '@fluentui/react-motion-components-preview';
 import type { ComponentProps, ComponentState, JSXElement, Slot } from '@fluentui/react-utilities';
 
 import type { DialogContextValue, DialogSurfaceContextValue } from '../../contexts';
@@ -10,11 +11,11 @@ export type DialogSlots = {
    * For more information refer to the [Motion docs page](https://react.fluentui.dev/?path=/docs/motion-motion-slot--docs).
    *
    */
-  surfaceMotion: Slot<PresenceMotionSlotProps>;
+  surfaceMotion: Slot<PresenceMotionSlotProps<ScaleParams>>;
 };
 
 export type InternalDialogSlots = {
-  surfaceMotion: NonNullable<Slot<PresenceMotionSlotProps>>;
+  surfaceMotion: NonNullable<Slot<PresenceMotionSlotProps<ScaleParams>>>;
 };
 
 export type DialogOpenChangeEvent = DialogOpenChangeData['event'];

--- a/packages/react-components/react-dialog/library/src/components/DialogSurface/DialogSurface.types.ts
+++ b/packages/react-components/react-dialog/library/src/components/DialogSurface/DialogSurface.types.ts
@@ -1,4 +1,5 @@
 import type { PresenceMotionSlotProps } from '@fluentui/react-motion';
+import type { FadeParams } from '@fluentui/react-motion-components-preview';
 import type { PortalProps } from '@fluentui/react-portal';
 import type { ComponentProps, ComponentState, Slot, ExtractSlotProps } from '@fluentui/react-utilities';
 
@@ -40,7 +41,7 @@ export type DialogSurfaceSlots = {
    * For more information refer to the [Motion docs page](https://react.fluentui.dev/?path=/docs/motion-motion-slot--docs).
    *
    */
-  backdropMotion: Slot<PresenceMotionSlotProps>;
+  backdropMotion: Slot<PresenceMotionSlotProps<FadeParams>>;
 };
 
 /**

--- a/packages/react-components/react-drawer/library/src/shared/drawerMotionUtils.tsx
+++ b/packages/react-components/react-drawer/library/src/shared/drawerMotionUtils.tsx
@@ -32,5 +32,5 @@ export function mergePresenceSlots<
         </Component>
       );
     },
-  };
+  } as PresenceMotionSlotProps<BaseMotionParams>;
 }

--- a/packages/react-components/react-motion/library/etc/react-motion.api.md
+++ b/packages/react-components/react-motion/library/etc/react-motion.api.md
@@ -100,7 +100,7 @@ export function motionSlot<MotionParams extends Record<string, MotionParam> = {}
 }): SlotComponentType<MotionSlotRenderProps & MotionParams>;
 
 // @public (undocumented)
-export type MotionSlotProps<MotionParams extends Record<string, MotionParam> = {}> = Pick<MotionComponentProps, 'imperativeRef' | 'onMotionFinish' | 'onMotionStart' | 'onMotionCancel'> & {
+export type MotionSlotProps<MotionParams extends Record<string, MotionParam> = {}> = Pick<MotionComponentProps, 'imperativeRef' | 'onMotionFinish' | 'onMotionStart' | 'onMotionCancel'> & Partial<MotionParams> & {
     as?: JSXIntrinsicElementKeys;
     children?: SlotRenderFunction<MotionSlotRenderProps & MotionParams & {
         children: JSXElement;
@@ -196,7 +196,7 @@ export function presenceMotionSlot<MotionParams extends Record<string, MotionPar
 }): SlotComponentType<PresenceMotionSlotRenderProps & MotionParams>;
 
 // @public (undocumented)
-export type PresenceMotionSlotProps<MotionParams extends Record<string, MotionParam> = {}> = Pick<PresenceComponentProps, 'imperativeRef' | 'onMotionFinish' | 'onMotionStart'> & {
+export type PresenceMotionSlotProps<MotionParams extends Record<string, MotionParam> = {}> = Pick<PresenceComponentProps, 'imperativeRef' | 'onMotionFinish' | 'onMotionStart'> & Partial<MotionParams> & {
     as?: JSXIntrinsicElementKeys;
     children?: SlotRenderFunction<PresenceMotionSlotRenderProps & MotionParams & {
         children: JSXElement;

--- a/packages/react-components/react-motion/library/src/slots/motionSlot.test.tsx
+++ b/packages/react-components/react-motion/library/src/slots/motionSlot.test.tsx
@@ -8,9 +8,15 @@ import * as React from 'react';
 import { createMotionComponent } from '../factories/createMotionComponent';
 import { motionSlot, type MotionSlotProps } from './motionSlot';
 
+type TestMotionParams = { duration?: number; easing?: string };
+
 type TestComponentSlots = { motion: Slot<MotionSlotProps> };
 type TestComponentProps = ComponentProps<Partial<TestComponentSlots>>;
 type TestComponentState = ComponentState<TestComponentSlots>;
+
+type ParamTestComponentSlots = { motion: Slot<MotionSlotProps<TestMotionParams>> };
+type ParamTestComponentProps = ComponentProps<Partial<ParamTestComponentSlots>>;
+type ParamTestComponentState = ComponentState<ParamTestComponentSlots>;
 
 const TestMotion = jest.fn(
   createMotionComponent({
@@ -42,6 +48,30 @@ const TestComponent: React.FC<TestComponentProps> = props => {
           </state.motion>
         )
       }
+    </div>
+  );
+};
+
+const ParamTestComponent: React.FC<ParamTestComponentProps> = props => {
+  const state: ParamTestComponentState = {
+    components: {
+      motion: TestMotion,
+    },
+    motion: motionSlot(props.motion, {
+      elementType: TestMotion,
+      defaultProps: {},
+    }),
+  };
+
+  assertSlots<ParamTestComponentSlots>(state);
+
+  return (
+    <div data-testid="root">
+      {state.motion && (
+        <state.motion>
+          <div data-testid="content" />
+        </state.motion>
+      )}
     </div>
   );
 };
@@ -87,5 +117,38 @@ describe('motionSlot', () => {
 
     expect(queryByTestId('content')).not.toBeNull();
     expect(TestMotion).not.toHaveBeenCalled();
+  });
+});
+
+describe('motionSlot (with MotionParams)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('forwards MotionParams directly to the motion component', () => {
+    render(<ParamTestComponent motion={{ duration: 500, easing: 'ease-in' }} />);
+
+    expect(TestMotion).toHaveBeenCalled();
+    const firstCall = TestMotion.mock.calls[0];
+    expect(firstCall[0]).toEqual(expect.objectContaining({ duration: 500, easing: 'ease-in' }));
+  });
+
+  it('passes MotionParams to the children render function', () => {
+    const renderFn = jest.fn((Component, props) => <Component {...props} />);
+    render(<ParamTestComponent motion={{ duration: 500, easing: 'ease-in', children: renderFn }} />);
+
+    expect(renderFn).toHaveBeenCalled();
+    const [, renderProps] = renderFn.mock.calls[0];
+    expect(renderProps).toEqual(expect.objectContaining({ duration: 500, easing: 'ease-in' }));
+  });
+
+  it('does not pass "as" or "children" through to the render function props', () => {
+    const renderFn = jest.fn((Component, props) => <Component {...props} />);
+    render(<ParamTestComponent motion={{ duration: 500, children: renderFn }} />);
+
+    expect(renderFn).toHaveBeenCalled();
+    const [, renderProps] = renderFn.mock.calls[0];
+    expect(renderProps).not.toHaveProperty('as');
+    expect(renderProps).not.toHaveProperty('children', renderFn);
   });
 });

--- a/packages/react-components/react-motion/library/src/slots/motionSlot.tsx
+++ b/packages/react-components/react-motion/library/src/slots/motionSlot.tsx
@@ -18,20 +18,21 @@ type MotionSlotRenderProps = Pick<MotionComponentProps, 'onMotionFinish' | 'onMo
 export type MotionSlotProps<MotionParams extends Record<string, MotionParam> = {}> = Pick<
   MotionComponentProps,
   'imperativeRef' | 'onMotionFinish' | 'onMotionStart' | 'onMotionCancel'
-> & {
-  // FIXME: 'as' property is required by design on the slot AP but it does not support components, only intrinsic
-  //        elements motion slots do not support intrinsic elements, only custom components.
-  /**
-   * @deprecated Do not use. Motion Slots do not support intrinsic elements.
-   *
-   * If you want to override the animation, use the children render function instead.
-   */
-  as?: JSXIntrinsicElementKeys;
+> &
+  Partial<MotionParams> & {
+    // FIXME: 'as' property is required by design on the slot AP but it does not support components, only intrinsic
+    //        elements motion slots do not support intrinsic elements, only custom components.
+    /**
+     * @deprecated Do not use. Motion Slots do not support intrinsic elements.
+     *
+     * If you want to override the animation, use the children render function instead.
+     */
+    as?: JSXIntrinsicElementKeys;
 
-  // TODO: remove once React v18 slot API is modified ComponentProps is not properly adding render function as a
-  //       possible value for children
-  children?: SlotRenderFunction<MotionSlotRenderProps & MotionParams & { children: JSXElement }>;
-};
+    // TODO: remove once React v18 slot API is modified ComponentProps is not properly adding render function as a
+    //       possible value for children
+    children?: SlotRenderFunction<MotionSlotRenderProps & MotionParams & { children: JSXElement }>;
+  };
 
 export function motionSlot<MotionParams extends Record<string, MotionParam> = {}>(
   motion: MotionSlotProps<MotionParams> | null | undefined,

--- a/packages/react-components/react-motion/library/src/slots/presenceMotionSlot.test.tsx
+++ b/packages/react-components/react-motion/library/src/slots/presenceMotionSlot.test.tsx
@@ -8,9 +8,15 @@ import * as React from 'react';
 import { createPresenceComponent } from '../factories/createPresenceComponent';
 import { presenceMotionSlot, type PresenceMotionSlotProps } from './presenceMotionSlot';
 
+type TestMotionParams = { duration?: number; easing?: string };
+
 type TestComponentSlots = { presenceMotion: Slot<PresenceMotionSlotProps> };
 type TestComponentProps = ComponentProps<Partial<TestComponentSlots>> & { visible: boolean };
 type TestComponentState = ComponentState<TestComponentSlots>;
+
+type ParamTestComponentSlots = { presenceMotion: Slot<PresenceMotionSlotProps<TestMotionParams>> };
+type ParamTestComponentProps = ComponentProps<Partial<ParamTestComponentSlots>> & { visible: boolean };
+type ParamTestComponentState = ComponentState<ParamTestComponentSlots>;
 
 const TestMotion = jest.fn(
   createPresenceComponent({
@@ -42,6 +48,30 @@ const TestComponent: React.FC<TestComponentProps> = props => {
           </state.presenceMotion>
         )
       }
+    </div>
+  );
+};
+
+const ParamTestComponent: React.FC<ParamTestComponentProps> = props => {
+  const state: ParamTestComponentState = {
+    components: {
+      presenceMotion: TestMotion,
+    },
+    presenceMotion: presenceMotionSlot(props.presenceMotion, {
+      elementType: TestMotion,
+      defaultProps: { visible: props.visible, unmountOnExit: true },
+    }),
+  };
+
+  assertSlots<ParamTestComponentSlots>(state);
+
+  return (
+    <div data-testid="root">
+      {state.presenceMotion && (
+        <state.presenceMotion>
+          <div data-testid="content" />
+        </state.presenceMotion>
+      )}
     </div>
   );
 };
@@ -129,5 +159,40 @@ describe('presenceMotionSlot', () => {
 
     expect(queryByTestId('content')).toBeNull();
     expect(TestMotion).not.toHaveBeenCalled();
+  });
+});
+
+describe('presenceMotionSlot (with MotionParams)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('forwards MotionParams directly to the motion component', () => {
+    render(<ParamTestComponent presenceMotion={{ duration: 500, easing: 'ease-in' }} visible />);
+
+    expect(TestMotion).toHaveBeenCalled();
+    const firstCall = TestMotion.mock.calls[0];
+    expect(firstCall[0]).toEqual(expect.objectContaining({ duration: 500, easing: 'ease-in' }));
+  });
+
+  it('passes MotionParams to the children render function', () => {
+    const renderFn = jest.fn((Component, props) => <Component {...props} />);
+    render(<ParamTestComponent presenceMotion={{ duration: 500, easing: 'ease-in', children: renderFn }} visible />);
+
+    expect(renderFn).toHaveBeenCalled();
+    const [, renderProps] = renderFn.mock.calls[0];
+    expect(renderProps).toEqual(
+      expect.objectContaining({ duration: 500, easing: 'ease-in', visible: true, unmountOnExit: true }),
+    );
+  });
+
+  it('does not pass "as" or "children" through to the render function props', () => {
+    const renderFn = jest.fn((Component, props) => <Component {...props} />);
+    render(<ParamTestComponent presenceMotion={{ duration: 500, children: renderFn }} visible />);
+
+    expect(renderFn).toHaveBeenCalled();
+    const [, renderProps] = renderFn.mock.calls[0];
+    expect(renderProps).not.toHaveProperty('as');
+    expect(renderProps).not.toHaveProperty('children', renderFn);
   });
 });

--- a/packages/react-components/react-motion/library/src/slots/presenceMotionSlot.tsx
+++ b/packages/react-components/react-motion/library/src/slots/presenceMotionSlot.tsx
@@ -21,20 +21,21 @@ type PresenceMotionSlotRenderProps = Pick<
 export type PresenceMotionSlotProps<MotionParams extends Record<string, MotionParam> = {}> = Pick<
   PresenceComponentProps,
   'imperativeRef' | 'onMotionFinish' | 'onMotionStart'
-> & {
-  // FIXME: 'as' property is required by design on the slot AP but it does not support components, only intrinsic
-  //        elements motion slots do not support intrinsic elements, only custom components.
-  /**
-   * @deprecated Do not use. Presence Motion Slots do not support intrinsic elements.
-   *
-   * If you want to override the animation, use the children render function instead.
-   */
-  as?: JSXIntrinsicElementKeys;
+> &
+  Partial<MotionParams> & {
+    // FIXME: 'as' property is required by design on the slot AP but it does not support components, only intrinsic
+    //        elements motion slots do not support intrinsic elements, only custom components.
+    /**
+     * @deprecated Do not use. Presence Motion Slots do not support intrinsic elements.
+     *
+     * If you want to override the animation, use the children render function instead.
+     */
+    as?: JSXIntrinsicElementKeys;
 
-  // TODO: remove once React v18 slot API is modified ComponentProps is not properly adding render function as a
-  //       possible value for children
-  children?: SlotRenderFunction<PresenceMotionSlotRenderProps & MotionParams & { children: JSXElement }>;
-};
+    // TODO: remove once React v18 slot API is modified ComponentProps is not properly adding render function as a
+    //       possible value for children
+    children?: SlotRenderFunction<PresenceMotionSlotRenderProps & MotionParams & { children: JSXElement }>;
+  };
 
 export function presenceMotionSlot<MotionParams extends Record<string, MotionParam> = {}>(
   motion: PresenceMotionSlotProps<MotionParams> | null | undefined,

--- a/packages/react-components/react-motion/stories/src/Motion/DirectParams.stories.tsx
+++ b/packages/react-components/react-motion/stories/src/Motion/DirectParams.stories.tsx
@@ -1,0 +1,178 @@
+import * as React from 'react';
+import type { JSXElement } from '@fluentui/react-components';
+import {
+  Dialog,
+  tokens,
+  DialogTrigger,
+  DialogSurface,
+  makeStyles,
+  DialogTitle,
+  DialogBody,
+  DialogActions,
+  DialogContent,
+  Button,
+  Field,
+  Slider,
+  Text,
+} from '@fluentui/react-components';
+
+const useStyles = makeStyles({
+  wrapper: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '20px',
+    maxWidth: '600px',
+  },
+  controls: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '8px',
+    padding: '12px',
+    border: `${tokens.strokeWidthThicker} solid ${tokens.colorNeutralForeground3}`,
+    borderRadius: tokens.borderRadiusMedium,
+  },
+  row: {
+    display: 'flex',
+    gap: '20px',
+    alignItems: 'start',
+  },
+  column: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '8px',
+    flex: 1,
+  },
+  codeBlock: {
+    fontFamily: tokens.fontFamilyMonospace,
+    fontSize: tokens.fontSizeBase200,
+    backgroundColor: tokens.colorNeutralBackground1Pressed,
+    borderRadius: tokens.borderRadiusMedium,
+    padding: '8px 12px',
+    whiteSpace: 'pre',
+  },
+});
+
+/**
+ * When a component's motion slot type includes generic parameters, those parameters
+ * can be passed directly as props on the slot object — no `children` render function needed.
+ *
+ * Dialog's `surfaceMotion` slot is typed with `ScaleParams`, exposing parameters like
+ * `duration`, `outScale`, and `easing` as direct overrides. This follows the same pattern
+ * as regular Fluent UI slots: `badge=&#123;&#123; status: 'available' &#125;&#125;`.
+ */
+export const DirectParams = (): JSXElement => {
+  const classes = useStyles();
+  const [duration, setDuration] = React.useState(600);
+  const [outScale, setOutScale] = React.useState(0.5);
+
+  return (
+    <div className={classes.wrapper}>
+      <div className={classes.controls}>
+        <Field label={`Enter duration: ${duration}ms`}>
+          <Slider min={100} max={2000} step={50} value={duration} onChange={(_, data) => setDuration(data.value)} />
+        </Field>
+        <Field label={`Out scale: ${outScale.toFixed(2)}`}>
+          <Slider min={0} max={1} step={0.05} value={outScale} onChange={(_, data) => setOutScale(data.value)} />
+        </Field>
+      </div>
+
+      <div className={classes.row}>
+        <div className={classes.column}>
+          <Text weight="semibold">Direct params (concise)</Text>
+          <Dialog
+            surfaceMotion={{
+              duration,
+              outScale,
+            }}
+          >
+            <DialogTrigger disableButtonEnhancement>
+              <Button>Open Dialog</Button>
+            </DialogTrigger>
+            <DialogSurface>
+              <DialogBody>
+                <DialogTitle>Direct param override</DialogTitle>
+                <DialogContent>
+                  The <code>duration</code> and <code>outScale</code> props are passed directly on the{' '}
+                  <code>surfaceMotion</code> slot object.
+                </DialogContent>
+                <DialogActions>
+                  <DialogTrigger disableButtonEnhancement>
+                    <Button appearance="secondary">Close</Button>
+                  </DialogTrigger>
+                </DialogActions>
+              </DialogBody>
+            </DialogSurface>
+          </Dialog>
+          <div className={classes.codeBlock}>
+            {`<Dialog
+  surfaceMotion={{
+    duration: ${duration},
+    outScale: ${outScale.toFixed(2)},
+  }}
+>`}
+          </div>
+        </div>
+
+        <div className={classes.column}>
+          <Text weight="semibold">Children render function (verbose)</Text>
+          <Dialog
+            surfaceMotion={{
+              children: (Motion, props) => (
+                <Motion {...props} duration={duration} outScale={outScale}>
+                  {props.children}
+                </Motion>
+              ),
+            }}
+          >
+            <DialogTrigger disableButtonEnhancement>
+              <Button>Open Dialog</Button>
+            </DialogTrigger>
+            <DialogSurface>
+              <DialogBody>
+                <DialogTitle>Render function override</DialogTitle>
+                <DialogContent>
+                  The same override using a <code>children</code> render function — functionally identical but more
+                  verbose.
+                </DialogContent>
+                <DialogActions>
+                  <DialogTrigger disableButtonEnhancement>
+                    <Button appearance="secondary">Close</Button>
+                  </DialogTrigger>
+                </DialogActions>
+              </DialogBody>
+            </DialogSurface>
+          </Dialog>
+          <div className={classes.codeBlock}>
+            {`<Dialog
+  surfaceMotion={{
+    children: (Motion, props) => (
+      <Motion
+        {...props}
+        duration={${duration}}
+        outScale={${outScale.toFixed(2)}}
+      >
+        {props.children}
+      </Motion>
+    ),
+  }}
+>`}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+DirectParams.parameters = {
+  docs: {
+    description: {
+      story:
+        'Motion slot parameters can be passed directly as props on the slot object, ' +
+        'without using the `children` render function. This works when the component ' +
+        'declares its motion slot with typed parameters ' +
+        '(e.g. `Slot<PresenceMotionSlotProps<ScaleParams>>`). ' +
+        'Compare the two approaches side by side — direct params for simple overrides, ' +
+        'render function for full motion replacement.',
+    },
+  },
+};

--- a/packages/react-components/react-motion/stories/src/Motion/index.stories.tsx
+++ b/packages/react-components/react-motion/stories/src/Motion/index.stories.tsx
@@ -4,6 +4,7 @@ import description from './MotionDescription.md';
 
 export { DisableMotion } from './DisableMotion.stories';
 export { CustomMotion } from './CustomMotion.stories';
+export { DirectParams } from './DirectParams.stories';
 
 export default {
   title: 'Motion/Motion Slot',

--- a/packages/react-components/react-tree/library/etc/react-tree.api.md
+++ b/packages/react-components/react-tree/library/etc/react-tree.api.md
@@ -13,6 +13,7 @@ import type { AvatarSize } from '@fluentui/react-avatar';
 import type { ButtonContextValue } from '@fluentui/react-button';
 import type { Checkbox } from '@fluentui/react-checkbox';
 import type { CheckboxProps } from '@fluentui/react-checkbox';
+import type { CollapseParams } from '@fluentui/react-motion-components-preview';
 import type { ComponentProps } from '@fluentui/react-utilities';
 import type { ComponentState } from '@fluentui/react-utilities';
 import type { ContextSelector } from '@fluentui/react-context-selector';
@@ -408,7 +409,7 @@ export type TreeSelectionValue = MultiSelectValue | SingleSelectValue;
 // @public (undocumented)
 export type TreeSlots = {
     root: Slot<'div'>;
-    collapseMotion?: Slot<PresenceMotionSlotProps>;
+    collapseMotion?: Slot<PresenceMotionSlotProps<CollapseParams>>;
 };
 
 // @public

--- a/packages/react-components/react-tree/library/src/components/Tree/Tree.types.ts
+++ b/packages/react-components/react-tree/library/src/components/Tree/Tree.types.ts
@@ -1,5 +1,6 @@
 import type * as React from 'react';
 import type { PresenceMotionSlotProps } from '@fluentui/react-motion';
+import type { CollapseParams } from '@fluentui/react-motion-components-preview';
 import type { ComponentProps, ComponentState, SelectionMode, Slot } from '@fluentui/react-utilities';
 import type { TreeContextValue, SubtreeContextValue } from '../../contexts';
 import type { ArrowDown, ArrowLeft, ArrowRight, ArrowUp, End, Enter, Home } from '@fluentui/keyboard-keys';
@@ -13,7 +14,7 @@ export type TreeSelectionValue = MultiSelectValue | SingleSelectValue;
 
 export type TreeSlots = {
   root: Slot<'div'>;
-  collapseMotion?: Slot<PresenceMotionSlotProps>;
+  collapseMotion?: Slot<PresenceMotionSlotProps<CollapseParams>>;
 };
 
 // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/packages/react-components/react-tree/stories/src/Tree/TreeMotionCustom.stories.md
+++ b/packages/react-components/react-tree/stories/src/Tree/TreeMotionCustom.stories.md
@@ -1,0 +1,16 @@
+`Tree`'s `collapseMotion` slot can directly take `Collapse` props, such as `duration`, `easing`, `animateOpacity` and others.
+
+The `collapseMotion` slot also supports the `children` render function, which allows replacing the default `Collapse` with a custom implementation. This story demonstrates the simpler direct prop approach.
+
+Note that `collapseMotion` must be set on each subtree `<Tree>` element — not the root — since the root tree does not animate:
+
+```tsx
+// Don't use collapseMotion on the root tree, which does not animate
+<Tree aria-label="...">
+  <TreeItem itemType="branch">
+    <TreeItemLayout>Branch label</TreeItemLayout>
+    {/* Use collapseMotion on the subtree */}
+    <Tree collapseMotion={{ duration, easing, animateOpacity }}>{/* leaf items */}</Tree>
+  </TreeItem>
+</Tree>
+```

--- a/packages/react-components/react-tree/stories/src/Tree/TreeMotionCustom.stories.tsx
+++ b/packages/react-components/react-tree/stories/src/Tree/TreeMotionCustom.stories.tsx
@@ -1,0 +1,77 @@
+import * as React from 'react';
+import type { JSXElement } from '@fluentui/react-components';
+import { Field, makeStyles, Slider, Switch, tokens, Tree, TreeItem, TreeItemLayout } from '@fluentui/react-components';
+
+const useStyles = makeStyles({
+  controls: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '8px',
+    marginBottom: '16px',
+    padding: '12px',
+    border: `${tokens.strokeWidthThicker} solid ${tokens.colorNeutralForeground3}`,
+    borderRadius: tokens.borderRadiusMedium,
+  },
+});
+
+export const MotionCustom = (): JSXElement => {
+  const classes = useStyles();
+  const [duration, setDuration] = React.useState(300);
+  const [animateOpacity, setAnimateOpacity] = React.useState(true);
+
+  return (
+    <>
+      <div className={classes.controls}>
+        <Field label={`Duration: ${duration}ms`}>
+          <Slider min={100} max={2000} step={50} value={duration} onChange={(_, data) => setDuration(data.value)} />
+        </Field>
+        <Switch
+          label="Animate opacity"
+          checked={animateOpacity}
+          onChange={(_, data) => setAnimateOpacity(data.checked)}
+        />
+      </div>
+
+      <Tree aria-label="Motion Custom" collapseMotion={{ duration, animateOpacity }}>
+        <TreeItem itemType="branch">
+          <TreeItemLayout>level 1, item 1</TreeItemLayout>
+          <Tree>
+            <TreeItem itemType="leaf">
+              <TreeItemLayout>level 2, item 1</TreeItemLayout>
+            </TreeItem>
+            <TreeItem itemType="leaf">
+              <TreeItemLayout>level 2, item 2</TreeItemLayout>
+            </TreeItem>
+            <TreeItem itemType="leaf">
+              <TreeItemLayout>level 2, item 3</TreeItemLayout>
+            </TreeItem>
+          </Tree>
+        </TreeItem>
+        <TreeItem itemType="branch">
+          <TreeItemLayout>level 1, item 2</TreeItemLayout>
+          <Tree>
+            <TreeItem itemType="branch">
+              <TreeItemLayout>level 2, item 1</TreeItemLayout>
+              <Tree>
+                <TreeItem itemType="leaf">
+                  <TreeItemLayout>level 3, item 1</TreeItemLayout>
+                </TreeItem>
+              </Tree>
+            </TreeItem>
+          </Tree>
+        </TreeItem>
+      </Tree>
+    </>
+  );
+};
+
+MotionCustom.parameters = {
+  docs: {
+    description: {
+      story:
+        'The `collapseMotion` slot on `Tree` is typed with `CollapseParams`, so motion ' +
+        'parameters like `duration` and `animateOpacity` can be passed directly as props — ' +
+        'no `children` render function needed.',
+    },
+  },
+};

--- a/packages/react-components/react-tree/stories/src/Tree/TreeMotionCustom.stories.tsx
+++ b/packages/react-components/react-tree/stories/src/Tree/TreeMotionCustom.stories.tsx
@@ -1,14 +1,62 @@
 import * as React from 'react';
-import type { JSXElement } from '@fluentui/react-components';
-import { Field, makeStyles, Slider, Switch, tokens, Tree, TreeItem, TreeItemLayout } from '@fluentui/react-components';
+import type { JSXElement, PersonaProps } from '@fluentui/react-components';
+import {
+  Field,
+  makeStyles,
+  motionTokens,
+  Persona,
+  Slider,
+  Switch,
+  tokens,
+  Tree,
+  TreeItem,
+  TreeItemLayout,
+} from '@fluentui/react-components';
+import description from './TreeMotionCustom.stories.md';
+
+const personaData = [
+  {
+    name: 'Kevin Sturgis',
+    image: 'persona-male.png',
+    status: 'available' as const,
+    useImage: true,
+    secondaryText: 'Available',
+  },
+  { name: 'Sarah Chen', status: 'busy' as const, useImage: false, secondaryText: 'In a meeting' },
+  {
+    name: 'Jessica Brown',
+    image: 'persona-female.png',
+    status: 'busy' as const,
+    useImage: true,
+    secondaryText: 'Do not disturb',
+  },
+  { name: 'Emily Johnson', status: 'available' as const, useImage: false, secondaryText: 'Available' },
+  { name: 'David Kim', status: 'offline' as const, useImage: false, secondaryText: 'Offline' },
+  {
+    name: 'Michael Rodriguez',
+    image: 'persona-male.png',
+    status: 'away' as const,
+    useImage: true,
+    secondaryText: 'Away',
+  },
+];
+
+const avatarFor = (useImage?: boolean, image?: string): PersonaProps['avatar'] =>
+  useImage
+    ? {
+        image: {
+          src: `https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-react-assets/${image}`,
+        },
+      }
+    : { color: 'colorful' };
 
 const useStyles = makeStyles({
   controls: {
     display: 'flex',
     flexDirection: 'column',
-    gap: '8px',
-    marginBottom: '16px',
-    padding: '12px',
+    gap: tokens.spacingVerticalS,
+    marginBottom: tokens.spacingVerticalL,
+    padding: tokens.spacingVerticalM,
     border: `${tokens.strokeWidthThicker} solid ${tokens.colorNeutralForeground3}`,
     borderRadius: tokens.borderRadiusMedium,
   },
@@ -16,8 +64,24 @@ const useStyles = makeStyles({
 
 export const MotionCustom = (): JSXElement => {
   const classes = useStyles();
-  const [duration, setDuration] = React.useState(300);
+  const [duration, setDuration] = React.useState(1000);
   const [animateOpacity, setAnimateOpacity] = React.useState(true);
+
+  const renderItems = (items: typeof personaData) =>
+    items.map(item => (
+      <TreeItem key={item.name} itemType="leaf">
+        <TreeItemLayout>
+          <Persona
+            name={item.name}
+            secondaryText={item.secondaryText}
+            presence={{ status: item.status }}
+            avatar={avatarFor(item.useImage, item.image)}
+          />
+        </TreeItemLayout>
+      </TreeItem>
+    ));
+
+  const easing = motionTokens.curveDecelerateMid;
 
   return (
     <>
@@ -32,33 +96,18 @@ export const MotionCustom = (): JSXElement => {
         />
       </div>
 
-      <Tree aria-label="Motion Custom" collapseMotion={{ duration, animateOpacity }}>
+      <Tree aria-label="Motion Custom">
         <TreeItem itemType="branch">
-          <TreeItemLayout>level 1, item 1</TreeItemLayout>
-          <Tree>
-            <TreeItem itemType="leaf">
-              <TreeItemLayout>level 2, item 1</TreeItemLayout>
-            </TreeItem>
-            <TreeItem itemType="leaf">
-              <TreeItemLayout>level 2, item 2</TreeItemLayout>
-            </TreeItem>
-            <TreeItem itemType="leaf">
-              <TreeItemLayout>level 2, item 3</TreeItemLayout>
-            </TreeItem>
-          </Tree>
+          <TreeItemLayout>Team A</TreeItemLayout>
+          <Tree collapseMotion={{ duration, easing, animateOpacity }}>{renderItems(personaData.slice(0, 3))}</Tree>
         </TreeItem>
         <TreeItem itemType="branch">
-          <TreeItemLayout>level 1, item 2</TreeItemLayout>
-          <Tree>
-            <TreeItem itemType="branch">
-              <TreeItemLayout>level 2, item 1</TreeItemLayout>
-              <Tree>
-                <TreeItem itemType="leaf">
-                  <TreeItemLayout>level 3, item 1</TreeItemLayout>
-                </TreeItem>
-              </Tree>
-            </TreeItem>
-          </Tree>
+          <TreeItemLayout>Team B</TreeItemLayout>
+          <Tree collapseMotion={{ duration, easing, animateOpacity }}>{renderItems(personaData.slice(3))}</Tree>
+        </TreeItem>
+        <TreeItem itemType="branch">
+          <TreeItemLayout>Team C</TreeItemLayout>
+          <Tree collapseMotion={{ duration, easing, animateOpacity }}>{renderItems(personaData)}</Tree>
         </TreeItem>
       </Tree>
     </>
@@ -68,10 +117,7 @@ export const MotionCustom = (): JSXElement => {
 MotionCustom.parameters = {
   docs: {
     description: {
-      story:
-        'The `collapseMotion` slot on `Tree` is typed with `CollapseParams`, so motion ' +
-        'parameters like `duration` and `animateOpacity` can be passed directly as props — ' +
-        'no `children` render function needed.',
+      story: description,
     },
   },
 };

--- a/packages/react-components/react-tree/stories/src/Tree/index.stories.tsx
+++ b/packages/react-components/react-tree/stories/src/Tree/index.stories.tsx
@@ -38,6 +38,7 @@ export { LazyLoading } from './TreeLazyLoading.stories';
 export { InfiniteScrolling } from './TreeInfiniteScrolling.stories';
 export { Virtualization } from './Virtualization.stories';
 export { DragAndDrop } from './TreeDragAndDrop.stories';
+export { MotionCustom } from './TreeMotionCustom.stories';
 
 export default {
   title: 'Components/Tree',


### PR DESCRIPTION
## Previous Behavior

`MotionSlotProps` and `PresenceMotionSlotProps` did not expose motion parameters (e.g. `duration`, `easing`) as direct props. To customize animation timing or easing on a motion slot, consumers had to use the `children` render function:

```tsx
<Dialog
  surfaceMotion={{
    children: (Motion, props) => <Motion {...props} duration={500} easing="ease-in" />
  }}
/>
```

`Dialog`'s `surfaceMotion` and `backdropMotion` slots were typed as `PresenceMotionSlotProps` with no params, giving no type-safe access to the underlying motion's parameters. `AccordionPanel`'s `collapseMotion` and `Tree`'s `collapseMotion` were similarly untyped.

## New Behavior

`MotionSlotProps<MotionParams>` and `PresenceMotionSlotProps<MotionParams>` now intersect with `Partial<MotionParams>`, so motion parameters are available as direct props on the slot object:

```tsx
<Dialog surfaceMotion={{ duration: 500, easing: "ease-in" }} />
```

The following motion slots are now typed with their specific parameter shapes:

- `Dialog`'s `surfaceMotion` → `PresenceMotionSlotProps<ScaleParams>`
- `Dialog`'s `backdropMotion` → `PresenceMotionSlotProps<FadeParams>`
- `AccordionPanel`'s `collapseMotion` → `PresenceMotionSlotProps<CollapseParams>`
- `Tree`'s `collapseMotion` → `PresenceMotionSlotProps<CollapseParams>`

The `children` render function approach continues to work as before.

## Stories

New and updated Storybook stories demonstrate the direct params API:

- **`react-motion` — `DirectParams`**: Interactive story using `Dialog` with sliders to control `duration` for `surfaceMotion` and `backdropMotion` directly as props.
- **`react-accordion` — `MotionCustom`**: Shows per-panel `collapseMotion` param overrides with realistic `Persona` list content, design tokens for easing (`motionTokens.curveDecelerateMid`), and an extracted `.md` story description.
- **`react-tree` — `MotionCustom`**: Same improvements as the Accordion story; also moves `collapseMotion` to each subtree (the root `Tree` does not animate).
