### PR TITLE
feat(react-teaching-popover): add base hooks and export them

### DIFF
--- a/change/@fluentui-react-teaching-popover-41e1d4a6-a64e-4523-831a-6420ce3cff5a.json
+++ b/change/@fluentui-react-teaching-popover-41e1d4a6-a64e-4523-831a-6420ce3cff5a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: export base hooks",
+  "packageName": "@fluentui/react-teaching-popover",
+  "email": "viktorgenaev@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-teaching-popover/library/etc/react-teaching-popover.api.md
+++ b/packages/react-components/react-teaching-popover/library/etc/react-teaching-popover.api.md
@@ -10,6 +10,7 @@ import type { ButtonProps } from '@fluentui/react-button';
 import type { ButtonState } from '@fluentui/react-button';
 import type { ComponentProps } from '@fluentui/react-utilities';
 import type { ComponentState } from '@fluentui/react-utilities';
+import type { DistributiveOmit } from '@fluentui/react-utilities';
 import type { EventData } from '@fluentui/react-utilities';
 import type { EventHandler } from '@fluentui/react-utilities';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
@@ -267,14 +268,13 @@ export type TeachingPopoverCarouselState = ComponentState<Required<TeachingPopov
 // @public
 export const TeachingPopoverFooter: ForwardRefComponent<TeachingPopoverFooterProps>;
 
-// @public (undocumented)
-export type TeachingPopoverFooterBaseProps = TeachingPopoverFooterProps;
+// @public
+export type TeachingPopoverFooterBaseProps = DistributiveOmit<TeachingPopoverFooterProps, 'primary' | 'secondary'>;
 
 // @public
 export type TeachingPopoverFooterBaseState = ComponentState<Pick<TeachingPopoverFooterSlots, 'root'>> & {
     footerLayout?: 'horizontal' | 'vertical';
     handleButtonClick: (event: React_2.MouseEvent<HTMLButtonElement & HTMLAnchorElement & HTMLDivElement>) => void;
-    hasSecondary: boolean;
 };
 
 // @public (undocumented)

--- a/packages/react-components/react-teaching-popover/library/etc/react-teaching-popover.api.md
+++ b/packages/react-components/react-teaching-popover/library/etc/react-teaching-popover.api.md
@@ -95,6 +95,12 @@ export type TeachingPopoverBodyState = ComponentState<TeachingPopoverBodySlots> 
 // @public
 export const TeachingPopoverCarousel: ForwardRefComponent<TeachingPopoverCarouselProps>;
 
+// @public (undocumented)
+export type TeachingPopoverCarouselBaseProps = TeachingPopoverCarouselProps;
+
+// @public (undocumented)
+export type TeachingPopoverCarouselBaseState = Omit<TeachingPopoverCarouselState, 'appearance'>;
+
 // @public
 export const TeachingPopoverCarouselCard: ForwardRefComponent<TeachingPopoverCarouselCardProps>;
 
@@ -122,6 +128,12 @@ export const TeachingPopoverCarouselFooter: ForwardRefComponent<TeachingPopoverC
 
 // @public
 export const TeachingPopoverCarouselFooterButton: ForwardRefComponent<TeachingPopoverCarouselFooterButtonProps>;
+
+// @public (undocumented)
+export type TeachingPopoverCarouselFooterButtonBaseProps = TeachingPopoverCarouselFooterButtonProps;
+
+// @public
+export type TeachingPopoverCarouselFooterButtonBaseState = ComponentState<TeachingPopoverCarouselFooterButtonSlots> & Pick<TeachingPopoverCarouselFooterButtonProps, 'navType' | 'altText'>;
 
 // @public (undocumented)
 export const teachingPopoverCarouselFooterButtonClassNames: SlotClassNames<TeachingPopoverCarouselFooterButtonSlots>;
@@ -165,8 +177,20 @@ export type TeachingPopoverCarouselFooterState = ComponentState<Required<Teachin
 // @public
 export const TeachingPopoverCarouselNav: ForwardRefComponent<TeachingPopoverCarouselNavProps>;
 
+// @public (undocumented)
+export type TeachingPopoverCarouselNavBaseProps = TeachingPopoverCarouselNavProps;
+
+// @public (undocumented)
+export type TeachingPopoverCarouselNavBaseState = TeachingPopoverCarouselNavState;
+
 // @public
 export const TeachingPopoverCarouselNavButton: ForwardRefComponent<TeachingPopoverCarouselNavButtonProps>;
+
+// @public (undocumented)
+export type TeachingPopoverCarouselNavButtonBaseProps = TeachingPopoverCarouselNavButtonProps;
+
+// @public (undocumented)
+export type TeachingPopoverCarouselNavButtonBaseState = Omit<TeachingPopoverCarouselNavButtonState, 'appearance'>;
 
 // @public (undocumented)
 export const teachingPopoverCarouselNavButtonClassNames: SlotClassNames<TeachingPopoverCarouselNavButtonSlots>;
@@ -244,6 +268,16 @@ export type TeachingPopoverCarouselState = ComponentState<Required<TeachingPopov
 export const TeachingPopoverFooter: ForwardRefComponent<TeachingPopoverFooterProps>;
 
 // @public (undocumented)
+export type TeachingPopoverFooterBaseProps = TeachingPopoverFooterProps;
+
+// @public
+export type TeachingPopoverFooterBaseState = ComponentState<Pick<TeachingPopoverFooterSlots, 'root'>> & {
+    footerLayout?: 'horizontal' | 'vertical';
+    handleButtonClick: (event: React_2.MouseEvent<HTMLButtonElement & HTMLAnchorElement & HTMLDivElement>) => void;
+    hasSecondary: boolean;
+};
+
+// @public (undocumented)
 export const teachingPopoverFooterClassNames: SlotClassNames<TeachingPopoverFooterSlots>;
 
 // @public (undocumented)
@@ -256,6 +290,12 @@ export type TeachingPopoverFooterState = ComponentState<TeachingPopoverFooterSlo
 
 // @public
 export const TeachingPopoverHeader: ForwardRefComponent<TeachingPopoverHeaderProps>;
+
+// @public (undocumented)
+export type TeachingPopoverHeaderBaseProps = TeachingPopoverHeaderProps;
+
+// @public (undocumented)
+export type TeachingPopoverHeaderBaseState = Omit<TeachingPopoverHeaderState, 'appearance'>;
 
 // @public (undocumented)
 export const teachingPopoverHeaderClassNames: SlotClassNames<TeachingPopoverHeaderSlots>;
@@ -298,6 +338,12 @@ export type TeachingPopoverSurfaceState = PopoverSurfaceState;
 export const TeachingPopoverTitle: ForwardRefComponent<TeachingPopoverTitleProps>;
 
 // @public (undocumented)
+export type TeachingPopoverTitleBaseProps = TeachingPopoverTitleProps;
+
+// @public (undocumented)
+export type TeachingPopoverTitleBaseState = Omit<TeachingPopoverTitleState, 'appearance'>;
+
+// @public (undocumented)
 export const teachingPopoverTitleClassNames: SlotClassNames<TeachingPopoverTitleSlots>;
 
 // @public
@@ -337,6 +383,9 @@ export const useTeachingPopoverBodyStyles_unstable: (state: TeachingPopoverBodyS
 export const useTeachingPopoverCarousel_unstable: (props: TeachingPopoverCarouselProps, ref: React_2.Ref<HTMLDivElement>) => TeachingPopoverCarouselState;
 
 // @public
+export const useTeachingPopoverCarouselBase_unstable: (props: TeachingPopoverCarouselBaseProps, ref: React_2.Ref<HTMLDivElement>) => TeachingPopoverCarouselBaseState;
+
+// @public
 export const useTeachingPopoverCarouselCard_unstable: (props: TeachingPopoverCarouselCardProps, ref: React_2.Ref<HTMLDivElement>) => TeachingPopoverCarouselCardState;
 
 // @public
@@ -352,6 +401,9 @@ export const useTeachingPopoverCarouselFooter_unstable: (props: TeachingPopoverC
 export const useTeachingPopoverCarouselFooterButton_unstable: (props: TeachingPopoverCarouselFooterButtonProps, ref: React_2.Ref<HTMLButtonElement | HTMLAnchorElement>) => TeachingPopoverCarouselFooterButtonState;
 
 // @public
+export const useTeachingPopoverCarouselFooterButtonBase_unstable: (props: TeachingPopoverCarouselFooterButtonBaseProps, ref: React_2.Ref<HTMLButtonElement | HTMLAnchorElement>) => TeachingPopoverCarouselFooterButtonBaseState;
+
+// @public
 export const useTeachingPopoverCarouselFooterButtonStyles_unstable: (state: TeachingPopoverCarouselFooterButtonState) => TeachingPopoverCarouselFooterButtonState;
 
 // @public
@@ -361,7 +413,13 @@ export const useTeachingPopoverCarouselFooterStyles_unstable: (state: TeachingPo
 export const useTeachingPopoverCarouselNav_unstable: (props: TeachingPopoverCarouselNavProps, ref: React_2.Ref<HTMLDivElement>) => TeachingPopoverCarouselNavState;
 
 // @public
+export const useTeachingPopoverCarouselNavBase_unstable: (props: TeachingPopoverCarouselNavBaseProps, ref: React_2.Ref<HTMLDivElement>) => TeachingPopoverCarouselNavBaseState;
+
+// @public
 export const useTeachingPopoverCarouselNavButton_unstable: (props: TeachingPopoverCarouselNavButtonProps, ref: React_2.Ref<HTMLButtonElement | HTMLAnchorElement>) => TeachingPopoverCarouselNavButtonState;
+
+// @public
+export const useTeachingPopoverCarouselNavButtonBase_unstable: (props: TeachingPopoverCarouselNavButtonBaseProps, ref: React_2.Ref<HTMLButtonElement | HTMLAnchorElement>) => TeachingPopoverCarouselNavButtonBaseState;
 
 // @public
 export const useTeachingPopoverCarouselNavButtonStyles_unstable: (state: TeachingPopoverCarouselNavButtonState) => TeachingPopoverCarouselNavButtonState;
@@ -385,7 +443,13 @@ export const useTeachingPopoverContextValues_unstable: (state: TeachingPopoverSt
 export const useTeachingPopoverFooter_unstable: (props: TeachingPopoverFooterProps, ref: React_2.Ref<HTMLDivElement>) => TeachingPopoverFooterState;
 
 // @public
+export const useTeachingPopoverFooterBase_unstable: (props: TeachingPopoverFooterBaseProps, ref: React_2.Ref<HTMLDivElement>) => TeachingPopoverFooterBaseState;
+
+// @public
 export const useTeachingPopoverHeader_unstable: (props: TeachingPopoverHeaderProps, ref: React_2.Ref<HTMLDivElement>) => TeachingPopoverHeaderState;
+
+// @public
+export const useTeachingPopoverHeaderBase_unstable: (props: TeachingPopoverHeaderBaseProps, ref: React_2.Ref<HTMLDivElement>) => TeachingPopoverHeaderBaseState;
 
 // @public
 export const useTeachingPopoverHeaderStyles_unstable: (state: TeachingPopoverHeaderState) => TeachingPopoverHeaderState;
@@ -398,6 +462,9 @@ export const useTeachingPopoverSurfaceStyles_unstable: (state: TeachingPopoverSu
 
 // @public
 export const useTeachingPopoverTitle_unstable: (props: TeachingPopoverTitleProps, ref: React_2.Ref<HTMLDivElement>) => TeachingPopoverTitleState;
+
+// @public
+export const useTeachingPopoverTitleBase_unstable: (props: TeachingPopoverTitleBaseProps, ref: React_2.Ref<HTMLDivElement>) => TeachingPopoverTitleBaseState;
 
 // @public
 export const useTeachingPopoverTitleStyles_unstable: (state: TeachingPopoverTitleState) => TeachingPopoverTitleState;

--- a/packages/react-components/react-teaching-popover/library/src/TeachingPopoverCarousel.ts
+++ b/packages/react-components/react-teaching-popover/library/src/TeachingPopoverCarousel.ts
@@ -1,4 +1,6 @@
 export type {
+  TeachingPopoverCarouselBaseProps,
+  TeachingPopoverCarouselBaseState,
   TeachingPopoverCarouselContextValues,
   TeachingPopoverCarouselProps,
   TeachingPopoverCarouselSlots,
@@ -11,4 +13,5 @@ export {
   useTeachingPopoverCarouselContextValues_unstable,
   useTeachingPopoverCarouselStyles_unstable,
   useTeachingPopoverCarousel_unstable,
+  useTeachingPopoverCarouselBase_unstable,
 } from './components/TeachingPopoverCarousel/index';

--- a/packages/react-components/react-teaching-popover/library/src/TeachingPopoverCarouselFooterButton.ts
+++ b/packages/react-components/react-teaching-popover/library/src/TeachingPopoverCarouselFooterButton.ts
@@ -1,4 +1,6 @@
 export type {
+  TeachingPopoverCarouselFooterButtonBaseProps,
+  TeachingPopoverCarouselFooterButtonBaseState,
   TeachingPopoverCarouselFooterButtonProps,
   TeachingPopoverCarouselFooterButtonSlots,
   TeachingPopoverCarouselFooterButtonState,
@@ -9,4 +11,5 @@ export {
   teachingPopoverCarouselFooterButtonClassNames,
   useTeachingPopoverCarouselFooterButtonStyles_unstable,
   useTeachingPopoverCarouselFooterButton_unstable,
+  useTeachingPopoverCarouselFooterButtonBase_unstable,
 } from './components/TeachingPopoverCarouselFooterButton/index';

--- a/packages/react-components/react-teaching-popover/library/src/TeachingPopoverCarouselNav.ts
+++ b/packages/react-components/react-teaching-popover/library/src/TeachingPopoverCarouselNav.ts
@@ -1,5 +1,7 @@
 export type {
   NavButtonRenderFunction,
+  TeachingPopoverCarouselNavBaseProps,
+  TeachingPopoverCarouselNavBaseState,
   TeachingPopoverCarouselNavProps,
   TeachingPopoverCarouselNavSlots,
   TeachingPopoverCarouselNavState,
@@ -10,4 +12,5 @@ export {
   teachingPopoverCarouselNavClassNames,
   useTeachingPopoverCarouselNavStyles_unstable,
   useTeachingPopoverCarouselNav_unstable,
+  useTeachingPopoverCarouselNavBase_unstable,
 } from './components/TeachingPopoverCarouselNav/index';

--- a/packages/react-components/react-teaching-popover/library/src/TeachingPopoverCarouselNavButton.ts
+++ b/packages/react-components/react-teaching-popover/library/src/TeachingPopoverCarouselNavButton.ts
@@ -1,4 +1,6 @@
 export type {
+  TeachingPopoverCarouselNavButtonBaseProps,
+  TeachingPopoverCarouselNavButtonBaseState,
   TeachingPopoverCarouselNavButtonProps,
   TeachingPopoverCarouselNavButtonSlots,
   TeachingPopoverCarouselNavButtonState,
@@ -9,4 +11,5 @@ export {
   teachingPopoverCarouselNavButtonClassNames,
   useTeachingPopoverCarouselNavButtonStyles_unstable,
   useTeachingPopoverCarouselNavButton_unstable,
+  useTeachingPopoverCarouselNavButtonBase_unstable,
 } from './components/TeachingPopoverCarouselNavButton/index';

--- a/packages/react-components/react-teaching-popover/library/src/TeachingPopoverFooter.ts
+++ b/packages/react-components/react-teaching-popover/library/src/TeachingPopoverFooter.ts
@@ -1,4 +1,6 @@
 export type {
+  TeachingPopoverFooterBaseProps,
+  TeachingPopoverFooterBaseState,
   TeachingPopoverFooterProps,
   TeachingPopoverFooterSlots,
   TeachingPopoverFooterState,
@@ -9,4 +11,5 @@ export {
   teachingPopoverFooterClassNames,
   useTeachingPopoverFooterStyles_unstable,
   useTeachingPopoverFooter_unstable,
+  useTeachingPopoverFooterBase_unstable,
 } from './components/TeachingPopoverFooter';

--- a/packages/react-components/react-teaching-popover/library/src/TeachingPopoverHeader.ts
+++ b/packages/react-components/react-teaching-popover/library/src/TeachingPopoverHeader.ts
@@ -1,4 +1,6 @@
 export type {
+  TeachingPopoverHeaderBaseProps,
+  TeachingPopoverHeaderBaseState,
   TeachingPopoverHeaderProps,
   TeachingPopoverHeaderSlots,
   TeachingPopoverHeaderState,
@@ -9,4 +11,5 @@ export {
   teachingPopoverHeaderClassNames,
   useTeachingPopoverHeaderStyles_unstable,
   useTeachingPopoverHeader_unstable,
+  useTeachingPopoverHeaderBase_unstable,
 } from './components/TeachingPopoverHeader/index';

--- a/packages/react-components/react-teaching-popover/library/src/TeachingPopoverTitle.ts
+++ b/packages/react-components/react-teaching-popover/library/src/TeachingPopoverTitle.ts
@@ -1,4 +1,6 @@
 export type {
+  TeachingPopoverTitleBaseProps,
+  TeachingPopoverTitleBaseState,
   TeachingPopoverTitleProps,
   TeachingPopoverTitleSlots,
   TeachingPopoverTitleState,
@@ -9,4 +11,5 @@ export {
   teachingPopoverTitleClassNames,
   useTeachingPopoverTitleStyles_unstable,
   useTeachingPopoverTitle_unstable,
+  useTeachingPopoverTitleBase_unstable,
 } from './components/TeachingPopoverTitle/index';

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarousel/TeachingPopoverCarousel.types.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarousel/TeachingPopoverCarousel.types.ts
@@ -29,3 +29,7 @@ export type TeachingPopoverCarouselState = ComponentState<Required<TeachingPopov
 export type TeachingPopoverCarouselContextValues = {
   carousel: CarouselContextValue;
 };
+
+export type TeachingPopoverCarouselBaseProps = TeachingPopoverCarouselProps;
+
+export type TeachingPopoverCarouselBaseState = Omit<TeachingPopoverCarouselState, 'appearance'>;

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarousel/index.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarousel/index.ts
@@ -1,12 +1,17 @@
 export { TeachingPopoverCarousel } from './TeachingPopoverCarousel';
 export type {
+  TeachingPopoverCarouselBaseProps,
+  TeachingPopoverCarouselBaseState,
   TeachingPopoverCarouselContextValues,
   TeachingPopoverCarouselProps,
   TeachingPopoverCarouselSlots,
   TeachingPopoverCarouselState,
 } from './TeachingPopoverCarousel.types';
 export { renderTeachingPopoverCarousel_unstable } from './renderTeachingPopoverCarousel';
-export { useTeachingPopoverCarousel_unstable } from './useTeachingPopoverCarousel';
+export {
+  useTeachingPopoverCarousel_unstable,
+  useTeachingPopoverCarouselBase_unstable,
+} from './useTeachingPopoverCarousel';
 export {
   teachingPopoverCarouselClassNames,
   useTeachingPopoverCarouselStyles_unstable,

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarousel/useTeachingPopoverCarousel.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarousel/useTeachingPopoverCarousel.ts
@@ -2,14 +2,25 @@
 
 import type * as React from 'react';
 import { getIntrinsicElementProps, slot, useEventCallback, useMergedRefs } from '@fluentui/react-utilities';
-import type { TeachingPopoverCarouselProps, TeachingPopoverCarouselState } from './TeachingPopoverCarousel.types';
+import type {
+  TeachingPopoverCarouselBaseProps,
+  TeachingPopoverCarouselBaseState,
+  TeachingPopoverCarouselProps,
+  TeachingPopoverCarouselState,
+} from './TeachingPopoverCarousel.types';
 import { usePopoverContext_unstable } from '@fluentui/react-popover';
 import { useCarousel_unstable } from './Carousel/Carousel';
 
-export const useTeachingPopoverCarousel_unstable = (
-  props: TeachingPopoverCarouselProps,
+/**
+ * Base hook that builds TeachingPopoverCarousel state for behavior and structure only.
+ * Does not read `appearance` from the popover context.
+ * @param props - TeachingPopoverCarousel properties
+ * @param ref - reference to root HTMLElement of TeachingPopoverCarousel
+ */
+export const useTeachingPopoverCarouselBase_unstable = (
+  props: TeachingPopoverCarouselBaseProps,
   ref: React.Ref<HTMLDivElement>,
-): TeachingPopoverCarouselState => {
+): TeachingPopoverCarouselBaseState => {
   const toggleOpen = usePopoverContext_unstable(c => c.toggleOpen);
   const handleFinish: TeachingPopoverCarouselProps['onFinish'] = useEventCallback((event, data) => {
     props.onFinish?.(event, data);
@@ -24,9 +35,7 @@ export const useTeachingPopoverCarousel_unstable = (
     onFinish: handleFinish,
   });
 
-  const appearance = usePopoverContext_unstable(context => context.appearance);
   return {
-    appearance,
     components: {
       root: 'div',
     },
@@ -38,5 +47,18 @@ export const useTeachingPopoverCarousel_unstable = (
       { elementType: 'div' },
     ),
     ...carousel,
+  };
+};
+
+export const useTeachingPopoverCarousel_unstable = (
+  props: TeachingPopoverCarouselProps,
+  ref: React.Ref<HTMLDivElement>,
+): TeachingPopoverCarouselState => {
+  const baseState = useTeachingPopoverCarouselBase_unstable(props, ref);
+  const appearance = usePopoverContext_unstable(context => context.appearance);
+
+  return {
+    ...baseState,
+    appearance,
   };
 };

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselFooterButton/TeachingPopoverCarouselFooterButton.types.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselFooterButton/TeachingPopoverCarouselFooterButton.types.ts
@@ -33,3 +33,13 @@ export type TeachingPopoverCarouselFooterButtonState = ButtonState &
     /* Rename popover appearance to prevent conflict with button appearance */
     popoverAppearance: PopoverContextValue['appearance'];
   };
+
+export type TeachingPopoverCarouselFooterButtonBaseProps = TeachingPopoverCarouselFooterButtonProps;
+
+/**
+ * Base state intentionally does not extend ButtonState — `useButton_unstable` is
+ * only invoked from the styled hook, which derives the right `appearance` from
+ * the popover context before calling it.
+ */
+export type TeachingPopoverCarouselFooterButtonBaseState = ComponentState<TeachingPopoverCarouselFooterButtonSlots> &
+  Pick<TeachingPopoverCarouselFooterButtonProps, 'navType' | 'altText'>;

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselFooterButton/index.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselFooterButton/index.ts
@@ -1,11 +1,16 @@
 export { TeachingPopoverCarouselFooterButton } from './TeachingPopoverCarouselFooterButton';
 export type {
+  TeachingPopoverCarouselFooterButtonBaseProps,
+  TeachingPopoverCarouselFooterButtonBaseState,
   TeachingPopoverCarouselFooterButtonProps,
   TeachingPopoverCarouselFooterButtonSlots,
   TeachingPopoverCarouselFooterButtonState,
 } from './TeachingPopoverCarouselFooterButton.types';
 export { renderTeachingPopoverCarouselFooterButton_unstable } from './renderTeachingPopoverCarouselFooterButton';
-export { useTeachingPopoverCarouselFooterButton_unstable } from './useTeachingPopoverCarouselFooterButton';
+export {
+  useTeachingPopoverCarouselFooterButton_unstable,
+  useTeachingPopoverCarouselFooterButtonBase_unstable,
+} from './useTeachingPopoverCarouselFooterButton';
 export {
   teachingPopoverCarouselFooterButtonClassNames,
   useTeachingPopoverCarouselFooterButtonStyles_unstable,

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselFooterButton/useTeachingPopoverCarouselFooterButton.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselFooterButton/useTeachingPopoverCarouselFooterButton.ts
@@ -3,6 +3,8 @@
 import * as React from 'react';
 import { getIntrinsicElementProps, mergeCallbacks, slot } from '@fluentui/react-utilities';
 import type {
+  TeachingPopoverCarouselFooterButtonBaseProps,
+  TeachingPopoverCarouselFooterButtonBaseState,
   TeachingPopoverCarouselFooterButtonProps,
   TeachingPopoverCarouselFooterButtonState,
 } from './TeachingPopoverCarouselFooterButton.types';
@@ -13,21 +15,19 @@ import { useButton_unstable } from '@fluentui/react-button';
 import { useCarouselValues_unstable } from '../TeachingPopoverCarousel/Carousel/useCarouselValues';
 
 /**
- * Create the state required to render TeachingPopoverCarouselFooterButton.
- *
- * The returned state can be modified with hooks such as useTeachingPopoverCarouselFooterButtonStyles_unstable,
- * before being passed to renderTeachingPopoverCarouselFooterButton_unstable.
- *
+ * Base hook that builds TeachingPopoverCarouselFooterButton state for behavior and structure only.
+ * Does not read `appearance` from the popover context, does not derive the button's
+ * appearance from the navType/popoverAppearance combination, and does not call
+ * `useButton_unstable` (the styled hook does that with the right appearance).
  * @param props - props from this instance of TeachingPopoverCarouselFooterButton
  * @param ref - reference to root HTMLDivElement of TeachingPopoverCarouselFooterButton
  */
-export const useTeachingPopoverCarouselFooterButton_unstable = (
-  props: TeachingPopoverCarouselFooterButtonProps,
+export const useTeachingPopoverCarouselFooterButtonBase_unstable = (
+  props: TeachingPopoverCarouselFooterButtonBaseProps,
   ref: React.Ref<HTMLButtonElement | HTMLAnchorElement>,
-): TeachingPopoverCarouselFooterButtonState => {
+): TeachingPopoverCarouselFooterButtonBaseState => {
   const { navType, altText } = props;
 
-  const popoverAppearance = usePopoverContext_unstable(context => context.appearance);
   const selectPageByDirection = useCarouselContext_unstable(c => c.selectPageByDirection);
   const values = useCarouselValues_unstable(snapshot => snapshot);
   const activeValue = useCarouselContext_unstable(c => c.value);
@@ -54,14 +54,6 @@ export const useTeachingPopoverCarouselFooterButton_unstable = (
     return values.indexOf(activeValue) === values.length - 1;
   }, [navType, activeValue, values]);
 
-  let buttonAppearanceType: 'primary' | 'outline' | undefined;
-
-  if (navType === 'next') {
-    buttonAppearanceType = popoverAppearance === 'brand' ? undefined : 'primary';
-  } else {
-    buttonAppearanceType = popoverAppearance === 'brand' ? 'outline' : undefined;
-  }
-
   /* Handle altText on trailing step */
   let buttonChild = props.children;
   if (isTrailing) {
@@ -69,20 +61,54 @@ export const useTeachingPopoverCarouselFooterButton_unstable = (
   }
 
   return {
-    ...useButton_unstable({ appearance: buttonAppearanceType, ...props }, ref),
     navType,
-    popoverAppearance,
     altText,
-    // Override useButton root slot
+    components: {
+      root: 'button',
+    },
     root: slot.always(
       getIntrinsicElementProps('button', {
         ref,
-        appearance: buttonAppearanceType,
         ...props,
         onClick: handleButtonClick,
         children: buttonChild,
       }),
       { elementType: 'button' },
     ),
+  };
+};
+
+/**
+ * Create the state required to render TeachingPopoverCarouselFooterButton.
+ *
+ * The returned state can be modified with hooks such as useTeachingPopoverCarouselFooterButtonStyles_unstable,
+ * before being passed to renderTeachingPopoverCarouselFooterButton_unstable.
+ *
+ * @param props - props from this instance of TeachingPopoverCarouselFooterButton
+ * @param ref - reference to root HTMLDivElement of TeachingPopoverCarouselFooterButton
+ */
+export const useTeachingPopoverCarouselFooterButton_unstable = (
+  props: TeachingPopoverCarouselFooterButtonProps,
+  ref: React.Ref<HTMLButtonElement | HTMLAnchorElement>,
+): TeachingPopoverCarouselFooterButtonState => {
+  const baseState = useTeachingPopoverCarouselFooterButtonBase_unstable(props, ref);
+  const popoverAppearance = usePopoverContext_unstable(context => context.appearance);
+
+  let buttonAppearanceType: 'primary' | 'outline' | undefined;
+
+  if (props.navType === 'next') {
+    buttonAppearanceType = popoverAppearance === 'brand' ? undefined : 'primary';
+  } else {
+    buttonAppearanceType = popoverAppearance === 'brand' ? 'outline' : undefined;
+  }
+
+  const buttonState = useButton_unstable({ appearance: buttonAppearanceType, ...props }, ref);
+
+  return {
+    ...buttonState,
+    navType: baseState.navType,
+    altText: baseState.altText,
+    root: baseState.root,
+    popoverAppearance,
   };
 };

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselNav/TeachingPopoverCarouselNav.types.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselNav/TeachingPopoverCarouselNav.types.ts
@@ -23,3 +23,7 @@ export type TeachingPopoverCarouselNavProps = Omit<
 > & {
   children: NavButtonRenderFunction;
 };
+
+export type TeachingPopoverCarouselNavBaseProps = TeachingPopoverCarouselNavProps;
+
+export type TeachingPopoverCarouselNavBaseState = TeachingPopoverCarouselNavState;

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselNav/index.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselNav/index.ts
@@ -1,12 +1,17 @@
 export { TeachingPopoverCarouselNav } from './TeachingPopoverCarouselNav';
 export type {
   NavButtonRenderFunction,
+  TeachingPopoverCarouselNavBaseProps,
+  TeachingPopoverCarouselNavBaseState,
   TeachingPopoverCarouselNavProps,
   TeachingPopoverCarouselNavSlots,
   TeachingPopoverCarouselNavState,
 } from './TeachingPopoverCarouselNav.types';
 export { renderTeachingPopoverCarouselNav_unstable } from './renderTeachingPopoverCarouselNav';
-export { useTeachingPopoverCarouselNav_unstable } from './useTeachingPopoverCarouselNav';
+export {
+  useTeachingPopoverCarouselNav_unstable,
+  useTeachingPopoverCarouselNavBase_unstable,
+} from './useTeachingPopoverCarouselNav';
 export {
   teachingPopoverCarouselNavClassNames,
   useTeachingPopoverCarouselNavStyles_unstable,

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselNav/useTeachingPopoverCarouselNav.tsx
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselNav/useTeachingPopoverCarouselNav.tsx
@@ -5,27 +5,23 @@ import { getIntrinsicElementProps, slot } from '@fluentui/react-utilities';
 import type * as React from 'react';
 
 import type {
+  TeachingPopoverCarouselNavBaseProps,
+  TeachingPopoverCarouselNavBaseState,
   TeachingPopoverCarouselNavProps,
   TeachingPopoverCarouselNavState,
 } from './TeachingPopoverCarouselNav.types';
 import { useCarouselValues_unstable } from '../TeachingPopoverCarousel/Carousel/useCarouselValues';
 
 /**
- * Returns the props and state required to render the component
+ * Base hook that builds TeachingPopoverCarouselNav state for behavior and structure only.
+ * Does not call `useArrowNavigationGroup` from `@fluentui/react-tabster`.
  * @param props - TeachingPopoverCarouselNav properties
  * @param ref - reference to root HTMLElement of TeachingPopoverCarouselNav
  */
-export const useTeachingPopoverCarouselNav_unstable = (
-  props: TeachingPopoverCarouselNavProps,
+export const useTeachingPopoverCarouselNavBase_unstable = (
+  props: TeachingPopoverCarouselNavBaseProps,
   ref: React.Ref<HTMLDivElement>,
-): TeachingPopoverCarouselNavState => {
-  const focusableGroupAttr = useArrowNavigationGroup({
-    circular: false,
-    axis: 'horizontal',
-    memorizeCurrent: false,
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    unstable_hasDefault: true,
-  });
+): TeachingPopoverCarouselNavBaseState => {
   const values = useCarouselValues_unstable(snapshot => snapshot);
 
   return {
@@ -40,10 +36,37 @@ export const useTeachingPopoverCarouselNav_unstable = (
         role: 'tablist',
         tabIndex: 0,
         ...props,
-        ...focusableGroupAttr,
         children: null,
       }),
       { elementType: 'div' },
     ),
+  };
+};
+
+/**
+ * Returns the props and state required to render the component
+ * @param props - TeachingPopoverCarouselNav properties
+ * @param ref - reference to root HTMLElement of TeachingPopoverCarouselNav
+ */
+export const useTeachingPopoverCarouselNav_unstable = (
+  props: TeachingPopoverCarouselNavProps,
+  ref: React.Ref<HTMLDivElement>,
+): TeachingPopoverCarouselNavState => {
+  const state = useTeachingPopoverCarouselNavBase_unstable(props, ref);
+
+  const focusableGroupAttr = useArrowNavigationGroup({
+    circular: false,
+    axis: 'horizontal',
+    memorizeCurrent: false,
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    unstable_hasDefault: true,
+  });
+
+  return {
+    ...state,
+    root: {
+      ...state.root,
+      ...focusableGroupAttr,
+    },
   };
 };

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselNavButton/TeachingPopoverCarouselNavButton.types.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselNavButton/TeachingPopoverCarouselNavButton.types.ts
@@ -23,3 +23,7 @@ export type TeachingPopoverCarouselNavButtonState = ComponentState<TeachingPopov
    */
   isSelected?: boolean;
 } & Pick<PopoverContextValue, 'appearance'>;
+
+export type TeachingPopoverCarouselNavButtonBaseProps = TeachingPopoverCarouselNavButtonProps;
+
+export type TeachingPopoverCarouselNavButtonBaseState = Omit<TeachingPopoverCarouselNavButtonState, 'appearance'>;

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselNavButton/index.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselNavButton/index.ts
@@ -1,11 +1,16 @@
 export { TeachingPopoverCarouselNavButton } from './TeachingPopoverCarouselNavButton';
 export type {
+  TeachingPopoverCarouselNavButtonBaseProps,
+  TeachingPopoverCarouselNavButtonBaseState,
   TeachingPopoverCarouselNavButtonProps,
   TeachingPopoverCarouselNavButtonSlots,
   TeachingPopoverCarouselNavButtonState,
 } from './TeachingPopoverCarouselNavButton.types';
 export { renderTeachingPopoverCarouselNavButton_unstable } from './renderTeachingPopoverCarouselNavButton';
-export { useTeachingPopoverCarouselNavButton_unstable } from './useTeachingPopoverCarouselNavButton';
+export {
+  useTeachingPopoverCarouselNavButton_unstable,
+  useTeachingPopoverCarouselNavButtonBase_unstable,
+} from './useTeachingPopoverCarouselNavButton';
 export {
   teachingPopoverCarouselNavButtonClassNames,
   useTeachingPopoverCarouselNavButtonStyles_unstable,

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselNavButton/useTeachingPopoverCarouselNavButton.tsx
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselNavButton/useTeachingPopoverCarouselNavButton.tsx
@@ -8,11 +8,62 @@ import { useTabsterAttributes } from '@fluentui/react-tabster';
 import { getIntrinsicElementProps, isHTMLElement, slot, useEventCallback } from '@fluentui/react-utilities';
 
 import type {
+  TeachingPopoverCarouselNavButtonBaseProps,
+  TeachingPopoverCarouselNavButtonBaseState,
   TeachingPopoverCarouselNavButtonProps,
   TeachingPopoverCarouselNavButtonState,
 } from './TeachingPopoverCarouselNavButton.types';
 import { useCarouselContext_unstable } from '../TeachingPopoverCarousel/Carousel/CarouselContext';
 import { useValueIdContext } from '../TeachingPopoverCarouselNav/valueIdContext';
+
+/**
+ * Base hook that builds TeachingPopoverCarouselNavButton state for behavior and structure only.
+ * Does not call `useTabsterAttributes` and does not read `appearance` from popover context.
+ * @param props - props from this instance of TeachingPopoverCarouselNavButton
+ * @param ref - reference to root HTMLElement of TeachingPopoverCarouselNavButton
+ */
+export const useTeachingPopoverCarouselNavButtonBase_unstable = (
+  props: TeachingPopoverCarouselNavButtonBaseProps,
+  ref: React.Ref<HTMLButtonElement | HTMLAnchorElement>,
+): TeachingPopoverCarouselNavButtonBaseState => {
+  const { onClick, as = 'a' } = props;
+
+  const value = useValueIdContext();
+
+  const selectPageByValue = useCarouselContext_unstable(c => c.selectPageByValue);
+  const isSelected = useCarouselContext_unstable(c => c.value === value);
+
+  const handleClick: ARIAButtonSlotProps<'a'>['onClick'] = useEventCallback(event => {
+    onClick?.(event);
+
+    if (!event.defaultPrevented && isHTMLElement(event.target)) {
+      selectPageByValue(event, value);
+    }
+  });
+
+  const _carouselButton = slot.always<ARIAButtonSlotProps<'a'>>(
+    getIntrinsicElementProps(as, useARIAButtonProps(props.as, props)),
+    {
+      elementType: 'button',
+      defaultProps: {
+        ref: ref as React.Ref<HTMLButtonElement & HTMLAnchorElement>,
+        role: 'tab',
+        type: 'button',
+        'aria-selected': `${!!isSelected}`,
+      },
+    },
+  );
+
+  _carouselButton.onClick = handleClick;
+
+  return {
+    isSelected,
+    components: {
+      root: 'button',
+    },
+    root: _carouselButton,
+  };
+};
 
 /**
  * Create the state required to render TeachingPopoverCarouselNavButton.
@@ -27,50 +78,21 @@ export const useTeachingPopoverCarouselNavButton_unstable = (
   props: TeachingPopoverCarouselNavButtonProps,
   ref: React.Ref<HTMLButtonElement | HTMLAnchorElement>,
 ): TeachingPopoverCarouselNavButtonState => {
-  const { onClick, as = 'a' } = props;
-
-  const value = useValueIdContext();
-
+  const baseState = useTeachingPopoverCarouselNavButtonBase_unstable(props, ref);
   const appearance = usePopoverContext_unstable(context => context.appearance);
-  const selectPageByValue = useCarouselContext_unstable(c => c.selectPageByValue);
-  const isSelected = useCarouselContext_unstable(c => c.value === value);
-
-  const handleClick: ARIAButtonSlotProps<'a'>['onClick'] = useEventCallback(event => {
-    onClick?.(event);
-
-    if (!event.defaultPrevented && isHTMLElement(event.target)) {
-      selectPageByValue(event, value);
-    }
-  });
 
   const defaultTabProps = useTabsterAttributes({
-    focusable: { isDefault: isSelected },
+    focusable: { isDefault: baseState.isSelected },
   });
 
-  const _carouselButton = slot.always<ARIAButtonSlotProps<'a'>>(
-    getIntrinsicElementProps(as, useARIAButtonProps(props.as, props)),
-    {
-      elementType: 'button',
-      defaultProps: {
-        ref: ref as React.Ref<HTMLButtonElement & HTMLAnchorElement>,
-        role: 'tab',
-        type: 'button',
-        'aria-selected': `${!!isSelected}`,
-        ...defaultTabProps,
-      },
+  return {
+    ...baseState,
+    // tabster attrs act as defaults: base's root keys win over them, matching the
+    // previous `defaultProps` merging behavior in slot.always.
+    root: {
+      ...defaultTabProps,
+      ...baseState.root,
     },
-  );
-
-  _carouselButton.onClick = handleClick;
-
-  const state: TeachingPopoverCarouselNavButtonState = {
-    isSelected,
     appearance,
-    components: {
-      root: 'button',
-    },
-    root: _carouselButton,
   };
-
-  return state;
 };

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverFooter/TeachingPopoverFooter.types.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverFooter/TeachingPopoverFooter.types.ts
@@ -1,6 +1,6 @@
 import type * as React from 'react';
 import type { Button } from '@fluentui/react-button';
-import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+import type { ComponentProps, ComponentState, DistributiveOmit, Slot } from '@fluentui/react-utilities';
 import type { PopoverContextValue } from '@fluentui/react-popover';
 
 export type TeachingPopoverFooterSlots = {
@@ -32,15 +32,17 @@ export type TeachingPopoverFooterState = ComponentState<TeachingPopoverFooterSlo
 export type TeachingPopoverFooterProps = ComponentProps<TeachingPopoverFooterSlots> &
   Pick<TeachingPopoverFooterState, 'footerLayout'>;
 
-export type TeachingPopoverFooterBaseProps = TeachingPopoverFooterProps;
+/**
+ * Base props omit the `primary` and `secondary` Button slots — those are styling
+ * concerns. The headless variant composes buttons as children of the root.
+ */
+export type TeachingPopoverFooterBaseProps = DistributiveOmit<TeachingPopoverFooterProps, 'primary' | 'secondary'>;
 
 /**
  * Base state intentionally omits the `primary` / `secondary` slot and `appearance` —
- * those are Button-styling concerns layered on by the styled hook. The styled hook
- * uses `handleButtonClick` and `hasSecondary` to wire user-provided callbacks correctly.
+ * those are Button-styling concerns layered on by the styled hook.
  */
 export type TeachingPopoverFooterBaseState = ComponentState<Pick<TeachingPopoverFooterSlots, 'root'>> & {
   footerLayout?: 'horizontal' | 'vertical';
   handleButtonClick: (event: React.MouseEvent<HTMLButtonElement & HTMLAnchorElement & HTMLDivElement>) => void;
-  hasSecondary: boolean;
 };

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverFooter/TeachingPopoverFooter.types.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverFooter/TeachingPopoverFooter.types.ts
@@ -1,3 +1,4 @@
+import type * as React from 'react';
 import type { Button } from '@fluentui/react-button';
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
 import type { PopoverContextValue } from '@fluentui/react-popover';
@@ -30,3 +31,16 @@ export type TeachingPopoverFooterState = ComponentState<TeachingPopoverFooterSlo
 
 export type TeachingPopoverFooterProps = ComponentProps<TeachingPopoverFooterSlots> &
   Pick<TeachingPopoverFooterState, 'footerLayout'>;
+
+export type TeachingPopoverFooterBaseProps = TeachingPopoverFooterProps;
+
+/**
+ * Base state intentionally omits the `primary` / `secondary` slot and `appearance` —
+ * those are Button-styling concerns layered on by the styled hook. The styled hook
+ * uses `handleButtonClick` and `hasSecondary` to wire user-provided callbacks correctly.
+ */
+export type TeachingPopoverFooterBaseState = ComponentState<Pick<TeachingPopoverFooterSlots, 'root'>> & {
+  footerLayout?: 'horizontal' | 'vertical';
+  handleButtonClick: (event: React.MouseEvent<HTMLButtonElement & HTMLAnchorElement & HTMLDivElement>) => void;
+  hasSecondary: boolean;
+};

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverFooter/index.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverFooter/index.ts
@@ -1,11 +1,13 @@
 export { TeachingPopoverFooter } from './TeachingPopoverFooter';
 export type {
+  TeachingPopoverFooterBaseProps,
+  TeachingPopoverFooterBaseState,
   TeachingPopoverFooterProps,
   TeachingPopoverFooterSlots,
   TeachingPopoverFooterState,
 } from './TeachingPopoverFooter.types';
 export { renderTeachingPopoverFooter_unstable } from './renderTeachingPopoverFooter';
-export { useTeachingPopoverFooter_unstable } from './useTeachingPopoverFooter';
+export { useTeachingPopoverFooter_unstable, useTeachingPopoverFooterBase_unstable } from './useTeachingPopoverFooter';
 export {
   teachingPopoverFooterClassNames,
   useTeachingPopoverFooterStyles_unstable,

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverFooter/useTeachingPopoverFooter.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverFooter/useTeachingPopoverFooter.ts
@@ -38,7 +38,6 @@ export const useTeachingPopoverFooterBase_unstable = (
   return {
     footerLayout: props.footerLayout ?? 'horizontal',
     handleButtonClick,
-    hasSecondary: props.secondary !== undefined,
     components: {
       root: 'div',
     },
@@ -72,7 +71,7 @@ export const useTeachingPopoverFooter_unstable = (
     defaultProps: {
       appearance: secondaryDefaultAppearance,
     },
-    renderByDefault: baseState.hasSecondary,
+    renderByDefault: props.secondary !== undefined,
     elementType: Button,
   });
 

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverFooter/useTeachingPopoverFooter.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverFooter/useTeachingPopoverFooter.ts
@@ -2,20 +2,27 @@
 
 import type * as React from 'react';
 import { getIntrinsicElementProps, mergeCallbacks, slot, useEventCallback } from '@fluentui/react-utilities';
-import type { TeachingPopoverFooterProps, TeachingPopoverFooterState } from './TeachingPopoverFooter.types';
+import type {
+  TeachingPopoverFooterBaseProps,
+  TeachingPopoverFooterBaseState,
+  TeachingPopoverFooterProps,
+  TeachingPopoverFooterState,
+} from './TeachingPopoverFooter.types';
 import { Button } from '@fluentui/react-button';
 import { usePopoverContext_unstable } from '@fluentui/react-popover';
 
 /**
- * Returns the props and state required to render the component
+ * Base hook that builds TeachingPopoverFooter state for behavior and structure only.
+ * Does not read `appearance` from the popover context and does not build the
+ * `primary` / `secondary` Button slots — those are styling concerns and are
+ * constructed by the styled hook.
  * @param props - TeachingPopoverFooter properties
  * @param ref - reference to root HTMLElement of TeachingPopoverFooter
  */
-export const useTeachingPopoverFooter_unstable = (
-  props: TeachingPopoverFooterProps,
+export const useTeachingPopoverFooterBase_unstable = (
+  props: TeachingPopoverFooterBaseProps,
   ref: React.Ref<HTMLDivElement>,
-): TeachingPopoverFooterState => {
-  const appearance = usePopoverContext_unstable(context => context.appearance);
+): TeachingPopoverFooterBaseState => {
   const toggleOpen = usePopoverContext_unstable(context => context.toggleOpen);
 
   const handleButtonClick = useEventCallback(
@@ -28,38 +35,12 @@ export const useTeachingPopoverFooter_unstable = (
     },
   );
 
-  const secondary = slot.optional(props.secondary, {
-    defaultProps: {
-      appearance: appearance === 'brand' ? 'primary' : undefined,
-    },
-    renderByDefault: props.secondary !== undefined,
-    elementType: Button,
-  });
-
-  // Merge any provided callback with close trigger
-  if (secondary) {
-    secondary.onClick = mergeCallbacks(handleButtonClick, secondary?.onClick);
-  }
-
-  const primary = slot.always(props.primary, {
-    defaultProps: {
-      appearance: appearance === 'brand' ? undefined : 'primary',
-    },
-    elementType: Button,
-  });
-
-  // Primary button will close the popover if no secondary action is available.
-  if (!secondary) {
-    primary.onClick = mergeCallbacks(handleButtonClick, primary?.onClick);
-  }
-
   return {
     footerLayout: props.footerLayout ?? 'horizontal',
-    appearance,
+    handleButtonClick,
+    hasSecondary: props.secondary !== undefined,
     components: {
       root: 'div',
-      primary: Button,
-      secondary: Button,
     },
     root: slot.always(
       getIntrinsicElementProps('div', {
@@ -68,6 +49,57 @@ export const useTeachingPopoverFooter_unstable = (
       }),
       { elementType: 'div' },
     ),
+  };
+};
+
+/**
+ * Returns the props and state required to render the component
+ * @param props - TeachingPopoverFooter properties
+ * @param ref - reference to root HTMLElement of TeachingPopoverFooter
+ */
+export const useTeachingPopoverFooter_unstable = (
+  props: TeachingPopoverFooterProps,
+  ref: React.Ref<HTMLDivElement>,
+): TeachingPopoverFooterState => {
+  const baseState = useTeachingPopoverFooterBase_unstable(props, ref);
+  const appearance = usePopoverContext_unstable(context => context.appearance);
+
+  const isBrand = appearance === 'brand';
+  const primaryDefaultAppearance = isBrand ? undefined : 'primary';
+  const secondaryDefaultAppearance = isBrand ? 'primary' : undefined;
+
+  const secondary = slot.optional(props.secondary, {
+    defaultProps: {
+      appearance: secondaryDefaultAppearance,
+    },
+    renderByDefault: baseState.hasSecondary,
+    elementType: Button,
+  });
+
+  if (secondary) {
+    secondary.onClick = mergeCallbacks(baseState.handleButtonClick, secondary?.onClick);
+  }
+
+  const primary = slot.always(props.primary, {
+    defaultProps: {
+      appearance: primaryDefaultAppearance,
+    },
+    elementType: Button,
+  });
+
+  if (!secondary) {
+    primary.onClick = mergeCallbacks(baseState.handleButtonClick, primary?.onClick);
+  }
+
+  return {
+    footerLayout: baseState.footerLayout,
+    appearance,
+    components: {
+      root: 'div',
+      primary: Button,
+      secondary: Button,
+    },
+    root: baseState.root,
     secondary,
     primary,
   };

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverHeader/TeachingPopoverHeader.types.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverHeader/TeachingPopoverHeader.types.ts
@@ -22,3 +22,7 @@ export type TeachingPopoverHeaderState = ComponentState<TeachingPopoverHeaderSlo
   Pick<PopoverContextValue, 'appearance'>;
 
 export type TeachingPopoverHeaderProps = ComponentProps<TeachingPopoverHeaderSlots>;
+
+export type TeachingPopoverHeaderBaseProps = TeachingPopoverHeaderProps;
+
+export type TeachingPopoverHeaderBaseState = Omit<TeachingPopoverHeaderState, 'appearance'>;

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverHeader/index.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverHeader/index.ts
@@ -1,11 +1,13 @@
 export { TeachingPopoverHeader } from './TeachingPopoverHeader';
 export type {
+  TeachingPopoverHeaderBaseProps,
+  TeachingPopoverHeaderBaseState,
   TeachingPopoverHeaderProps,
   TeachingPopoverHeaderSlots,
   TeachingPopoverHeaderState,
 } from './TeachingPopoverHeader.types';
 export { renderTeachingPopoverHeader_unstable } from './renderTeachingPopoverHeader';
-export { useTeachingPopoverHeader_unstable } from './useTeachingPopoverHeader';
+export { useTeachingPopoverHeader_unstable, useTeachingPopoverHeaderBase_unstable } from './useTeachingPopoverHeader';
 export {
   teachingPopoverHeaderClassNames,
   useTeachingPopoverHeaderStyles_unstable,

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverHeader/useTeachingPopoverHeader.tsx
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverHeader/useTeachingPopoverHeader.tsx
@@ -2,25 +2,30 @@
 
 import * as React from 'react';
 import { getIntrinsicElementProps, useEventCallback, slot } from '@fluentui/react-utilities';
-import type { TeachingPopoverHeaderProps, TeachingPopoverHeaderState } from './TeachingPopoverHeader.types';
+import type {
+  TeachingPopoverHeaderBaseProps,
+  TeachingPopoverHeaderBaseState,
+  TeachingPopoverHeaderProps,
+  TeachingPopoverHeaderState,
+} from './TeachingPopoverHeader.types';
 
 import { Dismiss12Regular, Lightbulb16Regular } from '@fluentui/react-icons';
 import { usePopoverContext_unstable } from '@fluentui/react-popover';
 
 /**
- * Returns the props and state required to render the component
+ * Base hook that builds TeachingPopoverHeader state for behavior and structure only.
+ * Does not add styling defaults such as icon JSX or `appearance` from popover context.
  * @param props - TeachingPopoverHeader properties
  * @param ref - reference to root HTMLElement of TeachingPopoverHeader
  */
-export const useTeachingPopoverHeader_unstable = (
-  props: TeachingPopoverHeaderProps,
+export const useTeachingPopoverHeaderBase_unstable = (
+  props: TeachingPopoverHeaderBaseProps,
   ref: React.Ref<HTMLDivElement>,
-): TeachingPopoverHeaderState => {
+): TeachingPopoverHeaderBaseState => {
   const { dismissButton, icon } = props;
 
   const setOpen = usePopoverContext_unstable(context => context.setOpen);
   const triggerRef = usePopoverContext_unstable(context => context.triggerRef);
-  const appearance = usePopoverContext_unstable(context => context.appearance);
 
   const onDismissButtonClick = useEventCallback((ev: React.MouseEvent<HTMLButtonElement>) => {
     if (!ev.defaultPrevented) {
@@ -33,7 +38,6 @@ export const useTeachingPopoverHeader_unstable = (
   });
 
   return {
-    appearance,
     components: {
       root: 'div',
       dismissButton: 'button',
@@ -49,7 +53,6 @@ export const useTeachingPopoverHeader_unstable = (
     icon: slot.optional(icon, {
       renderByDefault: true,
       defaultProps: {
-        children: <Lightbulb16Regular />,
         'aria-hidden': true,
       },
       elementType: 'div',
@@ -57,12 +60,40 @@ export const useTeachingPopoverHeader_unstable = (
     dismissButton: slot.optional(dismissButton, {
       renderByDefault: true,
       defaultProps: {
-        children: <Dismiss12Regular />,
         role: 'button',
         'aria-label': 'dismiss',
         onClick: onDismissButtonClick,
       },
       elementType: 'button',
     }),
+  };
+};
+
+/**
+ * Returns the props and state required to render the component
+ * @param props - TeachingPopoverHeader properties
+ * @param ref - reference to root HTMLElement of TeachingPopoverHeader
+ */
+export const useTeachingPopoverHeader_unstable = (
+  props: TeachingPopoverHeaderProps,
+  ref: React.Ref<HTMLDivElement>,
+): TeachingPopoverHeaderState => {
+  const baseState = useTeachingPopoverHeaderBase_unstable(props, ref);
+  const appearance = usePopoverContext_unstable(context => context.appearance);
+
+  const icon =
+    baseState.icon && baseState.icon.children === undefined
+      ? { ...baseState.icon, children: <Lightbulb16Regular /> }
+      : baseState.icon;
+  const dismissButton =
+    baseState.dismissButton && baseState.dismissButton.children === undefined
+      ? { ...baseState.dismissButton, children: <Dismiss12Regular /> }
+      : baseState.dismissButton;
+
+  return {
+    ...baseState,
+    appearance,
+    icon,
+    dismissButton,
   };
 };

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverTitle/TeachingPopoverTitle.types.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverTitle/TeachingPopoverTitle.types.ts
@@ -22,3 +22,7 @@ export type TeachingPopoverTitleProps = ComponentProps<TeachingPopoverTitleSlots
  */
 export type TeachingPopoverTitleState = ComponentState<TeachingPopoverTitleSlots> &
   Pick<PopoverContextValue, 'appearance'>;
+
+export type TeachingPopoverTitleBaseProps = TeachingPopoverTitleProps;
+
+export type TeachingPopoverTitleBaseState = Omit<TeachingPopoverTitleState, 'appearance'>;

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverTitle/index.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverTitle/index.ts
@@ -1,11 +1,13 @@
 export { TeachingPopoverTitle } from './TeachingPopoverTitle';
 export type {
+  TeachingPopoverTitleBaseProps,
+  TeachingPopoverTitleBaseState,
   TeachingPopoverTitleProps,
   TeachingPopoverTitleSlots,
   TeachingPopoverTitleState,
 } from './TeachingPopoverTitle.types';
 export { renderTeachingPopoverTitle_unstable } from './renderTeachingPopoverTitle';
-export { useTeachingPopoverTitle_unstable } from './useTeachingPopoverTitle';
+export { useTeachingPopoverTitle_unstable, useTeachingPopoverTitleBase_unstable } from './useTeachingPopoverTitle';
 export {
   teachingPopoverTitleClassNames,
   useTeachingPopoverTitleStyles_unstable,

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverTitle/useTeachingPopoverTitle.tsx
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverTitle/useTeachingPopoverTitle.tsx
@@ -2,25 +2,31 @@
 
 import * as React from 'react';
 import { getIntrinsicElementProps, useEventCallback, slot } from '@fluentui/react-utilities';
-import type { TeachingPopoverTitleProps, TeachingPopoverTitleState } from './TeachingPopoverTitle.types';
+import type {
+  TeachingPopoverTitleBaseProps,
+  TeachingPopoverTitleBaseState,
+  TeachingPopoverTitleProps,
+  TeachingPopoverTitleState,
+} from './TeachingPopoverTitle.types';
 import { DismissFilled, DismissRegular, bundleIcon } from '@fluentui/react-icons';
 import { usePopoverContext_unstable } from '@fluentui/react-popover';
 
 const DismissIcon = bundleIcon(DismissFilled, DismissRegular);
+
 /**
- * Returns the props and state required to render the component
+ * Base hook that builds TeachingPopoverTitle state for behavior and structure only.
+ * Does not bundle/render the dismiss icon and does not read `appearance` from popover context.
  * @param props - TeachingPopoverTitle properties
  * @param ref - reference to root HTMLElement of TeachingPopoverTitle
  */
-export const useTeachingPopoverTitle_unstable = (
-  props: TeachingPopoverTitleProps,
+export const useTeachingPopoverTitleBase_unstable = (
+  props: TeachingPopoverTitleBaseProps,
   ref: React.Ref<HTMLDivElement>,
-): TeachingPopoverTitleState => {
+): TeachingPopoverTitleBaseState => {
   const { dismissButton } = props;
 
   const setOpen = usePopoverContext_unstable(context => context.setOpen);
   const triggerRef = usePopoverContext_unstable(context => context.triggerRef);
-  const appearance = usePopoverContext_unstable(context => context.appearance);
 
   const onDismissButtonClick = useEventCallback((ev: React.MouseEvent<HTMLButtonElement>) => {
     if (!ev.defaultPrevented) {
@@ -33,7 +39,6 @@ export const useTeachingPopoverTitle_unstable = (
   });
 
   return {
-    appearance,
     components: {
       root: 'h2',
       dismissButton: 'button',
@@ -48,12 +53,35 @@ export const useTeachingPopoverTitle_unstable = (
     dismissButton: slot.optional(dismissButton, {
       renderByDefault: false,
       defaultProps: {
-        children: <DismissIcon />,
         onClick: onDismissButtonClick,
         'aria-label': 'dismiss',
         'aria-hidden': true,
       },
       elementType: 'button',
     }),
+  };
+};
+
+/**
+ * Returns the props and state required to render the component
+ * @param props - TeachingPopoverTitle properties
+ * @param ref - reference to root HTMLElement of TeachingPopoverTitle
+ */
+export const useTeachingPopoverTitle_unstable = (
+  props: TeachingPopoverTitleProps,
+  ref: React.Ref<HTMLDivElement>,
+): TeachingPopoverTitleState => {
+  const baseState = useTeachingPopoverTitleBase_unstable(props, ref);
+  const appearance = usePopoverContext_unstable(context => context.appearance);
+
+  const dismissButton =
+    baseState.dismissButton && baseState.dismissButton.children === undefined
+      ? { ...baseState.dismissButton, children: <DismissIcon /> }
+      : baseState.dismissButton;
+
+  return {
+    ...baseState,
+    appearance,
+    dismissButton,
   };
 };

--- a/packages/react-components/react-teaching-popover/library/src/index.ts
+++ b/packages/react-components/react-teaching-popover/library/src/index.ts
@@ -156,3 +156,27 @@ export type {
   TeachingPopoverCarouselFooterButtonSlots,
   TeachingPopoverCarouselFooterButtonState,
 } from './TeachingPopoverCarouselFooterButton';
+
+export { useTeachingPopoverHeaderBase_unstable } from './TeachingPopoverHeader';
+export type { TeachingPopoverHeaderBaseProps, TeachingPopoverHeaderBaseState } from './TeachingPopoverHeader';
+export { useTeachingPopoverFooterBase_unstable } from './TeachingPopoverFooter';
+export type { TeachingPopoverFooterBaseProps, TeachingPopoverFooterBaseState } from './TeachingPopoverFooter';
+export { useTeachingPopoverTitleBase_unstable } from './TeachingPopoverTitle';
+export type { TeachingPopoverTitleBaseProps, TeachingPopoverTitleBaseState } from './TeachingPopoverTitle';
+export { useTeachingPopoverCarouselBase_unstable } from './TeachingPopoverCarousel';
+export type { TeachingPopoverCarouselBaseProps, TeachingPopoverCarouselBaseState } from './TeachingPopoverCarousel';
+export { useTeachingPopoverCarouselFooterButtonBase_unstable } from './TeachingPopoverCarouselFooterButton';
+export type {
+  TeachingPopoverCarouselFooterButtonBaseProps,
+  TeachingPopoverCarouselFooterButtonBaseState,
+} from './TeachingPopoverCarouselFooterButton';
+export { useTeachingPopoverCarouselNavBase_unstable } from './TeachingPopoverCarouselNav';
+export type {
+  TeachingPopoverCarouselNavBaseProps,
+  TeachingPopoverCarouselNavBaseState,
+} from './TeachingPopoverCarouselNav';
+export { useTeachingPopoverCarouselNavButtonBase_unstable } from './TeachingPopoverCarouselNavButton';
+export type {
+  TeachingPopoverCarouselNavButtonBaseProps,
+  TeachingPopoverCarouselNavButtonBaseState,
+} from './TeachingPopoverCarouselNavButton';


### PR DESCRIPTION
## Summary

Splits each `useTeachingPopover*_unstable` hook into a headless `*Base_unstable` variant plus a thin styled wrapper, and publicly exports the base hooks and their associated `*BaseProps` / `*BaseState` types from `@fluentui/react-teaching-popover`. The base hooks omit styling defaults (icon JSX, `appearance` from popover context) so they can be reused by headless / custom-rendered compositions without inheriting Fluent-specific visuals.

## Previous Behavior

Only the styled `useTeachingPopover*_unstable` hooks were exported. Consumers had no way to opt out of the built-in `Lightbulb16Regular` / `Dismiss12Regular` default icons or the `appearance` pulled from `PopoverContext`.

## New Behavior

A `*Base_unstable` hook and matching `*BaseProps` / `*BaseState` types are publicly exported for every TeachingPopover subcomponent that owned a hook:

| Component | Base hook |
|---|---|
| `TeachingPopoverHeader` | `useTeachingPopoverHeaderBase_unstable` |
| `TeachingPopoverFooter` | `useTeachingPopoverFooterBase_unstable` |
| `TeachingPopoverTitle` | `useTeachingPopoverTitleBase_unstable` |
| `TeachingPopoverCarousel` | `useTeachingPopoverCarouselBase_unstable` |
| `TeachingPopoverCarouselFooterButton` | `useTeachingPopoverCarouselFooterButtonBase_unstable` |
| `TeachingPopoverCarouselNav` | `useTeachingPopoverCarouselNavBase_unstable` |
| `TeachingPopoverCarouselNavButton` | `useTeachingPopoverCarouselNavButtonBase_unstable` |

Each existing `useTeachingPopover*_unstable` hook now composes the corresponding base hook and layers back the styled defaults (icon children, `appearance`), so consumer behavior is unchanged.

## Stacking Note

This PR is part of a stacked series and should be merged **after** the regression test PR so the behavior contract is locked in before the refactor lands.

Merge order:
1. #36201 — hook regression tests
2. #36200 — base hooks + exports (this PR)

Depends on: #36201
