### PR TITLE
fix(react-tooltip): clip arrow filter shadow

### DIFF
--- a/change/@fluentui-react-tooltip-clip-arrow-filter-shadow.json
+++ b/change/@fluentui-react-tooltip-clip-arrow-filter-shadow.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: clip tooltip arrow before applying drop shadow",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "kirtiar15502@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-positioning/library/src/createArrowStyles.ts
+++ b/packages/react-components/react-positioning/library/src/createArrowStyles.ts
@@ -80,6 +80,7 @@ export function createArrowStyles(options: CreateArrowStylesOptions): GriffelSty
     backgroundClip: 'content-box',
 
     borderBottomLeftRadius: `${tokens.borderRadiusSmall} /* @noflip */`,
+    clipPath: 'polygon(-1px -1px, calc(100% + 1px) calc(100% + 1px), -1px calc(100% + 1px))',
     transform: 'rotate(var(--fui-positioning-arrow-angle)) /* @noflip */',
 
     height: 'var(--fui-positioning-arrow-height)',

--- a/packages/react-components/react-tooltip/library/src/components/Tooltip/useTooltipStyles.styles.ts
+++ b/packages/react-components/react-tooltip/library/src/components/Tooltip/useTooltipStyles.styles.ts
@@ -45,7 +45,10 @@ const useStyles = makeStyles({
     color: tokens.colorNeutralForegroundStaticInverted,
   },
 
-  arrow: createArrowStyles({ arrowHeight }),
+  arrow: {
+    ...createArrowStyles({ arrowHeight }),
+    clipPath: 'polygon(0% 0%, 100% 100%, 0% 100%)',
+  },
 });
 
 /**

--- a/packages/react-components/react-tooltip/library/src/components/Tooltip/useTooltipStyles.styles.ts
+++ b/packages/react-components/react-tooltip/library/src/components/Tooltip/useTooltipStyles.styles.ts
@@ -47,7 +47,6 @@ const useStyles = makeStyles({
 
   arrow: {
     ...createArrowStyles({ arrowHeight }),
-    clipPath: 'polygon(0% 0%, 100% 100%, 0% 100%)',
   },
 });
 


### PR DESCRIPTION
Problem
- Tooltip with `withArrow` can render a mirrored/extra visual artifact when the component's default drop-shadow filter is applied to rich tooltip content.

Root cause
- The arrow is implemented as a rotated square behind the tooltip body. The visible triangle is correct during normal painting, but the CSS filter samples the arrow element's full paint area, including the hidden half of the square.

Solution
- Clip the tooltip arrow element to the same triangular shape used by its pseudo-element before the drop-shadow filter is applied.
- Add a patch change file for `@fluentui/react-tooltip`.

Tests run
- corepack yarn prettier --check packages/react-components/react-tooltip/library/src/components/Tooltip/useTooltipStyles.styles.ts change/@fluentui-react-tooltip-clip-arrow-filter-shadow.json
- corepack yarn nx run react-tooltip:lint
- corepack yarn nx run react-tooltip:type-check
- corepack yarn nx run react-tooltip:test
- corepack yarn nx run react-tooltip:build
- git diff --check

Fixes #36265