### PR TITLE
fix(web-components): menu not closing after menu-list loses keyboard focus

### DIFF
--- a/change/@fluentui-web-components-2efee0b6-f5be-4ba7-bd0a-383d2acdc86a.json
+++ b/change/@fluentui-web-components-2efee0b6-f5be-4ba7-bd0a-383d2acdc86a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix menu not closing when menu list loses keyboard focus",
+  "packageName": "@fluentui/web-components",
+  "email": "machi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@microsoft/api-extractor": "7.51.0",
     "@microsoft/api-extractor-model": "7.31.2",
     "@microsoft/eslint-plugin-sdl": "1.0.1",
-    "@microsoft/focusgroup-polyfill": "^1.3.0",
+    "@microsoft/focusgroup-polyfill": "^1.4.1",
     "@microsoft/load-themed-styles": "1.10.26",
     "@microsoft/loader-load-themed-styles": "2.0.17",
     "@microsoft/tsdoc": "0.15.1",

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -77,7 +77,7 @@
   "devDependencies": {
     "@custom-elements-manifest/analyzer": "0.10.10",
     "@microsoft/fast-element": "2.0.0",
-    "@microsoft/focusgroup-polyfill": "^1.3.0",
+    "@microsoft/focusgroup-polyfill": "^1.4.1",
     "@tensile-perf/web-components": "~0.2.2",
     "@storybook/html": "9.1.17",
     "@storybook/html-vite": "9.1.17",
@@ -93,7 +93,7 @@
   },
   "peerDependencies": {
     "@microsoft/fast-element": "^2.0.0",
-    "@microsoft/focusgroup-polyfill": "^1.3.0"
+    "@microsoft/focusgroup-polyfill": "^1.4.1"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/web-components/src/menu/menu.spec.ts
+++ b/packages/web-components/src/menu/menu.spec.ts
@@ -139,6 +139,22 @@ test.describe('Menu', () => {
     await expect(menuList).toBeHidden();
   });
 
+  test('should close when the menu list loses keyboard focus', async ({ fastPage, page }) => {
+    const { element } = fastPage;
+    const menuButton = element.locator('fluent-menu-button');
+    const menuList = element.locator('fluent-menu-list');
+    const menuItems = element.locator('fluent-menu-item');
+
+    await menuButton.click();
+
+    await expect(menuList).toBeVisible();
+    await expect(menuItems.nth(0)).toBeFocused();
+
+    await page.keyboard.press('Tab');
+
+    await expect(menuList).toBeHidden();
+  });
+
   test('should NOT open on hover when the `openOnHover` property is false', async ({ fastPage }) => {
     const { element } = fastPage;
     const menuButton = element.locator('fluent-menu-button');

--- a/yarn.lock
+++ b/yarn.lock
@@ -2699,10 +2699,10 @@
   dependencies:
     exenv-es6 "^1.1.1"
 
-"@microsoft/focusgroup-polyfill@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@microsoft/focusgroup-polyfill/-/focusgroup-polyfill-1.3.0.tgz#12a4e9abac1b7736ca7c4f59c923a45713a8c274"
-  integrity sha512-rlhfgqEsC6jR36/LSrl4dd0xQha05gGv5q7cfz+dnGKGVcsCo6CI6C0GYiq+jSja+VzVY97fRQnMiBJR1EgOeg==
+"@microsoft/focusgroup-polyfill@^1.4.1":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/focusgroup-polyfill/-/focusgroup-polyfill-1.4.1.tgz#0d3feee675775f7a692a3b1e974eea107503c78e"
+  integrity sha512-nXn/kJ5ZnzpR+TWYGV+nU2yaHPJORjWf2lSQJ90VT6Ydsmmkaz/yOYW3CizDGPPsA7ouAu9K8khCUeyfBcz7UA==
 
 "@microsoft/load-themed-styles@1.10.26", "@microsoft/load-themed-styles@^1.10.26":
   version "1.10.26"


### PR DESCRIPTION
## Previous Behavior

When using keyboard to navigate out of a `<menu-list>` element inside a `<menu>`, it doesn’t close. This is because the focusgroup polyfill stops `keydown` event propagation on a focusgroup owner, so `<menu>` couldn’t get the `keydown` event when `Tab` key is pressed hence couldn’t trigger menu list close.

## New Behavior

`<menu-list>` closes properly.
