### PR TITLE
chore(react-menu): extract useMenuItemBase_unstable into a separate module

### DIFF
--- a/change/@fluentui-react-menu-f088e693-cbb1-405b-b804-a0c5ca5dc15a.json
+++ b/change/@fluentui-react-menu-f088e693-cbb1-405b-b804-a0c5ca5dc15a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: extract useMenuItemBase_unstable into a separate module",
+  "packageName": "@fluentui/react-menu",
+  "email": "viktorgenaev@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-menu/library/src/components/MenuItem/index.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuItem/index.ts
@@ -1,5 +1,6 @@
 export { MenuItem } from './MenuItem';
 export type { MenuItemProps, MenuItemSlots, MenuItemState } from './MenuItem.types';
 export { renderMenuItem_unstable } from './renderMenuItem';
-export { useMenuItem_unstable, useMenuItemBase_unstable } from './useMenuItem';
+export { useMenuItem_unstable } from './useMenuItem';
+export { useMenuItemBase_unstable } from './useMenuItemBase';
 export { menuItemClassNames, useMenuItemStyles_unstable } from './useMenuItemStyles.styles';

--- a/packages/react-components/react-menu/library/src/components/MenuItem/useMenuItem.tsx
+++ b/packages/react-components/react-menu/library/src/components/MenuItem/useMenuItem.tsx
@@ -1,16 +1,7 @@
 'use client';
 
 import * as React from 'react';
-import {
-  useEventCallback,
-  useMergedRefs,
-  getIntrinsicElementProps,
-  slot,
-  useIsomorphicLayoutEffect,
-} from '@fluentui/react-utilities';
 import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
-import { useCharacterSearch } from './useCharacterSearch';
-import { useMenuTriggerContext_unstable } from '../../contexts/menuTriggerContext';
 import {
   ChevronRightFilled,
   ChevronRightRegular,
@@ -18,14 +9,9 @@ import {
   ChevronLeftRegular,
   bundleIcon,
 } from '@fluentui/react-icons';
-import { useMenuListContext_unstable } from '../../contexts/menuListContext';
-import { useMenuContext_unstable } from '../../contexts/menuContext';
+import { useMenuItemBase_unstable } from './useMenuItemBase';
 import type { MenuItemProps, MenuItemState } from './MenuItem.types';
-import type { ARIAButtonElement, ARIAButtonElementIntersection, ARIAButtonProps } from '@fluentui/react-aria';
-import { useARIAButtonProps } from '@fluentui/react-aria';
-import { Enter, Space } from '@fluentui/keyboard-keys';
-import { useIsInMenuSplitGroup, useMenuSplitGroupContext_unstable } from '../../contexts/menuSplitGroupContext';
-import { useValidateNesting } from '../../utils/useValidateNesting';
+import type { ARIAButtonElement } from '@fluentui/react-aria';
 
 const ChevronRightIcon = bundleIcon(ChevronRightFilled, ChevronRightRegular);
 const ChevronLeftIcon = bundleIcon(ChevronLeftFilled, ChevronLeftRegular);
@@ -43,146 +29,4 @@ export const useMenuItem_unstable = (props: MenuItemProps, ref: React.Ref<ARIABu
   }
 
   return state;
-};
-
-/**
- * Base hook for MenuItem component, produces state required to render the component.
- * It doesn't set any design-related props specific to MenuItem such as submenu indicator icon.
- */
-export const useMenuItemBase_unstable = (
-  props: MenuItemProps,
-  ref: React.Ref<ARIAButtonElement<'div'>>,
-): MenuItemState => {
-  const isSubmenuTrigger = useMenuTriggerContext_unstable();
-  const persistOnClickContext = useMenuContext_unstable(context => context.persistOnItemClick);
-  const {
-    as = 'div',
-    disabled = false,
-    hasSubmenu = isSubmenuTrigger,
-    persistOnClick = persistOnClickContext,
-    content: _content, // `content` is a slot and it's type clashes with the HTMLElement `content` attribute
-    ...rest
-  } = props;
-  const { hasIcons, hasCheckmarks } = useIconAndCheckmarkAlignment({ hasSubmenu });
-  const setOpen = useMenuContext_unstable(context => context.setOpen);
-  const open = useMenuContext_unstable(context => context.open);
-  useNotifySplitItemMultiline({ multiline: !!props.subText, hasSubmenu });
-
-  const innerRef = React.useRef<ARIAButtonElementIntersection<'div'>>(null);
-  const dismissedWithKeyboardRef = React.useRef(false);
-
-  const validateNestingRef = useValidateNesting(getValidateNestingComponentName(props.role));
-
-  const state: MenuItemState = {
-    hasSubmenu,
-    submenuOpen: hasSubmenu && open,
-    disabled,
-    persistOnClick,
-    components: {
-      root: 'div',
-      icon: 'span',
-      checkmark: 'span',
-      submenuIndicator: 'span',
-      content: 'span',
-      secondaryContent: 'span',
-      subText: 'span',
-    },
-    root: slot.always(
-      getIntrinsicElementProps(
-        as,
-        useARIAButtonProps<'div', ARIAButtonProps<'div'>>(as, {
-          role: 'menuitem',
-          ...rest,
-          disabled: false,
-          disabledFocusable: disabled,
-          ref: useMergedRefs(ref, innerRef, validateNestingRef) as React.Ref<ARIAButtonElementIntersection<'div'>>,
-          onKeyDown: useEventCallback(event => {
-            props.onKeyDown?.(event);
-            if (!event.isDefaultPrevented() && (event.key === Space || event.key === Enter)) {
-              dismissedWithKeyboardRef.current = true;
-            }
-          }),
-          onMouseMove: useEventCallback(event => {
-            if (event.currentTarget.ownerDocument.activeElement !== event.currentTarget) {
-              innerRef.current?.focus();
-            }
-
-            props.onMouseMove?.(event);
-          }),
-          onClick: useEventCallback(event => {
-            if (!hasSubmenu && !persistOnClick) {
-              setOpen(event, {
-                open: false,
-                keyboard: dismissedWithKeyboardRef.current,
-                bubble: true,
-                type: 'menuItemClick',
-                event,
-              });
-              dismissedWithKeyboardRef.current = false;
-            }
-
-            props.onClick?.(event);
-          }),
-        }),
-      ),
-      { elementType: 'div' },
-    ),
-    icon: slot.optional(props.icon, { renderByDefault: hasIcons, elementType: 'span' }),
-    checkmark: slot.optional(props.checkmark, {
-      renderByDefault: hasCheckmarks,
-      elementType: 'span',
-    }),
-    submenuIndicator: slot.optional(props.submenuIndicator, {
-      renderByDefault: hasSubmenu,
-      elementType: 'span',
-    }),
-    content: slot.optional(props.content, {
-      renderByDefault: !!props.children,
-      defaultProps: { children: props.children },
-      elementType: 'span',
-    }),
-    secondaryContent: slot.optional(props.secondaryContent, { elementType: 'span' }),
-    subText: slot.optional(props.subText, { elementType: 'span' }),
-  };
-  useCharacterSearch(state, innerRef);
-  return state;
-};
-
-/**
- * MenuSplitGroup needs to apply extra styles when its main item is in multiline layout mode
- * Notify the parent MenuSplitGroup so that it can handle this case
- */
-const useNotifySplitItemMultiline = (options: { hasSubmenu: boolean; multiline: boolean }) => {
-  const { hasSubmenu, multiline } = options;
-  const isSplitItemTrigger = useIsInMenuSplitGroup() && hasSubmenu;
-
-  const { setMultiline } = useMenuSplitGroupContext_unstable();
-
-  useIsomorphicLayoutEffect(() => {
-    if (!isSplitItemTrigger) {
-      setMultiline(multiline);
-    }
-  }, [setMultiline, multiline, isSplitItemTrigger]);
-};
-
-const useIconAndCheckmarkAlignment = (options: { hasSubmenu: boolean }) => {
-  const { hasSubmenu } = options;
-  const hasIcons = useMenuListContext_unstable(context => context.hasIcons);
-  const hasCheckmarks = useMenuListContext_unstable(context => context.hasCheckmarks);
-  const isSplitItemTrigger = useIsInMenuSplitGroup() && hasSubmenu;
-
-  return {
-    hasIcons: hasIcons && !isSplitItemTrigger,
-    hasCheckmarks: hasCheckmarks && !isSplitItemTrigger,
-  };
-};
-
-const getValidateNestingComponentName = (role?: string) => {
-  switch (role) {
-    case 'menuitemcheckbox':
-      return 'MenuItemCheckbox';
-    case 'menuitemradio':
-      return 'MenuItemRadio';
-  }
-  return 'MenuItem';
 };

--- a/packages/react-components/react-menu/library/src/components/MenuItem/useMenuItemBase.tsx
+++ b/packages/react-components/react-menu/library/src/components/MenuItem/useMenuItemBase.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import * as React from 'react';
+import {
+  useEventCallback,
+  useMergedRefs,
+  getIntrinsicElementProps,
+  slot,
+  useIsomorphicLayoutEffect,
+} from '@fluentui/react-utilities';
+import { useCharacterSearch } from './useCharacterSearch';
+import { useMenuTriggerContext_unstable } from '../../contexts/menuTriggerContext';
+import { useMenuListContext_unstable } from '../../contexts/menuListContext';
+import { useMenuContext_unstable } from '../../contexts/menuContext';
+import type { MenuItemProps, MenuItemState } from './MenuItem.types';
+import type { ARIAButtonElement, ARIAButtonElementIntersection, ARIAButtonProps } from '@fluentui/react-aria';
+import { useARIAButtonProps } from '@fluentui/react-aria';
+import { Enter, Space } from '@fluentui/keyboard-keys';
+import { useIsInMenuSplitGroup, useMenuSplitGroupContext_unstable } from '../../contexts/menuSplitGroupContext';
+import { useValidateNesting } from '../../utils/useValidateNesting';
+
+/**
+ * Base hook for MenuItem component, produces state required to render the component.
+ * It doesn't set any design-related props specific to MenuItem such as submenu indicator icon.
+ */
+export const useMenuItemBase_unstable = (
+  props: MenuItemProps,
+  ref: React.Ref<ARIAButtonElement<'div'>>,
+): MenuItemState => {
+  const isSubmenuTrigger = useMenuTriggerContext_unstable();
+  const persistOnClickContext = useMenuContext_unstable(context => context.persistOnItemClick);
+  const {
+    as = 'div',
+    disabled = false,
+    hasSubmenu = isSubmenuTrigger,
+    persistOnClick = persistOnClickContext,
+    content: _content, // `content` is a slot and it's type clashes with the HTMLElement `content` attribute
+    ...rest
+  } = props;
+  const { hasIcons, hasCheckmarks } = useIconAndCheckmarkAlignment({ hasSubmenu });
+  const setOpen = useMenuContext_unstable(context => context.setOpen);
+  const open = useMenuContext_unstable(context => context.open);
+  useNotifySplitItemMultiline({ multiline: !!props.subText, hasSubmenu });
+
+  const innerRef = React.useRef<ARIAButtonElementIntersection<'div'>>(null);
+  const dismissedWithKeyboardRef = React.useRef(false);
+
+  const validateNestingRef = useValidateNesting(getValidateNestingComponentName(props.role));
+
+  const state: MenuItemState = {
+    hasSubmenu,
+    submenuOpen: hasSubmenu && open,
+    disabled,
+    persistOnClick,
+    components: {
+      root: 'div',
+      icon: 'span',
+      checkmark: 'span',
+      submenuIndicator: 'span',
+      content: 'span',
+      secondaryContent: 'span',
+      subText: 'span',
+    },
+    root: slot.always(
+      getIntrinsicElementProps(
+        as,
+        useARIAButtonProps<'div', ARIAButtonProps<'div'>>(as, {
+          role: 'menuitem',
+          ...rest,
+          disabled: false,
+          disabledFocusable: disabled,
+          ref: useMergedRefs(ref, innerRef, validateNestingRef) as React.Ref<ARIAButtonElementIntersection<'div'>>,
+          onKeyDown: useEventCallback(event => {
+            props.onKeyDown?.(event);
+            if (!event.isDefaultPrevented() && (event.key === Space || event.key === Enter)) {
+              dismissedWithKeyboardRef.current = true;
+            }
+          }),
+          onMouseMove: useEventCallback(event => {
+            if (event.currentTarget.ownerDocument.activeElement !== event.currentTarget) {
+              innerRef.current?.focus();
+            }
+
+            props.onMouseMove?.(event);
+          }),
+          onClick: useEventCallback(event => {
+            if (!hasSubmenu && !persistOnClick) {
+              setOpen(event, {
+                open: false,
+                keyboard: dismissedWithKeyboardRef.current,
+                bubble: true,
+                type: 'menuItemClick',
+                event,
+              });
+              dismissedWithKeyboardRef.current = false;
+            }
+
+            props.onClick?.(event);
+          }),
+        }),
+      ),
+      { elementType: 'div' },
+    ),
+    icon: slot.optional(props.icon, { renderByDefault: hasIcons, elementType: 'span' }),
+    checkmark: slot.optional(props.checkmark, {
+      renderByDefault: hasCheckmarks,
+      elementType: 'span',
+    }),
+    submenuIndicator: slot.optional(props.submenuIndicator, {
+      renderByDefault: hasSubmenu,
+      elementType: 'span',
+    }),
+    content: slot.optional(props.content, {
+      renderByDefault: !!props.children,
+      defaultProps: { children: props.children },
+      elementType: 'span',
+    }),
+    secondaryContent: slot.optional(props.secondaryContent, { elementType: 'span' }),
+    subText: slot.optional(props.subText, { elementType: 'span' }),
+  };
+  useCharacterSearch(state, innerRef);
+  return state;
+};
+
+/**
+ * MenuSplitGroup needs to apply extra styles when its main item is in multiline layout mode
+ * Notify the parent MenuSplitGroup so that it can handle this case
+ */
+const useNotifySplitItemMultiline = (options: { hasSubmenu: boolean; multiline: boolean }) => {
+  const { hasSubmenu, multiline } = options;
+  const isSplitItemTrigger = useIsInMenuSplitGroup() && hasSubmenu;
+
+  const { setMultiline } = useMenuSplitGroupContext_unstable();
+
+  useIsomorphicLayoutEffect(() => {
+    if (!isSplitItemTrigger) {
+      setMultiline(multiline);
+    }
+  }, [setMultiline, multiline, isSplitItemTrigger]);
+};
+
+const useIconAndCheckmarkAlignment = (options: { hasSubmenu: boolean }) => {
+  const { hasSubmenu } = options;
+  const hasIcons = useMenuListContext_unstable(context => context.hasIcons);
+  const hasCheckmarks = useMenuListContext_unstable(context => context.hasCheckmarks);
+  const isSplitItemTrigger = useIsInMenuSplitGroup() && hasSubmenu;
+
+  return {
+    hasIcons: hasIcons && !isSplitItemTrigger,
+    hasCheckmarks: hasCheckmarks && !isSplitItemTrigger,
+  };
+};
+
+const getValidateNestingComponentName = (role?: string) => {
+  switch (role) {
+    case 'menuitemcheckbox':
+      return 'MenuItemCheckbox';
+    case 'menuitemradio':
+      return 'MenuItemRadio';
+  }
+  return 'MenuItem';
+};

--- a/packages/react-components/react-menu/library/src/components/MenuItemCheckbox/useMenuItemCheckbox.tsx
+++ b/packages/react-components/react-menu/library/src/components/MenuItemCheckbox/useMenuItemCheckbox.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { slot } from '@fluentui/react-utilities';
 import { Checkmark16Filled } from '@fluentui/react-icons';
 import { useMenuListContext_unstable } from '../../contexts/menuListContext';
-import { useMenuItemBase_unstable } from '../MenuItem/useMenuItem';
+import { useMenuItemBase_unstable } from '../MenuItem/useMenuItemBase';
 import type { MenuItemCheckboxProps, MenuItemCheckboxState } from './MenuItemCheckbox.types';
 import type { ARIAButtonElement, ARIAButtonElementIntersection } from '@fluentui/react-aria';
 

--- a/packages/react-components/react-menu/library/src/components/MenuItemLink/useMenuItemLink.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuItemLink/useMenuItemLink.ts
@@ -4,7 +4,8 @@ import type * as React from 'react';
 import type { ExtractSlotProps, Slot } from '@fluentui/react-utilities';
 import { getIntrinsicElementProps, slot } from '@fluentui/react-utilities';
 import type { MenuItemLinkProps, MenuItemLinkState } from './MenuItemLink.types';
-import { useMenuItemBase_unstable, useMenuItem_unstable } from '../MenuItem/useMenuItem';
+import { useMenuItem_unstable } from '../MenuItem/useMenuItem';
+import { useMenuItemBase_unstable } from '../MenuItem/useMenuItemBase';
 import type { MenuItemProps } from '../MenuItem/MenuItem.types';
 
 /**

--- a/packages/react-components/react-menu/library/src/components/MenuItemRadio/useMenuItemRadio.tsx
+++ b/packages/react-components/react-menu/library/src/components/MenuItemRadio/useMenuItemRadio.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { slot } from '@fluentui/react-utilities';
 import { Checkmark16Filled } from '@fluentui/react-icons';
 import { useMenuListContext_unstable } from '../../contexts/menuListContext';
-import { useMenuItemBase_unstable } from '../MenuItem/useMenuItem';
+import { useMenuItemBase_unstable } from '../MenuItem/useMenuItemBase';
 import type {
   MenuItemRadioBaseProps,
   MenuItemRadioBaseState,


### PR DESCRIPTION
Splits `useMenuItemBase_unstable` out of `useMenuItem.tsx` into a new `useMenuItemBase.tsx`. The design hook `useMenuItem_unstable` keeps the module-level `bundleIcon` chevron icons.

Headless consumers that only import the base hook can now tree-shake the chevron icons — observed ~7kb minified savings in `@fluentui/react-headless-components-preview` (26kb → 19kb minified).

Internal consumers (`MenuItemCheckbox`, `MenuItemRadio`, `MenuItemLink`) updated to import the base hook from the new file. Public API unchanged, both hooks remain re-exported from the package barrel.

Follow-up from  #36110
