### PR TITLE
fix(web-components): preserve radio state after deferred upgrade

### DIFF
--- a/change/@fluentui-web-components-6f78c014-b0c7-4dd8-8ad7-93c0521f8c76.json
+++ b/change/@fluentui-web-components-6f78c014-b0c7-4dd8-8ad7-93c0521f8c76.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix(web-components): defer parent child collection until custom elements upgrade",
+  "packageName": "@fluentui/web-components",
+  "email": "kirtiar15502@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/accordion/accordion.ts
+++ b/packages/web-components/src/accordion/accordion.ts
@@ -1,7 +1,8 @@
-import { attr, FASTElement, Observable, observable, Updates } from '@microsoft/fast-element';
+import { attr, FASTElement, Observable, observable } from '@microsoft/fast-element';
 import { BaseAccordionItem } from '../accordion-item/accordion-item.base.js';
-import { waitForConnectedDescendants } from '../utils/request-idle-callback.js';
 import { isAccordionItem } from '../accordion-item/accordion-item.options.js';
+import { getUpgradedCustomElements, runAfterPendingDefinitions } from '../utils/custom-elements.js';
+import { waitForConnectedDescendants } from '../utils/request-idle-callback.js';
 import { AccordionExpandMode } from './accordion.options.js';
 
 /**
@@ -11,7 +12,7 @@ import { AccordionExpandMode } from './accordion.options.js';
  * @tag fluent-accordion
  *
  * @slot - The default slot for the accordion items
- * @fires { Event } change - Fires a custom 'change' event when the active item changes
+ * @fires change - Fires a custom 'change' event when the active item changes
  *
  * @public
  */
@@ -110,19 +111,26 @@ export class Accordion extends FASTElement {
    */
   private setItems = (): void => {
     waitForConnectedDescendants(this, () => {
-      if (!this.slottedAccordionItems?.length) {
+      if (this.slottedAccordionItems.length === 0) {
         return;
       }
 
-      // Get all existing children and remove event listeners
+      this.removeItemListeners(this.accordionItems ?? []);
+
       const children: Element[] = Array.from(this.children);
-      this.removeItemListeners(children);
+      const accordionItems = getUpgradedCustomElements(children, isAccordionItem);
+
+      runAfterPendingDefinitions(children, isAccordionItem, () => {
+        if (this.isConnected) {
+          this.setItems();
+        }
+      });
 
       // Resubscribe to the `disabled` attribute of all children
-      children.forEach((child: Element) => Observable.getNotifier(child).subscribe(this, 'disabled'));
+      accordionItems.forEach((child: Element) => Observable.getNotifier(child).subscribe(this, 'disabled'));
 
       // Add event listeners to each non-disabled AccordionItem
-      this.accordionItems = children.filter(child => !child.hasAttribute('disabled'));
+      this.accordionItems = accordionItems.filter(child => !child.hasAttribute('disabled'));
       this.accordionItems.forEach((item: Element, index: number) => {
         item.addEventListener('click', this.expandedChangedHandler);
         // Subscribe to the expanded attribute of the item

--- a/packages/web-components/src/listbox/listbox.spec.ts
+++ b/packages/web-components/src/listbox/listbox.spec.ts
@@ -148,3 +148,25 @@ test.describe('Listbox', () => {
     await expect(element).toHaveJSProperty('dropdown', undefined);
   });
 });
+
+test.describe('Listbox upgrade order', () => {
+  test('should apply multiple state when options upgrade after the listbox', async ({ fastPage }) => {
+    await fastPage.page.goto('/test/parent-child-upgrade-order.html');
+
+    const result = await fastPage.page.evaluate(async () => {
+      return (
+        window as unknown as {
+          runListboxUpgradeOrderTest(): Promise<{
+            firstOptionMultiple: boolean;
+            hasOwnMultiple: boolean;
+            optionsLength: number;
+          }>;
+        }
+      ).runListboxUpgradeOrderTest();
+    });
+
+    expect(result.optionsLength).toBe(3);
+    expect(result.firstOptionMultiple).toBe(true);
+    expect(result.hasOwnMultiple).toBe(false);
+  });
+});

--- a/packages/web-components/src/listbox/listbox.ts
+++ b/packages/web-components/src/listbox/listbox.ts
@@ -2,6 +2,7 @@ import { FASTElement, observable, Updates } from '@microsoft/fast-element';
 import type { BaseDropdown } from '../dropdown/dropdown.base.js';
 import type { DropdownOption } from '../option/option.js';
 import { isDropdownOption } from '../option/option.options.js';
+import { getUpgradedCustomElements, runAfterPendingDefinitions } from '../utils/custom-elements.js';
 import { toggleState } from '../utils/element-internals.js';
 import { waitForConnectedDescendants } from '../utils/request-idle-callback.js';
 import { uniqueId } from '../utils/unique-id.js';
@@ -83,6 +84,7 @@ export class Listbox extends FASTElement {
     next?.forEach((option, index) => {
       option.elementInternals.ariaPosInSet = `${index + 1}`;
       option.elementInternals.ariaSetSize = `${next.length}`;
+      option.multiple = !!this.multiple;
     });
   }
 
@@ -240,11 +242,16 @@ export class Listbox extends FASTElement {
   public slotchangeHandler(e?: Event): void {
     waitForConnectedDescendants(this, () => {
       if (this.defaultSlot) {
-        const options = this.defaultSlot
-          .assignedElements()
-          .filter<DropdownOption>((option): option is DropdownOption => isDropdownOption(option));
+        const assignedElements = this.defaultSlot.assignedElements();
+        const options = getUpgradedCustomElements(assignedElements, isDropdownOption);
 
         this.options = options;
+
+        runAfterPendingDefinitions(assignedElements, isDropdownOption, () => {
+          if (this.isConnected) {
+            this.slotchangeHandler();
+          }
+        });
       }
     });
   }

--- a/packages/web-components/src/listbox/listbox.ts
+++ b/packages/web-components/src/listbox/listbox.ts
@@ -2,6 +2,7 @@ import { FASTElement, observable, Updates } from '@microsoft/fast-element';
 import type { BaseDropdown } from '../dropdown/dropdown.base.js';
 import type { DropdownOption } from '../option/option.js';
 import { isDropdownOption } from '../option/option.options.js';
+import { getUpgradedCustomElements, runAfterPendingDefinitions } from '../utils/custom-elements.js';
 import { toggleState } from '../utils/element-internals.js';
 import { waitForConnectedDescendants } from '../utils/request-idle-callback.js';
 import { uniqueId } from '../utils/unique-id.js';
@@ -83,6 +84,7 @@ export class Listbox extends FASTElement {
     next?.forEach((option, index) => {
       option.elementInternals.ariaPosInSet = `${index + 1}`;
       option.elementInternals.ariaSetSize = `${next.length}`;
+      option.multiple = !!this.multiple;
     });
   }
 
@@ -244,11 +246,16 @@ export class Listbox extends FASTElement {
   public slotchangeHandler(e?: Event): void {
     waitForConnectedDescendants(this, () => {
       if (this.defaultSlot) {
-        const options = this.defaultSlot
-          .assignedElements()
-          .filter<DropdownOption>((option): option is DropdownOption => isDropdownOption(option));
+        const assignedElements = this.defaultSlot.assignedElements();
+        const options = getUpgradedCustomElements(assignedElements, isDropdownOption);
 
         this.options = options;
+
+        runAfterPendingDefinitions(assignedElements, isDropdownOption, () => {
+          if (this.isConnected) {
+            this.slotchangeHandler();
+          }
+        });
       }
     });
   }

--- a/packages/web-components/src/menu-list/menu-list.base.ts
+++ b/packages/web-components/src/menu-list/menu-list.base.ts
@@ -1,8 +1,9 @@
 import { FASTElement, Observable, observable, Updates } from '@microsoft/fast-element';
-import { isHTMLElement } from '../utils/typings.js';
 import type { MenuItemColumnCount } from '../menu-item/menu-item.js';
 import type { MenuItem } from '../menu-item/menu-item.js';
 import { isMenuItem, MenuItemRole } from '../menu-item/menu-item.options.js';
+import { isUpgradedCustomElement, runAfterPendingDefinitions } from '../utils/custom-elements.js';
+import { isHTMLElement } from '../utils/typings.js';
 
 /**
  * A Base MenuList Custom HTML Element.
@@ -49,11 +50,6 @@ export class BaseMenuList extends FASTElement {
    */
   public connectedCallback(): void {
     super.connectedCallback();
-
-    if (!this.slot && this.isNestedMenu()) {
-      this.slot = 'submenu';
-    }
-
     Updates.enqueue(() => {
       // wait until children have had a chance to
       // connect before setting/checking their props/attributes
@@ -112,7 +108,15 @@ export class BaseMenuList extends FASTElement {
       Observable.getNotifier(child).subscribe(this, 'hidden');
     });
 
-    this.menuChildren = children.filter(child => !child.hasAttribute('hidden'));
+    runAfterPendingDefinitions(children, isMenuItem, () => {
+      if (this.isConnected) {
+        this.setItems();
+      }
+    });
+
+    this.menuChildren = children.filter(
+      child => !child.hasAttribute('hidden') && (!isMenuItem(child) || isUpgradedCustomElement(child)),
+    );
 
     /**
      * Set the indent attribute on MenuItem elements based on their

--- a/packages/web-components/src/menu-list/menu-list.base.ts
+++ b/packages/web-components/src/menu-list/menu-list.base.ts
@@ -49,6 +49,11 @@ export class BaseMenuList extends FASTElement {
    */
   public connectedCallback(): void {
     super.connectedCallback();
+
+    if (!this.slot && this.isNestedMenu()) {
+      this.slot = 'submenu';
+    }
+
     Updates.enqueue(() => {
       // wait until children have had a chance to
       // connect before setting/checking their props/attributes

--- a/packages/web-components/src/menu-list/menu-list.base.ts
+++ b/packages/web-components/src/menu-list/menu-list.base.ts
@@ -1,8 +1,8 @@
 import { FASTElement, Observable, observable, Updates } from '@microsoft/fast-element';
-import { isHTMLElement } from '../utils/typings.js';
-import type { MenuItemColumnCount } from '../menu-item/menu-item.js';
 import type { MenuItem } from '../menu-item/menu-item.js';
 import { isMenuItem, MenuItemRole } from '../menu-item/menu-item.options.js';
+import { isUpgradedCustomElement, runAfterPendingDefinitions } from '../utils/custom-elements.js';
+import { isHTMLElement } from '../utils/typings.js';
 
 /**
  * A Base MenuList Custom HTML Element.
@@ -49,11 +49,6 @@ export class BaseMenuList extends FASTElement {
    */
   public connectedCallback(): void {
     super.connectedCallback();
-
-    if (!this.slot && this.isNestedMenu()) {
-      this.slot = 'submenu';
-    }
-
     Updates.enqueue(() => {
       // wait until children have had a chance to
       // connect before setting/checking their props/attributes
@@ -119,7 +114,15 @@ export class BaseMenuList extends FASTElement {
       Observable.getNotifier(child).subscribe(this, 'hidden');
     });
 
-    this.menuChildren = children.filter(child => !child.hasAttribute('hidden'));
+    runAfterPendingDefinitions(children, isMenuItem, () => {
+      if (this.isConnected) {
+        this.setItems();
+      }
+    });
+
+    this.menuChildren = children.filter(
+      child => !child.hasAttribute('hidden') && (!isMenuItem(child) || isUpgradedCustomElement(child)),
+    );
     this.menuItems = this.menuChildren?.filter(this.isMenuItemElement);
   }
 

--- a/packages/web-components/src/menu-list/menu-list.spec.ts
+++ b/packages/web-components/src/menu-list/menu-list.spec.ts
@@ -368,9 +368,9 @@ test.describe('MenuList', () => {
 
     await fastPage.setTemplate({
       innerHTML: /* html */ `
-        <${MenuItemTagName}
+        <${MenuItemTagName} role="menuitem"
           >Menu item 1
-          <${tagName} slot="submenu">
+          <${tagName}>
             <${MenuItemTagName}>Menu item 1.1</${MenuItemTagName}>
             <${MenuItemTagName}>Menu item 1.2</${MenuItemTagName}>
             <${MenuItemTagName}>Menu item 1.3</${MenuItemTagName}>
@@ -378,6 +378,8 @@ test.describe('MenuList', () => {
         </${MenuItemTagName}>
       `,
     });
+
+    await expect(element.nth(1)).toHaveAttribute('slot', 'submenu');
 
     await element.first().evaluate(node => {
       node.focus();

--- a/packages/web-components/src/radio-group/radio-group.base.ts
+++ b/packages/web-components/src/radio-group/radio-group.base.ts
@@ -1,13 +1,12 @@
-import { attr, FASTElement, Observable, observable } from '@microsoft/fast-element';
+import { attr, FASTElement, Observable, observable, Updates } from '@microsoft/fast-element';
 import type { Radio } from '../radio/radio.js';
 import { isRadio } from '../radio/radio.options.js';
+import { getUpgradedCustomElements, runAfterPendingDefinitions } from '../utils/custom-elements.js';
 import { RadioGroupOrientation } from './radio-group.options.js';
 
 /**
  * A Base Radio Group Custom HTML Element.
  * Implements the {@link https://w3c.github.io/aria/#radiogroup | ARIA `radiogroup` role}.
- *
- * @fires { Event } change - Fires a custom 'change' event when the checked radio changes
  *
  * @public
  */
@@ -227,7 +226,17 @@ export class BaseRadioGroup extends FASTElement {
    * @param next - the current slotted radios
    */
   slottedRadiosChanged(prev: Radio[] | undefined, next: Radio[]): void {
-    this.radios = [...this.querySelectorAll('*')].filter(x => isRadio(x)) as Radio[];
+    Updates.enqueue(() => {
+      const radioElements = [...this.querySelectorAll('*')].filter((element): element is Radio => isRadio(element));
+
+      this.radios = getUpgradedCustomElements(radioElements, isRadio);
+
+      runAfterPendingDefinitions(radioElements, isRadio, () => {
+        if (this.isConnected) {
+          this.radios = getUpgradedCustomElements([...this.querySelectorAll('*')], isRadio);
+        }
+      });
+    });
   }
 
   /**

--- a/packages/web-components/src/radio-group/radio-group.base.ts
+++ b/packages/web-components/src/radio-group/radio-group.base.ts
@@ -1,13 +1,12 @@
 import { attr, FASTElement, Observable, observable, Updates } from '@microsoft/fast-element';
 import type { Radio } from '../radio/radio.js';
 import { isRadio } from '../radio/radio.options.js';
+import { getUpgradedCustomElements, runAfterPendingDefinitions } from '../utils/custom-elements.js';
 import { RadioGroupOrientation } from './radio-group.options.js';
 
 /**
  * A Base Radio Group Custom HTML Element.
  * Implements the {@link https://w3c.github.io/aria/#radiogroup | ARIA `radiogroup` role}.
- *
- * @fires { Event } change - Fires a custom 'change' event when the checked radio changes
  *
  * @public
  */
@@ -228,7 +227,15 @@ export class BaseRadioGroup extends FASTElement {
    */
   slottedRadiosChanged(prev: Radio[] | undefined, next: Radio[]): void {
     Updates.enqueue(() => {
-      this.radios = [...this.querySelectorAll('*')].filter((x): x is Radio => isRadio(x));
+      const radioElements = [...this.querySelectorAll('*')].filter((element): element is Radio => isRadio(element));
+
+      this.radios = getUpgradedCustomElements(radioElements, isRadio);
+
+      runAfterPendingDefinitions(radioElements, isRadio, () => {
+        if (this.isConnected) {
+          this.radios = getUpgradedCustomElements([...this.querySelectorAll('*')], isRadio);
+        }
+      });
     });
   }
 

--- a/packages/web-components/src/radio-group/radio-group.spec.ts
+++ b/packages/web-components/src/radio-group/radio-group.spec.ts
@@ -792,3 +792,31 @@ test.describe('RadioGroup', () => {
     await expect(radios.nth(1)).toHaveJSProperty('checked', true);
   });
 });
+
+test.describe('RadioGroup upgrade order', () => {
+  test('should preserve checked state when radios upgrade after the radio group', async ({ fastPage }) => {
+    await fastPage.page.goto('/test/parent-child-upgrade-order.html');
+
+    const result = await fastPage.page.evaluate(async () => {
+      return (
+        window as unknown as {
+          runRadioGroupUpgradeOrderTest(): Promise<{
+            checkedRadioChecked: boolean;
+            checkedValue: string | null;
+            hasOwnChecked: boolean;
+            hasOwnCheckedBeforeUpgrade: boolean;
+            radiosLength: number;
+            radiosLengthBeforeUpgrade: number;
+          }>;
+        }
+      ).runRadioGroupUpgradeOrderTest();
+    });
+
+    expect(result.radiosLengthBeforeUpgrade).toBe(0);
+    expect(result.hasOwnCheckedBeforeUpgrade).toBe(false);
+    expect(result.radiosLength).toBe(3);
+    expect(result.checkedRadioChecked).toBe(true);
+    expect(result.checkedValue).toBe('banana');
+    expect(result.hasOwnChecked).toBe(false);
+  });
+});

--- a/packages/web-components/src/tree-item/tree-item.base.ts
+++ b/packages/web-components/src/tree-item/tree-item.base.ts
@@ -1,17 +1,8 @@
 import { attr, css, type ElementStyles, FASTElement, observable } from '@microsoft/fast-element';
 import { toggleState } from '../utils/element-internals.js';
-import { maybeSetAutoFocus } from '../utils/autofocus.js';
+import { getUpgradedCustomElements, runAfterPendingDefinitions } from '../utils/custom-elements.js';
 import { isTreeItem } from './tree-item.options.js';
 
-/**
- * Base class for Tree Item Custom HTML Element.
- * Based largely on the {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/li | `<li>`} element.
- *
- * @fires { ToggleEvent } toggle - Fires when the expanded state changes
- * @fires { Event } change - Fires when the selected state changes
- *
- * @public
- */
 export class BaseTreeItem extends FASTElement {
   /**
    * The internal {@link https://developer.mozilla.org/docs/Web/API/ElementInternals | `ElementInternals`} instance for the component.
@@ -39,18 +30,6 @@ export class BaseTreeItem extends FASTElement {
     this.elementInternals.role = 'treeitem';
   }
 
-  connectedCallback(): void {
-    super.connectedCallback();
-
-    this.tabIndex = Number(this.getAttribute('tabindex') || '0');
-
-    if (isTreeItem(this.parentElement)) {
-      this.slot ||= 'item';
-    }
-
-    maybeSetAutoFocus(this);
-  }
-
   /**
    * When true, the control will be appear expanded by user interaction.
    * When true, the control will be appear expanded by user interaction.
@@ -75,7 +54,7 @@ export class BaseTreeItem extends FASTElement {
       newState: next ? 'open' : 'closed',
     });
     toggleState(this.elementInternals, 'expanded', next);
-    if (this.childTreeItems?.length) {
+    if (this.childTreeItems && this.childTreeItems.length > 0) {
       this.elementInternals.ariaExpanded = next ? 'true' : 'false';
       // Update focusgroup attributes after subtree show/hide rendering is done.
       requestAnimationFrame(() => {
@@ -115,11 +94,8 @@ export class BaseTreeItem extends FASTElement {
    */
   protected selectedChanged(prev: boolean, next: boolean): void {
     this.$emit('change');
-
-    if (this.elementInternals) {
-      toggleState(this.elementInternals, 'selected', next);
-      this.elementInternals.ariaSelected = next ? 'true' : 'false';
-    }
+    toggleState(this.elementInternals, 'selected', next);
+    this.elementInternals.ariaSelected = next ? 'true' : 'false';
   }
 
   /**
@@ -235,6 +211,14 @@ export class BaseTreeItem extends FASTElement {
 
   /** @internal */
   public handleItemSlotChange() {
-    this.childTreeItems = this.itemSlot.assignedElements().filter(el => isTreeItem(el));
+    const assignedElements = this.itemSlot.assignedElements();
+
+    this.childTreeItems = getUpgradedCustomElements(assignedElements, isTreeItem);
+
+    runAfterPendingDefinitions(assignedElements, isTreeItem, () => {
+      if (this.isConnected) {
+        this.handleItemSlotChange();
+      }
+    });
   }
 }

--- a/packages/web-components/src/tree-item/tree-item.base.ts
+++ b/packages/web-components/src/tree-item/tree-item.base.ts
@@ -1,17 +1,8 @@
 import { attr, css, type ElementStyles, FASTElement, observable } from '@microsoft/fast-element';
 import { toggleState } from '../utils/element-internals.js';
-import { maybeSetAutoFocus } from '../utils/autofocus.js';
+import { getUpgradedCustomElements, runAfterPendingDefinitions } from '../utils/custom-elements.js';
 import { isTreeItem } from './tree-item.options.js';
 
-/**
- * Base class for Tree Item Custom HTML Element.
- * Based largely on the {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/li | `<li>`} element.
- *
- * @fires { ToggleEvent } toggle - Fires when the expanded state changes
- * @fires { Event } change - Fires when the selected state changes
- *
- * @public
- */
 export class BaseTreeItem extends FASTElement {
   /**
    * The internal {@link https://developer.mozilla.org/docs/Web/API/ElementInternals | `ElementInternals`} instance for the component.
@@ -39,18 +30,6 @@ export class BaseTreeItem extends FASTElement {
     this.elementInternals.role = 'treeitem';
   }
 
-  connectedCallback(): void {
-    super.connectedCallback();
-
-    this.tabIndex = Number(this.getAttribute('tabindex') || '0');
-
-    if (isTreeItem(this.parentElement)) {
-      this.slot ||= 'item';
-    }
-
-    maybeSetAutoFocus(this);
-  }
-
   /**
    * When true, the control will be appear expanded by user interaction.
    * When true, the control will be appear expanded by user interaction.
@@ -75,7 +54,7 @@ export class BaseTreeItem extends FASTElement {
       newState: next ? 'open' : 'closed',
     });
     toggleState(this.elementInternals, 'expanded', next);
-    if (this.childTreeItems?.length) {
+    if (this.childTreeItems && this.childTreeItems.length > 0) {
       this.elementInternals.ariaExpanded = next ? 'true' : 'false';
       // Update focusgroup attributes after subtree show/hide rendering is done.
       requestAnimationFrame(() => {
@@ -115,11 +94,8 @@ export class BaseTreeItem extends FASTElement {
    */
   protected selectedChanged(prev: boolean, next: boolean): void {
     this.$emit('change');
-
-    if (this.elementInternals) {
-      toggleState(this.elementInternals, 'selected', next);
-      this.elementInternals.ariaSelected = next ? 'true' : 'false';
-    }
+    toggleState(this.elementInternals, 'selected', next);
+    this.elementInternals.ariaSelected = next ? 'true' : 'false';
   }
 
   /**
@@ -199,6 +175,14 @@ export class BaseTreeItem extends FASTElement {
 
   /** @internal */
   public handleItemSlotChange() {
-    this.childTreeItems = this.itemSlot.assignedElements().filter(el => isTreeItem(el));
+    const assignedElements = this.itemSlot.assignedElements();
+
+    this.childTreeItems = getUpgradedCustomElements(assignedElements, isTreeItem);
+
+    runAfterPendingDefinitions(assignedElements, isTreeItem, () => {
+      if (this.isConnected) {
+        this.handleItemSlotChange();
+      }
+    });
   }
 }

--- a/packages/web-components/src/tree-item/tree-item.base.ts
+++ b/packages/web-components/src/tree-item/tree-item.base.ts
@@ -1,6 +1,7 @@
 import { attr, css, type ElementStyles, FASTElement, observable } from '@microsoft/fast-element';
-import { toggleState } from '../utils/element-internals.js';
+import { maybeSetAutoFocus } from '../utils/autofocus.js';
 import { getUpgradedCustomElements, runAfterPendingDefinitions } from '../utils/custom-elements.js';
+import { toggleState } from '../utils/element-internals.js';
 import { isTreeItem } from './tree-item.options.js';
 
 export class BaseTreeItem extends FASTElement {
@@ -28,6 +29,18 @@ export class BaseTreeItem extends FASTElement {
   constructor() {
     super();
     this.elementInternals.role = 'treeitem';
+  }
+
+  connectedCallback(): void {
+    super.connectedCallback();
+
+    this.tabIndex = Number(this.getAttribute('tabindex') || '0');
+
+    if (isTreeItem(this.parentElement)) {
+      this.slot ||= 'item';
+    }
+
+    maybeSetAutoFocus(this);
   }
 
   /**

--- a/packages/web-components/src/tree/tree.base.ts
+++ b/packages/web-components/src/tree/tree.base.ts
@@ -1,6 +1,7 @@
 import { FASTElement, observable } from '@microsoft/fast-element';
 import type { BaseTreeItem } from '../tree-item/tree-item.base.js';
 import { isTreeItem } from '../tree-item/tree-item.options.js';
+import { getUpgradedCustomElements, runAfterPendingDefinitions } from '../utils/custom-elements.js';
 
 export class BaseTree extends FASTElement {
   /**
@@ -160,7 +161,15 @@ export class BaseTree extends FASTElement {
 
   /** @internal */
   public handleDefaultSlotChange() {
-    this.childTreeItems = this.defaultSlot.assignedElements().filter(el => isTreeItem(el));
+    const assignedElements = this.defaultSlot.assignedElements();
+
+    this.childTreeItems = getUpgradedCustomElements(assignedElements, isTreeItem);
+
+    runAfterPendingDefinitions(assignedElements, isTreeItem, () => {
+      if (this.isConnected) {
+        this.handleDefaultSlotChange();
+      }
+    });
   }
 
   /**

--- a/packages/web-components/src/tree/tree.spec.ts
+++ b/packages/web-components/src/tree/tree.spec.ts
@@ -424,3 +424,27 @@ test.describe('Tree', () => {
     await expect(treeItems.nth(2)).toBeFocused();
   });
 });
+
+test.describe('Tree upgrade order', () => {
+  test('should apply tree state when tree items upgrade after the tree', async ({ fastPage }) => {
+    await fastPage.page.goto('/test/parent-child-upgrade-order.html');
+
+    const result = await fastPage.page.evaluate(async () => {
+      return (
+        window as unknown as {
+          runTreeUpgradeOrderTest(): Promise<{
+            childTreeItemsLength: number;
+            currentSelectedLocalName: string | undefined;
+            firstItemSize: string;
+            hasOwnSize: boolean;
+          }>;
+        }
+      ).runTreeUpgradeOrderTest();
+    });
+
+    expect(result.childTreeItemsLength).toBe(2);
+    expect(result.currentSelectedLocalName).toContain('tree-item');
+    expect(result.firstItemSize).toBe('medium');
+    expect(result.hasOwnSize).toBe(false);
+  });
+});

--- a/packages/web-components/src/tree/tree.spec.ts
+++ b/packages/web-components/src/tree/tree.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '../../test/playwright/index.js';
+import type { TreeItem } from '../tree-item/tree-item.js';
 import { tagName as TreeItemTagName } from '../tree-item/tree-item.options.js';
 import { tagName } from './tree.options.js';
 
@@ -62,6 +63,8 @@ test.describe('Tree', () => {
     await expect(treeItems).toHaveCount(4);
     const nestedItems = treeItems.nth(0).locator(TreeItemTagName);
     await expect(nestedItems).toHaveCount(1);
+    await expect(nestedItems).toHaveAttribute('slot', 'item');
+    await expect.poll(() => treeItems.nth(0).evaluate((node: TreeItem) => node.childTreeItems?.length ?? 0)).toBe(1);
   });
 
   test('works with size variants - small', async ({ fastPage }) => {

--- a/packages/web-components/src/utils/custom-elements.ts
+++ b/packages/web-components/src/utils/custom-elements.ts
@@ -1,0 +1,41 @@
+type ElementPredicate<T extends Element> = (element: Element) => element is T;
+
+/**
+ * Returns true once FAST has upgraded the element instance.
+ */
+export function isUpgradedCustomElement(element: Element): boolean {
+  return '$fastController' in element;
+}
+
+/**
+ * Filters matching custom elements down to instances that have finished upgrading.
+ */
+export function getUpgradedCustomElements<T extends Element>(
+  elements: readonly Element[],
+  predicate: ElementPredicate<T>,
+): T[] {
+  return elements.filter((element): element is T => predicate(element) && isUpgradedCustomElement(element));
+}
+
+/**
+ * Runs a callback after all matching, still-pending custom element tag definitions resolve.
+ */
+export function runAfterPendingDefinitions<T extends Element>(
+  elements: readonly Element[],
+  predicate: ElementPredicate<T>,
+  callback: () => void,
+): void {
+  const pendingTagNames = [
+    ...new Set(
+      elements
+        .filter(element => predicate(element) && !isUpgradedCustomElement(element))
+        .map(element => element.localName),
+    ),
+  ];
+
+  if (pendingTagNames.length === 0) {
+    return;
+  }
+
+  Promise.all(pendingTagNames.map(tagName => customElements.whenDefined(tagName))).then(callback);
+}

--- a/packages/web-components/test/parent-child-upgrade-order.html
+++ b/packages/web-components/test/parent-child-upgrade-order.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Parent child upgrade order</title>
+    <script type="module" src="/src/parent-child-upgrade-order.js"></script>
+  </head>
+  <body></body>
+</html>

--- a/packages/web-components/test/src/parent-child-upgrade-order.ts
+++ b/packages/web-components/test/src/parent-child-upgrade-order.ts
@@ -1,0 +1,134 @@
+import { Listbox } from '../../src/listbox/listbox.js';
+import { styles as listboxStyles } from '../../src/listbox/listbox.styles.js';
+import { template as listboxTemplate } from '../../src/listbox/listbox.template.js';
+import { DropdownOption } from '../../src/option/option.js';
+import { styles as optionStyles } from '../../src/option/option.styles.js';
+import { template as optionTemplate } from '../../src/option/option.template.js';
+import { TreeItem } from '../../src/tree-item/tree-item.js';
+import { styles as treeItemStyles } from '../../src/tree-item/tree-item.styles.js';
+import { template as treeItemTemplate } from '../../src/tree-item/tree-item.template.js';
+import { Tree } from '../../src/tree/tree.js';
+import { styles as treeStyles } from '../../src/tree/tree.styles.js';
+import { template as treeTemplate } from '../../src/tree/tree.template.js';
+
+type ListboxUpgradeOrderResult = {
+  firstOptionMultiple: boolean;
+  hasOwnMultiple: boolean;
+  optionsLength: number;
+};
+
+type TreeUpgradeOrderResult = {
+  childTreeItemsLength: number;
+  currentSelectedLocalName: string | undefined;
+  firstItemSize: string;
+  hasOwnSize: boolean;
+};
+
+const nextFrame = () => new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+
+(
+  window as unknown as {
+    runListboxUpgradeOrderTest(): Promise<ListboxUpgradeOrderResult>;
+  }
+).runListboxUpgradeOrderTest = async () => {
+  const id = Date.now().toString(36);
+  const listboxTagName = `upgrade-${id}-listbox`;
+  const optionTagName = `upgrade-${id}-option`;
+
+  document.body.innerHTML = `
+    <${listboxTagName}>
+      <${optionTagName}>Apple</${optionTagName}>
+      <${optionTagName}>Banana</${optionTagName}>
+      <${optionTagName}>Orange</${optionTagName}>
+    </${listboxTagName}>
+  `;
+
+  Listbox.compose({
+    name: listboxTagName,
+    template: listboxTemplate,
+    styles: listboxStyles,
+  }).define(customElements);
+
+  const listbox = document.querySelector<Listbox>(listboxTagName);
+  if (!listbox) {
+    throw new Error('Expected listbox to exist.');
+  }
+
+  customElements.upgrade(listbox);
+  listbox.multiple = true;
+
+  DropdownOption.compose({
+    name: optionTagName,
+    template: optionTemplate,
+    styles: optionStyles,
+  }).define(customElements);
+
+  await customElements.whenDefined(listboxTagName);
+  await customElements.whenDefined(optionTagName);
+  await nextFrame();
+  await nextFrame();
+
+  const firstOption = document.querySelector<DropdownOption>(optionTagName);
+  if (!firstOption) {
+    throw new Error('Expected option to exist.');
+  }
+
+  return {
+    firstOptionMultiple: firstOption.multiple,
+    hasOwnMultiple: Object.prototype.hasOwnProperty.call(firstOption, 'multiple'),
+    optionsLength: listbox.options.length,
+  };
+};
+
+(
+  window as unknown as {
+    runTreeUpgradeOrderTest(): Promise<TreeUpgradeOrderResult>;
+  }
+).runTreeUpgradeOrderTest = async () => {
+  const id = Date.now().toString(36);
+  const treeTagName = `upgrade-${id}-tree`;
+  const treeItemTagName = `upgrade-${id}-tree-item`;
+
+  document.body.innerHTML = `
+    <${treeTagName} size="medium">
+      <${treeItemTagName} selected>One</${treeItemTagName}>
+      <${treeItemTagName}>Two</${treeItemTagName}>
+    </${treeTagName}>
+  `;
+
+  Tree.compose({
+    name: treeTagName,
+    template: treeTemplate,
+    styles: treeStyles,
+  }).define(customElements);
+
+  const tree = document.querySelector<Tree>(treeTagName);
+  if (!tree) {
+    throw new Error('Expected tree to exist.');
+  }
+
+  customElements.upgrade(tree);
+
+  TreeItem.compose({
+    name: treeItemTagName,
+    template: treeItemTemplate,
+    styles: treeItemStyles,
+  }).define(customElements);
+
+  await customElements.whenDefined(treeTagName);
+  await customElements.whenDefined(treeItemTagName);
+  await nextFrame();
+  await nextFrame();
+
+  const firstItem = document.querySelector<TreeItem>(treeItemTagName);
+  if (!firstItem) {
+    throw new Error('Expected tree item to exist.');
+  }
+
+  return {
+    childTreeItemsLength: tree.childTreeItems.length,
+    currentSelectedLocalName: tree.currentSelected?.localName,
+    firstItemSize: firstItem.size,
+    hasOwnSize: Object.prototype.hasOwnProperty.call(firstItem, 'size'),
+  };
+};

--- a/packages/web-components/test/src/parent-child-upgrade-order.ts
+++ b/packages/web-components/test/src/parent-child-upgrade-order.ts
@@ -1,0 +1,138 @@
+import { Listbox } from '../../src/listbox/listbox.js';
+import { styles as listboxStyles } from '../../src/listbox/listbox.styles.js';
+import { template as listboxTemplate } from '../../src/listbox/listbox.template.js';
+import { DropdownOption } from '../../src/option/option.js';
+import { styles as optionStyles } from '../../src/option/option.styles.js';
+import { template as optionTemplate } from '../../src/option/option.template.js';
+import { TreeItem } from '../../src/tree-item/tree-item.js';
+import { styles as treeItemStyles } from '../../src/tree-item/tree-item.styles.js';
+import { template as treeItemTemplate } from '../../src/tree-item/tree-item.template.js';
+import { Tree } from '../../src/tree/tree.js';
+import { styles as treeStyles } from '../../src/tree/tree.styles.js';
+import { template as treeTemplate } from '../../src/tree/tree.template.js';
+
+type ListboxUpgradeOrderResult = {
+  firstOptionMultiple: boolean;
+  hasOwnMultiple: boolean;
+  optionsLength: number;
+};
+
+type TreeUpgradeOrderResult = {
+  childTreeItemsLength: number;
+  currentSelectedLocalName: string | undefined;
+  firstItemSize: string;
+  hasOwnSize: boolean;
+};
+
+const nextFrame = () => new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+
+(
+  window as unknown as {
+    runListboxUpgradeOrderTest(): Promise<ListboxUpgradeOrderResult>;
+  }
+).runListboxUpgradeOrderTest = async () => {
+  const id = Date.now().toString(36);
+  const listboxTagName = `upgrade-${id}-listbox`;
+  const optionTagName = `upgrade-${id}-option`;
+
+  document.body.innerHTML = `
+    <${listboxTagName}>
+      <${optionTagName}>Apple</${optionTagName}>
+      <${optionTagName}>Banana</${optionTagName}>
+      <${optionTagName}>Orange</${optionTagName}>
+    </${listboxTagName}>
+  `;
+
+  await Listbox.define({
+    name: listboxTagName,
+    registry: customElements,
+    template: listboxTemplate,
+    styles: listboxStyles,
+  });
+
+  const listbox = document.querySelector<Listbox>(listboxTagName);
+  if (!listbox) {
+    throw new Error('Expected listbox to exist.');
+  }
+
+  customElements.upgrade(listbox);
+  listbox.multiple = true;
+
+  await DropdownOption.define({
+    name: optionTagName,
+    registry: customElements,
+    template: optionTemplate,
+    styles: optionStyles,
+  });
+
+  await customElements.whenDefined(listboxTagName);
+  await customElements.whenDefined(optionTagName);
+  await nextFrame();
+  await nextFrame();
+
+  const firstOption = document.querySelector<DropdownOption>(optionTagName);
+  if (!firstOption) {
+    throw new Error('Expected option to exist.');
+  }
+
+  return {
+    firstOptionMultiple: firstOption.multiple,
+    hasOwnMultiple: Object.prototype.hasOwnProperty.call(firstOption, 'multiple'),
+    optionsLength: listbox.options.length,
+  };
+};
+
+(
+  window as unknown as {
+    runTreeUpgradeOrderTest(): Promise<TreeUpgradeOrderResult>;
+  }
+).runTreeUpgradeOrderTest = async () => {
+  const id = Date.now().toString(36);
+  const treeTagName = `upgrade-${id}-tree`;
+  const treeItemTagName = `upgrade-${id}-tree-item`;
+
+  document.body.innerHTML = `
+    <${treeTagName} size="medium">
+      <${treeItemTagName} selected>One</${treeItemTagName}>
+      <${treeItemTagName}>Two</${treeItemTagName}>
+    </${treeTagName}>
+  `;
+
+  await Tree.define({
+    name: treeTagName,
+    registry: customElements,
+    template: treeTemplate,
+    styles: treeStyles,
+  });
+
+  const tree = document.querySelector<Tree>(treeTagName);
+  if (!tree) {
+    throw new Error('Expected tree to exist.');
+  }
+
+  customElements.upgrade(tree);
+
+  await TreeItem.define({
+    name: treeItemTagName,
+    registry: customElements,
+    template: treeItemTemplate,
+    styles: treeItemStyles,
+  });
+
+  await customElements.whenDefined(treeTagName);
+  await customElements.whenDefined(treeItemTagName);
+  await nextFrame();
+  await nextFrame();
+
+  const firstItem = document.querySelector<TreeItem>(treeItemTagName);
+  if (!firstItem) {
+    throw new Error('Expected tree item to exist.');
+  }
+
+  return {
+    childTreeItemsLength: tree.childTreeItems.length,
+    currentSelectedLocalName: tree.currentSelected?.localName,
+    firstItemSize: firstItem.size,
+    hasOwnSize: Object.prototype.hasOwnProperty.call(firstItem, 'size'),
+  };
+};

--- a/packages/web-components/test/src/parent-child-upgrade-order.ts
+++ b/packages/web-components/test/src/parent-child-upgrade-order.ts
@@ -4,6 +4,12 @@ import { template as listboxTemplate } from '../../src/listbox/listbox.template.
 import { DropdownOption } from '../../src/option/option.js';
 import { styles as optionStyles } from '../../src/option/option.styles.js';
 import { template as optionTemplate } from '../../src/option/option.template.js';
+import { RadioGroup } from '../../src/radio-group/radio-group.js';
+import { styles as radioGroupStyles } from '../../src/radio-group/radio-group.styles.js';
+import { template as radioGroupTemplate } from '../../src/radio-group/radio-group.template.js';
+import { Radio } from '../../src/radio/radio.js';
+import { styles as radioStyles } from '../../src/radio/radio.styles.js';
+import { template as radioTemplate } from '../../src/radio/radio.template.js';
 import { TreeItem } from '../../src/tree-item/tree-item.js';
 import { styles as treeItemStyles } from '../../src/tree-item/tree-item.styles.js';
 import { template as treeItemTemplate } from '../../src/tree-item/tree-item.template.js';
@@ -15,6 +21,15 @@ type ListboxUpgradeOrderResult = {
   firstOptionMultiple: boolean;
   hasOwnMultiple: boolean;
   optionsLength: number;
+};
+
+type RadioGroupUpgradeOrderResult = {
+  checkedRadioChecked: boolean;
+  checkedValue: string | null;
+  hasOwnChecked: boolean;
+  hasOwnCheckedBeforeUpgrade: boolean;
+  radiosLength: number;
+  radiosLengthBeforeUpgrade: number;
 };
 
 type TreeUpgradeOrderResult = {
@@ -79,6 +94,69 @@ const nextFrame = () => new Promise<void>(resolve => requestAnimationFrame(() =>
     firstOptionMultiple: firstOption.multiple,
     hasOwnMultiple: Object.prototype.hasOwnProperty.call(firstOption, 'multiple'),
     optionsLength: listbox.options.length,
+  };
+};
+
+(
+  window as unknown as {
+    runRadioGroupUpgradeOrderTest(): Promise<RadioGroupUpgradeOrderResult>;
+  }
+).runRadioGroupUpgradeOrderTest = async () => {
+  const id = Date.now().toString(36);
+  const radioGroupTagName = `upgrade-${id}-radio-group`;
+  const radioTagName = `upgrade-${id}-radio`;
+
+  document.body.innerHTML = `
+    <${radioGroupTagName}>
+      <${radioTagName} value="apple">Apple</${radioTagName}>
+      <${radioTagName} value="banana" checked>Banana</${radioTagName}>
+      <${radioTagName} value="orange">Orange</${radioTagName}>
+    </${radioGroupTagName}>
+  `;
+
+  await RadioGroup.define({
+    name: radioGroupTagName,
+    registry: customElements,
+    template: radioGroupTemplate,
+    styles: radioGroupStyles,
+  });
+
+  const radioGroup = document.querySelector<RadioGroup>(radioGroupTagName);
+  const pendingCheckedRadio = document.querySelector<HTMLElement>(`${radioTagName}[checked]`);
+  if (!radioGroup || !pendingCheckedRadio) {
+    throw new Error('Expected radio group and checked radio to exist.');
+  }
+
+  customElements.upgrade(radioGroup);
+  await nextFrame();
+
+  const radiosLengthBeforeUpgrade = radioGroup.radios?.length ?? 0;
+  const hasOwnCheckedBeforeUpgrade = Object.prototype.hasOwnProperty.call(pendingCheckedRadio, 'checked');
+
+  await Radio.define({
+    name: radioTagName,
+    registry: customElements,
+    template: radioTemplate,
+    styles: radioStyles,
+  });
+
+  await customElements.whenDefined(radioGroupTagName);
+  await customElements.whenDefined(radioTagName);
+  await nextFrame();
+  await nextFrame();
+
+  const checkedRadio = radioGroup.radios.find(radio => radio.value === 'banana');
+  if (!checkedRadio) {
+    throw new Error('Expected checked radio to exist.');
+  }
+
+  return {
+    checkedRadioChecked: checkedRadio.checked,
+    checkedValue: radioGroup.value,
+    hasOwnChecked: radioGroup.radios.some(radio => Object.prototype.hasOwnProperty.call(radio, 'checked')),
+    hasOwnCheckedBeforeUpgrade,
+    radiosLength: radioGroup.radios.length,
+    radiosLengthBeforeUpgrade,
   };
 };
 


### PR DESCRIPTION
## Previous Behavior

Parent components could collect matching child tags before those child custom elements had upgraded. When the parent then wrote child state, those writes could create own properties on bare `HTMLElement` instances and shadow the eventual component accessors.

The reported RadioGroup case created an own `checked` property on pending radios, but the same parent/child collection pattern exists across Accordion/AccordionItem, Listbox/Option, MenuList/MenuItem, and Tree/TreeItem.

## New Behavior

Parent collection now goes through a shared upgraded-custom-element helper. Matching child tags are ignored until FAST has upgraded them, and the parent refreshes its collection once any matching pending tag definitions resolve.

This is wired into RadioGroup, Accordion, Listbox, MenuList, Tree, and TreeItem. Listbox also reapplies its current `multiple` state when options are collected after upgrade.

The regression fixture forces parent tags to upgrade before child tags and verifies:

- RadioGroup preserves checked state without an own `checked` shadow property.
- Listbox applies `multiple` to options after they upgrade without an own `multiple` shadow property.
- Tree applies `size` to tree items after they upgrade without an own `size` shadow property.

## Tests run

- `corepack yarn type-check` from `packages/web-components`
- `corepack yarn eslint src/accordion/accordion.ts src/listbox/listbox.ts src/listbox/listbox.spec.ts src/menu-list/menu-list.base.ts src/radio-group/radio-group.base.ts src/tree/tree.base.ts src/tree/tree.spec.ts src/tree-item/tree-item.base.ts src/utils/custom-elements.ts test/src/parent-child-upgrade-order.ts` from `packages/web-components`
- `corepack yarn e2e src/radio-group/radio-group.spec.ts src/listbox/listbox.spec.ts src/tree/tree.spec.ts --project=chromium -g "upgrade order"` from `packages/web-components`
- `corepack yarn e2e src/accordion/accordion.spec.ts src/listbox/listbox.spec.ts src/menu-list/menu-list.spec.ts src/radio-group/radio-group.spec.ts src/tree/tree.spec.ts --project=chromium --workers=1` from `packages/web-components`
- `corepack yarn prettier --check packages/web-components/src/accordion/accordion.ts packages/web-components/src/listbox/listbox.ts packages/web-components/src/listbox/listbox.spec.ts packages/web-components/src/menu-list/menu-list.base.ts packages/web-components/src/radio-group/radio-group.base.ts packages/web-components/src/tree/tree.base.ts packages/web-components/src/tree/tree.spec.ts packages/web-components/src/tree-item/tree-item.base.ts packages/web-components/src/utils/custom-elements.ts packages/web-components/test/parent-child-upgrade-order.html packages/web-components/test/src/parent-child-upgrade-order.ts`
- `corepack yarn check:change`
- `git diff --check`

## Related Issue(s)

- Fixes #36239