### PR TITLE
chore(react-tabster): bump tabster to ^8.8.0 and keyborg to ^2.14.1

### DIFF
--- a/change/@fluentui-react-tabster-010eb62f-da88-45c0-9b4a-5402a4ab4b32.json
+++ b/change/@fluentui-react-tabster-010eb62f-da88-45c0-9b4a-5402a4ab4b32.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: bump tabster to ^8.8.0 and keyborg to ^2.14.1",
+  "packageName": "@fluentui/react-tabster",
+  "email": "198982749+Copilot@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tabster/package.json
+++ b/packages/react-components/react-tabster/package.json
@@ -17,8 +17,8 @@
     "@fluentui/react-utilities": "^9.26.3",
     "@griffel/react": "^1.5.32",
     "@swc/helpers": "^0.5.1",
-    "keyborg": "^2.6.0",
-    "tabster": "^8.5.5"
+    "keyborg": "^2.14.1",
+    "tabster": "^8.8.0"
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",

--- a/packages/react-components/react-tabster/src/hooks/useFocusObserved.ts
+++ b/packages/react-components/react-tabster/src/hooks/useFocusObserved.ts
@@ -35,6 +35,7 @@ export function useFocusObserved(
     return {
       result: Promise.resolve(false),
       cancel: () => null,
+      diagnostics: {},
     };
   }, [observedAPIRef, name, timeout]);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3528,11 +3528,6 @@
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.40.1.tgz#e9f09b802f1291839247399028beaef9ce034c81"
   integrity sha512-h8d28xzYb98fMQKUz0w2fMc1XuGzLLjdyxVIbhbil4ELfk5/orZlSTpF/xdI9C8K0I8lCkq+1En2RJsawZekkg==
 
-"@rollup/rollup-linux-x64-gnu@4.40.0":
-  version "4.40.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.40.0.tgz#68b045a720bd9b4d905f462b997590c2190a6de0"
-  integrity sha512-RcDGMtqF9EFN8i2RYN2W+64CdHruJ5rPqrlYw+cgM3uOVPSsnAQps7cpjXe9be/yDp8UC7VLoCoKC8J3Kn2FkQ==
-
 "@rollup/rollup-linux-x64-gnu@4.40.1":
   version "4.40.1"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.40.1.tgz#0413169dc00470667dea8575c1129d4e7a73eb29"
@@ -13429,10 +13424,10 @@ jws@^4.0.0:
     jwa "^2.0.1"
     safe-buffer "^5.0.1"
 
-keyborg@2.6.0, keyborg@^2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/keyborg/-/keyborg-2.6.0.tgz#ebfcaaed2f517f9295058ff5d57d14e71958ab5a"
-  integrity sha512-o5kvLbuTF+o326CMVYpjlaykxqYP9DphFQZ2ZpgrvBouyvOxyEB7oqe8nOLFpiV5VCtz0D3pt8gXQYWpLpBnmA==
+keyborg@^2.14.0, keyborg@^2.14.1:
+  version "2.14.1"
+  resolved "https://registry.yarnpkg.com/keyborg/-/keyborg-2.14.1.tgz#044959ff0e4f95d062d1e07e2d3a0fbc2ad11d30"
+  integrity sha512-/WmmVBa6Me3hIKAOIyIq1sql+6oydQZzGMBDLNfOcJ8710byMsq3KSLS8GQhBJHOMtvnXnUBrDAIbABcZVipcg==
 
 keygrip@~1.1.0:
   version "1.1.0"
@@ -18977,15 +18972,13 @@ table@^6.0.7:
     string-width "^4.2.3"
     strip-ansi "^6.0.1"
 
-tabster@^8.5.5:
-  version "8.5.5"
-  resolved "https://registry.yarnpkg.com/tabster/-/tabster-8.5.5.tgz#fcd90edd8c5cd0bd42cd09a025b31afe6946fa15"
-  integrity sha512-fqoBWIZRPJ2LuAqQWbGGE1KkKz6sX+6ROOeHlXIyRM7qD7XZK0gWc50mJbI8G48wuy8201/kvGkYq3p+QmSTAg==
+tabster@^8.8.0:
+  version "8.8.0"
+  resolved "https://registry.yarnpkg.com/tabster/-/tabster-8.8.0.tgz#704ef2aec0fdd6f42cb350d781f248877da1996c"
+  integrity sha512-eGFXgtvKOQP5BywDI9Ngs+Atm6TRj45epAAqWKyVoi+HmOmdamEB//1H/FttLdNly/+Cz+GJ4RN8TnXTw0KwfA==
   dependencies:
-    keyborg "2.6.0"
+    keyborg "^2.14.0"
     tslib "^2.8.1"
-  optionalDependencies:
-    "@rollup/rollup-linux-x64-gnu" "4.40.0"
 
 tachometer@0.7.1:
   version "0.7.1"


### PR DESCRIPTION
Updates `tabster` (`^8.5.5` → `^8.8.0`) and `keyborg` (`^2.6.0` → `^2.14.1`) in `@fluentui/react-tabster`.

- **Dependency bumps**: updated versions in `packages/react-components/react-tabster/package.json` and refreshed `yarn.lock`.
- **Type fix in `useFocusObserved`**: tabster `8.8.0` adds a required `diagnostics` field to `ObservedElementAsyncRequest`. The local fallback returned when no observed-element API is available now includes it:

  ```ts
  return {
    result: Promise.resolve(false),
    cancel: () => null,
    diagnostics: {},
  };
  ```

- **Change file**: added a `patch` beachball entry for `@fluentui/react-tabster`.