### PR TITLE
fix: update import references to point directly to non-barrel files

### DIFF
--- a/change/@fluentui-web-components-e990ccf2-7c70-4035-a4c0-13b28fd11a18.json
+++ b/change/@fluentui-web-components-e990ccf2-7c70-4035-a4c0-13b28fd11a18.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "update import references to point directly to non-barrel files",
+  "packageName": "@fluentui/web-components",
+  "email": "13071055+chrisdholt@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/docs/web-components.api.md
+++ b/packages/web-components/docs/web-components.api.md
@@ -4570,7 +4570,7 @@ export const zIndexPriority = "var(--zIndexPriority)";
 
 // Warnings were encountered during analysis:
 //
-// dist/esm/accordion-item/accordion-item.d.ts:15:5 - (ae-forgotten-export) The symbol "StaticallyComposableHTML" needs to be exported by the entry point index.d.ts
+// dist/esm/accordion-item/accordion-item.d.ts:13:5 - (ae-forgotten-export) The symbol "StaticallyComposableHTML" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/web-components/src/accordion-item/accordion-item.styles.ts
+++ b/packages/web-components/src/accordion-item/accordion-item.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '../utils/index.js';
+import { display } from '../utils/display.js';
 import {
   borderRadiusMedium,
   borderRadiusSmall,

--- a/packages/web-components/src/accordion-item/accordion-item.template.ts
+++ b/packages/web-components/src/accordion-item/accordion-item.template.ts
@@ -1,6 +1,6 @@
 import { type ElementViewTemplate, html, ref } from '@microsoft/fast-element';
-import { startSlotTemplate } from '../patterns/index.js';
-import { staticallyCompose } from '../utils/index.js';
+import { startSlotTemplate } from '../patterns/start-end.js';
+import { staticallyCompose } from '../utils/template-helpers.js';
 import type { AccordionItem, AccordionItemOptions } from './accordion-item.js';
 
 const chevronRight20Filled = html.partial(`<svg

--- a/packages/web-components/src/accordion-item/accordion-item.ts
+++ b/packages/web-components/src/accordion-item/accordion-item.ts
@@ -1,12 +1,12 @@
 import { attr } from '@microsoft/fast-element';
-import type { StaticallyComposableHTML } from '../utils/index.js';
-import { StartEnd } from '../patterns/index.js';
-import type { StartEndOptions } from '../patterns/index.js';
+import type { StaticallyComposableHTML } from '../utils/template-helpers.js';
+import { StartEnd } from '../patterns/start-end.js';
+import type { StartEndOptions } from '../patterns/start-end.js';
 import { applyMixins } from '../utils/apply-mixins.js';
 import { BaseAccordionItem } from './accordion-item.base.js';
 import { AccordionItemMarkerPosition, AccordionItemSize } from './accordion-item.options.js';
 
-export type { StaticallyComposableHTML } from '../utils/index.js';
+export type { StaticallyComposableHTML } from '../utils/template-helpers.js';
 
 /**
  * Accordion Item configuration options

--- a/packages/web-components/src/accordion-item/accordion-item.ts
+++ b/packages/web-components/src/accordion-item/accordion-item.ts
@@ -1,12 +1,9 @@
 import { attr } from '@microsoft/fast-element';
 import type { StaticallyComposableHTML } from '../utils/template-helpers.js';
-import { StartEnd } from '../patterns/start-end.js';
-import type { StartEndOptions } from '../patterns/start-end.js';
+import { StartEnd, type StartEndOptions } from '../patterns/start-end.js';
 import { applyMixins } from '../utils/apply-mixins.js';
 import { BaseAccordionItem } from './accordion-item.base.js';
 import { AccordionItemMarkerPosition, AccordionItemSize } from './accordion-item.options.js';
-
-export type { StaticallyComposableHTML } from '../utils/template-helpers.js';
 
 /**
  * Accordion Item configuration options

--- a/packages/web-components/src/accordion/accordion.options.ts
+++ b/packages/web-components/src/accordion/accordion.options.ts
@@ -1,4 +1,4 @@
-import type { ValuesOf } from '../utils/index.js';
+import type { ValuesOf } from '../utils/typings.js';
 
 /**
  * Expand mode for {@link Accordion}

--- a/packages/web-components/src/accordion/accordion.styles.ts
+++ b/packages/web-components/src/accordion/accordion.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '../utils/index.js';
+import { display } from '../utils/display.js';
 
 export const styles = css`
   ${display('flex')}

--- a/packages/web-components/src/anchor-button/anchor-button.options.ts
+++ b/packages/web-components/src/anchor-button/anchor-button.options.ts
@@ -1,5 +1,5 @@
 import { ButtonAppearance, ButtonShape, ButtonSize } from '../button/button.options.js';
-import type { ValuesOf } from '../utils/index.js';
+import type { ValuesOf } from '../utils/typings.js';
 import type { AnchorOptions } from './anchor-button.js';
 
 /**

--- a/packages/web-components/src/anchor-button/anchor-button.template.ts
+++ b/packages/web-components/src/anchor-button/anchor-button.template.ts
@@ -1,5 +1,5 @@
 import { type ElementViewTemplate, html, type ViewTemplate } from '@microsoft/fast-element';
-import { endSlotTemplate, startSlotTemplate } from '../patterns/index.js';
+import { endSlotTemplate, startSlotTemplate } from '../patterns/start-end.js';
 import type { AnchorButton, AnchorOptions } from './anchor-button.js';
 
 /**

--- a/packages/web-components/src/anchor-button/anchor-button.ts
+++ b/packages/web-components/src/anchor-button/anchor-button.ts
@@ -1,6 +1,6 @@
 import { attr } from '@microsoft/fast-element';
-import type { StartEndOptions } from '../patterns/index.js';
-import { StartEnd } from '../patterns/index.js';
+import type { StartEndOptions } from '../patterns/start-end.js';
+import { StartEnd } from '../patterns/start-end.js';
 import { applyMixins } from '../utils/apply-mixins.js';
 import { swapStates, toggleState } from '../utils/element-internals.js';
 import { BaseAnchor } from './anchor-button.base.js';

--- a/packages/web-components/src/anchor-button/anchor-button.ts
+++ b/packages/web-components/src/anchor-button/anchor-button.ts
@@ -1,6 +1,5 @@
 import { attr } from '@microsoft/fast-element';
-import type { StartEndOptions } from '../patterns/start-end.js';
-import { StartEnd } from '../patterns/start-end.js';
+import { StartEnd, type StartEndOptions } from '../patterns/start-end.js';
 import { applyMixins } from '../utils/apply-mixins.js';
 import { swapStates, toggleState } from '../utils/element-internals.js';
 import { BaseAnchor } from './anchor-button.base.js';

--- a/packages/web-components/src/avatar/avatar.options.ts
+++ b/packages/web-components/src/avatar/avatar.options.ts
@@ -1,4 +1,4 @@
-import type { ValuesOf } from '../utils/index.js';
+import type { ValuesOf } from '../utils/typings.js';
 
 /**
  * The Avatar "active" state

--- a/packages/web-components/src/avatar/avatar.styles.ts
+++ b/packages/web-components/src/avatar/avatar.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '../utils/index.js';
+import { display } from '../utils/display.js';
 import {
   borderRadiusCircular,
   borderRadiusLarge,

--- a/packages/web-components/src/badge/badge.options.ts
+++ b/packages/web-components/src/badge/badge.options.ts
@@ -1,5 +1,6 @@
-import type { StartEndOptions } from '../patterns/index.js';
-import type { StaticallyComposableHTML, ValuesOf } from '../utils/index.js';
+import type { StartEndOptions } from '../patterns/start-end.js';
+import type { StaticallyComposableHTML } from '../utils/template-helpers.js';
+import type { ValuesOf } from '../utils/typings.js';
 import type { Badge } from './badge.js';
 
 /**

--- a/packages/web-components/src/badge/badge.styles.ts
+++ b/packages/web-components/src/badge/badge.styles.ts
@@ -6,7 +6,7 @@ import {
   badgeOutlineStyles,
   badgeSizeStyles,
   badgeTintStyles,
-} from '../styles/index.js';
+} from '../styles/partials/badge.partials.js';
 import { borderRadiusMedium, borderRadiusNone, borderRadiusSmall } from '../theme/design-tokens.js';
 // why is the border not showing up?
 /** Badge styles

--- a/packages/web-components/src/badge/badge.template.ts
+++ b/packages/web-components/src/badge/badge.template.ts
@@ -1,5 +1,5 @@
 import { type ElementViewTemplate, html } from '@microsoft/fast-element';
-import { endSlotTemplate, startSlotTemplate } from '../patterns/index.js';
+import { endSlotTemplate, startSlotTemplate } from '../patterns/start-end.js';
 import { staticallyCompose } from '../utils/template-helpers.js';
 import type { Badge } from './badge.js';
 import type { BadgeOptions } from './badge.options.js';

--- a/packages/web-components/src/badge/badge.ts
+++ b/packages/web-components/src/badge/badge.ts
@@ -1,6 +1,6 @@
 import { attr, FASTElement } from '@microsoft/fast-element';
 import { applyMixins } from '../utils/apply-mixins.js';
-import { StartEnd } from '../patterns/index.js';
+import { StartEnd } from '../patterns/start-end.js';
 import { BadgeAppearance, BadgeColor, BadgeShape, BadgeSize } from './badge.options.js';
 
 /**

--- a/packages/web-components/src/button/button.options.ts
+++ b/packages/web-components/src/button/button.options.ts
@@ -1,5 +1,5 @@
-import type { StartEndOptions } from '../patterns/index.js';
-import type { ValuesOf } from '../utils/index.js';
+import type { StartEndOptions } from '../patterns/start-end.js';
+import type { ValuesOf } from '../utils/typings.js';
 import type { Button } from './button.js';
 
 /**

--- a/packages/web-components/src/button/button.styles.ts
+++ b/packages/web-components/src/button/button.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '../utils/index.js';
+import { display } from '../utils/display.js';
 import {
   borderRadiusCircular,
   borderRadiusLarge,

--- a/packages/web-components/src/button/button.template.ts
+++ b/packages/web-components/src/button/button.template.ts
@@ -1,5 +1,5 @@
 import { type ElementViewTemplate, html, slotted } from '@microsoft/fast-element';
-import { endSlotTemplate, startSlotTemplate } from '../patterns/index.js';
+import { endSlotTemplate, startSlotTemplate } from '../patterns/start-end.js';
 import type { BaseButton } from './button.base.js';
 import type { ButtonOptions } from './button.options.js';
 

--- a/packages/web-components/src/button/button.ts
+++ b/packages/web-components/src/button/button.ts
@@ -1,5 +1,5 @@
 import { attr } from '@microsoft/fast-element';
-import { StartEnd } from '../patterns/index.js';
+import { StartEnd } from '../patterns/start-end.js';
 import { applyMixins } from '../utils/apply-mixins.js';
 import { BaseButton } from './button.base.js';
 import { ButtonAppearance, ButtonShape, ButtonSize } from './button.options.js';

--- a/packages/web-components/src/compound-button/compound-button.options.ts
+++ b/packages/web-components/src/compound-button/compound-button.options.ts
@@ -1,6 +1,6 @@
 import { ButtonAppearance, ButtonShape, ButtonSize } from '../button/button.options.js';
 import type { ButtonOptions } from '../button/button.options.js';
-import type { ValuesOf } from '../utils/index.js';
+import type { ValuesOf } from '../utils/typings.js';
 
 /**
  * Compound Button Appearance constants

--- a/packages/web-components/src/compound-button/compound-button.template.ts
+++ b/packages/web-components/src/compound-button/compound-button.template.ts
@@ -1,5 +1,5 @@
 import { type ElementViewTemplate, html, slotted } from '@microsoft/fast-element';
-import { endSlotTemplate, startSlotTemplate } from '../patterns/index.js';
+import { endSlotTemplate, startSlotTemplate } from '../patterns/start-end.js';
 import type { CompoundButton } from './compound-button.js';
 import type { CompoundButtonOptions } from './compound-button.options.js';
 

--- a/packages/web-components/src/counter-badge/counter-badge.options.ts
+++ b/packages/web-components/src/counter-badge/counter-badge.options.ts
@@ -1,5 +1,5 @@
 import type { BadgeOptions } from '../badge/badge.options.js';
-import type { ValuesOf } from '../utils/index.js';
+import type { ValuesOf } from '../utils/typings.js';
 
 /**
  * CounterBadge options

--- a/packages/web-components/src/counter-badge/counter-badge.styles.ts
+++ b/packages/web-components/src/counter-badge/counter-badge.styles.ts
@@ -1,5 +1,10 @@
 import { css } from '@microsoft/fast-element';
-import { badgeBaseStyles, badgeFilledStyles, badgeGhostStyles, badgeSizeStyles } from '../styles/index.js';
+import {
+  badgeBaseStyles,
+  badgeFilledStyles,
+  badgeGhostStyles,
+  badgeSizeStyles,
+} from '../styles/partials/badge.partials.js';
 import { borderRadiusMedium, borderRadiusSmall } from '../theme/design-tokens.js';
 
 /** Badge styles

--- a/packages/web-components/src/counter-badge/counter-badge.ts
+++ b/packages/web-components/src/counter-badge/counter-badge.ts
@@ -1,6 +1,6 @@
 import { attr, FASTElement, nullableNumberConverter } from '@microsoft/fast-element';
 import { applyMixins } from '../utils/apply-mixins.js';
-import { StartEnd } from '../patterns/index.js';
+import { StartEnd } from '../patterns/start-end.js';
 import {
   CounterBadgeAppearance,
   CounterBadgeColor,

--- a/packages/web-components/src/dialog-body/dialog-body.styles.ts
+++ b/packages/web-components/src/dialog-body/dialog-body.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '../utils/index.js';
+import { display } from '../utils/display.js';
 import {
   colorNeutralBackground1,
   colorNeutralForeground1,

--- a/packages/web-components/src/dialog/dialog.options.ts
+++ b/packages/web-components/src/dialog/dialog.options.ts
@@ -1,4 +1,4 @@
-import type { ValuesOf } from '../utils/index.js';
+import type { ValuesOf } from '../utils/typings.js';
 import { Dialog } from './dialog.js';
 
 /**

--- a/packages/web-components/src/divider/divider.options.ts
+++ b/packages/web-components/src/divider/divider.options.ts
@@ -1,5 +1,5 @@
 import { Orientation } from '@microsoft/fast-web-utilities';
-import type { ValuesOf } from '../utils/index.js';
+import type { ValuesOf } from '../utils/typings.js';
 
 /**
  * Divider roles

--- a/packages/web-components/src/divider/divider.styles.ts
+++ b/packages/web-components/src/divider/divider.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '../utils/index.js';
+import { display } from '../utils/display.js';
 import {
   colorBrandForeground1,
   colorBrandStroke1,

--- a/packages/web-components/src/drawer-body/drawer-body.styles.ts
+++ b/packages/web-components/src/drawer-body/drawer-body.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '../utils/index.js';
+import { display } from '../utils/display.js';
 import { spacingHorizontalM, spacingHorizontalXL } from '../theme/design-tokens.js';
 import { typographySubtitle1Styles } from '../styles/partials/typography.partials.js';
 

--- a/packages/web-components/src/drawer/drawer.options.ts
+++ b/packages/web-components/src/drawer/drawer.options.ts
@@ -1,4 +1,4 @@
-import type { ValuesOf } from '../utils/index.js';
+import type { ValuesOf } from '../utils/typings.js';
 
 /**
  * A drawer can be positioned on the left or right side of the viewport.

--- a/packages/web-components/src/drawer/drawer.styles.ts
+++ b/packages/web-components/src/drawer/drawer.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '../utils/index.js';
+import { display } from '../utils/display.js';
 import {
   colorBackgroundOverlay,
   colorNeutralBackground1,

--- a/packages/web-components/src/image/image.options.ts
+++ b/packages/web-components/src/image/image.options.ts
@@ -1,4 +1,4 @@
-import type { ValuesOf } from '../utils/index.js';
+import type { ValuesOf } from '../utils/typings.js';
 
 /**
  * Image fit

--- a/packages/web-components/src/label/label.options.ts
+++ b/packages/web-components/src/label/label.options.ts
@@ -1,4 +1,4 @@
-import type { ValuesOf } from '../utils/index.js';
+import type { ValuesOf } from '../utils/typings.js';
 
 /**
  * A Labels font size can be small, medium, or large

--- a/packages/web-components/src/label/label.styles.ts
+++ b/packages/web-components/src/label/label.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '../utils/index.js';
+import { display } from '../utils/display.js';
 import {
   colorNeutralForeground1,
   colorNeutralForegroundDisabled,

--- a/packages/web-components/src/link/link.options.ts
+++ b/packages/web-components/src/link/link.options.ts
@@ -1,5 +1,5 @@
 import { AnchorAttributes, AnchorTarget } from '../anchor-button/anchor-button.options.js';
-import type { ValuesOf } from '../utils/index.js';
+import type { ValuesOf } from '../utils/typings.js';
 
 /**
  * Link Appearance constants

--- a/packages/web-components/src/link/link.styles.ts
+++ b/packages/web-components/src/link/link.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '../utils/index.js';
+import { display } from '../utils/display.js';
 import {
   colorBrandForegroundLink,
   colorBrandForegroundLinkHover,

--- a/packages/web-components/src/menu-button/menu-button.options.ts
+++ b/packages/web-components/src/menu-button/menu-button.options.ts
@@ -1,6 +1,6 @@
 import type { ButtonOptions } from '../button/button.options.js';
 import { ButtonAppearance, ButtonShape, ButtonSize } from '../button/button.options.js';
-import type { ValuesOf } from '../utils/index.js';
+import type { ValuesOf } from '../utils/typings.js';
 
 /**
  * Menu Button Appearance constants

--- a/packages/web-components/src/menu-item/menu-item.options.ts
+++ b/packages/web-components/src/menu-item/menu-item.options.ts
@@ -1,4 +1,4 @@
-import type { ValuesOf } from '../utils/index.js';
+import type { ValuesOf } from '../utils/typings.js';
 import type { MenuItem } from './menu-item.js';
 
 /**

--- a/packages/web-components/src/menu-item/menu-item.styles.ts
+++ b/packages/web-components/src/menu-item/menu-item.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '../utils/index.js';
+import { display } from '../utils/display.js';
 import {
   borderRadiusMedium,
   colorCompoundBrandForeground1Pressed,

--- a/packages/web-components/src/menu-item/menu-item.template.ts
+++ b/packages/web-components/src/menu-item/menu-item.template.ts
@@ -1,7 +1,7 @@
 import type { ElementViewTemplate } from '@microsoft/fast-element';
 import { html, slotted } from '@microsoft/fast-element';
 import { staticallyCompose } from '../utils/template-helpers.js';
-import { endSlotTemplate, startSlotTemplate } from '../patterns/index.js';
+import { endSlotTemplate, startSlotTemplate } from '../patterns/start-end.js';
 import type { MenuItem, MenuItemOptions } from './menu-item.js';
 
 const Checkmark16Filled = html.partial(

--- a/packages/web-components/src/menu-list/menu-list.styles.ts
+++ b/packages/web-components/src/menu-list/menu-list.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '../utils/index.js';
+import { display } from '../utils/display.js';
 import {
   borderRadiusMedium,
   colorNeutralBackground1,

--- a/packages/web-components/src/menu/menu.styles.ts
+++ b/packages/web-components/src/menu/menu.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '../utils/index.js';
+import { display } from '../utils/display.js';
 import { colorNeutralStroke1, strokeWidthThin } from '../theme/design-tokens.js';
 
 /** Menu styles

--- a/packages/web-components/src/patterns/start-end.ts
+++ b/packages/web-components/src/patterns/start-end.ts
@@ -1,8 +1,8 @@
 //Copied from @microsoft/fast-foundation
 
 import { type CaptureType, html, ref } from '@microsoft/fast-element';
-import type { StaticallyComposableHTML } from '../utils/index.js';
-import { staticallyCompose } from '../utils/index.js';
+import type { StaticallyComposableHTML } from '../utils/template-helpers.js';
+import { staticallyCompose } from '../utils/template-helpers.js';
 
 /**
  * Start configuration options

--- a/packages/web-components/src/patterns/start-end.ts
+++ b/packages/web-components/src/patterns/start-end.ts
@@ -1,8 +1,7 @@
 //Copied from @microsoft/fast-foundation
 
 import { type CaptureType, html, ref } from '@microsoft/fast-element';
-import type { StaticallyComposableHTML } from '../utils/template-helpers.js';
-import { staticallyCompose } from '../utils/template-helpers.js';
+import { type StaticallyComposableHTML, staticallyCompose } from '../utils/template-helpers.js';
 
 /**
  * Start configuration options

--- a/packages/web-components/src/progress-bar/progress-bar.options.ts
+++ b/packages/web-components/src/progress-bar/progress-bar.options.ts
@@ -1,4 +1,4 @@
-import type { ValuesOf } from '../utils/index.js';
+import type { ValuesOf } from '../utils/typings.js';
 
 /**
  * ProgressBarThickness Constants

--- a/packages/web-components/src/progress-bar/progress-bar.styles.ts
+++ b/packages/web-components/src/progress-bar/progress-bar.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '../utils/index.js';
+import { display } from '../utils/display.js';
 import {
   borderRadiusMedium,
   borderRadiusNone,

--- a/packages/web-components/src/radio-group/radio-group.options.ts
+++ b/packages/web-components/src/radio-group/radio-group.options.ts
@@ -1,5 +1,5 @@
 import { Orientation } from '@microsoft/fast-web-utilities';
-import type { ValuesOf } from '../utils/index.js';
+import type { ValuesOf } from '../utils/typings.js';
 
 /**
  * Radio Group orientation

--- a/packages/web-components/src/radio-group/radio-group.styles.ts
+++ b/packages/web-components/src/radio-group/radio-group.styles.ts
@@ -9,7 +9,7 @@ import {
   spacingVerticalL,
   spacingVerticalS,
 } from '../theme/design-tokens.js';
-import { display } from '../utils/index.js';
+import { display } from '../utils/display.js';
 
 /** RadioGroup styles
  * @public

--- a/packages/web-components/src/radio/radio.template.ts
+++ b/packages/web-components/src/radio/radio.template.ts
@@ -1,5 +1,5 @@
 import { type ElementViewTemplate, html } from '@microsoft/fast-element';
-import { staticallyCompose } from '../utils/index.js';
+import { staticallyCompose } from '../utils/template-helpers.js';
 import type { Radio } from './radio.js';
 import type { RadioOptions } from './radio.options.js';
 

--- a/packages/web-components/src/rating-display/rating-display.options.ts
+++ b/packages/web-components/src/rating-display/rating-display.options.ts
@@ -1,4 +1,4 @@
-import type { ValuesOf } from '../utils/index.js';
+import type { ValuesOf } from '../utils/typings.js';
 
 /**
  * The color of the Rating Display items can be `neutral`, `brand`, or `marigold`.

--- a/packages/web-components/src/rating-display/rating-display.styles.ts
+++ b/packages/web-components/src/rating-display/rating-display.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '../utils/index.js';
+import { display } from '../utils/display.js';
 import {
   colorBrandBackground2,
   colorBrandForeground1,

--- a/packages/web-components/src/slider/slider.options.ts
+++ b/packages/web-components/src/slider/slider.options.ts
@@ -1,6 +1,7 @@
 import type { Direction } from '@microsoft/fast-web-utilities';
 import { Orientation } from '@microsoft/fast-web-utilities';
-import type { StaticallyComposableHTML, ValuesOf } from '../utils/index.js';
+import type { StaticallyComposableHTML } from '../utils/template-helpers.js';
+import type { ValuesOf } from '../utils/typings.js';
 import type { Slider } from './slider.js';
 
 /**

--- a/packages/web-components/src/slider/slider.styles.ts
+++ b/packages/web-components/src/slider/slider.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '../utils/index.js';
+import { display } from '../utils/display.js';
 import {
   borderRadiusCircular,
   borderRadiusMedium,

--- a/packages/web-components/src/spinner/spinner.options.ts
+++ b/packages/web-components/src/spinner/spinner.options.ts
@@ -1,4 +1,4 @@
-import type { ValuesOf } from '../utils/index.js';
+import type { ValuesOf } from '../utils/typings.js';
 
 /**
  * SpinnerAppearance constants

--- a/packages/web-components/src/spinner/spinner.styles.ts
+++ b/packages/web-components/src/spinner/spinner.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '../utils/index.js';
+import { display } from '../utils/display.js';
 import {
   colorBrandStroke1,
   colorBrandStroke2,

--- a/packages/web-components/src/styles/index.ts
+++ b/packages/web-components/src/styles/index.ts
@@ -1,1 +1,20 @@
-export * from './partials/index.js';
+export * from './partials/badge.partials.js';
+export {
+  typographyBody1Styles,
+  typographyBody1StrongStyles,
+  typographyBody1StrongerStyles,
+  typographyBody2Styles,
+  typographyCaption1StrongStyles,
+  typographyCaption1StrongerStyles,
+  typographyCaption1Styles,
+  typographyCaption2StrongStyles,
+  typographyCaption2Styles,
+  typographyDisplayStyles,
+  typographyLargeTitleStyles,
+  typographySubtitle1Styles,
+  typographySubtitle2StrongerStyles,
+  typographySubtitle2Styles,
+  typographyTitle1Styles,
+  typographyTitle2Styles,
+  typographyTitle3Styles,
+} from './partials/typography.partials.js';

--- a/packages/web-components/src/styles/partials/badge.partials.ts
+++ b/packages/web-components/src/styles/partials/badge.partials.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '../../utils/index.js';
+import { display } from '../../utils/display.js';
 import {
   borderRadiusCircular,
   colorBrandBackground,

--- a/packages/web-components/src/switch/switch.options.ts
+++ b/packages/web-components/src/switch/switch.options.ts
@@ -1,4 +1,4 @@
-import type { ValuesOf } from '../utils/index.js';
+import type { ValuesOf } from '../utils/typings.js';
 
 /**
  * SwitchLabelPosition Constants

--- a/packages/web-components/src/switch/switch.template.ts
+++ b/packages/web-components/src/switch/switch.template.ts
@@ -1,5 +1,5 @@
 import { type ElementViewTemplate, html } from '@microsoft/fast-element';
-import { staticallyCompose } from '../utils/index.js';
+import { staticallyCompose } from '../utils/template-helpers.js';
 import type { Switch, SwitchOptions } from './switch.js';
 
 export function switchTemplate<T extends Switch>(options: SwitchOptions = {}): ElementViewTemplate<T> {

--- a/packages/web-components/src/switch/switch.ts
+++ b/packages/web-components/src/switch/switch.ts
@@ -1,4 +1,4 @@
-import type { StaticallyComposableHTML } from '../utils/index.js';
+import type { StaticallyComposableHTML } from '../utils/template-helpers.js';
 import { BaseCheckbox } from '../checkbox/checkbox.base.js';
 
 export type SwitchOptions = {

--- a/packages/web-components/src/tab/tab.styles.ts
+++ b/packages/web-components/src/tab/tab.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '../utils/index.js';
+import { display } from '../utils/display.js';
 import {
   borderRadiusCircular,
   borderRadiusMedium,

--- a/packages/web-components/src/tab/tab.template.ts
+++ b/packages/web-components/src/tab/tab.template.ts
@@ -1,5 +1,5 @@
 import { type ElementViewTemplate, html } from '@microsoft/fast-element';
-import { endSlotTemplate, startSlotTemplate } from '../patterns/index.js';
+import { endSlotTemplate, startSlotTemplate } from '../patterns/start-end.js';
 import type { Tab, TabOptions } from './tab.js';
 
 export function tabTemplate<T extends Tab>(options: TabOptions = {}): ElementViewTemplate<T> {

--- a/packages/web-components/src/tablist/tablist.base.ts
+++ b/packages/web-components/src/tablist/tablist.base.ts
@@ -13,7 +13,7 @@ import type { Tab } from '../tab/tab.js';
 import { isTab } from '../tab/tab.options.js';
 import { swapStates, toggleState } from '../utils/element-internals.js';
 import { isFocusableElement } from '../utils/focusable-element.js';
-import { getDirection } from '../utils/index.js';
+import { getDirection } from '../utils/direction.js';
 import { waitForConnectedDescendants } from '../utils/request-idle-callback.js';
 import { TablistOrientation } from './tablist.options.js';
 

--- a/packages/web-components/src/tablist/tablist.options.ts
+++ b/packages/web-components/src/tablist/tablist.options.ts
@@ -1,5 +1,5 @@
 import { Orientation } from '@microsoft/fast-web-utilities';
-import type { ValuesOf } from '../utils/index.js';
+import type { ValuesOf } from '../utils/typings.js';
 
 /**
  * The appearance of the component

--- a/packages/web-components/src/tablist/tablist.styles.ts
+++ b/packages/web-components/src/tablist/tablist.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '../utils/index.js';
+import { display } from '../utils/display.js';
 import {
   borderRadiusCircular,
   colorCompoundBrandForeground1Hover,

--- a/packages/web-components/src/text/text.options.ts
+++ b/packages/web-components/src/text/text.options.ts
@@ -1,4 +1,4 @@
-import type { ValuesOf } from '../utils/index.js';
+import type { ValuesOf } from '../utils/typings.js';
 
 /**
  * TextSize constants

--- a/packages/web-components/src/text/text.styles.ts
+++ b/packages/web-components/src/text/text.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '../utils/index.js';
+import { display } from '../utils/display.js';
 import {
   fontFamilyBase,
   fontFamilyMonospace,

--- a/packages/web-components/src/textarea/textarea.base.ts
+++ b/packages/web-components/src/textarea/textarea.base.ts
@@ -1,5 +1,5 @@
 import { attr, FASTElement, nullableNumberConverter, observable } from '@microsoft/fast-element';
-import { whitespaceFilter } from '../utils/index.js';
+import { whitespaceFilter } from '../utils/whitespace-filter.js';
 import type { Label } from '../label/label.js';
 import { hasMatchingState, swapStates, toggleState } from '../utils/element-internals.js';
 import { TextAreaAutocomplete, TextAreaResize } from './textarea.options.js';

--- a/packages/web-components/src/toggle-button/toggle-button.options.ts
+++ b/packages/web-components/src/toggle-button/toggle-button.options.ts
@@ -1,6 +1,6 @@
 import { ButtonAppearance, ButtonShape, ButtonSize } from '../button/button.options.js';
-import type { ButtonOptions } from '../button/index.js';
-import type { ValuesOf } from '../utils/index.js';
+import type { ButtonOptions } from '../button/button.options.js';
+import type { ValuesOf } from '../utils/typings.js';
 
 /**
  * Toggle Button Appearance constants


### PR DESCRIPTION
## Previous Behavior
Component level imports reference barrel files.

## New Behavior
Component imports do not point to barrel files.

## Related Issue(s)
Dependent on removal of forced-colors.

- Fixes #
