### PR TITLE
fix(react-headless-components-preview): export useContextValues for components requiring context in render functions

### DIFF
--- a/change/@fluentui-react-headless-components-preview-466e0d72-6062-498b-93e6-5ffb040ca413.json
+++ b/change/@fluentui-react-headless-components-preview-466e0d72-6062-498b-93e6-5ffb040ca413.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: export useContextValues for headless components requiring context in render functions",
+  "packageName": "@fluentui/react-headless-components-preview",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-headless-components-preview/library/etc/accordion.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/accordion.api.md
@@ -121,7 +121,13 @@ export const useAccordionContextValues: (state: AccordionState) => AccordionCont
 export const useAccordionHeader: (props: AccordionHeaderProps, ref: React_2.Ref<HTMLElement>) => AccordionHeaderState;
 
 // @public
+export const useAccordionHeaderContextValues: (state: AccordionHeaderState) => AccordionHeaderContextValues_2;
+
+// @public
 export const useAccordionItem: (props: AccordionItemProps, ref: React_2.Ref<HTMLElement>) => AccordionItemState;
+
+// @public
+export const useAccordionItemContextValues: (state: AccordionItemState) => AccordionItemContextValues_2;
 
 // @public
 export const useAccordionPanel: (props: AccordionPanelProps, ref: React_2.Ref<HTMLElement>) => AccordionPanelState;

--- a/packages/react-components/react-headless-components-preview/library/etc/dropdown.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/dropdown.api.md
@@ -96,6 +96,9 @@ export const renderOptionGroup: (state: OptionGroupState_2) => JSXElement;
 // @public
 export const useDropdown: (props: DropdownProps, ref: React_2.Ref<HTMLButtonElement>) => DropdownState;
 
+// @public (undocumented)
+export const useDropdownContextValues: (state: DropdownState) => DropdownContextValues;
+
 // @public
 export const useListbox: (props: ListboxProps, ref: React_2.Ref<HTMLElement>) => ListboxState;
 

--- a/packages/react-components/react-headless-components-preview/library/etc/field.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/field.api.md
@@ -34,6 +34,9 @@ export const renderField: (state: FieldBaseState, contextValues: FieldContextVal
 // @public
 export const useField: (props: FieldProps, ref: React_2.Ref<HTMLDivElement>) => FieldState;
 
+// @public
+export const useFieldContextValues: (state: FieldState) => FieldContextValues_2;
+
 // (No @packageDocumentation comment for this package)
 
 ```

--- a/packages/react-components/react-headless-components-preview/library/etc/provider.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/provider.api.md
@@ -30,6 +30,9 @@ export const useProvider: (props: ProviderProps, ref: React_2.Ref<HTMLDivElement
 
 export { useProviderContext }
 
+// @public (undocumented)
+export const useProviderContextValues: (state: ProviderState) => ProviderContextValues;
+
 // (No @packageDocumentation comment for this package)
 
 ```

--- a/packages/react-components/react-headless-components-preview/library/etc/rating-display.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/rating-display.api.md
@@ -30,6 +30,9 @@ export const renderRatingDisplay: (state: RatingDisplayBaseState, contextValues:
 // @public
 export const useRatingDisplay: (props: RatingDisplayProps, ref: React_2.Ref<HTMLDivElement>) => RatingDisplayState;
 
+// @public (undocumented)
+export const useRatingDisplayContextValues: (state: RatingDisplayState) => RatingDisplayContextValues_2;
+
 // (No @packageDocumentation comment for this package)
 
 ```

--- a/packages/react-components/react-headless-components-preview/library/etc/rating.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/rating.api.md
@@ -58,6 +58,9 @@ export const renderRatingItem: (state: RatingItemBaseState) => JSXElement;
 // @public
 export const useRating: (props: RatingProps, ref: React_2.Ref<HTMLDivElement>) => RatingState;
 
+// @public (undocumented)
+export const useRatingContextValues: (state: RatingState) => RatingContextValues_2;
+
 // @public
 export const useRatingItem: (props: RatingItemProps, ref: React_2.Ref<HTMLSpanElement>) => RatingItemState;
 

--- a/packages/react-components/react-headless-components-preview/library/etc/tab-list.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/tab-list.api.md
@@ -64,6 +64,9 @@ export const useTab: (props: TabProps, ref: React_2.Ref<HTMLElement>) => TabStat
 // @public
 export const useTabList: (props: TabListProps, ref: React_2.Ref<HTMLElement>) => TabListState;
 
+// @public (undocumented)
+export const useTabListContextValues: (state: TabListState) => TabListContextValues_2;
+
 // (No @packageDocumentation comment for this package)
 
 ```

--- a/packages/react-components/react-headless-components-preview/library/src/accordion.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/accordion.ts
@@ -7,10 +7,20 @@ export {
 } from './components/Accordion';
 export type { AccordionSlots, AccordionProps, AccordionState, AccordionContextValues } from './components/Accordion';
 
-export { AccordionHeader, renderAccordionHeader, useAccordionHeader } from './components/Accordion';
+export {
+  AccordionHeader,
+  renderAccordionHeader,
+  useAccordionHeader,
+  useAccordionHeaderContextValues,
+} from './components/Accordion';
 export type { AccordionHeaderSlots, AccordionHeaderProps, AccordionHeaderState } from './components/Accordion';
 
-export { AccordionItem, renderAccordionItem, useAccordionItem } from './components/Accordion';
+export {
+  AccordionItem,
+  renderAccordionItem,
+  useAccordionItem,
+  useAccordionItemContextValues,
+} from './components/Accordion';
 export type { AccordionItemSlots, AccordionItemProps, AccordionItemState } from './components/Accordion';
 
 export { AccordionPanel, renderAccordionPanel, useAccordionPanel } from './components/Accordion';

--- a/packages/react-components/react-headless-components-preview/library/src/components/Accordion/AccordionHeader/index.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Accordion/AccordionHeader/index.ts
@@ -1,4 +1,4 @@
 export { AccordionHeader } from './AccordionHeader';
 export { renderAccordionHeader } from './renderAccordionHeader';
-export { useAccordionHeader } from './useAccordionHeader';
+export { useAccordionHeader, useAccordionHeaderContextValues } from './useAccordionHeader';
 export type { AccordionHeaderSlots, AccordionHeaderProps, AccordionHeaderState } from './AccordionHeader.types';

--- a/packages/react-components/react-headless-components-preview/library/src/components/Accordion/AccordionItem/index.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Accordion/AccordionItem/index.ts
@@ -1,4 +1,4 @@
 export { AccordionItem } from './AccordionItem';
 export { renderAccordionItem } from './renderAccordionItem';
-export { useAccordionItem } from './useAccordionItem';
+export { useAccordionItem, useAccordionItemContextValues } from './useAccordionItem';
 export type { AccordionItemSlots, AccordionItemProps, AccordionItemState } from './AccordionItem.types';

--- a/packages/react-components/react-headless-components-preview/library/src/components/Accordion/index.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Accordion/index.ts
@@ -3,10 +3,15 @@ export { renderAccordion } from './renderAccordion';
 export { useAccordion, useAccordionContext, useAccordionContextValues } from './useAccordion';
 export type { AccordionSlots, AccordionProps, AccordionState, AccordionContextValues } from './Accordion.types';
 
-export { AccordionHeader, renderAccordionHeader, useAccordionHeader } from './AccordionHeader';
+export {
+  AccordionHeader,
+  renderAccordionHeader,
+  useAccordionHeader,
+  useAccordionHeaderContextValues,
+} from './AccordionHeader';
 export type { AccordionHeaderSlots, AccordionHeaderProps, AccordionHeaderState } from './AccordionHeader';
 
-export { AccordionItem, renderAccordionItem, useAccordionItem } from './AccordionItem';
+export { AccordionItem, renderAccordionItem, useAccordionItem, useAccordionItemContextValues } from './AccordionItem';
 export type { AccordionItemSlots, AccordionItemProps, AccordionItemState } from './AccordionItem';
 
 export { AccordionPanel, renderAccordionPanel, useAccordionPanel } from './AccordionPanel';

--- a/packages/react-components/react-headless-components-preview/library/src/components/Dropdown/index.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Dropdown/index.ts
@@ -2,6 +2,7 @@ export { Dropdown } from './Dropdown';
 export type { DropdownProps, DropdownState } from './Dropdown.types';
 export { renderDropdown } from './renderDropdown';
 export { useDropdown } from './useDropdown';
+export { useDropdownContextValues } from './useDropdownContextValues';
 
 export { Listbox, renderListbox, useListbox, useListboxContextValues } from './Listbox';
 export type { ListboxSlots, ListboxProps, ListboxState, ListboxContextValues } from './Listbox';

--- a/packages/react-components/react-headless-components-preview/library/src/components/Field/index.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Field/index.ts
@@ -1,4 +1,5 @@
 export { Field } from './Field';
 export { renderField } from './renderField';
 export { useField } from './useField';
+export { useFieldContextValues } from './useFieldContextValues';
 export type { FieldSlots, FieldProps, FieldState } from './Field.types';

--- a/packages/react-components/react-headless-components-preview/library/src/components/Provider/index.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Provider/index.ts
@@ -2,4 +2,5 @@ export { Provider } from './Provider';
 export type { ProviderProps, ProviderState } from './Provider.types';
 export { renderProvider } from './renderProvider';
 export { useProvider } from './useProvider';
+export { useProviderContextValues } from './useProviderContextValues';
 export { useProviderContext } from './useProviderContext';

--- a/packages/react-components/react-headless-components-preview/library/src/components/Rating/index.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Rating/index.ts
@@ -4,4 +4,5 @@ export type { RatingItemSlots, RatingItemProps, RatingItemState } from './Rating
 export { Rating } from './Rating';
 export { renderRating } from './renderRating';
 export { useRating } from './useRating';
+export { useRatingContextValues } from './useRatingContextValues';
 export type { RatingSlots, RatingProps, RatingState } from './Rating.types';

--- a/packages/react-components/react-headless-components-preview/library/src/components/RatingDisplay/index.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/RatingDisplay/index.ts
@@ -1,4 +1,5 @@
 export { RatingDisplay } from './RatingDisplay';
 export { renderRatingDisplay } from './renderRatingDisplay';
 export { useRatingDisplay } from './useRatingDisplay';
+export { useRatingDisplayContextValues } from './useRatingDisplayContextValues';
 export type { RatingDisplaySlots, RatingDisplayProps, RatingDisplayState } from './RatingDisplay.types';

--- a/packages/react-components/react-headless-components-preview/library/src/components/TabList/index.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/TabList/index.ts
@@ -4,4 +4,5 @@ export { Tab, renderTab, useTab } from './Tab';
 export { TabList } from './TabList';
 export { renderTabList } from './renderTabList';
 export { useTabList } from './useTabList';
+export { useTabListContextValues } from './useTabListContextValues';
 export type { TabListSlots, TabListProps, TabListState } from './TabList.types';

--- a/packages/react-components/react-headless-components-preview/library/src/dropdown.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/dropdown.ts
@@ -2,6 +2,7 @@ export {
   Dropdown,
   renderDropdown,
   useDropdown,
+  useDropdownContextValues,
   Listbox,
   renderListbox,
   useListbox,

--- a/packages/react-components/react-headless-components-preview/library/src/field.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/field.ts
@@ -1,2 +1,2 @@
-export { Field, renderField, useField } from './components/Field/index';
+export { Field, renderField, useField, useFieldContextValues } from './components/Field/index';
 export type { FieldSlots, FieldProps, FieldState } from './components/Field/index';

--- a/packages/react-components/react-headless-components-preview/library/src/provider.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/provider.ts
@@ -1,2 +1,8 @@
-export { Provider, renderProvider, useProvider, useProviderContext } from './components/Provider/index';
+export {
+  Provider,
+  renderProvider,
+  useProvider,
+  useProviderContextValues,
+  useProviderContext,
+} from './components/Provider/index';
 export type { ProviderProps, ProviderState } from './components/Provider/index';

--- a/packages/react-components/react-headless-components-preview/library/src/rating-display.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/rating-display.ts
@@ -1,2 +1,7 @@
-export { RatingDisplay, renderRatingDisplay, useRatingDisplay } from './components/RatingDisplay';
+export {
+  RatingDisplay,
+  renderRatingDisplay,
+  useRatingDisplay,
+  useRatingDisplayContextValues,
+} from './components/RatingDisplay';
 export type { RatingDisplaySlots, RatingDisplayProps, RatingDisplayState } from './components/RatingDisplay';

--- a/packages/react-components/react-headless-components-preview/library/src/rating.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/rating.ts
@@ -5,6 +5,7 @@ export {
   Rating,
   renderRating,
   useRating,
+  useRatingContextValues,
 } from './components/Rating/index';
 export type {
   RatingItemSlots,

--- a/packages/react-components/react-headless-components-preview/library/src/tab-list.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/tab-list.ts
@@ -1,4 +1,12 @@
-export { Tab, renderTab, useTab, TabList, renderTabList, useTabList } from './components/TabList/index';
+export {
+  Tab,
+  renderTab,
+  useTab,
+  TabList,
+  renderTabList,
+  useTabList,
+  useTabListContextValues,
+} from './components/TabList/index';
 export type {
   TabSlots,
   TabValue,


### PR DESCRIPTION
## Description

This PR ensures that all headless components with render functions accepting context as the second parameter properly export their `useContextValues` hooks.

## Components Fixed

- **Dropdown** - export `useDropdownContextValues`
- **Provider** - export `useProviderContextValues`
- **Rating** - export `useRatingContextValues`
- **RatingDisplay** - export `useRatingDisplayContextValues`
- **Field** - export `useFieldContextValues`
- **TabList** - export `useTabListContextValues`
- **Accordion** components:
  - Accordion - export `useAccordionContextValues`
  - AccordionHeader - export `useAccordionHeaderContextValues`
  - AccordionItem - export `useAccordionItemContextValues`

## Why?

Components with render functions like `renderDropdown(state, contextValues)` require consumers to provide context values when calling the render function directly. These `useContextValues` hooks were already implemented but not exported, breaking the API contract for direct render function usage.

## Changes Made

- Added missing `useContextValues` exports at component-level index files
- Added missing `useContextValues` exports at package-level entry points
- No breaking changes to existing APIs