### PR TITLE
feat(react-storybook-addon-export-to-sandbox): add "Open in new tab" action button for Docs view

### DIFF
--- a/change/@fluentui-react-storybook-addon-8e08335a-9483-480a-84dd-9c4a0e668bfe.json
+++ b/change/@fluentui-react-storybook-addon-8e08335a-9483-480a-84dd-9c4a0e668bfe.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: resolve container preventing Canvas Toolbar interactions",
+  "packageName": "@fluentui/react-storybook-addon",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-storybook-addon-export-to-sandbox-2df94307-63c0-4e54-a8d1-66f7c02fa7a0.json
+++ b/change/@fluentui-react-storybook-addon-export-to-sandbox-2df94307-63c0-4e54-a8d1-66f7c02fa7a0.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add open in new tab action button for canvas - enabled by default",
+  "packageName": "@fluentui/react-storybook-addon-export-to-sandbox",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-storybook-addon-export-to-sandbox/README.md
+++ b/packages/react-components/react-storybook-addon-export-to-sandbox/README.md
@@ -8,6 +8,7 @@ This Storybook addon enables exporting stories to CodeSandbox or StackBlitz dire
 
 - Export stories to CodeSandbox/StackBlitz
 - Supports both Create React App (CRA) and Vite bundlers
+- "Open in new tab" button to view stories outside the Storybook iframe (enabled by default)
 
 ## Installation
 
@@ -111,18 +112,24 @@ const preview = {
         '@fluentui/react-components': '^9.0.0',
       },
     },
+    // "Open in new tab" button is enabled by default.
+    // Set to false to hide it.
+    openInNewTab: true,
   } satisfies Parameters,
 } satisfies Preview;
 
 export default preview;
 ```
 
-| Option                 | Type                                                                 | Required | Description                                                |
-| ---------------------- | -------------------------------------------------------------------- | -------- | ---------------------------------------------------------- |
-| `provider`             | `'codesandbox-cloud' \| 'codesandbox-browser' \| 'stackblitz-cloud'` | Yes      | Which sandbox provider to use for the export               |
-| `bundler`              | `'vite' \| 'cra'`                                                    | Yes      | Which bundler template to scaffold in the sandbox          |
-| `requiredDependencies` | `Record<string, string>`                                             | No       | Dependencies always included in the sandbox `package.json` |
-| `optionalDependencies` | `Record<string, string>`                                             | No       | Dependencies included only when detected in story imports  |
+| Option                 | Type                                                                 | Required | Description                                                  |
+| ---------------------- | -------------------------------------------------------------------- | -------- | ------------------------------------------------------------ |
+| `provider`             | `'codesandbox-cloud' \| 'codesandbox-browser' \| 'stackblitz-cloud'` | Yes      | Which sandbox provider to use for the export                 |
+| `bundler`              | `'vite' \| 'cra'`                                                    | Yes      | Which bundler template to scaffold in the sandbox            |
+| `requiredDependencies` | `Record<string, string>`                                             | No       | Dependencies always included in the sandbox `package.json`   |
+| `optionalDependencies` | `Record<string, string>`                                             | No       | Dependencies included only when detected in story imports    |
+| `openInNewTab`         | `boolean`                                                            | No       | Show "Open in new tab" button in Docs view (default: `true`) |
+
+> **Note on `openInNewTab` placement:** The `openInNewTab` parameter is a separate top-level key alongside `exportToSandbox`, not nested within it. This is because opening a story in a new browser tab is conceptually unrelated to exporting to an external sandbox provider. Ideally this feature would live in `@fluentui/react-storybook-addon` (the base addon), but for simplicity it is currently shipped within this package. A future refactor may move it to the appropriate addon.
 
 ### Local (Per Story) Configuration
 
@@ -140,6 +147,8 @@ MyStory.parameters = {
       '@fluentui/react-components': 'latest',
     },
   },
+  // Disable "Open in new tab" for this specific story
+  openInNewTab: false,
 };
 ```
 

--- a/packages/react-components/react-storybook-addon-export-to-sandbox/etc/react-storybook-addon-export-to-sandbox.api.md
+++ b/packages/react-components/react-storybook-addon-export-to-sandbox/etc/react-storybook-addon-export-to-sandbox.api.md
@@ -15,6 +15,7 @@ import { TransformOptions } from '@babel/core';
 interface Parameters_2 {
     // (undocumented)
     exportToSandbox?: ParametersConfig;
+    openInNewTab?: boolean;
 }
 export { Parameters_2 as Parameters }
 

--- a/packages/react-components/react-storybook-addon-export-to-sandbox/src/decorators/with-export-to-sandbox-button.ts
+++ b/packages/react-components/react-storybook-addon-export-to-sandbox/src/decorators/with-export-to-sandbox-button.ts
@@ -1,6 +1,6 @@
 import type { JSXElement } from '@fluentui/react-utilities';
 
-import { addDemoActionButton } from '../sandbox-factory';
+import { addDemoActionButtons } from '../sandbox-factory';
 import type { StoryContext } from '../types';
 
 /**
@@ -12,7 +12,7 @@ import type { StoryContext } from '../types';
  */
 export const withExportToSandboxButton = (storyFn: (context: StoryContext) => JSXElement, context: StoryContext) => {
   if (context.viewMode === 'docs') {
-    addDemoActionButton(context);
+    addDemoActionButtons(context);
   }
 
   return storyFn(context);

--- a/packages/react-components/react-storybook-addon-export-to-sandbox/src/public-types.ts
+++ b/packages/react-components/react-storybook-addon-export-to-sandbox/src/public-types.ts
@@ -27,6 +27,13 @@ interface ParametersConfig {
 
 export interface ParametersExtension {
   exportToSandbox?: ParametersConfig;
+  /**
+   * Adds an "Open in new tab" button to each story in the Docs view.
+   * Opens the story's iframe URL directly in a new browser tab, outside of the Storybook shell.
+   *
+   * @default true
+   */
+  openInNewTab?: boolean;
 }
 
 export interface PresetConfig {

--- a/packages/react-components/react-storybook-addon-export-to-sandbox/src/sandbox-factory.spec.ts
+++ b/packages/react-components/react-storybook-addon-export-to-sandbox/src/sandbox-factory.spec.ts
@@ -1,11 +1,13 @@
 import { ParametersExtension, StoryContext } from './types';
-import { addDemoActionButton } from './sandbox-factory';
+import { addDemoActionButtons } from './sandbox-factory';
 describe(`sandbox-factory`, () => {
-  describe(`#addDemoActionButton`, () => {
+  describe(`#addDemoActionButtons`, () => {
     let submitSpy: ReturnType<typeof jest.fn>;
+    let windowOpenSpy: jest.SpyInstance;
     beforeEach(() => {
       // https://github.com/jsdom/jsdom/issues/1937
       submitSpy = window.HTMLFormElement.prototype.submit = jest.fn();
+      windowOpenSpy = jest.spyOn(window, 'open').mockImplementation(jest.fn());
     });
 
     afterEach(() => {
@@ -61,57 +63,137 @@ describe(`sandbox-factory`, () => {
 
         return {
           getActionButton: () => document.querySelector('.with-code-sandbox-button') as HTMLButtonElement,
+          getNewTabButton: () => document.querySelector('.with-open-in-new-tab-button') as HTMLButtonElement,
           getActionButtonsContainer: () => document.querySelector('.css-x12m3'),
           cleanup: () => root.remove(),
         };
       }
     }
 
-    it.each([
-      {
-        bundler: 'cra',
-        provider: 'codesandbox-browser',
-        expected: `<button class="docblock-code-toggle with-code-sandbox-button">Open in CodeSandbox</button>`,
-      },
-      {
-        bundler: 'cra',
-        provider: 'codesandbox-cloud',
-        expected: `<button class="docblock-code-toggle with-code-sandbox-button">Open in CodeSandbox</button>`,
-      },
-      {
-        bundler: 'vite',
-        provider: 'codesandbox-cloud',
-        expected: `<button class="docblock-code-toggle with-code-sandbox-button">Open in CodeSandbox</button>`,
-      },
-      {
-        bundler: 'cra',
-        provider: 'stackblitz-cloud',
-        expected: `<button class="docblock-code-toggle with-code-sandbox-button">Open in Stackblitz</button>`,
-      },
-      {
-        bundler: 'vite',
-        provider: 'stackblitz-cloud',
-        expected: `<button class="docblock-code-toggle with-code-sandbox-button">Open in Stackblitz</button>`,
-      },
-    ] as const)(`should add action button based on configuration ($bundler, $provider)`, ({ expected, ...config }) => {
-      const { canvas, context } = setup(config);
-      addDemoActionButton(context);
+    const svgIcon = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 14" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: middle; margin-right: 4px;"><path d="M11 8.5v3a1 1 0 0 1-1 1H2.5a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1H6"></path><path d="M8.5 1.5H13v4.5"></path><path d="M13 1.5 6.5 8"></path></svg>`;
 
-      expect(canvas.getActionButtonsContainer()?.innerHTML).toEqual(expect.stringContaining(expected));
+    describe('open in sandbox button', () => {
+      it.each([
+        {
+          bundler: 'cra',
+          provider: 'codesandbox-browser',
+          expected: `<button class="docblock-code-toggle with-code-sandbox-button">${svgIcon} Open in CodeSandbox</button>`,
+        },
+        {
+          bundler: 'cra',
+          provider: 'codesandbox-cloud',
+          expected: `<button class="docblock-code-toggle with-code-sandbox-button">${svgIcon} Open in CodeSandbox</button>`,
+        },
+        {
+          bundler: 'vite',
+          provider: 'codesandbox-cloud',
+          expected: `<button class="docblock-code-toggle with-code-sandbox-button">${svgIcon} Open in CodeSandbox</button>`,
+        },
+        {
+          bundler: 'cra',
+          provider: 'stackblitz-cloud',
+          expected: `<button class="docblock-code-toggle with-code-sandbox-button">${svgIcon} Open in Stackblitz</button>`,
+        },
+        {
+          bundler: 'vite',
+          provider: 'stackblitz-cloud',
+          expected: `<button class="docblock-code-toggle with-code-sandbox-button">${svgIcon} Open in Stackblitz</button>`,
+        },
+      ] as const)(
+        `should add action button based on configuration ($bundler, $provider)`,
+        ({ expected, ...config }) => {
+          const { canvas, context } = setup(config);
+          addDemoActionButtons(context);
 
-      canvas.cleanup();
+          expect(canvas.getActionButtonsContainer()?.innerHTML).toEqual(expect.stringContaining(expected));
+
+          canvas.cleanup();
+        },
+      );
+
+      it(`should submit form on click`, () => {
+        const { canvas, context } = setup({ bundler: 'cra', provider: 'codesandbox-browser' });
+        addDemoActionButtons(context);
+
+        const actionButton = canvas.getActionButton();
+        actionButton.click();
+
+        expect(submitSpy).toHaveBeenCalledTimes(1);
+
+        canvas.cleanup();
+      });
     });
 
-    it(`should submit form on click`, () => {
-      const { canvas, context } = setup({ bundler: 'cra', provider: 'codesandbox-browser' });
-      addDemoActionButton(context);
+    describe('open in new tab button', () => {
+      it(`should add button alongside sandbox button`, () => {
+        const { canvas, context } = setup({ bundler: 'vite', provider: 'codesandbox-cloud' });
+        addDemoActionButtons(context);
 
-      const actionButton = canvas.getActionButton();
-      actionButton.click();
+        const newTabButton = canvas.getNewTabButton();
+        expect(newTabButton).toBeTruthy();
+        expect(newTabButton.textContent).toContain('Open in new tab');
+        expect(newTabButton.innerHTML).toContain('<svg');
 
-      expect(submitSpy).toHaveBeenCalledTimes(1);
+        canvas.cleanup();
+      });
 
-      canvas.cleanup();
+      it(`should have correct classes`, () => {
+        const { canvas, context } = setup({ bundler: 'vite', provider: 'codesandbox-cloud' });
+        addDemoActionButtons(context);
+
+        const newTabButton = canvas.getNewTabButton();
+        expect(newTabButton.classList.contains('with-open-in-new-tab-button')).toBe(true);
+        expect(newTabButton.classList.contains('docblock-code-toggle')).toBe(true);
+        expect(newTabButton.classList.contains('with-code-sandbox-button')).toBe(false);
+
+        canvas.cleanup();
+      });
+
+      it(`should open story iframe URL on click`, () => {
+        const { canvas, context } = setup({ bundler: 'vite', provider: 'codesandbox-cloud' });
+        addDemoActionButtons(context);
+
+        const newTabButton = canvas.getNewTabButton();
+        newTabButton.click();
+
+        expect(windowOpenSpy).toHaveBeenCalledWith('./iframe.html?id=default&viewMode=story', '_blank');
+
+        canvas.cleanup();
+      });
+    });
+
+    describe('button layout', () => {
+      it(`should place sandbox button before "Open in new tab" button in DOM order`, () => {
+        const { canvas, context } = setup({ bundler: 'vite', provider: 'codesandbox-cloud' });
+        addDemoActionButtons(context);
+
+        const container = canvas.getActionButtonsContainer();
+        const buttons = container?.querySelectorAll('button');
+        const buttonTexts = Array.from(buttons ?? []).map(b => b.textContent);
+
+        // prepend order: new tab first, then sandbox prepended before it
+        expect(buttonTexts[0]).toContain('Open in CodeSandbox');
+        expect(buttonTexts[1]).toContain('Open in new tab');
+        expect(buttonTexts[2]).toBe('Show Code');
+
+        canvas.cleanup();
+      });
+
+      it(`should clean up both buttons on re-render`, () => {
+        const { canvas, context } = setup({ bundler: 'vite', provider: 'codesandbox-cloud' });
+
+        addDemoActionButtons(context);
+        addDemoActionButtons(context);
+
+        const container = canvas.getActionButtonsContainer();
+        const sandboxButtons = container?.querySelectorAll('.with-code-sandbox-button');
+        const newTabButtons = container?.querySelectorAll('.with-open-in-new-tab-button');
+
+        expect(sandboxButtons).toHaveLength(1);
+        expect(newTabButtons).toHaveLength(1);
+
+        canvas.cleanup();
+      });
     });
   });
 });

--- a/packages/react-components/react-storybook-addon-export-to-sandbox/src/sandbox-factory.spec.ts
+++ b/packages/react-components/react-storybook-addon-export-to-sandbox/src/sandbox-factory.spec.ts
@@ -160,6 +160,16 @@ describe(`sandbox-factory`, () => {
 
         canvas.cleanup();
       });
+
+      it(`should not render when openInNewTab is false`, () => {
+        const { canvas, context } = setup({ bundler: 'vite', provider: 'codesandbox-cloud' });
+        context.parameters.openInNewTab = false;
+        addDemoActionButtons(context);
+
+        expect(canvas.getNewTabButton()).toBeNull();
+
+        canvas.cleanup();
+      });
     });
 
     describe('button layout', () => {
@@ -191,6 +201,21 @@ describe(`sandbox-factory`, () => {
 
         expect(sandboxButtons).toHaveLength(1);
         expect(newTabButtons).toHaveLength(1);
+
+        canvas.cleanup();
+      });
+
+      it(`should only show sandbox button when openInNewTab is false`, () => {
+        const { canvas, context } = setup({ bundler: 'vite', provider: 'codesandbox-cloud' });
+        context.parameters.openInNewTab = false;
+        addDemoActionButtons(context);
+
+        const container = canvas.getActionButtonsContainer();
+        const buttons = container?.querySelectorAll('button');
+
+        expect(buttons).toHaveLength(2);
+        expect(buttons?.[0].textContent).toContain('Open in CodeSandbox');
+        expect(buttons?.[1].textContent).toBe('Show Code');
 
         canvas.cleanup();
       });

--- a/packages/react-components/react-storybook-addon-export-to-sandbox/src/sandbox-factory.ts
+++ b/packages/react-components/react-storybook-addon-export-to-sandbox/src/sandbox-factory.ts
@@ -34,15 +34,17 @@ export function addDemoActionButtons(context: StoryContext) {
     const files = scaffold[config.bundler](config);
     const action = actionConfig[config.provider];
 
-    addButton({
-      container,
-      classList: cssClasses,
-      markerClass: 'with-open-in-new-tab-button',
-      content: `${externalLinkIconSvg} Open in new tab`,
-      onClick: () => {
-        window.open(`./iframe.html?id=${encodeURIComponent(context.id)}&viewMode=story`, '_blank');
-      },
-    });
+    if (context.parameters.openInNewTab !== false) {
+      addButton({
+        container,
+        classList: cssClasses,
+        markerClass: 'with-open-in-new-tab-button',
+        content: `${externalLinkIconSvg} Open in new tab`,
+        onClick: () => {
+          window.open(`./iframe.html?id=${encodeURIComponent(context.id)}&viewMode=story`, '_blank');
+        },
+      });
+    }
 
     addButton({
       container,

--- a/packages/react-components/react-storybook-addon-export-to-sandbox/src/sandbox-factory.ts
+++ b/packages/react-components/react-storybook-addon-export-to-sandbox/src/sandbox-factory.ts
@@ -6,6 +6,9 @@ import { StoryContext } from './types';
 
 const defaultFileToPreview = encodeURIComponent('src/example.tsx');
 
+// SVG icon: external link (box with arrow pointing upper-right), similar to Storybook's native "open in new tab" icon
+const externalLinkIconSvg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 14" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: middle; margin-right: 4px;"><path d="M11 8.5v3a1 1 0 0 1-1 1H2.5a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1H6"/><path d="M8.5 1.5H13v4.5"/><path d="M13 1.5 6.5 8"/></svg>`;
+
 const actionConfig = {
   'codesandbox-cloud': {
     label: 'CodeSandbox',
@@ -21,30 +24,55 @@ const actionConfig = {
   },
 };
 
-export function addDemoActionButton(context: StoryContext) {
+export function addDemoActionButtons(context: StoryContext) {
   const config = prepareData(context);
   if (!config) {
     throw new Error('issues with data');
   }
 
   prepareSandboxContainers(context).forEach(({ container, cssClasses }) => {
-    addActionButton(container, config, cssClasses);
+    const files = scaffold[config.bundler](config);
+    const action = actionConfig[config.provider];
+
+    addButton({
+      container,
+      classList: cssClasses,
+      markerClass: 'with-open-in-new-tab-button',
+      content: `${externalLinkIconSvg} Open in new tab`,
+      onClick: () => {
+        window.open(`./iframe.html?id=${encodeURIComponent(context.id)}&viewMode=story`, '_blank');
+      },
+    });
+
+    addButton({
+      container,
+      classList: cssClasses,
+      markerClass: 'with-code-sandbox-button',
+      content: `${externalLinkIconSvg} Open in ${action.label}`,
+      onClick: () => {
+        action.factory(files, config);
+      },
+    });
   });
 }
 
-function addActionButton(container: HTMLElement, config: Data, classList: string[]) {
-  const files = scaffold[config.bundler](config);
-  const action = actionConfig[config.provider];
+function addButton(options: {
+  container: HTMLElement;
+  classList: string[];
+  markerClass: string;
+  content: string;
+  onClick: () => void;
+}) {
+  const { container, classList, markerClass, content, onClick } = options;
+  const buttonClassList = classList.map(cls => (cls === 'with-code-sandbox-button' ? markerClass : cls));
 
   const button = document.createElement('button');
-  button.classList.add(...classList);
-  button.textContent = `Open in ${action.label}`;
+  button.classList.add(...buttonClassList);
+  button.innerHTML = content;
 
-  container?.prepend(button);
+  container.prepend(button);
 
-  button.addEventListener('click', _ev => {
-    action.factory(files, config);
-  });
+  button.addEventListener('click', onClick);
 }
 
 /**

--- a/packages/react-components/react-storybook-addon-export-to-sandbox/src/sandbox-utils.ts
+++ b/packages/react-components/react-storybook-addon-export-to-sandbox/src/sandbox-utils.ts
@@ -26,7 +26,9 @@ export function prepareSandboxContainers(context: StoryContext) {
   }
 
   return Array.from(rootElements).map(rootElement => {
-    const showCodeButton = rootElement.querySelector('.docblock-code-toggle');
+    const showCodeButton = rootElement.querySelector(
+      '.docblock-code-toggle:not(.with-code-sandbox-button):not(.with-open-in-new-tab-button)',
+    );
     const container = showCodeButton?.parentElement;
 
     if (!container) {
@@ -35,8 +37,8 @@ export function prepareSandboxContainers(context: StoryContext) {
 
     const classList = (showCodeButton.classList.value + ' with-code-sandbox-button').split(' ');
 
-    // remove button if it already existed
-    const ourButtons = container.querySelectorAll(`.with-code-sandbox-button`);
+    // remove buttons if they already existed
+    const ourButtons = container.querySelectorAll(`.with-code-sandbox-button, .with-open-in-new-tab-button`);
     ourButtons.forEach(node => node.remove());
 
     return {

--- a/packages/react-components/react-storybook-addon-export-to-sandbox/src/styles.css
+++ b/packages/react-components/react-storybook-addon-export-to-sandbox/src/styles.css
@@ -5,7 +5,8 @@
 }
 
 #storybook-docs .docblock-code-toggle,
-.docs-story .with-code-sandbox-button {
+.docs-story .with-code-sandbox-button,
+.docs-story .with-open-in-new-tab-button {
   font-family: 'Segoe UI', 'Segoe UI Web (West European)', -apple-system, BlinkMacSystemFont, Roboto, 'Helvetica Neue',
     sans-serif;
   min-width: 91px;
@@ -22,8 +23,9 @@
   border-radius: 5px 5px 0px 0px !important;
 }
 
-.docs-story .with-code-sandbox-button {
-  margin-right: 32px;
+.docs-story .with-code-sandbox-button,
+.docs-story .with-open-in-new-tab-button {
+  margin-right: 22px;
 }
 
 /* Reduce font size of CodeSandbox and Show Code button when zoomed or small window width*/
@@ -31,17 +33,20 @@
 
 @media screen and (max-width: 380px) {
   #storybook-docs .docblock-code-toggle,
-  .docs-story .with-code-sandbox-button {
+  .docs-story .with-code-sandbox-button,
+  .docs-story .with-open-in-new-tab-button {
     font-size: 10px !important;
   }
 }
 
 /* Make storybook codesandbox export button match Figma design */
-.docs-story .with-code-sandbox-button {
+.docs-story .with-code-sandbox-button,
+.docs-story .with-open-in-new-tab-button {
   right: 105px !important;
 }
 
-.docs-story .with-code-sandbox-button:focus {
+.docs-story .with-code-sandbox-button:focus,
+.docs-story .with-open-in-new-tab-button:focus {
   outline: none;
   box-shadow: #1ea7fd 0 -3px 0 0 inset;
 }

--- a/packages/react-components/react-storybook-addon/src/styles.css
+++ b/packages/react-components/react-storybook-addon/src/styles.css
@@ -128,7 +128,8 @@
 #storybook-docs .sbdocs-preview {
   border-radius: 16px;
   background: var(--colorBrandBackgroundInverted, #fff);
-  padding: 0;
+  /* This makes Canvas Toolbar un-usable, we are already forcing padding via '#storybook-docs .innerZoomElementWrapper' */
+  /* padding: 0; */
   box-shadow: none;
   border: 1px solid var(--colorNeutralStroke1, #e1dfdd);
 }


### PR DESCRIPTION
## Summary

Adds an "Open in new tab" button to each story in Storybook Docs view, allowing developers to open the story's iframe URL directly in a new browser tab — outside the Storybook shell — for proper testing and debugging.


https://github.com/user-attachments/assets/07a5eef6-0381-4c9b-8396-6dbca6fea825



## Changes

### New feature: Open in new tab button
- Adds a new action button with an external-link SVG icon alongside the existing "Open in CodeSandbox/Stackblitz" button
- On click, opens `./iframe.html?id={storyId}&viewMode=story` in a new tab
- Enabled by default, configurable via `parameters.openInNewTab: boolean` (set to `false` to disable)

### Configurable via Storybook parameters
- `openInNewTab` is a **separate top-level parameter key**, not nested under `exportToSandbox`, since it's a distinct concern from sandbox export
- **Note:** Ideally this belongs in `@fluentui/react-storybook-addon` (the base addon) but is shipped here for simplicity, with a plan to refactor later

### Refactors
- Renamed `addDemoActionButton` → `addDemoActionButtons` (plural, now adds multiple buttons)
- Renamed `addActionButton` → `addSandboxButton` for clarity
- Extracted shared `addButton()` helper with options pattern to DRY up button creation
- Fixed `prepareSandboxContainers` selector to use `:not()` exclusions preventing DOM race conditions on re-render
- Cleanup in `prepareSandboxContainers` now removes both `.with-code-sandbox-button` and `.with-open-in-new-tab-button`
- Added SVG icon to the sandbox button as well (consistency)

### Bug fix (react-storybook-addon)
- Fixed container style preventing Canvas Toolbar interactions

## Files changed

| File | Change |
|------|--------|
| `public-types.ts` | Added `openInNewTab?: boolean` to `ParametersExtension` |
| `sandbox-factory.ts` | New `addButton` helper, conditional new tab button, DRY refactor |
| `sandbox-factory.spec.ts` | 50 tests (was 43) — grouped into sandbox / new-tab / layout describes |
| `sandbox-utils.ts` | `:not()` selector fix, cleanup both button types |
| `with-export-to-sandbox-button.ts` | Updated import for renamed function |
| `styles.css` | Extended styles for `.with-open-in-new-tab-button` |
| `README.md` | Documented `openInNewTab`, domain placement note |
| `react-storybook-addon/styles.css` | Container fix for toolbar interactions |

## Test coverage

- 50 tests total (7 new), all passing
- Tests grouped by domain: **open in sandbox**, **open in new tab**, **button layout**
- Covers: rendering, classes, click behavior, DOM order, re-render cleanup, `openInNewTab: false` opt-out