### PR TITLE
feat(react-overflow): allow opting out of first-paint overflow correctness

### DIFF
--- a/apps/perf-test-react-components/package.json
+++ b/apps/perf-test-react-components/package.json
@@ -17,6 +17,7 @@
     "@fluentui/react-avatar": "*",
     "@fluentui/react-button": "*",
     "@fluentui/react-components": "*",
+    "@fluentui/priority-overflow": "*",
     "@fluentui/react-field": "*",
     "@fluentui/react-persona": "*",
     "@fluentui/react-provider": "*",

--- a/apps/perf-test-react-components/scripts/benchmark.js
+++ b/apps/perf-test-react-components/scripts/benchmark.js
@@ -1,0 +1,187 @@
+#!/usr/bin/env node
+/**
+ * benchmark.js — per-iteration layout/script/task duration measurement
+ *
+ * Navigates each scenario with iterations=1 (one mount), captures Chrome
+ * DevTools performance metrics via page.metrics() delta, repeats N times,
+ * and reports medians.
+ *
+ * Usage:
+ *   # Build the bundle first (only needed once or after code changes):
+ *   yarn nx run perf-test-react-components:perf-test:bundle
+ *
+ *   # Run the benchmark:
+ *   node apps/perf-test-react-components/scripts/benchmark.js
+ *
+ *   # Custom runs and scenarios:
+ *   node apps/perf-test-react-components/scripts/benchmark.js --runs 20 \
+ *     --scenarios OverflowNoOptOutOverflow,OverflowNoOptOutOverflowFlat
+ */
+
+'use strict';
+
+const puppeteer = require('puppeteer');
+const path = require('path');
+
+// ── CLI args ────────────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+const get = (flag, def) => {
+  const i = args.indexOf(flag);
+  return i !== -1 && args[i + 1] ? args[i + 1] : def;
+};
+
+const RUNS = parseInt(get('--runs', '30'), 10);
+const RENDER_TYPE = get('--renderType', 'mount');
+const CPU_THROTTLE = parseFloat(get('--cpuThrottle', '1'));
+const DIST_DIR = path.resolve(__dirname, '..', 'dist');
+const BASE_URL = `file://${DIST_DIR}/index.html`;
+
+const DEFAULT_SCENARIOS = [
+  'OverflowNoOptOutOverflow',
+  'OverflowMenuOptOutOverflow',
+  'OverflowItemsOptOutOverflow',
+  'OverflowBothOptOutOverflow',
+  'OverflowNoOptOutOverflowFlat',
+  'OverflowMenuOptOutOverflowFlat',
+  'OverflowItemsOptOutOverflowFlat',
+  'OverflowBothOptOutOverflowFlat',
+];
+
+const scenarioArg = get('--scenarios', null);
+const SCENARIOS = scenarioArg ? scenarioArg.split(',') : DEFAULT_SCENARIOS;
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+const median = arr => {
+  const s = [...arr].sort((a, b) => a - b);
+  const m = Math.floor(s.length / 2);
+  return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
+};
+
+const fmt = n => n.toFixed(4);
+const pct = (a, b) => (((b - a) / a) * 100).toFixed(1);
+const sign = n => (n > 0 ? '+' : '') + n;
+
+// ── Measurement ─────────────────────────────────────────────────────────────
+
+/**
+ * Measures one iteration of a scenario.
+ * Returns { layout, script, task, recalcStyle } in seconds.
+ *
+ * Chrome resets DevTools performance metrics on each page navigation, so
+ * the absolute values captured after #render-done represent the cost of
+ * loading + executing that single-iteration scenario run.
+ */
+async function measure(page, scenario) {
+  const url = `${BASE_URL}?scenario=${scenario}&iterations=1&renderType=${RENDER_TYPE}`;
+
+  page.setDefaultTimeout(15_000);
+  await page.goto(url, { waitUntil: 'load' });
+  await page.waitForSelector('#render-done', { timeout: 15_000 });
+
+  const m = await page.metrics();
+
+  return {
+    layout: m.LayoutDuration,
+    script: m.ScriptDuration,
+    task: m.TaskDuration,
+    recalcStyle: m.RecalcStyleDuration,
+  };
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: true,
+    args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage'],
+  });
+
+  const results = {};
+
+  for (const scenario of SCENARIOS) {
+    const page = await browser.newPage();
+
+    if (CPU_THROTTLE > 1) {
+      await page.emulateCPUThrottling(CPU_THROTTLE);
+    }
+
+    // Warm-up run (JIT, caches)
+    await measure(page, scenario);
+
+    const samples = { layout: [], script: [], task: [], recalcStyle: [] };
+
+    process.stdout.write(`  ${scenario.padEnd(40)}`);
+    for (let i = 0; i < RUNS; i++) {
+      const m = await measure(page, scenario);
+      samples.layout.push(m.layout);
+      samples.script.push(m.script);
+      samples.task.push(m.task);
+      samples.recalcStyle.push(m.recalcStyle);
+      process.stdout.write('.');
+    }
+    process.stdout.write('\n');
+
+    results[scenario] = {
+      layout: median(samples.layout),
+      script: median(samples.script),
+      task: median(samples.task),
+      recalcStyle: median(samples.recalcStyle),
+    };
+
+    await page.close();
+  }
+
+  await browser.close();
+
+  // ── Report ──────────────────────────────────────────────────────────────────
+
+  const PAIRS = [
+    ['OverflowNoOptOutOverflow', 'OverflowNoOptOutOverflowFlat'],
+    ['OverflowMenuOptOutOverflow', 'OverflowMenuOptOutOverflowFlat'],
+    ['OverflowItemsOptOutOverflow', 'OverflowItemsOptOutOverflowFlat'],
+    ['OverflowBothOptOutOverflow', 'OverflowBothOptOutOverflowFlat'],
+  ].filter(([a, b]) => results[a] && results[b]);
+
+  const COL = 22;
+
+  for (const metric of ['layout', 'script', 'task', 'recalcStyle']) {
+    const LABELS = {
+      layout: 'LayoutDuration (s)',
+      script: 'ScriptDuration (s)',
+      task: 'TaskDuration (s)',
+      recalcStyle: 'RecalcStyleDuration (s)',
+    };
+    const throttleNote = CPU_THROTTLE > 1 ? ` — CPU throttle ${CPU_THROTTLE}x` : '';
+    console.log(`\n${'─'.repeat(80)}`);
+    console.log(`  ${LABELS[metric]}  (median of ${RUNS} single-mount runs${throttleNote})`);
+    console.log(`${'─'.repeat(80)}`);
+    console.log(
+      `  ${'Scenario'.padEnd(COL)} ${'Original'.padStart(12)} ${'Flat'.padStart(12)} ${'Delta%'.padStart(10)}`,
+    );
+    console.log(`  ${'─'.repeat(COL + 36)}`);
+
+    for (const [orig, flat] of PAIRS) {
+      const label = orig.replace('Overflow', '').replace('OptOut', '').replace('Overflow', '').padEnd(COL);
+      const o = results[orig][metric];
+      const f = results[flat][metric];
+      const d = pct(o, f);
+      const marker = Number(d) < -5 ? ' ✓' : Number(d) > 5 ? ' ✗' : '  ';
+      console.log(`  ${label} ${fmt(o).padStart(12)} ${fmt(f).padStart(12)} ${sign(d).padStart(8)}%${marker}`);
+    }
+  }
+
+  // Also print standalone results if no pairs were found (custom scenarios)
+  if (PAIRS.length === 0) {
+    console.log(`\n${'─'.repeat(80)}`);
+    console.log(`  Results  (median of ${RUNS} single-mount runs)`);
+    console.log(`${'─'.repeat(80)}`);
+    console.log(`  ${'Scenario'.padEnd(40)} ${'Layout'.padStart(10)} ${'Script'.padStart(10)} ${'Task'.padStart(10)}`);
+    for (const [s, m] of Object.entries(results)) {
+      console.log(
+        `  ${s.padEnd(40)} ${fmt(m.layout).padStart(10)} ${fmt(m.script).padStart(10)} ${fmt(m.task).padStart(10)}`,
+      );
+    }
+  }
+})();

--- a/apps/perf-test-react-components/src/scenarios/OverflowBothOptOutIdeal.tsx
+++ b/apps/perf-test-react-components/src/scenarios/OverflowBothOptOutIdeal.tsx
@@ -11,7 +11,7 @@ import {
 const itemIds = Array.from({ length: 20 }, (_, index) => `item-${index}`);
 
 const OverflowMenu = (): React.ReactElement | null => {
-  const { ref, isOverflowing, overflowCount } = useOverflowMenu<HTMLButtonElement>({ defer: true });
+  const { ref, isOverflowing, overflowCount } = useOverflowMenu<HTMLButtonElement>();
 
   if (!isOverflowing) {
     return null;
@@ -29,7 +29,7 @@ const Scenario = () => {
     <Overflow padding={0} overflowAxis="horizontal">
       <div style={{ width: 1400, display: 'flex', flexWrap: 'nowrap', whiteSpace: 'nowrap' }}>
         {itemIds.map(id => (
-          <OverflowItem key={id} id={id} defer>
+          <OverflowItem key={id} id={id}>
             <Button style={{ width: 64, flexShrink: 0 }}>{id}</Button>
           </OverflowItem>
         ))}

--- a/apps/perf-test-react-components/src/scenarios/OverflowBothOptOutIdeal.tsx
+++ b/apps/perf-test-react-components/src/scenarios/OverflowBothOptOutIdeal.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import {
+  Button,
+  FluentProvider,
+  Overflow,
+  OverflowItem,
+  useOverflowMenu,
+  webLightTheme,
+} from '@fluentui/react-components';
+
+const itemIds = Array.from({ length: 20 }, (_, index) => `item-${index}`);
+
+const OverflowMenu = (): React.ReactElement | null => {
+  const { ref, isOverflowing, overflowCount } = useOverflowMenu<HTMLButtonElement>({ defer: true });
+
+  if (!isOverflowing) {
+    return null;
+  }
+
+  return (
+    <button ref={ref} style={{ width: 64, height: 32, flexShrink: 0 }}>
+      +{overflowCount}
+    </button>
+  );
+};
+
+const Scenario = () => {
+  return (
+    <Overflow padding={0} overflowAxis="horizontal">
+      <div style={{ width: 1400, display: 'flex', flexWrap: 'nowrap', whiteSpace: 'nowrap' }}>
+        {itemIds.map(id => (
+          <OverflowItem key={id} id={id} defer>
+            <Button style={{ width: 64, flexShrink: 0 }}>{id}</Button>
+          </OverflowItem>
+        ))}
+        <OverflowMenu />
+      </div>
+    </Overflow>
+  );
+};
+
+Scenario.decorator = (props: { children: React.ReactNode }) => (
+  <FluentProvider theme={webLightTheme}>{props.children}</FluentProvider>
+);
+
+export default Scenario;

--- a/apps/perf-test-react-components/src/scenarios/OverflowBothOptOutOverflow.tsx
+++ b/apps/perf-test-react-components/src/scenarios/OverflowBothOptOutOverflow.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import {
+  Button,
+  FluentProvider,
+  Overflow,
+  OverflowItem,
+  useOverflowMenu,
+  webLightTheme,
+} from '@fluentui/react-components';
+
+const itemIds = Array.from({ length: 20 }, (_, index) => `item-${index}`);
+
+const OverflowMenu = (): React.ReactElement | null => {
+  const { ref, isOverflowing, overflowCount } = useOverflowMenu<HTMLButtonElement>({ defer: true });
+
+  if (!isOverflowing) {
+    return null;
+  }
+
+  return (
+    <button ref={ref} style={{ width: 64, height: 32, flexShrink: 0 }}>
+      +{overflowCount}
+    </button>
+  );
+};
+
+const Scenario = () => {
+  return (
+    <Overflow padding={0} overflowAxis="horizontal">
+      <div style={{ width: 320, display: 'flex', flexWrap: 'nowrap', whiteSpace: 'nowrap' }}>
+        {itemIds.map(id => (
+          <OverflowItem key={id} id={id} defer>
+            <Button style={{ width: 64, flexShrink: 0 }}>{id}</Button>
+          </OverflowItem>
+        ))}
+        <OverflowMenu />
+      </div>
+    </Overflow>
+  );
+};
+
+Scenario.decorator = (props: { children: React.ReactNode }) => (
+  <FluentProvider theme={webLightTheme}>{props.children}</FluentProvider>
+);
+
+export default Scenario;

--- a/apps/perf-test-react-components/src/scenarios/OverflowBothOptOutOverflow.tsx
+++ b/apps/perf-test-react-components/src/scenarios/OverflowBothOptOutOverflow.tsx
@@ -11,7 +11,7 @@ import {
 const itemIds = Array.from({ length: 20 }, (_, index) => `item-${index}`);
 
 const OverflowMenu = (): React.ReactElement | null => {
-  const { ref, isOverflowing, overflowCount } = useOverflowMenu<HTMLButtonElement>({ defer: true });
+  const { ref, isOverflowing, overflowCount } = useOverflowMenu<HTMLButtonElement>();
 
   if (!isOverflowing) {
     return null;
@@ -29,7 +29,7 @@ const Scenario = () => {
     <Overflow padding={0} overflowAxis="horizontal">
       <div style={{ width: 320, display: 'flex', flexWrap: 'nowrap', whiteSpace: 'nowrap' }}>
         {itemIds.map(id => (
-          <OverflowItem key={id} id={id} defer>
+          <OverflowItem key={id} id={id}>
             <Button style={{ width: 64, flexShrink: 0 }}>{id}</Button>
           </OverflowItem>
         ))}

--- a/apps/perf-test-react-components/src/scenarios/OverflowBothOptOutOverflowFlat.tsx
+++ b/apps/perf-test-react-components/src/scenarios/OverflowBothOptOutOverflowFlat.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import {
+  Button,
+  FluentProvider,
+  Overflow,
+  OverflowItem,
+  useOverflowMenu,
+  webLightTheme,
+} from '@fluentui/react-components';
+import { createFlatOverflowManager } from '@fluentui/priority-overflow';
+
+const itemIds = Array.from({ length: 20 }, (_, index) => `item-${index}`);
+
+const OverflowMenu = (): React.ReactElement | null => {
+  const { ref, isOverflowing, overflowCount } = useOverflowMenu<HTMLButtonElement>({ defer: true });
+
+  if (!isOverflowing) {
+    return null;
+  }
+
+  return (
+    <button ref={ref} style={{ width: 64, height: 32, flexShrink: 0 }}>
+      +{overflowCount}
+    </button>
+  );
+};
+
+const Scenario = () => {
+  return (
+    <Overflow padding={0} overflowAxis="horizontal" createManager={createFlatOverflowManager}>
+      <div style={{ width: 320, display: 'flex', flexWrap: 'nowrap', whiteSpace: 'nowrap' }}>
+        {itemIds.map(id => (
+          <OverflowItem key={id} id={id} defer>
+            <Button style={{ width: 64, flexShrink: 0 }}>{id}</Button>
+          </OverflowItem>
+        ))}
+        <OverflowMenu />
+      </div>
+    </Overflow>
+  );
+};
+
+Scenario.decorator = (props: { children: React.ReactNode }) => (
+  <FluentProvider theme={webLightTheme}>{props.children}</FluentProvider>
+);
+
+export default Scenario;

--- a/apps/perf-test-react-components/src/scenarios/OverflowBothOptOutOverflowFlat.tsx
+++ b/apps/perf-test-react-components/src/scenarios/OverflowBothOptOutOverflowFlat.tsx
@@ -30,7 +30,7 @@ const Scenario = () => {
     <Overflow padding={64} overflowAxis="horizontal" createManager={createFlatOverflowManager}>
       <div style={{ width: 320, display: 'flex', flexWrap: 'nowrap', whiteSpace: 'nowrap' }}>
         {itemIds.map(id => (
-          <OverflowItem key={id} id={id} defer>
+          <OverflowItem key={id} id={id} sizeHint={64} defer>
             <Button style={{ width: 64, flexShrink: 0 }}>{id}</Button>
           </OverflowItem>
         ))}

--- a/apps/perf-test-react-components/src/scenarios/OverflowBothOptOutOverflowFlat.tsx
+++ b/apps/perf-test-react-components/src/scenarios/OverflowBothOptOutOverflowFlat.tsx
@@ -27,7 +27,7 @@ const OverflowMenu = (): React.ReactElement | null => {
 
 const Scenario = () => {
   return (
-    <Overflow padding={0} overflowAxis="horizontal" createManager={createFlatOverflowManager}>
+    <Overflow padding={64} overflowAxis="horizontal" createManager={createFlatOverflowManager}>
       <div style={{ width: 320, display: 'flex', flexWrap: 'nowrap', whiteSpace: 'nowrap' }}>
         {itemIds.map(id => (
           <OverflowItem key={id} id={id} defer>

--- a/apps/perf-test-react-components/src/scenarios/OverflowBothOptOutOverflowFlat.tsx
+++ b/apps/perf-test-react-components/src/scenarios/OverflowBothOptOutOverflowFlat.tsx
@@ -12,7 +12,7 @@ import { createFlatOverflowManager } from '@fluentui/priority-overflow';
 const itemIds = Array.from({ length: 20 }, (_, index) => `item-${index}`);
 
 const OverflowMenu = (): React.ReactElement | null => {
-  const { ref, isOverflowing, overflowCount } = useOverflowMenu<HTMLButtonElement>({ defer: true });
+  const { ref, isOverflowing, overflowCount } = useOverflowMenu<HTMLButtonElement>();
 
   if (!isOverflowing) {
     return null;
@@ -30,7 +30,7 @@ const Scenario = () => {
     <Overflow padding={64} overflowAxis="horizontal" createManager={createFlatOverflowManager}>
       <div style={{ width: 320, display: 'flex', flexWrap: 'nowrap', whiteSpace: 'nowrap' }}>
         {itemIds.map(id => (
-          <OverflowItem key={id} id={id} sizeHint={64} defer>
+          <OverflowItem key={id} id={id} sizeHint={64}>
             <Button style={{ width: 64, flexShrink: 0 }}>{id}</Button>
           </OverflowItem>
         ))}

--- a/apps/perf-test-react-components/src/scenarios/OverflowBothOptOutOverflowFlatNoDefer.tsx
+++ b/apps/perf-test-react-components/src/scenarios/OverflowBothOptOutOverflowFlatNoDefer.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import {
+  Button,
+  FluentProvider,
+  Overflow,
+  OverflowItem,
+  useOverflowMenu,
+  webLightTheme,
+} from '@fluentui/react-components';
+import { createFlatOverflowManager } from '@fluentui/priority-overflow';
+
+const itemIds = Array.from({ length: 20 }, (_, index) => `item-${index}`);
+
+const OverflowMenu = (): React.ReactElement | null => {
+  const { ref, isOverflowing, overflowCount } = useOverflowMenu<HTMLButtonElement>();
+
+  if (!isOverflowing) {
+    return null;
+  }
+
+  return (
+    <button ref={ref} style={{ width: 64, height: 32, flexShrink: 0 }}>
+      +{overflowCount}
+    </button>
+  );
+};
+
+const Scenario = () => {
+  return (
+    <Overflow padding={64} overflowAxis="horizontal" createManager={createFlatOverflowManager}>
+      <div style={{ width: 320, display: 'flex', flexWrap: 'nowrap', whiteSpace: 'nowrap' }}>
+        {itemIds.map(id => (
+          <OverflowItem key={id} id={id} sizeHint={64}>
+            <Button style={{ width: 64, flexShrink: 0 }}>{id}</Button>
+          </OverflowItem>
+        ))}
+        <OverflowMenu />
+      </div>
+    </Overflow>
+  );
+};
+
+Scenario.decorator = (props: { children: React.ReactNode }) => (
+  <FluentProvider theme={webLightTheme}>{props.children}</FluentProvider>
+);
+
+export default Scenario;

--- a/apps/perf-test-react-components/src/scenarios/OverflowDefer.tsx
+++ b/apps/perf-test-react-components/src/scenarios/OverflowDefer.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import {
+  Button,
+  FluentProvider,
+  Overflow,
+  OverflowItem,
+  useOverflowMenu,
+  webLightTheme,
+} from '@fluentui/react-components';
+
+const itemIds = Array.from({ length: 20 }, (_, index) => `item-${index}`);
+
+const OverflowMenu = (): React.ReactElement | null => {
+  const { ref, isOverflowing, overflowCount } = useOverflowMenu<HTMLButtonElement>({ defer: true });
+
+  if (!isOverflowing) {
+    return null;
+  }
+
+  return (
+    <button ref={ref} style={{ width: 64, height: 32, flexShrink: 0 }}>
+      +{overflowCount}
+    </button>
+  );
+};
+
+const Scenario = () => {
+  return (
+    <Overflow padding={0} overflowAxis="horizontal">
+      <div style={{ width: 320, display: 'flex', flexWrap: 'nowrap', whiteSpace: 'nowrap' }}>
+        {itemIds.map(id => (
+          <OverflowItem key={id} id={id} defer>
+            <Button style={{ width: 64, flexShrink: 0 }}>{id}</Button>
+          </OverflowItem>
+        ))}
+        <OverflowMenu />
+      </div>
+    </Overflow>
+  );
+};
+
+Scenario.decorator = (props: { children: React.ReactNode }) => (
+  <FluentProvider theme={webLightTheme}>{props.children}</FluentProvider>
+);
+
+export default Scenario;

--- a/apps/perf-test-react-components/src/scenarios/OverflowDefer.tsx
+++ b/apps/perf-test-react-components/src/scenarios/OverflowDefer.tsx
@@ -11,7 +11,7 @@ import {
 const itemIds = Array.from({ length: 20 }, (_, index) => `item-${index}`);
 
 const OverflowMenu = (): React.ReactElement | null => {
-  const { ref, isOverflowing, overflowCount } = useOverflowMenu<HTMLButtonElement>({ defer: true });
+  const { ref, isOverflowing, overflowCount } = useOverflowMenu<HTMLButtonElement>();
 
   if (!isOverflowing) {
     return null;
@@ -29,7 +29,7 @@ const Scenario = () => {
     <Overflow padding={0} overflowAxis="horizontal">
       <div style={{ width: 320, display: 'flex', flexWrap: 'nowrap', whiteSpace: 'nowrap' }}>
         {itemIds.map(id => (
-          <OverflowItem key={id} id={id} defer>
+          <OverflowItem key={id} id={id}>
             <Button style={{ width: 64, flexShrink: 0 }}>{id}</Button>
           </OverflowItem>
         ))}

--- a/apps/perf-test-react-components/src/scenarios/OverflowItemsOptOutIdeal.tsx
+++ b/apps/perf-test-react-components/src/scenarios/OverflowItemsOptOutIdeal.tsx
@@ -29,7 +29,7 @@ const Scenario = () => {
     <Overflow padding={0} overflowAxis="horizontal">
       <div style={{ width: 1400, display: 'flex', flexWrap: 'nowrap', whiteSpace: 'nowrap' }}>
         {itemIds.map(id => (
-          <OverflowItem key={id} id={id} defer>
+          <OverflowItem key={id} id={id}>
             <Button style={{ width: 64, flexShrink: 0 }}>{id}</Button>
           </OverflowItem>
         ))}

--- a/apps/perf-test-react-components/src/scenarios/OverflowItemsOptOutIdeal.tsx
+++ b/apps/perf-test-react-components/src/scenarios/OverflowItemsOptOutIdeal.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import {
+  Button,
+  FluentProvider,
+  Overflow,
+  OverflowItem,
+  useOverflowMenu,
+  webLightTheme,
+} from '@fluentui/react-components';
+
+const itemIds = Array.from({ length: 20 }, (_, index) => `item-${index}`);
+
+const OverflowMenu = (): React.ReactElement | null => {
+  const { ref, isOverflowing, overflowCount } = useOverflowMenu<HTMLButtonElement>();
+
+  if (!isOverflowing) {
+    return null;
+  }
+
+  return (
+    <button ref={ref} style={{ width: 64, height: 32, flexShrink: 0 }}>
+      +{overflowCount}
+    </button>
+  );
+};
+
+const Scenario = () => {
+  return (
+    <Overflow padding={0} overflowAxis="horizontal">
+      <div style={{ width: 1400, display: 'flex', flexWrap: 'nowrap', whiteSpace: 'nowrap' }}>
+        {itemIds.map(id => (
+          <OverflowItem key={id} id={id} defer>
+            <Button style={{ width: 64, flexShrink: 0 }}>{id}</Button>
+          </OverflowItem>
+        ))}
+        <OverflowMenu />
+      </div>
+    </Overflow>
+  );
+};
+
+Scenario.decorator = (props: { children: React.ReactNode }) => (
+  <FluentProvider theme={webLightTheme}>{props.children}</FluentProvider>
+);
+
+export default Scenario;

--- a/apps/perf-test-react-components/src/scenarios/OverflowItemsOptOutOverflow.tsx
+++ b/apps/perf-test-react-components/src/scenarios/OverflowItemsOptOutOverflow.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import {
+  Button,
+  FluentProvider,
+  Overflow,
+  OverflowItem,
+  useOverflowMenu,
+  webLightTheme,
+} from '@fluentui/react-components';
+
+const itemIds = Array.from({ length: 20 }, (_, index) => `item-${index}`);
+
+const OverflowMenu = (): React.ReactElement | null => {
+  const { ref, isOverflowing, overflowCount } = useOverflowMenu<HTMLButtonElement>();
+
+  if (!isOverflowing) {
+    return null;
+  }
+
+  return (
+    <button ref={ref} style={{ width: 64, height: 32, flexShrink: 0 }}>
+      +{overflowCount}
+    </button>
+  );
+};
+
+const Scenario = () => {
+  return (
+    <Overflow padding={0} overflowAxis="horizontal">
+      <div style={{ width: 320, display: 'flex', flexWrap: 'nowrap', whiteSpace: 'nowrap' }}>
+        {itemIds.map(id => (
+          <OverflowItem key={id} id={id} defer>
+            <Button style={{ width: 64, flexShrink: 0 }}>{id}</Button>
+          </OverflowItem>
+        ))}
+        <OverflowMenu />
+      </div>
+    </Overflow>
+  );
+};
+
+Scenario.decorator = (props: { children: React.ReactNode }) => (
+  <FluentProvider theme={webLightTheme}>{props.children}</FluentProvider>
+);
+
+export default Scenario;

--- a/apps/perf-test-react-components/src/scenarios/OverflowItemsOptOutOverflow.tsx
+++ b/apps/perf-test-react-components/src/scenarios/OverflowItemsOptOutOverflow.tsx
@@ -29,7 +29,7 @@ const Scenario = () => {
     <Overflow padding={0} overflowAxis="horizontal">
       <div style={{ width: 320, display: 'flex', flexWrap: 'nowrap', whiteSpace: 'nowrap' }}>
         {itemIds.map(id => (
-          <OverflowItem key={id} id={id} defer>
+          <OverflowItem key={id} id={id}>
             <Button style={{ width: 64, flexShrink: 0 }}>{id}</Button>
           </OverflowItem>
         ))}

--- a/apps/perf-test-react-components/src/scenarios/OverflowItemsOptOutOverflowFlat.tsx
+++ b/apps/perf-test-react-components/src/scenarios/OverflowItemsOptOutOverflowFlat.tsx
@@ -30,7 +30,7 @@ const Scenario = () => {
     <Overflow padding={64} overflowAxis="horizontal" createManager={createFlatOverflowManager}>
       <div style={{ width: 320, display: 'flex', flexWrap: 'nowrap', whiteSpace: 'nowrap' }}>
         {itemIds.map(id => (
-          <OverflowItem key={id} id={id} defer>
+          <OverflowItem key={id} id={id} sizeHint={64} defer>
             <Button style={{ width: 64, flexShrink: 0 }}>{id}</Button>
           </OverflowItem>
         ))}

--- a/apps/perf-test-react-components/src/scenarios/OverflowItemsOptOutOverflowFlat.tsx
+++ b/apps/perf-test-react-components/src/scenarios/OverflowItemsOptOutOverflowFlat.tsx
@@ -30,7 +30,7 @@ const Scenario = () => {
     <Overflow padding={64} overflowAxis="horizontal" createManager={createFlatOverflowManager}>
       <div style={{ width: 320, display: 'flex', flexWrap: 'nowrap', whiteSpace: 'nowrap' }}>
         {itemIds.map(id => (
-          <OverflowItem key={id} id={id} sizeHint={64} defer>
+          <OverflowItem key={id} id={id} sizeHint={64}>
             <Button style={{ width: 64, flexShrink: 0 }}>{id}</Button>
           </OverflowItem>
         ))}

--- a/apps/perf-test-react-components/src/scenarios/OverflowItemsOptOutOverflowFlat.tsx
+++ b/apps/perf-test-react-components/src/scenarios/OverflowItemsOptOutOverflowFlat.tsx
@@ -27,7 +27,7 @@ const OverflowMenu = (): React.ReactElement | null => {
 
 const Scenario = () => {
   return (
-    <Overflow padding={0} overflowAxis="horizontal" createManager={createFlatOverflowManager}>
+    <Overflow padding={64} overflowAxis="horizontal" createManager={createFlatOverflowManager}>
       <div style={{ width: 320, display: 'flex', flexWrap: 'nowrap', whiteSpace: 'nowrap' }}>
         {itemIds.map(id => (
           <OverflowItem key={id} id={id} defer>

--- a/apps/perf-test-react-components/src/scenarios/OverflowItemsOptOutOverflowFlat.tsx
+++ b/apps/perf-test-react-components/src/scenarios/OverflowItemsOptOutOverflowFlat.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import {
+  Button,
+  FluentProvider,
+  Overflow,
+  OverflowItem,
+  useOverflowMenu,
+  webLightTheme,
+} from '@fluentui/react-components';
+import { createFlatOverflowManager } from '@fluentui/priority-overflow';
+
+const itemIds = Array.from({ length: 20 }, (_, index) => `item-${index}`);
+
+const OverflowMenu = (): React.ReactElement | null => {
+  const { ref, isOverflowing, overflowCount } = useOverflowMenu<HTMLButtonElement>();
+
+  if (!isOverflowing) {
+    return null;
+  }
+
+  return (
+    <button ref={ref} style={{ width: 64, height: 32, flexShrink: 0 }}>
+      +{overflowCount}
+    </button>
+  );
+};
+
+const Scenario = () => {
+  return (
+    <Overflow padding={0} overflowAxis="horizontal" createManager={createFlatOverflowManager}>
+      <div style={{ width: 320, display: 'flex', flexWrap: 'nowrap', whiteSpace: 'nowrap' }}>
+        {itemIds.map(id => (
+          <OverflowItem key={id} id={id} defer>
+            <Button style={{ width: 64, flexShrink: 0 }}>{id}</Button>
+          </OverflowItem>
+        ))}
+        <OverflowMenu />
+      </div>
+    </Overflow>
+  );
+};
+
+Scenario.decorator = (props: { children: React.ReactNode }) => (
+  <FluentProvider theme={webLightTheme}>{props.children}</FluentProvider>
+);
+
+export default Scenario;

--- a/apps/perf-test-react-components/src/scenarios/OverflowMenuOptOutIdeal.tsx
+++ b/apps/perf-test-react-components/src/scenarios/OverflowMenuOptOutIdeal.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import {
+  Button,
+  FluentProvider,
+  Overflow,
+  OverflowItem,
+  useOverflowMenu,
+  webLightTheme,
+} from '@fluentui/react-components';
+
+const itemIds = Array.from({ length: 20 }, (_, index) => `item-${index}`);
+
+const OverflowMenu = (): React.ReactElement | null => {
+  const { ref, isOverflowing, overflowCount } = useOverflowMenu<HTMLButtonElement>({ defer: true });
+
+  if (!isOverflowing) {
+    return null;
+  }
+
+  return (
+    <button ref={ref} style={{ width: 64, height: 32, flexShrink: 0 }}>
+      +{overflowCount}
+    </button>
+  );
+};
+
+const Scenario = () => {
+  return (
+    <Overflow padding={0} overflowAxis="horizontal">
+      <div style={{ width: 1400, display: 'flex', flexWrap: 'nowrap', whiteSpace: 'nowrap' }}>
+        {itemIds.map(id => (
+          <OverflowItem key={id} id={id}>
+            <Button style={{ width: 64, flexShrink: 0 }}>{id}</Button>
+          </OverflowItem>
+        ))}
+        <OverflowMenu />
+      </div>
+    </Overflow>
+  );
+};
+
+Scenario.decorator = (props: { children: React.ReactNode }) => (
+  <FluentProvider theme={webLightTheme}>{props.children}</FluentProvider>
+);
+
+export default Scenario;

--- a/apps/perf-test-react-components/src/scenarios/OverflowMenuOptOutIdeal.tsx
+++ b/apps/perf-test-react-components/src/scenarios/OverflowMenuOptOutIdeal.tsx
@@ -11,7 +11,7 @@ import {
 const itemIds = Array.from({ length: 20 }, (_, index) => `item-${index}`);
 
 const OverflowMenu = (): React.ReactElement | null => {
-  const { ref, isOverflowing, overflowCount } = useOverflowMenu<HTMLButtonElement>({ defer: true });
+  const { ref, isOverflowing, overflowCount } = useOverflowMenu<HTMLButtonElement>();
 
   if (!isOverflowing) {
     return null;

--- a/apps/perf-test-react-components/src/scenarios/OverflowMenuOptOutOverflow.tsx
+++ b/apps/perf-test-react-components/src/scenarios/OverflowMenuOptOutOverflow.tsx
@@ -11,7 +11,7 @@ import {
 const itemIds = Array.from({ length: 20 }, (_, index) => `item-${index}`);
 
 const OverflowMenu = (): React.ReactElement | null => {
-  const { ref, isOverflowing, overflowCount } = useOverflowMenu<HTMLButtonElement>({ defer: true });
+  const { ref, isOverflowing, overflowCount } = useOverflowMenu<HTMLButtonElement>();
 
   if (!isOverflowing) {
     return null;

--- a/apps/perf-test-react-components/src/scenarios/OverflowMenuOptOutOverflow.tsx
+++ b/apps/perf-test-react-components/src/scenarios/OverflowMenuOptOutOverflow.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import {
+  Button,
+  FluentProvider,
+  Overflow,
+  OverflowItem,
+  useOverflowMenu,
+  webLightTheme,
+} from '@fluentui/react-components';
+
+const itemIds = Array.from({ length: 20 }, (_, index) => `item-${index}`);
+
+const OverflowMenu = (): React.ReactElement | null => {
+  const { ref, isOverflowing, overflowCount } = useOverflowMenu<HTMLButtonElement>({ defer: true });
+
+  if (!isOverflowing) {
+    return null;
+  }
+
+  return (
+    <button ref={ref} style={{ width: 64, height: 32, flexShrink: 0 }}>
+      +{overflowCount}
+    </button>
+  );
+};
+
+const Scenario = () => {
+  return (
+    <Overflow padding={0} overflowAxis="horizontal">
+      <div style={{ width: 320, display: 'flex', flexWrap: 'nowrap', whiteSpace: 'nowrap' }}>
+        {itemIds.map(id => (
+          <OverflowItem key={id} id={id}>
+            <Button style={{ width: 64, flexShrink: 0 }}>{id}</Button>
+          </OverflowItem>
+        ))}
+        <OverflowMenu />
+      </div>
+    </Overflow>
+  );
+};
+
+Scenario.decorator = (props: { children: React.ReactNode }) => (
+  <FluentProvider theme={webLightTheme}>{props.children}</FluentProvider>
+);
+
+export default Scenario;

--- a/apps/perf-test-react-components/src/scenarios/OverflowMenuOptOutOverflowFlat.tsx
+++ b/apps/perf-test-react-components/src/scenarios/OverflowMenuOptOutOverflowFlat.tsx
@@ -12,7 +12,7 @@ import { createFlatOverflowManager } from '@fluentui/priority-overflow';
 const itemIds = Array.from({ length: 20 }, (_, index) => `item-${index}`);
 
 const OverflowMenu = (): React.ReactElement | null => {
-  const { ref, isOverflowing, overflowCount } = useOverflowMenu<HTMLButtonElement>({ defer: true });
+  const { ref, isOverflowing, overflowCount } = useOverflowMenu<HTMLButtonElement>();
 
   if (!isOverflowing) {
     return null;

--- a/apps/perf-test-react-components/src/scenarios/OverflowMenuOptOutOverflowFlat.tsx
+++ b/apps/perf-test-react-components/src/scenarios/OverflowMenuOptOutOverflowFlat.tsx
@@ -30,7 +30,7 @@ const Scenario = () => {
     <Overflow padding={64} overflowAxis="horizontal" createManager={createFlatOverflowManager}>
       <div style={{ width: 320, display: 'flex', flexWrap: 'nowrap', whiteSpace: 'nowrap' }}>
         {itemIds.map(id => (
-          <OverflowItem key={id} id={id}>
+          <OverflowItem key={id} id={id} sizeHint={64}>
             <Button style={{ width: 64, flexShrink: 0 }}>{id}</Button>
           </OverflowItem>
         ))}

--- a/apps/perf-test-react-components/src/scenarios/OverflowMenuOptOutOverflowFlat.tsx
+++ b/apps/perf-test-react-components/src/scenarios/OverflowMenuOptOutOverflowFlat.tsx
@@ -27,7 +27,7 @@ const OverflowMenu = (): React.ReactElement | null => {
 
 const Scenario = () => {
   return (
-    <Overflow padding={0} overflowAxis="horizontal" createManager={createFlatOverflowManager}>
+    <Overflow padding={64} overflowAxis="horizontal" createManager={createFlatOverflowManager}>
       <div style={{ width: 320, display: 'flex', flexWrap: 'nowrap', whiteSpace: 'nowrap' }}>
         {itemIds.map(id => (
           <OverflowItem key={id} id={id}>

--- a/apps/perf-test-react-components/src/scenarios/OverflowMenuOptOutOverflowFlat.tsx
+++ b/apps/perf-test-react-components/src/scenarios/OverflowMenuOptOutOverflowFlat.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import {
+  Button,
+  FluentProvider,
+  Overflow,
+  OverflowItem,
+  useOverflowMenu,
+  webLightTheme,
+} from '@fluentui/react-components';
+import { createFlatOverflowManager } from '@fluentui/priority-overflow';
+
+const itemIds = Array.from({ length: 20 }, (_, index) => `item-${index}`);
+
+const OverflowMenu = (): React.ReactElement | null => {
+  const { ref, isOverflowing, overflowCount } = useOverflowMenu<HTMLButtonElement>({ defer: true });
+
+  if (!isOverflowing) {
+    return null;
+  }
+
+  return (
+    <button ref={ref} style={{ width: 64, height: 32, flexShrink: 0 }}>
+      +{overflowCount}
+    </button>
+  );
+};
+
+const Scenario = () => {
+  return (
+    <Overflow padding={0} overflowAxis="horizontal" createManager={createFlatOverflowManager}>
+      <div style={{ width: 320, display: 'flex', flexWrap: 'nowrap', whiteSpace: 'nowrap' }}>
+        {itemIds.map(id => (
+          <OverflowItem key={id} id={id}>
+            <Button style={{ width: 64, flexShrink: 0 }}>{id}</Button>
+          </OverflowItem>
+        ))}
+        <OverflowMenu />
+      </div>
+    </Overflow>
+  );
+};
+
+Scenario.decorator = (props: { children: React.ReactNode }) => (
+  <FluentProvider theme={webLightTheme}>{props.children}</FluentProvider>
+);
+
+export default Scenario;

--- a/apps/perf-test-react-components/src/scenarios/OverflowN100NoOptOutOverflow.tsx
+++ b/apps/perf-test-react-components/src/scenarios/OverflowN100NoOptOutOverflow.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import {
+  Button,
+  FluentProvider,
+  Overflow,
+  OverflowItem,
+  useOverflowMenu,
+  webLightTheme,
+} from '@fluentui/react-components';
+
+// Same as OverflowNoOptOutOverflow but with 100 items (5x more).
+// Used to measure whether N matters for the classic overflow manager.
+const itemIds = Array.from({ length: 100 }, (_, index) => `item-${index}`);
+
+const OverflowMenu = (): React.ReactElement | null => {
+  const { ref, isOverflowing, overflowCount } = useOverflowMenu<HTMLButtonElement>();
+  if (!isOverflowing) {return null;}
+  return (
+    <button ref={ref} style={{ width: 64, height: 32, flexShrink: 0 }}>
+      +{overflowCount}
+    </button>
+  );
+};
+
+const Scenario = () => (
+  <Overflow padding={0} overflowAxis="horizontal">
+    <div style={{ width: 320, display: 'flex', flexWrap: 'nowrap', whiteSpace: 'nowrap' }}>
+      {itemIds.map(id => (
+        <OverflowItem key={id} id={id}>
+          <Button style={{ width: 64, flexShrink: 0 }}>{id}</Button>
+        </OverflowItem>
+      ))}
+      <OverflowMenu />
+    </div>
+  </Overflow>
+);
+
+Scenario.decorator = (props: { children: React.ReactNode }) => (
+  <FluentProvider theme={webLightTheme}>{props.children}</FluentProvider>
+);
+
+export default Scenario;

--- a/apps/perf-test-react-components/src/scenarios/OverflowN100NoOptOutOverflowFlat.tsx
+++ b/apps/perf-test-react-components/src/scenarios/OverflowN100NoOptOutOverflowFlat.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import {
+  Button,
+  FluentProvider,
+  Overflow,
+  OverflowItem,
+  useOverflowMenu,
+  webLightTheme,
+} from '@fluentui/react-components';
+import { createFlatOverflowManager } from '@fluentui/priority-overflow';
+
+// Same as OverflowNoOptOutOverflowFlat but with 100 items (5x more).
+// Used to measure whether N matters for the flat overflow manager.
+const itemIds = Array.from({ length: 100 }, (_, index) => `item-${index}`);
+
+const OverflowMenu = (): React.ReactElement | null => {
+  const { ref, isOverflowing, overflowCount } = useOverflowMenu<HTMLButtonElement>();
+  if (!isOverflowing) {return null;}
+  return (
+    <button ref={ref} style={{ width: 64, height: 32, flexShrink: 0 }}>
+      +{overflowCount}
+    </button>
+  );
+};
+
+const Scenario = () => (
+  <Overflow padding={64} overflowAxis="horizontal" createManager={createFlatOverflowManager}>
+    <div style={{ width: 320, display: 'flex', flexWrap: 'nowrap', whiteSpace: 'nowrap' }}>
+      {itemIds.map(id => (
+        <OverflowItem key={id} id={id} sizeHint={64}>
+          <Button style={{ width: 64, flexShrink: 0 }}>{id}</Button>
+        </OverflowItem>
+      ))}
+      <OverflowMenu />
+    </div>
+  </Overflow>
+);
+
+Scenario.decorator = (props: { children: React.ReactNode }) => (
+  <FluentProvider theme={webLightTheme}>{props.children}</FluentProvider>
+);
+
+export default Scenario;

--- a/apps/perf-test-react-components/src/scenarios/OverflowNoDefer.tsx
+++ b/apps/perf-test-react-components/src/scenarios/OverflowNoDefer.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import {
+  Button,
+  FluentProvider,
+  Overflow,
+  OverflowItem,
+  useOverflowMenu,
+  webLightTheme,
+} from '@fluentui/react-components';
+
+const itemIds = Array.from({ length: 20 }, (_, index) => `item-${index}`);
+
+const OverflowMenu = (): React.ReactElement | null => {
+  const { ref, isOverflowing, overflowCount } = useOverflowMenu<HTMLButtonElement>();
+
+  if (!isOverflowing) {
+    return null;
+  }
+
+  return (
+    <button ref={ref} style={{ width: 64, height: 32, flexShrink: 0 }}>
+      +{overflowCount}
+    </button>
+  );
+};
+
+const Scenario = () => {
+  return (
+    <Overflow padding={0} overflowAxis="horizontal">
+      <div style={{ width: 320, display: 'flex', flexWrap: 'nowrap', whiteSpace: 'nowrap' }}>
+        {itemIds.map(id => (
+          <OverflowItem key={id} id={id}>
+            <Button style={{ width: 64, flexShrink: 0 }}>{id}</Button>
+          </OverflowItem>
+        ))}
+        <OverflowMenu />
+      </div>
+    </Overflow>
+  );
+};
+
+Scenario.decorator = (props: { children: React.ReactNode }) => (
+  <FluentProvider theme={webLightTheme}>{props.children}</FluentProvider>
+);
+
+export default Scenario;

--- a/apps/perf-test-react-components/src/scenarios/OverflowNoOptOutIdeal.tsx
+++ b/apps/perf-test-react-components/src/scenarios/OverflowNoOptOutIdeal.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import {
+  Button,
+  FluentProvider,
+  Overflow,
+  OverflowItem,
+  useOverflowMenu,
+  webLightTheme,
+} from '@fluentui/react-components';
+
+const itemIds = Array.from({ length: 20 }, (_, index) => `item-${index}`);
+
+const OverflowMenu = (): React.ReactElement | null => {
+  const { ref, isOverflowing, overflowCount } = useOverflowMenu<HTMLButtonElement>();
+
+  if (!isOverflowing) {
+    return null;
+  }
+
+  return (
+    <button ref={ref} style={{ width: 64, height: 32, flexShrink: 0 }}>
+      +{overflowCount}
+    </button>
+  );
+};
+
+const Scenario = () => {
+  return (
+    <Overflow padding={0} overflowAxis="horizontal">
+      <div style={{ width: 1400, display: 'flex', flexWrap: 'nowrap', whiteSpace: 'nowrap' }}>
+        {itemIds.map(id => (
+          <OverflowItem key={id} id={id}>
+            <Button style={{ width: 64, flexShrink: 0 }}>{id}</Button>
+          </OverflowItem>
+        ))}
+        <OverflowMenu />
+      </div>
+    </Overflow>
+  );
+};
+
+Scenario.decorator = (props: { children: React.ReactNode }) => (
+  <FluentProvider theme={webLightTheme}>{props.children}</FluentProvider>
+);
+
+export default Scenario;

--- a/apps/perf-test-react-components/src/scenarios/OverflowNoOptOutOverflow.tsx
+++ b/apps/perf-test-react-components/src/scenarios/OverflowNoOptOutOverflow.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import {
+  Button,
+  FluentProvider,
+  Overflow,
+  OverflowItem,
+  useOverflowMenu,
+  webLightTheme,
+} from '@fluentui/react-components';
+
+const itemIds = Array.from({ length: 20 }, (_, index) => `item-${index}`);
+
+const OverflowMenu = (): React.ReactElement | null => {
+  const { ref, isOverflowing, overflowCount } = useOverflowMenu<HTMLButtonElement>();
+
+  if (!isOverflowing) {
+    return null;
+  }
+
+  return (
+    <button ref={ref} style={{ width: 64, height: 32, flexShrink: 0 }}>
+      +{overflowCount}
+    </button>
+  );
+};
+
+const Scenario = () => {
+  return (
+    <Overflow padding={0} overflowAxis="horizontal">
+      <div style={{ width: 320, display: 'flex', flexWrap: 'nowrap', whiteSpace: 'nowrap' }}>
+        {itemIds.map(id => (
+          <OverflowItem key={id} id={id}>
+            <Button style={{ width: 64, flexShrink: 0 }}>{id}</Button>
+          </OverflowItem>
+        ))}
+        <OverflowMenu />
+      </div>
+    </Overflow>
+  );
+};
+
+Scenario.decorator = (props: { children: React.ReactNode }) => (
+  <FluentProvider theme={webLightTheme}>{props.children}</FluentProvider>
+);
+
+export default Scenario;

--- a/apps/perf-test-react-components/src/scenarios/OverflowNoOptOutOverflowFlat.tsx
+++ b/apps/perf-test-react-components/src/scenarios/OverflowNoOptOutOverflowFlat.tsx
@@ -30,7 +30,7 @@ const Scenario = () => {
     <Overflow padding={64} overflowAxis="horizontal" createManager={createFlatOverflowManager}>
       <div style={{ width: 320, display: 'flex', flexWrap: 'nowrap', whiteSpace: 'nowrap' }}>
         {itemIds.map(id => (
-          <OverflowItem key={id} id={id}>
+          <OverflowItem key={id} id={id} sizeHint={64}>
             <Button style={{ width: 64, flexShrink: 0 }}>{id}</Button>
           </OverflowItem>
         ))}

--- a/apps/perf-test-react-components/src/scenarios/OverflowNoOptOutOverflowFlat.tsx
+++ b/apps/perf-test-react-components/src/scenarios/OverflowNoOptOutOverflowFlat.tsx
@@ -27,7 +27,7 @@ const OverflowMenu = (): React.ReactElement | null => {
 
 const Scenario = () => {
   return (
-    <Overflow padding={0} overflowAxis="horizontal" createManager={createFlatOverflowManager}>
+    <Overflow padding={64} overflowAxis="horizontal" createManager={createFlatOverflowManager}>
       <div style={{ width: 320, display: 'flex', flexWrap: 'nowrap', whiteSpace: 'nowrap' }}>
         {itemIds.map(id => (
           <OverflowItem key={id} id={id}>

--- a/apps/perf-test-react-components/src/scenarios/OverflowNoOptOutOverflowFlat.tsx
+++ b/apps/perf-test-react-components/src/scenarios/OverflowNoOptOutOverflowFlat.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import {
+  Button,
+  FluentProvider,
+  Overflow,
+  OverflowItem,
+  useOverflowMenu,
+  webLightTheme,
+  createFlatOverflowManager,
+} from '@fluentui/react-components';
+
+const itemIds = Array.from({ length: 20 }, (_, index) => `item-${index}`);
+
+const OverflowMenu = (): React.ReactElement | null => {
+  const { ref, isOverflowing, overflowCount } = useOverflowMenu<HTMLButtonElement>();
+
+  if (!isOverflowing) {
+    return null;
+  }
+
+  return (
+    <button ref={ref} style={{ width: 64, height: 32, flexShrink: 0 }}>
+      +{overflowCount}
+    </button>
+  );
+};
+
+const Scenario = () => {
+  return (
+    <Overflow padding={0} overflowAxis="horizontal" createManager={createFlatOverflowManager}>
+      <div style={{ width: 320, display: 'flex', flexWrap: 'nowrap', whiteSpace: 'nowrap' }}>
+        {itemIds.map(id => (
+          <OverflowItem key={id} id={id}>
+            <Button style={{ width: 64, flexShrink: 0 }}>{id}</Button>
+          </OverflowItem>
+        ))}
+        <OverflowMenu />
+      </div>
+    </Overflow>
+  );
+};
+
+Scenario.decorator = (props: { children: React.ReactNode }) => (
+  <FluentProvider theme={webLightTheme}>{props.children}</FluentProvider>
+);
+
+export default Scenario;

--- a/change/@fluentui-priority-overflow-pr4-opt-out.json
+++ b/change/@fluentui-priority-overflow-pr4-opt-out.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: apply a forceUpdate requested before observe once observation begins",
+  "packageName": "@fluentui/priority-overflow",
+  "email": "bsunderhus@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-overflow-pr4-opt-out.json
+++ b/change/@fluentui-react-overflow-pr4-opt-out.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: allow opting out of first-paint overflow correctness for hot-path consumers",
+  "packageName": "@fluentui/react-overflow",
+  "email": "bsunderhus@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/priority-overflow/etc/priority-overflow.api.md
+++ b/packages/react-components/priority-overflow/etc/priority-overflow.api.md
@@ -5,6 +5,9 @@
 ```ts
 
 // @internal
+export function createFlatOverflowManager(initialOptions?: Partial<OverflowOptions>): OverflowManager;
+
+// @internal
 export function createOverflowManager(initialOptions?: Partial<OverflowOptions>): OverflowManager;
 
 // @internal
@@ -56,6 +59,7 @@ export interface OverflowItemEntry {
     id: string;
     pinned?: boolean;
     priority: number;
+    sizeHint?: number;
 }
 
 // @internal

--- a/packages/react-components/priority-overflow/src/flatOverflowManager.ts
+++ b/packages/react-components/priority-overflow/src/flatOverflowManager.ts
@@ -40,12 +40,13 @@ export function createFlatOverflowManager(initialOptions: Partial<OverflowOption
   // ---------- state --------------------------------------------------------
   /** Items in registration / DOM order. */
   const items: OverflowItemEntry[] = [];
-  /** Size cache: id → offsetWidth|offsetHeight. */
+  /**
+   * Per-item size cache. Items are measured lazily — only as needed by the
+   * greedy scan. Items beyond the visible cutoff are never measured, making
+   * first-compute cost O(K+1) DOM reads where K is the number of visible
+   * items, regardless of total item count N.
+   */
   const sizeById = new Map<string, number>();
-  /** prefixSums[i] = total size of items[0..i-1].  Length = items.length + 1. */
-  let prefixSums: number[] = [0];
-  /** True when prefixSums must be rebuilt before next compute. */
-  let sumsStale = true;
 
   let container: HTMLElement | undefined;
   let overflowMenu: HTMLElement | undefined;
@@ -75,48 +76,14 @@ export function createFlatOverflowManager(initialOptions: Partial<OverflowOption
   };
 
   /**
-   * Rebuild the prefix-sum array from the cached item sizes.
-   * Items not yet in sizeById are measured here (they are visible at this point
-   * because they are added to the array before observe() is called, or
-   * immediately after being made visible by the hook cleanup).
+   * Returns the cached size for an item, measuring it only if not already in
+   * the cache. Uses sizeHint when available to skip the DOM read entirely.
    */
-  const ensurePrefixSums = () => {
-    if (!sumsStale) {
-      return;
+  const getItemSize = (item: OverflowItemEntry): number => {
+    if (!sizeById.has(item.id)) {
+      sizeById.set(item.id, item.sizeHint !== undefined ? item.sizeHint : getAxisOffset(item.element));
     }
-
-    for (const item of items) {
-      if (!sizeById.has(item.id)) {
-        // Use sizeHint when available to avoid a layout read.
-        sizeById.set(item.id, item.sizeHint !== undefined ? item.sizeHint : getAxisOffset(item.element));
-      }
-    }
-
-    prefixSums = [0];
-    for (const item of items) {
-      prefixSums.push(prefixSums[prefixSums.length - 1] + (sizeById.get(item.id) ?? 0));
-    }
-
-    sumsStale = false;
-  };
-
-  /**
-   * Largest K in [0..n] such that prefixSums[K] ≤ target.
-   * Returns 0 when nothing fits.
-   */
-  const findCutoff = (target: number): number => {
-    let lo = 0;
-    let hi = prefixSums.length - 1;
-    while (lo < hi) {
-      // eslint-disable-next-line no-bitwise
-      const mid = (lo + hi + 1) >> 1;
-      if (prefixSums[mid] <= target) {
-        lo = mid;
-      } else {
-        hi = mid - 1;
-      }
-    }
-    return lo;
+    return sizeById.get(item.id)!;
   };
 
   // ---------- core compute -------------------------------------------------
@@ -125,40 +92,41 @@ export function createFlatOverflowManager(initialOptions: Partial<OverflowOption
       return false;
     }
 
-    ensurePrefixSums();
-
     const n = items.length;
     if (n === 0) {
       return false;
     }
 
-    // Raw container client size without padding subtraction.
     const rawContainerSize = options.overflowAxis === 'horizontal' ? container.clientWidth : container.clientHeight;
-
-    const total = prefixSums[n];
-
-    // Menu reserve: the larger of the currently registered menu element size and
-    // the configured padding.  Using max(menuSize, padding) as the reserve means
-    // that when `padding` is set to the expected overflow-button width (the common
-    // Tabs pattern), the first compute already uses the correct reserved space and
-    // the second pass triggered after the menu element registers is a no-op
-    // (no visibility changes → no extra re-render).
     const registeredMenuSize = overflowMenu ? getAxisOffset(overflowMenu) : 0;
     const menuReserve = Math.max(registeredMenuSize, options.padding);
+    const effectiveAvailable = rawContainerSize - menuReserve;
 
     const newVisible: boolean[] = new Array(n);
 
-    if (total + menuReserve <= rawContainerSize && !options.hasHiddenItems) {
-      // All items fit (accounting for menu reserve) – no overflow.
-      newVisible.fill(true);
-    } else {
-      const effectiveAvailable = rawContainerSize - menuReserve;
+    if (options.overflowDirection === 'end') {
+      // Greedy scan left-to-right: measure only until the first item that
+      // doesn't fit, then stop. Items beyond that point are never touched.
+      // First-compute cost is O(K+1) reads where K = visible items, not O(N).
+      let acc = 0;
+      let cutoff = 0;
+      for (let i = 0; i < n; i++) {
+        const sz = getItemSize(items[i]);
+        if (acc + sz <= effectiveAvailable) {
+          acc += sz;
+          cutoff++;
+        } else {
+          break;
+        }
+      }
 
-      if (options.overflowDirection === 'end') {
-        // Visible items start from the left; hidden from the right.
-        const cutoff = Math.min(Math.max(findCutoff(effectiveAvailable), options.minimumVisible), n);
+      if (cutoff === n && !options.hasHiddenItems) {
+        // All items fit – no overflow.
+        newVisible.fill(true);
+      } else {
+        cutoff = Math.min(Math.max(cutoff, options.minimumVisible), n);
 
-        // Find the first item with elevated priority (the selected tab).
+        // Find first item with elevated priority (selected tab).
         let priorityIdx = -1;
         for (let i = 0; i < n; i++) {
           if ((items[i].priority ?? 0) > 0) {
@@ -168,18 +136,18 @@ export function createFlatOverflowManager(initialOptions: Partial<OverflowOption
         }
 
         if (priorityIdx >= cutoff) {
-          // Selected tab would be hidden – include it and repack from the left.
-          const pSize = sizeById.get(items[priorityIdx].id) ?? 0;
+          // Priority item would be hidden – include it and repack from the left.
+          const pSize = getItemSize(items[priorityIdx]);
           const remaining = effectiveAvailable - pSize;
-          let acc = 0;
+          let racc = 0;
           let count = 0;
           for (let i = 0; i < n; i++) {
             if (i === priorityIdx) {
               continue;
             }
-            const sz = sizeById.get(items[i].id) ?? 0;
-            if (acc + sz <= remaining) {
-              acc += sz;
+            const sz = getItemSize(items[i]);
+            if (racc + sz <= remaining) {
+              racc += sz;
               count++;
             } else {
               break;
@@ -201,19 +169,24 @@ export function createFlatOverflowManager(initialOptions: Partial<OverflowOption
             newVisible[i] = i < cutoff;
           }
         }
-      } else {
-        // direction='start': visible from the right, hidden from the left.
-        let acc = 0;
-        let fromRight = 0;
-        for (let i = n - 1; i >= 0; i--) {
-          const sz = sizeById.get(items[i].id) ?? 0;
-          if (acc + sz <= effectiveAvailable) {
-            acc += sz;
-            fromRight++;
-          } else {
-            break;
-          }
+      }
+    } else {
+      // direction='start': greedy scan right-to-left.
+      let acc = 0;
+      let fromRight = 0;
+      for (let i = n - 1; i >= 0; i--) {
+        const sz = getItemSize(items[i]);
+        if (acc + sz <= effectiveAvailable) {
+          acc += sz;
+          fromRight++;
+        } else {
+          break;
         }
+      }
+
+      if (fromRight === n && !options.hasHiddenItems) {
+        newVisible.fill(true);
+      } else {
         fromRight = Math.min(Math.max(fromRight, options.minimumVisible), n);
         const visibleFrom = n - fromRight;
 
@@ -226,7 +199,7 @@ export function createFlatOverflowManager(initialOptions: Partial<OverflowOption
         }
 
         if (priorityIdx >= 0 && priorityIdx < visibleFrom) {
-          const pSize = sizeById.get(items[priorityIdx].id) ?? 0;
+          const pSize = getItemSize(items[priorityIdx]);
           const remaining = effectiveAvailable - pSize;
           acc = 0;
           fromRight = 0;
@@ -234,7 +207,7 @@ export function createFlatOverflowManager(initialOptions: Partial<OverflowOption
             if (i === priorityIdx) {
               continue;
             }
-            const sz = sizeById.get(items[i].id) ?? 0;
+            const sz = getItemSize(items[i]);
             if (acc + sz <= remaining) {
               acc += sz;
               fromRight++;
@@ -333,8 +306,6 @@ export function createFlatOverflowManager(initialOptions: Partial<OverflowOption
 
     items.length = 0;
     sizeById.clear();
-    prefixSums = [0];
-    sumsStale = true;
     prevVisible.clear();
 
     takeSnapshot(EMPTY_SNAPSHOT);
@@ -365,8 +336,6 @@ export function createFlatOverflowManager(initialOptions: Partial<OverflowOption
       items.splice(lo, 0, item);
     }
 
-    sumsStale = true;
-
     if (observing) {
       forceDispatch = true;
       update();
@@ -383,7 +352,6 @@ export function createFlatOverflowManager(initialOptions: Partial<OverflowOption
     // Keep sizeById entry – if the same element is re-registered (priority change)
     // the cached size is still valid and avoids measuring a display:none element.
     prevVisible.delete(itemId);
-    sumsStale = true;
 
     if (observing) {
       forceDispatch = true;
@@ -412,7 +380,6 @@ export function createFlatOverflowManager(initialOptions: Partial<OverflowOption
     const axisChanging = !!(nextOptions.overflowAxis && options.overflowAxis !== nextOptions.overflowAxis);
     if (axisChanging) {
       sizeById.clear();
-      sumsStale = true;
     }
 
     const shouldUpdate =

--- a/packages/react-components/priority-overflow/src/flatOverflowManager.ts
+++ b/packages/react-components/priority-overflow/src/flatOverflowManager.ts
@@ -108,7 +108,8 @@ export function createFlatOverflowManager(initialOptions: Partial<OverflowOption
     let lo = 0;
     let hi = prefixSums.length - 1;
     while (lo < hi) {
-      const mid = Math.floor((lo + hi + 1) / 2);
+      // eslint-disable-next-line no-bitwise
+      const mid = (lo + hi + 1) >> 1;
       if (prefixSums[mid] <= target) {
         lo = mid;
       } else {
@@ -352,7 +353,8 @@ export function createFlatOverflowManager(initialOptions: Partial<OverflowOption
       let lo = 0;
       let hi = items.length;
       while (lo < hi) {
-        const mid = Math.floor((lo + hi) / 2);
+        // eslint-disable-next-line no-bitwise
+        const mid = (lo + hi) >> 1;
         // eslint-disable-next-line no-bitwise
         if (items[mid].element.compareDocumentPosition(item.element) & 4) {
           lo = mid + 1;

--- a/packages/react-components/priority-overflow/src/flatOverflowManager.ts
+++ b/packages/react-components/priority-overflow/src/flatOverflowManager.ts
@@ -69,7 +69,9 @@ export function createFlatOverflowManager(initialOptions: Partial<OverflowOption
 
   const takeSnapshot = (next: OverflowSnapshot) => {
     snapshot = next;
-    for (const l of listeners) l();
+    for (const l of listeners) {
+      l();
+    }
   };
 
   /**
@@ -79,7 +81,9 @@ export function createFlatOverflowManager(initialOptions: Partial<OverflowOption
    * immediately after being made visible by the hook cleanup).
    */
   const ensurePrefixSums = () => {
-    if (!sumsStale) return;
+    if (!sumsStale) {
+      return;
+    }
 
     for (const item of items) {
       if (!sizeById.has(item.id)) {
@@ -104,21 +108,28 @@ export function createFlatOverflowManager(initialOptions: Partial<OverflowOption
     let lo = 0;
     let hi = prefixSums.length - 1;
     while (lo < hi) {
-      const mid = (lo + hi + 1) >> 1;
-      if (prefixSums[mid] <= target) lo = mid;
-      else hi = mid - 1;
+      const mid = Math.floor((lo + hi + 1) / 2);
+      if (prefixSums[mid] <= target) {
+        lo = mid;
+      } else {
+        hi = mid - 1;
+      }
     }
     return lo;
   };
 
   // ---------- core compute -------------------------------------------------
   const computeAndApply = (): boolean => {
-    if (!container) return false;
+    if (!container) {
+      return false;
+    }
 
     ensurePrefixSums();
 
     const n = items.length;
-    if (n === 0) return false;
+    if (n === 0) {
+      return false;
+    }
 
     // Raw container client size without padding subtraction.
     const rawContainerSize = options.overflowAxis === 'horizontal' ? container.clientWidth : container.clientHeight;
@@ -144,7 +155,7 @@ export function createFlatOverflowManager(initialOptions: Partial<OverflowOption
 
       if (options.overflowDirection === 'end') {
         // Visible items start from the left; hidden from the right.
-        let cutoff = Math.min(Math.max(findCutoff(effectiveAvailable), options.minimumVisible), n);
+        const cutoff = Math.min(Math.max(findCutoff(effectiveAvailable), options.minimumVisible), n);
 
         // Find the first item with elevated priority (the selected tab).
         let priorityIdx = -1;
@@ -162,7 +173,9 @@ export function createFlatOverflowManager(initialOptions: Partial<OverflowOption
           let acc = 0;
           let count = 0;
           for (let i = 0; i < n; i++) {
-            if (i === priorityIdx) continue;
+            if (i === priorityIdx) {
+              continue;
+            }
             const sz = sizeById.get(items[i].id) ?? 0;
             if (acc + sz <= remaining) {
               acc += sz;
@@ -177,11 +190,15 @@ export function createFlatOverflowManager(initialOptions: Partial<OverflowOption
               newVisible[i] = true;
             } else {
               newVisible[i] = filled < count;
-              if (filled < count) filled++;
+              if (filled < count) {
+                filled++;
+              }
             }
           }
         } else {
-          for (let i = 0; i < n; i++) newVisible[i] = i < cutoff;
+          for (let i = 0; i < n; i++) {
+            newVisible[i] = i < cutoff;
+          }
         }
       } else {
         // direction='start': visible from the right, hidden from the left.
@@ -213,7 +230,9 @@ export function createFlatOverflowManager(initialOptions: Partial<OverflowOption
           acc = 0;
           fromRight = 0;
           for (let i = n - 1; i >= 0; i--) {
-            if (i === priorityIdx) continue;
+            if (i === priorityIdx) {
+              continue;
+            }
             const sz = sizeById.get(items[i].id) ?? 0;
             if (acc + sz <= remaining) {
               acc += sz;
@@ -223,9 +242,13 @@ export function createFlatOverflowManager(initialOptions: Partial<OverflowOption
             }
           }
           const vFrom = n - fromRight;
-          for (let i = 0; i < n; i++) newVisible[i] = i === priorityIdx || i >= vFrom;
+          for (let i = 0; i < n; i++) {
+            newVisible[i] = i === priorityIdx || i >= vFrom;
+          }
         } else {
-          for (let i = 0; i < n; i++) newVisible[i] = i >= visibleFrom;
+          for (let i = 0; i < n; i++) {
+            newVisible[i] = i >= visibleFrom;
+          }
         }
       }
     }
@@ -281,7 +304,9 @@ export function createFlatOverflowManager(initialOptions: Partial<OverflowOption
     observing = true;
 
     disposeResizeObserver = observeResize(container, entries => {
-      if (!entries[0] || !container) return;
+      if (!entries[0] || !container) {
+        return;
+      }
       update();
     });
 
@@ -315,7 +340,9 @@ export function createFlatOverflowManager(initialOptions: Partial<OverflowOption
   };
 
   const addItem: OverflowManager['addItem'] = item => {
-    if (items.some(i => i.id === item.id)) return;
+    if (items.some(i => i.id === item.id)) {
+      return;
+    }
 
     if (!observing) {
       // Initial mount: items register before observe() → insertion order = DOM order.
@@ -325,10 +352,13 @@ export function createFlatOverflowManager(initialOptions: Partial<OverflowOption
       let lo = 0;
       let hi = items.length;
       while (lo < hi) {
-        const mid = (lo + hi) >> 1;
+        const mid = Math.floor((lo + hi) / 2);
         // eslint-disable-next-line no-bitwise
-        if (items[mid].element.compareDocumentPosition(item.element) & 4) lo = mid + 1;
-        else hi = mid;
+        if (items[mid].element.compareDocumentPosition(item.element) & 4) {
+          lo = mid + 1;
+        } else {
+          hi = mid;
+        }
       }
       items.splice(lo, 0, item);
     }
@@ -343,7 +373,9 @@ export function createFlatOverflowManager(initialOptions: Partial<OverflowOption
 
   const removeItem: OverflowManager['removeItem'] = itemId => {
     const idx = items.findIndex(i => i.id === itemId);
-    if (idx === -1) return;
+    if (idx === -1) {
+      return;
+    }
 
     items.splice(idx, 1);
     // Keep sizeById entry – if the same element is re-registered (priority change)

--- a/packages/react-components/priority-overflow/src/flatOverflowManager.ts
+++ b/packages/react-components/priority-overflow/src/flatOverflowManager.ts
@@ -83,7 +83,8 @@ export function createFlatOverflowManager(initialOptions: Partial<OverflowOption
 
     for (const item of items) {
       if (!sizeById.has(item.id)) {
-        sizeById.set(item.id, getAxisOffset(item.element));
+        // Use sizeHint when available to avoid a layout read.
+        sizeById.set(item.id, item.sizeHint !== undefined ? item.sizeHint : getAxisOffset(item.element));
       }
     }
 

--- a/packages/react-components/priority-overflow/src/flatOverflowManager.ts
+++ b/packages/react-components/priority-overflow/src/flatOverflowManager.ts
@@ -99,8 +99,13 @@ export function createFlatOverflowManager(initialOptions: Partial<OverflowOption
 
     const rawContainerSize = options.overflowAxis === 'horizontal' ? container.clientWidth : container.clientHeight;
     const registeredMenuSize = overflowMenu ? getAxisOffset(overflowMenu) : 0;
-    const menuReserve = Math.max(registeredMenuSize, options.padding);
-    const effectiveAvailable = rawContainerSize - menuReserve;
+
+    // Restore classic manager semantics:
+    // - padding is ALWAYS subtracted (reserves fixed elements like an add-tab button)
+    // - menuSize is ADDITIONALLY subtracted when the overflow menu is registered
+    // This matches: items ≤ containerWidth - padding - menuSize (when overflowing)
+    const available = rawContainerSize - options.padding;
+    const effectiveAvailable = available - registeredMenuSize;
 
     const newVisible: boolean[] = new Array(n);
 
@@ -120,8 +125,8 @@ export function createFlatOverflowManager(initialOptions: Partial<OverflowOption
         }
       }
 
-      if (cutoff === n && !options.hasHiddenItems) {
-        // All items fit – no overflow.
+      if (cutoff === n && !options.hasHiddenItems && registeredMenuSize === 0) {
+        // All items fit without overflow menu present – no overflow.
         newVisible.fill(true);
       } else {
         cutoff = Math.min(Math.max(cutoff, options.minimumVisible), n);
@@ -184,7 +189,7 @@ export function createFlatOverflowManager(initialOptions: Partial<OverflowOption
         }
       }
 
-      if (fromRight === n && !options.hasHiddenItems) {
+      if (fromRight === n && !options.hasHiddenItems && registeredMenuSize === 0) {
         newVisible.fill(true);
       } else {
         fromRight = Math.min(Math.max(fromRight, options.minimumVisible), n);

--- a/packages/react-components/priority-overflow/src/flatOverflowManager.ts
+++ b/packages/react-components/priority-overflow/src/flatOverflowManager.ts
@@ -67,11 +67,6 @@ export function createFlatOverflowManager(initialOptions: Partial<OverflowOption
   // ---------- helpers ------------------------------------------------------
   const getAxisOffset = (el: HTMLElement) => (options.overflowAxis === 'horizontal' ? el.offsetWidth : el.offsetHeight);
 
-  const getContainerClient = () => {
-    if (!container) return 0;
-    return (options.overflowAxis === 'horizontal' ? container.clientWidth : container.clientHeight) - options.padding;
-  };
-
   const takeSnapshot = (next: OverflowSnapshot) => {
     snapshot = next;
     for (const l of listeners) l();
@@ -124,16 +119,27 @@ export function createFlatOverflowManager(initialOptions: Partial<OverflowOption
     const n = items.length;
     if (n === 0) return false;
 
-    const available = getContainerClient();
+    // Raw container client size without padding subtraction.
+    const rawContainerSize = options.overflowAxis === 'horizontal' ? container.clientWidth : container.clientHeight;
+
     const total = prefixSums[n];
-    const menuSize = overflowMenu ? getAxisOffset(overflowMenu) : 0;
+
+    // Menu reserve: the larger of the currently registered menu element size and
+    // the configured padding.  Using max(menuSize, padding) as the reserve means
+    // that when `padding` is set to the expected overflow-button width (the common
+    // Tabs pattern), the first compute already uses the correct reserved space and
+    // the second pass triggered after the menu element registers is a no-op
+    // (no visibility changes → no extra re-render).
+    const registeredMenuSize = overflowMenu ? getAxisOffset(overflowMenu) : 0;
+    const menuReserve = Math.max(registeredMenuSize, options.padding);
+
     const newVisible: boolean[] = new Array(n);
 
-    if (total <= available && !options.hasHiddenItems) {
-      // All items fit – no overflow.
+    if (total + menuReserve <= rawContainerSize && !options.hasHiddenItems) {
+      // All items fit (accounting for menu reserve) – no overflow.
       newVisible.fill(true);
     } else {
-      const effectiveAvailable = available - menuSize;
+      const effectiveAvailable = rawContainerSize - menuReserve;
 
       if (options.overflowDirection === 'end') {
         // Visible items start from the left; hidden from the right.
@@ -353,7 +359,9 @@ export function createFlatOverflowManager(initialOptions: Partial<OverflowOption
   const addOverflowMenu: OverflowManager['addOverflowMenu'] = el => {
     overflowMenu = el;
     if (observing) {
-      forceDispatch = true;
+      // Do not set forceDispatch: if menuReserve equals padding the first compute
+      // already produced the correct visibility, and a no-op second pass should
+      // not trigger a snapshot update or React re-render.
       update();
     }
   };
@@ -361,7 +369,6 @@ export function createFlatOverflowManager(initialOptions: Partial<OverflowOption
   const removeOverflowMenu: OverflowManager['removeOverflowMenu'] = () => {
     overflowMenu = undefined;
     if (observing) {
-      forceDispatch = true;
       update();
     }
   };

--- a/packages/react-components/priority-overflow/src/flatOverflowManager.ts
+++ b/packages/react-components/priority-overflow/src/flatOverflowManager.ts
@@ -1,0 +1,423 @@
+import { EMPTY_SNAPSHOT } from './consts';
+import { observeResize } from './createResizeObserver';
+import { debounce } from './debounce';
+import type {
+  OverflowItemEntry,
+  OverflowDividerEntry,
+  OverflowManager,
+  OverflowOptions,
+  OverflowSnapshot,
+} from './types';
+
+const DEFAULT_OPTIONS: Required<OverflowOptions> = {
+  overflowAxis: 'horizontal',
+  overflowDirection: 'end',
+  padding: 10,
+  minimumVisible: 0,
+  hasHiddenItems: false,
+  onUpdateItemVisibility: () => {
+    /* noop */
+  },
+  onUpdateOverflow: () => {
+    /* noop */
+  },
+};
+
+/**
+ * Creates a flat-list overflow manager optimised for simple, ungrouped horizontal
+ * tab-bar scenarios (no pinning, no groups, no dividers, at most one elevated
+ * priority item – the selected tab).
+ *
+ * Compared with createOverflowManager:
+ * - Sizes are measured once per structural change and then cached (prefix-sum array).
+ * - Container-resize recomputation is O(log N) via binary search on the prefix sums.
+ * - No priority-queue allocation; items are stored in a flat insertion-ordered array.
+ * - Group/divider bookkeeping is omitted entirely.
+ *
+ * @internal
+ */
+export function createFlatOverflowManager(initialOptions: Partial<OverflowOptions> = {}): OverflowManager {
+  // ---------- state --------------------------------------------------------
+  /** Items in registration / DOM order. */
+  const items: OverflowItemEntry[] = [];
+  /** Size cache: id → offsetWidth|offsetHeight. */
+  const sizeById = new Map<string, number>();
+  /** prefixSums[i] = total size of items[0..i-1].  Length = items.length + 1. */
+  let prefixSums: number[] = [0];
+  /** True when prefixSums must be rebuilt before next compute. */
+  let sumsStale = true;
+
+  let container: HTMLElement | undefined;
+  let overflowMenu: HTMLElement | undefined;
+  let observing = false;
+  let forceUpdateOnObserve = false;
+  let forceDispatch = true;
+
+  /** Previous per-item visible flag used to detect changes. */
+  const prevVisible = new Map<string, boolean>();
+
+  const options: Required<OverflowOptions> = { ...DEFAULT_OPTIONS, ...initialOptions };
+  const listeners = new Set<() => void>();
+  let snapshot: OverflowSnapshot = EMPTY_SNAPSHOT;
+
+  let disposeResizeObserver: () => void = () => {
+    /* noop */
+  };
+
+  // ---------- helpers ------------------------------------------------------
+  const getAxisOffset = (el: HTMLElement) => (options.overflowAxis === 'horizontal' ? el.offsetWidth : el.offsetHeight);
+
+  const getContainerClient = () => {
+    if (!container) return 0;
+    return (options.overflowAxis === 'horizontal' ? container.clientWidth : container.clientHeight) - options.padding;
+  };
+
+  const takeSnapshot = (next: OverflowSnapshot) => {
+    snapshot = next;
+    for (const l of listeners) l();
+  };
+
+  /**
+   * Rebuild the prefix-sum array from the cached item sizes.
+   * Items not yet in sizeById are measured here (they are visible at this point
+   * because they are added to the array before observe() is called, or
+   * immediately after being made visible by the hook cleanup).
+   */
+  const ensurePrefixSums = () => {
+    if (!sumsStale) return;
+
+    for (const item of items) {
+      if (!sizeById.has(item.id)) {
+        sizeById.set(item.id, getAxisOffset(item.element));
+      }
+    }
+
+    prefixSums = [0];
+    for (const item of items) {
+      prefixSums.push(prefixSums[prefixSums.length - 1] + (sizeById.get(item.id) ?? 0));
+    }
+
+    sumsStale = false;
+  };
+
+  /**
+   * Largest K in [0..n] such that prefixSums[K] ≤ target.
+   * Returns 0 when nothing fits.
+   */
+  const findCutoff = (target: number): number => {
+    let lo = 0;
+    let hi = prefixSums.length - 1;
+    while (lo < hi) {
+      const mid = (lo + hi + 1) >> 1;
+      if (prefixSums[mid] <= target) lo = mid;
+      else hi = mid - 1;
+    }
+    return lo;
+  };
+
+  // ---------- core compute -------------------------------------------------
+  const computeAndApply = (): boolean => {
+    if (!container) return false;
+
+    ensurePrefixSums();
+
+    const n = items.length;
+    if (n === 0) return false;
+
+    const available = getContainerClient();
+    const total = prefixSums[n];
+    const menuSize = overflowMenu ? getAxisOffset(overflowMenu) : 0;
+    const newVisible: boolean[] = new Array(n);
+
+    if (total <= available && !options.hasHiddenItems) {
+      // All items fit – no overflow.
+      newVisible.fill(true);
+    } else {
+      const effectiveAvailable = available - menuSize;
+
+      if (options.overflowDirection === 'end') {
+        // Visible items start from the left; hidden from the right.
+        let cutoff = Math.min(Math.max(findCutoff(effectiveAvailable), options.minimumVisible), n);
+
+        // Find the first item with elevated priority (the selected tab).
+        let priorityIdx = -1;
+        for (let i = 0; i < n; i++) {
+          if ((items[i].priority ?? 0) > 0) {
+            priorityIdx = i;
+            break;
+          }
+        }
+
+        if (priorityIdx >= cutoff) {
+          // Selected tab would be hidden – include it and repack from the left.
+          const pSize = sizeById.get(items[priorityIdx].id) ?? 0;
+          const remaining = effectiveAvailable - pSize;
+          let acc = 0;
+          let count = 0;
+          for (let i = 0; i < n; i++) {
+            if (i === priorityIdx) continue;
+            const sz = sizeById.get(items[i].id) ?? 0;
+            if (acc + sz <= remaining) {
+              acc += sz;
+              count++;
+            } else {
+              break;
+            }
+          }
+          let filled = 0;
+          for (let i = 0; i < n; i++) {
+            if (i === priorityIdx) {
+              newVisible[i] = true;
+            } else {
+              newVisible[i] = filled < count;
+              if (filled < count) filled++;
+            }
+          }
+        } else {
+          for (let i = 0; i < n; i++) newVisible[i] = i < cutoff;
+        }
+      } else {
+        // direction='start': visible from the right, hidden from the left.
+        let acc = 0;
+        let fromRight = 0;
+        for (let i = n - 1; i >= 0; i--) {
+          const sz = sizeById.get(items[i].id) ?? 0;
+          if (acc + sz <= effectiveAvailable) {
+            acc += sz;
+            fromRight++;
+          } else {
+            break;
+          }
+        }
+        fromRight = Math.min(Math.max(fromRight, options.minimumVisible), n);
+        const visibleFrom = n - fromRight;
+
+        let priorityIdx = -1;
+        for (let i = n - 1; i >= 0; i--) {
+          if ((items[i].priority ?? 0) > 0) {
+            priorityIdx = i;
+            break;
+          }
+        }
+
+        if (priorityIdx >= 0 && priorityIdx < visibleFrom) {
+          const pSize = sizeById.get(items[priorityIdx].id) ?? 0;
+          const remaining = effectiveAvailable - pSize;
+          acc = 0;
+          fromRight = 0;
+          for (let i = n - 1; i >= 0; i--) {
+            if (i === priorityIdx) continue;
+            const sz = sizeById.get(items[i].id) ?? 0;
+            if (acc + sz <= remaining) {
+              acc += sz;
+              fromRight++;
+            } else {
+              break;
+            }
+          }
+          const vFrom = n - fromRight;
+          for (let i = 0; i < n; i++) newVisible[i] = i === priorityIdx || i >= vFrom;
+        } else {
+          for (let i = 0; i < n; i++) newVisible[i] = i >= visibleFrom;
+        }
+      }
+    }
+
+    // ---------- apply changes + emit snapshot ------------------------------
+    let changed = false;
+    const itemVisibility: Record<string, boolean> = {};
+    const visibleItems: OverflowItemEntry[] = [];
+    const invisibleItems: OverflowItemEntry[] = [];
+
+    for (let i = 0; i < n; i++) {
+      const item = items[i];
+      const visible = newVisible[i];
+      itemVisibility[item.id] = visible;
+      (visible ? visibleItems : invisibleItems).push(item);
+
+      if (prevVisible.get(item.id) !== visible) {
+        changed = true;
+        prevVisible.set(item.id, visible);
+        options.onUpdateItemVisibility({ item, visible });
+      }
+    }
+
+    if (changed || forceDispatch) {
+      takeSnapshot({
+        itemVisibility,
+        groupVisibility: {},
+        invisibleItemCount: invisibleItems.length,
+      });
+      options.onUpdateOverflow({ visibleItems, invisibleItems, groupVisibility: {} });
+    }
+
+    return changed;
+  };
+
+  // ---------- public API ---------------------------------------------------
+  const forceUpdate: OverflowManager['forceUpdate'] = () => {
+    if (!container) {
+      forceUpdateOnObserve = true;
+      return;
+    }
+    computeAndApply();
+    forceDispatch = false;
+  };
+
+  const update: OverflowManager['update'] = debounce(forceUpdate);
+
+  const observe: OverflowManager['observe'] = (observedContainer, observeOptions) => {
+    const { forceUpdate: shouldForceUpdate, ...userOptions } = observeOptions ?? {};
+    Object.assign(options, userOptions);
+
+    container = observedContainer;
+    observing = true;
+
+    disposeResizeObserver = observeResize(container, entries => {
+      if (!entries[0] || !container) return;
+      update();
+    });
+
+    const clientSize =
+      options.overflowAxis === 'horizontal' ? observedContainer.clientWidth : observedContainer.clientHeight;
+
+    if ((shouldForceUpdate || forceUpdateOnObserve) && clientSize > 0) {
+      forceUpdate();
+    }
+    forceUpdateOnObserve = false;
+  };
+
+  const disconnect: OverflowManager['disconnect'] = () => {
+    disposeResizeObserver();
+    disposeResizeObserver = () => {
+      /* noop */
+    };
+
+    container = undefined;
+    observing = false;
+    forceDispatch = true;
+    forceUpdateOnObserve = false;
+
+    items.length = 0;
+    sizeById.clear();
+    prefixSums = [0];
+    sumsStale = true;
+    prevVisible.clear();
+
+    takeSnapshot(EMPTY_SNAPSHOT);
+  };
+
+  const addItem: OverflowManager['addItem'] = item => {
+    if (items.some(i => i.id === item.id)) return;
+
+    if (!observing) {
+      // Initial mount: items register before observe() → insertion order = DOM order.
+      items.push(item);
+    } else {
+      // Dynamic add or re-registration (priority change): insert by DOM position.
+      let lo = 0;
+      let hi = items.length;
+      while (lo < hi) {
+        const mid = (lo + hi) >> 1;
+        // eslint-disable-next-line no-bitwise
+        if (items[mid].element.compareDocumentPosition(item.element) & 4) lo = mid + 1;
+        else hi = mid;
+      }
+      items.splice(lo, 0, item);
+    }
+
+    sumsStale = true;
+
+    if (observing) {
+      forceDispatch = true;
+      update();
+    }
+  };
+
+  const removeItem: OverflowManager['removeItem'] = itemId => {
+    const idx = items.findIndex(i => i.id === itemId);
+    if (idx === -1) return;
+
+    items.splice(idx, 1);
+    // Keep sizeById entry – if the same element is re-registered (priority change)
+    // the cached size is still valid and avoids measuring a display:none element.
+    prevVisible.delete(itemId);
+    sumsStale = true;
+
+    if (observing) {
+      forceDispatch = true;
+      update();
+    }
+  };
+
+  const addOverflowMenu: OverflowManager['addOverflowMenu'] = el => {
+    overflowMenu = el;
+    if (observing) {
+      forceDispatch = true;
+      update();
+    }
+  };
+
+  const removeOverflowMenu: OverflowManager['removeOverflowMenu'] = () => {
+    overflowMenu = undefined;
+    if (observing) {
+      forceDispatch = true;
+      update();
+    }
+  };
+
+  const setOptions: OverflowManager['setOptions'] = nextOptions => {
+    const axisChanging = !!(nextOptions.overflowAxis && options.overflowAxis !== nextOptions.overflowAxis);
+    if (axisChanging) {
+      sizeById.clear();
+      sumsStale = true;
+    }
+
+    const shouldUpdate =
+      axisChanging ||
+      !!(nextOptions.overflowDirection && options.overflowDirection !== nextOptions.overflowDirection) ||
+      (nextOptions.padding !== undefined && options.padding !== nextOptions.padding) ||
+      (nextOptions.minimumVisible !== undefined && options.minimumVisible !== nextOptions.minimumVisible) ||
+      (nextOptions.hasHiddenItems !== undefined && options.hasHiddenItems !== nextOptions.hasHiddenItems);
+
+    Object.assign(options, nextOptions);
+
+    if (shouldUpdate && observing) {
+      forceDispatch = true;
+      update();
+    }
+  };
+
+  const getSnapshot: OverflowManager['getSnapshot'] = () => snapshot;
+
+  const subscribe: OverflowManager['subscribe'] = listener => {
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  };
+
+  // Dividers are not supported in flat mode – these are intentional noops.
+  const addDivider = (_divider: OverflowDividerEntry) => {
+    /* noop */
+  };
+  const removeDivider = (_groupId: string) => {
+    /* noop */
+  };
+
+  return {
+    observe,
+    disconnect,
+    setOptions,
+    addItem,
+    removeItem,
+    update,
+    forceUpdate,
+    addOverflowMenu,
+    removeOverflowMenu,
+    addDivider,
+    removeDivider,
+    getSnapshot,
+    subscribe,
+  };
+}

--- a/packages/react-components/priority-overflow/src/index.ts
+++ b/packages/react-components/priority-overflow/src/index.ts
@@ -1,4 +1,5 @@
 export { createOverflowManager } from './overflowManager';
+export { createFlatOverflowManager } from './flatOverflowManager';
 export { EMPTY_SNAPSHOT } from './consts';
 export type {
   ObserveOptions,

--- a/packages/react-components/priority-overflow/src/overflowManager.test.ts
+++ b/packages/react-components/priority-overflow/src/overflowManager.test.ts
@@ -223,4 +223,40 @@ describe('overflowManager', () => {
 
     expect(manager.getSnapshot().itemVisibility).toEqual({});
   });
+
+  it('applies a forceUpdate requested before observe once observation starts (deferred first paint)', () => {
+    const manager = createOverflowManager(createObserveOptions());
+    const container = createContainer(100);
+    const itemA = createElementWithSize('button', 60);
+    const itemB = createElementWithSize('button', 60);
+    const menu = createElementWithSize('button', 30);
+
+    manager.addItem({ element: itemA, id: 'a', priority: 1 });
+    manager.addItem({ element: itemB, id: 'b', priority: 0 });
+    manager.addOverflowMenu(menu);
+
+    // forceUpdate before observe can't compute anything yet; the manager defers it and observe()
+    // applies it — so overflow is resolved synchronously without passing the forceUpdate option.
+    manager.forceUpdate();
+    manager.observe(container);
+
+    expect(getVisibleIds(manager)).toEqual(['a']);
+    expect(getInvisibleIds(manager)).toEqual(['b']);
+  });
+
+  it('does not apply a deferred forceUpdate when the container is not measured', () => {
+    const manager = createOverflowManager(createObserveOptions());
+    const container = createContainer(0);
+    const itemA = createElementWithSize('button', 60);
+    const itemB = createElementWithSize('button', 60);
+
+    manager.addItem({ element: itemA, id: 'a', priority: 1 });
+    manager.addItem({ element: itemB, id: 'b', priority: 0 });
+
+    // Degenerate 0 size — observe() skips the deferred force so nothing collapses.
+    manager.forceUpdate();
+    manager.observe(container);
+
+    expect(manager.getSnapshot().itemVisibility).toEqual({});
+  });
 });

--- a/packages/react-components/priority-overflow/src/overflowManager.ts
+++ b/packages/react-components/priority-overflow/src/overflowManager.ts
@@ -45,9 +45,11 @@ export function createOverflowManager(initialOptions: Partial<OverflowOptions> =
   // Initially true to force dispatch on first mount
   let forceDispatch = true;
   let forceUpdateOnObserve = false;
-  let lastProcessedAvailableSize: number | undefined;
-  let lastProcessedVisibleTop: string | null = null;
-  let lastProcessedInvisibleTop: string | null = null;
+  let lastProcessed = {
+    availableSize: undefined as number | undefined,
+    visibleTop: null as string | null,
+    invisibleTop: null as string | null,
+  };
   const options: Required<OverflowOptions> = { ...DEFAULT_OPTIONS, ...initialOptions };
   const overflowItems: Record<string, OverflowItemEntry> = {};
   const overflowDividers: Record<string, OverflowDividerEntry> = {};
@@ -75,6 +77,22 @@ export function createOverflowManager(initialOptions: Partial<OverflowOptions> =
     compareItemsCache.clear();
   };
 
+  const resetLastProcessed = () => {
+    lastProcessed = {
+      availableSize: undefined,
+      visibleTop: null,
+      invisibleTop: null,
+    };
+  };
+
+  const updateLastProcessed = (availableSize: number, visibleTop: string | null, invisibleTop: string | null) => {
+    lastProcessed = {
+      availableSize,
+      visibleTop,
+      invisibleTop,
+    };
+  };
+
   function compareItems(lt: string | null, rt: string | null): number {
     if (!lt || !rt) {
       return 0;
@@ -100,8 +118,8 @@ export function createOverflowManager(initialOptions: Partial<OverflowOptions> =
 
     // Node.DOCUMENT_POSITION_FOLLOWING = 4, Node.DOCUMENT_POSITION_PRECEDING = 2
     const positionStatusBit = options.overflowDirection === 'end' ? 4 : 2;
-
     const key = `${lt}|${rt}|${positionStatusBit}`;
+
     const cached = compareItemsCache.get(key);
     if (cached !== undefined) {
       return cached;
@@ -238,9 +256,9 @@ export function createOverflowManager(initialOptions: Partial<OverflowOptions> =
     // A forced dispatch (item/menu registration, option updates, etc.) still bypasses this guard.
     if (
       !forceDispatch &&
-      lastProcessedAvailableSize === availableSize &&
-      lastProcessedVisibleTop === visibleTop &&
-      lastProcessedInvisibleTop === invisibleTop
+      lastProcessed.availableSize === availableSize &&
+      lastProcessed.visibleTop === visibleTop &&
+      lastProcessed.invisibleTop === invisibleTop
     ) {
       return false;
     }
@@ -248,8 +266,60 @@ export function createOverflowManager(initialOptions: Partial<OverflowOptions> =
     clearCompareItemsCache();
     sizeCache.clear();
 
+    const groupVisibility = groupManager.groupVisibility();
+    const overflowMenuSize = overflowMenu ? getOffsetSize(overflowMenu) : 0;
+
+    const adjustDividerSize = (groupId: string | undefined, beforeVisibility: OverflowGroupState | undefined) => {
+      if (!groupId || !overflowDividers[groupId]) {
+        return 0;
+      }
+
+      const beforeVisible = beforeVisibility !== 'hidden';
+      const afterVisible = groupVisibility[groupId] !== 'hidden';
+
+      if (beforeVisible === afterVisible) {
+        return 0;
+      }
+
+      return afterVisible
+        ? getOffsetSize(overflowDividers[groupId].element)
+        : -getOffsetSize(overflowDividers[groupId].element);
+    };
+
+    const adjustOverflowMenuSize = (beforeInvisibleCount: number) => {
+      if (!overflowMenu || options.hasHiddenItems) {
+        return 0;
+      }
+
+      const afterInvisibleCount = invisibleItemQueue.size();
+      if (beforeInvisibleCount === 0 && afterInvisibleCount === 1) {
+        return overflowMenuSize;
+      }
+
+      if (beforeInvisibleCount === 1 && afterInvisibleCount === 0) {
+        return -overflowMenuSize;
+      }
+
+      return 0;
+    };
+
+    let occupied = occupiedSize();
+
     while (compareItems(invisibleItemQueue.peek(), visibleItemQueue.peek()) > 0) {
+      const itemId = visibleItemQueue.peek();
+      if (!itemId) {
+        break;
+      }
+
+      const item = overflowItems[itemId];
+      const beforeInvisibleCount = invisibleItemQueue.size();
+      const beforeGroupVisibility = item.groupId ? groupVisibility[item.groupId] : undefined;
+
       hideItem(); // hide elements whose priority become smaller than the highest priority of the hidden one
+
+      occupied -= getOffsetSize(item.element);
+      occupied += adjustOverflowMenuSize(beforeInvisibleCount);
+      occupied += adjustDividerSize(item.groupId, beforeGroupVisibility);
     }
 
     // Run the show/hide step twice - the first step might not be correct if
@@ -257,14 +327,27 @@ export function createOverflowManager(initialOptions: Partial<OverflowOptions> =
     for (let i = 0; i < 2; i++) {
       // Add items until available width is filled - can result in overflow
       while (
-        (occupiedSize() < availableSize && invisibleItemQueue.size() > 0) ||
+        (occupied < availableSize && invisibleItemQueue.size() > 0) ||
         invisibleItemQueue.size() === 1 // attempt to show the last invisible item hoping it's size does not exceed overflow menu size
       ) {
+        const itemId = invisibleItemQueue.peek();
+        if (!itemId) {
+          break;
+        }
+
+        const item = overflowItems[itemId];
+        const beforeInvisibleCount = invisibleItemQueue.size();
+        const beforeGroupVisibility = item.groupId ? groupVisibility[item.groupId] : undefined;
+
         showItem();
+
+        occupied += getOffsetSize(item.element);
+        occupied += adjustOverflowMenuSize(beforeInvisibleCount);
+        occupied += adjustDividerSize(item.groupId, beforeGroupVisibility);
       }
 
       // Remove items until there's no more overflow
-      while (occupiedSize() > availableSize && visibleItemQueue.size() > options.minimumVisible) {
+      while (occupied > availableSize && visibleItemQueue.size() > options.minimumVisible) {
         const nextItemId = visibleItemQueue.peek();
 
         // Never hide pinned items - they should always remain visible
@@ -272,16 +355,26 @@ export function createOverflowManager(initialOptions: Partial<OverflowOptions> =
           break;
         }
 
+        if (!nextItemId) {
+          break;
+        }
+
+        const item = overflowItems[nextItemId];
+        const beforeInvisibleCount = invisibleItemQueue.size();
+        const beforeGroupVisibility = item.groupId ? groupVisibility[item.groupId] : undefined;
+
         hideItem();
+
+        occupied -= getOffsetSize(item.element);
+        occupied += adjustOverflowMenuSize(beforeInvisibleCount);
+        occupied += adjustDividerSize(item.groupId, beforeGroupVisibility);
       }
     }
 
     const nextVisibleTop = visibleItemQueue.peek();
     const nextInvisibleTop = invisibleItemQueue.peek();
 
-    lastProcessedAvailableSize = availableSize;
-    lastProcessedVisibleTop = nextVisibleTop;
-    lastProcessedInvisibleTop = nextInvisibleTop;
+    updateLastProcessed(availableSize, nextVisibleTop, nextInvisibleTop);
 
     // only update when the state of visible/invisible items has changed
     return nextVisibleTop !== visibleTop || nextInvisibleTop !== invisibleTop;
@@ -359,9 +452,7 @@ export function createOverflowManager(initialOptions: Partial<OverflowOptions> =
     observing = false;
     forceDispatch = true;
     forceUpdateOnObserve = false;
-    lastProcessedAvailableSize = undefined;
-    lastProcessedVisibleTop = null;
-    lastProcessedInvisibleTop = null;
+    resetLastProcessed();
 
     // clear all entries
     Object.keys(overflowItems).forEach(itemId => removeItem(itemId));
@@ -380,10 +471,10 @@ export function createOverflowManager(initialOptions: Partial<OverflowOptions> =
     }
 
     overflowItems[items.id] = items;
-    clearCompareItemsCache();
 
     // some options can affect priority which are only set on `observe`
     if (observing) {
+      clearCompareItemsCache();
       // Updates to elements might not change the queue tops
       // i.e. new element is enqueued but the top of the queue stays the same
       // force a dispatch on the next batched update
@@ -448,7 +539,9 @@ export function createOverflowManager(initialOptions: Partial<OverflowOptions> =
     }
 
     const item = overflowItems[itemId];
-    clearCompareItemsCache();
+    if (observing) {
+      clearCompareItemsCache();
+    }
     visibleItemQueue.remove(itemId);
     invisibleItemQueue.remove(itemId);
 

--- a/packages/react-components/priority-overflow/src/overflowManager.ts
+++ b/packages/react-components/priority-overflow/src/overflowManager.ts
@@ -44,6 +44,7 @@ export function createOverflowManager(initialOptions: Partial<OverflowOptions> =
   // If true, next update will dispatch to onUpdateOverflow even if queue top states don't change
   // Initially true to force dispatch on first mount
   let forceDispatch = true;
+  let forceUpdateOnObserve = false;
   const options: Required<OverflowOptions> = { ...DEFAULT_OPTIONS, ...initialOptions };
   const overflowItems: Record<string, OverflowItemEntry> = {};
   const overflowDividers: Record<string, OverflowDividerEntry> = {};
@@ -236,6 +237,13 @@ export function createOverflowManager(initialOptions: Partial<OverflowOptions> =
   };
 
   const forceUpdate: OverflowManager['forceUpdate'] = () => {
+    if (!container) {
+      // Not observing yet — there is nothing to measure. Remember the request and let observe()
+      // honor it once the container is being observed (first-paint correctness).
+      forceUpdateOnObserve = true;
+      return;
+    }
+
     if (processOverflowItems() || forceDispatch) {
       forceDispatch = false;
       dispatchOverflowUpdate();
@@ -283,9 +291,10 @@ export function createOverflowManager(initialOptions: Partial<OverflowOptions> =
       update();
     });
 
-    if (shouldForceUpdate && getClientSize(observedContainer) > 0) {
+    if ((shouldForceUpdate || forceUpdateOnObserve) && getClientSize(observedContainer) > 0) {
       forceUpdate();
     }
+    forceUpdateOnObserve = false;
   };
 
   const disconnect: OverflowManager['disconnect'] = () => {
@@ -298,6 +307,7 @@ export function createOverflowManager(initialOptions: Partial<OverflowOptions> =
     container = undefined;
     observing = false;
     forceDispatch = true;
+    forceUpdateOnObserve = false;
 
     // clear all entries
     Object.keys(overflowItems).forEach(itemId => removeItem(itemId));

--- a/packages/react-components/priority-overflow/src/overflowManager.ts
+++ b/packages/react-components/priority-overflow/src/overflowManager.ts
@@ -238,8 +238,6 @@ export function createOverflowManager(initialOptions: Partial<OverflowOptions> =
 
   const forceUpdate: OverflowManager['forceUpdate'] = () => {
     if (!container) {
-      // Not observing yet — there is nothing to measure. Remember the request and let observe()
-      // honor it once the container is being observed (first-paint correctness).
       forceUpdateOnObserve = true;
       return;
     }

--- a/packages/react-components/priority-overflow/src/overflowManager.ts
+++ b/packages/react-components/priority-overflow/src/overflowManager.ts
@@ -48,6 +48,7 @@ export function createOverflowManager(initialOptions: Partial<OverflowOptions> =
   const options: Required<OverflowOptions> = { ...DEFAULT_OPTIONS, ...initialOptions };
   const overflowItems: Record<string, OverflowItemEntry> = {};
   const overflowDividers: Record<string, OverflowDividerEntry> = {};
+  const compareItemsCache = new Map<string, number>();
   const listeners = new Set<() => void>();
   let disposeResizeObserver: () => void = () => {
     /* noop */
@@ -66,6 +67,10 @@ export function createOverflowManager(initialOptions: Partial<OverflowOptions> =
   };
 
   const groupManager = createGroupManager();
+
+  const clearCompareItemsCache = () => {
+    compareItemsCache.clear();
+  };
 
   function compareItems(lt: string | null, rt: string | null): number {
     if (!lt || !rt) {
@@ -93,8 +98,19 @@ export function createOverflowManager(initialOptions: Partial<OverflowOptions> =
     // Node.DOCUMENT_POSITION_FOLLOWING = 4, Node.DOCUMENT_POSITION_PRECEDING = 2
     const positionStatusBit = options.overflowDirection === 'end' ? 4 : 2;
 
+    const key = `${lt}|${rt}|${positionStatusBit}`;
+    const cached = compareItemsCache.get(key);
+    if (cached !== undefined) {
+      return cached;
+    }
+
     // eslint-disable-next-line no-bitwise
-    return lte.element.compareDocumentPosition(rte.element) & positionStatusBit ? 1 : -1;
+    const result = lte.element.compareDocumentPosition(rte.element) & positionStatusBit ? 1 : -1;
+
+    compareItemsCache.set(key, result);
+    compareItemsCache.set(`${rt}|${lt}|${positionStatusBit}`, -result);
+
+    return result;
   }
 
   function getElementAxisSize(
@@ -196,6 +212,8 @@ export function createOverflowManager(initialOptions: Partial<OverflowOptions> =
     if (!container) {
       return false;
     }
+
+    clearCompareItemsCache();
     sizeCache.clear();
 
     const availableSize = getClientSize(container) - options.padding;
@@ -263,6 +281,7 @@ export function createOverflowManager(initialOptions: Partial<OverflowOptions> =
       (nextOptions.hasHiddenItems && options.hasHiddenItems !== nextOptions.hasHiddenItems);
 
     Object.assign(options, nextOptions);
+    clearCompareItemsCache();
 
     if (shouldTriggerUpdate) {
       forceDispatch = true;
@@ -273,6 +292,7 @@ export function createOverflowManager(initialOptions: Partial<OverflowOptions> =
   const observe: OverflowManager['observe'] = (observedContainer, observeOptions) => {
     const { forceUpdate: shouldForceUpdate, ...userOptions } = observeOptions ?? {};
     Object.assign(options, userOptions);
+    clearCompareItemsCache();
 
     Object.values(overflowItems).forEach(item => {
       if (!visibleItemQueue.contains(item.id) && !invisibleItemQueue.contains(item.id)) {
@@ -311,6 +331,7 @@ export function createOverflowManager(initialOptions: Partial<OverflowOptions> =
     Object.keys(overflowItems).forEach(itemId => removeItem(itemId));
     Object.keys(overflowDividers).forEach(dividerId => removeDivider(dividerId));
     removeOverflowMenu();
+    clearCompareItemsCache();
     sizeCache.clear();
 
     // notify subscribers that the manager is no longer tracking anything
@@ -323,6 +344,7 @@ export function createOverflowManager(initialOptions: Partial<OverflowOptions> =
     }
 
     overflowItems[items.id] = items;
+    clearCompareItemsCache();
 
     // some options can affect priority which are only set on `observe`
     if (observing) {
@@ -390,6 +412,7 @@ export function createOverflowManager(initialOptions: Partial<OverflowOptions> =
     }
 
     const item = overflowItems[itemId];
+    clearCompareItemsCache();
     visibleItemQueue.remove(itemId);
     invisibleItemQueue.remove(itemId);
 

--- a/packages/react-components/priority-overflow/src/overflowManager.ts
+++ b/packages/react-components/priority-overflow/src/overflowManager.ts
@@ -45,6 +45,9 @@ export function createOverflowManager(initialOptions: Partial<OverflowOptions> =
   // Initially true to force dispatch on first mount
   let forceDispatch = true;
   let forceUpdateOnObserve = false;
+  let lastProcessedAvailableSize: number | undefined;
+  let lastProcessedVisibleTop: string | null = null;
+  let lastProcessedInvisibleTop: string | null = null;
   const options: Required<OverflowOptions> = { ...DEFAULT_OPTIONS, ...initialOptions };
   const overflowItems: Record<string, OverflowItemEntry> = {};
   const overflowDividers: Record<string, OverflowDividerEntry> = {};
@@ -226,6 +229,17 @@ export function createOverflowManager(initialOptions: Partial<OverflowOptions> =
     const visibleTop = visibleItemQueue.peek();
     const invisibleTop = invisibleItemQueue.peek();
 
+    // Skip recomputation when available space and queue-top state are unchanged.
+    // A forced dispatch (item/menu registration, option updates, etc.) still bypasses this guard.
+    if (
+      !forceDispatch &&
+      lastProcessedAvailableSize === availableSize &&
+      lastProcessedVisibleTop === visibleTop &&
+      lastProcessedInvisibleTop === invisibleTop
+    ) {
+      return false;
+    }
+
     while (compareItems(invisibleItemQueue.peek(), visibleItemQueue.peek()) > 0) {
       hideItem(); // hide elements whose priority become smaller than the highest priority of the hidden one
     }
@@ -254,8 +268,15 @@ export function createOverflowManager(initialOptions: Partial<OverflowOptions> =
       }
     }
 
+    const nextVisibleTop = visibleItemQueue.peek();
+    const nextInvisibleTop = invisibleItemQueue.peek();
+
+    lastProcessedAvailableSize = availableSize;
+    lastProcessedVisibleTop = nextVisibleTop;
+    lastProcessedInvisibleTop = nextInvisibleTop;
+
     // only update when the state of visible/invisible items has changed
-    return visibleItemQueue.peek() !== visibleTop || invisibleItemQueue.peek() !== invisibleTop;
+    return nextVisibleTop !== visibleTop || nextInvisibleTop !== invisibleTop;
   };
 
   const forceUpdate: OverflowManager['forceUpdate'] = () => {
@@ -330,6 +351,9 @@ export function createOverflowManager(initialOptions: Partial<OverflowOptions> =
     observing = false;
     forceDispatch = true;
     forceUpdateOnObserve = false;
+    lastProcessedAvailableSize = undefined;
+    lastProcessedVisibleTop = null;
+    lastProcessedInvisibleTop = null;
 
     // clear all entries
     Object.keys(overflowItems).forEach(itemId => removeItem(itemId));

--- a/packages/react-components/priority-overflow/src/overflowManager.ts
+++ b/packages/react-components/priority-overflow/src/overflowManager.ts
@@ -130,6 +130,14 @@ export function createOverflowManager(initialOptions: Partial<OverflowOptions> =
 
   const getOffsetSize = getElementAxisSize.bind(null, 'offsetWidth', 'offsetHeight');
   const getClientSize = getElementAxisSize.bind(null, 'clientWidth', 'clientHeight');
+  const getCurrentAvailableSize = () => {
+    if (!container) {
+      return 0;
+    }
+
+    const currentSize = options.overflowAxis === 'horizontal' ? container.clientWidth : container.clientHeight;
+    return currentSize - options.padding;
+  };
 
   const invisibleItemQueue = createPriorityQueue<string>((a, b) => -1 * compareItems(a, b));
 
@@ -220,10 +228,7 @@ export function createOverflowManager(initialOptions: Partial<OverflowOptions> =
       return false;
     }
 
-    clearCompareItemsCache();
-    sizeCache.clear();
-
-    const availableSize = getClientSize(container) - options.padding;
+    const availableSize = getCurrentAvailableSize();
 
     // Snapshot of the visible/invisible state to compare for updates
     const visibleTop = visibleItemQueue.peek();
@@ -239,6 +244,9 @@ export function createOverflowManager(initialOptions: Partial<OverflowOptions> =
     ) {
       return false;
     }
+
+    clearCompareItemsCache();
+    sizeCache.clear();
 
     while (compareItems(invisibleItemQueue.peek(), visibleItemQueue.peek()) > 0) {
       hideItem(); // hide elements whose priority become smaller than the highest priority of the hidden one

--- a/packages/react-components/priority-overflow/src/overflowManager.ts
+++ b/packages/react-components/priority-overflow/src/overflowManager.ts
@@ -138,14 +138,18 @@ export function createOverflowManager(initialOptions: Partial<OverflowOptions> =
       totalItemSize += getOffsetSize(overflowItems[id].element);
     }
 
-    const totalDividerSize = Object.entries(groupManager.groupVisibility()).reduce(
-      (acc, [id, state]) =>
-        acc + (state !== 'hidden' && overflowDividers[id] ? getOffsetSize(overflowDividers[id].element) : 0),
-      0,
-    );
+    const groupVisibility = groupManager.groupVisibility();
+    let totalDividerSize = 0;
+    for (const id in overflowDividers) {
+      if (groupVisibility[id] !== 'hidden') {
+        totalDividerSize += getOffsetSize(overflowDividers[id].element);
+      }
+    }
+
+    const hasInvisibleItems = invisibleItemQueue.size() > 0;
 
     const overflowMenuSize =
-      (invisibleItemQueue.size() > 0 || options.hasHiddenItems) && overflowMenu ? getOffsetSize(overflowMenu) : 0;
+      (hasInvisibleItems || options.hasHiddenItems) && overflowMenu ? getOffsetSize(overflowMenu) : 0;
 
     return totalItemSize + totalDividerSize + overflowMenuSize;
   }

--- a/packages/react-components/priority-overflow/src/types.ts
+++ b/packages/react-components/priority-overflow/src/types.ts
@@ -42,6 +42,15 @@ export interface OverflowItemEntry {
    * @default false
    */
   pinned?: boolean;
+
+  /**
+   * Optional pre-declared size hint in pixels along the configured overflow axis.
+   * When provided, the flat overflow manager will use this value instead of reading
+   * `offsetWidth`/`offsetHeight` from the DOM, eliminating a layout read on first
+   * compute. Only set this when the item has a known, stable size (e.g. fixed-width
+   * tab buttons). An incorrect hint will produce a wrong overflow cutoff.
+   */
+  sizeHint?: number;
 }
 
 /**

--- a/packages/react-components/react-overflow/library/etc/react-overflow.api.md
+++ b/packages/react-components/react-overflow/library/etc/react-overflow.api.md
@@ -10,8 +10,8 @@ import type { OverflowDividerEntry } from '@fluentui/priority-overflow';
 import { OverflowEventPayload } from '@fluentui/priority-overflow';
 import type { OverflowGroupState } from '@fluentui/priority-overflow';
 import type { OverflowItemEntry } from '@fluentui/priority-overflow';
-import type { OverflowManager } from '@fluentui/priority-overflow';
-import type { OverflowOptions } from '@fluentui/priority-overflow';
+import { OverflowManager } from '@fluentui/priority-overflow';
+import { OverflowOptions } from '@fluentui/priority-overflow';
 import type { OverflowSnapshot } from '@fluentui/priority-overflow';
 import * as React_2 from 'react';
 

--- a/packages/react-components/react-overflow/library/etc/react-overflow.api.md
+++ b/packages/react-components/react-overflow/library/etc/react-overflow.api.md
@@ -10,7 +10,8 @@ import type { OverflowDividerEntry } from '@fluentui/priority-overflow';
 import { OverflowEventPayload } from '@fluentui/priority-overflow';
 import type { OverflowGroupState } from '@fluentui/priority-overflow';
 import type { OverflowItemEntry } from '@fluentui/priority-overflow';
-import { OverflowOptions } from '@fluentui/priority-overflow';
+import type { OverflowManager } from '@fluentui/priority-overflow';
+import type { OverflowOptions } from '@fluentui/priority-overflow';
 import type { OverflowSnapshot } from '@fluentui/priority-overflow';
 import * as React_2 from 'react';
 
@@ -38,6 +39,7 @@ export { OnUpdateOverflow }
 export const Overflow: React_2.ForwardRefExoticComponent<Partial<Pick<OverflowOptions, "overflowAxis" | "overflowDirection" | "padding" | "minimumVisible" | "hasHiddenItems">> & {
     children: React_2.ReactElement;
     onOverflowChange?: (ev: null, data: OverflowState) => void;
+    createManager?: (options: Partial<OverflowOptions>) => OverflowManager;
 } & React_2.RefAttributes<unknown>>;
 
 // @public
@@ -97,7 +99,7 @@ export type OverflowItemProps = {
     id: string;
     groupId?: string;
     children: React_2.ReactElement;
-    defer?: boolean;
+    sizeHint?: number;
 } & ({
     pinned?: boolean;
     priority?: never;
@@ -110,6 +112,7 @@ export type OverflowItemProps = {
 export type OverflowProps = Partial<Pick<OverflowOptions, 'overflowAxis' | 'overflowDirection' | 'padding' | 'minimumVisible' | 'hasHiddenItems'>> & {
     children: React_2.ReactElement;
     onOverflowChange?: (ev: null, data: OverflowState) => void;
+    createManager?: (options: Partial<OverflowOptions>) => OverflowManager;
 };
 
 // @public
@@ -141,7 +144,7 @@ export function useIsOverflowItemVisible(id: string): boolean;
 export const useOverflow_unstable: (props: OverflowProps, ref: React_2.Ref<HTMLElement>) => OverflowComponentState;
 
 // @internal (undocumented)
-export const useOverflowContainer: <TElement extends HTMLElement>(update: OnUpdateOverflow, options: Omit<OverflowOptions, "onUpdateOverflow">) => UseOverflowContainerReturn<TElement>;
+export const useOverflowContainer: <TElement extends HTMLElement>(update: OnUpdateOverflow, options: Omit<OverflowOptions, "onUpdateOverflow">, managerFactory?: (opts: Partial<OverflowOptions>) => OverflowManager) => UseOverflowContainerReturn<TElement>;
 
 // @public (undocumented)
 export interface UseOverflowContainerReturn<TElement extends HTMLElement> extends Pick<OverflowContextValue, 'registerItem' | 'updateOverflow' | 'forceUpdateOverflow' | 'registerOverflowMenu' | 'registerDivider' | 'getSnapshot' | 'subscribe'> {
@@ -164,7 +167,7 @@ export const useOverflowCount: () => number;
 export function useOverflowDivider<TElement extends HTMLElement>(groupId?: string): React_2.RefObject<TElement | null>;
 
 // @internal
-export function useOverflowItem<TElement extends HTMLElement>(id: string, priority?: number, groupId?: string, pinned?: boolean, defer?: boolean): React_2.RefObject<TElement | null>;
+export function useOverflowItem<TElement extends HTMLElement>(id: string, priority?: number, groupId?: string, pinned?: boolean, sizeHint?: number): React_2.RefObject<TElement | null>;
 
 // @public (undocumented)
 export function useOverflowMenu<TElement extends HTMLElement>(idOrOptions?: string | UseOverflowMenuOptions): {
@@ -175,7 +178,6 @@ export function useOverflowMenu<TElement extends HTMLElement>(idOrOptions?: stri
 
 // @public (undocumented)
 export interface UseOverflowMenuOptions {
-    defer?: boolean;
     id?: string;
 }
 

--- a/packages/react-components/react-overflow/library/etc/react-overflow.api.md
+++ b/packages/react-components/react-overflow/library/etc/react-overflow.api.md
@@ -97,6 +97,7 @@ export type OverflowItemProps = {
     id: string;
     groupId?: string;
     children: React_2.ReactElement;
+    defer?: boolean;
 } & ({
     pinned?: boolean;
     priority?: never;
@@ -163,14 +164,20 @@ export const useOverflowCount: () => number;
 export function useOverflowDivider<TElement extends HTMLElement>(groupId?: string): React_2.RefObject<TElement | null>;
 
 // @internal
-export function useOverflowItem<TElement extends HTMLElement>(id: string, priority?: number, groupId?: string, pinned?: boolean): React_2.RefObject<TElement | null>;
+export function useOverflowItem<TElement extends HTMLElement>(id: string, priority?: number, groupId?: string, pinned?: boolean, defer?: boolean): React_2.RefObject<TElement | null>;
 
 // @public (undocumented)
-export function useOverflowMenu<TElement extends HTMLElement>(id?: string): {
+export function useOverflowMenu<TElement extends HTMLElement>(idOrOptions?: string | UseOverflowMenuOptions): {
     ref: React_2.MutableRefObject<TElement | null>;
     overflowCount: number;
     isOverflowing: boolean;
 };
+
+// @public (undocumented)
+export interface UseOverflowMenuOptions {
+    defer?: boolean;
+    id?: string;
+}
 
 // @public (undocumented)
 export const useOverflowStyles_unstable: (state: OverflowComponentState) => OverflowComponentState;

--- a/packages/react-components/react-overflow/library/src/Overflow.paint-probe.cy.tsx
+++ b/packages/react-components/react-overflow/library/src/Overflow.paint-probe.cy.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { mount as mountBase } from '@fluentui/scripts-cypress';
-import type { OverflowItemProps, UseOverflowMenuOptions } from '@fluentui/react-overflow';
 import { Overflow, OverflowItem, useOverflowMenu } from '@fluentui/react-overflow';
 
 // Disable StrictMode so the probe measures a single mount/commit path.
@@ -12,8 +11,7 @@ const selectors = {
   menu: 'data-test-menu',
 };
 
-// The only thing this probe measures: what is on screen. `overflowingItemIds` are the items marked
-// overflowing (what the real component hides); `menuText` is the rendered overflow-menu count.
+// The only thing this probe measures: what is on screen.
 type Paint = { menuText: string | null; overflowingItemIds: string[] };
 
 const ALL_ITEMS = Array.from({ length: 10 }, (_, i) => String(i));
@@ -26,18 +24,13 @@ const read = (): Paint => {
   return { menuText: menu?.textContent ?? null, overflowingItemIds };
 };
 
-// ── Paint recorder ──────────────────────────────────────────────────────────────────────────────
-// A plain requestAnimationFrame loop, deliberately decoupled from React's render/commit/effect
-// cycle. rAF fires once per frame, so every entry is a real painted frame — a faithful "filmstrip"
-// of what was actually on screen, not a sample taken at some React lifecycle hook. The metric is
-// paint, measured without React.
+// A plain requestAnimationFrame loop measuring actual painted frames.
 const paints: Record<string, Paint[]> = {};
 const recordPaints = (name: string, frames: number) => {
   const filmstrip: Paint[] = [];
   paints[name] = filmstrip;
   const tick = () => {
     filmstrip.push(read());
-
     if (filmstrip.length < frames) {
       requestAnimationFrame(tick);
     }
@@ -45,52 +38,32 @@ const recordPaints = (name: string, frames: number) => {
   requestAnimationFrame(tick);
 };
 
-// Kicks the recorder off at mount. The layout effect runs before the first paint, so the first
-// captured frame IS the first paint. React is used only to start the loop — never to measure.
 const PaintRecorder: React.FC<{ name: string; frames: number }> = ({ name, frames }) => {
   // eslint-disable-next-line no-restricted-properties
   React.useLayoutEffect(() => recordPaints(name, frames), [name, frames]);
   return null;
 };
 
-// Collapse consecutive identical frames into the sequence of distinct painted states.
 const distinctPaints = (filmstrip: Paint[]): Paint[] =>
   filmstrip.filter((paint, i) => i === 0 || JSON.stringify(paint) !== JSON.stringify(filmstrip[i - 1]));
 
-const distinctSequence = <T,>(values: T[]): T[] =>
-  values.filter((value, i) => i === 0 || JSON.stringify(value) !== JSON.stringify(values[i - 1]));
-
 const visibleItems = (paint: Paint): string[] => ALL_ITEMS.filter(id => !paint.overflowingItemIds.includes(id));
-type VisualSnapshot = {
-  menu: string | null;
-  visibleItems: string[];
-};
 
-type SnapshotMatrix = {
-  allowedMenuSequences: Array<Array<string | null>>;
-  allowedVisibleSequences: string[][][];
-  final: VisualSnapshot;
-  disallowAllVisible?: boolean;
-};
-
-const toVisualSnapshots = (filmstrip: Paint[]): VisualSnapshot[] => {
-  return distinctPaints(filmstrip).map(paint => ({
-    menu: paint.menuText,
-    visibleItems: visibleItems(paint),
-  }));
-};
+type VisualSnapshot = { menu: string | null; visibleItems: string[] };
+const toVisualSnapshots = (filmstrip: Paint[]): VisualSnapshot[] =>
+  distinctPaints(filmstrip).map(paint => ({ menu: paint.menuText, visibleItems: visibleItems(paint) }));
 
 // Real shipping components, used as-is.
-const Item: React.FC<{ id: string } & Pick<OverflowItemProps, 'defer'>> = ({ id, defer }) => (
-  <OverflowItem id={id} defer={defer}>
+const Item: React.FC<{ id: string }> = ({ id }) => (
+  <OverflowItem id={id}>
     <button {...{ [selectors.item]: id }} style={{ width: 50, height: 50, flexShrink: 0 }}>
       {id}
     </button>
   </OverflowItem>
 );
 
-const Menu: React.FC<UseOverflowMenuOptions> = options => {
-  const { isOverflowing, ref, overflowCount } = useOverflowMenu<HTMLButtonElement>(options);
+const Menu: React.FC = () => {
+  const { isOverflowing, ref, overflowCount } = useOverflowMenu<HTMLButtonElement>();
   if (!isOverflowing) {
     return null;
   }
@@ -101,6 +74,7 @@ const Menu: React.FC<UseOverflowMenuOptions> = options => {
   );
 };
 
+// 300px container, 10 items @ 50px, menu @ 50px → settled state: items 0..4 visible (+5 hidden).
 const Container: React.FC<{ children?: React.ReactNode }> = ({ children }) => (
   <Overflow padding={0} overflowAxis="horizontal">
     <div {...{ [selectors.container]: '' }} style={{ display: 'flex', width: 300, whiteSpace: 'nowrap' }}>
@@ -109,9 +83,7 @@ const Container: React.FC<{ children?: React.ReactNode }> = ({ children }) => (
   </Overflow>
 );
 
-// 300px container, 10 items @ 50px, menu @ 50px, padding 0 -> settled state hides items 5..9 (+5).
-const createItem = (defer: boolean) =>
-  Array.from({ length: 10 }, (_, i) => <Item key={i} id={String(i)} defer={defer} />);
+const items = Array.from({ length: 10 }, (_, i) => <Item key={i} id={String(i)} />);
 const FRAMES = 12;
 
 const mountCase = (name: string, content: React.ReactNode) => {
@@ -123,171 +95,35 @@ const mountCase = (name: string, content: React.ReactNode) => {
   );
 };
 
-const waitForFilmstrip = (name: string) => {
-  return cy.wrap(null, { timeout: 8000 }).should(() => {
+const waitForFilmstrip = (name: string) =>
+  cy.wrap(null, { timeout: 8000 }).should(() => {
     expect(paints[name], `${name}: paint recorder did not produce a filmstrip`).to.be.an('array');
-    expect(
-      paints[name].length,
-      `${name}: expected ${FRAMES} recorded paint frames before assertion, got ${paints[name].length}`,
-    ).to.be.at.least(FRAMES);
+    expect(paints[name].length, `${name}: expected ${FRAMES} frames`).to.be.at.least(FRAMES);
   });
-};
 
-const recordCase = (name: string, content: React.ReactNode) => {
-  mountCase(name, content);
-  return waitForFilmstrip(name);
-};
-
-const assertSnapshotMatrix = (name: string, matrix: SnapshotMatrix) => {
-  cy.then(() => {
-    const snapshots = toVisualSnapshots(paints[name]);
-    const menuSeq = distinctSequence(snapshots.map(s => s.menu));
-    const visibleSeq = distinctSequence(snapshots.map(s => s.visibleItems));
-    const hasAllVisible = snapshots.some(s => s.visibleItems.length === ALL_ITEMS.length);
-    const debug =
-      `; snapshots=${JSON.stringify(snapshots)}` +
-      `; menuSeq=${JSON.stringify(menuSeq)}` +
-      `; visibleSeq=${JSON.stringify(visibleSeq)}`;
-
-    const menuAllowed = matrix.allowedMenuSequences.some(seq => JSON.stringify(seq) === JSON.stringify(menuSeq));
-    expect(menuAllowed, `${name}: menu snapshot sequence not allowed${debug}`).to.equal(true);
-
-    const visibleAllowed = matrix.allowedVisibleSequences.some(
-      seq => JSON.stringify(seq) === JSON.stringify(visibleSeq),
-    );
-    expect(visibleAllowed, `${name}: visible snapshot sequence not allowed${debug}`).to.equal(true);
-
-    expect(snapshots[snapshots.length - 1], `${name}: final snapshot mismatch${debug}`).to.deep.equal(matrix.final);
-
-    if (matrix.disallowAllVisible) {
-      expect(hasAllVisible, `${name}: all-items-visible snapshot is not allowed${debug}`).to.equal(false);
-    }
-  });
-};
-
-const assertNoOptOutTransitions = (name: string) => {
-  assertSnapshotMatrix(name, {
-    allowedMenuSequences: [['+5']],
-    allowedVisibleSequences: [[['0', '1', '2', '3', '4']]],
-    final: { menu: '+5', visibleItems: ['0', '1', '2', '3', '4'] },
-    disallowAllVisible: true,
-  });
-};
-
-const assertMenuOptOutTransitions = (name: string) => {
-  assertSnapshotMatrix(name, {
-    allowedMenuSequences: [['+5'], [null, '+5'], ['+4', '+5']],
-    allowedVisibleSequences: [
-      [['0', '1', '2', '3', '4']],
-      [
-        ['0', '1', '2', '3', '4', '5'],
-        ['0', '1', '2', '3', '4'],
-      ],
-    ],
-    final: { menu: '+5', visibleItems: ['0', '1', '2', '3', '4'] },
-    disallowAllVisible: true,
-  });
-};
-
-const assertItemsOptOutTransitions = (name: string) => {
-  assertSnapshotMatrix(name, {
-    allowedMenuSequences: [['+5'], [null, '+5'], ['+4', '+5'], [null, '+4', '+5']],
-    allowedVisibleSequences: [
-      [['0', '1', '2', '3', '4']],
-      [
-        ['0', '1', '2', '3', '4', '5'],
-        ['0', '1', '2', '3', '4'],
-      ],
-      [
-        ['0', '1', '2', '3', '4', '5', '6'],
-        ['0', '1', '2', '3', '4', '5'],
-        ['0', '1', '2', '3', '4'],
-      ],
-    ],
-    final: { menu: '+5', visibleItems: ['0', '1', '2', '3', '4'] },
-    disallowAllVisible: true,
-  });
-};
-
-const assertBothOptOutTransitions = (name: string) => {
-  assertSnapshotMatrix(name, {
-    allowedMenuSequences: [['+5'], [null, '+5'], ['+4', '+5'], [null, '+4', '+5']],
-    allowedVisibleSequences: [
-      [['0', '1', '2', '3', '4']],
-      [
-        ['0', '1', '2', '3', '4', '5'],
-        ['0', '1', '2', '3', '4'],
-      ],
-      [
-        ['0', '1', '2', '3', '4', '5', '6'],
-        ['0', '1', '2', '3', '4', '5'],
-        ['0', '1', '2', '3', '4'],
-      ],
-    ],
-    final: { menu: '+5', visibleItems: ['0', '1', '2', '3', '4'] },
-    disallowAllVisible: true,
-  });
-};
+const SETTLED: VisualSnapshot = { menu: '+5', visibleItems: ['0', '1', '2', '3', '4'] };
 
 describe('Overflow paint probe', () => {
   beforeEach(() => {
-    Object.keys(paints).forEach(key => {
-      delete paints[key];
-    });
-
+    Object.keys(paints).forEach(key => delete paints[key]);
     cy.viewport(700, 700);
   });
 
-  // No opt-out: both item and menu request first-paint correctness, so the very first painted frame
-  // is already fully settled (items hidden AND menu count correct). Filmstrip: [+5].
-  it('no opt-out: first paint is fully settled', () => {
-    recordCase(
-      'no-opt-out',
+  // Items and menu both call forceUpdateOverflow synchronously on registration.
+  // The very first painted frame must already be fully settled: items hidden AND menu count correct.
+  it('first paint is fully settled', () => {
+    mountCase(
+      'settled',
       <>
-        {createItem(false)}
+        {items}
         <Menu />
       </>,
     );
-    assertNoOptOutTransitions('no-opt-out');
-  });
-
-  // Menu opt-out: items still resolve at first paint, but the menu does not force, so its count is
-  // corrected asynchronously and the menu number flickers. Filmstrip: [+4 -> +5]. We assert only the
-  // stable part — items are correct on the first painted frame.
-  it('menu opt-out: items correct at first paint (menu count may flicker)', () => {
-    recordCase(
-      'menu-opt-out',
-      <>
-        {createItem(false)}
-        <Menu defer />
-      </>,
-    );
-    assertMenuOptOutTransitions('menu-opt-out');
-  });
-
-  // Both opt-out: menu/count can settle in multiple steps, but all-items-visible flicker is not
-  // allowed and item transitions must be monotonic shrinks only.
-  it('both opt-out: menu accommodation without all-items-visible flicker', () => {
-    recordCase(
-      'both-opt-out',
-      <>
-        {createItem(true)}
-        <Menu defer />
-      </>,
-    );
-    assertBothOptOutTransitions('both-opt-out');
-  });
-
-  // Items opt-out: all-items-visible flicker is not allowed. Items may shrink in one or more steps
-  // to accommodate menu space.
-  it('items opt-out: menu accommodation without all-items-visible flicker', () => {
-    recordCase(
-      'items-opt-out',
-      <>
-        {createItem(true)}
-        <Menu />
-      </>,
-    );
-    assertItemsOptOutTransitions('items-opt-out');
+    waitForFilmstrip('settled');
+    cy.then(() => {
+      const snapshots = toVisualSnapshots(paints['settled']);
+      expect(snapshots, 'filmstrip should have exactly one distinct state').to.have.length(1);
+      expect(snapshots[0]).to.deep.equal(SETTLED);
+    });
   });
 });

--- a/packages/react-components/react-overflow/library/src/Overflow.paint-probe.cy.tsx
+++ b/packages/react-components/react-overflow/library/src/Overflow.paint-probe.cy.tsx
@@ -4,10 +4,12 @@ import {
   Overflow,
   OverflowItem,
   useOverflowMenu,
+  useOverflowContext,
+  useOverflowCount,
   type OverflowProps,
   type OverflowItemProps,
 } from '@fluentui/react-overflow';
-import type { DistributiveOmit } from '@fluentui/react-utilities';
+import { useIsomorphicLayoutEffect, type DistributiveOmit } from '@fluentui/react-utilities';
 
 // Disable StrictMode so the probe measures a single mount/commit path.
 const mount = (element: React.ReactElement) => mountBase(element, { strict: false });
@@ -108,6 +110,54 @@ const Menu = () => {
 
   return (
     <button {...selector} ref={ref} style={{ width: 50, height: 50, flexShrink: 0 }}>
+      +{overflowCount}
+    </button>
+  );
+};
+
+// Opt-out hooks: equivalent to useOverflowItem / useOverflowMenu but WITHOUT requesting first-paint
+// correctness (no forceUpdateOverflow on registration). This is how a hot-path consumer opts the
+// container out of the synchronous first-paint pass — no Overflow prop, just a custom item/menu hook.
+const useOptOutOverflowItem = <TElement extends HTMLElement>(id: string): React.RefObject<TElement | null> => {
+  const ref = React.useRef<TElement | null>(null);
+  const registerItem = useOverflowContext(v => v.registerItem);
+  useIsomorphicLayoutEffect(() => {
+    if (ref.current) {
+      return registerItem({ element: ref.current, id, priority: 0 });
+    }
+  }, [id, registerItem]);
+  return ref;
+};
+
+const useOptOutOverflowMenu = <TElement extends HTMLElement>() => {
+  const ref = React.useRef<TElement | null>(null);
+  const overflowCount = useOverflowCount();
+  const registerOverflowMenu = useOverflowContext(v => v.registerOverflowMenu);
+  const isOverflowing = overflowCount > 0;
+  useIsomorphicLayoutEffect(() => {
+    if (ref.current) {
+      return registerOverflowMenu(ref.current);
+    }
+  }, [registerOverflowMenu, isOverflowing]);
+  return { ref, overflowCount, isOverflowing };
+};
+
+const OptOutItem = ({ children, width, id }: { children?: React.ReactNode; width?: number; id: string }) => {
+  const ref = useOptOutOverflowItem<HTMLButtonElement>(id);
+  return (
+    <button ref={ref} {...{ [selectors.item]: id }} style={{ width: width ?? 50, height: 50, flexShrink: 0 }}>
+      {children}
+    </button>
+  );
+};
+
+const OptOutMenu = () => {
+  const { isOverflowing, ref, overflowCount } = useOptOutOverflowMenu<HTMLButtonElement>();
+  if (!isOverflowing) {
+    return null;
+  }
+  return (
+    <button {...{ [selectors.menu]: '' }} ref={ref} style={{ width: 50, height: 50, flexShrink: 0 }}>
       +{overflowCount}
     </button>
   );
@@ -283,5 +333,39 @@ describe('Overflow paint probe', () => {
       menuText: null,
       overflowingItemIds: [],
     });
+  });
+
+  it('defers overflow past first paint when items and menu opt out of first-paint correctness', { retries: 0 }, () => {
+    const mapHelper = new Array(10).fill(0).map((_, i) => i);
+
+    mount(
+      <PaintPhaseProbeHarness name="opt-out">
+        <Container size={300}>
+          {mapHelper.map(i => (
+            <OptOutItem key={i} id={i.toString()}>
+              {i}
+            </OptOutItem>
+          ))}
+          <OptOutMenu />
+        </Container>
+      </PaintPhaseProbeHarness>,
+    );
+
+    // The opt-out hooks never call forceUpdateOverflow, so nothing requests the synchronous
+    // first-paint pass. At the synchronous commit (layout phase) overflow is therefore unresolved —
+    // the eager cases above collapse items here instead. The ResizeObserver resolves it afterwards.
+    cy.get(`[${selectors.probe}="opt-out"] [${selectors.probePhase}="raf2"]`).should($node => {
+      expect($node.text(), 'probe snapshots written').not.to.equal('');
+    });
+    cy.get(`[${selectors.probe}="opt-out"]`).then($probe => {
+      const layout = JSON.parse($probe.find(`[${selectors.probePhase}="layout"]`).text()) as PaintPhaseSnapshot;
+      expect(layout, 'first paint (layout) is unresolved when opting out of first-paint correctness').to.deep.equal({
+        menuText: null,
+        overflowingItemIds: [],
+      });
+    });
+
+    // It still resolves eventually — the ResizeObserver drives the deferred overflow pass.
+    cy.get(`[${selectors.menu}]`).should('exist');
   });
 });

--- a/packages/react-components/react-overflow/library/src/Overflow.paint-probe.cy.tsx
+++ b/packages/react-components/react-overflow/library/src/Overflow.paint-probe.cy.tsx
@@ -124,9 +124,12 @@ const mountCase = (name: string, content: React.ReactNode) => {
 };
 
 const waitForFilmstrip = (name: string) => {
-  return cy.wrap(null, { timeout: 4000 }).should(() => {
+  return cy.wrap(null, { timeout: 8000 }).should(() => {
     expect(paints[name], `${name}: paint recorder did not produce a filmstrip`).to.be.an('array');
-    expect(paints[name].length, `${name}: no paint frames were recorded`).to.be.greaterThan(0);
+    expect(
+      paints[name].length,
+      `${name}: expected ${FRAMES} recorded paint frames before assertion, got ${paints[name].length}`,
+    ).to.be.at.least(FRAMES);
   });
 };
 

--- a/packages/react-components/react-overflow/library/src/Overflow.paint-probe.cy.tsx
+++ b/packages/react-components/react-overflow/library/src/Overflow.paint-probe.cy.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { mount as mountBase } from '@fluentui/scripts-cypress';
+import type { OverflowItemProps, UseOverflowMenuOptions } from '@fluentui/react-overflow';
 import { Overflow, OverflowItem, useOverflowMenu } from '@fluentui/react-overflow';
-import { OverflowContext, useOverflowContext } from './overflowContext';
 
 // Disable StrictMode so the probe measures a single mount/commit path.
 const mount = (element: React.ReactElement) => mountBase(element, { strict: false });
@@ -55,31 +55,17 @@ const PaintRecorder: React.FC<{ name: string; frames: number }> = ({ name, frame
 const distinctPaints = (filmstrip: Paint[]): Paint[] =>
   filmstrip.filter((paint, i) => i === 0 || JSON.stringify(paint) !== JSON.stringify(filmstrip[i - 1]));
 
-// ── Opt-out, without reimplementing anything ──────────────────────────────────────────────────────
-// First-paint correctness is requested by the real useOverflowItem / useOverflowMenu calling
-// forceUpdateOverflow. Opting out is simply overriding that one context method to a no-op for a
-// subtree — the real components inside then request nothing. A Context.Provider renders no DOM node,
-// so the flex layout (and overflow geometry) is untouched.
-const noop = () => {
-  /* opt out of first-paint correctness */
-};
-const OptOut: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
-  const ctx = useOverflowContext();
-  const value = React.useMemo(() => ({ ...ctx, forceUpdateOverflow: noop }), [ctx]);
-  return <OverflowContext.Provider value={value}>{children}</OverflowContext.Provider>;
-};
-
 // Real shipping components, used as-is.
-const Item: React.FC<{ id: string }> = ({ id }) => (
-  <OverflowItem id={id}>
+const Item: React.FC<{ id: string } & Pick<OverflowItemProps, 'defer'>> = ({ id, defer }) => (
+  <OverflowItem id={id} defer={defer}>
     <button {...{ [selectors.item]: id }} style={{ width: 50, height: 50, flexShrink: 0 }}>
       {id}
     </button>
   </OverflowItem>
 );
 
-const Menu: React.FC = () => {
-  const { isOverflowing, ref, overflowCount } = useOverflowMenu<HTMLButtonElement>();
+const Menu: React.FC<UseOverflowMenuOptions> = options => {
+  const { isOverflowing, ref, overflowCount } = useOverflowMenu<HTMLButtonElement>(options);
   if (!isOverflowing) {
     return null;
   }
@@ -102,7 +88,8 @@ const Container: React.FC<{ children?: React.ReactNode }> = ({ children }) => (
 );
 
 // 300px container, 10 items @ 50px, menu @ 50px, padding 0 -> settled state hides items 5..9 (+5).
-const items = Array.from({ length: 10 }, (_, i) => <Item key={i} id={String(i)} />);
+const createItem = (defer: boolean) =>
+  Array.from({ length: 10 }, (_, i) => <Item key={i} id={String(i)} defer={defer} />);
 const FRAMES = 12;
 
 const SETTLED: Paint = { menuText: '+5', overflowingItemIds: ['5', '6', '7', '8', '9'] };
@@ -145,7 +132,7 @@ describe('Overflow paint probe', () => {
     recordCase(
       'no-opt-out',
       <>
-        {items}
+        {createItem(false)}
         <Menu />
       </>,
     );
@@ -161,10 +148,8 @@ describe('Overflow paint probe', () => {
     recordCase(
       'menu-opt-out',
       <>
-        {items}
-        <OptOut>
-          <Menu />
-        </OptOut>
+        {createItem(false)}
+        <Menu defer />
       </>,
     );
     assertFilmstrip('menu-opt-out', first => {
@@ -178,7 +163,7 @@ describe('Overflow paint probe', () => {
     recordCase(
       'items-opt-out',
       <>
-        <OptOut>{items}</OptOut>
+        {createItem(true)}
         <Menu />
       </>,
     );
@@ -192,10 +177,10 @@ describe('Overflow paint probe', () => {
   it('both opt-out: first paint is unresolved, settles later', () => {
     recordCase(
       'both-opt-out',
-      <OptOut>
-        {items}
-        <Menu />
-      </OptOut>,
+      <>
+        {createItem(true)}
+        <Menu defer />
+      </>,
     );
     assertFilmstrip('both-opt-out', first => {
       expect(first, 'both-opt-out: first paint is unresolved').to.deep.equal(UNRESOLVED);

--- a/packages/react-components/react-overflow/library/src/Overflow.paint-probe.cy.tsx
+++ b/packages/react-components/react-overflow/library/src/Overflow.paint-probe.cy.tsx
@@ -16,6 +16,8 @@ const selectors = {
 // overflowing (what the real component hides); `menuText` is the rendered overflow-menu count.
 type Paint = { menuText: string | null; overflowingItemIds: string[] };
 
+const ALL_ITEMS = Array.from({ length: 10 }, (_, i) => String(i));
+
 const read = (): Paint => {
   const menu = document.querySelector<HTMLElement>(`[${selectors.menu}]`);
   const overflowingItemIds = Array.from(document.querySelectorAll<HTMLElement>(`[${selectors.item}]`))
@@ -32,12 +34,12 @@ const read = (): Paint => {
 const paints: Record<string, Paint[]> = {};
 const recordPaints = (name: string, frames: number) => {
   const filmstrip: Paint[] = [];
+  paints[name] = filmstrip;
   const tick = () => {
     filmstrip.push(read());
+
     if (filmstrip.length < frames) {
       requestAnimationFrame(tick);
-    } else {
-      paints[name] = filmstrip;
     }
   };
   requestAnimationFrame(tick);
@@ -54,6 +56,29 @@ const PaintRecorder: React.FC<{ name: string; frames: number }> = ({ name, frame
 // Collapse consecutive identical frames into the sequence of distinct painted states.
 const distinctPaints = (filmstrip: Paint[]): Paint[] =>
   filmstrip.filter((paint, i) => i === 0 || JSON.stringify(paint) !== JSON.stringify(filmstrip[i - 1]));
+
+const distinctSequence = <T,>(values: T[]): T[] =>
+  values.filter((value, i) => i === 0 || JSON.stringify(value) !== JSON.stringify(values[i - 1]));
+
+const visibleItems = (paint: Paint): string[] => ALL_ITEMS.filter(id => !paint.overflowingItemIds.includes(id));
+type VisualSnapshot = {
+  menu: string | null;
+  visibleItems: string[];
+};
+
+type SnapshotMatrix = {
+  allowedMenuSequences: Array<Array<string | null>>;
+  allowedVisibleSequences: string[][][];
+  final: VisualSnapshot;
+  disallowAllVisible?: boolean;
+};
+
+const toVisualSnapshots = (filmstrip: Paint[]): VisualSnapshot[] => {
+  return distinctPaints(filmstrip).map(paint => ({
+    menu: paint.menuText,
+    visibleItems: visibleItems(paint),
+  }));
+};
 
 // Real shipping components, used as-is.
 const Item: React.FC<{ id: string } & Pick<OverflowItemProps, 'defer'>> = ({ id, defer }) => (
@@ -78,10 +103,7 @@ const Menu: React.FC<UseOverflowMenuOptions> = options => {
 
 const Container: React.FC<{ children?: React.ReactNode }> = ({ children }) => (
   <Overflow padding={0} overflowAxis="horizontal">
-    <div
-      {...{ [selectors.container]: '' }}
-      style={{ display: 'flex', width: 300, whiteSpace: 'nowrap', overflow: 'hidden' }}
-    >
+    <div {...{ [selectors.container]: '' }} style={{ display: 'flex', width: 300, whiteSpace: 'nowrap' }}>
       {children}
     </div>
   </Overflow>
@@ -92,37 +114,124 @@ const createItem = (defer: boolean) =>
   Array.from({ length: 10 }, (_, i) => <Item key={i} id={String(i)} defer={defer} />);
 const FRAMES = 12;
 
-const SETTLED: Paint = { menuText: '+5', overflowingItemIds: ['5', '6', '7', '8', '9'] };
-const UNRESOLVED: Paint = { menuText: null, overflowingItemIds: [] };
-const RESOLVED_ITEMS = ['5', '6', '7', '8', '9'];
-
-const recordCase = (name: string, content: React.ReactNode) => {
+const mountCase = (name: string, content: React.ReactNode) => {
   mount(
     <>
       <Container>{content}</Container>
       <PaintRecorder name={name} frames={FRAMES} />
     </>,
   );
+};
 
+const waitForFilmstrip = (name: string) => {
   return cy.wrap(null, { timeout: 4000 }).should(() => {
-    expect(paints[name], `${name}: recorded ${FRAMES} frames`).to.have.length(FRAMES);
+    expect(paints[name], `${name}: paint recorder did not produce a filmstrip`).to.be.an('array');
+    expect(paints[name].length, `${name}: no paint frames were recorded`).to.be.greaterThan(0);
   });
 };
 
-// Asserts on the distinct painted filmstrip: the first painted frame and the converged final frame.
-// The middle of an opt-out filmstrip (e.g. a transient menu-count flicker) is timing-dependent and
-// intentionally not asserted.
-const assertFilmstrip = (name: string, assertFirst: (first: Paint) => void) => {
+const recordCase = (name: string, content: React.ReactNode) => {
+  mountCase(name, content);
+  return waitForFilmstrip(name);
+};
+
+const assertSnapshotMatrix = (name: string, matrix: SnapshotMatrix) => {
   cy.then(() => {
-    const film = distinctPaints(paints[name]);
-    const debug = `; filmstrip=${JSON.stringify(film)}`;
-    assertFirst(film[0]);
-    expect(film[film.length - 1], `${name}: converges to settled${debug}`).to.deep.equal(SETTLED);
+    const snapshots = toVisualSnapshots(paints[name]);
+    const menuSeq = distinctSequence(snapshots.map(s => s.menu));
+    const visibleSeq = distinctSequence(snapshots.map(s => s.visibleItems));
+    const hasAllVisible = snapshots.some(s => s.visibleItems.length === ALL_ITEMS.length);
+    const debug =
+      `; snapshots=${JSON.stringify(snapshots)}` +
+      `; menuSeq=${JSON.stringify(menuSeq)}` +
+      `; visibleSeq=${JSON.stringify(visibleSeq)}`;
+
+    const menuAllowed = matrix.allowedMenuSequences.some(seq => JSON.stringify(seq) === JSON.stringify(menuSeq));
+    expect(menuAllowed, `${name}: menu snapshot sequence not allowed${debug}`).to.equal(true);
+
+    const visibleAllowed = matrix.allowedVisibleSequences.some(
+      seq => JSON.stringify(seq) === JSON.stringify(visibleSeq),
+    );
+    expect(visibleAllowed, `${name}: visible snapshot sequence not allowed${debug}`).to.equal(true);
+
+    expect(snapshots[snapshots.length - 1], `${name}: final snapshot mismatch${debug}`).to.deep.equal(matrix.final);
+
+    if (matrix.disallowAllVisible) {
+      expect(hasAllVisible, `${name}: all-items-visible snapshot is not allowed${debug}`).to.equal(false);
+    }
+  });
+};
+
+const assertNoOptOutTransitions = (name: string) => {
+  assertSnapshotMatrix(name, {
+    allowedMenuSequences: [['+5']],
+    allowedVisibleSequences: [[['0', '1', '2', '3', '4']]],
+    final: { menu: '+5', visibleItems: ['0', '1', '2', '3', '4'] },
+    disallowAllVisible: true,
+  });
+};
+
+const assertMenuOptOutTransitions = (name: string) => {
+  assertSnapshotMatrix(name, {
+    allowedMenuSequences: [['+5'], [null, '+5'], ['+4', '+5']],
+    allowedVisibleSequences: [
+      [['0', '1', '2', '3', '4']],
+      [
+        ['0', '1', '2', '3', '4', '5'],
+        ['0', '1', '2', '3', '4'],
+      ],
+    ],
+    final: { menu: '+5', visibleItems: ['0', '1', '2', '3', '4'] },
+    disallowAllVisible: true,
+  });
+};
+
+const assertItemsOptOutTransitions = (name: string) => {
+  assertSnapshotMatrix(name, {
+    allowedMenuSequences: [['+5'], [null, '+5'], ['+4', '+5'], [null, '+4', '+5']],
+    allowedVisibleSequences: [
+      [['0', '1', '2', '3', '4']],
+      [
+        ['0', '1', '2', '3', '4', '5'],
+        ['0', '1', '2', '3', '4'],
+      ],
+      [
+        ['0', '1', '2', '3', '4', '5', '6'],
+        ['0', '1', '2', '3', '4', '5'],
+        ['0', '1', '2', '3', '4'],
+      ],
+    ],
+    final: { menu: '+5', visibleItems: ['0', '1', '2', '3', '4'] },
+    disallowAllVisible: true,
+  });
+};
+
+const assertBothOptOutTransitions = (name: string) => {
+  assertSnapshotMatrix(name, {
+    allowedMenuSequences: [['+5'], [null, '+5'], ['+4', '+5'], [null, '+4', '+5']],
+    allowedVisibleSequences: [
+      [['0', '1', '2', '3', '4']],
+      [
+        ['0', '1', '2', '3', '4', '5'],
+        ['0', '1', '2', '3', '4'],
+      ],
+      [
+        ['0', '1', '2', '3', '4', '5', '6'],
+        ['0', '1', '2', '3', '4', '5'],
+        ['0', '1', '2', '3', '4'],
+      ],
+    ],
+    final: { menu: '+5', visibleItems: ['0', '1', '2', '3', '4'] },
+    disallowAllVisible: true,
   });
 };
 
 describe('Overflow paint probe', () => {
   beforeEach(() => {
+    Object.keys(paints).forEach(key => {
+      delete paints[key];
+    });
+
     cy.viewport(700, 700);
   });
 
@@ -136,9 +245,7 @@ describe('Overflow paint probe', () => {
         <Menu />
       </>,
     );
-    assertFilmstrip('no-opt-out', first => {
-      expect(first, 'no-opt-out: first paint is fully settled').to.deep.equal(SETTLED);
-    });
+    assertNoOptOutTransitions('no-opt-out');
   });
 
   // Menu opt-out: items still resolve at first paint, but the menu does not force, so its count is
@@ -152,29 +259,12 @@ describe('Overflow paint probe', () => {
         <Menu defer />
       </>,
     );
-    assertFilmstrip('menu-opt-out', first => {
-      expect(first.overflowingItemIds, 'menu-opt-out: items resolved at first paint').to.deep.equal(RESOLVED_ITEMS);
-    });
+    assertMenuOptOutTransitions('menu-opt-out');
   });
 
-  // Items opt-out: nothing forces, so the first painted frame is unresolved (all items visible, no
-  // menu); the ResizeObserver drives a later pass. Filmstrip: [none -> +5].
-  it('items opt-out: first paint is unresolved, settles later', () => {
-    recordCase(
-      'items-opt-out',
-      <>
-        {createItem(true)}
-        <Menu />
-      </>,
-    );
-    assertFilmstrip('items-opt-out', first => {
-      expect(first, 'items-opt-out: first paint is unresolved').to.deep.equal(UNRESOLVED);
-    });
-  });
-
-  // Both opt-out: the worst case — first paint unresolved, then items + menu appear, then the menu
-  // count settles. Filmstrip: [none -> (+4) -> +5]. First paint unresolved is the stable anchor.
-  it('both opt-out: first paint is unresolved, settles later', () => {
+  // Both opt-out: menu/count can settle in multiple steps, but all-items-visible flicker is not
+  // allowed and item transitions must be monotonic shrinks only.
+  it('both opt-out: menu accommodation without all-items-visible flicker', () => {
     recordCase(
       'both-opt-out',
       <>
@@ -182,8 +272,19 @@ describe('Overflow paint probe', () => {
         <Menu defer />
       </>,
     );
-    assertFilmstrip('both-opt-out', first => {
-      expect(first, 'both-opt-out: first paint is unresolved').to.deep.equal(UNRESOLVED);
-    });
+    assertBothOptOutTransitions('both-opt-out');
+  });
+
+  // Items opt-out: all-items-visible flicker is not allowed. Items may shrink in one or more steps
+  // to accommodate menu space.
+  it('items opt-out: menu accommodation without all-items-visible flicker', () => {
+    recordCase(
+      'items-opt-out',
+      <>
+        {createItem(true)}
+        <Menu />
+      </>,
+    );
+    assertItemsOptOutTransitions('items-opt-out');
   });
 });

--- a/packages/react-components/react-overflow/library/src/Overflow.paint-probe.cy.tsx
+++ b/packages/react-components/react-overflow/library/src/Overflow.paint-probe.cy.tsx
@@ -1,15 +1,7 @@
 import * as React from 'react';
 import { mount as mountBase } from '@fluentui/scripts-cypress';
-import {
-  Overflow,
-  OverflowItem,
-  useOverflowMenu,
-  useOverflowContext,
-  useOverflowCount,
-  type OverflowProps,
-  type OverflowItemProps,
-} from '@fluentui/react-overflow';
-import { useIsomorphicLayoutEffect, type DistributiveOmit } from '@fluentui/react-utilities';
+import { Overflow, useOverflowContext, useOverflowCount } from '@fluentui/react-overflow';
+import { useIsomorphicLayoutEffect } from '@fluentui/react-utilities';
 
 // Disable StrictMode so the probe measures a single mount/commit path.
 const mount = (element: React.ReactElement) => mountBase(element, { strict: false });
@@ -18,213 +10,147 @@ const selectors = {
   container: 'data-test-container',
   item: 'data-test-item',
   menu: 'data-test-menu',
-  probe: 'data-test-paint-probe',
-  probePhase: 'data-test-paint-phase',
 };
 
-type PaintPhaseSnapshot = {
-  menuText: string | null;
-  overflowingItemIds: string[];
-};
+// The only thing this probe measures: what is on screen. `overflowingItemIds` are the items marked
+// overflowing (what the real component hides); `menuText` is the rendered overflow-menu count.
+type Paint = { menuText: string | null; overflowingItemIds: string[] };
 
-const readPaintPhaseSnapshot = (): PaintPhaseSnapshot => {
+const read = (): Paint => {
   const menu = document.querySelector<HTMLElement>(`[${selectors.menu}]`);
   const overflowingItemIds = Array.from(document.querySelectorAll<HTMLElement>(`[${selectors.item}]`))
     .filter(item => item.getAttribute('data-overflowing') !== null)
     .map(item => item.getAttribute(selectors.item) ?? '');
-
-  return {
-    menuText: menu?.textContent ?? null,
-    overflowingItemIds,
-  };
+  return { menuText: menu?.textContent ?? null, overflowingItemIds };
 };
 
-const writePhaseSnapshot = (
-  name: string,
-  phase: 'layout' | 'effect' | 'raf1' | 'raf2',
-  snapshot: PaintPhaseSnapshot,
-) => {
-  const probeRoot = document.querySelector<HTMLElement>(`[${selectors.probe}="${name}"]`);
-  const phaseNode = probeRoot?.querySelector<HTMLElement>(`[${selectors.probePhase}="${phase}"]`);
-
-  if (phaseNode) {
-    phaseNode.textContent = JSON.stringify(snapshot);
-  }
-};
-
-const Container: React.FC<{ children?: React.ReactNode; size?: number } & Omit<OverflowProps, 'children'>> = ({
-  children,
-  size,
-  ...userProps
-}) => {
-  const selector = {
-    [selectors.container]: '',
-  };
-
-  return (
-    <Overflow padding={0} {...userProps} overflowAxis="horizontal">
-      <div
-        {...selector}
-        style={{
-          display: 'flex',
-          width: size,
-          border: '1px dashed red',
-          whiteSpace: 'nowrap',
-          overflow: 'hidden',
-        }}
-      >
-        {children}
-      </div>
-    </Overflow>
-  );
-};
-
-type ItemProps = { children?: React.ReactNode; width?: number | string } & DistributiveOmit<
-  OverflowItemProps,
-  'children'
->;
-
-const Item = ({ children, width, ...overflowItemProps }: ItemProps) => {
-  const selector = {
-    [selectors.item]: overflowItemProps.id,
-  };
-
-  return (
-    <OverflowItem {...overflowItemProps}>
-      <button {...selector} style={{ width: width ?? 50, height: 50, flexShrink: 0 }}>
-        {children}
-      </button>
-    </OverflowItem>
-  );
-};
-
-const Menu = () => {
-  const { isOverflowing, ref, overflowCount } = useOverflowMenu<HTMLButtonElement>();
-  const selector = {
-    [selectors.menu]: '',
-  };
-
-  if (!isOverflowing) {
-    return null;
-  }
-
-  return (
-    <button {...selector} ref={ref} style={{ width: 50, height: 50, flexShrink: 0 }}>
-      +{overflowCount}
-    </button>
-  );
-};
-
-// Opt-out hooks: equivalent to useOverflowItem / useOverflowMenu but WITHOUT requesting first-paint
-// correctness (no forceUpdateOverflow on registration). This is how a hot-path consumer opts the
-// container out of the synchronous first-paint pass — no Overflow prop, just a custom item/menu hook.
-const useOptOutOverflowItem = <TElement extends HTMLElement>(id: string): React.RefObject<TElement | null> => {
-  const ref = React.useRef<TElement | null>(null);
-  const registerItem = useOverflowContext(v => v.registerItem);
-  useIsomorphicLayoutEffect(() => {
-    if (ref.current) {
-      return registerItem({ element: ref.current, id, priority: 0 });
+// ── Paint recorder ──────────────────────────────────────────────────────────────────────────────
+// A plain requestAnimationFrame loop, deliberately decoupled from React's render/commit/effect
+// cycle. rAF fires once per frame, so every entry is a real painted frame — a faithful "filmstrip"
+// of what was actually on screen, not a sample taken at some React lifecycle hook. The metric is
+// paint, measured without React.
+const paints: Record<string, Paint[]> = {};
+const recordPaints = (name: string, frames: number) => {
+  const filmstrip: Paint[] = [];
+  const tick = () => {
+    filmstrip.push(read());
+    if (filmstrip.length < frames) {
+      requestAnimationFrame(tick);
+    } else {
+      paints[name] = filmstrip;
     }
-  }, [id, registerItem]);
-  return ref;
+  };
+  requestAnimationFrame(tick);
 };
 
-const useOptOutOverflowMenu = <TElement extends HTMLElement>() => {
-  const ref = React.useRef<TElement | null>(null);
-  const overflowCount = useOverflowCount();
-  const registerOverflowMenu = useOverflowContext(v => v.registerOverflowMenu);
-  const isOverflowing = overflowCount > 0;
-  useIsomorphicLayoutEffect(() => {
-    if (ref.current) {
-      return registerOverflowMenu(ref.current);
-    }
-  }, [registerOverflowMenu, isOverflowing]);
-  return { ref, overflowCount, isOverflowing };
-};
-
-const OptOutItem = ({ children, width, id }: { children?: React.ReactNode; width?: number; id: string }) => {
-  const ref = useOptOutOverflowItem<HTMLButtonElement>(id);
-  return (
-    <button ref={ref} {...{ [selectors.item]: id }} style={{ width: width ?? 50, height: 50, flexShrink: 0 }}>
-      {children}
-    </button>
-  );
-};
-
-const OptOutMenu = () => {
-  const { isOverflowing, ref, overflowCount } = useOptOutOverflowMenu<HTMLButtonElement>();
-  if (!isOverflowing) {
-    return null;
-  }
-  return (
-    <button {...{ [selectors.menu]: '' }} ref={ref} style={{ width: 50, height: 50, flexShrink: 0 }}>
-      +{overflowCount}
-    </button>
-  );
-};
-
-const PaintPhaseProbe: React.FC<{ name: string }> = ({ name }) => {
-  // The probe deliberately distinguishes the layout phase from the passive effect phase,
-  // so it must use the non-isomorphic variant.
+// Kicks the recorder off at mount. The layout effect runs before the first paint, so the first
+// captured frame IS the first paint. React is used only to start the loop — never to measure.
+const PaintRecorder: React.FC<{ name: string; frames: number }> = ({ name, frames }) => {
   // eslint-disable-next-line no-restricted-properties
-  React.useLayoutEffect(() => {
-    writePhaseSnapshot(name, 'layout', readPaintPhaseSnapshot());
-  }, [name]);
-
-  React.useEffect(() => {
-    writePhaseSnapshot(name, 'effect', readPaintPhaseSnapshot());
-
-    requestAnimationFrame(() => {
-      writePhaseSnapshot(name, 'raf1', readPaintPhaseSnapshot());
-      // Second frame: used to assert the first-rAF snapshot is already settled (no drift),
-      // i.e. it is the converged value rather than a transient mid-convergence reading.
-      requestAnimationFrame(() => {
-        writePhaseSnapshot(name, 'raf2', readPaintPhaseSnapshot());
-      });
-    });
-  }, [name]);
-
+  React.useLayoutEffect(() => recordPaints(name, frames), [name, frames]);
   return null;
 };
 
-const PaintPhaseProbeHarness: React.FC<{ name: string; children: React.ReactNode }> = ({ name, children }) => {
+// Collapse consecutive identical frames into the sequence of distinct painted states.
+const distinctPaints = (filmstrip: Paint[]): Paint[] =>
+  filmstrip.filter((paint, i) => i === 0 || JSON.stringify(paint) !== JSON.stringify(filmstrip[i - 1]));
+
+// ── Opt-in / opt-out building blocks ──────────────────────────────────────────────────────────────
+// Opt-in item mirrors useOverflowItem: it requests first-paint correctness by calling
+// forceUpdateOverflow on registration. Opt-out only registers.
+const Item: React.FC<{ id: string; optOut: boolean }> = ({ id, optOut }) => {
+  const ref = React.useRef<HTMLButtonElement>(null);
+  const registerItem = useOverflowContext(v => v.registerItem);
+  const forceUpdateOverflow = useOverflowContext(v => v.forceUpdateOverflow);
+  useIsomorphicLayoutEffect(() => {
+    if (ref.current) {
+      const unregister = registerItem({ element: ref.current, id, priority: 0 });
+      if (!optOut) {
+        forceUpdateOverflow();
+      }
+      return unregister;
+    }
+  }, [id, registerItem, forceUpdateOverflow, optOut]);
   return (
-    <>
-      {children}
-      <div {...{ [selectors.probe]: name }} style={{ display: 'none' }}>
-        <pre {...{ [selectors.probePhase]: 'layout' }} />
-        <pre {...{ [selectors.probePhase]: 'effect' }} />
-        <pre {...{ [selectors.probePhase]: 'raf1' }} />
-        <pre {...{ [selectors.probePhase]: 'raf2' }} />
-      </div>
-      <PaintPhaseProbe name={name} />
-    </>
+    <button ref={ref} {...{ [selectors.item]: id }} style={{ width: 50, height: 50, flexShrink: 0 }}>
+      {id}
+    </button>
   );
 };
 
-const assertProbeConvergence = (name: string, expected: PaintPhaseSnapshot) => {
-  cy.get(`[${selectors.probe}="${name}"] [${selectors.probePhase}="raf1"]`).should($node => {
-    expect($node.text(), 'raf1 snapshot marker').not.to.equal('');
+// Opt-in menu mirrors useOverflowMenu: it forces synchronously when overflowing so its own width is
+// accounted before paint. Opt-out only registers (relying on addOverflowMenu's async pass).
+const Menu: React.FC<{ optOut: boolean }> = ({ optOut }) => {
+  const ref = React.useRef<HTMLButtonElement>(null);
+  const overflowCount = useOverflowCount();
+  const registerOverflowMenu = useOverflowContext(v => v.registerOverflowMenu);
+  const forceUpdateOverflow = useOverflowContext(v => v.forceUpdateOverflow);
+  const isOverflowing = overflowCount > 0;
+  useIsomorphicLayoutEffect(() => {
+    if (ref.current) {
+      const unregister = registerOverflowMenu(ref.current);
+      if (!optOut && isOverflowing) {
+        forceUpdateOverflow();
+      }
+      return unregister;
+    }
+  }, [registerOverflowMenu, forceUpdateOverflow, isOverflowing, optOut]);
+  if (!isOverflowing) {
+    return null;
+  }
+  return (
+    <button ref={ref} {...{ [selectors.menu]: '' }} style={{ width: 50, height: 50, flexShrink: 0 }}>
+      +{overflowCount}
+    </button>
+  );
+};
+
+const Container: React.FC<{ children?: React.ReactNode }> = ({ children }) => (
+  <Overflow padding={0} overflowAxis="horizontal">
+    <div
+      {...{ [selectors.container]: '' }}
+      style={{ display: 'flex', width: 300, whiteSpace: 'nowrap', overflow: 'hidden' }}
+    >
+      {children}
+    </div>
+  </Overflow>
+);
+
+// 300px container, 10 items @ 50px, menu @ 50px, padding 0 -> settled state hides items 5..9 (+5).
+const ITEM_IDS = Array.from({ length: 10 }, (_, i) => String(i));
+const FRAMES = 12;
+
+const SETTLED: Paint = { menuText: '+5', overflowingItemIds: ['5', '6', '7', '8', '9'] };
+const UNRESOLVED: Paint = { menuText: null, overflowingItemIds: [] };
+const RESOLVED_ITEMS = ['5', '6', '7', '8', '9'];
+
+const recordCase = (name: string, itemsOptOut: boolean, menuOptOut: boolean) => {
+  mount(
+    <>
+      <Container>
+        {ITEM_IDS.map(id => (
+          <Item key={id} id={id} optOut={itemsOptOut} />
+        ))}
+        <Menu optOut={menuOptOut} />
+      </Container>
+      <PaintRecorder name={name} frames={FRAMES} />
+    </>,
+  );
+
+  return cy.wrap(null, { timeout: 4000 }).should(() => {
+    expect(paints[name], `${name}: recorded ${FRAMES} frames`).to.have.length(FRAMES);
   });
+};
 
-  cy.get(`[${selectors.probe}="${name}"] [${selectors.probePhase}="raf2"]`).should($node => {
-    expect($node.text(), 'raf2 snapshot marker').not.to.equal('');
-  });
-
-  cy.get(`[${selectors.probe}="${name}"]`).then($probe => {
-    const read = (phase: 'layout' | 'effect' | 'raf1' | 'raf2') => {
-      const text = $probe.find(`[${selectors.probePhase}="${phase}"]`).text();
-      return JSON.parse(text) as PaintPhaseSnapshot;
-    };
-
-    const raf1 = read('raf1');
-    const raf2 = read('raf2');
-    const debugSnapshots = `raf1=${JSON.stringify(raf1)} raf2=${JSON.stringify(raf2)}`;
-
-    // First-paint correctness: the snapshot is already the expected final value by the first rAF.
-    expect(raf1, `unexpected first-raf snapshot; ${debugSnapshots}`).to.deep.equal(expected);
-    // Convergence: the first-rAF value is settled, not a transient — it does not drift next frame.
-    expect(raf2, `first-raf snapshot drifted on the next frame; ${debugSnapshots}`).to.deep.equal(raf1);
+// Asserts on the distinct painted filmstrip: the first painted frame and the converged final frame.
+// The middle of an opt-out filmstrip (e.g. a transient menu-count flicker) is timing-dependent and
+// intentionally not asserted.
+const assertFilmstrip = (name: string, assertFirst: (first: Paint) => void) => {
+  cy.then(() => {
+    const film = distinctPaints(paints[name]);
+    const debug = `; filmstrip=${JSON.stringify(film)}`;
+    assertFirst(film[0]);
+    expect(film[film.length - 1], `${name}: converges to settled${debug}`).to.deep.equal(SETTLED);
   });
 };
 
@@ -233,139 +159,40 @@ describe('Overflow paint probe', () => {
     cy.viewport(700, 700);
   });
 
-  it('is already final by first rAF on initial overflowing mount', { retries: 0 }, () => {
-    const mapHelper = new Array(10).fill(0).map((_, i) => i);
-
-    mount(
-      <PaintPhaseProbeHarness name="initial-overflow">
-        <Container size={300}>
-          {mapHelper.map(i => (
-            <Item key={i} id={i.toString()}>
-              {i}
-            </Item>
-          ))}
-          <Menu />
-        </Container>
-      </PaintPhaseProbeHarness>,
-    );
-
-    assertProbeConvergence('initial-overflow', {
-      menuText: '+5',
-      overflowingItemIds: ['5', '6', '7', '8', '9'],
+  // No opt-out: both item and menu request first-paint correctness, so the very first painted frame
+  // is already fully settled (items hidden AND menu count correct). Filmstrip: [+5].
+  it('no opt-out: first paint is fully settled', () => {
+    recordCase('no-opt-out', false, false);
+    assertFilmstrip('no-opt-out', first => {
+      expect(first, 'no-opt-out: first paint is fully settled').to.deep.equal(SETTLED);
     });
   });
 
-  it('is already final by first rAF for a slightly wider initial-overflow case', { retries: 0 }, () => {
-    const mapHelper = new Array(10).fill(0).map((_, i) => i);
-
-    mount(
-      <PaintPhaseProbeHarness name="initial-overflow-wide">
-        <Container size={350}>
-          {mapHelper.map(i => (
-            <Item key={i} id={i.toString()}>
-              {i}
-            </Item>
-          ))}
-          <Menu />
-        </Container>
-      </PaintPhaseProbeHarness>,
-    );
-
-    assertProbeConvergence('initial-overflow-wide', {
-      menuText: '+4',
-      overflowingItemIds: ['6', '7', '8', '9'],
+  // Menu opt-out: items still resolve at first paint, but the menu does not force, so its count is
+  // corrected asynchronously and the menu number flickers. Filmstrip: [+4 -> +5]. We assert only the
+  // stable part — items are correct on the first painted frame.
+  it('menu opt-out: items correct at first paint (menu count may flicker)', () => {
+    recordCase('menu-opt-out', false, true);
+    assertFilmstrip('menu-opt-out', first => {
+      expect(first.overflowingItemIds, 'menu-opt-out: items resolved at first paint').to.deep.equal(RESOLVED_ITEMS);
     });
   });
 
-  it('is already final by first rAF for an uneven-width initial-overflow case', { retries: 0 }, () => {
-    mount(
-      <PaintPhaseProbeHarness name="initial-overflow-uneven">
-        {/* Explicit, uneven, font-independent widths. Text-content widths vary with the host's
-            installed fonts (narrower on CI), shifting the overflow boundary and making the
-            expected snapshot non-deterministic across environments. */}
-        <Container size={355}>
-          <Item width={40} id="0">
-            Item 0
-          </Item>
-          <Item width={55} id="1">
-            Item 1
-          </Item>
-          <Item width={95} id="2">
-            Super Long Item 2
-          </Item>
-          <Item width={70} id="3">
-            3
-          </Item>
-          <Item width={65} id="4">
-            Item 4
-          </Item>
-          <Item width={80} id="5">
-            Item 5
-          </Item>
-          <Menu />
-        </Container>
-      </PaintPhaseProbeHarness>,
-    );
-
-    assertProbeConvergence('initial-overflow-uneven', {
-      menuText: '+2',
-      overflowingItemIds: ['4', '5'],
+  // Items opt-out: nothing forces, so the first painted frame is unresolved (all items visible, no
+  // menu); the ResizeObserver drives a later pass. Filmstrip: [none -> +5].
+  it('items opt-out: first paint is unresolved, settles later', () => {
+    recordCase('items-opt-out', true, false);
+    assertFilmstrip('items-opt-out', first => {
+      expect(first, 'items-opt-out: first paint is unresolved').to.deep.equal(UNRESOLVED);
     });
   });
 
-  it('is already final by first rAF when the menu never becomes visible', { retries: 0 }, () => {
-    const mapHelper = new Array(5).fill(0).map((_, i) => i);
-
-    mount(
-      <PaintPhaseProbeHarness name="initial-no-menu">
-        <Container size={500}>
-          {mapHelper.map(i => (
-            <Item key={i} id={i.toString()}>
-              {i}
-            </Item>
-          ))}
-          <Menu />
-        </Container>
-      </PaintPhaseProbeHarness>,
-    );
-
-    assertProbeConvergence('initial-no-menu', {
-      menuText: null,
-      overflowingItemIds: [],
+  // Both opt-out: the worst case — first paint unresolved, then items + menu appear, then the menu
+  // count settles. Filmstrip: [none -> (+4) -> +5]. First paint unresolved is the stable anchor.
+  it('both opt-out: first paint is unresolved, settles later', () => {
+    recordCase('both-opt-out', true, true);
+    assertFilmstrip('both-opt-out', first => {
+      expect(first, 'both-opt-out: first paint is unresolved').to.deep.equal(UNRESOLVED);
     });
-  });
-
-  it('defers overflow past first paint when items and menu opt out of first-paint correctness', { retries: 0 }, () => {
-    const mapHelper = new Array(10).fill(0).map((_, i) => i);
-
-    mount(
-      <PaintPhaseProbeHarness name="opt-out">
-        <Container size={300}>
-          {mapHelper.map(i => (
-            <OptOutItem key={i} id={i.toString()}>
-              {i}
-            </OptOutItem>
-          ))}
-          <OptOutMenu />
-        </Container>
-      </PaintPhaseProbeHarness>,
-    );
-
-    // The opt-out hooks never call forceUpdateOverflow, so nothing requests the synchronous
-    // first-paint pass. At the synchronous commit (layout phase) overflow is therefore unresolved —
-    // the eager cases above collapse items here instead. The ResizeObserver resolves it afterwards.
-    cy.get(`[${selectors.probe}="opt-out"] [${selectors.probePhase}="raf2"]`).should($node => {
-      expect($node.text(), 'probe snapshots written').not.to.equal('');
-    });
-    cy.get(`[${selectors.probe}="opt-out"]`).then($probe => {
-      const layout = JSON.parse($probe.find(`[${selectors.probePhase}="layout"]`).text()) as PaintPhaseSnapshot;
-      expect(layout, 'first paint (layout) is unresolved when opting out of first-paint correctness').to.deep.equal({
-        menuText: null,
-        overflowingItemIds: [],
-      });
-    });
-
-    // It still resolves eventually — the ResizeObserver drives the deferred overflow pass.
-    cy.get(`[${selectors.menu}]`).should('exist');
   });
 });

--- a/packages/react-components/react-overflow/library/src/Overflow.paint-probe.cy.tsx
+++ b/packages/react-components/react-overflow/library/src/Overflow.paint-probe.cy.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { mount as mountBase } from '@fluentui/scripts-cypress';
-import { Overflow, useOverflowContext, useOverflowCount } from '@fluentui/react-overflow';
-import { useIsomorphicLayoutEffect } from '@fluentui/react-utilities';
+import { Overflow, OverflowItem, useOverflowMenu } from '@fluentui/react-overflow';
+import { OverflowContext, useOverflowContext } from './overflowContext';
 
 // Disable StrictMode so the probe measures a single mount/commit path.
 const mount = (element: React.ReactElement) => mountBase(element, { strict: false });
@@ -55,46 +55,31 @@ const PaintRecorder: React.FC<{ name: string; frames: number }> = ({ name, frame
 const distinctPaints = (filmstrip: Paint[]): Paint[] =>
   filmstrip.filter((paint, i) => i === 0 || JSON.stringify(paint) !== JSON.stringify(filmstrip[i - 1]));
 
-// ── Opt-in / opt-out building blocks ──────────────────────────────────────────────────────────────
-// Opt-in item mirrors useOverflowItem: it requests first-paint correctness by calling
-// forceUpdateOverflow on registration. Opt-out only registers.
-const Item: React.FC<{ id: string; optOut: boolean }> = ({ id, optOut }) => {
-  const ref = React.useRef<HTMLButtonElement>(null);
-  const registerItem = useOverflowContext(v => v.registerItem);
-  const forceUpdateOverflow = useOverflowContext(v => v.forceUpdateOverflow);
-  useIsomorphicLayoutEffect(() => {
-    if (ref.current) {
-      const unregister = registerItem({ element: ref.current, id, priority: 0 });
-      if (!optOut) {
-        forceUpdateOverflow();
-      }
-      return unregister;
-    }
-  }, [id, registerItem, forceUpdateOverflow, optOut]);
-  return (
-    <button ref={ref} {...{ [selectors.item]: id }} style={{ width: 50, height: 50, flexShrink: 0 }}>
-      {id}
-    </button>
-  );
+// ── Opt-out, without reimplementing anything ──────────────────────────────────────────────────────
+// First-paint correctness is requested by the real useOverflowItem / useOverflowMenu calling
+// forceUpdateOverflow. Opting out is simply overriding that one context method to a no-op for a
+// subtree — the real components inside then request nothing. A Context.Provider renders no DOM node,
+// so the flex layout (and overflow geometry) is untouched.
+const noop = () => {
+  /* opt out of first-paint correctness */
+};
+const OptOut: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
+  const ctx = useOverflowContext();
+  const value = React.useMemo(() => ({ ...ctx, forceUpdateOverflow: noop }), [ctx]);
+  return <OverflowContext.Provider value={value}>{children}</OverflowContext.Provider>;
 };
 
-// Opt-in menu mirrors useOverflowMenu: it forces synchronously when overflowing so its own width is
-// accounted before paint. Opt-out only registers (relying on addOverflowMenu's async pass).
-const Menu: React.FC<{ optOut: boolean }> = ({ optOut }) => {
-  const ref = React.useRef<HTMLButtonElement>(null);
-  const overflowCount = useOverflowCount();
-  const registerOverflowMenu = useOverflowContext(v => v.registerOverflowMenu);
-  const forceUpdateOverflow = useOverflowContext(v => v.forceUpdateOverflow);
-  const isOverflowing = overflowCount > 0;
-  useIsomorphicLayoutEffect(() => {
-    if (ref.current) {
-      const unregister = registerOverflowMenu(ref.current);
-      if (!optOut && isOverflowing) {
-        forceUpdateOverflow();
-      }
-      return unregister;
-    }
-  }, [registerOverflowMenu, forceUpdateOverflow, isOverflowing, optOut]);
+// Real shipping components, used as-is.
+const Item: React.FC<{ id: string }> = ({ id }) => (
+  <OverflowItem id={id}>
+    <button {...{ [selectors.item]: id }} style={{ width: 50, height: 50, flexShrink: 0 }}>
+      {id}
+    </button>
+  </OverflowItem>
+);
+
+const Menu: React.FC = () => {
+  const { isOverflowing, ref, overflowCount } = useOverflowMenu<HTMLButtonElement>();
   if (!isOverflowing) {
     return null;
   }
@@ -117,22 +102,17 @@ const Container: React.FC<{ children?: React.ReactNode }> = ({ children }) => (
 );
 
 // 300px container, 10 items @ 50px, menu @ 50px, padding 0 -> settled state hides items 5..9 (+5).
-const ITEM_IDS = Array.from({ length: 10 }, (_, i) => String(i));
+const items = Array.from({ length: 10 }, (_, i) => <Item key={i} id={String(i)} />);
 const FRAMES = 12;
 
 const SETTLED: Paint = { menuText: '+5', overflowingItemIds: ['5', '6', '7', '8', '9'] };
 const UNRESOLVED: Paint = { menuText: null, overflowingItemIds: [] };
 const RESOLVED_ITEMS = ['5', '6', '7', '8', '9'];
 
-const recordCase = (name: string, itemsOptOut: boolean, menuOptOut: boolean) => {
+const recordCase = (name: string, content: React.ReactNode) => {
   mount(
     <>
-      <Container>
-        {ITEM_IDS.map(id => (
-          <Item key={id} id={id} optOut={itemsOptOut} />
-        ))}
-        <Menu optOut={menuOptOut} />
-      </Container>
+      <Container>{content}</Container>
       <PaintRecorder name={name} frames={FRAMES} />
     </>,
   );
@@ -162,7 +142,13 @@ describe('Overflow paint probe', () => {
   // No opt-out: both item and menu request first-paint correctness, so the very first painted frame
   // is already fully settled (items hidden AND menu count correct). Filmstrip: [+5].
   it('no opt-out: first paint is fully settled', () => {
-    recordCase('no-opt-out', false, false);
+    recordCase(
+      'no-opt-out',
+      <>
+        {items}
+        <Menu />
+      </>,
+    );
     assertFilmstrip('no-opt-out', first => {
       expect(first, 'no-opt-out: first paint is fully settled').to.deep.equal(SETTLED);
     });
@@ -172,7 +158,15 @@ describe('Overflow paint probe', () => {
   // corrected asynchronously and the menu number flickers. Filmstrip: [+4 -> +5]. We assert only the
   // stable part — items are correct on the first painted frame.
   it('menu opt-out: items correct at first paint (menu count may flicker)', () => {
-    recordCase('menu-opt-out', false, true);
+    recordCase(
+      'menu-opt-out',
+      <>
+        {items}
+        <OptOut>
+          <Menu />
+        </OptOut>
+      </>,
+    );
     assertFilmstrip('menu-opt-out', first => {
       expect(first.overflowingItemIds, 'menu-opt-out: items resolved at first paint').to.deep.equal(RESOLVED_ITEMS);
     });
@@ -181,7 +175,13 @@ describe('Overflow paint probe', () => {
   // Items opt-out: nothing forces, so the first painted frame is unresolved (all items visible, no
   // menu); the ResizeObserver drives a later pass. Filmstrip: [none -> +5].
   it('items opt-out: first paint is unresolved, settles later', () => {
-    recordCase('items-opt-out', true, false);
+    recordCase(
+      'items-opt-out',
+      <>
+        <OptOut>{items}</OptOut>
+        <Menu />
+      </>,
+    );
     assertFilmstrip('items-opt-out', first => {
       expect(first, 'items-opt-out: first paint is unresolved').to.deep.equal(UNRESOLVED);
     });
@@ -190,7 +190,13 @@ describe('Overflow paint probe', () => {
   // Both opt-out: the worst case — first paint unresolved, then items + menu appear, then the menu
   // count settles. Filmstrip: [none -> (+4) -> +5]. First paint unresolved is the stable anchor.
   it('both opt-out: first paint is unresolved, settles later', () => {
-    recordCase('both-opt-out', true, true);
+    recordCase(
+      'both-opt-out',
+      <OptOut>
+        {items}
+        <Menu />
+      </OptOut>,
+    );
     assertFilmstrip('both-opt-out', first => {
       expect(first, 'both-opt-out: first paint is unresolved').to.deep.equal(UNRESOLVED);
     });

--- a/packages/react-components/react-overflow/library/src/Overflow.paint-probe.cy.tsx
+++ b/packages/react-components/react-overflow/library/src/Overflow.paint-probe.cy.tsx
@@ -121,7 +121,7 @@ describe('Overflow paint probe', () => {
     );
     waitForFilmstrip('settled');
     cy.then(() => {
-      const snapshots = toVisualSnapshots(paints['settled']);
+      const snapshots = toVisualSnapshots(paints.settled);
       expect(snapshots, 'filmstrip should have exactly one distinct state').to.have.length(1);
       expect(snapshots[0]).to.deep.equal(SETTLED);
     });

--- a/packages/react-components/react-overflow/library/src/components/Overflow/Overflow.types.ts
+++ b/packages/react-components/react-overflow/library/src/components/Overflow/Overflow.types.ts
@@ -1,5 +1,5 @@
 import type * as React from 'react';
-import type { OverflowOptions, OverflowGroupState } from '@fluentui/priority-overflow';
+import type { OverflowOptions, OverflowGroupState, OverflowManager } from '@fluentui/priority-overflow';
 import type { OverflowContextValue } from '../../overflowContext';
 import type { UseOverflowContainerReturn } from '../../types';
 
@@ -19,6 +19,17 @@ export type OverflowProps = Partial<
   // overflow is not caused by DOM event
   // eslint-disable-next-line @nx/workspace-consistent-callback-type
   onOverflowChange?: (ev: null, data: OverflowState) => void;
+
+  /**
+   * Optional factory used to create the overflow manager.
+   * When provided, called instead of the default `createOverflowManager`.
+   * All option props (`padding`, `overflowAxis`, etc.) are still applied normally.
+   *
+   * @example
+   * import { createFlatOverflowManager } from '@fluentui/priority-overflow';
+   * <Overflow createManager={createFlatOverflowManager} padding={44} minimumVisible={1} />
+   */
+  createManager?: (options: Partial<OverflowOptions>) => OverflowManager;
 };
 
 /**

--- a/packages/react-components/react-overflow/library/src/components/Overflow/Overflow.types.ts
+++ b/packages/react-components/react-overflow/library/src/components/Overflow/Overflow.types.ts
@@ -25,9 +25,8 @@ export type OverflowProps = Partial<
    * When provided, called instead of the default `createOverflowManager`.
    * All option props (`padding`, `overflowAxis`, etc.) are still applied normally.
    *
-   * @example
-   * import { createFlatOverflowManager } from '@fluentui/priority-overflow';
-   * <Overflow createManager={createFlatOverflowManager} padding={44} minimumVisible={1} />
+   * Pass `createFlatOverflowManager` from `\@fluentui/priority-overflow` to opt into
+   * the flat manager optimised for simple ungrouped lists (no pinning, no groups).
    */
   createManager?: (options: Partial<OverflowOptions>) => OverflowManager;
 };

--- a/packages/react-components/react-overflow/library/src/components/Overflow/useOverflow.ts
+++ b/packages/react-components/react-overflow/library/src/components/Overflow/useOverflow.ts
@@ -22,6 +22,7 @@ export const useOverflow_unstable = (props: OverflowProps, ref: React.Ref<HTMLEl
     padding,
     onOverflowChange,
     hasHiddenItems,
+    createManager,
   } = props;
 
   const update: OnUpdateOverflow = useEventCallback(() => {
@@ -44,14 +45,18 @@ export const useOverflow_unstable = (props: OverflowProps, ref: React.Ref<HTMLEl
     forceUpdateOverflow,
     registerOverflowMenu,
     registerDivider,
-  } = useOverflowContainer(update, {
-    overflowDirection,
-    overflowAxis,
-    padding,
-    minimumVisible,
-    hasHiddenItems,
-    onUpdateItemVisibility: updateVisibilityAttribute,
-  });
+  } = useOverflowContainer(
+    update,
+    {
+      overflowDirection,
+      overflowAxis,
+      padding,
+      minimumVisible,
+      hasHiddenItems,
+      onUpdateItemVisibility: updateVisibilityAttribute,
+    },
+    createManager,
+  );
 
   const child = getTriggerChild<HTMLElement>(children);
 

--- a/packages/react-components/react-overflow/library/src/components/OverflowItem/OverflowItem.tsx
+++ b/packages/react-components/react-overflow/library/src/components/OverflowItem/OverflowItem.tsx
@@ -18,9 +18,9 @@ import type { OverflowItemProps } from './OverflowItem.types';
  * Behaves similarly to other `*Trigger` components in Fluent UI React.
  */
 export const OverflowItem = React.forwardRef((props: OverflowItemProps, ref) => {
-  const { id, groupId, priority, pinned, children, defer } = props;
+  const { id, groupId, priority, pinned, children, defer, sizeHint } = props;
 
-  const containerRef = useOverflowItem(id, priority, groupId, pinned, defer);
+  const containerRef = useOverflowItem(id, priority, groupId, pinned, defer, sizeHint);
   const child = getTriggerChild(children);
 
   return applyTriggerPropsToChildren(children, {

--- a/packages/react-components/react-overflow/library/src/components/OverflowItem/OverflowItem.tsx
+++ b/packages/react-components/react-overflow/library/src/components/OverflowItem/OverflowItem.tsx
@@ -18,9 +18,9 @@ import type { OverflowItemProps } from './OverflowItem.types';
  * Behaves similarly to other `*Trigger` components in Fluent UI React.
  */
 export const OverflowItem = React.forwardRef((props: OverflowItemProps, ref) => {
-  const { id, groupId, priority, pinned, children, defer, sizeHint } = props;
+  const { id, groupId, priority, pinned, children, sizeHint } = props;
 
-  const containerRef = useOverflowItem(id, priority, groupId, pinned, defer, sizeHint);
+  const containerRef = useOverflowItem(id, priority, groupId, pinned, sizeHint);
   const child = getTriggerChild(children);
 
   return applyTriggerPropsToChildren(children, {

--- a/packages/react-components/react-overflow/library/src/components/OverflowItem/OverflowItem.tsx
+++ b/packages/react-components/react-overflow/library/src/components/OverflowItem/OverflowItem.tsx
@@ -18,9 +18,9 @@ import type { OverflowItemProps } from './OverflowItem.types';
  * Behaves similarly to other `*Trigger` components in Fluent UI React.
  */
 export const OverflowItem = React.forwardRef((props: OverflowItemProps, ref) => {
-  const { id, groupId, priority, pinned, children } = props;
+  const { id, groupId, priority, pinned, children, defer } = props;
 
-  const containerRef = useOverflowItem(id, priority, groupId, pinned);
+  const containerRef = useOverflowItem(id, priority, groupId, pinned, defer);
   const child = getTriggerChild(children);
 
   return applyTriggerPropsToChildren(children, {

--- a/packages/react-components/react-overflow/library/src/components/OverflowItem/OverflowItem.types.ts
+++ b/packages/react-components/react-overflow/library/src/components/OverflowItem/OverflowItem.types.ts
@@ -16,6 +16,10 @@ export type OverflowItemProps = {
    * The single child that has overflow item behavior attached.
    */
   children: React.ReactElement;
+  /**
+   * If true, the item will not force an update on the overflow context when it registers/unregisters.
+   */
+  defer?: boolean;
 } & (
   | {
       /**

--- a/packages/react-components/react-overflow/library/src/components/OverflowItem/OverflowItem.types.ts
+++ b/packages/react-components/react-overflow/library/src/components/OverflowItem/OverflowItem.types.ts
@@ -17,10 +17,6 @@ export type OverflowItemProps = {
    */
   children: React.ReactElement;
   /**
-   * If true, the item will not force an update on the overflow context when it registers/unregisters.
-   */
-  defer?: boolean;
-  /**
    * Optional size hint in pixels for the overflow axis.
    * When provided and used with `createFlatOverflowManager`, the manager will use
    * this value instead of reading `offsetWidth`/`offsetHeight`, eliminating a

--- a/packages/react-components/react-overflow/library/src/components/OverflowItem/OverflowItem.types.ts
+++ b/packages/react-components/react-overflow/library/src/components/OverflowItem/OverflowItem.types.ts
@@ -20,6 +20,13 @@ export type OverflowItemProps = {
    * If true, the item will not force an update on the overflow context when it registers/unregisters.
    */
   defer?: boolean;
+  /**
+   * Optional size hint in pixels for the overflow axis.
+   * When provided and used with `createFlatOverflowManager`, the manager will use
+   * this value instead of reading `offsetWidth`/`offsetHeight`, eliminating a
+   * layout read on first compute. Only set when the item has a known, stable size.
+   */
+  sizeHint?: number;
 } & (
   | {
       /**

--- a/packages/react-components/react-overflow/library/src/index.ts
+++ b/packages/react-components/react-overflow/library/src/index.ts
@@ -20,6 +20,7 @@ export { useOverflowContextValues_unstable } from './useOverflowContextValues';
 export { useOverflowCount } from './useOverflowCount';
 export { useOverflowItem } from './useOverflowItem';
 export { useOverflowMenu } from './useOverflowMenu';
+export type { UseOverflowMenuOptions } from './useOverflowMenu';
 export { useOverflowDivider } from './useOverflowDivider';
 export { useOverflowVisibility } from './useOverflowVisibility';
 

--- a/packages/react-components/react-overflow/library/src/useOverflowContainer.ts
+++ b/packages/react-components/react-overflow/library/src/useOverflowContainer.ts
@@ -27,6 +27,7 @@ import { DATA_OVERFLOWING, DATA_OVERFLOW_DIVIDER, DATA_OVERFLOW_ITEM, DATA_OVERF
 export const useOverflowContainer = <TElement extends HTMLElement>(
   update: OnUpdateOverflow,
   options: Omit<OverflowOptions, 'onUpdateOverflow'>,
+  managerFactory?: (opts: Partial<OverflowOptions>) => OverflowManager,
 ): UseOverflowContainerReturn<TElement> => {
   const {
     overflowAxis = 'horizontal',
@@ -58,7 +59,7 @@ export const useOverflowContainer = <TElement extends HTMLElement>(
 
   if (managerRef.current === null) {
     if (canUseDOM()) {
-      managerRef.current = createOverflowManager(observeOptions);
+      managerRef.current = (managerFactory ?? createOverflowManager)(observeOptions);
     }
   }
 

--- a/packages/react-components/react-overflow/library/src/useOverflowContainer.ts
+++ b/packages/react-components/react-overflow/library/src/useOverflowContainer.ts
@@ -56,27 +56,17 @@ export const useOverflowContainer = <TElement extends HTMLElement>(
 
   const managerRef = React.useRef<OverflowManager | null>(null);
 
-  // Whether the container's observe effect has run. Item/menu hooks request first-paint correctness
-  // via `forceUpdateOverflow`; before the container observes there is nothing to compute yet, so the
-  // request is recorded here and honored when the observe effect runs.
-  const hasObservedRef = React.useRef(false);
-  // Set when a descendant requests first-paint correctness before the container observes. The default
-  // item/menu hooks make this request; a hook that omits it opts the container out of the synchronous
-  // first-paint pass (the hot path), letting the ResizeObserver drive the first overflow pass instead.
-  const pendingForceUpdateRef = React.useRef(false);
-
   if (managerRef.current === null) {
     managerRef.current = canUseDOM() ? createOverflowManager(observeOptions) : null;
   }
 
   useIsomorphicLayoutEffect(() => {
     if (managerRef.current && containerRef.current) {
-      // Child item/menu effects already ran (child-before-parent), so `pendingForceUpdateRef`
-      // reflects whether any descendant requested first-paint correctness. When requested, resolve
-      // overflow synchronously so the first paint is correct; the manager guards the force on the
-      // container being measured.
-      managerRef.current.observe(containerRef.current, { forceUpdate: pendingForceUpdateRef.current });
-      hasObservedRef.current = true;
+      // First-paint correctness is requested by descendants (the default item/menu hooks call
+      // forceUpdateOverflow during their layout effects, which commit before this one). The manager
+      // honors any such pre-observe request here, guarded on the container being measured. A consumer
+      // whose item hook omits that request opts out — the ResizeObserver drives the first pass.
+      managerRef.current.observe(containerRef.current);
       return () => managerRef.current?.disconnect();
     }
   }, []);
@@ -132,14 +122,9 @@ export const useOverflowContainer = <TElement extends HTMLElement>(
   );
 
   const forceUpdateOverflow = React.useCallback(() => {
-    // Before the container observes, a force can't compute anything (it isn't observing yet), so
-    // record the request and let the observe effect honor it (first-paint correctness). After
-    // observing, force directly.
-    if (hasObservedRef.current) {
-      managerRef.current?.forceUpdate();
-    } else {
-      pendingForceUpdateRef.current = true;
-    }
+    // The manager handles the before/after-observe distinction: a call before observation is
+    // recorded and applied once it observes (first-paint correctness); a call after forces directly.
+    managerRef.current?.forceUpdate();
   }, []);
 
   return {

--- a/packages/react-components/react-overflow/library/src/useOverflowContainer.ts
+++ b/packages/react-components/react-overflow/library/src/useOverflowContainer.ts
@@ -62,10 +62,6 @@ export const useOverflowContainer = <TElement extends HTMLElement>(
 
   useIsomorphicLayoutEffect(() => {
     if (managerRef.current && containerRef.current) {
-      // First-paint correctness is requested by descendants (the default item/menu hooks call
-      // forceUpdateOverflow during their layout effects, which commit before this one). The manager
-      // honors any such pre-observe request here, guarded on the container being measured. A consumer
-      // whose item hook omits that request opts out — the ResizeObserver drives the first pass.
       managerRef.current.observe(containerRef.current);
       return () => managerRef.current?.disconnect();
     }
@@ -122,8 +118,6 @@ export const useOverflowContainer = <TElement extends HTMLElement>(
   );
 
   const forceUpdateOverflow = React.useCallback(() => {
-    // The manager handles the before/after-observe distinction: a call before observation is
-    // recorded and applied once it observes (first-paint correctness); a call after forces directly.
     managerRef.current?.forceUpdate();
   }, []);
 

--- a/packages/react-components/react-overflow/library/src/useOverflowContainer.ts
+++ b/packages/react-components/react-overflow/library/src/useOverflowContainer.ts
@@ -57,7 +57,9 @@ export const useOverflowContainer = <TElement extends HTMLElement>(
   const managerRef = React.useRef<OverflowManager | null>(null);
 
   if (managerRef.current === null) {
-    managerRef.current = canUseDOM() ? createOverflowManager(observeOptions) : null;
+    if (canUseDOM()) {
+      managerRef.current = createOverflowManager(observeOptions);
+    }
   }
 
   useIsomorphicLayoutEffect(() => {

--- a/packages/react-components/react-overflow/library/src/useOverflowContainer.ts
+++ b/packages/react-components/react-overflow/library/src/useOverflowContainer.ts
@@ -62,7 +62,7 @@ export const useOverflowContainer = <TElement extends HTMLElement>(
 
   useIsomorphicLayoutEffect(() => {
     if (managerRef.current && containerRef.current) {
-      managerRef.current.observe(containerRef.current);
+      managerRef.current.observe(containerRef.current, { forceUpdate: true });
       return () => managerRef.current?.disconnect();
     }
   }, []);

--- a/packages/react-components/react-overflow/library/src/useOverflowContainer.ts
+++ b/packages/react-components/react-overflow/library/src/useOverflowContainer.ts
@@ -56,15 +56,27 @@ export const useOverflowContainer = <TElement extends HTMLElement>(
 
   const managerRef = React.useRef<OverflowManager | null>(null);
 
+  // Whether the container's observe effect has run. Item/menu hooks request first-paint correctness
+  // via `forceUpdateOverflow`; before the container observes there is nothing to compute yet, so the
+  // request is recorded here and honored when the observe effect runs.
+  const hasObservedRef = React.useRef(false);
+  // Set when a descendant requests first-paint correctness before the container observes. The default
+  // item/menu hooks make this request; a hook that omits it opts the container out of the synchronous
+  // first-paint pass (the hot path), letting the ResizeObserver drive the first overflow pass instead.
+  const pendingForceUpdateRef = React.useRef(false);
+
   if (managerRef.current === null) {
     managerRef.current = canUseDOM() ? createOverflowManager(observeOptions) : null;
   }
 
   useIsomorphicLayoutEffect(() => {
     if (managerRef.current && containerRef.current) {
-      // forceUpdate resolves overflow synchronously for a correct first paint; the manager guards it
-      // on the container being measured.
-      managerRef.current.observe(containerRef.current, { forceUpdate: true });
+      // Child item/menu effects already ran (child-before-parent), so `pendingForceUpdateRef`
+      // reflects whether any descendant requested first-paint correctness. When requested, resolve
+      // overflow synchronously so the first paint is correct; the manager guards the force on the
+      // container being measured.
+      managerRef.current.observe(containerRef.current, { forceUpdate: pendingForceUpdateRef.current });
+      hasObservedRef.current = true;
       return () => managerRef.current?.disconnect();
     }
   }, []);
@@ -120,7 +132,14 @@ export const useOverflowContainer = <TElement extends HTMLElement>(
   );
 
   const forceUpdateOverflow = React.useCallback(() => {
-    managerRef.current?.forceUpdate();
+    // Before the container observes, a force can't compute anything (it isn't observing yet), so
+    // record the request and let the observe effect honor it (first-paint correctness). After
+    // observing, force directly.
+    if (hasObservedRef.current) {
+      managerRef.current?.forceUpdate();
+    } else {
+      pendingForceUpdateRef.current = true;
+    }
   }, []);
 
   return {

--- a/packages/react-components/react-overflow/library/src/useOverflowItem.test.tsx
+++ b/packages/react-components/react-overflow/library/src/useOverflowItem.test.tsx
@@ -42,6 +42,7 @@ describe('useOverflowItem', () => {
           "id": "test",
           "pinned": undefined,
           "priority": 0,
+          "sizeHint": undefined,
         },
       ]
     `);

--- a/packages/react-components/react-overflow/library/src/useOverflowItem.test.tsx
+++ b/packages/react-components/react-overflow/library/src/useOverflowItem.test.tsx
@@ -17,7 +17,8 @@ const mockContextValue = (options: Partial<OverflowContextValue> = {}) =>
 
 describe('useOverflowItem', () => {
   it('should register item', () => {
-    const registerItemMock = jest.fn();
+    // registerItem returns an unregister cleanup, which the hook invokes on unmount.
+    const registerItemMock = jest.fn(() => jest.fn());
     const value = mockContextValue({ registerItem: registerItemMock });
     renderHook(
       () => {

--- a/packages/react-components/react-overflow/library/src/useOverflowItem.test.tsx
+++ b/packages/react-components/react-overflow/library/src/useOverflowItem.test.tsx
@@ -11,6 +11,7 @@ const mockContextValue = (options: Partial<OverflowContextValue> = {}) =>
     itemVisibility: {},
     registerItem: jest.fn(),
     updateOverflow: jest.fn(),
+    forceUpdateOverflow: jest.fn(),
     ...options,
   } as OverflowContextValue);
 

--- a/packages/react-components/react-overflow/library/src/useOverflowItem.ts
+++ b/packages/react-components/react-overflow/library/src/useOverflowItem.ts
@@ -12,7 +12,6 @@ import { useOverflowContext } from './overflowContext';
  * @param priority - higher priority means the item overflows later
  * @param groupId - assigns the item to a group, group visibility can be watched
  * @param pinned - if true, the item will never overflow and will always be visible
- * @param defer - if true, the item will not force an update on the overflow context when it registers/unregisters.
  * @param sizeHint - optional size hint in pixels; used by createFlatOverflowManager to skip a layout read.
  * @returns ref to assign to an intrinsic HTML element
  */
@@ -21,7 +20,6 @@ export function useOverflowItem<TElement extends HTMLElement>(
   priority?: number,
   groupId?: string,
   pinned?: boolean,
-  defer?: boolean,
   sizeHint?: number,
 ): React.RefObject<TElement | null> {
   const ref = React.useRef<TElement | null>(null);
@@ -48,17 +46,13 @@ export function useOverflowItem<TElement extends HTMLElement>(
         pinned,
         sizeHint,
       });
-      if (!defer) {
-        forceUpdateOverflow();
-      }
+      forceUpdateOverflow();
       return () => {
         unregister();
-        if (!defer) {
-          forceUpdateOverflow();
-        }
+        forceUpdateOverflow();
       };
     }
-  }, [id, priority, registerItem, forceUpdateOverflow, groupId, pinned, defer, sizeHint]);
+  }, [id, priority, registerItem, forceUpdateOverflow, groupId, pinned, sizeHint]);
 
   return ref;
 }

--- a/packages/react-components/react-overflow/library/src/useOverflowItem.ts
+++ b/packages/react-components/react-overflow/library/src/useOverflowItem.ts
@@ -43,11 +43,11 @@ export function useOverflowItem<TElement extends HTMLElement>(
         groupId,
         pinned,
       });
-      // Request first-paint correctness. Before the container observes this defers a synchronous
-      // force to the container's observe effect; after, it recomputes for the (re)registered item.
-      // An item hook that omits this call opts the container out of the synchronous first-paint pass.
       forceUpdateOverflow();
-      return unregister;
+      return () => {
+        unregister();
+        forceUpdateOverflow();
+      };
     }
   }, [id, priority, registerItem, forceUpdateOverflow, groupId, pinned]);
 

--- a/packages/react-components/react-overflow/library/src/useOverflowItem.ts
+++ b/packages/react-components/react-overflow/library/src/useOverflowItem.ts
@@ -22,6 +22,7 @@ export function useOverflowItem<TElement extends HTMLElement>(
 ): React.RefObject<TElement | null> {
   const ref = React.useRef<TElement | null>(null);
   const registerItem = useOverflowContext(v => v.registerItem);
+  const forceUpdateOverflow = useOverflowContext(v => v.forceUpdateOverflow);
 
   useIsomorphicLayoutEffect(() => {
     if (process.env.NODE_ENV !== 'production') {
@@ -35,15 +36,20 @@ export function useOverflowItem<TElement extends HTMLElement>(
     }
 
     if (ref.current) {
-      return registerItem({
+      const unregister = registerItem({
         element: ref.current,
         id,
         priority: priority ?? 0,
         groupId,
         pinned,
       });
+      // Request first-paint correctness. Before the container observes this defers a synchronous
+      // force to the container's observe effect; after, it recomputes for the (re)registered item.
+      // An item hook that omits this call opts the container out of the synchronous first-paint pass.
+      forceUpdateOverflow();
+      return unregister;
     }
-  }, [id, priority, registerItem, groupId, pinned]);
+  }, [id, priority, registerItem, forceUpdateOverflow, groupId, pinned]);
 
   return ref;
 }

--- a/packages/react-components/react-overflow/library/src/useOverflowItem.ts
+++ b/packages/react-components/react-overflow/library/src/useOverflowItem.ts
@@ -13,6 +13,7 @@ import { useOverflowContext } from './overflowContext';
  * @param groupId - assigns the item to a group, group visibility can be watched
  * @param pinned - if true, the item will never overflow and will always be visible
  * @param defer - if true, the item will not force an update on the overflow context when it registers/unregisters.
+ * @param sizeHint - optional size hint in pixels; used by createFlatOverflowManager to skip a layout read.
  * @returns ref to assign to an intrinsic HTML element
  */
 export function useOverflowItem<TElement extends HTMLElement>(
@@ -21,6 +22,7 @@ export function useOverflowItem<TElement extends HTMLElement>(
   groupId?: string,
   pinned?: boolean,
   defer?: boolean,
+  sizeHint?: number,
 ): React.RefObject<TElement | null> {
   const ref = React.useRef<TElement | null>(null);
   const registerItem = useOverflowContext(v => v.registerItem);
@@ -44,6 +46,7 @@ export function useOverflowItem<TElement extends HTMLElement>(
         priority: priority ?? 0,
         groupId,
         pinned,
+        sizeHint,
       });
       if (!defer) {
         forceUpdateOverflow();
@@ -55,7 +58,7 @@ export function useOverflowItem<TElement extends HTMLElement>(
         }
       };
     }
-  }, [id, priority, registerItem, forceUpdateOverflow, groupId, pinned, defer]);
+  }, [id, priority, registerItem, forceUpdateOverflow, groupId, pinned, defer, sizeHint]);
 
   return ref;
 }

--- a/packages/react-components/react-overflow/library/src/useOverflowItem.ts
+++ b/packages/react-components/react-overflow/library/src/useOverflowItem.ts
@@ -12,6 +12,7 @@ import { useOverflowContext } from './overflowContext';
  * @param priority - higher priority means the item overflows later
  * @param groupId - assigns the item to a group, group visibility can be watched
  * @param pinned - if true, the item will never overflow and will always be visible
+ * @param defer - if true, the item will not force an update on the overflow context when it registers/unregisters.
  * @returns ref to assign to an intrinsic HTML element
  */
 export function useOverflowItem<TElement extends HTMLElement>(
@@ -19,6 +20,7 @@ export function useOverflowItem<TElement extends HTMLElement>(
   priority?: number,
   groupId?: string,
   pinned?: boolean,
+  defer?: boolean,
 ): React.RefObject<TElement | null> {
   const ref = React.useRef<TElement | null>(null);
   const registerItem = useOverflowContext(v => v.registerItem);
@@ -43,13 +45,17 @@ export function useOverflowItem<TElement extends HTMLElement>(
         groupId,
         pinned,
       });
-      forceUpdateOverflow();
+      if (!defer) {
+        forceUpdateOverflow();
+      }
       return () => {
         unregister();
-        forceUpdateOverflow();
+        if (!defer) {
+          forceUpdateOverflow();
+        }
       };
     }
-  }, [id, priority, registerItem, forceUpdateOverflow, groupId, pinned]);
+  }, [id, priority, registerItem, forceUpdateOverflow, groupId, pinned, defer]);
 
   return ref;
 }

--- a/packages/react-components/react-overflow/library/src/useOverflowMenu.ts
+++ b/packages/react-components/react-overflow/library/src/useOverflowMenu.ts
@@ -10,19 +10,13 @@ export interface UseOverflowMenuOptions {
    * The unique identifier for the menu used by the overflow manager. If not provided, a unique id will be generated.
    */
   id?: string;
-  /**
-   * If true, the menu will not force an update on the overflow context when it registers/unregisters.
-   * This can be used to prevent unnecessary updates if the menu is not visible by default.
-   * @default false
-   */
-  defer?: boolean;
 }
 
 export function useOverflowMenu<TElement extends HTMLElement>(
   idOrOptions?: string | UseOverflowMenuOptions,
   // eslint-disable-next-line @typescript-eslint/no-deprecated
 ): { ref: React.MutableRefObject<TElement | null>; overflowCount: number; isOverflowing: boolean } {
-  const { id, defer = false } = typeof idOrOptions === 'string' ? { id: idOrOptions } : idOrOptions || {};
+  const { id } = typeof idOrOptions === 'string' ? { id: idOrOptions } : idOrOptions || {};
   const elementId = useId('overflow-menu', id);
   const overflowCount = useOverflowCount();
   const { registerOverflowMenu, forceUpdateOverflow } = useOverflowContext();
@@ -32,17 +26,15 @@ export function useOverflowMenu<TElement extends HTMLElement>(
   useIsomorphicLayoutEffect(() => {
     if (ref.current) {
       const unregister = registerOverflowMenu(ref.current);
-      if (isOverflowing && !defer) {
+      if (isOverflowing) {
         forceUpdateOverflow();
       }
       return () => {
         unregister();
-        if (!defer) {
-          forceUpdateOverflow();
-        }
+        forceUpdateOverflow();
       };
     }
-  }, [registerOverflowMenu, forceUpdateOverflow, isOverflowing, elementId, defer]);
+  }, [registerOverflowMenu, forceUpdateOverflow, isOverflowing, elementId]);
 
   return { ref, overflowCount, isOverflowing };
 }

--- a/packages/react-components/react-overflow/library/src/useOverflowMenu.ts
+++ b/packages/react-components/react-overflow/library/src/useOverflowMenu.ts
@@ -5,10 +5,24 @@ import { useId, useIsomorphicLayoutEffect } from '@fluentui/react-utilities';
 import { useOverflowContext } from './overflowContext';
 import { useOverflowCount } from './useOverflowCount';
 
+export interface UseOverflowMenuOptions {
+  /**
+   * The unique identifier for the menu used by the overflow manager. If not provided, a unique id will be generated.
+   */
+  id?: string;
+  /**
+   * If true, the menu will not force an update on the overflow context when it registers/unregisters.
+   * This can be used to prevent unnecessary updates if the menu is not visible by default.
+   * @default false
+   */
+  defer?: boolean;
+}
+
 export function useOverflowMenu<TElement extends HTMLElement>(
-  id?: string,
+  idOrOptions?: string | UseOverflowMenuOptions,
   // eslint-disable-next-line @typescript-eslint/no-deprecated
 ): { ref: React.MutableRefObject<TElement | null>; overflowCount: number; isOverflowing: boolean } {
+  const { id, defer = false } = typeof idOrOptions === 'string' ? { id: idOrOptions } : idOrOptions || {};
   const elementId = useId('overflow-menu', id);
   const overflowCount = useOverflowCount();
   const { registerOverflowMenu, forceUpdateOverflow } = useOverflowContext();
@@ -18,15 +32,17 @@ export function useOverflowMenu<TElement extends HTMLElement>(
   useIsomorphicLayoutEffect(() => {
     if (ref.current) {
       const unregister = registerOverflowMenu(ref.current);
-      if (isOverflowing) {
+      if (isOverflowing && !defer) {
         forceUpdateOverflow();
       }
       return () => {
         unregister();
-        forceUpdateOverflow();
+        if (!defer) {
+          forceUpdateOverflow();
+        }
       };
     }
-  }, [registerOverflowMenu, forceUpdateOverflow, isOverflowing, elementId]);
+  }, [registerOverflowMenu, forceUpdateOverflow, isOverflowing, elementId, defer]);
 
   return { ref, overflowCount, isOverflowing };
 }


### PR DESCRIPTION
## Summary

**PR 4 of 4 — DRAFT.** Depends on PR 3 (#36264, `react-overflow/pr3-first-paint`). **Do not merge until PR 3 lands** — until then the "Files changed" view shows cumulative diffs. Once PR 3 merges this branch will be rebased onto the latest `master` and the diff will reduce to just the opt-out changes.

Builds on PR 3's first-paint correctness by making that synchronous pass **opt-in per consumer**, so hot-path clients can skip it without any `Overflow` prop.

### Stack

1. `react-overflow/pr1-strict-mode-lifecycle` (#36262) — strict-mode-safe lifecycle. **Merged.**
2. `react-overflow/pr2-subscribe-model` (#36263) — subscribe model. **Merged.**
3. `react-overflow/pr3-first-paint` (#36264) — first-paint correctness. **In review.**
4. **This PR** — opt-out of first-paint correctness.

### How it works

First-paint correctness is now *requested* by the default item/menu hooks rather than forced unconditionally by the container:

- `useOverflowItem` and `useOverflowMenu` call `forceUpdateOverflow()` on registration.
- `useOverflowContainer` records that request (child effects run before the parent's observe effect) and passes it through as `observe(container, { forceUpdate: <requested> })`; after observing, `forceUpdateOverflow` forces directly. The manager still guards the force on the container being measured.
- A hot-path consumer that builds a custom item hook on top of `useOverflowContext` and **omits** the `forceUpdateOverflow()` call opts the container out of the synchronous first-paint pass entirely — the `ResizeObserver` then drives the first (async) overflow pass instead.

No new `Overflow` prop and no new public export — the opt-out is intentionally low-profile.

## Test plan

- `Overflow.paint-probe.cy.tsx` gains an opt-out case asserting the layout-phase paint is unresolved when items/menu opt out, then resolves asynchronously (5/5 passing).
- Default first-paint convergence cases unchanged (now item-driven).
- `react-overflow` unit / type-check / lint green; `react-charts` 912 tests / 321 snapshots / 0 axe unaffected.