### PR TITLE
feat(react-headless-components-preview): export useRadioGroupContextValues from RadioGroup

### DIFF
--- a/change/@fluentui-react-headless-components-preview-5af590f0-8892-4efa-b855-d3d63439ee41.json
+++ b/change/@fluentui-react-headless-components-preview-5af590f0-8892-4efa-b855-d3d63439ee41.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Export useRadioGroupContextValues from RadioGroup",
+  "packageName": "@fluentui/react-headless-components-preview",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-headless-components-preview-5af590f0-8892-4efa-b855-d3d63439ee41.json
+++ b/change/@fluentui-react-headless-components-preview-5af590f0-8892-4efa-b855-d3d63439ee41.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Export useRadioGroupContextValues from RadioGroup",
+  "comment": "fix: export useRadioGroupContextValues from RadioGroup",
   "packageName": "@fluentui/react-headless-components-preview",
   "email": "dmytrokirpa@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/react-components/react-headless-components-preview/library/etc/radio-group.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/radio-group.api.md
@@ -62,6 +62,9 @@ export const useRadio: (props: RadioProps, ref: React_2.Ref<HTMLInputElement>) =
 // @public
 export const useRadioGroup: (props: RadioGroupProps, ref: React_2.Ref<HTMLDivElement>) => RadioGroupState;
 
+// @public (undocumented)
+export const useRadioGroupContextValues: (state: RadioGroupState) => RadioGroupContextValues_2;
+
 // (No @packageDocumentation comment for this package)
 
 ```

--- a/packages/react-components/react-headless-components-preview/library/src/components/RadioGroup/index.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/RadioGroup/index.ts
@@ -1,6 +1,7 @@
 export { RadioGroup } from './RadioGroup';
 export { renderRadioGroup } from './renderRadioGroup';
 export { useRadioGroup } from './useRadioGroup';
+export { useRadioGroupContextValues } from './useRadioGroupContextValues';
 export type { RadioGroupSlots, RadioGroupProps, RadioGroupState } from './RadioGroup.types';
 
 export { Radio, renderRadio, useRadio } from './Radio';

--- a/packages/react-components/react-headless-components-preview/library/src/radio-group.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/radio-group.ts
@@ -5,6 +5,7 @@ export {
   RadioGroup,
   renderRadioGroup,
   useRadioGroup,
+  useRadioGroupContextValues,
 } from './components/RadioGroup/index';
 export type {
   RadioSlots,


### PR DESCRIPTION
## Description

Exports `useRadioGroupContextValues` from the `RadioGroup` component in `react-headless-components-preview`, making the context-values hook part of the package's public API (`./radio-group` entrypoint and component `index`). The API report (`radio-group.api.md`) is updated accordingly.

This lets consumers build custom `RadioGroup` compositions while reusing the same context wiring as the built-in component.

## Changes

- Export `useRadioGroupContextValues` from `RadioGroup/index.ts`
- Re-export it from `src/radio-group.ts`
- Update `radio-group.api.md` API report

🤖 Generated with [Claude Code](https://claude.com/claude-code)