### PR TITLE
refactor(react-overflow,priority-overflow): subscribe model removes intermediate state from <Overflow>

### DIFF
--- a/change/@fluentui-priority-overflow-pr2-subscribe.json
+++ b/change/@fluentui-priority-overflow-pr2-subscribe.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: OverflowManager now exposes getSnapshot and subscribe so consumers can subscribe directly to overflow state without forcing intermediate re-renders.",
+  "packageName": "@fluentui/priority-overflow",
+  "email": "bsunderhus@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-priority-overflow-pr2-subscribe.json
+++ b/change/@fluentui-priority-overflow-pr2-subscribe.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "feat: OverflowManager now exposes getSnapshot and subscribe so consumers can subscribe directly to overflow state without forcing intermediate re-renders.",
+  "comment": "feat: expose getSnapshot and subscribe on OverflowManager",
   "packageName": "@fluentui/priority-overflow",
   "email": "bsunderhus@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-overflow-pr2-subscribe.json
+++ b/change/@fluentui-react-overflow-pr2-subscribe.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "fix: each overflow hook (useOverflowCount, useIsOverflowItemVisible, useIsOverflowGroupVisible, useOverflowVisibility) now subscribes to the manager snapshot directly so the Overflow container no longer holds intermediate state. itemVisibility, groupVisibility and hasOverflow on the context are kept for backward compatibility but are now deprecated.",
+  "comment": "fix: subscribe overflow hooks directly to the manager snapshot",
   "packageName": "@fluentui/react-overflow",
   "email": "bsunderhus@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-overflow-pr2-subscribe.json
+++ b/change/@fluentui-react-overflow-pr2-subscribe.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: each overflow hook (useOverflowCount, useIsOverflowItemVisible, useIsOverflowGroupVisible, useOverflowVisibility) now subscribes to the manager snapshot directly so the Overflow container no longer holds intermediate state. itemVisibility, groupVisibility and hasOverflow on the context are kept for backward compatibility but are now deprecated.",
+  "packageName": "@fluentui/react-overflow",
+  "email": "bsunderhus@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/priority-overflow/etc/priority-overflow.api.md
+++ b/packages/react-components/priority-overflow/etc/priority-overflow.api.md
@@ -7,6 +7,9 @@
 // @internal
 export function createOverflowManager(initialOptions?: Partial<ObserveOptions>): OverflowManager;
 
+// @internal
+export const EMPTY_SNAPSHOT: OverflowEventPayload;
+
 // @public
 export interface ObserveOptions {
     hasHiddenItems?: boolean;

--- a/packages/react-components/priority-overflow/etc/priority-overflow.api.md
+++ b/packages/react-components/priority-overflow/etc/priority-overflow.api.md
@@ -68,11 +68,13 @@ export interface OverflowManager {
     addOverflowMenu: (element: HTMLElement) => void;
     disconnect: () => void;
     forceUpdate: () => void;
+    getSnapshot: () => OverflowEventPayload;
     observe: (container: HTMLElement, options?: ObserveOptions) => void;
     removeDivider: (groupId: string) => void;
     removeItem: (itemId: string) => void;
     removeOverflowMenu: () => void;
     setOptions: (options: Partial<ObserveOptions>) => void;
+    subscribe: (listener: () => void) => () => void;
     update: () => void;
 }
 

--- a/packages/react-components/priority-overflow/etc/priority-overflow.api.md
+++ b/packages/react-components/priority-overflow/etc/priority-overflow.api.md
@@ -8,7 +8,7 @@
 export function createOverflowManager(initialOptions?: Partial<ObserveOptions>): OverflowManager;
 
 // @internal
-export const EMPTY_SNAPSHOT: OverflowEventPayload;
+export const EMPTY_SNAPSHOT: OverflowSnapshot;
 
 // @public
 export interface ObserveOptions {
@@ -71,7 +71,7 @@ export interface OverflowManager {
     addOverflowMenu: (element: HTMLElement) => void;
     disconnect: () => void;
     forceUpdate: () => void;
-    getSnapshot: () => OverflowEventPayload;
+    getSnapshot: () => OverflowSnapshot;
     observe: (container: HTMLElement, options?: ObserveOptions) => void;
     removeDivider: (groupId: string) => void;
     removeItem: (itemId: string) => void;
@@ -79,6 +79,13 @@ export interface OverflowManager {
     setOptions: (options: Partial<ObserveOptions>) => void;
     subscribe: (listener: () => void) => () => void;
     update: () => void;
+}
+
+// @public
+export interface OverflowSnapshot {
+    groupVisibility: Record<string, OverflowGroupState>;
+    invisibleItemCount: number;
+    itemVisibility: Record<string, boolean>;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/packages/react-components/priority-overflow/src/consts.ts
+++ b/packages/react-components/priority-overflow/src/consts.ts
@@ -1,2 +1,14 @@
+import type { OverflowEventPayload } from './types';
+
 export const DATA_OVERFLOWING = 'data-overflowing';
 export const DATA_OVERFLOW_GROUP = 'data-overflow-group';
+
+/**
+ * An empty, frozen overflow snapshot used as the default before anything has been measured.
+ * @internal
+ */
+export const EMPTY_SNAPSHOT: OverflowEventPayload = Object.freeze({
+  visibleItems: [],
+  invisibleItems: [],
+  groupVisibility: {},
+});

--- a/packages/react-components/priority-overflow/src/consts.ts
+++ b/packages/react-components/priority-overflow/src/consts.ts
@@ -1,4 +1,4 @@
-import type { OverflowEventPayload } from './types';
+import type { OverflowSnapshot } from './types';
 
 export const DATA_OVERFLOWING = 'data-overflowing';
 export const DATA_OVERFLOW_GROUP = 'data-overflow-group';
@@ -7,8 +7,8 @@ export const DATA_OVERFLOW_GROUP = 'data-overflow-group';
  * An empty, frozen overflow snapshot used as the default before anything has been measured.
  * @internal
  */
-export const EMPTY_SNAPSHOT: OverflowEventPayload = Object.freeze({
-  visibleItems: [],
-  invisibleItems: [],
+export const EMPTY_SNAPSHOT: OverflowSnapshot = Object.freeze({
+  itemVisibility: {},
   groupVisibility: {},
+  invisibleItemCount: 0,
 });

--- a/packages/react-components/priority-overflow/src/index.ts
+++ b/packages/react-components/priority-overflow/src/index.ts
@@ -12,4 +12,5 @@ export type {
   OverflowItemEntry,
   OverflowDividerEntry,
   OverflowManager,
+  OverflowSnapshot,
 } from './types';

--- a/packages/react-components/priority-overflow/src/index.ts
+++ b/packages/react-components/priority-overflow/src/index.ts
@@ -1,4 +1,5 @@
 export { createOverflowManager } from './overflowManager';
+export { EMPTY_SNAPSHOT } from './consts';
 export type {
   ObserveOptions,
   OnUpdateItemVisibility,

--- a/packages/react-components/priority-overflow/src/overflowManager.test.ts
+++ b/packages/react-components/priority-overflow/src/overflowManager.test.ts
@@ -1,5 +1,5 @@
 import { createOverflowManager } from './overflowManager';
-import type { ObserveOptions, OverflowEventPayload } from './types';
+import type { ObserveOptions } from './types';
 
 describe('overflowManager', () => {
   beforeAll(() => {
@@ -45,13 +45,20 @@ describe('overflowManager', () => {
     ...options,
   });
 
-  const lastDispatch = (onUpdateOverflow: jest.Mock): OverflowEventPayload =>
-    onUpdateOverflow.mock.calls[onUpdateOverflow.mock.calls.length - 1][0];
+  const getVisibleIds = (manager: ReturnType<typeof createOverflowManager>) =>
+    manager
+      .getSnapshot()
+      .visibleItems.map(item => item.id)
+      .sort();
 
-  it('should dispatch overflow update after forceUpdate', () => {
-    const onUpdateOverflow = jest.fn();
-    const options = createObserveOptions({ onUpdateOverflow });
-    const manager = createOverflowManager(options);
+  const getInvisibleIds = (manager: ReturnType<typeof createOverflowManager>) =>
+    manager
+      .getSnapshot()
+      .invisibleItems.map(item => item.id)
+      .sort();
+
+  it('should expose a stable snapshot after forceUpdate', () => {
+    const manager = createOverflowManager(createObserveOptions());
     const container = createContainer(100);
     const itemA = createElementWithSize('button', 40);
     const itemB = createElementWithSize('button', 40);
@@ -63,79 +70,74 @@ describe('overflowManager', () => {
     manager.observe(container);
     manager.forceUpdate();
 
-    const dispatch = lastDispatch(onUpdateOverflow);
-    expect(dispatch.visibleItems.map(item => item.id).sort()).toEqual(['a', 'b']);
-    expect(dispatch.invisibleItems).toEqual([]);
-    expect(dispatch.groupVisibility).toEqual({});
+    expect(getVisibleIds(manager)).toEqual(['a', 'b']);
+    expect(getInvisibleIds(manager)).toEqual([]);
+    expect(manager.getSnapshot().groupVisibility).toEqual({});
   });
 
-  it('should re-dispatch when setOptions changes a relevant option', () => {
-    const onUpdateOverflow = jest.fn();
-    const options = createObserveOptions({ onUpdateOverflow });
-    const manager = createOverflowManager(options);
+  it('should update snapshot and notify subscribers when options change', () => {
+    const manager = createOverflowManager(createObserveOptions());
     const container = createContainer(100);
     const itemA = createElementWithSize('button', 40);
     const itemB = createElementWithSize('button', 40);
     const menu = createElementWithSize('button', 20);
+    const listener = jest.fn();
 
     manager.addItem({ element: itemA, id: 'a', priority: 1 });
     manager.addItem({ element: itemB, id: 'b', priority: 0 });
     manager.addOverflowMenu(menu);
     manager.observe(container);
     manager.forceUpdate();
+    const unsubscribe = manager.subscribe(listener);
 
-    onUpdateOverflow.mockClear();
     manager.setOptions({ padding: 30 });
 
-    expect(onUpdateOverflow).toHaveBeenCalled();
-    const dispatch = lastDispatch(onUpdateOverflow);
-    expect(dispatch.visibleItems.map(item => item.id)).toEqual(['a']);
-    expect(dispatch.invisibleItems.map(item => item.id)).toEqual(['b']);
+    expect(listener).toHaveBeenCalled();
+    expect(getVisibleIds(manager)).toEqual(['a']);
+    expect(getInvisibleIds(manager)).toEqual(['b']);
+    expect(manager.getSnapshot().groupVisibility).toEqual({});
+
+    unsubscribe();
   });
 
-  it('should not re-dispatch when setOptions is called with a partial that does not change anything', () => {
-    const onUpdateOverflow = jest.fn();
-    const options = createObserveOptions({ onUpdateOverflow });
-    const manager = createOverflowManager(options);
+  it('should not notify subscribers when setOptions is called with a partial that does not change anything', () => {
+    const manager = createOverflowManager(createObserveOptions());
     const container = createContainer(100);
     const itemA = createElementWithSize('button', 40);
 
     manager.addItem({ element: itemA, id: 'a', priority: 1 });
-    manager.observe(container, options);
+    manager.observe(container);
     manager.forceUpdate();
 
-    onUpdateOverflow.mockClear();
+    const listener = jest.fn();
+    manager.subscribe(listener);
     manager.setOptions({ padding: 10 }); // padding is already 10; no real change
 
-    expect(onUpdateOverflow).not.toHaveBeenCalled();
+    expect(listener).not.toHaveBeenCalled();
   });
 
-  it('disconnect stops observation and re-observe restarts dispatching', () => {
-    const onUpdateOverflow = jest.fn();
-    const options = createObserveOptions({ onUpdateOverflow });
-    const manager = createOverflowManager(options);
+  it('should reset snapshot state when disconnect runs', () => {
+    const manager = createOverflowManager(createObserveOptions());
     const container = createContainer(100);
     const item = createElementWithSize('button', 40);
 
     manager.addItem({ element: item, id: 'a', priority: 1 });
     manager.observe(container);
     manager.forceUpdate();
-    expect(lastDispatch(onUpdateOverflow).visibleItems.map(i => i.id)).toEqual(['a']);
+
+    expect(getVisibleIds(manager)).toEqual(['a']);
 
     manager.disconnect();
-    onUpdateOverflow.mockClear();
 
-    manager.addItem({ element: item, id: 'a', priority: 1 });
-    manager.observe(container);
-    manager.forceUpdate();
-    expect(onUpdateOverflow).toHaveBeenCalled();
-    expect(lastDispatch(onUpdateOverflow).visibleItems.map(i => i.id)).toEqual(['a']);
+    expect(manager.getSnapshot()).toEqual({
+      visibleItems: [],
+      invisibleItems: [],
+      groupVisibility: {},
+    });
   });
 
   it('should remove items through removeItem', () => {
-    const onUpdateOverflow = jest.fn();
-    const options = createObserveOptions({ onUpdateOverflow });
-    const manager = createOverflowManager(options);
+    const manager = createOverflowManager(createObserveOptions());
     const container = createContainer(100);
     const item = createElementWithSize('button', 40);
 
@@ -143,13 +145,15 @@ describe('overflowManager', () => {
     manager.observe(container);
     manager.forceUpdate();
 
-    expect(lastDispatch(onUpdateOverflow).visibleItems.map(i => i.id)).toEqual(['a']);
+    expect(getVisibleIds(manager)).toEqual(['a']);
 
     manager.removeItem('a');
     manager.forceUpdate();
 
-    const dispatch = lastDispatch(onUpdateOverflow);
-    expect(dispatch.visibleItems).toEqual([]);
-    expect(dispatch.invisibleItems).toEqual([]);
+    expect(manager.getSnapshot()).toEqual({
+      visibleItems: [],
+      invisibleItems: [],
+      groupVisibility: {},
+    });
   });
 });

--- a/packages/react-components/priority-overflow/src/overflowManager.test.ts
+++ b/packages/react-components/priority-overflow/src/overflowManager.test.ts
@@ -46,15 +46,15 @@ describe('overflowManager', () => {
   });
 
   const getVisibleIds = (manager: ReturnType<typeof createOverflowManager>) =>
-    manager
-      .getSnapshot()
-      .visibleItems.map(item => item.id)
+    Object.entries(manager.getSnapshot().itemVisibility)
+      .filter(([, visible]) => visible)
+      .map(([id]) => id)
       .sort();
 
   const getInvisibleIds = (manager: ReturnType<typeof createOverflowManager>) =>
-    manager
-      .getSnapshot()
-      .invisibleItems.map(item => item.id)
+    Object.entries(manager.getSnapshot().itemVisibility)
+      .filter(([, visible]) => !visible)
+      .map(([id]) => id)
       .sort();
 
   it('should expose a stable snapshot after forceUpdate', () => {
@@ -130,9 +130,9 @@ describe('overflowManager', () => {
     manager.disconnect();
 
     expect(manager.getSnapshot()).toEqual({
-      visibleItems: [],
-      invisibleItems: [],
+      itemVisibility: {},
       groupVisibility: {},
+      invisibleItemCount: 0,
     });
   });
 
@@ -151,9 +151,9 @@ describe('overflowManager', () => {
     manager.forceUpdate();
 
     expect(manager.getSnapshot()).toEqual({
-      visibleItems: [],
-      invisibleItems: [],
+      itemVisibility: {},
       groupVisibility: {},
+      invisibleItemCount: 0,
     });
   });
 });

--- a/packages/react-components/priority-overflow/src/overflowManager.ts
+++ b/packages/react-components/priority-overflow/src/overflowManager.ts
@@ -9,6 +9,7 @@ import type {
   OverflowManager,
   ObserveOptions,
   OverflowDividerEntry,
+  OverflowEventPayload,
 } from './types';
 
 const DEFAULT_OPTIONS: Required<ObserveOptions> = {
@@ -46,8 +47,20 @@ export function createOverflowManager(initialOptions: Partial<ObserveOptions> = 
   const options: Required<ObserveOptions> = { ...DEFAULT_OPTIONS, ...initialOptions };
   const overflowItems: Record<string, OverflowItemEntry> = {};
   const overflowDividers: Record<string, OverflowDividerEntry> = {};
+  const listeners = new Set<() => void>();
   let disposeResizeObserver: () => void = () => {
     /* noop */
+  };
+
+  let snapshot: OverflowEventPayload = {
+    visibleItems: [],
+    invisibleItems: [],
+    groupVisibility: {},
+  };
+  const takeSnapshot = (nextSnapshot: OverflowEventPayload) => {
+    snapshot = nextSnapshot;
+    options.onUpdateOverflow(snapshot);
+    listeners.forEach(listener => listener());
   };
 
   const getNextItem = (queueToDequeue: PriorityQueue<string>, queueToEnqueue: PriorityQueue<string>) => {
@@ -159,8 +172,14 @@ export function createOverflowManager(initialOptions: Partial<ObserveOptions> = 
     const visibleItems = visibleItemIds.map(itemId => overflowItems[itemId]);
     const invisibleItems = invisibleItemIds.map(itemId => overflowItems[itemId]);
 
-    options.onUpdateOverflow({ visibleItems, invisibleItems, groupVisibility: groupManager.groupVisibility() });
+    takeSnapshot({
+      visibleItems,
+      invisibleItems,
+      groupVisibility: groupManager.groupVisibility(),
+    });
   };
+
+  const getSnapshot: OverflowManager['getSnapshot'] = () => snapshot;
 
   const processOverflowItems = (): boolean => {
     if (!container) {
@@ -271,6 +290,13 @@ export function createOverflowManager(initialOptions: Partial<ObserveOptions> = 
     Object.keys(overflowDividers).forEach(dividerId => removeDivider(dividerId));
     removeOverflowMenu();
     sizeCache.clear();
+
+    // notify subscribers that the manager is no longer tracking anything
+    takeSnapshot({
+      visibleItems: [],
+      invisibleItems: [],
+      groupVisibility: {},
+    });
   };
 
   const addItem: OverflowManager['addItem'] = items => {
@@ -351,6 +377,14 @@ export function createOverflowManager(initialOptions: Partial<ObserveOptions> = 
     }
   };
 
+  const subscribe: OverflowManager['subscribe'] = listener => {
+    listeners.add(listener);
+
+    return () => {
+      listeners.delete(listener);
+    };
+  };
+
   return {
     addItem,
     disconnect,
@@ -363,6 +397,8 @@ export function createOverflowManager(initialOptions: Partial<ObserveOptions> = 
     addDivider,
     removeDivider,
     setOptions,
+    getSnapshot,
+    subscribe,
   };
 }
 

--- a/packages/react-components/priority-overflow/src/overflowManager.ts
+++ b/packages/react-components/priority-overflow/src/overflowManager.ts
@@ -1,4 +1,4 @@
-import { DATA_OVERFLOWING, DATA_OVERFLOW_GROUP } from './consts';
+import { DATA_OVERFLOWING, DATA_OVERFLOW_GROUP, EMPTY_SNAPSHOT } from './consts';
 import { observeResize } from './createResizeObserver';
 import { debounce } from './debounce';
 import type { PriorityQueue } from './priorityQueue';
@@ -52,11 +52,7 @@ export function createOverflowManager(initialOptions: Partial<ObserveOptions> = 
     /* noop */
   };
 
-  let snapshot: OverflowEventPayload = {
-    visibleItems: [],
-    invisibleItems: [],
-    groupVisibility: {},
-  };
+  let snapshot: OverflowEventPayload = EMPTY_SNAPSHOT;
   const takeSnapshot = (nextSnapshot: OverflowEventPayload) => {
     snapshot = nextSnapshot;
     options.onUpdateOverflow(snapshot);
@@ -292,11 +288,7 @@ export function createOverflowManager(initialOptions: Partial<ObserveOptions> = 
     sizeCache.clear();
 
     // notify subscribers that the manager is no longer tracking anything
-    takeSnapshot({
-      visibleItems: [],
-      invisibleItems: [],
-      groupVisibility: {},
-    });
+    takeSnapshot(EMPTY_SNAPSHOT);
   };
 
   const addItem: OverflowManager['addItem'] = items => {

--- a/packages/react-components/priority-overflow/src/overflowManager.ts
+++ b/packages/react-components/priority-overflow/src/overflowManager.ts
@@ -9,7 +9,7 @@ import type {
   OverflowManager,
   ObserveOptions,
   OverflowDividerEntry,
-  OverflowEventPayload,
+  OverflowSnapshot,
 } from './types';
 
 const DEFAULT_OPTIONS: Required<ObserveOptions> = {
@@ -52,10 +52,9 @@ export function createOverflowManager(initialOptions: Partial<ObserveOptions> = 
     /* noop */
   };
 
-  let snapshot: OverflowEventPayload = EMPTY_SNAPSHOT;
-  const takeSnapshot = (nextSnapshot: OverflowEventPayload) => {
+  let snapshot: OverflowSnapshot = EMPTY_SNAPSHOT;
+  const takeSnapshot = (nextSnapshot: OverflowSnapshot) => {
     snapshot = nextSnapshot;
-    options.onUpdateOverflow(snapshot);
     listeners.forEach(listener => listener());
   };
 
@@ -117,11 +116,10 @@ export function createOverflowManager(initialOptions: Partial<ObserveOptions> = 
   const visibleItemQueue = createPriorityQueue<string>(compareItems);
 
   function occupiedSize(): number {
-    const totalItemSize = visibleItemQueue
-      .all()
-      .map(id => overflowItems[id].element)
-      .map(getOffsetSize)
-      .reduce((prev, current) => prev + current, 0);
+    let totalItemSize = 0;
+    for (const id of visibleItemQueue) {
+      totalItemSize += getOffsetSize(overflowItems[id].element);
+    }
 
     const totalDividerSize = Object.entries(groupManager.groupVisibility()).reduce(
       (acc, [id, state]) =>
@@ -162,17 +160,33 @@ export function createOverflowManager(initialOptions: Partial<ObserveOptions> = 
   };
 
   const dispatchOverflowUpdate = () => {
-    const visibleItemIds = visibleItemQueue.all();
-    const invisibleItemIds = invisibleItemQueue.all();
+    const groupVisibility = groupManager.groupVisibility();
 
-    const visibleItems = visibleItemIds.map(itemId => overflowItems[itemId]);
-    const invisibleItems = invisibleItemIds.map(itemId => overflowItems[itemId]);
+    // Build the legacy ordered-entry arrays and the snapshot's id -> visible map in a single pass
+    // over each queue.
+    const itemVisibility: Record<string, boolean> = {};
+    const visibleItems: OverflowItemEntry[] = [];
+    const invisibleItems: OverflowItemEntry[] = [];
 
+    for (const itemId of visibleItemQueue) {
+      itemVisibility[itemId] = true;
+      visibleItems.push(overflowItems[itemId]);
+    }
+    for (const itemId of invisibleItemQueue) {
+      itemVisibility[itemId] = false;
+      invisibleItems.push(overflowItems[itemId]);
+    }
+
+    // Set the snapshot first so `getSnapshot()` is current for both subscribers and any
+    // `onUpdateOverflow` consumer that reads it.
     takeSnapshot({
-      visibleItems,
-      invisibleItems,
-      groupVisibility: groupManager.groupVisibility(),
+      itemVisibility,
+      groupVisibility,
+      invisibleItemCount: invisibleItems.length,
     });
+
+    // Legacy event payload: ordered item entries for `onUpdateOverflow` consumers.
+    options.onUpdateOverflow({ visibleItems, invisibleItems, groupVisibility });
   };
 
   const getSnapshot: OverflowManager['getSnapshot'] = () => snapshot;

--- a/packages/react-components/priority-overflow/src/priorityQueue.ts
+++ b/packages/react-components/priority-overflow/src/priorityQueue.ts
@@ -1,7 +1,6 @@
 export type PriorityQueueCompareFn<T> = (a: T, b: T) => number;
 
-export interface PriorityQueue<T> {
-  all: () => T[];
+export interface PriorityQueue<T> extends Iterable<T> {
   clear: () => void;
   contains: (item: T) => boolean;
   dequeue: () => T;
@@ -107,12 +106,7 @@ export function createPriorityQueue<T>(compare: PriorityQueueCompareFn<T>): Prio
     size = 0;
   };
 
-  const all = () => {
-    return arr.slice(0, size);
-  };
-
   return {
-    all,
     clear,
     contains,
     dequeue,
@@ -120,5 +114,13 @@ export function createPriorityQueue<T>(compare: PriorityQueueCompareFn<T>): Prio
     peek,
     remove,
     size: () => size,
+    // Iterates items in heap order, without allocating an intermediate array. Bounded by `size`:
+    // `arr` keeps stale entries past `size` (dequeue/remove/clear shrink `size`, not `arr`), so the
+    // array's own iterator would yield removed items.
+    *[Symbol.iterator]() {
+      for (let index = 0; index < size; index++) {
+        yield arr[index];
+      }
+    },
   };
 }

--- a/packages/react-components/priority-overflow/src/types.ts
+++ b/packages/react-components/priority-overflow/src/types.ts
@@ -90,6 +90,29 @@ export interface OverflowEventPayload {
 }
 
 /**
+ * Indexed, immutable overflow state returned by `OverflowManager.getSnapshot`.
+ *
+ * Unlike {@link OverflowEventPayload}, this is shaped for O(1) consumer lookups (item/group
+ * visibility by id, item count) rather than ordered item entries.
+ */
+export interface OverflowSnapshot {
+  /**
+   * Visibility of each registered item, keyed by item id.
+   */
+  itemVisibility: Record<string, boolean>;
+
+  /**
+   * Current visibility state by group id.
+   */
+  groupVisibility: Record<string, OverflowGroupState>;
+
+  /**
+   * Number of items currently moved to overflow (invisible).
+   */
+  invisibleItemCount: number;
+}
+
+/**
  * Payload for item-level visibility updates.
  */
 export interface OnUpdateItemVisibilityPayload {
@@ -206,9 +229,9 @@ export interface OverflowManager {
   removeOverflowMenu: () => void;
 
   /**
-   * Returns the current canonical overflow snapshot.
+   * Returns the current overflow snapshot.
    */
-  getSnapshot: () => OverflowEventPayload;
+  getSnapshot: () => OverflowSnapshot;
 
   /**
    * Subscribes to snapshot changes.

--- a/packages/react-components/priority-overflow/src/types.ts
+++ b/packages/react-components/priority-overflow/src/types.ts
@@ -204,4 +204,14 @@ export interface OverflowManager {
    * Unsets the overflow menu element
    */
   removeOverflowMenu: () => void;
+
+  /**
+   * Returns the current canonical overflow snapshot.
+   */
+  getSnapshot: () => OverflowEventPayload;
+
+  /**
+   * Subscribes to snapshot changes.
+   */
+  subscribe: (listener: () => void) => () => void;
 }

--- a/packages/react-components/react-overflow/library/etc/react-overflow.api.md
+++ b/packages/react-components/react-overflow/library/etc/react-overflow.api.md
@@ -7,9 +7,9 @@
 import type { ObserveOptions } from '@fluentui/priority-overflow';
 import type { OnUpdateOverflow } from '@fluentui/priority-overflow';
 import type { OverflowDividerEntry } from '@fluentui/priority-overflow';
-import type { OverflowEventPayload } from '@fluentui/priority-overflow';
 import type { OverflowGroupState } from '@fluentui/priority-overflow';
 import type { OverflowItemEntry } from '@fluentui/priority-overflow';
+import type { OverflowSnapshot } from '@fluentui/priority-overflow';
 import * as React_2 from 'react';
 
 // @public (undocumented)

--- a/packages/react-components/react-overflow/library/etc/react-overflow.api.md
+++ b/packages/react-components/react-overflow/library/etc/react-overflow.api.md
@@ -4,11 +4,11 @@
 
 ```ts
 
-import type { ContextSelector } from '@fluentui/react-context-selector';
 import type { ObserveOptions } from '@fluentui/priority-overflow';
 import type { OnUpdateOverflow } from '@fluentui/priority-overflow';
 import type { OverflowDividerEntry } from '@fluentui/priority-overflow';
-import { OverflowGroupState } from '@fluentui/priority-overflow';
+import type { OverflowEventPayload } from '@fluentui/priority-overflow';
+import type { OverflowGroupState } from '@fluentui/priority-overflow';
 import type { OverflowItemEntry } from '@fluentui/priority-overflow';
 import * as React_2 from 'react';
 
@@ -72,12 +72,15 @@ export function useIsOverflowItemVisible(id: string): boolean;
 export const useOverflowContainer: <TElement extends HTMLElement>(update: OnUpdateOverflow, options: Omit<ObserveOptions, "onUpdateOverflow">) => UseOverflowContainerReturn<TElement>;
 
 // @internal (undocumented)
-export interface UseOverflowContainerReturn<TElement extends HTMLElement> extends Pick<OverflowContextValue, 'registerItem' | 'updateOverflow' | 'registerOverflowMenu' | 'registerDivider'> {
+export interface UseOverflowContainerReturn<TElement extends HTMLElement> extends Pick<OverflowContextValue, 'registerItem' | 'updateOverflow' | 'registerOverflowMenu' | 'registerDivider' | 'getSnapshot' | 'subscribe'> {
     containerRef: React_2.RefObject<TElement | null>;
 }
 
 // @internal (undocumented)
-export const useOverflowContext: <SelectedValue>(selector: ContextSelector<OverflowContextValue, SelectedValue>) => SelectedValue;
+export function useOverflowContext(): OverflowContextValue;
+
+// @internal (undocumented)
+export function useOverflowContext<SelectedValue>(selector: (context: OverflowContextValue) => SelectedValue): SelectedValue;
 
 // @public (undocumented)
 export const useOverflowCount: () => number;

--- a/packages/react-components/react-overflow/library/package.json
+++ b/packages/react-components/react-overflow/library/package.json
@@ -13,7 +13,6 @@
   "license": "MIT",
   "dependencies": {
     "@fluentui/priority-overflow": "^9.3.0",
-    "@fluentui/react-context-selector": "^9.2.17",
     "@fluentui/react-shared-contexts": "^9.26.2",
     "@fluentui/react-theme": "^9.2.1",
     "@fluentui/react-utilities": "^9.26.4",

--- a/packages/react-components/react-overflow/library/src/Overflow.cy.tsx
+++ b/packages/react-components/react-overflow/library/src/Overflow.cy.tsx
@@ -7,7 +7,7 @@ import {
   OverflowReorderObserver,
   useIsOverflowGroupVisible,
   useOverflowMenu,
-  useOverflowContext,
+  useOverflowVisibility,
   type OverflowProps,
   type OverflowItemProps,
   type OnOverflowChangeData,
@@ -96,7 +96,7 @@ const Item = ({ children, width, ...overflowItemProps }: ItemProps) => {
 
 const Menu: React.FC<{ width?: number }> = ({ width }) => {
   const { isOverflowing, ref, overflowCount } = useOverflowMenu<HTMLButtonElement>();
-  const itemVisibility = useOverflowContext(ctx => ctx.itemVisibility);
+  const { itemVisibility } = useOverflowVisibility();
   const selector = {
     [selectors.menu]: '',
   };

--- a/packages/react-components/react-overflow/library/src/components/Overflow.tsx
+++ b/packages/react-components/react-overflow/library/src/components/Overflow.tsx
@@ -2,7 +2,12 @@
 
 import * as React from 'react';
 import { mergeClasses } from '@griffel/react';
-import type { OnUpdateOverflow, OverflowGroupState, ObserveOptions } from '@fluentui/priority-overflow';
+import type {
+  ObserveOptions,
+  OnUpdateOverflow,
+  OverflowEventPayload,
+  OverflowGroupState,
+} from '@fluentui/priority-overflow';
 import {
   applyTriggerPropsToChildren,
   getTriggerChild,
@@ -10,7 +15,7 @@ import {
   useMergedRefs,
 } from '@fluentui/react-utilities';
 
-import { OverflowContext } from '../overflowContext';
+import { OverflowContext, type OverflowContextValue } from '../overflowContext';
 import { updateVisibilityAttribute, useOverflowContainer } from '../useOverflowContainer';
 import { useOverflowStyles } from './useOverflowStyles.styles';
 
@@ -51,42 +56,22 @@ export const Overflow = React.forwardRef((props: OverflowProps, ref) => {
     hasHiddenItems,
   } = props;
 
-  const [overflowState, setOverflowState] = React.useState<OverflowState>({
-    hasOverflow: false,
-    itemVisibility: {},
-    groupVisibility: {},
-  });
-
-  // useOverflowContainer wraps this method in a useEventCallback.
   const update: OnUpdateOverflow = data => {
-    const { visibleItems, invisibleItems, groupVisibility } = data;
-
-    const itemVisibility: Record<string, boolean> = {};
-    visibleItems.forEach(item => {
-      itemVisibility[item.id] = true;
-    });
-    invisibleItems.forEach(x => (itemVisibility[x.id] = false));
-    const newState = {
-      hasOverflow: data.invisibleItems.length > 0,
-      itemVisibility,
-      groupVisibility,
-    };
-    onOverflowChange?.(null, { ...newState });
-
-    setOverflowState(newState);
+    if (!onOverflowChange) {
+      return;
+    }
+    onOverflowChange(null, _overflowPayloadToState(data));
   };
 
-  const { containerRef, registerItem, updateOverflow, registerOverflowMenu, registerDivider } = useOverflowContainer(
-    update,
-    {
+  const { containerRef, getSnapshot, subscribe, registerItem, updateOverflow, registerOverflowMenu, registerDivider } =
+    useOverflowContainer(update, {
       overflowDirection,
       overflowAxis,
       padding,
       minimumVisible,
       hasHiddenItems,
       onUpdateItemVisibility: updateVisibilityAttribute,
-    },
-  );
+    });
 
   const child = getTriggerChild<HTMLElement>(children);
   const clonedChild = applyTriggerPropsToChildren(children, {
@@ -94,20 +79,37 @@ export const Overflow = React.forwardRef((props: OverflowProps, ref) => {
     className: mergeClasses('fui-Overflow', styles.overflowMenu, styles.overflowingItems, child?.props.className),
   });
 
-  return (
-    <OverflowContext.Provider
-      value={{
-        itemVisibility: overflowState.itemVisibility,
-        groupVisibility: overflowState.groupVisibility,
-        hasOverflow: overflowState.hasOverflow,
-        registerItem,
-        updateOverflow,
-        registerOverflowMenu,
-        registerDivider,
-        containerRef,
-      }}
-    >
-      {clonedChild}
-    </OverflowContext.Provider>
+  const ctx: OverflowContextValue = React.useMemo(
+    () => ({
+      groupVisibility: {},
+      itemVisibility: {},
+      hasOverflow: false,
+      registerItem,
+      updateOverflow,
+      registerOverflowMenu,
+      registerDivider,
+      containerRef,
+      getSnapshot,
+      subscribe,
+    }),
+    [getSnapshot, subscribe, registerItem, updateOverflow, registerOverflowMenu, registerDivider, containerRef],
   );
+
+  return <OverflowContext.Provider value={ctx}>{clonedChild}</OverflowContext.Provider>;
 });
+
+/**
+ * @internal
+ */
+export const _overflowPayloadToState = (data: OverflowEventPayload): OverflowState => {
+  const itemVisibility: Record<string, boolean> = {};
+  data.visibleItems.forEach(item => {
+    itemVisibility[item.id] = true;
+  });
+  data.invisibleItems.forEach(x => (itemVisibility[x.id] = false));
+  return {
+    itemVisibility,
+    groupVisibility: data.groupVisibility,
+    hasOverflow: data.invisibleItems.length > 0,
+  };
+};

--- a/packages/react-components/react-overflow/library/src/components/Overflow.tsx
+++ b/packages/react-components/react-overflow/library/src/components/Overflow.tsx
@@ -17,6 +17,7 @@ import {
 
 import { OverflowContext, type OverflowContextValue } from '../overflowContext';
 import { updateVisibilityAttribute, useOverflowContainer } from '../useOverflowContainer';
+import { selectVisibility } from '../useOverflowVisibility';
 import { useOverflowStyles } from './useOverflowStyles.styles';
 
 interface OverflowState {
@@ -57,10 +58,7 @@ export const Overflow = React.forwardRef((props: OverflowProps, ref) => {
   } = props;
 
   const update: OnUpdateOverflow = data => {
-    if (!onOverflowChange) {
-      return;
-    }
-    onOverflowChange(null, _overflowPayloadToState(data));
+    onOverflowChange?.(null, _overflowPayloadToState(data));
   };
 
   const { containerRef, getSnapshot, subscribe, registerItem, updateOverflow, registerOverflowMenu, registerDivider } =
@@ -101,15 +99,7 @@ export const Overflow = React.forwardRef((props: OverflowProps, ref) => {
 /**
  * @internal
  */
-export const _overflowPayloadToState = (data: OverflowEventPayload): OverflowState => {
-  const itemVisibility: Record<string, boolean> = {};
-  data.visibleItems.forEach(item => {
-    itemVisibility[item.id] = true;
-  });
-  data.invisibleItems.forEach(x => (itemVisibility[x.id] = false));
-  return {
-    itemVisibility,
-    groupVisibility: data.groupVisibility,
-    hasOverflow: data.invisibleItems.length > 0,
-  };
-};
+export const _overflowPayloadToState = (data: OverflowEventPayload): OverflowState => ({
+  ...selectVisibility(data),
+  hasOverflow: data.invisibleItems.length > 0,
+});

--- a/packages/react-components/react-overflow/library/src/components/Overflow.tsx
+++ b/packages/react-components/react-overflow/library/src/components/Overflow.tsx
@@ -2,12 +2,7 @@
 
 import * as React from 'react';
 import { mergeClasses } from '@griffel/react';
-import type {
-  ObserveOptions,
-  OnUpdateOverflow,
-  OverflowEventPayload,
-  OverflowGroupState,
-} from '@fluentui/priority-overflow';
+import type { ObserveOptions, OnUpdateOverflow, OverflowGroupState } from '@fluentui/priority-overflow';
 import {
   applyTriggerPropsToChildren,
   getTriggerChild,
@@ -17,7 +12,6 @@ import {
 
 import { OverflowContext, type OverflowContextValue } from '../overflowContext';
 import { updateVisibilityAttribute, useOverflowContainer } from '../useOverflowContainer';
-import { selectVisibility } from '../useOverflowVisibility';
 import { useOverflowStyles } from './useOverflowStyles.styles';
 
 interface OverflowState {
@@ -58,7 +52,13 @@ export const Overflow = React.forwardRef((props: OverflowProps, ref) => {
   } = props;
 
   const update: OnUpdateOverflow = data => {
-    onOverflowChange?.(null, _overflowPayloadToState(data));
+    const snapshot = getSnapshot();
+    const state: OverflowState = {
+      hasOverflow: snapshot.invisibleItemCount > 0,
+      itemVisibility: snapshot.itemVisibility,
+      groupVisibility: snapshot.groupVisibility,
+    };
+    onOverflowChange?.(null, state);
   };
 
   const { containerRef, getSnapshot, subscribe, registerItem, updateOverflow, registerOverflowMenu, registerDivider } =
@@ -94,12 +94,4 @@ export const Overflow = React.forwardRef((props: OverflowProps, ref) => {
   );
 
   return <OverflowContext.Provider value={ctx}>{clonedChild}</OverflowContext.Provider>;
-});
-
-/**
- * @internal
- */
-export const _overflowPayloadToState = (data: OverflowEventPayload): OverflowState => ({
-  ...selectVisibility(data),
-  hasOverflow: data.invisibleItems.length > 0,
 });

--- a/packages/react-components/react-overflow/library/src/overflowContext.ts
+++ b/packages/react-components/react-overflow/library/src/overflowContext.ts
@@ -6,6 +6,7 @@ import type {
   OverflowGroupState,
   OverflowEventPayload,
 } from '@fluentui/priority-overflow';
+import { EMPTY_SNAPSHOT } from '@fluentui/priority-overflow';
 import * as React from 'react';
 
 /**
@@ -49,11 +50,7 @@ const overflowContextDefaultValue: OverflowContextValue = {
   updateOverflow: noop,
   registerOverflowMenu: () => noop,
   registerDivider: () => noop,
-  getSnapshot: () => ({
-    visibleItems: [],
-    invisibleItems: [],
-    groupVisibility: {},
-  }),
+  getSnapshot: () => EMPTY_SNAPSHOT,
   subscribe: () => noop,
 };
 

--- a/packages/react-components/react-overflow/library/src/overflowContext.ts
+++ b/packages/react-components/react-overflow/library/src/overflowContext.ts
@@ -4,7 +4,7 @@ import type {
   OverflowItemEntry,
   OverflowDividerEntry,
   OverflowGroupState,
-  OverflowEventPayload,
+  OverflowSnapshot,
 } from '@fluentui/priority-overflow';
 import { EMPTY_SNAPSHOT } from '@fluentui/priority-overflow';
 import * as React from 'react';
@@ -30,7 +30,7 @@ export interface OverflowContextValue {
   registerDivider: (divider: OverflowDividerEntry) => () => void;
   updateOverflow: (padding?: number) => void;
   containerRef?: React.RefObject<HTMLElement | null>;
-  getSnapshot: () => OverflowEventPayload;
+  getSnapshot: () => OverflowSnapshot;
   subscribe: (listener: () => void) => () => void;
 }
 

--- a/packages/react-components/react-overflow/library/src/overflowContext.ts
+++ b/packages/react-components/react-overflow/library/src/overflowContext.ts
@@ -1,41 +1,71 @@
 'use client';
 
-import type * as React from 'react';
-import type { OverflowGroupState, OverflowItemEntry, OverflowDividerEntry } from '@fluentui/priority-overflow';
-import type { ContextSelector, Context } from '@fluentui/react-context-selector';
-import { createContext, useContextSelector } from '@fluentui/react-context-selector';
+import type {
+  OverflowItemEntry,
+  OverflowDividerEntry,
+  OverflowGroupState,
+  OverflowEventPayload,
+} from '@fluentui/priority-overflow';
+import * as React from 'react';
 
 /**
  * @internal
  */
 export interface OverflowContextValue {
+  /**
+   * @deprecated This value is not guaranteed to be up to date and should not be used directly. Use getSnapshot or the provided hooks instead
+   */
   itemVisibility: Record<string, boolean>;
+  /**
+   * @deprecated This value is not guaranteed to be up to date and should not be used directly. Use getSnapshot or the provided hooks instead
+   */
   groupVisibility: Record<string, OverflowGroupState>;
+  /**
+   * @deprecated This value is not guaranteed to be up to date and should not be used directly. Use getSnapshot or the provided hooks instead
+   */
   hasOverflow: boolean;
   registerItem: (item: OverflowItemEntry) => () => void;
   registerOverflowMenu: (el: HTMLElement) => () => void;
   registerDivider: (divider: OverflowDividerEntry) => () => void;
   updateOverflow: (padding?: number) => void;
   containerRef?: React.RefObject<HTMLElement | null>;
+  getSnapshot: () => OverflowEventPayload;
+  subscribe: (listener: () => void) => () => void;
 }
 
-export const OverflowContext = createContext<OverflowContextValue | undefined>(
+export const OverflowContext = React.createContext<OverflowContextValue | undefined>(
   undefined,
-) as Context<OverflowContextValue>;
+) as React.Context<OverflowContextValue>;
 
 const overflowContextDefaultValue: OverflowContextValue = {
+  hasOverflow: false,
   itemVisibility: {},
   groupVisibility: {},
-  hasOverflow: false,
   registerItem: () => () => null,
   updateOverflow: () => null,
   registerOverflowMenu: () => () => null,
   registerDivider: () => () => null,
+  getSnapshot: () => ({
+    visibleItems: [],
+    invisibleItems: [],
+    groupVisibility: {},
+  }),
+  subscribe: () => () => null,
 };
 
 /**
  * @internal
  */
-export const useOverflowContext = <SelectedValue>(
-  selector: ContextSelector<OverflowContextValue, SelectedValue>,
-): SelectedValue => useContextSelector(OverflowContext, (ctx = overflowContextDefaultValue) => selector(ctx));
+export function useOverflowContext(): OverflowContextValue;
+/**
+ * @internal
+ */
+export function useOverflowContext<SelectedValue>(
+  selector: (context: OverflowContextValue) => SelectedValue,
+): SelectedValue;
+export function useOverflowContext<SelectedValue>(
+  selector?: (context: OverflowContextValue) => SelectedValue,
+): SelectedValue | OverflowContextValue {
+  const context = React.useContext(OverflowContext) ?? overflowContextDefaultValue;
+  return selector ? selector(context) : context;
+}

--- a/packages/react-components/react-overflow/library/src/overflowContext.ts
+++ b/packages/react-components/react-overflow/library/src/overflowContext.ts
@@ -37,20 +37,24 @@ export const OverflowContext = React.createContext<OverflowContextValue | undefi
   undefined,
 ) as React.Context<OverflowContextValue>;
 
+const noop = () => {
+  /* noop */
+};
+
 const overflowContextDefaultValue: OverflowContextValue = {
   hasOverflow: false,
   itemVisibility: {},
   groupVisibility: {},
-  registerItem: () => () => null,
-  updateOverflow: () => null,
-  registerOverflowMenu: () => () => null,
-  registerDivider: () => () => null,
+  registerItem: () => noop,
+  updateOverflow: noop,
+  registerOverflowMenu: () => noop,
+  registerDivider: () => noop,
   getSnapshot: () => ({
     visibleItems: [],
     invisibleItems: [],
     groupVisibility: {},
   }),
-  subscribe: () => () => null,
+  subscribe: () => noop,
 };
 
 /**

--- a/packages/react-components/react-overflow/library/src/types.ts
+++ b/packages/react-components/react-overflow/library/src/types.ts
@@ -5,7 +5,10 @@ import type { OverflowContextValue } from './overflowContext';
  * @internal
  */
 export interface UseOverflowContainerReturn<TElement extends HTMLElement>
-  extends Pick<OverflowContextValue, 'registerItem' | 'updateOverflow' | 'registerOverflowMenu' | 'registerDivider'> {
+  extends Pick<
+    OverflowContextValue,
+    'registerItem' | 'updateOverflow' | 'registerOverflowMenu' | 'registerDivider' | 'getSnapshot' | 'subscribe'
+  > {
   /**
    * Ref to apply to the container that will overflow
    */

--- a/packages/react-components/react-overflow/library/src/useIsOverflowGroupVisible.ts
+++ b/packages/react-components/react-overflow/library/src/useIsOverflowGroupVisible.ts
@@ -8,5 +8,5 @@ import { useOverflowSnapshot } from './useOverflowSnapshot';
  * @returns visibility state of the group
  */
 export function useIsOverflowGroupVisible(id: string): OverflowGroupState {
-  return useOverflowSnapshot().groupVisibility[id];
+  return useOverflowSnapshot(snapshot => snapshot.groupVisibility[id]);
 }

--- a/packages/react-components/react-overflow/library/src/useIsOverflowGroupVisible.ts
+++ b/packages/react-components/react-overflow/library/src/useIsOverflowGroupVisible.ts
@@ -1,12 +1,12 @@
 'use client';
 
 import type { OverflowGroupState } from '@fluentui/priority-overflow';
-import { useOverflowContext } from './overflowContext';
+import { useOverflowSnapshot } from './useOverflowSnapshot';
 
 /**
  * @param id - unique identifier for a group of overflow items
  * @returns visibility state of the group
  */
 export function useIsOverflowGroupVisible(id: string): OverflowGroupState {
-  return useOverflowContext(ctx => ctx.groupVisibility[id]);
+  return useOverflowSnapshot().groupVisibility[id];
 }

--- a/packages/react-components/react-overflow/library/src/useIsOverflowItemVisible.ts
+++ b/packages/react-components/react-overflow/library/src/useIsOverflowItemVisible.ts
@@ -1,11 +1,11 @@
 'use client';
 
-import { useOverflowContext } from './overflowContext';
+import { useOverflowSnapshot } from './useOverflowSnapshot';
 
 /**
  * @param id - unique identifier for the item used by the overflow manager
  * @returns visibility state of an overflow item
  */
 export function useIsOverflowItemVisible(id: string): boolean {
-  return !!useOverflowContext(ctx => ctx.itemVisibility[id]);
+  return useOverflowSnapshot().visibleItems.some(item => item.id === id);
 }

--- a/packages/react-components/react-overflow/library/src/useIsOverflowItemVisible.ts
+++ b/packages/react-components/react-overflow/library/src/useIsOverflowItemVisible.ts
@@ -7,5 +7,5 @@ import { useOverflowSnapshot } from './useOverflowSnapshot';
  * @returns visibility state of an overflow item
  */
 export function useIsOverflowItemVisible(id: string): boolean {
-  return useOverflowSnapshot(snapshot => snapshot.visibleItems.some(item => item.id === id));
+  return useOverflowSnapshot(snapshot => !!snapshot.itemVisibility[id]);
 }

--- a/packages/react-components/react-overflow/library/src/useIsOverflowItemVisible.ts
+++ b/packages/react-components/react-overflow/library/src/useIsOverflowItemVisible.ts
@@ -7,5 +7,5 @@ import { useOverflowSnapshot } from './useOverflowSnapshot';
  * @returns visibility state of an overflow item
  */
 export function useIsOverflowItemVisible(id: string): boolean {
-  return useOverflowSnapshot().visibleItems.some(item => item.id === id);
+  return useOverflowSnapshot(snapshot => snapshot.visibleItems.some(item => item.id === id));
 }

--- a/packages/react-components/react-overflow/library/src/useOverflowContainer.test.tsx
+++ b/packages/react-components/react-overflow/library/src/useOverflowContainer.test.tsx
@@ -20,6 +20,8 @@ const mockOverflowManager = (options: Partial<OverflowManager> = {}) => {
     addDivider: jest.fn(),
     removeDivider: jest.fn(),
     setOptions: jest.fn(),
+    getSnapshot: jest.fn(() => ({ visibleItems: [], invisibleItems: [], groupVisibility: {} })),
+    subscribe: jest.fn(() => () => null),
   };
   (createOverflowManager as jest.Mock).mockReturnValue({
     ...defaultMock,

--- a/packages/react-components/react-overflow/library/src/useOverflowContainer.test.tsx
+++ b/packages/react-components/react-overflow/library/src/useOverflowContainer.test.tsx
@@ -20,7 +20,7 @@ const mockOverflowManager = (options: Partial<OverflowManager> = {}) => {
     addDivider: jest.fn(),
     removeDivider: jest.fn(),
     setOptions: jest.fn(),
-    getSnapshot: jest.fn(() => ({ visibleItems: [], invisibleItems: [], groupVisibility: {} })),
+    getSnapshot: jest.fn(() => ({ itemVisibility: {}, groupVisibility: {}, invisibleItemCount: 0 })),
     subscribe: jest.fn(() => () => null),
   };
   (createOverflowManager as jest.Mock).mockReturnValue({

--- a/packages/react-components/react-overflow/library/src/useOverflowContainer.ts
+++ b/packages/react-components/react-overflow/library/src/useOverflowContainer.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import * as React from 'react';
-import { createOverflowManager } from '@fluentui/priority-overflow';
+import { createOverflowManager, EMPTY_SNAPSHOT } from '@fluentui/priority-overflow';
 
 /**
  * @internal
@@ -119,7 +119,7 @@ export const useOverflowContainer = <TElement extends HTMLElement>(
   }, []);
 
   const getSnapshot = React.useCallback<OverflowManager['getSnapshot']>(
-    () => managerRef.current?.getSnapshot() ?? defaultSnapshot,
+    () => managerRef.current?.getSnapshot() ?? EMPTY_SNAPSHOT,
     [],
   );
 
@@ -141,12 +141,6 @@ export const useOverflowContainer = <TElement extends HTMLElement>(
 
 const noop = () => {
   /* noop */
-};
-
-const defaultSnapshot = {
-  visibleItems: [],
-  invisibleItems: [],
-  groupVisibility: {},
 };
 
 export const updateVisibilityAttribute: OnUpdateItemVisibility = ({ item, visible }) => {

--- a/packages/react-components/react-overflow/library/src/useOverflowContainer.ts
+++ b/packages/react-components/react-overflow/library/src/useOverflowContainer.ts
@@ -118,17 +118,35 @@ export const useOverflowContainer = <TElement extends HTMLElement>(
     managerRef.current?.update();
   }, []);
 
+  const getSnapshot = React.useCallback<OverflowManager['getSnapshot']>(
+    () => managerRef.current?.getSnapshot() ?? defaultSnapshot,
+    [],
+  );
+
+  const subscribe = React.useCallback<OverflowManager['subscribe']>(
+    listener => managerRef.current?.subscribe(listener) ?? noop,
+    [],
+  );
+
   return {
     registerItem,
     registerDivider,
     registerOverflowMenu,
     updateOverflow,
     containerRef,
+    getSnapshot,
+    subscribe,
   };
 };
 
 const noop = () => {
   /* noop */
+};
+
+const defaultSnapshot = {
+  visibleItems: [],
+  invisibleItems: [],
+  groupVisibility: {},
 };
 
 export const updateVisibilityAttribute: OnUpdateItemVisibility = ({ item, visible }) => {

--- a/packages/react-components/react-overflow/library/src/useOverflowCount.ts
+++ b/packages/react-components/react-overflow/library/src/useOverflowCount.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import type { OverflowEventPayload } from '@fluentui/priority-overflow';
+import type { OverflowSnapshot } from '@fluentui/priority-overflow';
 import { useOverflowSnapshot } from './useOverflowSnapshot';
 
 /**
@@ -8,4 +8,4 @@ import { useOverflowSnapshot } from './useOverflowSnapshot';
  */
 export const useOverflowCount = (): number => useOverflowSnapshot(selectInvisibleItemCount);
 
-const selectInvisibleItemCount = (snapshot: OverflowEventPayload): number => snapshot.invisibleItems.length;
+const selectInvisibleItemCount = (snapshot: OverflowSnapshot): number => snapshot.invisibleItemCount;

--- a/packages/react-components/react-overflow/library/src/useOverflowCount.ts
+++ b/packages/react-components/react-overflow/library/src/useOverflowCount.ts
@@ -1,17 +1,8 @@
 'use client';
 
-import { useOverflowContext } from './overflowContext';
+import { useOverflowSnapshot } from './useOverflowSnapshot';
 
 /**
  * @returns Number of items that are overflowing
  */
-export const useOverflowCount = (): number =>
-  useOverflowContext(v => {
-    return Object.entries(v.itemVisibility).reduce((acc, [id, visible]) => {
-      if (!visible) {
-        acc++;
-      }
-
-      return acc;
-    }, 0);
-  });
+export const useOverflowCount = (): number => useOverflowSnapshot().invisibleItems.length;

--- a/packages/react-components/react-overflow/library/src/useOverflowCount.ts
+++ b/packages/react-components/react-overflow/library/src/useOverflowCount.ts
@@ -1,8 +1,11 @@
 'use client';
 
+import type { OverflowEventPayload } from '@fluentui/priority-overflow';
 import { useOverflowSnapshot } from './useOverflowSnapshot';
 
 /**
  * @returns Number of items that are overflowing
  */
-export const useOverflowCount = (): number => useOverflowSnapshot().invisibleItems.length;
+export const useOverflowCount = (): number => useOverflowSnapshot(selectInvisibleItemCount);
+
+const selectInvisibleItemCount = (snapshot: OverflowEventPayload): number => snapshot.invisibleItems.length;

--- a/packages/react-components/react-overflow/library/src/useOverflowSnapshot.ts
+++ b/packages/react-components/react-overflow/library/src/useOverflowSnapshot.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import type { OverflowEventPayload } from '@fluentui/priority-overflow';
+import type { OverflowSnapshot } from '@fluentui/priority-overflow';
 import * as React from 'react';
 import { useEventCallback, useIsomorphicLayoutEffect } from '@fluentui/react-utilities';
 import { useOverflowContext } from './overflowContext';
@@ -8,39 +8,19 @@ import { useOverflowContext } from './overflowContext';
 /**
  * Subscribes to the overflow snapshot and returns a derived slice of it.
  *
- * Only re-renders the consuming component when the selected slice changes (per `isEqual`), so hooks
- * like `useIsOverflowItemVisible` don't re-render on every unrelated overflow change. Intentionally
- * implemented with state + effects (the `useSelector` pattern) rather than `useSyncExternalStore`,
- * which would force a synchronous re-render/flush on every snapshot change.
- *
  * @param selector - derives the slice of the snapshot the consumer depends on
- * @param isEqual - compares the previous and next slice; defaults to `Object.is`
  */
-export function useOverflowSnapshot<Selected>(
-  selector: (snapshot: OverflowEventPayload) => Selected,
-  isEqual: (a: Selected, b: Selected) => boolean = Object.is,
-): Selected {
+export function useOverflowSnapshot<Selected>(selector: (snapshot: OverflowSnapshot) => Selected): Selected {
   const { getSnapshot, subscribe } = useOverflowContext();
-
-  // Stable wrappers around the latest selector/isEqual, so the subscription effect runs once and
-  // does not need to re-subscribe when an inline selector changes identity between renders.
   const select = useEventCallback(selector);
-  const compareSelected = useEventCallback(isEqual);
 
   const [selected, setSelected] = React.useState(() => selector(getSnapshot()));
 
   useIsomorphicLayoutEffect(() => {
-    const checkForUpdates = () => {
-      setSelected(previous => {
-        const next = select(getSnapshot());
-        return compareSelected(previous, next) ? previous : next;
-      });
-    };
-
-    // The snapshot may have changed between render and subscription.
+    const checkForUpdates = () => setSelected(select(getSnapshot()));
     checkForUpdates();
     return subscribe(checkForUpdates);
-  }, [subscribe, getSnapshot, select, compareSelected]);
+  }, [subscribe, getSnapshot, select]);
 
   return selected;
 }

--- a/packages/react-components/react-overflow/library/src/useOverflowSnapshot.ts
+++ b/packages/react-components/react-overflow/library/src/useOverflowSnapshot.ts
@@ -2,16 +2,45 @@
 
 import type { OverflowEventPayload } from '@fluentui/priority-overflow';
 import * as React from 'react';
+import { useEventCallback, useIsomorphicLayoutEffect } from '@fluentui/react-utilities';
 import { useOverflowContext } from './overflowContext';
-import { useIsomorphicLayoutEffect } from '@fluentui/react-utilities';
 
-export const useOverflowSnapshot = (): OverflowEventPayload => {
+/**
+ * Subscribes to the overflow snapshot and returns a derived slice of it.
+ *
+ * Only re-renders the consuming component when the selected slice changes (per `isEqual`), so hooks
+ * like `useIsOverflowItemVisible` don't re-render on every unrelated overflow change. Intentionally
+ * implemented with state + effects (the `useSelector` pattern) rather than `useSyncExternalStore`,
+ * which would force a synchronous re-render/flush on every snapshot change.
+ *
+ * @param selector - derives the slice of the snapshot the consumer depends on
+ * @param isEqual - compares the previous and next slice; defaults to `Object.is`
+ */
+export function useOverflowSnapshot<Selected>(
+  selector: (snapshot: OverflowEventPayload) => Selected,
+  isEqual: (a: Selected, b: Selected) => boolean = Object.is,
+): Selected {
   const { getSnapshot, subscribe } = useOverflowContext();
-  const [snapshot, setSnapshot] = React.useState(() => getSnapshot());
+
+  // Stable wrappers around the latest selector/isEqual, so the subscription effect runs once and
+  // does not need to re-subscribe when an inline selector changes identity between renders.
+  const select = useEventCallback(selector);
+  const compareSelected = useEventCallback(isEqual);
+
+  const [selected, setSelected] = React.useState(() => selector(getSnapshot()));
+
   useIsomorphicLayoutEffect(() => {
-    return subscribe(() => {
-      setSnapshot(getSnapshot());
-    });
-  }, [subscribe, getSnapshot]);
-  return snapshot;
-};
+    const checkForUpdates = () => {
+      setSelected(previous => {
+        const next = select(getSnapshot());
+        return compareSelected(previous, next) ? previous : next;
+      });
+    };
+
+    // The snapshot may have changed between render and subscription.
+    checkForUpdates();
+    return subscribe(checkForUpdates);
+  }, [subscribe, getSnapshot, select, compareSelected]);
+
+  return selected;
+}

--- a/packages/react-components/react-overflow/library/src/useOverflowSnapshot.ts
+++ b/packages/react-components/react-overflow/library/src/useOverflowSnapshot.ts
@@ -1,0 +1,17 @@
+'use client';
+
+import type { OverflowEventPayload } from '@fluentui/priority-overflow';
+import * as React from 'react';
+import { useOverflowContext } from './overflowContext';
+import { useIsomorphicLayoutEffect } from '@fluentui/react-utilities';
+
+export const useOverflowSnapshot = (): OverflowEventPayload => {
+  const { getSnapshot, subscribe } = useOverflowContext();
+  const [snapshot, setSnapshot] = React.useState(() => getSnapshot());
+  useIsomorphicLayoutEffect(() => {
+    return subscribe(() => {
+      setSnapshot(getSnapshot());
+    });
+  }, [subscribe, getSnapshot]);
+  return snapshot;
+};

--- a/packages/react-components/react-overflow/library/src/useOverflowVisibility.test.tsx
+++ b/packages/react-components/react-overflow/library/src/useOverflowVisibility.test.tsx
@@ -5,26 +5,30 @@ import type { OverflowContextValue } from './overflowContext';
 import { OverflowContext } from './overflowContext';
 
 describe('useOverflowVisibility', () => {
-  it('should return item and group visiblity', () => {
+  it('should return item and group visiblity derived from the snapshot', () => {
     const groupVisibility = {
       foo: 'hidden',
       bar: 'overflow',
       baz: 'visible',
     } as const;
 
-    const itemVisibility = {
-      foo: true,
-      bar: true,
-      baz: false,
-    } as const;
-    const Wrapper: React.FC = props => {
+    const snapshot = {
+      visibleItems: [
+        { id: 'foo', element: document.createElement('div'), priority: 0 },
+        { id: 'bar', element: document.createElement('div'), priority: 0 },
+      ],
+      invisibleItems: [{ id: 'baz', element: document.createElement('div'), priority: 0 }],
+      groupVisibility,
+    };
+
+    const Wrapper: React.FC<{ children?: React.ReactNode }> = props => {
       return (
         <OverflowContext.Provider
           {...props}
           value={
             {
-              groupVisibility,
-              itemVisibility,
+              getSnapshot: () => snapshot,
+              subscribe: () => () => null,
             } as unknown as OverflowContextValue
           }
         />
@@ -32,6 +36,6 @@ describe('useOverflowVisibility', () => {
     };
     const { result } = renderHook(useOverflowVisibility, { wrapper: Wrapper });
     expect(result.current.groupVisibility).toEqual(groupVisibility);
-    expect(result.current.itemVisibility).toEqual(itemVisibility);
+    expect(result.current.itemVisibility).toEqual({ foo: true, bar: true, baz: false });
   });
 });

--- a/packages/react-components/react-overflow/library/src/useOverflowVisibility.test.tsx
+++ b/packages/react-components/react-overflow/library/src/useOverflowVisibility.test.tsx
@@ -13,12 +13,9 @@ describe('useOverflowVisibility', () => {
     } as const;
 
     const snapshot = {
-      visibleItems: [
-        { id: 'foo', element: document.createElement('div'), priority: 0 },
-        { id: 'bar', element: document.createElement('div'), priority: 0 },
-      ],
-      invisibleItems: [{ id: 'baz', element: document.createElement('div'), priority: 0 }],
+      itemVisibility: { foo: true, bar: true, baz: false },
       groupVisibility,
+      invisibleItemCount: 1,
     };
 
     const Wrapper: React.FC<{ children?: React.ReactNode }> = props => {

--- a/packages/react-components/react-overflow/library/src/useOverflowVisibility.ts
+++ b/packages/react-components/react-overflow/library/src/useOverflowVisibility.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import type { OverflowEventPayload, OverflowGroupState } from '@fluentui/priority-overflow';
+import type { OverflowGroupState, OverflowSnapshot } from '@fluentui/priority-overflow';
 import { useOverflowSnapshot } from './useOverflowSnapshot';
 
 /**
@@ -19,25 +19,12 @@ export function useOverflowVisibility(): {
   return useOverflowSnapshot(selectVisibility);
 }
 
-/**
- * Derives the item and group visibility maps from an overflow snapshot.
- * @internal
- */
-export const selectVisibility = (
-  snapshot: OverflowEventPayload,
+const selectVisibility = (
+  snapshot: OverflowSnapshot,
 ): {
   itemVisibility: Record<string, boolean>;
   groupVisibility: Record<string, OverflowGroupState>;
-} => {
-  const itemVisibility: Record<string, boolean> = {};
-  snapshot.visibleItems.forEach(item => {
-    itemVisibility[item.id] = true;
-  });
-  snapshot.invisibleItems.forEach(item => {
-    itemVisibility[item.id] = false;
-  });
-  return {
-    itemVisibility,
-    groupVisibility: snapshot.groupVisibility,
-  };
-};
+} => ({
+  itemVisibility: snapshot.itemVisibility,
+  groupVisibility: snapshot.groupVisibility,
+});

--- a/packages/react-components/react-overflow/library/src/useOverflowVisibility.ts
+++ b/packages/react-components/react-overflow/library/src/useOverflowVisibility.ts
@@ -1,7 +1,8 @@
 'use client';
 
+import type { OverflowEventPayload, OverflowGroupState } from '@fluentui/priority-overflow';
 import * as React from 'react';
-import { useOverflowContext } from './overflowContext';
+import { useOverflowSnapshot } from './useOverflowSnapshot';
 
 /**
  * A hook that returns the visibility status of all items and groups.
@@ -14,10 +15,27 @@ import { useOverflowContext } from './overflowContext';
  */
 export function useOverflowVisibility(): {
   itemVisibility: Record<string, boolean>;
-  groupVisibility: Record<string, import('@fluentui/priority-overflow').OverflowGroupState>;
+  groupVisibility: Record<string, OverflowGroupState>;
 } {
-  const itemVisibility = useOverflowContext(ctx => ctx.itemVisibility);
-  const groupVisibility = useOverflowContext(ctx => ctx.groupVisibility);
-
-  return React.useMemo(() => ({ itemVisibility, groupVisibility }), [itemVisibility, groupVisibility]);
+  const snapshot = useOverflowSnapshot();
+  return React.useMemo(() => snapshotToVisibility(snapshot), [snapshot]);
 }
+
+const snapshotToVisibility = (
+  snapshot: OverflowEventPayload,
+): {
+  itemVisibility: Record<string, boolean>;
+  groupVisibility: Record<string, OverflowGroupState>;
+} => {
+  const itemVisibility: Record<string, boolean> = {};
+  snapshot.visibleItems.forEach(item => {
+    itemVisibility[item.id] = true;
+  });
+  snapshot.invisibleItems.forEach(item => {
+    itemVisibility[item.id] = false;
+  });
+  return {
+    itemVisibility,
+    groupVisibility: snapshot.groupVisibility,
+  };
+};

--- a/packages/react-components/react-overflow/library/src/useOverflowVisibility.ts
+++ b/packages/react-components/react-overflow/library/src/useOverflowVisibility.ts
@@ -1,7 +1,6 @@
 'use client';
 
 import type { OverflowEventPayload, OverflowGroupState } from '@fluentui/priority-overflow';
-import * as React from 'react';
 import { useOverflowSnapshot } from './useOverflowSnapshot';
 
 /**
@@ -17,11 +16,14 @@ export function useOverflowVisibility(): {
   itemVisibility: Record<string, boolean>;
   groupVisibility: Record<string, OverflowGroupState>;
 } {
-  const snapshot = useOverflowSnapshot();
-  return React.useMemo(() => snapshotToVisibility(snapshot), [snapshot]);
+  return useOverflowSnapshot(selectVisibility);
 }
 
-const snapshotToVisibility = (
+/**
+ * Derives the item and group visibility maps from an overflow snapshot.
+ * @internal
+ */
+export const selectVisibility = (
   snapshot: OverflowEventPayload,
 ): {
   itemVisibility: Record<string, boolean>;


### PR DESCRIPTION
## Summary

**PR 2 of 3.** Depends on PR 1 (#36262, `react-overflow/pr1-strict-mode-lifecycle`). **Do not merge until PR 1 lands** — the "Files changed" view here will show PR 1's diff cumulatively until then; GitHub narrows it automatically once PR 1 merges.

Moves the overflow snapshot out of the `<Overflow>` container and into the manager itself, so each auxiliary hook subscribes directly to the manager without forcing intermediate React state.

### Stack

1. `react-overflow/pr1-strict-mode-lifecycle` (#36262) — strict-mode-safe lifecycle.
2. **This PR** — subscribe model.
3. `react-overflow/pr3-first-paint` — first-paint correctness.

### priority-overflow

- The manager caches the latest snapshot and exposes `getSnapshot` / `subscribe`.
- `dispatchOverflowUpdate` goes through a single `takeSnapshot` helper that updates the cache and fans out to listeners.
- The observe cleanup resets the snapshot so subscribers see an empty state.

### react-overflow

- `OverflowContextValue` exposes `getSnapshot` / `subscribe` directly from the manager.
- The context drops `@fluentui/react-context-selector` and uses plain `React.createContext`; `useOverflowContext` keeps the selector overload for backward compatibility.
- `itemVisibility`, `groupVisibility`, and `hasOverflow` on the context are kept as deprecated, always-empty placeholders so existing external consumers still type-check.
- New `useOverflowSnapshot` subscribes via `useState` + `useIsomorphicLayoutEffect`.
- `useOverflowCount`, `useIsOverflowItemVisible`, `useIsOverflowGroupVisible`, and `useOverflowVisibility` are rewritten on top of `useOverflowSnapshot`.
- `<Overflow>` no longer holds a `useState`; `onOverflowChange` callers receive the same `OnOverflowChangeData` shape, now derived from the snapshot.
- `@fluentui/react-context-selector` removed from package dependencies.

## Test plan

- [x] `yarn nx run priority-overflow:test` / `react-overflow:test`
- [x] `yarn nx run priority-overflow:lint` / `react-overflow:lint`
- [x] `yarn nx run react-overflow:type-check`
- [x] CI green
- [x] After PR 1 merges: mark this PR ready for review