### PR TITLE
fix(react-headless-components-preview): add missing jsx-runtime dependency

### DIFF
--- a/change/@fluentui-react-headless-components-preview-jsx-runtime-dep.json
+++ b/change/@fluentui-react-headless-components-preview-jsx-runtime-dep.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: add missing @fluentui/react-jsx-runtime dependency",
+  "packageName": "@fluentui/react-headless-components-preview",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-headless-components-preview/library/package.json
+++ b/packages/react-components/react-headless-components-preview/library/package.json
@@ -34,6 +34,7 @@
     "@fluentui/react-field": "^9.5.2",
     "@fluentui/react-image": "^9.4.2",
     "@fluentui/react-input": "^9.8.3",
+    "@fluentui/react-jsx-runtime": "^9.4.3",
     "@fluentui/react-label": "^9.4.2",
     "@fluentui/react-link": "^9.8.2",
     "@fluentui/react-menu": "^9.25.0",


### PR DESCRIPTION
## Summary
- add missing @fluentui/react-jsx-runtime dependency in react-headless-components-preview library package
- include a beachball change file with patch bump type

## Changes
- packages/react-components/react-headless-components-preview/library/package.json
- change/@fluentui-react-headless-components-preview-jsx-runtime-dep.json

## Validation
- no code behavior changes; dependency declaration fix only