### PR TITLE
Adds css reset to handle white-space overflow in dropdown

### DIFF
--- a/change/@fluentui-web-components-0205984a-f89b-427c-bd75-d79aa69d8970.json
+++ b/change/@fluentui-web-components-0205984a-f89b-427c-bd75-d79aa69d8970.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adds css and DOM slot containers to dropdown hardenning component against white-space vulnerabilities.",
+  "packageName": "@fluentui/web-components",
+  "email": "mibaraka@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-web-components-0205984a-f89b-427c-bd75-d79aa69d8970.json
+++ b/change/@fluentui-web-components-0205984a-f89b-427c-bd75-d79aa69d8970.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "Adds css and DOM slot containers to dropdown hardenning component against white-space vulnerabilities.",
+  "comment": "Adds white-space normal to dropdown .control div to prevent text overflow issues.",
   "packageName": "@fluentui/web-components",
   "email": "mibaraka@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/web-components/src/dropdown/dropdown.styles.ts
+++ b/packages/web-components/src/dropdown/dropdown.styles.ts
@@ -83,6 +83,7 @@ export const styles = css`
     min-width: 160px;
     overflow: hidden;
     padding: ${spacingVerticalSNudge} ${spacingHorizontalMNudge};
+    white-space: normal;
     position: relative;
     text-align: start;
     width: 100%;
@@ -100,14 +101,6 @@ export const styles = css`
     column-gap: ${spacingHorizontalS};
     padding: ${spacingVerticalS} ${spacingHorizontalM};
     ${typographyBody2Styles}
-  }
-
-  .control-slot-container {
-    overflow: hidden;
-  }
-
-  .indicator-slot-container {
-    margin-inline-start: ${spacingHorizontalS};
   }
 
   ::slotted(:is(input, button)) {

--- a/packages/web-components/src/dropdown/dropdown.styles.ts
+++ b/packages/web-components/src/dropdown/dropdown.styles.ts
@@ -102,6 +102,14 @@ export const styles = css`
     ${typographyBody2Styles}
   }
 
+  .control-slot-container {
+    overflow: hidden;
+  }
+
+  .indicator-slot-container {
+    margin-inline-start: ${spacingHorizontalS};
+  }
+
   ::slotted(:is(input, button)) {
     all: unset;
     flex: 1 1 auto;

--- a/packages/web-components/src/dropdown/dropdown.template.ts
+++ b/packages/web-components/src/dropdown/dropdown.template.ts
@@ -82,12 +82,8 @@ export function dropdownTemplate<T extends BaseDropdown>(options: DropdownOption
       @mousedown="${(x, c) => x.mousedownHandler(c.event as MouseEvent)}"
     >
       <div class="control">
-        <div class="control-slot-container">
-          <slot name="control" ${ref('controlSlot')}></slot>
-        </div>
-        <div class="indicator-slot-container">
-          <slot name="indicator" ${ref('indicatorSlot')}>${staticallyCompose(options.indicator)}</slot>
-        </div>
+        <slot name="control" ${ref('controlSlot')}></slot>
+        <slot name="indicator" ${ref('indicatorSlot')}>${staticallyCompose(options.indicator)}</slot>
       </div>
       <slot @slotchange="${(x, c) => x.slotchangeHandler(c.event)}"></slot>
     </template>

--- a/packages/web-components/src/dropdown/dropdown.template.ts
+++ b/packages/web-components/src/dropdown/dropdown.template.ts
@@ -82,8 +82,12 @@ export function dropdownTemplate<T extends BaseDropdown>(options: DropdownOption
       @mousedown="${(x, c) => x.mousedownHandler(c.event as MouseEvent)}"
     >
       <div class="control">
-        <slot name="control" ${ref('controlSlot')}></slot>
-        <slot name="indicator" ${ref('indicatorSlot')}>${staticallyCompose(options.indicator)}</slot>
+        <div class="control-slot-container">
+          <slot name="control" ${ref('controlSlot')}></slot>
+        </div>
+        <div class="indicator-slot-container">
+          <slot name="indicator" ${ref('indicatorSlot')}>${staticallyCompose(options.indicator)}</slot>
+        </div>
       </div>
       <slot @slotchange="${(x, c) => x.slotchangeHandler(c.event)}"></slot>
     </template>


### PR DESCRIPTION
## Previous Behavior

If client sets whitespace to nowrap, multi select dropdowns will break under overflow conditions.

## New Behavior

Dropdown handles non-normal whitespace and content overflow inside of dropdown by resetting white-space internally.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #36211 
