### PR TITLE
feat(react-headless-components-preview): export BadgeSlots, ComboboxSlots, useMenuListContextValues to complete consumer-side composition surface

### DIFF
--- a/change/@fluentui-react-headless-components-preview-2a767635-f12e-4d8e-bb66-e4b3c0d1885c.json
+++ b/change/@fluentui-react-headless-components-preview-2a767635-f12e-4d8e-bb66-e4b3c0d1885c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: export BadgeSlots, ComboboxSlots, useMenuListContextValues to complete consumer-side composition surface",
+  "packageName": "@fluentui/react-headless-components-preview",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-headless-components-preview/library/etc/badge.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/badge.api.md
@@ -6,6 +6,7 @@
 
 import type { BadgeBaseProps } from '@fluentui/react-badge';
 import { BadgeBaseState } from '@fluentui/react-badge';
+import type { BadgeSlots as BadgeSlots_2 } from '@fluentui/react-badge';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import { JSXElement } from '@fluentui/react-utilities';
 import type * as React_2 from 'react';
@@ -15,6 +16,9 @@ export const Badge: ForwardRefComponent<BadgeProps>;
 
 // @public
 export type BadgeProps = BadgeBaseProps;
+
+// @public
+export type BadgeSlots = BadgeSlots_2;
 
 // @public
 export type BadgeState = BadgeBaseState & {

--- a/packages/react-components/react-headless-components-preview/library/etc/combobox.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/combobox.api.md
@@ -7,6 +7,7 @@
 import type { BaseComboboxProps } from '@fluentui/react-combobox';
 import type { BaseComboboxState } from '@fluentui/react-combobox';
 import { ComboboxContextValues } from '@fluentui/react-combobox';
+import { ComboboxSlots } from '@fluentui/react-combobox';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import { JSXElement } from '@fluentui/react-utilities';
 import { ListboxContextValues as ListboxContextValues_2 } from '@fluentui/react-combobox';
@@ -26,6 +27,8 @@ export const Combobox: ForwardRefComponent<ComboboxProps>;
 
 // @public (undocumented)
 export type ComboboxProps = Omit<BaseComboboxProps, 'inlinePopup' | 'mountNode'>;
+
+export { ComboboxSlots }
 
 // @public (undocumented)
 export type ComboboxState = BaseComboboxState & {

--- a/packages/react-components/react-headless-components-preview/library/etc/menu.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/menu.api.md
@@ -60,7 +60,6 @@ import { renderMenuItemSwitch_unstable as renderMenuItemSwitch } from '@fluentui
 import { renderMenuSplitGroup_unstable as renderMenuSplitGroup } from '@fluentui/react-menu';
 import { renderMenuTrigger_unstable as renderMenuTrigger } from '@fluentui/react-menu';
 import { useMenuContext_unstable as useMenuContext } from '@fluentui/react-menu';
-import { useMenuContextValues_unstable as useMenuContextValues } from '@fluentui/react-menu';
 import { useMenuDivider_unstable as useMenuDivider } from '@fluentui/react-menu';
 import { useMenuGroup_unstable as useMenuGroup } from '@fluentui/react-menu';
 import { useMenuGroupContextValues_unstable as useMenuGroupContextValues } from '@fluentui/react-menu';
@@ -69,6 +68,7 @@ import { useMenuItemCheckboxBase_unstable as useMenuItemCheckbox } from '@fluent
 import { useMenuItemLinkBase_unstable as useMenuItemLink } from '@fluentui/react-menu';
 import { useMenuItemRadioBase_unstable as useMenuItemRadio } from '@fluentui/react-menu';
 import { useMenuItemSwitchBase_unstable as useMenuItemSwitch } from '@fluentui/react-menu';
+import { useMenuListContextValues_unstable as useMenuListContextValues } from '@fluentui/react-menu';
 
 // @public
 export const Menu: React_2.FC<MenuProps>;
@@ -240,7 +240,8 @@ export const useMenu: (props: MenuProps) => MenuState;
 
 export { useMenuContext }
 
-export { useMenuContextValues }
+// @public (undocumented)
+export const useMenuContextValues: (state: MenuState) => MenuContextValues;
 
 export { useMenuDivider }
 
@@ -263,6 +264,8 @@ export { useMenuItemSwitch }
 
 // @public
 export const useMenuList: (props: MenuListProps, ref: React_2.Ref<HTMLElement>) => MenuListState;
+
+export { useMenuListContextValues }
 
 // @public (undocumented)
 export const useMenuPopover: (props: MenuPopoverProps, ref: React_2.Ref<HTMLElement>) => MenuPopoverState;

--- a/packages/react-components/react-headless-components-preview/library/src/badge.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/badge.ts
@@ -1,2 +1,2 @@
-export { Badge, renderBadge, useBadge } from './components/Badge/index';
-export type { BadgeProps, BadgeState } from './components/Badge/index';
+export { Badge, renderBadge, useBadge } from './components/Badge';
+export type { BadgeSlots, BadgeProps, BadgeState } from './components/Badge';

--- a/packages/react-components/react-headless-components-preview/library/src/combobox.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/combobox.ts
@@ -15,6 +15,7 @@ export {
   useOptionGroup,
 } from './components/Combobox';
 export type {
+  ComboboxSlots,
   ComboboxProps,
   ComboboxState,
   ListboxSlots,

--- a/packages/react-components/react-headless-components-preview/library/src/components/Menu/Menu.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Menu/Menu.tsx
@@ -11,7 +11,7 @@ import type { MenuProps } from './Menu.types';
  */
 export const Menu: React.FC<MenuProps> = props => {
   const state = useMenu(props);
-  const contextValues = useMenuContextValues(state as Parameters<typeof useMenuContextValues>[0]);
+  const contextValues = useMenuContextValues(state);
 
   return renderMenu(state, contextValues);
 };

--- a/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuList/MenuList.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuList/MenuList.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import * as React from 'react';
-import { useMenuListContextValues_unstable } from '@fluentui/react-menu';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import { useMenuList } from './useMenuList';
+import { useMenuListContextValues } from './useMenuListContextValues';
 import { renderMenuList } from './renderMenuList';
 import type { MenuListProps } from './MenuList.types';
 
@@ -12,7 +12,7 @@ import type { MenuListProps } from './MenuList.types';
  */
 export const MenuList: ForwardRefComponent<MenuListProps> = React.forwardRef((props, ref) => {
   const state = useMenuList(props, ref);
-  const contextValues = useMenuListContextValues_unstable(state);
+  const contextValues = useMenuListContextValues(state);
   return renderMenuList(state, contextValues);
 });
 

--- a/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuList/index.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuList/index.ts
@@ -1,5 +1,6 @@
 export { MenuList } from './MenuList';
 export { useMenuList } from './useMenuList';
+export { useMenuListContextValues } from './useMenuListContextValues';
 export { renderMenuList } from './renderMenuList';
 export type {
   MenuListProps,

--- a/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuList/useMenuListContextValues.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuList/useMenuListContextValues.ts
@@ -1,0 +1,1 @@
+export { useMenuListContextValues_unstable as useMenuListContextValues } from '@fluentui/react-menu';

--- a/packages/react-components/react-headless-components-preview/library/src/components/Menu/index.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Menu/index.ts
@@ -15,7 +15,7 @@ export type {
 export { MenuTrigger, useMenuTrigger, renderMenuTrigger } from './MenuTrigger';
 export type { MenuTriggerProps, MenuTriggerState, MenuTriggerChildProps } from '@fluentui/react-menu';
 
-export { MenuList, useMenuList, renderMenuList } from './MenuList';
+export { MenuList, useMenuList, useMenuListContextValues, renderMenuList } from './MenuList';
 export type { MenuListProps, MenuListState, MenuListSlots } from './MenuList';
 
 export { MenuItem, useMenuItem, renderMenuItem } from './MenuItem';

--- a/packages/react-components/react-headless-components-preview/library/src/components/Menu/useMenuContextValues.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Menu/useMenuContextValues.ts
@@ -1,1 +1,6 @@
-export { useMenuContextValues_unstable as useMenuContextValues } from '@fluentui/react-menu';
+'use client';
+
+import { useMenuContextValues_unstable } from '@fluentui/react-menu';
+import type { MenuContextValues, MenuState } from './Menu.types';
+
+export const useMenuContextValues = useMenuContextValues_unstable as (state: MenuState) => MenuContextValues;

--- a/packages/react-components/react-headless-components-preview/library/src/menu.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/menu.ts
@@ -9,6 +9,7 @@ export {
   renderMenuTrigger,
   MenuList,
   useMenuList,
+  useMenuListContextValues,
   renderMenuList,
   MenuItem,
   useMenuItem,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

- `BadgeSlots`, `ComboboxSlots`, and `useMenuListContextValues` were not exported from headless
- `useMenuContextValues` required type-casting `useMenuContextValues(state as Parameters<typeof useMenuContextValues>[0])`;

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

- `BadgeSlots`, `ComboboxSlots`, and `useMenuListContextValues` now exported from headless
- `useMenuContextValues` doesn't require type-casting in consumer's codebases, as it's handled in headless


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
