### PR TITLE
ci: validate PR identity against workflow_run to prevent artifact poisoning

### DIFF
--- a/.github/scripts/validate-pr-number.js
+++ b/.github/scripts/validate-pr-number.js
@@ -6,11 +6,16 @@ module.exports = main;
 
 /**
  *
- * @param {{filePath:string}} options
- * @returns {number}
+ * @param {Pick<import('../../scripts/triage-bot/src/types.ts').GithubScriptsParams,'github'|'context'> & {filePath:string}} options
+ * @returns {Promise<number>}
  */
-function main(options) {
-  return validatePrNumber(options.filePath);
+async function main(options) {
+  const { filePath, github, context } = options;
+  const prNumber = validatePrNumber(filePath);
+
+  await validatePrIdentity({ prNumber, github, context });
+
+  return prNumber;
 }
 
 /**
@@ -19,18 +24,43 @@ function main(options) {
  * @returns {number}
  */
 function validatePrNumber(filePath) {
-  try {
-    const content = readFileSync(filePath, 'utf-8').trim();
-    const prNumber = Number(content);
+  const content = readFileSync(filePath, 'utf-8').trim();
+  const prNumber = Number(content);
 
-    if (isNaN(prNumber) || !Number.isInteger(prNumber)) {
-      throw new Error('The ID in pr.txt is not a valid PR number.');
-    }
-
-    console.info('✅ PR ID valid');
-    return prNumber;
-  } catch (err) {
-    console.error(`Error: ${err.message}`);
-    process.exit(1);
+  if (isNaN(prNumber) || !Number.isInteger(prNumber)) {
+    throw new Error('The ID in pr.txt is not a valid PR number.');
   }
+
+  console.info('✅ PR ID valid');
+  return prNumber;
+}
+
+/**
+ * Validates that the PR number from the artifact matches the workflow run that produced it.
+ * This prevents a malicious PR from injecting a different PR number in the artifact.
+ *
+ * NOTE: This function is designed to run exclusively within `workflow_run` triggered workflows.
+ * It uses `context.payload.workflow_run.repository` (not `context.repo`) because in a `workflow_run`
+ * context we need to reference the repository that originated the triggering workflow run.
+ *
+ * @param {{prNumber: number} & Pick<import('../../scripts/triage-bot/src/types.ts').GithubScriptsParams,'github'|'context'>} options
+ */
+async function validatePrIdentity({ prNumber, github, context }) {
+  const owner = context.payload.workflow_run.repository.owner.login;
+  const repo = context.payload.workflow_run.repository.name;
+  const expectedSha = context.payload.workflow_run.head_sha;
+
+  const { data: pr } = await github.rest.pulls.get({
+    owner,
+    repo,
+    pull_number: prNumber,
+  });
+
+  if (pr.head.sha !== expectedSha) {
+    throw new Error(
+      `❌ PR #${prNumber} head SHA (${pr.head.sha}) does not match workflow run head SHA (${expectedSha}).`,
+    );
+  }
+
+  console.info('✅ PR identity verified against workflow run');
 }

--- a/.github/workflows/bundle-size-comment.yml
+++ b/.github/workflows/bundle-size-comment.yml
@@ -32,7 +32,7 @@ jobs:
           result-encoding: string
           script: |
             const run = require('./.github/scripts/validate-pr-number');
-            return run({ filePath: 'results/pr.txt' });
+            return await run({ filePath: 'results/pr.txt', github, context });
 
       - name: 'Comment on PR'
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4

--- a/.github/workflows/pr-vrt-comment.yml
+++ b/.github/workflows/pr-vrt-comment.yml
@@ -74,7 +74,7 @@ jobs:
         with:
           script: |
             const run = require('./.github/scripts/validate-pr-number');
-            const pull_number = run({filePath:'results/pr.txt'});
+            const pull_number = await run({filePath:'results/pr.txt', github, context});
 
             const result = await github.rest.pulls.get({
               owner: context.payload.workflow_run.repository.owner.login,
@@ -83,15 +83,6 @@ jobs:
             });
 
             const pr = result.data;
-
-            if (pr.head.sha !== context.payload.workflow_run.head_commit.id) {
-              console.log(
-                "PR head sha does not match the workflow run head commit id. " +
-                "There has probably been a push to the PR, so we will not run the VR Diff for the last iteration. " +
-                "Exiting the script."
-              );
-              process.exit(0);
-            }
 
             const headOwner = pr.head.repo.owner.login;
             const baseOwner = pr.base.repo.owner.login;

--- a/.github/workflows/pr-website-deploy-comment.yml
+++ b/.github/workflows/pr-website-deploy-comment.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           script: |
             const run = require('./.github/scripts/validate-pr-number');
-            const result = run({filePath:'results/pr.txt'});
+            const result = await run({filePath:'results/pr.txt', github, context});
             return result;
           result-encoding: string
 


### PR DESCRIPTION
## Summary

Adds SHA verification to `validate-pr-number.js` to prevent artifact poisoning in `workflow_run` triggered workflows.

### Problem

The `pr.txt` artifact is produced by a PR workflow and consumed by `workflow_run` workflows (which run with elevated permissions). A malicious PR could craft the artifact (only if the PR would be physically approved by maintainer, which is highly unlikely) to contain a different PR number, causing:
- Deploy comments on unrelated PRs
- Commit statuses set on another PR's head SHA
- Azure blob uploads to wrong paths

### Solution

After reading the PR number from `pr.txt`, we now fetch the PR via the GitHub API and verify that `pr.head.sha` matches `context.payload.workflow_run.head_sha`. If they don't match, the workflow fails with a clear error annotation in the Actions UI.

### Changes

- **`.github/scripts/validate-pr-number.js`** — now async; adds `validatePrIdentity()` that verifies the PR's head SHA matches the workflow run's head SHA. Uses `context.payload.workflow_run.repository` (not `context.repo`) as required in `workflow_run` context.
- **`.github/workflows/pr-website-deploy-comment.yml`** — passes `github`/`context` for identity verification
- **`.github/workflows/bundle-size-comment.yml`** — passes `github`/`context` for identity verification
- **`.github/workflows/pr-vrt-comment.yml`** — passes `github`/`context`, removes redundant inline SHA check (now centralized)