### PR TITLE
feat(v9): add `module` export condition for ESM tree-shaking on node-targeted bundlers

### DIFF
--- a/change/@fluentui-chart-utilities-b37959c8-1fc0-4957-bef8-ef7436cd7541.json
+++ b/change/@fluentui-chart-utilities-b37959c8-1fc0-4957-bef8-ef7436cd7541.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/chart-utilities",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-global-context-e8e7b932-bc36-4fdc-9be9-1e12a1d8a949.json
+++ b/change/@fluentui-global-context-e8e7b932-bc36-4fdc-9be9-1e12a1d8a949.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/global-context",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-keyboard-keys-c678d39e-975b-4d2e-ae1a-de3f97489383.json
+++ b/change/@fluentui-keyboard-keys-c678d39e-975b-4d2e-ae1a-de3f97489383.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/keyboard-keys",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-priority-overflow-ddd98c10-4c8d-4597-b296-50c33b97a811.json
+++ b/change/@fluentui-priority-overflow-ddd98c10-4c8d-4597-b296-50c33b97a811.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/priority-overflow",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-accordion-24a1d1e2-1ae3-4d6b-8128-eb7dfe95f499.json
+++ b/change/@fluentui-react-accordion-24a1d1e2-1ae3-4d6b-8128-eb7dfe95f499.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-accordion",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-alert-a83574d9-d54d-47b0-b58f-96aefc791571.json
+++ b/change/@fluentui-react-alert-a83574d9-d54d-47b0-b58f-96aefc791571.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-alert",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-aria-ec2def8d-af70-4c22-ae1a-b6dacb83e837.json
+++ b/change/@fluentui-react-aria-ec2def8d-af70-4c22-ae1a-b6dacb83e837.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-aria",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-avatar-6ecfeed1-dee8-46f7-8e45-cff428e62deb.json
+++ b/change/@fluentui-react-avatar-6ecfeed1-dee8-46f7-8e45-cff428e62deb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-avatar",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-badge-36d58dfa-d47a-4090-b6df-3ddc9eae27e8.json
+++ b/change/@fluentui-react-badge-36d58dfa-d47a-4090-b6df-3ddc9eae27e8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-badge",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-breadcrumb-8830165f-d40a-48dd-9420-8e44e6e37c64.json
+++ b/change/@fluentui-react-breadcrumb-8830165f-d40a-48dd-9420-8e44e6e37c64.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-breadcrumb",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-button-5ca0f2ec-a203-47ba-af0b-af4795b41072.json
+++ b/change/@fluentui-react-button-5ca0f2ec-a203-47ba-af0b-af4795b41072.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-button",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-calendar-compat-a322fd69-9454-4406-a10f-2ab9c809f3ee.json
+++ b/change/@fluentui-react-calendar-compat-a322fd69-9454-4406-a10f-2ab9c809f3ee.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-calendar-compat",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-card-e94fecd0-f1b0-4726-a65b-8ea1e905b3c0.json
+++ b/change/@fluentui-react-card-e94fecd0-f1b0-4726-a65b-8ea1e905b3c0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-card",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-carousel-6907df6f-c557-487f-b926-dcea2ad9db44.json
+++ b/change/@fluentui-react-carousel-6907df6f-c557-487f-b926-dcea2ad9db44.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-carousel",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-charts-6c79d2b2-1236-4326-8d7e-3b95706edd2c.json
+++ b/change/@fluentui-react-charts-6c79d2b2-1236-4326-8d7e-3b95706edd2c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-charts",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-checkbox-4c5c4691-f756-4134-be64-866fab3b2c70.json
+++ b/change/@fluentui-react-checkbox-4c5c4691-f756-4134-be64-866fab3b2c70.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-color-picker-c39025a0-527e-43a7-bdb2-b8f3f6f32653.json
+++ b/change/@fluentui-react-color-picker-c39025a0-527e-43a7-bdb2-b8f3f6f32653.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-color-picker",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-combobox-2279c1cb-6864-4788-bac7-0505dde975b2.json
+++ b/change/@fluentui-react-combobox-2279c1cb-6864-4788-bac7-0505dde975b2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-combobox",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-components-afa0f223-70bc-49a0-85ef-5ccb4feff18a.json
+++ b/change/@fluentui-react-components-afa0f223-70bc-49a0-85ef-5ccb4feff18a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-components",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-context-selector-7955484a-23dc-4909-9b29-fc0cb35e56c9.json
+++ b/change/@fluentui-react-context-selector-7955484a-23dc-4909-9b29-fc0cb35e56c9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-context-selector",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-datepicker-compat-42a1ccdd-192d-4609-ba13-4aac94badd54.json
+++ b/change/@fluentui-react-datepicker-compat-42a1ccdd-192d-4609-ba13-4aac94badd54.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-datepicker-compat",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-dialog-587cb476-df03-4b70-99ca-93af982b6f50.json
+++ b/change/@fluentui-react-dialog-587cb476-df03-4b70-99ca-93af982b6f50.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-dialog",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-divider-3f853e4d-6f0b-4fb9-87b0-485f2d4839c9.json
+++ b/change/@fluentui-react-divider-3f853e4d-6f0b-4fb9-87b0-485f2d4839c9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-divider",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-drawer-e194a08d-0888-40b5-a147-369a950ba288.json
+++ b/change/@fluentui-react-drawer-e194a08d-0888-40b5-a147-369a950ba288.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-drawer",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-field-470f4e2f-092b-4903-bd34-d654b75731b8.json
+++ b/change/@fluentui-react-field-470f4e2f-092b-4903-bd34-d654b75731b8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-field",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-headless-components-preview-0cbb853a-317a-4383-a7be-92db2ea054de.json
+++ b/change/@fluentui-react-headless-components-preview-0cbb853a-317a-4383-a7be-92db2ea054de.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-headless-components-preview",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-icons-compat-3bf3eb47-ac44-4571-9305-11044a55d237.json
+++ b/change/@fluentui-react-icons-compat-3bf3eb47-ac44-4571-9305-11044a55d237.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-icons-compat",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-image-c303b1bf-f400-4a3e-9e68-a0e966bafffb.json
+++ b/change/@fluentui-react-image-c303b1bf-f400-4a3e-9e68-a0e966bafffb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-image",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-infobutton-34bbeca0-e082-464d-8820-8a545252a02d.json
+++ b/change/@fluentui-react-infobutton-34bbeca0-e082-464d-8820-8a545252a02d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-infobutton",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-infolabel-2c6af8d9-d1e7-4641-bf52-b59c7b159ac8.json
+++ b/change/@fluentui-react-infolabel-2c6af8d9-d1e7-4641-bf52-b59c7b159ac8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-infolabel",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-input-62cfaa70-308e-4d8d-b296-339766551db3.json
+++ b/change/@fluentui-react-input-62cfaa70-308e-4d8d-b296-339766551db3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-input",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-jsx-runtime-0c75dc50-61fb-49f5-b472-18ad918207ba.json
+++ b/change/@fluentui-react-jsx-runtime-0c75dc50-61fb-49f5-b472-18ad918207ba.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-jsx-runtime",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-label-5aa3bb7a-26a3-4b44-9fbc-9593db7fbfcb.json
+++ b/change/@fluentui-react-label-5aa3bb7a-26a3-4b44-9fbc-9593db7fbfcb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-label",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-link-5c956aaa-9ef3-42b2-953b-af7b9b467e9e.json
+++ b/change/@fluentui-react-link-5c956aaa-9ef3-42b2-953b-af7b9b467e9e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-link",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-list-bec2fc87-aaec-465b-9bed-e753037522a5.json
+++ b/change/@fluentui-react-list-bec2fc87-aaec-465b-9bed-e753037522a5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-list",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-menu-a1afb852-808b-4b9b-8412-bac5ed6e3af3.json
+++ b/change/@fluentui-react-menu-a1afb852-808b-4b9b-8412-bac5ed6e3af3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-menu",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-menu-grid-preview-e3405dd1-491b-40a4-a8b6-16b1fb14a018.json
+++ b/change/@fluentui-react-menu-grid-preview-e3405dd1-491b-40a4-a8b6-16b1fb14a018.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-menu-grid-preview",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-message-bar-17c4c1cb-68f9-4b1a-9c16-716aa6bfd315.json
+++ b/change/@fluentui-react-message-bar-17c4c1cb-68f9-4b1a-9c16-716aa6bfd315.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-message-bar",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-migration-v0-v9-173f8687-50f3-452d-a46c-7507bb15c424.json
+++ b/change/@fluentui-react-migration-v0-v9-173f8687-50f3-452d-a46c-7507bb15c424.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-migration-v0-v9",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-migration-v8-v9-e0c706a9-5ec7-4f6c-b42f-0af13e508b15.json
+++ b/change/@fluentui-react-migration-v8-v9-e0c706a9-5ec7-4f6c-b42f-0af13e508b15.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-migration-v8-v9",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-motion-812a7dcc-49a0-403a-b3c0-fa033fae5d4e.json
+++ b/change/@fluentui-react-motion-812a7dcc-49a0-403a-b3c0-fa033fae5d4e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-motion",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-motion-components-preview-6919eecc-3e3a-4ab2-9508-2acfc8be6892.json
+++ b/change/@fluentui-react-motion-components-preview-6919eecc-3e3a-4ab2-9508-2acfc8be6892.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-motion-components-preview",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-nav-eaf56730-d52b-4309-a6af-26f425d1e4af.json
+++ b/change/@fluentui-react-nav-eaf56730-d52b-4309-a6af-26f425d1e4af.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-nav",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-overflow-b940e0cd-3a31-4210-a484-205bfe15aa86.json
+++ b/change/@fluentui-react-overflow-b940e0cd-3a31-4210-a484-205bfe15aa86.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-overflow",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-persona-fe72f585-73fd-4728-b66b-81208f5db93a.json
+++ b/change/@fluentui-react-persona-fe72f585-73fd-4728-b66b-81208f5db93a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-persona",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-popover-d3158fd7-1157-4349-a532-d0a9333d8d59.json
+++ b/change/@fluentui-react-popover-d3158fd7-1157-4349-a532-d0a9333d8d59.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-popover",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-portal-7c7856eb-7a90-4391-bf5e-e46d4f8120a6.json
+++ b/change/@fluentui-react-portal-7c7856eb-7a90-4391-bf5e-e46d4f8120a6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-portal",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-portal-compat-45f99d4d-35b4-4112-99af-12aa3a6eadcd.json
+++ b/change/@fluentui-react-portal-compat-45f99d4d-35b4-4112-99af-12aa3a6eadcd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-portal-compat",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-portal-compat-context-988005d7-a101-4dc4-8bcd-1b600e00add9.json
+++ b/change/@fluentui-react-portal-compat-context-988005d7-a101-4dc4-8bcd-1b600e00add9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-portal-compat-context",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-positioning-75c6dfb1-fbac-4e84-b2fc-3a10e6bc3e43.json
+++ b/change/@fluentui-react-positioning-75c6dfb1-fbac-4e84-b2fc-3a10e6bc3e43.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-positioning",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-progress-0d1a6e0e-460c-433f-9f2e-066f9bb123f9.json
+++ b/change/@fluentui-react-progress-0d1a6e0e-460c-433f-9f2e-066f9bb123f9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-progress",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-provider-3b71f083-6280-4945-840a-9e4d65059122.json
+++ b/change/@fluentui-react-provider-3b71f083-6280-4945-840a-9e4d65059122.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-provider",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-radio-5a2cfd79-edb9-4bf8-b179-ed1431ee6e7f.json
+++ b/change/@fluentui-react-radio-5a2cfd79-edb9-4bf8-b179-ed1431ee6e7f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-radio",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-rating-c5360c9f-1ee0-4126-a996-d62c09304d3d.json
+++ b/change/@fluentui-react-rating-c5360c9f-1ee0-4126-a996-d62c09304d3d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-rating",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-search-f36078f9-e5fc-4344-b2db-44b941ffa91a.json
+++ b/change/@fluentui-react-search-f36078f9-e5fc-4344-b2db-44b941ffa91a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-search",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-select-50a85be5-0955-4c16-b6db-527d2bfe6f06.json
+++ b/change/@fluentui-react-select-50a85be5-0955-4c16-b6db-527d2bfe6f06.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-select",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-shared-contexts-e8cb05d3-69e1-4bc6-bab3-017d3e8a1494.json
+++ b/change/@fluentui-react-shared-contexts-e8cb05d3-69e1-4bc6-bab3-017d3e8a1494.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-shared-contexts",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-skeleton-b0363764-3e25-49b3-8534-959a0834591a.json
+++ b/change/@fluentui-react-skeleton-b0363764-3e25-49b3-8534-959a0834591a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-skeleton",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-slider-c6183a1f-7fc7-42f2-91d0-998387bcfd40.json
+++ b/change/@fluentui-react-slider-c6183a1f-7fc7-42f2-91d0-998387bcfd40.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-slider",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-spinbutton-dca37a6e-a46f-4f45-bd1e-92c5860795f8.json
+++ b/change/@fluentui-react-spinbutton-dca37a6e-a46f-4f45-bd1e-92c5860795f8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-spinbutton",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-spinner-f5da929d-c544-49d3-a8b9-4e942a0ab991.json
+++ b/change/@fluentui-react-spinner-f5da929d-c544-49d3-a8b9-4e942a0ab991.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-spinner",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-storybook-addon-22046dc1-5e5f-4957-b654-02a63311aa3b.json
+++ b/change/@fluentui-react-storybook-addon-22046dc1-5e5f-4957-b654-02a63311aa3b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-storybook-addon",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-storybook-addon-export-to-sandbox-c0469bed-1761-4a1f-930a-5f4a92d97749.json
+++ b/change/@fluentui-react-storybook-addon-export-to-sandbox-c0469bed-1761-4a1f-930a-5f4a92d97749.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-storybook-addon-export-to-sandbox",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-swatch-picker-2beeb0ee-6c84-4cbc-8418-06c3a2b20b7e.json
+++ b/change/@fluentui-react-swatch-picker-2beeb0ee-6c84-4cbc-8418-06c3a2b20b7e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-swatch-picker",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-switch-3dd465b9-7d34-4360-ba4b-78e0953a5f74.json
+++ b/change/@fluentui-react-switch-3dd465b9-7d34-4360-ba4b-78e0953a5f74.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-switch",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-table-2e387656-9d47-4fcf-a040-ded685f88e61.json
+++ b/change/@fluentui-react-table-2e387656-9d47-4fcf-a040-ded685f88e61.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-table",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tabs-cbe17ac0-877b-42ae-8b6c-2ca1c54f0b15.json
+++ b/change/@fluentui-react-tabs-cbe17ac0-877b-42ae-8b6c-2ca1c54f0b15.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-tabs",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tabster-ebc0290d-74b5-422e-ad4f-cee62c088f36.json
+++ b/change/@fluentui-react-tabster-ebc0290d-74b5-422e-ad4f-cee62c088f36.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-tabster",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tag-picker-766c6c8b-75ed-4068-8d69-017c7a2809ef.json
+++ b/change/@fluentui-react-tag-picker-766c6c8b-75ed-4068-8d69-017c7a2809ef.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-tag-picker",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tags-1edffb10-ddbd-4600-8119-079e31643710.json
+++ b/change/@fluentui-react-tags-1edffb10-ddbd-4600-8119-079e31643710.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-tags",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-teaching-popover-553c3344-fa74-41f3-96d3-c49ebb45fffa.json
+++ b/change/@fluentui-react-teaching-popover-553c3344-fa74-41f3-96d3-c49ebb45fffa.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-teaching-popover",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-text-b5a6e03f-c376-460a-a4e8-2b8c67f99eda.json
+++ b/change/@fluentui-react-text-b5a6e03f-c376-460a-a4e8-2b8c67f99eda.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-text",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-textarea-c90bdd60-d827-43ab-96b0-d4f519ef0176.json
+++ b/change/@fluentui-react-textarea-c90bdd60-d827-43ab-96b0-d4f519ef0176.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-textarea",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-theme-38b2cfbb-76be-4daa-ba35-588ce1e208bb.json
+++ b/change/@fluentui-react-theme-38b2cfbb-76be-4daa-ba35-588ce1e208bb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-theme",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-theme-sass-6eda362e-202b-44cb-9a94-3c6bbb3fef2e.json
+++ b/change/@fluentui-react-theme-sass-6eda362e-202b-44cb-9a94-3c6bbb3fef2e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-theme-sass",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-timepicker-compat-191558d0-8705-4856-935a-c47bbffe6f5c.json
+++ b/change/@fluentui-react-timepicker-compat-191558d0-8705-4856-935a-c47bbffe6f5c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-timepicker-compat",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-toast-6ca07605-6ced-470a-a8af-e9025f217c2d.json
+++ b/change/@fluentui-react-toast-6ca07605-6ced-470a-a8af-e9025f217c2d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-toast",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-toolbar-a424ed41-dd0d-4072-8a39-4a4f3b5e8dd7.json
+++ b/change/@fluentui-react-toolbar-a424ed41-dd0d-4072-8a39-4a4f3b5e8dd7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-toolbar",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tooltip-20492802-285d-4140-a5eb-2a617752160f.json
+++ b/change/@fluentui-react-tooltip-20492802-285d-4140-a5eb-2a617752160f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-tree-58c91467-4503-4983-b7bf-b42a20acc81b.json
+++ b/change/@fluentui-react-tree-58c91467-4503-4983-b7bf-b42a20acc81b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-tree",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-utilities-01a47879-4d97-4d59-82ba-62879cabef50.json
+++ b/change/@fluentui-react-utilities-01a47879-4d97-4d59-82ba-62879cabef50.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-utilities",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-virtualizer-bf8007d9-90c1-44e2-9773-8eedddda347d.json
+++ b/change/@fluentui-react-virtualizer-bf8007d9-90c1-44e2-9773-8eedddda347d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/react-virtualizer",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-tokens-010b8f43-184f-46ed-a093-72532aeec11d.json
+++ b/change/@fluentui-tokens-010b8f43-184f-46ed-a093-72532aeec11d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add `module` export condition so node-targeted bundlers resolve ESM (tree-shaking) while bare Node stays CommonJS; emit fully-specified .js import paths",
+  "packageName": "@fluentui/tokens",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/charts/chart-utilities/package.json
+++ b/packages/charts/chart-utilities/package.json
@@ -36,7 +36,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/charts/react-charts/library/.swcrc
+++ b/packages/charts/react-charts/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/charts/react-charts/library/package.json
+++ b/packages/charts/react-charts/library/package.json
@@ -65,7 +65,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/component-selector-preview/library/.swcrc
+++ b/packages/react-components/component-selector-preview/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/component-selector-preview/library/package.json
+++ b/packages/react-components/component-selector-preview/library/package.json
@@ -35,7 +35,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/deprecated/react-alert/.swcrc
+++ b/packages/react-components/deprecated/react-alert/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/deprecated/react-alert/package.json
+++ b/packages/react-components/deprecated/react-alert/package.json
@@ -38,7 +38,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/deprecated/react-infobutton/.swcrc
+++ b/packages/react-components/deprecated/react-infobutton/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/deprecated/react-infobutton/package.json
+++ b/packages/react-components/deprecated/react-infobutton/package.json
@@ -38,7 +38,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/deprecated/react-virtualizer/.swcrc
+++ b/packages/react-components/deprecated/react-virtualizer/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/deprecated/react-virtualizer/package.json
+++ b/packages/react-components/deprecated/react-virtualizer/package.json
@@ -34,7 +34,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/global-context/.swcrc
+++ b/packages/react-components/global-context/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/global-context/package.json
+++ b/packages/react-components/global-context/package.json
@@ -32,7 +32,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/keyboard-keys/.swcrc
+++ b/packages/react-components/keyboard-keys/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/keyboard-keys/package.json
+++ b/packages/react-components/keyboard-keys/package.json
@@ -23,7 +23,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/priority-overflow/.swcrc
+++ b/packages/react-components/priority-overflow/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/priority-overflow/package.json
+++ b/packages/react-components/priority-overflow/package.json
@@ -23,7 +23,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-accordion/library/.swcrc
+++ b/packages/react-components/react-accordion/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-accordion/library/package.json
+++ b/packages/react-components/react-accordion/library/package.json
@@ -40,7 +40,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-aria/library/.swcrc
+++ b/packages/react-components/react-aria/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-aria/library/package.json
+++ b/packages/react-components/react-aria/library/package.json
@@ -34,7 +34,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-avatar/library/.swcrc
+++ b/packages/react-components/react-avatar/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-avatar/library/package.json
+++ b/packages/react-components/react-avatar/library/package.json
@@ -43,7 +43,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-badge/library/.swcrc
+++ b/packages/react-components/react-badge/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-badge/library/package.json
+++ b/packages/react-components/react-badge/library/package.json
@@ -35,7 +35,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-breadcrumb/library/.swcrc
+++ b/packages/react-components/react-breadcrumb/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-breadcrumb/library/package.json
+++ b/packages/react-components/react-breadcrumb/library/package.json
@@ -39,7 +39,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-button/library/.swcrc
+++ b/packages/react-components/react-button/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-button/library/package.json
+++ b/packages/react-components/react-button/library/package.json
@@ -38,7 +38,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-calendar-compat/library/.swcrc
+++ b/packages/react-components/react-calendar-compat/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-calendar-compat/library/package.json
+++ b/packages/react-components/react-calendar-compat/library/package.json
@@ -33,7 +33,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-card/library/.swcrc
+++ b/packages/react-components/react-card/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-card/library/package.json
+++ b/packages/react-components/react-card/library/package.json
@@ -37,7 +37,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-carousel/library/.swcrc
+++ b/packages/react-components/react-carousel/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-carousel/library/package.json
+++ b/packages/react-components/react-carousel/library/package.json
@@ -43,7 +43,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-checkbox/library/.swcrc
+++ b/packages/react-components/react-checkbox/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-checkbox/library/package.json
+++ b/packages/react-components/react-checkbox/library/package.json
@@ -38,7 +38,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-color-picker/library/.swcrc
+++ b/packages/react-components/react-color-picker/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-color-picker/library/package.json
+++ b/packages/react-components/react-color-picker/library/package.json
@@ -37,7 +37,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-colorpicker-compat/.swcrc
+++ b/packages/react-components/react-colorpicker-compat/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-colorpicker-compat/package.json
+++ b/packages/react-components/react-colorpicker-compat/package.json
@@ -35,7 +35,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-combobox/library/.swcrc
+++ b/packages/react-components/react-combobox/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-combobox/library/package.json
+++ b/packages/react-components/react-combobox/library/package.json
@@ -42,7 +42,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-components/.swcrc
+++ b/packages/react-components/react-components/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-components/package.json
+++ b/packages/react-components/react-components/package.json
@@ -89,14 +89,20 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },
     "./package.json": "./package.json",
     "./unstable": {
       "types": "./dist/unstable.d.ts",
-      "node": "./lib-commonjs/unstable/index.js",
+      "node": {
+        "module": "./lib/unstable/index.js",
+        "default": "./lib-commonjs/unstable/index.js"
+      },
       "import": "./lib/unstable/index.js",
       "require": "./lib-commonjs/unstable/index.js"
     }

--- a/packages/react-components/react-context-selector/.swcrc
+++ b/packages/react-components/react-context-selector/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-context-selector/package.json
+++ b/packages/react-components/react-context-selector/package.json
@@ -34,7 +34,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-datepicker-compat/library/.swcrc
+++ b/packages/react-components/react-datepicker-compat/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-datepicker-compat/library/package.json
+++ b/packages/react-components/react-datepicker-compat/library/package.json
@@ -43,7 +43,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-dialog/library/.swcrc
+++ b/packages/react-components/react-dialog/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "experimental": {
       "plugins": [["swc-plugin-de-indent-template-literal", {}]]
     },

--- a/packages/react-components/react-dialog/library/package.json
+++ b/packages/react-components/react-dialog/library/package.json
@@ -42,7 +42,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-divider/library/.swcrc
+++ b/packages/react-components/react-divider/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-divider/library/package.json
+++ b/packages/react-components/react-divider/library/package.json
@@ -34,7 +34,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-drawer/library/.swcrc
+++ b/packages/react-components/react-drawer/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-drawer/library/package.json
+++ b/packages/react-components/react-drawer/library/package.json
@@ -39,7 +39,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-field/library/.swcrc
+++ b/packages/react-components/react-field/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-field/library/package.json
+++ b/packages/react-components/react-field/library/package.json
@@ -37,7 +37,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-headless-components-preview/library/.swcrc
+++ b/packages/react-components/react-headless-components-preview/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-headless-components-preview/library/package.json
+++ b/packages/react-components/react-headless-components-preview/library/package.json
@@ -76,277 +76,415 @@
   "exports": {
     "./accordion": {
       "types": "./dist/accordion.d.ts",
-      "node": "./lib-commonjs/accordion.js",
+      "node": {
+        "module": "./lib/accordion.js",
+        "default": "./lib-commonjs/accordion.js"
+      },
       "import": "./lib/accordion.js",
       "require": "./lib-commonjs/accordion.js"
     },
     "./avatar": {
       "types": "./dist/avatar.d.ts",
-      "node": "./lib-commonjs/avatar.js",
+      "node": {
+        "module": "./lib/avatar.js",
+        "default": "./lib-commonjs/avatar.js"
+      },
       "import": "./lib/avatar.js",
       "require": "./lib-commonjs/avatar.js"
     },
     "./badge": {
       "types": "./dist/badge.d.ts",
-      "node": "./lib-commonjs/badge.js",
+      "node": {
+        "module": "./lib/badge.js",
+        "default": "./lib-commonjs/badge.js"
+      },
       "import": "./lib/badge.js",
       "require": "./lib-commonjs/badge.js"
     },
     "./breadcrumb": {
       "types": "./dist/breadcrumb.d.ts",
-      "node": "./lib-commonjs/breadcrumb.js",
+      "node": {
+        "module": "./lib/breadcrumb.js",
+        "default": "./lib-commonjs/breadcrumb.js"
+      },
       "import": "./lib/breadcrumb.js",
       "require": "./lib-commonjs/breadcrumb.js"
     },
     "./button": {
       "types": "./dist/button.d.ts",
-      "node": "./lib-commonjs/button.js",
+      "node": {
+        "module": "./lib/button.js",
+        "default": "./lib-commonjs/button.js"
+      },
       "import": "./lib/button.js",
       "require": "./lib-commonjs/button.js"
     },
     "./card": {
       "types": "./dist/card.d.ts",
-      "node": "./lib-commonjs/card.js",
+      "node": {
+        "module": "./lib/card.js",
+        "default": "./lib-commonjs/card.js"
+      },
       "import": "./lib/card.js",
       "require": "./lib-commonjs/card.js"
     },
     "./checkbox": {
       "types": "./dist/checkbox.d.ts",
-      "node": "./lib-commonjs/checkbox.js",
+      "node": {
+        "module": "./lib/checkbox.js",
+        "default": "./lib-commonjs/checkbox.js"
+      },
       "import": "./lib/checkbox.js",
       "require": "./lib-commonjs/checkbox.js"
     },
     "./combobox": {
       "types": "./dist/combobox.d.ts",
-      "node": "./lib-commonjs/combobox.js",
+      "node": {
+        "module": "./lib/combobox.js",
+        "default": "./lib-commonjs/combobox.js"
+      },
       "import": "./lib/combobox.js",
       "require": "./lib-commonjs/combobox.js"
     },
     "./dialog": {
       "types": "./dist/dialog.d.ts",
-      "node": "./lib-commonjs/dialog.js",
+      "node": {
+        "module": "./lib/dialog.js",
+        "default": "./lib-commonjs/dialog.js"
+      },
       "import": "./lib/dialog.js",
       "require": "./lib-commonjs/dialog.js"
     },
     "./divider": {
       "types": "./dist/divider.d.ts",
-      "node": "./lib-commonjs/divider.js",
+      "node": {
+        "module": "./lib/divider.js",
+        "default": "./lib-commonjs/divider.js"
+      },
       "import": "./lib/divider.js",
       "require": "./lib-commonjs/divider.js"
     },
     "./drawer": {
       "types": "./dist/drawer.d.ts",
-      "node": "./lib-commonjs/drawer.js",
+      "node": {
+        "module": "./lib/drawer.js",
+        "default": "./lib-commonjs/drawer.js"
+      },
       "import": "./lib/drawer.js",
       "require": "./lib-commonjs/drawer.js"
     },
     "./dropdown": {
       "types": "./dist/dropdown.d.ts",
-      "node": "./lib-commonjs/dropdown.js",
+      "node": {
+        "module": "./lib/dropdown.js",
+        "default": "./lib-commonjs/dropdown.js"
+      },
       "import": "./lib/dropdown.js",
       "require": "./lib-commonjs/dropdown.js"
     },
     "./field": {
       "types": "./dist/field.d.ts",
-      "node": "./lib-commonjs/field.js",
+      "node": {
+        "module": "./lib/field.js",
+        "default": "./lib-commonjs/field.js"
+      },
       "import": "./lib/field.js",
       "require": "./lib-commonjs/field.js"
     },
     "./image": {
       "types": "./dist/image.d.ts",
-      "node": "./lib-commonjs/image.js",
+      "node": {
+        "module": "./lib/image.js",
+        "default": "./lib-commonjs/image.js"
+      },
       "import": "./lib/image.js",
       "require": "./lib-commonjs/image.js"
     },
     "./info-label": {
       "types": "./dist/info-label.d.ts",
-      "node": "./lib-commonjs/info-label.js",
+      "node": {
+        "module": "./lib/info-label.js",
+        "default": "./lib-commonjs/info-label.js"
+      },
       "import": "./lib/info-label.js",
       "require": "./lib-commonjs/info-label.js"
     },
     "./input": {
       "types": "./dist/input.d.ts",
-      "node": "./lib-commonjs/input.js",
+      "node": {
+        "module": "./lib/input.js",
+        "default": "./lib-commonjs/input.js"
+      },
       "import": "./lib/input.js",
       "require": "./lib-commonjs/input.js"
     },
     "./interaction-tag": {
       "types": "./dist/interaction-tag.d.ts",
-      "node": "./lib-commonjs/interaction-tag.js",
+      "node": {
+        "module": "./lib/interaction-tag.js",
+        "default": "./lib-commonjs/interaction-tag.js"
+      },
       "import": "./lib/interaction-tag.js",
       "require": "./lib-commonjs/interaction-tag.js"
     },
     "./label": {
       "types": "./dist/label.d.ts",
-      "node": "./lib-commonjs/label.js",
+      "node": {
+        "module": "./lib/label.js",
+        "default": "./lib-commonjs/label.js"
+      },
       "import": "./lib/label.js",
       "require": "./lib-commonjs/label.js"
     },
     "./link": {
       "types": "./dist/link.d.ts",
-      "node": "./lib-commonjs/link.js",
+      "node": {
+        "module": "./lib/link.js",
+        "default": "./lib-commonjs/link.js"
+      },
       "import": "./lib/link.js",
       "require": "./lib-commonjs/link.js"
     },
     "./menu": {
       "types": "./dist/menu.d.ts",
-      "node": "./lib-commonjs/menu.js",
+      "node": {
+        "module": "./lib/menu.js",
+        "default": "./lib-commonjs/menu.js"
+      },
       "import": "./lib/menu.js",
       "require": "./lib-commonjs/menu.js"
     },
     "./message-bar": {
       "types": "./dist/message-bar.d.ts",
-      "node": "./lib-commonjs/message-bar.js",
+      "node": {
+        "module": "./lib/message-bar.js",
+        "default": "./lib-commonjs/message-bar.js"
+      },
       "import": "./lib/message-bar.js",
       "require": "./lib-commonjs/message-bar.js"
     },
     "./nav": {
       "types": "./dist/nav.d.ts",
-      "node": "./lib-commonjs/nav.js",
+      "node": {
+        "module": "./lib/nav.js",
+        "default": "./lib-commonjs/nav.js"
+      },
       "import": "./lib/nav.js",
       "require": "./lib-commonjs/nav.js"
     },
     "./persona": {
       "types": "./dist/persona.d.ts",
-      "node": "./lib-commonjs/persona.js",
+      "node": {
+        "module": "./lib/persona.js",
+        "default": "./lib-commonjs/persona.js"
+      },
       "import": "./lib/persona.js",
       "require": "./lib-commonjs/persona.js"
     },
     "./popover": {
       "types": "./dist/popover.d.ts",
-      "node": "./lib-commonjs/popover.js",
+      "node": {
+        "module": "./lib/popover.js",
+        "default": "./lib-commonjs/popover.js"
+      },
       "import": "./lib/popover.js",
       "require": "./lib-commonjs/popover.js"
     },
     "./positioning": {
       "types": "./dist/positioning.d.ts",
-      "node": "./lib-commonjs/positioning.js",
+      "node": {
+        "module": "./lib/positioning.js",
+        "default": "./lib-commonjs/positioning.js"
+      },
       "import": "./lib/positioning.js",
       "require": "./lib-commonjs/positioning.js"
     },
     "./progress-bar": {
       "types": "./dist/progress-bar.d.ts",
-      "node": "./lib-commonjs/progress-bar.js",
+      "node": {
+        "module": "./lib/progress-bar.js",
+        "default": "./lib-commonjs/progress-bar.js"
+      },
       "import": "./lib/progress-bar.js",
       "require": "./lib-commonjs/progress-bar.js"
     },
     "./provider": {
       "types": "./dist/provider.d.ts",
-      "node": "./lib-commonjs/provider.js",
+      "node": {
+        "module": "./lib/provider.js",
+        "default": "./lib-commonjs/provider.js"
+      },
       "import": "./lib/provider.js",
       "require": "./lib-commonjs/provider.js"
     },
     "./radio-group": {
       "types": "./dist/radio-group.d.ts",
-      "node": "./lib-commonjs/radio-group.js",
+      "node": {
+        "module": "./lib/radio-group.js",
+        "default": "./lib-commonjs/radio-group.js"
+      },
       "import": "./lib/radio-group.js",
       "require": "./lib-commonjs/radio-group.js"
     },
     "./rating": {
       "types": "./dist/rating.d.ts",
-      "node": "./lib-commonjs/rating.js",
+      "node": {
+        "module": "./lib/rating.js",
+        "default": "./lib-commonjs/rating.js"
+      },
       "import": "./lib/rating.js",
       "require": "./lib-commonjs/rating.js"
     },
     "./rating-display": {
       "types": "./dist/rating-display.d.ts",
-      "node": "./lib-commonjs/rating-display.js",
+      "node": {
+        "module": "./lib/rating-display.js",
+        "default": "./lib-commonjs/rating-display.js"
+      },
       "import": "./lib/rating-display.js",
       "require": "./lib-commonjs/rating-display.js"
     },
     "./search-box": {
       "types": "./dist/search-box.d.ts",
-      "node": "./lib-commonjs/search-box.js",
+      "node": {
+        "module": "./lib/search-box.js",
+        "default": "./lib-commonjs/search-box.js"
+      },
       "import": "./lib/search-box.js",
       "require": "./lib-commonjs/search-box.js"
     },
     "./select": {
       "types": "./dist/select.d.ts",
-      "node": "./lib-commonjs/select.js",
+      "node": {
+        "module": "./lib/select.js",
+        "default": "./lib-commonjs/select.js"
+      },
       "import": "./lib/select.js",
       "require": "./lib-commonjs/select.js"
     },
     "./skeleton": {
       "types": "./dist/skeleton.d.ts",
-      "node": "./lib-commonjs/skeleton.js",
+      "node": {
+        "module": "./lib/skeleton.js",
+        "default": "./lib-commonjs/skeleton.js"
+      },
       "import": "./lib/skeleton.js",
       "require": "./lib-commonjs/skeleton.js"
     },
     "./slider": {
       "types": "./dist/slider.d.ts",
-      "node": "./lib-commonjs/slider.js",
+      "node": {
+        "module": "./lib/slider.js",
+        "default": "./lib-commonjs/slider.js"
+      },
       "import": "./lib/slider.js",
       "require": "./lib-commonjs/slider.js"
     },
     "./spin-button": {
       "types": "./dist/spin-button.d.ts",
-      "node": "./lib-commonjs/spin-button.js",
+      "node": {
+        "module": "./lib/spin-button.js",
+        "default": "./lib-commonjs/spin-button.js"
+      },
       "import": "./lib/spin-button.js",
       "require": "./lib-commonjs/spin-button.js"
     },
     "./spinner": {
       "types": "./dist/spinner.d.ts",
-      "node": "./lib-commonjs/spinner.js",
+      "node": {
+        "module": "./lib/spinner.js",
+        "default": "./lib-commonjs/spinner.js"
+      },
       "import": "./lib/spinner.js",
       "require": "./lib-commonjs/spinner.js"
     },
     "./switch": {
       "types": "./dist/switch.d.ts",
-      "node": "./lib-commonjs/switch.js",
+      "node": {
+        "module": "./lib/switch.js",
+        "default": "./lib-commonjs/switch.js"
+      },
       "import": "./lib/switch.js",
       "require": "./lib-commonjs/switch.js"
     },
     "./tab-list": {
       "types": "./dist/tab-list.d.ts",
-      "node": "./lib-commonjs/tab-list.js",
+      "node": {
+        "module": "./lib/tab-list.js",
+        "default": "./lib-commonjs/tab-list.js"
+      },
       "import": "./lib/tab-list.js",
       "require": "./lib-commonjs/tab-list.js"
     },
     "./tag": {
       "types": "./dist/tag.d.ts",
-      "node": "./lib-commonjs/tag.js",
+      "node": {
+        "module": "./lib/tag.js",
+        "default": "./lib-commonjs/tag.js"
+      },
       "import": "./lib/tag.js",
       "require": "./lib-commonjs/tag.js"
     },
     "./tag-group": {
       "types": "./dist/tag-group.d.ts",
-      "node": "./lib-commonjs/tag-group.js",
+      "node": {
+        "module": "./lib/tag-group.js",
+        "default": "./lib-commonjs/tag-group.js"
+      },
       "import": "./lib/tag-group.js",
       "require": "./lib-commonjs/tag-group.js"
     },
     "./teaching-popover": {
       "types": "./dist/teaching-popover.d.ts",
-      "node": "./lib-commonjs/teaching-popover.js",
+      "node": {
+        "module": "./lib/teaching-popover.js",
+        "default": "./lib-commonjs/teaching-popover.js"
+      },
       "import": "./lib/teaching-popover.js",
       "require": "./lib-commonjs/teaching-popover.js"
     },
     "./textarea": {
       "types": "./dist/textarea.d.ts",
-      "node": "./lib-commonjs/textarea.js",
+      "node": {
+        "module": "./lib/textarea.js",
+        "default": "./lib-commonjs/textarea.js"
+      },
       "import": "./lib/textarea.js",
       "require": "./lib-commonjs/textarea.js"
     },
     "./toast": {
       "types": "./dist/toast.d.ts",
-      "node": "./lib-commonjs/toast.js",
+      "node": {
+        "module": "./lib/toast.js",
+        "default": "./lib-commonjs/toast.js"
+      },
       "import": "./lib/toast.js",
       "require": "./lib-commonjs/toast.js"
     },
     "./toggle-button": {
       "types": "./dist/toggle-button.d.ts",
-      "node": "./lib-commonjs/toggle-button.js",
+      "node": {
+        "module": "./lib/toggle-button.js",
+        "default": "./lib-commonjs/toggle-button.js"
+      },
       "import": "./lib/toggle-button.js",
       "require": "./lib-commonjs/toggle-button.js"
     },
     "./toolbar": {
       "types": "./dist/toolbar.d.ts",
-      "node": "./lib-commonjs/toolbar.js",
+      "node": {
+        "module": "./lib/toolbar.js",
+        "default": "./lib-commonjs/toolbar.js"
+      },
       "import": "./lib/toolbar.js",
       "require": "./lib-commonjs/toolbar.js"
     },
     "./tooltip": {
       "types": "./dist/tooltip.d.ts",
-      "node": "./lib-commonjs/tooltip.js",
+      "node": {
+        "module": "./lib/tooltip.js",
+        "default": "./lib-commonjs/tooltip.js"
+      },
       "import": "./lib/tooltip.js",
       "require": "./lib-commonjs/tooltip.js"
     },

--- a/packages/react-components/react-icons-compat/library/.swcrc
+++ b/packages/react-components/react-icons-compat/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-icons-compat/library/package.json
+++ b/packages/react-components/react-icons-compat/library/package.json
@@ -34,7 +34,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-image/library/.swcrc
+++ b/packages/react-components/react-image/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-image/library/package.json
+++ b/packages/react-components/react-image/library/package.json
@@ -34,7 +34,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-infolabel/library/.swcrc
+++ b/packages/react-components/react-infolabel/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-infolabel/library/package.json
+++ b/packages/react-components/react-infolabel/library/package.json
@@ -32,7 +32,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-input/library/.swcrc
+++ b/packages/react-components/react-input/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-input/library/package.json
+++ b/packages/react-components/react-input/library/package.json
@@ -35,7 +35,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-jsx-runtime/.swcrc
+++ b/packages/react-components/react-jsx-runtime/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "experimental": {
       "plugins": [["swc-plugin-de-indent-template-literal", {}]]
     },

--- a/packages/react-components/react-jsx-runtime/package.json
+++ b/packages/react-components/react-jsx-runtime/package.json
@@ -28,19 +28,28 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },
     "./jsx-dev-runtime": {
       "types": "./dist/jsx-dev-runtime.d.ts",
-      "node": "./lib-commonjs/jsx-dev-runtime.js",
+      "node": {
+        "module": "./lib/jsx-dev-runtime.js",
+        "default": "./lib-commonjs/jsx-dev-runtime.js"
+      },
       "import": "./lib/jsx-dev-runtime.js",
       "require": "./lib-commonjs/jsx-dev-runtime.js"
     },
     "./jsx-runtime": {
       "types": "./dist/jsx-runtime.d.ts",
-      "node": "./lib-commonjs/jsx-runtime.js",
+      "node": {
+        "module": "./lib/jsx-runtime.js",
+        "default": "./lib-commonjs/jsx-runtime.js"
+      },
       "import": "./lib/jsx-runtime.js",
       "require": "./lib-commonjs/jsx-runtime.js"
     },

--- a/packages/react-components/react-label/library/.swcrc
+++ b/packages/react-components/react-label/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-label/library/package.json
+++ b/packages/react-components/react-label/library/package.json
@@ -34,7 +34,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-link/library/.swcrc
+++ b/packages/react-components/react-link/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-link/library/package.json
+++ b/packages/react-components/react-link/library/package.json
@@ -36,7 +36,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-list/library/.swcrc
+++ b/packages/react-components/react-list/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-list/library/package.json
+++ b/packages/react-components/react-list/library/package.json
@@ -38,7 +38,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-menu-grid-preview/library/.swcrc
+++ b/packages/react-components/react-menu-grid-preview/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-menu-grid-preview/library/package.json
+++ b/packages/react-components/react-menu-grid-preview/library/package.json
@@ -39,7 +39,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-menu/library/.swcrc
+++ b/packages/react-components/react-menu/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-menu/library/package.json
+++ b/packages/react-components/react-menu/library/package.json
@@ -43,7 +43,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-message-bar/library/.swcrc
+++ b/packages/react-components/react-message-bar/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-message-bar/library/package.json
+++ b/packages/react-components/react-message-bar/library/package.json
@@ -33,7 +33,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-migration-v0-v9/library/.swcrc
+++ b/packages/react-components/react-migration-v0-v9/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-migration-v0-v9/library/package.json
+++ b/packages/react-components/react-migration-v0-v9/library/package.json
@@ -40,7 +40,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-migration-v8-v9/library/.swcrc
+++ b/packages/react-components/react-migration-v8-v9/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-migration-v8-v9/library/package.json
+++ b/packages/react-components/react-migration-v8-v9/library/package.json
@@ -35,7 +35,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-motion-components-preview/library/.swcrc
+++ b/packages/react-components/react-motion-components-preview/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-motion-components-preview/library/package.json
+++ b/packages/react-components/react-motion-components-preview/library/package.json
@@ -31,7 +31,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-motion/library/.swcrc
+++ b/packages/react-components/react-motion/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-motion/library/package.json
+++ b/packages/react-components/react-motion/library/package.json
@@ -31,7 +31,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-nav/library/.swcrc
+++ b/packages/react-components/react-nav/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-nav/library/package.json
+++ b/packages/react-components/react-nav/library/package.json
@@ -38,7 +38,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-overflow/library/.swcrc
+++ b/packages/react-components/react-overflow/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-overflow/library/package.json
+++ b/packages/react-components/react-overflow/library/package.json
@@ -34,7 +34,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-persona/library/.swcrc
+++ b/packages/react-components/react-persona/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-persona/library/package.json
+++ b/packages/react-components/react-persona/library/package.json
@@ -36,7 +36,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-popover/library/.swcrc
+++ b/packages/react-components/react-popover/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-popover/library/package.json
+++ b/packages/react-components/react-popover/library/package.json
@@ -42,7 +42,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-portal-compat-context/.swcrc
+++ b/packages/react-components/react-portal-compat-context/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-portal-compat-context/package.json
+++ b/packages/react-components/react-portal-compat-context/package.json
@@ -27,7 +27,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-portal-compat/.swcrc
+++ b/packages/react-components/react-portal-compat/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-portal-compat/package.json
+++ b/packages/react-components/react-portal-compat/package.json
@@ -30,7 +30,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-portal/library/.swcrc
+++ b/packages/react-components/react-portal/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-portal/library/package.json
+++ b/packages/react-components/react-portal/library/package.json
@@ -33,7 +33,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-positioning/library/.swcrc
+++ b/packages/react-components/react-positioning/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-positioning/library/package.json
+++ b/packages/react-components/react-positioning/library/package.json
@@ -35,7 +35,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-progress/library/.swcrc
+++ b/packages/react-components/react-progress/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-progress/library/package.json
+++ b/packages/react-components/react-progress/library/package.json
@@ -36,7 +36,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-provider/library/.swcrc
+++ b/packages/react-components/react-provider/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-provider/library/package.json
+++ b/packages/react-components/react-provider/library/package.json
@@ -37,7 +37,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-radio/library/.swcrc
+++ b/packages/react-components/react-radio/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-radio/library/package.json
+++ b/packages/react-components/react-radio/library/package.json
@@ -37,7 +37,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-rating/library/.swcrc
+++ b/packages/react-components/react-rating/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-rating/library/package.json
+++ b/packages/react-components/react-rating/library/package.json
@@ -30,7 +30,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-search/library/.swcrc
+++ b/packages/react-components/react-search/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-search/library/package.json
+++ b/packages/react-components/react-search/library/package.json
@@ -36,7 +36,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-select/library/.swcrc
+++ b/packages/react-components/react-select/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-select/library/package.json
+++ b/packages/react-components/react-select/library/package.json
@@ -36,7 +36,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-shared-contexts/library/.swcrc
+++ b/packages/react-components/react-shared-contexts/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-shared-contexts/library/package.json
+++ b/packages/react-components/react-shared-contexts/library/package.json
@@ -28,7 +28,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-skeleton/library/.swcrc
+++ b/packages/react-components/react-skeleton/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-skeleton/library/package.json
+++ b/packages/react-components/react-skeleton/library/package.json
@@ -35,7 +35,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-slider/library/.swcrc
+++ b/packages/react-components/react-slider/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-slider/library/package.json
+++ b/packages/react-components/react-slider/library/package.json
@@ -36,7 +36,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-spinbutton/library/.swcrc
+++ b/packages/react-components/react-spinbutton/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-spinbutton/library/package.json
+++ b/packages/react-components/react-spinbutton/library/package.json
@@ -37,7 +37,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-spinner/library/.swcrc
+++ b/packages/react-components/react-spinner/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-spinner/library/package.json
+++ b/packages/react-components/react-spinner/library/package.json
@@ -35,7 +35,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-storybook-addon-export-to-sandbox/.swcrc
+++ b/packages/react-components/react-storybook-addon-export-to-sandbox/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-storybook-addon-export-to-sandbox/package.json
+++ b/packages/react-components/react-storybook-addon-export-to-sandbox/package.json
@@ -29,8 +29,11 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
-      "node": "./lib-commonjs/index.js",
       "require": "./lib-commonjs/index.js"
     },
     "./preset": "./preset.js",

--- a/packages/react-components/react-storybook-addon/.swcrc
+++ b/packages/react-components/react-storybook-addon/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-storybook-addon/package.json
+++ b/packages/react-components/react-storybook-addon/package.json
@@ -47,7 +47,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-swatch-picker/library/.swcrc
+++ b/packages/react-components/react-swatch-picker/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-swatch-picker/library/package.json
+++ b/packages/react-components/react-swatch-picker/library/package.json
@@ -32,7 +32,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-switch/library/.swcrc
+++ b/packages/react-components/react-switch/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-switch/library/package.json
+++ b/packages/react-components/react-switch/library/package.json
@@ -38,7 +38,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-table/library/.swcrc
+++ b/packages/react-components/react-table/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-table/library/package.json
+++ b/packages/react-components/react-table/library/package.json
@@ -41,7 +41,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-tabs/library/.swcrc
+++ b/packages/react-components/react-tabs/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-tabs/library/package.json
+++ b/packages/react-components/react-tabs/library/package.json
@@ -36,7 +36,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-tabster/.swcrc
+++ b/packages/react-components/react-tabster/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-tabster/package.json
+++ b/packages/react-components/react-tabster/package.json
@@ -35,7 +35,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-tag-picker/library/.swcrc
+++ b/packages/react-components/react-tag-picker/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-tag-picker/library/package.json
+++ b/packages/react-components/react-tag-picker/library/package.json
@@ -44,7 +44,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-tags/library/.swcrc
+++ b/packages/react-components/react-tags/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-tags/library/package.json
+++ b/packages/react-components/react-tags/library/package.json
@@ -39,7 +39,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-teaching-popover/library/.swcrc
+++ b/packages/react-components/react-teaching-popover/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-teaching-popover/library/package.json
+++ b/packages/react-components/react-teaching-popover/library/package.json
@@ -41,7 +41,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-text/library/.swcrc
+++ b/packages/react-components/react-text/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-text/library/package.json
+++ b/packages/react-components/react-text/library/package.json
@@ -34,7 +34,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-textarea/library/.swcrc
+++ b/packages/react-components/react-textarea/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-textarea/library/package.json
+++ b/packages/react-components/react-textarea/library/package.json
@@ -35,7 +35,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-theme-sass/.swcrc
+++ b/packages/react-components/react-theme-sass/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-theme-sass/package.json
+++ b/packages/react-components/react-theme-sass/package.json
@@ -24,9 +24,12 @@
   },
   "exports": {
     ".": {
-      "style": "./sass/tokens.scss",
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "style": "./sass/tokens.scss",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-theme/library/.swcrc
+++ b/packages/react-components/react-theme/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-theme/library/package.json
+++ b/packages/react-components/react-theme/library/package.json
@@ -24,7 +24,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-timepicker-compat/library/.swcrc
+++ b/packages/react-components/react-timepicker-compat/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-timepicker-compat/library/package.json
+++ b/packages/react-components/react-timepicker-compat/library/package.json
@@ -37,7 +37,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-toast/library/.swcrc
+++ b/packages/react-components/react-toast/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-toast/library/package.json
+++ b/packages/react-components/react-toast/library/package.json
@@ -41,7 +41,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-toolbar/library/.swcrc
+++ b/packages/react-components/react-toolbar/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-toolbar/library/package.json
+++ b/packages/react-components/react-toolbar/library/package.json
@@ -39,7 +39,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-tooltip/library/.swcrc
+++ b/packages/react-components/react-tooltip/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-tooltip/library/package.json
+++ b/packages/react-components/react-tooltip/library/package.json
@@ -38,7 +38,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-tree/library/.swcrc
+++ b/packages/react-components/react-tree/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "experimental": {
       "plugins": [["swc-plugin-de-indent-template-literal", {}]]
     },

--- a/packages/react-components/react-tree/library/package.json
+++ b/packages/react-components/react-tree/library/package.json
@@ -39,7 +39,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-utilities-compat/library/.swcrc
+++ b/packages/react-components/react-utilities-compat/library/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/react-utilities-compat/library/package.json
+++ b/packages/react-components/react-utilities-compat/library/package.json
@@ -35,7 +35,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/react-utilities/.swcrc
+++ b/packages/react-components/react-utilities/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "experimental": {
       "plugins": [["swc-plugin-de-indent-template-literal", {}]]
     },

--- a/packages/react-components/react-utilities/package.json
+++ b/packages/react-components/react-utilities/package.json
@@ -29,7 +29,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/recipes/.swcrc
+++ b/packages/react-components/recipes/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/recipes/package.json
+++ b/packages/react-components/recipes/package.json
@@ -36,7 +36,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/react-components/theme-designer/.swcrc
+++ b/packages/react-components/theme-designer/.swcrc
@@ -10,6 +10,7 @@
     "/**/*.test.tsx"
   ],
   "jsc": {
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": true,

--- a/packages/react-components/theme-designer/package.json
+++ b/packages/react-components/theme-designer/package.json
@@ -39,7 +39,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -24,7 +24,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./lib-commonjs/index.js",
+      "node": {
+        "module": "./lib/index.js",
+        "default": "./lib-commonjs/index.js"
+      },
       "import": "./lib/index.js",
       "require": "./lib-commonjs/index.js"
     },

--- a/tools/workspace-plugin/src/generators/migrate-converged-pkg/index.spec.ts
+++ b/tools/workspace-plugin/src/generators/migrate-converged-pkg/index.spec.ts
@@ -931,7 +931,10 @@ describe('migrate-converged-pkg generator', () => {
           Object {
             ".": Object {
               "import": "./lib/index.js",
-              "node": "./lib-commonjs/index.js",
+              "node": Object {
+                "default": "./lib-commonjs/index.js",
+                "module": "./lib/index.js",
+              },
               "require": "./lib-commonjs/index.js",
               "style": "./css/index.css",
               "types": "./dist/index.d.ts",
@@ -1089,6 +1092,7 @@ describe('migrate-converged-pkg generator', () => {
           '/**/*.test.tsx',
         ],
         jsc: {
+          baseUrl: '.',
           parser: {
             syntax: 'typescript',
             tsx: true,
@@ -1447,7 +1451,10 @@ describe('migrate-converged-pkg generator', () => {
         expect(pkgJson.exports['./unstable']).toMatchInlineSnapshot(`
           Object {
             "import": "./lib/unstable/index.js",
-            "node": "./lib-commonjs/unstable/index.js",
+            "node": Object {
+              "default": "./lib-commonjs/unstable/index.js",
+              "module": "./lib/unstable/index.js",
+            },
             "require": "./lib-commonjs/unstable/index.js",
             "types": "./dist/unstable.d.ts",
           }

--- a/tools/workspace-plugin/src/generators/migrate-converged-pkg/index.ts
+++ b/tools/workspace-plugin/src/generators/migrate-converged-pkg/index.ts
@@ -381,6 +381,7 @@ const templates = {
         '/**/*.test.tsx',
       ],
       jsc: {
+        baseUrl: '.',
         parser: {
           syntax: 'typescript',
           tsx: true,
@@ -630,7 +631,13 @@ function setupUnstableApi(tree: Tree, options: NormalizedSchemaWithTsConfigs) {
       Object.assign(stableJson.exports, {
         './unstable': {
           types: unstableJson.typings?.replace(/\.\.\//g, ''),
-          ...(packageJson.main ? { node: './lib-commonjs/unstable/index.js' } : null),
+          ...(packageJson.main
+            ? {
+                node: packageJson.module
+                  ? { module: './lib/unstable/index.js', default: './lib-commonjs/unstable/index.js' }
+                  : './lib-commonjs/unstable/index.js',
+              }
+            : null),
           ...(packageJson.module ? { import: './lib/unstable/index.js' } : null),
           require: './lib-commonjs/unstable/index.js',
         },
@@ -685,13 +692,19 @@ function updatePackageJson(tree: Tree, options: NormalizedSchemaWithTsConfigs) {
   }
 
   function setupExportMaps(json: PackageJson) {
+    const commonjs = json.main ? normalizePackageEntryPointPaths(json.main) : null;
+    const esm = json.module ? normalizePackageEntryPointPaths(json.module) : null;
+
     json.exports = {
       '.': {
         types: json.typings,
         ...(json.style ? { style: normalizePackageEntryPointPaths(json.style) } : null),
-        ...(json.main ? { node: normalizePackageEntryPointPaths(json.main) } : null),
-        ...(json.module ? { import: normalizePackageEntryPointPaths(json.module) } : null),
-        ...(json.main ? { require: normalizePackageEntryPointPaths(json.main) } : null),
+        // The `module` condition lets ESM-aware bundlers (webpack/rollup/vite) pick the ESM build on
+        // node-targeted builds so they can tree-shake, while bare Node ignores `module` and falls back
+        // to CommonJS (`default`) - keeping SSR resolution single-instance and dual-package-hazard free.
+        ...(commonjs ? { node: esm ? { module: esm, default: commonjs } : commonjs } : null),
+        ...(esm ? { import: esm } : null),
+        ...(commonjs ? { require: commonjs } : null),
       },
       './package.json': './package.json',
     };

--- a/tools/workspace-plugin/src/types.ts
+++ b/tools/workspace-plugin/src/types.ts
@@ -47,7 +47,17 @@ export interface PackageJson {
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
   peerDependencies?: Record<string, string>;
-  exports?: Record<string, string | Partial<{ types: string; node: string; import: string; require: string }>>;
+  exports?: Record<
+    string,
+    | string
+    | Partial<{
+        types: string;
+        style: string;
+        node: string | { module: string; default: string };
+        import: string;
+        require: string;
+      }>
+  >;
 }
 
 export interface PackageJsonWithBeachball extends PackageJson {


### PR DESCRIPTION
> Draft — opening for early feedback / CI.

## Problem

For node-targeted builds (SSR frameworks, `platform: node` bundling), our v9 export maps resolve the `node` condition **first**, pointing it at the CommonJS barrel (`lib-commonjs`). Bundlers therefore get non-tree-shakeable CJS and apps ship bloated server bundles, even though a perfectly good ESM build (`lib/`) exists. We can't simply drop `node` (breaks bare-Node SSR) or point it at `lib/` (re-introduces the dual-package hazard + breaks `require()` on older Node).

## Solution

Add a **`module` condition nested inside `node`** to every converged v9 package:

```jsonc
"exports": {
  ".": {
    "types": "./dist/index.d.ts",
    "node": {
      "module": "./lib/index.js",          // bundlers that understand `module` -> ESM -> tree-shake
      "default": "./lib-commonjs/index.js" // bare Node -> CommonJS (SSR-safe)
    },
    "import": "./lib/index.js",
    "require": "./lib-commonjs/index.js"
  }
}
```

- **Node ignores the `module` condition** (it's not a Node-implemented condition), so bare-Node SSR stays all-CommonJS -> single instance, no dual-package hazard, universal `require()`/`import` load.
- **Node-targeted bundlers** (webpack / rollup / vite / esbuild) pick the ESM build and tree-shake — no consumer config required.
- This is the documented "stateless" webpack pattern and mirrors how `@griffel/*` already behaves via its legacy `main`/`module` fields.

To make `lib/` valid, fully-specified ESM, the swc build now emits `.js` import extensions (enabled via `baseUrl` in `.swcrc`, the same mechanism `@fluentui/tokens` already used).

## Changes

- **Generator (source of truth):** `migrate-converged-pkg` `setupExportMaps` now emits the `module` condition (root `.` and `./unstable`); `.swcrc` template gains `baseUrl`. Widened the `exports` type. Specs updated.
- **Rollout:** applied across all converged v9 packages.
  - `package.json` export maps: **88**
  - `.swcrc` (`baseUrl` / `.js` emit): **86**
  - beachball change files: **83** (77 `patch`, 6 `prerelease` for packages disallowing `patch`)

## Validation

- `react-text` / `react-button`: full build OK; ESM output uses fully-specified `./Foo.js` imports.
- Bare-Node `require('@fluentui/react-text')` -> CommonJS.
- esbuild `--conditions=module` -> all inputs resolved from `lib/` (ESM, tree-shakeable).
- Generator unit tests: 238/238.
- Full `nx run-many -t build -p tag:vNext` sweep passes, **except** a **pre-existing** api-extractor failure in `react-overflow:build` (reproduces identically on `master` without this change — `useOverflow_unstable` analysis "software defect"). Tracked separately.

## Notes for reviewers

- No public API or runtime behavior change; this only affects how bundlers vs Node resolve the package entry.
- `@fluentui/tokens` and the other 5 alpha/deprecated packages get `prerelease` change files because they disallow `patch`.
