### PR TITLE
fix(deps): bump tar to >=7.5.8 to address CVE-2026-26960

### DIFF
--- a/package.json
+++ b/package.json
@@ -366,7 +366,7 @@
     "**/tar-fs": "^2.1.4",
     "jackspeak": "2.1.1",
     "**/micromatch/braces": "^3.0.3",
-    "**/just-scripts-utils/tar": "^7.5.7",
+    "**/just-scripts-utils/tar": "^7.5.8",
     "**/body-parser/qs": "^6.14.2",
     "**/@cypress/request/qs": "^6.14.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -19337,10 +19337,10 @@ tar-stream@^3.1.7:
     fast-fifo "^1.2.0"
     streamx "^2.15.0"
 
-tar@^6.1.9, tar@^7.5.7:
-  version "7.5.7"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.7.tgz#adf99774008ba1c89819f15dbd6019c630539405"
-  integrity sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==
+tar@^6.1.9, tar@^7.5.8:
+  version "7.5.16"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.16.tgz#f11e063afed4554f758049d082909e37d6b53ced"
+  integrity sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==
   dependencies:
     "@isaacs/fs-minipass" "^4.0.0"
     chownr "^3.0.0"


### PR DESCRIPTION
## Summary

Bumps the transitive `tar` dependency to a patched version to address **[CVE-2026-26960](https://github.com/advisories/GHSA-83g3-92jg-28cx)** — arbitrary file read/write via hardlink target escape through a symlink chain during `tar.extract()` with default options.

## Change

- `package.json` — bump the existing resolution `**/just-scripts-utils/tar` from `^7.5.7` → `^7.5.8`.
- `yarn.lock` — re-resolved `tar` `7.5.7` → `7.5.16` (latest patched in the `>=7.5.8` line) via `yarn install`. Diff is contained to the single `tar` entry.

No `package.json` of any published package changed and no published source was touched, so no beachball change file is required.

## Why

`tar < 7.5.8` validates hardlink targets with a string-based `path.posix.normalize` check that cannot see on-disk symlinks already materialized earlier in the same extraction. A crafted archive (`a/b/c/up -> ../..`, `a/b/escape -> c/up/../..`, then a hardlink `exfil -> a/b/escape/<target>`) passes the `..` rejection because the `..` lives in the symlink entries, not the hardlink's own linkpath — and `fs.link` then follows `escape` outside the extraction root.

`tar@7.5.8` fixes this by adding `ENSURE_NO_SYMLINK`, which `lstat`s every component of the link target on disk before creating any hard/symlink and aborts with `SymlinkError` if any component is a symlink. Affected `< 7.5.8`; fixed in `7.5.8`.

## Verification

- `yarn install` completes cleanly (`success Saved lockfile`, patches + postinstall OK).
- `yarn.lock` now resolves `tar@^6.1.9, tar@^7.5.8 -> 7.5.16`.
