### PR TITLE
fix(react-menu): remove the tabster restorer source from MenuPopover

### DIFF
--- a/change/@fluentui-react-menu-b854a376-deed-4e31-ad96-3a351d4890c6.json
+++ b/change/@fluentui-react-menu-b854a376-deed-4e31-ad96-3a351d4890c6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove the tabster restorer source from MenuPopover",
+  "packageName": "@fluentui/react-menu",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-menu/library/src/components/MenuPopover/useMenuPopover.ts
+++ b/packages/react-components/react-menu/library/src/components/MenuPopover/useMenuPopover.ts
@@ -3,7 +3,6 @@
 import { ArrowLeft, Tab, ArrowRight, Escape } from '@fluentui/keyboard-keys';
 import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
 import { useMotionForwardedRef } from '@fluentui/react-motion';
-import { useRestoreFocusSource } from '@fluentui/react-tabster';
 import { getIntrinsicElementProps, useEventCallback, useMergedRefs, slot, useTimeout } from '@fluentui/react-utilities';
 import * as React from 'react';
 
@@ -128,14 +127,12 @@ export const useMenuPopoverBase_unstable = (props: MenuPopoverProps, ref: React.
  * @param ref - reference to root HTMLElement of MenuPopover
  */
 export const useMenuPopover_unstable = (props: MenuPopoverProps, ref: React.Ref<HTMLElement>): MenuPopoverState => {
-  const restoreFocusSourceAttributes = useRestoreFocusSource();
   const motionRef = useMotionForwardedRef();
   const baseState = useMenuPopoverBase_unstable(props, ref);
 
   return {
     ...baseState,
     root: {
-      ...restoreFocusSourceAttributes,
       ...baseState.root,
       ref: useMergedRefs(baseState.root.ref, motionRef) as React.Ref<HTMLDivElement>,
     },


### PR DESCRIPTION
Follow-up to #32840 and #36313.

## Background

#32840 moved `Menu` away from the tabster `Restorer` API for focus restoration — it removed `useRestoreFocusTarget` from `MenuTrigger` and restores focus to the trigger **manually** instead, because _"the restorer can cause unintended focus switching whenever other restore sources lose focus to body."_

That PR intentionally **kept the restorer source on `MenuPopover`** — _"to make sure that users can still use `Menu` without a trigger easily."_

## Change

This removes the remaining `useRestoreFocusSource()` from `MenuPopover`, completing the move away from the tabster restorer for `Menu`:

- Menus **with a trigger** are unaffected — focus is restored to the trigger manually (since #32840).
- The restorer source was the only remaining piece tying `Menu` focus restoration to tabster's restorer — the mechanism behind the "unintended focus switching" #32840 set out to avoid.
- It also removes the incidental restorer ↔ groupper-escape interaction addressed in #36313 (now handled explicitly via `ignoreKeydown`).

## Tradeoff

Per #32840's note, the restorer source was kept for **triggerless `Menu`** usage. With this change a triggerless menu no longer restores focus via tabster on close (focus is allowed to fall to `<body>`), consistent with #32840's stated preference: _"allow lost focus to body in applications rather than unexpected focus switches."_

## Related

- #32840 — removed the restorer target from `MenuTrigger`, kept the source on `MenuPopover`
- #36313 — `ignoreKeydown` Escape on `MenuPopover`
