### PR TITLE
test(react-teaching-popover): add hook regression tests

### DIFF
--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarousel/useTeachingPopoverCarousel.test.tsx
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarousel/useTeachingPopoverCarousel.test.tsx
@@ -1,0 +1,105 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { PopoverProvider } from '@fluentui/react-popover';
+import type { PopoverContextValue } from '@fluentui/react-popover';
+import { useTeachingPopoverCarousel_unstable } from './useTeachingPopoverCarousel';
+import type { TeachingPopoverCarouselProps, TeachingPopoverCarouselState } from './TeachingPopoverCarousel.types';
+
+const defaultPopoverContext: PopoverContextValue = {
+  open: true,
+  setOpen: () => null,
+  toggleOpen: () => null,
+  triggerRef: { current: null },
+  contentRef: { current: null },
+  arrowRef: { current: null },
+  openOnContext: false,
+  openOnHover: false,
+  size: 'medium',
+  inline: false,
+};
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+function Harness({
+  hookProps,
+  captureState,
+}: {
+  hookProps: TeachingPopoverCarouselProps;
+  captureState: (state: TeachingPopoverCarouselState) => void;
+}) {
+  const ref = React.useRef<HTMLDivElement>(null);
+  const state = useTeachingPopoverCarousel_unstable(hookProps, ref);
+  captureState(state);
+
+  // Render the root slot's element so the merged ref (including the internal rootRef)
+  // attaches to a real DOM node — otherwise the internal carousel useEffect crashes
+  // when querying for carousel items.
+  const {
+    as,
+    ref: rootRef,
+    ...rootProps
+  } = state.root as unknown as React.HTMLAttributes<HTMLDivElement> & {
+    as?: string;
+    ref?: React.Ref<HTMLDivElement>;
+  };
+  return <div {...rootProps} ref={rootRef} />;
+}
+
+function renderCarouselHook(
+  hookProps: TeachingPopoverCarouselProps,
+  contextValue: Partial<PopoverContextValue> = {},
+): TeachingPopoverCarouselState {
+  let captured!: TeachingPopoverCarouselState;
+  const captureState = (state: TeachingPopoverCarouselState) => {
+    captured = state;
+  };
+  render(
+    <PopoverProvider value={{ ...defaultPopoverContext, ...contextValue }}>
+      <Harness hookProps={hookProps} captureState={captureState} />
+    </PopoverProvider>,
+  );
+  return captured;
+}
+
+describe('useTeachingPopoverCarousel_unstable', () => {
+  it('returns components shape { root: div }', () => {
+    const state = renderCarouselHook({ defaultValue: 'page-1' });
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    expect(state.components).toEqual({ root: 'div' });
+  });
+
+  it('always returns a root slot', () => {
+    const state = renderCarouselHook({ defaultValue: 'page-1' });
+    expect(state.root).toBeDefined();
+  });
+
+  it('exposes carousel state fields (store, selectPageByDirection, selectPageByValue, value)', () => {
+    const state = renderCarouselHook({ defaultValue: 'page-1' });
+    expect(state.store).toBeDefined();
+    expect(typeof state.selectPageByDirection).toBe('function');
+    expect(typeof state.selectPageByValue).toBe('function');
+    expect(state.value).toBe('page-1');
+  });
+
+  it('reflects controlled value prop on state.value', () => {
+    const state = renderCarouselHook({ value: 'page-3' });
+    expect(state.value).toBe('page-3');
+  });
+
+  it.each([undefined, 'brand', 'inverted'] as const)(
+    'state.appearance reflects popover-context appearance=%p',
+    appearance => {
+      const state = renderCarouselHook({ defaultValue: 'page-1' }, { appearance });
+      expect(state.appearance).toBe(appearance);
+    },
+  );
+
+  it('spreads extra props onto root', () => {
+    const state = renderCarouselHook({
+      defaultValue: 'page-1',
+      className: 'custom-class',
+      'aria-label': 'carousel',
+    });
+    expect(state.root.className).toBe('custom-class');
+    expect(state.root['aria-label']).toBe('carousel');
+  });
+});

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselFooterButton/useTeachingPopoverCarouselFooterButton.test.tsx
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselFooterButton/useTeachingPopoverCarouselFooterButton.test.tsx
@@ -1,0 +1,202 @@
+import * as React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import { PopoverProvider } from '@fluentui/react-popover';
+import type { PopoverContextValue } from '@fluentui/react-popover';
+import { CarouselProvider } from '../TeachingPopoverCarousel/Carousel/CarouselContext';
+import type { CarouselContextValue } from '../TeachingPopoverCarousel/Carousel/CarouselContext';
+import { createCarouselStore } from '../TeachingPopoverCarousel/Carousel/createCarouselStore';
+import { useTeachingPopoverCarouselFooterButton_unstable } from './useTeachingPopoverCarouselFooterButton';
+
+const defaultPopoverContext: PopoverContextValue = {
+  open: true,
+  setOpen: () => null,
+  toggleOpen: () => null,
+  triggerRef: { current: null },
+  contentRef: { current: null },
+  arrowRef: { current: null },
+  openOnContext: false,
+  openOnHover: false,
+  size: 'medium',
+  inline: false,
+};
+
+type WrapperOptions = {
+  popover?: Partial<PopoverContextValue>;
+  carousel?: Partial<CarouselContextValue>;
+  storeValues?: string[];
+};
+
+function makeWrapper(options: WrapperOptions = {}) {
+  const store = createCarouselStore();
+  for (const v of options.storeValues ?? []) {
+    store.addValue(v);
+  }
+  const carouselValue: CarouselContextValue = {
+    store,
+    value: null,
+    selectPageByDirection: () => null,
+    selectPageByValue: () => null,
+    ...options.carousel,
+  };
+  const popoverValue: PopoverContextValue = { ...defaultPopoverContext, ...options.popover };
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(
+      PopoverProvider,
+      { value: popoverValue },
+      React.createElement(CarouselProvider, { value: carouselValue }, children),
+    );
+}
+
+function makeMouseEvent(defaultPrevented = false): React.MouseEvent<HTMLButtonElement & HTMLAnchorElement> {
+  return {
+    isDefaultPrevented: () => defaultPrevented,
+  } as unknown as React.MouseEvent<HTMLButtonElement & HTMLAnchorElement>;
+}
+
+describe('useTeachingPopoverCarouselFooterButton_unstable', () => {
+  it('inherits ButtonState components shape (root: button, icon: span)', () => {
+    const ref = React.createRef<HTMLButtonElement | HTMLAnchorElement>();
+    const { result } = renderHook(
+      () => useTeachingPopoverCarouselFooterButton_unstable({ navType: 'next', altText: 'Done' }, ref),
+      { wrapper: makeWrapper() },
+    );
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    expect(result.current.components).toEqual({ root: 'button', icon: 'span' });
+  });
+
+  it('echoes navType and altText on state', () => {
+    const ref = React.createRef<HTMLButtonElement | HTMLAnchorElement>();
+    const { result } = renderHook(
+      () => useTeachingPopoverCarouselFooterButton_unstable({ navType: 'prev', altText: 'Skip' }, ref),
+      { wrapper: makeWrapper() },
+    );
+    expect(result.current.navType).toBe('prev');
+    expect(result.current.altText).toBe('Skip');
+  });
+
+  it.each([
+    ['next', 'brand', 'secondary'],
+    ['next', 'inverted', 'primary'],
+    ['prev', 'brand', 'outline'],
+    ['prev', 'inverted', 'secondary'],
+  ] as const)(
+    'navType=%p + popover appearance=%p → ButtonState appearance=%p',
+    (navType, popoverAppearance, expected) => {
+      const ref = React.createRef<HTMLButtonElement | HTMLAnchorElement>();
+      const { result } = renderHook(
+        () => useTeachingPopoverCarouselFooterButton_unstable({ navType, altText: 'Done' }, ref),
+        { wrapper: makeWrapper({ popover: { appearance: popoverAppearance } }) },
+      );
+      expect(result.current.appearance).toBe(expected);
+    },
+  );
+
+  it('popoverAppearance on state reflects popover-context appearance', () => {
+    const ref = React.createRef<HTMLButtonElement | HTMLAnchorElement>();
+    const { result } = renderHook(
+      () => useTeachingPopoverCarouselFooterButton_unstable({ navType: 'next', altText: 'Done' }, ref),
+      { wrapper: makeWrapper({ popover: { appearance: 'brand' } }) },
+    );
+    expect(result.current.popoverAppearance).toBe('brand');
+  });
+
+  it('isTrailing on navType="prev" replaces root.children with altText at first step', () => {
+    const ref = React.createRef<HTMLButtonElement | HTMLAnchorElement>();
+    const { result } = renderHook(
+      () =>
+        useTeachingPopoverCarouselFooterButton_unstable(
+          { navType: 'prev', altText: 'Start', children: 'Previous' },
+          ref,
+        ),
+      {
+        wrapper: makeWrapper({
+          storeValues: ['page-1', 'page-2', 'page-3'],
+          carousel: { value: 'page-1' },
+        }),
+      },
+    );
+    expect(result.current.root.children).toBe('Start');
+  });
+
+  it('isTrailing on navType="next" replaces root.children with altText at last step', () => {
+    const ref = React.createRef<HTMLButtonElement | HTMLAnchorElement>();
+    const { result } = renderHook(
+      () =>
+        useTeachingPopoverCarouselFooterButton_unstable({ navType: 'next', altText: 'Finish', children: 'Next' }, ref),
+      {
+        wrapper: makeWrapper({
+          storeValues: ['page-1', 'page-2', 'page-3'],
+          carousel: { value: 'page-3' },
+        }),
+      },
+    );
+    expect(result.current.root.children).toBe('Finish');
+  });
+
+  it('uses props.children at intermediate steps', () => {
+    const ref = React.createRef<HTMLButtonElement | HTMLAnchorElement>();
+    const { result } = renderHook(
+      () =>
+        useTeachingPopoverCarouselFooterButton_unstable({ navType: 'next', altText: 'Finish', children: 'Next' }, ref),
+      {
+        wrapper: makeWrapper({
+          storeValues: ['page-1', 'page-2', 'page-3'],
+          carousel: { value: 'page-2' },
+        }),
+      },
+    );
+    expect(result.current.root.children).toBe('Next');
+  });
+
+  it('uses props.children when activeValue is missing', () => {
+    const ref = React.createRef<HTMLButtonElement | HTMLAnchorElement>();
+    const { result } = renderHook(
+      () =>
+        useTeachingPopoverCarouselFooterButton_unstable({ navType: 'next', altText: 'Finish', children: 'Next' }, ref),
+      { wrapper: makeWrapper({ storeValues: ['page-1', 'page-2'], carousel: { value: null } }) },
+    );
+    expect(result.current.root.children).toBe('Next');
+  });
+
+  it('root.onClick calls selectPageByDirection with the navType', () => {
+    const ref = React.createRef<HTMLButtonElement | HTMLAnchorElement>();
+    const selectPageByDirection = jest.fn();
+    const { result } = renderHook(
+      () => useTeachingPopoverCarouselFooterButton_unstable({ navType: 'next', altText: 'Done' }, ref),
+      { wrapper: makeWrapper({ carousel: { selectPageByDirection } }) },
+    );
+    const ev = makeMouseEvent();
+    result.current.root.onClick?.(ev);
+    expect(selectPageByDirection).toHaveBeenCalledWith(ev, 'next');
+  });
+
+  it('root.onClick short-circuits when ev.isDefaultPrevented() is true', () => {
+    const ref = React.createRef<HTMLButtonElement | HTMLAnchorElement>();
+    const selectPageByDirection = jest.fn();
+    const { result } = renderHook(
+      () => useTeachingPopoverCarouselFooterButton_unstable({ navType: 'next', altText: 'Done' }, ref),
+      { wrapper: makeWrapper({ carousel: { selectPageByDirection } }) },
+    );
+    const ev = makeMouseEvent(true);
+    result.current.root.onClick?.(ev);
+    expect(selectPageByDirection).not.toHaveBeenCalled();
+  });
+
+  it('merges user-provided onClick with internal handler', () => {
+    const ref = React.createRef<HTMLButtonElement | HTMLAnchorElement>();
+    const selectPageByDirection = jest.fn();
+    const userOnClick = jest.fn();
+    const { result } = renderHook(
+      () =>
+        useTeachingPopoverCarouselFooterButton_unstable(
+          { navType: 'next', altText: 'Done', onClick: userOnClick },
+          ref,
+        ),
+      { wrapper: makeWrapper({ carousel: { selectPageByDirection } }) },
+    );
+    const ev = makeMouseEvent();
+    result.current.root.onClick?.(ev);
+    expect(userOnClick).toHaveBeenCalledWith(ev);
+    expect(selectPageByDirection).toHaveBeenCalledWith(ev, 'next');
+  });
+});

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselNav/useTeachingPopoverCarouselNav.test.tsx
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselNav/useTeachingPopoverCarouselNav.test.tsx
@@ -1,0 +1,85 @@
+import * as React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import { CarouselProvider } from '../TeachingPopoverCarousel/Carousel/CarouselContext';
+import type { CarouselContextValue } from '../TeachingPopoverCarousel/Carousel/CarouselContext';
+import { createCarouselStore } from '../TeachingPopoverCarousel/Carousel/createCarouselStore';
+import { useTeachingPopoverCarouselNav_unstable } from './useTeachingPopoverCarouselNav';
+
+function makeWrapper(storeValues: string[] = []) {
+  const store = createCarouselStore();
+  for (const v of storeValues) {
+    store.addValue(v);
+  }
+  const carouselValue: CarouselContextValue = {
+    store,
+    value: null,
+    selectPageByDirection: () => null,
+    selectPageByValue: () => null,
+  };
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(CarouselProvider, { value: carouselValue }, children);
+}
+
+describe('useTeachingPopoverCarouselNav_unstable', () => {
+  it('returns components shape { root: div }', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const { result } = renderHook(() => useTeachingPopoverCarouselNav_unstable({ children: () => null }, ref), {
+      wrapper: makeWrapper(),
+    });
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    expect(result.current.components).toEqual({ root: 'div' });
+  });
+
+  it('always returns a root slot', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const { result } = renderHook(() => useTeachingPopoverCarouselNav_unstable({ children: () => null }, ref), {
+      wrapper: makeWrapper(),
+    });
+    expect(result.current.root).toBeDefined();
+  });
+
+  it('root has role="tablist" and tabIndex 0', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const { result } = renderHook(() => useTeachingPopoverCarouselNav_unstable({ children: () => null }, ref), {
+      wrapper: makeWrapper(),
+    });
+    expect(result.current.root.role).toBe('tablist');
+    expect(result.current.root.tabIndex).toBe(0);
+  });
+
+  it('root.children is null (children prop is a render function, not rendered into root)', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const renderFn = (v: string) => React.createElement('button', { key: v }, v);
+    const { result } = renderHook(() => useTeachingPopoverCarouselNav_unstable({ children: renderFn }, ref), {
+      wrapper: makeWrapper(),
+    });
+    expect(result.current.root.children).toBeNull();
+  });
+
+  it('renderNavButton equals props.children', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const renderFn = (v: string) => React.createElement('button', { key: v }, v);
+    const { result } = renderHook(() => useTeachingPopoverCarouselNav_unstable({ children: renderFn }, ref), {
+      wrapper: makeWrapper(),
+    });
+    expect(result.current.renderNavButton).toBe(renderFn);
+  });
+
+  it('values snapshot reflects the carousel store contents', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const { result } = renderHook(() => useTeachingPopoverCarouselNav_unstable({ children: () => null }, ref), {
+      wrapper: makeWrapper(['page-1', 'page-2', 'page-3']),
+    });
+    expect(result.current.values).toEqual(['page-1', 'page-2', 'page-3']);
+  });
+
+  it('root carries tabster arrow-navigation data attributes', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const { result } = renderHook(() => useTeachingPopoverCarouselNav_unstable({ children: () => null }, ref), {
+      wrapper: makeWrapper(),
+    });
+    const rootKeys = Object.keys(result.current.root);
+    const hasTabsterAttr = rootKeys.some(k => k.startsWith('data-tabster'));
+    expect(hasTabsterAttr).toBe(true);
+  });
+});

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselNavButton/useTeachingPopoverCarouselNavButton.test.tsx
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselNavButton/useTeachingPopoverCarouselNavButton.test.tsx
@@ -1,0 +1,157 @@
+import * as React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import { PopoverProvider } from '@fluentui/react-popover';
+import type { PopoverContextValue } from '@fluentui/react-popover';
+import { CarouselProvider } from '../TeachingPopoverCarousel/Carousel/CarouselContext';
+import type { CarouselContextValue } from '../TeachingPopoverCarousel/Carousel/CarouselContext';
+import { createCarouselStore } from '../TeachingPopoverCarousel/Carousel/createCarouselStore';
+import { ValueIdContextProvider } from '../TeachingPopoverCarouselNav/valueIdContext';
+import { useTeachingPopoverCarouselNavButton_unstable } from './useTeachingPopoverCarouselNavButton';
+
+const defaultPopoverContext: PopoverContextValue = {
+  open: true,
+  setOpen: () => null,
+  toggleOpen: () => null,
+  triggerRef: { current: null },
+  contentRef: { current: null },
+  arrowRef: { current: null },
+  openOnContext: false,
+  openOnHover: false,
+  size: 'medium',
+  inline: false,
+};
+
+type WrapperOptions = {
+  popover?: Partial<PopoverContextValue>;
+  carousel?: Partial<CarouselContextValue>;
+  valueId?: string;
+};
+
+function makeWrapper(options: WrapperOptions = {}) {
+  const carouselValue: CarouselContextValue = {
+    store: createCarouselStore(),
+    value: null,
+    selectPageByDirection: () => null,
+    selectPageByValue: () => null,
+    ...options.carousel,
+  };
+  const popoverValue: PopoverContextValue = { ...defaultPopoverContext, ...options.popover };
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(
+      PopoverProvider,
+      { value: popoverValue },
+      React.createElement(
+        CarouselProvider,
+        { value: carouselValue },
+        React.createElement(ValueIdContextProvider, { value: options.valueId ?? '' }, children),
+      ),
+    );
+}
+
+function makeMouseEvent(
+  target: HTMLElement | null,
+  defaultPrevented = false,
+): React.MouseEvent<HTMLButtonElement & HTMLAnchorElement> {
+  return {
+    target,
+    defaultPrevented,
+    preventDefault: () => null,
+  } as unknown as React.MouseEvent<HTMLButtonElement & HTMLAnchorElement>;
+}
+
+describe('useTeachingPopoverCarouselNavButton_unstable', () => {
+  it('returns components shape { root: button }', () => {
+    const ref = React.createRef<HTMLButtonElement | HTMLAnchorElement>();
+    const { result } = renderHook(() => useTeachingPopoverCarouselNavButton_unstable({}, ref), {
+      wrapper: makeWrapper({ valueId: 'page-1' }),
+    });
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    expect(result.current.components).toEqual({ root: 'button' });
+  });
+
+  it('root has role="tab" and type="button"', () => {
+    const ref = React.createRef<HTMLButtonElement | HTMLAnchorElement>();
+    const { result } = renderHook(() => useTeachingPopoverCarouselNavButton_unstable({}, ref), {
+      wrapper: makeWrapper({ valueId: 'page-1' }),
+    });
+    expect(result.current.root.role).toBe('tab');
+    expect((result.current.root as { type?: string }).type).toBe('button');
+  });
+
+  it('isSelected is true when carousel.value matches valueIdContext value', () => {
+    const ref = React.createRef<HTMLButtonElement | HTMLAnchorElement>();
+    const { result } = renderHook(() => useTeachingPopoverCarouselNavButton_unstable({}, ref), {
+      wrapper: makeWrapper({ valueId: 'page-2', carousel: { value: 'page-2' } }),
+    });
+    expect(result.current.isSelected).toBe(true);
+    expect(result.current.root['aria-selected']).toBe('true');
+  });
+
+  it('isSelected is false when carousel.value does not match', () => {
+    const ref = React.createRef<HTMLButtonElement | HTMLAnchorElement>();
+    const { result } = renderHook(() => useTeachingPopoverCarouselNavButton_unstable({}, ref), {
+      wrapper: makeWrapper({ valueId: 'page-2', carousel: { value: 'page-1' } }),
+    });
+    expect(result.current.isSelected).toBe(false);
+    expect(result.current.root['aria-selected']).toBe('false');
+  });
+
+  it('root.onClick calls selectPageByValue with the valueId from context', () => {
+    const ref = React.createRef<HTMLButtonElement | HTMLAnchorElement>();
+    const selectPageByValue = jest.fn();
+    const { result } = renderHook(() => useTeachingPopoverCarouselNavButton_unstable({}, ref), {
+      wrapper: makeWrapper({ valueId: 'page-2', carousel: { selectPageByValue } }),
+    });
+    const target = document.createElement('a');
+    const ev = makeMouseEvent(target);
+    result.current.root.onClick?.(ev);
+    expect(selectPageByValue).toHaveBeenCalledWith(ev, 'page-2');
+  });
+
+  it('root.onClick short-circuits when ev.defaultPrevented is true', () => {
+    const ref = React.createRef<HTMLButtonElement | HTMLAnchorElement>();
+    const selectPageByValue = jest.fn();
+    const { result } = renderHook(() => useTeachingPopoverCarouselNavButton_unstable({}, ref), {
+      wrapper: makeWrapper({ valueId: 'page-2', carousel: { selectPageByValue } }),
+    });
+    const target = document.createElement('a');
+    const ev = makeMouseEvent(target, true);
+    result.current.root.onClick?.(ev);
+    expect(selectPageByValue).not.toHaveBeenCalled();
+  });
+
+  it('user-provided onClick is invoked before selectPageByValue', () => {
+    const ref = React.createRef<HTMLButtonElement | HTMLAnchorElement>();
+    const selectPageByValue = jest.fn();
+    const userOnClick = jest.fn();
+    const { result } = renderHook(() => useTeachingPopoverCarouselNavButton_unstable({ onClick: userOnClick }, ref), {
+      wrapper: makeWrapper({ valueId: 'page-2', carousel: { selectPageByValue } }),
+    });
+    const target = document.createElement('a');
+    const ev = makeMouseEvent(target);
+    result.current.root.onClick?.(ev);
+    expect(userOnClick).toHaveBeenCalledWith(ev);
+    expect(selectPageByValue).toHaveBeenCalledWith(ev, 'page-2');
+  });
+
+  it('root carries tabster default-focus attributes', () => {
+    const ref = React.createRef<HTMLButtonElement | HTMLAnchorElement>();
+    const { result } = renderHook(() => useTeachingPopoverCarouselNavButton_unstable({}, ref), {
+      wrapper: makeWrapper({ valueId: 'page-2', carousel: { value: 'page-2' } }),
+    });
+    const rootKeys = Object.keys(result.current.root);
+    const hasTabsterAttr = rootKeys.some(k => k.startsWith('data-tabster'));
+    expect(hasTabsterAttr).toBe(true);
+  });
+
+  it.each([undefined, 'brand', 'inverted'] as const)(
+    'state.appearance reflects popover-context appearance=%p',
+    appearance => {
+      const ref = React.createRef<HTMLButtonElement | HTMLAnchorElement>();
+      const { result } = renderHook(() => useTeachingPopoverCarouselNavButton_unstable({}, ref), {
+        wrapper: makeWrapper({ valueId: 'page-1', popover: { appearance } }),
+      });
+      expect(result.current.appearance).toBe(appearance);
+    },
+  );
+});

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverFooter/useTeachingPopoverFooter.test.tsx
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverFooter/useTeachingPopoverFooter.test.tsx
@@ -1,0 +1,190 @@
+import * as React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import { Button } from '@fluentui/react-button';
+import { PopoverProvider } from '@fluentui/react-popover';
+import type { PopoverContextValue } from '@fluentui/react-popover';
+import { useTeachingPopoverFooter_unstable } from './useTeachingPopoverFooter';
+
+const defaultPopoverContext: PopoverContextValue = {
+  open: true,
+  setOpen: () => null,
+  toggleOpen: () => null,
+  triggerRef: { current: null },
+  contentRef: { current: null },
+  arrowRef: { current: null },
+  openOnContext: false,
+  openOnHover: false,
+  size: 'medium',
+  inline: false,
+};
+
+function makeWrapper(contextValue: Partial<PopoverContextValue> = {}) {
+  const value = { ...defaultPopoverContext, ...contextValue };
+  return ({ children }: { children: React.ReactNode }) => React.createElement(PopoverProvider, { value }, children);
+}
+
+function makeMouseEvent(
+  defaultPrevented = false,
+): React.MouseEvent<HTMLButtonElement & HTMLAnchorElement & HTMLDivElement> {
+  return {
+    isDefaultPrevented: () => defaultPrevented,
+  } as unknown as React.MouseEvent<HTMLButtonElement & HTMLAnchorElement & HTMLDivElement>;
+}
+
+describe('useTeachingPopoverFooter_unstable', () => {
+  it('returns components shape { root: div, primary: Button, secondary: Button }', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const { result } = renderHook(() => useTeachingPopoverFooter_unstable({ primary: 'OK' }, ref), {
+      wrapper: makeWrapper(),
+    });
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    expect(result.current.components).toEqual({ root: 'div', primary: Button, secondary: Button });
+  });
+
+  it('always returns a root slot', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const { result } = renderHook(() => useTeachingPopoverFooter_unstable({ primary: 'OK' }, ref), {
+      wrapper: makeWrapper(),
+    });
+    expect(result.current.root).toBeDefined();
+  });
+
+  it('footerLayout defaults to "horizontal"', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const { result } = renderHook(() => useTeachingPopoverFooter_unstable({ primary: 'OK' }, ref), {
+      wrapper: makeWrapper(),
+    });
+    expect(result.current.footerLayout).toBe('horizontal');
+  });
+
+  it('footerLayout honors "vertical" override', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const { result } = renderHook(
+      () => useTeachingPopoverFooter_unstable({ primary: 'OK', footerLayout: 'vertical' }, ref),
+      { wrapper: makeWrapper() },
+    );
+    expect(result.current.footerLayout).toBe('vertical');
+  });
+
+  it('primary slot is always defined', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const { result } = renderHook(() => useTeachingPopoverFooter_unstable({ primary: 'OK' }, ref), {
+      wrapper: makeWrapper(),
+    });
+    expect(result.current.primary).toBeDefined();
+  });
+
+  it('secondary is undefined when prop omitted', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const { result } = renderHook(() => useTeachingPopoverFooter_unstable({ primary: 'OK' }, ref), {
+      wrapper: makeWrapper(),
+    });
+    expect(result.current.secondary).toBeUndefined();
+  });
+
+  it('secondary is defined when prop provided', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const { result } = renderHook(
+      () => useTeachingPopoverFooter_unstable({ primary: 'OK', secondary: 'Cancel' }, ref),
+      { wrapper: makeWrapper() },
+    );
+    expect(result.current.secondary).toBeDefined();
+  });
+
+  it('primary.appearance is undefined when popover appearance="brand"', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const { result } = renderHook(() => useTeachingPopoverFooter_unstable({ primary: 'OK' }, ref), {
+      wrapper: makeWrapper({ appearance: 'brand' }),
+    });
+    expect(result.current.primary.appearance).toBeUndefined();
+  });
+
+  it('primary.appearance is "primary" when popover appearance is not "brand"', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const { result } = renderHook(() => useTeachingPopoverFooter_unstable({ primary: 'OK' }, ref), {
+      wrapper: makeWrapper({ appearance: 'inverted' }),
+    });
+    expect(result.current.primary.appearance).toBe('primary');
+  });
+
+  it('secondary.appearance is "primary" when popover appearance="brand"', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const { result } = renderHook(
+      () => useTeachingPopoverFooter_unstable({ primary: 'OK', secondary: 'Cancel' }, ref),
+      { wrapper: makeWrapper({ appearance: 'brand' }) },
+    );
+    expect(result.current.secondary?.appearance).toBe('primary');
+  });
+
+  it('secondary.appearance is undefined when popover appearance is not "brand"', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const { result } = renderHook(
+      () => useTeachingPopoverFooter_unstable({ primary: 'OK', secondary: 'Cancel' }, ref),
+      { wrapper: makeWrapper({ appearance: 'inverted' }) },
+    );
+    expect(result.current.secondary?.appearance).toBeUndefined();
+  });
+
+  it('when no secondary, primary.onClick calls toggleOpen', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const toggleOpen = jest.fn();
+    const { result } = renderHook(() => useTeachingPopoverFooter_unstable({ primary: 'OK' }, ref), {
+      wrapper: makeWrapper({ toggleOpen }),
+    });
+    const ev = makeMouseEvent();
+    result.current.primary.onClick?.(ev);
+    expect(toggleOpen).toHaveBeenCalledWith(ev);
+  });
+
+  it('when secondary is present, secondary.onClick calls toggleOpen and primary does not', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const toggleOpen = jest.fn();
+    const { result } = renderHook(
+      () => useTeachingPopoverFooter_unstable({ primary: 'OK', secondary: 'Cancel' }, ref),
+      { wrapper: makeWrapper({ toggleOpen }) },
+    );
+    const evPrimary = makeMouseEvent();
+    result.current.primary.onClick?.(evPrimary);
+    expect(toggleOpen).not.toHaveBeenCalled();
+
+    const evSecondary = makeMouseEvent();
+    result.current.secondary?.onClick?.(evSecondary);
+    expect(toggleOpen).toHaveBeenCalledWith(evSecondary);
+  });
+
+  it('onClick short-circuits when ev.isDefaultPrevented() is true', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const toggleOpen = jest.fn();
+    const { result } = renderHook(() => useTeachingPopoverFooter_unstable({ primary: 'OK' }, ref), {
+      wrapper: makeWrapper({ toggleOpen }),
+    });
+    const ev = makeMouseEvent(true);
+    result.current.primary.onClick?.(ev);
+    expect(toggleOpen).not.toHaveBeenCalled();
+  });
+
+  it('merges user-provided primary.onClick with internal handler', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const toggleOpen = jest.fn();
+    const userOnClick = jest.fn();
+    const { result } = renderHook(
+      () => useTeachingPopoverFooter_unstable({ primary: { children: 'OK', onClick: userOnClick } }, ref),
+      { wrapper: makeWrapper({ toggleOpen }) },
+    );
+    const ev = makeMouseEvent();
+    result.current.primary.onClick?.(ev);
+    expect(toggleOpen).toHaveBeenCalledWith(ev);
+    expect(userOnClick).toHaveBeenCalledWith(ev);
+  });
+
+  it.each([undefined, 'brand', 'inverted'] as const)(
+    'state.appearance reflects popover-context appearance=%p',
+    appearance => {
+      const ref = React.createRef<HTMLDivElement>();
+      const { result } = renderHook(() => useTeachingPopoverFooter_unstable({ primary: 'OK' }, ref), {
+        wrapper: makeWrapper({ appearance }),
+      });
+      expect(result.current.appearance).toBe(appearance);
+    },
+  );
+});

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverHeader/useTeachingPopoverHeader.test.tsx
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverHeader/useTeachingPopoverHeader.test.tsx
@@ -1,0 +1,131 @@
+import * as React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import { Dismiss12Regular, Lightbulb16Regular } from '@fluentui/react-icons';
+import { PopoverProvider } from '@fluentui/react-popover';
+import type { PopoverContextValue } from '@fluentui/react-popover';
+import { useTeachingPopoverHeader_unstable } from './useTeachingPopoverHeader';
+
+const defaultPopoverContext: PopoverContextValue = {
+  open: true,
+  setOpen: () => null,
+  toggleOpen: () => null,
+  triggerRef: { current: null },
+  contentRef: { current: null },
+  arrowRef: { current: null },
+  openOnContext: false,
+  openOnHover: false,
+  size: 'medium',
+  inline: false,
+};
+
+function makeWrapper(contextValue: Partial<PopoverContextValue> = {}) {
+  const value = { ...defaultPopoverContext, ...contextValue };
+  return ({ children }: { children: React.ReactNode }) => React.createElement(PopoverProvider, { value }, children);
+}
+
+describe('useTeachingPopoverHeader_unstable', () => {
+  it('returns components shape { root: div, dismissButton: button, icon: div }', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const { result } = renderHook(() => useTeachingPopoverHeader_unstable({}, ref), { wrapper: makeWrapper() });
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    expect(result.current.components).toEqual({ root: 'div', dismissButton: 'button', icon: 'div' });
+  });
+
+  it('always returns a root slot', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const { result } = renderHook(() => useTeachingPopoverHeader_unstable({}, ref), { wrapper: makeWrapper() });
+    expect(result.current.root).toBeDefined();
+  });
+
+  it('icon is rendered by default with Lightbulb icon and aria-hidden', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const { result } = renderHook(() => useTeachingPopoverHeader_unstable({}, ref), { wrapper: makeWrapper() });
+    expect(result.current.icon).toBeDefined();
+    const iconChildren = result.current.icon?.children as React.ReactElement | undefined;
+    expect(iconChildren).toBeDefined();
+    expect((iconChildren as React.ReactElement).type).toBe(Lightbulb16Regular);
+    expect(result.current.icon?.['aria-hidden']).toBe(true);
+  });
+
+  it('honors user-provided icon slot', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const customIcon = React.createElement('span', { 'data-testid': 'custom-icon' });
+    const { result } = renderHook(() => useTeachingPopoverHeader_unstable({ icon: { children: customIcon } }, ref), {
+      wrapper: makeWrapper(),
+    });
+    expect(result.current.icon).toBeDefined();
+    expect(result.current.icon?.children).toBe(customIcon);
+  });
+
+  it('dismissButton is rendered by default with Dismiss icon, role and aria-label', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const { result } = renderHook(() => useTeachingPopoverHeader_unstable({}, ref), { wrapper: makeWrapper() });
+    expect(result.current.dismissButton).toBeDefined();
+    const btnChildren = result.current.dismissButton?.children as React.ReactElement | undefined;
+    expect((btnChildren as React.ReactElement).type).toBe(Dismiss12Regular);
+    expect(result.current.dismissButton?.role).toBe('button');
+    expect(result.current.dismissButton?.['aria-label']).toBe('dismiss');
+    expect(typeof result.current.dismissButton?.onClick).toBe('function');
+  });
+
+  it('honors user-provided dismissButton slot', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const customChild = React.createElement('span', { 'data-testid': 'custom-dismiss' });
+    const { result } = renderHook(
+      () => useTeachingPopoverHeader_unstable({ dismissButton: { children: customChild } }, ref),
+      { wrapper: makeWrapper() },
+    );
+    expect(result.current.dismissButton?.children).toBe(customChild);
+  });
+
+  it('dismissButton.onClick calls setOpen(ev, false) and focuses triggerRef', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const setOpen = jest.fn();
+    const focus = jest.fn();
+    const triggerEl = { focus } as unknown as HTMLElement;
+    const triggerRef = { current: triggerEl } as React.RefObject<HTMLElement>;
+    const { result } = renderHook(() => useTeachingPopoverHeader_unstable({}, ref), {
+      wrapper: makeWrapper({ setOpen, triggerRef }),
+    });
+    const ev = { defaultPrevented: false } as unknown as React.MouseEvent<HTMLButtonElement>;
+    result.current.dismissButton?.onClick?.(ev);
+    expect(setOpen).toHaveBeenCalledWith(ev, false);
+    expect(focus).toHaveBeenCalledTimes(1);
+  });
+
+  it('dismissButton.onClick skips setOpen when ev.defaultPrevented is true (but still focuses triggerRef)', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const setOpen = jest.fn();
+    const focus = jest.fn();
+    const triggerEl = { focus } as unknown as HTMLElement;
+    const triggerRef = { current: triggerEl } as React.RefObject<HTMLElement>;
+    const { result } = renderHook(() => useTeachingPopoverHeader_unstable({}, ref), {
+      wrapper: makeWrapper({ setOpen, triggerRef }),
+    });
+    const ev = { defaultPrevented: true } as unknown as React.MouseEvent<HTMLButtonElement>;
+    result.current.dismissButton?.onClick?.(ev);
+    expect(setOpen).not.toHaveBeenCalled();
+    expect(focus).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([undefined, 'brand', 'inverted'] as const)(
+    'state.appearance reflects popover-context appearance=%p',
+    appearance => {
+      const ref = React.createRef<HTMLDivElement>();
+      const { result } = renderHook(() => useTeachingPopoverHeader_unstable({}, ref), {
+        wrapper: makeWrapper({ appearance }),
+      });
+      expect(result.current.appearance).toBe(appearance);
+    },
+  );
+
+  it('spreads extra props onto root', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const { result } = renderHook(
+      () => useTeachingPopoverHeader_unstable({ className: 'custom-class', 'aria-label': 'header' }, ref),
+      { wrapper: makeWrapper() },
+    );
+    expect(result.current.root.className).toBe('custom-class');
+    expect(result.current.root['aria-label']).toBe('header');
+  });
+});

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverTitle/useTeachingPopoverTitle.test.tsx
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverTitle/useTeachingPopoverTitle.test.tsx
@@ -1,0 +1,107 @@
+import * as React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import { PopoverProvider } from '@fluentui/react-popover';
+import type { PopoverContextValue } from '@fluentui/react-popover';
+import { useTeachingPopoverTitle_unstable } from './useTeachingPopoverTitle';
+
+const defaultPopoverContext: PopoverContextValue = {
+  open: true,
+  setOpen: () => null,
+  toggleOpen: () => null,
+  triggerRef: { current: null },
+  contentRef: { current: null },
+  arrowRef: { current: null },
+  openOnContext: false,
+  openOnHover: false,
+  size: 'medium',
+  inline: false,
+};
+
+function makeWrapper(contextValue: Partial<PopoverContextValue> = {}) {
+  const value = { ...defaultPopoverContext, ...contextValue };
+  return ({ children }: { children: React.ReactNode }) => React.createElement(PopoverProvider, { value }, children);
+}
+
+describe('useTeachingPopoverTitle_unstable', () => {
+  it('returns components shape { root: h2, dismissButton: button }', () => {
+    const ref = React.createRef<HTMLHeadingElement>();
+    const { result } = renderHook(() => useTeachingPopoverTitle_unstable({}, ref), { wrapper: makeWrapper() });
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    expect(result.current.components).toEqual({ root: 'h2', dismissButton: 'button' });
+  });
+
+  it('always returns a root slot', () => {
+    const ref = React.createRef<HTMLHeadingElement>();
+    const { result } = renderHook(() => useTeachingPopoverTitle_unstable({}, ref), { wrapper: makeWrapper() });
+    expect(result.current.root).toBeDefined();
+  });
+
+  it('dismissButton is undefined when prop omitted (renderByDefault: false)', () => {
+    const ref = React.createRef<HTMLHeadingElement>();
+    const { result } = renderHook(() => useTeachingPopoverTitle_unstable({}, ref), { wrapper: makeWrapper() });
+    expect(result.current.dismissButton).toBeUndefined();
+  });
+
+  it('dismissButton is defined with default props when prop is provided', () => {
+    const ref = React.createRef<HTMLHeadingElement>();
+    const { result } = renderHook(() => useTeachingPopoverTitle_unstable({ dismissButton: {} }, ref), {
+      wrapper: makeWrapper(),
+    });
+    expect(result.current.dismissButton).toBeDefined();
+    expect(result.current.dismissButton?.['aria-label']).toBe('dismiss');
+    expect(result.current.dismissButton?.['aria-hidden']).toBe(true);
+    expect(typeof result.current.dismissButton?.onClick).toBe('function');
+    expect(result.current.dismissButton?.children).toBeDefined();
+  });
+
+  it('dismissButton.onClick calls setOpen(ev, false) and focuses triggerRef', () => {
+    const ref = React.createRef<HTMLHeadingElement>();
+    const setOpen = jest.fn();
+    const focus = jest.fn();
+    const triggerEl = { focus } as unknown as HTMLElement;
+    const triggerRef = { current: triggerEl } as React.RefObject<HTMLElement>;
+    const { result } = renderHook(() => useTeachingPopoverTitle_unstable({ dismissButton: {} }, ref), {
+      wrapper: makeWrapper({ setOpen, triggerRef }),
+    });
+    const ev = { defaultPrevented: false } as unknown as React.MouseEvent<HTMLButtonElement>;
+    result.current.dismissButton?.onClick?.(ev);
+    expect(setOpen).toHaveBeenCalledWith(ev, false);
+    expect(focus).toHaveBeenCalledTimes(1);
+  });
+
+  it('dismissButton.onClick skips setOpen when ev.defaultPrevented is true', () => {
+    const ref = React.createRef<HTMLHeadingElement>();
+    const setOpen = jest.fn();
+    const focus = jest.fn();
+    const triggerEl = { focus } as unknown as HTMLElement;
+    const triggerRef = { current: triggerEl } as React.RefObject<HTMLElement>;
+    const { result } = renderHook(() => useTeachingPopoverTitle_unstable({ dismissButton: {} }, ref), {
+      wrapper: makeWrapper({ setOpen, triggerRef }),
+    });
+    const ev = { defaultPrevented: true } as unknown as React.MouseEvent<HTMLButtonElement>;
+    result.current.dismissButton?.onClick?.(ev);
+    expect(setOpen).not.toHaveBeenCalled();
+    expect(focus).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([undefined, 'brand', 'inverted'] as const)(
+    'state.appearance reflects popover-context appearance=%p',
+    appearance => {
+      const ref = React.createRef<HTMLHeadingElement>();
+      const { result } = renderHook(() => useTeachingPopoverTitle_unstable({}, ref), {
+        wrapper: makeWrapper({ appearance }),
+      });
+      expect(result.current.appearance).toBe(appearance);
+    },
+  );
+
+  it('spreads extra props onto root', () => {
+    const ref = React.createRef<HTMLHeadingElement>();
+    const { result } = renderHook(
+      () => useTeachingPopoverTitle_unstable({ className: 'custom-class', 'aria-label': 'title' }, ref),
+      { wrapper: makeWrapper() },
+    );
+    expect(result.current.root.className).toBe('custom-class');
+    expect(result.current.root['aria-label']).toBe('title');
+  });
+});


### PR DESCRIPTION
Adds hook-level regression tests for the seven `useTeachingPopover*_unstable` hooks that are about to be split into base/styled variants. The tests lock in the current observable behavior of each styled hook so a follow-up refactor PR (introducing `useTeachingPopover*Base_unstable`) can be verified to be behavior-preserving.

## Hooks covered

| Hook | Test file | Cases |
|---|---|---|
| `useTeachingPopoverHeader_unstable` | `TeachingPopoverHeader/useTeachingPopoverHeader.test.tsx` | 12 |
| `useTeachingPopoverFooter_unstable` | `TeachingPopoverFooter/useTeachingPopoverFooter.test.tsx` | 18 |
| `useTeachingPopoverTitle_unstable` | `TeachingPopoverTitle/useTeachingPopoverTitle.test.tsx` | 10 |
| `useTeachingPopoverCarousel_unstable` | `TeachingPopoverCarousel/useTeachingPopoverCarousel.test.tsx` | 8 |
| `useTeachingPopoverCarouselFooterButton_unstable` | `TeachingPopoverCarouselFooterButton/useTeachingPopoverCarouselFooterButton.test.tsx` | 14 |
| `useTeachingPopoverCarouselNav_unstable` | `TeachingPopoverCarouselNav/useTeachingPopoverCarouselNav.test.tsx` | 7 |
| `useTeachingPopoverCarouselNavButton_unstable` | `TeachingPopoverCarouselNavButton/useTeachingPopoverCarouselNavButton.test.tsx` | 11 |

## Stacking Note

This PR is part of a stacked series and **must be merged first** so the regression suite is in place before the base-hook refactor lands.

Merge order:
1. #36201 — hook regression tests (this PR)
2. #36200 — base hooks + exports

Required by: #36200
