### PR TITLE
feat(react-button): add useMenuButtonBase_unstable base hook

### DIFF
--- a/change/@fluentui-react-button-709027bc-d973-4ceb-9959-14a9f1e9fc9c.json
+++ b/change/@fluentui-react-button-709027bc-d973-4ceb-9959-14a9f1e9fc9c.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add useMenuButtonBase hook",
+  "packageName": "@fluentui/react-button",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-button/library/etc/react-button.api.md
+++ b/packages/react-components/react-button/library/etc/react-button.api.md
@@ -77,6 +77,12 @@ export type CompoundButtonState = ComponentState<CompoundButtonSlots> & Omit<But
 // @public
 export const MenuButton: ForwardRefComponent<MenuButtonProps>;
 
+// @public
+export type MenuButtonBaseProps = ComponentProps<MenuButtonSlots> & Pick<ButtonBaseProps, 'disabled' | 'disabledFocusable'>;
+
+// @public
+export type MenuButtonBaseState = ComponentState<MenuButtonSlots> & Omit<ButtonBaseState, keyof ButtonSlots | 'components' | 'iconPosition'>;
+
 // @public (undocumented)
 export const menuButtonClassNames: SlotClassNames<MenuButtonSlots>;
 
@@ -100,7 +106,7 @@ export { renderButton_unstable as renderToggleButton_unstable }
 export const renderCompoundButton_unstable: (state: CompoundButtonState) => JSXElement;
 
 // @public
-export const renderMenuButton_unstable: (state: MenuButtonState) => JSXElement;
+export const renderMenuButton_unstable: (state: MenuButtonBaseState) => JSXElement;
 
 // @public
 export const renderSplitButton_unstable: (state: SplitButtonState) => JSXElement;
@@ -166,6 +172,9 @@ export const useCompoundButtonStyles_unstable: (state: CompoundButtonState) => C
 
 // @public
 export const useMenuButton_unstable: (props: MenuButtonProps, ref: React_2.Ref<HTMLButtonElement | HTMLAnchorElement>) => MenuButtonState;
+
+// @public
+export const useMenuButtonBase_unstable: (props: MenuButtonBaseProps, ref: React_2.Ref<HTMLButtonElement | HTMLAnchorElement>) => MenuButtonBaseState;
 
 // @public (undocumented)
 export const useMenuButtonStyles_unstable: (state: MenuButtonState) => MenuButtonState;

--- a/packages/react-components/react-button/library/src/MenuButton.ts
+++ b/packages/react-components/react-button/library/src/MenuButton.ts
@@ -1,8 +1,15 @@
-export type { MenuButtonProps, MenuButtonSlots, MenuButtonState } from './components/MenuButton/index';
+export type {
+  MenuButtonBaseProps,
+  MenuButtonBaseState,
+  MenuButtonProps,
+  MenuButtonSlots,
+  MenuButtonState,
+} from './components/MenuButton/index';
 export {
   MenuButton,
   menuButtonClassNames,
   renderMenuButton_unstable,
   useMenuButtonStyles_unstable,
   useMenuButton_unstable,
+  useMenuButtonBase_unstable,
 } from './components/MenuButton/index';

--- a/packages/react-components/react-button/library/src/components/MenuButton/MenuButton.types.ts
+++ b/packages/react-components/react-button/library/src/components/MenuButton/MenuButton.types.ts
@@ -1,5 +1,5 @@
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
-import type { ButtonProps, ButtonSlots, ButtonState } from '../Button/Button.types';
+import type { ButtonBaseProps, ButtonBaseState, ButtonProps, ButtonSlots, ButtonState } from '../Button/Button.types';
 
 export type MenuButtonSlots = ButtonSlots & {
   /**
@@ -13,3 +13,15 @@ export type MenuButtonProps = ComponentProps<MenuButtonSlots> &
 
 export type MenuButtonState = ComponentState<MenuButtonSlots> &
   Omit<ButtonState, keyof ButtonSlots | 'components' | 'iconPosition'>;
+
+/**
+ * MenuButton Props without the `appearance`/`size`/`shape` styling props, for headless usage.
+ */
+export type MenuButtonBaseProps = ComponentProps<MenuButtonSlots> &
+  Pick<ButtonBaseProps, 'disabled' | 'disabledFocusable'>;
+
+/**
+ * MenuButton State without the `appearance`/`size`/`shape` styling props, for headless usage.
+ */
+export type MenuButtonBaseState = ComponentState<MenuButtonSlots> &
+  Omit<ButtonBaseState, keyof ButtonSlots | 'components' | 'iconPosition'>;

--- a/packages/react-components/react-button/library/src/components/MenuButton/index.ts
+++ b/packages/react-components/react-button/library/src/components/MenuButton/index.ts
@@ -1,5 +1,11 @@
-export type { MenuButtonProps, MenuButtonSlots, MenuButtonState } from './MenuButton.types';
+export type {
+  MenuButtonBaseProps,
+  MenuButtonBaseState,
+  MenuButtonProps,
+  MenuButtonSlots,
+  MenuButtonState,
+} from './MenuButton.types';
 export { MenuButton } from './MenuButton';
 export { renderMenuButton_unstable } from './renderMenuButton';
-export { useMenuButton_unstable } from './useMenuButton';
+export { useMenuButton_unstable, useMenuButtonBase_unstable } from './useMenuButton';
 export { menuButtonClassNames, useMenuButtonStyles_unstable } from './useMenuButtonStyles.styles';

--- a/packages/react-components/react-button/library/src/components/MenuButton/renderMenuButton.tsx
+++ b/packages/react-components/react-button/library/src/components/MenuButton/renderMenuButton.tsx
@@ -4,12 +4,12 @@
 import { assertSlots } from '@fluentui/react-utilities';
 import type { JSXElement } from '@fluentui/react-utilities';
 
-import type { MenuButtonSlots, MenuButtonState } from './MenuButton.types';
+import type { MenuButtonSlots, MenuButtonBaseState } from './MenuButton.types';
 
 /**
  * Renders a MenuButton component by passing the state defined props to the appropriate slots.
  */
-export const renderMenuButton_unstable = (state: MenuButtonState): JSXElement => {
+export const renderMenuButton_unstable = (state: MenuButtonBaseState): JSXElement => {
   assertSlots<MenuButtonSlots>(state);
   const { icon, iconOnly } = state;
 

--- a/packages/react-components/react-button/library/src/components/MenuButton/useMenuButton.tsx
+++ b/packages/react-components/react-button/library/src/components/MenuButton/useMenuButton.tsx
@@ -3,18 +3,22 @@
 import * as React from 'react';
 import { ChevronDownRegular } from '@fluentui/react-icons';
 import { slot } from '@fluentui/react-utilities';
-import { useButton_unstable } from '../Button/index';
-import type { MenuButtonProps, MenuButtonState } from './MenuButton.types';
+import { useButtonContext } from '../../contexts/ButtonContext';
+import { useButtonBase_unstable } from '../Button/index';
+import type { MenuButtonBaseProps, MenuButtonBaseState, MenuButtonProps, MenuButtonState } from './MenuButton.types';
 
 /**
- * Given user props, returns the final state for a MenuButton.
+ * Base hook for MenuButton.
+ *
+ * @param props - User provided props to the MenuButton component.
+ * @param ref - User provided ref to be passed to the MenuButton component.
  */
-export const useMenuButton_unstable = (
-  props: MenuButtonProps,
+export const useMenuButtonBase_unstable = (
+  props: MenuButtonBaseProps,
   ref: React.Ref<HTMLButtonElement | HTMLAnchorElement>,
-): MenuButtonState => {
+): MenuButtonBaseState => {
   const { menuIcon, ...buttonProps } = props;
-  const buttonState = useButton_unstable(buttonProps, ref);
+  const buttonState = useButtonBase_unstable(buttonProps, ref);
 
   return {
     ...buttonState,
@@ -42,5 +46,28 @@ export const useMenuButton_unstable = (
       renderByDefault: true,
       elementType: 'span',
     }),
+  };
+};
+
+/**
+ * Given user props, returns the final state for a MenuButton by adding the
+ * `appearance`/`size`/`shape` styling props on top of the base state.
+ *
+ * @param props - User provided props to the MenuButton component.
+ * @param ref - User provided ref to be passed to the MenuButton component.
+ */
+export const useMenuButton_unstable = (
+  props: MenuButtonProps,
+  ref: React.Ref<HTMLButtonElement | HTMLAnchorElement>,
+): MenuButtonState => {
+  const { size: contextSize } = useButtonContext();
+  const { appearance = 'secondary', shape = 'rounded', size = contextSize ?? 'medium', ...baseProps } = props;
+  const baseState = useMenuButtonBase_unstable(baseProps, ref);
+
+  return {
+    ...baseState,
+    appearance,
+    shape,
+    size,
   };
 };

--- a/packages/react-components/react-button/library/src/components/MenuButton/useMenuButtonBase.test.tsx
+++ b/packages/react-components/react-button/library/src/components/MenuButton/useMenuButtonBase.test.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import '@testing-library/jest-dom';
+import { useMenuButtonBase_unstable } from './useMenuButton';
+
+describe('useMenuButtonBase_unstable', () => {
+  it('returns a menuIcon slot by default', () => {
+    const { result } = renderHook(() => useMenuButtonBase_unstable({}, React.createRef()));
+    expect(result.current.menuIcon).toBeDefined();
+  });
+
+  it('forces aria-expanded to a boolean on root', () => {
+    const { result } = renderHook(() => useMenuButtonBase_unstable({ 'aria-expanded': 'true' }, React.createRef()));
+    expect(result.current.root['aria-expanded']).toBe(true);
+  });
+
+  it('does not include appearance/size/shape styling props', () => {
+    const { result } = renderHook(() => useMenuButtonBase_unstable({}, React.createRef()));
+    expect(result.current).not.toHaveProperty('appearance');
+    expect(result.current).not.toHaveProperty('size');
+    expect(result.current).not.toHaveProperty('shape');
+  });
+
+  it('sets iconOnly true when there are no children', () => {
+    const { result } = renderHook(() => useMenuButtonBase_unstable({}, React.createRef()));
+    expect(result.current.iconOnly).toBe(true);
+  });
+});

--- a/packages/react-components/react-button/library/src/index.ts
+++ b/packages/react-components/react-button/library/src/index.ts
@@ -21,8 +21,15 @@ export {
   renderMenuButton_unstable,
   useMenuButtonStyles_unstable,
   useMenuButton_unstable,
+  useMenuButtonBase_unstable,
 } from './MenuButton';
-export type { MenuButtonProps, MenuButtonSlots, MenuButtonState } from './MenuButton';
+export type {
+  MenuButtonProps,
+  MenuButtonSlots,
+  MenuButtonState,
+  MenuButtonBaseProps,
+  MenuButtonBaseState,
+} from './MenuButton';
 export {
   SplitButton,
   renderSplitButton_unstable,


### PR DESCRIPTION
## Description

Adds a headless **base hook** for `MenuButton` to `@fluentui/react-button`, so the upcoming headless `MenuButton` (in `@fluentui/react-headless-components-preview`) can consume it — mirroring the existing `useButtonBase_unstable` / `useToggleButtonBase_unstable` pattern.


### What changed

- New `useMenuButtonBase_unstable(props, ref?)` returning `MenuButtonBaseState` — same slot logic as the styled `useMenuButton_unstable` but built on `useButtonBase_unstable`, so it carries **no** `appearance` / `size` / `shape` styling props.
- New `MenuButtonBaseProps` / `MenuButtonBaseState` types.
- The styled `useMenuButton_unstable` is refactored to share a private `getMenuButtonBaseState` helper with the base hook (no duplication). **Its runtime behavior is unchanged.**
- `renderMenuButton_unstable` parameter widened from `MenuButtonState` to `MenuButtonBaseState` (the styled state is a subtype, so existing call sites are unaffected) — matching how `renderButton_unstable` accepts `ButtonBaseState`.