### PR TITLE
feat(storybook): add react compiler behind env flag

### DIFF
--- a/apps/public-docsite-v9-headless/.storybook/main.js
+++ b/apps/public-docsite-v9-headless/.storybook/main.js
@@ -1,4 +1,5 @@
 const headlessMain = require('../../../packages/react-components/react-headless-components-preview/stories/.storybook/main');
+const { registerRules, rules } = require('@fluentui/scripts-storybook');
 
 module.exports = /** @type {Omit<import('../../../.storybook/main'), 'typescript'|'babel'>} */ ({
   ...headlessMain,
@@ -10,5 +11,14 @@ module.exports = /** @type {Omit<import('../../../.storybook/main'), 'typescript
   staticDirs: ['../public'],
   build: {
     previewUrl: process.env.DEPLOY_PATH,
+  },
+  webpackFinal: (config, options) => {
+    const localConfig = /** @type config */ ({ ...headlessMain.webpackFinal(config, options) });
+
+    if (process.env.REACT_COMPILER) {
+      registerRules({ rules: rules.reactCompilerRule, config: localConfig });
+    }
+
+    return localConfig;
   },
 });

--- a/apps/public-docsite-v9/.storybook/main.js
+++ b/apps/public-docsite-v9/.storybook/main.js
@@ -41,7 +41,10 @@ module.exports = /** @type {Omit<import('../../../.storybook/main'), 'typescript
 
     // add your own webpack tweaks if needed
     registerTsPaths({ configFile: tsConfigAllPath, config: localConfig });
-    registerRules({ rules: [rules.scssRule], config: localConfig });
+    registerRules({
+      rules: [rules.scssRule, ...(process.env.REACT_COMPILER ? rules.reactCompilerRule : [])],
+      config: localConfig,
+    });
 
     return localConfig;
   },

--- a/monosize.config.mjs
+++ b/monosize.config.mjs
@@ -13,6 +13,12 @@ const config = {
     tableName: 'fluentuilatest',
   }),
   bundler: webpackBundler(config => {
+    config.externals = config.externals ?? {};
+    config.externals = {
+      react: 'React',
+      'react-dom': 'ReactDOM',
+      'react/compiler-runtime': 'ReactCompilerRuntime',
+    };
     return config;
   }),
   reportResolvers: {

--- a/package.json
+++ b/package.json
@@ -271,6 +271,7 @@
     "raw-loader": "4.0.2",
     "react": "19.2.0",
     "react-app-polyfill": "2.0.0",
+    "react-compiler-webpack": "1.0.0",
     "react-dom": "19.2.0",
     "react-frame-component": "4.1.1",
     "react-is": "19.2.0",

--- a/scripts/storybook/src/rules.js
+++ b/scripts/storybook/src/rules.js
@@ -124,8 +124,29 @@ const swcRule = {
   ],
 };
 
+/**
+ * React Compiler webpack rules. Must run before SWC (enforce: 'pre') because the compiler needs JSX syntax intact.
+ * Opt-in only — gate usage behind `process.env.REACT_COMPILER`.
+ *
+ * @type {import("webpack").RuleSetRule[]}
+ */
+const reactCompilerRule = [
+  {
+    test: /\.(ts|tsx)$/,
+    include: [/packages\/react-components\//],
+    exclude: [/node_modules/],
+    enforce: 'pre',
+    use: [
+      {
+        loader: require('react-compiler-webpack').reactCompilerLoader,
+      },
+    ],
+  },
+];
+
 exports.tsRule = tsRule;
 exports.scssRule = scssRule;
 exports.cssRule = cssRule;
 exports.griffelRule = griffelRule;
 exports.swcRule = swcRule;
+exports.reactCompilerRule = reactCompilerRule;

--- a/yarn.lock
+++ b/yarn.lock
@@ -16923,6 +16923,15 @@ react-app-polyfill@2.0.0:
     regenerator-runtime "^0.13.7"
     whatwg-fetch "^3.4.1"
 
+react-compiler-webpack@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/react-compiler-webpack/-/react-compiler-webpack-1.0.0.tgz#60fac1205100a3c771aad36c695853e71ffc4184"
+  integrity sha512-psMWf+k7psntYKTo6IdiQrERADKobtCrahfJ0QAsC+ccbqANKS/3go6+dLvYauUpMBpmrMlt5AqACRJZ4bKCtg==
+  dependencies:
+    "@babel/core" "^7.28.5"
+    "@babel/plugin-syntax-jsx" "^7.27.1"
+    "@babel/plugin-syntax-typescript" "^7.27.1"
+
 react-custom-scrollbars@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/react-custom-scrollbars/-/react-custom-scrollbars-4.2.1.tgz#830fd9502927e97e8a78c2086813899b2a8b66db"


### PR DESCRIPTION
## React Compiler: Storybook integration & monosize config

### Summary

Adds opt-in React Compiler support to v9 and headless Storybook dev servers, and fixes the root monosize bundle-size config to declare explicit externals.

### Changes

#### React Compiler in Storybook (`scripts/storybook`, `apps/public-docsite-v9`, `apps/public-docsite-v9-headless`)

- Adds a new `reactCompilerRule` webpack rule in `scripts/storybook/src/rules.js` that runs `react-compiler-webpack` loader with `enforce: 'pre'` so it processes TSX before SWC strips JSX syntax.
- The rule is scoped to `packages/react-components/` sources only.
- Integrates the rule into both `public-docsite-v9` and `public-docsite-v9-headless` Storybook configs, gated behind the `REACT_COMPILER` environment variable.

#### Monosize externals (`monosize.config.mjs`)

- Provides explicit `externals` for `react`, `react-dom`, and `react/compiler-runtime` in the root monosize webpack bundler config to prevent them from being included in bundle-size measurements.

#### Dependencies (`package.json`)

- Adds `babel-plugin-react-compiler@1.0.0` and `react-compiler-webpack@1.0.0` as root devDependencies.

### Run docsite with compiler

```bash
REACT_COMPILER=true yarn nx run public-docsite-v9-headless:storybook
```

<img width="1487" height="570" alt="image" src="https://github.com/user-attachments/assets/b4efc53d-b723-4bbf-8706-065943cace6a" />
