### PR TITLE
chore: add release pipeline for react-headless-components-preview

### DIFF
--- a/azure-pipelines.release.headless.yml
+++ b/azure-pipelines.release.headless.yml
@@ -67,19 +67,24 @@ extends:
                 displayName: yarn
 
               - script: |
-                  FLUENT_PROD_BUILD=true yarn nx run react-headless-components-preview:build --nxBail
+                  echo "Following packages will be published (if they contain changes):"
+                  yarn nx show projects -p 'tag:react-headless,!tag:npm:private' --exclude 'apps/**'
+                displayName: Show packages
+
+              - script: |
+                  FLUENT_PROD_BUILD=true yarn nx run-many -t build -p 'tag:react-headless,!tag:npm:private,!tag:type:stories' --exclude 'apps/**' --nxBail
                 displayName: build
 
               - script: |
-                  FLUENT_PROD_BUILD=true yarn nx run react-headless-components-preview:test --nxBail
+                  FLUENT_PROD_BUILD=true yarn nx run-many -t test -p 'tag:react-headless,!tag:npm:private,!tag:type:stories' --exclude 'apps/**' --nxBail
                 displayName: test
 
               - script: |
-                  FLUENT_PROD_BUILD=true yarn nx run react-headless-components-preview:lint --nxBail
+                  FLUENT_PROD_BUILD=true yarn nx run-many -t lint -p 'tag:react-headless,!tag:npm:private,!tag:type:stories' --exclude 'apps/**' --nxBail
                 displayName: lint
 
               - script: |
-                  yarn publish:beachball -n $(npmToken) --config scripts/beachball/src/release-headless.config.js --message 'release: applying package updates - react-headless-components-preview'
+                  yarn publish:beachball -n $(npmToken) --config scripts/beachball/src/release-headless.config.js --message 'release: applying package updates - react-headless'
                   git reset --hard origin/master
                 env:
                   GITHUB_PAT: $(githubPAT)

--- a/azure-pipelines.release.headless.yml
+++ b/azure-pipelines.release.headless.yml
@@ -1,0 +1,91 @@
+pr: none
+trigger: none
+
+# Customize build number to include package prefix
+# Example: headless_20201022.1
+name: 'headless_$(Date:yyyyMMdd)$(Rev:.r)'
+
+parameters:
+  - name: dryRun
+    displayName: Dry Run Mode
+    type: boolean
+    default: false
+
+variables:
+  - group: 'Github and NPM secrets'
+  - template: .devops/templates/variables.yml
+    parameters:
+      skipComponentGovernanceDetection: false
+  - name: tags
+    value: production,externalfacing
+
+resources:
+  repositories:
+    - repository: 1esPipelines
+      type: git
+      name: 1ESPipelineTemplates/1ESPipelineTemplates
+      ref: refs/tags/release
+
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
+  parameters:
+    pool:
+      name: Azure-Pipelines-1ESPT-ExDShared
+      image: windows-latest
+      os: windows # We need windows because compliance task only run on windows.
+    stages:
+      - stage: main
+        jobs:
+          - job: Release
+            pool:
+              name: '1ES-Host-Ubuntu'
+              image: '1ES-PT-Ubuntu-20.04'
+              os: linux
+            timeoutInMinutes: 90
+            workspace:
+              clean: all
+            templateContext:
+              outputParentDirectory: $(System.DefaultWorkingDirectory)
+              outputs:
+                - output: pipelineArtifact
+                  targetPath: $(System.DefaultWorkingDirectory)
+                  artifactName: output
+            steps:
+              - template: .devops/templates/tools.yml@self
+                parameters:
+                  dryRun: ${{ parameters.dryRun }}
+
+              - script: |
+                  git config user.name "Fluent UI Build"
+                  git config user.email "fluentui-internal@service.microsoft.com"
+                  git remote set-url origin https://$(githubUser):$(githubPAT)@github.com/microsoft/fluentui.git
+                displayName: Authenticate git for pushes
+
+              - task: Bash@3
+                inputs:
+                  filePath: yarn-ci.sh
+                displayName: yarn
+
+              - script: |
+                  FLUENT_PROD_BUILD=true yarn nx run react-headless-components-preview:build --nxBail
+                displayName: build
+
+              - script: |
+                  FLUENT_PROD_BUILD=true yarn nx run react-headless-components-preview:test --nxBail
+                displayName: test
+
+              - script: |
+                  FLUENT_PROD_BUILD=true yarn nx run react-headless-components-preview:lint --nxBail
+                displayName: lint
+
+              - script: |
+                  yarn publish:beachball -n $(npmToken) --config scripts/beachball/src/release-headless.config.js --message 'release: applying package updates - react-headless-components-preview'
+                  git reset --hard origin/master
+                env:
+                  GITHUB_PAT: $(githubPAT)
+                displayName: Publish changes and bump versions
+                condition: not(${{ parameters.dryRun }})
+
+              - template: .devops/templates/cleanup.yml@self
+                parameters:
+                  checkForModifiedFiles: false

--- a/change/@fluentui-react-headless-components-preview-c0f6f365-8692-4be6-bf8a-8b2611061bb6.json
+++ b/change/@fluentui-react-headless-components-preview-c0f6f365-8692-4be6-bf8a-8b2611061bb6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: update project nx tag",
+  "packageName": "@fluentui/react-headless-components-preview",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-headless-components-preview/library/project.json
+++ b/packages/react-components/react-headless-components-preview/library/project.json
@@ -3,7 +3,7 @@
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-headless-components-preview/library/src",
-  "tags": ["platform:web", "vNext", "react-headless"],
+  "tags": ["platform:web", "react-headless"],
   "implicitDependencies": [],
   "targets": {
     "generate-api": {

--- a/packages/react-components/react-headless-components-preview/library/project.json
+++ b/packages/react-components/react-headless-components-preview/library/project.json
@@ -3,7 +3,7 @@
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-headless-components-preview/library/src",
-  "tags": ["platform:web", "vNext"],
+  "tags": ["platform:web", "vNext", "react-headless"],
   "implicitDependencies": [],
   "targets": {
     "generate-api": {

--- a/packages/react-components/react-headless-components-preview/library/project.json
+++ b/packages/react-components/react-headless-components-preview/library/project.json
@@ -3,7 +3,7 @@
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-headless-components-preview/library/src",
-  "tags": ["platform:web", "react-headless"],
+  "tags": ["vNext", "platform:web", "react-headless"],
   "implicitDependencies": [],
   "targets": {
     "generate-api": {

--- a/packages/react-components/react-headless-components-preview/stories/project.json
+++ b/packages/react-components/react-headless-components-preview/stories/project.json
@@ -3,6 +3,6 @@
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-headless-components-preview/stories/src",
-  "tags": ["platform:web", "type:stories", "react-headless"],
+  "tags": ["vNext", "platform:web", "type:stories", "react-headless"],
   "implicitDependencies": []
 }

--- a/packages/react-components/react-headless-components-preview/stories/project.json
+++ b/packages/react-components/react-headless-components-preview/stories/project.json
@@ -3,6 +3,6 @@
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-headless-components-preview/stories/src",
-  "tags": ["vNext", "platform:web", "type:stories", "react-headless"],
+  "tags": ["platform:web", "type:stories", "react-headless"],
   "implicitDependencies": []
 }

--- a/packages/react-components/react-headless-components-preview/stories/project.json
+++ b/packages/react-components/react-headless-components-preview/stories/project.json
@@ -3,6 +3,6 @@
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "packages/react-components/react-headless-components-preview/stories/src",
-  "tags": ["vNext", "platform:web", "type:stories"],
+  "tags": ["vNext", "platform:web", "type:stories", "react-headless"],
   "implicitDependencies": []
 }

--- a/scripts/beachball/src/config.test.ts
+++ b/scripts/beachball/src/config.test.ts
@@ -1,3 +1,4 @@
+import headlessConfig from './release-headless.config';
 import toolsConfig from './release-tools.config';
 import v8Config from './release-v8.config';
 import vNextConfig from './release-vNext.config';
@@ -111,6 +112,22 @@ describe(`beachball configs`, () => {
     );
 
     expect(webComponentsConfig.changelog).toEqual(sharedConfig.changelog);
+  });
+
+  it(`should generate react-headless release config`, () => {
+    expect(headlessConfig.scope).toEqual(
+      expect.arrayContaining(['packages/react-components/react-headless-components-preview/library']),
+    );
+
+    // Ensure only headless packages are included, not broader vNext or tools packages
+    const nonHeadlessScopes = [
+      'packages/react-components/react-components',
+      'packages/react-components/react-button',
+      'packages/react',
+    ];
+    expect(headlessConfig.scope.some(scope => nonHeadlessScopes.includes(scope))).toBe(false);
+
+    expect(headlessConfig.changelog).toEqual(sharedConfig.changelog);
   });
 
   it(`should generate tools release config`, () => {

--- a/scripts/beachball/src/config.test.ts
+++ b/scripts/beachball/src/config.test.ts
@@ -100,6 +100,9 @@ describe(`beachball configs`, () => {
 
     // Ensure that vNext config does not include "tools" packages
     expect(vNextConfig.scope.some(scope => toolsConfig.scope.includes(scope))).toBe(false);
+
+    // Ensure that vNext config does not include "react-headless" packages
+    expect(vNextConfig.scope.some(scope => headlessConfig.scope.includes(scope))).toBe(false);
   });
 
   it(`should generate web-components release config`, () => {

--- a/scripts/beachball/src/release-headless.config.js
+++ b/scripts/beachball/src/release-headless.config.js
@@ -1,13 +1,22 @@
 require('./register').register();
 
+const { getAllPackageInfo } = require('@fluentui/scripts-monorepo');
+
 const { config: sharedConfig } = require('./shared.config');
+
+function getHeadlessPaths() {
+  const allProjects = getAllPackageInfo();
+  return Object.values(allProjects)
+    .filter(project => project.projectConfig.tags?.includes('react-headless') && !project.packageJson.private)
+    .map(project => project.packagePath);
+}
 
 /**
  * @type {typeof sharedConfig}
  */
 const config = {
   ...sharedConfig,
-  scope: ['packages/react-components/react-headless-components-preview/library'],
+  scope: getHeadlessPaths(),
 };
 
 module.exports = config;

--- a/scripts/beachball/src/release-headless.config.js
+++ b/scripts/beachball/src/release-headless.config.js
@@ -1,0 +1,13 @@
+require('./register').register();
+
+const { config: sharedConfig } = require('./shared.config');
+
+/**
+ * @type {typeof sharedConfig}
+ */
+const config = {
+  ...sharedConfig,
+  scope: ['packages/react-components/react-headless-components-preview/library'],
+};
+
+module.exports = config;

--- a/scripts/beachball/src/release-headless.config.js
+++ b/scripts/beachball/src/release-headless.config.js
@@ -1,22 +1,16 @@
 require('./register').register();
 
-const { getAllPackageInfo } = require('@fluentui/scripts-monorepo');
-
 const { config: sharedConfig } = require('./shared.config');
+const { getConfig } = require('./utils');
 
-function getHeadlessPaths() {
-  const allProjects = getAllPackageInfo();
-  return Object.values(allProjects)
-    .filter(project => project.projectConfig.tags?.includes('react-headless') && !project.packageJson.private)
-    .map(project => project.packagePath);
-}
+const { scope } = getConfig({ version: 'headless' });
 
 /**
  * @type {typeof sharedConfig}
  */
 const config = {
   ...sharedConfig,
-  scope: getHeadlessPaths(),
+  scope,
 };
 
 module.exports = config;

--- a/scripts/beachball/src/utils.ts
+++ b/scripts/beachball/src/utils.ts
@@ -10,6 +10,7 @@ import { getAllPackageInfo, isConvergedPackage } from '@fluentui/scripts-monorep
 export function getConfig({ version }: { version: 'web-components' }): { scope: string[] };
 export function getConfig({ version }: { version: 'v8' }): { scope: string[] };
 export function getConfig({ version }: { version: 'tools' }): { scope: string[] };
+export function getConfig({ version }: { version: 'headless' }): { scope: string[] };
 export function getConfig({ version }: { version: 'vNext' }): {
   scope: string[];
   groupConfig: {
@@ -18,8 +19,8 @@ export function getConfig({ version }: { version: 'vNext' }): {
     include: string[];
   };
 };
-export function getConfig({ version }: { version: 'v8' | 'vNext' | 'web-components' | 'tools' }) {
-  const { vNextPaths, webComponentsPaths, toolsPaths, v8Paths } = getPackagePaths();
+export function getConfig({ version }: { version: 'v8' | 'vNext' | 'web-components' | 'tools' | 'headless' }) {
+  const { vNextPaths, webComponentsPaths, toolsPaths, v8Paths, headlessPaths } = getPackagePaths();
 
   if (version === 'vNext') {
     return {
@@ -48,6 +49,12 @@ export function getConfig({ version }: { version: 'v8' | 'vNext' | 'web-componen
     };
   }
 
+  if (version === 'headless') {
+    return {
+      scope: [...headlessPaths],
+    };
+  }
+
   throw new Error('Unsupported version scopes acquisition');
 }
 
@@ -66,6 +73,12 @@ const isToolsPackage: typeof isConvergedPackage = metadata => {
 
   return hasToolsTag && !isPrivate && !isV8Package(metadata);
 };
+const isHeadlessPackage: typeof isConvergedPackage = metadata => {
+  const hasHeadlessTag = Boolean(metadata.project.tags?.includes('react-headless'));
+  const isPrivate = Boolean(metadata.packageJson.private);
+
+  return hasHeadlessTag && !isPrivate;
+};
 
 function getPackagePaths() {
   const allProjects = getAllPackageInfo();
@@ -73,6 +86,7 @@ function getPackagePaths() {
   const webComponentsPaths: string[] = [];
   const v8Paths: string[] = [];
   const toolsPaths: string[] = [];
+  const headlessPaths: string[] = [];
 
   for (const project of Object.values(allProjects)) {
     const isPrivate = Boolean(project.packageJson.private);
@@ -89,7 +103,10 @@ function getPackagePaths() {
     if (isV8Package(metadata)) {
       v8Paths.push(project.packagePath);
     }
+    if (isHeadlessPackage(metadata)) {
+      headlessPaths.push(project.packagePath);
+    }
   }
 
-  return { vNextPaths, webComponentsPaths, toolsPaths, v8Paths };
+  return { vNextPaths, webComponentsPaths, toolsPaths, v8Paths, headlessPaths };
 }

--- a/scripts/beachball/src/utils.ts
+++ b/scripts/beachball/src/utils.ts
@@ -91,7 +91,7 @@ function getPackagePaths() {
   for (const project of Object.values(allProjects)) {
     const isPrivate = Boolean(project.packageJson.private);
     const metadata = { project: project.projectConfig, packageJson: project.packageJson };
-    if (isConvergedPackage(metadata) && !isToolsPackage(metadata) && !isPrivate) {
+    if (isConvergedPackage(metadata) && !isToolsPackage(metadata) && !isHeadlessPackage(metadata) && !isPrivate) {
       vNextPaths.push(project.packagePath);
     }
     if (isWebComponentPackage(metadata)) {


### PR DESCRIPTION
## Summary

- Adds `azure-pipelines.release.headless.yml` — a dedicated release pipeline for `@fluentui/react-headless-components-preview`, modeled on the existing tools release pipeline
- Adds `scripts/beachball/src/release-headless.config.js` — a scoped beachball config that targets only the headless library package, preventing unintended vNext-wide publishes

## Test plan

- [ ] Trigger the pipeline in dry-run mode (`dryRun: true`) to verify build/test/lint steps pass for `react-headless-components-preview`
- [ ] Verify beachball picks up only `@fluentui/react-headless-components-preview` change files in a dry run

🤖 Generated with [Claude Code](https://claude.com/claude-code)