### PR TITLE
fix: remove unnecessary preventDefault() inhibiting element behaviors in drawer

### DIFF
--- a/change/@fluentui-web-components-84319bed-e452-4772-bbfe-2e17fbcc9ee3.json
+++ b/change/@fluentui-web-components-84319bed-e452-4772-bbfe-2e17fbcc9ee3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: remove errant preventDefault causing element interactions to be blocked inside drawer",
+  "packageName": "@fluentui/web-components",
+  "email": "13071055+chrisdholt@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/drawer/drawer.ts
+++ b/packages/web-components/src/drawer/drawer.ts
@@ -171,7 +171,6 @@ export class Drawer extends FASTElement {
    * Handles click events on the drawer.
    */
   public clickHandler(event: Event): boolean {
-    event.preventDefault();
     if (this.dialog.open && event.target === this.dialog) {
       this.hide();
     }


### PR DESCRIPTION
## Previous Behavior
Prevent default (called by default in the underlying framework) blocks expected interactions for elements within the drawer component. Anchors do not navigate, form labels do not select radios, etc. 

## New Behavior
Remove the errant behavior, elements work as expected.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
