### PR TITLE
test(react-tree): add unit tests for useTree_unstable, useFlatTree_unstable and useTreeItem_unstable hooks

### DIFF
--- a/packages/react-components/react-tree/library/src/components/FlatTree/useFlatTree.test.ts
+++ b/packages/react-components/react-tree/library/src/components/FlatTree/useFlatTree.test.ts
@@ -1,0 +1,84 @@
+import * as React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import { useFlatTree_unstable } from './useFlatTree';
+import { useFlatTreeContextValues_unstable } from './useFlatTreeContextValues';
+
+describe('useFlatTree_unstable', () => {
+  let ref: React.RefObject<HTMLElement | null>;
+
+  beforeEach(() => {
+    ref = React.createRef<HTMLElement>();
+  });
+
+  it('returns default state with div root element', () => {
+    const { result } = renderHook(() => useFlatTree_unstable({}, ref));
+
+    expect(result.current).toMatchObject({
+      components: { root: 'div' },
+      contextType: 'root',
+      level: 1,
+    });
+  });
+
+  it('reflects size prop in state', () => {
+    const { result } = renderHook(() => useFlatTree_unstable({ size: 'small' }, ref));
+
+    expect(result.current.size).toBe('small');
+  });
+
+  it('reflects appearance prop in state', () => {
+    const { result } = renderHook(() => useFlatTree_unstable({ appearance: 'subtle' }, ref));
+
+    expect(result.current.appearance).toBe('subtle');
+  });
+
+  it('reflects selectionMode prop in state', () => {
+    const { result } = renderHook(() => useFlatTree_unstable({ selectionMode: 'multiselect' }, ref));
+
+    expect(result.current.selectionMode).toBe('multiselect');
+  });
+
+  it('defaults navigationMode to tree', () => {
+    const { result } = renderHook(() => useFlatTree_unstable({}, ref));
+
+    expect(result.current.navigationMode).toBe('tree');
+  });
+});
+
+describe('useFlatTreeContextValues_unstable', () => {
+  let ref: React.RefObject<HTMLElement | null>;
+
+  beforeEach(() => {
+    ref = React.createRef<HTMLElement>();
+  });
+
+  it('returns tree context with root contextType', () => {
+    const { result } = renderHook(() => {
+      const state = useFlatTree_unstable({}, ref);
+      return useFlatTreeContextValues_unstable(state);
+    });
+
+    expect(result.current.tree).toMatchObject({
+      contextType: 'root',
+      level: 1,
+    });
+  });
+
+  it('reflects selectionMode in tree context', () => {
+    const { result } = renderHook(() => {
+      const state = useFlatTree_unstable({ selectionMode: 'single' }, ref);
+      return useFlatTreeContextValues_unstable(state);
+    });
+
+    expect(result.current.tree.selectionMode).toBe('single');
+  });
+
+  it('reflects size in tree context', () => {
+    const { result } = renderHook(() => {
+      const state = useFlatTree_unstable({ size: 'small' }, ref);
+      return useFlatTreeContextValues_unstable(state);
+    });
+
+    expect(result.current.tree.size).toBe('small');
+  });
+});

--- a/packages/react-components/react-tree/library/src/components/Tree/useTree.test.ts
+++ b/packages/react-components/react-tree/library/src/components/Tree/useTree.test.ts
@@ -1,0 +1,90 @@
+import * as React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import { useTree_unstable } from './useTree';
+import { useTreeContextValues_unstable } from './useTreeContextValues';
+
+describe('useTree_unstable', () => {
+  let ref: React.RefObject<HTMLElement | null>;
+
+  beforeEach(() => {
+    ref = React.createRef<HTMLElement>();
+  });
+
+  it('returns default state with div root element', () => {
+    const { result } = renderHook(() => useTree_unstable({}, ref));
+
+    expect(result.current).toMatchObject({
+      components: { root: 'div' },
+      contextType: 'root',
+      level: 1,
+    });
+  });
+
+  it('reflects size prop in state', () => {
+    const { result } = renderHook(() => useTree_unstable({ size: 'small' }, ref));
+
+    expect(result.current.size).toBe('small');
+  });
+
+  it('reflects appearance prop in state', () => {
+    const { result } = renderHook(() => useTree_unstable({ appearance: 'subtle-alpha' }, ref));
+
+    expect(result.current.appearance).toBe('subtle-alpha');
+  });
+
+  it('reflects selectionMode prop in state', () => {
+    const { result } = renderHook(() => useTree_unstable({ selectionMode: 'multiselect' }, ref));
+
+    expect(result.current.selectionMode).toBe('multiselect');
+  });
+
+  it('defaults navigationMode to tree', () => {
+    const { result } = renderHook(() => useTree_unstable({}, ref));
+
+    expect(result.current.navigationMode).toBe('tree');
+  });
+
+  it('reflects navigationMode prop in state', () => {
+    const { result } = renderHook(() => useTree_unstable({ navigationMode: 'treegrid' }, ref));
+
+    expect(result.current.navigationMode).toBe('treegrid');
+  });
+});
+
+describe('useTreeContextValues_unstable', () => {
+  let ref: React.RefObject<HTMLElement | null>;
+
+  beforeEach(() => {
+    ref = React.createRef<HTMLElement>();
+  });
+
+  it('returns tree context with root contextType', () => {
+    const { result } = renderHook(() => {
+      const state = useTree_unstable({}, ref);
+      return useTreeContextValues_unstable(state);
+    });
+
+    expect(result.current.tree).toMatchObject({
+      contextType: 'root',
+      level: 1,
+    });
+  });
+
+  it('reflects selectionMode in tree context', () => {
+    const { result } = renderHook(() => {
+      const state = useTree_unstable({ selectionMode: 'single' }, ref);
+      return useTreeContextValues_unstable(state);
+    });
+
+    expect(result.current.tree.selectionMode).toBe('single');
+  });
+
+  it('reflects appearance in tree context', () => {
+    const { result } = renderHook(() => {
+      const state = useTree_unstable({ appearance: 'transparent' }, ref);
+      return useTreeContextValues_unstable(state);
+    });
+
+    expect(result.current.tree.appearance).toBe('transparent');
+  });
+});

--- a/packages/react-components/react-tree/library/src/components/TreeItem/useTreeItem.test.tsx
+++ b/packages/react-components/react-tree/library/src/components/TreeItem/useTreeItem.test.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import { useTreeItem_unstable } from './useTreeItem';
+import { useTreeItemContextValues_unstable } from './useTreeItemContextValues';
+
+describe('useTreeItem_unstable', () => {
+  let ref: React.RefObject<HTMLDivElement | null>;
+
+  beforeEach(() => {
+    ref = React.createRef<HTMLDivElement>();
+  });
+
+  it('returns default state with div root element', () => {
+    const { result } = renderHook(() => useTreeItem_unstable({ value: 'item-1', itemType: 'leaf' }, ref));
+
+    expect(result.current).toMatchObject({
+      components: { root: 'div' },
+      itemType: 'leaf',
+      value: 'item-1',
+    });
+  });
+
+  it('reflects branch itemType in state', () => {
+    const { result } = renderHook(() => useTreeItem_unstable({ value: 'item-1', itemType: 'branch' }, ref));
+
+    expect(result.current.itemType).toBe('branch');
+  });
+
+  it('reflects value prop in state', () => {
+    const { result } = renderHook(() => useTreeItem_unstable({ value: 'custom-value', itemType: 'leaf' }, ref));
+
+    expect(result.current.value).toBe('custom-value');
+  });
+
+  it('defaults open to false for leaf items', () => {
+    const { result } = renderHook(() => useTreeItem_unstable({ value: 'item-1', itemType: 'leaf' }, ref));
+
+    expect(result.current.open).toBe(false);
+  });
+});
+
+describe('useTreeItemContextValues_unstable', () => {
+  let ref: React.RefObject<HTMLDivElement | null>;
+
+  beforeEach(() => {
+    ref = React.createRef<HTMLDivElement>();
+  });
+
+  it('returns treeItem context with value and itemType', () => {
+    const { result } = renderHook(() => {
+      const state = useTreeItem_unstable({ value: 'item-1', itemType: 'leaf' }, ref);
+      return useTreeItemContextValues_unstable(state);
+    });
+
+    expect(result.current.treeItem).toMatchObject({
+      value: 'item-1',
+      itemType: 'leaf',
+    });
+  });
+
+  it('reflects open state in treeItem context', () => {
+    const { result } = renderHook(() => {
+      const state = useTreeItem_unstable({ value: 'item-1', itemType: 'branch', open: true }, ref);
+      return useTreeItemContextValues_unstable(state);
+    });
+
+    expect(result.current.treeItem.open).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds unit tests that cover the core behaviour of the main tree hooks before introducing new exports on top of them:

- `useTree_unstable` — default state (div root, contextType root, level 1), size, appearance, selectionMode, navigationMode; context values shape
- `useFlatTree_unstable` — same set of assertions as Tree (FlatTree shares the same root tree logic); context values shape
- `useTreeItem_unstable` — default state, itemType, value, open; context values shape

## Stack order (review in this order)

1. **This PR** — hook unit tests ← _you are here_
2. feat(react-tree): export `useTreeItemPersonaLayoutContextValues_unstable` and `TreeItemPersonaLayoutContextValues`
3. feat(react-headless-components-preview): headless Tree component family

## Test plan

- [ ] `nx test react-tree` passes with the three new test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)