### PR TITLE
fix(react-utilities): add focusgroupstart property to baseElementProperties

### DIFF
--- a/change/@fluentui-react-utilities-09d37eba-060e-4811-8b6c-263cebae681f.json
+++ b/change/@fluentui-react-utilities-09d37eba-060e-4811-8b6c-263cebae681f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: add focusgroupstart property to baseElementProperties",
+  "packageName": "@fluentui/react-utilities",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-utilities/src/utils/properties.ts
+++ b/packages/react-components/react-utilities/src/utils/properties.ts
@@ -120,6 +120,7 @@ export const baseElementProperties = toObjectMap([
   'lang', // global
   'popover', // global
   'focusgroup', // global
+  'focusgroupstart', // global
   'ref', // global
   'role', // global
   'style', // global


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

`focusgroup` prop was forwarded to html elements, but `focusgroupstart` didn't

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

Allow passing both `focusgroup` and `focusgroupstart` props to underlying html elements

Explainer for the `focusgroupstart` attibute - https://open-ui.org/components/scoped-focusgroup.explainer/#the-focusgroupstart-attribute
