### PR TITLE
fix: updates web-components broken release

### DIFF
--- a/change/@fluentui-chart-web-components-eb196a09-6b47-48ce-98f7-ea6fc545c5d7.json
+++ b/change/@fluentui-chart-web-components-eb196a09-6b47-48ce-98f7-ea6fc545c5d7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: fixing package bump issue to latest published version",
+  "packageName": "@fluentui/chart-web-components",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-web-components-2fc9e6fe-fc4a-47a7-8ff8-1595688644c7.json
+++ b/change/@fluentui-web-components-2fc9e6fe-fc4a-47a7-8ff8-1595688644c7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": " chore: fixing package bump issue to latest published version",
+  "packageName": "@fluentui/web-components",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-web-components-b94e4cb5-2fad-446a-977a-a7e101d65b0f.json
+++ b/change/@fluentui-web-components-b94e4cb5-2fad-446a-977a-a7e101d65b0f.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "fix: improve SSR compatibility and component lifecycle management for Menu, Accordion, Dropdown, Tablist, and waitForConnectedDescendants",
-  "packageName": "@fluentui/web-components",
-  "email": "863023+radium-v@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/packages/charts/chart-web-components/CHANGELOG.json
+++ b/packages/charts/chart-web-components/CHANGELOG.json
@@ -2,6 +2,21 @@
   "name": "@fluentui/chart-web-components",
   "entries": [
     {
+      "date": "Wed, 29 Apr 2026 19:07:13 GMT",
+      "tag": "@fluentui/chart-web-components_v0.0.72",
+      "version": "0.0.72",
+      "comments": {
+        "patch": [
+          {
+            "author": "beachball",
+            "package": "@fluentui/chart-web-components",
+            "comment": "Bump @fluentui/web-components to v3.0.0-rc.14",
+            "commit": "1176b50b415faa35a2763cac41c572b063bcc524"
+          }
+        ]
+      }
+    },
+    {
       "date": "Thu, 09 Apr 2026 04:07:27 GMT",
       "tag": "@fluentui/chart-web-components_v0.0.71",
       "version": "0.0.71",

--- a/packages/charts/chart-web-components/CHANGELOG.md
+++ b/packages/charts/chart-web-components/CHANGELOG.md
@@ -1,8 +1,17 @@
 # Change Log - @fluentui/chart-web-components
 
-This log was last generated on Thu, 09 Apr 2026 04:07:27 GMT and should not be manually modified.
+This log was last generated on Wed, 29 Apr 2026 19:07:13 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## [0.0.72](https://github.com/microsoft/fluentui/tree/@fluentui/chart-web-components_v0.0.72)
+
+Wed, 29 Apr 2026 19:07:13 GMT 
+[Compare changes](https://github.com/microsoft/fluentui/compare/@fluentui/chart-web-components_v0.0.71..@fluentui/chart-web-components_v0.0.72)
+
+### Patches
+
+- Bump @fluentui/web-components to v3.0.0-rc.14 ([commit](https://github.com/microsoft/fluentui/commit/1176b50b415faa35a2763cac41c572b063bcc524) by beachball)
 
 ## [0.0.71](https://github.com/microsoft/fluentui/tree/@fluentui/chart-web-components_v0.0.71)
 

--- a/packages/charts/chart-web-components/package.json
+++ b/packages/charts/chart-web-components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fluentui/chart-web-components",
   "description": "A library of Fluent Chart Web Components",
-  "version": "0.0.71",
+  "version": "0.0.72",
   "author": {
     "name": "Microsoft"
   },
@@ -70,7 +70,7 @@
   "dependencies": {
     "@microsoft/fast-web-utilities": "^6.0.0",
     "@fluentui/tokens": "^1.0.0-alpha.23",
-    "@fluentui/web-components": "^3.0.0-rc.13",
+    "@fluentui/web-components": "^3.0.0-rc.14",
     "@types/d3-selection": "^3.0.0",
     "@types/d3-shape": "^3.0.0",
     "d3-selection": "^3.0.0",

--- a/packages/web-components/CHANGELOG.json
+++ b/packages/web-components/CHANGELOG.json
@@ -2,6 +2,21 @@
   "name": "@fluentui/web-components",
   "entries": [
     {
+      "date": "Wed, 29 Apr 2026 19:07:13 GMT",
+      "tag": "@fluentui/web-components_v3.0.0-rc.14",
+      "version": "3.0.0-rc.14",
+      "comments": {
+        "prerelease": [
+          {
+            "author": "863023+radium-v@users.noreply.github.com",
+            "package": "@fluentui/web-components",
+            "commit": "c2bf30e8260326f8e7c018853e4e86cbfae0d2d0",
+            "comment": "fix: improve SSR compatibility and component lifecycle management for Menu, Accordion, Dropdown, Tablist, and waitForConnectedDescendants"
+          }
+        ]
+      }
+    },
+    {
       "date": "Thu, 09 Apr 2026 04:07:27 GMT",
       "tag": "@fluentui/web-components_v3.0.0-rc.13",
       "version": "3.0.0-rc.13",

--- a/packages/web-components/CHANGELOG.md
+++ b/packages/web-components/CHANGELOG.md
@@ -1,8 +1,17 @@
 # Change Log - @fluentui/web-components
 
-This log was last generated on Thu, 09 Apr 2026 04:07:27 GMT and should not be manually modified.
+This log was last generated on Wed, 29 Apr 2026 19:07:13 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## [3.0.0-rc.14](https://github.com/microsoft/fluentui/tree/@fluentui/web-components_v3.0.0-rc.14)
+
+Wed, 29 Apr 2026 19:07:13 GMT 
+[Compare changes](https://github.com/microsoft/fluentui/compare/@fluentui/web-components_v3.0.0-rc.13..@fluentui/web-components_v3.0.0-rc.14)
+
+### Changes
+
+- fix: improve SSR compatibility and component lifecycle management for Menu, Accordion, Dropdown, Tablist, and waitForConnectedDescendants ([PR #36018](https://github.com/microsoft/fluentui/pull/36018) by 863023+radium-v@users.noreply.github.com)
 
 ## [3.0.0-rc.13](https://github.com/microsoft/fluentui/tree/@fluentui/web-components_v3.0.0-rc.13)
 

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fluentui/web-components",
   "description": "A library of Fluent Web Components",
-  "version": "3.0.0-rc.13",
+  "version": "3.0.0-rc.14",
   "author": {
     "name": "Microsoft",
     "url": "https://discord.gg/FcSNfg4"


### PR DESCRIPTION
## Previous Behavior

Out of date versions for charts-web-components and web-components packages.

@Hotell I believe we may also need a git tag added for the versions.

## New Behavior

This bumps to current latest with the correct changelogs generated by running the beachball `bump` command locally.

- Fixes #
The release pipeline for both web-components packages.