### PR TITLE
test(react-nav): add hook-level regression tests for react-nav components

### DIFF
--- a/packages/react-components/react-nav/library/src/components/AppItem/useAppItem.test.tsx
+++ b/packages/react-components/react-nav/library/src/components/AppItem/useAppItem.test.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+
+import { useAppItem_unstable } from './useAppItem';
+import { NavProvider } from '../NavContext';
+import type { NavContextValue } from '../NavContext.types';
+
+const defaultNavContextValue: NavContextValue = {
+  selectedValue: undefined,
+  selectedCategoryValue: undefined,
+  onRegister: () => undefined,
+  onUnregister: () => undefined,
+  onSelect: () => undefined,
+  getRegisteredNavItems: () => ({ registeredNavItems: {} }),
+  onRequestNavCategoryItemToggle: () => undefined,
+  openCategories: [],
+  multiple: true,
+  density: 'small',
+  tabbable: false,
+};
+
+describe('useAppItem_unstable', () => {
+  it('uses an anchor root when href is provided', () => {
+    const wrapper = ({ children }: { children?: React.ReactNode }) => (
+      <NavProvider value={defaultNavContextValue}>{children}</NavProvider>
+    );
+
+    const { result } = renderHook(() => useAppItem_unstable({ href: '/app' }, React.createRef()), { wrapper });
+
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    expect(result.current.components.root).toBe('a');
+  });
+
+  it('inherits density from Nav context', () => {
+    const wrapper = ({ children }: { children?: React.ReactNode }) => (
+      <NavProvider value={defaultNavContextValue}>{children}</NavProvider>
+    );
+
+    const { result } = renderHook(() => useAppItem_unstable({}, React.createRef()), { wrapper });
+
+    expect(result.current.density).toBe('small');
+  });
+});

--- a/packages/react-components/react-nav/library/src/components/AppItemStatic/useAppItemStatic.test.tsx
+++ b/packages/react-components/react-nav/library/src/components/AppItemStatic/useAppItemStatic.test.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+
+import { useAppItemStatic_unstable } from './useAppItemStatic';
+import { NavProvider } from '../NavContext';
+import type { NavContextValue } from '../NavContext.types';
+
+const defaultNavContextValue: NavContextValue = {
+  selectedValue: undefined,
+  selectedCategoryValue: undefined,
+  onRegister: () => undefined,
+  onUnregister: () => undefined,
+  onSelect: () => undefined,
+  getRegisteredNavItems: () => ({ registeredNavItems: {} }),
+  onRequestNavCategoryItemToggle: () => undefined,
+  openCategories: [],
+  multiple: true,
+  density: 'small',
+  tabbable: false,
+};
+
+describe('useAppItemStatic_unstable', () => {
+  it('creates a div root and optional icon slot', () => {
+    const wrapper = ({ children }: { children?: React.ReactNode }) => (
+      <NavProvider value={defaultNavContextValue}>{children}</NavProvider>
+    );
+
+    const { result } = renderHook(() => useAppItemStatic_unstable({ icon: 'icon' }, React.createRef()), { wrapper });
+
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    expect(result.current.components.root).toBe('div');
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    expect(result.current.components.icon).toBe('span');
+    expect(result.current.icon).toBeDefined();
+  });
+
+  it('inherits density from Nav context', () => {
+    const wrapper = ({ children }: { children?: React.ReactNode }) => (
+      <NavProvider value={defaultNavContextValue}>{children}</NavProvider>
+    );
+
+    const { result } = renderHook(() => useAppItemStatic_unstable({}, React.createRef()), { wrapper });
+
+    expect(result.current.density).toBe('small');
+  });
+});

--- a/packages/react-components/react-nav/library/src/components/Nav/useNav.test.tsx
+++ b/packages/react-components/react-nav/library/src/components/Nav/useNav.test.tsx
@@ -1,0 +1,77 @@
+import * as React from 'react';
+import { act, renderHook } from '@testing-library/react-hooks';
+
+import { useNav_unstable } from './useNav';
+
+describe('useNav_unstable', () => {
+  it('initializes only the first defaultOpenCategories entry when multiple is false', () => {
+    const { result } = renderHook(() =>
+      useNav_unstable({ defaultOpenCategories: ['category-1', 'category-2'], multiple: false }, React.createRef()),
+    );
+
+    expect(result.current.openCategories).toEqual(['category-1']);
+  });
+
+  it('updates selected values and calls onNavItemSelect from onSelect', () => {
+    const onNavItemSelect = jest.fn();
+
+    const { result } = renderHook(() => useNav_unstable({ onNavItemSelect }, React.createRef()));
+
+    act(() => {
+      result.current.onSelect({} as React.MouseEvent<HTMLButtonElement>, {
+        type: 'click',
+        event: {} as React.MouseEvent<HTMLButtonElement>,
+        value: 'item-1',
+        categoryValue: 'category-1',
+      });
+    });
+
+    expect(result.current.selectedValue).toBe('item-1');
+    expect(result.current.selectedCategoryValue).toBe('category-1');
+    expect(onNavItemSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it('toggles open categories through onRequestNavCategoryItemToggle', () => {
+    const { result } = renderHook(() =>
+      useNav_unstable({ defaultOpenCategories: ['category-1'], multiple: true }, React.createRef()),
+    );
+
+    act(() => {
+      result.current.onRequestNavCategoryItemToggle({} as React.MouseEvent<HTMLButtonElement>, {
+        type: 'click',
+        event: {} as React.MouseEvent<HTMLButtonElement>,
+        value: '',
+        categoryValue: 'category-1',
+      });
+    });
+
+    expect(result.current.openCategories).toEqual([]);
+
+    act(() => {
+      result.current.onRequestNavCategoryItemToggle({} as React.MouseEvent<HTMLButtonElement>, {
+        type: 'click',
+        event: {} as React.MouseEvent<HTMLButtonElement>,
+        value: '',
+        categoryValue: 'category-2',
+      });
+    });
+
+    expect(result.current.openCategories).toEqual(['category-2']);
+  });
+
+  it('tracks previous selected value in getRegisteredNavItems', () => {
+    const { result, rerender } = renderHook(
+      ({ selectedValue }) => useNav_unstable({ selectedValue }, React.createRef()),
+      { initialProps: { selectedValue: 'item-1' } },
+    );
+
+    rerender({ selectedValue: 'item-2' });
+
+    expect(result.current.getRegisteredNavItems()).toEqual(
+      expect.objectContaining({
+        selectedValue: 'item-2',
+        previousSelectedValue: 'item-1',
+      }),
+    );
+  });
+});

--- a/packages/react-components/react-nav/library/src/components/NavCategoryItem/useNavCategoryItem.test.tsx
+++ b/packages/react-components/react-nav/library/src/components/NavCategoryItem/useNavCategoryItem.test.tsx
@@ -1,0 +1,82 @@
+import * as React from 'react';
+import { act, renderHook } from '@testing-library/react-hooks';
+
+import { useNavCategoryItem_unstable } from './useNavCategoryItem';
+import { NavProvider } from '../NavContext';
+import type { NavContextValue } from '../NavContext.types';
+import { NavCategoryProvider } from '../NavCategoryContext';
+import type { NavCategoryContextValue } from '../NavCategoryContext';
+
+const createNavContextValue = (overrides?: Partial<NavContextValue>): NavContextValue => ({
+  selectedValue: undefined,
+  selectedCategoryValue: undefined,
+  onRegister: () => undefined,
+  onUnregister: () => undefined,
+  onSelect: () => undefined,
+  getRegisteredNavItems: () => ({ registeredNavItems: {} }),
+  onRequestNavCategoryItemToggle: () => undefined,
+  openCategories: [],
+  multiple: true,
+  density: 'medium',
+  tabbable: false,
+  ...overrides,
+});
+
+const createCategoryContextValue = (overrides?: Partial<NavCategoryContextValue>): NavCategoryContextValue => ({
+  open: false,
+  value: 'category-1',
+  ...overrides,
+});
+
+describe('useNavCategoryItem_unstable', () => {
+  it('is selected and sets aria-current when closed with matching selectedCategoryValue', () => {
+    const wrapper = ({ children }: { children?: React.ReactNode }) => (
+      <NavProvider value={createNavContextValue({ selectedCategoryValue: 'category-1' })}>
+        <NavCategoryProvider value={createCategoryContextValue()}>{children}</NavCategoryProvider>
+      </NavProvider>
+    );
+
+    const { result } = renderHook(() => useNavCategoryItem_unstable({}, React.createRef()), { wrapper });
+
+    expect(result.current.selected).toBe(true);
+    expect(result.current.root['aria-current']).toBe('page');
+    expect(result.current.root['aria-expanded']).toBe(false);
+  });
+
+  it('does not mark selected while open even if selectedCategoryValue matches', () => {
+    const wrapper = ({ children }: { children?: React.ReactNode }) => (
+      <NavProvider value={createNavContextValue({ selectedCategoryValue: 'category-1' })}>
+        <NavCategoryProvider value={createCategoryContextValue({ open: true })}>{children}</NavCategoryProvider>
+      </NavProvider>
+    );
+
+    const { result } = renderHook(() => useNavCategoryItem_unstable({}, React.createRef()), { wrapper });
+
+    expect(result.current.selected).toBe(false);
+    expect(result.current.root['aria-current']).toBe('false');
+    expect(result.current.root['aria-expanded']).toBe(true);
+  });
+
+  it('requests category toggle on click', () => {
+    const onRequestNavCategoryItemToggle = jest.fn();
+    const wrapper = ({ children }: { children?: React.ReactNode }) => (
+      <NavProvider value={createNavContextValue({ onRequestNavCategoryItemToggle })}>
+        <NavCategoryProvider value={createCategoryContextValue({ value: 'category-2' })}>
+          {children}
+        </NavCategoryProvider>
+      </NavProvider>
+    );
+
+    const { result } = renderHook(() => useNavCategoryItem_unstable({}, React.createRef()), { wrapper });
+
+    act(() => {
+      result.current.root.onClick?.({} as React.MouseEvent<HTMLButtonElement>);
+    });
+
+    expect(onRequestNavCategoryItemToggle).toHaveBeenCalledTimes(1);
+    expect(onRequestNavCategoryItemToggle).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ categoryValue: 'category-2', value: '' }),
+    );
+  });
+});

--- a/packages/react-components/react-nav/library/src/components/NavItem/useNavItem.test.tsx
+++ b/packages/react-components/react-nav/library/src/components/NavItem/useNavItem.test.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react';
+import { act, renderHook } from '@testing-library/react-hooks';
+
+import { useNavItem_unstable } from './useNavItem';
+import { NavProvider } from '../NavContext';
+import type { NavContextValue } from '../NavContext.types';
+
+const createNavContextValue = (overrides?: Partial<NavContextValue>): NavContextValue => ({
+  selectedValue: 'item-1',
+  selectedCategoryValue: undefined,
+  onRegister: () => undefined,
+  onUnregister: () => undefined,
+  onSelect: () => undefined,
+  getRegisteredNavItems: () => ({ registeredNavItems: {} }),
+  onRequestNavCategoryItemToggle: () => undefined,
+  openCategories: [],
+  multiple: true,
+  density: 'medium',
+  tabbable: false,
+  ...overrides,
+});
+
+describe('useNavItem_unstable', () => {
+  it('marks the item as selected when selectedValue matches', () => {
+    const wrapper = ({ children }: { children?: React.ReactNode }) => (
+      <NavProvider value={createNavContextValue()}>{children}</NavProvider>
+    );
+
+    const { result } = renderHook(() => useNavItem_unstable({ value: 'item-1' }, React.createRef()), { wrapper });
+
+    expect(result.current.selected).toBe(true);
+    expect(result.current.root['aria-current']).toBe('page');
+  });
+
+  it('calls onSelect with value when clicked and not prevented', () => {
+    const onSelect = jest.fn();
+    const wrapper = ({ children }: { children?: React.ReactNode }) => (
+      <NavProvider value={createNavContextValue({ selectedValue: undefined, onSelect })}>{children}</NavProvider>
+    );
+
+    const { result } = renderHook(() => useNavItem_unstable({ value: 'item-2' }, React.createRef()), { wrapper });
+
+    act(() => {
+      result.current.root.onClick?.({
+        target: document.createElement('button'),
+        defaultPrevented: false,
+      } as unknown as React.MouseEvent<HTMLButtonElement> & React.MouseEvent<HTMLAnchorElement>);
+    });
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ value: 'item-2', type: 'click' }),
+    );
+  });
+
+  it('registers on mount and unregisters on unmount', () => {
+    const onRegister = jest.fn();
+    const onUnregister = jest.fn();
+    const wrapper = ({ children }: { children?: React.ReactNode }) => (
+      <NavProvider value={createNavContextValue({ onRegister, onUnregister })}>{children}</NavProvider>
+    );
+
+    const { unmount } = renderHook(() => useNavItem_unstable({ value: 'item-1' }, React.createRef()), { wrapper });
+
+    expect(onRegister).toHaveBeenCalledTimes(1);
+    unmount();
+    expect(onUnregister).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/react-components/react-nav/library/src/components/NavSubItem/useNavSubItem.test.tsx
+++ b/packages/react-components/react-nav/library/src/components/NavSubItem/useNavSubItem.test.tsx
@@ -1,0 +1,92 @@
+import * as React from 'react';
+import { act, renderHook } from '@testing-library/react-hooks';
+
+import { useNavSubItem_unstable } from './useNavSubItem';
+import { NavProvider } from '../NavContext';
+import type { NavContextValue } from '../NavContext.types';
+import { NavCategoryProvider } from '../NavCategoryContext';
+import type { NavCategoryContextValue } from '../NavCategoryContext';
+
+const createNavContextValue = (overrides?: Partial<NavContextValue>): NavContextValue => ({
+  selectedValue: 'sub-item-1',
+  selectedCategoryValue: undefined,
+  onRegister: () => undefined,
+  onUnregister: () => undefined,
+  onSelect: () => undefined,
+  getRegisteredNavItems: () => ({ registeredNavItems: {} }),
+  onRequestNavCategoryItemToggle: () => undefined,
+  openCategories: [],
+  multiple: true,
+  density: 'medium',
+  tabbable: false,
+  ...overrides,
+});
+
+const createCategoryContextValue = (overrides?: Partial<NavCategoryContextValue>): NavCategoryContextValue => ({
+  open: true,
+  value: 'category-1',
+  ...overrides,
+});
+
+describe('useNavSubItem_unstable', () => {
+  it('marks sub item selected when selectedValue matches', () => {
+    const wrapper = ({ children }: { children?: React.ReactNode }) => (
+      <NavProvider value={createNavContextValue()}>
+        <NavCategoryProvider value={createCategoryContextValue()}>{children}</NavCategoryProvider>
+      </NavProvider>
+    );
+
+    const { result } = renderHook(() => useNavSubItem_unstable({ value: 'sub-item-1' }, React.createRef()), {
+      wrapper,
+    });
+
+    expect(result.current.selected).toBe(true);
+    expect(result.current.root['aria-current']).toBe('page');
+  });
+
+  it('calls onSelect with parent category value when clicked', () => {
+    const onSelect = jest.fn();
+    const wrapper = ({ children }: { children?: React.ReactNode }) => (
+      <NavProvider value={createNavContextValue({ selectedValue: undefined, onSelect })}>
+        <NavCategoryProvider value={createCategoryContextValue({ value: 'category-2' })}>
+          {children}
+        </NavCategoryProvider>
+      </NavProvider>
+    );
+
+    const { result } = renderHook(() => useNavSubItem_unstable({ value: 'sub-item-2' }, React.createRef()), {
+      wrapper,
+    });
+
+    act(() => {
+      result.current.root.onClick?.({
+        target: document.createElement('button'),
+        defaultPrevented: false,
+      } as unknown as React.MouseEvent<HTMLButtonElement> & React.MouseEvent<HTMLAnchorElement>);
+    });
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ value: 'sub-item-2', categoryValue: 'category-2' }),
+    );
+  });
+
+  it('registers and unregisters by sub item value', () => {
+    const onRegister = jest.fn();
+    const onUnregister = jest.fn();
+    const wrapper = ({ children }: { children?: React.ReactNode }) => (
+      <NavProvider value={createNavContextValue({ onRegister, onUnregister })}>
+        <NavCategoryProvider value={createCategoryContextValue()}>{children}</NavCategoryProvider>
+      </NavProvider>
+    );
+
+    const { unmount } = renderHook(() => useNavSubItem_unstable({ value: 'sub-item-3' }, React.createRef()), {
+      wrapper,
+    });
+
+    expect(onRegister).toHaveBeenCalledTimes(1);
+    unmount();
+    expect(onUnregister).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/react-components/react-nav/library/src/components/NavSubItemGroup/useNavSubItemGroup.test.tsx
+++ b/packages/react-components/react-nav/library/src/components/NavSubItemGroup/useNavSubItemGroup.test.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+
+import { useNavSubItemGroup_unstable } from './useNavSubItemGroup';
+import { NavCategoryProvider } from '../NavCategoryContext';
+import type { NavCategoryContextValue } from '../NavCategoryContext';
+
+const createCategoryContextValue = (overrides?: Partial<NavCategoryContextValue>): NavCategoryContextValue => ({
+  open: true,
+  value: 'category-1',
+  ...overrides,
+});
+
+describe('useNavSubItemGroup_unstable', () => {
+  it('reads open state from NavCategory context', () => {
+    const wrapper = ({ children }: { children?: React.ReactNode }) => (
+      <NavCategoryProvider value={createCategoryContextValue({ open: false })}>{children}</NavCategoryProvider>
+    );
+
+    const { result } = renderHook(() => useNavSubItemGroup_unstable({}, React.createRef()), { wrapper });
+
+    expect(result.current.open).toBe(false);
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    expect(result.current.components.root).toBe('div');
+  });
+
+  it('configures collapseMotion visibility based on open state', () => {
+    const wrapper = ({ children }: { children?: React.ReactNode }) => (
+      <NavCategoryProvider value={createCategoryContextValue({ open: true })}>{children}</NavCategoryProvider>
+    );
+
+    const { result } = renderHook(() => useNavSubItemGroup_unstable({}, React.createRef()), { wrapper });
+
+    expect(result.current.collapseMotion).toBeDefined();
+    expect((result.current.collapseMotion as unknown as Record<string, unknown>).visible).toBe(true);
+  });
+});


### PR DESCRIPTION
## Stack

This PR is part of a 3-PR stack. Review and merge bottom-up:

1. 👉 **#36212** — test(react-nav): hook-level regression tests _(base: `master`)_ — **merge first**
2. **#35812** — feat(react-nav): expose base hooks _(base: #36212)_ — depends on #36212
3. **#36213** — feat(react-headless-components-preview): add Nav component _(base: #35812)_ — depends on #35812

---

## Summary

Add hook-level tests covering `useNavBase_unstable`, `useAppItemBase_unstable`, `useAppItemStaticBase_unstable`, `useNavCategoryItemBase_unstable`, `useNavItemBase_unstable`, `useNavSubItemBase_unstable`, and `useNavSubItemGroupBase_unstable` to lock in current behavior before refactor.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>