### PR TITLE
fix: add tagName as an export from options and use across definitions

### DIFF
--- a/change/@fluentui-web-components-fcb93eeb-4330-41eb-ac53-2f548489a13f.json
+++ b/change/@fluentui-web-components-fcb93eeb-4330-41eb-ac53-2f548489a13f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: add tagName export in options and leverage for consistent name implementation",
+  "packageName": "@fluentui/web-components",
+  "email": "13071055+chrisdholt@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/accordion-item/accordion-item.definition.ts
+++ b/packages/web-components/src/accordion-item/accordion-item.definition.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
+import { tagName } from './accordion-item.options.js';
 import { AccordionItem } from './accordion-item.js';
 import { styles } from './accordion-item.styles.js';
 import { template } from './accordion-item.template.js';
@@ -10,7 +10,7 @@ import { template } from './accordion-item.template.js';
  * HTML Element: \<fluent-accordion-item\>
  */
 export const definition = AccordionItem.compose({
-  name: `${FluentDesignSystem.prefix}-accordion-item`,
+  name: tagName,
   template,
   styles,
 });

--- a/packages/web-components/src/accordion-item/accordion-item.options.ts
+++ b/packages/web-components/src/accordion-item/accordion-item.options.ts
@@ -1,3 +1,4 @@
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import { isCustomElement, type ValuesOf } from '../utils/typings.js';
 import type { BaseAccordionItem } from './accordion-item.base.js';
 
@@ -45,3 +46,10 @@ export function isAccordionItem(
 ): element is BaseAccordionItem {
   return isCustomElement(tagName)(element);
 }
+
+/**
+ * The tag name for the accordion item element.
+ *
+ * @public
+ */
+export const tagName = `${FluentDesignSystem.prefix}-accordion-item` as const;

--- a/packages/web-components/src/accordion-item/index.ts
+++ b/packages/web-components/src/accordion-item/index.ts
@@ -5,3 +5,4 @@ export { AccordionItemSize, AccordionItemMarkerPosition } from './accordion-item
 export { styles as accordionItemStyles } from './accordion-item.styles.js';
 export { definition as accordionItemDefinition } from './accordion-item.definition.js';
 export { template as accordionItemTemplate } from './accordion-item.template.js';
+export { tagName as AccordionItemTagName } from './accordion-item.options.js';

--- a/packages/web-components/src/accordion/accordion.definition.ts
+++ b/packages/web-components/src/accordion/accordion.definition.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
+import { tagName } from './accordion.options.js';
 import { Accordion } from './accordion.js';
 import { styles } from './accordion.styles.js';
 import { template } from './accordion.template.js';
@@ -9,7 +9,7 @@ import { template } from './accordion.template.js';
  * HTML Element: \<fluent-accordion\>
  */
 export const definition = Accordion.compose({
-  name: `${FluentDesignSystem.prefix}-accordion`,
+  name: tagName,
   template,
   styles,
 });

--- a/packages/web-components/src/accordion/accordion.options.ts
+++ b/packages/web-components/src/accordion/accordion.options.ts
@@ -1,4 +1,5 @@
 import type { ValuesOf } from '../utils/typings.js';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 
 /**
  * Expand mode for {@link Accordion}
@@ -14,3 +15,10 @@ export const AccordionExpandMode = {
  * @public
  */
 export type AccordionExpandMode = ValuesOf<typeof AccordionExpandMode>;
+
+/**
+ * The tag name for the accordion element.
+ *
+ * @public
+ */
+export const tagName = `${FluentDesignSystem.prefix}-accordion` as const;

--- a/packages/web-components/src/accordion/index.ts
+++ b/packages/web-components/src/accordion/index.ts
@@ -3,3 +3,4 @@ export { AccordionExpandMode } from './accordion.options.js';
 export { template as accordionTemplate } from './accordion.template.js';
 export { styles as accordionStyles } from './accordion.styles.js';
 export { definition as accordionDefinition } from './accordion.definition.js';
+export { tagName as AccordionTagName } from './accordion.options.js';

--- a/packages/web-components/src/anchor-button/anchor-button.definition.ts
+++ b/packages/web-components/src/anchor-button/anchor-button.definition.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
+import { tagName } from './anchor-button.options.js';
 import { AnchorButton } from './anchor-button.js';
 import { styles } from './anchor-button.styles.js';
 import { template } from './anchor-button.template.js';
@@ -9,7 +9,7 @@ import { template } from './anchor-button.template.js';
  * HTML Element: \<fluent-anchor-button\>
  */
 export const definition = AnchorButton.compose({
-  name: `${FluentDesignSystem.prefix}-anchor-button`,
+  name: tagName,
   template,
   styles,
 });

--- a/packages/web-components/src/anchor-button/anchor-button.options.ts
+++ b/packages/web-components/src/anchor-button/anchor-button.options.ts
@@ -1,3 +1,4 @@
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import { ButtonAppearance, ButtonShape, ButtonSize } from '../button/button.options.js';
 import type { ValuesOf } from '../utils/typings.js';
 import type { AnchorOptions } from './anchor-button.js';
@@ -81,3 +82,10 @@ export const AnchorAttributes = {
  * @public
  */
 export type AnchorAttributes = ValuesOf<typeof AnchorAttributes>;
+
+/**
+ * The tag name for the anchor button element.
+ *
+ * @public
+ */
+export const tagName = `${FluentDesignSystem.prefix}-anchor-button` as const;

--- a/packages/web-components/src/anchor-button/index.ts
+++ b/packages/web-components/src/anchor-button/index.ts
@@ -5,3 +5,4 @@ export { AnchorButtonAppearance, AnchorButtonShape, AnchorButtonSize, AnchorTarg
 export type { AnchorButtonOptions } from './anchor-button.options.js';
 export { styles as AnchorButtonStyles } from './anchor-button.styles.js';
 export { template as AnchorButtonTemplate } from './anchor-button.template.js';
+export { tagName as AnchorButtonTagName } from './anchor-button.options.js';

--- a/packages/web-components/src/avatar/avatar.definition.ts
+++ b/packages/web-components/src/avatar/avatar.definition.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
+import { tagName } from './avatar.options.js';
 import { Avatar } from './avatar.js';
 import { styles } from './avatar.styles.js';
 import { template } from './avatar.template.js';
@@ -11,7 +11,7 @@ import { template } from './avatar.template.js';
  * HTML Element: \<fluent-badge\>
  */
 export const definition = Avatar.compose({
-  name: `${FluentDesignSystem.prefix}-avatar`,
+  name: tagName,
   template,
   styles,
 });

--- a/packages/web-components/src/avatar/avatar.options.ts
+++ b/packages/web-components/src/avatar/avatar.options.ts
@@ -1,7 +1,6 @@
 import type { ValuesOf } from '../utils/typings.js';
 import { FluentDesignSystem } from '../fluent-design-system.js';
 
-
 /**
  * The Avatar "active" state
  */

--- a/packages/web-components/src/avatar/avatar.options.ts
+++ b/packages/web-components/src/avatar/avatar.options.ts
@@ -1,4 +1,6 @@
 import type { ValuesOf } from '../utils/typings.js';
+import { FluentDesignSystem } from '../fluent-design-system.js';
+
 
 /**
  * The Avatar "active" state
@@ -123,3 +125,10 @@ export const AvatarSize = {
  * @public
  */
 export type AvatarSize = ValuesOf<typeof AvatarSize>;
+
+/**
+ * The tag name for the avatar element.
+ *
+ * @public
+ */
+export const tagName = `${FluentDesignSystem.prefix}-avatar` as const;

--- a/packages/web-components/src/avatar/index.ts
+++ b/packages/web-components/src/avatar/index.ts
@@ -11,3 +11,4 @@ export {
 export { template as AvatarTemplate } from './avatar.template.js';
 export { styles as AvatarStyles } from './avatar.styles.js';
 export { definition as AvatarDefinition } from './avatar.definition.js';
+export { tagName as AvatarTagName } from './avatar.options.js';

--- a/packages/web-components/src/badge/badge.definition.ts
+++ b/packages/web-components/src/badge/badge.definition.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
+import { tagName } from './badge.options.js';
 import { Badge } from './badge.js';
 import { styles } from './badge.styles.js';
 import { template } from './badge.template.js';
@@ -10,7 +10,7 @@ import { template } from './badge.template.js';
  * HTML Element: \<fluent-badge\>
  */
 export const definition = Badge.compose({
-  name: `${FluentDesignSystem.prefix}-badge`,
+  name: tagName,
   template,
   styles,
 });

--- a/packages/web-components/src/badge/badge.options.ts
+++ b/packages/web-components/src/badge/badge.options.ts
@@ -1,6 +1,7 @@
 import type { StartEndOptions } from '../patterns/start-end.js';
 import type { StaticallyComposableHTML } from '../utils/template-helpers.js';
 import type { ValuesOf } from '../utils/typings.js';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import type { Badge } from './badge.js';
 
 /**
@@ -84,3 +85,10 @@ export const BadgeSize = {
  * @public
  */
 export type BadgeSize = ValuesOf<typeof BadgeSize>;
+
+/**
+ * The tag name for the badge element.
+ *
+ * @public
+ */
+export const tagName = `${FluentDesignSystem.prefix}-badge` as const;

--- a/packages/web-components/src/badge/index.ts
+++ b/packages/web-components/src/badge/index.ts
@@ -3,3 +3,4 @@ export { BadgeAppearance, BadgeColor, BadgeShape, BadgeSize } from './badge.opti
 export { template as BadgeTemplate } from './badge.template.js';
 export { styles as BadgeStyles } from './badge.styles.js';
 export { definition as BadgeDefinition } from './badge.definition.js';
+export { tagName as BadgeTagName } from './badge.options.js';

--- a/packages/web-components/src/button/button.definition.ts
+++ b/packages/web-components/src/button/button.definition.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
+import { tagName } from './button.options.js';
 import { Button } from './button.js';
 import { styles } from './button.styles.js';
 import { template } from './button.template.js';
@@ -11,7 +11,7 @@ import { template } from './button.template.js';
  * HTML Element: `<fluent-button>`
  */
 export const definition = Button.compose({
-  name: `${FluentDesignSystem.prefix}-button`,
+  name: tagName,
   template,
   styles,
 });

--- a/packages/web-components/src/button/button.options.ts
+++ b/packages/web-components/src/button/button.options.ts
@@ -1,5 +1,6 @@
 import type { StartEndOptions } from '../patterns/start-end.js';
 import type { ValuesOf } from '../utils/typings.js';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import type { Button } from './button.js';
 
 /**
@@ -91,3 +92,10 @@ export const ButtonFormTarget = {
  * @public
  */
 export type ButtonFormTarget = ValuesOf<typeof ButtonFormTarget>;
+
+/**
+ * The tag name for the button element.
+ *
+ * @public
+ */
+export const tagName = `${FluentDesignSystem.prefix}-button` as const;

--- a/packages/web-components/src/button/index.ts
+++ b/packages/web-components/src/button/index.ts
@@ -5,3 +5,4 @@ export { ButtonAppearance, ButtonFormTarget, ButtonShape, ButtonSize, ButtonType
 export type { ButtonOptions } from './button.options.js';
 export { styles as ButtonStyles } from './button.styles.js';
 export { template as ButtonTemplate } from './button.template.js';
+export { tagName as ButtonTagName } from './button.options.js';

--- a/packages/web-components/src/checkbox/checkbox.definition.ts
+++ b/packages/web-components/src/checkbox/checkbox.definition.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
+import { tagName } from './checkbox.options.js';
 import { Checkbox } from './checkbox.js';
 import { styles } from './checkbox.styles.js';
 import { template } from './checkbox.template.js';
@@ -11,7 +11,7 @@ import { template } from './checkbox.template.js';
  * HTML Element: \<fluent-checkbox\>
  */
 export const definition = Checkbox.compose({
-  name: `${FluentDesignSystem.prefix}-checkbox`,
+  name: tagName,
   template,
   styles,
 });

--- a/packages/web-components/src/checkbox/checkbox.options.ts
+++ b/packages/web-components/src/checkbox/checkbox.options.ts
@@ -1,3 +1,4 @@
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import type { StaticallyComposableHTML } from '../utils/template-helpers.js';
 import type { ValuesOf } from '../utils/typings.js';
 import type { Checkbox } from './checkbox.js';
@@ -34,3 +35,10 @@ export const CheckboxSize = {
 
 /** @public */
 export type CheckboxSize = ValuesOf<typeof CheckboxSize>;
+
+/**
+ * The tag name for the checkbox element.
+ *
+ * @public
+ */
+export const tagName = `${FluentDesignSystem.prefix}-checkbox` as const;

--- a/packages/web-components/src/checkbox/index.ts
+++ b/packages/web-components/src/checkbox/index.ts
@@ -5,3 +5,4 @@ export { CheckboxShape, CheckboxSize } from './checkbox.options.js';
 export type { CheckboxOptions } from './checkbox.options.js';
 export { styles as CheckboxStyles } from './checkbox.styles.js';
 export { template as CheckboxTemplate } from './checkbox.template.js';
+export { tagName as CheckboxTagName } from './checkbox.options.js';

--- a/packages/web-components/src/compound-button/compound-button.definition.ts
+++ b/packages/web-components/src/compound-button/compound-button.definition.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
+import { tagName } from './compound-button.options.js';
 import { CompoundButton } from './compound-button.js';
 import { styles } from './compound-button.styles.js';
 import { template } from './compound-button.template.js';
@@ -9,7 +9,7 @@ import { template } from './compound-button.template.js';
  * HTML Element: \<fluent-comopund-button\>
  */
 export const definition = CompoundButton.compose({
-  name: `${FluentDesignSystem.prefix}-compound-button`,
+  name: tagName,
   template,
   styles,
 });

--- a/packages/web-components/src/compound-button/compound-button.options.ts
+++ b/packages/web-components/src/compound-button/compound-button.options.ts
@@ -1,3 +1,4 @@
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import { ButtonAppearance, ButtonShape, ButtonSize } from '../button/button.options.js';
 import type { ButtonOptions } from '../button/button.options.js';
 import type { ValuesOf } from '../utils/typings.js';
@@ -39,3 +40,10 @@ export const CompoundButtonSize = ButtonSize;
 export type CompoundButtonSize = ValuesOf<typeof CompoundButtonSize>;
 
 export type { ButtonOptions as CompoundButtonOptions };
+
+/**
+ * The tag name for the compound button element.
+ *
+ * @public
+ */
+export const tagName = `${FluentDesignSystem.prefix}-compound-button` as const;

--- a/packages/web-components/src/compound-button/index.ts
+++ b/packages/web-components/src/compound-button/index.ts
@@ -3,3 +3,4 @@ export { CompoundButtonAppearance, CompoundButtonShape, CompoundButtonSize } fro
 export { template as CompoundButtonTemplate } from './compound-button.template.js';
 export { styles as CompoundButtonStyles } from './compound-button.styles.js';
 export { definition as CompoundButtonDefinition } from './compound-button.definition.js';
+export { tagName as CompoundButtonTagName } from './compound-button.options.js';

--- a/packages/web-components/src/counter-badge/counter-badge.definition.ts
+++ b/packages/web-components/src/counter-badge/counter-badge.definition.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
+import { tagName } from './counter-badge.options.js';
 import { CounterBadge } from './counter-badge.js';
 import { styles } from './counter-badge.styles.js';
 import { template } from './counter-badge.template.js';
@@ -9,7 +9,7 @@ import { template } from './counter-badge.template.js';
  * HTML Element: \<fluent-counter-badge\>
  */
 export const definition = CounterBadge.compose({
-  name: `${FluentDesignSystem.prefix}-counter-badge`,
+  name: tagName,
   template,
   styles,
 });

--- a/packages/web-components/src/counter-badge/counter-badge.options.ts
+++ b/packages/web-components/src/counter-badge/counter-badge.options.ts
@@ -1,3 +1,4 @@
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import type { BadgeOptions } from '../badge/badge.options.js';
 import type { ValuesOf } from '../utils/typings.js';
 
@@ -76,3 +77,10 @@ export const CounterBadgeSize = {
  * @public
  */
 export type CounterBadgeSize = ValuesOf<typeof CounterBadgeSize>;
+
+/**
+ * The tag name for the counter badge element.
+ *
+ * @public
+ */
+export const tagName = `${FluentDesignSystem.prefix}-counter-badge` as const;

--- a/packages/web-components/src/counter-badge/index.ts
+++ b/packages/web-components/src/counter-badge/index.ts
@@ -8,3 +8,4 @@ export {
 export { template as CounterBadgeTemplate } from './counter-badge.template.js';
 export { styles as CounterBadgeStyles } from './counter-badge.styles.js';
 export { definition as CounterBadgeDefinition } from './counter-badge.definition.js';
+export { tagName as CounterBadgeTagName } from './counter-badge.options.js';

--- a/packages/web-components/src/dialog-body/dialog-body.definition.ts
+++ b/packages/web-components/src/dialog-body/dialog-body.definition.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
+import { tagName } from './dialog-body.options.js';
 import { DialogBody } from './dialog-body.js';
 import { template } from './dialog-body.template.js';
 import { styles } from './dialog-body.styles.js';
@@ -11,7 +11,7 @@ import { styles } from './dialog-body.styles.js';
  * HTML Element: \<fluent-dialog-body\>
  */
 export const definition = DialogBody.compose({
-  name: `${FluentDesignSystem.prefix}-dialog-body`,
+  name: tagName,
   template,
   styles,
 });

--- a/packages/web-components/src/dialog-body/dialog-body.options.ts
+++ b/packages/web-components/src/dialog-body/dialog-body.options.ts
@@ -1,0 +1,8 @@
+import { FluentDesignSystem } from '../fluent-design-system.js';
+
+/**
+ * The tag name for the dialog body element.
+ *
+ * @public
+ */
+export const tagName = `${FluentDesignSystem.prefix}-dialog-body` as const;

--- a/packages/web-components/src/dialog-body/index.ts
+++ b/packages/web-components/src/dialog-body/index.ts
@@ -2,3 +2,4 @@ export { DialogBody } from './dialog-body.js';
 export { definition as DialogBodyDefinition } from './dialog-body.definition.js';
 export { template as DialogBodyTemplate } from './dialog-body.template.js';
 export { styles as DialogBodyStyles } from './dialog-body.styles.js';
+export { tagName as DialogBodyTagName } from './dialog-body.options.js';

--- a/packages/web-components/src/dialog/dialog.definition.ts
+++ b/packages/web-components/src/dialog/dialog.definition.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
+import { tagName } from './dialog.options.js';
 import { Dialog } from './dialog.js';
 import { template } from './dialog.template.js';
 import { styles } from './dialog.styles.js';
@@ -11,7 +11,7 @@ import { styles } from './dialog.styles.js';
  * HTML Element: \<fluent-dialog\>
  */
 export const definition = Dialog.compose({
-  name: `${FluentDesignSystem.prefix}-dialog`,
+  name: tagName,
   template,
   styles,
 });

--- a/packages/web-components/src/dialog/dialog.options.ts
+++ b/packages/web-components/src/dialog/dialog.options.ts
@@ -1,4 +1,5 @@
 import type { ValuesOf } from '../utils/typings.js';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import { Dialog } from './dialog.js';
 
 /**
@@ -28,3 +29,10 @@ export function isDialog(element?: Node | null, tagName: string = '-dialog'): el
 
   return (element as Element).tagName.toLowerCase().endsWith(tagName);
 }
+
+/**
+ * The tag name for the dialog element.
+ *
+ * @public
+ */
+export const tagName = `${FluentDesignSystem.prefix}-dialog` as const;

--- a/packages/web-components/src/dialog/index.ts
+++ b/packages/web-components/src/dialog/index.ts
@@ -3,3 +3,4 @@ export { DialogType, isDialog } from './dialog.options.js';
 export { definition as DialogDefinition } from './dialog.definition.js';
 export { template as DialogTemplate } from './dialog.template.js';
 export { styles as DialogStyles } from './dialog.styles.js';
+export { tagName as DialogTagName } from './dialog.options.js';

--- a/packages/web-components/src/divider/divider.definition.ts
+++ b/packages/web-components/src/divider/divider.definition.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
+import { tagName } from './divider.options.js';
 import { Divider } from './divider.js';
 import { template } from './divider.template.js';
 import { styles } from './divider.styles.js';
@@ -11,7 +11,7 @@ import { styles } from './divider.styles.js';
  * HTML Element: \<fluent-divider\>
  */
 export const definition = Divider.compose({
-  name: `${FluentDesignSystem.prefix}-divider`,
+  name: tagName,
   template,
   styles,
 });

--- a/packages/web-components/src/divider/divider.options.ts
+++ b/packages/web-components/src/divider/divider.options.ts
@@ -1,5 +1,6 @@
 import { Orientation } from '@microsoft/fast-web-utilities';
 import type { ValuesOf } from '../utils/typings.js';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 
 /**
  * Divider roles
@@ -66,3 +67,10 @@ export const DividerAppearance = {
  * @public
  */
 export type DividerAppearance = ValuesOf<typeof DividerAppearance>;
+
+/**
+ * The tag name for the divider element.
+ *
+ * @public
+ */
+export const tagName = `${FluentDesignSystem.prefix}-divider` as const;

--- a/packages/web-components/src/divider/index.ts
+++ b/packages/web-components/src/divider/index.ts
@@ -4,3 +4,4 @@ export { DividerAlignContent, DividerAppearance, DividerOrientation, DividerRole
 export { definition as DividerDefinition } from './divider.definition.js';
 export { template as DividerTemplate } from './divider.template.js';
 export { styles as DividerStyles } from './divider.styles.js';
+export { tagName as DividerTagName } from './divider.options.js';

--- a/packages/web-components/src/drawer-body/drawer-body.definition.ts
+++ b/packages/web-components/src/drawer-body/drawer-body.definition.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
+import { tagName } from './drawer-body.options.js';
 import { DrawerBody } from './drawer-body.js';
 import { styles } from './drawer-body.styles.js';
 import { template } from './drawer-body.template.js';
@@ -11,7 +11,7 @@ import { template } from './drawer-body.template.js';
  */
 
 export const definition = DrawerBody.compose({
-  name: `${FluentDesignSystem.prefix}-drawer-body`,
+  name: tagName,
   template,
   styles,
 });

--- a/packages/web-components/src/drawer-body/drawer-body.options.ts
+++ b/packages/web-components/src/drawer-body/drawer-body.options.ts
@@ -1,0 +1,8 @@
+import { FluentDesignSystem } from '../fluent-design-system.js';
+
+/**
+ * The tag name for the drawer body element.
+ *
+ * @public
+ */
+export const tagName = `${FluentDesignSystem.prefix}-drawer-body` as const;

--- a/packages/web-components/src/drawer-body/index.ts
+++ b/packages/web-components/src/drawer-body/index.ts
@@ -2,3 +2,4 @@ export * from './drawer-body.js';
 export { definition as DrawerBodyDefinition } from './drawer-body.definition.js';
 export { styles as DrawerBodyStyles } from './drawer-body.styles.js';
 export { template as DrawerBodyTemplate } from './drawer-body.template.js';
+export { tagName as DrawerBodyTagName } from './drawer-body.options.js';

--- a/packages/web-components/src/drawer/drawer.definition.ts
+++ b/packages/web-components/src/drawer/drawer.definition.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
+import { tagName } from './drawer.options.js';
 import { Drawer } from './drawer.js';
 import { styles } from './drawer.styles.js';
 import { template } from './drawer.template.js';
@@ -11,7 +11,7 @@ import { template } from './drawer.template.js';
  */
 
 export const definition = Drawer.compose({
-  name: `${FluentDesignSystem.prefix}-drawer`,
+  name: tagName,
   template,
   styles,
 });

--- a/packages/web-components/src/drawer/drawer.options.ts
+++ b/packages/web-components/src/drawer/drawer.options.ts
@@ -1,4 +1,5 @@
 import type { ValuesOf } from '../utils/typings.js';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 
 /**
  * A drawer can be positioned on the left or right side of the viewport.
@@ -44,3 +45,10 @@ export const DrawerType = {
  * @public
  */
 export type DrawerType = ValuesOf<typeof DrawerType>;
+
+/**
+ * The tag name for the drawer element.
+ *
+ * @public
+ */
+export const tagName = `${FluentDesignSystem.prefix}-drawer` as const;

--- a/packages/web-components/src/drawer/index.ts
+++ b/packages/web-components/src/drawer/index.ts
@@ -3,3 +3,4 @@ export * from './drawer.options.js';
 export { definition as DrawerDefinition } from './drawer.definition.js';
 export { styles as DrawerStyles } from './drawer.styles.js';
 export { template as DrawerTemplate } from './drawer.template.js';
+export { tagName as DrawerTagName } from './drawer.options.js';

--- a/packages/web-components/src/dropdown/dropdown.definition.ts
+++ b/packages/web-components/src/dropdown/dropdown.definition.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
+import { tagName } from './dropdown.options.js';
 import { Dropdown } from './dropdown.js';
 import { styles } from './dropdown.styles.js';
 import { template } from './dropdown.template.js';
@@ -11,7 +11,7 @@ import { template } from './dropdown.template.js';
  * HTML Element: `<fluent-dropdown>`
  */
 export const definition = Dropdown.compose({
-  name: `${FluentDesignSystem.prefix}-dropdown`,
+  name: tagName,
   template,
   styles,
 });

--- a/packages/web-components/src/dropdown/dropdown.options.ts
+++ b/packages/web-components/src/dropdown/dropdown.options.ts
@@ -1,3 +1,4 @@
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import type { StaticallyComposableHTML } from '../utils/template-helpers.js';
 import type { ValuesOf } from '../utils/typings.js';
 import type { BaseDropdown } from './dropdown.base.js';
@@ -65,3 +66,10 @@ export const DropdownType = {
 
 /** @public */
 export type DropdownType = ValuesOf<typeof DropdownType>;
+
+/**
+ * The tag name for the dropdown element.
+ *
+ * @public
+ */
+export const tagName = `${FluentDesignSystem.prefix}-dropdown` as const;

--- a/packages/web-components/src/dropdown/index.ts
+++ b/packages/web-components/src/dropdown/index.ts
@@ -15,3 +15,4 @@ export {
   template as DropdownTemplate,
   dropdownTemplate,
 } from './dropdown.template.js';
+export { tagName as DropdownTagName } from './dropdown.options.js';

--- a/packages/web-components/src/field/field.definition.ts
+++ b/packages/web-components/src/field/field.definition.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
+import { tagName } from './field.options.js';
 import { Field } from './field.js';
 import { styles } from './field.styles.js';
 import { template } from './field.template.js';
@@ -11,7 +11,7 @@ import { template } from './field.template.js';
  * HTML Element: `<fluent-field>`
  */
 export const definition = Field.compose({
-  name: `${FluentDesignSystem.prefix}-field`,
+  name: tagName,
   template,
   styles,
   shadowOptions: {

--- a/packages/web-components/src/field/field.options.ts
+++ b/packages/web-components/src/field/field.options.ts
@@ -1,3 +1,4 @@
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import type { ValuesOf } from '../utils/typings.js';
 
 /**
@@ -47,3 +48,10 @@ export const ValidationFlags = {
 
 /** @public */
 export type ValidationFlags = ValuesOf<typeof ValidationFlags>;
+
+/**
+ * The tag name for the field element.
+ *
+ * @public
+ */
+export const tagName = `${FluentDesignSystem.prefix}-field` as const;

--- a/packages/web-components/src/field/index.ts
+++ b/packages/web-components/src/field/index.ts
@@ -5,3 +5,4 @@ export type { SlottableInput } from './field.options.js';
 export { definition as FieldDefinition } from './field.definition.js';
 export { styles as FieldStyles } from './field.styles.js';
 export { template as FieldTemplate } from './field.template.js';
+export { tagName as FieldTagName } from './field.options.js';

--- a/packages/web-components/src/fluent-design-system.ts
+++ b/packages/web-components/src/fluent-design-system.ts
@@ -1,5 +1,5 @@
 export const FluentDesignSystem = Object.freeze({
   prefix: 'fluent',
   shadowRootMode: 'open',
-  registry: customElements,
+  registry: globalThis.customElements,
 });

--- a/packages/web-components/src/image/image.definition.ts
+++ b/packages/web-components/src/image/image.definition.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
+import { tagName } from './image.options.js';
 import { Image } from './image.js';
 import { template } from './image.template.js';
 import { styles } from './image.styles.js';
@@ -11,7 +11,7 @@ import { styles } from './image.styles.js';
  * HTML Element: \<fluent-image\>
  */
 export const definition = Image.compose({
-  name: `${FluentDesignSystem.prefix}-image`,
+  name: tagName,
   template,
   styles,
 });

--- a/packages/web-components/src/image/image.options.ts
+++ b/packages/web-components/src/image/image.options.ts
@@ -1,7 +1,6 @@
 import type { ValuesOf } from '../utils/typings.js';
 import { FluentDesignSystem } from '../fluent-design-system.js';
 
-
 /**
  * Image fit
  * @public

--- a/packages/web-components/src/image/image.options.ts
+++ b/packages/web-components/src/image/image.options.ts
@@ -1,4 +1,6 @@
 import type { ValuesOf } from '../utils/typings.js';
+import { FluentDesignSystem } from '../fluent-design-system.js';
+
 
 /**
  * Image fit
@@ -27,3 +29,10 @@ export const ImageShape = {
 } as const;
 
 export type ImageShape = ValuesOf<typeof ImageShape>;
+
+/**
+ * The tag name for the image element.
+ *
+ * @public
+ */
+export const tagName = `${FluentDesignSystem.prefix}-image` as const;

--- a/packages/web-components/src/image/index.ts
+++ b/packages/web-components/src/image/index.ts
@@ -3,3 +3,4 @@ export { ImageFit, ImageShape } from './image.options.js';
 export { definition as ImageDefinition } from './image.definition.js';
 export { template as ImageTemplate } from './image.template.js';
 export { styles as ImageStyles } from './image.styles.js';
+export { tagName as ImageTagName } from './image.options.js';

--- a/packages/web-components/src/label/index.ts
+++ b/packages/web-components/src/label/index.ts
@@ -3,3 +3,4 @@ export { LabelSize, LabelWeight } from './label.options.js';
 export { definition as LabelDefinition } from './label.definition.js';
 export { styles as LabelStyles } from './label.styles.js';
 export { template as LabelTemplate } from './label.template.js';
+export { tagName as LabelTagName } from './label.options.js';

--- a/packages/web-components/src/label/label.definition.ts
+++ b/packages/web-components/src/label/label.definition.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
+import { tagName } from './label.options.js';
 import { Label } from './label.js';
 import { styles } from './label.styles.js';
 import { template } from './label.template.js';
@@ -12,7 +12,7 @@ import { template } from './label.template.js';
  * HTML Element: \<fluent-label\>
  */
 export const definition = Label.compose({
-  name: `${FluentDesignSystem.prefix}-label`,
+  name: tagName,
   template,
   styles,
 });

--- a/packages/web-components/src/label/label.options.ts
+++ b/packages/web-components/src/label/label.options.ts
@@ -1,4 +1,5 @@
 import type { ValuesOf } from '../utils/typings.js';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 
 /**
  * A Labels font size can be small, medium, or large
@@ -28,3 +29,10 @@ export const LabelWeight = {
  * @public
  */
 export type LabelWeight = ValuesOf<typeof LabelWeight>;
+
+/**
+ * The tag name for the label element.
+ *
+ * @public
+ */
+export const tagName = `${FluentDesignSystem.prefix}-label` as const;

--- a/packages/web-components/src/link/index.ts
+++ b/packages/web-components/src/link/index.ts
@@ -3,3 +3,4 @@ export { Link } from './link.js';
 export { LinkAppearance, LinkTarget } from './link.options.js';
 export { styles as LinkStyles } from './link.styles.js';
 export { template as LinkTemplate } from './link.template.js';
+export { tagName as LinkTagName } from './link.options.js';

--- a/packages/web-components/src/link/link.definition.ts
+++ b/packages/web-components/src/link/link.definition.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
+import { tagName } from './link.options.js';
 import { Link } from './link.js';
 import { styles } from './link.styles.js';
 import { template } from './link.template.js';
@@ -9,7 +9,7 @@ import { template } from './link.template.js';
  * HTML Element: \<fluent-link\>
  */
 export const definition = Link.compose({
-  name: `${FluentDesignSystem.prefix}-link`,
+  name: tagName,
   template,
   styles,
 });

--- a/packages/web-components/src/link/link.options.ts
+++ b/packages/web-components/src/link/link.options.ts
@@ -1,3 +1,4 @@
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import { AnchorAttributes, AnchorTarget } from '../anchor-button/anchor-button.options.js';
 import type { ValuesOf } from '../utils/typings.js';
 
@@ -42,3 +43,10 @@ export const LinkAttributes = AnchorAttributes;
  * @public
  */
 export type LinkAttributes = ValuesOf<typeof LinkAttributes>;
+
+/**
+ * The tag name for the link element.
+ *
+ * @public
+ */
+export const tagName = `${FluentDesignSystem.prefix}-link` as const;

--- a/packages/web-components/src/listbox/index.ts
+++ b/packages/web-components/src/listbox/index.ts
@@ -3,3 +3,4 @@ export { Listbox } from './listbox.js';
 export { isListbox } from './listbox.options.js';
 export { styles as ListboxStyles } from './listbox.styles.js';
 export { template as ListboxTemplate, listboxTemplate } from './listbox.template.js';
+export { tagName as ListboxTagName } from './listbox.options.js';

--- a/packages/web-components/src/listbox/listbox.definition.ts
+++ b/packages/web-components/src/listbox/listbox.definition.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
+import { tagName } from './listbox.options.js';
 import { Listbox } from './listbox.js';
 import { styles } from './listbox.styles.js';
 import { template } from './listbox.template.js';
@@ -11,7 +11,7 @@ import { template } from './listbox.template.js';
  * HTML Element: `<fluent-listbox>`
  */
 export const definition = Listbox.compose({
-  name: `${FluentDesignSystem.prefix}-listbox`,
+  name: tagName,
   template,
   styles,
 });

--- a/packages/web-components/src/listbox/listbox.options.ts
+++ b/packages/web-components/src/listbox/listbox.options.ts
@@ -1,3 +1,4 @@
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import type { Listbox } from './listbox.js';
 
 /**
@@ -15,3 +16,10 @@ export function isListbox(element?: Node | null, tagName: string = '-listbox'): 
 
   return (element as Element).tagName.toLowerCase().endsWith(tagName);
 }
+
+/**
+ * The tag name for the listbox element.
+ *
+ * @public
+ */
+export const tagName = `${FluentDesignSystem.prefix}-listbox` as const;

--- a/packages/web-components/src/menu-button/index.ts
+++ b/packages/web-components/src/menu-button/index.ts
@@ -4,3 +4,4 @@ export { MenuButton } from './menu-button.js';
 export { MenuButtonAppearance, MenuButtonShape, MenuButtonSize } from './menu-button.options.js';
 export type { MenuButtonOptions } from './menu-button.options.js';
 export { template as MenuButtonTemplate } from './menu-button.template.js';
+export { tagName as MenuButtonTagName } from './menu-button.options.js';

--- a/packages/web-components/src/menu-button/menu-button.definition.ts
+++ b/packages/web-components/src/menu-button/menu-button.definition.ts
@@ -1,5 +1,5 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
 import { styles } from '../button/button.styles.js';
+import { tagName } from './menu-button.options.js';
 import { MenuButton } from './menu-button.js';
 import { template } from './menu-button.template.js';
 
@@ -9,7 +9,7 @@ import { template } from './menu-button.template.js';
  * HTML Element: \<fluent-button\>
  */
 export const definition = MenuButton.compose({
-  name: `${FluentDesignSystem.prefix}-menu-button`,
+  name: tagName,
   template,
   styles,
 });

--- a/packages/web-components/src/menu-button/menu-button.options.ts
+++ b/packages/web-components/src/menu-button/menu-button.options.ts
@@ -1,3 +1,4 @@
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import type { ButtonOptions } from '../button/button.options.js';
 import { ButtonAppearance, ButtonShape, ButtonSize } from '../button/button.options.js';
 import type { ValuesOf } from '../utils/typings.js';
@@ -39,3 +40,10 @@ export const MenuButtonSize = ButtonSize;
 export type MenuButtonSize = ValuesOf<typeof MenuButtonSize>;
 
 export type { ButtonOptions as MenuButtonOptions };
+
+/**
+ * The tag name for the menu button element.
+ *
+ * @public
+ */
+export const tagName = `${FluentDesignSystem.prefix}-menu-button` as const;

--- a/packages/web-components/src/menu-item/index.ts
+++ b/packages/web-components/src/menu-item/index.ts
@@ -4,3 +4,4 @@ export type { MenuItemColumnCount, MenuItemOptions } from './menu-item.js';
 export { MenuItemRole, roleForMenuItem } from './menu-item.options.js';
 export { styles as MenuItemStyles } from './menu-item.styles.js';
 export { template as MenuItemTemplate } from './menu-item.template.js';
+export { tagName as MenuItemTagName } from './menu-item.options.js';

--- a/packages/web-components/src/menu-item/menu-item.definition.ts
+++ b/packages/web-components/src/menu-item/menu-item.definition.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
+import { tagName } from './menu-item.options.js';
 import { MenuItem } from './menu-item.js';
 import { styles } from './menu-item.styles.js';
 import { template } from './menu-item.template.js';
@@ -9,7 +9,7 @@ import { template } from './menu-item.template.js';
  * HTML Element: <fluent-menu-item>
  */
 export const definition = MenuItem.compose({
-  name: `${FluentDesignSystem.prefix}-menu-item`,
+  name: tagName,
   template,
   styles,
 });

--- a/packages/web-components/src/menu-item/menu-item.options.ts
+++ b/packages/web-components/src/menu-item/menu-item.options.ts
@@ -1,4 +1,5 @@
 import type { ValuesOf } from '../utils/typings.js';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import type { MenuItem } from './menu-item.js';
 
 /**
@@ -54,3 +55,10 @@ export function isMenuItem(element?: Node | null, tagName: string = '-menu-item'
 
   return (element as Element).tagName.toLowerCase().endsWith(tagName);
 }
+
+/**
+ * The tag name for the menu item element.
+ *
+ * @public
+ */
+export const tagName = `${FluentDesignSystem.prefix}-menu-item` as const;

--- a/packages/web-components/src/menu-list/index.ts
+++ b/packages/web-components/src/menu-list/index.ts
@@ -3,3 +3,4 @@ export { MenuList } from './menu-list.js';
 export { template as MenuListTemplate } from './menu-list.template.js';
 export { styles as MenuListStyles } from './menu-list.styles.js';
 export { definition as MenuListDefinition } from './menu-list.definition.js';
+export { tagName as MenuListTagName } from './menu-list.options.js';

--- a/packages/web-components/src/menu-list/menu-list.definition.ts
+++ b/packages/web-components/src/menu-list/menu-list.definition.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
+import { tagName } from './menu-list.options.js';
 import { MenuList } from './menu-list.js';
 import { styles } from './menu-list.styles.js';
 import { template } from './menu-list.template.js';
@@ -9,7 +9,7 @@ import { template } from './menu-list.template.js';
  * HTML Element: <fluent-menu-list>
  */
 export const definition = MenuList.compose({
-  name: `${FluentDesignSystem.prefix}-menu-list`,
+  name: tagName,
   template,
   styles,
 });

--- a/packages/web-components/src/menu-list/menu-list.options.ts
+++ b/packages/web-components/src/menu-list/menu-list.options.ts
@@ -1,0 +1,8 @@
+import { FluentDesignSystem } from '../fluent-design-system.js';
+
+/**
+ * The tag name for the menu list element.
+ *
+ * @public
+ */
+export const tagName = `${FluentDesignSystem.prefix}-menu-list` as const;

--- a/packages/web-components/src/menu/index.ts
+++ b/packages/web-components/src/menu/index.ts
@@ -2,3 +2,4 @@ export { Menu } from './menu.js';
 export { template as MenuTemplate } from './menu.template.js';
 export { styles as MenuStyles } from './menu.styles.js';
 export { definition as MenuDefinition } from './menu.definition.js';
+export { tagName as MenuTagName } from './menu.options.js';

--- a/packages/web-components/src/menu/menu.definition.ts
+++ b/packages/web-components/src/menu/menu.definition.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
+import { tagName } from './menu.options.js';
 import { Menu } from './menu.js';
 import { styles } from './menu.styles.js';
 import { template } from './menu.template.js';
@@ -11,7 +11,7 @@ import { template } from './menu.template.js';
  * HTML Element: <fluent-menu>
  */
 export const definition = Menu.compose({
-  name: `${FluentDesignSystem.prefix}-menu`,
+  name: tagName,
   template,
   styles,
 });

--- a/packages/web-components/src/menu/menu.options.ts
+++ b/packages/web-components/src/menu/menu.options.ts
@@ -1,0 +1,8 @@
+import { FluentDesignSystem } from '../fluent-design-system.js';
+
+/**
+ * The tag name for the menu element.
+ *
+ * @public
+ */
+export const tagName = `${FluentDesignSystem.prefix}-menu` as const;

--- a/packages/web-components/src/message-bar/index.ts
+++ b/packages/web-components/src/message-bar/index.ts
@@ -3,3 +3,4 @@ export { MessageBar } from './message-bar.js';
 export { MessageBarIntent, MessageBarLayout, MessageBarShape } from './message-bar.options.js';
 export { styles as MessageBarStyles } from './message-bar.styles.js';
 export { template as MessageBarTemplate } from './message-bar.template.js';
+export { tagName as MessageBarTagName } from './message-bar.options.js';

--- a/packages/web-components/src/message-bar/message-bar.definition.ts
+++ b/packages/web-components/src/message-bar/message-bar.definition.ts
@@ -1,4 +1,5 @@
 import { FluentDesignSystem } from '../fluent-design-system.js';
+import { tagName } from './message-bar.options.js';
 import { MessageBar } from './message-bar.js';
 import { styles } from './message-bar.styles.js';
 import { template } from './message-bar.template.js';
@@ -11,7 +12,7 @@ import { template } from './message-bar.template.js';
  * HTML Element: `<fluent-message-bar>`
  */
 export const definition = MessageBar.compose({
-  name: `${FluentDesignSystem.prefix}-message-bar`,
+  name: tagName,
   template,
   styles,
   shadowOptions: {

--- a/packages/web-components/src/message-bar/message-bar.options.ts
+++ b/packages/web-components/src/message-bar/message-bar.options.ts
@@ -1,3 +1,4 @@
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import type { ValuesOf } from '../utils/typings.js';
 
 /**
@@ -37,3 +38,10 @@ export const MessageBarIntent = {
 } as const;
 
 export type MessageBarIntent = ValuesOf<typeof MessageBarIntent>;
+
+/**
+ * The tag name for the message bar element.
+ *
+ * @public
+ */
+export const tagName = `${FluentDesignSystem.prefix}-message-bar` as const;

--- a/packages/web-components/src/option/index.ts
+++ b/packages/web-components/src/option/index.ts
@@ -3,3 +3,4 @@ export { DropdownOption } from './option.js';
 export { isDropdownOption, type DropdownOptionOptions } from './option.options.js';
 export { styles as DropdownOptionStyles } from './option.styles.js';
 export { template as DropdownOptionTemplate } from './option.template.js';
+export { tagName as OptionTagName } from './option.options.js';

--- a/packages/web-components/src/option/option.definition.ts
+++ b/packages/web-components/src/option/option.definition.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
+import { tagName } from './option.options.js';
 import { DropdownOption } from './option.js';
 import { styles } from './option.styles.js';
 import { template } from './option.template.js';
@@ -11,7 +11,7 @@ import { template } from './option.template.js';
  * HTML Element: `<fluent-option>`
  */
 export const definition = DropdownOption.compose({
-  name: `${FluentDesignSystem.prefix}-option`,
+  name: tagName,
   template,
   styles,
 });

--- a/packages/web-components/src/option/option.options.ts
+++ b/packages/web-components/src/option/option.options.ts
@@ -1,3 +1,4 @@
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import type { StartOptions } from '../patterns/start-end.js';
 import type { StaticallyComposableHTML } from '../utils/template-helpers.js';
 import type { DropdownOption } from './option.js';
@@ -26,3 +27,10 @@ export function isDropdownOption(value: Node | null, tagName: string = '-option'
 export type DropdownOptionOptions = StartOptions<DropdownOption> & {
   checkedIndicator?: StaticallyComposableHTML<DropdownOption>;
 };
+
+/**
+ * The tag name for the option element.
+ *
+ * @public
+ */
+export const tagName = `${FluentDesignSystem.prefix}-option` as const;

--- a/packages/web-components/src/progress-bar/index.ts
+++ b/packages/web-components/src/progress-bar/index.ts
@@ -4,3 +4,4 @@ export { ProgressBar } from './progress-bar.js';
 export { ProgressBarShape, ProgressBarThickness, ProgressBarValidationState } from './progress-bar.options.js';
 export { styles as ProgressBarStyles } from './progress-bar.styles.js';
 export { template as ProgressBarTemplate } from './progress-bar.template.js';
+export { tagName as ProgressBarTagName } from './progress-bar.options.js';

--- a/packages/web-components/src/progress-bar/progress-bar.definition.ts
+++ b/packages/web-components/src/progress-bar/progress-bar.definition.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
+import { tagName } from './progress-bar.options.js';
 import { ProgressBar } from './progress-bar.js';
 import { styles } from './progress-bar.styles.js';
 import { template } from './progress-bar.template.js';
@@ -12,7 +12,7 @@ import { template } from './progress-bar.template.js';
  * HTML Element: \<fluent-progress-bar\>
  */
 export const definition = ProgressBar.compose({
-  name: `${FluentDesignSystem.prefix}-progress-bar`,
+  name: tagName,
   template,
   styles,
 });

--- a/packages/web-components/src/progress-bar/progress-bar.options.ts
+++ b/packages/web-components/src/progress-bar/progress-bar.options.ts
@@ -1,4 +1,5 @@
 import type { ValuesOf } from '../utils/typings.js';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 
 /**
  * ProgressBarThickness Constants
@@ -45,3 +46,10 @@ export const ProgressBarValidationState = {
  * @public
  */
 export type ProgressBarValidationState = ValuesOf<typeof ProgressBarValidationState>;
+
+/**
+ * The tag name for the progress bar element.
+ *
+ * @public
+ */
+export const tagName = `${FluentDesignSystem.prefix}-progress-bar` as const;

--- a/packages/web-components/src/radio-group/index.ts
+++ b/packages/web-components/src/radio-group/index.ts
@@ -4,3 +4,4 @@ export { RadioGroupOrientation } from './radio-group.options.js';
 export { definition as RadioGroupDefinition } from './radio-group.definition.js';
 export { styles as RadioGroupStyles } from './radio-group.styles.js';
 export { template as RadioGroupTemplate } from './radio-group.template.js';
+export { tagName as RadioGroupTagName } from './radio-group.options.js';

--- a/packages/web-components/src/radio-group/radio-group.definition.ts
+++ b/packages/web-components/src/radio-group/radio-group.definition.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
+import { tagName } from './radio-group.options.js';
 import { RadioGroup } from './radio-group.js';
 import { styles } from './radio-group.styles.js';
 import { template } from './radio-group.template.js';
@@ -12,7 +12,7 @@ import { template } from './radio-group.template.js';
  * HTML Element: \<fluent-radio-group\>
  */
 export const definition = RadioGroup.compose({
-  name: `${FluentDesignSystem.prefix}-radio-group`,
+  name: tagName,
   template,
   styles,
 });

--- a/packages/web-components/src/radio-group/radio-group.options.ts
+++ b/packages/web-components/src/radio-group/radio-group.options.ts
@@ -1,5 +1,6 @@
 import { Orientation } from '@microsoft/fast-web-utilities';
 import type { ValuesOf } from '../utils/typings.js';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 
 /**
  * Radio Group orientation
@@ -12,3 +13,10 @@ export const RadioGroupOrientation = Orientation;
  * @public
  */
 export type RadioGroupOrientation = ValuesOf<typeof RadioGroupOrientation>;
+
+/**
+ * The tag name for the radio group element.
+ *
+ * @public
+ */
+export const tagName = `${FluentDesignSystem.prefix}-radio-group` as const;

--- a/packages/web-components/src/radio/index.ts
+++ b/packages/web-components/src/radio/index.ts
@@ -3,3 +3,4 @@ export { Radio } from './radio.js';
 export type { RadioControl, RadioOptions } from './radio.options.js';
 export { styles as RadioStyles } from './radio.styles.js';
 export { template as RadioTemplate } from './radio.template.js';
+export { tagName as RadioTagName } from './radio.options.js';

--- a/packages/web-components/src/radio/radio.definition.ts
+++ b/packages/web-components/src/radio/radio.definition.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
+import { tagName } from './radio.options.js';
 import { Radio } from './radio.js';
 import { styles } from './radio.styles.js';
 import { template } from './radio.template.js';
@@ -12,7 +12,7 @@ import { template } from './radio.template.js';
  * HTML Element: \<fluent-radio\>
  */
 export const definition = Radio.compose({
-  name: `${FluentDesignSystem.prefix}-radio`,
+  name: tagName,
   template,
   styles,
 });

--- a/packages/web-components/src/radio/radio.options.ts
+++ b/packages/web-components/src/radio/radio.options.ts
@@ -1,3 +1,4 @@
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import type { StaticallyComposableHTML } from '../utils/template-helpers.js';
 import { isCustomElement } from '../utils/typings.js';
 import type { Radio } from './radio.js';
@@ -28,3 +29,10 @@ export type { CheckboxSize as RadioSize } from '../checkbox/checkbox.options.js'
 export function isRadio(element?: Node | null, tagName: string = '-radio'): element is Radio {
   return isCustomElement(tagName)(element);
 }
+
+/**
+ * The tag name for the radio element.
+ *
+ * @public
+ */
+export const tagName = `${FluentDesignSystem.prefix}-radio` as const;

--- a/packages/web-components/src/rating-display/index.ts
+++ b/packages/web-components/src/rating-display/index.ts
@@ -4,3 +4,4 @@ export { RatingDisplayColor, RatingDisplaySize } from './rating-display.options.
 export { template as RatingDisplayTemplate } from './rating-display.template.js';
 export { styles as RatingDisplayStyles } from './rating-display.styles.js';
 export { definition as RatingDisplayDefinition } from './rating-display.definition.js';
+export { tagName as RatingDisplayTagName } from './rating-display.options.js';

--- a/packages/web-components/src/rating-display/rating-display.definition.ts
+++ b/packages/web-components/src/rating-display/rating-display.definition.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
+import { tagName } from './rating-display.options.js';
 import { RatingDisplay } from './rating-display.js';
 import { styles } from './rating-display.styles.js';
 import { template } from './rating-display.template.js';
@@ -11,7 +11,7 @@ import { template } from './rating-display.template.js';
  * HTML Element: `<fluent-rating-display>`
  */
 export const definition = RatingDisplay.compose({
-  name: `${FluentDesignSystem.prefix}-rating-display`,
+  name: tagName,
   template,
   styles,
 });

--- a/packages/web-components/src/rating-display/rating-display.options.ts
+++ b/packages/web-components/src/rating-display/rating-display.options.ts
@@ -1,4 +1,5 @@
 import type { ValuesOf } from '../utils/typings.js';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 
 /**
  * The color of the Rating Display items can be `neutral`, `brand`, or `marigold`.
@@ -31,3 +32,10 @@ export type RatingDisplayColor = ValuesOf<typeof RatingDisplayColor>;
  * @public
  */
 export type RatingDisplaySize = ValuesOf<typeof RatingDisplaySize>;
+
+/**
+ * The tag name for the rating display element.
+ *
+ * @public
+ */
+export const tagName = `${FluentDesignSystem.prefix}-rating-display` as const;

--- a/packages/web-components/src/slider/index.ts
+++ b/packages/web-components/src/slider/index.ts
@@ -4,3 +4,4 @@ export { SliderMode, SliderOrientation, SliderSize } from './slider.options.js';
 export type { SliderConfiguration, SliderOptions } from './slider.options.js';
 export { styles as SliderStyles } from './slider.styles.js';
 export { template as SliderTemplate } from './slider.template.js';
+export { tagName as SliderTagName } from './slider.options.js';

--- a/packages/web-components/src/slider/slider.definition.ts
+++ b/packages/web-components/src/slider/slider.definition.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
+import { tagName } from './slider.options.js';
 import { Slider } from './slider.js';
 import { styles } from './slider.styles.js';
 import { template } from './slider.template.js';
@@ -12,7 +12,7 @@ import { template } from './slider.template.js';
  * HTML Element: \<fluent-slider\>
  */
 export const definition = Slider.compose({
-  name: `${FluentDesignSystem.prefix}-slider`,
+  name: tagName,
   template,
   styles,
 });

--- a/packages/web-components/src/slider/slider.options.ts
+++ b/packages/web-components/src/slider/slider.options.ts
@@ -2,6 +2,7 @@ import type { Direction } from '@microsoft/fast-web-utilities';
 import { Orientation } from '@microsoft/fast-web-utilities';
 import type { StaticallyComposableHTML } from '../utils/template-helpers.js';
 import type { ValuesOf } from '../utils/typings.js';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import type { Slider } from './slider.js';
 
 /**
@@ -61,3 +62,10 @@ export interface SliderConfiguration {
 export type SliderOptions = {
   thumb?: StaticallyComposableHTML<Slider>;
 };
+
+/**
+ * The tag name for the slider element.
+ *
+ * @public
+ */
+export const tagName = `${FluentDesignSystem.prefix}-slider` as const;

--- a/packages/web-components/src/spinner/index.ts
+++ b/packages/web-components/src/spinner/index.ts
@@ -4,3 +4,4 @@ export { SpinnerAppearance, SpinnerSize } from './spinner.options.js';
 export { template as SpinnerTemplate } from './spinner.template.js';
 export { styles as SpinnerStyles } from './spinner.styles.js';
 export { definition as SpinnerDefinition } from './spinner.definition.js';
+export { tagName as SpinnerTagName } from './spinner.options.js';

--- a/packages/web-components/src/spinner/spinner.definition.ts
+++ b/packages/web-components/src/spinner/spinner.definition.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
+import { tagName } from './spinner.options.js';
 import { Spinner } from './spinner.js';
 import { styles } from './spinner.styles.js';
 import { template } from './spinner.template.js';
@@ -9,7 +9,7 @@ import { template } from './spinner.template.js';
  * HTML Element: \<fluent-spinner\>
  */
 export const definition = Spinner.compose({
-  name: `${FluentDesignSystem.prefix}-spinner`,
+  name: tagName,
   template,
   styles,
 });

--- a/packages/web-components/src/spinner/spinner.options.ts
+++ b/packages/web-components/src/spinner/spinner.options.ts
@@ -1,4 +1,5 @@
 import type { ValuesOf } from '../utils/typings.js';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 
 /**
  * SpinnerAppearance constants
@@ -34,3 +35,10 @@ export const SpinnerSize = {
  * @public
  */
 export type SpinnerSize = ValuesOf<typeof SpinnerSize>;
+
+/**
+ * The tag name for the spinner element.
+ *
+ * @public
+ */
+export const tagName = `${FluentDesignSystem.prefix}-spinner` as const;

--- a/packages/web-components/src/switch/index.ts
+++ b/packages/web-components/src/switch/index.ts
@@ -4,3 +4,4 @@ export type { SwitchOptions } from './switch.js';
 export { SwitchLabelPosition } from './switch.options.js';
 export { styles as SwitchStyles } from './switch.styles.js';
 export { template as SwitchTemplate } from './switch.template.js';
+export { tagName as SwitchTagName } from './switch.options.js';

--- a/packages/web-components/src/switch/switch.definition.ts
+++ b/packages/web-components/src/switch/switch.definition.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
+import { tagName } from './switch.options.js';
 import { Switch } from './switch.js';
 import { template } from './switch.template.js';
 import { styles } from './switch.styles.js';
@@ -11,7 +11,7 @@ import { styles } from './switch.styles.js';
  * HTML Element: \<fluent-switch\>
  */
 export const definition = Switch.compose({
-  name: `${FluentDesignSystem.prefix}-switch`,
+  name: tagName,
   template,
   styles,
 });

--- a/packages/web-components/src/switch/switch.options.ts
+++ b/packages/web-components/src/switch/switch.options.ts
@@ -1,4 +1,5 @@
 import type { ValuesOf } from '../utils/typings.js';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 
 /**
  * SwitchLabelPosition Constants
@@ -15,3 +16,10 @@ export const SwitchLabelPosition = {
  * @public
  */
 export type SwitchLabelPosition = ValuesOf<typeof SwitchLabelPosition>;
+
+/**
+ * The tag name for the switch element.
+ *
+ * @public
+ */
+export const tagName = `${FluentDesignSystem.prefix}-switch` as const;

--- a/packages/web-components/src/tab/index.ts
+++ b/packages/web-components/src/tab/index.ts
@@ -4,3 +4,4 @@ export { Tab } from './tab.js';
 export type { TabOptions } from './tab.js';
 export { styles as TabStyles } from './tab.styles.js';
 export { template as TabTemplate } from './tab.template.js';
+export { tagName as TabTagName } from './tab.options.js';

--- a/packages/web-components/src/tab/tab.definition.ts
+++ b/packages/web-components/src/tab/tab.definition.ts
@@ -1,10 +1,10 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
+import { tagName } from './tab.options.js';
 import { Tab } from './tab.js';
 import { template } from './tab.template.js';
 import { styles } from './tab.styles.js';
 
 export const definition = Tab.compose({
-  name: `${FluentDesignSystem.prefix}-tab`,
+  name: tagName,
   template,
   styles,
 });

--- a/packages/web-components/src/tab/tab.options.ts
+++ b/packages/web-components/src/tab/tab.options.ts
@@ -1,3 +1,4 @@
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import type { Tab } from './tab.js';
 
 /**
@@ -15,3 +16,10 @@ export function isTab(element?: Node | null, tagName: string = '-tab'): element 
 
   return (element as Element).tagName.toLowerCase().endsWith(tagName);
 }
+
+/**
+ * The tag name for the tab element.
+ *
+ * @public
+ */
+export const tagName = `${FluentDesignSystem.prefix}-tab` as const;

--- a/packages/web-components/src/tablist/index.ts
+++ b/packages/web-components/src/tablist/index.ts
@@ -4,3 +4,4 @@ export { Tablist } from './tablist.js';
 export { TablistAppearance, TablistOrientation, TablistSize } from './tablist.options.js';
 export { styles as TablistStyles } from './tablist.styles.js';
 export { template as TablistTemplate } from './tablist.template.js';
+export { tagName as TablistTagName } from './tablist.options.js';

--- a/packages/web-components/src/tablist/tablist.definition.ts
+++ b/packages/web-components/src/tablist/tablist.definition.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
+import { tagName } from './tablist.options.js';
 import { Tablist } from './tablist.js';
 import { template } from './tablist.template.js';
 import { styles } from './tablist.styles.js';
@@ -9,7 +9,7 @@ import { styles } from './tablist.styles.js';
  * HTML Element: \<fluent-tablist\>
  */
 export const definition = Tablist.compose({
-  name: `${FluentDesignSystem.prefix}-tablist`,
+  name: tagName,
   template,
   styles,
 });

--- a/packages/web-components/src/tablist/tablist.options.ts
+++ b/packages/web-components/src/tablist/tablist.options.ts
@@ -1,5 +1,6 @@
 import { Orientation } from '@microsoft/fast-web-utilities';
 import type { ValuesOf } from '../utils/typings.js';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 
 /**
  * The appearance of the component
@@ -43,3 +44,10 @@ export const TablistOrientation = Orientation;
  * @public
  */
 export type TablistOrientation = ValuesOf<typeof TablistOrientation>;
+
+/**
+ * The tag name for the tablist element.
+ *
+ * @public
+ */
+export const tagName = `${FluentDesignSystem.prefix}-tablist` as const;

--- a/packages/web-components/src/text-input/index.ts
+++ b/packages/web-components/src/text-input/index.ts
@@ -5,3 +5,4 @@ export { TextInputAppearance, TextInputControlSize, TextInputType } from './text
 export type { TextInputOptions } from './text-input.options.js';
 export { styles as TextInputStyles } from './text-input.styles.js';
 export { template as TextInputTemplate } from './text-input.template.js';
+export { tagName as TextInputTagName } from './text-input.options.js';

--- a/packages/web-components/src/text-input/text-input.definition.ts
+++ b/packages/web-components/src/text-input/text-input.definition.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
+import { tagName } from './text-input.options.js';
 import { TextInput } from './text-input.js';
 import { styles } from './text-input.styles.js';
 import { template } from './text-input.template.js';
@@ -11,7 +11,7 @@ import { template } from './text-input.template.js';
  * HTML Element: `<fluent-text-input>`
  */
 export const definition = TextInput.compose({
-  name: `${FluentDesignSystem.prefix}-text-input`,
+  name: tagName,
   template,
   styles,
   shadowOptions: {

--- a/packages/web-components/src/text-input/text-input.options.ts
+++ b/packages/web-components/src/text-input/text-input.options.ts
@@ -1,3 +1,4 @@
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import type { StartEndOptions } from '../patterns/start-end.js';
 import type { ValuesOf } from '../utils/typings.js';
 import type { TextInput } from './text-input.js';
@@ -70,3 +71,10 @@ export const ImplicitSubmissionBlockingTypes = [
   'url',
   'week',
 ];
+
+/**
+ * The tag name for the text input element.
+ *
+ * @public
+ */
+export const tagName = `${FluentDesignSystem.prefix}-text-input` as const;

--- a/packages/web-components/src/text/index.ts
+++ b/packages/web-components/src/text/index.ts
@@ -3,3 +3,4 @@ export { TextAlign, TextFont, TextSize, TextWeight } from './text.options.js';
 export { template as TextTemplate } from './text.template.js';
 export { styles as TextStyles } from './text.styles.js';
 export { definition as TextDefinition } from './text.definition.js';
+export { tagName as TextTagName } from './text.options.js';

--- a/packages/web-components/src/text/text.definition.ts
+++ b/packages/web-components/src/text/text.definition.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
+import { tagName } from './text.options.js';
 import { Text } from './text.js';
 import { styles } from './text.styles.js';
 import { template } from './text.template.js';
@@ -12,7 +12,7 @@ import { template } from './text.template.js';
  * HTML Element: \<fluent-text\>
  */
 export const definition = Text.compose({
-  name: `${FluentDesignSystem.prefix}-text`,
+  name: tagName,
   template,
   styles,
 });

--- a/packages/web-components/src/text/text.options.ts
+++ b/packages/web-components/src/text/text.options.ts
@@ -1,4 +1,5 @@
 import type { ValuesOf } from '../utils/typings.js';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 
 /**
  * TextSize constants
@@ -73,3 +74,10 @@ export const TextAlign = {
  * @public
  */
 export type TextAlign = ValuesOf<typeof TextAlign>;
+
+/**
+ * The tag name for the text element.
+ *
+ * @public
+ */
+export const tagName = `${FluentDesignSystem.prefix}-text` as const;

--- a/packages/web-components/src/textarea/index.ts
+++ b/packages/web-components/src/textarea/index.ts
@@ -10,3 +10,4 @@ export {
 } from './textarea.options.js';
 export { styles as TextAreaStyles } from './textarea.styles.js';
 export { template as TextAreaTemplate } from './textarea.template.js';
+export { tagName as TextareaTagName } from './textarea.options.js';

--- a/packages/web-components/src/textarea/textarea.definition.ts
+++ b/packages/web-components/src/textarea/textarea.definition.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
+import { tagName } from './textarea.options.js';
 import { TextArea } from './textarea.js';
 import { styles } from './textarea.styles.js';
 import { template } from './textarea.template.js';
@@ -11,7 +11,7 @@ import { template } from './textarea.template.js';
  * HTML Element: `<fluent-textarea>`
  */
 export const definition = TextArea.compose({
-  name: `${FluentDesignSystem.prefix}-textarea`,
+  name: tagName,
   template,
   styles,
   shadowOptions: {

--- a/packages/web-components/src/textarea/textarea.options.ts
+++ b/packages/web-components/src/textarea/textarea.options.ts
@@ -1,3 +1,4 @@
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import type { ValuesOf } from '../utils/typings.js';
 
 /**
@@ -59,3 +60,10 @@ export const TextAreaResize = {
 } as const;
 
 export type TextAreaResize = ValuesOf<typeof TextAreaResize>;
+
+/**
+ * The tag name for the textarea element.
+ *
+ * @public
+ */
+export const tagName = `${FluentDesignSystem.prefix}-textarea` as const;

--- a/packages/web-components/src/toggle-button/index.ts
+++ b/packages/web-components/src/toggle-button/index.ts
@@ -4,3 +4,4 @@ export { ToggleButtonAppearance, ToggleButtonShape, ToggleButtonSize } from './t
 export type { ToggleButtonOptions } from './toggle-button.options.js';
 export { styles as ToggleButtonStyles } from './toggle-button.styles.js';
 export { template as ToggleButtonTemplate } from './toggle-button.template.js';
+export { tagName as ToggleButtonTagName } from './toggle-button.options.js';

--- a/packages/web-components/src/toggle-button/toggle-button.definition.ts
+++ b/packages/web-components/src/toggle-button/toggle-button.definition.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
+import { tagName } from './toggle-button.options.js';
 import { ToggleButton } from './toggle-button.js';
 import { styles } from './toggle-button.styles.js';
 import { template } from './toggle-button.template.js';
@@ -10,7 +10,7 @@ import { template } from './toggle-button.template.js';
  * HTML Element: \<fluent-toggle-button\>
  */
 export const definition = ToggleButton.compose({
-  name: `${FluentDesignSystem.prefix}-toggle-button`,
+  name: tagName,
   template,
   styles,
 });

--- a/packages/web-components/src/toggle-button/toggle-button.options.ts
+++ b/packages/web-components/src/toggle-button/toggle-button.options.ts
@@ -1,3 +1,4 @@
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import { ButtonAppearance, ButtonShape, ButtonSize } from '../button/button.options.js';
 import type { ButtonOptions } from '../button/button.options.js';
 import type { ValuesOf } from '../utils/typings.js';
@@ -38,3 +39,10 @@ export const ToggleButtonSize = ButtonSize;
 export type ToggleButtonSize = ValuesOf<typeof ToggleButtonSize>;
 
 export type { ButtonOptions as ToggleButtonOptions };
+
+/**
+ * The tag name for the toggle button element.
+ *
+ * @public
+ */
+export const tagName = `${FluentDesignSystem.prefix}-toggle-button` as const;

--- a/packages/web-components/src/tooltip/index.ts
+++ b/packages/web-components/src/tooltip/index.ts
@@ -3,3 +3,4 @@ export { Tooltip } from './tooltip.js';
 export { TooltipPositioningOption } from './tooltip.options.js';
 export { styles as TooltipStyles } from './tooltip.styles.js';
 export { template as TooltipTemplate } from './tooltip.template.js';
+export { tagName as TooltipTagName } from './tooltip.options.js';

--- a/packages/web-components/src/tooltip/tooltip.definition.ts
+++ b/packages/web-components/src/tooltip/tooltip.definition.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
+import { tagName } from './tooltip.options.js';
 import { Tooltip } from './tooltip.js';
 import { styles } from './tooltip.styles.js';
 import { template } from './tooltip.template.js';
@@ -11,7 +11,7 @@ import { template } from './tooltip.template.js';
  * HTML Element: `<fluent-tooltip>`
  */
 export const definition = Tooltip.compose({
-  name: `${FluentDesignSystem.prefix}-tooltip`,
+  name: tagName,
   template,
   styles,
 });

--- a/packages/web-components/src/tooltip/tooltip.options.ts
+++ b/packages/web-components/src/tooltip/tooltip.options.ts
@@ -1,3 +1,4 @@
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import type { ValuesOf } from '../utils/typings.js';
 
 /**
@@ -24,3 +25,10 @@ export const TooltipPositioningOption = {
  * @public
  */
 export type TooltipPositioningOption = ValuesOf<typeof TooltipPositioningOption>;
+
+/**
+ * The tag name for the tooltip element.
+ *
+ * @public
+ */
+export const tagName = `${FluentDesignSystem.prefix}-tooltip` as const;

--- a/packages/web-components/src/tree-item/index.ts
+++ b/packages/web-components/src/tree-item/index.ts
@@ -4,3 +4,4 @@ export { template as TreeItemTemplate } from './tree-item.template.js';
 export { styles as TreeItemStyles } from './tree-item.styles.js';
 export { definition as TreeItemDefinition } from './tree-item.definition.js';
 export type { isTreeItem, TreeItemAppearance, TreeItemSize } from './tree-item.options.js';
+export { tagName as TreeItemTagName } from './tree-item.options.js';

--- a/packages/web-components/src/tree-item/tree-item.definition.ts
+++ b/packages/web-components/src/tree-item/tree-item.definition.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
+import { tagName } from './tree-item.options.js';
 import { TreeItem } from './tree-item.js';
 import { styles as treeItemStyle } from './tree-item.styles.js';
 import { template as treeItemTemplate } from './tree-item.template.js';
@@ -10,7 +10,7 @@ import { template as treeItemTemplate } from './tree-item.template.js';
  * HTML Element: \<fluent-tree-item\>
  */
 export const definition = TreeItem.compose({
-  name: `${FluentDesignSystem.prefix}-tree-item`,
+  name: tagName,
   template: treeItemTemplate,
   styles: treeItemStyle,
 });

--- a/packages/web-components/src/tree-item/tree-item.options.ts
+++ b/packages/web-components/src/tree-item/tree-item.options.ts
@@ -1,3 +1,4 @@
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import { ValuesOf } from '../utils/typings.js';
 import { BaseTreeItem } from './tree-item.base.js';
 
@@ -31,3 +32,10 @@ export function isTreeItem(element?: Node | null, tagName: string = '-tree-item'
 
   return (element as Element).tagName.toLowerCase().endsWith(tagName);
 }
+
+/**
+ * The tag name for the tree item element.
+ *
+ * @public
+ */
+export const tagName = `${FluentDesignSystem.prefix}-tree-item` as const;

--- a/packages/web-components/src/tree/index.ts
+++ b/packages/web-components/src/tree/index.ts
@@ -3,3 +3,4 @@ export { Tree } from './tree.js';
 export { template as TreeTemplate } from './tree.template.js';
 export { styles as TreeStyles } from './tree.styles.js';
 export { definition as TreeDefinition } from './tree.definition.js';
+export { tagName as TreeTagName } from './tree.options.js';

--- a/packages/web-components/src/tree/tree.definition.ts
+++ b/packages/web-components/src/tree/tree.definition.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
+import { tagName } from './tree.options.js';
 import { Tree } from './tree.js';
 import { styles as treeStyle } from './tree.styles.js';
 import { template as treeTemplate } from './tree.template.js';
@@ -10,7 +10,7 @@ import { template as treeTemplate } from './tree.template.js';
  * HTML Element: \<fluent-tree\>
  */
 export const definition = Tree.compose({
-  name: `${FluentDesignSystem.prefix}-tree`,
+  name: tagName,
   template: treeTemplate,
   styles: treeStyle,
 });

--- a/packages/web-components/src/tree/tree.options.ts
+++ b/packages/web-components/src/tree/tree.options.ts
@@ -1,0 +1,8 @@
+import { FluentDesignSystem } from '../fluent-design-system.js';
+
+/**
+ * The tag name for the tree element.
+ *
+ * @public
+ */
+export const tagName = `${FluentDesignSystem.prefix}-tree` as const;


### PR DESCRIPTION
## Previous Behavior
Tag names were created adhoc and hardcoded.

## New Behavior
Tag name is now created with a consistent approach to be leveraged and invoked through an "API"

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
