### PR TITLE
chore(react-popover): revert base hooks 

### DIFF
--- a/change/@fluentui-react-popover-98a97b8b-4832-4a28-b30a-86efc758dfb9.json
+++ b/change/@fluentui-react-popover-98a97b8b-4832-4a28-b30a-86efc758dfb9.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: revert base hooks for Popover component",
+  "packageName": "@fluentui/react-popover",
+  "email": "viktorgenaev@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-popover/library/src/Popover.ts
+++ b/packages/react-components/react-popover/library/src/Popover.ts
@@ -1,17 +1,14 @@
 export type {
   OnOpenChangeData,
   OpenPopoverEvents,
-  PopoverBaseProps,
   PopoverContextValues,
   PopoverProps,
   PopoverSize,
-  PopoverBaseState,
   PopoverState,
 } from './components/Popover/index';
 export {
   Popover,
   renderPopover_unstable,
   usePopover_unstable,
-  usePopoverBase_unstable,
   usePopoverContextValues_unstable,
 } from './components/Popover/index';

--- a/packages/react-components/react-popover/library/src/PopoverSurface.ts
+++ b/packages/react-components/react-popover/library/src/PopoverSurface.ts
@@ -1,10 +1,4 @@
-export type {
-  PopoverSurfaceBaseProps,
-  PopoverSurfaceProps,
-  PopoverSurfaceSlots,
-  PopoverSurfaceBaseState,
-  PopoverSurfaceState,
-} from './components/PopoverSurface/index';
+export type { PopoverSurfaceProps, PopoverSurfaceSlots, PopoverSurfaceState } from './components/PopoverSurface/index';
 export {
   PopoverSurface,
   arrowHeights,
@@ -12,5 +6,4 @@ export {
   renderPopoverSurface_unstable,
   usePopoverSurfaceStyles_unstable,
   usePopoverSurface_unstable,
-  usePopoverSurfaceBase_unstable,
 } from './components/PopoverSurface/index';

--- a/packages/react-components/react-popover/library/src/components/Popover/Popover.types.ts
+++ b/packages/react-components/react-popover/library/src/components/Popover/Popover.types.ts
@@ -159,8 +159,6 @@ export type PopoverProps = ComponentProps<Partial<PopoverSlots>> &
     unstable_disableAutoFocus?: boolean;
   };
 
-export type PopoverBaseProps = Omit<PopoverProps, 'appearance' | 'size'>;
-
 /**
  * Popover State
  */
@@ -222,8 +220,6 @@ export type PopoverState = ComponentState<InternalPopoverSlots> &
     // eslint-disable-next-line @typescript-eslint/no-deprecated
     triggerRef: React.MutableRefObject<HTMLElement | null>;
   };
-
-export type PopoverBaseState = Omit<PopoverState, 'appearance' | 'components' | 'size' | 'surfaceMotion'>;
 
 /**
  * Data attached to open/close events

--- a/packages/react-components/react-popover/library/src/components/Popover/index.ts
+++ b/packages/react-components/react-popover/library/src/components/Popover/index.ts
@@ -1,14 +1,6 @@
 export { Popover } from './Popover';
-export type {
-  OnOpenChangeData,
-  OpenPopoverEvents,
-  PopoverBaseProps,
-  PopoverProps,
-  PopoverSize,
-  PopoverBaseState,
-  PopoverState,
-} from './Popover.types';
+export type { OnOpenChangeData, OpenPopoverEvents, PopoverProps, PopoverSize, PopoverState } from './Popover.types';
 export { renderPopover_unstable } from './renderPopover';
-export { usePopover_unstable, usePopoverBase_unstable } from './usePopover';
+export { usePopover_unstable } from './usePopover';
 export { usePopoverContextValues_unstable } from './usePopoverContextValues';
 export type { PopoverContextValues } from './usePopoverContextValues';

--- a/packages/react-components/react-popover/library/src/components/Popover/usePopover.ts
+++ b/packages/react-components/react-popover/library/src/components/Popover/usePopover.ts
@@ -19,13 +19,7 @@ import {
 } from '@fluentui/react-positioning';
 import { useFocusFinders, useActivateModal } from '@fluentui/react-tabster';
 import { arrowHeights } from '../PopoverSurface/index';
-import type {
-  OpenPopoverEvents,
-  PopoverBaseProps,
-  PopoverBaseState,
-  PopoverProps,
-  PopoverState,
-} from './Popover.types';
+import type { OpenPopoverEvents, PopoverProps, PopoverState } from './Popover.types';
 import { popoverSurfaceBorderRadius } from './constants';
 import { presenceMotionSlot } from '@fluentui/react-motion';
 import { PopoverSurfaceMotion } from './PopoverSurfaceMotion';
@@ -39,59 +33,24 @@ import { PopoverSurfaceMotion } from './PopoverSurfaceMotion';
  * @param props - props from this instance of Popover
  */
 export const usePopover_unstable = (props: PopoverProps): PopoverState => {
-  const { appearance, size = 'medium' } = props;
-  const positioning = resolvePositioningShorthand(props.positioning);
-  const withArrow = props.withArrow && !positioning.coverTarget;
-
+  const [contextTarget, setContextTarget] = usePositioningMouseTarget();
   const { targetDocument } = useFluent();
 
+  const positioning = resolvePositioningShorthand(props.positioning);
   const handlePositionEnd = usePositioningSlideDirection({
     targetDocument,
     onPositioningEnd: positioning.onPositioningEnd,
   });
 
-  const state = usePopoverBase_unstable({
+  const initialState = {
+    size: 'medium',
+    contextTarget,
+    setContextTarget,
     ...props,
     positioning: {
       ...positioning,
       onPositioningEnd: handlePositionEnd,
-      // Update the offset with the arrow size only when it's available
-      ...(withArrow ? { offset: mergeArrowOffset(positioning.offset, arrowHeights[size]) } : {}),
     },
-  });
-
-  return {
-    components: {
-      surfaceMotion: PopoverSurfaceMotion,
-    },
-    appearance,
-    size,
-    ...state,
-    surfaceMotion: presenceMotionSlot(props.surfaceMotion, {
-      elementType: PopoverSurfaceMotion,
-      defaultProps: {
-        visible: state.open,
-        appear: true,
-        unmountOnExit: true,
-      },
-    }),
-  };
-};
-
-/**
- * Base hook that builds Popover state for behavior and structure only.
- * Does not add design-related defaults such as appearance or size.
- * Does not manage focus behavior, it's handled by `usePopoverFocusManagement_unstable`.
- *
- * @internal
- * @param props - props from this instance of Popover
- */
-export const usePopoverBase_unstable = (props: PopoverBaseProps): PopoverBaseState => {
-  const [contextTarget, setContextTarget] = usePositioningMouseTarget();
-  const initialState = {
-    contextTarget,
-    setContextTarget,
-    ...props,
   } as const;
 
   const children = React.Children.toArray(props.children) as React.ReactElement[];
@@ -139,7 +98,7 @@ export const usePopoverBase_unstable = (props: PopoverBaseProps): PopoverBaseSta
     }
   });
 
-  const toggleOpen = React.useCallback<PopoverBaseState['toggleOpen']>(
+  const toggleOpen = React.useCallback<PopoverState['toggleOpen']>(
     (e: OpenPopoverEvents) => {
       setOpen(e, !open);
     },
@@ -147,7 +106,6 @@ export const usePopoverBase_unstable = (props: PopoverBaseProps): PopoverBaseSta
   );
 
   const positioningRefs = usePopoverRefs(initialState);
-  const { targetDocument } = useFluent();
 
   useOnClickOutside({
     contains: elementContains,
@@ -171,8 +129,7 @@ export const usePopoverBase_unstable = (props: PopoverBaseProps): PopoverBaseSta
   // When trapFocus is enabled, close the popover if focus is programmatically moved outside
   // (e.g. via element.focus()), which doesn't trigger click or scroll dismiss handlers.
   // Internal `closeOnFocusOutside` prop allows consumers to opt out during gradual rollout.
-  const closeOnFocusOutside =
-    (props as PopoverBaseProps & { closeOnFocusOutside?: boolean }).closeOnFocusOutside ?? true;
+  const closeOnFocusOutside = (props as PopoverProps & { closeOnFocusOutside?: boolean }).closeOnFocusOutside ?? true;
 
   const closeOnFocusOutCallback = useEventCallback((ev: FocusEvent) => {
     const target = (ev.composedPath()[0] ?? ev.target) as HTMLElement;
@@ -226,6 +183,9 @@ export const usePopoverBase_unstable = (props: PopoverBaseProps): PopoverBaseSta
   }, [findFirstFocusable, activateModal, open, positioningRefs.contentRef, props.unstable_disableAutoFocus]);
 
   return {
+    components: {
+      surfaceMotion: PopoverSurfaceMotion,
+    },
     ...initialState,
     ...positioningRefs,
     // eslint-disable-next-line @typescript-eslint/no-deprecated
@@ -238,6 +198,14 @@ export const usePopoverBase_unstable = (props: PopoverBaseProps): PopoverBaseSta
     setContextTarget,
     contextTarget,
     inline: props.inline ?? false,
+    surfaceMotion: presenceMotionSlot(props.surfaceMotion, {
+      elementType: PopoverSurfaceMotion,
+      defaultProps: {
+        visible: open,
+        appear: true,
+        unmountOnExit: true,
+      },
+    }),
   };
 };
 
@@ -245,11 +213,11 @@ export const usePopoverBase_unstable = (props: PopoverBaseProps): PopoverBaseSta
  * Creates and manages the Popover open state
  */
 function useOpenState(
-  state: Pick<PopoverBaseState, 'setContextTarget' | 'onOpenChange'> & Pick<PopoverBaseProps, 'open' | 'defaultOpen'>,
+  state: Pick<PopoverState, 'setContextTarget' | 'onOpenChange'> & Pick<PopoverProps, 'open' | 'defaultOpen'>,
 ) {
   'use no memo';
 
-  const onOpenChange: PopoverBaseState['onOpenChange'] = useEventCallback((e, data) => state.onOpenChange?.(e, data));
+  const onOpenChange: PopoverState['onOpenChange'] = useEventCallback((e, data) => state.onOpenChange?.(e, data));
 
   const [open, setOpenState] = useControllableState({
     state: state.open,
@@ -282,8 +250,8 @@ function useOpenState(
  * Creates and sets the necessary trigger, target and content refs used by Popover
  */
 function usePopoverRefs(
-  state: Pick<PopoverBaseState, 'contextTarget'> &
-    Pick<PopoverBaseProps, 'positioning' | 'openOnContext' | 'withArrow'>,
+  state: Pick<PopoverState, 'size' | 'contextTarget'> &
+    Pick<PopoverProps, 'positioning' | 'openOnContext' | 'withArrow'>,
 ) {
   'use no memo';
 
@@ -298,6 +266,10 @@ function usePopoverRefs(
   // no reason to render arrow when covering the target
   if (positioningOptions.coverTarget) {
     state.withArrow = false;
+  }
+
+  if (state.withArrow) {
+    positioningOptions.offset = mergeArrowOffset(positioningOptions.offset, arrowHeights[state.size]);
   }
 
   const { targetRef: triggerRef, containerRef: contentRef, arrowRef } = usePositioning(positioningOptions);

--- a/packages/react-components/react-popover/library/src/components/PopoverSurface/PopoverSurface.types.ts
+++ b/packages/react-components/react-popover/library/src/components/PopoverSurface/PopoverSurface.types.ts
@@ -13,8 +13,6 @@ export type PopoverSurfaceSlots = {
   root: Slot<'div'>;
 };
 
-export type PopoverSurfaceBaseProps = PopoverSurfaceProps;
-
 /**
  * PopoverSurface State
  */
@@ -25,5 +23,3 @@ export type PopoverSurfaceState = ComponentState<PopoverSurfaceSlots> &
      */
     arrowClassName?: string;
   };
-
-export type PopoverSurfaceBaseState = Omit<PopoverSurfaceState, 'appearance' | 'size'>;

--- a/packages/react-components/react-popover/library/src/components/PopoverSurface/index.ts
+++ b/packages/react-components/react-popover/library/src/components/PopoverSurface/index.ts
@@ -1,13 +1,7 @@
 export { PopoverSurface } from './PopoverSurface';
-export type {
-  PopoverSurfaceBaseProps,
-  PopoverSurfaceProps,
-  PopoverSurfaceSlots,
-  PopoverSurfaceBaseState,
-  PopoverSurfaceState,
-} from './PopoverSurface.types';
+export type { PopoverSurfaceProps, PopoverSurfaceSlots, PopoverSurfaceState } from './PopoverSurface.types';
 export { renderPopoverSurface_unstable } from './renderPopoverSurface';
-export { usePopoverSurface_unstable, usePopoverSurfaceBase_unstable } from './usePopoverSurface';
+export { usePopoverSurface_unstable } from './usePopoverSurface';
 export {
   arrowHeights,
   popoverSurfaceClassNames,

--- a/packages/react-components/react-popover/library/src/components/PopoverSurface/usePopoverSurface.ts
+++ b/packages/react-components/react-popover/library/src/components/PopoverSurface/usePopoverSurface.ts
@@ -1,15 +1,10 @@
 'use client';
 
 import type * as React from 'react';
-import { useMergedRefs, slot } from '@fluentui/react-utilities';
+import { getIntrinsicElementProps, useMergedRefs, slot } from '@fluentui/react-utilities';
 import { useModalAttributes } from '@fluentui/react-tabster';
 import { usePopoverContext_unstable } from '../../popoverContext';
-import type {
-  PopoverSurfaceProps,
-  PopoverSurfaceState,
-  PopoverSurfaceBaseProps,
-  PopoverSurfaceBaseState,
-} from './PopoverSurface.types';
+import type { PopoverSurfaceProps, PopoverSurfaceState } from './PopoverSurface.types';
 import { useMotionForwardedRef } from '@fluentui/react-motion';
 
 /**
@@ -25,60 +20,45 @@ export const usePopoverSurface_unstable = (
   props: PopoverSurfaceProps,
   ref: React.Ref<HTMLDivElement>,
 ): PopoverSurfaceState => {
-  const size = usePopoverContext_unstable(context => context.size);
-  const appearance = usePopoverContext_unstable(context => context.appearance);
-  const motionForwardedRef = useMotionForwardedRef();
-  const state = usePopoverSurfaceBase_unstable(props, useMergedRefs(ref, motionForwardedRef));
-
-  return {
-    appearance,
-    size,
-    ...state,
-  };
-};
-
-/**
- * Base hook that builds PopoverSurface state for behavior and structure only.
- *
- * @internal
- * @param props - User provided props to the PopoverSurface component.
- * @param ref - User provided ref to be passed to the PopoverSurface component.
- */
-export const usePopoverSurfaceBase_unstable = (
-  props: PopoverSurfaceBaseProps,
-  ref: React.Ref<HTMLDivElement>,
-): PopoverSurfaceBaseState => {
   const contentRef = usePopoverContext_unstable(context => context.contentRef);
   const openOnHover = usePopoverContext_unstable(context => context.openOnHover);
   const setOpen = usePopoverContext_unstable(context => context.setOpen);
   const mountNode = usePopoverContext_unstable(context => context.mountNode);
   const arrowRef = usePopoverContext_unstable(context => context.arrowRef);
+  const size = usePopoverContext_unstable(context => context.size);
   const withArrow = usePopoverContext_unstable(context => context.withArrow);
+  const appearance = usePopoverContext_unstable(context => context.appearance);
   const trapFocus = usePopoverContext_unstable(context => context.trapFocus);
   const inertTrapFocus = usePopoverContext_unstable(context => context.inertTrapFocus);
   const inline = usePopoverContext_unstable(context => context.inline);
+  const motionForwardedRef = useMotionForwardedRef();
   const { modalAttributes } = useModalAttributes({
     trapFocus,
     legacyTrapFocus: !inertTrapFocus,
     alwaysFocusable: !trapFocus,
   });
 
-  const state: PopoverSurfaceBaseState = {
+  const state: PopoverSurfaceState = {
     inline,
+    appearance,
     withArrow,
+    size,
     arrowRef,
     mountNode,
     components: {
       root: 'div',
     },
     root: slot.always(
-      {
-        ref: useMergedRefs(ref, contentRef) as React.Ref<HTMLDivElement>,
+      getIntrinsicElementProps('div', {
+        // FIXME:
+        // `contentRef` is wrongly assigned to be `HTMLElement` instead of `HTMLDivElement`
+        // but since it would be a breaking change to fix it, we are casting ref to it's proper type
+        ref: useMergedRefs(ref, contentRef, motionForwardedRef) as React.Ref<HTMLDivElement>,
         role: trapFocus ? 'dialog' : 'group',
         'aria-modal': trapFocus ? true : undefined,
         ...modalAttributes,
         ...props,
-      },
+      }),
       { elementType: 'div' },
     ),
   };

--- a/packages/react-components/react-popover/library/src/index.ts
+++ b/packages/react-components/react-popover/library/src/index.ts
@@ -20,9 +20,3 @@ export { PopoverProvider, usePopoverContext_unstable } from './popoverContext';
 export type { PopoverContextValue } from './popoverContext';
 export { PopoverTrigger, renderPopoverTrigger_unstable, usePopoverTrigger_unstable } from './PopoverTrigger';
 export type { PopoverTriggerChildProps, PopoverTriggerProps, PopoverTriggerState } from './PopoverTrigger';
-
-// Experimental APIs
-// export type { PopoverBaseProps, PopoverBaseState } from './Popover';
-// export { usePopoverBase_unstable } from './Popover';
-// export type { PopoverSurfaceBaseProps, PopoverSurfaceBaseState } from './PopoverSurface';
-// export { usePopoverSurfaceBase_unstable } from './PopoverSurface';


### PR DESCRIPTION
Revert base hooks from `react-popover`, because we do not expose them and we do not need them for react-headless package. 

