### PR TITLE
fix(ts-minbar-test-react-components): pin @griffel/react to ~1.5.32 to avoid 1.6.x default import breakage

### DIFF
--- a/apps/ts-minbar-test-react-components/src/index.ts
+++ b/apps/ts-minbar-test-react-components/src/index.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs';
 import * as path from 'path';
 import {
   prepareTempDirs,
@@ -22,16 +23,21 @@ async function performTest() {
     tempPaths = prepareTempDirs(`${testName}-`);
     logger(`✔️ Temporary directories created under ${tempPaths.root}`);
 
+    // Pin @griffel/react via resolutions so yarn can't hoist 1.6.x into nested node_modules.
+    // 1.6.x switched src/*.d.ts to a default React import which requires esModuleInterop —
+    // a flag we don't mandate for consumers. See microsoft/griffel#863.
+    const pkgJsonPath = path.join(tempPaths.testApp, 'package.json');
+    const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
+    pkgJson.resolutions = { ...pkgJson.resolutions, '@griffel/react': '1.5.32' };
+    fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2));
+
     // Install dependencies, using the minimum TS version supported for consumers
-    // @griffel/react is pinned to <1.6.0 because 1.6.x switched to a default React import
-    // which requires esModuleInterop — a flag we don't mandate for consumers.
     const dependencies = [
       '@types/react@17',
       '@types/react-dom@17',
       'react@17',
       'react-dom@17',
       `typescript@${tsVersion}`,
-      '@griffel/react@~1.5.32',
     ].join(' ');
     await shEcho(`yarn add ${dependencies}`, tempPaths.testApp);
     logger(`✔️ Dependencies were installed`);

--- a/apps/ts-minbar-test-react-components/src/index.ts
+++ b/apps/ts-minbar-test-react-components/src/index.ts
@@ -23,14 +23,6 @@ async function performTest() {
     tempPaths = prepareTempDirs(`${testName}-`);
     logger(`✔️ Temporary directories created under ${tempPaths.root}`);
 
-    // Pin @griffel/react via resolutions so yarn can't hoist 1.6.x into nested node_modules.
-    // 1.6.x switched src/*.d.ts to a default React import which requires esModuleInterop —
-    // a flag we don't mandate for consumers. See microsoft/griffel#863.
-    const pkgJsonPath = path.join(tempPaths.testApp, 'package.json');
-    const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
-    pkgJson.resolutions = { ...pkgJson.resolutions, '@griffel/react': '1.5.32' };
-    fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2));
-
     // Install dependencies, using the minimum TS version supported for consumers
     const dependencies = [
       '@types/react@17',
@@ -41,6 +33,14 @@ async function performTest() {
     ].join(' ');
     await shEcho(`yarn add ${dependencies}`, tempPaths.testApp);
     logger(`✔️ Dependencies were installed`);
+
+    // Pin @griffel/react via resolutions so yarn can't nest 1.6.x inside @fluentui/react-components.
+    // 1.6.x switched src/*.d.ts to a default React import which requires esModuleInterop —
+    // a flag we don't mandate for consumers. See microsoft/griffel#863.
+    const pkgJsonPath = path.join(tempPaths.testApp, 'package.json');
+    const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
+    pkgJson.resolutions = { ...pkgJson.resolutions, '@griffel/react': '1.5.32' };
+    fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2));
 
     const packedPackages = await packProjectPackages(logger, '@fluentui/react-components');
     await addResolutionPathsForProjectPackages(tempPaths.testApp);

--- a/apps/ts-minbar-test-react-components/src/index.ts
+++ b/apps/ts-minbar-test-react-components/src/index.ts
@@ -23,12 +23,15 @@ async function performTest() {
     logger(`✔️ Temporary directories created under ${tempPaths.root}`);
 
     // Install dependencies, using the minimum TS version supported for consumers
+    // @griffel/react is pinned to <1.6.0 because 1.6.x switched to a default React import
+    // which requires esModuleInterop — a flag we don't mandate for consumers.
     const dependencies = [
       '@types/react@17',
       '@types/react-dom@17',
       'react@17',
       'react-dom@17',
       `typescript@${tsVersion}`,
+      '@griffel/react@~1.5.32',
     ].join(' ');
     await shEcho(`yarn add ${dependencies}`, tempPaths.testApp);
     logger(`✔️ Dependencies were installed`);


### PR DESCRIPTION
## Summary

- `@griffel/react@1.6.2` was published on 2026-04-29 and introduced a breaking change: `src/RendererContext.d.ts` and `src/TextDirectionContext.d.ts` switched from `import * as React from 'react'` to `import React from 'react'` (default import)
- The default import requires `esModuleInterop: true`, which the `ts-minbar-test-react-components` tsconfig intentionally omits
- Component packages declare `"@griffel/react": "^1.5.32"`, which allows `1.6.x`, so the test's fresh install resolved `1.6.2` from npm and started failing with `TS1259`
- This fix pins `@griffel/react` to `~1.5.32` in the test's dependency installation, blocking the `1.6.x` range until griffel addresses the semver violation

## Test plan

- [ ] `ts-minbar-test-react-components` CI job passes
- [ ] No other integration tests affected (change is scoped to the test runner setup only)

## Issue

- Upstream Griffel issue: microsoft/griffel#863