### PR TITLE
test(react-table): add unit tests for useTable_unstable and useDataGrid_unstable hooks

### DIFF
--- a/packages/react-components/react-table/library/src/components/DataGrid/useDataGrid.test.ts
+++ b/packages/react-components/react-table/library/src/components/DataGrid/useDataGrid.test.ts
@@ -1,0 +1,85 @@
+import * as React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import { useDataGrid_unstable } from './useDataGrid';
+import { useDataGridContextValues_unstable } from './useDataGridContextValues';
+import { createTableColumn } from '../../hooks';
+
+const columns = [createTableColumn({ columnId: 'name' }), createTableColumn({ columnId: 'age' })];
+const items = [
+  { name: 'Alice', age: 30 },
+  { name: 'Bob', age: 25 },
+];
+
+describe('useDataGrid_unstable', () => {
+  let ref: React.RefObject<HTMLElement | null>;
+
+  beforeEach(() => {
+    ref = React.createRef<HTMLElement>();
+  });
+
+  it('returns default state with table element and medium size', () => {
+    const { result } = renderHook(() => useDataGrid_unstable({ columns, items }, ref));
+
+    expect(result.current).toMatchObject({
+      components: { root: 'table' },
+      size: 'medium',
+      noNativeElements: false,
+      focusMode: 'cell',
+      selectableRows: false,
+    });
+  });
+
+  it('reflects selectionMode in selectableRows', () => {
+    const { result } = renderHook(() => useDataGrid_unstable({ columns, items, selectionMode: 'multiselect' }, ref));
+
+    expect(result.current.selectableRows).toBe(true);
+  });
+
+  it('exposes sorted rows via tableState', () => {
+    const { result } = renderHook(() => useDataGrid_unstable({ columns, items }, ref));
+
+    expect(result.current.tableState.getRows()).toHaveLength(items.length);
+  });
+
+  it('reflects resizableColumns prop', () => {
+    const { result } = renderHook(() => useDataGrid_unstable({ columns, items, resizableColumns: true }, ref));
+
+    expect(result.current.resizableColumns).toBe(true);
+  });
+});
+
+describe('useDataGridContextValues_unstable', () => {
+  let ref: React.RefObject<HTMLElement | null>;
+
+  beforeEach(() => {
+    ref = React.createRef<HTMLElement>();
+  });
+
+  it('includes table and dataGrid context', () => {
+    const { result } = renderHook(() => {
+      const state = useDataGrid_unstable({ columns, items }, ref);
+      return useDataGridContextValues_unstable(state);
+    });
+
+    expect(result.current).toMatchObject({
+      table: {
+        size: 'medium',
+        noNativeElements: false,
+        sortable: false,
+      },
+      dataGrid: expect.objectContaining({
+        focusMode: 'cell',
+        selectableRows: false,
+      }),
+    });
+  });
+
+  it('reflects selectionMode in dataGrid context', () => {
+    const { result } = renderHook(() => {
+      const state = useDataGrid_unstable({ columns, items, selectionMode: 'single' }, ref);
+      return useDataGridContextValues_unstable(state);
+    });
+
+    expect(result.current.dataGrid.selectableRows).toBe(true);
+  });
+});

--- a/packages/react-components/react-table/library/src/components/Table/useTable.test.ts
+++ b/packages/react-components/react-table/library/src/components/Table/useTable.test.ts
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import { useTable_unstable } from './useTable';
+
+describe('useTable_unstable', () => {
+  let ref: React.RefObject<HTMLElement | null>;
+
+  beforeEach(() => {
+    ref = React.createRef<HTMLElement>();
+  });
+
+  it('returns default state with table element and medium size', () => {
+    const { result } = renderHook(() => useTable_unstable({}, ref));
+
+    expect(result.current).toMatchObject({
+      components: { root: 'table' },
+      root: expect.objectContaining({ ref }),
+      size: 'medium',
+      noNativeElements: false,
+      sortable: false,
+    });
+  });
+
+  it('renders as div with role="table" when noNativeElements is true', () => {
+    const { result } = renderHook(() => useTable_unstable({ noNativeElements: true }, ref));
+
+    expect(result.current.components.root).toBe('div');
+    expect(result.current.root).toMatchObject({ role: 'table' });
+    expect(result.current.noNativeElements).toBe(true);
+  });
+
+  it('respects explicit as prop', () => {
+    const { result } = renderHook(() => useTable_unstable({ as: 'div' }, ref));
+
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    expect(result.current.components.root).toBe('div');
+  });
+
+  it('passes size prop through to state', () => {
+    const { result } = renderHook(() => useTable_unstable({ size: 'small' }, ref));
+
+    expect(result.current.size).toBe('small');
+  });
+
+  it('reflects sortable prop in state', () => {
+    const { result } = renderHook(() => useTable_unstable({ sortable: true }, ref));
+
+    expect(result.current.sortable).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds unit tests that cover the core behaviour of the two main table hooks before introducing new exports on top of them:

- `useTable_unstable` — default state, `noNativeElements`, `as` prop, `size`, `sortable`
- `useDataGrid_unstable` / `useDataGridContextValues_unstable` — default state, `selectionMode → selectableRows`, `tableState.getRows()`, `resizableColumns`, context shape

## Stack order (review in this order)

1. **This PR** — hook unit tests ← _you are here_
2. feat(react-table): export `useTableContextValues_unstable` and `useTableCellLayoutContextValues_unstable`
3. feat(react-headless-components-preview): headless Table and DataGrid component families

## Test plan

- [ ] `nx test react-table` passes with the new test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)