### PR TITLE
feat(web-components): implement BaseCounterBadge class and update CounterBadge component structure

### DIFF
--- a/change/@fluentui-web-components-37693143-a3ff-456b-8d13-63f5d2a3db74.json
+++ b/change/@fluentui-web-components-37693143-a3ff-456b-8d13-63f5d2a3db74.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "fix: use volatile getter for counter-badge display value",
+  "comment": "feat: implement BaseCounterBadge class and update CounterBadge component structure",
   "packageName": "@fluentui/web-components",
   "email": "863023+radium-v@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-web-components-37693143-a3ff-456b-8d13-63f5d2a3db74.json
+++ b/change/@fluentui-web-components-37693143-a3ff-456b-8d13-63f5d2a3db74.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: use volatile getter for counter-badge display value",
+  "packageName": "@fluentui/web-components",
+  "email": "863023+radium-v@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/docs/web-components.api.md
+++ b/packages/web-components/docs/web-components.api.md
@@ -587,6 +587,17 @@ export class BaseCheckbox extends FASTElement {
 }
 
 // @public
+export class BaseCounterBadge extends FASTElement {
+    count: number;
+    get displayValue(): string | undefined;
+    dot: boolean;
+    // @internal
+    elementInternals: ElementInternals;
+    overflowCount: number;
+    showZero: boolean;
+}
+
+// @public
 export class BaseDivider extends FASTElement {
     // (undocumented)
     connectedCallback(): void;
@@ -2399,25 +2410,17 @@ export const CompoundButtonStyles: ElementStyles;
 // @public
 export const CompoundButtonTemplate: ElementViewTemplate<CompoundButton>;
 
-// Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
-// Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "CounterBadge" because one of its declarations is marked as @internal
+// Warning: (ae-missing-release-tag) "CounterBadge" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
-export class CounterBadge extends FASTElement {
+export class CounterBadge extends BaseCounterBadge {
     appearance?: CounterBadgeAppearance;
     color?: CounterBadgeColor;
-    count: number;
-    get displayValue(): string | undefined;
-    dot: boolean;
-    // @internal
-    elementInternals: ElementInternals;
-    overflowCount: number;
     shape?: CounterBadgeShape;
-    showZero: boolean;
     size?: CounterBadgeSize;
 }
 
-// @internal
+// @public (undocumented)
 export interface CounterBadge extends StartEnd {
 }
 
@@ -2472,6 +2475,9 @@ export type CounterBadgeSize = ValuesOf<typeof CounterBadgeSize>;
 
 // @public
 export const CounterBadgeStyles: ElementStyles;
+
+// @public
+export const CounterBadgeTagName: "fluent-counter-badge";
 
 // @public
 export const CounterBadgeTemplate: ElementViewTemplate<CounterBadge>;

--- a/packages/web-components/docs/web-components.api.md
+++ b/packages/web-components/docs/web-components.api.md
@@ -2407,16 +2407,11 @@ export class CounterBadge extends FASTElement {
     appearance?: CounterBadgeAppearance;
     color?: CounterBadgeColor;
     count: number;
-    // (undocumented)
-    protected countChanged(): void;
+    get displayValue(): string | undefined;
     dot: boolean;
     // @internal
     elementInternals: ElementInternals;
     overflowCount: number;
-    // (undocumented)
-    protected overflowCountChanged(): void;
-    // @internal
-    setCount(): string | void;
     shape?: CounterBadgeShape;
     showZero: boolean;
     size?: CounterBadgeSize;

--- a/packages/web-components/src/badge/index.ts
+++ b/packages/web-components/src/badge/index.ts
@@ -1,6 +1,12 @@
-export { Badge } from './badge.js';
-export { BadgeAppearance, BadgeColor, BadgeShape, BadgeSize } from './badge.options.js';
-export { template as BadgeTemplate } from './badge.template.js';
-export { styles as BadgeStyles } from './badge.styles.js';
 export { definition as BadgeDefinition } from './badge.definition.js';
-export { tagName as BadgeTagName } from './badge.options.js';
+export { Badge } from './badge.js';
+export {
+  BadgeAppearance,
+  BadgeColor,
+  BadgeShape,
+  BadgeSize,
+  tagName as BadgeTagName,
+  type BadgeOptions,
+} from './badge.options.js';
+export { styles as BadgeStyles } from './badge.styles.js';
+export { template as BadgeTemplate } from './badge.template.js';

--- a/packages/web-components/src/counter-badge/counter-badge.base.ts
+++ b/packages/web-components/src/counter-badge/counter-badge.base.ts
@@ -1,0 +1,78 @@
+import { attr, FASTElement, nullableNumberConverter, volatile } from '@microsoft/fast-element';
+
+/**
+ * The base class used for constructing a fluent-counter-badge custom element.
+ * Contains the count-related state and display logic, without any visual
+ * appearance attributes.
+ *
+ * @public
+ */
+export class BaseCounterBadge extends FASTElement {
+  /**
+   * The internal {@link https://developer.mozilla.org/docs/Web/API/ElementInternals | `ElementInternals`} instance for the component.
+   *
+   * @internal
+   */
+  public elementInternals: ElementInternals = this.attachInternals();
+
+  /**
+   * The count to be displayed in the badge.
+   *
+   * @public
+   * @remarks
+   * HTML Attribute: `count`
+   */
+  @attr({ converter: nullableNumberConverter })
+  public count: number = 0;
+
+  /**
+   * The maximum count to be displayed before showing the overflow count (e.g. "99+").
+   *
+   * @public
+   * @remarks
+   * HTML Attribute: `overflow-count`
+   */
+  @attr({ attribute: 'overflow-count', converter: nullableNumberConverter })
+  public overflowCount: number = 99;
+
+  /**
+   * Whether to show the badge when the count is zero. By default, the badge will be hidden when the count is zero.
+   *
+   * @public
+   * @remarks
+   * HTML Attribute: `show-zero`
+   */
+  @attr({ attribute: 'show-zero', mode: 'boolean' })
+  public showZero: boolean = false;
+
+  /**
+   * Whether to display the badge as a dot. When true, the badge will be displayed as a dot and the count will not be
+   * shown.
+   *
+   * @public
+   * @remarks
+   * HTML Attribute: `dot`
+   */
+  @attr({ mode: 'boolean' })
+  public dot: boolean = false;
+
+  /**
+   * The value to be displayed in the badge, which is determined by the `count`, `overflow-count`, and `show-zero` attributes.
+   *
+   * @public
+   */
+  @volatile
+  public get displayValue(): string | undefined {
+    const count: number = this.count ?? 0;
+
+    if ((!this.showZero && count === 0) || this.dot) {
+      return '';
+    }
+
+    if (this.overflowCount > 0 && count > this.overflowCount) {
+      return `${this.overflowCount}+`;
+    }
+
+    return `${count}`;
+  }
+}

--- a/packages/web-components/src/counter-badge/counter-badge.options.ts
+++ b/packages/web-components/src/counter-badge/counter-badge.options.ts
@@ -1,15 +1,18 @@
 import { FluentDesignSystem } from '../fluent-design-system.js';
-import type { BadgeOptions } from '../badge/badge.options.js';
+import type { StartEndOptions } from '../patterns/start-end.js';
 import type { ValuesOf } from '../utils/typings.js';
+import type { CounterBadge } from './counter-badge.js';
 
 /**
- * CounterBadge options
+ * Template options for CounterBadge component.
+ *
  * @public
  */
-export type CounterBadgeOptions = BadgeOptions;
+export type CounterBadgeOptions = StartEndOptions<CounterBadge>;
 
 /**
- * CounterBadgeAppearance constants
+ * Values for the `appearance` attribute on CounterBadge elements.
+ *
  * @public
  */
 export const CounterBadgeAppearance = {
@@ -18,13 +21,14 @@ export const CounterBadgeAppearance = {
 } as const;
 
 /**
- * A CounterBadge can have an appearance of filled or ghost
+ * Type for the `appearance` attribute on CounterBadge elements, based on the CounterBadgeAppearance constants.
  * @public
  */
 export type CounterBadgeAppearance = ValuesOf<typeof CounterBadgeAppearance>;
 
 /**
- * CounterBadgeColor constants
+ * Values for the `color` attribute on CounterBadge elements.
+ *
  * @public
  */
 export const CounterBadgeColor = {
@@ -39,13 +43,14 @@ export const CounterBadgeColor = {
 } as const;
 
 /**
- * A CounterBadge can be one of preset colors
+ * Type for the `color` attribute on CounterBadge elements, based on the CounterBadgeColor constants.
  * @public
  */
 export type CounterBadgeColor = ValuesOf<typeof CounterBadgeColor>;
 
 /**
- * A CounterBadge shape can be circular or rounded.
+ * Values for the `shape` attribute on CounterBadge elements.
+ *
  * @public
  */
 export const CounterBadgeShape = {
@@ -54,13 +59,15 @@ export const CounterBadgeShape = {
 } as const;
 
 /**
- * A CounterBadge can be one of preset colors
+ * Type for the `shape` attribute on CounterBadge elements, based on the CounterBadgeShape constants.
+ *
  * @public
  */
 export type CounterBadgeShape = ValuesOf<typeof CounterBadgeShape>;
 
 /**
- * A CounterBadge can be square, circular or rounded.
+ * Values for the `size` attribute on CounterBadge elements.
+ *
  * @public
  */
 export const CounterBadgeSize = {
@@ -73,7 +80,8 @@ export const CounterBadgeSize = {
 } as const;
 
 /**
- * A CounterBadge can be on of several preset sizes.
+ * Type for the `size` attribute on CounterBadge elements, based on the CounterBadgeSize constants.
+ *
  * @public
  */
 export type CounterBadgeSize = ValuesOf<typeof CounterBadgeSize>;

--- a/packages/web-components/src/counter-badge/counter-badge.spec.ts
+++ b/packages/web-components/src/counter-badge/counter-badge.spec.ts
@@ -38,7 +38,7 @@ test.describe('CounterBadge component', () => {
 
     await expect(element).toHaveAttribute('overflow-count', '100');
 
-    await expect(element).toContainText('100');
+    await expect(element).toHaveText('100');
   });
 
   test('should display an overflow count when the `count` attribute is greater than the `overflow-count` attribute', async ({
@@ -50,7 +50,7 @@ test.describe('CounterBadge component', () => {
 
     await expect(element).toHaveAttribute('overflow-count', '100');
 
-    await expect(element).toContainText('100+');
+    await expect(element).toHaveText('100+');
 
     await test.step('should display the count when the `count` attribute is less than the `overflow-count` attribute', async () => {
       await element.evaluate((node: CounterBadge) => {
@@ -59,7 +59,7 @@ test.describe('CounterBadge component', () => {
 
       await expect(element).toHaveAttribute('overflow-count', '100');
 
-      await expect(element).toContainText('99');
+      await expect(element).toHaveText('99');
     });
   });
 
@@ -72,7 +72,7 @@ test.describe('CounterBadge component', () => {
 
     await expect(element).toHaveAttribute('overflow-count', '100');
 
-    await expect(element).toContainText('100+');
+    await expect(element).toHaveText('100+');
 
     await element.evaluate((node: CounterBadge) => {
       node.overflowCount = 101;
@@ -80,7 +80,7 @@ test.describe('CounterBadge component', () => {
 
     await expect(element).toHaveAttribute('overflow-count', '101');
 
-    await expect(element).toContainText('101');
+    await expect(element).toHaveText('101');
   });
 
   test('should display the count when the `count` attribute is set', async ({ fastPage }) => {
@@ -90,7 +90,7 @@ test.describe('CounterBadge component', () => {
 
     await expect(element).toHaveAttribute('count', '5');
 
-    await expect(element).toContainText('5');
+    await expect(element).toHaveText('5');
   });
 
   test('should show 0 when showZero attribute is present and value is 0', async ({ fastPage }) => {
@@ -102,7 +102,7 @@ test.describe('CounterBadge component', () => {
 
     await expect(element).toHaveJSProperty('showZero', true);
 
-    await expect(element).toContainText('0');
+    await expect(element).toHaveText('0');
 
     await element.evaluate(node => {
       node.removeAttribute('show-zero');
@@ -112,7 +112,7 @@ test.describe('CounterBadge component', () => {
 
     await expect(element).toHaveJSProperty('showZero', false);
 
-    await expect(element).not.toContainText('0');
+    await expect(element).not.toHaveText('0');
   });
 
   test('should display "0" when the `showZero` property is set to true and the `count` property is set to 0', async ({
@@ -124,7 +124,7 @@ test.describe('CounterBadge component', () => {
 
     await expect(element).toHaveJSProperty('showZero', false);
 
-    await expect(element).not.toContainText('0');
+    await expect(element).not.toHaveText('0');
 
     await element.evaluate((node: CounterBadge) => {
       node.showZero = true;
@@ -133,7 +133,7 @@ test.describe('CounterBadge component', () => {
 
     await expect(element).toHaveJSProperty('showZero', true);
 
-    await expect(element).toContainText('0');
+    await expect(element).toHaveText('0');
   });
 
   test('should display as a dot when the `dot` property is set to true', async ({ fastPage }) => {
@@ -141,7 +141,7 @@ test.describe('CounterBadge component', () => {
 
     await fastPage.setTemplate({ attributes: { count: '5' } });
 
-    await expect(element).toContainText('5');
+    await expect(element).toHaveText('5');
 
     await expect(element).toHaveJSProperty('dot', false);
 
@@ -151,7 +151,7 @@ test.describe('CounterBadge component', () => {
 
     await expect(element).toHaveJSProperty('dot', true);
 
-    await expect(element).not.toContainText('5');
+    await expect(element).not.toHaveText('5');
   });
 
   test('should display as a number when the `dot` property is set to false', async ({ fastPage }) => {
@@ -159,7 +159,7 @@ test.describe('CounterBadge component', () => {
 
     await fastPage.setTemplate({ attributes: { count: '5', dot: true } });
 
-    await expect(element).not.toContainText('5');
+    await expect(element).not.toHaveText('5');
 
     await expect(element).toHaveJSProperty('dot', true);
 
@@ -167,7 +167,7 @@ test.describe('CounterBadge component', () => {
       node.dot = false;
     });
 
-    await expect(element).toContainText('5');
+    await expect(element).toHaveText('5');
 
     await expect(element).toHaveJSProperty('dot', false);
   });
@@ -234,5 +234,37 @@ test.describe('CounterBadge component', () => {
         await expect(element).toHaveAttribute('appearance', appearance);
       });
     }
+  });
+
+  test('should NOT display the word "null" when only the `count` attribute is present', async ({ fastPage }) => {
+    const { element } = fastPage;
+
+    await fastPage.setTemplate({ attributes: { count: '5' } });
+
+    await expect(element).toHaveText('5');
+
+    await element.evaluate(node => {
+      node.removeAttribute('overflow-count');
+    });
+
+    await expect(element).not.toHaveText('null');
+
+    await expect(element).toHaveText('5');
+  });
+
+  test('should display the raw `count` when the `overflow-count` attribute is zero', async ({ fastPage }) => {
+    const { element } = fastPage;
+
+    await fastPage.setTemplate({ attributes: { count: '5', 'overflow-count': '0' } });
+
+    await expect(element).toHaveText('5');
+  });
+
+  test('should display the raw `count` when the `overflow-count` attribute is negative', async ({ fastPage }) => {
+    const { element } = fastPage;
+
+    await fastPage.setTemplate({ attributes: { count: '5', 'overflow-count': '-5' } });
+
+    await expect(element).toHaveText('5');
   });
 });

--- a/packages/web-components/src/counter-badge/counter-badge.template.ts
+++ b/packages/web-components/src/counter-badge/counter-badge.template.ts
@@ -1,17 +1,26 @@
 import { type ElementViewTemplate, html } from '@microsoft/fast-element';
-import { badgeTemplate } from '../badge/badge.template.js';
-import type { Badge } from '../badge/badge.js';
+import { endSlotTemplate, startSlotTemplate } from '../patterns/start-end.js';
 import type { CounterBadge } from './counter-badge.js';
 import type { CounterBadgeOptions } from './counter-badge.options.js';
 
-function composeTemplate<T extends CounterBadge & Badge>(options: CounterBadgeOptions = {}): ElementViewTemplate<T> {
-  return badgeTemplate<T>({
-    defaultContent: html<T>`${x => x.displayValue}`,
-  });
+/**
+ * Generates a template for the CounterBadge component.
+ *
+ * @public
+ */
+export function counterBadgeTemplate<T extends CounterBadge>(
+  options: CounterBadgeOptions = {},
+): ElementViewTemplate<T> {
+  return html<T>`
+    ${startSlotTemplate(options)}
+    <span>${x => x.displayValue}</span>
+    ${endSlotTemplate(options)}
+  `;
 }
 
 /**
- * The template for the Counter Badge component.
+ * The template for the fluent-counter-badge component.
+ *
  * @public
  */
-export const template: ElementViewTemplate<CounterBadge> = composeTemplate<CounterBadge & Badge>();
+export const template: ElementViewTemplate<CounterBadge> = counterBadgeTemplate();

--- a/packages/web-components/src/counter-badge/counter-badge.template.ts
+++ b/packages/web-components/src/counter-badge/counter-badge.template.ts
@@ -6,7 +6,7 @@ import type { CounterBadgeOptions } from './counter-badge.options.js';
 
 function composeTemplate<T extends CounterBadge & Badge>(options: CounterBadgeOptions = {}): ElementViewTemplate<T> {
   return badgeTemplate<T>({
-    defaultContent: html<T>`${x => x.setCount()}`,
+    defaultContent: html<T>`${x => x.displayValue}`,
   });
 }
 

--- a/packages/web-components/src/counter-badge/counter-badge.ts
+++ b/packages/web-components/src/counter-badge/counter-badge.ts
@@ -1,4 +1,4 @@
-import { attr, FASTElement, nullableNumberConverter } from '@microsoft/fast-element';
+import { attr, FASTElement, nullableNumberConverter, volatile } from '@microsoft/fast-element';
 import { applyMixins } from '../utils/apply-mixins.js';
 import { StartEnd } from '../patterns/start-end.js';
 import {
@@ -72,9 +72,6 @@ export class CounterBadge extends FASTElement {
    */
   @attr({ converter: nullableNumberConverter })
   public count: number = 0;
-  protected countChanged() {
-    this.setCount();
-  }
 
   /**
    * Max number to be displayed
@@ -85,9 +82,6 @@ export class CounterBadge extends FASTElement {
    */
   @attr({ attribute: 'overflow-count', converter: nullableNumberConverter })
   public overflowCount: number = 99;
-  protected overflowCountChanged() {
-    this.setCount();
-  }
 
   /**
    * If the badge should be shown when count is 0
@@ -110,13 +104,12 @@ export class CounterBadge extends FASTElement {
   public dot: boolean = false;
 
   /**
-   * Function to set the count
-   * This is the default slotted content for the counter badge
-   * If children are slotted, that will override the value returned
+   * The value to be displayed in the badge, which is determined by the `count`, `overflow-count`, and `show-zero` attributes.
    *
-   * @internal
+   * @public
    */
-  public setCount(): string | void {
+  @volatile
+  public get displayValue(): string | undefined {
     const count: number | null = this.count ?? 0;
 
     if ((count !== 0 || this.showZero) && !this.dot) {

--- a/packages/web-components/src/counter-badge/counter-badge.ts
+++ b/packages/web-components/src/counter-badge/counter-badge.ts
@@ -1,6 +1,7 @@
-import { attr, FASTElement, nullableNumberConverter, volatile } from '@microsoft/fast-element';
-import { applyMixins } from '../utils/apply-mixins.js';
+import { attr } from '@microsoft/fast-element';
 import { StartEnd } from '../patterns/start-end.js';
+import { applyMixins } from '../utils/apply-mixins.js';
+import { BaseCounterBadge } from './counter-badge.base.js';
 import {
   CounterBadgeAppearance,
   CounterBadgeColor,
@@ -9,20 +10,14 @@ import {
 } from './counter-badge.options.js';
 
 /**
- * The base class used for constructing a fluent-badge custom element
+ * A CounterBadge Custom HTML Element.
+ * Based on BaseCounterBadge and includes style and layout specific attributes.
  *
  * @tag fluent-counter-badge
  *
  * @public
  */
-export class CounterBadge extends FASTElement {
-  /**
-   * The internal {@link https://developer.mozilla.org/docs/Web/API/ElementInternals | `ElementInternals`} instance for the component.
-   *
-   * @internal
-   */
-  public elementInternals: ElementInternals = this.attachInternals();
-
+export class CounterBadge extends BaseCounterBadge {
   /**
    * The appearance the badge should have.
    *
@@ -62,70 +57,8 @@ export class CounterBadge extends FASTElement {
    */
   @attr
   public size?: CounterBadgeSize;
-
-  /**
-   * The count the badge should have.
-   *
-   * @public
-   * @remarks
-   * HTML Attribute: count
-   */
-  @attr({ converter: nullableNumberConverter })
-  public count: number = 0;
-
-  /**
-   * Max number to be displayed
-   *
-   * @public
-   * @remarks
-   * HTML Attribute: overflow-count
-   */
-  @attr({ attribute: 'overflow-count', converter: nullableNumberConverter })
-  public overflowCount: number = 99;
-
-  /**
-   * If the badge should be shown when count is 0
-   *
-   * @public
-   * @remarks
-   * HTML Attribute: show-zero
-   */
-  @attr({ attribute: 'show-zero', mode: 'boolean' })
-  public showZero: boolean = false;
-
-  /**
-   * If a dot should be displayed without the count
-   *
-   * @public
-   * @remarks
-   * HTML Attribute: dot
-   */
-  @attr({ mode: 'boolean' })
-  public dot: boolean = false;
-
-  /**
-   * The value to be displayed in the badge, which is determined by the `count`, `overflow-count`, and `show-zero` attributes.
-   *
-   * @public
-   */
-  @volatile
-  public get displayValue(): string | undefined {
-    const count: number | null = this.count ?? 0;
-
-    if ((count !== 0 || this.showZero) && !this.dot) {
-      return count > this.overflowCount ? `${this.overflowCount}+` : `${count}`;
-    }
-
-    return;
-  }
 }
 
-/**
- * Mark internal because exporting class and interface of the same name
- * confuses API extractor.
- * TODO: Below will be unnecessary when Badge class gets updated
- * @internal
- */
 /* eslint-disable-next-line */
 export interface CounterBadge extends StartEnd {}
 applyMixins(CounterBadge, StartEnd);

--- a/packages/web-components/src/counter-badge/index.ts
+++ b/packages/web-components/src/counter-badge/index.ts
@@ -1,11 +1,12 @@
+export { BaseCounterBadge } from './counter-badge.base.js';
+export { definition as CounterBadgeDefinition } from './counter-badge.definition.js';
 export { CounterBadge } from './counter-badge.js';
 export {
   CounterBadgeAppearance,
   CounterBadgeColor,
   CounterBadgeShape,
   CounterBadgeSize,
+  tagName as CounterBadgeTagName,
 } from './counter-badge.options.js';
-export { template as CounterBadgeTemplate } from './counter-badge.template.js';
 export { styles as CounterBadgeStyles } from './counter-badge.styles.js';
-export { definition as CounterBadgeDefinition } from './counter-badge.definition.js';
-export { tagName as CounterBadgeTagName } from './counter-badge.options.js';
+export { template as CounterBadgeTemplate } from './counter-badge.template.js';

--- a/packages/web-components/src/index.ts
+++ b/packages/web-components/src/index.ts
@@ -72,6 +72,7 @@ export {
   CompoundButtonTemplate,
 } from './compound-button/index.js';
 export {
+  BaseCounterBadge,
   CounterBadge,
   CounterBadgeAppearance,
   CounterBadgeColor,
@@ -79,6 +80,7 @@ export {
   CounterBadgeShape,
   CounterBadgeSize,
   CounterBadgeStyles,
+  CounterBadgeTagName,
   CounterBadgeTemplate,
 } from './counter-badge/index.js';
 export { Dialog, DialogType, DialogDefinition, DialogTemplate, DialogStyles, isDialog } from './dialog/index.js';


### PR DESCRIPTION
## Previous Behavior

Counter badge behavior was implemented directly on `CounterBadge` and templating depended on `badgeTemplate` with `setCount()` as default content. Display logic could produce undesirable values in edge cases (for example when `overflow-count` was removed or invalid). Tests primarily used substring assertions (`toContainText`), which could allow false positives.

## New Behavior

`CounterBadge` has been split so count/display behavior now lives in a reusable `BaseCounterBadge`, while visual/style attributes remain on `CounterBadge`. The counter badge template is now explicit and self-contained (`startSlotTemplate`, `<span>${x => x.displayValue}</span>`, `endSlotTemplate`) and no longer composes through `badgeTemplate`. `displayValue` is a volatile getter that safely handles zero/hidden/dot states and only applies overflow formatting when `overflowCount > 0`, preventing invalid outputs like `null+`. Test coverage was expanded with targeted regression tests for removed `overflow-count`, zero overflow count, and negative overflow count, and assertions were tightened to `toHaveText` for exact text validation.
