### PR TITLE
feat(react-headless-components-preview): enhance Radio and RadioGroup components with focus behavior attributes

### DIFF
--- a/packages/react-components/react-headless-components-preview/library/etc/react-headless-components-preview.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/react-headless-components-preview.api.md
@@ -400,7 +400,11 @@ export type RadioGroupProps = RadioGroupBaseProps;
 export type RadioGroupSlots = RadioGroupSlots_2;
 
 // @public
-export type RadioGroupState = RadioGroupBaseState;
+export type RadioGroupState = RadioGroupBaseState & {
+    root: {
+        focusgroup?: string;
+    };
+};
 
 // @public
 export type RadioProps = RadioBaseProps;
@@ -412,6 +416,9 @@ export type RadioSlots = RadioSlots_2;
 export type RadioState = RadioBaseState & {
     root: {
         'data-disabled'?: string;
+    };
+    input: {
+        focusgroupstart?: string;
     };
 };
 

--- a/packages/react-components/react-headless-components-preview/library/src/components/RadioGroup/Radio/Radio.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/RadioGroup/Radio/Radio.types.ts
@@ -20,4 +20,10 @@ export type RadioState = RadioBaseState & {
      */
     'data-disabled'?: string;
   };
+  input: {
+    /**
+     * Data attribute set when the radio is checked.
+     */
+    focusgroupstart?: string;
+  };
 };

--- a/packages/react-components/react-headless-components-preview/library/src/components/RadioGroup/Radio/useRadio.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/RadioGroup/Radio/useRadio.ts
@@ -18,5 +18,8 @@ export const useRadio = (props: RadioProps, ref: React.Ref<HTMLInputElement>): R
   // Set data attribute for disabled state to simplify styling.
   state.root['data-disabled'] = stringifyDataAttribute(state.input.disabled);
 
+  // set focusroupstart attribute to the selected radio to support focus behavior in RadioGroup
+  state.input.focusgroupstart = stringifyDataAttribute(state.input.defaultChecked || state.input.checked);
+
   return state;
 };

--- a/packages/react-components/react-headless-components-preview/library/src/components/RadioGroup/RadioGroup.test.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/RadioGroup/RadioGroup.test.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { render } from '@testing-library/react';
 import { isConformant } from '../../testing/isConformant';
 import { RadioGroup } from './RadioGroup';
+import { Radio } from './Radio';
 
 describe('RadioGroup', () => {
   isConformant({
@@ -10,10 +11,20 @@ describe('RadioGroup', () => {
   });
 
   it('renders a default state', () => {
-    const { getByRole, getByText } = render(<RadioGroup>Default RadioGroup</RadioGroup>);
-    const radiogroup = getByRole('radiogroup');
+    const { getByRole, getAllByRole } = render(
+      <RadioGroup defaultValue="option2">
+        <Radio label="Option #1" value="option1" />
+        <Radio label="Option #2" value="option2" />
+        <Radio label="Option #3" value="option3" />
+      </RadioGroup>,
+    );
 
-    expect(radiogroup).toBeInTheDocument();
-    expect(getByText('Default RadioGroup')).toBeInTheDocument();
+    expect(getByRole('radiogroup')).toHaveAttribute('focusgroup', 'radiogroup');
+    expect(getAllByRole('radio')).toHaveLength(3);
+
+    expect(getByRole('radio', { name: 'Option #1' })).not.toBeChecked();
+    expect(getByRole('radio', { name: 'Option #2' })).toBeChecked();
+    expect(getByRole('radio', { name: 'Option #2' })).toHaveAttribute('focusgroupstart');
+    expect(getByRole('radio', { name: 'Option #3' })).not.toBeChecked();
   });
 });

--- a/packages/react-components/react-headless-components-preview/library/src/components/RadioGroup/RadioGroup.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/RadioGroup/RadioGroup.types.ts
@@ -18,7 +18,12 @@ export type RadioGroupProps = RadioGroupBaseProps;
 /**
  * RadioGroup component state
  */
-export type RadioGroupState = RadioGroupBaseState;
+export type RadioGroupState = RadioGroupBaseState & {
+  root: {
+    /** Defines the element focus behavior for the radio group. */
+    focusgroup?: string;
+  };
+};
 
 /**
  * RadioGroup component context values

--- a/packages/react-components/react-headless-components-preview/library/src/components/RadioGroup/useRadioGroup.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/RadioGroup/useRadioGroup.ts
@@ -10,6 +10,8 @@ import type { RadioGroupProps, RadioGroupState } from './RadioGroup.types';
  * The returned state can be modified with hooks before being passed to `renderRadioGroup`.
  */
 export const useRadioGroup = (props: RadioGroupProps, ref: React.Ref<HTMLDivElement>): RadioGroupState => {
+  'use no memo';
+
   const state: RadioGroupState = useRadioGroupBase_unstable(props, ref);
 
   // Defines the element focus behavior for the radio group.

--- a/packages/react-components/react-headless-components-preview/library/src/components/RadioGroup/useRadioGroup.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/RadioGroup/useRadioGroup.ts
@@ -10,7 +10,10 @@ import type { RadioGroupProps, RadioGroupState } from './RadioGroup.types';
  * The returned state can be modified with hooks before being passed to `renderRadioGroup`.
  */
 export const useRadioGroup = (props: RadioGroupProps, ref: React.Ref<HTMLDivElement>): RadioGroupState => {
-  const state = useRadioGroupBase_unstable(props, ref);
+  const state: RadioGroupState = useRadioGroupBase_unstable(props, ref);
+
+  // Defines the element focus behavior for the radio group.
+  state.root.focusgroup = 'radiogroup';
 
   return state;
 };


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

Initial focus went to the first `radio` element in a `radioroup` 

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

Focus goes the checked `radio` element in a `radioroup`. It's achieved by using `focusgroup` HTML attribute on the `radiogroup` and `focusgroupstart` on the checked radio element.

## Related Issue/PR(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Depends on #36020
