### PR TITLE
ci: migrate runners to Node.js (ACTIVE) 24 and bump nrwl/nx-set-shas to v5.0.1

### DIFF
--- a/.devops/templates/tools.yml
+++ b/.devops/templates/tools.yml
@@ -17,10 +17,9 @@ steps:
       # 👉 NOTE:
       # - we can use only versions that ship with container, otherwise we will run into nodejs installation issues.
       # - as 1es bumps those versions within container automatically we need to use `<major>.x` to not run into issues once they bump the versions.
-      # - `checkLatest: true` is required because some dependencies (e.g. @microsoft/fast-build) require node >=22.18.0,
-      #   while the 1ES container may still ship an older 22.x (e.g. 22.14.0). This forces the task to install the latest 22.x.
+      # - `checkLatest: true` forces the task to install the latest 24.x in case the 1ES container ships an older 24.x patch release.
       # https://github.com/actions/runner-images/blob/ubuntu20/20230924.1/images/linux/Ubuntu2004-Readme.md#nodejs
-      version: '22.x'
+      version: '24.x'
       checkLatest: true
     displayName: 'Install Node.js'
     retryCountOnTaskFailure: 1

--- a/.github/actions/run-publish-vr-screenshot/action.yml
+++ b/.github/actions/run-publish-vr-screenshot/action.yml
@@ -29,14 +29,14 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: nrwl/nx-set-shas@v4
+    - uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
       with:
         main-branch-name: 'master'
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       with:
         cache: 'yarn'
-        node-version: '20'
+        node-version: '24'
 
     - run: yarn install --frozen-lockfile
       shell: bash

--- a/.github/instructions/copilot.instructions.md
+++ b/.github/instructions/copilot.instructions.md
@@ -12,7 +12,7 @@ This is a large Nx monorepo with the following key characteristics:
 
 - **Package Manager**: Yarn v1 with strict dependency management
 - **Build System**: Nx workspace with custom plugins (`tools/workspace-plugin/`)
-- **Node.js Versions**: ^22.0.0
+- **Node.js Versions**: ^22.0.0 || ^24.0.0 (CI runs on Node.js 24 — the current Active LTS)
 - **Languages**: TypeScript (strict mode), React, Web Components
 - **Testing**: Jest, Cypress (E2E), Storybook + StoryWright (Visual Regression), SSR testing (test-ssr)
 - **Documentation**: Storybook sites, api.md files via API Extractor

--- a/.github/workflows/bundle-size-base.yml
+++ b/.github/workflows/bundle-size-base.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           cache: 'yarn'
-          node-version: '22'
+          node-version: '24'
 
       - run: yarn install --frozen-lockfile
 

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -28,14 +28,14 @@ jobs:
           fetch-depth: 0
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        uses: nrwl/nx-set-shas@826660b82addbef3abff5fa871492ebad618c9e1 # v4.3.3
+        uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
         with:
           main-branch-name: 'master'
 
       - uses: actions/setup-node@v6
         with:
           cache: 'yarn'
-          node-version: '22'
+          node-version: '24'
 
       - run: echo number of CPUs "$(getconf _NPROCESSORS_ONLN)"
 

--- a/.github/workflows/check-packages.yml
+++ b/.github/workflows/check-packages.yml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'yarn'
 
       - uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5
@@ -46,7 +46,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22.x
+          node-version: 24.x
 
       - uses: actions/github-script@v8
         with:
@@ -73,7 +73,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22.x
+          node-version: 24.x
 
       - uses: actions/github-script@v8
         with:

--- a/.github/workflows/check-tooling.yml
+++ b/.github/workflows/check-tooling.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
 
       - run: yarn install --frozen-lockfile
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -27,6 +27,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           cache: 'yarn'
-          node-version: '22'
+          node-version: '24'
 
       - run: yarn install --frozen-lockfile

--- a/.github/workflows/docsite-publish-ghpages.yml
+++ b/.github/workflows/docsite-publish-ghpages.yml
@@ -19,13 +19,13 @@ jobs:
           fetch-depth: 0
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        uses: nrwl/nx-set-shas@826660b82addbef3abff5fa871492ebad618c9e1 # v4.3.3
+        uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
         with:
           main-branch-name: 'master'
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'yarn'
 
       - name: Install packages

--- a/.github/workflows/pr-vrt.yml
+++ b/.github/workflows/pr-vrt.yml
@@ -31,14 +31,14 @@ jobs:
           fetch-depth: 0
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        uses: nrwl/nx-set-shas@826660b82addbef3abff5fa871492ebad618c9e1 # v4.3.3
+        uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
         with:
           main-branch-name: 'master'
 
       - uses: actions/setup-node@v6
         with:
           cache: 'yarn'
-          node-version: '22'
+          node-version: '24'
 
       - run: yarn install --frozen-lockfile
       - run: yarn playwright install --with-deps

--- a/.github/workflows/pr-website-deploy.yml
+++ b/.github/workflows/pr-website-deploy.yml
@@ -28,14 +28,14 @@ jobs:
           fetch-depth: 0
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        uses: nrwl/nx-set-shas@826660b82addbef3abff5fa871492ebad618c9e1 # v4.3.3
+        uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
         with:
           main-branch-name: 'master'
 
       - uses: actions/setup-node@v6
         with:
           cache: 'yarn'
-          node-version: '22'
+          node-version: '24'
 
       - run: echo number of CPUs "$(getconf _NPROCESSORS_ONLN)"
       - name: NodeJS heap default size

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,14 +35,14 @@ jobs:
           fetch-depth: 0
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        uses: nrwl/nx-set-shas@826660b82addbef3abff5fa871492ebad618c9e1 # v4.3.3
+        uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
         with:
           main-branch-name: 'master'
 
       - uses: actions/setup-node@v6
         with:
           cache: 'yarn'
-          node-version: '22'
+          node-version: '24'
 
       - run: echo number of CPUs "$(getconf _NPROCESSORS_ONLN)"
 
@@ -118,14 +118,14 @@ jobs:
           fetch-depth: 0
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        uses: nrwl/nx-set-shas@826660b82addbef3abff5fa871492ebad618c9e1 # v4.3.3
+        uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
         with:
           main-branch-name: 'master'
 
       - uses: actions/setup-node@v6
         with:
           cache: 'yarn'
-          node-version: '22'
+          node-version: '24'
 
       - run: echo number of CPUs "$(getconf _NPROCESSORS_ONLN)"
 
@@ -175,14 +175,14 @@ jobs:
           fetch-depth: 0
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        uses: nrwl/nx-set-shas@826660b82addbef3abff5fa871492ebad618c9e1 # v4.3.3
+        uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
         with:
           main-branch-name: 'master'
 
       - uses: actions/setup-node@v6
         with:
           cache: 'yarn'
-          node-version: '22'
+          node-version: '24'
 
       - run: echo number of CPUs "$(getconf _NPROCESSORS_ONLN)"
 

--- a/.github/workflows/vrt-baseline.yml
+++ b/.github/workflows/vrt-baseline.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           cache: 'yarn'
-          node-version: '22'
+          node-version: '24'
 
       - run: yarn install --frozen-lockfile
       - run: yarn playwright install --with-deps


### PR DESCRIPTION
## Summary

Bumps CI runtime from Node.js 22 → 24 (current Active LTS) and resolves the GitHub Actions deprecation warning for the Node 20-based `nrwl/nx-set-shas` action.

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: nrwl/nx-set-shas@826660b… Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.

## Changes

- **GitHub Actions workflows** — `actions/setup-node` `node-version` bumped `22` → `24` (10 workflow files).
- **`nrwl/nx-set-shas`** — pinned SHA `826660b…` (v4.3.3, Node 20) → `afb73a62d26e41464e9254689e1fd6122ee683c1` (v5.0.1, Node 24 runtime). 7 occurrences across 6 workflows.
- **Composite action** `.github/actions/run-publish-vr-screenshot/action.yml` — `node-version: '20'` → `'24'`, `actions/setup-node@v4` → `@v6`, and `nrwl/nx-set-shas@v4` floating tag → pinned v5.0.1 SHA. (Currently unused but kept in sync.)
- **Azure DevOps** — `.devops/templates/tools.yml` `UseNode@1` `version: '22.x'` → `'24.x'` (single edit propagates to every `azure-pipelines.*.yml` consuming this template).
- **Docs** — `.github/instructions/copilot.instructions.md` Node.js Versions line updated to `^22.0.0 || ^24.0.0` and notes CI runs on Node.js 24 (current Active LTS).

## Out of scope

- `engines.node` in root + `packages/web-components/package.json` already allows `^22.0.0 || ^24.0.0` — kept as-is so local devs on 22 are unaffected.

## Verification

```
grep -rnE "node-version: '?(22|20)'?|version: '22\.x'|nx-set-shas@(826660b|v4)\b" .github .devops
# → no matches
```

After merge, the "Node.js 20 actions are deprecated" warning should disappear from CI runs and `setup-node` logs should show v24.