### PR TITLE
test(react-tag-picker): add hooks regression tests

### DIFF
--- a/change/@fluentui-react-tag-picker-hook-regression-tests.json
+++ b/change/@fluentui-react-tag-picker-hook-regression-tests.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "test: add hook regression tests for the TagPicker family",
+  "packageName": "@fluentui/react-tag-picker",
+  "email": "viktorgenaev@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tag-picker/library/src/components/TagPicker/useTagPicker.test.tsx
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPicker/useTagPicker.test.tsx
@@ -1,0 +1,48 @@
+import { renderHook } from '@testing-library/react-hooks';
+import * as React from 'react';
+
+import { useTagPicker_unstable } from './useTagPicker';
+import type { TagPickerProps } from './TagPicker.types';
+
+const trigger = <div />;
+const popover = <div />;
+
+const renderRoot = (props: Partial<TagPickerProps> = {}) =>
+  renderHook(() => useTagPicker_unstable({ children: [trigger, popover], ...props } as TagPickerProps));
+
+describe('useTagPicker_unstable', () => {
+  it('defaults size to "medium", inline to false, and noPopover to false', () => {
+    const { result } = renderRoot();
+    expect(result.current.size).toBe('medium');
+    expect(result.current.inline).toBe(false);
+    expect(result.current.noPopover).toBe(false);
+  });
+
+  it('honors explicit size and inline props', () => {
+    const { result } = renderRoot({ size: 'large', inline: true });
+    expect(result.current.size).toBe('large');
+    expect(result.current.inline).toBe(true);
+  });
+
+  it('generates a non-empty popoverId', () => {
+    const { result } = renderRoot();
+    expect(result.current.popoverId.length).toBeGreaterThan(0);
+  });
+
+  it('hides the popover when closed and unfocused', () => {
+    const { result } = renderRoot({ defaultOpen: false });
+    expect(result.current.open).toBe(false);
+    expect(result.current.popover).toBeUndefined();
+  });
+
+  it('renders the popover when defaultOpen is true', () => {
+    const { result } = renderRoot({ defaultOpen: true });
+    expect(result.current.open).toBe(true);
+    expect(result.current.popover).toBeDefined();
+  });
+
+  it('reflects controlled selectedOptions on state', () => {
+    const { result } = renderRoot({ selectedOptions: ['apple', 'banana'] });
+    expect(result.current.selectedOptions).toEqual(['apple', 'banana']);
+  });
+});

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerButton/useTagPickerButton.test.tsx
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerButton/useTagPickerButton.test.tsx
@@ -1,0 +1,89 @@
+import { renderHook } from '@testing-library/react-hooks';
+import * as React from 'react';
+
+import { TagPickerContextProvider } from '../../contexts/TagPickerContext';
+import type { TagPickerContextValue } from '../../contexts/TagPickerContext';
+import { useTagPickerButton_unstable } from './useTagPickerButton';
+
+const baseContext: TagPickerContextValue = {
+  triggerRef: React.createRef<HTMLButtonElement>(),
+  popoverRef: React.createRef<HTMLDivElement>(),
+  targetRef: React.createRef<HTMLDivElement>(),
+  tagPickerGroupRef: React.createRef<HTMLDivElement>(),
+  secondaryActionRef: React.createRef<HTMLSpanElement>(),
+  open: false,
+  clearSelection: () => null,
+  getOptionById: () => undefined,
+  selectedOptions: [],
+  selectOption: () => null,
+  setHasFocus: () => null,
+  setOpen: () => null,
+  setValue: () => null,
+  value: undefined,
+  popoverId: 'button-popover-id',
+  size: 'medium',
+  appearance: 'outline',
+  disabled: false,
+};
+
+const wrap = (overrides: Partial<TagPickerContextValue> = {}): React.FC<{ children?: React.ReactNode }> => {
+  const value: TagPickerContextValue = { ...baseContext, ...overrides };
+  const Wrapper: React.FC<{ children?: React.ReactNode }> = ({ children }) => (
+    <TagPickerContextProvider value={value}>{children}</TagPickerContextProvider>
+  );
+  return Wrapper;
+};
+
+describe('useTagPickerButton_unstable', () => {
+  it('defaults the button type to "button"', () => {
+    const ref = React.createRef<HTMLButtonElement>();
+    const { result } = renderHook(() => useTagPickerButton_unstable({}, ref), { wrapper: wrap() });
+    expect(result.current.root.type).toBe('button');
+  });
+
+  it('inherits size from picker context', () => {
+    const ref = React.createRef<HTMLButtonElement>();
+    const { result } = renderHook(() => useTagPickerButton_unstable({}, ref), { wrapper: wrap({ size: 'large' }) });
+    expect(result.current.size).toBe('large');
+  });
+
+  it('derives hasSelectedOption from picker selectedOptions length', () => {
+    const ref = React.createRef<HTMLButtonElement>();
+    const empty = renderHook(() => useTagPickerButton_unstable({}, ref), {
+      wrapper: wrap({ selectedOptions: [] }),
+    });
+    const oneSelected = renderHook(() => useTagPickerButton_unstable({}, ref), {
+      wrapper: wrap({ selectedOptions: ['apple'] }),
+    });
+
+    expect(empty.result.current.hasSelectedOption).toBe(false);
+    expect(oneSelected.result.current.hasSelectedOption).toBe(true);
+  });
+
+  it('binds aria-controls to popoverId only when open', () => {
+    const ref = React.createRef<HTMLButtonElement>();
+    const closed = renderHook(() => useTagPickerButton_unstable({}, ref), {
+      wrapper: wrap({ open: false, popoverId: 'pop-1' }),
+    });
+    const opened = renderHook(() => useTagPickerButton_unstable({}, ref), {
+      wrapper: wrap({ open: true, popoverId: 'pop-1' }),
+    });
+
+    expect(closed.result.current.root['aria-controls']).toBeUndefined();
+    expect(opened.result.current.root['aria-controls']).toBe('pop-1');
+  });
+
+  it('renders the picker value as button children, falling back to placeholder', () => {
+    const ref = React.createRef<HTMLButtonElement>();
+    const withValue = renderHook(() => useTagPickerButton_unstable({}, ref), {
+      wrapper: wrap({ value: 'Selected fruit' }),
+    });
+    const withPlaceholder = renderHook(
+      () => useTagPickerButton_unstable({ placeholder: 'Pick a fruit' } as never, ref),
+      { wrapper: wrap({ value: undefined }) },
+    );
+
+    expect(withValue.result.current.root.children).toBe('Selected fruit');
+    expect(withPlaceholder.result.current.root.children).toBe('Pick a fruit');
+  });
+});

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerControl/useTagPickerControl.test.tsx
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerControl/useTagPickerControl.test.tsx
@@ -1,0 +1,116 @@
+import { renderHook } from '@testing-library/react-hooks';
+import * as React from 'react';
+
+import { TagPickerContextProvider } from '../../contexts/TagPickerContext';
+import type { TagPickerContextValue } from '../../contexts/TagPickerContext';
+import { useTagPickerControl_unstable } from './useTagPickerControl';
+
+const makeContext = (overrides: Partial<TagPickerContextValue> = {}): TagPickerContextValue => ({
+  triggerRef: React.createRef<HTMLInputElement>(),
+  popoverRef: React.createRef<HTMLDivElement>(),
+  targetRef: React.createRef<HTMLDivElement>(),
+  tagPickerGroupRef: React.createRef<HTMLDivElement>(),
+  secondaryActionRef: React.createRef<HTMLSpanElement>(),
+  open: false,
+  clearSelection: () => null,
+  getOptionById: () => undefined,
+  selectedOptions: [],
+  selectOption: () => null,
+  setHasFocus: () => null,
+  setOpen: () => null,
+  setValue: () => null,
+  value: undefined,
+  popoverId: 'control-popover-id',
+  size: 'medium',
+  appearance: 'outline',
+  disabled: false,
+  ...overrides,
+});
+
+const wrap = (overrides: Partial<TagPickerContextValue> = {}): React.FC<{ children?: React.ReactNode }> => {
+  const value = makeContext(overrides);
+  const Wrapper: React.FC<{ children?: React.ReactNode }> = ({ children }) => (
+    <TagPickerContextProvider value={value}>{children}</TagPickerContextProvider>
+  );
+  return Wrapper;
+};
+
+describe('useTagPickerControl_unstable', () => {
+  it('always renders the internal aside slot', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const { result } = renderHook(() => useTagPickerControl_unstable({}, ref), { wrapper: wrap() });
+
+    expect(result.current.aside).toBeDefined();
+  });
+
+  it('renders an expandIcon by default and hides it when noPopover is set', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const withPopover = renderHook(() => useTagPickerControl_unstable({}, ref), { wrapper: wrap() });
+    const noPopover = renderHook(() => useTagPickerControl_unstable({}, ref), {
+      wrapper: wrap({ noPopover: true }),
+    });
+
+    expect(withPopover.result.current.expandIcon).toBeDefined();
+    expect(noPopover.result.current.expandIcon).toBeUndefined();
+  });
+
+  it('binds aria-expanded on expandIcon to picker open state', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const closed = renderHook(() => useTagPickerControl_unstable({}, ref), { wrapper: wrap({ open: false }) });
+    const opened = renderHook(() => useTagPickerControl_unstable({}, ref), { wrapper: wrap({ open: true }) });
+
+    expect(closed.result.current.expandIcon?.['aria-expanded']).toBe(false);
+    expect(opened.result.current.expandIcon?.['aria-expanded']).toBe(true);
+  });
+
+  it('sets aria-owns on root only when open and a popover exists', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const opened = renderHook(() => useTagPickerControl_unstable({}, ref), {
+      wrapper: wrap({ open: true, popoverId: 'pop-1' }),
+    });
+    const openedNoPopover = renderHook(() => useTagPickerControl_unstable({}, ref), {
+      wrapper: wrap({ open: true, popoverId: 'pop-1', noPopover: true }),
+    });
+
+    expect(opened.result.current.root['aria-owns']).toBe('pop-1');
+    expect(openedNoPopover.result.current.root['aria-owns']).toBeUndefined();
+  });
+
+  it('inherits size, appearance and disabled from picker context', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const { result } = renderHook(() => useTagPickerControl_unstable({}, ref), {
+      wrapper: wrap({ size: 'large', appearance: 'filled-darker', disabled: true }),
+    });
+
+    expect(result.current.size).toBe('large');
+    expect(result.current.appearance).toBe('filled-darker');
+    expect(result.current.disabled).toBe(true);
+  });
+
+  it('renders the secondaryAction slot when provided', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const { result } = renderHook(() => useTagPickerControl_unstable({ secondaryAction: 'Open advanced' }, ref), {
+      wrapper: wrap(),
+    });
+
+    expect(result.current.secondaryAction?.children).toBe('Open advanced');
+  });
+
+  it('does not toggle open when mousedown target is unrelated to the control internals', () => {
+    const setOpen = jest.fn();
+    const ref = React.createRef<HTMLDivElement>();
+    const { result } = renderHook(() => useTagPickerControl_unstable({}, ref), {
+      wrapper: wrap({ open: false, setOpen }),
+    });
+
+    // The handler only fires setOpen when the mousedown target matches one of the internal refs
+    // (expand icon, inner root, group ref, aside). An unrelated target must short-circuit.
+    result.current.root.onMouseDown?.({
+      isDefaultPrevented: () => false,
+      preventDefault: jest.fn(),
+      target: document.createElement('span'),
+    } as unknown as React.MouseEvent<HTMLDivElement>);
+
+    expect(setOpen).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerInput/useTagPickerInput.test.tsx
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerInput/useTagPickerInput.test.tsx
@@ -1,0 +1,154 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { ArrowLeft, Backspace, Enter, Space } from '@fluentui/keyboard-keys';
+import * as React from 'react';
+
+import { TagPickerContextProvider } from '../../contexts/TagPickerContext';
+import type { TagPickerContextValue } from '../../contexts/TagPickerContext';
+import { useTagPickerInput_unstable } from './useTagPickerInput';
+
+const findLastFocusable = jest.fn();
+jest.mock('@fluentui/react-tabster', () => ({
+  ...jest.requireActual('@fluentui/react-tabster'),
+  useFocusFinders: () => ({ findLastFocusable }),
+}));
+
+const makeContext = (overrides: Partial<TagPickerContextValue> = {}): TagPickerContextValue => ({
+  triggerRef: React.createRef<HTMLInputElement>(),
+  popoverRef: React.createRef<HTMLDivElement>(),
+  targetRef: React.createRef<HTMLDivElement>(),
+  tagPickerGroupRef: React.createRef<HTMLDivElement>(),
+  secondaryActionRef: React.createRef<HTMLSpanElement>(),
+  open: false,
+  clearSelection: () => null,
+  getOptionById: () => undefined,
+  selectedOptions: [],
+  selectOption: () => null,
+  setHasFocus: () => null,
+  setOpen: () => null,
+  setValue: () => null,
+  value: undefined,
+  popoverId: 'input-popover-id',
+  size: 'medium',
+  appearance: 'outline',
+  disabled: false,
+  ...overrides,
+});
+
+const wrap = (overrides: Partial<TagPickerContextValue> = {}): React.FC<{ children?: React.ReactNode }> => {
+  const value = makeContext(overrides);
+  const Wrapper: React.FC<{ children?: React.ReactNode }> = ({ children }) => (
+    <TagPickerContextProvider value={value}>{children}</TagPickerContextProvider>
+  );
+  return Wrapper;
+};
+
+describe('useTagPickerInput_unstable', () => {
+  it('renders the input with type="text"', () => {
+    const ref = React.createRef<HTMLInputElement>();
+    const { result } = renderHook(() => useTagPickerInput_unstable({}, ref), { wrapper: wrap() });
+    expect(result.current.root.type).toBe('text');
+  });
+
+  it('inherits size and disabled from picker context when not overridden by props', () => {
+    const ref = React.createRef<HTMLInputElement>();
+    const { result } = renderHook(() => useTagPickerInput_unstable({}, ref), {
+      wrapper: wrap({ size: 'large', disabled: true }),
+    });
+
+    expect(result.current.size).toBe('large');
+    expect(result.current.disabled).toBe(true);
+  });
+
+  it('binds aria-controls to popoverId only when open and a popover exists', () => {
+    const ref = React.createRef<HTMLInputElement>();
+    const closed = renderHook(() => useTagPickerInput_unstable({}, ref), {
+      wrapper: wrap({ open: false, popoverId: 'pop-1' }),
+    });
+    const opened = renderHook(() => useTagPickerInput_unstable({}, ref), {
+      wrapper: wrap({ open: true, popoverId: 'pop-1' }),
+    });
+    const openedNoPopover = renderHook(() => useTagPickerInput_unstable({}, ref), {
+      wrapper: wrap({ open: true, popoverId: 'pop-1', noPopover: true }),
+    });
+
+    expect(closed.result.current.root['aria-controls']).toBeUndefined();
+    expect(opened.result.current.root['aria-controls']).toBe('pop-1');
+    expect(openedNoPopover.result.current.root['aria-controls']).toBeUndefined();
+  });
+
+  it('closes the popover when Space is pressed while open', () => {
+    const setOpen = jest.fn();
+    const ref = React.createRef<HTMLInputElement>();
+    const { result } = renderHook(() => useTagPickerInput_unstable({}, ref), {
+      wrapper: wrap({ open: true, setOpen }),
+    });
+
+    const event = {
+      key: Space,
+      code: Space,
+      currentTarget: { selectionStart: 0, selectionEnd: 0 },
+      preventDefault: jest.fn(),
+    } as unknown as React.KeyboardEvent<HTMLInputElement>;
+    result.current.root.onKeyDown?.(event);
+
+    expect(setOpen).toHaveBeenCalledWith(event, false);
+  });
+
+  it('opens the popover when Enter is pressed while closed', () => {
+    const setOpen = jest.fn();
+    const ref = React.createRef<HTMLInputElement>();
+    const { result } = renderHook(() => useTagPickerInput_unstable({}, ref), {
+      wrapper: wrap({ open: false, setOpen }),
+    });
+
+    const event = {
+      key: Enter,
+      code: Enter,
+      currentTarget: { selectionStart: 0, selectionEnd: 0 },
+      preventDefault: jest.fn(),
+    } as unknown as React.KeyboardEvent<HTMLInputElement>;
+    result.current.root.onKeyDown?.(event);
+
+    expect(setOpen).toHaveBeenCalledWith(event, true);
+  });
+
+  it.each([
+    ['ArrowLeft', ArrowLeft],
+    ['Backspace', Backspace],
+  ])('looks for the last focusable inside the group when %s is pressed at the start of the input', (_label, key) => {
+    findLastFocusable.mockReset();
+    const group = document.createElement('div');
+    const ref = React.createRef<HTMLInputElement>();
+    const { result } = renderHook(() => useTagPickerInput_unstable({}, ref), {
+      wrapper: wrap({ tagPickerGroupRef: { current: group } }),
+    });
+
+    const event = {
+      key,
+      code: key,
+      currentTarget: { selectionStart: 0, selectionEnd: 0 },
+      preventDefault: jest.fn(),
+    } as unknown as React.KeyboardEvent<HTMLInputElement>;
+    result.current.root.onKeyDown?.(event);
+
+    expect(findLastFocusable).toHaveBeenCalledWith(group);
+  });
+
+  it('forwards keydown events to the user-supplied onKeyDown', () => {
+    const userKeyDown = jest.fn();
+    const ref = React.createRef<HTMLInputElement>();
+    const { result } = renderHook(() => useTagPickerInput_unstable({ onKeyDown: userKeyDown }, ref), {
+      wrapper: wrap({ open: false }),
+    });
+
+    const event = {
+      key: 'a',
+      code: 'KeyA',
+      currentTarget: { selectionStart: 1, selectionEnd: 1 },
+      preventDefault: jest.fn(),
+    } as unknown as React.KeyboardEvent<HTMLInputElement>;
+    result.current.root.onKeyDown?.(event);
+
+    expect(userKeyDown).toHaveBeenCalledWith(event);
+  });
+});


### PR DESCRIPTION
  Adds hook-level regression tests that lock down the existing runtime behavior of the four hooks being refactored in #36260, so the base-hook extraction can be verified to be behavior-preserving:

  - useTagPicker — default size/inline/noPopover, explicit prop overrides, generated popoverId, popover visibility gated on open state, controlled
  selectedOptions.
  - useTagPickerControl — internal aside slot, expandIcon shown by default / hidden with noPopover, aria-expanded and aria-owns wiring, context
  inheritance (size/appearance/disabled), secondaryAction slot, mousedown short-circuit for unrelated targets.
  - useTagPickerInput — type="text", context inheritance, aria-controls gating, Space/Enter open-toggle, ArrowLeft/Backspace focus-into-group, user
  onKeyDown forwarding.
  - useTagPickerButton — default button type, size inheritance, hasSelectedOption derivation, aria-controls gating, value/placeholder children.
