### PR TITLE
feat(react-headless-components-preview): update stories styles to use CSS modules

### DIFF
--- a/packages/react-components/react-headless-components-preview/stories/src/Card/card.module.css
+++ b/packages/react-components/react-headless-components-preview/stories/src/Card/card.module.css
@@ -19,7 +19,7 @@
 }
 
 .card:focus-visible {
-  outline: var(--stroke-thick) solid var(--text);
+  outline: var(--stroke-thick) solid var(--accent);
   outline-offset: 2px;
 }
 
@@ -131,7 +131,7 @@
 }
 
 .iconButton:focus-visible {
-  outline: var(--stroke-thick) solid var(--text);
+  outline: var(--stroke-thick) solid var(--accent);
   outline-offset: 2px;
 }
 
@@ -171,7 +171,7 @@
 }
 
 .footerButton:focus-visible {
-  outline: var(--stroke-thick) solid var(--text);
+  outline: var(--stroke-thick) solid var(--accent);
   outline-offset: 2px;
 }
 
@@ -186,7 +186,7 @@
 }
 
 .checkbox:focus-visible {
-  outline: var(--stroke-thick) solid var(--text);
+  outline: var(--stroke-thick) solid var(--accent);
   outline-offset: 2px;
 }
 

--- a/packages/react-components/react-headless-components-preview/stories/src/Dialog/dialog.module.css
+++ b/packages/react-components/react-headless-components-preview/stories/src/Dialog/dialog.module.css
@@ -65,6 +65,14 @@
   transition: background var(--duration-fast) var(--ease-standard);
 }
 
+.btn:focus {
+  outline: none;
+}
+
+.btn:focus-visible {
+  box-shadow: 0 0 0 2px var(--bg-elev), 0 0 0 4px var(--accent);
+}
+
 .btn:hover {
   background: var(--surface-sunken);
 }

--- a/packages/react-components/react-headless-components-preview/stories/src/Drawer/InlineDrawer.stories.tsx
+++ b/packages/react-components/react-headless-components-preview/stories/src/Drawer/InlineDrawer.stories.tsx
@@ -36,7 +36,7 @@ export const Inline = (): React.ReactNode => {
       </Drawer>
 
       <main className={styles.inlineMain}>
-        <button className={styles.secondaryButton} onClick={toggleDrawer}>
+        <button className={styles.primaryButton} onClick={toggleDrawer}>
           {open ? 'Hide inline drawer' : 'Show inline drawer'}
         </button>
       </main>

--- a/packages/react-components/react-headless-components-preview/stories/src/Drawer/drawer.module.css
+++ b/packages/react-components/react-headless-components-preview/stories/src/Drawer/drawer.module.css
@@ -125,7 +125,7 @@
 }
 
 .closeButton:focus-visible {
-  outline: var(--stroke-thick) solid var(--text);
+  outline: var(--stroke-thick) solid var(--accent);
   outline-offset: 2px;
 }
 
@@ -135,20 +135,20 @@
   height: 32px;
   padding: 0 var(--space-3);
   border: 0;
-  border-radius: var(--radius-md);
-  background: var(--text);
-  color: var(--text-on-accent);
+  border-radius: var(--radius-pill);
+  background: var(--accent);
+  color: var(--accent-contrast);
   font-size: 13.5px;
   font-weight: 500;
   cursor: pointer;
 }
 
 .primaryButton:hover {
-  background: var(--text-muted);
+  background: var(--accent-strong);
 }
 
 .primaryButton:focus-visible {
-  outline: var(--stroke-thick) solid var(--text);
+  outline: var(--stroke-thick) solid var(--accent);
   outline-offset: 2px;
 }
 
@@ -170,7 +170,7 @@
 }
 
 .secondaryButton:focus-visible {
-  outline: var(--stroke-thick) solid var(--text);
+  outline: var(--stroke-thick) solid var(--accent);
   outline-offset: 2px;
 }
 

--- a/packages/react-components/react-headless-components-preview/stories/src/Input/input.module.css
+++ b/packages/react-components/react-headless-components-preview/stories/src/Input/input.module.css
@@ -16,8 +16,7 @@
 
 .wrap:has(:focus-visible),
 .wrap:focus-within {
-  border-color: var(--text);
-  box-shadow: 0 0 0 3px var(--surface-muted);
+  box-shadow: 0 0 0 2px var(--bg-elev), 0 0 0 4px var(--accent);
 }
 
 .wrap[data-disabled],

--- a/packages/react-components/react-headless-components-preview/stories/src/MessageBar/MessageBarDefault.stories.tsx
+++ b/packages/react-components/react-headless-components-preview/stories/src/MessageBar/MessageBarDefault.stories.tsx
@@ -26,7 +26,7 @@ export const Default = (): React.ReactNode => (
       <button type="button" className={styles.actionBtn}>
         Action
       </button>
-      <button type="button" className={styles.iconBtn} aria-label="Dismiss">
+      <button type="button" className={`${styles.actionBtn} ${styles.iconBtn}`} aria-label="Dismiss">
         <DismissRegular aria-hidden />
       </button>
     </MessageBarActions>

--- a/packages/react-components/react-headless-components-preview/stories/src/Popover/popover.module.css
+++ b/packages/react-components/react-headless-components-preview/stories/src/Popover/popover.module.css
@@ -18,7 +18,7 @@
 }
 
 .trigger:focus-visible {
-  outline: var(--stroke-thick) solid var(--text);
+  outline: var(--stroke-thick) solid var(--accent);
   outline-offset: 2px;
 }
 
@@ -54,7 +54,7 @@
 }
 
 .contextTrigger:focus-visible {
-  outline: var(--stroke-thick) solid var(--text);
+  outline: var(--stroke-thick) solid var(--accent);
   outline-offset: 2px;
 }
 
@@ -129,7 +129,7 @@
 }
 
 .actionButton:focus-visible {
-  outline: var(--stroke-thick) solid var(--text);
+  outline: var(--stroke-thick) solid var(--accent);
   outline-offset: 2px;
 }
 

--- a/packages/react-components/react-headless-components-preview/stories/src/Rating/rating.module.css
+++ b/packages/react-components/react-headless-components-preview/stories/src/Rating/rating.module.css
@@ -8,6 +8,11 @@
 .item {
   position: relative;
   display: inline-flex;
+  border-radius: var(--radius-sm);
+}
+
+.item:has(:focus-within) {
+  box-shadow: 0 0 0 2px var(--bg-elev), 0 0 0 4px var(--accent);
 }
 
 .input {

--- a/packages/react-components/react-headless-components-preview/stories/src/Select/select.module.css
+++ b/packages/react-components/react-headless-components-preview/stories/src/Select/select.module.css
@@ -25,8 +25,7 @@
 
 .select:focus-visible {
   outline: none;
-  border-color: var(--text);
-  box-shadow: 0 0 0 3px var(--surface-muted);
+  box-shadow: 0 0 0 2px var(--bg-elev), 0 0 0 4px var(--accent);
 }
 
 .select:disabled {

--- a/packages/react-components/react-headless-components-preview/stories/src/SpinButton/spin-button.module.css
+++ b/packages/react-components/react-headless-components-preview/stories/src/SpinButton/spin-button.module.css
@@ -16,8 +16,7 @@
 }
 
 .wrap:has(:focus-visible) {
-  border-color: var(--text);
-  box-shadow: 0 0 0 3px var(--surface-muted);
+  box-shadow: 0 0 0 2px var(--bg-elev), 0 0 0 4px var(--accent);
 }
 
 .input {

--- a/packages/react-components/react-headless-components-preview/stories/src/TabList/tab-list.module.css
+++ b/packages/react-components/react-headless-components-preview/stories/src/TabList/tab-list.module.css
@@ -4,6 +4,7 @@
   padding: 4px;
   background: var(--surface-muted);
   border-radius: var(--radius-pill);
+  width: max-content;
 }
 
 .tabsVertical {
@@ -35,15 +36,15 @@
   color: var(--text);
 }
 
-.tab:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 2px var(--bg-elev), 0 0 0 4px var(--accent);
-}
-
 .tab[data-selected] {
   background: var(--bg-elev);
   color: var(--text);
   box-shadow: var(--shadow-1);
+}
+
+.tab:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--bg-elev), 0 0 0 4px var(--accent);
 }
 
 .layout {

--- a/packages/react-components/react-headless-components-preview/stories/src/Textarea/textarea.module.css
+++ b/packages/react-components/react-headless-components-preview/stories/src/Textarea/textarea.module.css
@@ -14,8 +14,7 @@
 }
 
 .wrap:has(:focus-visible) {
-  border-color: var(--text);
-  box-shadow: 0 0 0 3px var(--surface-muted);
+  box-shadow: 0 0 0 2px var(--bg-elev), 0 0 0 4px var(--accent);
 }
 
 .textarea {

--- a/packages/react-components/react-headless-components-preview/stories/src/Tooltip/TooltipControlled.stories.tsx
+++ b/packages/react-components/react-headless-components-preview/stories/src/Tooltip/TooltipControlled.stories.tsx
@@ -1,28 +1,26 @@
 import * as React from 'react';
 import { Tooltip } from '@fluentui/react-headless-components-preview/tooltip';
 
+import styles from './tooltip.module.css';
+
 export const Controlled = (): React.ReactNode => {
   const [visible, setVisible] = React.useState(false);
   const toggleTooltip = () => setVisible(v => !v);
 
   return (
-    <div className="flex gap-2 items-center">
+    <div className={styles.row}>
       <Tooltip
         content={{
-          className: 'bg-gray-900 text-white text-xs px-2 py-1 rounded shadow-md',
+          className: styles.content,
           children: 'Controlled tooltip',
         }}
         relationship="description"
         visible={visible}
+        positioning={{ offset: 8 }}
       >
-        <button className="px-3 py-1.5 rounded border border-gray-300 bg-white hover:bg-gray-50 text-sm cursor-pointer">
-          Trigger
-        </button>
+        <button className={`${styles.trigger} ${styles.triggerOutline}`}>Trigger</button>
       </Tooltip>
-      <button
-        onClick={toggleTooltip}
-        className="px-3 py-1.5 rounded border border-gray-300 bg-white hover:bg-gray-50 text-sm cursor-pointer"
-      >
+      <button onClick={toggleTooltip} className={styles.trigger}>
         {visible ? 'Hide' : 'Show'} Tooltip
       </button>
     </div>

--- a/packages/react-components/react-headless-components-preview/stories/src/Tooltip/TooltipDefault.stories.tsx
+++ b/packages/react-components/react-headless-components-preview/stories/src/Tooltip/TooltipDefault.stories.tsx
@@ -1,16 +1,19 @@
 import * as React from 'react';
 import { Tooltip } from '@fluentui/react-headless-components-preview/tooltip';
 
+import styles from './tooltip.module.css';
+
 export const Default = (): React.ReactNode => (
-  <Tooltip
-    content={{
-      className: 'bg-gray-900 text-white text-xs px-2 py-1 rounded shadow-md',
-      children: 'This is the tooltip label',
-    }}
-    relationship="description"
-  >
-    <button className="px-3 py-1.5 rounded border border-gray-300 bg-white hover:bg-gray-50 text-sm cursor-pointer">
-      Hover or focus me
-    </button>
-  </Tooltip>
+  <div className={styles.row}>
+    <Tooltip
+      content={{
+        className: styles.content,
+        children: 'This is the tooltip label',
+      }}
+      relationship="description"
+      positioning={{ offset: 8 }}
+    >
+      <button className={styles.trigger}>Hover or focus me</button>
+    </Tooltip>
+  </div>
 );

--- a/packages/react-components/react-headless-components-preview/stories/src/Tooltip/TooltipPositions.stories.tsx
+++ b/packages/react-components/react-headless-components-preview/stories/src/Tooltip/TooltipPositions.stories.tsx
@@ -1,21 +1,21 @@
 import * as React from 'react';
 import { Tooltip } from '@fluentui/react-headless-components-preview/tooltip';
 
+import styles from './tooltip.module.css';
+
 export const Positions = (): React.ReactNode => (
-  <div className="flex gap-4 flex-wrap p-20">
+  <div className={styles.row}>
     {(['above', 'below', 'before', 'after'] as const).map(position => (
       <Tooltip
         key={position}
         content={{
-          className: 'bg-gray-900 text-white text-xs px-2 py-1 rounded shadow-md',
+          className: styles.content,
           children: `Position: ${position}`,
         }}
         relationship="description"
-        positioning={position}
+        positioning={{ position, offset: 8 }}
       >
-        <button className="px-3 py-1.5 rounded border border-gray-300 bg-white hover:bg-gray-50 text-sm cursor-pointer capitalize">
-          {position}
-        </button>
+        <button className={`${styles.trigger} ${styles.capitalize}`}>{position}</button>
       </Tooltip>
     ))}
   </div>

--- a/packages/react-components/react-headless-components-preview/stories/src/Tooltip/TooltipRelationshipDescription.stories.tsx
+++ b/packages/react-components/react-headless-components-preview/stories/src/Tooltip/TooltipRelationshipDescription.stories.tsx
@@ -1,18 +1,21 @@
 import * as React from 'react';
 import { Tooltip } from '@fluentui/react-headless-components-preview/tooltip';
 
+import styles from './tooltip.module.css';
+
 export const RelationshipDescription = (): React.ReactNode => (
-  <Tooltip
-    content={{
-      className: 'bg-gray-900 text-white text-xs px-2 py-1 rounded shadow-md',
-      children: 'This is the description of the button',
-    }}
-    relationship="description"
-  >
-    <button className="px-3 py-1.5 rounded border border-gray-300 bg-white hover:bg-gray-50 text-sm cursor-pointer">
-      Button
-    </button>
-  </Tooltip>
+  <div className={styles.row}>
+    <Tooltip
+      content={{
+        className: styles.content,
+        children: 'This is the description of the button',
+      }}
+      relationship="description"
+      positioning={{ offset: 8 }}
+    >
+      <button className={styles.trigger}>Button</button>
+    </Tooltip>
+  </div>
 );
 
 RelationshipDescription.storyName = 'Relationship: description';

--- a/packages/react-components/react-headless-components-preview/stories/src/Tooltip/TooltipRelationshipLabel.stories.tsx
+++ b/packages/react-components/react-headless-components-preview/stories/src/Tooltip/TooltipRelationshipLabel.stories.tsx
@@ -1,25 +1,26 @@
 import * as React from 'react';
 import { Tooltip } from '@fluentui/react-headless-components-preview/tooltip';
 
-const tooltipContent = (text: string) => ({
-  className: 'bg-gray-900 text-white text-xs px-2 py-1 rounded shadow-md',
-  children: text,
-});
+import styles from './tooltip.module.css';
 
 export const RelationshipLabel = (): React.ReactNode => (
-  <div className="flex gap-2">
-    <Tooltip content={tooltipContent('Bold')} relationship="label">
-      <button className="w-8 h-8 rounded border border-gray-300 bg-white hover:bg-gray-50 font-bold text-sm cursor-pointer">
-        B
-      </button>
+  <div className={styles.row}>
+    <Tooltip content={{ className: styles.content, children: 'Bold' }} relationship="label" positioning={{ offset: 8 }}>
+      <button className={`${styles.trigger} ${styles.triggerOutline} ${styles.triggerIcon} ${styles.bold}`}>B</button>
     </Tooltip>
-    <Tooltip content={tooltipContent('Italic')} relationship="label">
-      <button className="w-8 h-8 rounded border border-gray-300 bg-white hover:bg-gray-50 italic text-sm cursor-pointer">
-        I
-      </button>
+    <Tooltip
+      content={{ className: styles.content, children: 'Italic' }}
+      relationship="label"
+      positioning={{ offset: 8 }}
+    >
+      <button className={`${styles.trigger} ${styles.triggerOutline} ${styles.triggerIcon} ${styles.italic}`}>I</button>
     </Tooltip>
-    <Tooltip content={tooltipContent('Underline')} relationship="label">
-      <button className="w-8 h-8 rounded border border-gray-300 bg-white hover:bg-gray-50 underline text-sm cursor-pointer">
+    <Tooltip
+      content={{ className: styles.content, children: 'Underline' }}
+      relationship="label"
+      positioning={{ offset: 8 }}
+    >
+      <button className={`${styles.trigger} ${styles.triggerOutline} ${styles.triggerIcon} ${styles.underline}`}>
         U
       </button>
     </Tooltip>

--- a/packages/react-components/react-headless-components-preview/stories/src/Tooltip/TooltipWithArrow.stories.tsx
+++ b/packages/react-components/react-headless-components-preview/stories/src/Tooltip/TooltipWithArrow.stories.tsx
@@ -1,36 +1,19 @@
 import * as React from 'react';
 import { Tooltip } from '@fluentui/react-headless-components-preview/tooltip';
 
-const contentClass = [
-  'bg-gray-900 text-white text-xs px-2 py-1 rounded shadow-md overflow-visible',
-  // Arrow base (the rotated square rendered by withArrow)
-  '[&_[data-arrow]]:absolute [&_[data-arrow]]:w-2 [&_[data-arrow]]:h-2 [&_[data-arrow]]:bg-gray-900 [&_[data-arrow]]:rotate-45',
-  // Main-axis offset
-  "[&[data-placement^='above']_[data-arrow]]:-bottom-1",
-  "[&[data-placement^='below']_[data-arrow]]:-top-1",
-  "[&[data-placement^='before']_[data-arrow]]:-right-1",
-  "[&[data-placement^='after']_[data-arrow]]:-left-1",
-  // Cross-axis centering
-  "[&[data-placement='above']_[data-arrow]]:inset-x-0 [&[data-placement='above']_[data-arrow]]:mx-auto",
-  "[&[data-placement='below']_[data-arrow]]:inset-x-0 [&[data-placement='below']_[data-arrow]]:mx-auto",
-  "[&[data-placement='before']_[data-arrow]]:inset-y-0 [&[data-placement='before']_[data-arrow]]:my-auto",
-  "[&[data-placement='after']_[data-arrow]]:inset-y-0 [&[data-placement='after']_[data-arrow]]:my-auto",
-  // Start/end-aligned placements
-  "[&[data-placement$='-start']_[data-arrow]]:start-[var(--arrow-padding,8px)]",
-  "[&[data-placement$='-end']_[data-arrow]]:end-[var(--arrow-padding,8px)]",
-].join(' ');
+import styles from './tooltip.module.css';
+
+const contentClass = [styles.content, styles.contentWithArrow].join(' ');
 
 export const WithArrow = (): React.ReactNode => (
-  <div className="flex flex-col items-start gap-4 p-16">
+  <div className={styles.row}>
     <Tooltip
       relationship="description"
       content={{ className: contentClass, children: 'Center-aligned tooltip' }}
       withArrow
       positioning={{ position: 'below', offset: 10 }}
     >
-      <button className="px-3 py-1.5 rounded border border-gray-300 bg-white hover:bg-gray-50 text-sm cursor-pointer">
-        Center-aligned
-      </button>
+      <button className={styles.trigger}>Center-aligned</button>
     </Tooltip>
 
     <Tooltip
@@ -39,9 +22,7 @@ export const WithArrow = (): React.ReactNode => (
       content={{ className: contentClass, children: 'Start-aligned tooltip' }}
       withArrow
     >
-      <button className="px-3 py-1.5 rounded border border-gray-300 bg-white hover:bg-gray-50 text-sm cursor-pointer">
-        Start-aligned
-      </button>
+      <button className={styles.trigger}>Start-aligned</button>
     </Tooltip>
   </div>
 );

--- a/packages/react-components/react-headless-components-preview/stories/src/Tooltip/tooltip.module.css
+++ b/packages/react-components/react-headless-components-preview/stories/src/Tooltip/tooltip.module.css
@@ -1,0 +1,136 @@
+/* Tooltip content bubble — inverse surface (dark on light, light on dark) */
+.content {
+  background: var(--bg-elev);
+  color: var(--text);
+  font-size: 12px;
+  line-height: 1.4;
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-3);
+  border: none;
+  max-width: 240px;
+}
+
+/*
+  Arrow-enabled content: keep overflow visible so the rotated square
+  isn't clipped, and replace box-shadow with a drop-shadow filter so
+  the shadow wraps the arrow too.
+*/
+.contentWithArrow {
+  overflow: visible;
+  box-shadow: none;
+  filter: drop-shadow(0 2px 6px rgba(0, 0, 0, 0.22));
+}
+
+.contentWithArrow [data-arrow] {
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  background: var(--bg-elev);
+  transform: rotate(45deg);
+}
+
+/* Main-axis placement — push arrow to the outer edge */
+.contentWithArrow[data-placement^='above'] [data-arrow] {
+  bottom: -4px;
+}
+
+.contentWithArrow[data-placement^='below'] [data-arrow] {
+  top: -4px;
+}
+
+.contentWithArrow[data-placement^='before'] [data-arrow] {
+  right: -4px;
+}
+
+.contentWithArrow[data-placement^='after'] [data-arrow] {
+  left: -4px;
+}
+
+/* Cross-axis centering for cardinal placements */
+.contentWithArrow[data-placement='above'] [data-arrow],
+.contentWithArrow[data-placement='below'] [data-arrow] {
+  inset-inline: 0;
+  margin-inline: auto;
+}
+
+.contentWithArrow[data-placement='before'] [data-arrow],
+.contentWithArrow[data-placement='after'] [data-arrow] {
+  inset-block: 0;
+  margin-block: auto;
+}
+
+/* Start/end-aligned placements — offset from the near edge */
+.contentWithArrow[data-placement$='-start'] [data-arrow] {
+  inset-inline-start: var(--arrow-padding, 8px);
+}
+
+.contentWithArrow[data-placement$='-end'] [data-arrow] {
+  inset-inline-end: var(--arrow-padding, 8px);
+}
+
+/* Trigger button — primary filled style */
+.trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 32px;
+  padding: 0 var(--space-3);
+  border: 0;
+  border-radius: var(--radius-pill);
+  background: var(--accent);
+  color: var(--accent-contrast);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.trigger:hover {
+  background: var(--accent-strong);
+}
+
+.trigger:focus-visible {
+  outline: var(--stroke-thick) solid var(--accent);
+  outline-offset: 2px;
+}
+
+.triggerOutline {
+  background: transparent;
+  color: var(--text);
+  border: 1px solid var(--border-strong);
+}
+
+.triggerOutline:hover {
+  background: var(--surface-muted);
+  border-color: var(--text);
+}
+
+/* Icon-only trigger — square, fixed size */
+.triggerIcon {
+  width: 32px;
+  padding: 0;
+}
+
+/* Layout helpers */
+.row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  padding: var(--space-8);
+}
+
+.capitalize {
+  text-transform: capitalize;
+}
+
+.bold {
+  font-weight: bold;
+}
+
+.italic {
+  font-style: italic;
+}
+
+.underline {
+  text-decoration: underline;
+}


### PR DESCRIPTION
## Summary

- Use consistent styles across Card, Dialog, Drawer, Input, MessageBar, Popover, Rating, Select, SpinButton, TabList, and Textarea stories (theme colors, no more black&white theming, focus outline, etc)
- Refactor all Tooltip stories to use `tooltip.module.css` instead of TW styles

https://github.com/user-attachments/assets/665ea0c1-85e3-4fb7-ad9a-661005131d18

## Test plan

- [x] Visually verify each component story renders correctly in Storybook
- [x] Confirm styles are scoped and no cross-component leakage

🤖 Generated with [Claude Code](https://claude.com/claude-code)