### PR TITLE
fix(public-docsite-v9): exclude packages that are deprecated and excluded from path aliases + without stories from storybook config

### DIFF
--- a/apps/public-docsite-v9/.storybook/main.js
+++ b/apps/public-docsite-v9/.storybook/main.js
@@ -11,12 +11,26 @@ module.exports = /** @type {Omit<import('../../../.storybook/main'), 'typescript
     ...rootMain.stories,
     '../src/**/*.mdx',
     '../src/**/index.stories.@(ts|tsx)',
-    ...getPackageStoriesGlob({ packageName: '@fluentui/react-components', callerPath: __dirname }),
+    ...getPackageStoriesGlob({
+      packageName: '@fluentui/react-components',
+      callerPath: __dirname,
+      excludeStoriesInsertionFromPackages: [
+        // Exclude packages that don't have story files
+        '@fluentui/react-icons-compat',
+        '@fluentui/react-tabster',
+        '@fluentui/react-utilities',
+        // Exclude deprecated packages
+        '@fluentui/react-alert',
+        '@fluentui/react-infobutton',
+        '@fluentui/react-virtualizer',
+      ],
+    }),
     ...getPackageStoriesGlob({
       packageName: '@fluentui/public-docsite-v9',
       callerPath: __dirname,
       excludeStoriesInsertionFromPackages: [
         '@fluentui/react-storybook-addon',
+        '@fluentui/react-storybook-addon-export-to-sandbox',
         '@fluentui/theme-designer',
         // Exclude non v9 stories
         '@fluentui/react',


### PR DESCRIPTION
## Description

Excludes packages that don't have story files or are deprecated from story glob resolution in the public-docsite-v9 Storybook config. This fixes build warnings ("No story files found") and runtime webpack errors caused by unresolvable modules in deprecated packages.

### Packages excluded from `@fluentui/react-components` stories:
- `@fluentui/react-icons-compat` — no stories
- `@fluentui/react-tabster` — no stories
- `@fluentui/react-utilities` — no stories
- `@fluentui/react-alert` — deprecated
- `@fluentui/react-infobutton` — deprecated
- `@fluentui/react-virtualizer` — deprecated

### Packages excluded from `@fluentui/public-docsite-v9` stories:
- `@fluentui/react-storybook-addon-export-to-sandbox` — no stories