### PR TITLE
feat(react-tag-picker): export base hooks

### DIFF
--- a/change/@fluentui-react-tag-picker-base-hooks.json
+++ b/change/@fluentui-react-tag-picker-base-hooks.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add base hooks/types for headless composition",
+  "packageName": "@fluentui/react-tag-picker",
+  "email": "viktorgenaev@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tag-picker/library/etc/react-tag-picker.api.md
+++ b/packages/react-components/react-tag-picker/library/etc/react-tag-picker.api.md
@@ -12,6 +12,7 @@ import type { ComboboxState } from '@fluentui/react-combobox';
 import type { ComponentProps } from '@fluentui/react-utilities';
 import type { ComponentState } from '@fluentui/react-utilities';
 import type { ContextSelector } from '@fluentui/react-context-selector';
+import type { DistributiveOmit } from '@fluentui/react-utilities';
 import type { DropdownProps } from '@fluentui/react-combobox';
 import type { EventData } from '@fluentui/react-utilities';
 import type { EventHandler } from '@fluentui/react-utilities';
@@ -60,7 +61,16 @@ export const renderTagPickerOptionGroup: (state: TagPickerOptionGroupState) => J
 export const TagPicker: React_2.FC<TagPickerProps>;
 
 // @public
+export type TagPickerBaseProps = DistributiveOmit<TagPickerProps, 'positioning'>;
+
+// @public
 export const TagPickerButton: ForwardRefComponent<TagPickerButtonProps>;
+
+// @public
+export type TagPickerButtonBaseProps = DistributiveOmit<TagPickerButtonProps, 'size' | 'appearance'>;
+
+// @public
+export type TagPickerButtonBaseState = DistributiveOmit<TagPickerButtonState, 'size'>;
 
 // @public (undocumented)
 export const tagPickerButtonClassNames: SlotClassNames<TagPickerButtonSlots>;
@@ -79,6 +89,9 @@ export type TagPickerButtonSlots = {
 export type TagPickerButtonState = ComponentState<TagPickerButtonSlots> & Pick<TagPickerContextValue, 'size'> & {
     hasSelectedOption: boolean;
 };
+
+// @public (undocumented)
+export const TagPickerContextProvider: React_2.Provider<TagPickerContextValue | undefined> & React_2.FC<React_2.ProviderProps<TagPickerContextValue | undefined>>;
 
 // @public (undocumented)
 export interface TagPickerContextValue extends Pick<ComboboxBaseState, 'open' | 'clearSelection' | 'getOptionById' | 'selectedOptions' | 'selectOption' | 'setHasFocus' | 'setOpen' | 'setValue' | 'value' | 'appearance' | 'disabled'> {
@@ -109,6 +122,9 @@ export type TagPickerContextValues = {
 
 // @public
 export const TagPickerControl: ForwardRefComponent<TagPickerControlProps>;
+
+// @public
+export type TagPickerControlBaseState = DistributiveOmit<TagPickerControlState, 'size' | 'appearance'>;
 
 // @public (undocumented)
 export const tagPickerControlClassNames: SlotClassNames<TagPickerControlSlots & TagPickerControlInternalSlots>;
@@ -148,6 +164,12 @@ export type TagPickerGroupState = TagGroupState & {
 
 // @public
 export const TagPickerInput: ForwardRefComponent<TagPickerInputProps>;
+
+// @public
+export type TagPickerInputBaseProps = DistributiveOmit<TagPickerInputProps, 'appearance'>;
+
+// @public
+export type TagPickerInputBaseState = DistributiveOmit<TagPickerInputState, 'size'>;
 
 // @public (undocumented)
 export const tagPickerInputClassNames: SlotClassNames<TagPickerInputSlots>;
@@ -263,7 +285,13 @@ export type TagPickerState = ComponentState<TagPickerSlots> & Pick<ComboboxState
 export const useTagPicker_unstable: (props: TagPickerProps) => TagPickerState;
 
 // @public
+export const useTagPickerBase_unstable: (props: TagPickerBaseProps) => TagPickerState;
+
+// @public
 export const useTagPickerButton_unstable: (props: TagPickerButtonProps, ref: React_2.Ref<HTMLButtonElement>) => TagPickerButtonState;
+
+// @public
+export const useTagPickerButtonBase_unstable: (props: TagPickerButtonBaseProps, ref: React_2.Ref<HTMLButtonElement>) => TagPickerButtonBaseState;
 
 // @public
 export const useTagPickerButtonStyles_unstable: (state: TagPickerButtonState) => TagPickerButtonState;
@@ -273,6 +301,9 @@ export const useTagPickerContext_unstable: <T>(selector: ContextSelector<TagPick
 
 // @public
 export const useTagPickerControl_unstable: (props: TagPickerControlProps, ref: React_2.Ref<HTMLDivElement>) => TagPickerControlState;
+
+// @public
+export const useTagPickerControlBase_unstable: (props: TagPickerControlProps, ref: React_2.Ref<HTMLDivElement>) => TagPickerControlBaseState;
 
 // @public
 export const useTagPickerControlStyles_unstable: (state: TagPickerControlState) => TagPickerControlState;
@@ -287,7 +318,10 @@ export const useTagPickerGroup_unstable: (props: TagPickerGroupProps, ref: React
 export const useTagPickerGroupStyles_unstable: (state: TagPickerGroupState) => TagPickerGroupState;
 
 // @public
-export const useTagPickerInput_unstable: (propsArg: TagPickerInputProps, ref: React_2.Ref<HTMLInputElement>) => TagPickerInputState;
+export const useTagPickerInput_unstable: (props: TagPickerInputProps, ref: React_2.Ref<HTMLInputElement>) => TagPickerInputState;
+
+// @public
+export const useTagPickerInputBase_unstable: (props: TagPickerInputBaseProps, ref: React_2.Ref<HTMLInputElement>) => TagPickerInputBaseState;
 
 // @public
 export const useTagPickerInputStyles_unstable: (state: TagPickerInputState) => TagPickerInputState;

--- a/packages/react-components/react-tag-picker/library/src/TagPicker.ts
+++ b/packages/react-components/react-tag-picker/library/src/TagPicker.ts
@@ -1,4 +1,5 @@
 export type {
+  TagPickerBaseProps,
   TagPickerContextValues,
   TagPickerOnOpenChangeData,
   TagPickerOnOptionSelectData,
@@ -7,4 +8,9 @@ export type {
   TagPickerSlots,
   TagPickerState,
 } from './components/TagPicker/index';
-export { TagPicker, renderTagPicker_unstable, useTagPicker_unstable } from './components/TagPicker/index';
+export {
+  TagPicker,
+  renderTagPicker_unstable,
+  useTagPicker_unstable,
+  useTagPickerBase_unstable,
+} from './components/TagPicker/index';

--- a/packages/react-components/react-tag-picker/library/src/TagPickerButton.ts
+++ b/packages/react-components/react-tag-picker/library/src/TagPickerButton.ts
@@ -1,4 +1,6 @@
 export type {
+  TagPickerButtonBaseProps,
+  TagPickerButtonBaseState,
   TagPickerButtonProps,
   TagPickerButtonSlots,
   TagPickerButtonState,
@@ -9,4 +11,5 @@ export {
   tagPickerButtonClassNames,
   useTagPickerButtonStyles_unstable,
   useTagPickerButton_unstable,
+  useTagPickerButtonBase_unstable,
 } from './components/TagPickerButton/index';

--- a/packages/react-components/react-tag-picker/library/src/TagPickerControl.ts
+++ b/packages/react-components/react-tag-picker/library/src/TagPickerControl.ts
@@ -1,4 +1,5 @@
 export type {
+  TagPickerControlBaseState,
   TagPickerControlCSSProperties,
   TagPickerControlInternalSlots,
   TagPickerControlProps,
@@ -13,4 +14,5 @@ export {
   tagPickerControlClassNames,
   useTagPickerControlStyles_unstable,
   useTagPickerControl_unstable,
+  useTagPickerControlBase_unstable,
 } from './components/TagPickerControl/index';

--- a/packages/react-components/react-tag-picker/library/src/TagPickerInput.ts
+++ b/packages/react-components/react-tag-picker/library/src/TagPickerInput.ts
@@ -1,8 +1,15 @@
-export type { TagPickerInputProps, TagPickerInputSlots, TagPickerInputState } from './components/TagPickerInput/index';
+export type {
+  TagPickerInputBaseProps,
+  TagPickerInputBaseState,
+  TagPickerInputProps,
+  TagPickerInputSlots,
+  TagPickerInputState,
+} from './components/TagPickerInput/index';
 export {
   TagPickerInput,
   renderTagPickerInput_unstable,
   tagPickerInputClassNames,
   useTagPickerInputStyles_unstable,
   useTagPickerInput_unstable,
+  useTagPickerInputBase_unstable,
 } from './components/TagPickerInput/index';

--- a/packages/react-components/react-tag-picker/library/src/components/TagPicker/TagPicker.types.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPicker/TagPicker.types.ts
@@ -1,5 +1,12 @@
 import type * as React from 'react';
-import type { ComponentProps, ComponentState, EventData, EventHandler, JSXElement } from '@fluentui/react-utilities';
+import type {
+  ComponentProps,
+  ComponentState,
+  DistributiveOmit,
+  EventData,
+  EventHandler,
+  JSXElement,
+} from '@fluentui/react-utilities';
 import type { ComboboxProps, ComboboxState, ListboxContextValue } from '@fluentui/react-combobox';
 import type { TagPickerContextValue } from '../../contexts/TagPickerContext';
 import type { ActiveDescendantContextValue } from '@fluentui/react-aria';
@@ -106,3 +113,9 @@ export type TagPickerContextValues = {
   activeDescendant: ActiveDescendantContextValue;
   listbox: ListboxContextValue;
 };
+
+/**
+ * TagPicker Base Props - omits the floating-ui `positioning` prop; the styled wrapper
+ * {@link TagPickerProps} re-introduces it via `usePositioning`.
+ */
+export type TagPickerBaseProps = DistributiveOmit<TagPickerProps, 'positioning'>;

--- a/packages/react-components/react-tag-picker/library/src/components/TagPicker/index.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPicker/index.ts
@@ -1,5 +1,6 @@
 export { TagPicker } from './TagPicker';
 export type {
+  TagPickerBaseProps,
   TagPickerContextValues,
   TagPickerOnOpenChangeData,
   TagPickerOnOptionSelectData,
@@ -9,4 +10,4 @@ export type {
   TagPickerState,
 } from './TagPicker.types';
 export { renderTagPicker_unstable } from './renderTagPicker';
-export { useTagPicker_unstable } from './useTagPicker';
+export { useTagPicker_unstable, useTagPickerBase_unstable } from './useTagPicker';

--- a/packages/react-components/react-tag-picker/library/src/components/TagPicker/useTagPicker.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPicker/useTagPicker.ts
@@ -3,6 +3,7 @@
 import * as React from 'react';
 import { elementContains, useEventCallback, useId, useMergedRefs } from '@fluentui/react-utilities';
 import type {
+  TagPickerBaseProps,
   TagPickerOnOpenChangeData,
   TagPickerOnOptionSelectData,
   TagPickerProps,
@@ -18,28 +19,16 @@ import { useComboboxBaseState } from '@fluentui/react-combobox';
 const fallbackPositions: PositioningShorthandValue[] = ['above', 'after', 'after-top', 'before', 'before-top'];
 
 /**
- * Create the state required to render Picker.
- *
- * The returned state can be modified with hooks such as usePickerStyles_unstable,
- * before being passed to renderPicker_unstable.
- *
- * @param props - props from this instance of Picker
+ * Create the base state required to render TagPicker, without floating-ui positioning.
+ * @param props - props from this instance of TagPicker (without `positioning`)
  */
-export const useTagPicker_unstable = (props: TagPickerProps): TagPickerState => {
+export const useTagPickerBase_unstable = (props: TagPickerBaseProps): TagPickerState => {
   const popoverId = useId('picker-listbox');
   const triggerInnerRef = React.useRef<HTMLInputElement | HTMLButtonElement>(null);
   const secondaryActionRef = React.useRef<HTMLSpanElement>(null);
   const tagPickerGroupRef = React.useRef<HTMLDivElement>(null);
-  const { positioning, size = 'medium', inline = false, noPopover = false, disableAutoFocus } = props;
-
-  const { targetRef, containerRef } = usePositioning({
-    position: 'below' as const,
-    align: 'start' as const,
-    offset: { crossAxis: 0, mainAxis: 2 },
-    fallbackPositions,
-    matchTargetSize: 'width' as const,
-    ...resolvePositioningShorthand(positioning),
-  });
+  const passiveTargetRef = React.useRef<HTMLDivElement>(null);
+  const { size = 'medium', inline = false, noPopover = false, disableAutoFocus } = props;
 
   const {
     controller: activeDescendantController,
@@ -83,10 +72,10 @@ export const useTagPicker_unstable = (props: TagPickerProps): TagPickerState => 
     noPopover,
     disabled: comboboxState.disabled,
     triggerRef: useMergedRefs(triggerInnerRef, activeParentRef),
-    popoverRef: useMergedRefs(listboxRef, containerRef),
+    popoverRef: useMergedRefs(listboxRef),
     secondaryActionRef,
     tagPickerGroupRef,
-    targetRef,
+    targetRef: passiveTargetRef,
     size,
     inline,
     open: comboboxState.open,
@@ -122,6 +111,35 @@ export const useTagPicker_unstable = (props: TagPickerProps): TagPickerState => 
     setOpen: comboboxState.setOpen,
     setValue: comboboxState.setValue,
     value: comboboxState.value,
+  };
+};
+
+/**
+ * Create the state required to render Picker.
+ *
+ * The returned state can be modified with hooks such as usePickerStyles_unstable,
+ * before being passed to renderPicker_unstable.
+ *
+ * @param props - props from this instance of Picker
+ */
+export const useTagPicker_unstable = (props: TagPickerProps): TagPickerState => {
+  const { positioning } = props;
+
+  const { targetRef, containerRef } = usePositioning({
+    position: 'below' as const,
+    align: 'start' as const,
+    offset: { crossAxis: 0, mainAxis: 2 },
+    fallbackPositions,
+    matchTargetSize: 'width' as const,
+    ...resolvePositioningShorthand(positioning),
+  });
+
+  const baseState = useTagPickerBase_unstable(props);
+
+  return {
+    ...baseState,
+    targetRef,
+    popoverRef: useMergedRefs(baseState.popoverRef, containerRef),
   };
 };
 

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerButton/TagPickerButton.types.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerButton/TagPickerButton.types.ts
@@ -1,5 +1,5 @@
 import type { DropdownProps } from '@fluentui/react-combobox';
-import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+import type { ComponentProps, ComponentState, DistributiveOmit, Slot } from '@fluentui/react-utilities';
 import type { TagPickerContextValue } from '../../contexts/TagPickerContext';
 
 export type TagPickerButtonSlots = {
@@ -21,3 +21,13 @@ export type TagPickerButtonState = ComponentState<TagPickerButtonSlots> &
   Pick<TagPickerContextValue, 'size'> & {
     hasSelectedOption: boolean;
   };
+
+/**
+ * TagPickerButton Base Props - omits design-only props
+ */
+export type TagPickerButtonBaseProps = DistributiveOmit<TagPickerButtonProps, 'size' | 'appearance'>;
+
+/**
+ * TagPickerButton Base State - omits design-only state
+ */
+export type TagPickerButtonBaseState = DistributiveOmit<TagPickerButtonState, 'size'>;

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerButton/index.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerButton/index.ts
@@ -1,5 +1,11 @@
 export { TagPickerButton } from './TagPickerButton';
-export type { TagPickerButtonProps, TagPickerButtonSlots, TagPickerButtonState } from './TagPickerButton.types';
+export type {
+  TagPickerButtonBaseProps,
+  TagPickerButtonBaseState,
+  TagPickerButtonProps,
+  TagPickerButtonSlots,
+  TagPickerButtonState,
+} from './TagPickerButton.types';
 export { renderTagPickerButton_unstable } from './renderTagPickerButton';
-export { useTagPickerButton_unstable } from './useTagPickerButton';
+export { useTagPickerButton_unstable, useTagPickerButtonBase_unstable } from './useTagPickerButton';
 export { tagPickerButtonClassNames, useTagPickerButtonStyles_unstable } from './useTagPickerButtonStyles.styles';

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerButton/useTagPickerButton.tsx
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerButton/useTagPickerButton.tsx
@@ -2,23 +2,25 @@
 
 import type * as React from 'react';
 import { useActiveDescendantContext } from '@fluentui/react-aria';
-import type { TagPickerButtonProps, TagPickerButtonState } from './TagPickerButton.types';
+import type {
+  TagPickerButtonBaseProps,
+  TagPickerButtonBaseState,
+  TagPickerButtonProps,
+  TagPickerButtonState,
+} from './TagPickerButton.types';
 import { useTagPickerContext_unstable } from '../../contexts/TagPickerContext';
 import { useButtonTriggerSlot } from '@fluentui/react-combobox';
 
 /**
- * Create the state required to render PickerButton.
+ * Create the base state required to render TagPickerButton, without design-only props.
  *
- * The returned state can be modified with hooks such as usePickerButtonStyles_unstable,
- * before being passed to renderPickerButton_unstable.
- *
- * @param props - props from this instance of PickerButton
- * @param ref - reference to root HTMLDivElement of PickerButton
+ * @param props - props from this instance of TagPickerButton (without size, appearance)
+ * @param ref - reference to root HTMLButtonElement of TagPickerButton
  */
-export const useTagPickerButton_unstable = (
-  props: TagPickerButtonProps,
+export const useTagPickerButtonBase_unstable = (
+  props: TagPickerButtonBaseProps,
   ref: React.Ref<HTMLButtonElement>,
-): TagPickerButtonState => {
+): TagPickerButtonBaseState => {
   const { controller: activeDescendantController } = useActiveDescendantContext();
   const triggerRef = useTagPickerContext_unstable(ctx => ctx.triggerRef);
   const open = useTagPickerContext_unstable(ctx => ctx.open);
@@ -39,7 +41,7 @@ export const useTagPickerButton_unstable = (
       tabIndex: 0,
       children:
         value ||
-        // @ts-expect-error - FIXME: TS2339: Property 'placeholder' does not exist on type 'TagPickerButtonProps'
+        // @ts-expect-error - FIXME: TS2339: Property 'placeholder' does not exist on type 'TagPickerButtonBaseProps'
         props.placeholder,
       'aria-controls': open ? popoverId : undefined,
       ref,
@@ -54,16 +56,33 @@ export const useTagPickerButton_unstable = (
     },
   });
 
-  const size = useTagPickerContext_unstable(ctx => ctx.size);
-
-  const state: TagPickerButtonState = {
+  return {
     components: {
       root: 'button',
     },
     root,
-    size,
     hasSelectedOption,
   };
+};
 
-  return state;
+/**
+ * Create the state required to render PickerButton.
+ *
+ * The returned state can be modified with hooks such as usePickerButtonStyles_unstable,
+ * before being passed to renderPickerButton_unstable.
+ *
+ * @param props - props from this instance of PickerButton
+ * @param ref - reference to root HTMLDivElement of PickerButton
+ */
+export const useTagPickerButton_unstable = (
+  props: TagPickerButtonProps,
+  ref: React.Ref<HTMLButtonElement>,
+): TagPickerButtonState => {
+  const baseState = useTagPickerButtonBase_unstable(props, ref);
+  const size = useTagPickerContext_unstable(ctx => ctx.size);
+
+  return {
+    ...baseState,
+    size,
+  };
 };

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerButton/useTagPickerButton.tsx
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerButton/useTagPickerButton.tsx
@@ -66,13 +66,13 @@ export const useTagPickerButtonBase_unstable = (
 };
 
 /**
- * Create the state required to render PickerButton.
+ * Create the state required to render TagPickerButton.
  *
- * The returned state can be modified with hooks such as usePickerButtonStyles_unstable,
- * before being passed to renderPickerButton_unstable.
+ * The returned state can be modified with hooks such as useTagPickerButtonStyles_unstable,
+ * before being passed to renderTagPickerButton_unstable.
  *
- * @param props - props from this instance of PickerButton
- * @param ref - reference to root HTMLDivElement of PickerButton
+ * @param props - props from this instance of TagPickerButton
+ * @param ref - reference to root HTMLButtonElement of TagPickerButton
  */
 export const useTagPickerButton_unstable = (
   props: TagPickerButtonProps,

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerControl/TagPickerControl.types.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerControl/TagPickerControl.types.ts
@@ -1,4 +1,10 @@
-import type { ComponentProps, ComponentState, ExtractSlotProps, Slot } from '@fluentui/react-utilities';
+import type {
+  ComponentProps,
+  ComponentState,
+  DistributiveOmit,
+  ExtractSlotProps,
+  Slot,
+} from '@fluentui/react-utilities';
 import type { TagPickerContextValue } from '../../contexts/TagPickerContext';
 import type { ComboboxSlots } from '@fluentui/react-combobox';
 import type * as React from 'react';
@@ -32,3 +38,8 @@ export type TagPickerControlState = ComponentState<TagPickerControlSlots & TagPi
   Pick<TagPickerContextValue, 'size' | 'appearance' | 'disabled'> & {
     invalid: boolean;
   };
+
+/**
+ * TagPickerControl Base State - omits design-only state derived from picker context.
+ */
+export type TagPickerControlBaseState = DistributiveOmit<TagPickerControlState, 'size' | 'appearance'>;

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerControl/index.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerControl/index.ts
@@ -1,5 +1,6 @@
 export { TagPickerControl } from './TagPickerControl';
 export type {
+  TagPickerControlBaseState,
   TagPickerControlCSSProperties,
   TagPickerControlInternalSlots,
   TagPickerControlProps,
@@ -7,7 +8,7 @@ export type {
   TagPickerControlState,
 } from './TagPickerControl.types';
 export { renderTagPickerControl_unstable } from './renderTagPickerControl';
-export { useTagPickerControl_unstable } from './useTagPickerControl';
+export { useTagPickerControl_unstable, useTagPickerControlBase_unstable } from './useTagPickerControl';
 export {
   iconSizes,
   tagPickerControlAsideWidthToken,

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerControl/useTagPickerControl.tsx
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerControl/useTagPickerControl.tsx
@@ -11,7 +11,7 @@ import {
   useMergedRefs,
 } from '@fluentui/react-utilities';
 import { useFluent_unstable } from '@fluentui/react-shared-contexts';
-import type { TagPickerControlProps, TagPickerControlState } from './TagPickerControl.types';
+import type { TagPickerControlBaseState, TagPickerControlProps, TagPickerControlState } from './TagPickerControl.types';
 import { useTagPickerContext_unstable } from '../../contexts/TagPickerContext';
 import { ChevronDownRegular } from '@fluentui/react-icons';
 import { useResizeObserverRef } from '../../utils/useResizeObserverRef';
@@ -20,18 +20,15 @@ import { useFieldContext_unstable } from '@fluentui/react-field';
 import { useExpandLabel } from '../../utils/useExpandLabel';
 
 /**
- * Create the state required to render PickerControl.
+ * Create the base state required to render TagPickerControl, without design-only state.
  *
- * The returned state can be modified with hooks such as usePickerControlStyles_unstable,
- * before being passed to renderPickerControl_unstable.
- *
- * @param props - props from this instance of PickerControl
- * @param ref - reference to root HTMLDivElement of PickerControl
+ * @param props - props from this instance of TagPickerControl
+ * @param ref - reference to root HTMLDivElement of TagPickerControl
  */
-export const useTagPickerControl_unstable = (
+export const useTagPickerControlBase_unstable = (
   props: TagPickerControlProps,
   ref: React.Ref<HTMLDivElement>,
-): TagPickerControlState => {
+): TagPickerControlBaseState => {
   const targetRef = useTagPickerContext_unstable(ctx => ctx.targetRef);
   const triggerRef = useTagPickerContext_unstable(ctx => ctx.triggerRef);
   const tagPickerGroupRef = useTagPickerContext_unstable(ctx => ctx.tagPickerGroupRef);
@@ -39,8 +36,6 @@ export const useTagPickerControl_unstable = (
   const popoverId = useTagPickerContext_unstable(ctx => ctx.popoverId);
   const setOpen = useTagPickerContext_unstable(ctx => ctx.setOpen);
   const secondaryInnerActionRef = useTagPickerContext_unstable(ctx => ctx.secondaryActionRef);
-  const size = useTagPickerContext_unstable(ctx => ctx.size);
-  const appearance = useTagPickerContext_unstable(ctx => ctx.appearance);
   const disabled = useTagPickerContext_unstable(ctx => ctx.disabled);
   const invalid = useFieldContext_unstable()?.validationState === 'error';
   const noPopover = useTagPickerContext_unstable(ctx => ctx.noPopover ?? false);
@@ -114,7 +109,7 @@ export const useTagPickerControl_unstable = (
     }
   });
 
-  const state: TagPickerControlState = {
+  const state: TagPickerControlBaseState = {
     components: {
       root: 'div',
       expandIcon: 'span',
@@ -133,13 +128,14 @@ export const useTagPickerControl_unstable = (
     aside,
     expandIcon,
     secondaryAction,
-    size,
-    appearance,
     disabled,
     invalid,
   };
 
-  const expandIconLabelRef = useExpandLabel({ tagPickerId, state: state as Pick<TagPickerControlState, 'expandIcon'> });
+  const expandIconLabelRef = useExpandLabel({
+    tagPickerId,
+    state: state as Pick<TagPickerControlBaseState, 'expandIcon'>,
+  });
 
   const expandIconLabelMergeRef = useMergedRefs(expandIcon?.ref, expandIconLabelRef);
   if (state.expandIcon) {
@@ -153,4 +149,28 @@ export const useTagPickerControl_unstable = (
   }, [targetDocument]);
 
   return state;
+};
+
+/**
+ * Create the state required to render PickerControl.
+ *
+ * The returned state can be modified with hooks such as usePickerControlStyles_unstable,
+ * before being passed to renderPickerControl_unstable.
+ *
+ * @param props - props from this instance of PickerControl
+ * @param ref - reference to root HTMLDivElement of PickerControl
+ */
+export const useTagPickerControl_unstable = (
+  props: TagPickerControlProps,
+  ref: React.Ref<HTMLDivElement>,
+): TagPickerControlState => {
+  const baseState = useTagPickerControlBase_unstable(props, ref);
+  const size = useTagPickerContext_unstable(ctx => ctx.size);
+  const appearance = useTagPickerContext_unstable(ctx => ctx.appearance);
+
+  return {
+    ...baseState,
+    size,
+    appearance,
+  };
 };

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerInput/TagPickerInput.types.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerInput/TagPickerInput.types.ts
@@ -1,4 +1,4 @@
-import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
+import type { ComponentProps, ComponentState, DistributiveOmit, Slot } from '@fluentui/react-utilities';
 import type { ComboboxProps } from '@fluentui/react-combobox';
 import type { TagPickerContextValue } from '../../contexts/TagPickerContext';
 
@@ -23,3 +23,13 @@ export type TagPickerInputProps = Omit<
  */
 export type TagPickerInputState = ComponentState<TagPickerInputSlots> &
   Pick<TagPickerContextValue, 'size' | 'disabled'>;
+
+/**
+ * TagPickerInput Base Props - omits design-only props
+ */
+export type TagPickerInputBaseProps = DistributiveOmit<TagPickerInputProps, 'appearance'>;
+
+/**
+ * TagPickerInput Base State - omits design-only state
+ */
+export type TagPickerInputBaseState = DistributiveOmit<TagPickerInputState, 'size'>;

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerInput/index.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerInput/index.ts
@@ -1,5 +1,11 @@
 export { TagPickerInput } from './TagPickerInput';
-export type { TagPickerInputProps, TagPickerInputSlots, TagPickerInputState } from './TagPickerInput.types';
+export type {
+  TagPickerInputBaseProps,
+  TagPickerInputBaseState,
+  TagPickerInputProps,
+  TagPickerInputSlots,
+  TagPickerInputState,
+} from './TagPickerInput.types';
 export { renderTagPickerInput_unstable } from './renderTagPickerInput';
-export { useTagPickerInput_unstable } from './useTagPickerInput';
+export { useTagPickerInput_unstable, useTagPickerInputBase_unstable } from './useTagPickerInput';
 export { tagPickerInputClassNames, useTagPickerInputStyles_unstable } from './useTagPickerInputStyles.styles';

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerInput/useTagPickerInput.test.tsx
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerInput/useTagPickerInput.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook, act } from '@testing-library/react-hooks';
 import { ArrowLeft, Backspace, Enter, Space } from '@fluentui/keyboard-keys';
 import * as React from 'react';
 
@@ -89,7 +89,9 @@ describe('useTagPickerInput_unstable', () => {
       currentTarget: { selectionStart: 0, selectionEnd: 0 },
       preventDefault: jest.fn(),
     } as unknown as React.KeyboardEvent<HTMLInputElement>;
-    result.current.root.onKeyDown?.(event);
+    act(() => {
+      result.current.root.onKeyDown?.(event);
+    });
 
     expect(setOpen).toHaveBeenCalledWith(event, false);
   });
@@ -107,7 +109,9 @@ describe('useTagPickerInput_unstable', () => {
       currentTarget: { selectionStart: 0, selectionEnd: 0 },
       preventDefault: jest.fn(),
     } as unknown as React.KeyboardEvent<HTMLInputElement>;
-    result.current.root.onKeyDown?.(event);
+    act(() => {
+      result.current.root.onKeyDown?.(event);
+    });
 
     expect(setOpen).toHaveBeenCalledWith(event, true);
   });
@@ -129,7 +133,9 @@ describe('useTagPickerInput_unstable', () => {
       currentTarget: { selectionStart: 0, selectionEnd: 0 },
       preventDefault: jest.fn(),
     } as unknown as React.KeyboardEvent<HTMLInputElement>;
-    result.current.root.onKeyDown?.(event);
+    act(() => {
+      result.current.root.onKeyDown?.(event);
+    });
 
     expect(findLastFocusable).toHaveBeenCalledWith(group);
   });
@@ -147,7 +153,9 @@ describe('useTagPickerInput_unstable', () => {
       currentTarget: { selectionStart: 1, selectionEnd: 1 },
       preventDefault: jest.fn(),
     } as unknown as React.KeyboardEvent<HTMLInputElement>;
-    result.current.root.onKeyDown?.(event);
+    act(() => {
+      result.current.root.onKeyDown?.(event);
+    });
 
     expect(userKeyDown).toHaveBeenCalledWith(event);
   });

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerInput/useTagPickerInput.tsx
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerInput/useTagPickerInput.tsx
@@ -2,7 +2,12 @@
 
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import type { TagPickerInputProps, TagPickerInputState } from './TagPickerInput.types';
+import type {
+  TagPickerInputBaseProps,
+  TagPickerInputBaseState,
+  TagPickerInputProps,
+  TagPickerInputState,
+} from './TagPickerInput.types';
 import { useActiveDescendantContext } from '@fluentui/react-aria';
 import { useTagPickerContext_unstable } from '../../contexts/TagPickerContext';
 import {
@@ -18,27 +23,24 @@ import { tagPickerInputCSSRules } from '../../utils/tokens';
 import { useFocusFinders } from '@fluentui/react-tabster';
 
 /**
- * Create the state required to render TagPickerInput.
+ * Create the base state required to render TagPickerInput, without design-only props.
+ * The Base hook omits Tabster-driven focus management; consumers can re-add it via the
+ * styled wrapper {@link useTagPickerInput_unstable} or by composing their own keydown handler.
  *
- * The returned state can be modified with hooks such as useTagPickerInputStyles_unstable,
- * before being passed to renderTagPickerInput_unstable.
- *
- * @param props - props from this instance of TagPickerInput
- * @param ref - reference to root HTMLDivElement of TagPickerInput
+ * @param props - props from this instance of TagPickerInput (without appearance)
+ * @param ref - reference to root HTMLInputElement of TagPickerInput
  */
-export const useTagPickerInput_unstable = (
-  propsArg: TagPickerInputProps,
+export const useTagPickerInputBase_unstable = (
+  props: TagPickerInputBaseProps,
   ref: React.Ref<HTMLInputElement>,
-): TagPickerInputState => {
-  const props = useFieldControlProps_unstable(propsArg, {
+): TagPickerInputBaseState => {
+  const fieldProps = useFieldControlProps_unstable(props, {
     supportsLabelFor: true,
     supportsRequired: true,
     supportsSize: true,
   });
   const { controller: activeDescendantController } = useActiveDescendantContext();
-  const size = useTagPickerContext_unstable(ctx => ctx.size);
   const contextDisabled = useTagPickerContext_unstable(ctx => ctx.disabled);
-  const tagPickerGroupRef = useTagPickerContext_unstable(ctx => ctx.tagPickerGroupRef);
 
   const triggerRef = useTagPickerContext_unstable(ctx => ctx.triggerRef as React.RefObject<HTMLInputElement>);
   const selectedOptions = useTagPickerContext_unstable(ctx => ctx.selectedOptions);
@@ -70,8 +72,7 @@ export const useTagPickerInput_unstable = (
     }
   }, [triggerRef]);
 
-  const { value = contextValue, disabled = contextDisabled } = props;
-  const { findLastFocusable } = useFocusFinders();
+  const { value = contextValue, disabled = contextDisabled } = fieldProps;
 
   const isTypingRef = React.useRef(false);
 
@@ -81,17 +82,10 @@ export const useTagPickerInput_unstable = (
       value: value ?? '',
       'aria-controls': open ? popoverId : undefined,
       disabled,
-      ...getIntrinsicElementProps('input', props),
+      ...getIntrinsicElementProps('input', fieldProps),
       onKeyDown: useEventCallback((event: React.KeyboardEvent<HTMLInputElement>) => {
-        props.onKeyDown?.(event);
-        if (
-          (event.key === ArrowLeft || event.key === Backspace) &&
-          event.currentTarget.selectionStart === 0 &&
-          event.currentTarget.selectionEnd === 0 &&
-          tagPickerGroupRef.current
-        ) {
-          findLastFocusable(tagPickerGroupRef.current)?.focus();
-        } else if (event.key === Space) {
+        fieldProps.onKeyDown?.(event);
+        if (event.key === Space) {
           if (open && !isTypingRef.current) {
             setOpen(event, false);
           }
@@ -123,21 +117,55 @@ export const useTagPickerInput_unstable = (
         setOpen,
         setValue,
         multiselect: true,
-        value: props.value,
+        value: fieldProps.value,
       },
     },
   );
 
-  const state: TagPickerInputState = {
+  return {
     components: {
       root: 'input',
     },
     root,
     disabled,
+  };
+};
+
+/**
+ * Create the state required to render TagPickerInput.
+ *
+ * The returned state can be modified with hooks such as useTagPickerInputStyles_unstable,
+ * before being passed to renderTagPickerInput_unstable.
+ *
+ * @param props - props from this instance of TagPickerInput
+ * @param ref - reference to root HTMLInputElement of TagPickerInput
+ */
+export const useTagPickerInput_unstable = (
+  props: TagPickerInputProps,
+  ref: React.Ref<HTMLInputElement>,
+): TagPickerInputState => {
+  const tagPickerGroupRef = useTagPickerContext_unstable(ctx => ctx.tagPickerGroupRef);
+  const { findLastFocusable } = useFocusFinders();
+
+  const onKeyDown = useEventCallback((event: React.KeyboardEvent<HTMLInputElement>) => {
+    props.onKeyDown?.(event);
+    if (
+      (event.key === ArrowLeft || event.key === Backspace) &&
+      event.currentTarget.selectionStart === 0 &&
+      event.currentTarget.selectionEnd === 0 &&
+      tagPickerGroupRef.current
+    ) {
+      findLastFocusable(tagPickerGroupRef.current)?.focus();
+    }
+  });
+
+  const baseState = useTagPickerInputBase_unstable({ ...props, onKeyDown }, ref);
+  const size = useTagPickerContext_unstable(ctx => ctx.size);
+
+  return {
+    ...baseState,
     size,
   };
-
-  return state;
 };
 
 /**

--- a/packages/react-components/react-tag-picker/library/src/index.ts
+++ b/packages/react-components/react-tag-picker/library/src/index.ts
@@ -1,5 +1,6 @@
-export { TagPicker, renderTagPicker_unstable, useTagPicker_unstable } from './TagPicker';
+export { TagPicker, renderTagPicker_unstable, useTagPicker_unstable, useTagPickerBase_unstable } from './TagPicker';
 export type {
+  TagPickerBaseProps,
   TagPickerContextValues,
   TagPickerProps,
   TagPickerSlots,
@@ -14,8 +15,15 @@ export {
   renderTagPickerInput_unstable,
   useTagPickerInputStyles_unstable,
   useTagPickerInput_unstable,
+  useTagPickerInputBase_unstable,
 } from './TagPickerInput';
-export type { TagPickerInputProps, TagPickerInputSlots, TagPickerInputState } from './TagPickerInput';
+export type {
+  TagPickerInputBaseProps,
+  TagPickerInputBaseState,
+  TagPickerInputProps,
+  TagPickerInputSlots,
+  TagPickerInputState,
+} from './TagPickerInput';
 export {
   TagPickerList,
   tagPickerListClassNames,
@@ -30,16 +38,29 @@ export {
   renderTagPickerButton_unstable,
   useTagPickerButtonStyles_unstable,
   useTagPickerButton_unstable,
+  useTagPickerButtonBase_unstable,
 } from './TagPickerButton';
-export type { TagPickerButtonProps, TagPickerButtonSlots, TagPickerButtonState } from './TagPickerButton';
+export type {
+  TagPickerButtonBaseProps,
+  TagPickerButtonBaseState,
+  TagPickerButtonProps,
+  TagPickerButtonSlots,
+  TagPickerButtonState,
+} from './TagPickerButton';
 export {
   TagPickerControl,
   tagPickerControlClassNames,
   renderTagPickerControl_unstable,
   useTagPickerControlStyles_unstable,
   useTagPickerControl_unstable,
+  useTagPickerControlBase_unstable,
 } from './TagPickerControl';
-export type { TagPickerControlProps, TagPickerControlSlots, TagPickerControlState } from './TagPickerControl';
+export type {
+  TagPickerControlBaseState,
+  TagPickerControlProps,
+  TagPickerControlSlots,
+  TagPickerControlState,
+} from './TagPickerControl';
 export {
   TagPickerOption,
   tagPickerOptionClassNames,
@@ -72,5 +93,5 @@ export type {
 
 export { useTagPickerFilter } from './utils/useTagPickerFilter';
 
-export { useTagPickerContext_unstable } from './contexts/TagPickerContext';
+export { TagPickerContextProvider, useTagPickerContext_unstable } from './contexts/TagPickerContext';
 export type { TagPickerContextValue } from './contexts/TagPickerContext';


### PR DESCRIPTION
 Exposes "base" hooks and their types from `@fluentui/react-tag-picker`, so other packages (@fluentui/react-headless-components-preview) can compose a headless `TagPicker` without re-implementing its state logic.

  - Exposed base hooks: 
    - useTagPickerBase_unstable
    - useTagPickerControlBase_unstable
    - useTagPickerInputBase_unstable
    - useTagPickerButtonBase_unstable
    
  - Export TagPickerContextProvider alongside the existing useTagPickerContext_unstable

