### PR TITLE
fix(Option): when disabled, hover styles should not show

### DIFF
--- a/change/@fluentui-react-combobox-a2384656-e329-436f-b5ad-0d9a316c1794.json
+++ b/change/@fluentui-react-combobox-a2384656-e329-436f-b5ad-0d9a316c1794.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(Option): when disabled, hover styles should not show",
+  "packageName": "@fluentui/react-combobox",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/library/src/components/Option/useOptionStyles.styles.ts
+++ b/packages/react-components/react-combobox/library/src/components/Option/useOptionStyles.styles.ts
@@ -27,7 +27,9 @@ const useStyles = makeStyles({
     lineHeight: tokens.lineHeightBase300,
     padding: `${tokens.spacingVerticalSNudge} ${tokens.spacingHorizontalS}`,
     position: 'relative',
+  },
 
+  interactive: {
     ':hover': {
       backgroundColor: tokens.colorNeutralBackground1Hover,
       color: tokens.colorNeutralForeground1Hover,
@@ -60,18 +62,7 @@ const useStyles = makeStyles({
 
   disabled: {
     color: tokens.colorNeutralForegroundDisabled,
-
-    ':hover': {
-      backgroundColor: tokens.colorTransparentBackground,
-      color: tokens.colorNeutralForegroundDisabled,
-      [`& .${optionClassNames.checkIcon}`]: shorthands.borderColor(tokens.colorNeutralForegroundDisabled),
-    },
-
-    ':active': {
-      backgroundColor: tokens.colorTransparentBackground,
-      color: tokens.colorNeutralForegroundDisabled,
-      [`& .${optionClassNames.checkIcon}`]: shorthands.borderColor(tokens.colorNeutralForegroundDisabled),
-    },
+    cursor: 'default',
 
     '@media (forced-colors: active)': {
       color: 'GrayText',
@@ -141,6 +132,7 @@ export const useOptionStyles_unstable = (state: OptionState): OptionState => {
   state.root.className = mergeClasses(
     optionClassNames.root,
     styles.root,
+    !disabled && styles.interactive,
     styles.active,
     disabled && styles.disabled,
     selected && styles.selected,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

oops hover styles in HCM

## New Behavior

split the hover/active styles into an `interactive` block, similar to what we do in other components, and only add that block when not disabled.

## Related Issue(s)

- Fixes [ADO bug](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/34247)
