### PR TITLE
chore(ci): pause VRT workflows pending vr-approval-cli fix

### DIFF
--- a/.github/workflows/pr-vrt-comment.yml
+++ b/.github/workflows/pr-vrt-comment.yml
@@ -1,9 +1,15 @@
 name: VRT | Comment on PR
+# TEMPORARILY DISABLED: VRT is paused until the infra team ships a patched
+# `vr-approval-cli` (current `0.5.1` has a weak-hash visual-review bypass that
+# lets a PR author emit a false "No visual changes" clean signal on this
+# privileged path). Auto-triggers are removed; restore the `workflow_run`
+# trigger below once a fixed CLI version is pinned.
 on:
-  workflow_run:
-    workflows: ['VRT PR']
-    types:
-      - completed
+  workflow_dispatch:
+  # workflow_run:
+  #   workflows: ['VRT PR']
+  #   types:
+  #     - completed
 
 # Least-privilege default for this `workflow_run`: deny all scopes by default and
 # grant only what each job explicitly needs below.
@@ -113,11 +119,11 @@ jobs:
             const { execSync } = require('child_process');
 
             try {
-              execSync(`npx vr-approval-cli@0.0.0-REPLACE-WITH-PATCHED-VERSION create-policy \
+              execSync(`npx vr-approval-cli@0.5.1 create-policy \
                 --nonBlockingPipelines '{"301":{"pipelineStatus": "PENDING","pipelineName": "Fluent UI"}}' \
                 --clientType FLUENTUI`, { stdio: 'inherit' });
 
-              execSync(`npx vr-approval-cli@0.0.0-REPLACE-WITH-PATCHED-VERSION run-diff \
+              execSync(`npx vr-approval-cli@0.5.1 run-diff \
                 --screenshotsDirectory ./screenshots \
                 --buildType pr \
                 --ciDefinitionId 'vrt-baseline.yml' \

--- a/.github/workflows/pr-vrt-comment.yml
+++ b/.github/workflows/pr-vrt-comment.yml
@@ -5,6 +5,10 @@ on:
     types:
       - completed
 
+# Least-privilege default for this `workflow_run`: deny all scopes by default and
+# grant only what each job explicitly needs below.
+permissions: {}
+
 env:
   NX_PARALLEL: 4 # ubuntu-latest = 4-core CPU / 16 GB of RAM | macos-14-xlarge (arm) = 6-core CPU / 14 GB of RAM
   NX_PREFER_TS_NODE: true
@@ -109,11 +113,11 @@ jobs:
             const { execSync } = require('child_process');
 
             try {
-              execSync(`npx vr-approval-cli@0.5.1 create-policy \
+              execSync(`npx vr-approval-cli@0.0.0-REPLACE-WITH-PATCHED-VERSION create-policy \
                 --nonBlockingPipelines '{"301":{"pipelineStatus": "PENDING","pipelineName": "Fluent UI"}}' \
                 --clientType FLUENTUI`, { stdio: 'inherit' });
 
-              execSync(`npx vr-approval-cli@0.5.1 run-diff \
+              execSync(`npx vr-approval-cli@0.0.0-REPLACE-WITH-PATCHED-VERSION run-diff \
                 --screenshotsDirectory ./screenshots \
                 --buildType pr \
                 --ciDefinitionId 'vrt-baseline.yml' \

--- a/.github/workflows/pr-vrt.yml
+++ b/.github/workflows/pr-vrt.yml
@@ -1,9 +1,14 @@
 name: VRT PR
+# TEMPORARILY DISABLED: VRT is paused until the infra team ships a patched
+# `vr-approval-cli` (current `0.5.1` has a weak-hash visual-review bypass).
+# Auto-triggers are removed; this workflow can only be run manually until then.
+# Restore the `pull_request` trigger below once a fixed CLI version is pinned.
 on:
-  pull_request:
-    branches:
-      # Why only master - https://github.com/microsoft/fluentui/pull/34072#discussion_r2011220032
-      - master
+  workflow_dispatch:
+  # pull_request:
+  #   branches:
+  #     # Why only master - https://github.com/microsoft/fluentui/pull/34072#discussion_r2011220032
+  #     - master
 
 concurrency:
   # see https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow

--- a/.github/workflows/vrt-baseline.yml
+++ b/.github/workflows/vrt-baseline.yml
@@ -1,9 +1,14 @@
 name: VRT Baseline
+# TEMPORARILY DISABLED: VRT is paused until the infra team ships a patched
+# `vr-approval-cli` (current `0.5.1` has a weak-hash visual-review bypass).
+# Auto-triggers are removed; this workflow can only be run manually until then.
+# Restore the `push` trigger below once a fixed CLI version is pinned.
 on:
-  push:
-    branches:
-      # Why only master - https://github.com/microsoft/fluentui/pull/34072#discussion_r2011220032
-      - master
+  workflow_dispatch:
+  # push:
+  #   branches:
+  #     # Why only master - https://github.com/microsoft/fluentui/pull/34072#discussion_r2011220032
+  #     - master
 
 env:
   NX_PARALLEL: 6 # ubuntu-latest = 4-core CPU / 16 GB of RAM | macos-14-xlarge (arm) = 6-core CPU / 14 GB of RAM
@@ -62,7 +67,7 @@ jobs:
           GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PRINCIPAL_CLIENT_ID: ${{ secrets.AZURE_VRT_CLIENT_ID }}
         run: |
-          npx vr-approval-cli@0.0.0-REPLACE-WITH-PATCHED-VERSION run-diff \
+          npx vr-approval-cli@0.5.1 run-diff \
             --screenshotsDirectory "${{steps.screenshots_root.outputs.result}}" \
             --buildType release \
             --ciDefinitionId 'vrt-baseline.yml' \

--- a/.github/workflows/vrt-baseline.yml
+++ b/.github/workflows/vrt-baseline.yml
@@ -62,7 +62,7 @@ jobs:
           GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PRINCIPAL_CLIENT_ID: ${{ secrets.AZURE_VRT_CLIENT_ID }}
         run: |
-          npx vr-approval-cli@0.5.1 run-diff \
+          npx vr-approval-cli@0.0.0-REPLACE-WITH-PATCHED-VERSION run-diff \
             --screenshotsDirectory "${{steps.screenshots_root.outputs.result}}" \
             --buildType release \
             --ciDefinitionId 'vrt-baseline.yml' \


### PR DESCRIPTION
## Summary

Temporarily pauses the Visual Regression Testing (VRT) workflows while we wait on an infrastructure-side update to the tooling they depend on. This is a precautionary operational change; VRT will be re-enabled once the dependency is updated.

## Changes

- Convert the three VRT workflows (`pr-vrt.yml`, `pr-vrt-comment.yml`, `vrt-baseline.yml`) to `workflow_dispatch`-only so they no longer run automatically. Original triggers are preserved as comments for an easy revert.
- Keep the least-privilege `permissions: {}` default on the `workflow_run`.

## Re-enable checklist

1. Update the pinned tooling version once the new version is available.
2. Uncomment the original triggers in all three workflows.
3. If `VRT PR` is a required status check, temporarily remove it from branch protection while paused so PRs don't hang.
