### PR TITLE
fix: simplify mergeStyles argument type

### DIFF
--- a/change/@fluentui-merge-styles-9f0f4ab7-7a99-4d0e-9d25-22c0e7f7c314.json
+++ b/change/@fluentui-merge-styles-9f0f4ab7-7a99-4d0e-9d25-22c0e7f7c314.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: simplify mergeStyles argument type to avoid excessive type instantiation",
+  "packageName": "@fluentui/merge-styles",
+  "email": "mariamsulakian@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/merge-styles/src/mergeStyles.ts
+++ b/packages/merge-styles/src/mergeStyles.ts
@@ -1,13 +1,12 @@
 import { extractStyleParts } from './extractStyleParts';
-import { IStyle, IStyleBaseArray } from './IStyle';
+import { IStyle } from './IStyle';
 import { IStyleOptions } from './IStyleOptions';
 import { isShadowConfig, ShadowConfig } from './shadowConfig';
 import { getStyleOptions } from './StyleOptionsState';
 import { Stylesheet } from './Stylesheet';
 import { styleToClassName } from './styleToClassName';
 
-type Missing = false | null | undefined;
-type StyleArg = IStyle | IStyleBaseArray | Missing;
+type StyleArg = IStyle;
 type StyleArgWithShadow = StyleArg | ShadowConfig;
 
 export function mergeStyles(...args: StyleArg[]): string;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally
  * Change file added manually for @fluentui/merge-styles.


PR flow tips:
* [x] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

`mergeStyles` defined its public style argument type as a union of `IStyle`, `IStyleBaseArray`, and falsey values. `IStyle` already includes those same falsey values and recursively includes `IStyleBaseArray`, so TypeScript had duplicate recursive paths to expand.

## New Behavior

`mergeStyles` now aliases its style argument type directly to `IStyle`, preserving the same accepted inputs while reducing unnecessary recursive type expansion. This helps avoid excessive type instantiation errors from the public overloads.

## Validation

- `PATH=/opt/homebrew/Cellar/node@22/22.22.0/bin:$PATH node node_modules/typescript/bin/tsc -p packages/merge-styles/tsconfig.json --noEmit --skipLibCheck`
- `git diff --check`

Note: `beachball check` and the Jest command could not run in this local checkout because the dependency install left missing files inside `node_modules`.

## Related Issue(s)

- Fixes #31477
