### PR TITLE
feat(react-compiler): enable react-compiler-analyzer lint on PR runs and apply --fix

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -81,6 +81,34 @@ jobs:
           git status --porcelain
           git diff-index --quiet HEAD -- || exit 1
 
+  react-compiler-analyzer:
+    if: ${{ github.repository_owner == 'microsoft' }}
+    runs-on: macos-14-xlarge
+    permissions:
+      contents: 'read'
+      actions: 'read'
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Derive appropriate SHAs for base and head for `nx affected` commands
+        uses: nrwl/nx-set-shas@826660b82addbef3abff5fa871492ebad618c9e1 # v4.3.3
+        with:
+          main-branch-name: 'master'
+
+      - uses: actions/setup-node@v6
+        with:
+          cache: 'yarn'
+          node-version: '22'
+
+      - run: yarn install --frozen-lockfile
+
+      - name: React Compiler analysis (affected)
+        run: |
+          yarn nx affected -t react-compiler-analyzer--lint --nxBail
+
   react-major-versions-integration:
     if: ${{ github.repository_owner == 'microsoft' }}
     runs-on: macos-14-xlarge

--- a/change/@fluentui-react-accordion-a884b1a2-796b-40f9-9c8b-97f06471c87c.json
+++ b/change/@fluentui-react-accordion-a884b1a2-796b-40f9-9c8b-97f06471c87c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-accordion",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-avatar-3eadb5cb-c453-4641-8392-6e19302133f7.json
+++ b/change/@fluentui-react-avatar-3eadb5cb-c453-4641-8392-6e19302133f7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-avatar",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-badge-88e55114-fea3-4f1f-968e-e648be6b3565.json
+++ b/change/@fluentui-react-badge-88e55114-fea3-4f1f-968e-e648be6b3565.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-badge",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-breadcrumb-3ca1975f-5fda-42ec-84fe-9d45149325e6.json
+++ b/change/@fluentui-react-breadcrumb-3ca1975f-5fda-42ec-84fe-9d45149325e6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-breadcrumb",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-button-4e484176-bd79-431f-86dd-99cb58049ba4.json
+++ b/change/@fluentui-react-button-4e484176-bd79-431f-86dd-99cb58049ba4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-button",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-calendar-compat-39a967cc-9abc-4dfb-b776-0179cb88fab7.json
+++ b/change/@fluentui-react-calendar-compat-39a967cc-9abc-4dfb-b776-0179cb88fab7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-calendar-compat",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-card-7006c0a9-99e5-4ede-86fc-e3642aa07b90.json
+++ b/change/@fluentui-react-card-7006c0a9-99e5-4ede-86fc-e3642aa07b90.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-card",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-carousel-6016eed3-972d-4dfc-adb8-c68c5bc96c2d.json
+++ b/change/@fluentui-react-carousel-6016eed3-972d-4dfc-adb8-c68c5bc96c2d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-carousel",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-checkbox-90ae745a-4deb-4b45-a28e-d7577dc22883.json
+++ b/change/@fluentui-react-checkbox-90ae745a-4deb-4b45-a28e-d7577dc22883.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-color-picker-7cb3d6aa-022c-4364-ae78-2298cb21b6d4.json
+++ b/change/@fluentui-react-color-picker-7cb3d6aa-022c-4364-ae78-2298cb21b6d4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-color-picker",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-combobox-d0867dfd-237b-4f55-a27b-5c00f03b8ca6.json
+++ b/change/@fluentui-react-combobox-d0867dfd-237b-4f55-a27b-5c00f03b8ca6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-combobox",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-datepicker-compat-b4ca8644-29aa-4199-af39-fff9a0373bb4.json
+++ b/change/@fluentui-react-datepicker-compat-b4ca8644-29aa-4199-af39-fff9a0373bb4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-datepicker-compat",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-dialog-8a9c874b-18ca-4e8b-b94a-24e0afdb7126.json
+++ b/change/@fluentui-react-dialog-8a9c874b-18ca-4e8b-b94a-24e0afdb7126.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-dialog",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-divider-168d4d51-915d-4108-9b72-cfaa552d86d8.json
+++ b/change/@fluentui-react-divider-168d4d51-915d-4108-9b72-cfaa552d86d8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-divider",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-drawer-c33f7732-8411-4b9d-a489-a60014d5d3a6.json
+++ b/change/@fluentui-react-drawer-c33f7732-8411-4b9d-a489-a60014d5d3a6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-drawer",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-field-c62c8a7e-412d-4efc-88b1-9d1f8c83056f.json
+++ b/change/@fluentui-react-field-c62c8a7e-412d-4efc-88b1-9d1f8c83056f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-field",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-headless-components-preview-94d314f5-6de5-4a6f-a0ef-ffb23c2e00a5.json
+++ b/change/@fluentui-react-headless-components-preview-94d314f5-6de5-4a6f-a0ef-ffb23c2e00a5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-headless-components-preview",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-image-9bb8d228-2321-4d09-872d-01fb3901f81f.json
+++ b/change/@fluentui-react-image-9bb8d228-2321-4d09-872d-01fb3901f81f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-image",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-infolabel-bffc592a-d1d5-4e41-a947-83df0e08bbc5.json
+++ b/change/@fluentui-react-infolabel-bffc592a-d1d5-4e41-a947-83df0e08bbc5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-infolabel",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-input-515b735a-4fa6-447e-a75a-43045e0771cb.json
+++ b/change/@fluentui-react-input-515b735a-4fa6-447e-a75a-43045e0771cb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-input",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-label-37fce7bc-ec3c-40d6-9c52-43ee53b30d2f.json
+++ b/change/@fluentui-react-label-37fce7bc-ec3c-40d6-9c52-43ee53b30d2f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-label",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-link-a8819ee5-fe1c-4d6f-bb60-ce4635acdaf5.json
+++ b/change/@fluentui-react-link-a8819ee5-fe1c-4d6f-bb60-ce4635acdaf5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-link",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-list-ee48dc26-99a5-497d-8977-bbe5351003bc.json
+++ b/change/@fluentui-react-list-ee48dc26-99a5-497d-8977-bbe5351003bc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-list",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-menu-ab913c8f-339c-4562-8569-04f73ed11252.json
+++ b/change/@fluentui-react-menu-ab913c8f-339c-4562-8569-04f73ed11252.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-menu",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-menu-grid-preview-d4dbb7cd-4589-465c-8dd4-95839197866e.json
+++ b/change/@fluentui-react-menu-grid-preview-d4dbb7cd-4589-465c-8dd4-95839197866e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-menu-grid-preview",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-message-bar-8d936db1-33ab-4859-9aad-652bcf419620.json
+++ b/change/@fluentui-react-message-bar-8d936db1-33ab-4859-9aad-652bcf419620.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-message-bar",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-migration-v0-v9-0787e48f-6116-445a-87b0-c63b484bb4ca.json
+++ b/change/@fluentui-react-migration-v0-v9-0787e48f-6116-445a-87b0-c63b484bb4ca.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-migration-v0-v9",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-migration-v8-v9-8babc766-fe60-4754-86b2-1632e0d31b74.json
+++ b/change/@fluentui-react-migration-v8-v9-8babc766-fe60-4754-86b2-1632e0d31b74.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-migration-v8-v9",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-motion-b83b6b6c-5254-4516-b066-ace5853a9000.json
+++ b/change/@fluentui-react-motion-b83b6b6c-5254-4516-b066-ace5853a9000.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-motion",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-nav-54d1b4f4-6b73-40f6-80cc-0f306ca5b680.json
+++ b/change/@fluentui-react-nav-54d1b4f4-6b73-40f6-80cc-0f306ca5b680.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-nav",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-overflow-6554822a-2180-4562-9b3e-0505acc69dec.json
+++ b/change/@fluentui-react-overflow-6554822a-2180-4562-9b3e-0505acc69dec.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-overflow",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-persona-7fef7899-691e-415b-878e-470ac5111255.json
+++ b/change/@fluentui-react-persona-7fef7899-691e-415b-878e-470ac5111255.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-persona",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-popover-219b5e6c-edee-42a6-9a73-c6758952a38a.json
+++ b/change/@fluentui-react-popover-219b5e6c-edee-42a6-9a73-c6758952a38a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-popover",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-portal-compat-b4b8a2af-b4a9-4499-8122-6e682ac393ba.json
+++ b/change/@fluentui-react-portal-compat-b4b8a2af-b4a9-4499-8122-6e682ac393ba.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-portal-compat",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-portal-f0e8d7c8-a769-45b9-9269-aa3fb5367ce8.json
+++ b/change/@fluentui-react-portal-f0e8d7c8-a769-45b9-9269-aa3fb5367ce8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-portal",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-positioning-fe047126-c2d5-40cf-9386-69727a28d74b.json
+++ b/change/@fluentui-react-positioning-fe047126-c2d5-40cf-9386-69727a28d74b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-positioning",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-progress-0a3e0210-dc28-4094-aadc-a3b47e80fdb1.json
+++ b/change/@fluentui-react-progress-0a3e0210-dc28-4094-aadc-a3b47e80fdb1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-progress",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-provider-3f55f88f-7fce-4ad6-9403-7d78c5bd37d6.json
+++ b/change/@fluentui-react-provider-3f55f88f-7fce-4ad6-9403-7d78c5bd37d6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-provider",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-radio-7e990871-1b41-4dfd-a33f-fa10df3f5091.json
+++ b/change/@fluentui-react-radio-7e990871-1b41-4dfd-a33f-fa10df3f5091.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-radio",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-rating-0b681307-fc52-453e-8aad-f9ca82403263.json
+++ b/change/@fluentui-react-rating-0b681307-fc52-453e-8aad-f9ca82403263.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-rating",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-search-c28c8fe2-5505-420d-b7c0-923c336f629d.json
+++ b/change/@fluentui-react-search-c28c8fe2-5505-420d-b7c0-923c336f629d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-search",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-select-41989df9-7cbe-45b0-84e3-92c369ce91c5.json
+++ b/change/@fluentui-react-select-41989df9-7cbe-45b0-84e3-92c369ce91c5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-select",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-skeleton-e806c81a-0bd1-40df-a789-03940cdf12af.json
+++ b/change/@fluentui-react-skeleton-e806c81a-0bd1-40df-a789-03940cdf12af.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-skeleton",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-slider-4ce11824-4393-4042-89c4-c08346bf93b2.json
+++ b/change/@fluentui-react-slider-4ce11824-4393-4042-89c4-c08346bf93b2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-slider",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-spinbutton-da9ab2d9-4fc3-44bc-9b32-409985a58c9e.json
+++ b/change/@fluentui-react-spinbutton-da9ab2d9-4fc3-44bc-9b32-409985a58c9e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-spinbutton",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-spinner-697ecc3c-5157-443e-8951-b32af20bec0a.json
+++ b/change/@fluentui-react-spinner-697ecc3c-5157-443e-8951-b32af20bec0a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-spinner",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-swatch-picker-64c24df9-6e11-44cf-a9a4-a6f6e664f757.json
+++ b/change/@fluentui-react-swatch-picker-64c24df9-6e11-44cf-a9a4-a6f6e664f757.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-swatch-picker",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-switch-627ccb3d-0bf4-41c2-9581-92d340f8b049.json
+++ b/change/@fluentui-react-switch-627ccb3d-0bf4-41c2-9581-92d340f8b049.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-switch",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-table-15f6d77a-f89a-4943-a856-d36e9fccbaae.json
+++ b/change/@fluentui-react-table-15f6d77a-f89a-4943-a856-d36e9fccbaae.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-table",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tabs-fac16f1b-8c23-4818-a1ef-577ed7f3c39d.json
+++ b/change/@fluentui-react-tabs-fac16f1b-8c23-4818-a1ef-577ed7f3c39d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-tabs",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tabster-ddd31529-6d64-4993-94b1-de0c3ac615d8.json
+++ b/change/@fluentui-react-tabster-ddd31529-6d64-4993-94b1-de0c3ac615d8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-tabster",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tag-picker-522ea7cf-acc7-4044-b641-c63d26ec7eb2.json
+++ b/change/@fluentui-react-tag-picker-522ea7cf-acc7-4044-b641-c63d26ec7eb2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-tag-picker",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tags-9d8588e7-affe-4b5a-bbf5-ecda6b922193.json
+++ b/change/@fluentui-react-tags-9d8588e7-affe-4b5a-bbf5-ecda6b922193.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-tags",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-teaching-popover-9845de04-69dc-4b13-9689-617c901ad5a5.json
+++ b/change/@fluentui-react-teaching-popover-9845de04-69dc-4b13-9689-617c901ad5a5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-teaching-popover",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-text-bbc231c0-1313-435b-ab87-2be2a0129121.json
+++ b/change/@fluentui-react-text-bbc231c0-1313-435b-ab87-2be2a0129121.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-text",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-textarea-a50d7453-a29b-4d82-ac03-02fa512a18c8.json
+++ b/change/@fluentui-react-textarea-a50d7453-a29b-4d82-ac03-02fa512a18c8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-textarea",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-timepicker-compat-1b527051-9864-4d36-bdd1-36250fc45345.json
+++ b/change/@fluentui-react-timepicker-compat-1b527051-9864-4d36-bdd1-36250fc45345.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-timepicker-compat",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-toast-955c357c-e9d0-4741-bc91-7b2ab9d0e994.json
+++ b/change/@fluentui-react-toast-955c357c-e9d0-4741-bc91-7b2ab9d0e994.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-toast",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-toolbar-c3fa9959-51a0-4f09-91cf-940034318cae.json
+++ b/change/@fluentui-react-toolbar-c3fa9959-51a0-4f09-91cf-940034318cae.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-toolbar",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tooltip-724de996-0315-4a7a-a43f-8ab5928740ec.json
+++ b/change/@fluentui-react-tooltip-724de996-0315-4a7a-a43f-8ab5928740ec.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tree-88301544-9fbf-40f3-b04d-9823fc9f8e60.json
+++ b/change/@fluentui-react-tree-88301544-9fbf-40f3-b04d-9823fc9f8e60.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-tree",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-utilities-fc585059-74e6-4164-b54f-0855cfd54cda.json
+++ b/change/@fluentui-react-utilities-fc585059-74e6-4164-b54f-0855cfd54cda.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-utilities",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-virtualizer-cf33639e-83df-4051-846b-349284f2d20d.json
+++ b/change/@fluentui-react-virtualizer-cf33639e-83df-4051-846b-349284f2d20d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: remove redundant use no memo directives, and add justification to valid ones",
+  "packageName": "@fluentui/react-virtualizer",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@eslint/compat": "1.3.0",
     "@eslint/js": "9.26.0",
     "@floating-ui/dom": "1.6.12",
-    "@fluentui/react-compiler-analyzer": "0.0.0-experimental.rc-analyzer.20260514-5d0a891a8f.0",
+    "@fluentui/react-compiler-analyzer": "0.0.0-experimental.rc-analyzer.20260526-7c5862ce36.0",
     "@fluentui/react-icons": "^2.0.306",
     "@griffel/babel-preset": "1.5.8",
     "@griffel/eslint-plugin": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@eslint/compat": "1.3.0",
     "@eslint/js": "9.26.0",
     "@floating-ui/dom": "1.6.12",
-    "@fluentui/react-compiler-analyzer": "0.0.0-experimental.rc-analyzer.20260505-0d531266b1.0",
+    "@fluentui/react-compiler-analyzer": "0.0.0-experimental.rc-analyzer.20260514-5d0a891a8f.0",
     "@fluentui/react-icons": "^2.0.306",
     "@griffel/babel-preset": "1.5.8",
     "@griffel/eslint-plugin": "^2.0.0",

--- a/packages/eslint-plugin/src/configs/core.js
+++ b/packages/eslint-plugin/src/configs/core.js
@@ -242,6 +242,9 @@ module.exports = defineConfig(
       ...fluentRules,
       ...jsDocRules,
       ...importRules,
+      // Deprecated since ESLint v4 in favor of `padding-line-between-statements`.
+      // Inherited from airbnb config — safe to disable.
+      'lines-around-directive': 'off',
     },
   },
   {

--- a/packages/react-components/deprecated/react-virtualizer/src/components/Virtualizer/useVirtualizer.ts
+++ b/packages/react-components/deprecated/react-virtualizer/src/components/Virtualizer/useVirtualizer.ts
@@ -12,8 +12,6 @@ import { flushSync } from 'react-dom';
  * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
  */
 export function useVirtualizer_unstable(props: VirtualizerProps): VirtualizerState {
-  'use no memo';
-
   const {
     itemSize,
     numItems,

--- a/packages/react-components/deprecated/react-virtualizer/src/components/Virtualizer/useVirtualizerStyles.styles.ts
+++ b/packages/react-components/deprecated/react-virtualizer/src/components/Virtualizer/useVirtualizerStyles.styles.ts
@@ -36,8 +36,6 @@ const useStyles = makeStyles({
  * @deprecated migrated to \@fluentui\-contrib/react\-virtualizer for stable release.
  */
 export const useVirtualizerStyles_unstable = (state: VirtualizerState): VirtualizerState => {
-  'use no memo';
-
   const styles = useStyles();
   const { reversed, axis, beforeBufferHeight, afterBufferHeight, bufferSize } = state;
   const horizontal = axis === 'horizontal';

--- a/packages/react-components/deprecated/react-virtualizer/src/components/VirtualizerScrollView/useVirtualizerScrollViewStyles.styles.ts
+++ b/packages/react-components/deprecated/react-virtualizer/src/components/VirtualizerScrollView/useVirtualizerScrollViewStyles.styles.ts
@@ -47,8 +47,6 @@ const useStyles = makeStyles({
 export const useVirtualizerScrollViewStyles_unstable = (
   state: VirtualizerScrollViewState,
 ): VirtualizerScrollViewState => {
-  'use no memo';
-
   const styles = useStyles();
 
   // Default virtualizer styles base

--- a/packages/react-components/deprecated/react-virtualizer/src/components/VirtualizerScrollViewDynamic/useVirtualizerScrollViewDynamic.tsx
+++ b/packages/react-components/deprecated/react-virtualizer/src/components/VirtualizerScrollViewDynamic/useVirtualizerScrollViewDynamic.tsx
@@ -20,8 +20,6 @@ import { useDynamicVirtualizerPagination } from '../../hooks/useDynamicPaginatio
 export function useVirtualizerScrollViewDynamic_unstable(
   props: VirtualizerScrollViewDynamicProps,
 ): VirtualizerScrollViewDynamicState {
-  'use no memo';
-
   const contextState = useVirtualizerContextState_unstable(props.virtualizerContext);
   const {
     imperativeRef,

--- a/packages/react-components/deprecated/react-virtualizer/src/components/VirtualizerScrollViewDynamic/useVirtualizerScrollViewDynamicStyles.styles.ts
+++ b/packages/react-components/deprecated/react-virtualizer/src/components/VirtualizerScrollViewDynamic/useVirtualizerScrollViewDynamicStyles.styles.ts
@@ -49,8 +49,6 @@ const useStyles = makeStyles({
 export const useVirtualizerScrollViewDynamicStyles_unstable = (
   state: VirtualizerScrollViewDynamicState,
 ): VirtualizerScrollViewDynamicState => {
-  'use no memo';
-
   const styles = useStyles();
 
   // Default virtualizer styles base

--- a/packages/react-components/deprecated/react-virtualizer/src/hooks/useDynamicPagination.ts
+++ b/packages/react-components/deprecated/react-virtualizer/src/hooks/useDynamicPagination.ts
@@ -15,8 +15,6 @@ export const useDynamicVirtualizerPagination = (
   virtualizerProps: VirtualizerDynamicPaginationProps,
   paginationEnabled: Boolean = true,
 ): ((instance: HTMLElement | HTMLDivElement | null) => void) => {
-  'use no memo';
-
   const { axis = 'vertical', currentIndex, progressiveItemSizes, virtualizerLength } = virtualizerProps;
 
   const [setScrollTimer, clearScrollTimer] = useTimeout();

--- a/packages/react-components/deprecated/react-virtualizer/src/hooks/useIntersectionObserver.ts
+++ b/packages/react-components/deprecated/react-virtualizer/src/hooks/useIntersectionObserver.ts
@@ -62,8 +62,6 @@ export const useIntersectionObserver = (
 
   observer: React.MutableRefObject<IntersectionObserver | undefined>;
 } => {
-  'use no memo';
-
   // TODO: exclude types from this lint rule: https://github.com/microsoft/fluentui/issues/31286
 
   const observer = useRef<IntersectionObserver>(undefined);

--- a/packages/react-components/deprecated/react-virtualizer/src/hooks/useMutationObserver.ts
+++ b/packages/react-components/deprecated/react-virtualizer/src/hooks/useMutationObserver.ts
@@ -15,8 +15,6 @@ export const useMutationObserver = (
 ): {
   observer: React.MutableRefObject<MutationObserver | undefined>;
 } => {
-  'use no memo';
-
   // TODO: exclude types from this lint rule: https://github.com/microsoft/fluentui/issues/31286
 
   const observer = useRef<MutationObserver | undefined>(undefined);

--- a/packages/react-components/deprecated/react-virtualizer/src/hooks/useResizeObserverRef.ts
+++ b/packages/react-components/deprecated/react-virtualizer/src/hooks/useResizeObserverRef.ts
@@ -13,8 +13,6 @@ import type { ResizeCallbackWithRef } from './hooks.types';
 export const useResizeObserverRef_unstable = (
   resizeCallback: ResizeCallbackWithRef,
 ): ((instance: HTMLElement | HTMLDivElement | null) => void) => {
-  'use no memo';
-
   const { targetDocument } = useFluent();
   const container = React.useRef<HTMLElement | null>(null);
   const containerHeightRef = React.useRef<number>(0);

--- a/packages/react-components/deprecated/react-virtualizer/src/hooks/useStaticPagination.ts
+++ b/packages/react-components/deprecated/react-virtualizer/src/hooks/useStaticPagination.ts
@@ -15,8 +15,6 @@ export const useStaticVirtualizerPagination = (
   virtualizerProps: VirtualizerStaticPaginationProps,
   paginationEnabled: Boolean = true,
 ): ((instance: HTMLElement | HTMLDivElement | null) => void) => {
-  'use no memo';
-
   const { itemSize, axis = 'vertical' } = virtualizerProps;
 
   const [setScrollTimer, clearScrollTimer] = useTimeout();

--- a/packages/react-components/react-accordion/library/src/components/Accordion/useAccordionStyles.styles.ts
+++ b/packages/react-components/react-accordion/library/src/components/Accordion/useAccordionStyles.styles.ts
@@ -7,8 +7,6 @@ export const accordionClassNames: SlotClassNames<AccordionSlots> = {
 };
 
 export const useAccordionStyles_unstable = (state: AccordionState): AccordionState => {
-  'use no memo';
-
   state.root.className = mergeClasses(accordionClassNames.root, state.root.className);
 
   return state;

--- a/packages/react-components/react-accordion/library/src/components/AccordionHeader/useAccordionHeaderStyles.styles.ts
+++ b/packages/react-components/react-accordion/library/src/components/AccordionHeader/useAccordionHeaderStyles.styles.ts
@@ -107,8 +107,6 @@ const useStyles = makeStyles({
 
 /** Applies style classnames to slots */
 export const useAccordionHeaderStyles_unstable = (state: AccordionHeaderState): AccordionHeaderState => {
-  'use no memo';
-
   const styles = useStyles();
   // eslint-disable-next-line react-hooks/immutability
   state.root.className = mergeClasses(

--- a/packages/react-components/react-accordion/library/src/components/AccordionItem/useAccordionItemStyles.styles.ts
+++ b/packages/react-components/react-accordion/library/src/components/AccordionItem/useAccordionItemStyles.styles.ts
@@ -7,8 +7,6 @@ export const accordionItemClassNames: SlotClassNames<AccordionItemSlots> = {
 };
 
 export const useAccordionItemStyles_unstable = (state: AccordionItemState): AccordionItemState => {
-  'use no memo';
-
   state.root.className = mergeClasses(accordionItemClassNames.root, state.root.className);
 
   return state;

--- a/packages/react-components/react-accordion/library/src/components/AccordionPanel/useAccordionPanelStyles.styles.ts
+++ b/packages/react-components/react-accordion/library/src/components/AccordionPanel/useAccordionPanelStyles.styles.ts
@@ -21,8 +21,6 @@ const useStyles = makeStyles({
 
 /** Applies style classnames to slots */
 export const useAccordionPanelStyles_unstable = (state: AccordionPanelState): AccordionPanelState => {
-  'use no memo';
-
   const styles = useStyles();
   // eslint-disable-next-line react-hooks/immutability
   state.root.className = mergeClasses(accordionPanelClassNames.root, styles.root, state.root.className);

--- a/packages/react-components/react-avatar/library/src/components/Avatar/useAvatarStyles.styles.ts
+++ b/packages/react-components/react-avatar/library/src/components/Avatar/useAvatarStyles.styles.ts
@@ -480,8 +480,6 @@ const useRingColorStyles = makeStyles({
 });
 
 export const useAvatarStyles_unstable = (state: AvatarState): AvatarState => {
-  'use no memo';
-
   const { size, shape, active, activeAppearance, color } = state;
 
   const rootClassName = useRootClassName();

--- a/packages/react-components/react-avatar/library/src/components/AvatarGroup/useAvatarGroupStyles.styles.ts
+++ b/packages/react-components/react-avatar/library/src/components/AvatarGroup/useAvatarGroupStyles.styles.ts
@@ -31,8 +31,6 @@ const useStyles = makeStyles({
  * Apply styling to the AvatarGroup slots based on the state
  */
 export const useAvatarGroupStyles_unstable = (state: AvatarGroupState): AvatarGroupState => {
-  'use no memo';
-
   const { layout, size } = state;
   const styles = useStyles();
   const sizeStyles = useSizeStyles();

--- a/packages/react-components/react-avatar/library/src/components/AvatarGroupItem/useAvatarGroupItemStyles.styles.ts
+++ b/packages/react-components/react-avatar/library/src/components/AvatarGroupItem/useAvatarGroupItemStyles.styles.ts
@@ -161,8 +161,6 @@ const usePieStyles = makeStyles({
  * Apply styling to the AvatarGroupItem slots based on the state
  */
 export const useAvatarGroupItemStyles_unstable = (state: AvatarGroupItemState): AvatarGroupItemState => {
-  'use no memo';
-
   const { isOverflowItem, layout, size } = state;
   const { dir } = useFluent();
 

--- a/packages/react-components/react-avatar/library/src/components/AvatarGroupPopover/useAvatarGroupPopoverStyles.styles.ts
+++ b/packages/react-components/react-avatar/library/src/components/AvatarGroupPopover/useAvatarGroupPopoverStyles.styles.ts
@@ -118,8 +118,6 @@ const useTriggerButtonStyles = makeStyles({
  * Apply styling to the AvatarGroupPopover slots based on the state
  */
 export const useAvatarGroupPopoverStyles_unstable = (state: AvatarGroupPopoverState): AvatarGroupPopoverState => {
-  'use no memo';
-
   const { indicator, size, layout, popoverOpen } = state;
   const sizeStyles = useSizeStyles();
   const triggerButtonStyles = useTriggerButtonStyles();

--- a/packages/react-components/react-badge/library/src/components/Badge/useBadgeStyles.styles.ts
+++ b/packages/react-components/react-badge/library/src/components/Badge/useBadgeStyles.styles.ts
@@ -300,8 +300,6 @@ const useIconStyles = makeStyles({
  * Applies style classnames to slots
  */
 export const useBadgeStyles_unstable = (state: BadgeState): BadgeState => {
-  'use no memo';
-
   const rootClassName = useRootClassName();
   const rootStyles = useRootStyles();
 

--- a/packages/react-components/react-badge/library/src/components/CounterBadge/useCounterBadgeStyles.styles.ts
+++ b/packages/react-components/react-badge/library/src/components/CounterBadge/useCounterBadgeStyles.styles.ts
@@ -27,8 +27,6 @@ const useStyles = makeStyles({
  * Applies style classnames to slots
  */
 export const useCounterBadgeStyles_unstable = (state: CounterBadgeState): CounterBadgeState => {
-  'use no memo';
-
   const styles = useStyles();
   // eslint-disable-next-line react-hooks/immutability
   state.root.className = mergeClasses(

--- a/packages/react-components/react-badge/library/src/components/PresenceBadge/usePresenceBadgeStyles.styles.ts
+++ b/packages/react-components/react-badge/library/src/components/PresenceBadge/usePresenceBadgeStyles.styles.ts
@@ -107,8 +107,6 @@ const useStyles = makeStyles({
  * Applies style classnames to slots
  */
 export const usePresenceBadgeStyles_unstable = (state: PresenceBadgeState): PresenceBadgeState => {
-  'use no memo';
-
   const rootClassName = useRootClassName();
   const iconClassName = useIconClassName();
   const styles = useStyles();

--- a/packages/react-components/react-breadcrumb/library/src/components/Breadcrumb/useBreadcrumbStyles.styles.ts
+++ b/packages/react-components/react-breadcrumb/library/src/components/Breadcrumb/useBreadcrumbStyles.styles.ts
@@ -21,8 +21,6 @@ const useListClassName = makeResetStyles({
  * Apply styling to the Breadcrumb slots based on the state
  */
 export const useBreadcrumbStyles_unstable = (state: BreadcrumbState): BreadcrumbState => {
-  'use no memo';
-
   const listBaseClassName = useListClassName();
   // eslint-disable-next-line react-hooks/immutability
   state.root.className = mergeClasses(breadcrumbClassNames.root, state.root.className);

--- a/packages/react-components/react-breadcrumb/library/src/components/BreadcrumbButton/useBreadcrumbButtonStyles.styles.ts
+++ b/packages/react-components/react-breadcrumb/library/src/components/BreadcrumbButton/useBreadcrumbButtonStyles.styles.ts
@@ -110,8 +110,6 @@ const useStyles = makeStyles({
  * Apply styling to the BreadcrumbButton slots based on the state
  */
 export const useBreadcrumbButtonStyles_unstable = (state: BreadcrumbButtonState): BreadcrumbButtonState => {
-  'use no memo';
-
   const styles = useStyles();
   const iconStyles = useIconStyles();
 

--- a/packages/react-components/react-breadcrumb/library/src/components/BreadcrumbDivider/useBreadcrumbDividerStyles.styles.ts
+++ b/packages/react-components/react-breadcrumb/library/src/components/BreadcrumbDivider/useBreadcrumbDividerStyles.styles.ts
@@ -31,8 +31,6 @@ const useIconStyles = makeStyles({
  * Apply styling to the BreadcrumbDivider slots based on the state
  */
 export const useBreadcrumbDividerStyles_unstable = (state: BreadcrumbDividerState): BreadcrumbDividerState => {
-  'use no memo';
-
   const styles = useStyles();
   const iconStyles = useIconStyles();
   const { size = 'medium' } = state;

--- a/packages/react-components/react-breadcrumb/library/src/components/BreadcrumbItem/useBreadcrumbItemStyles.styles.ts
+++ b/packages/react-components/react-breadcrumb/library/src/components/BreadcrumbItem/useBreadcrumbItemStyles.styles.ts
@@ -21,8 +21,6 @@ const useBreadcrumbItemResetStyles = makeResetStyles({
  * Apply styling to the BreadcrumbItem slots based on the state
  */
 export const useBreadcrumbItemStyles_unstable = (state: BreadcrumbItemState): BreadcrumbItemState => {
-  'use no memo';
-
   const resetStyles = useBreadcrumbItemResetStyles();
 
   // eslint-disable-next-line react-hooks/immutability

--- a/packages/react-components/react-button/library/src/components/Button/useButtonStyles.styles.ts
+++ b/packages/react-components/react-button/library/src/components/Button/useButtonStyles.styles.ts
@@ -551,8 +551,6 @@ const useIconStyles = makeStyles({
 });
 
 export const useButtonStyles_unstable = (state: ButtonState): ButtonState => {
-  'use no memo';
-
   const rootBaseClassName = useRootBaseClassName();
   const iconBaseClassName = useIconBaseClassName();
 

--- a/packages/react-components/react-button/library/src/components/CompoundButton/useCompoundButtonStyles.styles.ts
+++ b/packages/react-components/react-button/library/src/components/CompoundButton/useCompoundButtonStyles.styles.ts
@@ -259,8 +259,6 @@ const useSecondaryContentStyles = makeStyles({
 });
 
 export const useCompoundButtonStyles_unstable = (state: CompoundButtonState): CompoundButtonState => {
-  'use no memo';
-
   const rootStyles = useRootStyles();
   const rootIconOnlyStyles = useRootIconOnlyStyles();
   const iconStyles = useIconStyles();

--- a/packages/react-components/react-button/library/src/components/MenuButton/useMenuButtonStyles.styles.ts
+++ b/packages/react-components/react-button/library/src/components/MenuButton/useMenuButtonStyles.styles.ts
@@ -106,8 +106,6 @@ const useMenuIconStyles = makeStyles({
 });
 
 export const useMenuButtonStyles_unstable = (state: MenuButtonState): MenuButtonState => {
-  'use no memo';
-
   const rootExpandedStyles = useRootExpandedStyles();
   const iconExpandedStyles = useIconExpandedStyles();
   const menuIconStyles = useMenuIconStyles();

--- a/packages/react-components/react-button/library/src/components/SplitButton/useSplitButtonStyles.styles.ts
+++ b/packages/react-components/react-button/library/src/components/SplitButton/useSplitButtonStyles.styles.ts
@@ -174,8 +174,6 @@ const useRootStyles = makeStyles({
 });
 
 export const useSplitButtonStyles_unstable = (state: SplitButtonState): SplitButtonState => {
-  'use no memo';
-
   const rootStyles = useRootStyles();
   const focusStyles = useFocusStyles();
 

--- a/packages/react-components/react-button/library/src/components/ToggleButton/useToggleButtonStyles.styles.ts
+++ b/packages/react-components/react-button/library/src/components/ToggleButton/useToggleButtonStyles.styles.ts
@@ -306,8 +306,6 @@ const usePrimaryHighContrastStyles = makeStyles({
 });
 
 export const useToggleButtonStyles_unstable = (state: ToggleButtonState): ToggleButtonState => {
-  'use no memo';
-
   const rootCheckedStyles = useRootCheckedStyles();
   const accessibleCheckedStyles = useCheckedAccessibleStyles();
   const rootDisabledStyles = useRootDisabledStyles();

--- a/packages/react-components/react-calendar-compat/library/src/components/Calendar/useCalendarStyles.styles.ts
+++ b/packages/react-components/react-calendar-compat/library/src/components/Calendar/useCalendarStyles.styles.ts
@@ -113,7 +113,7 @@ const useLiveRegionStyles = makeStyles({
  * @internal
  */
 export const useCalendarStyles_unstable = (props: CalendarStyleProps): CalendarStyles => {
-  'use no memo';
+  'use no memo'; // justified: compiler would optimize useCalendarStyles_unstable — manual opt-out to preserve runtime behavior
 
   const rootStyles = useRootStyles();
   const dividerStyles = useDividerStyles();

--- a/packages/react-components/react-calendar-compat/library/src/components/CalendarDay/useCalendarDayStyles.styles.ts
+++ b/packages/react-components/react-calendar-compat/library/src/components/CalendarDay/useCalendarDayStyles.styles.ts
@@ -143,7 +143,7 @@ const useDisabledStyleStyles = makeStyles({
  * @internal
  */
 export const useCalendarDayStyles_unstable = (props: CalendarDayStyleProps): CalendarDayStyles => {
-  'use no memo';
+  'use no memo'; // justified: compiler would optimize useCalendarDayStyles_unstable — manual opt-out to preserve runtime behavior
 
   const rootStyles = useRootStyles();
   const headerStyles = useHeaderStyles();

--- a/packages/react-components/react-calendar-compat/library/src/components/CalendarDayGrid/CalendarGridDayCell.tsx
+++ b/packages/react-components/react-calendar-compat/library/src/components/CalendarDayGrid/CalendarGridDayCell.tsx
@@ -24,7 +24,7 @@ export interface CalendarGridDayCellProps extends CalendarGridRowProps {
  * @internal
  */
 export const CalendarGridDayCell: React.FunctionComponent<CalendarGridDayCellProps> = props => {
-  'use no memo';
+  'use no memo'; // justified: compiler would optimize unknown function — manual opt-out to preserve runtime behavior
 
   const {
     navigatedDate,

--- a/packages/react-components/react-calendar-compat/library/src/components/CalendarDayGrid/useCalendarDayGridStyles.styles.ts
+++ b/packages/react-components/react-calendar-compat/library/src/components/CalendarDayGrid/useCalendarDayGridStyles.styles.ts
@@ -390,7 +390,7 @@ const useCornerBorderAndRadiusStyles = makeStyles({
  * @internal
  */
 export const useCalendarDayGridStyles_unstable = (props: CalendarDayGridStyleProps): CalendarDayGridStyles => {
-  'use no memo';
+  'use no memo'; // justified: compiler would optimize useCalendarDayGridStyles_unstable — manual opt-out to preserve runtime behavior
 
   const wrapperStyles = useWrapperStyles();
   const tableStyles = useTableStyles();

--- a/packages/react-components/react-calendar-compat/library/src/components/CalendarDayGrid/useWeeks.ts
+++ b/packages/react-components/react-calendar-compat/library/src/components/CalendarDayGrid/useWeeks.ts
@@ -13,8 +13,6 @@ export function useWeeks(
   onSelectDate: (date: Date) => void,
   getSetRefCallback: (dayKey: string) => (element: HTMLElement | null) => void,
 ): DayInfo[][] {
-  'use no memo';
-
   /**
    * Initial parsing of the given props to generate IDayInfo two dimensional array, which contains a representation
    * of every day in the grid. Convenient for helping with conversions between day refs and Date objects in callbacks.

--- a/packages/react-components/react-calendar-compat/library/src/components/CalendarMonth/useCalendarMonthStyles.styles.ts
+++ b/packages/react-components/react-calendar-compat/library/src/components/CalendarMonth/useCalendarMonthStyles.styles.ts
@@ -9,7 +9,7 @@ import type { CalendarMonthStyleProps, CalendarMonthStyles } from './CalendarMon
  * @internal
  */
 export const useCalendarMonthStyles_unstable = (props: CalendarMonthStyleProps): CalendarMonthStyles => {
-  'use no memo';
+  'use no memo'; // justified: compiler would optimize useCalendarMonthStyles_unstable — manual opt-out to preserve runtime behavior
 
   return useCalendarPickerStyles_unstable(props);
 };

--- a/packages/react-components/react-calendar-compat/library/src/components/CalendarPicker/useCalendarPickerStyles.styles.ts
+++ b/packages/react-components/react-calendar-compat/library/src/components/CalendarPicker/useCalendarPickerStyles.styles.ts
@@ -288,7 +288,7 @@ const useDisabledStyles = makeStyles({
  * @internal
  */
 export const useCalendarPickerStyles_unstable = (props: CalendarPickerStyleProps): CalendarPickerStyles => {
-  'use no memo';
+  'use no memo'; // justified: compiler would optimize useCalendarPickerStyles_unstable — manual opt-out to preserve runtime behavior
 
   const rootStyles = useRootStyles();
   const headerContainerStyles = useHeaderContainerStyles();

--- a/packages/react-components/react-calendar-compat/library/src/components/CalendarYear/useCalendarYearStyles.styles.ts
+++ b/packages/react-components/react-calendar-compat/library/src/components/CalendarYear/useCalendarYearStyles.styles.ts
@@ -9,7 +9,7 @@ import type { CalendarYearStyleProps, CalendarYearStyles } from './CalendarYear.
  * @internal
  */
 export const useCalendarYearStyles_unstable = (props: CalendarYearStyleProps): CalendarYearStyles => {
-  'use no memo';
+  'use no memo'; // justified: compiler would optimize useCalendarYearStyles_unstable — manual opt-out to preserve runtime behavior
 
   return useCalendarPickerStyles_unstable(props);
 };

--- a/packages/react-components/react-card/library/src/components/Card/useCardStyles.styles.ts
+++ b/packages/react-components/react-card/library/src/components/Card/useCardStyles.styles.ts
@@ -412,8 +412,6 @@ const useCardStyles = makeStyles({
  * Apply styling to the Card slots based on the state.
  */
 export const useCardStyles_unstable = (state: CardState): CardState => {
-  'use no memo';
-
   const resetStyles = useCardResetStyles();
   const styles = useCardStyles();
 

--- a/packages/react-components/react-card/library/src/components/CardFooter/useCardFooterStyles.styles.ts
+++ b/packages/react-components/react-card/library/src/components/CardFooter/useCardFooterStyles.styles.ts
@@ -37,8 +37,6 @@ const useStyles = makeStyles({
  * Apply styling to the CardFooter slots based on the state.
  */
 export const useCardFooterStyles_unstable = (state: CardFooterState): CardFooterState => {
-  'use no memo';
-
   const styles = useStyles();
   // eslint-disable-next-line react-hooks/immutability
   state.root.className = mergeClasses(cardFooterClassNames.root, styles.root, state.root.className);

--- a/packages/react-components/react-card/library/src/components/CardHeader/useCardHeaderStyles.styles.ts
+++ b/packages/react-components/react-card/library/src/components/CardHeader/useCardHeaderStyles.styles.ts
@@ -97,8 +97,6 @@ const useStylesFlex = makeStyles<keyof CardHeaderSlots>({
  * Apply styling to the CardHeader slots based on the state.
  */
 export const useCardHeaderStyles_unstable = (state: CardHeaderState): CardHeaderState => {
-  'use no memo';
-
   const styles = useStyles();
   const stylesGrid = useStylesGrid();
   const stylesFlex = useStylesFlex();

--- a/packages/react-components/react-card/library/src/components/CardPreview/useCardPreviewStyles.styles.ts
+++ b/packages/react-components/react-card/library/src/components/CardPreview/useCardPreviewStyles.styles.ts
@@ -36,8 +36,6 @@ const useStyles = makeStyles({
  * Apply styling to the CardPreview slots based on the state.
  */
 export const useCardPreviewStyles_unstable = (state: CardPreviewState): CardPreviewState => {
-  'use no memo';
-
   const styles = useStyles();
   // eslint-disable-next-line react-hooks/immutability
   state.root.className = mergeClasses(cardPreviewClassNames.root, styles.root, state.root.className);

--- a/packages/react-components/react-carousel/library/src/components/Carousel/useCarousel.ts
+++ b/packages/react-components/react-carousel/library/src/components/Carousel/useCarousel.ts
@@ -25,7 +25,7 @@ import { useAnnounce } from '@fluentui/react-shared-contexts';
  * @param ref - reference to root HTMLDivElement of Carousel
  */
 export function useCarousel_unstable(props: CarouselProps, ref: React.Ref<HTMLDivElement>): CarouselState {
-  'use no memo';
+  'use no memo'; // justified: compiler would optimize useCarousel_unstable — manual opt-out to preserve runtime behavior
 
   const {
     align = 'center',

--- a/packages/react-components/react-carousel/library/src/components/Carousel/useCarouselStyles.styles.ts
+++ b/packages/react-components/react-carousel/library/src/components/Carousel/useCarouselStyles.styles.ts
@@ -32,8 +32,6 @@ const useStyles = makeStyles({
  * Apply styling to the Carousel slots based on the state
  */
 export const useCarouselStyles_unstable = (state: CarouselState): CarouselState => {
-  'use no memo';
-
   const styles = useStyles();
   const { appearance } = state;
 

--- a/packages/react-components/react-carousel/library/src/components/CarouselAutoplayButton/useCarouselAutoplayButtonStyles.styles.ts
+++ b/packages/react-components/react-carousel/library/src/components/CarouselAutoplayButton/useCarouselAutoplayButtonStyles.styles.ts
@@ -36,8 +36,6 @@ const useStyles = makeStyles({
 export const useCarouselAutoplayButtonStyles_unstable = (
   state: CarouselAutoplayButtonState,
 ): CarouselAutoplayButtonState => {
-  'use no memo';
-
   const styles = useStyles();
 
   useToggleButtonStyles_unstable(state);

--- a/packages/react-components/react-carousel/library/src/components/CarouselButton/useCarouselButtonStyles.styles.ts
+++ b/packages/react-components/react-carousel/library/src/components/CarouselButton/useCarouselButtonStyles.styles.ts
@@ -31,7 +31,7 @@ const useStyles = makeStyles({
  * Apply styling to the CarouselButton slots based on the state
  */
 export const useCarouselButtonStyles_unstable = (state: CarouselButtonState): CarouselButtonState => {
-  'use no memo';
+  'use no memo'; // justified: compiler would optimize useCarouselButtonStyles_unstable — manual opt-out to preserve runtime behavior
 
   const styles = useStyles();
 

--- a/packages/react-components/react-carousel/library/src/components/CarouselCard/useCarouselCardStyles.styles.ts
+++ b/packages/react-components/react-carousel/library/src/components/CarouselCard/useCarouselCardStyles.styles.ts
@@ -35,8 +35,6 @@ const useStyles = makeStyles({
  * Apply styling to the CarouselCard slots based on the state
  */
 export const useCarouselCardStyles_unstable = (state: CarouselCardState): CarouselCardState => {
-  'use no memo';
-
   const { autoSize } = state;
   const appearance = useCarouselContext(context => context.appearance);
 

--- a/packages/react-components/react-carousel/library/src/components/CarouselNav/useCarouselNavStyles.styles.ts
+++ b/packages/react-components/react-carousel/library/src/components/CarouselNav/useCarouselNavStyles.styles.ts
@@ -36,8 +36,6 @@ const useStyles = makeStyles({
  * Apply styling to the CarouselNav slots based on the state
  */
 export const useCarouselNavStyles_unstable = (state: CarouselNavState): CarouselNavState => {
-  'use no memo';
-
   const styles = useStyles();
   // eslint-disable-next-line react-hooks/immutability
   state.root.className = mergeClasses(carouselNavClassNames.root, styles.root, state.root.className);

--- a/packages/react-components/react-carousel/library/src/components/CarouselNavButton/useCarouselNavButtonStyles.styles.ts
+++ b/packages/react-components/react-carousel/library/src/components/CarouselNavButton/useCarouselNavButtonStyles.styles.ts
@@ -126,8 +126,6 @@ const useStyles = makeStyles({
  * Apply styling to the CarouselNavButton slots based on the state
  */
 export const useCarouselNavButtonStyles_unstable = (state: CarouselNavButtonState): CarouselNavButtonState => {
-  'use no memo';
-
   const styles = useStyles();
 
   const { selected, appearance } = state;

--- a/packages/react-components/react-carousel/library/src/components/CarouselNavContainer/useCarouselNavContainerStyles.styles.ts
+++ b/packages/react-components/react-carousel/library/src/components/CarouselNavContainer/useCarouselNavContainerStyles.styles.ts
@@ -94,8 +94,6 @@ const useStyles = makeStyles({
  * Apply styling to the CarouselNavContainer slots based on the state
  */
 export const useCarouselNavContainerStyles_unstable = (state: CarouselNavContainerState): CarouselNavContainerState => {
-  'use no memo';
-
   const { layout } = state;
   const isOverlay = layout === 'overlay' || layout === 'overlay-wide' || layout === 'overlay-expanded';
   const isWide = layout === 'inline-wide' || layout === 'overlay-wide';

--- a/packages/react-components/react-carousel/library/src/components/CarouselNavImageButton/useCarouselNavImageButtonStyles.styles.ts
+++ b/packages/react-components/react-carousel/library/src/components/CarouselNavImageButton/useCarouselNavImageButtonStyles.styles.ts
@@ -47,8 +47,6 @@ const useStyles = makeStyles({
 export const useCarouselNavImageButtonStyles_unstable = (
   state: CarouselNavImageButtonState,
 ): CarouselNavImageButtonState => {
-  'use no memo';
-
   const { selected } = state;
   const styles = useStyles();
 

--- a/packages/react-components/react-carousel/library/src/components/CarouselSlider/useCarouselSliderStyles.styles.ts
+++ b/packages/react-components/react-carousel/library/src/components/CarouselSlider/useCarouselSliderStyles.styles.ts
@@ -28,8 +28,6 @@ const useStyles = makeStyles({
  * Apply styling to the CarouselSlider slots based on the state
  */
 export const useCarouselSliderStyles_unstable = (state: CarouselSliderState): CarouselSliderState => {
-  'use no memo';
-
   const appearance = useCarouselContext(context => context.appearance);
   const styles = useStyles();
 

--- a/packages/react-components/react-carousel/library/src/components/CarouselViewport/useCarouselViewportStyles.styles.ts
+++ b/packages/react-components/react-carousel/library/src/components/CarouselViewport/useCarouselViewportStyles.styles.ts
@@ -22,8 +22,6 @@ const useStyles = makeStyles({
  * Apply styling to the CarouselViewport slots based on the state
  */
 export const useCarouselViewportStyles_unstable = (state: CarouselViewportState): CarouselViewportState => {
-  'use no memo';
-
   const styles = useStyles();
   // eslint-disable-next-line react-hooks/immutability
   state.root.className = mergeClasses(carouselViewportClassNames.root, styles.root, state.root.className);

--- a/packages/react-components/react-checkbox/library/src/components/Checkbox/useCheckbox.tsx
+++ b/packages/react-components/react-checkbox/library/src/components/Checkbox/useCheckbox.tsx
@@ -32,8 +32,6 @@ import { useFocusWithin } from '@fluentui/react-tabster';
  * @param ref - reference to `<input>` element of Checkbox
  */
 export const useCheckbox_unstable = (props: CheckboxProps, ref: React.Ref<HTMLInputElement>): CheckboxState => {
-  'use no memo';
-
   // Merge props from surrounding <Field>, if any
   props = useFieldControlProps_unstable(props, { supportsLabelFor: true, supportsRequired: true });
 
@@ -88,7 +86,7 @@ export const useCheckboxBase_unstable = (
   props: CheckboxBaseProps,
   ref: React.Ref<HTMLInputElement>,
 ): CheckboxBaseState => {
-  'use no memo';
+  'use no memo'; // justified: compiler would optimize useCheckboxBase_unstable — manual opt-out to preserve runtime behavior
 
   const { disabled = false, required, labelPosition = 'after', onChange } = props;
 

--- a/packages/react-components/react-checkbox/library/src/components/Checkbox/useCheckboxStyles.styles.ts
+++ b/packages/react-components/react-checkbox/library/src/components/Checkbox/useCheckboxStyles.styles.ts
@@ -187,8 +187,6 @@ const useLabelStyles = makeStyles({
  * Apply styling to the Checkbox slots based on the state
  */
 export const useCheckboxStyles_unstable = (state: CheckboxState): CheckboxState => {
-  'use no memo';
-
   const { checked, disabled, labelPosition, shape, size } = state;
 
   const rootBaseClassName = useRootBaseClassName();

--- a/packages/react-components/react-color-picker/library/src/components/AlphaSlider/useAlphaSliderState.ts
+++ b/packages/react-components/react-color-picker/library/src/components/AlphaSlider/useAlphaSliderState.ts
@@ -13,8 +13,6 @@ import { adjustToTransparency, calculateTransparencyValue, getSliderDirection } 
 import { createHsvColor } from '../../utils/createHsvColor';
 
 export const useAlphaSliderState_unstable = (state: AlphaSliderState, props: AlphaSliderProps): AlphaSliderState => {
-  'use no memo';
-
   const { dir } = useFluent();
   const onChangeFromContext = useColorPickerContextValue_unstable(ctx => ctx.requestChange);
   const colorFromContext = useColorPickerContextValue_unstable(ctx => ctx.color);

--- a/packages/react-components/react-color-picker/library/src/components/AlphaSlider/useAlphaSliderStyles.styles.ts
+++ b/packages/react-components/react-color-picker/library/src/components/AlphaSlider/useAlphaSliderStyles.styles.ts
@@ -56,8 +56,6 @@ const useThumbStyles = makeStyles({
  * Apply styling to the AlphaSlider slots based on the state
  */
 export const useAlphaSliderStyles_unstable = (state: AlphaSliderState): AlphaSliderState => {
-  'use no memo';
-
   const styles = useStyles();
   const thumbStyles = useThumbStyles();
   // eslint-disable-next-line react-hooks/immutability

--- a/packages/react-components/react-color-picker/library/src/components/ColorArea/useColorAreaStyles.styles.ts
+++ b/packages/react-components/react-color-picker/library/src/components/ColorArea/useColorAreaStyles.styles.ts
@@ -110,8 +110,6 @@ const useShapeStyles = makeStyles({
  * Apply styling to the ColorArea slots based on the state
  */
 export const useColorAreaStyles_unstable = (state: ColorAreaState): ColorAreaState => {
-  'use no memo';
-
   const rootStyles = useRootStyles();
   const thumbStyles = useThumbStyles();
   const inputStyles = useInputStyles();

--- a/packages/react-components/react-color-picker/library/src/components/ColorPicker/useColorPickerStyles.styles.ts
+++ b/packages/react-components/react-color-picker/library/src/components/ColorPicker/useColorPickerStyles.styles.ts
@@ -24,8 +24,6 @@ const useStyles = makeStyles({
  * Apply styling to the ColorPicker slots based on the state
  */
 export const useColorPickerStyles_unstable = (state: ColorPickerState): ColorPickerState => {
-  'use no memo';
-
   const styles = useStyles();
   // eslint-disable-next-line react-hooks/immutability
   state.root.className = mergeClasses(colorPickerClassNames.root, styles.root, state.root.className);

--- a/packages/react-components/react-color-picker/library/src/components/ColorSlider/useColorSlider.ts
+++ b/packages/react-components/react-color-picker/library/src/components/ColorSlider/useColorSlider.ts
@@ -33,7 +33,7 @@ export const useColorSlider_unstable = (
   props: ColorSliderProps,
   ref: React.Ref<HTMLInputElement>,
 ): ColorSliderState => {
-  'use no memo';
+  'use no memo'; // justified: compiler would optimize useColorSlider_unstable — manual opt-out to preserve runtime behavior
 
   const { dir } = useFluent();
   const onChangeFromContext = useColorPickerContextValue_unstable(ctx => ctx.requestChange);

--- a/packages/react-components/react-color-picker/library/src/components/ColorSlider/useColorSliderStyles.styles.ts
+++ b/packages/react-components/react-color-picker/library/src/components/ColorSlider/useColorSliderStyles.styles.ts
@@ -198,8 +198,6 @@ const useInputStyles = makeStyles({
  * Apply styling to the ColorSlider slots based on the state
  */
 export const useColorSliderStyles_unstable = (state: ColorSliderState): ColorSliderState => {
-  'use no memo';
-
   const rootStyles = useRootStyles();
   const styles = useStyles();
   const railStyles = useRailStyles();

--- a/packages/react-components/react-combobox/library/src/components/Combobox/useCombobox.tsx
+++ b/packages/react-components/react-combobox/library/src/components/Combobox/useCombobox.tsx
@@ -38,8 +38,6 @@ export const useComboboxBase_unstable = (
   props: BaseComboboxProps,
   ref: React.Ref<HTMLInputElement>,
 ): BaseComboboxState => {
-  'use no memo';
-
   // Merge props from surrounding <Field>, if any
   props = useFieldControlProps_unstable(props, { supportsLabelFor: true, supportsRequired: true });
   const {
@@ -215,8 +213,6 @@ export const useComboboxBase_unstable = (
  * @param ref - reference to root HTMLElement of Combobox
  */
 export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLInputElement>): ComboboxState => {
-  'use no memo';
-
   const { appearance = 'outline', size = 'medium', ...baseProps } = props;
   const baseState = useComboboxBase_unstable(baseProps, ref);
 

--- a/packages/react-components/react-combobox/library/src/components/Combobox/useComboboxStyles.styles.ts
+++ b/packages/react-components/react-combobox/library/src/components/Combobox/useComboboxStyles.styles.ts
@@ -285,8 +285,6 @@ const useIconStyles = makeStyles({
  * Apply styling to the Combobox slots based on the state
  */
 export const useComboboxStyles_unstable = (state: ComboboxState): ComboboxState => {
-  'use no memo';
-
   const { appearance, open, size, showClearIcon } = state;
   const invalid = `${state.input['aria-invalid']}` === 'true';
   const disabled = state.input.disabled;

--- a/packages/react-components/react-combobox/library/src/components/Combobox/useInputTriggerSlot.ts
+++ b/packages/react-components/react-combobox/library/src/components/Combobox/useInputTriggerSlot.ts
@@ -34,8 +34,6 @@ export function useInputTriggerSlot(
   ref: React.Ref<HTMLInputElement>,
   options: UseInputTriggerSlotOptions,
 ): SlotComponentType<ExtractSlotProps<Slot<'input'>>> {
-  'use no memo';
-
   const {
     state: {
       open,

--- a/packages/react-components/react-combobox/library/src/components/Dropdown/useButtonTriggerSlot.ts
+++ b/packages/react-components/react-combobox/library/src/components/Dropdown/useButtonTriggerSlot.ts
@@ -26,8 +26,6 @@ export function useButtonTriggerSlot(
   ref: React.Ref<HTMLButtonElement>,
   options: UseButtonTriggerSlotOptions,
 ): SlotComponentType<ExtractSlotProps<Slot<'button'>>> {
-  'use no memo';
-
   const {
     state: { open, setOpen, getOptionById },
     defaultProps,

--- a/packages/react-components/react-combobox/library/src/components/Dropdown/useDropdown.tsx
+++ b/packages/react-components/react-combobox/library/src/components/Dropdown/useDropdown.tsx
@@ -32,8 +32,6 @@ export const useDropdownBase_unstable = (
   props: DropdownBaseProps,
   ref: React.Ref<HTMLButtonElement>,
 ): DropdownBaseState => {
-  'use no memo';
-
   // Merge props from surrounding <Field>, if any
   props = useFieldControlProps_unstable(props, { supportsLabelFor: true });
   const {
@@ -164,8 +162,6 @@ export const useDropdownBase_unstable = (
  * @param ref - reference to root HTMLElement of Dropdown
  */
 export const useDropdown_unstable = (props: DropdownProps, ref: React.Ref<HTMLButtonElement>): DropdownState => {
-  'use no memo';
-
   const { appearance = 'outline', size = 'medium', ...baseProps } = props;
   const baseState = useDropdownBase_unstable(baseProps, ref);
 

--- a/packages/react-components/react-combobox/library/src/components/Dropdown/useDropdownStyles.styles.ts
+++ b/packages/react-components/react-combobox/library/src/components/Dropdown/useDropdownStyles.styles.ts
@@ -259,8 +259,6 @@ const useBaseClearButtonStyle = makeResetStyles({
  * Apply styling to the Dropdown slots based on the state
  */
 export const useDropdownStyles_unstable = (state: DropdownState): DropdownState => {
-  'use no memo';
-
   const { appearance, open, placeholderVisible, showClearButton, size } = state;
   const invalid = `${state.button['aria-invalid']}` === 'true';
   const disabled = state.button.disabled;

--- a/packages/react-components/react-combobox/library/src/components/Listbox/useListbox.ts
+++ b/packages/react-components/react-combobox/library/src/components/Listbox/useListbox.ts
@@ -40,8 +40,6 @@ const UNSAFE_noLongerUsed = {
  * @param ref - reference to root HTMLElement of Listbox
  */
 export const useListbox_unstable = (props: ListboxProps, ref: React.Ref<HTMLElement>): ListboxState => {
-  'use no memo';
-
   const { multiselect, disableAutoFocus = false } = props;
   const optionCollection = useOptionCollection();
 

--- a/packages/react-components/react-combobox/library/src/components/Listbox/useListboxStyles.styles.ts
+++ b/packages/react-components/react-combobox/library/src/components/Listbox/useListboxStyles.styles.ts
@@ -30,8 +30,6 @@ const useStyles = makeStyles({
  * Apply styling to the Listbox slots based on the state
  */
 export const useListboxStyles_unstable = (state: ListboxState): ListboxState => {
-  'use no memo';
-
   const styles = useStyles();
   // eslint-disable-next-line react-hooks/immutability
   state.root.className = mergeClasses(listboxClassNames.root, styles.root, state.root.className);

--- a/packages/react-components/react-combobox/library/src/components/Option/useOption.tsx
+++ b/packages/react-components/react-combobox/library/src/components/Option/useOption.tsx
@@ -42,8 +42,6 @@ function getTextString(text: string | undefined, children: React.ReactNode) {
  * @param ref - reference to root HTMLElement of Option
  */
 export const useOption_unstable = (props: OptionProps, ref: React.Ref<HTMLElement>): OptionState => {
-  'use no memo';
-
   const state = useOptionBase_unstable(props, ref);
 
   // check icon

--- a/packages/react-components/react-combobox/library/src/components/Option/useOptionStyles.styles.ts
+++ b/packages/react-components/react-combobox/library/src/components/Option/useOptionStyles.styles.ts
@@ -125,8 +125,6 @@ const useStyles = makeStyles({
  * Apply styling to the Option slots based on the state
  */
 export const useOptionStyles_unstable = (state: OptionState): OptionState => {
-  'use no memo';
-
   const { disabled, multiselect, selected } = state;
   const styles = useStyles();
   // eslint-disable-next-line react-hooks/immutability

--- a/packages/react-components/react-combobox/library/src/components/OptionGroup/useOptionGroupStyles.styles.ts
+++ b/packages/react-components/react-combobox/library/src/components/OptionGroup/useOptionGroupStyles.styles.ts
@@ -43,8 +43,6 @@ const useStyles = makeStyles({
  * Apply styling to the OptionGroup slots based on the state
  */
 export const useOptionGroupStyles_unstable = (state: OptionGroupState): OptionGroupState => {
-  'use no memo';
-
   const styles = useStyles();
   // eslint-disable-next-line react-hooks/immutability
   state.root.className = mergeClasses(optionGroupClassNames.root, styles.root, state.root.className);

--- a/packages/react-components/react-combobox/library/src/utils/useComboboxBaseState.ts
+++ b/packages/react-components/react-combobox/library/src/utils/useComboboxBaseState.ts
@@ -24,8 +24,6 @@ export const useComboboxBaseState = (
     activeDescendantController: ActiveDescendantImperativeRef;
   },
 ): ComboboxBaseState => {
-  'use no memo';
-
   const {
     appearance = 'outline',
     disableAutoFocus,

--- a/packages/react-components/react-datepicker-compat/library/src/components/DatePicker/useDatePicker.tsx
+++ b/packages/react-components/react-datepicker-compat/library/src/components/DatePicker/useDatePicker.tsx
@@ -44,8 +44,6 @@ function useFocusLogic() {
 }
 
 function usePopupVisibility(props: DatePickerProps) {
-  'use no memo';
-
   const [open, setOpen] = useControllableState({
     initialState: false,
     defaultState: props.defaultOpen,
@@ -106,8 +104,6 @@ const defaultParseDateFromString = (dateStr: string) => {
  * @param ref - reference to root Input slot
  */
 export const useDatePicker_unstable = (props: DatePickerProps, ref: React.Ref<HTMLInputElement>): DatePickerState => {
-  'use no memo';
-
   const {
     allowTextInput = false,
     allFocusable = false,

--- a/packages/react-components/react-datepicker-compat/library/src/components/DatePicker/useDatePickerStyles.styles.ts
+++ b/packages/react-components/react-datepicker-compat/library/src/components/DatePicker/useDatePickerStyles.styles.ts
@@ -48,8 +48,6 @@ const usePopupSurfaceClassName = makeResetStyles({
  * Apply styling to the DatePicker slots based on the state
  */
 export const useDatePickerStyles_unstable = (state: DatePickerState): DatePickerState => {
-  'use no memo';
-
   const styles = useStyles();
   const popupSurfaceClassName = usePopupSurfaceClassName();
   const { disabled, inlinePopup } = state;

--- a/packages/react-components/react-dialog/library/src/components/DialogActions/useDialogActionsStyles.styles.ts
+++ b/packages/react-components/react-dialog/library/src/components/DialogActions/useDialogActionsStyles.styles.ts
@@ -58,8 +58,6 @@ const useStyles = makeStyles({
  * Apply styling to the DialogActions slots based on the state
  */
 export const useDialogActionsStyles_unstable = (state: DialogActionsState): DialogActionsState => {
-  'use no memo';
-
   const resetStyles = useResetStyles();
   const styles = useStyles();
   // eslint-disable-next-line react-hooks/immutability

--- a/packages/react-components/react-dialog/library/src/components/DialogBody/useDialogBodyStyles.styles.ts
+++ b/packages/react-components/react-dialog/library/src/components/DialogBody/useDialogBodyStyles.styles.ts
@@ -40,8 +40,6 @@ const useResetStyles = makeResetStyles({
  * Apply styling to the DialogBody slots based on the state
  */
 export const useDialogBodyStyles_unstable = (state: DialogBodyState): DialogBodyState => {
-  'use no memo';
-
   const resetStyles = useResetStyles();
 
   // eslint-disable-next-line react-hooks/immutability

--- a/packages/react-components/react-dialog/library/src/components/DialogContent/useDialogContentStyles.styles.ts
+++ b/packages/react-components/react-dialog/library/src/components/DialogContent/useDialogContentStyles.styles.ts
@@ -34,8 +34,6 @@ const useStyles = makeResetStyles({
  * Apply styling to the DialogContent slots based on the state
  */
 export const useDialogContentStyles_unstable = (state: DialogContentState): DialogContentState => {
-  'use no memo';
-
   const styles = useStyles();
   // eslint-disable-next-line react-hooks/immutability
   state.root.className = mergeClasses(dialogContentClassNames.root, styles, state.root.className);

--- a/packages/react-components/react-dialog/library/src/components/DialogSurface/useDialogSurfaceStyles.styles.ts
+++ b/packages/react-components/react-dialog/library/src/components/DialogSurface/useDialogSurfaceStyles.styles.ts
@@ -80,8 +80,6 @@ const useStyles = makeStyles({
  * Apply styling to the DialogSurface slots based on the state
  */
 export const useDialogSurfaceStyles_unstable = (state: DialogSurfaceState): DialogSurfaceState => {
-  'use no memo';
-
   const { root, backdrop, open, unmountOnClose, treatBackdropAsNested, backdropAppearance } = state;
 
   const rootBaseStyle = useRootBaseStyle();

--- a/packages/react-components/react-dialog/library/src/components/DialogTitle/useDialogTitleStyles.styles.ts
+++ b/packages/react-components/react-dialog/library/src/components/DialogTitle/useDialogTitleStyles.styles.ts
@@ -65,8 +65,6 @@ export const useDialogTitleInternalStyles = makeResetStyles({
  * Apply styling to the DialogTitle slots based on the state
  */
 export const useDialogTitleStyles_unstable = (state: DialogTitleState): DialogTitleState => {
-  'use no memo';
-
   const rootResetStyles = useRootResetStyles();
   const actionResetStyles = useActionResetStyles();
   const styles = useStyles();

--- a/packages/react-components/react-divider/library/src/components/Divider/useDividerStyles.styles.ts
+++ b/packages/react-components/react-divider/library/src/components/Divider/useDividerStyles.styles.ts
@@ -249,8 +249,6 @@ const useVerticalStyles = makeStyles({
 });
 
 export const useDividerStyles_unstable = (state: DividerState): DividerState => {
-  'use no memo';
-
   const baseStyles = useBaseStyles();
   const horizontalStyles = useHorizontalStyles();
   const verticalStyles = useVerticalStyles();

--- a/packages/react-components/react-drawer/library/src/components/Drawer/useDrawerStyles.styles.ts
+++ b/packages/react-components/react-drawer/library/src/components/Drawer/useDrawerStyles.styles.ts
@@ -11,8 +11,6 @@ export const drawerClassNames: SlotClassNames<Omit<DrawerSlots, 'surfaceMotion'>
  * Apply styling to the Drawer slots based on the state
  */
 export const useDrawerStyles_unstable = (state: DrawerState): DrawerState => {
-  'use no memo';
-
   state.root.className = mergeClasses(drawerClassNames.root, state.root.className);
 
   return state;

--- a/packages/react-components/react-drawer/library/src/components/DrawerBody/useDrawerBodyStyles.styles.ts
+++ b/packages/react-components/react-drawer/library/src/components/DrawerBody/useDrawerBodyStyles.styles.ts
@@ -34,8 +34,6 @@ const useStyles = makeResetStyles({
  * Apply styling to the DrawerBody slots based on the state
  */
 export const useDrawerBodyStyles_unstable = (state: DrawerBodyState): DrawerBodyState => {
-  'use no memo';
-
   const styles = useStyles();
 
   // eslint-disable-next-line react-hooks/immutability

--- a/packages/react-components/react-drawer/library/src/components/DrawerFooter/useDrawerFooterStyles.styles.ts
+++ b/packages/react-components/react-drawer/library/src/components/DrawerFooter/useDrawerFooterStyles.styles.ts
@@ -47,8 +47,6 @@ const useDrawerFooterStyles = makeStyles({
  * Apply styling to the DrawerFooter slots based on the state
  */
 export const useDrawerFooterStyles_unstable = (state: DrawerFooterState): DrawerFooterState => {
-  'use no memo';
-
   const styles = useStyles();
   const rootStyles = useDrawerFooterStyles();
 

--- a/packages/react-components/react-drawer/library/src/components/DrawerHeader/useDrawerHeaderStyles.styles.ts
+++ b/packages/react-components/react-drawer/library/src/components/DrawerHeader/useDrawerHeaderStyles.styles.ts
@@ -47,8 +47,6 @@ const useDrawerHeaderStyles = makeStyles({
  * Apply styling to the DrawerHeader slots based on the state
  */
 export const useDrawerHeaderStyles_unstable = (state: DrawerHeaderState): DrawerHeaderState => {
-  'use no memo';
-
   const styles = useStyles();
   const rootStyles = useDrawerHeaderStyles();
 

--- a/packages/react-components/react-drawer/library/src/components/DrawerHeaderNavigation/useDrawerHeaderNavigationStyles.styles.ts
+++ b/packages/react-components/react-drawer/library/src/components/DrawerHeaderNavigation/useDrawerHeaderNavigationStyles.styles.ts
@@ -23,8 +23,6 @@ const useStyles = makeResetStyles({
 export const useDrawerHeaderNavigationStyles_unstable = (
   state: DrawerHeaderNavigationState,
 ): DrawerHeaderNavigationState => {
-  'use no memo';
-
   const styles = useStyles();
 
   // eslint-disable-next-line react-hooks/immutability

--- a/packages/react-components/react-drawer/library/src/components/DrawerHeaderTitle/useDrawerHeaderTitleStyles.styles.ts
+++ b/packages/react-components/react-drawer/library/src/components/DrawerHeaderTitle/useDrawerHeaderTitleStyles.styles.ts
@@ -33,8 +33,6 @@ const useStyles = makeStyles({
  * Apply styling to the DrawerHeaderTitle slots based on the state
  */
 export const useDrawerHeaderTitleStyles_unstable = (state: DrawerHeaderTitleState): DrawerHeaderTitleState => {
-  'use no memo';
-
   const styles = useStyles();
 
   const {

--- a/packages/react-components/react-drawer/library/src/components/InlineDrawer/useInlineDrawerStyles.styles.ts
+++ b/packages/react-components/react-drawer/library/src/components/InlineDrawer/useInlineDrawerStyles.styles.ts
@@ -89,8 +89,6 @@ function getAnimationExitClass(state: InlineDrawerState, classNames: ReturnType<
  * Apply styling to the InlineDrawer slots based on the state
  */
 export const useInlineDrawerStyles_unstable = (state: InlineDrawerState): InlineDrawerState => {
-  'use no memo';
-
   const resetStyles = useDrawerResetStyles();
   const baseClassNames = useDrawerBaseClassNames(state);
   const rootStyles = useDrawerRootStyles();

--- a/packages/react-components/react-drawer/library/src/components/OverlayDrawer/OverlayDrawerSurface/useOverlayDrawerSurfaceStyles.styles.ts
+++ b/packages/react-components/react-drawer/library/src/components/OverlayDrawer/OverlayDrawerSurface/useOverlayDrawerSurfaceStyles.styles.ts
@@ -27,8 +27,6 @@ const useBackdropStyles = makeStyles({
  * Apply styling to the OverlayDrawerSurface slots based on the state
  */
 export const useOverlayDrawerSurfaceStyles_unstable = (state: DialogSurfaceState): DialogSurfaceState => {
-  'use no memo';
-
   const { treatBackdropAsNested, backdrop, open, unmountOnClose } = state;
 
   const backdropResetStyles = useBackdropResetStyles();

--- a/packages/react-components/react-drawer/library/src/components/OverlayDrawer/useOverlayDrawerStyles.styles.ts
+++ b/packages/react-components/react-drawer/library/src/components/OverlayDrawer/useOverlayDrawerStyles.styles.ts
@@ -43,8 +43,6 @@ const useDrawerRootStyles = makeStyles({
  * Apply styling to the OverlayDrawer slots based on the state
  */
 export const useOverlayDrawerStyles_unstable = (state: OverlayDrawerState): OverlayDrawerState => {
-  'use no memo';
-
   const baseClassNames = useDrawerBaseClassNames(state);
   const resetStyles = useDrawerResetStyles();
   const rootStyles = useDrawerRootStyles();

--- a/packages/react-components/react-field/library/src/components/Field/useFieldStyles.styles.ts
+++ b/packages/react-components/react-field/library/src/components/Field/useFieldStyles.styles.ts
@@ -123,8 +123,6 @@ const useValidationMessageIconStyles = makeStyles({
  * Apply styling to the Field slots based on the state
  */
 export const useFieldStyles_unstable = (state: FieldState): FieldState => {
-  'use no memo';
-
   const { validationState, size } = state;
   const horizontal = state.orientation === 'horizontal';
 

--- a/packages/react-components/react-headless-components-preview/library/src/components/Accordion/AccordionHeader/useAccordionHeader.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Accordion/AccordionHeader/useAccordionHeader.ts
@@ -15,8 +15,6 @@ import { stringifyDataAttribute } from '../../../utils';
  * The returned state can be modified with hooks before being passed to `renderAccordionHeader`.
  */
 export const useAccordionHeader = (props: AccordionHeaderProps, ref: React.Ref<HTMLElement>): AccordionHeaderState => {
-  'use no memo';
-
   const state: AccordionHeaderState = useAccordionHeaderBase_unstable(props, ref);
 
   // Set data attributes for open, disabled, and expand icon position states to simplify styling.

--- a/packages/react-components/react-headless-components-preview/library/src/components/Accordion/AccordionItem/useAccordionItem.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Accordion/AccordionItem/useAccordionItem.ts
@@ -15,8 +15,6 @@ import { stringifyDataAttribute } from '../../../utils';
  * The returned state can be modified with hooks before being passed to `renderAccordionItem`.
  */
 export const useAccordionItem = (props: AccordionItemProps, ref: React.Ref<HTMLElement>): AccordionItemState => {
-  'use no memo';
-
   const state: AccordionItemState = useAccordionItem_unstable(props, ref);
 
   // Set data attributes for open and disabled states to simplify styling of these states.

--- a/packages/react-components/react-headless-components-preview/library/src/components/Accordion/AccordionPanel/useAccordionPanel.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Accordion/AccordionPanel/useAccordionPanel.ts
@@ -11,8 +11,6 @@ import { stringifyDataAttribute } from '../../../utils';
  * The returned state can be modified with hooks before being passed to `renderAccordionPanel`.
  */
 export const useAccordionPanel = (props: AccordionPanelProps, ref: React.Ref<HTMLElement>): AccordionPanelState => {
-  'use no memo';
-
   const state: AccordionPanelState = useAccordionPanelBase_unstable(props, ref);
 
   // Set data attribute for open state to simplify styling.

--- a/packages/react-components/react-headless-components-preview/library/src/components/Accordion/useAccordion.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Accordion/useAccordion.ts
@@ -15,8 +15,6 @@ import { stringifyDataAttribute } from '../../utils';
  * The returned state can be modified with hooks before being passed to `renderAccordion`.
  */
 export const useAccordion = (props: AccordionProps, ref: React.Ref<HTMLElement>): AccordionState => {
-  'use no memo';
-
   const state: AccordionState = useAccordionBase_unstable(props, ref);
 
   // Set data attributes for collapsible and multiple states to simplify styling of these states.

--- a/packages/react-components/react-headless-components-preview/library/src/components/Badge/useBadge.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Badge/useBadge.ts
@@ -10,8 +10,6 @@ import type { BadgeProps, BadgeState } from './Badge.types';
  * The returned state can be modified with hooks before being passed to `renderBadge`.
  */
 export const useBadge = (props: BadgeProps, ref: React.Ref<HTMLDivElement>): BadgeState => {
-  'use no memo';
-
   const state: BadgeState = useBadgeBase_unstable(props, ref);
 
   // Set data-icon-position only when an icon slot is present.

--- a/packages/react-components/react-headless-components-preview/library/src/components/Breadcrumb/BreadcrumbButton/useBreadcrumbButton.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Breadcrumb/BreadcrumbButton/useBreadcrumbButton.ts
@@ -14,8 +14,6 @@ export const useBreadcrumbButton = (
   props: BreadcrumbButtonProps,
   ref: React.Ref<HTMLButtonElement | HTMLAnchorElement>,
 ): BreadcrumbButtonState => {
-  'use no memo';
-
   const state: BreadcrumbButtonState = useBreadcrumbButtonBase_unstable(props, ref);
 
   // Set data attribute for current state to simplify styling of the active breadcrumb item.

--- a/packages/react-components/react-headless-components-preview/library/src/components/Button/useButton.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Button/useButton.ts
@@ -11,8 +11,6 @@ import { stringifyDataAttribute } from '../../utils';
  * The returned state can be modified with hooks before being passed to `renderButton`.
  */
 export const useButton = (props: ButtonProps, ref: React.Ref<HTMLButtonElement | HTMLAnchorElement>): ButtonState => {
-  'use no memo';
-
   const state: ButtonState = useButtonBase_unstable(props, ref);
 
   // Set data attributes for disabled, disabledFocusable, and iconOnly states to simplify styling of these states.

--- a/packages/react-components/react-headless-components-preview/library/src/components/Card/useCard.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Card/useCard.ts
@@ -11,8 +11,6 @@ import { stringifyDataAttribute } from '../../utils/stringifyDataAttribute';
  * The returned state can be modified with hooks before being passed to `renderCard`.
  */
 export const useCard = (props: CardProps, ref: React.Ref<HTMLDivElement>): CardState => {
-  ('use no memo');
-
   const state: CardState = useCardBase_unstable(props, ref);
 
   // eslint-disable-next-line react-hooks/immutability

--- a/packages/react-components/react-headless-components-preview/library/src/components/Checkbox/useCheckbox.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Checkbox/useCheckbox.ts
@@ -15,8 +15,6 @@ import { stringifyDataAttribute } from '../../utils';
  * @param ref - reference to root HTMLInputElement of Checkbox
  */
 export const useCheckbox = (props: CheckboxProps, ref: React.Ref<HTMLInputElement>): CheckboxState => {
-  'use no memo';
-
   const state: CheckboxState = useCheckboxBase_unstable(props, ref);
 
   // Set data attributes for disabled and checked states to simplify styling of these states.

--- a/packages/react-components/react-headless-components-preview/library/src/components/Combobox/useCombobox.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Combobox/useCombobox.ts
@@ -9,8 +9,6 @@ import { stringifyDataAttribute } from '../../utils';
 import { useListboxPopupState } from '../Dropdown/useListboxPopupState';
 
 export const useCombobox = (props: ComboboxProps, ref: React.Ref<HTMLInputElement>): ComboboxState => {
-  'use no memo';
-
   const { freeform } = props;
 
   const {

--- a/packages/react-components/react-headless-components-preview/library/src/components/Divider/useDivider.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Divider/useDivider.ts
@@ -10,8 +10,6 @@ import type { DividerProps, DividerState } from './Divider.types';
  * The returned state can be modified with hooks before being passed to `renderDivider`.
  */
 export const useDivider = (props: DividerProps, ref: React.Ref<HTMLElement>): DividerState => {
-  'use no memo';
-
   const state: DividerState = useDividerBase_unstable(props, ref);
 
   // Set data attribute for orientation to simplify styling of vertical vs horizontal dividers.

--- a/packages/react-components/react-headless-components-preview/library/src/components/Drawer/DrawerFooter/useDrawerFooter.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Drawer/DrawerFooter/useDrawerFooter.ts
@@ -9,8 +9,6 @@ import { stringifyDataAttribute } from '../../../utils';
  * Returns the state for a DrawerFooter component, given its props and ref.
  */
 export const useDrawerFooter = (props: DrawerFooterProps, ref: React.Ref<HTMLElement>): DrawerFooterState => {
-  'use no memo';
-
   const state: DrawerFooterState = useDrawerFooter_unstable(props, ref);
   // eslint-disable-next-line react-hooks/immutability
   state.root['data-scroll-state'] = stringifyDataAttribute(state.scrollState);

--- a/packages/react-components/react-headless-components-preview/library/src/components/Drawer/DrawerHeader/useDrawerHeader.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Drawer/DrawerHeader/useDrawerHeader.ts
@@ -9,8 +9,6 @@ import { stringifyDataAttribute } from '../../../utils';
  * Returns the state for a DrawerHeader component, given its props and ref.
  */
 export const useDrawerHeader = (props: DrawerHeaderProps, ref: React.Ref<HTMLElement>): DrawerHeaderState => {
-  'use no memo';
-
   const state: DrawerHeaderState = useDrawerHeader_unstable(props, ref);
   // eslint-disable-next-line react-hooks/immutability
   state.root['data-scroll-state'] = stringifyDataAttribute(state.scrollState);

--- a/packages/react-components/react-headless-components-preview/library/src/components/Drawer/DrawerHeaderTitle/useDrawerHeaderTitle.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Drawer/DrawerHeaderTitle/useDrawerHeaderTitle.ts
@@ -13,8 +13,6 @@ export const useDrawerHeaderTitle = (
   props: DrawerHeaderTitleProps,
   ref: React.Ref<HTMLDivElement>,
 ): DrawerHeaderTitleState => {
-  'use no memo';
-
   const state = useDrawerHeaderTitle_unstable(props, ref);
   const { dialogTitleId } = useDialogContext();
 

--- a/packages/react-components/react-headless-components-preview/library/src/components/Drawer/InlineDrawer/useInlineDrawer.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Drawer/InlineDrawer/useInlineDrawer.ts
@@ -10,8 +10,6 @@ import type { InlineDrawerProps, InlineDrawerState } from './InlineDrawer.types'
  * Returns the state for an InlineDrawer component, given its props and ref.
  */
 export const useInlineDrawer = (props: InlineDrawerProps, ref: React.Ref<HTMLElement>): InlineDrawerState => {
-  'use no memo';
-
   const state: InlineDrawerState = useInlineDrawerBase_unstable(props, ref);
 
   // eslint-disable-next-line react-hooks/immutability

--- a/packages/react-components/react-headless-components-preview/library/src/components/Drawer/OverlayDrawer/useOverlayDrawer.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Drawer/OverlayDrawer/useOverlayDrawer.ts
@@ -10,8 +10,6 @@ import type { OverlayDrawerProps, OverlayDrawerState } from './OverlayDrawer.typ
  * Returns the state for an OverlayDrawer component, given its props and ref.
  */
 export const useOverlayDrawer = (props: OverlayDrawerProps, ref: React.Ref<HTMLDialogElement>): OverlayDrawerState => {
-  'use no memo';
-
   const {
     open = false,
     position = 'start',

--- a/packages/react-components/react-headless-components-preview/library/src/components/Drawer/useDrawer.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Drawer/useDrawer.ts
@@ -10,8 +10,6 @@ import type { DrawerProps, DrawerState } from './Drawer.types';
  * The returned state can be modified with hooks before being passed to `renderDrawer`.
  */
 export const useDrawer = (props: DrawerProps, ref: React.Ref<HTMLElement>): DrawerState => {
-  'use no memo';
-
   const { type, ...restProps } = props;
   const elementType = (type === 'inline' ? InlineDrawer : OverlayDrawer) as React.FC<
     InlineDrawerProps | OverlayDrawerProps

--- a/packages/react-components/react-headless-components-preview/library/src/components/Dropdown/Listbox/useListbox.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Dropdown/Listbox/useListbox.ts
@@ -10,8 +10,6 @@ import type { ListboxProps, ListboxState } from './Listbox.types';
  * The returned state can be modified with hooks before being passed to `renderListbox`.
  */
 export const useListbox = (props: ListboxProps, ref: React.Ref<HTMLElement>): ListboxState => {
-  ('use no memo');
-
   const state = useListbox_unstable(props, ref);
 
   // eslint-disable-next-line react-hooks/immutability

--- a/packages/react-components/react-headless-components-preview/library/src/components/Dropdown/Option/useOption.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Dropdown/Option/useOption.ts
@@ -11,8 +11,6 @@ import { stringifyDataAttribute } from '../../../utils/stringifyDataAttribute';
  * The returned state can be modified with hooks before being passed to `renderOption`.
  */
 export const useOption = (props: OptionProps, ref: React.Ref<HTMLElement>): OptionState => {
-  ('use no memo');
-
   const state: OptionState = useOptionBase_unstable(props, ref);
 
   // eslint-disable-next-line react-hooks/immutability

--- a/packages/react-components/react-headless-components-preview/library/src/components/Dropdown/OptionGroup/useOptionGroup.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Dropdown/OptionGroup/useOptionGroup.ts
@@ -10,7 +10,7 @@ import type { OptionGroupProps, OptionGroupState } from './OptionGroup.types';
  * The returned state can be modified with hooks before being passed to `renderOptionGroup`.
  */
 export const useOptionGroup = (props: OptionGroupProps, ref: React.Ref<HTMLElement>): OptionGroupState => {
-  'use no memo';
+  'use no memo'; // justified: compiler would optimize useOptionGroup — manual opt-out to preserve runtime behavior
 
   return useOptionGroup_unstable(props, ref);
 };

--- a/packages/react-components/react-headless-components-preview/library/src/components/Dropdown/useDropdown.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Dropdown/useDropdown.ts
@@ -19,8 +19,6 @@ import { useListboxPopupState } from './useListboxPopupState';
  * @param ref - reference to root HTMLButtonElement of Dropdown
  */
 export const useDropdown = (props: DropdownProps, ref: React.Ref<HTMLButtonElement>): DropdownState => {
-  'use no memo';
-
   const {
     props: mergedProps,
     triggerRef,

--- a/packages/react-components/react-headless-components-preview/library/src/components/Dropdown/useListboxPopupState.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Dropdown/useListboxPopupState.ts
@@ -86,8 +86,6 @@ export function useListboxPopupState<TProps extends ListboxPopupBaseProps, TTrig
   initialProps: TProps,
   options: UseListboxPopupStateOptions<TProps>,
 ): UseListboxPopupStateReturn<TProps, TTrigger> {
-  'use no memo';
-
   const { primarySlotTagName, fieldControlOptions, baseStateExtras, rootDefaultProps } = options;
 
   const positioningOptions = resolvePositioningShorthand(initialProps.positioning);

--- a/packages/react-components/react-headless-components-preview/library/src/components/Field/useField.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Field/useField.ts
@@ -10,8 +10,6 @@ import type { FieldProps, FieldState } from './Field.types';
  * The returned state can be modified with hooks before being passed to `renderField`.
  */
 export const useField = (props: FieldProps, ref: React.Ref<HTMLDivElement>): FieldState => {
-  'use no memo';
-
   const state: FieldState = useFieldBase_unstable(props, ref);
 
   // eslint-disable-next-line react-hooks/immutability

--- a/packages/react-components/react-headless-components-preview/library/src/components/Input/useInput.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Input/useInput.ts
@@ -11,8 +11,6 @@ import { stringifyDataAttribute } from '../../utils';
  * The returned state can be modified with hooks before being passed to `renderInput`.
  */
 export const useInput = (props: InputProps, ref: React.Ref<HTMLInputElement>): InputState => {
-  'use no memo';
-
   const state: InputState = useInputBase_unstable(props, ref);
 
   // Set data attribute for disabled state to simplify styling.

--- a/packages/react-components/react-headless-components-preview/library/src/components/Label/useLabel.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Label/useLabel.ts
@@ -11,8 +11,6 @@ import { stringifyDataAttribute } from '../../utils';
  * The returned state can be modified with hooks before being passed to `renderLabel`.
  */
 export const useLabel = (props: LabelProps, ref: React.Ref<HTMLLabelElement>): LabelState => {
-  'use no memo';
-
   const state: LabelState = useLabelBase_unstable(props, ref);
 
   // Set data attribute for disabled state to simplify styling.

--- a/packages/react-components/react-headless-components-preview/library/src/components/Link/useLink.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Link/useLink.ts
@@ -11,8 +11,6 @@ import { stringifyDataAttribute } from '../../utils';
  * The returned state can be modified with hooks before being passed to `renderLink`.
  */
 export const useLink = (props: LinkProps, ref: React.Ref<HTMLElement>): LinkState => {
-  'use no memo';
-
   const state: LinkState = useLinkBase_unstable(props, ref);
 
   // eslint-disable-next-line react-hooks/immutability

--- a/packages/react-components/react-headless-components-preview/library/src/components/Menu/useMenu.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Menu/useMenu.ts
@@ -206,8 +206,6 @@ const useMenuOpenState = (
     menuPopoverRef: React.MutableRefObject<HTMLElement | null>;
   } & Pick<MenuProps, 'open' | 'defaultOpen' | 'onOpenChange'>,
 ) => {
-  'use no memo';
-
   const { targetDocument } = useFluent();
   const parentSetOpen = useMenuContext(ctx => ctx.setOpen);
   const onOpenChange: MenuProps['onOpenChange'] = useEventCallback((e, data) => state.onOpenChange?.(e, data));

--- a/packages/react-components/react-headless-components-preview/library/src/components/MessageBar/MessageBarActions/useMessageBarActions.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/MessageBar/MessageBarActions/useMessageBarActions.ts
@@ -18,8 +18,6 @@ export const useMessageBarActions = (
   props: MessageBarActionsProps,
   ref: React.Ref<HTMLDivElement>,
 ): MessageBarActionsState => {
-  'use no memo';
-
   const state: MessageBarActionsState = useMessageBarActions_unstable(props, ref);
 
   // eslint-disable-next-line react-hooks/immutability

--- a/packages/react-components/react-headless-components-preview/library/src/components/MessageBar/MessageBarBody/useMessageBarBody.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/MessageBar/MessageBarBody/useMessageBarBody.ts
@@ -13,7 +13,7 @@ export const useMessageBarBody = (
   props: MessageBarBodyProps,
   ref: ReactTypes.Ref<HTMLDivElement>,
 ): MessageBarBodyState => {
-  'use no memo';
+  'use no memo'; // justified: compiler would optimize useMessageBarBody — manual opt-out to preserve runtime behavior
 
   return useMessageBarBody_unstable(props, ref);
 };

--- a/packages/react-components/react-headless-components-preview/library/src/components/MessageBar/MessageBarTitle/useMessageBarTitle.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/MessageBar/MessageBarTitle/useMessageBarTitle.ts
@@ -10,7 +10,7 @@ import type { MessageBarTitleProps, MessageBarTitleState } from './MessageBarTit
  * The returned state can be modified with hooks before being passed to `renderMessageBarTitle`.
  */
 export const useMessageBarTitle = (props: MessageBarTitleProps, ref: React.Ref<HTMLElement>): MessageBarTitleState => {
-  'use no memo';
+  'use no memo'; // justified: compiler would optimize useMessageBarTitle — manual opt-out to preserve runtime behavior
 
   return useMessageBarTitle_unstable(props, ref);
 };

--- a/packages/react-components/react-headless-components-preview/library/src/components/MessageBar/useMessageBar.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/MessageBar/useMessageBar.ts
@@ -15,8 +15,6 @@ import { stringifyDataAttribute } from '../../utils';
  * The returned state can be modified with hooks before being passed to `renderMessageBar`.
  */
 export const useMessageBar = (props: MessageBarProps, ref: React.Ref<HTMLDivElement>): MessageBarState => {
-  'use no memo';
-
   const state: MessageBarState = useMessageBarBase_unstable(props, ref);
 
   // eslint-disable-next-line react-hooks/immutability

--- a/packages/react-components/react-headless-components-preview/library/src/components/ProgressBar/useProgressBar.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/ProgressBar/useProgressBar.ts
@@ -15,8 +15,6 @@ import type { ProgressBarProps, ProgressBarState } from './ProgressBar.types';
  * @param ref - reference to root HTMLDivElement of ProgressBar
  */
 export const useProgressBar = (props: ProgressBarProps, ref: React.Ref<HTMLDivElement>): ProgressBarState => {
-  'use no memo';
-
   const state = useProgressBarBase_unstable(props, ref);
 
   if (state.bar && state.value !== undefined) {

--- a/packages/react-components/react-headless-components-preview/library/src/components/RadioGroup/Radio/useRadio.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/RadioGroup/Radio/useRadio.ts
@@ -11,8 +11,6 @@ import { stringifyDataAttribute } from '../../../utils';
  * The returned state can be modified with hooks before being passed to `renderRadio`.
  */
 export const useRadio = (props: RadioProps, ref: React.Ref<HTMLInputElement>): RadioState => {
-  'use no memo';
-
   const state: RadioState = useRadioBase_unstable(props, ref);
 
   // Set data attribute for disabled state to simplify styling.

--- a/packages/react-components/react-headless-components-preview/library/src/components/RatingDisplay/useRatingDisplay.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/RatingDisplay/useRatingDisplay.tsx
@@ -11,8 +11,6 @@ import type { RatingDisplayProps, RatingDisplayState } from './RatingDisplay.typ
  * The returned state can be modified with hooks before being passed to `renderRatingDisplay`.
  */
 export const useRatingDisplay = (props: RatingDisplayProps, ref: React.Ref<HTMLDivElement>): RatingDisplayState => {
-  'use no memo';
-
   const state = useRatingDisplayBase_unstable(
     {
       icon: 'span',

--- a/packages/react-components/react-headless-components-preview/library/src/components/SearchBox/useSearchBox.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/SearchBox/useSearchBox.ts
@@ -11,8 +11,6 @@ import { stringifyDataAttribute } from '../../utils';
  * The returned state can be modified with hooks before being passed to `renderSearchBox`.
  */
 export const useSearchBox = (props: SearchBoxProps, ref: React.Ref<HTMLInputElement>): SearchBoxState => {
-  'use no memo';
-
   const state: SearchBoxState = useSearchBoxBase_unstable(props, ref);
 
   // Set data attributes for disabled and focused states to simplify styling of these states.

--- a/packages/react-components/react-headless-components-preview/library/src/components/Select/useSelect.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Select/useSelect.ts
@@ -15,8 +15,6 @@ import { stringifyDataAttribute } from '../../utils';
  * @param ref - reference to root HTMLSelectElement
  */
 export const useSelect = (props: SelectProps, ref: React.Ref<HTMLSelectElement>): SelectState => {
-  'use no memo';
-
   const state: SelectState = useSelectBase_unstable(props, ref);
 
   // Set data attribute for disabled state to simplify styling.

--- a/packages/react-components/react-headless-components-preview/library/src/components/Slider/useSlider.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Slider/useSlider.ts
@@ -11,8 +11,6 @@ import { stringifyDataAttribute } from '../../utils';
  * The returned state can be modified with hooks before being passed to `renderSlider`.
  */
 export const useSlider = (props: SliderProps, ref: React.Ref<HTMLInputElement>): SliderState => {
-  'use no memo';
-
   const state: SliderState = useSliderBase_unstable(props, ref);
 
   // Set data attributes for disabled and vertical states to simplify styling of these states.

--- a/packages/react-components/react-headless-components-preview/library/src/components/SpinButton/useSpinButton.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/SpinButton/useSpinButton.ts
@@ -11,8 +11,6 @@ import { stringifyDataAttribute } from '../../utils';
  * The returned state can be modified with hooks before being passed to `renderSpinButton`.
  */
 export const useSpinButton = (props: SpinButtonProps, ref: React.Ref<HTMLInputElement>): SpinButtonState => {
-  'use no memo';
-
   const state: SpinButtonState = useSpinButtonBase_unstable(props, ref);
 
   // Set data attributes for disabled, spin direction, and bound states to simplify styling.

--- a/packages/react-components/react-headless-components-preview/library/src/components/Spinner/useSpinner.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Spinner/useSpinner.ts
@@ -10,8 +10,6 @@ import type { SpinnerProps, SpinnerState } from './Spinner.types';
  * The returned state can be modified with hooks before being passed to `renderSpinner`.
  */
 export const useSpinner = (props: SpinnerProps, ref: React.Ref<HTMLElement>): SpinnerState => {
-  'use no memo';
-
   const state: SpinnerState = useSpinnerBase_unstable(props, ref);
 
   // eslint-disable-next-line react-hooks/immutability

--- a/packages/react-components/react-headless-components-preview/library/src/components/Switch/useSwitch.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Switch/useSwitch.ts
@@ -11,8 +11,6 @@ import { stringifyDataAttribute } from '../../utils';
  * The returned state can be modified with hooks before being passed to `renderSwitch`.
  */
 export const useSwitch = (props: SwitchProps, ref: React.Ref<HTMLInputElement>): SwitchState => {
-  'use no memo';
-
   const state: SwitchState = useSwitchBase_unstable(props, ref);
 
   // Set data attributes for disabled, disabledFocusable, and checked states to simplify styling.

--- a/packages/react-components/react-headless-components-preview/library/src/components/TabList/Tab/useTab.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/TabList/Tab/useTab.ts
@@ -11,8 +11,6 @@ import { stringifyDataAttribute } from '../../../utils';
  * The returned state can be modified with hooks before being passed to `renderTab`.
  */
 export const useTab = (props: TabProps, ref: React.Ref<HTMLElement>): TabState => {
-  'use no memo';
-
   const state: TabState = useTabBase_unstable(props, ref);
 
   // eslint-disable-next-line react-hooks/immutability

--- a/packages/react-components/react-headless-components-preview/library/src/components/TabList/useTabList.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/TabList/useTabList.ts
@@ -10,8 +10,6 @@ import type { TabListProps, TabListState } from './TabList.types';
  * The returned state can be modified with hooks before being passed to `renderTabList`.
  */
 export const useTabList = (props: TabListProps, ref: React.Ref<HTMLElement>): TabListState => {
-  'use no memo';
-
   const state: TabListState = useTabListBase_unstable(props, ref);
 
   // eslint-disable-next-line react-hooks/immutability

--- a/packages/react-components/react-headless-components-preview/library/src/components/ToggleButton/useToggleButton.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/ToggleButton/useToggleButton.ts
@@ -14,8 +14,6 @@ export const useToggleButton = (
   props: ToggleButtonProps,
   ref: React.Ref<HTMLButtonElement | HTMLAnchorElement>,
 ): ToggleButtonState => {
-  'use no memo';
-
   const state: ToggleButtonState = useToggleButtonBase_unstable(props, ref);
 
   // Set data attributes for disabled, disabledFocusable, iconOnly, and checked states to simplify styling of these states.

--- a/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarButton/useToolbarButton.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarButton/useToolbarButton.ts
@@ -14,8 +14,6 @@ export const useToolbarButton = (
   props: ToolbarButtonProps,
   ref: React.Ref<HTMLButtonElement | HTMLAnchorElement>,
 ): ToolbarButtonState => {
-  'use no memo';
-
   const state: ToolbarButtonState = useToolbarButtonBase_unstable(props, ref);
 
   // Set data attributes for vertical, disabled, disabledFocusable, and iconOnly states to simplify styling.

--- a/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarDivider/useToolbarDivider.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarDivider/useToolbarDivider.ts
@@ -11,8 +11,6 @@ import { stringifyDataAttribute } from '../../../utils';
  * The returned state can be modified with hooks before being passed to `renderToolbarDivider`.
  */
 export const useToolbarDivider = (props: ToolbarDividerProps, ref: React.Ref<HTMLElement>): ToolbarDividerState => {
-  'use no memo';
-
   const state: ToolbarDividerState = useToolbarDividerBase_unstable(props, ref);
 
   // Set data-vertical based on the resolved orientation of the divider (already inverted relative to the toolbar).

--- a/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarGroup/useToolbarGroup.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarGroup/useToolbarGroup.ts
@@ -11,8 +11,6 @@ import { stringifyDataAttribute } from '../../../utils';
  * The returned state can be modified with hooks before being passed to `renderToolbarGroup`.
  */
 export const useToolbarGroup = (props: ToolbarGroupProps, ref: React.Ref<HTMLDivElement>): ToolbarGroupState => {
-  'use no memo';
-
   const state: ToolbarGroupState = useToolbarGroup_unstable(props, ref);
 
   // Set data-vertical based on the toolbar context orientation.

--- a/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarRadioButton/useToolbarRadioButton.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarRadioButton/useToolbarRadioButton.ts
@@ -14,8 +14,6 @@ export const useToolbarRadioButton = (
   props: ToolbarRadioButtonProps,
   ref: React.Ref<HTMLButtonElement | HTMLAnchorElement>,
 ): ToolbarRadioButtonState => {
-  'use no memo';
-
   const state: ToolbarRadioButtonState = useToolbarRadioButtonBase_unstable(props, ref);
 
   // eslint-disable-next-line react-hooks/immutability

--- a/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarRadioGroup/useToolbarRadioGroup.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarRadioGroup/useToolbarRadioGroup.ts
@@ -13,7 +13,7 @@ export const useToolbarRadioGroup = (
   props: ToolbarRadioGroupProps,
   ref: React.Ref<HTMLDivElement>,
 ): ToolbarRadioGroupState => {
-  'use no memo';
+  'use no memo'; // justified: compiler would optimize useToolbarRadioGroup — manual opt-out to preserve runtime behavior
 
   // ToolbarRadioGroup reuses ToolbarGroup logic with role='radiogroup'.
   return useToolbarGroup({ role: 'radiogroup', ...props }, ref) as unknown as ToolbarRadioGroupState;

--- a/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarToggleButton/useToolbarToggleButton.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/ToolbarToggleButton/useToolbarToggleButton.ts
@@ -14,8 +14,6 @@ export const useToolbarToggleButton = (
   props: ToolbarToggleButtonProps,
   ref: React.Ref<HTMLButtonElement | HTMLAnchorElement>,
 ): ToolbarToggleButtonState => {
-  ('use no memo');
-
   const state: ToolbarToggleButtonState = useToolbarToggleButtonBase_unstable(props, ref);
 
   // eslint-disable-next-line react-hooks/immutability

--- a/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/useToolbar.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/useToolbar.ts
@@ -15,8 +15,6 @@ import { stringifyDataAttribute } from '../../utils';
  * The returned state can be modified with hooks before being passed to `renderToolbar`.
  */
 export const useToolbar = (props: ToolbarProps, ref: React.Ref<HTMLElement>): ToolbarState => {
-  'use no memo';
-
   const state: ToolbarState = useToolbarBase_unstable(props, ref);
 
   // eslint-disable-next-line react-hooks/immutability

--- a/packages/react-components/react-headless-components-preview/library/src/components/Tooltip/useTooltip.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Tooltip/useTooltip.ts
@@ -28,8 +28,6 @@ import { resolvePositioningShorthand, usePositioning } from '../../positioning';
  * @param props - props from this instance of Tooltip
  */
 export const useTooltip = (props: TooltipProps): TooltipState => {
-  'use no memo';
-
   const isServerSideRender = useIsSSR();
   const { targetDocument } = useFluent();
 

--- a/packages/react-components/react-image/library/src/components/Image/useImageStyles.styles.ts
+++ b/packages/react-components/react-image/library/src/components/Image/useImageStyles.styles.ts
@@ -72,8 +72,6 @@ const useStyles = makeStyles({
 });
 
 export const useImageStyles_unstable = (state: ImageState): ImageState => {
-  'use no memo';
-
   const styles = useStyles();
 
   const { height, width } = state.root;

--- a/packages/react-components/react-infolabel/library/src/components/InfoButton/useInfoButtonStyles.styles.ts
+++ b/packages/react-components/react-infolabel/library/src/components/InfoButton/useInfoButtonStyles.styles.ts
@@ -108,8 +108,6 @@ const usePopoverSurfaceStyles = makeStyles({
  * Apply styling to the InfoButton slots based on the state
  */
 export const useInfoButtonStyles_unstable = (state: InfoButtonState): InfoButtonState => {
-  'use no memo';
-
   const { size } = state;
   const { open } = state.popover;
   const buttonStyles = useButtonStyles();

--- a/packages/react-components/react-infolabel/library/src/components/InfoLabel/useInfoLabelStyles.styles.ts
+++ b/packages/react-components/react-infolabel/library/src/components/InfoLabel/useInfoLabelStyles.styles.ts
@@ -39,8 +39,6 @@ const useInfoButtonStyles = makeStyles({
  * Apply styling to the InfoLabel slots based on the state
  */
 export const useInfoLabelStyles_unstable = (state: InfoLabelState): InfoLabelState => {
-  'use no memo';
-
   // eslint-disable-next-line react-hooks/immutability
   state.root.className = mergeClasses(infoLabelClassNames.root, state.root.className);
 

--- a/packages/react-components/react-input/library/src/components/Input/useInputStyles.styles.ts
+++ b/packages/react-components/react-input/library/src/components/Input/useInputStyles.styles.ts
@@ -329,8 +329,6 @@ const useContentStyles = makeStyles({
  * Apply styling to the Input slots based on the state
  */
 export const useInputStyles_unstable = (state: InputState): InputState => {
-  'use no memo';
-
   const { size, appearance } = state;
   const disabled = state.input.disabled;
   const invalid = `${state.input['aria-invalid']}` === 'true';

--- a/packages/react-components/react-label/library/src/components/Label/useLabelStyles.styles.ts
+++ b/packages/react-components/react-label/library/src/components/Label/useLabelStyles.styles.ts
@@ -56,8 +56,6 @@ const useStyles = makeStyles({
  * Apply styling to the Label slots based on the state
  */
 export const useLabelStyles_unstable = (state: LabelState): LabelState => {
-  'use no memo';
-
   const styles = useStyles();
   // eslint-disable-next-line react-hooks/immutability
   state.root.className = mergeClasses(

--- a/packages/react-components/react-link/library/src/components/Link/useLinkStyles.styles.ts
+++ b/packages/react-components/react-link/library/src/components/Link/useLinkStyles.styles.ts
@@ -112,8 +112,6 @@ const useStyles = makeStyles({
 });
 
 export const useLinkStyles_unstable = (state: LinkState): LinkState => {
-  'use no memo';
-
   const styles = useStyles();
   const { appearance, disabled, inline, root, backgroundAppearance } = state;
 

--- a/packages/react-components/react-list/library/src/components/List/useListStyles.styles.ts
+++ b/packages/react-components/react-list/library/src/components/List/useListStyles.styles.ts
@@ -19,8 +19,6 @@ const useRootBaseStyles = makeResetStyles({
  * Apply styling to the List slots based on the state
  */
 export const useListStyles_unstable = (state: ListState): ListState => {
-  'use no memo';
-
   const rootStyles = useRootBaseStyles();
 
   // eslint-disable-next-line react-hooks/immutability

--- a/packages/react-components/react-list/library/src/components/ListItem/useListItemStyles.styles.ts
+++ b/packages/react-components/react-list/library/src/components/ListItem/useListItemStyles.styles.ts
@@ -50,8 +50,6 @@ const useStyles = makeStyles({
  * Apply styling to the ListItem slots based on the state
  */
 export const useListItemStyles_unstable = (state: ListItemState): ListItemState => {
-  'use no memo';
-
   const rootBaseStyles = useRootBaseStyles();
   const checkmarkBaseStyles = useCheckmarkBaseStyles();
   const styles = useStyles();

--- a/packages/react-components/react-menu-grid-preview/library/src/components/MenuGrid/useMenuGridStyles.styles.ts
+++ b/packages/react-components/react-menu-grid-preview/library/src/components/MenuGrid/useMenuGridStyles.styles.ts
@@ -23,8 +23,6 @@ const useStyles = makeStyles({
  * Apply styling to the Menu slots based on the state
  */
 export const useMenuGridStyles_unstable = (state: MenuGridState): MenuGridState => {
-  'use no memo';
-
   const styles = useStyles();
   // eslint-disable-next-line react-hooks/immutability
   state.root.className = mergeClasses(menuGridClassNames.root, styles.root, state.root.className);

--- a/packages/react-components/react-menu-grid-preview/library/src/components/MenuGridCell/useMenuGridCellStyles.styles.ts
+++ b/packages/react-components/react-menu-grid-preview/library/src/components/MenuGridCell/useMenuGridCellStyles.styles.ts
@@ -22,8 +22,6 @@ const useRootStyles = makeStyles({
 });
 
 export const useMenuGridCellStyles_unstable = (state: MenuGridCellState): MenuGridCellState => {
-  'use no memo';
-
   const rootStyles = useRootStyles();
   // eslint-disable-next-line react-hooks/immutability
   state.root.className = mergeClasses(

--- a/packages/react-components/react-menu-grid-preview/library/src/components/MenuGridGroup/useMenuGridGroupStyles.styles.ts
+++ b/packages/react-components/react-menu-grid-preview/library/src/components/MenuGridGroup/useMenuGridGroupStyles.styles.ts
@@ -7,8 +7,6 @@ export const menuGridGroupClassNames: SlotClassNames<MenuGridGroupSlots> = {
 };
 
 export const useMenuGridGroupStyles_unstable = (state: MenuGridGroupState): MenuGridGroupState => {
-  'use no memo';
-
   state.root.className = mergeClasses(menuGridGroupClassNames.root, state.root.className);
 
   return state;

--- a/packages/react-components/react-menu-grid-preview/library/src/components/MenuGridGroupHeader/useMenuGridGroupHeaderStyles.styles.ts
+++ b/packages/react-components/react-menu-grid-preview/library/src/components/MenuGridGroupHeader/useMenuGridGroupHeaderStyles.styles.ts
@@ -23,8 +23,6 @@ const useStyles = makeStyles({
 });
 
 export const useMenuGridGroupHeaderStyles_unstable = (state: MenuGridGroupHeaderState): MenuGridGroupHeaderState => {
-  'use no memo';
-
   const styles = useStyles();
   // eslint-disable-next-line react-hooks/immutability
   state.root.className = mergeClasses(menuGridGroupHeaderClassNames.root, styles.root, state.root.className);

--- a/packages/react-components/react-menu-grid-preview/library/src/components/MenuGridItem/useMenuGridItemStyles.styles.ts
+++ b/packages/react-components/react-menu-grid-preview/library/src/components/MenuGridItem/useMenuGridItemStyles.styles.ts
@@ -31,8 +31,6 @@ const useStyles = makeStyles({
 });
 
 export const useMenuGridItemStyles_unstable = (state: MenuGridItemState): MenuGridItemState => {
-  'use no memo';
-
   const styles = useStyles();
 
   // eslint-disable-next-line react-hooks/immutability

--- a/packages/react-components/react-menu-grid-preview/library/src/components/MenuGridRow/useCharacterSearch.ts
+++ b/packages/react-components/react-menu-grid-preview/library/src/components/MenuGridRow/useCharacterSearch.ts
@@ -12,7 +12,7 @@ export const useCharacterSearch = (): {
   characterSearchOnKeyDown: React.KeyboardEventHandler<HTMLElement>;
   characterSearchRef: React.RefObject<HTMLElement | null>;
 } => {
-  'use no memo';
+  'use no memo'; // justified: compiler would optimize useCharacterSearch — manual opt-out to preserve runtime behavior
 
   const characterSearchRef = React.useRef<HTMLDivElement>(null);
 

--- a/packages/react-components/react-menu-grid-preview/library/src/components/MenuGridRow/useMenuGridRowStyles.styles.ts
+++ b/packages/react-components/react-menu-grid-preview/library/src/components/MenuGridRow/useMenuGridRowStyles.styles.ts
@@ -60,8 +60,6 @@ const useRootBaseStyles = makeResetStyles({
 });
 
 export const useMenuGridRowStyles_unstable = (state: MenuGridRowState): MenuGridRowState => {
-  'use no memo';
-
   const rootBaseStyles = useRootBaseStyles();
   // eslint-disable-next-line react-hooks/immutability
   state.root.className = mergeClasses(menuGridRowClassNames.root, rootBaseStyles, state.root.className);

--- a/packages/react-components/react-menu-grid-preview/library/src/utils/useValidateNesting.ts
+++ b/packages/react-components/react-menu-grid-preview/library/src/utils/useValidateNesting.ts
@@ -16,8 +16,6 @@ const menuItemRoleToNameMapping = {
 };
 
 export const useValidateNesting = (componentName: NestingComponentName): React.RefObject<HTMLElement | null> => {
-  'use no memo';
-
   const { targetDocument } = useFluent();
   const triggerRef = useMenuContext_unstable((context: MenuContextValue) => context.triggerRef);
   const inline = useMenuContext_unstable((context: MenuContextValue) => context.inline);

--- a/packages/react-components/react-menu/library/src/components/Menu/useMenu.tsx
+++ b/packages/react-components/react-menu/library/src/components/Menu/useMenu.tsx
@@ -272,8 +272,6 @@ const useMenuOpenState = (
   > &
     Pick<MenuProps, 'open' | 'defaultOpen' | 'onOpenChange'>,
 ) => {
-  'use no memo';
-
   const { targetDocument } = useFluent();
   const parentSetOpen = useMenuContext_unstable(context => context.setOpen);
   const onOpenChange: MenuProps['onOpenChange'] = useEventCallback((e, data) => state.onOpenChange?.(e, data));

--- a/packages/react-components/react-menu/library/src/components/MenuDivider/useMenuDividerStyles.styles.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuDivider/useMenuDividerStyles.styles.ts
@@ -18,8 +18,6 @@ const useStyles = makeStyles({
 });
 
 export const useMenuDividerStyles_unstable = (state: MenuDividerState): MenuDividerState => {
-  'use no memo';
-
   const styles = useStyles();
   // eslint-disable-next-line react-hooks/immutability
   state.root.className = mergeClasses(menuDividerClassNames.root, styles.root, state.root.className);

--- a/packages/react-components/react-menu/library/src/components/MenuGroup/useMenuGroupStyles.styles.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuGroup/useMenuGroupStyles.styles.ts
@@ -7,8 +7,6 @@ export const menuGroupClassNames: SlotClassNames<MenuGroupSlots> = {
 };
 
 export const useMenuGroupStyles_unstable = (state: MenuGroupState): MenuGroupState => {
-  'use no memo';
-
   state.root.className = mergeClasses(menuGroupClassNames.root, state.root.className);
 
   return state;

--- a/packages/react-components/react-menu/library/src/components/MenuGroupHeader/useMenuGroupHeaderStyles.styles.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuGroupHeader/useMenuGroupHeaderStyles.styles.ts
@@ -23,8 +23,6 @@ const useStyles = makeStyles({
 });
 
 export const useMenuGroupHeaderStyles_unstable = (state: MenuGroupHeaderState): MenuGroupHeaderState => {
-  'use no memo';
-
   const styles = useStyles();
   // eslint-disable-next-line react-hooks/immutability
   state.root.className = mergeClasses(menuGroupHeaderClassNames.root, styles.root, state.root.className);

--- a/packages/react-components/react-menu/library/src/components/MenuItem/useCharacterSearch.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuItem/useCharacterSearch.ts
@@ -6,8 +6,6 @@ import type { MenuItemState } from '../../components/index';
 import type { ARIAButtonElementIntersection } from '@fluentui/react-aria';
 
 export const useCharacterSearch = (state: MenuItemState, ref: React.RefObject<HTMLElement | null>): MenuItemState => {
-  'use no memo';
-
   const setFocusByFirstCharacter = useMenuListContext_unstable(context => context.setFocusByFirstCharacter);
 
   const { onKeyDown: originalOnKeyDown } = state.root;

--- a/packages/react-components/react-menu/library/src/components/MenuItem/useMenuItemStyles.styles.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuItem/useMenuItemStyles.styles.ts
@@ -258,8 +258,6 @@ const useMultilineStyles = makeStyles({
 
 /** Applies style classnames to slots */
 export const useMenuItemStyles_unstable = (state: MenuItemState): MenuItemState => {
-  'use no memo';
-
   const styles = useStyles();
   const rootBaseStyles = useRootBaseStyles();
   const contentBaseStyles = useContentBaseStyles();

--- a/packages/react-components/react-menu/library/src/components/MenuItemCheckbox/useMenuItemCheckboxStyles.styles.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuItemCheckbox/useMenuItemCheckboxStyles.styles.ts
@@ -17,8 +17,6 @@ export const menuItemCheckboxClassNames: SlotClassNames<Omit<MenuItemSlots, 'sub
 };
 
 export const useMenuItemCheckboxStyles_unstable = (state: MenuItemCheckboxState): MenuItemCheckboxState => {
-  'use no memo';
-
   // eslint-disable-next-line react-hooks/immutability
   state.root.className = mergeClasses(menuItemCheckboxClassNames.root, state.root.className);
 

--- a/packages/react-components/react-menu/library/src/components/MenuItemLink/useMenuItemLinkStyles.styles.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuItemLink/useMenuItemLinkStyles.styles.ts
@@ -30,8 +30,6 @@ const useStyles = makeStyles({
  * Apply styling to the MenuItemLink slots based on the state
  */
 export const useMenuItemLinkStyles_unstable = (state: MenuItemLinkState): MenuItemLinkState => {
-  'use no memo';
-
   useMenuItemStyles_unstable(state as MenuItemState);
   const styles = useStyles();
   // eslint-disable-next-line react-hooks/immutability

--- a/packages/react-components/react-menu/library/src/components/MenuItemRadio/useMenuItemRadioStyles.styles.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuItemRadio/useMenuItemRadioStyles.styles.ts
@@ -17,8 +17,6 @@ export const menuItemRadioClassNames: SlotClassNames<Omit<MenuItemSlots, 'submen
 };
 
 export const useMenuItemRadioStyles_unstable = (state: MenuItemRadioState): void => {
-  'use no memo';
-
   // eslint-disable-next-line react-hooks/immutability
   state.root.className = mergeClasses(menuItemRadioClassNames.root, state.root.className);
 

--- a/packages/react-components/react-menu/library/src/components/MenuItemSwitch/useMenuItemSwitchStyles.styles.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuItemSwitch/useMenuItemSwitchStyles.styles.ts
@@ -97,8 +97,6 @@ const useMultilineStyles = makeStyles({
  * Apply styling to the MenuItemSwitch slots based on the state
  */
 export const useMenuItemSwitchStyles_unstable = (state: MenuItemSwitchState): MenuItemSwitchState => {
-  'use no memo';
-
   const { checked, subText } = state;
   const multiline = !!subText;
   const switchIndicatorStyles = useSwitchIndicatorStyles();

--- a/packages/react-components/react-menu/library/src/components/MenuList/useMenuListStyles.styles.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuList/useMenuListStyles.styles.ts
@@ -23,8 +23,6 @@ const useStyles = makeStyles({
  * Apply styling to the Menu slots based on the state
  */
 export const useMenuListStyles_unstable = (state: MenuListState): MenuListState => {
-  'use no memo';
-
   const styles = useStyles();
   // eslint-disable-next-line react-hooks/immutability
   state.root.className = mergeClasses(

--- a/packages/react-components/react-menu/library/src/components/MenuPopover/useMenuPopover.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuPopover/useMenuPopover.ts
@@ -23,7 +23,7 @@ import type { MenuPopoverProps, MenuPopoverState } from './MenuPopover.types';
  * @param ref - reference to root HTMLElement of MenuPopover
  */
 export const useMenuPopoverBase_unstable = (props: MenuPopoverProps, ref: React.Ref<HTMLElement>): MenuPopoverState => {
-  'use no memo';
+  'use no memo'; // justified: compiler would optimize useMenuPopoverBase_unstable — manual opt-out to preserve runtime behavior
 
   const safeZone = useMenuContext_unstable(context => context.safeZone);
   const popoverRef = useMenuContext_unstable(context => context.menuPopoverRef);

--- a/packages/react-components/react-menu/library/src/components/MenuPopover/useMenuPopoverStyles.styles.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuPopover/useMenuPopoverStyles.styles.ts
@@ -30,8 +30,6 @@ const useStyles = makeStyles({
  * Apply styling to the Menu slots based on the state
  */
 export const useMenuPopoverStyles_unstable = (state: MenuPopoverState): MenuPopoverState => {
-  'use no memo';
-
   const styles = useStyles();
   // eslint-disable-next-line react-hooks/immutability
   state.root.className = mergeClasses(menuPopoverClassNames.root, styles.root, state.root.className);

--- a/packages/react-components/react-menu/library/src/components/MenuSplitGroup/useMenuSplitGroupContextValues.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuSplitGroup/useMenuSplitGroupContextValues.ts
@@ -4,7 +4,7 @@ import * as React from 'react';
 import type { MenuSplitGroupContextValues, MenuSplitGroupState } from './MenuSplitGroup.types';
 
 export const useMenuSplitGroupContextValues = (state: MenuSplitGroupState): MenuSplitGroupContextValues => {
-  'use no memo';
+  'use no memo'; // justified: compiler would optimize useMenuSplitGroupContextValues — manual opt-out to preserve runtime behavior
 
   return React.useMemo(() => {
     return {

--- a/packages/react-components/react-menu/library/src/components/MenuSplitGroup/useMenuSplitGroupStyles.styles.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuSplitGroup/useMenuSplitGroupStyles.styles.ts
@@ -44,8 +44,6 @@ const useStyles = makeStyles({
  * Apply styling to the MenuSplitGroup slots based on the state
  */
 export const useMenuSplitGroupStyles_unstable = (state: MenuSplitGroupState): MenuSplitGroupState => {
-  'use no memo';
-
   const styles = useStyles();
   // eslint-disable-next-line react-hooks/immutability
   state.root.className = mergeClasses(menuSplitGroupClassNames.root, styles.root, state.root.className);

--- a/packages/react-components/react-menu/library/src/selectable/useCheckmarkStyles.styles.ts
+++ b/packages/react-components/react-menu/library/src/selectable/useCheckmarkStyles.styles.ts
@@ -25,8 +25,6 @@ const useStyles = makeStyles({
 export const useCheckmarkStyles_unstable = (
   state: MenuItemSelectableState & Pick<MenuItemState, 'checkmark'>,
 ): void => {
-  'use no memo';
-
   const styles = useStyles();
   if (state.checkmark) {
     // eslint-disable-next-line react-hooks/immutability

--- a/packages/react-components/react-menu/library/src/utils/useValidateNesting.ts
+++ b/packages/react-components/react-menu/library/src/utils/useValidateNesting.ts
@@ -9,8 +9,6 @@ import { useMenuContext_unstable } from '../contexts/menuContext';
 type NestingComponentName = 'MenuList' | 'MenuItem' | 'MenuItemCheckbox' | 'MenuItemRadio';
 
 export const useValidateNesting = (componentName: NestingComponentName): React.RefObject<HTMLElement | null> => {
-  'use no memo';
-
   const { targetDocument } = useFluent();
   const triggerRef = useMenuContext_unstable((context: MenuContextValue) => context.triggerRef);
   const inline = useMenuContext_unstable((context: MenuContextValue) => context.inline);

--- a/packages/react-components/react-message-bar/library/src/components/MessageBar/useMessageBarStyles.styles.ts
+++ b/packages/react-components/react-message-bar/library/src/components/MessageBar/useMessageBarStyles.styles.ts
@@ -101,8 +101,6 @@ const useRootIntentStyles = makeStyles({
  * Apply styling to the MessageBar slots based on the state
  */
 export const useMessageBarStyles_unstable = (state: MessageBarState): MessageBarState => {
-  'use no memo';
-
   const rootBaseStyles = useRootBaseStyles();
   const iconBaseStyles = useIconBaseStyles();
   const iconIntentStyles = useIconIntentStyles();

--- a/packages/react-components/react-message-bar/library/src/components/MessageBarActions/useMessageBarActionsStyles.styles.ts
+++ b/packages/react-components/react-message-bar/library/src/components/MessageBarActions/useMessageBarActionsStyles.styles.ts
@@ -43,8 +43,6 @@ const useMultilineStyles = makeStyles({
  * Apply styling to the MessageBarActions slots based on the state
  */
 export const useMessageBarActionsStyles_unstable = (state: MessageBarActionsState): MessageBarActionsState => {
-  'use no memo';
-
   const rootBaseStyles = useRootBaseStyles();
   const containerActionBaseStyles = useContainerActionBaseStyles();
   const multilineStyles = useMultilineStyles();

--- a/packages/react-components/react-message-bar/library/src/components/MessageBarBody/useMessageBarBodyStyles.styles.ts
+++ b/packages/react-components/react-message-bar/library/src/components/MessageBarBody/useMessageBarBodyStyles.styles.ts
@@ -19,8 +19,6 @@ const useRootBaseStyles = makeResetStyles({
  * Apply styling to the MessageBarBody slots based on the state
  */
 export const useMessageBarBodyStyles_unstable = (state: MessageBarBodyState): MessageBarBodyState => {
-  'use no memo';
-
   const rootBaseStyles = useRootBaseStyles();
   // eslint-disable-next-line react-hooks/immutability
   state.root.className = mergeClasses(messageBarBodyClassNames.root, rootBaseStyles, state.root.className);

--- a/packages/react-components/react-message-bar/library/src/components/MessageBarGroup/useMessageBarGroupStyles.styles.ts
+++ b/packages/react-components/react-message-bar/library/src/components/MessageBarGroup/useMessageBarGroupStyles.styles.ts
@@ -10,8 +10,6 @@ export const messageBarGroupClassNames: SlotClassNames<MessageBarGroupSlots> = {
  * Apply styling to the MessageBarGroup slots based on the state
  */
 export const useMessageBarGroupStyles_unstable = (state: MessageBarGroupState): MessageBarGroupState => {
-  'use no memo';
-
   state.root.className = mergeClasses(messageBarGroupClassNames.root, state.root.className);
   return state;
 };

--- a/packages/react-components/react-message-bar/library/src/components/MessageBarTitle/useMessageBarTitleStyles.styles.ts
+++ b/packages/react-components/react-message-bar/library/src/components/MessageBarTitle/useMessageBarTitleStyles.styles.ts
@@ -23,8 +23,6 @@ const useRootBaseStyles = makeResetStyles({
  * Apply styling to the MessageBarTitle slots based on the state
  */
 export const useMessageBarTitleStyles_unstable = (state: MessageBarTitleState): MessageBarTitleState => {
-  'use no memo';
-
   const rootBaseStyles = useRootBaseStyles();
   // eslint-disable-next-line react-hooks/immutability
   state.root.className = mergeClasses(messageBarTitleClassNames.root, rootBaseStyles, state.root.className);

--- a/packages/react-components/react-migration-v0-v9/library/src/components/List/List/useListStyles.styles.ts
+++ b/packages/react-components/react-migration-v0-v9/library/src/components/List/List/useListStyles.styles.ts
@@ -32,8 +32,6 @@ const useStyles = makeStyles({
  * Apply styling to the List slots based on the state
  */
 export const useListStyles_unstable = (state: ListState): ListState => {
-  'use no memo';
-
   const rootStyles = useRootBaseStyles();
   const styles = useStyles();
 

--- a/packages/react-components/react-migration-v0-v9/library/src/components/List/ListItem/useListItemStyles.styles.ts
+++ b/packages/react-components/react-migration-v0-v9/library/src/components/List/ListItem/useListItemStyles.styles.ts
@@ -63,8 +63,6 @@ const useStyles = makeStyles({
  * Apply styling to the ListItem slots based on the state
  */
 export const useListItemStyles_unstable = (state: ListItemState): ListItemState => {
-  'use no memo';
-
   const rootBaseStyles = useRootBaseStyles();
   const styles = useStyles();
 

--- a/packages/react-components/react-migration-v0-v9/library/src/components/Video/Video.tsx
+++ b/packages/react-components/react-migration-v0-v9/library/src/components/Video/Video.tsx
@@ -44,8 +44,6 @@ export interface VideoProps extends React.VideoHTMLAttributes<HTMLVideoElement> 
 }
 
 export const Video = React.forwardRef<HTMLVideoElement, VideoProps>((props, ref) => {
-  'use no memo';
-
   const { className, muted, ...rest } = props;
 
   const videoRef = React.useRef<HTMLVideoElement>(null);

--- a/packages/react-components/react-migration-v8-v9/library/src/components/Checkbox/CheckboxShim.tsx
+++ b/packages/react-components/react-migration-v8-v9/library/src/components/Checkbox/CheckboxShim.tsx
@@ -14,8 +14,6 @@ const getClassNames = classNamesFunction<ICheckboxStyleProps, ICheckboxStyles>({
 });
 
 export const CheckboxShim = React.forwardRef((props, _ref) => {
-  'use no memo';
-
   const { className, styles: stylesV8, onRenderLabel, label, componentRef } = props;
   const shimProps = useCheckboxProps(props);
   const styles = getClassNames(stylesV8);

--- a/packages/react-components/react-motion/library/src/factories/createMotionComponent.ts
+++ b/packages/react-components/react-motion/library/src/factories/createMotionComponent.ts
@@ -93,8 +93,6 @@ export function createMotionComponent<MotionParams extends Record<string, Motion
   value: AtomMotion | AtomMotion[] | AtomMotionFn<MotionParams>,
 ): MotionComponent<MotionParams> {
   const Atom: React.FC<MotionComponentProps & MotionParams> = props => {
-    'use no memo';
-
     const {
       children,
       imperativeRef,

--- a/packages/react-components/react-motion/library/src/factories/createPresenceComponent.ts
+++ b/packages/react-components/react-motion/library/src/factories/createPresenceComponent.ts
@@ -97,8 +97,6 @@ export function createPresenceComponent<MotionParams extends Record<string, Moti
 ): PresenceComponent<MotionParams> {
   return Object.assign(
     (props: PresenceComponentProps & MotionParams) => {
-      'use no memo';
-
       const itemContext = React.useContext(PresenceGroupChildContext);
       const merged = { ...itemContext, ...props };
       const skipMotions = useMotionBehaviourContext() === 'skip';

--- a/packages/react-components/react-motion/library/src/hooks/useAnimateAtoms.ts
+++ b/packages/react-components/react-motion/library/src/hooks/useAnimateAtoms.ts
@@ -228,8 +228,6 @@ export function useAnimateAtoms(): (
   value: AtomMotion | AtomMotion[],
   options: { isReducedMotion: boolean },
 ) => AnimationHandle {
-  'use no memo';
-
   if (process.env.NODE_ENV === 'test') {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     return useAnimateAtomsInTestEnvironment();

--- a/packages/react-components/react-nav/library/src/components/AppItem/useAppItemStyles.styles.ts
+++ b/packages/react-components/react-nav/library/src/components/AppItem/useAppItemStyles.styles.ts
@@ -38,8 +38,6 @@ export const useAppItemStyles = makeStyles({
  * Apply styling to the AppItem slots based on the state
  */
 export const useAppItemStyles_unstable = (state: AppItemState): AppItemState => {
-  'use no memo';
-
   const rootDefaultClassName = useRootDefaultClassName();
   const iconStyles = useIconStyles();
   const appItemSpecificStyles = useAppItemStyles();

--- a/packages/react-components/react-nav/library/src/components/AppItemStatic/useAppItemStaticStyles.styles.ts
+++ b/packages/react-components/react-nav/library/src/components/AppItemStatic/useAppItemStaticStyles.styles.ts
@@ -27,8 +27,6 @@ const useAppItemStaticStyles = makeStyles({
  * Apply styling to the AppItemStatic slots based on the state
  */
 export const useAppItemStaticStyles_unstable = (state: AppItemStaticState): AppItemStaticState => {
-  'use no memo';
-
   const rootDefaultClassName = useRootDefaultClassName();
   const iconStyles = useIconStyles();
   const appItemSpecificStyles = useAppItemStyles();

--- a/packages/react-components/react-nav/library/src/components/Hamburger/useHamburgerStyles.styles.ts
+++ b/packages/react-components/react-nav/library/src/components/Hamburger/useHamburgerStyles.styles.ts
@@ -33,8 +33,6 @@ const useStyles = makeStyles({
  * Apply styling to the Hamburger slots based on the state
  */
 export const useHamburgerStyles_unstable = (state: HamburgerState): HamburgerState => {
-  'use no memo';
-
   useButtonStyles_unstable(state);
   const styles = useStyles();
 

--- a/packages/react-components/react-nav/library/src/components/Nav/useNavStyles.styles.ts
+++ b/packages/react-components/react-nav/library/src/components/Nav/useNavStyles.styles.ts
@@ -26,8 +26,6 @@ const useStyles = makeStyles({
  * Apply styling to the Nav slots based on the state
  */
 export const useNavStyles_unstable = (state: NavState): NavState => {
-  'use no memo';
-
   const styles = useStyles();
   // eslint-disable-next-line react-hooks/immutability
   state.root.className = mergeClasses(navClassNames.root, styles.root, state.root.className);

--- a/packages/react-components/react-nav/library/src/components/NavCategoryItem/useNavCategoryItem.styles.ts
+++ b/packages/react-components/react-nav/library/src/components/NavCategoryItem/useNavCategoryItem.styles.ts
@@ -41,8 +41,6 @@ export const useRootStyles = makeStyles({
  * Apply styling to the NavCategoryItem slots based on the state
  */
 export const useNavCategoryItemStyles_unstable = (state: NavCategoryItemState): NavCategoryItemState => {
-  'use no memo';
-
   const rootStyles = useRootStyles();
   const smallStyles = useSmallStyles();
   const defaultRootClassName = useRootDefaultClassName();

--- a/packages/react-components/react-nav/library/src/components/NavDivider/useNavDividerStyles.styles.ts
+++ b/packages/react-components/react-nav/library/src/components/NavDivider/useNavDividerStyles.styles.ts
@@ -22,8 +22,6 @@ const useStyles = makeStyles({
  * Apply styling to the NavDivider slots based on the state
  */
 export const useNavDividerStyles_unstable = (state: NavDividerState): NavDividerState => {
-  'use no memo';
-
   const styles = useStyles();
 
   // eslint-disable-next-line react-hooks/immutability

--- a/packages/react-components/react-nav/library/src/components/NavDrawer/useNavDrawerStyles.styles.ts
+++ b/packages/react-components/react-nav/library/src/components/NavDrawer/useNavDrawerStyles.styles.ts
@@ -29,8 +29,6 @@ const useStyles = makeStyles({
  * Apply styling to the NavDrawer slots based on the state
  */
 export const useNavDrawerStyles_unstable = (state: NavDrawerState): NavDrawerState => {
-  'use no memo';
-
   const { size } = state;
 
   const styles = useStyles();

--- a/packages/react-components/react-nav/library/src/components/NavDrawerBody/useNavDrawerBodyStyles.styles.ts
+++ b/packages/react-components/react-nav/library/src/components/NavDrawerBody/useNavDrawerBodyStyles.styles.ts
@@ -27,8 +27,6 @@ const useStyles = makeStyles({
  * Apply styling to the NavDrawerBody slots based on the state
  */
 export const useNavDrawerBodyStyles_unstable = (state: NavDrawerBodyState): NavDrawerBodyState => {
-  'use no memo';
-
   useDrawerBodyStyles_unstable(state);
   const styles = useStyles();
   // eslint-disable-next-line react-hooks/immutability

--- a/packages/react-components/react-nav/library/src/components/NavDrawerFooter/useNavDrawerFooterStyles.styles.ts
+++ b/packages/react-components/react-nav/library/src/components/NavDrawerFooter/useNavDrawerFooterStyles.styles.ts
@@ -26,8 +26,6 @@ const useStyles = makeStyles({
  * Apply styling to the NavDrawerFooter slots based on the state
  */
 export const useNavDrawerFooterStyles_unstable = (state: NavDrawerFooterState): NavDrawerFooterState => {
-  'use no memo';
-
   useDrawerFooterStyles_unstable(state);
   const styles = useStyles();
   // eslint-disable-next-line react-hooks/immutability

--- a/packages/react-components/react-nav/library/src/components/NavDrawerHeader/useNavDrawerHeaderStyles.styles.ts
+++ b/packages/react-components/react-nav/library/src/components/NavDrawerHeader/useNavDrawerHeaderStyles.styles.ts
@@ -25,8 +25,6 @@ const useStyles = makeStyles({
  * Apply styling to the NavDrawerHeader slots based on the state
  */
 export const useNavDrawerHeaderStyles_unstable = (state: NavDrawerHeaderState): NavDrawerHeaderState => {
-  'use no memo';
-
   useDrawerHeaderStyles_unstable(state);
   const styles = useStyles();
   // eslint-disable-next-line react-hooks/immutability

--- a/packages/react-components/react-nav/library/src/components/NavItem/useNavItemStyles.styles.ts
+++ b/packages/react-components/react-nav/library/src/components/NavItem/useNavItemStyles.styles.ts
@@ -20,8 +20,6 @@ export const navItemClassNames: SlotClassNames<NavItemSlots> = {
  * Apply styling to the NavItem slots based on the state
  */
 export const useNavItemStyles_unstable = (state: NavItemState): NavItemState => {
-  'use no memo';
-
   const rootDefaultClassName = useRootDefaultClassName();
   const smallStyles = useSmallStyles();
   const contentStyles = useContentStyles();

--- a/packages/react-components/react-nav/library/src/components/NavSectionHeader/useNavSectionHeaderStyles.styles.ts
+++ b/packages/react-components/react-nav/library/src/components/NavSectionHeader/useNavSectionHeaderStyles.styles.ts
@@ -24,8 +24,6 @@ const useStyles = makeStyles({
  * Apply styling to the NavSectionHeader slots based on the state
  */
 export const useNavSectionHeaderStyles_unstable = (state: NavSectionHeaderState): NavSectionHeaderState => {
-  'use no memo';
-
   const styles = useStyles();
   // eslint-disable-next-line react-hooks/immutability
   state.root.className = mergeClasses(navSectionHeaderClassNames.root, styles.root, state.root.className);

--- a/packages/react-components/react-nav/library/src/components/NavSubItem/useNavSubItemStyles.styles.ts
+++ b/packages/react-components/react-nav/library/src/components/NavSubItem/useNavSubItemStyles.styles.ts
@@ -36,8 +36,6 @@ const useNavSubItemSpecificStyles = makeStyles({
  * Apply styling to the NavSubItem slots based on the state
  */
 export const useNavSubItemStyles_unstable = (state: NavSubItemState): NavSubItemState => {
-  'use no memo';
-
   const rootDefaultClassName = useRootDefaultClassName();
   const smallStyles = useSmallStyles();
   const contentStyles = useContentStyles();

--- a/packages/react-components/react-nav/library/src/components/NavSubItemGroup/useNavSubItemGroupStyles.styles.ts
+++ b/packages/react-components/react-nav/library/src/components/NavSubItemGroup/useNavSubItemGroupStyles.styles.ts
@@ -23,8 +23,6 @@ const useStyles = makeStyles({
  * Apply styling to the NavSubItemGroup slots based on the state
  */
 export const useNavSubItemGroupStyles_unstable = (state: NavSubItemGroupState): NavSubItemGroupState => {
-  'use no memo';
-
   const styles = useStyles();
 
   // eslint-disable-next-line react-hooks/immutability

--- a/packages/react-components/react-nav/library/src/components/SplitNavItem/useSplitNavItemStyles.styles.ts
+++ b/packages/react-components/react-nav/library/src/components/SplitNavItem/useSplitNavItemStyles.styles.ts
@@ -95,8 +95,6 @@ const useSplitNaveItemStyles = makeStyles({
  * Apply styling to the SplitNavItem slots based on the state
  */
 export const useSplitNavItemStyles_unstable = (state: SplitNavItemState): SplitNavItemState => {
-  'use no memo';
-
   const splitNavItemStyles = useSplitNaveItemStyles();
   const sharedRootClassNames = useRootDefaultClassName();
 

--- a/packages/react-components/react-overflow/library/src/useOverflowContainer.ts
+++ b/packages/react-components/react-overflow/library/src/useOverflowContainer.ts
@@ -28,8 +28,6 @@ export const useOverflowContainer = <TElement extends HTMLElement>(
   update: OnUpdateOverflow,
   options: Omit<ObserveOptions, 'onUpdateOverflow'>,
 ): UseOverflowContainerReturn<TElement> => {
-  'use no memo';
-
   const {
     overflowAxis = 'horizontal',
     overflowDirection = 'end',

--- a/packages/react-components/react-persona/library/src/components/Persona/usePersonaStyles.styles.ts
+++ b/packages/react-components/react-persona/library/src/components/Persona/usePersonaStyles.styles.ts
@@ -124,8 +124,6 @@ const usePresenceSpacingStyles = makeStyles({
  * Apply styling to the Persona slots based on the state
  */
 export const usePersonaStyles_unstable = (state: PersonaState): PersonaState => {
-  'use no memo';
-
   const { presenceOnly, size, textAlignment, textPosition } = state;
 
   const alignToPrimary = presenceOnly && textAlignment === 'start' && size !== 'extra-large' && size !== 'huge';

--- a/packages/react-components/react-popover/library/src/components/Popover/usePopover.ts
+++ b/packages/react-components/react-popover/library/src/components/Popover/usePopover.ts
@@ -215,8 +215,6 @@ export const usePopover_unstable = (props: PopoverProps): PopoverState => {
 function useOpenState(
   state: Pick<PopoverState, 'setContextTarget' | 'onOpenChange'> & Pick<PopoverProps, 'open' | 'defaultOpen'>,
 ) {
-  'use no memo';
-
   const onOpenChange: PopoverState['onOpenChange'] = useEventCallback((e, data) => state.onOpenChange?.(e, data));
 
   const [open, setOpenState] = useControllableState({

--- a/packages/react-components/react-popover/library/src/components/Popover/usePopover.ts
+++ b/packages/react-components/react-popover/library/src/components/Popover/usePopover.ts
@@ -254,8 +254,6 @@ function usePopoverRefs(
   state: Pick<PopoverState, 'size' | 'contextTarget'> &
     Pick<PopoverProps, 'positioning' | 'openOnContext' | 'withArrow'>,
 ) {
-  'use no memo';
-
   const positioningOptions = {
     position: 'above' as const,
     align: 'center' as const,

--- a/packages/react-components/react-popover/library/src/components/PopoverSurface/usePopoverSurfaceStyles.styles.ts
+++ b/packages/react-components/react-popover/library/src/components/PopoverSurface/usePopoverSurfaceStyles.styles.ts
@@ -65,8 +65,6 @@ const useStyles = makeStyles({
  * Apply styling to the PopoverSurface slots based on the state
  */
 export const usePopoverSurfaceStyles_unstable = (state: PopoverSurfaceState): PopoverSurfaceState => {
-  'use no memo';
-
   const styles = useStyles();
   // eslint-disable-next-line react-hooks/immutability
   state.root.className = mergeClasses(

--- a/packages/react-components/react-portal-compat/src/PortalCompatProvider.tsx
+++ b/packages/react-components/react-portal-compat/src/PortalCompatProvider.tsx
@@ -10,8 +10,6 @@ import type { RegisterPortalFn } from '@fluentui/react-portal-compat-context';
 const CLASS_NAME_REGEX = new RegExp(`([^\\s]*${fluentProviderClassNames.root}\\w+)`, 'g');
 
 export function useProviderThemeClasses(): string[] {
-  'use no memo';
-
   const themeClassName = useThemeClassName();
   const cssVariablesClasses = React.useMemo<string[]>(
     // "themeClassName" may contain multiple classes while we want to add only classes that host CSS variables

--- a/packages/react-components/react-portal/library/src/components/Portal/usePortalMountNode.ts
+++ b/packages/react-components/react-portal/library/src/components/Portal/usePortalMountNode.ts
@@ -38,8 +38,6 @@ type UseElementFactory = (options: UseElementFactoryOptions) => HTMLDivElement |
  * Creates a new element on a "document.body" to mount portals.
  */
 const useLegacyElementFactory: UseElementFactory = options => {
-  'use no memo';
-
   const { className, dir, focusVisibleRef, targetNode } = options;
 
   const targetElement = React.useMemo(() => {
@@ -120,7 +118,7 @@ const initializeElementFactory = () => {
  * - all other methods (and properties) will be called by React once a portal is mounted
  */
 const useModernElementFactory: UseElementFactory = options => {
-  'use no memo';
+  'use no memo'; // justified: compiler would optimize dispose — manual opt-out to preserve runtime behavior
 
   const { className, dir, focusVisibleRef, targetNode } = options;
 
@@ -239,7 +237,7 @@ const useElementFactory = useInsertionEffect ? useModernElementFactory : useLega
  * Creates a new element on a "document.body" to mount portals.
  */
 export const usePortalMountNode = (options: UsePortalMountNodeOptions): HTMLElement | null => {
-  ('use no memo');
+  ('use no memo'); // justified: compiler would optimize usePortalMountNode — manual opt-out to preserve runtime behavior
 
   const { targetDocument, dir } = useFluent();
   const mountNode = usePortalMountNodeContext();

--- a/packages/react-components/react-positioning/library/src/usePositioning.ts
+++ b/packages/react-components/react-positioning/library/src/usePositioning.ts
@@ -20,8 +20,6 @@ import { useCallbackRef, hasAutofocusFilter } from './utils';
  * @internal
  */
 export function usePositioning(options: PositioningProps & PositioningOptions): UsePositioningReturn {
-  'use no memo';
-
   const managerRef = React.useRef<PositionManager | null>(null);
   const targetRef = React.useRef<TargetElement | null>(null);
   const overrideTargetRef = React.useRef<TargetElement | null>(null);

--- a/packages/react-components/react-progress/library/src/components/ProgressBar/useProgressBarStyles.styles.ts
+++ b/packages/react-components/react-progress/library/src/components/ProgressBar/useProgressBarStyles.styles.ts
@@ -97,8 +97,6 @@ const useBarStyles = makeStyles({
  * Apply styling to the ProgressBar slots based on the state
  */
 export const useProgressBarStyles_unstable = (state: ProgressBarState): ProgressBarState => {
-  'use no memo';
-
   const { color, max, shape, thickness, value } = state;
   const rootStyles = useRootStyles();
   const barStyles = useBarStyles();

--- a/packages/react-components/react-provider/library/src/components/FluentProvider/useFluentProvider.ts
+++ b/packages/react-components/react-provider/library/src/components/FluentProvider/useFluentProvider.ts
@@ -35,8 +35,6 @@ export const useFluentProvider_unstable = (
   props: FluentProviderProps,
   ref: React.Ref<HTMLElement>,
 ): FluentProviderState => {
-  'use no memo';
-
   const parentContext = useFluent();
   const parentTheme = useTheme();
   const parentOverrides = useOverrides();

--- a/packages/react-components/react-provider/library/src/components/FluentProvider/useFluentProviderStyles.styles.ts
+++ b/packages/react-components/react-provider/library/src/components/FluentProvider/useFluentProviderStyles.styles.ts
@@ -21,8 +21,6 @@ const useStyles = makeStyles({
 
 /** Applies style classnames to slots */
 export const useFluentProviderStyles_unstable = (state: FluentProviderState): FluentProviderState => {
-  'use no memo';
-
   const renderer = useRenderer_unstable();
   const styles = useStyles({ dir: state.dir, renderer });
 

--- a/packages/react-components/react-provider/library/src/components/FluentProvider/useFluentProviderThemeStyleTag.ts
+++ b/packages/react-components/react-provider/library/src/components/FluentProvider/useFluentProviderThemeStyleTag.ts
@@ -51,8 +51,6 @@ const insertSheet = (tag: HTMLStyleElement, rule: string) => {
 export const useFluentProviderThemeStyleTag = (
   options: Pick<FluentProviderState, 'theme' | 'targetDocument'> & { rendererAttributes: Record<string, string> },
 ): { styleTagId: string; rule: string } => {
-  'use no memo';
-
   const { targetDocument, theme, rendererAttributes } = options;
 
   const styleTag = React.useRef<HTMLStyleElement | undefined | null>(undefined);

--- a/packages/react-components/react-radio/library/src/components/Radio/useRadioStyles.styles.ts
+++ b/packages/react-components/react-radio/library/src/components/Radio/useRadioStyles.styles.ts
@@ -210,8 +210,6 @@ const useLabelStyles = makeStyles({
  * Apply styling to the Radio slots based on the state
  */
 export const useRadioStyles_unstable = (state: RadioState): RadioState => {
-  'use no memo';
-
   const { labelPosition } = state;
 
   const rootBaseClassName = useRootBaseClassName();

--- a/packages/react-components/react-radio/library/src/components/RadioGroup/useRadioGroupStyles.styles.ts
+++ b/packages/react-components/react-radio/library/src/components/RadioGroup/useRadioGroupStyles.styles.ts
@@ -23,8 +23,6 @@ const useStyles = makeStyles({
  * Apply styling to the RadioGroup slots based on the state
  */
 export const useRadioGroupStyles_unstable = (state: RadioGroupState): RadioGroupState => {
-  'use no memo';
-
   const styles = useStyles();
 
   // eslint-disable-next-line react-hooks/immutability

--- a/packages/react-components/react-rating/library/src/components/Rating/useRatingStyles.styles.ts
+++ b/packages/react-components/react-rating/library/src/components/Rating/useRatingStyles.styles.ts
@@ -21,8 +21,6 @@ const useRootClassName = makeResetStyles({
  * Apply styling to the Rating slots based on the state
  */
 export const useRatingStyles_unstable = (state: RatingState): RatingState => {
-  'use no memo';
-
   const rootClassName = useRootClassName();
   // eslint-disable-next-line react-hooks/immutability
   state.root.className = mergeClasses(ratingClassNames.root, rootClassName, state.root.className);

--- a/packages/react-components/react-rating/library/src/components/RatingDisplay/useRatingDisplayStyles.styles.ts
+++ b/packages/react-components/react-rating/library/src/components/RatingDisplay/useRatingDisplayStyles.styles.ts
@@ -52,8 +52,6 @@ const useLabelStyles = makeStyles({
  * Apply styling to the RatingDisplay slots based on the state
  */
 export const useRatingDisplayStyles_unstable = (state: RatingDisplayState): RatingDisplayState => {
-  'use no memo';
-
   const { size } = state;
   const rootClassName = useRootClassName();
   // eslint-disable-next-line react-hooks/immutability

--- a/packages/react-components/react-rating/library/src/components/RatingItem/useRatingItemStyles.styles.ts
+++ b/packages/react-components/react-rating/library/src/components/RatingItem/useRatingItemStyles.styles.ts
@@ -119,8 +119,6 @@ const useIndicatorStyles = makeStyles({
  * Apply styling to the RatingItem slots based on the state
  */
 export const useRatingItemStyles_unstable = (state: RatingItemState): RatingItemState => {
-  'use no memo';
-
   const { color, size, iconFillWidth, appearance } = state;
   const styles = useStyles();
   const inputBaseClassName = useInputBaseClassName();

--- a/packages/react-components/react-search/library/src/components/SearchBox/useSearchBoxStyles.styles.ts
+++ b/packages/react-components/react-search/library/src/components/SearchBox/useSearchBoxStyles.styles.ts
@@ -113,8 +113,6 @@ const useDismissStyles = makeStyles({
  * Apply styling to the SearchBox slots based on the state
  */
 export const useSearchBoxStyles_unstable = (state: SearchBoxState): SearchBoxState => {
-  'use no memo';
-
   const { disabled, focused, size } = state;
 
   const rootStyles = useRootStyles();

--- a/packages/react-components/react-select/library/src/components/Select/useSelectStyles.styles.ts
+++ b/packages/react-components/react-select/library/src/components/Select/useSelectStyles.styles.ts
@@ -248,8 +248,6 @@ const useIconStyles = makeStyles({
  * Apply styling to the Select slots based on the state
  */
 export const useSelectStyles_unstable = (state: SelectState): SelectState => {
-  'use no memo';
-
   const { size, appearance } = state;
   const disabled = state.select.disabled;
   const invalid = `${state.select['aria-invalid']}` === 'true';

--- a/packages/react-components/react-skeleton/library/src/components/Skeleton/useSkeletonStyles.styles.ts
+++ b/packages/react-components/react-skeleton/library/src/components/Skeleton/useSkeletonStyles.styles.ts
@@ -17,8 +17,6 @@ const useStyles = makeStyles({
  * Apply styling to the Skeleton slots based on the state
  */
 export const useSkeletonStyles_unstable = (state: SkeletonState): SkeletonState => {
-  'use no memo';
-
   const styles = useStyles();
 
   // eslint-disable-next-line react-hooks/immutability

--- a/packages/react-components/react-skeleton/library/src/components/SkeletonItem/useSkeletonItemStyles.styles.ts
+++ b/packages/react-components/react-skeleton/library/src/components/SkeletonItem/useSkeletonItemStyles.styles.ts
@@ -156,8 +156,6 @@ const useCircleSizeStyles = makeStyles({
  * Apply styling to the SkeletonItem slots based on the state
  */
 export const useSkeletonItemStyles_unstable = (state: SkeletonItemState): SkeletonItemState => {
-  'use no memo';
-
   const { animation, appearance, size, shape } = state;
 
   const rootStyles = useStyles();

--- a/packages/react-components/react-slider/library/src/components/Slider/useSliderState.tsx
+++ b/packages/react-components/react-slider/library/src/components/Slider/useSliderState.tsx
@@ -13,8 +13,6 @@ const getPercent = (value: number, min: number, max: number) => {
 };
 
 export const useSliderState_unstable = (state: SliderBaseState, props: SliderBaseProps): SliderBaseState => {
-  'use no memo';
-
   const { min = 0, max = 100, step } = props;
   const { dir } = useFluent();
   const [currentValue, setCurrentValue] = useControllableState({

--- a/packages/react-components/react-slider/library/src/components/Slider/useSliderStyles.styles.ts
+++ b/packages/react-components/react-slider/library/src/components/Slider/useSliderStyles.styles.ts
@@ -273,8 +273,6 @@ const useInputStyles = makeStyles({
  * Apply styling to the Slider slots based on the state
  */
 export const useSliderStyles_unstable = (state: SliderState): SliderState => {
-  'use no memo';
-
   const rootStyles = useRootStyles();
   const railStyles = useRailStyles();
   const thumbStyles = useThumbStyles();

--- a/packages/react-components/react-spinbutton/library/src/components/SpinButton/useSpinButtonStyles.styles.ts
+++ b/packages/react-components/react-spinbutton/library/src/components/SpinButton/useSpinButtonStyles.styles.ts
@@ -393,8 +393,6 @@ const useButtonStyles = makeStyles({
  * Apply styling to the SpinButton slots based on the state
  */
 export const useSpinButtonStyles_unstable = (state: SpinButtonState): SpinButtonState => {
-  'use no memo';
-
   const { appearance, spinState, size } = state;
   const disabled = state.input.disabled;
   const invalid = `${state.input['aria-invalid']}` === 'true';

--- a/packages/react-components/react-spinner/library/src/components/Spinner/useSpinnerStyles.styles.ts
+++ b/packages/react-components/react-spinner/library/src/components/Spinner/useSpinnerStyles.styles.ts
@@ -227,8 +227,6 @@ const useLabelStyles = makeStyles({
  * Apply styling to the Spinner slots based on the state
  */
 export const useSpinnerStyles_unstable = (state: SpinnerState): SpinnerState => {
-  'use no memo';
-
   const { labelPosition, size, appearance } = state;
   const { dir } = useFluent();
 

--- a/packages/react-components/react-swatch-picker/library/src/components/ColorSwatch/useColorSwatchStyles.styles.ts
+++ b/packages/react-components/react-swatch-picker/library/src/components/ColorSwatch/useColorSwatchStyles.styles.ts
@@ -178,8 +178,6 @@ const useIconStyles = makeStyles({
  * Apply styling to the ColorSwatch slots based on the state
  */
 export const useColorSwatchStyles_unstable = (state: ColorSwatchState): ColorSwatchState => {
-  'use no memo';
-
   const { size = 'medium', shape = 'square' } = state;
 
   const resetStyles = useResetStyles();

--- a/packages/react-components/react-swatch-picker/library/src/components/EmptySwatch/useEmptySwatchStyles.styles.ts
+++ b/packages/react-components/react-swatch-picker/library/src/components/EmptySwatch/useEmptySwatchStyles.styles.ts
@@ -56,8 +56,6 @@ const useShapeStyles = makeStyles({
  * Apply styling to the EmptySwatch slots based on the state
  */
 export const useEmptySwatchStyles_unstable = (state: EmptySwatchState): EmptySwatchState => {
-  'use no memo';
-
   const styles = useStyles();
   const sizeStyles = useSizeStyles();
   const shapeStyles = useShapeStyles();

--- a/packages/react-components/react-swatch-picker/library/src/components/ImageSwatch/useImageSwatchStyles.styles.ts
+++ b/packages/react-components/react-swatch-picker/library/src/components/ImageSwatch/useImageSwatchStyles.styles.ts
@@ -111,8 +111,6 @@ const useShapeStyles = makeStyles({
  * Apply styling to the ImageSwatch slots based on the state
  */
 export const useImageSwatchStyles_unstable = (state: ImageSwatchState): ImageSwatchState => {
-  'use no memo';
-
   const styles = useStyles();
   const selectedStyles = useStylesSelected();
   const sizeStyles = useSizeStyles();

--- a/packages/react-components/react-swatch-picker/library/src/components/SwatchPicker/useSwatchPickerStyles.styles.ts
+++ b/packages/react-components/react-swatch-picker/library/src/components/SwatchPicker/useSwatchPickerStyles.styles.ts
@@ -30,8 +30,6 @@ const useStyles = makeStyles({
  * Apply styling to the SwatchPicker slots based on the state
  */
 export const useSwatchPickerStyles_unstable = (state: SwatchPickerState): SwatchPickerState => {
-  'use no memo';
-
   const styles = useStyles();
   const layoutStyle = state.isGrid ? styles.grid : styles.row;
 

--- a/packages/react-components/react-swatch-picker/library/src/components/SwatchPickerRow/useSwatchPickerRowStyles.styles.ts
+++ b/packages/react-components/react-swatch-picker/library/src/components/SwatchPickerRow/useSwatchPickerRowStyles.styles.ts
@@ -29,8 +29,6 @@ const useStyles = makeStyles({
  * Apply styling to the SwatchPickerRow slots based on the state
  */
 export const useSwatchPickerRowStyles_unstable = (state: SwatchPickerRowState): SwatchPickerRowState => {
-  'use no memo';
-
   const resetStyles = useResetStyles();
   const styles = useStyles();
   const spacingStyle = state.spacing === 'small' ? styles.spacingSmall : styles.spacingMedium;

--- a/packages/react-components/react-switch/library/src/components/Switch/useSwitchStyles.styles.ts
+++ b/packages/react-components/react-switch/library/src/components/Switch/useSwitchStyles.styles.ts
@@ -290,8 +290,6 @@ const useLabelStyles = makeStyles({
  * Apply styling to the Switch slots based on the state
  */
 export const useSwitchStyles_unstable = (state: SwitchState): SwitchState => {
-  'use no memo';
-
   const rootBaseClassName = useRootBaseClassName();
   const rootStyles = useRootStyles();
   const indicatorBaseClassName = useIndicatorBaseClassName();

--- a/packages/react-components/react-table/library/src/components/DataGrid/useDataGridStyles.styles.ts
+++ b/packages/react-components/react-table/library/src/components/DataGrid/useDataGridStyles.styles.ts
@@ -13,8 +13,6 @@ export const dataGridClassNames: SlotClassNames<DataGridSlots> = {
  * Apply styling to the DataGrid slots based on the state
  */
 export const useDataGridStyles_unstable = (state: DataGridState): DataGridState => {
-  'use no memo';
-
   useTableStyles_unstable(state);
   // eslint-disable-next-line react-hooks/immutability
   state.root.className = mergeClasses(dataGridClassNames.root, state.root.className);

--- a/packages/react-components/react-table/library/src/components/DataGridBody/useDataGridBodyStyles.styles.ts
+++ b/packages/react-components/react-table/library/src/components/DataGridBody/useDataGridBodyStyles.styles.ts
@@ -13,8 +13,6 @@ export const dataGridBodyClassNames: SlotClassNames<DataGridBodySlots> = {
  * Apply styling to the DataGridBody slots based on the state
  */
 export const useDataGridBodyStyles_unstable = (state: DataGridBodyState): DataGridBodyState => {
-  'use no memo';
-
   useTableBodyStyles_unstable(state);
   // eslint-disable-next-line react-hooks/immutability
   state.root.className = mergeClasses(dataGridBodyClassNames.root, state.root.className);

--- a/packages/react-components/react-table/library/src/components/DataGridCell/useDataGridCellStyles.styles.ts
+++ b/packages/react-components/react-table/library/src/components/DataGridCell/useDataGridCellStyles.styles.ts
@@ -13,8 +13,6 @@ export const dataGridCellClassNames: SlotClassNames<DataGridCellSlots> = {
  * Apply styling to the DataGridCell slots based on the state
  */
 export const useDataGridCellStyles_unstable = (state: DataGridCellState): DataGridCellState => {
-  'use no memo';
-
   useTableCellStyles_unstable(state);
   // eslint-disable-next-line react-hooks/immutability
   state.root.className = mergeClasses(dataGridCellClassNames.root, state.root.className);

--- a/packages/react-components/react-table/library/src/components/DataGridHeader/useDataGridHeaderStyles.styles.ts
+++ b/packages/react-components/react-table/library/src/components/DataGridHeader/useDataGridHeaderStyles.styles.ts
@@ -13,8 +13,6 @@ export const dataGridHeaderClassNames: SlotClassNames<DataGridHeaderSlots> = {
  * Apply styling to the DataGridHeader slots based on the state
  */
 export const useDataGridHeaderStyles_unstable = (state: DataGridHeaderState): DataGridHeaderState => {
-  'use no memo';
-
   useTableHeaderStyles_unstable(state);
   // eslint-disable-next-line react-hooks/immutability
   state.root.className = mergeClasses(dataGridHeaderClassNames.root, state.root.className);

--- a/packages/react-components/react-table/library/src/components/DataGridHeaderCell/useDataGridHeaderCellStyles.styles.ts
+++ b/packages/react-components/react-table/library/src/components/DataGridHeaderCell/useDataGridHeaderCellStyles.styles.ts
@@ -16,8 +16,6 @@ export const dataGridHeaderCellClassNames: SlotClassNames<DataGridHeaderCellSlot
  * Apply styling to the DataGridHeaderCell slots based on the state
  */
 export const useDataGridHeaderCellStyles_unstable = (state: DataGridHeaderCellState): DataGridHeaderCellState => {
-  'use no memo';
-
   useTableHeaderCellStyles_unstable(state);
   // eslint-disable-next-line react-hooks/immutability
   state.root.className = mergeClasses(dataGridHeaderCellClassNames.root, state.root.className);

--- a/packages/react-components/react-table/library/src/components/DataGridRow/useDataGridRowStyles.styles.ts
+++ b/packages/react-components/react-table/library/src/components/DataGridRow/useDataGridRowStyles.styles.ts
@@ -36,8 +36,6 @@ const useStyles = makeStyles({
  * Apply styling to the DataGridRow slots based on the state
  */
 export const useDataGridRowStyles_unstable = (state: DataGridRowState): DataGridRowState => {
-  'use no memo';
-
   const isSubtle = useDataGridContext_unstable(ctx => ctx.subtleSelection);
   const styles = useStyles();
 

--- a/packages/react-components/react-table/library/src/components/DataGridSelectionCell/useDataGridSelectionCellStyles.styles.ts
+++ b/packages/react-components/react-table/library/src/components/DataGridSelectionCell/useDataGridSelectionCellStyles.styles.ts
@@ -17,8 +17,6 @@ export const dataGridSelectionCellClassNames: SlotClassNames<DataGridSelectionCe
 export const useDataGridSelectionCellStyles_unstable = (
   state: DataGridSelectionCellState,
 ): DataGridSelectionCellState => {
-  'use no memo';
-
   useTableSelectionCellStyles_unstable(state);
   // eslint-disable-next-line react-hooks/immutability
   state.root.className = mergeClasses(dataGridSelectionCellClassNames.root, state.root.className);

--- a/packages/react-components/react-table/library/src/components/Table/useTableStyles.styles.ts
+++ b/packages/react-components/react-table/library/src/components/Table/useTableStyles.styles.ts
@@ -39,8 +39,6 @@ const useStyles = makeStyles({
  * Apply styling to the Table slots based on the state
  */
 export const useTableStyles_unstable = (state: TableState): TableState => {
-  'use no memo';
-
   const styles = useStyles();
   const layoutStyles = {
     table: useTableLayoutStyles(),

--- a/packages/react-components/react-table/library/src/components/TableBody/useTableBodyStyles.styles.ts
+++ b/packages/react-components/react-table/library/src/components/TableBody/useTableBodyStyles.styles.ts
@@ -25,8 +25,6 @@ export const tableBodyClassNames: SlotClassNames<TableBodySlots> = {
  * Apply styling to the TableBody slots based on the state
  */
 export const useTableBodyStyles_unstable = (state: TableBodyState): TableBodyState => {
-  'use no memo';
-
   const layoutStyles = {
     table: useTableLayoutStyles(),
     flex: useFlexLayoutStyles(),

--- a/packages/react-components/react-table/library/src/components/TableCell/useTableCellStyles.styles.ts
+++ b/packages/react-components/react-table/library/src/components/TableCell/useTableCellStyles.styles.ts
@@ -70,8 +70,6 @@ const useStyles = makeStyles({
  * Apply styling to the TableCell slots based on the state
  */
 export const useTableCellStyles_unstable = (state: TableCellState): TableCellState => {
-  'use no memo';
-
   const styles = useStyles();
   const layoutStyles = {
     table: useTableLayoutStyles(),

--- a/packages/react-components/react-table/library/src/components/TableCellActions/useTableCellActionsStyles.styles.ts
+++ b/packages/react-components/react-table/library/src/components/TableCellActions/useTableCellActionsStyles.styles.ts
@@ -31,8 +31,6 @@ const useStyles = makeStyles({
  * Apply styling to the TableCellActions slots based on the state
  */
 export const useTableCellActionsStyles_unstable = (state: TableCellActionsState): TableCellActionsState => {
-  'use no memo';
-
   const styles = useStyles();
   // eslint-disable-next-line react-hooks/immutability
   state.root.className = mergeClasses(

--- a/packages/react-components/react-table/library/src/components/TableCellLayout/useTableCellLayoutStyles.styles.ts
+++ b/packages/react-components/react-table/library/src/components/TableCellLayout/useTableCellLayoutStyles.styles.ts
@@ -75,8 +75,6 @@ const useStyles = makeStyles({
  * Apply styling to the TableCellLayout slots based on the state
  */
 export const useTableCellLayoutStyles_unstable = (state: TableCellLayoutState): TableCellLayoutState => {
-  'use no memo';
-
   const styles = useStyles();
   const { truncate } = state;
 

--- a/packages/react-components/react-table/library/src/components/TableHeader/useTableHeaderStyles.styles.ts
+++ b/packages/react-components/react-table/library/src/components/TableHeader/useTableHeaderStyles.styles.ts
@@ -25,8 +25,6 @@ const useTableLayoutStyles = makeStyles({
  * Apply styling to the TableHeader slots based on the state
  */
 export const useTableHeaderStyles_unstable = (state: TableHeaderState): TableHeaderState => {
-  'use no memo';
-
   const layoutStyles = {
     table: useTableLayoutStyles(),
     flex: useFlexLayoutStyles(),

--- a/packages/react-components/react-table/library/src/components/TableHeaderCell/useTableHeaderCellStyles.styles.ts
+++ b/packages/react-components/react-table/library/src/components/TableHeaderCell/useTableHeaderCellStyles.styles.ts
@@ -98,8 +98,6 @@ const useStyles = makeStyles({
  * Apply styling to the TableHeaderCell slots based on the state
  */
 export const useTableHeaderCellStyles_unstable = (state: TableHeaderCellState): TableHeaderCellState => {
-  'use no memo';
-
   const styles = useStyles();
   const layoutStyles = {
     table: useTableLayoutStyles(),

--- a/packages/react-components/react-table/library/src/components/TableResizeHandle/useTableResizeHandleStyles.styles.ts
+++ b/packages/react-components/react-table/library/src/components/TableResizeHandle/useTableResizeHandleStyles.styles.ts
@@ -56,8 +56,6 @@ const useStyles = makeStyles({
  * Apply styling to the TableResizeHandle slots based on the state
  */
 export const useTableResizeHandleStyles_unstable = (state: TableResizeHandleState): TableResizeHandleState => {
-  'use no memo';
-
   const styles = useStyles();
   // eslint-disable-next-line react-hooks/immutability
   state.root.className = mergeClasses(tableResizeHandleClassNames.root, styles.root, state.root.className);

--- a/packages/react-components/react-table/library/src/components/TableRow/useTableRowStyles.styles.ts
+++ b/packages/react-components/react-table/library/src/components/TableRow/useTableRowStyles.styles.ts
@@ -140,8 +140,6 @@ const useStyles = makeStyles({
  * Apply styling to the TableRow slots based on the state
  */
 export const useTableRowStyles_unstable = (state: TableRowState): TableRowState => {
-  'use no memo';
-
   const styles = useStyles();
   const layoutStyles = {
     table: useTableLayoutStyles(),

--- a/packages/react-components/react-table/library/src/components/TableSelectionCell/useTableSelectionCellStyles.styles.ts
+++ b/packages/react-components/react-table/library/src/components/TableSelectionCell/useTableSelectionCellStyles.styles.ts
@@ -71,8 +71,6 @@ const useStyles = makeStyles({
  * Apply styling to the TableSelectionCell slots based on the state
  */
 export const useTableSelectionCellStyles_unstable = (state: TableSelectionCellState): TableSelectionCellState => {
-  'use no memo';
-
   const styles = useStyles();
   const layoutStyles = {
     table: useTableLayoutStyles(),

--- a/packages/react-components/react-table/library/src/hooks/useTableColumnSizing.tsx
+++ b/packages/react-components/react-table/library/src/hooks/useTableColumnSizing.tsx
@@ -27,8 +27,6 @@ export const defaultColumnSizingState: TableColumnSizingState = {
 };
 
 export function useTableColumnSizing_unstable<TItem>(params?: UseTableColumnSizingParams) {
-  'use no memo';
-
   // False positive, these plugin hooks are intended to be run on every render
 
   return (tableState: TableFeaturesState<TItem>): TableFeaturesState<TItem> =>

--- a/packages/react-components/react-table/library/src/hooks/useTableSelection.ts
+++ b/packages/react-components/react-table/library/src/hooks/useTableSelection.ts
@@ -23,8 +23,6 @@ export const defaultTableSelectionState: TableSelectionState = {
 export function useTableSelection<TItem>(
   options: SelectionHookParams,
 ): (tableState: TableFeaturesState<TItem>) => TableFeaturesState<TItem> {
-  'use no memo';
-
   // False positive, these plugin hooks are intended to be run on every render
   // eslint-disable-next-line react-hooks/rules-of-hooks
   return (tableState: TableFeaturesState<TItem>) => useTableSelectionState(tableState, options);

--- a/packages/react-components/react-table/library/src/hooks/useTableSort.ts
+++ b/packages/react-components/react-table/library/src/hooks/useTableSort.ts
@@ -23,8 +23,6 @@ export const defaultTableSortState: TableSortState<unknown> = {
 };
 
 export function useTableSort<TItem>(options: UseTableSortOptions) {
-  'use no memo';
-
   // False positive, these plugin hooks are intended to be run on every render
   // eslint-disable-next-line react-hooks/rules-of-hooks
   return (tableState: TableFeaturesState<TItem>): TableFeaturesState<TItem> => useTableSortState(tableState, options);

--- a/packages/react-components/react-tabs/library/src/components/Tab/useTabStyles.styles.ts
+++ b/packages/react-components/react-tabs/library/src/components/Tab/useTabStyles.styles.ts
@@ -598,7 +598,7 @@ const useContentStyles = makeStyles({
  * Apply styling to the Tab slots based on the state
  */
 export const useTabStyles_unstable = (state: TabState): TabState => {
-  'use no memo';
+  'use no memo'; // justified: compiler would optimize useTabStyles_unstable — manual opt-out to preserve runtime behavior
 
   useTabIndicatorStyles_unstable(state);
 
@@ -619,8 +619,6 @@ export const useTabStyles_unstable = (state: TabState): TabState => {
  * @returns The state object with updated button styles
  */
 export const useTabIndicatorStyles_unstable = (state: TabState): TabState => {
-  'use no memo';
-
   const rootStyles = useRootStyles();
   const pendingIndicatorStyles = usePendingIndicatorStyles();
   const activeIndicatorStyles = useActiveIndicatorStyles();
@@ -673,8 +671,6 @@ export const useTabIndicatorStyles_unstable = (state: TabState): TabState => {
  * @returns The state object with updated button styles
  */
 export const useTabButtonStyles_unstable = (state: TabState, slot: TabState['root']): TabState => {
-  'use no memo';
-
   const rootStyles = useRootStyles();
   const focusStyles = useFocusStyles();
   const circularStyles = useCircularAppearanceStyles();
@@ -739,8 +735,6 @@ export const useTabButtonStyles_unstable = (state: TabState, slot: TabState['roo
  * @returns The state object with updated content styles
  */
 export const useTabContentStyles_unstable = (state: TabState): TabState => {
-  'use no memo';
-
   const iconStyles = useIconStyles();
   const contentStyles = useContentStyles();
 

--- a/packages/react-components/react-tabs/library/src/components/TabList/useTabListStyles.styles.ts
+++ b/packages/react-components/react-tabs/library/src/components/TabList/useTabListStyles.styles.ts
@@ -40,8 +40,6 @@ const useStyles = makeStyles({
  * Apply styling to the TabList slots based on the state
  */
 export const useTabListStyles_unstable = (state: TabListState): TabListState => {
-  'use no memo';
-
   const { appearance, vertical, size } = state;
 
   const styles = useStyles();

--- a/packages/react-components/react-tabster/src/hooks/useMergeTabsterAttributes.ts
+++ b/packages/react-components/react-tabster/src/hooks/useMergeTabsterAttributes.ts
@@ -15,8 +15,6 @@ import { TABSTER_ATTRIBUTE_NAME } from 'tabster';
 export const useMergedTabsterAttributes_unstable = (
   ...attributes: (Partial<Types.TabsterDOMAttribute> | null | undefined)[]
 ): Types.TabsterDOMAttribute => {
-  'use no memo';
-
   const stringAttributes = attributes.reduce<string[]>((acc, curr) => {
     if (curr?.[TABSTER_ATTRIBUTE_NAME]) {
       acc.push(curr[TABSTER_ATTRIBUTE_NAME]);
@@ -67,8 +65,6 @@ const safelyParseJSON = (json: string): object => {
  * This hook will console.warn if the attributes change at runtime.
  */
 const useWarnIfUnstableAttributes = (attributes: string[]) => {
-  'use no memo';
-
   const initialAttributesRef = React.useRef(attributes);
 
   // eslint-disable-next-line react-hooks/refs

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerButton/useTagPickerButtonStyles.styles.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerButton/useTagPickerButtonStyles.styles.ts
@@ -128,8 +128,6 @@ const useStyles = makeStyles({
  * Apply styling to the PickerButton slots based on the state
  */
 export const useTagPickerButtonStyles_unstable = (state: TagPickerButtonState): TagPickerButtonState => {
-  'use no memo';
-
   const styles = useStyles();
   // eslint-disable-next-line react-hooks/immutability
   state.root.className = mergeClasses(

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerControl/useTagPickerControlStyles.styles.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerControl/useTagPickerControlStyles.styles.ts
@@ -232,8 +232,6 @@ const useSecondaryActionStyles = makeStyles({
  * Apply styling to the PickerControl slots based on the state
  */
 export const useTagPickerControlStyles_unstable = (state: TagPickerControlState): TagPickerControlState => {
-  'use no memo';
-
   const styles = useStyles();
   const iconStyles = useIconStyles();
   const asideStyles = useAsideStyles();

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerGroup/useTagPickerGroupStyles.styles.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerGroup/useTagPickerGroupStyles.styles.ts
@@ -39,8 +39,6 @@ const useStyles = makeStyles({
  * Apply styling to the TagPickerGroup slots based on the state
  */
 export const useTagPickerGroupStyles_unstable = (state: TagPickerGroupState): TagPickerGroupState => {
-  'use no memo';
-
   useTagGroupStyles_unstable(state);
   const styles = useStyles();
   // eslint-disable-next-line react-hooks/immutability

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerInput/useTagPickerInputStyles.styles.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerInput/useTagPickerInputStyles.styles.ts
@@ -68,8 +68,6 @@ const useStyles = makeStyles({
  * Apply styling to the TagPickerInput slots based on the state
  */
 export const useTagPickerInputStyles_unstable = (state: TagPickerInputState): TagPickerInputState => {
-  'use no memo';
-
   const baseStyle = useBaseStyle();
   const styles = useStyles();
   // eslint-disable-next-line react-hooks/immutability

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerList/useTagPickerListStyles.styles.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerList/useTagPickerListStyles.styles.ts
@@ -29,8 +29,6 @@ const useStyles = makeStyles({
  * Apply styling to the TagPickerList slots based on the state
  */
 export const useTagPickerListStyles_unstable = (state: TagPickerListState): TagPickerListState => {
-  'use no memo';
-
   const styles = useStyles();
   // eslint-disable-next-line react-hooks/immutability
   state.root.className = mergeClasses(

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerOption/useTagPickerOptionStyles.styles.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerOption/useTagPickerOptionStyles.styles.ts
@@ -38,8 +38,6 @@ const useMediaBaseStyle = makeResetStyles({
  * Apply styling to the TagPickerOption slots based on the state
  */
 export const useTagPickerOptionStyles_unstable = (state: TagPickerOptionState): TagPickerOptionState => {
-  'use no memo';
-
   const rootBaseStyle = useRootBaseStyle();
   const rootStyles = useRootStyles();
   const secondaryContentBaseStyle = useSecondaryContentBaseStyle();

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerOptionGroup/useTagPickerOptionGroupStyles.styles.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerOptionGroup/useTagPickerOptionGroupStyles.styles.ts
@@ -14,8 +14,6 @@ export const tagPickerOptionGroupClassNames: SlotClassNames<TagPickerOptionGroup
  * Apply styling to the TagPickerOptionGroup slots based on the state
  */
 export const useTagPickerOptionGroupStyles = (state: TagPickerOptionGroupState): TagPickerOptionGroupState => {
-  'use no memo';
-
   useOptionGroupStyles_unstable(state);
   // eslint-disable-next-line react-hooks/immutability
   state.root.className = mergeClasses(tagPickerOptionGroupClassNames.root, state.root.className);

--- a/packages/react-components/react-tags/library/src/components/InteractionTag/useInteractionTagStyles.styles.ts
+++ b/packages/react-components/react-tags/library/src/components/InteractionTag/useInteractionTagStyles.styles.ts
@@ -35,8 +35,6 @@ const useRootStyles = makeStyles({
  * Apply styling to the InteractionTag slots based on the state
  */
 export const useInteractionTagStyles_unstable = (state: InteractionTagState): InteractionTagState => {
-  'use no memo';
-
   const rootBaseClassName = useRootBaseClassName();
   const rootStyles = useRootStyles();
 

--- a/packages/react-components/react-tags/library/src/components/InteractionTagPrimary/useInteractionTagPrimaryStyles.styles.ts
+++ b/packages/react-components/react-tags/library/src/components/InteractionTagPrimary/useInteractionTagPrimaryStyles.styles.ts
@@ -316,8 +316,6 @@ const useRootWithSecondaryActionStyles = makeStyles({
 export const useInteractionTagPrimaryStyles_unstable = (
   state: InteractionTagPrimaryState,
 ): InteractionTagPrimaryState => {
-  'use no memo';
-
   const rootRoundedBaseClassName = useRootRoundedBaseClassName();
   const rootCircularBaseClassName = useRootCircularBaseClassName();
   const rootStyles = useRootStyles();

--- a/packages/react-components/react-tags/library/src/components/InteractionTagSecondary/useInteractionTagSecondaryStyles.styles.ts
+++ b/packages/react-components/react-tags/library/src/components/InteractionTagSecondary/useInteractionTagSecondaryStyles.styles.ts
@@ -212,8 +212,6 @@ const useRootDisabledStyles = makeStyles({
 export const useInteractionTagSecondaryStyles_unstable = (
   state: InteractionTagSecondaryState,
 ): InteractionTagSecondaryState => {
-  'use no memo';
-
   const rootBaseClassName = useRootBaseClassName();
   const rootStyles = useRootStyles();
   const rootDisabledStyles = useRootDisabledStyles();

--- a/packages/react-components/react-tags/library/src/components/Tag/useTagStyles.styles.ts
+++ b/packages/react-components/react-tags/library/src/components/Tag/useTagStyles.styles.ts
@@ -360,8 +360,6 @@ export const useSecondaryTextBaseClassName = makeResetStyles({
  * Apply styling to the Tag slots based on the state
  */
 export const useTagStyles_unstable = (state: TagState): TagState => {
-  'use no memo';
-
   const rootRoundedBaseClassName = useRootRoundedBaseClassName();
   const rootCircularBaseClassName = useRootCircularBaseClassName();
 

--- a/packages/react-components/react-tags/library/src/components/TagGroup/useTagGroupStyles.styles.ts
+++ b/packages/react-components/react-tags/library/src/components/TagGroup/useTagGroupStyles.styles.ts
@@ -31,8 +31,6 @@ const useRootStyles = makeStyles({
  * Apply styling to the TagGroup slots based on the state
  */
 export const useTagGroupStyles_unstable = (state: TagGroupState): TagGroupState => {
-  'use no memo';
-
   const styles = useRootStyles();
   const { size } = state;
   // eslint-disable-next-line react-hooks/immutability

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverBody/useTeachingPopoverBodyStyles.styles.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverBody/useTeachingPopoverBodyStyles.styles.ts
@@ -51,8 +51,6 @@ const useStyles = makeStyles({
 
 /** Applies style classnames to slots */
 export const useTeachingPopoverBodyStyles_unstable = (state: TeachingPopoverBodyState): TeachingPopoverBodyState => {
-  'use no memo';
-
   const { mediaLength } = state;
   const styles = useStyles();
   const mediaStyles = useMediaStyles();

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarousel/Carousel/Carousel.tsx
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarousel/Carousel/Carousel.tsx
@@ -24,8 +24,6 @@ export function useCarousel_unstable(options: UseCarouselOptions): {
     selectPageByValue: (event: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>, newValue: string) => void;
   };
 } {
-  'use no memo';
-
   const { announcement, onValueChange, onFinish } = options;
 
   const { targetDocument } = useFluent();

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarousel/useTeachingPopoverCarouselStyles.styles.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarousel/useTeachingPopoverCarouselStyles.styles.ts
@@ -17,8 +17,6 @@ const useStyles = makeStyles({
 export const useTeachingPopoverCarouselStyles_unstable = (
   state: TeachingPopoverCarouselState,
 ): TeachingPopoverCarouselState => {
-  'use no memo';
-
   const styles = useStyles();
 
   // eslint-disable-next-line react-hooks/immutability

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselCard/useTeachingPopoverCarouselCardStyles.styles.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselCard/useTeachingPopoverCarouselCardStyles.styles.ts
@@ -19,8 +19,6 @@ const useStyles = makeStyles({
 export const useTeachingPopoverCarouselCardStyles_unstable = (
   state: TeachingPopoverCarouselCardState,
 ): TeachingPopoverCarouselCardState => {
-  'use no memo';
-
   const styles = useStyles();
 
   // eslint-disable-next-line react-hooks/immutability

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselFooter/useTeachingPopoverCarouselFooterStyles.styles.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselFooter/useTeachingPopoverCarouselFooterStyles.styles.ts
@@ -35,8 +35,6 @@ const useStyles = makeStyles({
 export const useTeachingPopoverCarouselFooterStyles_unstable = (
   state: TeachingPopoverCarouselFooterState,
 ): TeachingPopoverCarouselFooterState => {
-  'use no memo';
-
   const styles = useStyles();
   const { layout } = state;
 

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselFooterButton/useTeachingPopoverCarouselFooterButtonStyles.styles.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselFooterButton/useTeachingPopoverCarouselFooterButtonStyles.styles.ts
@@ -54,7 +54,7 @@ const useStyles = makeStyles({
 export const useTeachingPopoverCarouselFooterButtonStyles_unstable = (
   state: TeachingPopoverCarouselFooterButtonState,
 ): TeachingPopoverCarouselFooterButtonState => {
-  'use no memo';
+  'use no memo'; // justified: compiler would optimize useTeachingPopoverCarouselFooterButtonStyles_unstable — manual opt-out to preserve runtime behavior
 
   const styles = useStyles();
   const { navType, popoverAppearance } = state;

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselNav/useTeachingPopoverCarouselNavStyles.styles.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselNav/useTeachingPopoverCarouselNavStyles.styles.ts
@@ -32,8 +32,6 @@ const useStyles = makeStyles({
 export const useTeachingPopoverCarouselNavStyles_unstable = (
   state: TeachingPopoverCarouselNavState,
 ): TeachingPopoverCarouselNavState => {
-  'use no memo';
-
   const styles = useStyles();
 
   // eslint-disable-next-line react-hooks/immutability

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselNavButton/useTeachingPopoverCarouselNavButtonStyles.styles.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselNavButton/useTeachingPopoverCarouselNavButtonStyles.styles.ts
@@ -76,8 +76,6 @@ const useStyles = makeStyles({
 export const useTeachingPopoverCarouselNavButtonStyles_unstable = (
   state: TeachingPopoverCarouselNavButtonState,
 ): TeachingPopoverCarouselNavButtonState => {
-  'use no memo';
-
   const styles = useStyles();
   const { appearance, isSelected } = state;
 

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselPageCount/useTeachingPopoverCarouselPageCountStyles.styles.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselPageCount/useTeachingPopoverCarouselPageCountStyles.styles.ts
@@ -28,8 +28,6 @@ const useStyles = makeStyles({
 export const useTeachingPopoverCarouselPageCountStyles_unstable = (
   state: TeachingPopoverCarouselPageCountState,
 ): TeachingPopoverCarouselPageCountState => {
-  'use no memo';
-
   const styles = useStyles();
   // eslint-disable-next-line react-hooks/immutability
   state.root.className = mergeClasses(

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverFooter/useTeachingPopoverFooterStyles.styles.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverFooter/useTeachingPopoverFooterStyles.styles.ts
@@ -53,8 +53,6 @@ const useStyles = makeStyles({
 export const useTeachingPopoverFooterStyles_unstable = (
   state: TeachingPopoverFooterState,
 ): TeachingPopoverFooterState => {
-  'use no memo';
-
   const styles = useStyles();
   const { appearance, footerLayout } = state;
 

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverHeader/useTeachingPopoverHeaderStyles.styles.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverHeader/useTeachingPopoverHeaderStyles.styles.ts
@@ -77,8 +77,6 @@ const useStyles = makeStyles({
 export const useTeachingPopoverHeaderStyles_unstable = (
   state: TeachingPopoverHeaderState,
 ): TeachingPopoverHeaderState => {
-  'use no memo';
-
   const styles = useStyles();
   const { appearance } = state;
 

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverSurface/useTeachingPopoverSurfaceStyles.styles.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverSurface/useTeachingPopoverSurfaceStyles.styles.ts
@@ -25,8 +25,6 @@ const useStyles = makeStyles({
 export const useTeachingPopoverSurfaceStyles_unstable = (
   state: TeachingPopoverSurfaceState,
 ): TeachingPopoverSurfaceState => {
-  'use no memo';
-
   const styles = useStyles();
 
   // Make sure to merge teaching bubble surface prior to popover styles

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverTitle/useTeachingPopoverTitleStyles.styles.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverTitle/useTeachingPopoverTitleStyles.styles.ts
@@ -53,8 +53,6 @@ const useStyles = makeStyles({
 
 /** Applies style classnames to slots */
 export const useTeachingPopoverTitleStyles_unstable = (state: TeachingPopoverTitleState): TeachingPopoverTitleState => {
-  'use no memo';
-
   const styles = useStyles();
   const { appearance } = state;
 

--- a/packages/react-components/react-text/library/src/components/Text/useTextStyles.styles.ts
+++ b/packages/react-components/react-text/library/src/components/Text/useTextStyles.styles.ts
@@ -112,8 +112,6 @@ const useStyles = makeStyles({
  * Apply styling to the Text slots based on the state
  */
 export const useTextStyles_unstable = (state: TextState): TextState => {
-  'use no memo';
-
   const styles = useStyles();
 
   // eslint-disable-next-line react-hooks/immutability

--- a/packages/react-components/react-text/library/src/components/presets/createPreset.ts
+++ b/packages/react-components/react-text/library/src/components/presets/createPreset.ts
@@ -13,8 +13,6 @@ export function createPreset(options: {
 }): React.FunctionComponent<TextPresetProps> {
   const { useStyles, className, displayName } = options;
   const Wrapper: ForwardRefComponent<TextPresetProps> = React.forwardRef((props, ref) => {
-    'use no memo';
-
     const styles = useStyles();
     const state = useText_unstable(props as TextProps, ref);
 

--- a/packages/react-components/react-textarea/library/src/components/Textarea/useTextareaStyles.styles.ts
+++ b/packages/react-components/react-textarea/library/src/components/Textarea/useTextareaStyles.styles.ts
@@ -220,8 +220,6 @@ const useTextareaResizeStyles = makeStyles({
  * Apply styling to the Textarea slots based on the state
  */
 export const useTextareaStyles_unstable = (state: TextareaState): TextareaState => {
-  'use no memo';
-
   const { size, appearance, resize } = state;
   const disabled = state.textarea.disabled;
   const invalid = `${state.textarea['aria-invalid']}` === 'true';

--- a/packages/react-components/react-timepicker-compat/library/src/components/TimePicker/useTimePickerStyles.styles.ts
+++ b/packages/react-components/react-timepicker-compat/library/src/components/TimePicker/useTimePickerStyles.styles.ts
@@ -23,8 +23,6 @@ const useStyles = makeStyles({
  * Apply styling to the TimePicker slots based on the state
  */
 export const useTimePickerStyles_unstable = (state: TimePickerState): TimePickerState => {
-  'use no memo';
-
   const styles = useStyles();
 
   // eslint-disable-next-line react-hooks/immutability

--- a/packages/react-components/react-toast/library/src/components/AriaLive/useAriaLiveStyles.styles.ts
+++ b/packages/react-components/react-toast/library/src/components/AriaLive/useAriaLiveStyles.styles.ts
@@ -26,8 +26,6 @@ const useResetStyles = makeResetStyles({
  * Apply styling to the AriaLive slots based on the state
  */
 export const useAriaLiveStyles_unstable = (state: AriaLiveState): AriaLiveState => {
-  'use no memo';
-
   const visuallyHidden = useResetStyles();
   // eslint-disable-next-line react-hooks/immutability
   state.assertive.className = mergeClasses(visuallyHidden, ariaLiveClassNames.assertive, state.assertive.className);

--- a/packages/react-components/react-toast/library/src/components/Toast/useToastStyles.styles.ts
+++ b/packages/react-components/react-toast/library/src/components/Toast/useToastStyles.styles.ts
@@ -34,8 +34,6 @@ const useStyles = makeStyles({
  * Apply styling to the Toast slots based on the state
  */
 export const useToastStyles_unstable = (state: ToastState): ToastState => {
-  'use no memo';
-
   const rootBaseClassName = useRootBaseClassName();
   const styles = useStyles();
   // eslint-disable-next-line react-hooks/immutability

--- a/packages/react-components/react-toast/library/src/components/ToastBody/useToastBodyStyles.styles.ts
+++ b/packages/react-components/react-toast/library/src/components/ToastBody/useToastBodyStyles.styles.ts
@@ -44,8 +44,6 @@ const useInvertedStyles = makeStyles({
  * Apply styling to the ToastBody slots based on the state
  */
 export const useToastBodyStyles_unstable = (state: ToastBodyState): ToastBodyState => {
-  'use no memo';
-
   const rootBaseClassName = useRootBaseClassName();
   const subtitleBaseClassName = useSubtitleBaseClassName();
   const invertedStyles = useInvertedStyles();

--- a/packages/react-components/react-toast/library/src/components/ToastContainer/useToastContainerStyles.styles.ts
+++ b/packages/react-components/react-toast/library/src/components/ToastContainer/useToastContainerStyles.styles.ts
@@ -25,8 +25,6 @@ const useRootBaseClassName = makeResetStyles({
  * Apply styling to the ToastContainer slots based on the state
  */
 export const useToastContainerStyles_unstable = (state: ToastContainerState): ToastContainerState => {
-  'use no memo';
-
   const rootBaseClassName = useRootBaseClassName();
   // eslint-disable-next-line react-hooks/immutability
   state.root.className = mergeClasses(toastContainerClassNames.root, rootBaseClassName, state.root.className);

--- a/packages/react-components/react-toast/library/src/components/ToastFooter/useToastFooterStyles.styles.ts
+++ b/packages/react-components/react-toast/library/src/components/ToastFooter/useToastFooterStyles.styles.ts
@@ -24,8 +24,6 @@ const useRootBaseClassName = makeResetStyles({
  * Apply styling to the ToastFooter slots based on the state
  */
 export const useToastFooterStyles_unstable = (state: ToastFooterState): ToastFooterState => {
-  'use no memo';
-
   const rootBaseClassName = useRootBaseClassName();
   // eslint-disable-next-line react-hooks/immutability
   state.root.className = mergeClasses(toastFooterClassNames.root, rootBaseClassName, state.root.className);

--- a/packages/react-components/react-toast/library/src/components/ToastTitle/useToastTitleStyles.styles.ts
+++ b/packages/react-components/react-toast/library/src/components/ToastTitle/useToastTitleStyles.styles.ts
@@ -83,8 +83,6 @@ const useIntentIconStylesInverted = makeStyles({
  * Apply styling to the ToastTitle slots based on the state
  */
 export const useToastTitleStyles_unstable = (state: ToastTitleState): ToastTitleState => {
-  'use no memo';
-
   const rootBaseClassName = useRootBaseClassName();
   const actionBaseClassName = useActionBaseClassName();
   const mediaBaseClassName = useMediaBaseClassName();

--- a/packages/react-components/react-toast/library/src/components/Toaster/useToaster.tsx
+++ b/packages/react-components/react-toast/library/src/components/Toaster/useToaster.tsx
@@ -20,8 +20,6 @@ import { useToastAnnounce } from './useToastAnnounce';
  * @param props - props from this instance of Toaster
  */
 export const useToaster_unstable = (props: ToasterProps): ToasterState => {
-  'use no memo';
-
   const { offset, announce: announceProp, mountNode, inline = false, ...rest } = props;
   const announceRef = React.useRef<Announce>(() => null);
   const { toastsToRender, isToastVisible, pauseAllToasts, playAllToasts, tryRestoreFocus, closeAllToasts } =

--- a/packages/react-components/react-toast/library/src/components/Toaster/useToasterStyles.styles.ts
+++ b/packages/react-components/react-toast/library/src/components/Toaster/useToasterStyles.styles.ts
@@ -28,8 +28,6 @@ const useToasterStyles = makeStyles({
  * Apply styling to the Toaster slots based on the state
  */
 export const useToasterStyles_unstable = (state: ToasterState): ToasterState => {
-  'use no memo';
-
   const rootBaseClassName = useRootBaseClassName();
   const styles = useToasterStyles();
   const className = mergeClasses(

--- a/packages/react-components/react-toolbar/library/src/components/Toolbar/useToolbarStyles.styles.ts
+++ b/packages/react-components/react-toolbar/library/src/components/Toolbar/useToolbarStyles.styles.ts
@@ -30,8 +30,6 @@ const useStyles = makeStyles({
  * Apply styling to the Toolbar slots based on the state
  */
 export const useToolbarStyles_unstable = (state: ToolbarState): ToolbarState => {
-  'use no memo';
-
   const styles = useStyles();
   const { vertical, size } = state;
   // eslint-disable-next-line react-hooks/immutability

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarButton/useToolbarButtonStyles.styles.ts
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarButton/useToolbarButtonStyles.styles.ts
@@ -18,8 +18,6 @@ const useBaseStyles = makeStyles({
  * Apply styling to the ToolbarButton slots based on the state
  */
 export const useToolbarButtonStyles_unstable = (state: ToolbarButtonState): void => {
-  'use no memo';
-
   const buttonStyles = useBaseStyles();
 
   // eslint-disable-next-line react-hooks/immutability

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarDivider/useToolbarDividerStyles.styles.ts
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarDivider/useToolbarDividerStyles.styles.ts
@@ -20,8 +20,6 @@ const useBaseStyles = makeStyles({
  * Apply styling to the ToolbarDivider slots based on the state
  */
 export const useToolbarDividerStyles_unstable = (state: ToolbarDividerState): ToolbarDividerState => {
-  'use no memo';
-
   useDividerStyles_unstable(state);
   const { vertical } = state;
   const toolbarDividerStyles = useBaseStyles();

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarGroup/useToolbarGroupStyles.styles.ts
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarGroup/useToolbarGroupStyles.styles.ts
@@ -24,8 +24,6 @@ const useStyles = makeStyles({
  * Apply styling to the Toolbar slots based on the state
  */
 export const useToolbarGroupStyles_unstable = (state: ToolbarGroupState): ToolbarGroupState => {
-  'use no memo';
-
   const { vertical } = state;
   const styles = useStyles();
 

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarRadioButton/useToolbarRadioButtonStyles.styles.ts
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarRadioButton/useToolbarRadioButtonStyles.styles.ts
@@ -21,8 +21,6 @@ const useBaseStyles = makeStyles({
  * Apply styling to the ToolbarRadioButton slots based on the state
  */
 export const useToolbarRadioButtonStyles_unstable = (state: ToolbarRadioButtonState): ToolbarRadioButtonState => {
-  'use no memo';
-
   const toggleButtonStyles = useBaseStyles();
 
   // eslint-disable-next-line react-hooks/immutability

--- a/packages/react-components/react-toolbar/library/src/components/ToolbarToggleButton/useToolbarToggleButtonStyles.styles.ts
+++ b/packages/react-components/react-toolbar/library/src/components/ToolbarToggleButton/useToolbarToggleButtonStyles.styles.ts
@@ -21,8 +21,6 @@ const useBaseStyles = makeStyles({
  * Apply styling to the ToolbarToggleButton slots based on the state
  */
 export const useToolbarToggleButtonStyles_unstable = (state: ToolbarToggleButtonState): ToolbarToggleButtonState => {
-  'use no memo';
-
   const toggleButtonStyles = useBaseStyles();
 
   // eslint-disable-next-line react-hooks/immutability

--- a/packages/react-components/react-tooltip/library/src/components/Tooltip/useTooltip.tsx
+++ b/packages/react-components/react-tooltip/library/src/components/Tooltip/useTooltip.tsx
@@ -12,7 +12,7 @@ import { useTooltipBase_unstable } from './useTooltipBase';
  * @param props - props from this instance of Tooltip
  */
 export const useTooltip_unstable = (props: TooltipProps): TooltipState => {
-  'use no memo';
+  'use no memo'; // justified: compiler would optimize useTooltip_unstable — manual opt-out to preserve runtime behavior
 
   const { appearance = 'normal', ...baseProps } = props;
 

--- a/packages/react-components/react-tooltip/library/src/components/Tooltip/useTooltipBase.tsx
+++ b/packages/react-components/react-tooltip/library/src/components/Tooltip/useTooltipBase.tsx
@@ -35,8 +35,6 @@ import { Escape } from '@fluentui/keyboard-keys';
  * @param props - props from this instance of Tooltip
  */
 export const useTooltipBase_unstable = (props: TooltipBaseProps): TooltipBaseState => {
-  'use no memo';
-
   const context = useTooltipVisibility();
   const isServerSideRender = useIsSSR();
   const { targetDocument } = useFluent();

--- a/packages/react-components/react-tooltip/library/src/components/Tooltip/useTooltipStyles.styles.ts
+++ b/packages/react-components/react-tooltip/library/src/components/Tooltip/useTooltipStyles.styles.ts
@@ -52,8 +52,6 @@ const useStyles = makeStyles({
  * Apply styling to the Tooltip slots based on the state
  */
 export const useTooltipStyles_unstable = (state: TooltipState): TooltipState => {
-  'use no memo';
-
   const styles = useStyles();
 
   // eslint-disable-next-line react-hooks/immutability

--- a/packages/react-components/react-tree/library/src/components/FlatTree/useFlatTree.ts
+++ b/packages/react-components/react-tree/library/src/components/FlatTree/useFlatTree.ts
@@ -14,8 +14,6 @@ export const useFlatTree_unstable: (props: FlatTreeProps, ref: React.Ref<HTMLEle
   props,
   ref,
 ) => {
-  'use no memo';
-
   const isRoot = React.useContext(SubtreeContext) === undefined;
   // as level is static, this doesn't break rule of hooks
   // and if this becomes an issue later on, this can be easily converted

--- a/packages/react-components/react-tree/library/src/components/FlatTree/useFlatTreeStyles.styles.ts
+++ b/packages/react-components/react-tree/library/src/components/FlatTree/useFlatTreeStyles.styles.ts
@@ -16,8 +16,6 @@ const useBaseStyles = makeResetStyles({
 });
 
 export const useFlatTreeStyles_unstable = (state: FlatTreeState): FlatTreeState => {
-  'use no memo';
-
   const baseStyles = useBaseStyles();
   // eslint-disable-next-line react-hooks/immutability
   state.root.className = mergeClasses(flatTreeClassNames.root, baseStyles, state.root.className);

--- a/packages/react-components/react-tree/library/src/components/FlatTree/useHeadlessFlatTree.ts
+++ b/packages/react-components/react-tree/library/src/components/FlatTree/useHeadlessFlatTree.ts
@@ -123,8 +123,6 @@ export function useHeadlessFlatTree_unstable<Props extends HeadlessTreeItemProps
   props: Props[],
   options: HeadlessFlatTreeOptions = {},
 ): HeadlessFlatTreeReturn<Props> {
-  'use no memo';
-
   const headlessTree = React.useMemo(() => createHeadlessTree(props), [props]);
   const [openItems, setOpenItems] = useControllableOpenItems(options);
   const [checkedItems, setCheckedItems] = useFlatControllableCheckedItems(options, headlessTree);

--- a/packages/react-components/react-tree/library/src/components/Tree/useTree.ts
+++ b/packages/react-components/react-tree/library/src/components/Tree/useTree.ts
@@ -14,8 +14,6 @@ import { ImmutableSet } from '../../utils/ImmutableSet';
 import { ImmutableMap } from '../../utils/ImmutableMap';
 
 export const useTree_unstable = (props: TreeProps, ref: React.Ref<HTMLElement>): TreeState => {
-  'use no memo';
-
   const isRoot = React.useContext(SubtreeContext) === undefined;
   // as level is static, this doesn't break rule of hooks
   // and if this becomes an issue later on, this can be easily converted
@@ -24,7 +22,7 @@ export const useTree_unstable = (props: TreeProps, ref: React.Ref<HTMLElement>):
 };
 
 function useNestedRootTree(props: TreeProps, ref: React.Ref<HTMLElement>): TreeState {
-  'use no memo';
+  'use no memo'; // justified: compiler would optimize useNestedRootTree — manual opt-out to preserve runtime behavior
 
   const [openItems, setOpenItems] = useControllableOpenItems(props);
   const checkedItems = useNestedCheckedItems(props);
@@ -70,8 +68,6 @@ function useNestedRootTree(props: TreeProps, ref: React.Ref<HTMLElement>): TreeS
 }
 
 function useNestedSubtree(props: TreeProps, ref: React.Ref<HTMLElement>): TreeState {
-  'use no memo';
-
   if (process.env.NODE_ENV === 'development') {
     // this doesn't break rule of hooks, as environment is a static value
     // eslint-disable-next-line react-hooks/rules-of-hooks

--- a/packages/react-components/react-tree/library/src/components/Tree/useTreeContextValues.ts
+++ b/packages/react-components/react-tree/library/src/components/Tree/useTreeContextValues.ts
@@ -5,8 +5,6 @@ import type { TreeContextValue } from '../../contexts';
 import type { TreeContextValues, TreeState } from './Tree.types';
 
 export function useTreeContextValues_unstable(state: TreeState): TreeContextValues {
-  'use no memo';
-
   if (state.contextType === 'root') {
     const {
       openItems,

--- a/packages/react-components/react-tree/library/src/components/Tree/useTreeStyles.styles.ts
+++ b/packages/react-components/react-tree/library/src/components/Tree/useTreeStyles.styles.ts
@@ -22,8 +22,6 @@ const useStyles = makeStyles({
 });
 
 export const useTreeStyles_unstable = (state: TreeState): TreeState => {
-  'use no memo';
-
   const baseStyles = useBaseStyles();
   const styles = useStyles();
   const isSubTree = state.level > 1;

--- a/packages/react-components/react-tree/library/src/components/TreeItem/useTreeItem.tsx
+++ b/packages/react-components/react-tree/library/src/components/TreeItem/useTreeItem.tsx
@@ -34,8 +34,6 @@ import { treeClassNames } from '../../Tree';
  * @param ref - reference to root HTMLElement of TreeItem
  */
 export function useTreeItem_unstable(props: TreeItemProps, ref: React.Ref<HTMLDivElement>): TreeItemState {
-  'use no memo';
-
   const treeType = useTreeContext_unstable(ctx => ctx.treeType);
   if (treeType === 'flat') {
     warnIfNoProperPropsFlatTreeItem(props);

--- a/packages/react-components/react-tree/library/src/components/TreeItem/useTreeItemStyles.styles.ts
+++ b/packages/react-components/react-tree/library/src/components/TreeItem/useTreeItemStyles.styles.ts
@@ -63,8 +63,6 @@ const useStyles = makeStyles({
  * Apply styling to the TreeItem slots based on the state
  */
 export const useTreeItemStyles_unstable = (state: TreeItemState): TreeItemState => {
-  'use no memo';
-
   const baseStyles = useBaseStyles();
   const styles = useStyles();
 

--- a/packages/react-components/react-tree/library/src/components/TreeItemLayout/useTreeItemLayout.tsx
+++ b/packages/react-components/react-tree/library/src/components/TreeItemLayout/useTreeItemLayout.tsx
@@ -38,8 +38,6 @@ export const useTreeItemLayout_unstable = (
   props: TreeItemLayoutProps,
   ref: React.Ref<HTMLElement>,
 ): TreeItemLayoutState => {
-  'use no memo';
-
   const { main, iconAfter, iconBefore } = props;
 
   const layoutRef = useTreeItemContext_unstable(ctx => ctx.layoutRef);

--- a/packages/react-components/react-tree/library/src/components/TreeItemLayout/useTreeItemLayoutStyles.styles.ts
+++ b/packages/react-components/react-tree/library/src/components/TreeItemLayout/useTreeItemLayoutStyles.styles.ts
@@ -159,8 +159,6 @@ const useIconAfterStyles = makeStyles({
  * Apply styling to the TreeItemLayout slots based on the state
  */
 export const useTreeItemLayoutStyles_unstable = (state: TreeItemLayoutState): TreeItemLayoutState => {
-  'use no memo';
-
   const { main, iconAfter, iconBefore, expandIcon, root, aside, actions, selector } = state;
   const rootStyles = useRootStyles();
   const rootBaseStyles = useRootBaseStyles();

--- a/packages/react-components/react-tree/library/src/components/TreeItemPersonaLayout/useTreeItemPersonaLayoutStyles.styles.ts
+++ b/packages/react-components/react-tree/library/src/components/TreeItemPersonaLayout/useTreeItemPersonaLayoutStyles.styles.ts
@@ -160,8 +160,6 @@ const useExpandIconBaseStyles = makeResetStyles({
 export const useTreeItemPersonaLayoutStyles_unstable = (
   state: TreeItemPersonaLayoutState,
 ): TreeItemPersonaLayoutState => {
-  'use no memo';
-
   const rootBaseStyles = useRootBaseStyles();
   const rootStyles = useRootStyles();
   const mediaBaseStyles = useMediaBaseStyles();

--- a/packages/react-components/react-tree/library/src/hooks/useFlatTreeNavigation.ts
+++ b/packages/react-components/react-tree/library/src/hooks/useFlatTreeNavigation.ts
@@ -19,7 +19,7 @@ export function useFlatTreeNavigation(navigationMode: TreeNavigationMode = 'tree
   rootRef: React.RefCallback<HTMLElement>;
   forceUpdateRovingTabIndex: () => void;
 } {
-  'use no memo';
+  'use no memo'; // justified: compiler would optimize useFlatTreeNavigation — manual opt-out to preserve runtime behavior
 
   const { walkerRef, rootRef: walkerRootRef } = useHTMLElementWalkerRef();
   const { rove, forceUpdate: forceUpdateRovingTabIndex, initialize: initializeRovingTabIndex } = useRovingTabIndex();

--- a/packages/react-components/react-tree/library/src/hooks/useTreeNavigation.ts
+++ b/packages/react-components/react-tree/library/src/hooks/useTreeNavigation.ts
@@ -21,7 +21,7 @@ export function useTreeNavigation(navigationMode: TreeNavigationMode = 'tree'): 
   treeRef: React.RefCallback<HTMLElement>;
   forceUpdateRovingTabIndex: () => void;
 } {
-  'use no memo';
+  'use no memo'; // justified: compiler would optimize useTreeNavigation — manual opt-out to preserve runtime behavior
 
   const { rove, initialize: initializeRovingTabIndex, forceUpdate: forceUpdateRovingTabIndex } = useRovingTabIndex();
   const { findFirstFocusable } = useFocusFinders();

--- a/packages/react-components/react-utilities/src/hooks/useControllableState.ts
+++ b/packages/react-components/react-utilities/src/hooks/useControllableState.ts
@@ -43,7 +43,7 @@ function isFactoryDispatch<State>(newState: React.SetStateAction<State>): newSta
 export const useControllableState = <State>(
   options: UseControllableStateOptions<State>,
 ): [State, React.Dispatch<React.SetStateAction<State>>] => {
-  'use no memo';
+  'use no memo'; // justified: compiler would optimize useControllableState — manual opt-out to preserve runtime behavior
 
   if (process.env.NODE_ENV !== 'production') {
     if (options.state !== undefined && options.defaultState !== undefined) {
@@ -92,8 +92,6 @@ function isInitializer<State>(value: State | (() => State)): value is () => Stat
  * @returns - whether the value is controlled
  */
 const useIsControlled = <V>(controlledValue: V | undefined): controlledValue is V => {
-  'use no memo';
-
   const [isControlled] = React.useState<boolean>(() => controlledValue !== undefined);
 
   if (process.env.NODE_ENV !== 'production') {

--- a/packages/react-components/react-utilities/src/hooks/useId.ts
+++ b/packages/react-components/react-utilities/src/hooks/useId.ts
@@ -31,8 +31,6 @@ export function resetIdsForTests(): void {
  * @returns The ID
  */
 export function useId(prefix: string = 'fui-', providedId?: string): string {
-  'use no memo';
-
   const contextValue = useSSRContext();
   const idPrefix = useIdPrefix();
 

--- a/packages/react-components/react-utilities/src/hooks/useMergedRefs.ts
+++ b/packages/react-components/react-utilities/src/hooks/useMergedRefs.ts
@@ -16,8 +16,6 @@ export type RefObjectFunction<T> = React.RefObject<T | null> & ((value: T | null
  */
 // LegacyRef is actually not supported, but in React v18 types this is leaking directly from forwardRef component declaration
 export function useMergedRefs<T>(...refs: (React.Ref<T> | undefined)[]): RefObjectFunction<T> {
-  'use no memo';
-
   const mergedCallback = React.useCallback(
     // eslint-disable-next-line react-hooks/immutability
     (value: T | null) => {

--- a/packages/react-components/react-utilities/src/selection/useSelection.ts
+++ b/packages/react-components/react-utilities/src/selection/useSelection.ts
@@ -82,8 +82,6 @@ function useMultipleSelection(params: Omit<SelectionHookParams, 'selectionMode'>
 }
 
 export function useSelection(params: SelectionHookParams): readonly [Set<SelectionItemId>, SelectionMethods] {
-  'use no memo';
-
   if (params.selectionMode === 'multiselect') {
     // selectionMode is a static value, so we can safely ignore rules-of-hooks
     // eslint-disable-next-line react-hooks/rules-of-hooks

--- a/yarn.lock
+++ b/yarn.lock
@@ -1841,10 +1841,10 @@
     prop-types "^15.7.2"
     react-is "^17.0.2"
 
-"@fluentui/react-compiler-analyzer@0.0.0-experimental.rc-analyzer.20260514-5d0a891a8f.0":
-  version "0.0.0-experimental.rc-analyzer.20260514-5d0a891a8f.0"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-compiler-analyzer/-/react-compiler-analyzer-0.0.0-experimental.rc-analyzer.20260514-5d0a891a8f.0.tgz#871b79822e176c257c754d5983dc71701157e6be"
-  integrity sha512-GoaiQn7NUMBUPeAtlM8vm+xWYDOl2BiTL4mGbJ3cbRAMtwxfKzqyiV4gQsVGivCJ6Srl0LiDkBXMqF9NJOGwQw==
+"@fluentui/react-compiler-analyzer@0.0.0-experimental.rc-analyzer.20260526-7c5862ce36.0":
+  version "0.0.0-experimental.rc-analyzer.20260526-7c5862ce36.0"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-compiler-analyzer/-/react-compiler-analyzer-0.0.0-experimental.rc-analyzer.20260526-7c5862ce36.0.tgz#ea2ed759ed4c70a7f14dbab5e244f0f830c47e54"
+  integrity sha512-1fW/0YrInAvQfFKD2hxx8A/j8Egt/mBJfims39IthjAxU53pQFciv1EUcQupUwbY7AWZAwcanrLGF9E7cO7sKQ==
   dependencies:
     "@babel/core" "^7.28.5"
     "@babel/preset-typescript" "^7.28.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1841,10 +1841,10 @@
     prop-types "^15.7.2"
     react-is "^17.0.2"
 
-"@fluentui/react-compiler-analyzer@0.0.0-experimental.rc-analyzer.20260505-0d531266b1.0":
-  version "0.0.0-experimental.rc-analyzer.20260505-0d531266b1.0"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-compiler-analyzer/-/react-compiler-analyzer-0.0.0-experimental.rc-analyzer.20260505-0d531266b1.0.tgz#1d4640114fe797c40379c8e2f63d6181c83c652f"
-  integrity sha512-PdjcIsqGk3BurY07nN1oviRAlQvUoN+sdSzTRmVuAkmm8WOBflFR4RxJSCAC+0UCkAUkIZK//SkVKkAAN3oQ8g==
+"@fluentui/react-compiler-analyzer@0.0.0-experimental.rc-analyzer.20260514-5d0a891a8f.0":
+  version "0.0.0-experimental.rc-analyzer.20260514-5d0a891a8f.0"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-compiler-analyzer/-/react-compiler-analyzer-0.0.0-experimental.rc-analyzer.20260514-5d0a891a8f.0.tgz#871b79822e176c257c754d5983dc71701157e6be"
+  integrity sha512-GoaiQn7NUMBUPeAtlM8vm+xWYDOl2BiTL4mGbJ3cbRAMtwxfKzqyiV4gQsVGivCJ6Srl0LiDkBXMqF9NJOGwQw==
   dependencies:
     "@babel/core" "^7.28.5"
     "@babel/preset-typescript" "^7.28.5"


### PR DESCRIPTION
## Description

Enable the `react-compiler-analyzer--lint` target in the PR CI pipeline as a dedicated parallel job and fix `'use no memo'` directives across all v9 packages, and clean up a deprecated ESLint rule.

## Motivation

- Running the React Compiler analysis as a separate parallel job keeps the critical-path `main` job lean while still catching React Compiler compatibility regressions before merge.
- Applying `--fix` across all `react-components/**` ensures up to date baseline — no false positives 
  - react compiler analyzer  identifies redundant `use no memo` directives. TLDR, if compiler bails out, the `use no memo` is redundant and our `lint` command flags it
- The `lines-around-directive` rule has been deprecated since 2017 and causes unnecessary lint errors on directives like `'use no memo'`.

## Follow up

it seems we use `use no memo` directive on purpose in some style hooks, compiler is able compile those as they don't modify the references rather re-set the `state`.  We will check the actual need of the no memo as a follow up.

Modules to check:
- packages/react-components/react-calendar-compat/library/src/components/Calendar/useCalendarStyles.styles.ts
- packages/react-components/react-calendar-compat/library/src/components/CalendarDay/useCalendarDayStyles.styles.ts
- packages/react-components/react-calendar-compat/library/src/components/CalendarDayGrid/useCalendarDayGridStyles.styles.ts
- packages/react-components/react-calendar-compat/library/src/components/CalendarMonth/useCalendarMonthStyles.styles.ts
- packages/react-components/react-calendar-compat/library/src/components/CalendarPicker/useCalendarPickerStyles.styles.ts
- packages/react-components/react-calendar-compat/library/src/components/CalendarYear/useCalendarYearStyles.styles.ts
- packages/react-components/react-carousel/library/src/components/CarouselButton/useCarouselButtonStyles.styles.ts
- packages/react-components/react-tabs/library/src/components/Tab/useTabStyles.styles.ts
- packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselFooterButton/useTeachingPopoverCarouselFooterButtonStyles.styles.ts

### Changes

1. **`.github/workflows/pr.yml`**
   - Remove `react-compiler-analyzer--lint` from the `main` job's `nx affected` task list.
   - Add a new `react-compiler-analyzer` job that runs in parallel with the existing jobs (`main`, `e2e`, `react-major-versions-integration`). It checks out the repo, derives affected SHAs, and runs `yarn nx affected -t react-compiler-analyzer--lint --nxBail`.
2. **`package.json`** — Bump `@fluentui/react-compiler-analyzer` from `0.0.0-experimental.rc-analyzer.20260505-0d531266b1.0` to `0.0.0-experimental.rc-analyzer.20260514-5d0a891a8f.0`.
3. **`react-components/**`** — Run `react-compiler-analyzer --fix` across all v9 packages: removed redundant `'use no memo'` directives and added justification comments to valid ones (~380 files changed).
4. **`packages/eslint-plugin/src/configs/core.js`** — Disable the deprecated `lines-around-directive` ESLint rule (deprecated since ESLint v4, inherited from airbnb config).
5. **`yarn.lock`** — Updated lockfile reflecting the version bump.