### PR TITLE
fix: support external focus management on Combobox and Dropdown

### DIFF
--- a/change/@fluentui-react-combobox-0207f64c-2f2c-4b8f-b386-397ce38c1b95.json
+++ b/change/@fluentui-react-combobox-0207f64c-2f2c-4b8f-b386-397ce38c1b95.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Exposed `activeDescendantImperativeRef` on Combobox, Dropdown, and Listbox",
+  "packageName": "@fluentui/react-combobox",
+  "email": "personal_dev@mkurr.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/library/etc/react-combobox.api.md
+++ b/packages/react-components/react-combobox/library/etc/react-combobox.api.md
@@ -49,6 +49,7 @@ export type ComboboxBaseProps = SelectionProps & HighlightedOptionProps & Pick<P
     positioning?: PositioningShorthand;
     size?: 'small' | 'medium' | 'large';
     value?: string;
+    activeDescendantImperativeRef?: React_2.RefObject<ActiveDescendantImperativeRef | null>;
 };
 
 // @public
@@ -174,6 +175,7 @@ export type ListboxContextValues = {
 // @public
 export type ListboxProps = ComponentProps<ListboxSlots> & SelectionProps & {
     disableAutoFocus?: boolean;
+    activeDescendantImperativeRef?: React_2.RefObject<ActiveDescendantImperativeRef | null>;
 };
 
 // @public (undocumented)

--- a/packages/react-components/react-combobox/library/src/components/Combobox/Combobox.test.tsx
+++ b/packages/react-components/react-combobox/library/src/components/Combobox/Combobox.test.tsx
@@ -8,6 +8,7 @@ import { isConformant } from '../../testing/isConformant';
 import { resetIdsForTests } from '@fluentui/react-utilities';
 import { comboboxClassNames } from './useComboboxStyles.styles';
 import type { ComboboxProps } from '@fluentui/react-combobox';
+import type { ActiveDescendantImperativeRef } from '@fluentui/react-aria';
 
 describe('Combobox', () => {
   beforeEach(() => {
@@ -1195,6 +1196,28 @@ describe('Combobox', () => {
       );
 
       expect(container.querySelector(`.${comboboxClassNames.expandIcon}`)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('activeDescendantImperativeRef', () => {
+    it('passes activeDescendantImperativeRef through to useActiveDescendant', () => {
+      const imperativeRef = React.createRef<ActiveDescendantImperativeRef>();
+
+      const { getByRole } = render(
+        <Combobox open inlinePopup disableAutoFocus activeDescendantImperativeRef={imperativeRef}>
+          <Option>Red</Option>
+          <Option>Green</Option>
+          <Option>Blue</Option>
+        </Combobox>,
+      );
+
+      const firstId = imperativeRef.current?.first();
+      const lastId = imperativeRef.current?.last();
+
+      expect(firstId).toBeTruthy();
+      expect(lastId).toBeTruthy();
+      expect(lastId).not.toBe(firstId);
+      expect(getByRole('combobox').getAttribute('aria-activedescendant')).toBe(lastId);
     });
   });
 });

--- a/packages/react-components/react-combobox/library/src/components/Combobox/useCombobox.tsx
+++ b/packages/react-components/react-combobox/library/src/components/Combobox/useCombobox.tsx
@@ -46,6 +46,7 @@ export const useComboboxBase_unstable = (
     controller: activeDescendantController,
   } = useActiveDescendant<HTMLInputElement, HTMLDivElement>({
     matchOption: isComboboxOptionElement,
+    imperativeRef: props.activeDescendantImperativeRef,
   });
   const comboboxInternalState = useComboboxBaseState({ ...props, editable: true, activeDescendantController });
   const { appearance: _appearance, size: _size, ...baseState } = comboboxInternalState;

--- a/packages/react-components/react-combobox/library/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/react-components/react-combobox/library/src/components/Dropdown/Dropdown.test.tsx
@@ -8,6 +8,7 @@ import { isConformant } from '../../testing/isConformant';
 import { resetIdsForTests } from '@fluentui/react-utilities';
 import { dropdownClassNames } from './useDropdownStyles.styles';
 import type { DropdownProps } from '@fluentui/react-combobox';
+import type { ActiveDescendantImperativeRef } from '@fluentui/react-aria';
 
 describe('Dropdown', () => {
   beforeEach(() => {
@@ -805,6 +806,28 @@ describe('Dropdown', () => {
       expect(activeOptionText).toBe('Green');
       userEvent.keyboard('{ArrowUp}');
       expect(activeOptionText).toBe('Red');
+    });
+  });
+
+  describe('activeDescendantImperativeRef', () => {
+    it('passes activeDescendantImperativeRef through to useActiveDescendant', () => {
+      const imperativeRef = React.createRef<ActiveDescendantImperativeRef>();
+
+      const { getByRole } = render(
+        <Dropdown open inlinePopup disableAutoFocus activeDescendantImperativeRef={imperativeRef}>
+          <Option>Red</Option>
+          <Option>Green</Option>
+          <Option>Blue</Option>
+        </Dropdown>,
+      );
+
+      const firstId = imperativeRef.current?.first();
+      const lastId = imperativeRef.current?.last();
+
+      expect(firstId).toBeTruthy();
+      expect(lastId).toBeTruthy();
+      expect(lastId).not.toBe(firstId);
+      expect(getByRole('combobox').getAttribute('aria-activedescendant')).toBe(lastId);
     });
   });
 });

--- a/packages/react-components/react-combobox/library/src/components/Dropdown/useDropdown.tsx
+++ b/packages/react-components/react-combobox/library/src/components/Dropdown/useDropdown.tsx
@@ -40,6 +40,7 @@ export const useDropdownBase_unstable = (
     controller: activeDescendantController,
   } = useActiveDescendant<HTMLButtonElement, HTMLDivElement>({
     matchOption: isComboboxOptionElement,
+    imperativeRef: props.activeDescendantImperativeRef,
   });
 
   const dropdownInternalState = useComboboxBaseState({ ...props, activeDescendantController, freeform: false });

--- a/packages/react-components/react-combobox/library/src/components/Listbox/Listbox.test.tsx
+++ b/packages/react-components/react-combobox/library/src/components/Listbox/Listbox.test.tsx
@@ -3,6 +3,7 @@ import { fireEvent, render } from '@testing-library/react';
 import { Listbox } from './Listbox';
 import { Option } from '../Option/index';
 import { isConformant } from '../../testing/isConformant';
+import type { ActiveDescendantImperativeRef } from '@fluentui/react-aria';
 
 describe('Listbox', () => {
   isConformant({
@@ -375,5 +376,27 @@ describe('Listbox', () => {
 
     expect(getByTestId('red').getAttribute('aria-selected')).toEqual('true');
     expect(onOptionSelect).toHaveBeenCalled();
+  });
+
+  describe('activeDescendantImperativeRef', () => {
+    it('passes activeDescendantImperativeRef through to useActiveDescendant', () => {
+      const imperativeRef = React.createRef<ActiveDescendantImperativeRef>();
+
+      const { getByRole } = render(
+        <Listbox disableAutoFocus activeDescendantImperativeRef={imperativeRef}>
+          <Option>Red</Option>
+          <Option>Green</Option>
+          <Option>Blue</Option>
+        </Listbox>,
+      );
+
+      const firstId = imperativeRef.current?.first();
+      const lastId = imperativeRef.current?.last();
+
+      expect(firstId).toBeTruthy();
+      expect(lastId).toBeTruthy();
+      expect(lastId).not.toBe(firstId);
+      expect(getByRole('listbox').getAttribute('aria-activedescendant')).toBe(lastId);
+    });
   });
 });

--- a/packages/react-components/react-combobox/library/src/components/Listbox/Listbox.types.ts
+++ b/packages/react-components/react-combobox/library/src/components/Listbox/Listbox.types.ts
@@ -24,6 +24,13 @@ export type ListboxProps = ComponentProps<ListboxSlots> &
      * @default false
      */
     disableAutoFocus?: boolean;
+
+    /**
+     * Imperative ref that lets you manually control the active descendant associated
+     * with the Listbox. Typical use case for this is if you need to programmatically
+     * focus an active descendant.
+     */
+    activeDescendantImperativeRef?: React.RefObject<ActiveDescendantImperativeRef | null>;
   };
 
 /**

--- a/packages/react-components/react-combobox/library/src/components/Listbox/Listbox.types.ts
+++ b/packages/react-components/react-combobox/library/src/components/Listbox/Listbox.types.ts
@@ -1,3 +1,4 @@
+import type * as React from 'react';
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
 import type {
   ActiveDescendantChangeEvent,

--- a/packages/react-components/react-combobox/library/src/components/Listbox/useListbox.ts
+++ b/packages/react-components/react-combobox/library/src/components/Listbox/useListbox.ts
@@ -40,7 +40,7 @@ const UNSAFE_noLongerUsed = {
  * @param ref - reference to root HTMLElement of Listbox
  */
 export const useListbox_unstable = (props: ListboxProps, ref: React.Ref<HTMLElement>): ListboxState => {
-  const { multiselect, disableAutoFocus = false } = props;
+  const { multiselect, disableAutoFocus = false, activeDescendantImperativeRef } = props;
   const optionCollection = useOptionCollection();
 
   const {
@@ -49,6 +49,7 @@ export const useListbox_unstable = (props: ListboxProps, ref: React.Ref<HTMLElem
     controller,
   } = useActiveDescendant<HTMLInputElement, HTMLDivElement>({
     matchOption: isComboboxOptionElement,
+    imperativeRef: activeDescendantImperativeRef,
   });
 
   const hasListboxContext = useHasParentContext(ListboxContext);

--- a/packages/react-components/react-combobox/library/src/utils/ComboboxBase.types.ts
+++ b/packages/react-components/react-combobox/library/src/utils/ComboboxBase.types.ts
@@ -1,5 +1,9 @@
 import type * as React from 'react';
-import type { ActiveDescendantChangeEvent, ActiveDescendantContextValue } from '@fluentui/react-aria';
+import type {
+  ActiveDescendantChangeEvent,
+  ActiveDescendantContextValue,
+  ActiveDescendantImperativeRef,
+} from '@fluentui/react-aria';
 import type { PositioningShorthand } from '@fluentui/react-positioning';
 import type { EventData, EventHandler } from '@fluentui/react-utilities';
 import type { ComboboxContextValue } from '../contexts/ComboboxContext';
@@ -86,6 +90,13 @@ export type ComboboxBaseProps = SelectionProps &
      * Use this with `onOptionSelect` to directly control the displayed value string
      */
     value?: string;
+
+    /**
+     * Imperative ref that lets you manually control the active descendant associated
+     * with the Combobox. Typical use case for this is if you need to programmatically
+     * focus an active descendant.
+     */
+    activeDescendantImperativeRef?: React.RefObject<ActiveDescendantImperativeRef | null>;
   };
 
 /**


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

This PR exposes a ref to the activeDescendantImperative api so that consumers can control the focus for Combobox, Dropdown, and Listbox programmatically. 

## Previous Behavior

If a consumer wanted to move focus to an option, they usually would use the native `.focus()` api on their target element. This however was a pitfall for Combobox, Dropdown, and Listbox as they own their own focus state for the options via `useActiveDescendant`. Meaning any attempts at using the `.focus()` api would get overwritten or seemingly ignored because it's the wrong tool to begin with.

You can see the issue on the Storybook for Combobox + Virtualizer: https://storybooks.fluentui.dev/react/?path=/docs/components-combobox--docs#virtualizer

1. Open the combobox and select an option far down the list (e.g. Option 500).
2. Close the combobox
  a. You might have to lose focus by tabbing away and back to the combobox. See GIF.
3. Reopen the combobox with keyboard
4. See the virtual window scrolled into view Option 500
5. Press the down arrow but notice the focus moves to Option 489 for example (it might differ based on viewport size)

The expected behavior there is for it to move the focus down to Option 501. The reason this is occuring is because the virtual window is only rendering into the DOM Options 489-570 for example and there is no way to sync what item to focus in the active descendant.

GIF of buggy behavior

Note: I did notice if you re-open the combobox again, the 2nd time the focus is properly moved. 

<img width="800" height="553" alt="Screen Recording 2026-06-03 at 12 19 48 PM" src="https://github.com/user-attachments/assets/a8271fbb-0727-4e88-a2ce-72bd56267354" />


## New Behavior

Consumers can now use the `activeDescendantImperativeRef` prop to get at the same underlying focus state and can correctly move focus to a target of their choice. 

Going back to the Combobox + Virtualizer example, the consumer would need to update their code so that on open they use the `activeDescendantImperativeRef.focus(targetHtmlid)` method to sync focus.

## Related Issue(s)

