### PR TITLE
fix(react-toolbar): use subtle appearance for radio button by default

### DIFF
--- a/change/@fluentui-react-toolbar-8d7e6aa1-3637-4ad5-b61c-0cc124682991.json
+++ b/change/@fluentui-react-toolbar-8d7e6aa1-3637-4ad5-b61c-0cc124682991.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: use subtle appearance for radio button by default",
+  "packageName": "@fluentui/react-toolbar",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarRadioButton/useToolbarRadioButton.test.tsx
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarRadioButton/useToolbarRadioButton.test.tsx
@@ -41,7 +41,7 @@ describe('useToolbarRadioButton_unstable', () => {
     const { result } = renderHook(() => useToolbarRadioButton_unstable(propsMock, ref));
 
     expect(result.current).toMatchObject({
-      appearance: 'secondary',
+      appearance: 'subtle',
       checked: false,
       name: 'test-radio',
       value: 'test-value',

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarRadioButton/useToolbarRadioButton.ts
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarRadioButton/useToolbarRadioButton.ts
@@ -22,7 +22,7 @@ export const useToolbarRadioButton_unstable = (
   ref: React.Ref<HTMLButtonElement | HTMLAnchorElement>,
 ): ToolbarRadioButtonState => {
   const contextSize = useToolbarContext_unstable(ctx => ctx.size);
-  const { appearance = 'secondary', size = contextSize, ...baseProps } = props;
+  const { appearance = 'subtle', size = contextSize, ...baseProps } = props;
   const state = useToolbarRadioButtonBase_unstable(baseProps, ref);
 
   return {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

`ToolbarRadioButton` uses `secondary`as a default `appearance` variant which is incorrect, as but it shouldn't according to types https://github.com/microsoft/fluentui/blob/master/packages/react-components/react-toolbar/library/src/components/ToolbarRadioButton/ToolbarRadioButton.types.ts#L9

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

`ToolbarRadioButton` uses `subtle` as a default `appearance` variant and consistent with `ToolbarButton` and `ToolbarToggleButton`

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Related to #36021 and #35903
