### PR TITLE
fix: prevent Calendar day cells from expanding

### DIFF
--- a/change/@fluentui-react-5e1a9878-e11f-4ae1-9cbf-71a0a7d296b9.json
+++ b/change/@fluentui-react-5e1a9878-e11f-4ae1-9cbf-71a0a7d296b9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: keep Calendar day cells from expanding with external table cell padding",
+  "packageName": "@fluentui/react",
+  "email": "kirtiar15502@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/CalendarDayGrid/CalendarDayGrid.styles.ts
+++ b/packages/react/src/components/CalendarDayGrid/CalendarDayGrid.styles.ts
@@ -103,6 +103,7 @@ export const styles = (props: ICalendarDayGridStyleProps): ICalendarDayGridStyle
       {
         margin: 0,
         padding: 0,
+        boxSizing: 'border-box',
         width: 28,
         height: 28,
         lineHeight: 28,
@@ -112,6 +113,9 @@ export const styles = (props: ICalendarDayGridStyleProps): ICalendarDayGridStyle
         cursor: 'pointer',
         position: 'relative',
         selectors: {
+          '&&': {
+            padding: 0,
+          },
           [HighContrastSelector]: {
             color: 'WindowText',
             backgroundColor: 'transparent',

--- a/packages/react/src/components/CalendarDayGrid/CalendarDayGrid.test.tsx
+++ b/packages/react/src/components/CalendarDayGrid/CalendarDayGrid.test.tsx
@@ -2,6 +2,8 @@ import { CalendarDayGrid } from './CalendarDayGrid';
 import { defaultCalendarStrings } from '../Calendar/index';
 import { DateRangeType, DayOfWeek, FirstWeekOfYear } from '@fluentui/date-time-utilities';
 import { isConformant } from '../../common/isConformant';
+import { getTheme } from '../../Styling';
+import { styles } from './CalendarDayGrid.styles';
 
 describe('CalendarDayGrid', () => {
   isConformant({
@@ -30,5 +32,23 @@ describe('CalendarDayGrid', () => {
       'component-handles-ref',
       'component-has-root-ref',
     ],
+  });
+
+  it('keeps day cells from expanding under external table cell padding', () => {
+    const calendarStyles = styles({
+      theme: getTheme(),
+      dateRangeType: DateRangeType.Day,
+    });
+
+    expect(calendarStyles.dayCell).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          boxSizing: 'border-box',
+          selectors: expect.objectContaining({
+            '&&': { padding: 0 },
+          }),
+        }),
+      ]),
+    );
   });
 });


### PR DESCRIPTION
## Previous Behavior

Calendar day cells could expand when an app-level table-cell padding rule had higher specificity than the default day-cell padding. For example, a scoped `td { padding: 15px; }` rule can turn the intended 28px cell into a 58px cell, which matches the DatePicker overflow reported in #36274.

## New Behavior

Calendar day cells keep their fixed sizing by using border-box sizing and a higher-specificity zero-padding rule for the day-cell slot. This keeps the day grid at its expected width even when a surrounding app has scoped table-cell padding.

## Related Issue(s)

- Fixes #36274

## Tests

- `corepack yarn nx run react:test --testPathPatterns=CalendarDayGrid.test.tsx --runInBand --excludeTaskDependencies`
- `node node_modules\\eslint\\bin\\eslint.js packages\\react\\src\\components\\CalendarDayGrid\\CalendarDayGrid.styles.ts packages\\react\\src\\components\\CalendarDayGrid\\CalendarDayGrid.test.tsx`
- `node node_modules\\prettier\\bin-prettier.js --check packages\\react\\src\\components\\CalendarDayGrid\\CalendarDayGrid.styles.ts packages\\react\\src\\components\\CalendarDayGrid\\CalendarDayGrid.test.tsx change\\@fluentui-react-5e1a9878-e11f-4ae1-9cbf-71a0a7d296b9.json`
- `git diff --check`
- Browser sanity check confirmed a 28px day cell under scoped external `td { padding: 15px; }`.