### PR TITLE
test(react-toolbar): baseline hook tests + coverage gaps flagged in #35903

### DIFF
--- a/packages/react-components/react-toolbar/library/src/components/Toolbar/useToolbar.test.tsx
+++ b/packages/react-components/react-toolbar/library/src/components/Toolbar/useToolbar.test.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+
+import type { ToolbarProps } from './Toolbar.types';
+import { useToolbar_unstable } from './useToolbar';
+
+describe('useToolbar_unstable', () => {
+  let ref: React.RefObject<HTMLDivElement | null>;
+
+  beforeEach(() => {
+    ref = React.createRef<HTMLDivElement | null>();
+  });
+
+  it('should return state with default props', () => {
+    const { result } = renderHook(() => useToolbar_unstable({}, ref));
+
+    expect(result.current).toMatchObject({
+      vertical: false,
+      size: 'medium',
+      checkedValues: {},
+      components: {
+        root: 'div',
+      },
+      root: expect.objectContaining({
+        role: 'toolbar',
+        ref,
+      }),
+    });
+  });
+
+  it('should reflect custom props in state', () => {
+    const props = {
+      checkedValues: { group1: ['item1', 'item2'] },
+      size: 'small',
+      vertical: true,
+    } satisfies ToolbarProps;
+
+    const { result } = renderHook(() => useToolbar_unstable(props, ref));
+
+    expect(result.current).toMatchObject({
+      checkedValues: props.checkedValues,
+      size: props.size,
+      vertical: props.vertical,
+      root: expect.objectContaining({
+        role: 'toolbar',
+        'aria-orientation': 'vertical',
+        ref,
+      }),
+    });
+  });
+});

--- a/packages/react-components/react-toolbar/library/src/components/Toolbar/useToolbar.test.tsx
+++ b/packages/react-components/react-toolbar/library/src/components/Toolbar/useToolbar.test.tsx
@@ -48,4 +48,24 @@ describe('useToolbar_unstable', () => {
       }),
     });
   });
+
+  it('should omit aria-orientation from root when horizontal', () => {
+    const { result } = renderHook(() => useToolbar_unstable({ size: 'large', vertical: false }, ref));
+
+    expect(result.current).toMatchObject({
+      size: 'large',
+      vertical: false,
+    });
+    expect(result.current.root).not.toHaveProperty('aria-orientation');
+  });
+
+  it('should render root with Tabster arrow-navigation attributes', () => {
+    const { result } = renderHook(() => useToolbar_unstable({ size: 'large', vertical: true }, ref));
+
+    const tabsterAttrOnRoot = result.current.root['data-tabster' as keyof typeof result.current.root];
+
+    expect(tabsterAttrOnRoot).toMatchInlineSnapshot(
+      `"{\\"mover\\":{\\"cyclic\\":true,\\"direction\\":0,\\"memorizeCurrent\\":true}}"`,
+    );
+  });
 });

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarButton/useToolbarButton.test.tsx
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarButton/useToolbarButton.test.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+
+import { useToolbarButton_unstable } from './useToolbarButton';
+
+describe('useToolbarButton_unstable', () => {
+  let ref: React.RefObject<HTMLButtonElement | null>;
+
+  beforeEach(() => {
+    ref = React.createRef<HTMLButtonElement>();
+  });
+
+  it('should return state with default props', () => {
+    const { result } = renderHook(() => useToolbarButton_unstable({}, ref));
+
+    expect(result.current).toMatchObject({
+      appearance: 'subtle',
+      size: 'medium',
+      shape: 'rounded',
+      vertical: false,
+      root: expect.objectContaining({
+        type: 'button',
+        ref,
+      }),
+    });
+  });
+
+  it('should reflect custom props in state', () => {
+    const props = { appearance: 'primary', disabled: true, vertical: true } as const;
+
+    const { result } = renderHook(() => useToolbarButton_unstable(props, ref));
+
+    expect(result.current).toMatchObject({
+      appearance: props.appearance,
+      size: 'medium',
+      shape: 'rounded',
+      vertical: props.vertical,
+      disabled: props.disabled,
+    });
+  });
+});

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarDivider/useToolbarDivider.test.tsx
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarDivider/useToolbarDivider.test.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+
+import { ToolbarContext } from '../Toolbar/ToolbarContext';
+import { useToolbarDivider_unstable } from './useToolbarDivider';
+import type { ToolbarContextValue } from '../Toolbar/Toolbar.types';
+
+const renderWithToolbarContext = (contextValue: Partial<ToolbarContextValue>) => {
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <ToolbarContext.Provider
+      value={{
+        size: 'medium',
+        vertical: false,
+        checkedValues: {},
+        handleToggleButton: () => null,
+        handleRadio: () => null,
+        ...contextValue,
+      }}
+    >
+      {children}
+    </ToolbarContext.Provider>
+  );
+
+  return wrapper;
+};
+
+describe('useToolbarDivider_unstable', () => {
+  let ref: React.RefObject<HTMLElement | null>;
+
+  beforeEach(() => {
+    ref = React.createRef<HTMLElement>();
+  });
+
+  it('should return state with default props', () => {
+    const { result } = renderHook(() => useToolbarDivider_unstable({}, ref));
+
+    expect(result.current).toMatchObject({
+      appearance: 'default',
+      alignContent: 'center',
+      inset: false,
+      vertical: true,
+    });
+  });
+
+  it('should reflect custom props and toolbar context in state', () => {
+    const { result } = renderHook(() => useToolbarDivider_unstable({}, ref), {
+      wrapper: renderWithToolbarContext({ vertical: true }),
+    });
+
+    expect(result.current).toMatchObject({
+      appearance: 'default',
+      alignContent: 'center',
+      inset: false,
+      vertical: false,
+    });
+  });
+});

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarRadioButton/useToolbarRadioButton.test.tsx
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarRadioButton/useToolbarRadioButton.test.tsx
@@ -1,46 +1,93 @@
-import { renderHook } from '@testing-library/react-hooks';
 import * as React from 'react';
+import { act, renderHook } from '@testing-library/react-hooks';
 
 import { ToolbarContext } from '../Toolbar/ToolbarContext';
 import { useToolbarRadioButton_unstable } from './useToolbarRadioButton';
+import type { ToolbarContextValue } from '../Toolbar/Toolbar.types';
 import type { ToolbarRadioButtonProps } from './ToolbarRadioButton.types';
 
-const refMock = React.createRef<HTMLButtonElement>();
 const propsMock: ToolbarRadioButtonProps = {
   name: 'test-radio',
   value: 'test-value',
 };
 
-const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  return (
-    <ToolbarContext.Provider value={{ size: 'large', vertical: false, checkedValues: {} }}>
+const renderWithToolbarContext = (contextValue: Partial<ToolbarContextValue>) => {
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <ToolbarContext.Provider
+      value={{
+        size: 'medium',
+        vertical: false,
+        checkedValues: {},
+        handleToggleButton: () => null,
+        handleRadio: () => null,
+        ...contextValue,
+      }}
+    >
       {children}
     </ToolbarContext.Provider>
   );
+
+  return wrapper;
 };
 
-describe('useToolbarRadioButton', () => {
-  describe('size', () => {
-    it('applies the medium size by default', () => {
-      const { result } = renderHook(() => useToolbarRadioButton_unstable(propsMock, refMock));
+describe('useToolbarRadioButton_unstable', () => {
+  let ref: React.RefObject<HTMLButtonElement | null>;
 
-      expect(result.current.size).toBe('medium');
+  beforeEach(() => {
+    ref = React.createRef<HTMLButtonElement>();
+  });
+
+  it('should return state with default props', () => {
+    const { result } = renderHook(() => useToolbarRadioButton_unstable(propsMock, ref));
+
+    expect(result.current).toMatchObject({
+      appearance: 'secondary',
+      checked: false,
+      name: 'test-radio',
+      value: 'test-value',
+      size: 'medium',
+      root: expect.objectContaining({
+        role: 'radio',
+        'aria-checked': false,
+      }),
+    });
+    expect(result.current.root['aria-pressed']).toBeUndefined();
+  });
+
+  it('should reflect custom props and toolbar context in state', () => {
+    const { result } = renderHook(
+      () => useToolbarRadioButton_unstable({ ...propsMock, appearance: 'primary', size: 'small' }, ref),
+      {
+        wrapper: renderWithToolbarContext({ checkedValues: { 'test-radio': ['test-value'] }, size: 'large' }),
+      },
+    );
+
+    expect(result.current).toMatchObject({
+      appearance: 'primary',
+      checked: true,
+      name: 'test-radio',
+      value: 'test-value',
+      size: 'small',
+      root: expect.objectContaining({
+        role: 'radio',
+        'aria-checked': true,
+      }),
+    });
+  });
+
+  it('should call onClick and toolbar radio handlers', () => {
+    const handleRadio = jest.fn();
+    const onClick = jest.fn();
+    const { result } = renderHook(() => useToolbarRadioButton_unstable({ ...propsMock, onClick }, ref), {
+      wrapper: renderWithToolbarContext({ handleRadio }),
+    });
+    const event = {} as React.MouseEvent<HTMLButtonElement & HTMLAnchorElement>;
+
+    act(() => {
+      result.current.root.onClick?.(event);
     });
 
-    it('applies the size from a context', () => {
-      const { result } = renderHook(() => useToolbarRadioButton_unstable(propsMock, refMock), {
-        wrapper: Wrapper,
-      });
-
-      expect(result.current.size).toBe('large');
-    });
-
-    it('applies the size from props over context', () => {
-      const { result } = renderHook(() => useToolbarRadioButton_unstable({ ...propsMock, size: 'small' }, refMock), {
-        wrapper: Wrapper,
-      });
-
-      expect(result.current.size).toBe('small');
-    });
+    expect(handleRadio).toHaveBeenCalledWith(event, 'test-radio', 'test-value', false);
+    expect(onClick).toHaveBeenCalledWith(event);
   });
 });

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarToggleButton/useToolbarToggleButton.test.tsx
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarToggleButton/useToolbarToggleButton.test.tsx
@@ -1,0 +1,89 @@
+import * as React from 'react';
+import { act, renderHook } from '@testing-library/react-hooks';
+
+import { ToolbarContext } from '../Toolbar/ToolbarContext';
+import { useToolbarToggleButton_unstable } from './useToolbarToggleButton';
+import type { ToolbarContextValue } from '../Toolbar/Toolbar.types';
+import type { ToolbarToggleButtonProps } from './ToolbarToggleButton.types';
+
+const propsMock: ToolbarToggleButtonProps = {
+  name: 'text',
+  value: 'bold',
+};
+
+const renderWithToolbarContext = (contextValue: Partial<ToolbarContextValue>) => {
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <ToolbarContext.Provider
+      value={{
+        size: 'medium',
+        vertical: false,
+        checkedValues: {},
+        handleToggleButton: () => null,
+        handleRadio: () => null,
+        ...contextValue,
+      }}
+    >
+      {children}
+    </ToolbarContext.Provider>
+  );
+
+  return wrapper;
+};
+
+describe('useToolbarToggleButton_unstable', () => {
+  let ref: React.RefObject<HTMLButtonElement | null>;
+
+  beforeEach(() => {
+    ref = React.createRef<HTMLButtonElement>();
+  });
+
+  it('should return state with default props', () => {
+    const { result } = renderHook(() => useToolbarToggleButton_unstable(propsMock, ref));
+
+    expect(result.current).toMatchObject({
+      appearance: 'secondary',
+      checked: false,
+      name: 'text',
+      size: 'medium',
+      shape: 'rounded',
+      value: 'bold',
+    });
+  });
+
+  it('should reflect custom props and toolbar context in state', () => {
+    const { result } = renderHook(
+      () => useToolbarToggleButton_unstable({ ...propsMock, appearance: 'primary', size: 'small' }, ref),
+      {
+        wrapper: renderWithToolbarContext({ checkedValues: { text: ['bold'] } }),
+      },
+    );
+
+    expect(result.current).toMatchObject({
+      appearance: 'secondary',
+      checked: true,
+      name: 'text',
+      size: 'small',
+      shape: 'rounded',
+      value: 'bold',
+    });
+  });
+
+  it('should call onClick and toolbar toggle handlers', () => {
+    const handleToggleButton = jest.fn();
+    const onClick = jest.fn();
+    const { result } = renderHook(() => useToolbarToggleButton_unstable({ ...propsMock, onClick }, ref), {
+      wrapper: renderWithToolbarContext({ handleToggleButton }),
+    });
+    const event = {
+      preventDefault: jest.fn(),
+      stopPropagation: jest.fn(),
+    } as unknown as React.MouseEvent<HTMLButtonElement & HTMLAnchorElement>;
+
+    act(() => {
+      result.current.root.onClick?.(event);
+    });
+
+    expect(handleToggleButton).toHaveBeenCalledWith(event, 'text', 'bold', false);
+    expect(onClick).toHaveBeenCalledWith(event);
+  });
+});


### PR DESCRIPTION
## Summary

Companion to #35903. Isolates the hook-level test additions from that PR as a master-passing baseline, plus fills the two coverage gaps flagged during review.

- **Commit 1** — cherry-picks the 5 new test files from #35903 against master.
- **Commit 2** — adds test cases flagged in the review:
  - `useToolbar`: asserts `aria-orientation` is absent on horizontal roots, and confirms Tabster arrow-navigation attributes are attached by the non-base hook.

## Why

These tests are useful independent of #35903 — they pin existing behavior so that the refactor in #35903 produces a reviewable diff. Any assertion that needs updating there surfaces a behavior change worth discussing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)