### PR TITLE
docs(public-docsite): update icon tool documentation

### DIFF
--- a/apps/public-docsite/src/pages/Styles/FabricIconsPage/FabricIconsPage.tsx
+++ b/apps/public-docsite/src/pages/Styles/FabricIconsPage/FabricIconsPage.tsx
@@ -39,7 +39,7 @@ function _otherSections(platform: Platforms): IPageSectionProps<Platforms>[] {
           jumpLinks: [
             { text: enDash + ' Fluent UI React', url: 'fluent-ui-react' },
             { text: enDash + ' Fabric Core', url: 'fabric-core' },
-            { text: enDash + ' Fluent UI Icons tool', url: 'fluent-ui-icons-tool' },
+            { text: enDash + ' Icon subsets', url: 'icon-subsets' },
           ],
         },
 

--- a/apps/public-docsite/src/pages/Styles/FabricIconsPage/docs/web/FabricIconsUsage.md
+++ b/apps/public-docsite/src/pages/Styles/FabricIconsPage/docs/web/FabricIconsUsage.md
@@ -59,6 +59,6 @@ In your app, combine the base `ms-Icon` class with a modifier class for the spec
 
 Note the `aria-hidden` attribute, which prevents screen readers from reading the icon. In cases where meaning is conveyed only through the icon, such as an icon-only navigation bar, use the [`aria-label` attribute](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute) on the button for accessibility.
 
-### Fluent UI icons tool
+### Icon subsets
 
-The [Fluent UI icons tool](https://aka.ms/fluentui-icons) lets you search and browse all of Fluent UI's font-based icons. You can also use it to create and maintain subsets of the icon font to use in your web apps, which are drop-in replacements for the default Fabric Core and Fluent UI React icon sets. In addition, the Fluent UI Icons tool is updated with new icons more frequently than the Fluent UI set. You can see detailed docs for the tool at https://aka.ms/fluentui-icons?help=1.
+The Fluent UI icons subsetting tool is no longer publicly available. For web apps that need font-based icons, use the default CDN, host the font files from `@fluentui/font-icons-mdl2/fonts` yourself and pass that location to `initializeIcons`, or register custom icons with `registerIcons`.

--- a/docs/react-wiki-archive/BestPractices/Using-icons.md
+++ b/docs/react-wiki-archive/BestPractices/Using-icons.md
@@ -32,9 +32,7 @@ If you would like the icons to be served from your own CDN, simply copy the file
 
 ### Creating an icon subset
 
-The Fabric Icons tool, https://aka.ms/uifabric-icons, lets you search and browse all of Fabric/Fluent UI's MDL2 icons. You can also use it to create and maintain subsets of the icon font to use in your web apps, which are drop-in replacements for the default Fabric Core and Fluent UI React icon sets. In addition, the Fabric Icons tool is updated with new icons several times a month, whereas the default Fluent UI React set is updated only occasionally. You can see detailed docs for the tool at https://aka.ms/uifabric-icons?help.
-
-Note that if you use the Fabric icons tool to create your own icon subset, you will also need to host those assets on your own CDN.
+The Fabric Icons subsetting tool is no longer publicly available. To serve font-based icons without using the default CDN, copy the font files from `@uifabric/icons/fonts` (or `@fluentui/font-icons-mdl2/fonts` in version 8+) to your own CDN and pass that base URL to `initializeIcons`.
 
 ### What does `initializeIcons` do?
 

--- a/docs/react-wiki-archive/Releases/Fabric5.md
+++ b/docs/react-wiki-archive/Releases/Fabric5.md
@@ -30,7 +30,7 @@ In Fabric 5, we did this:
 
 2. We added a method `registerIcons` to the `@uifabric/styling` package which enables the partner to register a subset definition (including which font to use for what codes.)
 
-3. We updated the [Icon subset tool](https://aka.ms/uifabric-icons) to generate a package, including TypeScript code which would call `registerIcons` with multiple subsets.
+3. We updated the Icon subset tool, which is no longer publicly available, to generate a package, including TypeScript code which would call `registerIcons` with multiple subsets.
 
 4. The tool can now allow a partner to choose the icons that are important to them, and then for remaining ones, can optionally split them into chunks. That means rendering the common icons would always download the first chunk but all other icons would only download the subset containing them when actually used.
 
@@ -54,7 +54,7 @@ So, your options for supporting icons in your project are:
 
 3. Import directly from `@uifabric/icons/lib/fabric-icons-0` to register only the first subset (which includes just the icons that Fabric components use, plus common commanding icons.) Less than 1k gzip penalty for registering just the core icons + 4k core only font subset.
 
-4. Custom icons! Use the [icon subset tool](https://aka.ms/uifabric-icons) to choose the exact set of icons to register and build your own icon registration code. You can even choose to use inlined icons and include them with your JavaScript bundle.
+4. Custom icons! The icon subset tool previously let you choose the exact set of icons to register and build your own icon registration code. You could even choose to use inlined icons and include them with your JavaScript bundle. The tool is no longer publicly available.
 
 # Glamor replacement
 


### PR DESCRIPTION
## Summary
- remove the public docs link to the Fluent UI icons subsetting tool that is no longer publicly available
- rename the section to Icon subsets and point users to supported font hosting and custom icon registration options
- update archived icon guidance to avoid the stale tool URL

Fixes #35338

## Validation
- npx -y prettier@2.8.8 --check apps/public-docsite/src/pages/Styles/FabricIconsPage/FabricIconsPage.tsx apps/public-docsite/src/pages/Styles/FabricIconsPage/docs/web/FabricIconsUsage.md docs/react-wiki-archive/BestPractices/Using-icons.md
- npx -y beachball@2.31.0 check --branch origin/master
- git diff --check