### PR TITLE
fix: enable preflight styles for component examples

### DIFF
--- a/apps/public-docsite-v9-headless/.storybook/preview-head.html
+++ b/apps/public-docsite-v9-headless/.storybook/preview-head.html
@@ -1,8 +1,99 @@
 <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
 <style type="text/tailwindcss">
+  @layer theme, base, utilities;
   @import 'tailwindcss/theme' layer(theme);
   @import 'tailwindcss/utilities' layer(utilities);
   :root {
     interpolate-size: allow-keywords;
+  }
+</style>
+<!--
+  Tailwind's Preflight is omitted above because it resets h1/h2/p/a in
+  MDX docs (which rely on typography from react-storybook-addon/src/styles.css).
+  Re-apply the essential resets here inside `@layer base`, scoped to
+  `.docs-story` so rendered Canvas examples get border/box-sizing/form-element
+  normalization without affecting the surrounding MDX page. -->
+<style>
+  @layer base {
+    @scope (.docs-story) {
+      *,
+      ::before,
+      ::after,
+      ::backdrop,
+      ::file-selector-button {
+        box-sizing: border-box;
+        border: 0 solid currentColor;
+      }
+
+      img,
+      svg,
+      video,
+      canvas,
+      audio,
+      iframe,
+      embed,
+      object {
+        display: block;
+        vertical-align: middle;
+      }
+
+      img,
+      video {
+        max-width: 100%;
+        height: auto;
+      }
+
+      button,
+      input,
+      optgroup,
+      select,
+      textarea,
+      ::file-selector-button {
+        font-family: inherit;
+        font-feature-settings: inherit;
+        font-variation-settings: inherit;
+        font-size: 100%;
+        font-weight: inherit;
+        line-height: inherit;
+        letter-spacing: inherit;
+        color: inherit;
+      }
+
+      button,
+      select {
+        text-transform: none;
+      }
+
+      button,
+      input:where([type='button'], [type='reset'], [type='submit']),
+      ::file-selector-button {
+        appearance: button;
+        background-color: transparent;
+        background-image: none;
+      }
+
+      :-moz-focusring {
+        outline: auto;
+      }
+
+      ::placeholder {
+        opacity: 1;
+        color: color-mix(in oklab, currentColor 50%, transparent);
+      }
+
+      textarea {
+        resize: vertical;
+      }
+
+      ol,
+      ul,
+      menu {
+        list-style: none;
+      }
+
+      [hidden]:where(:not([hidden='until-found'])) {
+        display: none !important;
+      }
+    }
   }
 </style>


### PR DESCRIPTION
Enable TW preflight for story examples 

## Previous Behavior

<img width="2260" height="1616" alt="image" src="https://github.com/user-attachments/assets/b474b956-b3a1-4eff-91b0-2f0700bfd413" />


<img width="2260" height="1616" alt="image" src="https://github.com/user-attachments/assets/347c3064-33e9-408b-9f89-5ff0146f7a94" />

## New Behavior

<img width="767" height="628" alt="Screenshot 2026-04-23 at 13 06 09" src="https://github.com/user-attachments/assets/16fb9cb3-9de4-449d-ab4a-7d6fdf573aa1" />


<img width="737" height="641" alt="Screenshot 2026-04-23 at 13 07 12" src="https://github.com/user-attachments/assets/844b1148-70ec-42d0-9a0e-415a1915400e" />

