### PR TITLE
fix(web-components): remove unnecessary id property mappings in accordion-item

### DIFF
--- a/change/@fluentui-web-components-24da5c95-a59f-4902-9a3e-84a255feae1f.json
+++ b/change/@fluentui-web-components-24da5c95-a59f-4902-9a3e-84a255feae1f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: remove unnecessary id property mappings in accordion-item",
+  "packageName": "@fluentui/web-components",
+  "email": "863023+radium-v@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/docs/web-components.api.md
+++ b/packages/web-components/docs/web-components.api.md
@@ -437,7 +437,6 @@ export class BaseAccordionItem extends FASTElement {
     expandbutton: HTMLElement;
     expanded: boolean;
     headinglevel: 1 | 2 | 3 | 4 | 5 | 6;
-    id: string;
 }
 
 // @public

--- a/packages/web-components/src/accordion-item/accordion-item.base.ts
+++ b/packages/web-components/src/accordion-item/accordion-item.base.ts
@@ -1,6 +1,4 @@
-import { attr, FASTElement, nullableNumberConverter } from '@microsoft/fast-element';
-import { uniqueId } from '@microsoft/fast-web-utilities';
-import { toggleState } from '../utils/element-internals.js';
+import { attr, FASTElement, nullableNumberConverter, observable } from '@microsoft/fast-element';
 
 /**
  *
@@ -59,17 +57,8 @@ export class BaseAccordionItem extends FASTElement {
   public disabled: boolean = false;
 
   /**
-   * The item ID
-   *
-   * @public
-   * @remarks
-   * HTML Attribute: id
-   */
-  @attr
-  public id: string = uniqueId('accordion-');
-
-  /**
    * @internal
    */
+  @observable
   public expandbutton!: HTMLElement;
 }

--- a/packages/web-components/src/accordion-item/accordion-item.spec.ts
+++ b/packages/web-components/src/accordion-item/accordion-item.spec.ts
@@ -116,20 +116,6 @@ test.describe('Accordion item', () => {
     await expect(firstItem).toHaveJSProperty('expanded', true);
   });
 
-  test('should set internal properties to match the id when provided', async ({ fastPage }) => {
-    const { element } = fastPage;
-    const button = element.locator('button');
-
-    await fastPage.setTemplate(/* html */ `
-      <fluent-accordion>
-        <fluent-accordion-item id="foo">Item 1</fluent-accordion-item>
-      </fluent-accordion>
-    `);
-
-    await expect(element.locator(`[role="region"]`)).toHaveAttribute('aria-labelledby', 'foo');
-    await expect(button).toHaveId('foo');
-  });
-
   for (const size of Object.values(AccordionItemSize)) {
     test(`should set the \`size\` property to "${size}" when the attribute is set to "${size}"`, async ({
       fastPage,

--- a/packages/web-components/src/accordion-item/accordion-item.template.ts
+++ b/packages/web-components/src/accordion-item/accordion-item.template.ts
@@ -41,11 +41,11 @@ export function accordionItemTemplate<T extends AccordionItem>(
       <button
         class="button"
         part="button"
-        ${ref('expandbutton')}
-        ?disabled="${x => (x.disabled ? 'true' : void 0)}"
+        id="control"
+        aria-controls="panel"
         aria-expanded="${x => x.expanded}"
-        aria-controls="${x => x.id}-panel"
-        id="${x => x.id}"
+        ?disabled="${x => x.disabled}"
+        ${ref('expandbutton')}
       >
         <slot name="heading"></slot>
       </button>
@@ -53,7 +53,7 @@ export function accordionItemTemplate<T extends AccordionItem>(
       <slot name="marker-expanded"> ${staticallyCompose(options.expandedIcon)} </slot>
       <slot name="marker-collapsed"> ${staticallyCompose(options.collapsedIcon)} </slot>
     </div>
-    <div class="content" part="content" id="${x => x.id}-panel" role="region" aria-labelledby="${x => x.id}">
+    <div class="content" part="content" id="panel" role="region" aria-labelledby="control">
       <slot></slot>
     </div>
   `;


### PR DESCRIPTION
## Previous Behavior

The `BaseAccordionItem` class was overriding the native `id` property with an `@attr`-decorated version that generated a unique ID via `uniqueId()`. This was only needed to wire up `aria-controls` and `aria-labelledby` between the heading button and the content panel inside the shadow DOM. Since those references never cross the shadow boundary, they don't need to be derived from the host element's `id` at all.

## New Behavior

This PR removes the `@attr id` override and switches the template to use static internal IDs (`control` and `panel`) for the ARIA linkage. This also removes the `uniqueId` and `toggleState` imports that are no longer needed, and adds `@observable` to `expandbutton` so it participates in FAST's reactivity system.

The test `should set internal properties to match the id when provided` has been removed since it asserted the old coupling behavior. All remaining accordion tests pass.

I've verified via VoiceOver that screen reader support remains unaffected, with no observed changes to the output or navigation.