### PR TITLE
fix: clean up fast-element dependency hierarchy and update to 2.10.4

### DIFF
--- a/apps/vr-tests-web-components/package.json
+++ b/apps/vr-tests-web-components/package.json
@@ -18,7 +18,7 @@
     "html-react-parser": "4.0.0",
     "@fluentui/tokens": ">=1.0.0-alpha",
     "@fluentui/web-components": ">=3.0.0-alpha",
-    "@microsoft/fast-element": "2.0.0",
+    "@microsoft/fast-element": "^2.0.0",
     "tslib": "^2.1.0"
   }
 }

--- a/change/@fluentui-chart-web-components-efc149c5-3d43-4300-a413-b3d9048e2248.json
+++ b/change/@fluentui-chart-web-components-efc149c5-3d43-4300-a413-b3d9048e2248.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: update fast-element dependency version",
+  "packageName": "@fluentui/chart-web-components",
+  "email": "863023+radium-v@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-web-components-38caae0f-3c50-46f0-b0c2-bb87de96d641.json
+++ b/change/@fluentui-web-components-38caae0f-3c50-46f0-b0c2-bb87de96d641.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: remove hoisted peer dependency entries",
+  "packageName": "@fluentui/web-components",
+  "email": "863023+radium-v@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@microsoft/api-extractor": "7.51.0",
     "@microsoft/api-extractor-model": "7.31.2",
     "@microsoft/eslint-plugin-sdl": "1.0.1",
+    "@microsoft/fast-element": "2.10.4",
     "@microsoft/focusgroup-polyfill": "^1.4.1",
     "@microsoft/load-themed-styles": "1.10.26",
     "@microsoft/loader-load-themed-styles": "2.0.17",

--- a/packages/charts/chart-web-components/package.json
+++ b/packages/charts/chart-web-components/package.json
@@ -61,7 +61,6 @@
     "test:dev": "node ./scripts/e2e.js"
   },
   "devDependencies": {
-    "@microsoft/fast-element": "2.0.0",
     "@tensile-perf/web-components": "~0.2.2",
     "@storybook/html": "9.1.17",
     "@storybook/html-vite": "9.1.17",
@@ -79,7 +78,7 @@
     "tslib": "^2.1.0"
   },
   "peerDependencies": {
-    "@microsoft/fast-element": "^2.0.0-beta.26 || ^2.0.0"
+    "@microsoft/fast-element": "^2.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -90,8 +90,6 @@
   },
   "devDependencies": {
     "@custom-elements-manifest/analyzer": "0.10.10",
-    "@microsoft/fast-element": "2.0.0",
-    "@microsoft/focusgroup-polyfill": "^1.4.1",
     "@tensile-perf/web-components": "~0.2.2",
     "@storybook/html": "9.1.17",
     "@storybook/html-vite": "9.1.17",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2687,10 +2687,10 @@
     eslint-plugin-react "7.35.2"
     eslint-plugin-security "1.4.0"
 
-"@microsoft/fast-element@2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@microsoft/fast-element/-/fast-element-2.0.0.tgz#4b3551159290f14ec59f9b48c6c4c26b4e086a0f"
-  integrity sha512-Tzv4dCGTg10NNyqWWGRy3bYG4vacQUapjy5gpdpmFbSgvNF8aOzJJMkG5CfVUDoC9gWxY1ZyGgjXX0p86ZXX5w==
+"@microsoft/fast-element@2.10.4", "@microsoft/fast-element@^2.0.0":
+  version "2.10.4"
+  resolved "https://registry.yarnpkg.com/@microsoft/fast-element/-/fast-element-2.10.4.tgz#12b8c6c90902f2a54d5b27f618d7d095e133546d"
+  integrity sha512-OkHIlMztq7+PgkRF1LscgBd/MVzMhGrWPkJRDvOEqdqEdZOKocKvaKcUKZubIBz4RpLIrhLD3lOJzCsspk6jXg==
 
 "@microsoft/fast-web-utilities@^6.0.0":
   version "6.0.0"


### PR DESCRIPTION
## Previous Behavior

The `@microsoft/fast-element` dependency was pinned to version `2.0.0` across multiple packages, and the dependency hierarchy had several issues:

- `packages/web-components/package.json` listed `@microsoft/fast-element` and `@microsoft/focusgroup-polyfill` as `devDependencies` despite already declaring them as `peerDependencies`, duplicating the hoisted entries unnecessarily.
- `packages/charts/chart-web-components/package.json` had a redundant `devDependencies` entry for `@microsoft/fast-element` pinned to `2.0.0`, and its `peerDependencies` range included the pre-release syntax `^2.0.0-beta.26 || ^2.0.0`.
- `apps/vr-tests-web-components/package.json` pinned `@microsoft/fast-element` to exactly `2.0.0`.
- The root `package.json` did not hoist `@microsoft/fast-element`, so the resolved version in `yarn.lock` was stuck at `2.0.0`.

## New Behavior

- Removed the redundant `devDependencies` entries for `@microsoft/fast-element` and `@microsoft/focusgroup-polyfill` from `packages/web-components/package.json` since they are already declared as `peerDependencies` and satisfied by the root.
- Removed the redundant `devDependencies` entry for `@microsoft/fast-element` from `packages/charts/chart-web-components/package.json`.
- Simplified the `peerDependencies` range in `chart-web-components` to `^2.0.0` (dropping the unnecessary beta range).
- Changed `apps/vr-tests-web-components` to use `^2.0.0` instead of the exact pin.
- Added `@microsoft/fast-element` at version `2.10.4` to the root `devDependencies` so it is hoisted and all workspace packages resolve to the same up-to-date version.
- `yarn.lock` now resolves `@microsoft/fast-element` to `2.10.4`.