### PR TITLE
fix(ci): install latest 22.x Node to satisfy @microsoft/fast-build engines

### DIFF
--- a/.devops/templates/tools.yml
+++ b/.devops/templates/tools.yml
@@ -17,9 +17,11 @@ steps:
       # 👉 NOTE:
       # - we can use only versions that ship with container, otherwise we will run into nodejs installation issues.
       # - as 1es bumps those versions within container automatically we need to use `<major>.x` to not run into issues once they bump the versions.
+      # - `checkLatest: true` is required because some dependencies (e.g. @microsoft/fast-build) require node >=22.18.0,
+      #   while the 1ES container may still ship an older 22.x (e.g. 22.14.0). This forces the task to install the latest 22.x.
       # https://github.com/actions/runner-images/blob/ubuntu20/20230924.1/images/linux/Ubuntu2004-Readme.md#nodejs
       version: '22.x'
-      checkLatest: false
+      checkLatest: true
     displayName: 'Install Node.js'
     retryCountOnTaskFailure: 1
 


### PR DESCRIPTION
## Problem

`yarn install` fails on Azure CI with:

```
error @microsoft/fast-build@0.6.0: The engine "node" is incompatible with this module. Expected version ">=22.18.0". Got "22.14.0"
error Found incompatible module.
```

## Cause

- PR #36105 introduced `@microsoft/fast-build@0.6.0` and `@microsoft/fast-test-harness@0.1.0` to root devDependencies.
- Both packages declare `engines.node: ">=22.18.0"` (verified across all published versions, 0.1.1 → 0.7.0 — so downgrading is not an option).
- The 1ES container ships Node `22.14.0`. The Azure pipeline's `UseNode@1` task was pinned with `version: '22.x'` + `checkLatest: false`, so it just reused the container's older 22.x instead of installing a newer one.
- GitHub Actions workflows are unaffected because `actions/setup-node` with `node-version: '22'` already resolves to the latest 22.x.

## Fix

Set `checkLatest: true` on the `UseNode@1` task in `.devops/templates/tools.yml`. This forces the task to fetch the latest 22.x when the container's bundled Node is older, while still respecting the `22.x` major-version pin.

## Verification

- All Azure pipelines source Node setup from `.devops/templates/tools.yml`, so the fix applies broadly with a single change.
- Local install is unaffected (devs use `engines: ^22.0.0 || ^24.0.0` from root `package.json`; this only changes the ADO Node install task).