### PR TITLE
fix(web-componets): fix components for native focusgroup implementation

### DIFF
--- a/change/@fluentui-web-components-ce5d6bec-0682-4483-9813-9fd1c1275adb.json
+++ b/change/@fluentui-web-components-ce5d6bec-0682-4483-9813-9fd1c1275adb.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix components for native focusgroup implementation",
+  "packageName": "@fluentui/web-components",
+  "email": "machi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/menu-item/menu-item.template.ts
+++ b/packages/web-components/src/menu-item/menu-item.template.ts
@@ -14,6 +14,7 @@ const chevronRight16Filled = html.partial(
 export function menuItemTemplate<T extends MenuItem>(options: MenuItemOptions = {}): ElementViewTemplate<T> {
   return html<T>`
     <template
+      tabindex="0"
       @keydown="${(x, c) => x.handleMenuItemKeyDown(c.event as KeyboardEvent)}"
       @click="${(x, c) => x.handleMenuItemClick(c.event as MouseEvent)}"
       @mouseover="${(x, c) => x.handleMouseOver(c.event as MouseEvent)}"

--- a/packages/web-components/src/radio-group/radio-group.base.ts
+++ b/packages/web-components/src/radio-group/radio-group.base.ts
@@ -178,6 +178,7 @@ export class BaseRadioGroup extends FASTElement {
 
       radio.name = this.name ?? radio.name;
       radio.disabled = !!this.disabled || !!radio.disabledAttribute;
+      radio.toggleAttribute('focusgroupstart', radio.checked && !radio.disabled);
     });
 
     if (!this.dirtyState && this.initialValue) {

--- a/packages/web-components/src/tablist/tablist.base.ts
+++ b/packages/web-components/src/tablist/tablist.base.ts
@@ -130,6 +130,7 @@ export class BaseTablist extends FASTElement {
       }
 
       const isSelected = this.activeid === tab.id;
+      tab.toggleAttribute('focusgroupstart', isSelected);
       tab.setAttribute('aria-selected', isSelected.toString());
 
       // Only set the data-hasIndent attribute if the tab has a start slot and the orientation is vertical

--- a/packages/web-components/src/tablist/tablist.template.ts
+++ b/packages/web-components/src/tablist/tablist.template.ts
@@ -7,7 +7,7 @@ import type { Tablist } from './tablist.js';
 export const template = html<Tablist>`
   <template
     role="tablist"
-    focusgroup="tablist inline block nomemory"
+    focusgroup="tablist inline block"
     @focusin="${(x, c) => x.handleFocusIn(c.event as FocusEvent)}"
   >
     <slot name="tab" ${slotted('slottedTabs')}></slot>


### PR DESCRIPTION
Fixed the following bugs when used with native focusgroup (in Chromium Canary):

* tablist: initially selected tab should be the focusgroupstart element
* radio-group: initially checked radio should be the focusgroupstart element
* menu-item: element should always have `tabindex=0`
