### PR TITLE
fix: via.placeholder.com shut down in 2024 (now connection-refused)

### DIFF
--- a/apps/public-docsite-v9/src/Concepts/Migration/FromV8/Components/Image/Image.mdx
+++ b/apps/public-docsite-v9/src/Concepts/Migration/FromV8/Components/Image/Image.mdx
@@ -80,7 +80,7 @@ const Component = () => {
 
   return (
     <Image
-      src="https://via.placeholder.com/300x300"
+      src="https://placehold.co/300x300"
       alt="Example image"
       onLoad={() => setLoaded(true)}
       className={!isLoaded ? styles.fadeIn400 : ''}
@@ -112,7 +112,7 @@ const Component = () => {
 
   return (
     <Image
-      src="https://via.placeholder.com/300x300"
+      src="https://placehold.co/300x300"
       alt="Example image"
       onLoad={() => setLoaded(true)}
       onError={() => setLoaded(false)}


### PR DESCRIPTION
`apps/public-docsite-v9/src/Concepts/Migration/FromV8/Components/Image/Image.mdx` references `via.placeholder.com/...` URLs. The service was shut down in 2024 and the DNS record no longer resolves.

---

#### Why this is needed

`via.placeholder.com` was shut down in 2024 and its DNS record no longer resolves — every request now hangs or returns a connection error. Browsers render a broken-image icon in place of the intended placeholder.

Verify in any shell:

```
curl -sI --max-time 3 https://via.placeholder.com/300x200 || echo 'connection refused / DNS gone'
```

#### What this PR changes

Updates the Fluent UI v9 migration docs page's `<Image>` example so the Image component docs actually render an example image on the live docsite instead of a broken-image icon.

#### Replacement details

One match; the same code block appears twice in the file (both occurrences fixed via the same needle because the script's replace-all flag is on). `placehold.co/300x300` preserves the exact `<W>x<H>` path shape from via.placeholder.

#### Background

I'm tracking dead image-placeholder endpoints (`source.unsplash.com/*`, `via.placeholder.com/*`, `placekitten.com/*`) across public repos as part of [tteg](https://github.com/kiluazen/tteg), a tiny CLI/HTTP API I built so projects can drop in real Unsplash photos without registering an Unsplash app or managing API keys. tteg is **not** introduced as a dependency by this PR — the diff uses the dependency-free canonical replacement domain. If you want topic-matched real photos as a follow-up, the no-key HTTP API is at `https://tteg-api-53227342417.asia-south1.run.app/search?q=<query>&n=1` (CORS-on, no auth).

One extra artifact you may find handy: a public scanner at <https://tteg.kushalsm.com/scan?url=> that highlights dead-placeholder patterns in any landing page — useful for verifying the fix lands and for finding other places dead URLs slipped in. Source: <https://github.com/kiluazen/tteg-landing/blob/main/scan.html>.

Research note covering the broader broken-placeholder landscape: <https://github.com/kiluazen/tteg/blob/research-note-autark/RESEARCH.md>.
