### PR TITLE
RFC: Bring the CAP visual language into Fluent UI v9

### DIFF
--- a/docs/react-v9/contributing/rfcs/react-components/convergence/cap-theme-in-fluent-v9.md
+++ b/docs/react-v9/contributing/rfcs/react-components/convergence/cap-theme-in-fluent-v9.md
@@ -66,18 +66,13 @@ That is the entire opt-in surface today.
 Because CAP is a styling layer over Fluent components, the direction of change is one-way:
 
 - Component APIs, slots, state fields, and structural primitives are owned by Fluent v9.
-- A CAP override hook can only re-style slots and consume state that the underlying Fluent component already exposes. When a CAP design requires something the component doesn't expose, the missing piece has to be added in `@fluentui/react-components` first — with the usual API review, change file, and version bump — and CAP then updates its override hook to use it.
+- A CAP override hook can only re-style slots and consume state that the underlying Fluent component already exposes. When a CAP design requires something the component doesn't expose, the missing piece has to be added in `@fluentui/react-components` first — with the usual API review, change file, and version bump — and CAP then updates its override hook to style it.
 - This RFC does not change that direction. It moves CAP closer to Fluent so the Fluent-side changes and the CAP-side follow-ups can be coordinated in the same repo, but Fluent stays the source of truth for component shape and CAP stays a pure consumer of those shapes.
-
-### Consumers
-
-- **Teams (current).** Teams CAP adoption is gated behind a feature flag in Teams: when the flag is enabled, Teams imports `TEAMS_STYLE_HOOKS` from `@fluentui-contrib/react-cap-theme` and passes it to the `customStyleHooks_unstable` prop of `FluentProvider`. `TEAMS_STYLE_HOOKS` itself is authored inside `@fluentui-contrib/react-cap-theme` (not in Teams) — it is layered on top of `CAP_STYLE_HOOKS` so that Teams overrides only the per-component hooks where it needs to differentiate from the CAP base.
-- **SharePoint (current, via wrappers).** SharePoint already integrates CAP, but through a different path than Teams: instead of importing `CAP_STYLE_HOOKS` and passing it to `customStyleHooks_unstable`, SharePoint maintains its own layer of wrapper components that re-export the Fluent v9 components with the CAP look pre-applied. We are planning with the SharePoint team to migrate them off this in-house wrapper layer. Two shapes are on the table: (a) SharePoint consumes Fluent components directly and applies `CAP_STYLE_HOOKS` through `customStyleHooks_unstable` (the Teams pattern), or (b) the wrapper components themselves move into the CAP package and SharePoint imports them from there.
 
 ## Goals
 
 1. Eliminate the `@fluentui-contrib/*` install requirement for CAP consumers.
-2. Make CAP discoverable and try-able from `react.fluentui.dev`.
+2. Make CAP discoverable and try-able from main documentation site in `https://storybooks.fluentui.dev/react`.
 3. Preserve bundle-size invariants for consumers who don't opt in to CAP.
 4. **Position CAP for potential graduation into the default Fluent visual language.** If a future direction is for CAP to _become_ Fluent v9's baseline look (rather than remain an opt-in overlay), having CAP already authored, released, and CI-gated inside `@fluentui/react-components` turns that transition into an easier step than starting from a separate repo: the override hooks already live next to the components they re-skin, the bundle-size and VR baselines are already established against the rest of v9, and the consumer-facing import path does not have to change. The work proposed here is the same work either way; co-location just preserves the optionality.
 
@@ -183,7 +178,7 @@ The goal is to give CAP a single, central place where anyone — designers, part
 
 Proposed UX (subject to docs-site team input — see [open questions](#open-questions-for-engineering-review)):
 
-- A **visual-language toggle** in the existing theme picker toolbar, **separate from the theme dropdown** (which today switches between web / teams / high-contrast / light / dark). Toggle positions: `Fluent` | `CAP`.
+- A **visual-language toggle** added to the existing theme picker toolbar, **separate from the theme dropdown** (which today switches between `webLightTheme`, `webDarkTheme`, `teamsLightTheme`, `teamsDarkTheme`, `teamsLightV21Theme`, `teamsDarkV21Theme`, and `teamsHighContrastTheme`). The toggle switches between `Fluent` and `CAP` and layers on top of whichever base theme is selected in the dropdown.
 - Toggle state is read by the docs-site's top-level `<FluentProvider>` wrapper. When `CAP` is selected, the wrapper passes `CAP_STYLE_HOOKS` to `customStyleHooks_unstable`.
 - Every component page renders with the toggle applied, so a consumer evaluating CAP can browse `<Button>`, `<Card>`, `<Menu>`, etc., in CAP without leaving the page. Visual regression of the docs-site against both toggle states should be added to the existing `vr-tests-react-components` matrix to catch CAP regressions.
 - The same toggle is also available in the local Storybook dev environment. When a CAP author is implementing or tweaking an override hook, they can switch the story between `Fluent` and `CAP` in the same browser window — without rebuilding, without spinning up a separate CAP-only preview app, and against the exact local Fluent component code they're editing.
@@ -192,7 +187,7 @@ A working prototype of this toggle is up for review at [microsoft/fluentui#36308
 
 ## Open questions for engineering review
 
-This section lists the decisions the author needs from Fluent v9 engineering.
+This section lists the open decisions and feedback the author needs from Fluent v9 engineering before this RFC can move forward.
 
 1. **Which distribution shape should the new in-repo package adopt?** See [Distribution shape — considered alternatives](#distribution-shape--considered-alternatives) for the three candidates: `@fluentui/react-cap-theme` (separate stable package), `@fluentui/react-cap-theme-preview` (separate preview package), or `@fluentui/react-components/cap` (suite subpath).
 2. **Docs-site toggle UX.** Does the docs-site team agree with the toolbar-toggle design described above?

--- a/docs/react-v9/contributing/rfcs/react-components/convergence/cap-theme-in-fluent-v9.md
+++ b/docs/react-v9/contributing/rfcs/react-components/convergence/cap-theme-in-fluent-v9.md
@@ -4,24 +4,48 @@
 
 _Contributors: (author: Enrico Gianoglio)_
 
+> **Status — request for engineering review.** This RFC proposes making the CAP visual language a part of `@fluentui/react-components`. Phase 1 has been prototyped end-to-end and the bundle-size impact has been measured against live monosize fixtures (see [Bundle-size analysis](#bundle-size-analysis)). Phases 2–3 still need owner and timeline commitment from the Fluent v9 team and the `fluentui-contrib` maintainers. **Open questions** for reviewers are collected at the end of the document.
+
 ## Summary
 
 Make the **CAP visual language** a first-class part of Fluent UI v9 so that:
 
 1. A consumer of Fluent v9 can opt in to CAP **without installing any separate package** (no `@fluentui-contrib/*` dependency).
-2. All future CAP work happens inside the Fluent v9 repo, on the Fluent release cadence, with the same CI guarantees (bundle size, conformance, VR) as the rest of v9.
+2. All future CAP work happens inside the Fluent v9 repo, on the Fluent release cadence, with the same CI guarantees (bundle size, conformance, VR, a11y) as the rest of v9.
 3. CAP is discoverable and try-able directly on https://react.fluentui.dev/ — as a **visual-language toggle** that overlays the currently-selected base theme (web / teams / high-contrast / light / dark), _not_ as additional entries in the theme dropdown.
-4. Consumers who already pass their own `customStyleHooks_unstable` (brand overrides, internal design systems built on Fluent) can adopt CAP **without losing their overrides**. See [Phase 3 — `composeStyleHooks` helper](#phase-3--composestylehooks-helper).
 
-The change is small because the consumer-facing primitive already exists: `FluentProvider` accepts a `customStyleHooks_unstable` prop today and CAP is just a value to pass to it. We propose shipping that value (`CAP_STYLE_HOOKS`) from `@fluentui/react-components`, wiring it into the docs site as a toggle, moving the source into the Fluent v9 monorepo, and adding a small public helper (`composeStyleHooks`) so consumers can layer CAP on top of their own overrides.
+The change is small because the consumer-facing primitive already exists: `FluentProvider` accepts a `customStyleHooks_unstable` prop today and CAP is just a value to pass to it. We propose shipping that value (`CAP_STYLE_HOOKS`) from `@fluentui/react-components`, wiring it into the docs site as a toggle, and moving the source into the Fluent v9 monorepo.
 
-## Background
+## Why — motivation and benefits
 
-### What CAP is
+### The problem in one sentence
+
+> "We should try to get off this island of working in FluentUI Contrib so that the CAP theme becomes synonymous with Fluent and not a separate entity."
+
+### Concrete pain caused by the current arrangement
+
+CAP today exists as `@fluentui-contrib/react-cap-theme`. That arrangement actively works against adoption and against Fluent's own goals.
+
+- **Discovery.** A team browsing `react.fluentui.dev` cannot find CAP. CAP isn't a theme in the theme picker, isn't documented on the same site, and isn't surfaced anywhere in the suite's README or API docs. The only way to learn that CAP exists is to be told.
+- **Install friction.** Adopting CAP requires adding a `@fluentui-contrib/*` line to `package.json`. For internal Microsoft consumers this is read as "third-party / experimental" by reviewers and security audits, even though the underlying code overrides Fluent components themselves.
+- **Release cadence drift.** CAP releases are decoupled from Fluent's pipeline. Bundle-size, VR, conformance and a11y CI in Fluent v9 do not gate CAP changes against the components CAP overrides. A breaking change to a Fluent component slot can silently invalidate the matching CAP override hook until a CAP consumer notices visually.
+- **Harder to act on CAP's API needs.** When CAP needs something Fluent doesn't expose today (an additional slot, a richer state field, a render-prop hook), having CAP and the components in the same repo makes those needs much easier to see, discuss, and address — the gap, the component, and the override sit next to each other.
+- **Ecosystem signal.** As long as CAP lives in `fluentui-contrib`, the implicit message is "CAP is one of many community experiments."
+
+### Benefits of bringing CAP into v9
+
+- **Zero-install adoption.** `import { CAP_STYLE_HOOKS } from '@fluentui/react-components'` — no new package, no `package.json` change beyond what teams already have.
+- **One source of truth.** CAP overrides live next to the components they override. PRs touching, e.g., `<Button>` slots can include the matching CAP hook update in the same change, reviewed by the same owners, gated by the same VR.
+- **Aligned release cadence.** CAP rides the Fluent v9 release train. Every Fluent minor that ships includes a CAP version that has already been validated against the components in that minor.
+- **CI parity.** Bundle-size budgets, conformance, accessibility, and visual regression run against CAP the same way they run against every other v9 package. Regressions surface in the PR that introduces them, not weeks later when a consumer files a bug.
+- **First-class discovery.** Docs site shows CAP as a visual-language toggle. Anyone evaluating Fluent for a new product sees CAP in the same flow they choose between web / teams / light / dark.
+- **No re-architecture for consumers.** Phase 1 is purely additive; existing CAP consumers (those who installed `@fluentui-contrib/react-cap-theme` directly) keep working unchanged through Phase 3.
+
+## Background — what CAP is
 
 CAP is a **visual-language overlay** — a set of style decisions (border-radius, spacing, hover/focus treatment, etc.) that re-skin a subset of Fluent v9 components.
 
-CAP **is**:
+CAP today **is**:
 
 - A single value: `CAP_STYLE_HOOKS`, a map matching `FluentProviderCustomStyleHooks`.
 - Composed of per-component override hooks across Fluent component packages.
@@ -36,59 +60,41 @@ import { CAP_STYLE_HOOKS } from '@fluentui-contrib/react-cap-theme';
 </FluentProvider>;
 ```
 
-That is the entire opt-in surface today.
+That is the entire opt-in surface today. `@fluentui-contrib/react-cap-theme` also ships a sibling map `TEAMS_STYLE_HOOKS`: rather than re-implementing styles from scratch, Teams layers **product-specific overrides on top of the CAP base hooks** as their own `PRODUCT_STYLE_HOOKS` map. Products consume CAP as a foundation and override only the per-component hooks they need to differentiate, instead of forking the entire visual language.
 
-A sibling map `TEAMS_STYLE_HOOKS` is shipped from the same package and follows the same pattern.
+CAP **is not**:
 
-### Where CAP lives today and why that hurts
+- A separate provider. There is no `<CapProvider>`. CAP rides on `FluentProvider`'s existing prop.
+- A runtime style engine. CAP overrides use Griffel `makeStyles()` and are extracted to atomic CSS at build time, like every other v9 component.
 
-`CAP_STYLE_HOOKS` is published from `@fluentui-contrib/react-cap-theme`. Consequences:
+## Goals and non-goals
 
-- CAP is perceived as a third-party theme rather than a peer of `webLightTheme` / `teamsLightTheme`.
-- It is not selectable from the Fluent v9 docs, so adoption requires extra discovery.
-- Product teams must add a non-Fluent package to `package.json` just to access one exported value.
-- Every API gap forces a fork (an override hook in contrib) instead of an upstream contribution that benefits all Fluent users.
-- CAP releases are decoupled from Fluent's release pipeline; bundle-size and VR signals don't gate CAP changes against the Fluent components they override.
+**Goals**
 
-## Problem statement
+1. Eliminate the `@fluentui-contrib/*` install requirement for CAP consumers.
+2. Give the Fluent v9 team ownership of CAP source, releases, and CI.
+3. Make CAP discoverable and try-able from `react.fluentui.dev`.
+4. Preserve bundle-size invariants for consumers who don't opt in to CAP.
+5. **Position CAP for potential graduation into the default Fluent visual language.** If a future direction is for CAP to _become_ Fluent v9's baseline look (rather than remain an opt-in overlay), having CAP already authored, released, and CI-gated inside `@fluentui/react-components` turns that transition into a configuration change — flip the suite's default styles to consume the CAP hooks internally — rather than a migration with a new package, a new install, and a consumer rename. The work proposed here is the same work either way; only the eventual default differs.
 
-> "We should try to get off this island of working in FluentUI Contrib so that the CAP theme becomes synonymous with Fluent and not a separate entity."
+## Proposal — phased approach
 
-Three things must change:
+| Phase                             | Goal                                                                                                                                                                                | Risk                            |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| **1. Re-export from Fluent v9**   | `@fluentui/react-components` internally depends on `@fluentui-contrib/react-cap-theme` and re-exports `CAP_STYLE_HOOKS`. Products import CAP from Fluent. Docs site shows a toggle. | Low — additive only.            |
+| **2. Move source into Fluent v9** | New `packages/react-components/react-cap-theme/` package in the Fluent monorepo. Contrib package becomes a deprecated shim re-exporting from Fluent.                                | Medium — coordinated migration. |
+| **3. Deprecate contrib package**  | Mark `@fluentui-contrib/react-cap-theme` deprecated on npm after one Fluent minor cycle.                                                                                            | Low.                            |
 
-1. **Consumer install surface.** A product team opting in to CAP should not see `@fluentui-contrib/*` in their `package.json`. CAP should be reachable from the package they already have.
-2. **Development location.** New CAP override hooks (and any related Fluent component extensions) should be authored and reviewed inside the Fluent v9 repo, with the same CI as the rest of v9.
+### Phase 1 — re-export contrib from Fluent v9
 
-The proposal must also avoid:
-
-- Regressing bundle size for consumers who don't opt in to CAP.
-- Forcing every CAP consumer to rewrite provider plumbing.
-- Coupling brand-specific knowledge into base primitives like `FluentProvider`.
-
-## Detailed Design or Proposal
-
-### Phased approach
-
-| Phase                                  | Goal                                                                                                                                                                                | Risk                            |
-| -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
-| **1. Re-export from Fluent v9**        | `@fluentui/react-components` internally depends on `@fluentui-contrib/react-cap-theme` and re-exports `CAP_STYLE_HOOKS`. Products import CAP from Fluent. Docs site shows a toggle. | Low — additive only.            |
-| **2. Move source into Fluent v9**      | New `packages/react-components/react-cap-theme/` package in the Fluent monorepo. Contrib package becomes a deprecated shim re-exporting from Fluent.                                | Medium — coordinated migration. |
-| **3. Ship `composeStyleHooks` helper** | Public utility for layering multiple style-hook maps (consumer brand + CAP).                                                                                                        | Low.                            |
-| **4. Deprecate contrib package**       | Mark `@fluentui-contrib/react-cap-theme` deprecated on npm after one Fluent minor cycle.                                                                                            | Low.                            |
-
-### Phase 1 — Re-export contrib from Fluent v9
-
-`@fluentui/react-components` adds `@fluentui-contrib/react-cap-theme` as an internal dependency and re-exports the hooks map:
+`@fluentui/react-components` adds `@fluentui-contrib/react-cap-theme` as an internal dependency and re-exports the hooks map from `src/index.ts`:
 
 ```ts
 // packages/react-components/react-components/src/index.ts
 export { CAP_STYLE_HOOKS } from '@fluentui-contrib/react-cap-theme';
-// (and TEAMS_STYLE_HOOKS, if Fluent also wants to surface it)
 ```
 
-That's the entire Phase 1 change to the public API.
-
-Result for the product team:
+That is the entire Phase 1 change to the public API. Result for the product team:
 
 ```bash
 # what they already have
@@ -104,13 +110,13 @@ import { FluentProvider, webLightTheme, CAP_STYLE_HOOKS } from '@fluentui/react-
 </FluentProvider>;
 ```
 
-No `@fluentui-contrib/*` in `package.json`. The contrib dependency is an internal implementation detail.
+No `@fluentui-contrib/*` in `package.json`. The contrib dependency is an internal implementation detail. The bundle-size cost of this re-export is documented empirically in [Bundle-size analysis](#bundle-size-analysis); the headline result is **0 bytes for tree-shakable named-import consumers**.
 
 #### Why no `CapProvider` wrapper
 
 Earlier drafts proposed a `<CapProvider>` component. Rejected: `FluentProvider` already has a first-class `customStyleHooks_unstable` prop. Adding a second provider component would duplicate the prop, force existing `<FluentProvider>` users to swap to a different component just to opt in, and complicate library code that wraps `<FluentProvider>` internally. The simpler answer is "expose the value and let consumers pass it to the prop they already use."
 
-### Phase 2 — Move source into Fluent v9
+### Phase 2 — move source into Fluent v9
 
 Create a new sibling package:
 
@@ -139,63 +145,87 @@ The folder structure mirrors today's contrib source layout.
 export { CAP_STYLE_HOOKS } from '@fluentui/react-cap-theme';
 ```
 
-### Phase 3 — `composeStyleHooks` helper
+## Phase 3 — deprecation of `@fluentui-contrib/react-cap-theme`
 
-**This is the answer to the most common product-team blocker.** Today, `customStyleHooks_unstable` is a single map and assigning it replaces whatever was there. A product team that already does this:
+`@fluentui-contrib/react-cap-theme` is currently consumed by Teams behind a feature flag, so deprecation needs to be coordinated with that rollout rather than rushed. After one Fluent v9 minor cycle with `@fluentui/react-cap-theme` as the source of truth — and once Teams has migrated its import path to `@fluentui/react-components` — ship a final contrib release that adds the npm `"deprecated"` field pointing at `@fluentui/react-components` and stop accepting new feature PRs against it.
 
-```tsx
-const productHooks = {
-  useButtonStyles_unstable: useBrandedButtonStyles,
-  useInputStyles_unstable: useBrandedInputStyles,
-};
+## Distribution shape — considered alternatives
 
-<FluentProvider customStyleHooks_unstable={productHooks}>
+Three import shapes were considered for shipping `CAP_STYLE_HOOKS` to consumers:
+
+- **Option A — main-barrel re-export** (`import { CAP_STYLE_HOOKS } from '@fluentui/react-components'`). Best discoverability, zero install surface, one extra `export` line in the suite. Tree-shaking holds for named imports (0 bytes); the only cost is +15.8 kB gzipped for `import *` consumers, which is a discouraged pattern with no evidence of real-world use.
+- **Option B — subpath export** (`import { CAP_STYLE_HOOKS } from '@fluentui/react-components/cap'`). Goes against an explicit repo policy: the suite's only existing subpath, `@fluentui/react-components/unstable`, is **already deprecated** with a banner that forbids new exports, directing preview/unstable APIs to ship as `*-preview` packages instead (see [`src/unstable/index.ts`](https://github.com/microsoft/fluentui/blob/master/packages/react-components/react-components/src/unstable/index.ts)). Adding a second subpath for CAP would re-introduce exactly the pattern the team is moving away from.
+- **Option C — separate package** (`@fluentui/react-cap-theme-preview`, no re-export). Solves ownership and CI but re-introduces the extra-package install and keeps the discoverability problem CAP has today.
+
+### Decision
+
+**Phase 1 ships Option A.** The +15.8 kB gzipped cost only materializes on `import *`, and the discoverability + zero-install win is exactly what the RFC sets out to deliver.
+
+## Bundle-size analysis
+
+The claim of Phase 1 was verified against the live monosize fixtures of `@fluentui/react-components` by a clean before/after comparison.
+
+### Methodology
+
+- Both runs used `yarn nx run react-components:build --skip-nx-cache` → forced fresh transpile of all 71 tasks (suite + dependencies).
+- `lib/index.js` and `lib-commonjs/index.js` SHA-256 hashes were captured between runs and verified to differ — the only source change being the `export { CAP_STYLE_HOOKS }` line being toggled on/off.
+- Bundle measurement was run via `yarn monosize measure` directly from the suite directory — bypasses Nx cache entirely; webpack recompiles all 4 fixtures from scratch on each invocation.
+- After the experiment, `lib/` hashes were verified to match the original WITH-CAP state byte-for-byte and the auto-generated `etc/react-components.api.md` was restored via `git checkout --`.
+
+### Results — re-export cost (with vs without)
+
+| Fixture                                            | WITH CAP re-exported (min / gz) | WITHOUT CAP re-exported (min / gz) |      Δ min |         Δ gz |
+| -------------------------------------------------- | ------------------------------: | ---------------------------------: | ---------: | -----------: |
+| `Button + FluentProvider + webLightTheme`          |            66.328 kB / 19.02 kB |               66.328 kB / 19.02 kB |      **0** |        **0** |
+| `Accordion + Button + FP + Image + Menu + Popover` |           226.19 kB / 67.909 kB |              226.19 kB / 67.909 kB |      **0** |        **0** |
+| `FluentProvider + webLightTheme`                   |           39.525 kB / 13.113 kB |              39.525 kB / 13.113 kB |      **0** |        **0** |
+| `entire library` (`import *`)                      |           1.389 MB / 341.137 kB |              1.295 MB / 325.342 kB | **−94 kB** | **−15.8 kB** |
+
+### Results — actual usage cost (when CAP is imported)
+
+A separate sanity run measured the cost when a fixture **actively imports** `CAP_STYLE_HOOKS` (not just when CAP is reachable through the barrel):
+
+| Fixture                                   | Without `CAP_STYLE_HOOKS` import (min / gz) | With `CAP_STYLE_HOOKS` import (min / gz) |                      Δ |
+| ----------------------------------------- | ------------------------------------------: | ---------------------------------------: | ---------------------: |
+| `Button + FluentProvider + webLightTheme` |                        66.328 kB / 19.02 kB |                   218.595 kB / 55.266 kB | +152.27 kB / +36.25 kB |
+
+CAP statically imports per-component override modules from ≈20 Fluent component packages (Accordion, Avatar, Badge, Button, Card, Carousel, Checkbox, Combobox, Dialog, Drawer, Image, Input, Label, Link, Menu, Popover, Search, Tabs, Tags, TeachingPopover, Toolbar, Tooltip). When a consumer actually uses CAP, they pay for that graph — that's the cost of the visual language, not of the re-export pattern.
+
+### Why tree-shaking holds
+
+- `@fluentui-contrib/react-cap-theme@0.4.2` declares `"sideEffects": false` in its `package.json`.
+- Its `makeStyles()` calls are Griffel-extracted at build time into atomic CSS in `lib/`. There is no runtime style-engine import path that the bundler can't follow statically.
+- The re-export is a pure `export { … } from …` (no side-effecting `import`).
+
+### Verifying locally
+
+For reviewers who want to reproduce the tables above:
+
+```bash
+# from repo root
+cd packages/react-components/react-components
+yarn monosize measure      # direct invocation bypasses Nx cache
 ```
 
-…cannot opt in to CAP without **losing their own overrides**.
+To measure "without CAP": comment out the `export { CAP_STYLE_HOOKS }` line in the suite's `src/index.ts`, run `yarn nx run react-components:build --skip-nx-cache` (forces a fresh `lib/`), then run `yarn monosize measure` again. Restore by uncommenting and re-running build, then `git checkout -- packages/react-components/react-components/etc/react-components.api.md` (the auto-generated API report regenerates on every build).
 
-Ship a tiny composition utility:
+## Docs-site UX
 
-```ts
-// packages/react-components/react-provider/library/src/utils/composeStyleHooks.ts
-import type { FluentProviderCustomStyleHooks } from '../components/FluentProvider/FluentProvider.types';
+The goal is that someone landing on https://react.fluentui.dev/ can try CAP in one click, without changing imports or installing anything.
 
-/**
- * Combine multiple custom-style-hook maps into one. For each component, every
- * matching hook runs in order; later hooks see the state mutated by earlier
- * hooks. Conflicting className writes resolve by Griffel's `mergeClasses`
- * rule (rightmost class wins on the same CSS rule).
- *
- * Typical usage: layer CAP on top of a consumer's brand overrides.
- */
-export function composeStyleHooks(
-  ...maps: ReadonlyArray<FluentProviderCustomStyleHooks | undefined>
-): FluentProviderCustomStyleHooks {
-  const defined = maps.filter((m): m is FluentProviderCustomStyleHooks => Boolean(m));
-  const keys = new Set(defined.flatMap(Object.keys));
-  const out: Record<string, (state: unknown) => void> = {};
+Proposed UX (subject to docs-site team input — see [open questions](#open-questions-for-engineering-review)):
 
-  for (const key of keys) {
-    const hooks = defined.map(m => (m as Record<string, unknown>)[key]).filter(Boolean) as Array<(s: unknown) => void>;
-    out[key] = state => {
-      for (const h of hooks) h(state);
-    };
-  }
+- A **visual-language toggle** in the existing theme picker toolbar, **separate from the theme dropdown** (which today switches between web / teams / high-contrast / light / dark). Toggle positions: `Default` | `CAP`. Default off.
+- Toggle state is read by the docs-site's top-level `<FluentProvider>` wrapper. When `CAP` is selected, the wrapper passes `CAP_STYLE_HOOKS` to `customStyleHooks_unstable`.
+- Every component page renders with the toggle applied, so a consumer evaluating CAP can browse `<Button>`, `<Card>`, `<Menu>`, etc., in CAP without leaving the page. Visual regression of the docs-site against both toggle states should be added to the existing `vr-tests-react-components` matrix to catch CAP regressions.
 
-  return out as FluentProviderCustomStyleHooks;
-}
-```
+A working prototype of this toggle is up for review at [microsoft/fluentui#36308](https://github.com/microsoft/fluentui/pull/36308).
 
-Re-exported from `@fluentui/react-components`. Usage:
+## Open questions for engineering review
 
-```tsx
-import { FluentProvider, webLightTheme, CAP_STYLE_HOOKS, composeStyleHooks } from '@fluentui/react-components';
+This section lists the decisions the author needs from Fluent v9 engineering, docs-site engineering. Inline answers welcome via PR comment.
 
-const productHooks = {
-  useButtonStyles_unstable: useBrandedButtonStyles,
-};
-
-<FluentProvider theme={webLightTheme} customStyleHooks_unstable={composeStyleHooks(productHooks, CAP_STYLE_HOOKS)}>
-  <App />
-</FluentProvider>;
-```
+1. **Skip Phase 1 entirely?** Phase 1 (suite re-exports from contrib while contrib remains the source of truth) is a transitional step that ships zero-install + the docs-site toggle one release earlier, but doesn't actually solve the ownership / CI-gating / release-cadence problems the RFC's "Why" section lists — those all require Phase 2. Should we collapse Phase 1 and Phase 2 into a single move: introduce `@fluentui/react-cap-theme-preview` (or `@fluentui/react-cap-theme`) directly in the monorepo, suite re-exports `CAP_STYLE_HOOKS` from it, contrib becomes a deprecated shim re-exporting from the new package — all in one Fluent minor? Trade-off: collapses two ship vehicles into one and avoids the awkward "contrib is source, suite re-exports" intermediate state, at the cost of front-loading the migration mechanics (CODEOWNERS, git history, package shape, executors, CI surface). Phase 1 makes more sense if Phase 2 ownership is uncertain or migration mechanics need negotiation; skip-Phase-1 makes more sense if those are resolvable up front.
+2. **Distribution shape — confirm Option A.** Does Fluent v9 engineering agree with the main-barrel re-export (`import { CAP_STYLE_HOOKS } from '@fluentui/react-components'`) over a subpath (`import { CAP_STYLE_HOOKS } from '@fluentui/react-components/cap'`) or a separate preview package (`import { CAP_STYLE_HOOKS } from '@fluentui/react-cap-theme-preview'`)? The bundle-size data argues for Option A, but the trade-off table is ultimately a judgement call about future-proofing — see [Distribution shape — considered alternatives](#distribution-shape--considered-alternatives).
+3. **Phase 1 ship vehicle.** Can Phase 1 (a single re-export line plus a `dependencies` entry) ship in the next Fluent v9 minor release, or does it need to wait for Phase 2 to land first?
+4. **Docs-site toggle UX.** Does the docs-site team agree with the toolbar-toggle design described above?

--- a/docs/react-v9/contributing/rfcs/react-components/convergence/cap-theme-in-fluent-v9.md
+++ b/docs/react-v9/contributing/rfcs/react-components/convergence/cap-theme-in-fluent-v9.md
@@ -84,9 +84,9 @@ Because CAP is a styling layer over Fluent components, the direction of change i
 ## Proposal — phased approach
 
 | Phase                             | Goal                                                                                                                                                                                |
-| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --- |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **1. Re-export from Fluent v9**   | `@fluentui/react-components` internally depends on `@fluentui-contrib/react-cap-theme` and re-exports `CAP_STYLE_HOOKS`. Products import CAP from Fluent. Docs site shows a toggle. |
-| **2. Move source into Fluent v9** | New `packages/react-components/react-cap-theme/` package in the Fluent monorepo. Contrib package becomes a deprecated shim re-exporting from Fluent.                                |     |
+| **2. Move source into Fluent v9** | New `packages/react-components/react-cap-theme/` package in the Fluent monorepo. Contrib package becomes a deprecated shim re-exporting from Fluent.                                |
 
 ### Phase 1 — re-export contrib from Fluent v9
 

--- a/docs/react-v9/contributing/rfcs/react-components/convergence/cap-theme-in-fluent-v9.md
+++ b/docs/react-v9/contributing/rfcs/react-components/convergence/cap-theme-in-fluent-v9.md
@@ -4,7 +4,7 @@
 
 _Contributors: (author: Enrico Gianoglio)_
 
-> **Status — request for engineering review.** This RFC proposes making the CAP visual language a part of `@fluentui/react-components`. Phase 1 has been prototyped end-to-end and the bundle-size impact has been measured against live monosize fixtures (see [Bundle-size analysis](#bundle-size-analysis)). Phases 2–3 still need owner and timeline commitment from the Fluent v9 team and the `fluentui-contrib` maintainers. **Open questions** for reviewers are collected at the end of the document.
+> **Status — request for engineering review.** This RFC proposes making the CAP visual language a part of `@fluentui/react-components`. Phase 1 has been prototyped end-to-end and the bundle-size impact has been measured against live monosize fixtures (see [Bundle-size analysis](#bundle-size-analysis)).
 
 ## Summary
 

--- a/docs/react-v9/contributing/rfcs/react-components/convergence/cap-theme-in-fluent-v9.md
+++ b/docs/react-v9/contributing/rfcs/react-components/convergence/cap-theme-in-fluent-v9.md
@@ -24,12 +24,11 @@ The change is small because the consumer-facing primitive already exists: `Fluen
 
 ### Concrete pain caused by the current arrangement
 
-CAP today exists as `@fluentui-contrib/react-cap-theme`. Starting CAP in `fluentui-contrib` made sense at the time: it let the visual language be prototyped and iterated on quickly, outside Fluent's release cadence and CI surface, without committing the Fluent v9 team to ownership before the shape of CAP had settled. CAP is not "done" yet — the API surface is still evolving — but it has reached a point where its overall shape, its consumer story (Teams), and its potential trajectory toward Fluent's default look are taking form. The costs of keeping it in contrib now actively work against adoption.
+CAP today exists as `@fluentui-contrib/react-cap-theme`. Starting CAP in `fluentui-contrib` made sense at the time: it let the visual language be prototyped and iterated on quickly, outside Fluent's release cadence and CI surface, without committing the Fluent v9 team to ownership before the shape of CAP had settled. CAP is not "done" yet — the API surface is still evolving — but it has reached a point where its overall shape and its consumer story (Teams) are taking form. The costs of keeping it in contrib now actively work against adoption.
 
 - **Discovery.** CAP is technically documented on `react.fluentui.dev`, but only under the `Contributors Packages` section — it's not surfaced in the suite's README, in the API docs, or anywhere in the main browsing flow. A team evaluating Fluent for a new product is unlikely to find CAP unless someone tells them where to look.
 - **Install friction.** Adopting CAP requires adding a `@fluentui-contrib/*` line to `package.json`. For internal Microsoft consumers this is read as "third-party / experimental" by reviewers and security audits, even though the underlying code overrides Fluent components themselves.
-- **Release cadence drift.** CAP releases are decoupled from Fluent's pipeline. Bundle-size, VR, conformance and a11y CI in Fluent v9 do not gate CAP changes against the components CAP overrides. A breaking change to a Fluent component slot can silently invalidate the matching CAP override hook until a CAP consumer notices visually.
-- **Harder to act on CAP's API needs.** When CAP needs something Fluent doesn't expose today (an additional slot, a richer state field, a render-prop hook), having CAP and the components in the same repo makes those needs much easier to see, discuss, and address — the gap, the component, and the override sit next to each other.
+- **Surfacing CAP's needs from Fluent.** CAP can only override what Fluent components already expose. When a CAP override needs an additional slot, a richer state field, or a render-prop hook that doesn't exist yet, that's a Fluent change — it has to land in `@fluentui/react-components` first, and CAP catches up afterwards. Today, with CAP in a separate repo, that gap is harder to spot, harder to discuss with the component owner, and harder to land in lockstep. With CAP in the Fluent monorepo, the missing API, the component, and the override hook all sit next to each other and can be addressed in a single PR reviewed by the same owners.
 - **Ecosystem signal.** As long as CAP lives in `fluentui-contrib`, the implicit message is "CAP is one of many community experiments."
 
 ### Benefits of bringing CAP into v9
@@ -39,17 +38,17 @@ CAP today exists as `@fluentui-contrib/react-cap-theme`. Starting CAP in `fluent
 - **Aligned release cadence.** CAP rides the Fluent v9 release train. Every Fluent minor that ships includes a CAP version that has already been validated against the components in that minor.
 - **CI parity.** Bundle-size budgets, conformance, accessibility, and visual regression run against CAP the same way they run against every other v9 package. Regressions surface in the PR that introduces them, not weeks later when a consumer files a bug.
 - **First-class discovery.** Docs site shows CAP as a visual-language toggle.
-- **No re-architecture for consumers.** Phase 1 is purely additive; existing CAP consumers (those who installed `@fluentui-contrib/react-cap-theme` directly) keep working unchanged through Phase 3.
 
 ## Background — what CAP is
 
-CAP is a **visual-language overlay** — a set of style decisions (border-radius, spacing, hover/focus treatment, etc.) that re-skin a subset of Fluent v9 components.
+CAP is a set of **custom style hooks** that re-skin a subset of Fluent v9 components. It is implemented entirely through Fluent v9's existing `customStyleHooks_unstable` extension point on `FluentProvider`.
 
-CAP today **is**:
+Concretely, `@fluentui-contrib/react-cap-theme` exports two values:
 
-- A single value: `CAP_STYLE_HOOKS`, a map matching `FluentProviderCustomStyleHooks`.
-- Composed of per-component override hooks across Fluent component packages.
-- Activated by passing it to the existing `customStyleHooks_unstable` prop on `FluentProvider`:
+- `CAP_STYLE_HOOKS` — a map matching `FluentProviderCustomStyleHooks`, with per-component override hooks for the Fluent components CAP re-skins today: `react-accordion`, `react-avatar`, `react-badge`, `react-button`, `react-card`, `react-carousel`, `react-checkbox`, `react-combobox`, `react-dialog`, `react-drawer`, `react-image`, `react-input`, `react-label`, `react-link`, `react-menu`, `react-popover`, `react-search`, `react-tabs`, `react-tags`, `react-teaching-popover`, `react-toolbar`, `react-tooltip`.
+- `TEAMS_STYLE_HOOKS` — the same shape, layered on top of `CAP_STYLE_HOOKS` to add Teams-product-specific overrides without re-implementing the CAP base.
+
+It is activated by passing the map to the existing `customStyleHooks_unstable` prop on `FluentProvider`:
 
 ```tsx
 import { FluentProvider, webLightTheme } from '@fluentui/react-components';
@@ -60,23 +59,34 @@ import { CAP_STYLE_HOOKS } from '@fluentui-contrib/react-cap-theme';
 </FluentProvider>;
 ```
 
-That is the entire opt-in surface today. `@fluentui-contrib/react-cap-theme` also ships a sibling map `TEAMS_STYLE_HOOKS`: rather than re-implementing styles from scratch, Teams layers **product-specific overrides on top of the CAP base hooks** as their own `PRODUCT_STYLE_HOOKS` map. Products consume CAP as a foundation and override only the per-component hooks they need to differentiate, instead of forking the entire visual language.
+That is the entire opt-in surface today.
+
+### Direction of dependency: Fluent first, then CAP
+
+Because CAP is a styling layer over Fluent components, the direction of change is one-way:
+
+- Component APIs, slots, state fields, and structural primitives are owned by Fluent v9.
+- A CAP override hook can only re-style slots and consume state that the underlying Fluent component already exposes. When a CAP design requires something the component doesn't expose, the missing piece has to be added in `@fluentui/react-components` first — with the usual API review, change file, and version bump — and CAP then updates its override hook to use it.
+- This RFC does not change that direction. It moves CAP closer to Fluent so the Fluent-side changes and the CAP-side follow-ups can be coordinated in the same repo, but Fluent stays the source of truth for component shape and CAP stays a pure consumer of those shapes.
+
+### Consumers
+
+- **Teams (current).** Teams CAP adoption is gated behind a feature flag in Teams: when the flag is enabled, Teams imports `TEAMS_STYLE_HOOKS` from `@fluentui-contrib/react-cap-theme` and passes it to the `customStyleHooks_unstable` prop of `FluentProvider`. `TEAMS_STYLE_HOOKS` itself is authored inside `@fluentui-contrib/react-cap-theme` (not in Teams) — it is layered on top of `CAP_STYLE_HOOKS` so that Teams overrides only the per-component hooks where it needs to differentiate from the CAP base.
+- **SharePoint (current, via wrappers).** SharePoint already integrates CAP, but through a different path than Teams: instead of importing `CAP_STYLE_HOOKS` and passing it to `customStyleHooks_unstable`, SharePoint maintains its own layer of wrapper components that re-export the Fluent v9 components with the CAP look pre-applied. We are planning with the SharePoint team to migrate them off this in-house wrapper layer. Two shapes are on the table: (a) SharePoint consumes Fluent components directly and applies `CAP_STYLE_HOOKS` through `customStyleHooks_unstable` (the Teams pattern), or (b) the wrapper components themselves move into the CAP package and SharePoint imports them from there.
 
 ## Goals
 
 1. Eliminate the `@fluentui-contrib/*` install requirement for CAP consumers.
-2. Give the Fluent v9 team ownership of CAP source, releases, and CI.
-3. Make CAP discoverable and try-able from `react.fluentui.dev`.
-4. Preserve bundle-size invariants for consumers who don't opt in to CAP.
-5. **Position CAP for potential graduation into the default Fluent visual language.** If a future direction is for CAP to _become_ Fluent v9's baseline look (rather than remain an opt-in overlay), having CAP already authored, released, and CI-gated inside `@fluentui/react-components` turns that transition into a configuration change — flip the suite's default styles to consume the CAP hooks internally — rather than a migration with a new package, a new install, and a consumer rename. The work proposed here is the same work either way; only the eventual default differs.
+2. Make CAP discoverable and try-able from `react.fluentui.dev`.
+3. Preserve bundle-size invariants for consumers who don't opt in to CAP.
+4. **Position CAP for potential graduation into the default Fluent visual language.** If a future direction is for CAP to _become_ Fluent v9's baseline look (rather than remain an opt-in overlay), having CAP already authored, released, and CI-gated inside `@fluentui/react-components` turns that transition into an easier step than starting from a separate repo: the override hooks already live next to the components they re-skin, the bundle-size and VR baselines are already established against the rest of v9, and the consumer-facing import path does not have to change. The work proposed here is the same work either way; co-location just preserves the optionality.
 
 ## Proposal — phased approach
 
 | Phase                             | Goal                                                                                                                                                                                |
-| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --- |
 | **1. Re-export from Fluent v9**   | `@fluentui/react-components` internally depends on `@fluentui-contrib/react-cap-theme` and re-exports `CAP_STYLE_HOOKS`. Products import CAP from Fluent. Docs site shows a toggle. |
-| **2. Move source into Fluent v9** | New `packages/react-components/react-cap-theme/` package in the Fluent monorepo. Contrib package becomes a deprecated shim re-exporting from Fluent.                                |
-| **3. Deprecate contrib package**  | Mark `@fluentui-contrib/react-cap-theme` deprecated on npm after one Fluent minor cycle.                                                                                            |
+| **2. Move source into Fluent v9** | New `packages/react-components/react-cap-theme/` package in the Fluent monorepo. Contrib package becomes a deprecated shim re-exporting from Fluent.                                |     |
 
 ### Phase 1 — re-export contrib from Fluent v9
 
@@ -103,11 +113,7 @@ import { FluentProvider, webLightTheme, CAP_STYLE_HOOKS } from '@fluentui/react-
 </FluentProvider>;
 ```
 
-No `@fluentui-contrib/*` in `package.json`. The contrib dependency is an internal implementation detail. The bundle-size cost of this re-export is documented empirically in [Bundle-size analysis](#bundle-size-analysis); the headline result is **0 bytes for tree-shakable named-import consumers**.
-
-#### Why no `CapProvider` wrapper
-
-Earlier drafts proposed a `<CapProvider>` component. Rejected: `FluentProvider` already has a first-class `customStyleHooks_unstable` prop. Adding a second provider component would duplicate the prop, force existing `<FluentProvider>` users to swap to a different component just to opt in, and complicate library code that wraps `<FluentProvider>` internally. The simpler answer is "expose the value and let consumers pass it to the prop they already use."
+The bundle-size cost of this re-export is documented empirically in [Bundle-size analysis](#bundle-size-analysis); the headline result is **0 bytes for tree-shakable named-import consumers**.
 
 ### Phase 2 — move source into Fluent v9
 
@@ -125,7 +131,6 @@ packages/react-components/
         react-card/
         ...
       index.ts
-    stories/src/                   # optional CAP-specific stories
 ```
 
 The folder structure mirrors today's contrib source layout.
@@ -138,15 +143,11 @@ The folder structure mirrors today's contrib source layout.
 export { CAP_STYLE_HOOKS } from '@fluentui/react-cap-theme';
 ```
 
-## Phase 3 — deprecation of `@fluentui-contrib/react-cap-theme`
-
-`@fluentui-contrib/react-cap-theme` is currently consumed by Teams behind a feature flag, so deprecation needs to be coordinated with that rollout rather than rushed. After one Fluent v9 minor cycle with `@fluentui/react-cap-theme` as the source of truth — and once Teams has migrated its import path to `@fluentui/react-components` — ship a final contrib release that adds the npm `"deprecated"` field pointing at `@fluentui/react-components` and stop accepting new feature PRs against it.
-
 ## Distribution shape — considered alternatives
 
 Three import shapes were considered for shipping `CAP_STYLE_HOOKS` to consumers:
 
-- **Option A — main-barrel re-export** (`import { CAP_STYLE_HOOKS } from '@fluentui/react-components'`). Best discoverability, zero install surface, one extra `export` line in the suite. Tree-shaking holds for named imports (0 bytes); the only cost is +15.8 kB gzipped for `import *` consumers, which is a discouraged pattern with no evidence of real-world use.
+- **Option A — main-barrel re-export** (`import { CAP_STYLE_HOOKS } from '@fluentui/react-components'`). Best discoverability, zero install surface, one extra `export` line in the suite. Tree-shaking holds for named imports (0 bytes); the only cost is ≈+16 kB gzipped for `import *` consumers, which is a discouraged pattern with no evidence of real-world use.
 - **Option B — subpath export** (`import { CAP_STYLE_HOOKS } from '@fluentui/react-components/cap'`). Goes against an explicit repo policy: the suite's only existing subpath, `@fluentui/react-components/unstable`, is **already deprecated** with a banner that forbids new exports, directing preview/unstable APIs to ship as `*-preview` packages instead (see [`src/unstable/index.ts`](https://github.com/microsoft/fluentui/blob/master/packages/react-components/react-components/src/unstable/index.ts)). Adding a second subpath for CAP would re-introduce exactly the pattern the team is moving away from.
 - **Option C — separate package** (`@fluentui/react-cap-theme-preview`, no re-export). Solves ownership and CI but re-introduces the extra-package install and keeps the discoverability problem CAP has today.
 
@@ -156,60 +157,69 @@ The claim of Phase 1 was verified against the live monosize fixtures of `@fluent
 
 ### Methodology
 
-- Both runs used `yarn nx run react-components:build --skip-nx-cache` → forced fresh transpile of all 71 tasks (suite + dependencies).
-- `lib/index.js` and `lib-commonjs/index.js` SHA-256 hashes were captured between runs and verified to differ — the only source change being the `export { CAP_STYLE_HOOKS }` line being toggled on/off.
-- Bundle measurement was run via `yarn monosize measure` directly from the suite directory — bypasses Nx cache entirely; webpack recompiles all 4 fixtures from scratch on each invocation.
-- After the experiment, `lib/` hashes were verified to match the original WITH-CAP state byte-for-byte and the auto-generated `etc/react-components.api.md` was restored via `git checkout --`.
+- **Baseline** captured first on a clean tree by running `yarn nx run react-components:bundle-size --skip-nx-cache` against the 4 existing fixtures.
+- **Phase 1 prototype** was then applied — adding `@fluentui-contrib/react-cap-theme` as a `dependencies` entry in `packages/react-components/react-components/package.json` and a single `export { CAP_STYLE_HOOKS } from '@fluentui-contrib/react-cap-theme'` line to `src/index.ts` — followed by `yarn install` and a re-run of the same command. `--skip-nx-cache` is required because `package.json` is not in the `bundle-size` target's input list.
+- For the actual-usage measurement, a throwaway fixture (`ButtonProviderAndThemeWithCAP.fixture.js`) was added that imports `{ Button, FluentProvider, webLightTheme, CAP_STYLE_HOOKS }` together, alongside the existing `ButtonProviderAndTheme.fixture.js` which imports the same set minus `CAP_STYLE_HOOKS`. The delta between those two fixtures is the cost paid by a consumer who actually opts in to CAP.
+- All measurements use `monosize` + `monosize-bundler-webpack`, which produces a minified bundle per fixture and gzip-sizes it.
+- After the experiment, the package.json, src/index.ts, yarn.lock, auto-generated `etc/react-components.api.md` and the throwaway fixture were reverted/removed (`git checkout --` / `rm`).
 
 ### Results — re-export cost (with vs without)
 
-Three of the four fixtures — `Button + FluentProvider + webLightTheme`, `Accordion + Button + FP + Image + Menu + Popover`, and `FluentProvider + webLightTheme` — showed a **0-byte delta** in both minified and gzipped output. The only fixture with a measurable delta is `entire library` (`import *`):
+Three of the four fixtures — `Button + FluentProvider + webLightTheme`, `Accordion + Button + FP + Image + Menu + Popover`, and `FluentProvider + webLightTheme` — showed a **0-byte delta** in both minified and gzipped output (byte-for-byte identical across the before/after runs). The only fixture with a measurable delta is `entire library` (`import *`):
 
-| `entire library` (`import *`) |        Min |           Gz |
-| ----------------------------- | ---------: | -----------: |
-| With CAP re-exported          |   1.389 MB |   341.137 kB |
-| Without CAP re-exported       |   1.295 MB |   325.342 kB |
-| **Δ (cost of the re-export)** | **+94 kB** | **+15.8 kB** |
+| `entire library` (`import *`) |        Min |             Gz |
+| ----------------------------- | ---------: | -------------: |
+| Without CAP re-exported       |   1.295 MB |     325.342 kB |
+| With CAP re-exported          |   1.391 MB |     341.577 kB |
+| **Δ (cost of the re-export)** | **+96 kB** | **+16.235 kB** |
 
 ### Results — actual usage cost (when CAP is imported)
 
 A separate sanity run measured the cost when a fixture **actively imports** `CAP_STYLE_HOOKS` (not just when CAP is reachable through the barrel). Fixture: `Button + FluentProvider + webLightTheme`.
 
-| `Button + FluentProvider + webLightTheme` |            Min |            Gz |
-| ----------------------------------------- | -------------: | ------------: |
-| Without `CAP_STYLE_HOOKS` import          |      66.328 kB |      19.02 kB |
-| With `CAP_STYLE_HOOKS` import             |     218.595 kB |     55.266 kB |
-| **Δ (cost of using CAP)**                 | **+152.27 kB** | **+36.25 kB** |
+| `Button + FluentProvider + webLightTheme` |            Min |             Gz |
+| ----------------------------------------- | -------------: | -------------: |
+| Without `CAP_STYLE_HOOKS` import          |      66.328 kB |      19.020 kB |
+| With `CAP_STYLE_HOOKS` import             |     220.097 kB |      55.797 kB |
+| **Δ (cost of using CAP)**                 | **+153.77 kB** | **+36.777 kB** |
 
 CAP statically imports per-component override modules from ≈20 Fluent component packages (Accordion, Avatar, Badge, Button, Card, Carousel, Checkbox, Combobox, Dialog, Drawer, Image, Input, Label, Link, Menu, Popover, Search, Tabs, Tags, TeachingPopover, Toolbar, Tooltip). When a consumer actually uses CAP, they pay for that graph — that's the cost of the visual language, not of the re-export pattern.
 
-### Why tree-shaking holds
-
-- `@fluentui-contrib/react-cap-theme@0.4.2` declares `"sideEffects": false` in its `package.json`.
-- Its `makeStyles()` calls are Griffel-extracted at build time into atomic CSS in `lib/`. There is no runtime style-engine import path that the bundler can't follow statically.
-- The re-export is a pure `export { … } from …` (no side-effecting `import`).
-
 ### Verifying locally
 
-For reviewers who want to reproduce the tables above:
+To reproduce the tables above:
 
 ```bash
-# from repo root
-cd packages/react-components/react-components
-yarn monosize measure      # direct invocation bypasses Nx cache
+# from repo root, on a clean tree → baseline numbers
+yarn nx run react-components:bundle-size --skip-nx-cache
+
+# apply the 2-line Phase 1 prototype:
+#   1. add `"@fluentui-contrib/react-cap-theme": "^0.4.2"` to dependencies of
+#      packages/react-components/react-components/package.json
+#   2. add `export { CAP_STYLE_HOOKS } from '@fluentui-contrib/react-cap-theme';`
+#      to packages/react-components/react-components/src/index.ts
+yarn install
+yarn nx run react-components:bundle-size --skip-nx-cache    # → re-export cost
+
+# optional: actual-usage cost
+# add a fixture importing { Button, FluentProvider, webLightTheme, CAP_STYLE_HOOKS }
+# into packages/react-components/react-components/bundle-size/, then re-run.
 ```
 
-To measure "without CAP": comment out the `export { CAP_STYLE_HOOKS }` line in the suite's `src/index.ts`, run `yarn nx run react-components:build --skip-nx-cache` (forces a fresh `lib/`), then run `yarn monosize measure` again. Restore by uncommenting and re-running build, then `git checkout -- packages/react-components/react-components/etc/react-components.api.md` (the auto-generated API report regenerates on every build).
+`--skip-nx-cache` is required because `package.json` is not an input of the `bundle-size` target — without it the second run returns the cached baseline. Editing `src/index.ts` would bust the cache on its own, but `package.json` won't.
+
+To reset: `git checkout -- packages/react-components/react-components/{package.json,src/index.ts,etc/react-components.api.md} && yarn install`.
 
 ## Docs-site UX
 
-The goal is that someone landing on https://react.fluentui.dev/ can try CAP in one click, without changing imports or installing anything.
+The goal is to give CAP a single, central place where anyone — designers, partner teams evaluating Fluent, Fluent engineers reviewing a CAP-related PR — can see every component rendered in CAP without setting up a project, changing imports, or installing anything.
 
 Proposed UX (subject to docs-site team input — see [open questions](#open-questions-for-engineering-review)):
 
 - A **visual-language toggle** in the existing theme picker toolbar, **separate from the theme dropdown** (which today switches between web / teams / high-contrast / light / dark). Toggle positions: `Default` | `CAP`. Default off.
 - Toggle state is read by the docs-site's top-level `<FluentProvider>` wrapper. When `CAP` is selected, the wrapper passes `CAP_STYLE_HOOKS` to `customStyleHooks_unstable`.
 - Every component page renders with the toggle applied, so a consumer evaluating CAP can browse `<Button>`, `<Card>`, `<Menu>`, etc., in CAP without leaving the page. Visual regression of the docs-site against both toggle states should be added to the existing `vr-tests-react-components` matrix to catch CAP regressions.
+- The same toggle is also available in the local Storybook dev environment (`yarn start` on the suite). When a CAP author is implementing or tweaking an override hook, they can switch the story between `Default` and `CAP` in the same browser window — without rebuilding, without spinning up a separate CAP-only preview app, and against the exact local Fluent component code they're editing.
 
 A working prototype of this toggle is up for review at [microsoft/fluentui#36308](https://github.com/microsoft/fluentui/pull/36308).
 
@@ -217,7 +227,6 @@ A working prototype of this toggle is up for review at [microsoft/fluentui#36308
 
 This section lists the decisions the author needs from Fluent v9 engineering, docs-site engineering. Inline answers welcome via PR comment.
 
-1. **Skip Phase 1 entirely?** Phase 1 (suite re-exports from contrib while contrib remains the source of truth) is a transitional step that ships zero-install + the docs-site toggle one release earlier, but doesn't actually solve the ownership / CI-gating / release-cadence problems the RFC's "Why" section lists — those all require Phase 2. Should we collapse Phase 1 and Phase 2 into a single move: introduce `@fluentui/react-cap-theme-preview` (or `@fluentui/react-cap-theme`) directly in the monorepo, suite re-exports `CAP_STYLE_HOOKS` from it, contrib becomes a deprecated shim re-exporting from the new package — all in one Fluent minor? Trade-off: collapses two ship vehicles into one and avoids the awkward "contrib is source, suite re-exports" intermediate state, at the cost of front-loading the migration mechanics (CODEOWNERS, git history, package shape, executors, CI surface). Phase 1 makes more sense if Phase 2 ownership is uncertain or migration mechanics need negotiation; skip-Phase-1 makes more sense if those are resolvable up front.
+1. **Skip Phase 1 entirely?** Phase 1 (suite re-exports from contrib while contrib remains the source of truth) is a transitional step that ships zero-install + the docs-site toggle one release earlier, but it's just an intermediate step. Should we collapse Phase 1 and Phase 2 into a single move: introduce `@fluentui/react-cap-theme` directly in the monorepo, suite re-exports `CAP_STYLE_HOOKS` from it, contrib becomes a deprecated shim re-exporting from the new package — all in one Fluent minor?
 2. **Distribution shape — confirm Option A.** Does Fluent v9 engineering agree with the main-barrel re-export (`import { CAP_STYLE_HOOKS } from '@fluentui/react-components'`) over a subpath (`import { CAP_STYLE_HOOKS } from '@fluentui/react-components/cap'`) or a separate preview package (`import { CAP_STYLE_HOOKS } from '@fluentui/react-cap-theme-preview'`)? The bundle-size data argues for Option A, but the trade-off table is ultimately a judgement call about future-proofing — see [Distribution shape — considered alternatives](#distribution-shape--considered-alternatives).
-3. **Phase 1 ship vehicle.** Can Phase 1 (a single re-export line plus a `dependencies` entry) ship in the next Fluent v9 minor release, or does it need to wait for Phase 2 to land first?
-4. **Docs-site toggle UX.** Does the docs-site team agree with the toolbar-toggle design described above?
+3. **Docs-site toggle UX.** Does the docs-site team agree with the toolbar-toggle design described above?

--- a/docs/react-v9/contributing/rfcs/react-components/convergence/cap-theme-in-fluent-v9.md
+++ b/docs/react-v9/contributing/rfcs/react-components/convergence/cap-theme-in-fluent-v9.md
@@ -4,7 +4,7 @@
 
 _Contributors: (author: Enrico Gianoglio)_
 
-> **Status — request for engineering review.** This RFC proposes graduating the **CAP visual language** — currently shipped as `@fluentui-contrib/react-cap-theme` — into `@fluentui/react-components`, so consumers can opt in without installing a separate package. The first phase (re-exporting `CAP_STYLE_HOOKS` from the suite) has been prototyped end-to-end and its bundle-size impact has been measured against the suite's existing bundle-size fixtures (see [Bundle-size analysis](#bundle-size-analysis)).
+> **Status — request for engineering review.** This RFC proposes graduating the **CAP visual language** — currently shipped as `@fluentui-contrib/react-cap-theme` — into the Fluent v9 monorepo as a new in-repo package, `@fluentui/react-cap-theme`. The remaining decision is how consumers import `CAP_STYLE_HOOKS` (see [Distribution shape](#distribution-shape--considered-alternatives) — three candidates: separate preview package, separate stable package, or suite subpath). A prototype validated the docs-site toggle UX end-to-end and measured the bundle-size impact of an earlier suite-barrel re-export shape (see [Bundle-size analysis](#bundle-size-analysis)).
 
 ## Summary
 
@@ -81,47 +81,22 @@ Because CAP is a styling layer over Fluent components, the direction of change i
 3. Preserve bundle-size invariants for consumers who don't opt in to CAP.
 4. **Position CAP for potential graduation into the default Fluent visual language.** If a future direction is for CAP to _become_ Fluent v9's baseline look (rather than remain an opt-in overlay), having CAP already authored, released, and CI-gated inside `@fluentui/react-components` turns that transition into an easier step than starting from a separate repo: the override hooks already live next to the components they re-skin, the bundle-size and VR baselines are already established against the rest of v9, and the consumer-facing import path does not have to change. The work proposed here is the same work either way; co-location just preserves the optionality.
 
-## Proposal — phased approach
+## Proposal — internalize CAP into the Fluent v9 monorepo
 
-| Phase                             | Goal                                                                                                                                                                                |
-| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **1. Re-export from Fluent v9**   | `@fluentui/react-components` internally depends on `@fluentui-contrib/react-cap-theme` and re-exports `CAP_STYLE_HOOKS`. Products import CAP from Fluent. Docs site shows a toggle. |
-| **2. Move source into Fluent v9** | New `packages/react-components/react-cap-theme/` package in the Fluent monorepo. Contrib package becomes a deprecated shim re-exporting from Fluent.                                |
+Introduce a new sibling package in the Fluent v9 monorepo. **The suite does not take a dependency on `@fluentui-contrib/*`.** The remaining decision — how that package is exposed to consumers — is captured in [Distribution shape](#distribution-shape--considered-alternatives).
 
-### Phase 1 — re-export contrib from Fluent v9
+| Step                            | What lands                                                                                                                                                                                                                                                                                          |
+| ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **1. New in-repo package**      | Source of truth for `CAP_STYLE_HOOKS` lives in `packages/react-components/react-cap-theme/`.                                                                                                                                                                                                        |
+| **2. Move source from contrib** | The content of `@fluentui-contrib/react-cap-theme` is moved into the new in-repo package; the contrib package becomes a deprecated shim that re-exports from whichever Fluent package consumers are directed to. Fluent UI v9 Storybook site exposes the toggle regardless of which shape is chosen |
 
-`@fluentui/react-components` adds `@fluentui-contrib/react-cap-theme` as an internal dependency and re-exports the hooks map from `src/index.ts`:
+### New in-repo package — source layout
 
-```ts
-// packages/react-components/react-components/src/index.ts
-export { CAP_STYLE_HOOKS } from '@fluentui-contrib/react-cap-theme';
-```
-
-That is the entire Phase 1 change to the public API. Result for the product team:
-
-```bash
-# what they already have
-yarn add @fluentui/react-components
-```
-
-```tsx
-// what they write
-import { FluentProvider, webLightTheme, CAP_STYLE_HOOKS } from '@fluentui/react-components';
-
-<FluentProvider theme={webLightTheme} customStyleHooks_unstable={CAP_STYLE_HOOKS}>
-  <App />
-</FluentProvider>;
-```
-
-The bundle-size cost of this re-export is documented empirically in [Bundle-size analysis](#bundle-size-analysis); the headline result is **0 bytes for tree-shakable named-import consumers**.
-
-### Phase 2 — move source into Fluent v9
-
-Create a new sibling package:
+Folder layout mirrors today's contrib source so the migration is mostly a move:
 
 ```
 packages/react-components/
-  react-cap-theme/                 # new — source of truth post-Phase-2
+  react-cap-theme/                 # new — source of truth
     library/src/
       capStyleHooks.ts             # exports CAP_STYLE_HOOKS
       components/                  # per-component override hooks
@@ -131,16 +106,6 @@ packages/react-components/
         react-card/
         ...
       index.ts
-```
-
-The folder structure mirrors today's contrib source layout.
-
-`@fluentui/react-cap-theme` replaces `@fluentui-contrib/react-cap-theme` as the source. The contrib package becomes a thin re-export shim with a deprecation notice:
-
-```ts
-// fluentui-contrib/packages/react-cap-theme/src/index.ts (post-Phase-2)
-/** @deprecated Import from `@fluentui/react-components` instead. */
-export { CAP_STYLE_HOOKS } from '@fluentui/react-cap-theme';
 ```
 
 ## Distribution shape — considered alternatives
@@ -153,12 +118,14 @@ Three import shapes were considered for shipping `CAP_STYLE_HOOKS` to consumers:
 
 ## Bundle-size analysis
 
-The claim of Phase 1 was verified against the live monosize fixtures of `@fluentui/react-components` by a clean before/after comparison.
+The cost of adding `CAP_STYLE_HOOKS` to the suite barrel was verified against the live monosize fixtures of `@fluentui/react-components` by a clean before/after comparison.
+
+The prototype used `@fluentui-contrib/react-cap-theme` as the source of the re-export because the in-repo `@fluentui/react-cap-theme` package does not exist yet. The numbers below reflect the cost of the **import surface** — what gets pulled into the consumer's bundle when CAP is reachable through the suite barrel and when it is actually used. This is governed by what `monosize` measures (the minified + gzipped consumer bundle), and is independent of where the source code lives in the Fluent monorepo: the in-repo `@fluentui/react-cap-theme` package will resolve to the same per-component override modules at consumer build time as today's contrib package does, so the numbers carry over.
 
 ### Methodology
 
 - **Baseline** captured first on a clean tree by running `yarn nx run react-components:bundle-size --skip-nx-cache` against the 4 existing fixtures.
-- **Phase 1 prototype** was then applied — adding `@fluentui-contrib/react-cap-theme` as a `dependencies` entry in `packages/react-components/react-components/package.json` and a single `export { CAP_STYLE_HOOKS } from '@fluentui-contrib/react-cap-theme'` line to `src/index.ts` — followed by `yarn install` and a re-run of the same command. `--skip-nx-cache` is required because `package.json` is not in the `bundle-size` target's input list.
+- **Re-export prototype** was then applied — adding `@fluentui-contrib/react-cap-theme` as a `dependencies` entry in `packages/react-components/react-components/package.json` and a single `export { CAP_STYLE_HOOKS } from '@fluentui-contrib/react-cap-theme'` line to `src/index.ts` — followed by `yarn install` and a re-run of the same command. `--skip-nx-cache` is required because `package.json` is not in the `bundle-size` target's input list.
 - For the actual-usage measurement, a throwaway fixture (`ButtonProviderAndThemeWithCAP.fixture.js`) was added that imports `{ Button, FluentProvider, webLightTheme, CAP_STYLE_HOOKS }` together, alongside the existing `ButtonProviderAndTheme.fixture.js` which imports the same set minus `CAP_STYLE_HOOKS`. The delta between those two fixtures is the cost paid by a consumer who actually opts in to CAP.
 - All measurements use `monosize` + `monosize-bundler-webpack`, which produces a minified bundle per fixture and gzip-sizes it.
 - After the experiment, the package.json, src/index.ts, yarn.lock, auto-generated `etc/react-components.api.md` and the throwaway fixture were reverted/removed (`git checkout --` / `rm`).
@@ -193,7 +160,7 @@ To reproduce the tables above:
 # from repo root, on a clean tree → baseline numbers
 yarn nx run react-components:bundle-size --skip-nx-cache
 
-# apply the 2-line Phase 1 prototype:
+# apply the 2-line re-export prototype (stand-in for the in-repo package):
 #   1. add `"@fluentui-contrib/react-cap-theme": "^0.4.2"` to dependencies of
 #      packages/react-components/react-components/package.json
 #   2. add `export { CAP_STYLE_HOOKS } from '@fluentui-contrib/react-cap-theme';`
@@ -216,17 +183,16 @@ The goal is to give CAP a single, central place where anyone — designers, part
 
 Proposed UX (subject to docs-site team input — see [open questions](#open-questions-for-engineering-review)):
 
-- A **visual-language toggle** in the existing theme picker toolbar, **separate from the theme dropdown** (which today switches between web / teams / high-contrast / light / dark). Toggle positions: `Default` | `CAP`. Default off.
+- A **visual-language toggle** in the existing theme picker toolbar, **separate from the theme dropdown** (which today switches between web / teams / high-contrast / light / dark). Toggle positions: `Fluent` | `CAP`.
 - Toggle state is read by the docs-site's top-level `<FluentProvider>` wrapper. When `CAP` is selected, the wrapper passes `CAP_STYLE_HOOKS` to `customStyleHooks_unstable`.
 - Every component page renders with the toggle applied, so a consumer evaluating CAP can browse `<Button>`, `<Card>`, `<Menu>`, etc., in CAP without leaving the page. Visual regression of the docs-site against both toggle states should be added to the existing `vr-tests-react-components` matrix to catch CAP regressions.
-- The same toggle is also available in the local Storybook dev environment (`yarn start` on the suite). When a CAP author is implementing or tweaking an override hook, they can switch the story between `Default` and `CAP` in the same browser window — without rebuilding, without spinning up a separate CAP-only preview app, and against the exact local Fluent component code they're editing.
+- The same toggle is also available in the local Storybook dev environment. When a CAP author is implementing or tweaking an override hook, they can switch the story between `Fluent` and `CAP` in the same browser window — without rebuilding, without spinning up a separate CAP-only preview app, and against the exact local Fluent component code they're editing.
 
 A working prototype of this toggle is up for review at [microsoft/fluentui#36308](https://github.com/microsoft/fluentui/pull/36308).
 
 ## Open questions for engineering review
 
-This section lists the decisions the author needs from Fluent v9 engineering, docs-site engineering. Inline answers welcome via PR comment.
+This section lists the decisions the author needs from Fluent v9 engineering.
 
-1. **Skip Phase 1 entirely?** Phase 1 (suite re-exports from contrib while contrib remains the source of truth) is a transitional step that ships zero-install + the docs-site toggle one release earlier, but it's just an intermediate step. Should we collapse Phase 1 and Phase 2 into a single move: introduce `@fluentui/react-cap-theme` directly in the monorepo, suite re-exports `CAP_STYLE_HOOKS` from it, contrib becomes a deprecated shim re-exporting from the new package — all in one Fluent minor?
-2. **Distribution shape — confirm Option A.** Does Fluent v9 engineering agree with the main-barrel re-export (`import { CAP_STYLE_HOOKS } from '@fluentui/react-components'`) over a subpath (`import { CAP_STYLE_HOOKS } from '@fluentui/react-components/cap'`) or a separate preview package (`import { CAP_STYLE_HOOKS } from '@fluentui/react-cap-theme-preview'`)? The bundle-size data argues for Option A, but the trade-off table is ultimately a judgement call about future-proofing — see [Distribution shape — considered alternatives](#distribution-shape--considered-alternatives).
-3. **Docs-site toggle UX.** Does the docs-site team agree with the toolbar-toggle design described above?
+1. **Which distribution shape should the new in-repo package adopt?** See [Distribution shape — considered alternatives](#distribution-shape--considered-alternatives) for the three candidates: `@fluentui/react-cap-theme` (separate stable package), `@fluentui/react-cap-theme-preview` (separate preview package), or `@fluentui/react-components/cap` (suite subpath).
+2. **Docs-site toggle UX.** Does the docs-site team agree with the toolbar-toggle design described above?

--- a/docs/react-v9/contributing/rfcs/react-components/convergence/cap-theme-in-fluent-v9.md
+++ b/docs/react-v9/contributing/rfcs/react-components/convergence/cap-theme-in-fluent-v9.md
@@ -24,9 +24,9 @@ The change is small because the consumer-facing primitive already exists: `Fluen
 
 ### Concrete pain caused by the current arrangement
 
-CAP today exists as `@fluentui-contrib/react-cap-theme`. That arrangement actively works against adoption and against Fluent's own goals.
+CAP today exists as `@fluentui-contrib/react-cap-theme`. Starting CAP in `fluentui-contrib` made sense at the time: it let the visual language be prototyped and iterated on quickly, outside Fluent's release cadence and CI surface, without committing the Fluent v9 team to ownership before the shape of CAP had settled. CAP is not "done" yet — the API surface is still evolving — but it has reached a point where its overall shape, its consumer story (Teams), and its potential trajectory toward Fluent's default look are taking form. The costs of keeping it in contrib now actively work against adoption.
 
-- **Discovery.** A team browsing `react.fluentui.dev` cannot find CAP. CAP isn't a theme in the theme picker, isn't documented on the same site, and isn't surfaced anywhere in the suite's README or API docs. The only way to learn that CAP exists is to be told.
+- **Discovery.** CAP is technically documented on `react.fluentui.dev`, but only under the `Contributors Packages` section — it's not surfaced in the suite's README, in the API docs, or anywhere in the main browsing flow. A team evaluating Fluent for a new product is unlikely to find CAP unless someone tells them where to look.
 - **Install friction.** Adopting CAP requires adding a `@fluentui-contrib/*` line to `package.json`. For internal Microsoft consumers this is read as "third-party / experimental" by reviewers and security audits, even though the underlying code overrides Fluent components themselves.
 - **Release cadence drift.** CAP releases are decoupled from Fluent's pipeline. Bundle-size, VR, conformance and a11y CI in Fluent v9 do not gate CAP changes against the components CAP overrides. A breaking change to a Fluent component slot can silently invalidate the matching CAP override hook until a CAP consumer notices visually.
 - **Harder to act on CAP's API needs.** When CAP needs something Fluent doesn't expose today (an additional slot, a richer state field, a render-prop hook), having CAP and the components in the same repo makes those needs much easier to see, discuss, and address — the gap, the component, and the override sit next to each other.
@@ -38,7 +38,7 @@ CAP today exists as `@fluentui-contrib/react-cap-theme`. That arrangement active
 - **One source of truth.** CAP overrides live next to the components they override. PRs touching, e.g., `<Button>` slots can include the matching CAP hook update in the same change, reviewed by the same owners, gated by the same VR.
 - **Aligned release cadence.** CAP rides the Fluent v9 release train. Every Fluent minor that ships includes a CAP version that has already been validated against the components in that minor.
 - **CI parity.** Bundle-size budgets, conformance, accessibility, and visual regression run against CAP the same way they run against every other v9 package. Regressions surface in the PR that introduces them, not weeks later when a consumer files a bug.
-- **First-class discovery.** Docs site shows CAP as a visual-language toggle. Anyone evaluating Fluent for a new product sees CAP in the same flow they choose between web / teams / light / dark.
+- **First-class discovery.** Docs site shows CAP as a visual-language toggle.
 - **No re-architecture for consumers.** Phase 1 is purely additive; existing CAP consumers (those who installed `@fluentui-contrib/react-cap-theme` directly) keep working unchanged through Phase 3.
 
 ## Background — what CAP is
@@ -62,14 +62,7 @@ import { CAP_STYLE_HOOKS } from '@fluentui-contrib/react-cap-theme';
 
 That is the entire opt-in surface today. `@fluentui-contrib/react-cap-theme` also ships a sibling map `TEAMS_STYLE_HOOKS`: rather than re-implementing styles from scratch, Teams layers **product-specific overrides on top of the CAP base hooks** as their own `PRODUCT_STYLE_HOOKS` map. Products consume CAP as a foundation and override only the per-component hooks they need to differentiate, instead of forking the entire visual language.
 
-CAP **is not**:
-
-- A separate provider. There is no `<CapProvider>`. CAP rides on `FluentProvider`'s existing prop.
-- A runtime style engine. CAP overrides use Griffel `makeStyles()` and are extracted to atomic CSS at build time, like every other v9 component.
-
-## Goals and non-goals
-
-**Goals**
+## Goals
 
 1. Eliminate the `@fluentui-contrib/*` install requirement for CAP consumers.
 2. Give the Fluent v9 team ownership of CAP source, releases, and CI.
@@ -79,11 +72,11 @@ CAP **is not**:
 
 ## Proposal — phased approach
 
-| Phase                             | Goal                                                                                                                                                                                | Risk                            |
-| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
-| **1. Re-export from Fluent v9**   | `@fluentui/react-components` internally depends on `@fluentui-contrib/react-cap-theme` and re-exports `CAP_STYLE_HOOKS`. Products import CAP from Fluent. Docs site shows a toggle. | Low — additive only.            |
-| **2. Move source into Fluent v9** | New `packages/react-components/react-cap-theme/` package in the Fluent monorepo. Contrib package becomes a deprecated shim re-exporting from Fluent.                                | Medium — coordinated migration. |
-| **3. Deprecate contrib package**  | Mark `@fluentui-contrib/react-cap-theme` deprecated on npm after one Fluent minor cycle.                                                                                            | Low.                            |
+| Phase                             | Goal                                                                                                                                                                                |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **1. Re-export from Fluent v9**   | `@fluentui/react-components` internally depends on `@fluentui-contrib/react-cap-theme` and re-exports `CAP_STYLE_HOOKS`. Products import CAP from Fluent. Docs site shows a toggle. |
+| **2. Move source into Fluent v9** | New `packages/react-components/react-cap-theme/` package in the Fluent monorepo. Contrib package becomes a deprecated shim re-exporting from Fluent.                                |
+| **3. Deprecate contrib package**  | Mark `@fluentui-contrib/react-cap-theme` deprecated on npm after one Fluent minor cycle.                                                                                            |
 
 ### Phase 1 — re-export contrib from Fluent v9
 
@@ -157,10 +150,6 @@ Three import shapes were considered for shipping `CAP_STYLE_HOOKS` to consumers:
 - **Option B — subpath export** (`import { CAP_STYLE_HOOKS } from '@fluentui/react-components/cap'`). Goes against an explicit repo policy: the suite's only existing subpath, `@fluentui/react-components/unstable`, is **already deprecated** with a banner that forbids new exports, directing preview/unstable APIs to ship as `*-preview` packages instead (see [`src/unstable/index.ts`](https://github.com/microsoft/fluentui/blob/master/packages/react-components/react-components/src/unstable/index.ts)). Adding a second subpath for CAP would re-introduce exactly the pattern the team is moving away from.
 - **Option C — separate package** (`@fluentui/react-cap-theme-preview`, no re-export). Solves ownership and CI but re-introduces the extra-package install and keeps the discoverability problem CAP has today.
 
-### Decision
-
-**Phase 1 ships Option A.** The +15.8 kB gzipped cost only materializes on `import *`, and the discoverability + zero-install win is exactly what the RFC sets out to deliver.
-
 ## Bundle-size analysis
 
 The claim of Phase 1 was verified against the live monosize fixtures of `@fluentui/react-components` by a clean before/after comparison.
@@ -174,20 +163,23 @@ The claim of Phase 1 was verified against the live monosize fixtures of `@fluent
 
 ### Results — re-export cost (with vs without)
 
-| Fixture                                            | WITH CAP re-exported (min / gz) | WITHOUT CAP re-exported (min / gz) |      Δ min |         Δ gz |
-| -------------------------------------------------- | ------------------------------: | ---------------------------------: | ---------: | -----------: |
-| `Button + FluentProvider + webLightTheme`          |            66.328 kB / 19.02 kB |               66.328 kB / 19.02 kB |      **0** |        **0** |
-| `Accordion + Button + FP + Image + Menu + Popover` |           226.19 kB / 67.909 kB |              226.19 kB / 67.909 kB |      **0** |        **0** |
-| `FluentProvider + webLightTheme`                   |           39.525 kB / 13.113 kB |              39.525 kB / 13.113 kB |      **0** |        **0** |
-| `entire library` (`import *`)                      |           1.389 MB / 341.137 kB |              1.295 MB / 325.342 kB | **−94 kB** | **−15.8 kB** |
+Three of the four fixtures — `Button + FluentProvider + webLightTheme`, `Accordion + Button + FP + Image + Menu + Popover`, and `FluentProvider + webLightTheme` — showed a **0-byte delta** in both minified and gzipped output. The only fixture with a measurable delta is `entire library` (`import *`):
+
+| `entire library` (`import *`) |        Min |           Gz |
+| ----------------------------- | ---------: | -----------: |
+| With CAP re-exported          |   1.389 MB |   341.137 kB |
+| Without CAP re-exported       |   1.295 MB |   325.342 kB |
+| **Δ (cost of the re-export)** | **+94 kB** | **+15.8 kB** |
 
 ### Results — actual usage cost (when CAP is imported)
 
-A separate sanity run measured the cost when a fixture **actively imports** `CAP_STYLE_HOOKS` (not just when CAP is reachable through the barrel):
+A separate sanity run measured the cost when a fixture **actively imports** `CAP_STYLE_HOOKS` (not just when CAP is reachable through the barrel). Fixture: `Button + FluentProvider + webLightTheme`.
 
-| Fixture                                   | Without `CAP_STYLE_HOOKS` import (min / gz) | With `CAP_STYLE_HOOKS` import (min / gz) |                      Δ |
-| ----------------------------------------- | ------------------------------------------: | ---------------------------------------: | ---------------------: |
-| `Button + FluentProvider + webLightTheme` |                        66.328 kB / 19.02 kB |                   218.595 kB / 55.266 kB | +152.27 kB / +36.25 kB |
+| `Button + FluentProvider + webLightTheme` |            Min |            Gz |
+| ----------------------------------------- | -------------: | ------------: |
+| Without `CAP_STYLE_HOOKS` import          |      66.328 kB |      19.02 kB |
+| With `CAP_STYLE_HOOKS` import             |     218.595 kB |     55.266 kB |
+| **Δ (cost of using CAP)**                 | **+152.27 kB** | **+36.25 kB** |
 
 CAP statically imports per-component override modules from ≈20 Fluent component packages (Accordion, Avatar, Badge, Button, Card, Carousel, Checkbox, Combobox, Dialog, Drawer, Image, Input, Label, Link, Menu, Popover, Search, Tabs, Tags, TeachingPopover, Toolbar, Tooltip). When a consumer actually uses CAP, they pay for that graph — that's the cost of the visual language, not of the re-export pattern.
 

--- a/docs/react-v9/contributing/rfcs/react-components/convergence/cap-theme-in-fluent-v9.md
+++ b/docs/react-v9/contributing/rfcs/react-components/convergence/cap-theme-in-fluent-v9.md
@@ -4,7 +4,7 @@
 
 _Contributors: (author: Enrico Gianoglio)_
 
-> **Status — request for engineering review.** This RFC proposes making the CAP visual language a part of `@fluentui/react-components`. Phase 1 has been prototyped end-to-end and the bundle-size impact has been measured against live monosize fixtures (see [Bundle-size analysis](#bundle-size-analysis)).
+> **Status — request for engineering review.** This RFC proposes graduating the **CAP visual language** — currently shipped as `@fluentui-contrib/react-cap-theme` — into `@fluentui/react-components`, so consumers can opt in without installing a separate package. The first phase (re-exporting `CAP_STYLE_HOOKS` from the suite) has been prototyped end-to-end and its bundle-size impact has been measured against the suite's existing bundle-size fixtures (see [Bundle-size analysis](#bundle-size-analysis)).
 
 ## Summary
 

--- a/docs/react-v9/contributing/rfcs/react-components/convergence/cap-theme-in-fluent-v9.md
+++ b/docs/react-v9/contributing/rfcs/react-components/convergence/cap-theme-in-fluent-v9.md
@@ -1,0 +1,201 @@
+# RFC: Bring the CAP visual language into Fluent UI v9
+
+---
+
+_Contributors: (author: Enrico Gianoglio)_
+
+## Summary
+
+Make the **CAP visual language** a first-class part of Fluent UI v9 so that:
+
+1. A consumer of Fluent v9 can opt in to CAP **without installing any separate package** (no `@fluentui-contrib/*` dependency).
+2. All future CAP work happens inside the Fluent v9 repo, on the Fluent release cadence, with the same CI guarantees (bundle size, conformance, VR) as the rest of v9.
+3. CAP is discoverable and try-able directly on https://react.fluentui.dev/ — as a **visual-language toggle** that overlays the currently-selected base theme (web / teams / high-contrast / light / dark), _not_ as additional entries in the theme dropdown.
+4. Consumers who already pass their own `customStyleHooks_unstable` (brand overrides, internal design systems built on Fluent) can adopt CAP **without losing their overrides**. See [Phase 3 — `composeStyleHooks` helper](#phase-3--composestylehooks-helper).
+
+The change is small because the consumer-facing primitive already exists: `FluentProvider` accepts a `customStyleHooks_unstable` prop today and CAP is just a value to pass to it. We propose shipping that value (`CAP_STYLE_HOOKS`) from `@fluentui/react-components`, wiring it into the docs site as a toggle, moving the source into the Fluent v9 monorepo, and adding a small public helper (`composeStyleHooks`) so consumers can layer CAP on top of their own overrides.
+
+## Background
+
+### What CAP is
+
+CAP is a **visual-language overlay** — a set of style decisions (border-radius, spacing, hover/focus treatment, etc.) that re-skin a subset of Fluent v9 components.
+
+CAP **is**:
+
+- A single value: `CAP_STYLE_HOOKS`, a map matching `FluentProviderCustomStyleHooks`.
+- Composed of per-component override hooks across Fluent component packages.
+- Activated by passing it to the existing `customStyleHooks_unstable` prop on `FluentProvider`:
+
+```tsx
+import { FluentProvider, webLightTheme } from '@fluentui/react-components';
+import { CAP_STYLE_HOOKS } from '@fluentui-contrib/react-cap-theme';
+
+<FluentProvider theme={webLightTheme} customStyleHooks_unstable={CAP_STYLE_HOOKS}>
+  <App />
+</FluentProvider>;
+```
+
+That is the entire opt-in surface today.
+
+A sibling map `TEAMS_STYLE_HOOKS` is shipped from the same package and follows the same pattern.
+
+### Where CAP lives today and why that hurts
+
+`CAP_STYLE_HOOKS` is published from `@fluentui-contrib/react-cap-theme`. Consequences:
+
+- CAP is perceived as a third-party theme rather than a peer of `webLightTheme` / `teamsLightTheme`.
+- It is not selectable from the Fluent v9 docs, so adoption requires extra discovery.
+- Product teams must add a non-Fluent package to `package.json` just to access one exported value.
+- Every API gap forces a fork (an override hook in contrib) instead of an upstream contribution that benefits all Fluent users.
+- CAP releases are decoupled from Fluent's release pipeline; bundle-size and VR signals don't gate CAP changes against the Fluent components they override.
+
+## Problem statement
+
+> "We should try to get off this island of working in FluentUI Contrib so that the CAP theme becomes synonymous with Fluent and not a separate entity."
+
+Three things must change:
+
+1. **Consumer install surface.** A product team opting in to CAP should not see `@fluentui-contrib/*` in their `package.json`. CAP should be reachable from the package they already have.
+2. **Development location.** New CAP override hooks (and any related Fluent component extensions) should be authored and reviewed inside the Fluent v9 repo, with the same CI as the rest of v9.
+
+The proposal must also avoid:
+
+- Regressing bundle size for consumers who don't opt in to CAP.
+- Forcing every CAP consumer to rewrite provider plumbing.
+- Coupling brand-specific knowledge into base primitives like `FluentProvider`.
+
+## Detailed Design or Proposal
+
+### Phased approach
+
+| Phase                                  | Goal                                                                                                                                                                                | Risk                            |
+| -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| **1. Re-export from Fluent v9**        | `@fluentui/react-components` internally depends on `@fluentui-contrib/react-cap-theme` and re-exports `CAP_STYLE_HOOKS`. Products import CAP from Fluent. Docs site shows a toggle. | Low — additive only.            |
+| **2. Move source into Fluent v9**      | New `packages/react-components/react-cap-theme/` package in the Fluent monorepo. Contrib package becomes a deprecated shim re-exporting from Fluent.                                | Medium — coordinated migration. |
+| **3. Ship `composeStyleHooks` helper** | Public utility for layering multiple style-hook maps (consumer brand + CAP).                                                                                                        | Low.                            |
+| **4. Deprecate contrib package**       | Mark `@fluentui-contrib/react-cap-theme` deprecated on npm after one Fluent minor cycle.                                                                                            | Low.                            |
+
+### Phase 1 — Re-export contrib from Fluent v9
+
+`@fluentui/react-components` adds `@fluentui-contrib/react-cap-theme` as an internal dependency and re-exports the hooks map:
+
+```ts
+// packages/react-components/react-components/src/index.ts
+export { CAP_STYLE_HOOKS } from '@fluentui-contrib/react-cap-theme';
+// (and TEAMS_STYLE_HOOKS, if Fluent also wants to surface it)
+```
+
+That's the entire Phase 1 change to the public API.
+
+Result for the product team:
+
+```bash
+# what they already have
+yarn add @fluentui/react-components
+```
+
+```tsx
+// what they write
+import { FluentProvider, webLightTheme, CAP_STYLE_HOOKS } from '@fluentui/react-components';
+
+<FluentProvider theme={webLightTheme} customStyleHooks_unstable={CAP_STYLE_HOOKS}>
+  <App />
+</FluentProvider>;
+```
+
+No `@fluentui-contrib/*` in `package.json`. The contrib dependency is an internal implementation detail.
+
+#### Why no `CapProvider` wrapper
+
+Earlier drafts proposed a `<CapProvider>` component. Rejected: `FluentProvider` already has a first-class `customStyleHooks_unstable` prop. Adding a second provider component would duplicate the prop, force existing `<FluentProvider>` users to swap to a different component just to opt in, and complicate library code that wraps `<FluentProvider>` internally. The simpler answer is "expose the value and let consumers pass it to the prop they already use."
+
+### Phase 2 — Move source into Fluent v9
+
+Create a new sibling package:
+
+```
+packages/react-components/
+  react-cap-theme/                 # new — source of truth post-Phase-2
+    library/src/
+      capStyleHooks.ts             # exports CAP_STYLE_HOOKS
+      components/                  # per-component override hooks
+        react-accordion/
+        react-avatar/
+        react-button/
+        react-card/
+        ...
+      index.ts
+    stories/src/                   # optional CAP-specific stories
+```
+
+The folder structure mirrors today's contrib source layout.
+
+`@fluentui/react-cap-theme` replaces `@fluentui-contrib/react-cap-theme` as the source. The contrib package becomes a thin re-export shim with a deprecation notice:
+
+```ts
+// fluentui-contrib/packages/react-cap-theme/src/index.ts (post-Phase-2)
+/** @deprecated Import from `@fluentui/react-components` instead. */
+export { CAP_STYLE_HOOKS } from '@fluentui/react-cap-theme';
+```
+
+### Phase 3 — `composeStyleHooks` helper
+
+**This is the answer to the most common product-team blocker.** Today, `customStyleHooks_unstable` is a single map and assigning it replaces whatever was there. A product team that already does this:
+
+```tsx
+const productHooks = {
+  useButtonStyles_unstable: useBrandedButtonStyles,
+  useInputStyles_unstable: useBrandedInputStyles,
+};
+
+<FluentProvider customStyleHooks_unstable={productHooks}>
+```
+
+…cannot opt in to CAP without **losing their own overrides**.
+
+Ship a tiny composition utility:
+
+```ts
+// packages/react-components/react-provider/library/src/utils/composeStyleHooks.ts
+import type { FluentProviderCustomStyleHooks } from '../components/FluentProvider/FluentProvider.types';
+
+/**
+ * Combine multiple custom-style-hook maps into one. For each component, every
+ * matching hook runs in order; later hooks see the state mutated by earlier
+ * hooks. Conflicting className writes resolve by Griffel's `mergeClasses`
+ * rule (rightmost class wins on the same CSS rule).
+ *
+ * Typical usage: layer CAP on top of a consumer's brand overrides.
+ */
+export function composeStyleHooks(
+  ...maps: ReadonlyArray<FluentProviderCustomStyleHooks | undefined>
+): FluentProviderCustomStyleHooks {
+  const defined = maps.filter((m): m is FluentProviderCustomStyleHooks => Boolean(m));
+  const keys = new Set(defined.flatMap(Object.keys));
+  const out: Record<string, (state: unknown) => void> = {};
+
+  for (const key of keys) {
+    const hooks = defined.map(m => (m as Record<string, unknown>)[key]).filter(Boolean) as Array<(s: unknown) => void>;
+    out[key] = state => {
+      for (const h of hooks) h(state);
+    };
+  }
+
+  return out as FluentProviderCustomStyleHooks;
+}
+```
+
+Re-exported from `@fluentui/react-components`. Usage:
+
+```tsx
+import { FluentProvider, webLightTheme, CAP_STYLE_HOOKS, composeStyleHooks } from '@fluentui/react-components';
+
+const productHooks = {
+  useButtonStyles_unstable: useBrandedButtonStyles,
+};
+
+<FluentProvider theme={webLightTheme} customStyleHooks_unstable={composeStyleHooks(productHooks, CAP_STYLE_HOOKS)}>
+  <App />
+</FluentProvider>;
+```


### PR DESCRIPTION
## Overview
Proposes making the **CAP visual language** a first-class part of Fluent UI v9: consumers opt in via `@fluentui/react-components` alone (no `@fluentui-contrib/*` dependency), CAP source lives in the Fluent monorepo, and CAP is discoverable on the docs site as a visual-language picker alongside the theme picker.

Implementation tracked in #36308 .

## What's in this RFC
A phased move of CAP_STYLE_HOOKS from fluentui-contrib into Fluent v9:
- **Phase 1 — re-export.** `@fluentui/react-components` adds the contrib package as an internal dependency and re-exports `CAP_STYLE_HOOKS` from the main barrel. Consumers drop `@fluentui-contrib/*` from `package.json` and write `import { CAP_STYLE_HOOKS } from '@fluentui/react-components'`.
- **Phase 2 — move source.** A new `packages/react-components/react-cap-theme/` package owns CAP inside the monorepo, on Fluent's release cadence, gated by Fluent's CI (bundle size, VR, conformance). The contrib package becomes a deprecated re-export shim.

### What's already validated

- **Bundle size.** Phase 1 was prototyped against live monosize fixtures: **0 bytes** for tree-shakable named-import consumers across all 3 component-level fixtures; ≈+16 kB gz only for `import *`. When CAP is *actively* imported on a small-app baseline, +36.78 kB gz — that's the cost of the visual language (transitively imports override modules from ~20 Fluent component packages), not the re-export. Tables and methodology are in the RFC.
- **Docs-site toggle UX.** A working prototype is up at [feat(react-components): integrate CAP visual language as a opt-in #36308](https://github.com/microsoft/fluentui/pull/36308) — adds a CAP visual-language toggle to the Storybook toolbar that overlays the currently-selected theme.

### What I'm asking reviewers to decide
The RFC closes with the following open questions:

1. **Skip Phase 1 entirely?** Collapse Phase 1+2 into a single `@fluentui/react-cap-theme` move?
2. **Distribution shape** — confirm main-barrel re-export over subpath or separate preview package.
3. **Docs-site toggle UX** — does docs-site engineering agree with the toolbar-toggle design? https://fluentuipr.z22.web.core.windows.net/pull/36308/public-docsite-v9/react/index.html?path=/docs/components-button-button--docs
<img width="680" height="215" alt="Screenshot 2026-06-16 at 13 29 06" src="https://github.com/user-attachments/assets/77fd54b1-acb7-435f-a549-c8592852244d" />