### PR TITLE
fix(web-components): SB docsite build

### DIFF
--- a/change/@fluentui-web-components-0cc7cb7d-11d6-4f62-ac35-d648276e84e1.json
+++ b/change/@fluentui-web-components-0cc7cb7d-11d6-4f62-ac35-d648276e84e1.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "fix: docsite build target",
+  "packageName": "@fluentui/web-components",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -91,7 +91,7 @@
     "start": "yarn start-storybook -p 6006 --docs",
     "start-storybook": "storybook dev",
     "build-storybook": "yarn analyze && storybook build -o ./dist/storybook --docs",
-    "build-storybook:docsite": "cross-env DEPLOY_PATH=/web-components/ storybook build -o ./dist/storybook --docs",
+    "build-storybook:docsite": "yarn analyze && cross-env DEPLOY_PATH=/web-components/ storybook build -o ./dist/storybook --docs",
     "e2e": "node ./scripts/e2e.js",
     "e2e:local": "node ./scripts/e2e.js --ui"
   },


### PR DESCRIPTION
PR #36271 added import customElementsManifest from '../custom-elements.json' to .storybook/preview.mjs. The regular build-storybook script already ran `yarn analyze` first, but the CI docsite variant `build-storybook:docsite` was never updated,  so on a clean CI checkout the manifest doesn't exist
