### PR TITLE
fix(react-utilities): replace deprecated TypeScript assertion syntax

### DIFF
--- a/change/@fluentui-react-utilities-3850e341-ac46-4500-90cc-1c51709bc0a0.json
+++ b/change/@fluentui-react-utilities-3850e341-ac46-4500-90cc-1c51709bc0a0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "style: replace deprecated assertion syntax that causes issues to babel tsx",
+  "packageName": "@fluentui/react-utilities",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-utilities/src/virtualParent/isVirtualElement.ts
+++ b/packages/react-components/react-utilities/src/virtualParent/isVirtualElement.ts
@@ -5,5 +5,5 @@ import type { VirtualElement } from './types';
  * @internal
  */
 export function isVirtualElement(element: Node | VirtualElement): element is VirtualElement {
-  return element && !!(<VirtualElement>element)._virtual;
+  return element && !!(element as VirtualElement)._virtual;
 }


### PR DESCRIPTION
## Description

Replaces the legacy TypeScript angle-bracket type assertion syntax (`<Type>expr`) with the `as` syntax (`expr as Type`) in `isVirtualElement.ts`.

The angle-bracket assertion syntax (`<VirtualElement>element`) is invalid when processed by Babel's TSX parser — Babel interprets it as a JSX element rather than a type assertion. While TypeScript's own compiler handles it correctly in `.ts` files, this causes issues when the code is run through Babel (e.g., when testing out React Compiler integration).

### Change

```diff
- return element && !!(<VirtualElement>element)._virtual;
+ return element && !!(element as VirtualElement)._virtual;
```

Both forms are semantically identical in TypeScript, but only the `as` syntax is compatible with Babel's TypeScript transform.