### PR TITLE
fix(react-card): avoid pulling griffel in base hooks

### DIFF
--- a/change/@fluentui-react-card-c273bc2b-822e-4a34-bc44-57e000ac8bd5.json
+++ b/change/@fluentui-react-card-c273bc2b-822e-4a34-bc44-57e000ac8bd5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: avoid pulling griffel in CardHeader and CardPreview base hooks",
+  "packageName": "@fluentui/react-card",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-card/library/src/components/CardHeader/useCardHeader.ts
+++ b/packages/react-components/react-card/library/src/components/CardHeader/useCardHeader.ts
@@ -4,7 +4,6 @@ import * as React from 'react';
 import { getIntrinsicElementProps, useId, slot } from '@fluentui/react-utilities';
 import type { CardHeaderBaseProps, CardHeaderBaseState, CardHeaderProps, CardHeaderState } from './CardHeader.types';
 import { useCardContext_unstable } from '../Card/CardContext';
-import { cardHeaderClassNames } from './useCardHeaderStyles.styles';
 
 /**
  * Finds the first child of CardHeader with an id prop.
@@ -77,7 +76,7 @@ export const useCardHeaderBase_unstable = (
   const headerRef = React.useRef<HTMLDivElement>(null);
 
   const hasChildId = React.useRef(false);
-  const generatedId = useId(cardHeaderClassNames.header, referenceId);
+  const generatedId = useId('fui-CardHeader__header', referenceId);
 
   const headerSlot = slot.optional(header, {
     renderByDefault: true,

--- a/packages/react-components/react-card/library/src/components/CardPreview/useCardPreview.ts
+++ b/packages/react-components/react-card/library/src/components/CardPreview/useCardPreview.ts
@@ -9,7 +9,6 @@ import type {
   CardPreviewState,
 } from './CardPreview.types';
 import { useCardContext_unstable } from '../Card/CardContext';
-import { cardPreviewClassNames } from './useCardPreviewStyles.styles';
 
 /**
  * Create the state required to render CardPreview.
@@ -52,7 +51,7 @@ export const useCardPreviewBase_unstable = (
     }
 
     if (previewRef.current && previewRef.current.parentNode) {
-      const img = previewRef.current.parentNode.querySelector<HTMLImageElement>(`.${cardPreviewClassNames.root} > img`);
+      const img = previewRef.current.parentNode.querySelector<HTMLImageElement>(`.fui-CardPreview > img`);
 
       if (img) {
         const ariaLabel = img.getAttribute('aria-label');


### PR DESCRIPTION
## Summary

- Remove imports of `cardHeaderClassNames` / `cardPreviewClassNames` from the base hooks (`useCardHeaderBase_unstable`, `useCardPreviewBase_unstable`) so consumers using the base hooks don't transitively pull in the Griffel styles module.
- Replace the imported constants with their literal class name strings (`fui-CardHeader__header`, `fui-CardPreview`) at the two usage sites.