### PR TITLE
feat(react-tags): decouple useTagGroupBase_unstable from Tabster + export contexts

### DIFF
--- a/change/@fluentui-react-tags-80527846-5fc6-4b8e-adcc-b758379cefb2.json
+++ b/change/@fluentui-react-tags-80527846-5fc6-4b8e-adcc-b758379cefb2.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Decouple useTagGroupBase_unstable from Tabster (pluggable arrowNavigationProps/onAfterTagDismiss options); export TagGroupContextProvider/useTagGroupContext_unstable and InteractionTagContextProvider/useInteractionTagContext_unstable for headless consumers",
+  "packageName": "@fluentui/react-tags",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tags/library/etc/react-tags.api.md
+++ b/packages/react-components/react-tags/library/etc/react-tags.api.md
@@ -29,6 +29,18 @@ export type InteractionTagBaseState<Value = TagValue> = Omit<InteractionTagState
 // @public (undocumented)
 export const interactionTagClassNames: SlotClassNames<InteractionTagSlots>;
 
+// @public (undocumented)
+export const InteractionTagContextProvider: React_2.Provider<InteractionTagContextValue<string> | undefined>;
+
+// @public
+export type InteractionTagContextValue<Value = string> = Required<Pick<InteractionTagState, 'appearance' | 'disabled' | 'selected' | 'selectedValues' | 'shape' | 'size'> & {
+    handleTagDismiss: TagDismissHandler<Value>;
+    interactionTagPrimaryId: string;
+    value?: Value;
+}> & {
+    handleTagSelect?: TagSelectHandler<Value>;
+};
+
 // @public
 export const InteractionTagPrimary: ForwardRefComponent<InteractionTagPrimaryProps>;
 
@@ -161,6 +173,12 @@ export type TagGroupBaseState<Value = TagValue> = Omit<TagGroupState<Value>, 'ap
 export const tagGroupClassNames: SlotClassNames<TagGroupSlots>;
 
 // @public (undocumented)
+export const TagGroupContextProvider: React_2.Provider<TagGroupContextValue | undefined>;
+
+// @public
+export type TagGroupContextValue = Required<Pick<TagGroupState, 'handleTagDismiss' | 'size'>> & Partial<Pick<TagGroupState, 'disabled' | 'appearance' | 'dismissible' | 'handleTagSelect' | 'role' | 'selectedValues'>>;
+
+// @public (undocumented)
 export type TagGroupContextValues = {
     tagGroup: TagGroupContextValue;
 };
@@ -229,6 +247,9 @@ export const useInteractionTag_unstable: (props: InteractionTagProps, ref: React
 export const useInteractionTagBase_unstable: (props: InteractionTagBaseProps, ref: React_2.Ref<HTMLDivElement>) => InteractionTagBaseState;
 
 // @public (undocumented)
+export const useInteractionTagContext_unstable: () => InteractionTagContextValue;
+
+// @public (undocumented)
 export function useInteractionTagContextValues_unstable(state: InteractionTagState): InteractionTagContextValues;
 
 // @public
@@ -265,7 +286,16 @@ export const useTagBase_unstable: (props: TagBaseProps, ref: React_2.Ref<HTMLSpa
 export const useTagGroup_unstable: (props: TagGroupProps, ref: React_2.Ref<HTMLDivElement>) => TagGroupState;
 
 // @public
-export const useTagGroupBase_unstable: (props: TagGroupBaseProps, ref: React_2.Ref<HTMLDivElement>) => TagGroupBaseState;
+export const useTagGroupBase_unstable: (props: TagGroupBaseProps, ref: React_2.Ref<HTMLDivElement>, options?: UseTagGroupBaseOptions) => TagGroupBaseState;
+
+// @public (undocumented)
+export type UseTagGroupBaseOptions = {
+    arrowNavigationProps?: object;
+    onAfterTagDismiss?: (container: HTMLElement | null) => void;
+};
+
+// @public (undocumented)
+export const useTagGroupContext_unstable: () => TagGroupContextValue;
 
 // @public (undocumented)
 export function useTagGroupContextValues_unstable(state: TagGroupState): TagGroupContextValues;

--- a/packages/react-components/react-tags/library/etc/react-tags.api.md
+++ b/packages/react-components/react-tags/library/etc/react-tags.api.md
@@ -150,6 +150,9 @@ export type TagBaseState = DistributiveOmit<TagState, 'appearance' | 'size' | 's
 export const tagClassNames: SlotClassNames<TagSlots>;
 
 // @public (undocumented)
+export type TagContextValues = TagAvatarContextValues;
+
+// @public (undocumented)
 export type TagDismissData<Value = TagValue> = {
     value: Value;
 };

--- a/packages/react-components/react-tags/library/src/TagGroup.ts
+++ b/packages/react-components/react-tags/library/src/TagGroup.ts
@@ -5,6 +5,7 @@ export type {
   TagGroupProps,
   TagGroupSlots,
   TagGroupState,
+  UseTagGroupBaseOptions,
 } from './components/TagGroup/index';
 export {
   TagGroup,

--- a/packages/react-components/react-tags/library/src/components/TagGroup/index.ts
+++ b/packages/react-components/react-tags/library/src/components/TagGroup/index.ts
@@ -8,6 +8,6 @@ export type {
   TagGroupState,
 } from './TagGroup.types';
 export { renderTagGroup_unstable } from './renderTagGroup';
-export { useTagGroupBase_unstable, useTagGroup_unstable } from './useTagGroup';
+export { useTagGroupBase_unstable, useTagGroup_unstable, type UseTagGroupBaseOptions } from './useTagGroup';
 export { tagGroupClassNames, useTagGroupStyles_unstable } from './useTagGroupStyles.styles';
 export { useTagGroupContextValues_unstable } from './useTagGroupContextValues';

--- a/packages/react-components/react-tags/library/src/components/TagGroup/useTagGroup.ts
+++ b/packages/react-components/react-tags/library/src/components/TagGroup/useTagGroup.ts
@@ -15,6 +15,11 @@ import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts
 import { interactionTagSecondaryClassNames } from '../InteractionTagSecondary/useInteractionTagSecondaryStyles.styles';
 import type { TagValue } from '../../utils/types';
 
+export type UseTagGroupBaseOptions = {
+  arrowNavigationProps?: object;
+  onAfterTagDismiss?: (container: HTMLElement | null) => void;
+};
+
 /**
  * Create the base state required to render TagGroup, without design-only props.
  *
@@ -24,6 +29,7 @@ import type { TagValue } from '../../utils/types';
 export const useTagGroupBase_unstable = (
   props: TagGroupBaseProps,
   ref: React.Ref<HTMLDivElement>,
+  options?: UseTagGroupBaseOptions,
 ): TagGroupBaseState => {
   const {
     onDismiss,
@@ -37,8 +43,6 @@ export const useTagGroupBase_unstable = (
   } = props;
 
   const innerRef = React.useRef<HTMLElement>(undefined);
-  const { targetDocument } = useFluent();
-  const { findNextFocusable, findPrevFocusable } = useFocusFinders();
 
   const [items, setItems] = useControllableState<Array<TagValue>>({
     defaultState: defaultSelectedValues,
@@ -48,26 +52,7 @@ export const useTagGroupBase_unstable = (
 
   const handleTagDismiss: TagGroupBaseState['handleTagDismiss'] = useEventCallback((e, data) => {
     onDismiss?.(e, data);
-
-    // set focus after tag dismiss
-    const activeElement = targetDocument?.activeElement;
-    if (innerRef.current?.contains(activeElement as HTMLElement)) {
-      // focus on next tag only if the active element is within the current tag group
-      const next = findNextFocusable(activeElement as HTMLElement, { container: innerRef.current });
-      if (next) {
-        next.focus();
-        return;
-      }
-
-      // if there is no next focusable, focus on the previous focusable
-      if (activeElement?.className.includes(interactionTagSecondaryClassNames.root)) {
-        const prev = findPrevFocusable(activeElement.parentElement as HTMLElement, { container: innerRef.current });
-        prev?.focus();
-      } else {
-        const prev = findPrevFocusable(activeElement as HTMLElement, { container: innerRef.current });
-        prev?.focus();
-      }
-    }
+    options?.onAfterTagDismiss?.(innerRef.current ?? null);
   });
 
   const handleTagSelect: TagGroupBaseState['handleTagSelect'] = useEventCallback(
@@ -79,12 +64,6 @@ export const useTagGroupBase_unstable = (
       }
     }),
   );
-
-  const arrowNavigationProps = useArrowNavigationGroup({
-    circular: true,
-    axis: 'both',
-    memorizeCurrent: true,
-  });
 
   return {
     handleTagDismiss,
@@ -105,7 +84,7 @@ export const useTagGroupBase_unstable = (
         ref: useMergedRefs(ref, innerRef) as React.Ref<HTMLDivElement>,
         role,
         'aria-disabled': disabled,
-        ...arrowNavigationProps,
+        ...(options?.arrowNavigationProps as Record<string, unknown> | undefined),
         ...rest,
       }),
       { elementType: 'div' },
@@ -116,6 +95,9 @@ export const useTagGroupBase_unstable = (
 /**
  * Create the state required to render TagGroup.
  *
+ * Composes with `useTagGroupBase_unstable` and supplies Tabster-backed arrow
+ * navigation and post-dismiss focus restoration via the base hook's `options`.
+ *
  * The returned state can be modified with hooks such as useTagGroupStyles_unstable,
  * before being passed to renderTagGroup_unstable.
  *
@@ -124,8 +106,39 @@ export const useTagGroupBase_unstable = (
  */
 export const useTagGroup_unstable = (props: TagGroupProps, ref: React.Ref<HTMLDivElement>): TagGroupState => {
   const { size = 'medium', appearance = 'filled' } = props;
+
+  const { targetDocument } = useFluent();
+  const { findNextFocusable, findPrevFocusable } = useFocusFinders();
+
+  const arrowNavigationProps = useArrowNavigationGroup({
+    circular: true,
+    axis: 'both',
+    memorizeCurrent: true,
+  });
+
+  const onAfterTagDismiss = useEventCallback((container: HTMLElement | null) => {
+    const activeElement = targetDocument?.activeElement;
+    if (container?.contains(activeElement as HTMLElement)) {
+      // focus on next tag only if the active element is within the current tag group
+      const next = findNextFocusable(activeElement as HTMLElement, { container });
+      if (next) {
+        next.focus();
+        return;
+      }
+
+      // if there is no next focusable, focus on the previous focusable
+      if (activeElement?.className.includes(interactionTagSecondaryClassNames.root)) {
+        const prev = findPrevFocusable(activeElement.parentElement as HTMLElement, { container });
+        prev?.focus();
+      } else {
+        const prev = findPrevFocusable(activeElement as HTMLElement, { container });
+        prev?.focus();
+      }
+    }
+  });
+
   return {
-    ...useTagGroupBase_unstable(props, ref),
+    ...useTagGroupBase_unstable(props, ref, { arrowNavigationProps, onAfterTagDismiss }),
     size,
     appearance,
   };

--- a/packages/react-components/react-tags/library/src/index.ts
+++ b/packages/react-components/react-tags/library/src/index.ts
@@ -6,7 +6,7 @@ export {
   useTagBase_unstable,
   useTag_unstable,
 } from './Tag';
-export type { TagBaseProps, TagBaseState, TagProps, TagSlots, TagState } from './Tag';
+export type { TagBaseProps, TagBaseState, TagContextValues, TagProps, TagSlots, TagState } from './Tag';
 
 export {
   InteractionTag,

--- a/packages/react-components/react-tags/library/src/index.ts
+++ b/packages/react-components/react-tags/library/src/index.ts
@@ -73,6 +73,13 @@ export type {
   TagGroupState,
   TagGroupContextValues,
 } from './TagGroup';
+export type { UseTagGroupBaseOptions } from './TagGroup';
+
+export { TagGroupContextProvider, useTagGroupContext_unstable } from './contexts/tagGroupContext';
+export type { TagGroupContextValue } from './contexts/tagGroupContext';
+
+export { InteractionTagContextProvider, useInteractionTagContext_unstable } from './contexts/interactionTagContext';
+export type { InteractionTagContextValue } from './contexts/interactionTagContext';
 
 export { useTagAvatarContextValues_unstable } from './utils';
 export type {


### PR DESCRIPTION
## Stack

This PR is part of a 3-PR stack. Review and merge bottom-up:

1. 👉 **#36225** — feat(react-tags): decouple useTagGroupBase_unstable from Tabster + export contexts _(base: `master`)_ — **merge first**
2. **#36226** — test(react-tags): add hook regression tests for Tag family _(base: #36225)_ — depends on #36225
3. **#36227** — feat(react-headless-components-preview): add Tag family _(base: #36226)_ — merge last; depends on #36226

---

## Summary

- Decouples `useTagGroupBase_unstable` from `@fluentui/react-tabster` and `@fluentui/react-shared-contexts`. Arrow-key navigation and post-dismiss focus restoration are now pluggable via a new optional `UseTagGroupBaseOptions` argument (`arrowNavigationProps`, `onAfterTagDismiss`), mirroring the `useMenuTriggerBase_unstable` pattern. The styled `useTagGroup_unstable` keeps full behaviour by supplying Tabster-backed implementations through that options bag.
- Adds package-entry exports for the Tag contexts so headless consumers can produce context values readable by the canonical base hooks: `TagGroupContextProvider` / `useTagGroupContext_unstable`, `InteractionTagContextProvider` / `useInteractionTagContext_unstable`, and the `TagGroupContextValue` / `InteractionTagContextValue` types. Also re-exports the previously-missing `TagContextValues` type.

