### PR TITLE
feat(react-menu): add more base hooks and expose them

### DIFF
--- a/change/@fluentui-react-menu-d76677a3-6018-4f05-a403-e59905ec8e5f.json
+++ b/change/@fluentui-react-menu-d76677a3-6018-4f05-a403-e59905ec8e5f.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: expose react-menu base hooks",
+  "packageName": "@fluentui/react-menu",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-menu/library/etc/react-menu.api.md
+++ b/packages/react-components/react-menu/library/etc/react-menu.api.md
@@ -33,6 +33,12 @@ export const Menu: React_2.FC<MenuProps>;
 export const MENU_ENTER_EVENT = "fuimenuenter";
 
 // @public (undocumented)
+export type MenuBaseProps = Omit<MenuProps, 'surfaceMotion'>;
+
+// @public (undocumented)
+export type MenuBaseState = Omit<MenuState, 'surfaceMotion' | 'components'>;
+
+// @public (undocumented)
 export type MenuCheckedValueChangeData = {
     checkedItems: string[];
     name: string;
@@ -166,6 +172,12 @@ export type MenuItemProps = Omit<ComponentProps<Partial<MenuItemSlots>>, 'conten
 
 // @public
 export const MenuItemRadio: ForwardRefComponent<MenuItemRadioProps>;
+
+// @public
+export type MenuItemRadioBaseProps = MenuItemRadioProps;
+
+// @public
+export type MenuItemRadioBaseState = MenuItemRadioState;
 
 // @public (undocumented)
 export const menuItemRadioClassNames: SlotClassNames<Omit<MenuItemSlots, 'submenuIndicator'>>;
@@ -484,6 +496,13 @@ export const useMenu_unstable: (props: MenuProps & {
     };
 }) => MenuState;
 
+// @public
+export const useMenuBase_unstable: (props: MenuBaseProps & {
+    safeZone?: boolean | {
+        timeout?: number;
+    };
+}) => MenuBaseState;
+
 // @public (undocumented)
 export const useMenuContext_unstable: <T>(selector: ContextSelector<MenuContextValue, T>) => T;
 
@@ -518,7 +537,13 @@ export const useMenuGroupStyles_unstable: (state: MenuGroupState) => MenuGroupSt
 export const useMenuItem_unstable: (props: MenuItemProps, ref: React_2.Ref<ARIAButtonElement<"div">>) => MenuItemState;
 
 // @public
+export const useMenuItemBase_unstable: (props: MenuItemProps, ref: React_2.Ref<ARIAButtonElement<"div">>) => MenuItemState;
+
+// @public
 export const useMenuItemCheckbox_unstable: (props: MenuItemCheckboxProps, ref: React_2.Ref<ARIAButtonElement<"div">>) => MenuItemCheckboxState;
+
+// @public
+export const useMenuItemCheckboxBase_unstable: (props: MenuItemCheckboxProps, ref: React_2.Ref<ARIAButtonElement<"div">>) => MenuItemCheckboxState;
 
 // @public (undocumented)
 export const useMenuItemCheckboxStyles_unstable: (state: MenuItemCheckboxState) => MenuItemCheckboxState;
@@ -527,10 +552,16 @@ export const useMenuItemCheckboxStyles_unstable: (state: MenuItemCheckboxState) 
 export const useMenuItemLink_unstable: (props: MenuItemLinkProps, ref: React_2.Ref<HTMLAnchorElement>) => MenuItemLinkState;
 
 // @public
+export const useMenuItemLinkBase_unstable: (props: MenuItemLinkProps, ref: React_2.Ref<HTMLAnchorElement>) => MenuItemLinkState;
+
+// @public
 export const useMenuItemLinkStyles_unstable: (state: MenuItemLinkState) => MenuItemLinkState;
 
 // @public
 export const useMenuItemRadio_unstable: (props: MenuItemRadioProps, ref: React_2.Ref<ARIAButtonElement<"div">>) => MenuItemRadioState;
+
+// @public
+export const useMenuItemRadioBase_unstable: (props: MenuItemRadioBaseProps, ref: React_2.Ref<ARIAButtonElement<"div">>) => MenuItemRadioBaseState;
 
 // @public (undocumented)
 export const useMenuItemRadioStyles_unstable: (state: MenuItemRadioState) => void;
@@ -542,10 +573,16 @@ export const useMenuItemStyles_unstable: (state: MenuItemState) => MenuItemState
 export const useMenuItemSwitch_unstable: (props: MenuItemSwitchProps, ref: React_2.Ref<HTMLDivElement>) => MenuItemSwitchState;
 
 // @public
+export const useMenuItemSwitchBase_unstable: (props: MenuItemSwitchProps, ref: React_2.Ref<HTMLDivElement>) => MenuItemSwitchState;
+
+// @public
 export const useMenuItemSwitchStyles_unstable: (state: MenuItemSwitchState) => MenuItemSwitchState;
 
 // @public
 export const useMenuList_unstable: (props: MenuListProps, ref: React_2.Ref<HTMLElement>) => MenuListState;
+
+// @public
+export const useMenuListBase_unstable: (props: MenuListProps, ref: React_2.Ref<HTMLElement>) => MenuListState;
 
 // @public (undocumented)
 export const useMenuListContext_unstable: <T>(selector: ContextSelector<MenuListContextValue, T>) => T;
@@ -560,6 +597,9 @@ export const useMenuListStyles_unstable: (state: MenuListState) => MenuListState
 export const useMenuPopover_unstable: (props: MenuPopoverProps, ref: React_2.Ref<HTMLElement>) => MenuPopoverState;
 
 // @public
+export const useMenuPopoverBase_unstable: (props: MenuPopoverProps, ref: React_2.Ref<HTMLElement>) => MenuPopoverState;
+
+// @public
 export const useMenuPopoverStyles_unstable: (state: MenuPopoverState) => MenuPopoverState;
 
 // @public
@@ -570,6 +610,14 @@ export const useMenuSplitGroupStyles_unstable: (state: MenuSplitGroupState) => M
 
 // @public
 export const useMenuTrigger_unstable: (props: MenuTriggerProps) => MenuTriggerState;
+
+// @public
+export const useMenuTriggerBase_unstable: (props: MenuTriggerProps, options?: UseMenuTriggerBaseOptions) => MenuTriggerState;
+
+// @public
+export type UseMenuTriggerBaseOptions = {
+    focusFirst?: () => void;
+};
 
 // @public (undocumented)
 export const useMenuTriggerContext_unstable: () => boolean;

--- a/packages/react-components/react-menu/library/src/Menu.ts
+++ b/packages/react-components/react-menu/library/src/Menu.ts
@@ -1,4 +1,6 @@
 export type {
+  MenuBaseProps,
+  MenuBaseState,
   MenuContextValues,
   MenuOpenChangeData,
   MenuOpenEvent,
@@ -8,4 +10,10 @@ export type {
   MenuSlots,
   MenuState,
 } from './components/Menu/index';
-export { Menu, renderMenu_unstable, useMenuContextValues_unstable, useMenu_unstable } from './components/Menu/index';
+export {
+  Menu,
+  renderMenu_unstable,
+  useMenuContextValues_unstable,
+  useMenuBase_unstable,
+  useMenu_unstable,
+} from './components/Menu/index';

--- a/packages/react-components/react-menu/library/src/MenuItemLink.ts
+++ b/packages/react-components/react-menu/library/src/MenuItemLink.ts
@@ -3,6 +3,7 @@ export {
   MenuItemLink,
   menuItemLinkClassNames,
   renderMenuItemLink_unstable,
+  useMenuItemLinkBase_unstable,
   useMenuItemLinkStyles_unstable,
   useMenuItemLink_unstable,
 } from './components/MenuItemLink/index';

--- a/packages/react-components/react-menu/library/src/MenuItemRadio.ts
+++ b/packages/react-components/react-menu/library/src/MenuItemRadio.ts
@@ -1,9 +1,14 @@
-export type { MenuItemRadioProps, MenuItemRadioState } from './components/MenuItemRadio/index';
+export type {
+  MenuItemRadioBaseProps,
+  MenuItemRadioBaseState,
+  MenuItemRadioProps,
+  MenuItemRadioState,
+} from './components/MenuItemRadio/index';
 export {
   MenuItemRadio,
   menuItemRadioClassNames,
   renderMenuItemRadio_unstable,
+  useMenuItemRadioBase_unstable,
   useMenuItemRadioStyles_unstable,
   useMenuItemRadio_unstable,
-  useMenuItemRadioBase_unstable,
 } from './components/MenuItemRadio/index';

--- a/packages/react-components/react-menu/library/src/MenuList.ts
+++ b/packages/react-components/react-menu/library/src/MenuList.ts
@@ -12,6 +12,7 @@ export {
   MenuList,
   menuListClassNames,
   renderMenuList_unstable,
+  useMenuListBase_unstable,
   useMenuListContextValues_unstable,
   useMenuListStyles_unstable,
   useMenuList_unstable,

--- a/packages/react-components/react-menu/library/src/MenuPopover.ts
+++ b/packages/react-components/react-menu/library/src/MenuPopover.ts
@@ -3,6 +3,7 @@ export {
   MenuPopover,
   menuPopoverClassNames,
   renderMenuPopover_unstable,
+  useMenuPopoverBase_unstable,
   useMenuPopoverStyles_unstable,
   useMenuPopover_unstable,
 } from './components/MenuPopover/index';

--- a/packages/react-components/react-menu/library/src/MenuTrigger.ts
+++ b/packages/react-components/react-menu/library/src/MenuTrigger.ts
@@ -1,2 +1,12 @@
-export type { MenuTriggerChildProps, MenuTriggerProps, MenuTriggerState } from './components/MenuTrigger/index';
-export { MenuTrigger, renderMenuTrigger_unstable, useMenuTrigger_unstable } from './components/MenuTrigger/index';
+export type {
+  MenuTriggerChildProps,
+  MenuTriggerProps,
+  MenuTriggerState,
+  UseMenuTriggerBaseOptions,
+} from './components/MenuTrigger/index';
+export {
+  MenuTrigger,
+  renderMenuTrigger_unstable,
+  useMenuTrigger_unstable,
+  useMenuTriggerBase_unstable,
+} from './components/MenuTrigger/index';

--- a/packages/react-components/react-menu/library/src/components/Menu/Menu.types.ts
+++ b/packages/react-components/react-menu/library/src/components/Menu/Menu.types.ts
@@ -187,6 +187,10 @@ export type MenuState = ComponentState<InternalMenuSlots> &
     safeZone?: React.ReactElement | null;
   };
 
+export type MenuBaseProps = Omit<MenuProps, 'surfaceMotion'>;
+
+export type MenuBaseState = Omit<MenuState, 'surfaceMotion' | 'components'>;
+
 export type MenuContextValues = {
   menu: MenuContextValue;
 };

--- a/packages/react-components/react-menu/library/src/components/Menu/index.ts
+++ b/packages/react-components/react-menu/library/src/components/Menu/index.ts
@@ -1,5 +1,7 @@
 export { Menu } from './Menu';
 export type {
+  MenuBaseProps,
+  MenuBaseState,
   MenuContextValues,
   MenuOpenChangeData,
   MenuOpenEvent,
@@ -10,5 +12,5 @@ export type {
   MenuState,
 } from './Menu.types';
 export { renderMenu_unstable } from './renderMenu';
-export { useMenu_unstable } from './useMenu';
+export { useMenu_unstable, useMenuBase_unstable } from './useMenu';
 export { useMenuContextValues_unstable } from './useMenuContextValues';

--- a/packages/react-components/react-menu/library/src/components/Menu/useMenu.tsx
+++ b/packages/react-components/react-menu/library/src/components/Menu/useMenu.tsx
@@ -27,7 +27,14 @@ import { useFocusFinders } from '@fluentui/react-tabster';
 import { useMenuContext_unstable } from '../../contexts/menuContext';
 import { MENU_SAFEZONE_TIMEOUT_EVENT, MENU_ENTER_EVENT, useOnMenuMouseEnter, useIsSubmenu } from '../../utils';
 import { menuItemClassNames } from '../MenuItem/useMenuItemStyles.styles';
-import type { MenuOpenChangeData, MenuOpenEvent, MenuProps, MenuState } from './Menu.types';
+import type {
+  MenuBaseProps,
+  MenuBaseState,
+  MenuOpenChangeData,
+  MenuOpenEvent,
+  MenuProps,
+  MenuState,
+} from './Menu.types';
 import { MenuSurfaceMotion } from './MenuSurfaceMotion';
 
 // If it's not possible to position the submenu in smaller viewports, try
@@ -50,6 +57,34 @@ const submenuFallbackPositions: PositioningShorthandValue[] = [
  * @param props - props from this instance of Menu
  */
 export const useMenu_unstable = (props: MenuProps & { safeZone?: boolean | { timeout?: number } }): MenuState => {
+  const { surfaceMotion, ...baseProps } = props;
+  const baseState = useMenuBase_unstable(baseProps);
+
+  return {
+    ...baseState,
+    components: {
+      surfaceMotion: MenuSurfaceMotion,
+    },
+    surfaceMotion: presenceMotionSlot(surfaceMotion, {
+      elementType: MenuSurfaceMotion,
+      defaultProps: {
+        visible: baseState.open,
+        appear: true,
+        unmountOnExit: true,
+      },
+    }),
+  };
+};
+
+/**
+ * Base hook for Menu component, produces state required to render the component.
+ * It doesn't set any design-related slots specific to Menu such as `surfaceMotion`.
+ *
+ * @param props - props from this instance of Menu
+ */
+export const useMenuBase_unstable = (
+  props: MenuBaseProps & { safeZone?: boolean | { timeout?: number } },
+): MenuBaseState => {
   const isSubmenu = useIsSubmenu();
   const {
     hoverDelay = 500,
@@ -190,9 +225,6 @@ export const useMenu_unstable = (props: MenuProps & { safeZone?: boolean | { tim
     mountNode,
     triggerRef,
     menuPopoverRef,
-    components: {
-      surfaceMotion: MenuSurfaceMotion,
-    },
     openOnContext,
     open,
     setOpen,
@@ -200,14 +232,6 @@ export const useMenu_unstable = (props: MenuProps & { safeZone?: boolean | { tim
     onCheckedValueChange,
     persistOnItemClick,
     safeZone: safeZoneHandle.elementToRender,
-    surfaceMotion: presenceMotionSlot(props.surfaceMotion, {
-      elementType: MenuSurfaceMotion,
-      defaultProps: {
-        visible: open,
-        appear: true,
-        unmountOnExit: true,
-      },
-    }),
   };
 };
 

--- a/packages/react-components/react-menu/library/src/components/MenuItem/useMenuItem.tsx
+++ b/packages/react-components/react-menu/library/src/components/MenuItem/useMenuItem.tsx
@@ -48,8 +48,6 @@ export const useMenuItem_unstable = (props: MenuItemProps, ref: React.Ref<ARIABu
 /**
  * Base hook for MenuItem component, produces state required to render the component.
  * It doesn't set any design-related props specific to MenuItem such as submenu indicator icon.
- *
- * @internal
  */
 export const useMenuItemBase_unstable = (
   props: MenuItemProps,

--- a/packages/react-components/react-menu/library/src/components/MenuItemCheckbox/useMenuItemCheckbox.tsx
+++ b/packages/react-components/react-menu/library/src/components/MenuItemCheckbox/useMenuItemCheckbox.tsx
@@ -25,8 +25,6 @@ export const useMenuItemCheckbox_unstable = (
 
 /**
  * Base hook for MenuItemCheckbox component, produces state required to render the component
- *
- * @internal
  */
 export const useMenuItemCheckboxBase_unstable = (
   props: MenuItemCheckboxProps,

--- a/packages/react-components/react-menu/library/src/components/MenuItemLink/index.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuItemLink/index.ts
@@ -1,5 +1,5 @@
 export { MenuItemLink } from './MenuItemLink';
 export type { MenuItemLinkProps, MenuItemLinkSlots, MenuItemLinkState } from './MenuItemLink.types';
 export { renderMenuItemLink_unstable } from './renderMenuItemLink';
-export { useMenuItemLink_unstable } from './useMenuItemLink';
+export { useMenuItemLinkBase_unstable, useMenuItemLink_unstable } from './useMenuItemLink';
 export { menuItemLinkClassNames, useMenuItemLinkStyles_unstable } from './useMenuItemLinkStyles.styles';

--- a/packages/react-components/react-menu/library/src/components/MenuItemLink/useMenuItemLink.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuItemLink/useMenuItemLink.ts
@@ -4,7 +4,7 @@ import type * as React from 'react';
 import type { ExtractSlotProps, Slot } from '@fluentui/react-utilities';
 import { getIntrinsicElementProps, slot } from '@fluentui/react-utilities';
 import type { MenuItemLinkProps, MenuItemLinkState } from './MenuItemLink.types';
-import { useMenuItem_unstable } from '../MenuItem/useMenuItem';
+import { useMenuItemBase_unstable, useMenuItem_unstable } from '../MenuItem/useMenuItem';
 import type { MenuItemProps } from '../MenuItem/MenuItem.types';
 
 /**
@@ -25,6 +25,37 @@ export const useMenuItemLink_unstable = (
   // FIXME: casting because the root slot changes from div to a,
   // ideal solution would be to extract common logic from useMenuItem_unstable root
   // and use it in both without assuming element type
+  const _props = { ...props, ...(baseState.root as ExtractSlotProps<Slot<'a'>>), ref, tabIndex: props.tabIndex };
+
+  return {
+    ...baseState,
+    components: {
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
+      ...baseState.components,
+      root: 'a',
+    },
+    root: slot.always(
+      getIntrinsicElementProps('a', {
+        role: 'menuitem',
+        ..._props,
+      }),
+      { elementType: 'a' },
+    ),
+  };
+};
+
+/**
+ * Base hook for MenuItemLink, mirrors `useMenuItemLink_unstable` but composes with
+ * `useMenuItemBase_unstable`.
+ *
+ * @param props - props from this instance of MenuItemLink
+ * @param ref - reference to root HTMLElement of MenuItemLink
+ */
+export const useMenuItemLinkBase_unstable = (
+  props: MenuItemLinkProps,
+  ref: React.Ref<HTMLAnchorElement>,
+): MenuItemLinkState => {
+  const baseState = useMenuItemBase_unstable(props as MenuItemProps, null);
   const _props = { ...props, ...(baseState.root as ExtractSlotProps<Slot<'a'>>), ref, tabIndex: props.tabIndex };
 
   return {

--- a/packages/react-components/react-menu/library/src/components/MenuItemRadio/useMenuItemRadio.tsx
+++ b/packages/react-components/react-menu/library/src/components/MenuItemRadio/useMenuItemRadio.tsx
@@ -33,8 +33,6 @@ export const useMenuItemRadio_unstable = (
 /**
  * Base hook for MenuItemRadio component, produces state required to render the component.
  * It doesn't set any design-related props specific to MenuItemRadio.
- *
- * @internal
  */
 export const useMenuItemRadioBase_unstable = (
   props: MenuItemRadioBaseProps,

--- a/packages/react-components/react-menu/library/src/components/MenuItemSwitch/useMenuItemSwitch.tsx
+++ b/packages/react-components/react-menu/library/src/components/MenuItemSwitch/useMenuItemSwitch.tsx
@@ -34,7 +34,6 @@ export const useMenuItemSwitch_unstable = (
  * Base hook for MenuItemSwitch component, produces state required to render the component.
  * It doesn't set any design-related props specific to MenuItemSwitch.
  *
- * @internal
  * @param props - props from this instance of MenuItemSwitch
  * @param ref - reference to root HTMLDivElement of MenuItemSwitch
  */

--- a/packages/react-components/react-menu/library/src/components/MenuList/index.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuList/index.ts
@@ -10,6 +10,6 @@ export type {
   UninitializedMenuListState,
 } from './MenuList.types';
 export { renderMenuList_unstable } from './renderMenuList';
-export { useMenuList_unstable } from './useMenuList';
+export { useMenuList_unstable, useMenuListBase_unstable } from './useMenuList';
 export { menuListClassNames, useMenuListStyles_unstable } from './useMenuListStyles.styles';
 export { useMenuListContextValues_unstable } from './useMenuListContextValues';

--- a/packages/react-components/react-menu/library/src/components/MenuList/useMenuList.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuList/useMenuList.ts
@@ -21,15 +21,21 @@ import { MenuContext } from '../../contexts/menuContext';
 import type { MenuListProps, MenuListState } from './MenuList.types';
 import { useValidateNesting } from '../../utils/useValidateNesting';
 
+const MENU_ITEM_ROLES = ['menuitem', 'menuitemcheckbox', 'menuitemradio'];
+const MENU_ITEM_ROLES_SELECTOR = MENU_ITEM_ROLES.map(role => `[role="${role}"]`).join(',');
+
 /**
- * Returns the props and state required to render the component
+ * Returns the props and state required to render the component.
+ *
+ * Composes with `useMenuListBase_unstable` and adds Tabster-driven keyboard
+ * navigation: circular arrow-key focus, a `TabsterMoveFocusEvent` listener
+ * that lets `useMenuPopover_unstable` handle Tab key presses, a focus-aware
+ * `setFocusByFirstCharacter`, and the `hasIcons` / `hasCheckmarks` slot
+ * alignment hints sourced from the parent `MenuContext`.
  */
 export const useMenuList_unstable = (props: MenuListProps, ref: React.Ref<HTMLElement>): MenuListState => {
-  const { findAllFocusable } = useFocusFinders();
-  const { targetDocument } = useFluent();
   const menuContext = useMenuContextSelectors();
   const hasMenuContext = useHasParentContext(MenuContext);
-  const focusAttributes = useArrowNavigationGroup({ circular: true });
 
   if (usingPropsAndMenuContext(props, menuContext, hasMenuContext)) {
     // TODO throw warnings in development safely
@@ -37,84 +43,101 @@ export const useMenuList_unstable = (props: MenuListProps, ref: React.Ref<HTMLEl
     console.warn('You are using both MenuList and Menu props, we recommend you to use Menu props when available');
   }
 
-  const innerRef = React.useRef<HTMLElement>(null);
-  const validateNestingRef = useValidateNesting('MenuList');
+  const wrapperRef = React.useRef<HTMLElement>(null);
+  const { findAllFocusable } = useFocusFinders();
+  const { targetDocument } = useFluent();
+  const focusAttributes = useArrowNavigationGroup({ circular: true });
+
+  const baseState = useMenuListBase_unstable(props, ref);
+  // recreate root non-mutatively: merge wrapperRef so the effect below can
+  // observe the rendered DOM element, and add Tabster arrow-nav attributes
+  const mergedRootRef = useMergedRefs(baseState.root.ref, wrapperRef) as React.Ref<HTMLDivElement>;
 
   React.useEffect(() => {
-    const element = innerRef.current;
+    const element = wrapperRef.current;
 
-    if (hasMenuContext && targetDocument && element) {
-      const onTabsterMoveFocus = (e: TabsterMoveFocusEvent) => {
-        const nextElement = e.detail.next;
-
-        if (nextElement && element.contains(targetDocument.activeElement) && !element.contains(nextElement)) {
-          // Preventing Tabster from handling Tab press, useMenuPopover will handle it.
-          e.preventDefault();
-        }
-      };
-
-      targetDocument.addEventListener(TabsterMoveFocusEventName, onTabsterMoveFocus);
-
-      return () => {
-        targetDocument.removeEventListener(TabsterMoveFocusEventName, onTabsterMoveFocus);
-      };
+    if (!hasMenuContext || !targetDocument || !element) {
+      return;
     }
-  }, [innerRef, targetDocument, hasMenuContext]);
+
+    const onTabsterMoveFocus = (e: TabsterMoveFocusEvent) => {
+      const nextElement = e.detail.next;
+      if (nextElement && element.contains(targetDocument.activeElement) && !element.contains(nextElement)) {
+        // Preventing Tabster from handling Tab press, useMenuPopover will handle it.
+        e.preventDefault();
+      }
+    };
+
+    targetDocument.addEventListener(TabsterMoveFocusEventName, onTabsterMoveFocus);
+    return () => {
+      targetDocument.removeEventListener(TabsterMoveFocusEventName, onTabsterMoveFocus);
+    };
+  }, [hasMenuContext, targetDocument]);
 
   const setFocusByFirstCharacter = React.useCallback(
     (e: React.KeyboardEvent<HTMLElement>, itemEl: HTMLElement) => {
-      // TODO use some kind of children registration to reduce dependency on DOM roles
-      const acceptedRoles = ['menuitem', 'menuitemcheckbox', 'menuitemradio'];
-      if (!innerRef.current) {
+      if (!wrapperRef.current) {
         return;
       }
-
       const menuItems = findAllFocusable(
-        innerRef.current,
-        (el: HTMLElement) => el.hasAttribute('role') && acceptedRoles.indexOf(el.getAttribute('role')!) !== -1,
+        wrapperRef.current,
+        (el: HTMLElement) => el.hasAttribute('role') && MENU_ITEM_ROLES.indexOf(el.getAttribute('role')!) !== -1,
       );
-
-      let startIndex = menuItems.indexOf(itemEl) + 1;
-      if (startIndex === menuItems.length) {
-        startIndex = 0;
-      }
-
-      const firstChars = menuItems.map(menuItem => menuItem.textContent?.charAt(0).toLowerCase());
-      const char = e.key.toLowerCase();
-
-      const getIndexFirstChars = (start: number, firstChar: string) => {
-        for (let i = start; i < firstChars.length; i++) {
-          if (char === firstChars[i]) {
-            return i;
-          }
-        }
-        return -1;
-      };
-
-      // Check remaining slots in the menu
-      let index = getIndexFirstChars(startIndex, char);
-
-      // If not found in remaining slots, check from beginning
-      if (index === -1) {
-        index = getIndexFirstChars(0, char);
-      }
-
-      // If match was found...
-      if (index > -1) {
-        menuItems[index].focus();
-      }
+      focusItemMatchingFirstCharacter(menuItems, e.key, itemEl);
     },
     [findAllFocusable],
   );
 
+  return {
+    ...baseState,
+    root: {
+      ...focusAttributes,
+      ...baseState.root,
+      ref: mergedRootRef,
+    },
+    setFocusByFirstCharacter,
+  };
+};
+
+/**
+ * Base hook for MenuList component, produces state required to render the component.
+ *
+ * Does not invoke any Tabster APIs internally: arrow-key navigation and the
+ * focus-aware `setFocusByFirstCharacter` are added by the wrapper
+ * `useMenuList_unstable`. The base's `setFocusByFirstCharacter` walks the DOM
+ * via `querySelectorAll` and does not filter by Tabster's focusability rules,
+ * so consumers integrating their own focus management should layer that on top.
+ *
+ * @param props - props from this instance of MenuList
+ * @param ref - reference to root HTMLElement of MenuList
+ */
+export const useMenuListBase_unstable = (props: MenuListProps, ref: React.Ref<HTMLElement>): MenuListState => {
+  const triggerId = useMenuContext_unstable(context => context.triggerId);
+  const checkedValuesContext = useMenuContext_unstable(context => context.checkedValues);
+  const onCheckedValueChangeContext = useMenuContext_unstable(context => context.onCheckedValueChange);
+  const hasIconsContext = useMenuContext_unstable(context => context.hasIcons);
+  const hasCheckmarksContext = useMenuContext_unstable(context => context.hasCheckmarks);
+  const hasMenuContext = useHasParentContext(MenuContext);
+
+  const innerRef = React.useRef<HTMLElement>(null);
+  const validateNestingRef = useValidateNesting('MenuList');
+
+  const setFocusByFirstCharacter = React.useCallback((e: React.KeyboardEvent<HTMLElement>, itemEl: HTMLElement) => {
+    if (!innerRef.current) {
+      return;
+    }
+    const menuItems = Array.from(innerRef.current.querySelectorAll<HTMLElement>(MENU_ITEM_ROLES_SELECTOR));
+    focusItemMatchingFirstCharacter(menuItems, e.key, itemEl);
+  }, []);
+
   const [checkedValues, setCheckedValues] = useControllableState({
-    state: props.checkedValues ?? (hasMenuContext ? menuContext.checkedValues : undefined),
+    state: props.checkedValues ?? (hasMenuContext ? checkedValuesContext : undefined),
     defaultState: props.defaultCheckedValues,
     initialState: {},
   });
 
   const handleCheckedValueChange =
-    props.onCheckedValueChange ?? (hasMenuContext ? menuContext.onCheckedValueChange : undefined);
+    props.onCheckedValueChange ?? (hasMenuContext ? onCheckedValueChangeContext : undefined);
 
   const toggleCheckbox = useEventCallback(
     (e: React.MouseEvent | React.KeyboardEvent, name: string, value: string, checked: boolean) => {
@@ -148,20 +171,51 @@ export const useMenuList_unstable = (props: MenuListProps, ref: React.Ref<HTMLEl
         // but since it would be a breaking change to fix it, we are casting ref to it's proper type
         ref: useMergedRefs(ref, innerRef, validateNestingRef) as React.Ref<HTMLDivElement>,
         role: 'menu',
-        'aria-labelledby': menuContext.triggerId,
-        ...focusAttributes,
+        'aria-labelledby': triggerId,
         ...props,
       }),
       { elementType: 'div' },
     ),
-    hasIcons: menuContext.hasIcons || false,
-    hasCheckmarks: menuContext.hasCheckmarks || false,
     checkedValues,
+    hasIcons: props.hasIcons ?? hasIconsContext ?? false,
+    hasCheckmarks: props.hasCheckmarks ?? hasCheckmarksContext ?? false,
     hasMenuContext,
     setFocusByFirstCharacter,
     selectRadio,
     toggleCheckbox,
   };
+};
+
+/**
+ * Focuses the next menu item whose textContent starts with the typed character,
+ * wrapping around the list. Shared between the Tabster-free base impl and the
+ * Tabster-aware wrapper.
+ */
+const focusItemMatchingFirstCharacter = (menuItems: HTMLElement[], key: string, current: HTMLElement) => {
+  let startIndex = menuItems.indexOf(current) + 1;
+  if (startIndex === menuItems.length) {
+    startIndex = 0;
+  }
+
+  const firstChars = menuItems.map(menuItem => menuItem.textContent?.charAt(0).toLowerCase());
+  const char = key.toLowerCase();
+
+  const getIndexFirstChars = (start: number) => {
+    for (let i = start; i < firstChars.length; i++) {
+      if (char === firstChars[i]) {
+        return i;
+      }
+    }
+    return -1;
+  };
+
+  let index = getIndexFirstChars(startIndex);
+  if (index === -1) {
+    index = getIndexFirstChars(0);
+  }
+  if (index > -1) {
+    menuItems[index].focus();
+  }
 };
 
 /**

--- a/packages/react-components/react-menu/library/src/components/MenuPopover/index.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuPopover/index.ts
@@ -1,5 +1,5 @@
 export { MenuPopover } from './MenuPopover';
 export type { MenuPopoverProps, MenuPopoverSlots, MenuPopoverState } from './MenuPopover.types';
 export { renderMenuPopover_unstable } from './renderMenuPopover';
-export { useMenuPopover_unstable } from './useMenuPopover';
+export { useMenuPopover_unstable, useMenuPopoverBase_unstable } from './useMenuPopover';
 export { menuPopoverClassNames, useMenuPopoverStyles_unstable } from './useMenuPopoverStyles.styles';

--- a/packages/react-components/react-menu/library/src/components/MenuPopover/useMenuPopover.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuPopover/useMenuPopover.ts
@@ -13,15 +13,16 @@ import { dispatchMenuEnterEvent, useIsSubmenu } from '../../utils/index';
 import type { MenuPopoverProps, MenuPopoverState } from './MenuPopover.types';
 
 /**
- * Create the state required to render MenuPopover.
+ * Base hook for MenuPopover, produces state required to render the component.
  *
- * The returned state can be modified with hooks such as useMenuPopoverStyles_unstable,
- * before being passed to renderMenuPopover_unstable.
+ * Does not invoke `@fluentui/react-tabster` focus-restoration or
+ * `@fluentui/react-motion` ref-forwarding APIs internally; the wrapper
+ * `useMenuPopover_unstable` layers those on top.
  *
  * @param props - props from this instance of MenuPopover
  * @param ref - reference to root HTMLElement of MenuPopover
  */
-export const useMenuPopover_unstable = (props: MenuPopoverProps, ref: React.Ref<HTMLElement>): MenuPopoverState => {
+export const useMenuPopoverBase_unstable = (props: MenuPopoverProps, ref: React.Ref<HTMLElement>): MenuPopoverState => {
   'use no memo';
 
   const safeZone = useMenuContext_unstable(context => context.safeZone);
@@ -35,7 +36,6 @@ export const useMenuPopover_unstable = (props: MenuPopoverProps, ref: React.Ref<
   const shouldCloseOnArrowLeft = useMenuListContext_unstable(ctx => ctx.shouldCloseOnArrowLeft ?? true);
 
   const canDispatchCustomEventRef = React.useRef(true);
-  const restoreFocusSourceAttributes = useRestoreFocusSource();
   const [setThrottleTimeout, clearThrottleTimeout] = useTimeout();
 
   const { dir } = useFluent();
@@ -73,20 +73,15 @@ export const useMenuPopover_unstable = (props: MenuPopoverProps, ref: React.Ref<
   const rootProps = slot.always(
     getIntrinsicElementProps('div', {
       role: 'presentation',
-      ...restoreFocusSourceAttributes,
       ...props,
       // FIXME:
       // `ref` is wrongly assigned to be `HTMLElement` instead of `HTMLDivElement`
       // but since it would be a breaking change to fix it, we are casting ref to it's proper type
-      ref: useMergedRefs(
-        ref,
-        popoverRef,
-        mouseOverListenerCallbackRef,
-        useMotionForwardedRef(),
-      ) as React.Ref<HTMLDivElement>,
+      ref: useMergedRefs(ref, popoverRef, mouseOverListenerCallbackRef) as React.Ref<HTMLDivElement>,
     }),
     { elementType: 'div' },
   );
+
   const { onMouseEnter: onMouseEnterOriginal, onKeyDown: onKeyDownOriginal } = rootProps;
   rootProps.onMouseEnter = useEventCallback((event: React.MouseEvent<HTMLDivElement>) => {
     if (openOnHover || isSubmenu) {
@@ -94,6 +89,7 @@ export const useMenuPopover_unstable = (props: MenuPopoverProps, ref: React.Ref<
     }
     onMouseEnterOriginal?.(event);
   });
+
   rootProps.onKeyDown = useEventCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
     const key = event.key;
     if (key === Escape || (isSubmenu && shouldCloseOnArrowLeft && key === CloseArrowKey)) {
@@ -119,5 +115,29 @@ export const useMenuPopover_unstable = (props: MenuPopoverProps, ref: React.Ref<
     safeZone,
     components: { root: 'div' },
     root: rootProps,
+  };
+};
+
+/**
+ * Create the state required to render MenuPopover.
+ *
+ * The returned state can be modified with hooks such as useMenuPopoverStyles_unstable,
+ * before being passed to renderMenuPopover_unstable.
+ *
+ * @param props - props from this instance of MenuPopover
+ * @param ref - reference to root HTMLElement of MenuPopover
+ */
+export const useMenuPopover_unstable = (props: MenuPopoverProps, ref: React.Ref<HTMLElement>): MenuPopoverState => {
+  const restoreFocusSourceAttributes = useRestoreFocusSource();
+  const motionRef = useMotionForwardedRef();
+  const baseState = useMenuPopoverBase_unstable(props, ref);
+
+  return {
+    ...baseState,
+    root: {
+      ...restoreFocusSourceAttributes,
+      ...baseState.root,
+      ref: useMergedRefs(baseState.root.ref, motionRef) as React.Ref<HTMLDivElement>,
+    },
   };
 };

--- a/packages/react-components/react-menu/library/src/components/MenuTrigger/index.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuTrigger/index.ts
@@ -1,4 +1,5 @@
 export { MenuTrigger } from './MenuTrigger';
 export type { MenuTriggerChildProps, MenuTriggerProps, MenuTriggerState } from './MenuTrigger.types';
 export { renderMenuTrigger_unstable } from './renderMenuTrigger';
-export { useMenuTrigger_unstable } from './useMenuTrigger';
+export { useMenuTrigger_unstable, useMenuTriggerBase_unstable } from './useMenuTrigger';
+export type { UseMenuTriggerBaseOptions } from './useMenuTrigger';

--- a/packages/react-components/react-menu/library/src/components/MenuTrigger/useMenuTrigger.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuTrigger/useMenuTrigger.ts
@@ -26,15 +26,62 @@ function noop() {
 
 /**
  * Create the state required to render MenuTrigger.
- * Clones the only child component and adds necessary event handling behaviours to open a popup menu
+ * Clones the only child component and adds necessary event handling behaviours to open a popup menu.
+ *
+ * Composes with `useMenuTriggerBase_unstable` and supplies Tabster's `findFirstFocusable`
+ * as the `focusFirst` callback so that submenu-trigger keyboard navigation honours
+ * Tabster movers, focus traps, and other Tabster-managed state.
  *
  * @param props - props from this instance of MenuTrigger
  */
 export const useMenuTrigger_unstable = (props: MenuTriggerProps): MenuTriggerState => {
+  const menuPopoverRef = useMenuContext_unstable(context => context.menuPopoverRef);
+
+  const { findFirstFocusable } = useFocusFinders();
+
+  const focusFirst = React.useCallback(() => {
+    const firstFocusable = findFirstFocusable(menuPopoverRef.current);
+    firstFocusable?.focus();
+  }, [findFirstFocusable, menuPopoverRef]);
+
+  return useMenuTriggerBase_unstable(props, { focusFirst });
+};
+
+/**
+ * Options accepted by `useMenuTriggerBase_unstable`.
+ */
+export type UseMenuTriggerBaseOptions = {
+  /**
+   * Pluggable "focus the first focusable element in the menu popover" callback,
+   * invoked when an already-open submenu trigger receives the open arrow key.
+   *
+   * Not provided by the base hook itself - the base hook is intentionally headless
+   * and leaves focus discovery to the caller. `useMenuTrigger_unstable` plugs in a
+   * Tabster-aware implementation; a headless consumer is expected to supply its own.
+   * If omitted, the keyboard handler is a no-op for that case.
+   */
+  focusFirst?: () => void;
+};
+
+/**
+ * Base hook for MenuTrigger component, produces state required to render the component.
+ *
+ * Headless: this hook does not import from `@fluentui/react-tabster` and does not
+ * perform any focus discovery on its own. The submenu-already-open arrow-key path
+ * delegates to the optional `options.focusFirst` callback, which lets consumers wire
+ * up whichever focus-finding strategy fits their environment (Tabster, a native DOM
+ * query, a virtual focus manager, etc.). When `focusFirst` is not provided that path
+ * becomes a no-op.
+ *
+ * @public
+ */
+export const useMenuTriggerBase_unstable = (
+  props: MenuTriggerProps,
+  options?: UseMenuTriggerBaseOptions,
+): MenuTriggerState => {
   const { children, disableButtonEnhancement = false } = props;
 
   const triggerRef = useMenuContext_unstable(context => context.triggerRef);
-  const menuPopoverRef = useMenuContext_unstable(context => context.menuPopoverRef);
   const setOpen = useMenuContext_unstable(context => context.setOpen);
   const open = useMenuContext_unstable(context => context.open);
   const triggerId = useMenuContext_unstable(context => context.triggerId);
@@ -44,11 +91,7 @@ export const useMenuTrigger_unstable = (props: MenuTriggerProps): MenuTriggerSta
   const isSubmenu = useIsSubmenu();
   const shouldOpenOnArrowRight = useMenuListContext_unstable(ctx => ctx.shouldOpenOnArrowRight ?? true);
 
-  const { findFirstFocusable } = useFocusFinders();
-  const focusFirst = React.useCallback(() => {
-    const firstFocusable = findFirstFocusable(menuPopoverRef.current);
-    firstFocusable?.focus();
-  }, [findFirstFocusable, menuPopoverRef]);
+  const focusFirst = options?.focusFirst;
 
   const openedWithKeyboardRef = React.useRef(false);
   const openedViaSafeZoneRef = React.useRef(false);
@@ -113,7 +156,7 @@ export const useMenuTrigger_unstable = (props: MenuTriggerProps): MenuTriggerSta
 
     // if menu is already open, can't rely on effects to focus
     if (open && key === OpenArrowKey && isSubmenu && shouldOpenOnArrowRight) {
-      focusFirst();
+      focusFirst?.();
     }
   };
 

--- a/packages/react-components/react-menu/library/src/index.ts
+++ b/packages/react-components/react-menu/library/src/index.ts
@@ -6,8 +6,16 @@ export type { MenuGroupContextValue } from './contexts/menuGroupContext';
 export { MenuListProvider, useMenuListContext_unstable } from './contexts/menuListContext';
 export type { MenuListContextValue } from './contexts/menuListContext';
 
-export { Menu, renderMenu_unstable, useMenuContextValues_unstable, useMenu_unstable } from './Menu';
+export {
+  Menu,
+  renderMenu_unstable,
+  useMenuBase_unstable,
+  useMenuContextValues_unstable,
+  useMenu_unstable,
+} from './Menu';
 export type {
+  MenuBaseProps,
+  MenuBaseState,
   MenuContextValues,
   MenuOpenChangeData,
   MenuOpenEvent,
@@ -47,6 +55,7 @@ export {
   MenuItem,
   menuItemClassNames,
   renderMenuItem_unstable,
+  useMenuItemBase_unstable,
   useMenuItemStyles_unstable,
   useMenuItem_unstable,
 } from './MenuItem';
@@ -55,6 +64,7 @@ export {
   MenuItemCheckbox,
   menuItemCheckboxClassNames,
   renderMenuItemCheckbox_unstable,
+  useMenuItemCheckboxBase_unstable,
   useMenuItemCheckboxStyles_unstable,
   useMenuItemCheckbox_unstable,
 } from './MenuItemCheckbox';
@@ -63,14 +73,21 @@ export {
   MenuItemRadio,
   menuItemRadioClassNames,
   renderMenuItemRadio_unstable,
+  useMenuItemRadioBase_unstable,
   useMenuItemRadioStyles_unstable,
   useMenuItemRadio_unstable,
 } from './MenuItemRadio';
-export type { MenuItemRadioProps, MenuItemRadioState } from './MenuItemRadio';
+export type {
+  MenuItemRadioBaseProps,
+  MenuItemRadioBaseState,
+  MenuItemRadioProps,
+  MenuItemRadioState,
+} from './MenuItemRadio';
 export {
   MenuList,
   menuListClassNames,
   renderMenuList_unstable,
+  useMenuListBase_unstable,
   useMenuListContextValues_unstable,
   useMenuListStyles_unstable,
   useMenuList_unstable,
@@ -90,6 +107,7 @@ export {
   MenuPopover,
   menuPopoverClassNames,
   renderMenuPopover_unstable,
+  useMenuPopoverBase_unstable,
   useMenuPopoverStyles_unstable,
   useMenuPopover_unstable,
 } from './MenuPopover';
@@ -102,8 +120,18 @@ export {
   useMenuSplitGroup_unstable,
 } from './MenuSplitGroup';
 export type { MenuSplitGroupProps, MenuSplitGroupSlots, MenuSplitGroupState } from './MenuSplitGroup';
-export { MenuTrigger, renderMenuTrigger_unstable, useMenuTrigger_unstable } from './MenuTrigger';
-export type { MenuTriggerChildProps, MenuTriggerProps, MenuTriggerState } from './MenuTrigger';
+export {
+  MenuTrigger,
+  renderMenuTrigger_unstable,
+  useMenuTrigger_unstable,
+  useMenuTriggerBase_unstable,
+} from './MenuTrigger';
+export type {
+  MenuTriggerChildProps,
+  MenuTriggerProps,
+  MenuTriggerState,
+  UseMenuTriggerBaseOptions,
+} from './MenuTrigger';
 
 export { useCheckmarkStyles_unstable } from './selectable/index';
 export type { MenuItemSelectableProps, MenuItemSelectableState, SelectableHandler } from './selectable/index';
@@ -112,6 +140,7 @@ export {
   MenuItemLink,
   menuItemLinkClassNames,
   renderMenuItemLink_unstable,
+  useMenuItemLinkBase_unstable,
   useMenuItemLinkStyles_unstable,
   useMenuItemLink_unstable,
 } from './MenuItemLink';
@@ -120,16 +149,11 @@ export type { MenuItemLinkProps, MenuItemLinkSlots, MenuItemLinkState } from './
 export { MENU_ENTER_EVENT, dispatchMenuEnterEvent, useOnMenuMouseEnter } from './utils';
 export {
   MenuItemSwitch,
-  useMenuItemSwitch_unstable,
-  useMenuItemSwitchStyles_unstable,
-  renderMenuItemSwitch_unstable,
   menuItemSwitchClassNames,
+  renderMenuItemSwitch_unstable,
+  useMenuItemSwitchBase_unstable,
+  useMenuItemSwitchStyles_unstable,
+  useMenuItemSwitch_unstable,
 } from './MenuItemSwitch';
 
-export type { MenuItemSwitchProps, MenuItemSwitchState, MenuItemSwitchSlots } from './MenuItemSwitch';
-
-// Experimental: Base hooks - will be enabled in the experimental release branch
-// export { useMenuItemBase_unstable } from './MenuItem';
-// export { useMenuItemCheckboxBase_unstable } from './MenuItemCheckbox';
-// export { useMenuItemRadioBase_unstable } from './MenuItemRadio';
-// export { useMenuItemSwitchBase_unstable } from './MenuItemSwitch';
+export type { MenuItemSwitchProps, MenuItemSwitchSlots, MenuItemSwitchState } from './MenuItemSwitch';


### PR DESCRIPTION
 Exposes a set of headless `*Base_unstable` hooks across `react-menu` subcomponents. These hooks omit Tabster, motion, and Griffel-specific concerns.

  ## Previous Behavior

  Only `useMenu_unstable`, `useMenuList_unstable`, `useMenuPopover_unstable`, and the various `useMenuItem*_unstable` hooks were publicly exported. Tabster and motion could not be opted out.

  ## New Behavior

  A set of `*Base_unstable` hooks is now publicly exported across all `react-menu` subcomponents. The base hooks omit Tabster and motion, leaving behavior, ARIA, and selection state intact.
