### PR TITLE
fix(docs): Card examples reflow at small widths

### DIFF
--- a/packages/react-components/react-card/stories/src/Card/CardAction.stories.tsx
+++ b/packages/react-components/react-card/stories/src/Card/CardAction.stories.tsx
@@ -37,8 +37,8 @@ const useStyles = makeStyles({
   description: { margin: '0 0 12px' },
 
   card: {
-    width: '400px',
-    maxWidth: '100%',
+    maxWidth: '400px',
+    width: '100%',
     height: 'fit-content',
   },
 

--- a/packages/react-components/react-card/stories/src/Card/CardAppearance.stories.tsx
+++ b/packages/react-components/react-card/stories/src/Card/CardAppearance.stories.tsx
@@ -24,8 +24,8 @@ const useStyles = makeStyles({
   description: { margin: '0 0 12px' },
 
   card: {
-    width: '480px',
-    maxWidth: '100%',
+    maxWidth: '480px',
+    width: '100%',
     height: 'fit-content',
   },
 

--- a/packages/react-components/react-card/stories/src/Card/CardDefault.stories.tsx
+++ b/packages/react-components/react-card/stories/src/Card/CardDefault.stories.tsx
@@ -23,8 +23,8 @@ const resolveAsset = (asset: string) => {
 const useStyles = makeStyles({
   card: {
     margin: 'auto',
-    width: '720px',
-    maxWidth: '100%',
+    maxWidth: '720px',
+    width: '100%',
   },
 });
 

--- a/packages/react-components/react-card/stories/src/Card/CardDisabled.stories.tsx
+++ b/packages/react-components/react-card/stories/src/Card/CardDisabled.stories.tsx
@@ -12,8 +12,9 @@ const useStyles = makeStyles({
     gap: '16px',
   },
   card: {
-    width: '400px',
-    maxWidth: '100%',
+    maxWidth: '400px',
+    minWidth: '230px',
+    width: '100%',
   },
 });
 
@@ -60,7 +61,7 @@ export const Disabled = (): JSXElement => {
     <div className={styles.container}>
       <div>
         <h3>Default Card</h3>
-        <div style={{ display: 'flex', gap: '16px' }}>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '16px' }}>
           <Card className={styles.card}>
             <CardContentExample />
           </Card>
@@ -73,7 +74,7 @@ export const Disabled = (): JSXElement => {
 
       <div>
         <h3>Interactive Card</h3>
-        <div style={{ display: 'flex', gap: '16px' }}>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '16px' }}>
           <Card className={styles.card} onClick={() => alert('Card clicked')}>
             <CardContentExample />
           </Card>
@@ -87,7 +88,7 @@ export const Disabled = (): JSXElement => {
       <div>
         <h3>Selectable Card</h3>
         <div style={{ display: 'flex', flexDirection: 'column', rowGap: '16px' }}>
-          <div style={{ display: 'flex', gap: '16px' }}>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: '16px' }}>
             <Card
               className={styles.card}
               selected={isSelected1}
@@ -100,7 +101,7 @@ export const Disabled = (): JSXElement => {
             </Card>
           </div>
 
-          <div style={{ display: 'flex', gap: '16px' }}>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: '16px' }}>
             <Card
               className={styles.card}
               selected={isSelected2}
@@ -118,7 +119,7 @@ export const Disabled = (): JSXElement => {
 
       <div>
         <h3>Outline Card</h3>
-        <div style={{ display: 'flex', gap: '16px' }}>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '16px' }}>
           <Card className={styles.card} appearance="outline">
             <CardContentExample />
           </Card>

--- a/packages/react-components/react-card/stories/src/Card/CardFocusMode.stories.tsx
+++ b/packages/react-components/react-card/stories/src/Card/CardFocusMode.stories.tsx
@@ -25,8 +25,8 @@ const useStyles = makeStyles({
   description: { margin: '0 0 12px' },
 
   card: {
-    width: '400px',
-    maxWidth: '100%',
+    maxWidth: '400px',
+    width: '100%',
     height: 'fit-content',
   },
 

--- a/packages/react-components/react-card/stories/src/Card/CardOrientation.stories.tsx
+++ b/packages/react-components/react-card/stories/src/Card/CardOrientation.stories.tsx
@@ -20,13 +20,13 @@ const useStyles = makeStyles({
   },
 
   card: {
-    width: '360px',
-    maxWidth: '100%',
+    width: '100%',
     height: 'fit-content',
   },
 
   section: {
-    width: 'fit-content',
+    maxWidth: '360px',
+    width: '100%',
   },
 
   title: { margin: '0 0 12px' },

--- a/packages/react-components/react-card/stories/src/Card/CardSelectable.stories.tsx
+++ b/packages/react-components/react-card/stories/src/Card/CardSelectable.stories.tsx
@@ -19,8 +19,8 @@ const useStyles = makeStyles({
   },
 
   card: {
-    width: '400px',
-    maxWidth: '100%',
+    maxWidth: '400px',
+    width: '100%',
     height: 'fit-content',
   },
 

--- a/packages/react-components/react-card/stories/src/Card/CardSelectableIndicator.stories.tsx
+++ b/packages/react-components/react-card/stories/src/Card/CardSelectableIndicator.stories.tsx
@@ -28,8 +28,8 @@ const useStyles = makeStyles({
   },
 
   card: {
-    width: '400px',
-    maxWidth: '100%',
+    maxWidth: '400px',
+    width: '100%',
     height: 'fit-content',
   },
 

--- a/packages/react-components/react-card/stories/src/Card/CardSize.stories.tsx
+++ b/packages/react-components/react-card/stories/src/Card/CardSize.stories.tsx
@@ -22,8 +22,8 @@ const useStyles = makeStyles({
   title: { margin: '0 0 12px' },
 
   card: {
-    width: '300px',
-    maxWidth: '100%',
+    maxWidth: '300px',
+    width: '100%',
     height: 'fit-content',
   },
 
@@ -112,8 +112,9 @@ export const Size = (): JSXElement => {
 Size.parameters = {
   docs: {
     description: {
-      story: `Size options are mainly to provide variety, and consistency when using cards for different usages. It
-      relates to padding and border-radius and not so much the actual dimensions of the card.`,
+      story:
+        'Size options are mainly to provide variety, and consistency when using cards for different usages.' +
+        'It relates to padding and border-radius and not so much the actual dimensions of the card.',
     },
   },
 };

--- a/packages/react-components/react-card/stories/src/Card/CardTemplates.stories.tsx
+++ b/packages/react-components/react-card/stories/src/Card/CardTemplates.stories.tsx
@@ -29,7 +29,8 @@ const useStyles = makeStyles({
   },
 
   card: {
-    width: '280px',
+    maxWidth: '280px',
+    width: '100%',
     height: 'fit-content',
   },
 
@@ -57,6 +58,7 @@ const useStyles = makeStyles({
     gap: '16px',
     display: 'flex',
     flexDirection: 'column',
+    width: '100%',
   },
 });
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

Example-only change, no package changes.

## Previous Behavior

It looks like the `width` and `max-width` styles in the example code for Card were mixed up. The behavior we want is to have the Card examples max at a certain px width, but reflow down smaller at small screen sizes or small available container widths.

e.g.:
<img width="468" height="999" alt="screenshot of the appearance example showing cards getting clipped by the bounds of the example" src="https://github.com/user-attachments/assets/aefc4253-8de7-4e79-a6d7-eaab274c8352" />
<img width="442" height="604" alt="screenshot a focusmode example showing a larger card getting clipped" src="https://github.com/user-attachments/assets/cd347bb2-8ca0-4c3f-b451-00e228ee8d15" />

## New Behavior
fixed!
(there were some variations in the fixes based on the specific example layouts, but all now look the same at larger widths and collapse well at smaller widths)

<img width="382" height="880" alt="Screenshot of the appearance example showing reflowing cards" src="https://github.com/user-attachments/assets/22a9b0bd-02f9-47b3-85ca-eece300e2104" />

Fixed for each example.

## Related Issue(s)

This came up as related to an ADO issue that was closed for a separate reason.
