### PR TITLE
fix(v0): avoid useContextSelector useState eager-bailout pitfall

### DIFF
--- a/packages/fluentui/react-bindings/src/context-selector/createContext.ts
+++ b/packages/fluentui/react-bindings/src/context-selector/createContext.ts
@@ -8,8 +8,6 @@ const createProvider = <Value>(Original: React.Provider<ContextValue<Value>>) =>
   const Provider: React.FC<React.ProviderProps<Value>> = props => {
     // Holds an actual "props.value"
     const valueRef = React.useRef(props.value);
-    // Used to sync context updates and avoid stale values, can be considered as render/effect counter of Provider.
-    const versionRef = React.useRef(0);
 
     // A stable object, is used to avoid context updates via mutation of its values.
     const contextValue = React.useRef<ContextValue<Value>>();
@@ -17,18 +15,16 @@ const createProvider = <Value>(Original: React.Provider<ContextValue<Value>>) =>
     if (!contextValue.current) {
       contextValue.current = {
         value: valueRef,
-        version: versionRef,
         listeners: [],
       };
     }
 
     useIsomorphicLayoutEffect(() => {
       valueRef.current = props.value;
-      versionRef.current += 1;
 
       runWithNormalPriority(() => {
         (contextValue.current as ContextValue<Value>).listeners.forEach(listener => {
-          listener([versionRef.current, props.value]);
+          listener(props.value);
         });
       });
     }, [props.value]);
@@ -47,7 +43,6 @@ const createProvider = <Value>(Original: React.Provider<ContextValue<Value>>) =>
 export const createContext = <Value>(defaultValue: Value): Context<Value> => {
   const context = React.createContext<ContextValue<Value>>({
     value: { current: defaultValue },
-    version: { current: -1 },
     listeners: [],
   });
 

--- a/packages/fluentui/react-bindings/src/context-selector/types.ts
+++ b/packages/fluentui/react-bindings/src/context-selector/types.ts
@@ -7,20 +7,15 @@ export type Context<Value> = React.Context<Value> & {
 
 export type ContextSelector<Value, SelectedValue> = (value: Value) => SelectedValue;
 
-export type ContextVersion = number;
-
 export type ContextValue<Value> = {
   /** Holds a set of subscribers from components. */
-  listeners: ((payload: readonly [ContextVersion, Value]) => void)[];
+  listeners: ((payload: Value) => void)[];
 
   /** Holds an actual value of React's context that will be propagated down for computations. */
   value: React.MutableRefObject<Value>;
-
-  /** A version field is used to sync a context value and consumers. */
-  version: React.MutableRefObject<ContextVersion>;
 };
 
 export type ContextValues<Value> = ContextValue<Value> & {
   /** List of listners to publish changes */
-  listeners: ((payload: readonly [ContextVersion, Record<string, Value>]) => void)[];
+  listeners: ((payload: Record<string, Value>) => void)[];
 };

--- a/packages/fluentui/react-bindings/src/context-selector/useContextSelector.ts
+++ b/packages/fluentui/react-bindings/src/context-selector/useContextSelector.ts
@@ -1,8 +1,7 @@
 import * as React from 'react';
 
-import { Context, ContextSelector, ContextValue, ContextVersion } from './types';
+import { Context, ContextSelector, ContextValue } from './types';
 import { useIsomorphicLayoutEffect } from '../hooks/useIsomorphicLayoutEffect';
-import { useEventCallback } from '../hooks/useEventCallback';
 
 /**
  * This hook returns context selected value by selector.
@@ -14,69 +13,52 @@ export const useContextSelector = <Value, SelectedValue>(
   selector: ContextSelector<Value, SelectedValue>,
 ): SelectedValue => {
   const contextValue = React.useContext(context as unknown as Context<ContextValue<Value>>);
+  const { value: valueRef, listeners } = contextValue;
 
-  const {
-    value: { current: value },
-    version: { current: version },
-    listeners,
-  } = contextValue;
-  const selected = selector(value);
+  // Read valueRef during render and return selector(value) directly. This is analogous to `useSyncExternalStore`'s
+  // `getSnapshot` and is the only way to select a slice from a shared ref-based store without re-rendering every
+  // consumer on every provider update.
+  const valueAtRender = selector(valueRef.current);
+  const [, forceUpdate] = React.useReducer((x: number) => x + 1, 0);
 
-  const [state, setState] = React.useState<readonly [Value, SelectedValue]>([value, selected]);
-  const dispatch = (
-    payload:
-      | undefined // undefined from render below
-      | readonly [ContextVersion, Value], // from provider effect
-  ) => {
-    setState(prevState => {
-      if (!payload) {
-        // early bail out when is dispatched during render
-        return [value, selected] as const;
-      }
-
-      if (payload[0] <= version) {
-        if (Object.is(prevState[1], selected)) {
-          return prevState; // bail out
-        }
-
-        return [value, selected] as const;
-      }
-
-      try {
-        if (Object.is(prevState[0], payload[1])) {
-          return prevState; // do not update
-        }
-
-        const nextSelected = selector(payload[1]);
-
-        if (Object.is(prevState[1], nextSelected)) {
-          return prevState; // do not update
-        }
-
-        return [payload[1], nextSelected] as const;
-      } catch {
-        // ignored (stale props or some other reason)
-      }
-      return [...prevState] as const; // schedule update
-    });
-  };
-
-  if (!Object.is(state[1], selected)) {
-    // schedule re-render
-    // this is safe because it's self contained
-    dispatch(undefined);
-  }
-
-  const stableDispatch = useEventCallback(dispatch);
+  // Refs holding the current selector and the most-recently-returned slice. Updated in a layout effect (ordering:
+  // children first, then provider) so they are current by the time the provider's listener loop fires.
+  const selectorRef = React.useRef<ContextSelector<Value, SelectedValue>>(selector);
+  const lastValueAtRender = React.useRef<SelectedValue>(valueAtRender);
 
   useIsomorphicLayoutEffect(() => {
-    listeners.push(stableDispatch);
+    selectorRef.current = selector;
+    lastValueAtRender.current = valueAtRender;
+  });
+
+  useIsomorphicLayoutEffect(() => {
+    const listener = (payload: Value) => {
+      // Selectors can throw on transiently-inconsistent inputs (stale props vs. newer context value). Swallow so a
+      // single consumer's throw doesn't abort the provider's `listeners.forEach`.
+      try {
+        const nextSelectedValue = selectorRef.current(payload);
+
+        if (!Object.is(lastValueAtRender.current, nextSelectedValue)) {
+          forceUpdate();
+        }
+      } catch {
+        // ignored (stale props or similar — heals on the next parent-driven render)
+      }
+    };
+
+    listeners.push(listener);
+
+    // Effect-fixup: catch updates that occurred between render and effect run (Relay's useFragmentInternal pattern).
+    listener(valueRef.current);
 
     return () => {
-      const index = listeners.indexOf(stableDispatch);
-      listeners.splice(index, 1);
-    };
-  }, [stableDispatch, listeners]);
+      const index = listeners.indexOf(listener);
 
-  return state[1] as SelectedValue;
+      if (index !== -1) {
+        listeners.splice(index, 1);
+      }
+    };
+  }, [listeners, valueRef]);
+
+  return valueAtRender;
 };

--- a/packages/fluentui/react-bindings/src/context-selector/useContextSelectors.ts
+++ b/packages/fluentui/react-bindings/src/context-selector/useContextSelectors.ts
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { Context, ContextSelector, ContextVersion, ContextValues } from './types';
+import { Context, ContextSelector, ContextValues } from './types';
 import { useIsomorphicLayoutEffect } from '../hooks/useIsomorphicLayoutEffect';
-import { useEventCallback } from '../hooks/useEventCallback';
 
 /**
  * This hook returns context selected value by selectors.
@@ -18,90 +17,63 @@ export const useContextSelectors = <
   selectors: Selectors,
 ): Record<Properties, SelectedValue> => {
   const contextValue = React.useContext(context as unknown as Context<ContextValues<Value>>);
+  const { value: valueRef, listeners } = contextValue;
 
-  const {
-    value: { current: value },
-    version: { current: version },
-    listeners,
-  } = contextValue;
-
-  const selected = {} as Record<Properties, SelectedValue>;
+  // Read valueRef during render and return selectors(value) directly. This is analogous to `useSyncExternalStore`'s
+  // `getSnapshot` and is the only way to select slices from a shared ref-based store without re-rendering every
+  // consumer on every provider update.
+  const valueAtRender = {} as Record<Properties, SelectedValue>;
   Object.keys(selectors).forEach((key: Properties) => {
-    selected[key] = selectors[key](value);
+    valueAtRender[key] = selectors[key](valueRef.current);
   });
 
-  const [state, setState] = React.useState<readonly [Value, Record<Properties, SelectedValue>]>([value, selected]);
-  const dispatch = (
-    payload:
-      | undefined // undefined from render below
-      | readonly [ContextVersion, Value], // from provider effect
-  ) => {
-    setState(prevState => {
-      if (!payload) {
-        // early bail out when is dispatched during render
-        return [value, selected] as const;
-      }
+  const [, forceUpdate] = React.useReducer((x: number) => x + 1, 0);
 
-      if (payload[0] <= version) {
-        const stateHasNotChanged = Object.keys(selectors).every((key: Properties) =>
-          Object.is((prevState[1] as { [key: string]: any })[key] as SelectedValue, selected[key]),
-        );
-
-        if (stateHasNotChanged) {
-          return prevState; // bail out
-        }
-
-        return [value, selected] as const;
-      }
-
-      try {
-        const statePayloadHasChanged = Object.keys(prevState[0]).some((key: Properties) => {
-          return !Object.is(prevState[0] /* previous contextValue */[key], payload[1] /* current contextValue */[key]);
-        });
-
-        if (!statePayloadHasChanged) {
-          return prevState;
-        }
-
-        const nextSelected = {} as Record<Properties, SelectedValue>;
-        Object.keys(selectors).forEach((key: Properties) => {
-          nextSelected[key] = selectors[key](payload[1]);
-        });
-
-        const selectedHasNotChanged = Object.keys(selectors).every((key: Properties) => {
-          return Object.is(prevState[1][key] /* previous { [key]: selector(value) } */, nextSelected[key]);
-        });
-
-        if (selectedHasNotChanged) {
-          return prevState;
-        }
-
-        return [payload[1], nextSelected] as const;
-      } catch {
-        // ignored (stale props or some other reason)
-      }
-      return [...prevState] as const; // schedule update
-    });
-  };
-
-  // schedule re-render when selected context is updated
-  const hasSelectedValuesUpdates = Object.keys(selectors).find(
-    (key: Properties) => !Object.is(state[1] /* previous { [key]: selector(value) } */[key], selected[key]),
-  );
-  if (hasSelectedValuesUpdates !== undefined) {
-    dispatch(undefined);
-  }
-
-  const stableDispatch = useEventCallback(dispatch);
+  // Refs holding the current selectors map and the most-recently-returned slice map. Updated in a layout effect
+  // (ordering: children first, then provider) so they are current by the time the provider's listener loop fires.
+  const selectorsRef = React.useRef<Selectors>(selectors);
+  const lastValueAtRender = React.useRef<Record<Properties, SelectedValue>>(valueAtRender);
 
   useIsomorphicLayoutEffect(() => {
-    listeners.push(stableDispatch);
+    selectorsRef.current = selectors;
+    lastValueAtRender.current = valueAtRender;
+  });
+
+  useIsomorphicLayoutEffect(() => {
+    const listener = (payload: Record<string, Value>) => {
+      // Selectors can throw on transiently-inconsistent inputs. Swallow so a single consumer's throw doesn't abort
+      // the provider's `listeners.forEach`.
+      try {
+        const nextSelected = {} as Record<Properties, SelectedValue>;
+        Object.keys(selectorsRef.current).forEach((key: Properties) => {
+          nextSelected[key] = selectorsRef.current[key](payload as unknown as Value);
+        });
+
+        const hasChanges = Object.keys(selectorsRef.current).some(
+          (key: Properties) => !Object.is(lastValueAtRender.current[key], nextSelected[key]),
+        );
+
+        if (hasChanges) {
+          forceUpdate();
+        }
+      } catch {
+        // ignored (stale props or similar — heals on the next parent-driven render)
+      }
+    };
+
+    listeners.push(listener);
+
+    // Effect-fixup: catch updates that occurred between render and effect run (Relay's useFragmentInternal pattern).
+    listener(valueRef.current as unknown as Record<string, Value>);
 
     return () => {
-      const index = listeners.indexOf(stableDispatch);
-      listeners.splice(index, 1);
-    };
-  }, [stableDispatch, listeners]);
+      const index = listeners.indexOf(listener);
 
-  return state[1] as Record<Properties, SelectedValue>;
+      if (index !== -1) {
+        listeners.splice(index, 1);
+      }
+    };
+  }, [listeners, valueRef]);
+
+  return valueAtRender;
 };

--- a/packages/fluentui/react-bindings/test/context-selector/useContextSelector-test.tsx
+++ b/packages/fluentui/react-bindings/test/context-selector/useContextSelector-test.tsx
@@ -93,4 +93,95 @@ describe('useContextSelector', () => {
     expect(document.querySelector<HTMLElement>('.test-component')?.dataset.active).toBe('true');
     expect(onUpdate).toHaveBeenCalledTimes(2);
   });
+
+  it('memoized consumers re-render only when their selected slice changes', () => {
+    const MemoizedTestComponent = React.memo(TestComponent);
+
+    const onUpdates: Record<number, jest.Mock> = {
+      1: jest.fn(),
+      2: jest.fn(),
+      3: jest.fn(),
+      4: jest.fn(),
+    };
+
+    render(
+      <TestProvider>
+        <MemoizedTestComponent index={1} onUpdate={onUpdates[1]} />
+        <MemoizedTestComponent index={2} onUpdate={onUpdates[2]} />
+        <MemoizedTestComponent index={3} onUpdate={onUpdates[3]} />
+        <MemoizedTestComponent index={4} onUpdate={onUpdates[4]} />
+      </TestProvider>,
+    );
+
+    // Initial render. TestProvider starts at index=0, so none are active. Each memoized item has committed once — the
+    // `onUpdate` effect fires once per item on mount.
+    Object.values(onUpdates).forEach(m => expect(m).toHaveBeenCalledTimes(1));
+
+    // Click 1: 0 → 1. Only index=1 flips (active: false → true).
+    jest.clearAllMocks();
+    act(() => {
+      document.querySelector<HTMLElement>('.test-provider')?.click();
+    });
+
+    expect(onUpdates[1]).toHaveBeenCalledTimes(1); // false => true
+    expect(onUpdates[2]).toHaveBeenCalledTimes(0);
+    expect(onUpdates[3]).toHaveBeenCalledTimes(0);
+    expect(onUpdates[4]).toHaveBeenCalledTimes(0);
+
+    // Click 2: 1 → 2. index=1 flips (true → false), index=2 flips (false → true).
+    // Items 3 and 4 did not change and must not re-render.
+    jest.clearAllMocks();
+    act(() => {
+      document.querySelector<HTMLElement>('.test-provider')?.click();
+    });
+
+    expect(onUpdates[1]).toHaveBeenCalledTimes(1); // true => false
+    expect(onUpdates[2]).toHaveBeenCalledTimes(1); // false => true
+    expect(onUpdates[3]).toHaveBeenCalledTimes(0); // ← was 2 under the old eager-bailout with `useState()`
+    expect(onUpdates[4]).toHaveBeenCalledTimes(0);
+
+    // Click 3: 2 → 3.
+    jest.clearAllMocks();
+    act(() => {
+      document.querySelector<HTMLElement>('.test-provider')?.click();
+    });
+
+    expect(onUpdates[1]).toHaveBeenCalledTimes(0);
+    expect(onUpdates[2]).toHaveBeenCalledTimes(1); // true => false
+    expect(onUpdates[3]).toHaveBeenCalledTimes(1); // false => true
+    expect(onUpdates[4]).toHaveBeenCalledTimes(0);
+  });
+
+  it('a single consumer throw does not starve later subscribers of context updates', () => {
+    const ThrowingConsumer: React.FC<{ threshold: number }> = ({ threshold }) => {
+      useContextSelector(TestContext, v => {
+        if (v.index > threshold) {
+          throw new Error('selector cannot handle this value');
+        }
+        return v.index;
+      });
+
+      return null;
+    };
+
+    const onUpdate = jest.fn();
+
+    render(
+      <TestProvider>
+        <ThrowingConsumer threshold={0} />
+        <TestComponent index={1} onUpdate={onUpdate} />
+      </TestProvider>,
+    );
+
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+
+    // Click: index goes 0 → 1. The first consumer's selector will throw (1 > 0). The downstream TestComponent must
+    // still receive the update because listener error isolation prevents `listeners.forEach` from short-circuiting.
+    act(() => {
+      document.querySelector<HTMLElement>('.test-provider')?.click();
+    });
+
+    expect(document.querySelector<HTMLElement>('.test-component')?.dataset.active).toBe('true');
+    expect(onUpdate).toHaveBeenCalledTimes(2);
+  });
 });


### PR DESCRIPTION
## Summary

Backports microsoft/fluentui#36002 to `@fluentui/react-bindings` on the `react-v0` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)