### PR TITLE
fix(react-headless-components-preview): descendant clicks no longer trigger dialog backdrop dismissal

### DIFF
--- a/change/@fluentui-react-headless-components-preview-4d18c2b1-55ef-4149-bfc7-e30efaac9d70.json
+++ b/change/@fluentui-react-headless-components-preview-4d18c2b1-55ef-4149-bfc7-e30efaac9d70.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "fix(react-headless-components-preview): descendant clicks no longer trigger Dialog backdrop dismissal",
+  "comment": "fix: descendant clicks no longer trigger Dialog backdrop dismissal",
   "packageName": "@fluentui/react-headless-components-preview",
   "email": "vgenaev@gmail.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-headless-components-preview-4d18c2b1-55ef-4149-bfc7-e30efaac9d70.json
+++ b/change/@fluentui-react-headless-components-preview-4d18c2b1-55ef-4149-bfc7-e30efaac9d70.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(react-headless-components-preview): descendant clicks no longer trigger Dialog backdrop dismissal",
+  "packageName": "@fluentui/react-headless-components-preview",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-headless-components-preview/library/src/components/Dialog/Dialog.cy.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Dialog/Dialog.cy.tsx
@@ -7,7 +7,8 @@ import { Dialog, DialogActions, DialogBody, DialogSurface, DialogTitle, DialogTr
 import type { DialogProps, DialogSurfaceProps } from '.';
 import { Button } from '../Button';
 import { Provider } from '../Provider';
-import { Popover, PopoverSurface, PopoverTrigger } from '../Popover';
+// TODO: replace with headless alternatives when available
+import { Popover, PopoverSurface, PopoverTrigger } from '@fluentui/react-popover';
 import { Tooltip } from '@fluentui/react-tooltip';
 import { Menu, MenuItem, MenuList, MenuPopover, MenuTrigger } from '@fluentui/react-menu';
 
@@ -255,7 +256,12 @@ describe('Dialog', () => {
 
   describe('backdrop click (modal)', () => {
     it('should close when the backdrop is clicked', () => {
-      mount(<BasicDialog modalType="modal" surfaceProps={{ id: 'dialog-surface' }} />);
+      // Constrain the dialog so that `realClick({ x: -10, y: -10 })` lands inside
+      // the iframe viewport — without explicit dimensions the dialog spans nearly
+      // the full 500px width and the negative-offset click would go off-screen.
+      mount(
+        <BasicDialog modalType="modal" surfaceProps={{ id: 'dialog-surface', style: { width: 200, height: 100 } }} />,
+      );
       cy.get(dialogTriggerOpenSelector).realClick();
       cy.get(dialogSurfaceSelector).should('exist');
 

--- a/packages/react-components/react-headless-components-preview/library/src/components/Dialog/Dialog.cy.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Dialog/Dialog.cy.tsx
@@ -7,8 +7,7 @@ import { Dialog, DialogActions, DialogBody, DialogSurface, DialogTitle, DialogTr
 import type { DialogProps, DialogSurfaceProps } from '.';
 import { Button } from '../Button';
 import { Provider } from '../Provider';
-// TODO: replace with headless alternatives when available
-import { Popover, PopoverSurface, PopoverTrigger } from '@fluentui/react-popover';
+import { Popover, PopoverSurface, PopoverTrigger } from '../Popover';
 import { Tooltip } from '@fluentui/react-tooltip';
 import { Menu, MenuItem, MenuList, MenuPopover, MenuTrigger } from '@fluentui/react-menu';
 
@@ -254,6 +253,51 @@ describe('Dialog', () => {
     });
   });
 
+  describe('backdrop click (modal)', () => {
+    it('should close when the backdrop is clicked', () => {
+      mount(<BasicDialog modalType="modal" surfaceProps={{ id: 'dialog-surface' }} />);
+      cy.get(dialogTriggerOpenSelector).realClick();
+      cy.get(dialogSurfaceSelector).should('exist');
+
+      cy.get(dialogSurfaceSelector).realClick({ x: -10, y: -10 });
+      cy.get(dialogSurfaceSelector).should('not.exist');
+    });
+
+    it('should not close when a descendant button receives a keyboard click', () => {
+      mount(<BasicDialog modalType="modal" />);
+      cy.get(dialogTriggerOpenSelector).realClick();
+      cy.get(dialogPrimaryButtonSelector).focus().realType('{enter}');
+      cy.get(dialogSurfaceSelector).should('exist');
+    });
+
+    it('should not close when clicking inside a portaled Popover descendant', () => {
+      mount(
+        <Dialog modalType="modal">
+          <DialogTrigger>
+            <Button id={dialogTriggerOpenId}>Open dialog</Button>
+          </DialogTrigger>
+          <DialogSurface>
+            <DialogBody>
+              <DialogTitle>Dialog title</DialogTitle>
+              <Popover>
+                <PopoverTrigger disableButtonEnhancement>
+                  <Button id="popover-trigger-btn">Toggle popover</Button>
+                </PopoverTrigger>
+                <PopoverSurface aria-label="popover">
+                  <Button id="popover-inner-btn">Inner action</Button>
+                </PopoverSurface>
+              </Popover>
+            </DialogBody>
+          </DialogSurface>
+        </Dialog>,
+      );
+      cy.get(dialogTriggerOpenSelector).realClick();
+      cy.get('#popover-trigger-btn').realClick();
+      cy.get('#popover-inner-btn').should('be.visible').realClick();
+      cy.get(dialogSurfaceSelector).should('exist');
+    });
+  });
+
   describe('modalType = non-modal', () => {
     it('should be able to focus inside non-modal dialog after navigating outside', () => {
       mount(
@@ -321,10 +365,7 @@ describe('Dialog', () => {
     cy.get(dialogSurfaceSelector).should('have.length', 1);
     cy.get('#open-second-dialog-btn').should('exist').realClick();
     cy.get(dialogSurfaceSelector).should('have.length', 2);
-    // Use Escape to close only the top-most nested dialog.
-    // Clicking inside nested modal dialogs can be interpreted as a backdrop click
-    // by the parent native <dialog> in some browsers.
-    cy.get('#close-second-dialog-btn').should('exist').focus().realType('{esc}');
+    cy.get('#close-second-dialog-btn').should('exist').realClick();
     cy.get(dialogSurfaceSelector).should('have.length', 1);
     cy.get('#close-first-dialog-btn').should('exist').realClick();
     cy.get(dialogSurfaceSelector).should('not.exist');

--- a/packages/react-components/react-headless-components-preview/library/src/components/Dialog/DialogSurface/useDialogSurface.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Dialog/DialogSurface/useDialogSurface.ts
@@ -126,17 +126,23 @@ export const useDialogSurface = (props: DialogSurfaceProps, ref: React.Ref<HTMLD
   // the user clicks the backdrop (outside the dialog content bounding rect).
   const handleClick = useEventCallback((event: React.MouseEvent<HTMLDialogElement>) => {
     props.onClick?.(event);
-    if (modalType === 'modal' && !event.isDefaultPrevented()) {
-      const rect = event.currentTarget.getBoundingClientRect();
-      const isBackdropClick =
-        event.clientX < rect.left ||
-        event.clientX > rect.right ||
-        event.clientY < rect.top ||
-        event.clientY > rect.bottom;
+    if (modalType !== 'modal' || event.isDefaultPrevented()) {
+      return;
+    }
 
-      if (isBackdropClick) {
-        requestOpenChange({ type: 'backdropClick', open: false, event });
-      }
+    if (event.target !== event.currentTarget) {
+      return;
+    }
+
+    const rect = event.currentTarget.getBoundingClientRect();
+    const isBackdropClick =
+      event.clientX < rect.left ||
+      event.clientX > rect.right ||
+      event.clientY < rect.top ||
+      event.clientY > rect.bottom;
+
+    if (isBackdropClick) {
+      requestOpenChange({ type: 'backdropClick', open: false, event });
     }
   });
 


### PR DESCRIPTION
`Enter` or `Space` on a focused `<button>` inside the dialog dispatched a synthetic click with `clientX/Y === 0`. The click bubbled to the dialog and was interpreted as a backdrop click, dialog closed before any descendant handler could run (e.g. a `PopoverTrigger` failed to open its popover).

## Previous Behavior

https://github.com/user-attachments/assets/e40e8c41-79d1-49a9-b2f0-9479b940ce28

## New Behavior

`DialogSurface.handleClick` now early-returns when `event.target !== event.currentTarget`. Only events that originated directly on the `<dialog>` element itself reach geometric check