### PR TITLE
Revert "fix(ts-minbar-test-react-components): pin @griffel/react to ~1.5.32 to avoid 1.6.x default import breakage"

### DIFF
--- a/apps/ts-minbar-test-react-components/src/index.ts
+++ b/apps/ts-minbar-test-react-components/src/index.ts
@@ -1,4 +1,3 @@
-import * as fs from 'fs';
 import * as path from 'path';
 import {
   prepareTempDirs,
@@ -33,14 +32,6 @@ async function performTest() {
     ].join(' ');
     await shEcho(`yarn add ${dependencies}`, tempPaths.testApp);
     logger(`✔️ Dependencies were installed`);
-
-    // Pin @griffel/react via resolutions so yarn can't nest 1.6.x inside @fluentui/react-components.
-    // 1.6.x switched src/*.d.ts to a default React import which requires esModuleInterop —
-    // a flag we don't mandate for consumers. See microsoft/griffel#863.
-    const pkgJsonPath = path.join(tempPaths.testApp, 'package.json');
-    const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
-    pkgJson.resolutions = { ...pkgJson.resolutions, '@griffel/react': '1.5.32' };
-    fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2));
 
     const packedPackages = await packProjectPackages(logger, '@fluentui/react-components');
     await addResolutionPathsForProjectPackages(tempPaths.testApp);


### PR DESCRIPTION
Reverts microsoft/fluentui#36075