### PR TITLE
chore(ci): adopt validate-pr-number for consistency

### DIFF
--- a/.github/workflows/bundle-size-comment.yml
+++ b/.github/workflows/bundle-size-comment.yml
@@ -12,6 +12,11 @@ jobs:
     permissions:
       pull-requests: write
     steps:
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            .github
+
       - name: Download artifact
         uses: actions/download-artifact@v7
         with:
@@ -22,12 +27,16 @@ jobs:
 
       - name: Load PR number
         id: pr_number
-        run: echo "id=$(cat pr.txt)" >> $GITHUB_OUTPUT
-        working-directory: ./results
+        uses: actions/github-script@v8
+        with:
+          result-encoding: string
+          script: |
+            const run = require('./.github/scripts/validate-pr-number');
+            return run({ filePath: 'results/pr.txt' });
 
       - name: 'Comment on PR'
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: bundle-size-report
-          number: ${{ steps.pr_number.outputs.id }}
+          number: ${{ steps.pr_number.outputs.result }}
           path: ./results/monosize-report.md


### PR DESCRIPTION
## Previous Behavior

  The `bundle-size-comment.yml` workflow loaded the PR number from a downloaded artifact using shell command substitution:

```yaml
  - name: Load PR number
    id: pr_number
    run: echo "id=$(cat pr.txt)" >> $GITHUB_OUTPUT
    working-directory: ./results
```

##  New Behavior

  The PR number is now parsed via the existing .github/scripts/validate-pr-number.js helper (already used by pr-vrt-comment.yml), which:

  - reads pr.txt with fs.readFileSync,
  - coerces the trimmed content with Number(...),
  - fails the step if the result is NaN or non-integer.
