### PR TITLE
fix(web-components): descendant check perf regressions

### DIFF
--- a/change/@fluentui-web-components-b94e4cb5-2fad-446a-977a-a7e101d65b0f.json
+++ b/change/@fluentui-web-components-b94e4cb5-2fad-446a-977a-a7e101d65b0f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: improve SSR compatibility and component lifecycle management for Menu, Accordion, Dropdown, Tablist, and waitForConnectedDescendants",
+  "packageName": "@fluentui/web-components",
+  "email": "863023+radium-v@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/docs/web-components.api.md
+++ b/packages/web-components/docs/web-components.api.md
@@ -3243,11 +3243,14 @@ export class Menu extends FASTElement {
     persistOnItemClick?: boolean;
     persistOnItemClickChanged(oldValue: boolean, newValue: boolean): void;
     primaryAction: HTMLSlotElement;
+    // @deprecated
     setComponent(): void;
-    slottedMenuList: MenuList[];
+    slottedMenuList: HTMLElement[];
     // @internal
-    slottedMenuListChanged(prev: MenuList[] | undefined, next: MenuList[] | undefined): void;
+    slottedMenuListChanged(prev: HTMLElement[] | undefined, next: HTMLElement[] | undefined): void;
     slottedTriggers: HTMLElement[];
+    // @internal
+    slottedTriggersChanged(prev: HTMLElement[] | undefined, next: HTMLElement[] | undefined): void;
     split?: boolean;
     toggleHandler: (e: Event) => void;
     toggleMenu: () => void;

--- a/packages/web-components/playwright.config.ts
+++ b/packages/web-components/playwright.config.ts
@@ -2,7 +2,7 @@ import type { PlaywrightTestConfig } from '@playwright/test';
 import { devices } from '@playwright/test';
 
 const config: PlaywrightTestConfig = {
-  reporter: 'list',
+  reporter: process.env.CI ? 'github' : 'list',
   retries: 3,
   fullyParallel: process.env.CI ? false : true,
   timeout: process.env.CI ? 10000 : 30000,
@@ -27,6 +27,8 @@ const config: PlaywrightTestConfig = {
     command: 'yarn vite preview test/harness',
     port: 5173,
     reuseExistingServer: true,
+    stderr: 'pipe',
+    stdout: 'pipe',
   },
 };
 

--- a/packages/web-components/src/accordion/accordion.ts
+++ b/packages/web-components/src/accordion/accordion.ts
@@ -43,7 +43,7 @@ export class Accordion extends FASTElement {
     }
 
     // Clean up single expand mode behavior
-    (expandedItem as BaseAccordionItem)?.expandbutton.removeAttribute('aria-disabled');
+    (expandedItem as BaseAccordionItem)?.expandbutton?.removeAttribute('aria-disabled');
   }
 
   /**
@@ -61,10 +61,14 @@ export class Accordion extends FASTElement {
    * @internal
    */
   public slottedAccordionItemsChanged(oldValue: HTMLElement[], newValue: HTMLElement[]): void {
-    if (this.$fastController.isConnected) {
-      this.setItems();
-    }
+    this.setItems();
   }
+
+  /**
+   * Guard flag to prevent re-entrant calls to setSingleExpandMode.
+   * @internal
+   */
+  private _isAdjusting: boolean = false;
 
   /**
    * Watch for changes to the slotted accordion items `disabled` and `expanded` attributes
@@ -76,8 +80,10 @@ export class Accordion extends FASTElement {
     } else if (propertyName === 'expanded') {
       // we only need to manage single expanded instances
       // such as scenarios where a child is programatically expanded
-      if (source.expanded && this.isSingleExpandMode()) {
+      if (source.expanded && this.isSingleExpandMode() && !this._isAdjusting) {
+        this._isAdjusting = true;
         this.setSingleExpandMode(source);
+        this._isAdjusting = false;
       }
     }
   }
@@ -146,27 +152,25 @@ export class Accordion extends FASTElement {
    * @returns {void}
    */
   private setSingleExpandMode(expandedItem: Element): void {
-    requestAnimationFrame(() => {
-      if (this.accordionItems.length === 0) {
-        return;
-      }
-      const currentItems = Array.from(this.accordionItems);
-      this.activeItemIndex = currentItems.indexOf(expandedItem);
+    if (this.accordionItems.length === 0) {
+      return;
+    }
+    const currentItems = Array.from(this.accordionItems);
+    this.activeItemIndex = currentItems.indexOf(expandedItem);
 
-      currentItems.forEach((item: Element, index: number) => {
-        if (isAccordionItem(item)) {
-          if (this.activeItemIndex === index) {
-            item.expanded = true;
-            item.expandbutton.setAttribute('aria-disabled', 'true');
-          } else {
-            item.expanded = false;
+    currentItems.forEach((item: Element, index: number) => {
+      if (isAccordionItem(item)) {
+        if (this.activeItemIndex === index) {
+          item.expanded = true;
+          item.expandbutton?.setAttribute('aria-disabled', 'true');
+        } else {
+          item.expanded = false;
 
-            if (!item.hasAttribute('disabled')) {
-              item.expandbutton.removeAttribute('aria-disabled');
-            }
+          if (!item.hasAttribute('disabled')) {
+            item.expandbutton?.removeAttribute('aria-disabled');
           }
         }
-      });
+      }
     });
   }
 
@@ -206,9 +210,7 @@ export class Accordion extends FASTElement {
   connectedCallback(): void {
     super.connectedCallback();
 
-    requestAnimationFrame(() => {
-      this.expandmode = this.expandmode || AccordionExpandMode.multi;
-      this.setItems();
-    });
+    this.expandmode = this.expandmode || AccordionExpandMode.multi;
+    this.setItems();
   }
 }

--- a/packages/web-components/src/dropdown/dropdown.base.ts
+++ b/packages/web-components/src/dropdown/dropdown.base.ts
@@ -232,20 +232,24 @@ export class BaseDropdown extends FASTElement {
 
       notifier.notify('multiple');
 
-      Updates.enqueue(() => {
-        this.options.forEach(option => {
-          option.disabled = option.disabledAttribute || this.disabled;
-          option.name = this.name;
-        });
-
-        this.enabledOptions
-          .filter(x => x.defaultSelected)
-          .forEach((x, i) => {
-            x.selected = this.multiple || i === 0;
+      waitForConnectedDescendants(
+        next,
+        () => {
+          this.options.forEach(option => {
+            option.disabled = option.disabledAttribute || this.disabled;
+            option.name = this.name;
           });
 
-        this.setValidity();
-      });
+          this.enabledOptions
+            .filter(x => x.defaultSelected)
+            .forEach((x, i) => {
+              x.selected = this.multiple || i === 0;
+            });
+
+          this.setValidity();
+        },
+        { idleCallback: true },
+      );
 
       if (AnchorPositioningCSSSupported) {
         // The `anchor-name` property seems to not be isolated between instances in Safari Technology Preview 220 (18.4).

--- a/packages/web-components/src/dropdown/dropdown.base.ts
+++ b/packages/web-components/src/dropdown/dropdown.base.ts
@@ -802,6 +802,12 @@ export class BaseDropdown extends FASTElement {
   }
 
   /**
+   * Guard flag to prevent reentrant calls to `insertControl`.
+   * @internal
+   */
+  private _insertingControl = false;
+
+  /**
    * Inserts the control element based on the dropdown type.
    *
    * @public
@@ -809,6 +815,11 @@ export class BaseDropdown extends FASTElement {
    * This method can be overridden in derived classes to provide custom control elements, though this is not recommended.
    */
   protected insertControl(): void {
+    if (this._insertingControl) {
+      return;
+    }
+
+    this._insertingControl = true;
     this.controlSlot?.assignedNodes().forEach(x => this.removeChild(x));
 
     if (this.type === DropdownType.combobox) {
@@ -817,6 +828,7 @@ export class BaseDropdown extends FASTElement {
     }
 
     dropdownButtonTemplate.render(this, this);
+    this._insertingControl = false;
   }
 
   /**

--- a/packages/web-components/src/dropdown/dropdown.base.ts
+++ b/packages/web-components/src/dropdown/dropdown.base.ts
@@ -965,20 +965,22 @@ export class BaseDropdown extends FASTElement {
    * @internal
    */
   public setValidity(flags?: Partial<ValidityState>, message?: string, anchor?: HTMLElement): void {
-    if (this.$fastController.isConnected) {
-      if (this.disabled || !this.required) {
-        this.elementInternals.setValidity({});
-        return;
-      }
-
-      const valueMissing = this.required && this.listbox.selectedOptions.length === 0;
-
-      this.elementInternals.setValidity(
-        { valueMissing, ...flags },
-        message ?? this.validationMessage,
-        anchor ?? this.control,
-      );
+    if (!this.elementInternals) {
+      return;
     }
+
+    if (this.disabled || !this.required) {
+      this.elementInternals.setValidity({});
+      return;
+    }
+
+    const valueMissing = this.required && this.listbox.selectedOptions.length === 0;
+
+    this.elementInternals.setValidity(
+      { valueMissing, ...flags },
+      message ?? this.validationMessage,
+      anchor ?? this.control,
+    );
   }
 
   /**

--- a/packages/web-components/src/dropdown/dropdown.base.ts
+++ b/packages/web-components/src/dropdown/dropdown.base.ts
@@ -942,7 +942,9 @@ export class BaseDropdown extends FASTElement {
    */
   public selectOption(index: number = this.selectedIndex, shouldEmit: boolean = false): void {
     this.listbox.selectOption(index);
-    this.control.value = this.displayValue;
+    if (this.control) {
+      this.control.value = this.displayValue;
+    }
 
     this.setValidity();
 

--- a/packages/web-components/src/dropdown/dropdown.styles.ts
+++ b/packages/web-components/src/dropdown/dropdown.styles.ts
@@ -4,7 +4,7 @@ import {
   typographyBody2Styles,
   typographyCaption1Styles,
 } from '../styles/partials/typography.partials.js';
-import { flipBlockState, openState, placeholderShownState } from '../styles/states/index.js';
+import { openState, placeholderShownState } from '../styles/states/index.js';
 import {
   borderRadiusMedium,
   borderRadiusNone,
@@ -233,6 +233,7 @@ export const styles = css`
     color: ${colorNeutralForegroundDisabled};
   }
 
+  ::slotted(:not([slot]):not([popover])),
   ::slotted([popover]:not(:popover-open)) {
     display: none;
   }

--- a/packages/web-components/src/menu/menu.ts
+++ b/packages/web-components/src/menu/menu.ts
@@ -2,8 +2,6 @@ import { attr, FASTElement, observable, Updates } from '@microsoft/fast-element'
 import { keyEnter, keyEscape, keySpace, keyTab } from '@microsoft/fast-web-utilities';
 import { MenuItem } from '../menu-item/menu-item.js';
 import { MenuItemRole } from '../menu-item/menu-item.options.js';
-import type { MenuList } from '../menu-list/menu-list.js';
-import { waitForConnectedDescendants } from '../utils/request-idle-callback.js';
 
 /**
  * A Menu component that provides a customizable menu element.
@@ -90,7 +88,7 @@ export class Menu extends FASTElement {
    * @public
    */
   @observable
-  public slottedMenuList!: MenuList[];
+  public slottedMenuList!: HTMLElement[];
 
   /**
    * Sets up the component when the slotted menu list changes.
@@ -98,8 +96,16 @@ export class Menu extends FASTElement {
    * @param next - The new items in the slotted menu list.
    * @internal
    */
-  slottedMenuListChanged(prev: MenuList[] | undefined, next: MenuList[] | undefined): void {
-    this.setComponent();
+  slottedMenuListChanged(prev: HTMLElement[] | undefined, next: HTMLElement[] | undefined): void {
+    this._menuListAbortController?.abort();
+
+    if (!next?.length) {
+      return;
+    }
+
+    this._menuList = next[0];
+    this._menuList.popover = this.openOnContext ? 'manual' : '';
+    this.addMenuListListeners();
   }
 
   /**
@@ -108,6 +114,29 @@ export class Menu extends FASTElement {
    */
   @observable
   public slottedTriggers!: HTMLElement[];
+
+  /**
+   * Ensures the trigger is properly set up when the slotted triggers change.
+   * This includes setting ARIA attributes and adding event listeners based on the current property values.
+   *
+   * @param prev - The previous items in the slotted triggers list.
+   * @param next - The current items in the slotted triggers list.
+   * @internal
+   */
+  public slottedTriggersChanged(prev: HTMLElement[] | undefined, next: HTMLElement[] | undefined): void {
+    this._triggerAbortController?.abort();
+
+    if (next?.length) {
+      const trigger = next[0];
+      this._trigger = trigger;
+
+      if (this._trigger?.isConnected) {
+        this._trigger.setAttribute('aria-haspopup', 'true');
+        this._trigger.setAttribute('aria-expanded', `${this._open}`);
+        this.addTriggerListeners();
+      }
+    }
+  }
 
   /**
    * Holds the primary slot element.
@@ -134,12 +163,25 @@ export class Menu extends FASTElement {
   private _menuList?: HTMLElement;
 
   /**
+   * @internal
+   */
+  private _triggerAbortController?: AbortController;
+
+  /**
+   * @internal
+   */
+  private _menuListAbortController?: AbortController;
+
+  /**
    * Called when the element is connected to the DOM.
    * Sets up the component.
    * @public
    */
   public connectedCallback() {
     super.connectedCallback();
+
+    // Retained for backward compatibility. The trigger and menu list listeners are now managed by their respective
+    // slot-changed callbacks, so this method is no longer responsible for setting up the component. However, it is left in place to avoid breaking changes for any existing implementations that may be relying on it.
     this.setComponent();
   }
 
@@ -150,37 +192,18 @@ export class Menu extends FASTElement {
    */
   public disconnectedCallback() {
     super.disconnectedCallback();
-    this.removeListeners();
+
+    this._triggerAbortController?.abort();
+    this._menuListAbortController?.abort();
   }
 
   /**
    * Sets the component.
-   * Sets the trigger and menu list elements and adds event listeners.
+   * @deprecated This method is no longer used. Trigger and menu-list listeners are now
+   * managed by their respective slot-changed callbacks.
    * @public
    */
-  public setComponent(): void {
-    waitForConnectedDescendants(
-      this,
-      () => {
-        const trigger = this.slottedTriggers?.[0];
-        const menuList = this.slottedMenuList?.[0];
-        if (!trigger || !menuList) {
-          this.removeListeners();
-          return;
-        }
-
-        this._trigger = trigger;
-        this._menuList = menuList;
-
-        this._trigger.setAttribute('aria-haspopup', 'true');
-        this._trigger.setAttribute('aria-expanded', `${this._open}`);
-        this._menuList.setAttribute('popover', this.openOnContext ? 'manual' : '');
-        this.removeListeners();
-        this.addListeners();
-      },
-      { shallow: true },
-    );
-  }
+  public setComponent(): void {}
 
   /**
    * Toggles the open state of the menu.
@@ -274,10 +297,9 @@ export class Menu extends FASTElement {
    * @public
    */
   public openOnHoverChanged(oldValue: boolean, newValue: boolean): void {
-    if (newValue) {
-      this._trigger?.addEventListener('mouseover', this.openMenu);
-    } else {
-      this._trigger?.removeEventListener('mouseover', this.openMenu);
+    if (this._trigger) {
+      this._triggerAbortController?.abort();
+      this.addTriggerListeners();
     }
   }
 
@@ -289,10 +311,9 @@ export class Menu extends FASTElement {
    * @param newValue - The new value of 'persistOnItemClick'.
    */
   public persistOnItemClickChanged(oldValue: boolean, newValue: boolean): void {
-    if (!newValue) {
-      this._menuList?.addEventListener('change', this.closeMenu);
-    } else {
-      this._menuList?.removeEventListener('change', this.closeMenu);
+    if (this._menuList) {
+      this._menuListAbortController?.abort();
+      this.addMenuListListeners();
     }
   }
 
@@ -305,9 +326,14 @@ export class Menu extends FASTElement {
    */
   public openOnContextChanged(oldValue: boolean, newValue: boolean): void {
     if (newValue) {
-      this._trigger?.addEventListener('contextmenu', this.openMenu);
+      this._menuList?.setAttribute('popover', 'manual');
     } else {
-      this._trigger?.removeEventListener('contextmenu', this.openMenu);
+      this._menuList?.setAttribute('popover', '');
+    }
+
+    if (this._trigger) {
+      this._triggerAbortController?.abort();
+      this.addTriggerListeners();
     }
   }
 
@@ -327,54 +353,37 @@ export class Menu extends FASTElement {
   }
 
   /**
-   * Adds event listeners.
-   * Adds click and keydown event listeners to the trigger.
-   * Adds a 'toggle' event listener to the menu list.
-   * If 'openOnHover' is true, adds a 'mouseover' event listener to the trigger.
-   * If 'openOnContext' is true, adds a 'contextmenu' event listener to the trigger and a document 'click' event listener.
+   * Adds trigger-related event listeners.
    * @internal
    */
-  private addListeners(): void {
-    this._menuList?.addEventListener('toggle', this.toggleHandler);
+  private addTriggerListeners(): void {
+    this._triggerAbortController = new AbortController();
+    const { signal } = this._triggerAbortController;
 
-    this._trigger?.addEventListener('keydown', this.triggerKeydownHandler);
+    this._trigger?.addEventListener('keydown', this.triggerKeydownHandler, { signal });
 
-    if (!this.persistOnItemClick) {
-      this._menuList?.addEventListener('change', this.closeMenu);
-    }
     if (this.openOnHover) {
-      this._trigger?.addEventListener('mouseover', this.openMenu);
+      this._trigger?.addEventListener('mouseover', this.openMenu, { signal });
     } else if (this.openOnContext) {
-      this._trigger?.addEventListener('contextmenu', this.openMenu);
-      document.addEventListener('click', this.documentClickHandler);
+      this._trigger?.addEventListener('contextmenu', this.openMenu, { signal });
+      document.addEventListener('click', this.documentClickHandler, { signal });
     } else {
-      this._trigger?.addEventListener('click', this.toggleMenu);
+      this._trigger?.addEventListener('click', this.toggleMenu, { signal });
     }
   }
 
   /**
-   * Removes event listeners.
-   * Removes click and keydown event listeners from the trigger.
-   * Also removes toggle event listener from the menu list.
-   * Also removes 'mouseover' event listeners from the trigger.
-   * Also removes 'contextmenu' event listeners from the trigger and document 'click' event listeners.
+   * Adds menu-list event listeners.
    * @internal
    */
-  private removeListeners(): void {
-    this._menuList?.removeEventListener('toggle', this.toggleHandler);
+  private addMenuListListeners(): void {
+    this._menuListAbortController = new AbortController();
+    const { signal } = this._menuListAbortController;
 
-    this._trigger?.removeEventListener('keydown', this.triggerKeydownHandler);
+    this._menuList?.addEventListener('toggle', this.toggleHandler, { signal });
+
     if (!this.persistOnItemClick) {
-      this._menuList?.removeEventListener('change', this.closeMenu);
-    }
-    if (this.openOnHover) {
-      this._trigger?.removeEventListener('mouseover', this.openMenu);
-    }
-    if (this.openOnContext) {
-      this._trigger?.removeEventListener('contextmenu', this.openMenu);
-      document.removeEventListener('click', this.documentClickHandler);
-    } else {
-      this._trigger?.removeEventListener('click', this.toggleMenu);
+      this._menuList?.addEventListener('change', this.closeMenu, { signal });
     }
   }
 

--- a/packages/web-components/src/tablist/tablist.base.ts
+++ b/packages/web-components/src/tablist/tablist.base.ts
@@ -217,7 +217,7 @@ export class BaseTablist extends FASTElement {
   private getTabIds(): Array<string> {
     return (
       this.tabs?.map((tab: HTMLElement) => {
-        return tab.id ?? `tab-${uniqueId()}`;
+        return tab.getAttribute('id') ?? `tab-${uniqueId()}`;
       }) ?? []
     );
   }

--- a/packages/web-components/src/tablist/tablist.base.ts
+++ b/packages/web-components/src/tablist/tablist.base.ts
@@ -215,9 +215,11 @@ export class BaseTablist extends FASTElement {
   }
 
   private getTabIds(): Array<string> {
-    return this.tabs.map((tab: HTMLElement) => {
-      return tab.getAttribute('id') ?? `tab-${uniqueId()}`;
-    });
+    return (
+      this.tabs?.map((tab: HTMLElement) => {
+        return tab.id ?? `tab-${uniqueId()}`;
+      }) ?? []
+    );
   }
 
   private setComponent(): void {
@@ -335,9 +337,13 @@ export class BaseTablist extends FASTElement {
   public connectedCallback(): void {
     super.connectedCallback();
 
-    waitForConnectedDescendants(this, () => {
-      this.tabIds = this.getTabIds();
-      this.setTabs();
-    });
+    waitForConnectedDescendants(
+      this,
+      () => {
+        this.tabIds = this.getTabIds();
+        this.setTabs();
+      },
+      { shallow: true },
+    );
   }
 }

--- a/packages/web-components/src/utils/request-idle-callback.ts
+++ b/packages/web-components/src/utils/request-idle-callback.ts
@@ -67,7 +67,7 @@ export function waitForConnectedDescendants(
 
   const scheduleCheck = (deadline?: IdleDeadline) => {
     if (target.querySelector(selector) === null || (deadline && deadline.timeRemaining() <= 0)) {
-      requestAnimationFrame(callback);
+      callback();
       return;
     }
 

--- a/packages/web-components/src/utils/request-idle-callback.ts
+++ b/packages/web-components/src/utils/request-idle-callback.ts
@@ -21,7 +21,7 @@ export function requestIdleCallback(
       didTimeout: options?.timeout ? Date.now() - start >= options.timeout : false,
       timeRemaining: () => 0,
     });
-  }, 1);
+  }, options?.timeout ?? 1);
 }
 
 /**

--- a/packages/web-components/src/utils/request-idle-callback.ts
+++ b/packages/web-components/src/utils/request-idle-callback.ts
@@ -59,15 +59,38 @@ export function cancelIdleCallback(id: ReturnType<typeof globalThis.requestIdleC
 export function waitForConnectedDescendants(
   target: HTMLElement,
   callback: () => void,
-  options?: { shallow?: boolean; timeout?: number },
+  options?: {
+    /**
+     * Whether to only check direct children of the target element, rather than all descendants.
+     * @defaultValue `false`
+     */
+    shallow?: boolean;
+    /**
+     * The maximum time to wait for each idle callback before rechecking for connected descendants, in milliseconds.
+     * @defaultValue `50`
+     */
+    timeout?: number;
+    /**
+     * Whether to call the callback on the next idle period after descendants are connected, rather than immediately.
+     * This can be used to defer work until after the browser has had a chance to perform any necessary updates
+     * following the connection of the descendants.
+     * @defaultValue `false`
+     */
+    idleCallback?: boolean;
+  },
 ): void {
   const shallow = options?.shallow ?? false;
   const timeout = options?.timeout ?? 50;
+  const useIdleCallback = options?.idleCallback ?? false;
   const selector = `${shallow ? ':scope > ' : ''}:not(:defined)`;
 
   const scheduleCheck = (deadline?: IdleDeadline) => {
     if (target.querySelector(selector) === null || (deadline && deadline.timeRemaining() <= 0)) {
-      callback();
+      if (useIdleCallback) {
+        requestIdleCallback(callback, { timeout });
+      } else {
+        callback();
+      }
       return;
     }
 


### PR DESCRIPTION
## Previous Behavior

Several web components (`Menu`, `Accordion`, `Dropdown`, `Tablist`) relied on `waitForConnectedDescendants` with `requestAnimationFrame` wrappers in `connectedCallback` and slot-changed handlers. This caused performance regressions and timing issues:

- `Menu` used `waitForConnectedDescendants` in `setComponent()` to set up trigger and menu list listeners, and manually managed add/remove listener pairs that were error-prone.
- `Accordion` wrapped `connectedCallback` and `setSingleExpandMode` in `requestAnimationFrame`, causing unnecessary async deferral and allowing re-entrant calls to `setSingleExpandMode`.
- `Dropdown` used `Updates.enqueue` for control setup and lacked guards against re-entrant `insertControl` calls. `setValidity` and `selectOption` could throw when `elementInternals` or `control` were not yet available.
- `Tablist` did not handle undefined `tabs` in `getTabIds`.
- `waitForConnectedDescendants` always used `requestAnimationFrame` for its callback, even when immediate invocation was sufficient.

## New Behavior

- **Menu**: Trigger and menu-list listeners are now managed by their respective slot-changed callbacks (`slottedTriggersChanged`, `slottedMenuListChanged`) using `AbortController` for clean teardown. `setComponent()` is deprecated (kept as a no-op for backward compatibility). `removeListeners`/`addListeners` replaced with scoped `addTriggerListeners`/`addMenuListListeners`.
- **Accordion**: Removed `requestAnimationFrame` wrappers from `connectedCallback` and `setSingleExpandMode`. Added `_isAdjusting` guard to prevent re-entrant `setSingleExpandMode` calls. Added optional chaining on `expandbutton` access.
- **Dropdown**: Replaced `Updates.enqueue` with `waitForConnectedDescendants` using the new `idleCallback` option for deferred control setup. Added `_insertingControl` re-entrancy guard. Added null checks for `this.control` in `selectOption` and `this.elementInternals` in `setValidity`.
- **Tablist**: Added null check for `tabs` in `getTabIds`.
- **waitForConnectedDescendants**: Invokes the callback directly instead of wrapping in `requestAnimationFrame`. Added new `idleCallback` option to defer callback to the next idle period when needed. Added JSDoc for all options.
- **Dropdown styles**: Added rule to hide slotted elements with no `slot` and no `popover` attribute.

## Related Issue(s)

- Fixes #36007