### PR TITLE
feat(react-headless-components-preview): add trapFocus prop

### DIFF
--- a/change/@fluentui-react-headless-components-preview-a9515cf6-8f18-49c7-b702-e82d80f4d14c.json
+++ b/change/@fluentui-react-headless-components-preview-a9515cf6-8f18-49c7-b702-e82d80f4d14c.json
@@ -1,7 +1,7 @@
 {
-  "type": "patch",
+  "type": "minor",
   "comment": "feat(react-headless-components-preview): add trapFocus prop to Popover for modal focus-trap via native dialog API",
   "packageName": "@fluentui/react-headless-components-preview",
   "email": "vgenaev@gmail.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "minor"
 }

--- a/change/@fluentui-react-headless-components-preview-a9515cf6-8f18-49c7-b702-e82d80f4d14c.json
+++ b/change/@fluentui-react-headless-components-preview-a9515cf6-8f18-49c7-b702-e82d80f4d14c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat(react-headless-components-preview): add trapFocus prop to Popover for modal focus-trap via native dialog API",
+  "packageName": "@fluentui/react-headless-components-preview",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-headless-components-preview/library/docs/popover-spec.md
+++ b/packages/react-components/react-headless-components-preview/library/docs/popover-spec.md
@@ -34,6 +34,7 @@ Popover is a compound component. `PopoverTrigger` is optional — a surface with
 | `openOnContext`   | `boolean`                                                   | `false`     | Open on the trigger's context-menu event (right-click / Shift+F10). Click and keyboard activation are ignored while on.      |
 | `withArrow`       | `boolean`                                                   | `false`     | Render an arrow element inside the surface. Consumer CSS positions/rotates it using `[data-placement]`.                      |
 | `positioning`     | `PositioningShorthand`                                      | `undefined` | Shorthand (`'below-start'`) or object (`{ position, align, offset, ... }`). See [Positioning](#positioning).                 |
+| `trapFocus`       | `boolean`                                                   | `false`     | Open the popover as a modal via `HTMLDialogElement.showModal()`. See [Focus management](#focus-management).                  |
 
 ### `PopoverTrigger`
 
@@ -44,21 +45,21 @@ Popover is a compound component. `PopoverTrigger` is optional — a surface with
 
 ### `PopoverSurface`
 
-| Prop       | Type        | Default | Description                                                                                                          |
-| ---------- | ----------- | ------- | -------------------------------------------------------------------------------------------------------------------- |
-| `tabIndex` | `number`    | —       | Forwarded to the rendered `<div>` so the surface can be focusable when the consumer needs it (e.g. `tabIndex={-1}`). |
-| `children` | `ReactNode` | —       | Surface content.                                                                                                     |
+| Prop       | Type        | Default | Description                                                                                                             |
+| ---------- | ----------- | ------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `tabIndex` | `number`    | —       | Forwarded to the rendered `<dialog>` so the surface can be focusable when the consumer needs it (e.g. `tabIndex={-1}`). |
+| `children` | `ReactNode` | —       | Surface content.                                                                                                        |
 
 ## States
 
-| State              | Trigger                                                                                                                                    | Behaviour                                                                                                                                                                                                                                                 | ARIA                                                                                    |
-| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| **Closed**         | Initial, or after dismissal                                                                                                                | Surface unmounted. Trigger has `aria-expanded="false"`, no `data-open`.                                                                                                                                                                                   | `aria-expanded="false"` on trigger.                                                     |
-| **Open**           | `open={true}` / click / keyboard activation / hover / right-click (depending on props)                                                     | Surface mounted and promoted into the top layer via `showPopover()` (feature-detected). `data-placement` reflects the requested placement; `usePlacementObserver` overwrites it with the resolved placement.                                              | `aria-expanded="true"`, `data-open` on trigger; `role="group"`, `data-open` on surface. |
-| **Hover-held**     | `openOnHover` and pointer inside trigger or surface                                                                                        | Popover stays open while pointer is inside either element; closes `mouseLeaveDelay` ms after it leaves both.                                                                                                                                              | Same as Open.                                                                           |
-| **Context-pinned** | `openOnContext` + right-click                                                                                                              | `onOpenChange(e, { type: 'contextmenu', open: true })` with the mouse event; `contextTarget` state stores `{ x, y }`. Click and keyboard activation on the trigger do nothing.                                                                            | Same as Open.                                                                           |
-| **Dismissing**     | Browser-driven: Escape, click-outside, popover-stack peer dismissal. Plus React-driven hover-leave (`openOnHover`) and programmatic close. | `toggle` event on the surface mirrors the browser's decision into React; `onOpenChange(e, { open: false, type })` fires with the originating event.                                                                                                       | `aria-expanded` returns to `"false"` on trigger.                                        |
-| **Nested**         | Popover rendered inside another Popover's surface                                                                                          | Nested popovers participate in the browser-managed `popover="auto"` stack. Escape, click-outside, and peer-dismissal use native HTML Popover semantics, and each surface mirrors its own `toggle` event back into React — no React-side Escape filtering. | Each surface keeps its own `role="group"`.                                              |
+| State              | Trigger                                                                                                                                    | Behaviour                                                                                                                                                                                                                                                                                                                                                                              | ARIA                                                                                                                                                                  |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Closed**         | Initial, or after dismissal                                                                                                                | Surface unmounted. Trigger has `aria-expanded="false"`, no `data-open`.                                                                                                                                                                                                                                                                                                                | `aria-expanded="false"` on trigger.                                                                                                                                   |
+| **Open**           | `open={true}` / click / keyboard activation / hover / right-click (depending on props)                                                     | Surface mounted and promoted into the top layer. `usePopover` calls `showModal()` when `trapFocus={true}` (modal trap), otherwise `showPopover()` (non-modal). Both methods are feature-detected. `data-placement` reflects the requested placement; `usePlacementObserver` overwrites it with the resolved placement.                                                                 | `aria-expanded="true"`, `data-open` on trigger; `data-open` on surface. Surface role is `group` (default) or `dialog` (`trapFocus={true}`, supplied by the platform). |
+| **Hover-held**     | `openOnHover` and pointer inside trigger or surface                                                                                        | Popover stays open while pointer is inside either element; closes `mouseLeaveDelay` ms after it leaves both.                                                                                                                                                                                                                                                                           | Same as Open.                                                                                                                                                         |
+| **Context-pinned** | `openOnContext` + right-click                                                                                                              | `onOpenChange(e, { type: 'contextmenu', open: true })` with the mouse event; `contextTarget` state stores `{ x, y }`. Click and keyboard activation on the trigger do nothing.                                                                                                                                                                                                         | Same as Open.                                                                                                                                                         |
+| **Dismissing**     | Browser-driven: Escape, click-outside, popover-stack peer dismissal. Plus React-driven hover-leave (`openOnHover`) and programmatic close. | `toggle` event on the surface mirrors the browser's decision into React; `onOpenChange(e, { open: false, type })` fires with the originating event.                                                                                                                                                                                                                                    | `aria-expanded` returns to `"false"` on trigger.                                                                                                                      |
+| **Nested**         | Popover rendered inside another Popover's surface                                                                                          | Nested popovers participate in the browser-managed `popover="auto"` stack. Escape, click-outside, and peer-dismissal use native HTML Popover semantics, and each surface mirrors its own `toggle` event back into React — no React-side Escape filtering. A nested `trapFocus` popover stacks via `showModal()` and suspends the outer trap until it closes (browser top-layer rules). | Each surface keeps its own role per its `trapFocus` setting.                                                                                                          |
 
 ## Keyboard Navigation
 
@@ -72,12 +73,12 @@ Popover is a compound component. `PopoverTrigger` is optional — a surface with
 
 ### Inside surface
 
-| Key               | Action                                                                                                                                              |
-| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Tab**           | Default browser tab order. The surface does **not** trap focus in this iteration; Tab can move focus out of the surface.                            |
-| **Shift + Tab**   | Default browser reverse tab order.                                                                                                                  |
-| **Escape**        | Dismiss the current popover. Filtered to the nearest enclosing surface, so Escape in a nested popover only closes that popover — not its ancestors. |
-| **Enter / Space** | Default button activation inside the surface.                                                                                                       |
+| Key               | Action                                                                                                                                                            |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Tab**           | Default browser tab order; Tab may move focus out of the surface. With `trapFocus={true}`, the platform's modal `<dialog>` semantics keep Tab inside the surface. |
+| **Shift + Tab**   | Default browser reverse tab order.                                                                                                                                |
+| **Escape**        | Dismiss the current popover. Filtered to the nearest enclosing surface, so Escape in a nested popover only closes that popover — not its ancestors.               |
+| **Enter / Space** | Default button activation inside the surface.                                                                                                                     |
 
 ## Events
 
@@ -101,11 +102,11 @@ There is no separate `onDismiss`. The `open: false` dispatches go through `onOpe
   // click / keydown / context / hover handlers merged onto the cloned child
 />
 
-// Surface (top layer)
-<div
+// Surface (top layer) — always a <dialog popover="auto">; role differs per trapFocus
+<dialog
   id={surfaceId}
   popover="auto"
-  role="group"
+  role={trapFocus ? undefined /* platform supplies role="dialog" + aria-modal */ : 'group'}
   data-popover-surface=""
   data-placement="below-start"   // requested placement; live-updated by observer
   data-open="true"
@@ -129,24 +130,38 @@ Instead, the relationship is wired **explicitly** and uniformly:
 
 This matches the behavioural guarantees consumers would get from `popovertarget` (for the ARIA-relationship piece).
 
+### Surface element
+
+`PopoverSurface` always renders as a native **`<dialog popover="auto">`**. A single element supports both show modes the component switches between at open time:
+
+- `surface.showPopover()` — non-modal popover (default, `trapFocus={false}`).
+- `surface.showModal()` — modal dialog (`trapFocus={true}`).
+
+The element choice follows the [Open UI popover-vs-dialog research](https://open-ui.org/components/popover.research.explainer/#popover-vs-dialog), which recommends `<dialog popover>` for top-layer non-modal cases — it preserves popover-style stacking and light-dismiss in the default path while leaving modal trap as a one-method swap when consumers opt in.
+
 ### Role selection
 
-The surface always renders as **`role="group"`** in this iteration — a non-modal anchored container suitable for menus, cards, and informational overlays. Modal `role="dialog"` (with `aria-modal="true"`, `aria-haspopup="dialog"` on the trigger, and a focus trap) is planned for a follow-up iteration that re-introduces a focus-management hook. Consumers needing modal semantics today should reach for the `Dialog` headless component instead.
+The role on the surface depends on `trapFocus`:
+
+| `trapFocus` | Implicit/explicit role                                                                                                                                                                                    | Why                                                                                                                                   |
+| ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `false`     | Explicit `role="group"`, overriding `<dialog>`'s implicit `role="dialog"`.                                                                                                                                | Non-modal anchored container suitable for menus, cards, and informational overlays. Matches the prior contract.                       |
+| `true`      | No explicit role; the platform supplies `role="dialog"` (or `role="alertdialog"` if a consumer sets it via `...props`) and `aria-modal="true"` automatically when the dialog is opened via `showModal()`. | Modal dialog semantics for assistive tech; the explicit `role="group"` is dropped so the platform-provided semantics aren't shadowed. |
 
 ### Focus management
 
-This iteration ships **no built-in focus management**:
+Focus management is delegated to the platform; the component adds no React-side focus trap, focus finder, or restoration logic.
 
-- **No auto-focus on open.** Whatever was focused before `open` flipped to `true` remains focused. Consumers who need focus inside the surface (e.g., for menu/dialog-style flows) should call `.focus()` on the desired element themselves, typically in their `onOpenChange` handler or in an effect keyed on the popover's open state.
-- **No focus trap.** Tab / Shift+Tab follow the document's normal tab order. With a top-layer surface, focus may move to elements behind the surface — expected for a non-modal popover.
+- **`trapFocus={false}` (default).** No autofocus on open unless a child element has the HTML `autofocus` attribute (in which case the popover-side focusing steps focus it per the popover spec). No focus trap — Tab follows the document's normal tab order. Light dismiss is browser-managed.
+- **`trapFocus={true}`.** The browser opens the surface via `dialog.showModal()` and runs the modal `<dialog>` focusing steps: focus moves to the first sequentially-focusable descendant (or to a child carrying `autofocus`), the rest of the page is **inert**, and Tab cycles inside the surface. On close, `dialog.close()` restores focus to whatever element was focused when `showModal()` ran — typically the trigger.
 
-### Auto-focus on open — not currently supported
+#### Specifying initial focus
 
-The previously-reserved `disableAutoFocus` prop has been **removed** from `PopoverProps`. The component does not move focus on open, so an opt-out flag is unnecessary. A future iteration will introduce a focus-management hook covering both auto-focus on open and focus trap; an opt-in/opt-out prop (likely with a different name reflecting the broader semantics) will arrive together with that hook.
+Consumers control which child receives initial focus via the standard React `autoFocus` attribute on the desired child JSX element. There is no `initialFocusRef` prop — the HTML attribute already covers it for both show modes.
 
-### Focus restore on dismiss — native only
+#### Cancel handling (modal Esc)
 
-The component does **not** supplement the browser's focus restore. What `popover="auto"` provides is what the consumer gets. Per the HTML Popover spec, the `hide popover` algorithm restores focus to a stored `previously focused element` — but that field is set only for the **first popover in the auto stack** (the spec text states: _"This ensures that focus is returned to the previously-focused element only for the first popover in a stack."_), and only when focus is currently inside the dismissing surface, and only when the popover is dismissed via the spec's hide algorithm (Escape close-watcher, click-outside light-dismiss, peer-auto dismissal, an explicit `hidePopover()` call).
+When `trapFocus={true}`, Escape fires the native `cancel` event on the dialog. `usePopover` listens for `cancel`, calls `event.preventDefault()` (so the browser doesn't close the dialog before React re-renders), and routes through `setOpen(false)`. The subsequent close — driven by `open` flipping to `false` — runs `dialog.close()`, which performs the spec-mandated focus restoration to the trigger. This keeps controlled consumers authoritative without losing the platform's restore behavior.
 
 ### Labeling
 
@@ -201,7 +216,7 @@ The surface is rendered with `popover="auto"`, so the **browser owns light dismi
 | Context menu             | `openOnContext={true}` → `contextmenu` on trigger defers to the trailing `pointerup` (see [Context-menu open deferral](#context-menu-open-deferral)), then calls `setOpen(true)` and stores the cursor `{x, y}` as `contextTarget`. |
 | Programmatic             | Consumer sets `open={true}` or uses `defaultOpen` / `positioningRef.setTarget`.                                                                                                                                                     |
 
-When `open` flips to `true`, `usePopover` calls `surface.showPopover()` and the surface enters the top layer with `popover="auto"`.
+When `open` flips to `true`, `usePopover` calls `surface.showModal()` if `trapFocus` is set (modal `<dialog>` semantics: focus trap, autofocus, inert backdrop, spec-mandated focus restoration on close), or `surface.showPopover()` otherwise (non-modal popover with browser-managed light dismiss). When `open` flips to `false`, the trap path additionally calls `dialog.close()` while the element is still connected so the browser runs its native close-the-dialog focus restoration.
 
 #### Context-menu open deferral
 

--- a/packages/react-components/react-headless-components-preview/library/etc/popover.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/popover.api.md
@@ -33,7 +33,7 @@ export const Popover: {
 };
 
 // @public
-export type PopoverContextValue = Pick<PopoverState, 'open' | 'setOpen' | 'toggleOpen' | 'triggerRef' | 'contentRef' | 'arrowRef' | 'openOnHover' | 'openOnContext' | 'withArrow' | 'surfaceId'> & {
+export type PopoverContextValue = Pick<PopoverState, 'open' | 'setOpen' | 'toggleOpen' | 'triggerRef' | 'contentRef' | 'arrowRef' | 'openOnHover' | 'openOnContext' | 'withArrow' | 'surfaceId' | 'trapFocus'> & {
     positioning: {
         targetRef: React_2.RefCallback<HTMLElement>;
         containerRef: React_2.RefCallback<HTMLElement>;
@@ -51,10 +51,11 @@ export type PopoverProps = {
     mouseLeaveDelay?: number;
     positioning?: PositioningShorthand;
     withArrow?: boolean;
+    trapFocus?: boolean;
 };
 
 // @public
-export type PopoverState = Required<Pick<PopoverProps, 'open'>> & Pick<PopoverProps, 'onOpenChange' | 'openOnContext' | 'openOnHover' | 'withArrow'> & {
+export type PopoverState = Required<Pick<PopoverProps, 'open' | 'trapFocus'>> & Pick<PopoverProps, 'onOpenChange' | 'openOnContext' | 'openOnHover' | 'withArrow'> & {
     setOpen: (e: OpenPopoverEvents, open: boolean) => void;
     toggleOpen: (e: OpenPopoverEvents) => void;
     triggerRef: React_2.RefObject<HTMLElement | null>;
@@ -82,7 +83,7 @@ export type PopoverSurfaceProps = ComponentProps<PopoverSurfaceSlots>;
 
 // @public
 export type PopoverSurfaceSlots = {
-    root: Slot<'div'>;
+    root: Slot<'dialog'>;
 };
 
 // @public (undocumented)
@@ -129,7 +130,7 @@ export const usePopoverContextValues: (state: PopoverState) => {
 };
 
 // @public
-export const usePopoverSurface: (props: PopoverSurfaceProps, ref: React_2.Ref<HTMLDivElement>) => PopoverSurfaceState;
+export const usePopoverSurface: (props: PopoverSurfaceProps, ref: React_2.Ref<HTMLDialogElement>) => PopoverSurfaceState;
 
 // @public
 export const usePopoverTrigger: (props: PopoverTriggerProps) => PopoverTriggerState;

--- a/packages/react-components/react-headless-components-preview/library/src/components/Popover/Popover.cy.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Popover/Popover.cy.tsx
@@ -313,70 +313,101 @@ describe('Popover', () => {
     });
   });
 
-  describe('with Iframe', () => {
-    const iframeContent = `<div id="iframecontent">
-  <button>Hello World!</button>
-</div>`;
+  describe('Focus trap', () => {
+    const trapSurfaceSelector = '[role="dialog"]';
 
-    const ExampleFrame = () => {
-      return <iframe title="frame" srcDoc={iframeContent} />;
-    };
-
-    it('should not close when focus is on an internal iframe', () => {
+    it('moves focus into the surface on open and walks through focusables', () => {
       mount(
-        <>
-          <Popover>
-            <PopoverTrigger disableButtonEnhancement>
-              <button>Popover trigger</button>
-            </PopoverTrigger>
-            <PopoverSurface>
-              <ExampleFrame />
-            </PopoverSurface>
-          </Popover>
-        </>,
+        <Popover trapFocus>
+          <PopoverTrigger disableButtonEnhancement>
+            <button data-testid="trigger">Trigger</button>
+          </PopoverTrigger>
+          <PopoverSurface data-testid="surface">
+            <button data-testid="first">First</button>
+            <button data-testid="second">Second</button>
+            <button data-testid="third">Third</button>
+          </PopoverSurface>
+        </Popover>,
       );
 
-      cy.get(popoverTriggerSelector)
-        .click()
-        .get('iframe')
-        .focus()
-        .wait(2000)
-        .get(popoverContentSelector)
-        .should('exist');
+      cy.get('[data-testid=trigger]').realClick();
+      cy.get(trapSurfaceSelector).should('be.visible');
+
+      cy.focused().should('have.attr', 'data-testid', 'first');
+
+      cy.realPress('Tab');
+      cy.focused().should('have.attr', 'data-testid', 'second');
+      cy.realPress('Tab');
+      cy.focused().should('have.attr', 'data-testid', 'third');
     });
 
-    it('should not close when focus is on an internal iframe in a nested popover', () => {
+    it('honors the autofocus HTML attribute on a child', () => {
+      const setAutofocus = (el: HTMLInputElement | null) => el?.setAttribute('autofocus', '');
+
       mount(
-        <>
-          <Popover>
-            <PopoverTrigger disableButtonEnhancement>
-              <button>First</button>
-            </PopoverTrigger>
-            <PopoverSurface>
-              <Popover>
-                <PopoverTrigger>
-                  <button>Second</button>
-                </PopoverTrigger>
-                <PopoverSurface>
-                  <ExampleFrame />
-                </PopoverSurface>
-              </Popover>
-            </PopoverSurface>
-          </Popover>
-        </>,
+        <Popover trapFocus>
+          <PopoverTrigger disableButtonEnhancement>
+            <button data-testid="trigger">Trigger</button>
+          </PopoverTrigger>
+          <PopoverSurface data-testid="surface">
+            <button data-testid="first">First</button>
+            <input data-testid="auto" ref={setAutofocus} />
+            <button data-testid="last">Last</button>
+          </PopoverSurface>
+        </Popover>,
       );
 
-      cy.get(popoverTriggerSelector)
-        .first()
-        .click()
-        .get(popoverTriggerSelector)
-        .eq(1)
-        .click()
-        .get('iframe')
-        .focus()
-        .wait(2000)
-        .get(popoverContentSelector)
-        .should('have.length', 2);
+      cy.get('[data-testid=trigger]').realClick();
+      cy.get(trapSurfaceSelector).should('be.visible');
+      cy.focused().should('have.attr', 'data-testid', 'auto');
+    });
+
+    it('restores focus to the trigger on Escape', () => {
+      mount(
+        <Popover trapFocus>
+          <PopoverTrigger disableButtonEnhancement>
+            <button data-testid="trigger">Trigger</button>
+          </PopoverTrigger>
+          <PopoverSurface data-testid="surface">
+            <button data-testid="inner">Inner</button>
+          </PopoverSurface>
+        </Popover>,
+      );
+
+      cy.get('[data-testid=trigger]').realClick();
+      cy.get(trapSurfaceSelector).should('be.visible');
+      cy.realPress('Escape');
+      cy.get(trapSurfaceSelector).should('not.exist');
+      cy.focused().should('have.attr', 'data-testid', 'trigger');
+    });
+
+    it('makes content behind the surface inert (cannot be clicked)', () => {
+      const Example = () => {
+        const [outsideClicks, setOutsideClicks] = React.useState(0);
+        return (
+          <>
+            <button data-testid="outside" onClick={() => setOutsideClicks(c => c + 1)}>
+              Outside ({outsideClicks})
+            </button>
+            <Popover trapFocus>
+              <PopoverTrigger disableButtonEnhancement>
+                <button data-testid="trigger">Trigger</button>
+              </PopoverTrigger>
+              <PopoverSurface data-testid="surface">
+                <button data-testid="inner">Inner</button>
+              </PopoverSurface>
+            </Popover>
+          </>
+        );
+      };
+
+      mount(<Example />);
+      cy.get('[data-testid=trigger]').realClick();
+      cy.get(trapSurfaceSelector).should('be.visible');
+
+      cy.get('[data-testid=outside]').realClick();
+      cy.get('[data-testid=outside]').should('have.text', 'Outside (0)');
+      cy.get(trapSurfaceSelector).should('be.visible');
     });
   });
 });

--- a/packages/react-components/react-headless-components-preview/library/src/components/Popover/Popover.test.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Popover/Popover.test.tsx
@@ -136,7 +136,7 @@ describe('Popover', () => {
       </Popover>,
     );
 
-    expect(getByRole('group')).toBeInTheDocument();
+    expect(getByRole('group', { hidden: true })).toBeInTheDocument();
   });
 
   it('sets data-open attribute on surface', () => {
@@ -149,7 +149,7 @@ describe('Popover', () => {
       </Popover>,
     );
 
-    expect(getByRole('group')).toHaveAttribute('data-open');
+    expect(getByRole('group', { hidden: true })).toHaveAttribute('data-open');
   });
 
   it('mirrors a browser-driven `toggle` event into React state and closes the surface', () => {
@@ -162,7 +162,7 @@ describe('Popover', () => {
       </Popover>,
     );
 
-    const surface = getByRole('group');
+    const surface = getByRole('group', { hidden: true });
     const toggleEvent = new Event('toggle');
     (toggleEvent as unknown as { newState: string }).newState = 'closed';
     fireEvent(surface, toggleEvent);
@@ -180,6 +180,6 @@ describe('Popover', () => {
       </Popover>,
     );
 
-    expect(getByRole('group')).toHaveAttribute('popover', 'auto');
+    expect(getByRole('group', { hidden: true })).toHaveAttribute('popover', 'auto');
   });
 });

--- a/packages/react-components/react-headless-components-preview/library/src/components/Popover/Popover.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Popover/Popover.types.ts
@@ -70,12 +70,27 @@ export type PopoverProps = {
    * @default false
    */
   withArrow?: boolean;
+
+  /**
+   * When true, opens the popover as a modal via `HTMLDialogElement.showModal()`.
+   * Focus is trapped inside the surface, the rest of the page is inert, and
+   * focus is restored to the trigger when the popover closes — all spec-mandated
+   * by the native dialog element.
+   *
+   * When false (default), the popover is non-modal: opens via `showPopover()`,
+   * the browser handles light dismiss (Escape, click-outside, popover-stack
+   * peer dismissal), and no focus trap or autofocus is applied unless a child
+   * has the HTML `autofocus` attribute.
+   *
+   * @default false
+   */
+  trapFocus?: boolean;
 };
 
 /**
  * Popover State
  */
-export type PopoverState = Required<Pick<PopoverProps, 'open'>> &
+export type PopoverState = Required<Pick<PopoverProps, 'open' | 'trapFocus'>> &
   Pick<PopoverProps, 'onOpenChange' | 'openOnContext' | 'openOnHover' | 'withArrow'> & {
     setOpen: (e: OpenPopoverEvents, open: boolean) => void;
     toggleOpen: (e: OpenPopoverEvents) => void;
@@ -105,6 +120,7 @@ export type PopoverContextValue = Pick<
   | 'openOnContext'
   | 'withArrow'
   | 'surfaceId'
+  | 'trapFocus'
 > & {
   positioning: {
     targetRef: React.RefCallback<HTMLElement>;

--- a/packages/react-components/react-headless-components-preview/library/src/components/Popover/PopoverSurface/PopoverSurface.test.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Popover/PopoverSurface/PopoverSurface.test.tsx
@@ -28,7 +28,7 @@ describe('PopoverSurface', () => {
       </Popover>,
     );
 
-    expect(getByRole('group')).toBeInTheDocument();
+    expect(getByRole('group', { hidden: true })).toBeInTheDocument();
   });
 
   it('has data-open attribute when open', () => {
@@ -41,7 +41,7 @@ describe('PopoverSurface', () => {
       </Popover>,
     );
 
-    expect(getByRole('group')).toHaveAttribute('data-open');
+    expect(getByRole('group', { hidden: true })).toHaveAttribute('data-open');
   });
 
   it('has popover="auto" attribute by default', () => {
@@ -54,7 +54,7 @@ describe('PopoverSurface', () => {
       </Popover>,
     );
 
-    expect(getByRole('group')).toHaveAttribute('popover', 'auto');
+    expect(getByRole('group', { hidden: true })).toHaveAttribute('popover', 'auto');
   });
 
   it('mirrors a browser-driven `toggle` event into onOpenChange', () => {
@@ -69,7 +69,7 @@ describe('PopoverSurface', () => {
       </Popover>,
     );
 
-    const surface = getByRole('group');
+    const surface = getByRole('group', { hidden: true });
     const toggleEvent = new Event('toggle');
     (toggleEvent as unknown as { newState: string }).newState = 'closed';
     fireEvent(surface, toggleEvent);
@@ -87,7 +87,7 @@ describe('PopoverSurface', () => {
       </Popover>,
     );
 
-    expect(getByRole('group').querySelector('[data-arrow]')).toBeInTheDocument();
+    expect(getByRole('group', { hidden: true }).querySelector('[data-arrow]')).toBeInTheDocument();
   });
 
   it('applies custom className', () => {
@@ -100,11 +100,11 @@ describe('PopoverSurface', () => {
       </Popover>,
     );
 
-    expect(getByRole('group')).toHaveClass('my-surface');
+    expect(getByRole('group', { hidden: true })).toHaveClass('my-surface');
   });
 
   it('keeps trigger aria-details linked to the surface even when a custom id is provided', () => {
-    const { getByText, getByRole } = render(
+    const { getByRole, getByText } = render(
       <Popover open>
         <PopoverTrigger>
           <button>Trigger</button>
@@ -113,7 +113,7 @@ describe('PopoverSurface', () => {
       </Popover>,
     );
 
-    const surface = getByRole('group');
+    const surface = getByRole('group', { hidden: true });
     const trigger = getByText('Trigger');
 
     expect(surface.id).not.toBe('user-provided-id');

--- a/packages/react-components/react-headless-components-preview/library/src/components/Popover/PopoverSurface/PopoverSurface.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Popover/PopoverSurface/PopoverSurface.tsx
@@ -9,10 +9,15 @@ import { renderPopoverSurface } from './renderPopoverSurface';
 /**
  * Headless PopoverSurface component.
  *
- * Renders the popover content area using native HTML popover attribute
- * for top-layer rendering.
+ * Renders the popover content area as a native `<dialog popover="auto">` so
+ * a single element supports both non-modal (`showPopover()`) and modal
+ * (`showModal()`) show modes; the choice is driven by the parent
+ * `Popover`'s `trapFocus` prop.
  */
-export const PopoverSurface: ForwardRefComponent<PopoverSurfaceProps> = React.forwardRef((props, ref) => {
+export const PopoverSurface: ForwardRefComponent<PopoverSurfaceProps> = React.forwardRef<
+  HTMLDialogElement,
+  PopoverSurfaceProps
+>((props, ref) => {
   const state = usePopoverSurface(props, ref);
   return renderPopoverSurface(state);
 });

--- a/packages/react-components/react-headless-components-preview/library/src/components/Popover/PopoverSurface/PopoverSurface.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Popover/PopoverSurface/PopoverSurface.types.ts
@@ -2,10 +2,14 @@ import type * as React from 'react';
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
 
 /**
- * PopoverSurface Slots
+ * PopoverSurface Slots.
+ *
+ * The root renders as a native `<dialog popover="auto">` so a single element
+ * supports both show modes: `showPopover()` for non-modal (default) and
+ * `showModal()` for the modal/focus-trap path.
  */
 export type PopoverSurfaceSlots = {
-  root: Slot<'div'>;
+  root: Slot<'dialog'>;
 };
 
 export type PopoverSurfaceProps = ComponentProps<PopoverSurfaceSlots>;

--- a/packages/react-components/react-headless-components-preview/library/src/components/Popover/PopoverSurface/usePopoverSurface.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Popover/PopoverSurface/usePopoverSurface.ts
@@ -30,7 +30,7 @@ export const usePopoverSurface = (
     root: slot.always(
       {
         ref: useMergedRefs(ref, contentRef, positioningCtx.containerRef) as React.Ref<HTMLDialogElement>,
-        role: trapFocus ? undefined : 'group',
+        role: trapFocus ? 'dialog' : 'group',
         ...props,
         id: surfaceId,
         popover: trapFocus ? undefined : 'auto',

--- a/packages/react-components/react-headless-components-preview/library/src/components/Popover/PopoverSurface/usePopoverSurface.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Popover/PopoverSurface/usePopoverSurface.ts
@@ -8,13 +8,11 @@ import type { PopoverSurfaceProps, PopoverSurfaceState } from './PopoverSurface.
 
 /**
  * Returns the state for a PopoverSurface component.
- *
- * The surface is rendered with `popover="auto"` so the browser owns light
- * dismiss (Escape, click-outside, popover-stack peer dismissal) — there is
- * no React-side Escape handler. Hover handlers stay because hover is an
- * open-side concern.
  */
-export const usePopoverSurface = (props: PopoverSurfaceProps, ref: React.Ref<HTMLDivElement>): PopoverSurfaceState => {
+export const usePopoverSurface = (
+  props: PopoverSurfaceProps,
+  ref: React.Ref<HTMLDialogElement>,
+): PopoverSurfaceState => {
   const contentRef = usePopoverContext(context => context.contentRef);
   const openOnHover = usePopoverContext(context => context.openOnHover);
   const setOpen = usePopoverContext(context => context.setOpen);
@@ -23,36 +21,37 @@ export const usePopoverSurface = (props: PopoverSurfaceProps, ref: React.Ref<HTM
   const open = usePopoverContext(context => context.open);
   const positioningCtx = usePopoverContext(context => context.positioning);
   const surfaceId = usePopoverContext(context => context.surfaceId);
+  const trapFocus = usePopoverContext(context => context.trapFocus);
 
   const state: PopoverSurfaceState = {
     withArrow,
     arrowRef,
-    components: { root: 'div' },
+    components: { root: 'dialog' },
     root: slot.always(
       {
-        ref: useMergedRefs(ref, contentRef, positioningCtx.containerRef) as React.Ref<HTMLDivElement>,
-        role: 'group',
+        ref: useMergedRefs(ref, contentRef, positioningCtx.containerRef) as React.Ref<HTMLDialogElement>,
+        role: trapFocus ? undefined : 'group',
         ...props,
         id: surfaceId,
-        popover: 'auto',
+        popover: trapFocus ? undefined : 'auto',
         'data-popover-surface': '',
         'data-open': stringifyDataAttribute(open),
       },
-      { elementType: 'div' },
+      { elementType: 'dialog' },
     ),
     'data-open': open ? 'true' : 'false',
   };
 
   const { onMouseEnter: onMouseEnterOriginal, onMouseLeave: onMouseLeaveOriginal } = state.root;
 
-  state.root.onMouseEnter = useEventCallback((e: React.MouseEvent<HTMLDivElement>) => {
+  state.root.onMouseEnter = useEventCallback((e: React.MouseEvent<HTMLDialogElement>) => {
     if (openOnHover) {
       setOpen(e, true);
     }
     onMouseEnterOriginal?.(e);
   });
 
-  state.root.onMouseLeave = useEventCallback((e: React.MouseEvent<HTMLDivElement>) => {
+  state.root.onMouseLeave = useEventCallback((e: React.MouseEvent<HTMLDialogElement>) => {
     if (openOnHover) {
       setOpen(e, false);
     }

--- a/packages/react-components/react-headless-components-preview/library/src/components/Popover/popoverContext.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Popover/popoverContext.ts
@@ -18,6 +18,7 @@ const popoverContextDefaultValue: PopoverContextValue = {
   openOnContext: false,
   openOnHover: false,
   withArrow: false,
+  trapFocus: false,
   positioning: {
     targetRef: () => undefined,
     containerRef: () => undefined,

--- a/packages/react-components/react-headless-components-preview/library/src/components/Popover/usePopover.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Popover/usePopover.ts
@@ -10,18 +10,20 @@ const SUPPORTS_POPOVER_OPEN_SELECTOR =
 
 type ToggleEvent = Event & { newState?: 'open' | 'closed' };
 
+const isDialogElement = (el: Element | null): el is HTMLDialogElement =>
+  !!el && typeof (el as HTMLDialogElement).showModal === 'function';
+
 /**
  * Returns the state for a Popover component.
- *
- * The surface is rendered with `popover="auto"` so the browser owns light
- * dismiss (Escape, click-outside, popover-stack peer dismissal). React
- * mirrors the surface's `toggle` events back into state and fires
- * `onOpenChange`, so controlled consumers stay in sync with what the
- * browser does.
- *
  */
 export const usePopover = (props: PopoverProps): PopoverState => {
-  const { openOnHover = false, openOnContext = false, mouseLeaveDelay = 500, withArrow = false } = props;
+  const {
+    openOnHover = false,
+    openOnContext = false,
+    mouseLeaveDelay = 500,
+    withArrow = false,
+    trapFocus = false,
+  } = props;
 
   const [open, setOpenState] = useControllableState({
     state: props.open,
@@ -87,11 +89,36 @@ export const usePopover = (props: PopoverProps): PopoverState => {
     props.onOpenChange?.(event, { event, type: event.type, open: nextOpen });
   });
 
+  const onSurfaceClose = useEventCallback((event: Event) => {
+    setOpenState(false);
+    props.onOpenChange?.(event, { event, type: event.type, open: false });
+  });
+
   React.useEffect(() => {
     const surface = contentRef.current;
 
-    if (!surface || !open) {
+    if (!surface) {
       return;
+    }
+
+    if (!open) {
+      if (isDialogElement(surface) && surface.open) {
+        surface.close();
+      }
+      return;
+    }
+
+    if (trapFocus) {
+      if (!isDialogElement(surface)) {
+        return;
+      }
+
+      if (!surface.open) {
+        surface.showModal();
+      }
+
+      surface.addEventListener('close', onSurfaceClose);
+      return () => surface.removeEventListener('close', onSurfaceClose);
     }
 
     if (typeof surface.showPopover !== 'function') {
@@ -104,7 +131,7 @@ export const usePopover = (props: PopoverProps): PopoverState => {
 
     surface.addEventListener('toggle', onSurfaceToggle);
     return () => surface.removeEventListener('toggle', onSurfaceToggle);
-  }, [open, contentRef, onSurfaceToggle]);
+  }, [open, trapFocus, contentRef, onSurfaceToggle, onSurfaceClose]);
 
   const children = React.Children.toArray(props.children) as React.ReactElement[];
 
@@ -142,6 +169,7 @@ export const usePopover = (props: PopoverProps): PopoverState => {
     openOnHover,
     openOnContext,
     withArrow,
+    trapFocus,
     onOpenChange: props.onOpenChange,
     contextTarget,
     setContextTarget,
@@ -161,6 +189,7 @@ export const usePopoverContextValues = (state: PopoverState): { popover: Popover
     openOnHover,
     openOnContext,
     withArrow,
+    trapFocus,
     positioning,
     surfaceId,
   } = state;
@@ -176,6 +205,7 @@ export const usePopoverContextValues = (state: PopoverState): { popover: Popover
       openOnHover,
       openOnContext,
       withArrow,
+      trapFocus,
       positioning: {
         targetRef: positioning.targetRef,
         containerRef: positioning.containerRef,


### PR DESCRIPTION
## Previous Behavior

Popover had no focus trap. The surface rendered as a `<div popover="auto">` and relied entirely on the browser's light-dismiss (Escape, click-outside, popover-stack peer dismissal). 

## New Behavior

 Adds a trapFocus prop on Popover that delegates modal behavior. The surface always renders as a single <dialog popover="auto"> element; the show mode is wired in usePopover:

  - trapFocus={false} (default) — surface.showPopover(). Browser owns light dismiss; no focus trap or autofocus. Explicit role="group" overrides the dialog's implicit role="dialog" so assistive tech
  doesn't announce modal semantics that aren't present.
  - trapFocus={true} — surface.showModal(). The platform supplies the focus trap, autofocus, trigger-restoration on close, and inert background — all spec-mandated by <dialog>. The explicit role is
  dropped so the implicit role="dialog" + aria-modal="true" apply. The cancel event is intercepted (preventDefault + close via onOpenChange) so Escape flows through the same React state path as any other
   dismiss.

A single element supporting both modes means consumers flip one prop instead of swapping component variants, and there's no portal/stacking-context divergence between the two paths.

**IMPORTANT NOTE:** 

There one notable behavioral difference compared to a custom focus trap implementation: By default with a native dialog, all elements within the same document, except the dialog and its descendants become inert, but it is scoped only **to the containing document**. If the dialog is rendered inside an iframe, the rest of the parent page remains interactive (focusable), which differs to v9 behaviour

Example: https://dialog-focus-trap-test.surge.sh/ 