### PR TITLE
fix(Link): add disabled styles for high contrast mode

### DIFF
--- a/change/@fluentui-react-link-046c4989-5d7d-41a2-949f-dd71ad60c063.json
+++ b/change/@fluentui-react-link-046c4989-5d7d-41a2-949f-dd71ad60c063.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(Link): add disabled styles for high contrast mode",
+  "packageName": "@fluentui/react-link",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-link/library/src/components/Link/useLinkStyles.styles.ts
+++ b/packages/react-components/react-link/library/src/components/Link/useLinkStyles.styles.ts
@@ -90,6 +90,19 @@ const useStyles = makeStyles({
       textDecorationLine: 'none',
       color: tokens.colorNeutralForegroundDisabled,
     },
+
+    // There is no native disabled state for links, so we need to explicitly style the disabled state for high contrast mode.
+    '@media (forced-colors: active)': {
+      color: 'GrayText',
+
+      ':hover': {
+        color: 'GrayText',
+      },
+
+      ':active': {
+        color: 'GrayText',
+      },
+    },
   },
   inverted: {
     color: tokens.colorBrandForegroundInverted,


### PR DESCRIPTION
## Previous Behavior

Disabled links have the same color as static text:
<img width="1537" height="1074" alt="screenshot of the Fluent link storybook showing a regular link and disabled link. Both the disabled link and text are white on black." src="https://github.com/user-attachments/assets/f412d0d6-4ba5-44dc-afb6-714b3afbd1d5" />


## New Behavior

Disabled links adopt the same color as disabled form controls:
<img width="1516" height="1064" alt="the same screenshot, but now the disabled link is grey instead of white." src="https://github.com/user-attachments/assets/882e14d9-2ec0-4ec1-8cdd-b1ba584f4361" />


## Related Issue(s)

- Fixes [ADO issue](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/35145)
