### PR TITLE
feat(react-headless-components-preview): add headless List and ListItem components

### DIFF
--- a/change/@fluentui-react-list-b1d5584a-1533-4c65-96b4-988e2060b18f.json
+++ b/change/@fluentui-react-list-b1d5584a-1533-4c65-96b4-988e2060b18f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: fix useList and useListItem as prop handling",
+  "packageName": "@fluentui/react-list",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-headless-components-preview/library/package.json
+++ b/packages/react-components/react-headless-components-preview/library/package.json
@@ -32,6 +32,7 @@
     "@fluentui/react-input": "^9.8.0",
     "@fluentui/react-label": "^9.3.15",
     "@fluentui/react-link": "^9.8.0",
+    "@fluentui/react-list": "^9.6.13",
     "@fluentui/react-message-bar": "^9.6.23",
     "@fluentui/react-persona": "^9.7.1",
     "@fluentui/react-portal": "^9.8.11",

--- a/packages/react-components/react-headless-components-preview/library/src/List.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/List.ts
@@ -1,0 +1,11 @@
+export { List, renderList, useList, useListContextValues } from './components/List';
+export type { ListSlots, ListProps, ListState, ListContextValues } from './components/List';
+
+export { ListItem, renderListItem, useListItem } from './components/List';
+export type {
+  ListItemSlots,
+  ListItemProps,
+  ListItemState,
+  ListItemValue,
+  ListItemActionEventData,
+} from './components/List';

--- a/packages/react-components/react-headless-components-preview/library/src/components/List/List.test.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/List/List.test.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { isConformant } from '../../testing/isConformant';
+import { List } from './List';
+
+describe('List', () => {
+  isConformant({
+    Component: List,
+    displayName: 'List',
+  });
+
+  it('renders a default list', () => {
+    const { getByRole } = render(<List>content</List>);
+    expect(getByRole('list')).toBeInTheDocument();
+  });
+
+  it('renders a listbox when selectionMode is provided', () => {
+    const { getByRole } = render(<List selectionMode="single">content</List>);
+    expect(getByRole('listbox')).toBeInTheDocument();
+  });
+
+  it('renders a grid when navigationMode is composite', () => {
+    const { getByRole } = render(<List navigationMode="composite">content</List>);
+    expect(getByRole('grid')).toBeInTheDocument();
+  });
+});

--- a/packages/react-components/react-headless-components-preview/library/src/components/List/List.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/List/List.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import * as React from 'react';
+import type { ForwardRefComponent } from '@fluentui/react-utilities';
+import type { ListProps } from './List.types';
+import { useList, useListContextValues } from './useList';
+import { renderList } from './renderList';
+
+export const List: ForwardRefComponent<ListProps> = React.forwardRef((props, ref) => {
+  const state = useList(props, ref);
+  const contextValues = useListContextValues(state);
+  return renderList(state, contextValues);
+});
+
+List.displayName = 'List';

--- a/packages/react-components/react-headless-components-preview/library/src/components/List/List.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/List/List.types.ts
@@ -1,0 +1,11 @@
+import type {
+  ListSlots as ListBaseSlots,
+  ListProps as ListBaseProps,
+  ListState as ListBaseState,
+  ListContextValues as ListBaseContextValues,
+} from '@fluentui/react-list';
+
+export type ListSlots = ListBaseSlots;
+export type ListProps = ListBaseProps;
+export type ListState = ListBaseState;
+export type ListContextValues = ListBaseContextValues;

--- a/packages/react-components/react-headless-components-preview/library/src/components/List/ListItem/ListItem.test.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/List/ListItem/ListItem.test.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { isConformant } from '../../../testing/isConformant';
+import { List } from '../List';
+import { ListItem } from './ListItem';
+
+describe('ListItem', () => {
+  isConformant({
+    Component: ListItem,
+    displayName: 'ListItem',
+    renderOptions: {
+      wrapper: ({ children }) => <List>{children}</List>,
+    },
+  });
+
+  it('renders a default list item', () => {
+    const { getByRole } = render(
+      <List>
+        <ListItem>Item</ListItem>
+      </List>,
+    );
+    expect(getByRole('listitem')).toBeInTheDocument();
+  });
+
+  it('renders as option when inside a selectable list', () => {
+    const { getByRole } = render(
+      <List selectionMode="single">
+        <ListItem value="a">Item</ListItem>
+      </List>,
+    );
+    expect(getByRole('option')).toBeInTheDocument();
+  });
+});

--- a/packages/react-components/react-headless-components-preview/library/src/components/List/ListItem/ListItem.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/List/ListItem/ListItem.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import * as React from 'react';
+import type { ForwardRefComponent } from '@fluentui/react-utilities';
+import type { ListItemProps } from './ListItem.types';
+import { useListItem } from './useListItem';
+import { renderListItem } from './renderListItem';
+
+export const ListItem: ForwardRefComponent<ListItemProps> = React.forwardRef((props, ref) => {
+  const state = useListItem(props, ref);
+  return renderListItem(state);
+});
+
+ListItem.displayName = 'ListItem';

--- a/packages/react-components/react-headless-components-preview/library/src/components/List/ListItem/ListItem.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/List/ListItem/ListItem.types.ts
@@ -1,0 +1,12 @@
+import type {
+  ListItemSlots as ListItemBaseSlots,
+  ListItemProps as ListItemBaseProps,
+  ListItemState as ListItemBaseState,
+  ListItemValue,
+  ListItemActionEventData,
+} from '@fluentui/react-list';
+
+export type ListItemSlots = ListItemBaseSlots;
+export type ListItemProps = ListItemBaseProps;
+export type ListItemState = ListItemBaseState;
+export type { ListItemValue, ListItemActionEventData };

--- a/packages/react-components/react-headless-components-preview/library/src/components/List/ListItem/index.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/List/ListItem/index.ts
@@ -1,0 +1,10 @@
+export { ListItem } from './ListItem';
+export { useListItem } from './useListItem';
+export { renderListItem } from './renderListItem';
+export type {
+  ListItemSlots,
+  ListItemProps,
+  ListItemState,
+  ListItemValue,
+  ListItemActionEventData,
+} from './ListItem.types';

--- a/packages/react-components/react-headless-components-preview/library/src/components/List/ListItem/renderListItem.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/List/ListItem/renderListItem.ts
@@ -1,0 +1,3 @@
+import { renderListItem_unstable } from '@fluentui/react-list';
+
+export const renderListItem = renderListItem_unstable;

--- a/packages/react-components/react-headless-components-preview/library/src/components/List/ListItem/useListItem.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/List/ListItem/useListItem.ts
@@ -1,0 +1,5 @@
+'use client';
+
+import { useListItem_unstable } from '@fluentui/react-list';
+
+export const useListItem = useListItem_unstable;

--- a/packages/react-components/react-headless-components-preview/library/src/components/List/index.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/List/index.ts
@@ -1,0 +1,7 @@
+export { List } from './List';
+export { useList, useListContextValues } from './useList';
+export { renderList } from './renderList';
+export type { ListSlots, ListProps, ListState, ListContextValues } from './List.types';
+
+export { ListItem, renderListItem, useListItem } from './ListItem';
+export type { ListItemSlots, ListItemProps, ListItemState, ListItemValue, ListItemActionEventData } from './ListItem';

--- a/packages/react-components/react-headless-components-preview/library/src/components/List/renderList.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/List/renderList.ts
@@ -1,0 +1,3 @@
+import { renderList_unstable } from '@fluentui/react-list';
+
+export const renderList = renderList_unstable;

--- a/packages/react-components/react-headless-components-preview/library/src/components/List/useList.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/List/useList.ts
@@ -1,0 +1,8 @@
+'use client';
+
+import { useList_unstable, useListContextValues_unstable } from '@fluentui/react-list';
+import type { ListState, ListContextValues } from './List.types';
+
+export const useList = useList_unstable;
+
+export const useListContextValues = useListContextValues_unstable as (state: ListState) => ListContextValues;

--- a/packages/react-components/react-headless-components-preview/library/src/index.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/index.ts
@@ -282,3 +282,9 @@ export type {
   ToolbarToggleButtonProps,
   ToolbarToggleButtonState,
 } from './Toolbar';
+
+export { List, renderList, useList, useListContextValues } from './List';
+export type { ListSlots, ListProps, ListState, ListContextValues } from './List';
+
+export { ListItem, renderListItem, useListItem } from './List';
+export type { ListItemSlots, ListItemProps, ListItemState, ListItemValue, ListItemActionEventData } from './List';

--- a/packages/react-components/react-list/library/etc/react-list.api.md
+++ b/packages/react-components/react-list/library/etc/react-list.api.md
@@ -76,6 +76,9 @@ export const renderListItem_unstable: (state: ListItemState) => JSXElement;
 export const useList_unstable: (props: ListProps, ref: React_2.Ref<HTMLDivElement | HTMLUListElement | HTMLOListElement>) => ListState;
 
 // @public
+export function useListContextValues_unstable(state: ListState): ListContextValues;
+
+// @public
 export const useListItem_unstable: (props: ListItemProps, ref: React_2.Ref<HTMLLIElement | HTMLDivElement>) => ListItemState;
 
 // @public

--- a/packages/react-components/react-list/library/src/List.ts
+++ b/packages/react-components/react-list/library/src/List.ts
@@ -11,6 +11,7 @@ export {
   List,
   listClassNames,
   renderList_unstable,
-  useListStyles_unstable,
   useList_unstable,
+  useListContextValues_unstable,
+  useListStyles_unstable,
 } from './components/List/index';

--- a/packages/react-components/react-list/library/src/components/List/index.ts
+++ b/packages/react-components/react-list/library/src/components/List/index.ts
@@ -10,4 +10,5 @@ export type {
 } from './List.types';
 export { renderList_unstable } from './renderList';
 export { useList_unstable } from './useList';
+export { useListContextValues_unstable } from './useListContextValues';
 export { listClassNames, useListStyles_unstable } from './useListStyles.styles';

--- a/packages/react-components/react-list/library/src/components/List/useList.test.ts
+++ b/packages/react-components/react-list/library/src/components/List/useList.test.ts
@@ -1,0 +1,96 @@
+import * as React from 'react';
+import { act, renderHook } from '@testing-library/react-hooks';
+
+import { useList_unstable } from './useList';
+
+describe('useList_unstable', () => {
+  let ref: React.RefObject<HTMLDivElement | HTMLUListElement | HTMLOListElement | null>;
+
+  beforeEach(() => {
+    ref = React.createRef<HTMLDivElement | HTMLUListElement | HTMLOListElement>();
+  });
+
+  it('returns default state for non-selectable list', () => {
+    const { result } = renderHook(() => useList_unstable({}, ref));
+
+    expect(result.current).toMatchObject({
+      components: {
+        root: 'ul',
+      },
+      root: expect.objectContaining({
+        ref,
+        role: 'list',
+      }),
+      listItemRole: 'listitem',
+      navigationMode: undefined,
+      selection: undefined,
+    });
+  });
+
+  it('returns selection state and listbox role when selectionMode is enabled', () => {
+    const onSelectionChange = jest.fn();
+    const { result } = renderHook(() =>
+      useList_unstable(
+        {
+          selectionMode: 'single',
+          onSelectionChange,
+        },
+        ref,
+      ),
+    );
+
+    expect(result.current.root).toMatchObject({
+      role: 'listbox',
+    });
+    expect(result.current.selection).toBeDefined();
+
+    act(() => {
+      result.current.selection?.toggleItem({} as React.SyntheticEvent, 'item-1');
+    });
+
+    expect(result.current.selection?.selectedItems).toEqual(['item-1']);
+    expect(onSelectionChange).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        type: 'change',
+        selectedItems: ['item-1'],
+      }),
+    );
+  });
+
+  it('uses div root and grid roles in composite navigation mode', () => {
+    const { result } = renderHook(() => useList_unstable({ navigationMode: 'composite' }, ref));
+
+    expect(result.current).toMatchObject({
+      components: {
+        root: 'div',
+      },
+      root: expect.objectContaining({
+        role: 'grid',
+      }),
+      listItemRole: 'row',
+      navigationMode: 'composite',
+    });
+  });
+
+  it('respects an explicit as prop in returned root component', () => {
+    const { result } = renderHook(() => useList_unstable({ as: 'ol' }, ref));
+
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    expect(result.current.components.root).toBe('ol');
+    expect(result.current.root.role).toBe('list');
+  });
+  it('respects explicit as prop even in composite navigation mode', () => {
+    const { result } = renderHook(() => useList_unstable({ as: 'ol', navigationMode: 'composite' }, ref));
+
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    expect(result.current.components.root).toBe('ol');
+  });
+
+  it('determines default root component based on composite navigation mode', () => {
+    const { result } = renderHook(() => useList_unstable({ navigationMode: 'composite' }, ref));
+
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    expect(result.current.components.root).toBe('div');
+  });
+});

--- a/packages/react-components/react-list/library/src/components/List/useList.ts
+++ b/packages/react-components/react-list/library/src/components/List/useList.ts
@@ -31,7 +31,7 @@ export const useList_unstable = (
 ): ListState => {
   const { navigationMode, selectionMode, selectedItems, defaultSelectedItems, onSelectionChange } = props;
 
-  const as = props.as || navigationMode === 'composite' ? 'div' : DEFAULT_ROOT_EL_TYPE;
+  const as = props.as || (navigationMode === 'composite' ? 'div' : DEFAULT_ROOT_EL_TYPE);
 
   const arrowNavigationAttributes = useArrowNavigationGroup({
     axis: 'vertical',

--- a/packages/react-components/react-list/library/src/components/ListItem/useListItem.test.tsx
+++ b/packages/react-components/react-list/library/src/components/ListItem/useListItem.test.tsx
@@ -1,0 +1,131 @@
+import * as React from 'react';
+import { act, renderHook } from '@testing-library/react-hooks';
+import { Space } from '@fluentui/keyboard-keys';
+
+import { useListItem_unstable } from './useListItem';
+import { ListContextProvider, ListSynchronousContextProvider } from '../List/listContext';
+import type { ListContextValue, ListSynchronousContextValue } from '../List/List.types';
+import type { ListSelectionState } from '../../hooks/types';
+
+describe('useListItem_unstable', () => {
+  let ref: React.RefObject<HTMLLIElement | HTMLDivElement | null>;
+
+  beforeEach(() => {
+    ref = React.createRef<HTMLLIElement | HTMLDivElement>();
+  });
+
+  it('returns default state when list context is not provided', () => {
+    const { result } = renderHook(() => useListItem_unstable({}, ref));
+
+    expect(result.current).toMatchObject({
+      components: {
+        root: 'li',
+      },
+      root: expect.objectContaining({
+        role: 'listitem',
+      }),
+      selectable: false,
+      navigable: false,
+      checkmark: undefined,
+    });
+  });
+
+  it('uses div root and row role in composite navigation mode', () => {
+    const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => {
+      const listContextValue: ListContextValue = {
+        selection: undefined,
+        validateListItem: jest.fn(),
+      };
+      const syncContextValue: ListSynchronousContextValue = {
+        navigationMode: 'composite',
+        listItemRole: 'row',
+      };
+
+      return (
+        <ListContextProvider value={listContextValue}>
+          <ListSynchronousContextProvider value={syncContextValue}>{children}</ListSynchronousContextProvider>
+        </ListContextProvider>
+      );
+    };
+
+    const { result } = renderHook(() => useListItem_unstable({}, ref), { wrapper });
+
+    expect(result.current).toMatchObject({
+      components: {
+        root: 'div',
+      },
+      root: expect.objectContaining({
+        role: 'row',
+      }),
+      navigable: true,
+    });
+  });
+
+  it('respects an explicit as prop in returned root component', () => {
+    const { result } = renderHook(() => useListItem_unstable({ as: 'li' }, ref));
+
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    expect(result.current.components.root).toBe('li');
+  });
+
+  it('returns selectable state and toggles selection with keyboard action', () => {
+    const toggleItem = jest.fn();
+    const selection: ListSelectionState = {
+      isSelected: () => true,
+      toggleItem,
+      deselectItem: jest.fn(),
+      selectItem: jest.fn(),
+      clearSelection: jest.fn(),
+      toggleAllItems: jest.fn(),
+      setSelectedItems: jest.fn(),
+      selectedItems: ['item-1'],
+    };
+
+    const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => {
+      const listContextValue: ListContextValue = {
+        selection,
+        validateListItem: jest.fn(),
+      };
+      const syncContextValue: ListSynchronousContextValue = {
+        navigationMode: 'items',
+        listItemRole: 'option',
+      };
+
+      return (
+        <ListContextProvider value={listContextValue}>
+          <ListSynchronousContextProvider value={syncContextValue}>{children}</ListSynchronousContextProvider>
+        </ListContextProvider>
+      );
+    };
+
+    const { result } = renderHook(() => useListItem_unstable({ value: 'item-1' }, ref), { wrapper });
+
+    expect(result.current).toMatchObject({
+      selectable: true,
+      navigable: true,
+      root: expect.objectContaining({
+        role: 'option',
+        'aria-selected': true,
+      }),
+      checkmark: expect.objectContaining({
+        checked: true,
+      }),
+    });
+
+    const target = document.createElement('div');
+    const event = {
+      key: Space,
+      target,
+      currentTarget: target,
+      preventDefault: jest.fn(),
+      defaultPrevented: false,
+    } as unknown as React.KeyboardEvent<HTMLLIElement> & React.KeyboardEvent<HTMLDivElement>;
+
+    act(() => {
+      result.current.root.onKeyDown?.(event);
+    });
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(toggleItem).toHaveBeenCalledWith(event, 'item-1');
+  });
+});

--- a/packages/react-components/react-list/library/src/components/ListItem/useListItem.tsx
+++ b/packages/react-components/react-list/library/src/components/ListItem/useListItem.tsx
@@ -54,7 +54,7 @@ export const useListItem_unstable = (
   const isSelected = useListContext_unstable(ctx => ctx.selection?.isSelected(value)) ?? false;
   const validateListItem = useListContext_unstable(ctx => ctx.validateListItem);
 
-  const as = props.as || navigationMode === 'composite' ? 'div' : DEFAULT_ROOT_EL_TYPE;
+  const as = props.as || (navigationMode === 'composite' ? 'div' : DEFAULT_ROOT_EL_TYPE);
 
   const finalListItemRole = role || listItemRole;
 

--- a/packages/react-components/react-list/library/src/index.ts
+++ b/packages/react-components/react-list/library/src/index.ts
@@ -1,6 +1,13 @@
-export { List, listClassNames, renderList_unstable, useListStyles_unstable, useList_unstable } from './List';
+export {
+  List,
+  listClassNames,
+  renderList_unstable,
+  useList_unstable,
+  useListContextValues_unstable,
+  useListStyles_unstable,
+} from './List';
 
-export type { ListProps, ListSlots, ListState } from './List';
+export type { ListContextValues, ListProps, ListSlots, ListState } from './List';
 export {
   ListItem,
   listItemClassNames,


### PR DESCRIPTION
## Summary

Adds headless wrappers for the `react-list` component family to `@fluentui/react-headless-components-preview`. Both components delegate to `@fluentui/react-list` hooks and render functions — no Griffel styling, no design tokens.

- `List` — wraps `useList_unstable` + `useListContextValues_unstable` + `renderList_unstable`
- `ListItem` — wraps `useListItem_unstable` + `renderListItem_unstable`

## Stack order (review in this order)

1. test(react-list): hook unit tests + bug fix (#36053)
2. feat(react-list): base hook exports (#36054)
3. **This PR** — headless List + ListItem ← _you are here_

## Test plan

- [ ] `List` and `ListItem` render without any applied styling
- [ ] Context values propagate correctly from `List` down to `ListItem`
- [ ] Selection and navigation modes work end-to-end
- [ ] Consumers can apply arbitrary `className`/`style`

🤖 Generated with [Claude Code](https://claude.com/claude-code)