### PR TITLE
feat(eslint-plugin): wire base-hook-signature and base-hook-no-forbidden-runtime

### DIFF
--- a/packages/eslint-plugin/src/internal.js
+++ b/packages/eslint-plugin/src/internal.js
@@ -35,6 +35,8 @@ const __internal = {
           /** @type {import('eslint').Linter.RulesRecord} */
           rules: {
             '@nx/workspace-consistent-callback-type': 'error',
+            '@nx/workspace-base-hook-signature': 'error',
+            '@nx/workspace-base-hook-no-forbidden-runtime': 'error',
             '@nx/workspace-no-restricted-globals': restrictedGlobals.react,
             '@nx/workspace-no-missing-jsx-pragma': ['error', { runtime: 'automatic' }],
           },


### PR DESCRIPTION
## Summary

Wires the two new workspace rules into the internal `@fluentui/eslint-plugin` config:

- `'@nx/workspace-base-hook-signature': 'error'`
- `'@nx/workspace-base-hook-no-forbidden-runtime': 'error'`

After this lands, every project that consumes `@fluentui/eslint-plugin`'s internal preset (i.e. all `react-components` packages via `eslint.config.js` → root `eslint.config.js`) enforces both rules on `useFooBase` hook files.

## Plan reference

Part of the split of #36251 — see `prd/eslint-rules-base-hook-pr-split.spec.md` (PR3).

## Merge order — IMPORTANT

This PR **must merge last**, after:

1. `tools/ws-lint/rule-base-hook-signature` (registers `base-hook-signature`)
2. `tools/ws-lint/rule-base-hook-no-forbidden-runtime` (registers `base-hook-no-forbidden-runtime`)

Without those, `nx run-many -t lint` will fail with `Could not find "workspace-base-hook-*" in plugin "@nx"`.

## Additional gate

Lint cannot pass cleanly until the separate **`useTagGroup.ts` suppression PR** lands — the new `base-hook-signature` rule already detected a real violation in `packages/react-components/react-tags/library/src/components/TagGroup/useTagGroup.ts` (3 positional params instead of ≤ 2). That fix/suppression is being landed separately.

## Verification

After PR1 + PR2 are on master and this branch is rebased:

```
nx run eslint-rules:test
nx run-many -t lint
```

## ESLint CLI perf (combined cost of both rules, TIMING=200)

| Project | Combined ms | Combined % |
|---|---:|---:|
| `react-button` | **2.30 ms** | 0.1% |
| `react-combobox` | **3.21 ms** | 0.1% |
| `react-tags` | **3.07 ms** | 0.1% |

Negligible — total lint runtime per package is dominated by `@typescript-eslint/no-deprecated` (≈1000 ms) and `react-hooks/static-components` (≈400 ms).

## Out of scope

- `useTagGroup.ts` fix/suppression (separate PR).
- Beachball change file (declined — tooling-only change).
