### PR TITLE
fix(react-menu): change the signature for the useMenuTriggerBase hook

### DIFF
--- a/change/@fluentui-react-headless-components-preview-8bb06d39-1438-4d76-9874-026b92c92ee7.json
+++ b/change/@fluentui-react-headless-components-preview-8bb06d39-1438-4d76-9874-026b92c92ee7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: update useMenuTriggerBase hook signature",
+  "packageName": "@fluentui/react-headless-components-preview",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-menu-5dc54882-30b5-4f86-affc-ec45b2a32981.json
+++ b/change/@fluentui-react-menu-5dc54882-30b5-4f86-affc-ec45b2a32981.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: update useMenuTriggerBase hook signature",
+  "packageName": "@fluentui/react-menu",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuTrigger/useMenuTrigger.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuTrigger/useMenuTrigger.ts
@@ -38,7 +38,7 @@ export const useMenuTrigger = (props: MenuTriggerProps): MenuTriggerState => {
     firstFocusable?.focus();
   }, [menuPopoverRef]);
 
-  const baseState = useMenuTriggerBase_unstable(props, { focusFirst });
+  const baseState = useMenuTriggerBase_unstable({ ...props, focusFirst });
   const open = useMenuContext(ctx => ctx.open);
   const openOnContext = useMenuContext(ctx => ctx.openOnContext);
   const setOpen = useMenuContext(ctx => ctx.setOpen);

--- a/packages/react-components/react-menu/library/etc/react-menu.api.md
+++ b/packages/react-components/react-menu/library/etc/react-menu.api.md
@@ -414,6 +414,11 @@ export type MenuState = ComponentState<InternalMenuSlots> & Required<Pick<MenuPr
 // @public
 export const MenuTrigger: React_2.FC<MenuTriggerProps>;
 
+// @public (undocumented)
+export type MenuTriggerBaseProps = MenuTriggerProps & {
+    focusFirst?: () => void;
+};
+
 // @public
 export type MenuTriggerChildProps<Type extends ARIAButtonType = ARIAButtonType, Props = {}> = ARIAButtonResultProps<Type, Props & {
     'aria-haspopup'?: 'menu';
@@ -612,12 +617,7 @@ export const useMenuSplitGroupStyles_unstable: (state: MenuSplitGroupState) => M
 export const useMenuTrigger_unstable: (props: MenuTriggerProps) => MenuTriggerState;
 
 // @public
-export const useMenuTriggerBase_unstable: (props: MenuTriggerProps, options?: UseMenuTriggerBaseOptions) => MenuTriggerState;
-
-// @public
-export type UseMenuTriggerBaseOptions = {
-    focusFirst?: () => void;
-};
+export const useMenuTriggerBase_unstable: (props: MenuTriggerBaseProps) => MenuTriggerState;
 
 // @public (undocumented)
 export const useMenuTriggerContext_unstable: () => boolean;

--- a/packages/react-components/react-menu/library/src/MenuTrigger.ts
+++ b/packages/react-components/react-menu/library/src/MenuTrigger.ts
@@ -1,8 +1,8 @@
 export type {
   MenuTriggerChildProps,
+  MenuTriggerBaseProps,
   MenuTriggerProps,
   MenuTriggerState,
-  UseMenuTriggerBaseOptions,
 } from './components/MenuTrigger/index';
 export {
   MenuTrigger,

--- a/packages/react-components/react-menu/library/src/components/MenuTrigger/MenuTrigger.types.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuTrigger/MenuTrigger.types.ts
@@ -12,13 +12,9 @@ export type MenuTriggerProps = TriggerProps<MenuTriggerChildProps> & {
 
 export type MenuTriggerBaseProps = MenuTriggerProps & {
   /**
-   * Pluggable "focus the first focusable element in the menu popover" callback,
-   * invoked when an already-open submenu trigger receives the open arrow key.
-   *
-   * Not provided by the base hook itself - the base hook is intentionally headless
-   * and leaves focus discovery to the caller. `useMenuTrigger_unstable` plugs in a
-   * Tabster-aware implementation; a headless consumer is expected to supply its own.
-   * If omitted, the keyboard handler is a no-op for that case.
+   * Optional callback to focus the first focusable element in the menu popover
+   * when an arrow key is pressed on an open submenu trigger.
+   * If omitted, the keyboard handler is a no-op.
    */
   focusFirst?: () => void;
 };

--- a/packages/react-components/react-menu/library/src/components/MenuTrigger/MenuTrigger.types.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuTrigger/MenuTrigger.types.ts
@@ -10,6 +10,19 @@ export type MenuTriggerProps = TriggerProps<MenuTriggerChildProps> & {
   disableButtonEnhancement?: boolean;
 };
 
+export type MenuTriggerBaseProps = MenuTriggerProps & {
+  /**
+   * Pluggable "focus the first focusable element in the menu popover" callback,
+   * invoked when an already-open submenu trigger receives the open arrow key.
+   *
+   * Not provided by the base hook itself - the base hook is intentionally headless
+   * and leaves focus discovery to the caller. `useMenuTrigger_unstable` plugs in a
+   * Tabster-aware implementation; a headless consumer is expected to supply its own.
+   * If omitted, the keyboard handler is a no-op for that case.
+   */
+  focusFirst?: () => void;
+};
+
 /**
  * Props that are passed to the child of the MenuTrigger when cloned to ensure correct behaviour for the Menu
  */

--- a/packages/react-components/react-menu/library/src/components/MenuTrigger/index.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuTrigger/index.ts
@@ -1,5 +1,9 @@
 export { MenuTrigger } from './MenuTrigger';
-export type { MenuTriggerChildProps, MenuTriggerProps, MenuTriggerState } from './MenuTrigger.types';
+export type {
+  MenuTriggerChildProps,
+  MenuTriggerBaseProps,
+  MenuTriggerProps,
+  MenuTriggerState,
+} from './MenuTrigger.types';
 export { renderMenuTrigger_unstable } from './renderMenuTrigger';
 export { useMenuTrigger_unstable, useMenuTriggerBase_unstable } from './useMenuTrigger';
-export type { UseMenuTriggerBaseOptions } from './useMenuTrigger';

--- a/packages/react-components/react-menu/library/src/components/MenuTrigger/useMenuTrigger.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuTrigger/useMenuTrigger.ts
@@ -15,7 +15,7 @@ import {
 } from '@fluentui/react-utilities';
 import * as React from 'react';
 
-import type { MenuTriggerProps, MenuTriggerState } from './MenuTrigger.types';
+import type { MenuTriggerBaseProps, MenuTriggerProps, MenuTriggerState } from './MenuTrigger.types';
 import { useMenuContext_unstable } from '../../contexts/menuContext';
 import { useMenuListContext_unstable } from '../../contexts/menuListContext';
 import { useIsSubmenu, useOnMenuSafeZoneTimeout } from '../../utils';
@@ -44,24 +44,12 @@ export const useMenuTrigger_unstable = (props: MenuTriggerProps): MenuTriggerSta
     firstFocusable?.focus();
   }, [findFirstFocusable, menuPopoverRef]);
 
-  return useMenuTriggerBase_unstable(props, { focusFirst });
+  return useMenuTriggerBase_unstable({ ...props, focusFirst });
 };
 
 /**
  * Options accepted by `useMenuTriggerBase_unstable`.
  */
-export type UseMenuTriggerBaseOptions = {
-  /**
-   * Pluggable "focus the first focusable element in the menu popover" callback,
-   * invoked when an already-open submenu trigger receives the open arrow key.
-   *
-   * Not provided by the base hook itself - the base hook is intentionally headless
-   * and leaves focus discovery to the caller. `useMenuTrigger_unstable` plugs in a
-   * Tabster-aware implementation; a headless consumer is expected to supply its own.
-   * If omitted, the keyboard handler is a no-op for that case.
-   */
-  focusFirst?: () => void;
-};
 
 /**
  * Base hook for MenuTrigger component, produces state required to render the component.
@@ -75,11 +63,8 @@ export type UseMenuTriggerBaseOptions = {
  *
  * @public
  */
-export const useMenuTriggerBase_unstable = (
-  props: MenuTriggerProps,
-  options?: UseMenuTriggerBaseOptions,
-): MenuTriggerState => {
-  const { children, disableButtonEnhancement = false } = props;
+export const useMenuTriggerBase_unstable = (props: MenuTriggerBaseProps): MenuTriggerState => {
+  const { children, disableButtonEnhancement = false, focusFirst } = props;
 
   const triggerRef = useMenuContext_unstable(context => context.triggerRef);
   const setOpen = useMenuContext_unstable(context => context.setOpen);
@@ -90,8 +75,6 @@ export const useMenuTriggerBase_unstable = (
 
   const isSubmenu = useIsSubmenu();
   const shouldOpenOnArrowRight = useMenuListContext_unstable(ctx => ctx.shouldOpenOnArrowRight ?? true);
-
-  const focusFirst = options?.focusFirst;
 
   const openedWithKeyboardRef = React.useRef(false);
   const openedViaSafeZoneRef = React.useRef(false);

--- a/packages/react-components/react-menu/library/src/index.ts
+++ b/packages/react-components/react-menu/library/src/index.ts
@@ -126,12 +126,7 @@ export {
   useMenuTrigger_unstable,
   useMenuTriggerBase_unstable,
 } from './MenuTrigger';
-export type {
-  MenuTriggerChildProps,
-  MenuTriggerProps,
-  MenuTriggerState,
-  UseMenuTriggerBaseOptions,
-} from './MenuTrigger';
+export type { MenuTriggerChildProps, MenuTriggerProps, MenuTriggerState, MenuTriggerBaseProps } from './MenuTrigger';
 
 export { useCheckmarkStyles_unstable } from './selectable/index';
 export type { MenuItemSelectableProps, MenuItemSelectableState, SelectableHandler } from './selectable/index';


### PR DESCRIPTION
> [!IMPORTANT]
> This change affects the public API, but as there’s been no public NPM release since the PR merged three days ago, it should be safe to change it

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

`useMenuTriggerBase_unstable(props: MenuItemTriggerProps, options?: UseMenuTriggerOptions) => MenuTriggerState` has been introduced in the https://github.com/microsoft/fluentui/pull/36087, but its signature is not aligned with the pattern used across Fluent codebase `(props, ref?) => ...`

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

Change the hook signature from:
```ts
type UseMenuTriggerOptions = {
 focusFirst?: () => void;
}

const useMenuTriggerBase_unstable = (props: MenuItemTriggerProps, options?: UseMenuTriggerOptions) => MenuTriggerState {}
```
to:
```ts
type MenuItemTriggerBaseProps = MenuItemTriggerProps & {
  focusFirst?: () => void;
}

const useMenuTriggerBase_unstable = (props: MenuItemTriggerBaseProps) => MenuTriggerState {
}
```

Also updated the only consumer of the base hook `useMenutTrigger` in `react-headless-components-preview`

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Original PR https://github.com/microsoft/fluentui/pull/36087
- Discussion https://github.com/microsoft/fluentui/pull/36228/changes#r3275533252