### PR TITLE
refactor(web-components): replace compose() with plain definition objects

### DIFF
--- a/apps/vr-tests-web-components/project.json
+++ b/apps/vr-tests-web-components/project.json
@@ -3,5 +3,10 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "application",
   "implicitDependencies": [],
+  "targets": {
+    "build-storybook": {
+      "dependsOn": ["^build"]
+    }
+  },
   "tags": ["web-components"]
 }

--- a/apps/vr-tests-web-components/src/stories/accordion/accordion.stories.tsx
+++ b/apps/vr-tests-web-components/src/stories/accordion/accordion.stories.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react';
 import { default as parse } from 'html-react-parser';
 import { Steps } from 'storywright';
-import { accordionDefinition, accordionItemDefinition, FluentDesignSystem } from '@fluentui/web-components';
 import { DARK_MODE, getStoryVariant, RTL } from '../../utilities/WCThemeDecorator.js';
 
-accordionDefinition.define(FluentDesignSystem.registry);
-accordionItemDefinition.define(FluentDesignSystem.registry);
+import '@fluentui/web-components/accordion/define.js';
+import '@fluentui/web-components/accordion-item/define.js';
 
 export default {
   title: 'Accordion',

--- a/apps/vr-tests-web-components/src/stories/avatar/avatar.stories.tsx
+++ b/apps/vr-tests-web-components/src/stories/avatar/avatar.stories.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react';
 import { default as parse } from 'html-react-parser';
 import { Steps } from 'storywright';
-import { AvatarDefinition, FluentDesignSystem } from '@fluentui/web-components';
 import { DARK_MODE, getStoryVariant, RTL } from '../../utilities/WCThemeDecorator.js';
 
-AvatarDefinition.define(FluentDesignSystem.registry);
+import '@fluentui/web-components/avatar/define.js';
 
 export default {
   title: 'Avatar',

--- a/apps/vr-tests-web-components/src/stories/badge/badge.stories.tsx
+++ b/apps/vr-tests-web-components/src/stories/badge/badge.stories.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react';
 import { default as parse } from 'html-react-parser';
 import { Steps } from 'storywright';
-import { BadgeDefinition, FluentDesignSystem } from '@fluentui/web-components';
 import { DARK_MODE, getStoryVariant } from '../../utilities/WCThemeDecorator.js';
 
-BadgeDefinition.define(FluentDesignSystem.registry);
+import '@fluentui/web-components/badge/define.js';
 
 export default {
   title: 'Badge',

--- a/apps/vr-tests-web-components/src/stories/button/button.stories.tsx
+++ b/apps/vr-tests-web-components/src/stories/button/button.stories.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react';
 import { default as parse } from 'html-react-parser';
 import { Steps } from 'storywright';
-import { ButtonDefinition, FluentDesignSystem } from '@fluentui/web-components';
 import { DARK_MODE, getStoryVariant, RTL } from '../../utilities/WCThemeDecorator.js';
 
-ButtonDefinition.define(FluentDesignSystem.registry);
+import '@fluentui/web-components/button/define.js';
 
 const buttonId = 'button-id';
 

--- a/apps/vr-tests-web-components/src/stories/checkbox/checkbox-indeterminate.stories.tsx
+++ b/apps/vr-tests-web-components/src/stories/checkbox/checkbox-indeterminate.stories.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react';
 import { default as parse } from 'html-react-parser';
 import { Steps, type StoryParameters } from 'storywright';
-import { CheckboxDefinition, FluentDesignSystem } from '@fluentui/web-components';
 import { DARK_MODE, getStoryVariant } from '../../utilities/WCThemeDecorator.js';
 
-CheckboxDefinition.define(FluentDesignSystem.registry);
+import '@fluentui/web-components/checkbox/define.js';
 
 export default {
   title: 'Checkbox',

--- a/apps/vr-tests-web-components/src/stories/checkbox/checkbox.stories.tsx
+++ b/apps/vr-tests-web-components/src/stories/checkbox/checkbox.stories.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react';
 import { default as parse } from 'html-react-parser';
 import { Steps } from 'storywright';
-import { CheckboxDefinition, FluentDesignSystem } from '@fluentui/web-components';
 import { DARK_MODE, getStoryVariant, RTL } from '../../utilities/WCThemeDecorator.js';
 
-CheckboxDefinition.define(FluentDesignSystem.registry);
+import '@fluentui/web-components/checkbox/define.js';
 
 export default {
   title: 'Checkbox',

--- a/apps/vr-tests-web-components/src/stories/divider/divider.stories.tsx
+++ b/apps/vr-tests-web-components/src/stories/divider/divider.stories.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react';
 import { default as parse } from 'html-react-parser';
 import { Steps } from 'storywright';
-import { DividerDefinition, FluentDesignSystem } from '@fluentui/web-components';
 import { DARK_MODE, getStoryVariant, RTL } from '../../utilities/WCThemeDecorator.js';
 
-DividerDefinition.define(FluentDesignSystem.registry);
+import '@fluentui/web-components/divider/define.js';
 
 export default {
   title: 'Divider',

--- a/apps/vr-tests-web-components/src/stories/label/label.stories.tsx
+++ b/apps/vr-tests-web-components/src/stories/label/label.stories.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react';
 import { default as parse } from 'html-react-parser';
 import { Steps } from 'storywright';
-import { LabelDefinition, FluentDesignSystem } from '@fluentui/web-components';
 import { DARK_MODE, getStoryVariant, RTL } from '../../utilities/WCThemeDecorator.js';
 
-LabelDefinition.define(FluentDesignSystem.registry);
+import '@fluentui/web-components/label/define.js';
 
 export default {
   title: 'Label',

--- a/apps/vr-tests-web-components/src/stories/link/link.stories.tsx
+++ b/apps/vr-tests-web-components/src/stories/link/link.stories.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
 import { default as parse } from 'html-react-parser';
 import { Steps } from 'storywright';
-import { LinkDefinition, FluentDesignSystem } from '@fluentui/web-components';
 
-LinkDefinition.define(FluentDesignSystem.registry);
+import '@fluentui/web-components/link/define.js';
 
 const linkId = 'link-id';
 

--- a/apps/vr-tests-web-components/src/stories/menu-list/menu-list.stories.tsx
+++ b/apps/vr-tests-web-components/src/stories/menu-list/menu-list.stories.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react';
 import { default as parse } from 'html-react-parser';
 import { Steps } from 'storywright';
-import { MenuListDefinition, MenuItemDefinition, FluentDesignSystem } from '@fluentui/web-components';
 import { DARK_MODE, getStoryVariant, RTL } from '../../utilities/WCThemeDecorator.js';
 
-MenuListDefinition.define(FluentDesignSystem.registry);
-MenuItemDefinition.define(FluentDesignSystem.registry);
+import '@fluentui/web-components/menu-list/define.js';
+import '@fluentui/web-components/menu-item/define.js';
 
 const createDecorator =
   (wrapperStyle: React.CSSProperties = { width: '320px' }) =>

--- a/apps/vr-tests-web-components/src/stories/progress-bar/progress-bar.stories.tsx
+++ b/apps/vr-tests-web-components/src/stories/progress-bar/progress-bar.stories.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react';
 import { default as parse } from 'html-react-parser';
 import { Steps } from 'storywright';
-import { ProgressBarDefinition, FluentDesignSystem } from '@fluentui/web-components';
 import { DARK_MODE, getStoryVariant, RTL } from '../../utilities/WCThemeDecorator.js';
 
-ProgressBarDefinition.define(FluentDesignSystem.registry);
+import '@fluentui/web-components/progress-bar/define.js';
 
 export default {
   title: 'ProgressBar',

--- a/apps/vr-tests-web-components/src/stories/radio-group/radio-group.stories.tsx
+++ b/apps/vr-tests-web-components/src/stories/radio-group/radio-group.stories.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react';
 import { default as parse } from 'html-react-parser';
 import { Steps } from 'storywright';
-import { RadioDefinition, RadioGroupDefinition, FluentDesignSystem } from '@fluentui/web-components';
 import { DARK_MODE, getStoryVariant, RTL } from '../../utilities/WCThemeDecorator.js';
 
-RadioDefinition.define(FluentDesignSystem.registry);
-RadioGroupDefinition.define(FluentDesignSystem.registry);
+import '@fluentui/web-components/radio/define.js';
+import '@fluentui/web-components/radio-group/define.js';
 
 export default {
   title: 'RadioGroup',

--- a/apps/vr-tests-web-components/src/stories/radio/radio.stories.tsx
+++ b/apps/vr-tests-web-components/src/stories/radio/radio.stories.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import { default as parse } from 'html-react-parser';
 import { Steps } from 'storywright';
-import { RadioDefinition, FluentDesignSystem } from '@fluentui/web-components';
 import { DARK_MODE, getStoryVariant } from '../../utilities/WCThemeDecorator.js';
 
-RadioDefinition.define(FluentDesignSystem.registry);
+import '@fluentui/web-components/radio/define.js';
+
 export default {
   title: 'Radio',
   decorators: [

--- a/apps/vr-tests-web-components/src/stories/slider/slider.stories.tsx
+++ b/apps/vr-tests-web-components/src/stories/slider/slider.stories.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
 import { default as parse } from 'html-react-parser';
 import { Steps, Keys, type StoryParameters } from 'storywright';
-import { SliderDefinition, FluentDesignSystem } from '@fluentui/web-components';
+import '@fluentui/web-components/slider/define.js';
 import { DARK_MODE, getStoryVariant, RTL } from '../../utilities/WCThemeDecorator.js';
-
-SliderDefinition.define(FluentDesignSystem.registry);
 
 export default {
   title: 'Slider',

--- a/apps/vr-tests-web-components/src/stories/switch/switch.stories.tsx
+++ b/apps/vr-tests-web-components/src/stories/switch/switch.stories.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
 import { default as parse } from 'html-react-parser';
 import { Steps } from 'storywright';
-import { SwitchDefinition, FluentDesignSystem } from '@fluentui/web-components';
+import '@fluentui/web-components/switch/define.js';
 import { DARK_MODE, getStoryVariant, RTL } from '../../utilities/WCThemeDecorator.js';
-
-SwitchDefinition.define(FluentDesignSystem.registry);
 
 const controlId = 'switch-id';
 

--- a/apps/vr-tests-web-components/src/stories/text-input/text-input.stories.tsx
+++ b/apps/vr-tests-web-components/src/stories/text-input/text-input.stories.tsx
@@ -1,12 +1,10 @@
 import * as React from 'react';
 import { default as parse } from 'html-react-parser';
 import { Steps } from 'storywright';
-import { TextInputDefinition, LabelDefinition, FluentDesignSystem } from '@fluentui/web-components';
+import '@fluentui/web-components/text-input/define.js';
+import '@fluentui/web-components/label/define.js';
 import { tokens } from '@fluentui/tokens';
 import { DARK_MODE, getStoryVariant, RTL } from '../../utilities/WCThemeDecorator.js';
-
-TextInputDefinition.define(FluentDesignSystem.registry);
-LabelDefinition.define(FluentDesignSystem.registry);
 
 export default {
   title: 'TextInput',

--- a/apps/vr-tests-web-components/src/stories/text/text.stories.tsx
+++ b/apps/vr-tests-web-components/src/stories/text/text.stories.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
 import { default as parse } from 'html-react-parser';
 import { Steps } from 'storywright';
-import { TextDefinition, FluentDesignSystem, colorNeutralBackground6 } from '@fluentui/web-components';
-
-TextDefinition.define(FluentDesignSystem.registry);
+import { colorNeutralBackground6 } from '@fluentui/web-components';
+import '@fluentui/web-components/text/define.js';
 
 export default {
   title: 'Text',

--- a/change/@fluentui-chart-web-components-0db36d7a-4ed7-406b-8773-bb7426bfdaa8.json
+++ b/change/@fluentui-chart-web-components-0db36d7a-4ed7-406b-8773-bb7426bfdaa8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "refactor: replace compose() with plain definition objects",
+  "packageName": "@fluentui/chart-web-components",
+  "email": "863023+radium-v@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-web-components-b4d8c7d8-5a79-4565-b6c0-74ba5d844bdd.json
+++ b/change/@fluentui-web-components-b4d8c7d8-5a79-4565-b6c0-74ba5d844bdd.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "refactor: replace compose() with plain definition objects",
+  "packageName": "@fluentui/web-components",
+  "email": "863023+radium-v@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charts/chart-web-components/docs/chart-web-components.api.md
+++ b/packages/charts/chart-web-components/docs/chart-web-components.api.md
@@ -7,7 +7,7 @@
 import { ElementStyles } from '@microsoft/fast-element';
 import { ElementViewTemplate } from '@microsoft/fast-element';
 import { FASTElement } from '@microsoft/fast-element';
-import { FASTElementDefinition } from '@microsoft/fast-element';
+import type { PartialFASTElementDefinition } from '@microsoft/fast-element';
 
 // Warning: (ae-missing-release-tag) "DonutChart" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -69,8 +69,8 @@ export class DonutChart extends FASTElement {
     width: number;
 }
 
-// @public (undocumented)
-export const DonutChartDefinition: FASTElementDefinition<typeof DonutChart>;
+// @public
+export const DonutChartDefinition: PartialFASTElementDefinition;
 
 // @public
 export const DonutChartStyles: ElementStyles;
@@ -135,7 +135,7 @@ export class HorizontalBarChart extends FASTElement {
 }
 
 // @public
-export const HorizontalBarChartDefinition: FASTElementDefinition<typeof HorizontalBarChart>;
+export const HorizontalBarChartDefinition: PartialFASTElementDefinition;
 
 // @public
 export const HorizontalBarChartStyles: ElementStyles;

--- a/packages/charts/chart-web-components/src/donut-chart/define.ts
+++ b/packages/charts/chart-web-components/src/donut-chart/define.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '@fluentui/web-components';
 import { definition } from './donut-chart.definition.js';
+import { DonutChart } from './donut-chart.js';
 
-definition.define(FluentDesignSystem.registry);
+DonutChart.define(definition);

--- a/packages/charts/chart-web-components/src/donut-chart/donut-chart.bench.ts
+++ b/packages/charts/chart-web-components/src/donut-chart/donut-chart.bench.ts
@@ -1,7 +1,4 @@
-import { FluentDesignSystem } from '@fluentui/web-components';
-import { definition } from './donut-chart.definition.js';
-
-definition.define(FluentDesignSystem.registry);
+import './define.js';
 
 const itemRenderer = () => {
   const donutChart = document.createElement('fluent-donut-chart');

--- a/packages/charts/chart-web-components/src/donut-chart/donut-chart.definition.ts
+++ b/packages/charts/chart-web-components/src/donut-chart/donut-chart.definition.ts
@@ -1,18 +1,19 @@
 import { FluentDesignSystem } from '@fluentui/web-components';
-import { DonutChart } from './donut-chart.js';
+import type { PartialFASTElementDefinition } from '@microsoft/fast-element';
 import { styles } from './donut-chart.styles.js';
 import { template } from './donut-chart.template.js';
 
 /**
+ * The definition for the `<fluent-donut-chart>` element.
+ *
  * @public
- * @remarks
- * HTML Element: `<fluent-donut-chart>`
  */
-export const definition = DonutChart.compose({
+export const definition: PartialFASTElementDefinition = {
   name: `${FluentDesignSystem.prefix}-donut-chart`,
-  template,
-  styles,
+  registry: FluentDesignSystem.registry,
   shadowOptions: {
     delegatesFocus: true,
   },
-});
+  styles,
+  template,
+};

--- a/packages/charts/chart-web-components/src/horizontal-bar-chart/define.ts
+++ b/packages/charts/chart-web-components/src/horizontal-bar-chart/define.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '@fluentui/web-components';
 import { definition } from './horizontal-bar-chart.definition.js';
+import { HorizontalBarChart } from './horizontal-bar-chart.js';
 
-definition.define(FluentDesignSystem.registry);
+HorizontalBarChart.define(definition);

--- a/packages/charts/chart-web-components/src/horizontal-bar-chart/horizontal-bar-chart.bench.ts
+++ b/packages/charts/chart-web-components/src/horizontal-bar-chart/horizontal-bar-chart.bench.ts
@@ -1,7 +1,4 @@
-import { FluentDesignSystem } from '@fluentui/web-components';
-import { definition } from './horizontal-bar-chart.definition.js';
-
-definition.define(FluentDesignSystem.registry);
+import './define.js';
 
 const itemRenderer = () => {
   const horizontalbarchart = document.createElement('fluent-horizontal-bar-chart');

--- a/packages/charts/chart-web-components/src/horizontal-bar-chart/horizontal-bar-chart.definition.ts
+++ b/packages/charts/chart-web-components/src/horizontal-bar-chart/horizontal-bar-chart.definition.ts
@@ -1,20 +1,19 @@
 import { FluentDesignSystem } from '@fluentui/web-components';
-import { HorizontalBarChart } from './horizontal-bar-chart.js';
+import type { PartialFASTElementDefinition } from '@microsoft/fast-element';
 import { styles } from './horizontal-bar-chart.styles.js';
 import { template } from './horizontal-bar-chart.template.js';
 
 /**
- * The Fluent Textarea Element definition.
+ * The definition for the `<fluent-horizontal-bar-chart>` element.
  *
  * @public
- * @remarks
- * HTML Element: `<fluent-textarea>`
  */
-export const definition = HorizontalBarChart.compose({
+export const definition: PartialFASTElementDefinition = {
   name: `${FluentDesignSystem.prefix}-horizontal-bar-chart`,
-  template,
-  styles,
+  registry: FluentDesignSystem.registry,
   shadowOptions: {
     delegatesFocus: true,
   },
-});
+  styles,
+  template,
+};

--- a/packages/web-components/docs/web-components.api.md
+++ b/packages/web-components/docs/web-components.api.md
@@ -9,8 +9,8 @@ import { CSSDirective } from '@microsoft/fast-element';
 import { ElementStyles } from '@microsoft/fast-element';
 import { ElementViewTemplate } from '@microsoft/fast-element';
 import { FASTElement } from '@microsoft/fast-element';
-import { FASTElementDefinition } from '@microsoft/fast-element';
 import { HTMLDirective } from '@microsoft/fast-element';
+import type { PartialFASTElementDefinition } from '@microsoft/fast-element';
 import { SyntheticViewTemplate } from '@microsoft/fast-element';
 import { ViewTemplate } from '@microsoft/fast-element';
 
@@ -31,8 +31,8 @@ export class Accordion extends FASTElement {
     slottedAccordionItemsChanged(oldValue: HTMLElement[], newValue: HTMLElement[]): void;
 }
 
-// @public (undocumented)
-export const accordionDefinition: FASTElementDefinition<typeof Accordion>;
+// @public
+export const accordionDefinition: PartialFASTElementDefinition;
 
 // @public
 export const AccordionExpandMode: {
@@ -59,8 +59,8 @@ export class AccordionItem extends BaseAccordionItem {
 export interface AccordionItem extends StartEnd {
 }
 
-// @public (undocumented)
-export const accordionItemDefinition: FASTElementDefinition<typeof AccordionItem>;
+// @public
+export const accordionItemDefinition: PartialFASTElementDefinition;
 
 // Warning: (ae-missing-release-tag) "AccordionItemMarkerPosition" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -140,8 +140,8 @@ export const AnchorButtonAppearance: {
 // @public
 export type AnchorButtonAppearance = ValuesOf<typeof AnchorButtonAppearance>;
 
-// @public (undocumented)
-export const AnchorButtonDefinition: FASTElementDefinition<typeof AnchorButton>;
+// @public
+export const AnchorButtonDefinition: PartialFASTElementDefinition;
 
 // @public
 export const AnchorButtonShape: {
@@ -267,7 +267,7 @@ export const AvatarColor: {
 export type AvatarColor = ValuesOf<typeof AvatarColor>;
 
 // @public
-export const AvatarDefinition: FASTElementDefinition<typeof Avatar>;
+export const AvatarDefinition: PartialFASTElementDefinition;
 
 // Warning: (ae-missing-release-tag) "AvatarNamedColor" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -390,8 +390,8 @@ export const BadgeColor: {
 // @public
 export type BadgeColor = ValuesOf<typeof BadgeColor>;
 
-// @public (undocumented)
-export const BadgeDefinition: FASTElementDefinition<typeof Badge>;
+// @public
+export const BadgeDefinition: PartialFASTElementDefinition;
 
 // @public
 export const BadgeShape: {
@@ -1160,7 +1160,7 @@ export const ButtonAppearance: {
 export type ButtonAppearance = ValuesOf<typeof ButtonAppearance>;
 
 // @public
-export const ButtonDefinition: FASTElementDefinition<typeof Button>;
+export const ButtonDefinition: PartialFASTElementDefinition;
 
 // @public
 export const ButtonFormTarget: {
@@ -1226,7 +1226,7 @@ export class Checkbox extends BaseCheckbox {
 }
 
 // @public
-export const CheckboxDefinition: FASTElementDefinition<typeof Checkbox>;
+export const CheckboxDefinition: PartialFASTElementDefinition;
 
 // @public
 export type CheckboxOptions = {
@@ -2371,8 +2371,8 @@ export const CompoundButtonAppearance: {
 // @public
 export type CompoundButtonAppearance = ValuesOf<typeof CompoundButtonAppearance>;
 
-// @public (undocumented)
-export const CompoundButtonDefinition: FASTElementDefinition<typeof CompoundButton>;
+// @public
+export const CompoundButtonDefinition: PartialFASTElementDefinition;
 
 // @public
 export const CompoundButtonShape: {
@@ -2440,8 +2440,8 @@ export const CounterBadgeColor: {
 // @public
 export type CounterBadgeColor = ValuesOf<typeof CounterBadgeColor>;
 
-// @public (undocumented)
-export const CounterBadgeDefinition: FASTElementDefinition<typeof CounterBadge>;
+// @public
+export const CounterBadgeDefinition: PartialFASTElementDefinition;
 
 // @public
 export const CounterBadgeShape: {
@@ -2534,7 +2534,7 @@ export class DialogBody extends FASTElement {
 }
 
 // @public
-export const DialogBodyDefinition: FASTElementDefinition<typeof DialogBody>;
+export const DialogBodyDefinition: PartialFASTElementDefinition;
 
 // @public
 export const DialogBodyStyles: ElementStyles;
@@ -2543,7 +2543,7 @@ export const DialogBodyStyles: ElementStyles;
 export const DialogBodyTemplate: ElementViewTemplate;
 
 // @public
-export const DialogDefinition: FASTElementDefinition<typeof Dialog>;
+export const DialogDefinition: PartialFASTElementDefinition;
 
 // @public
 export const DialogStyles: ElementStyles;
@@ -2608,7 +2608,7 @@ export const DividerAppearance: {
 export type DividerAppearance = ValuesOf<typeof DividerAppearance>;
 
 // @public
-export const DividerDefinition: FASTElementDefinition<typeof Divider>;
+export const DividerDefinition: PartialFASTElementDefinition;
 
 // @public
 export const DividerOrientation: {
@@ -2676,8 +2676,8 @@ export class DrawerBody extends FASTElement {
     clickHandler(event: PointerEvent): boolean | void;
 }
 
-// @public (undocumented)
-export const DrawerBodyDefinition: FASTElementDefinition<typeof DrawerBody>;
+// @public
+export const DrawerBodyDefinition: PartialFASTElementDefinition;
 
 // @public
 export const DrawerBodyStyles: ElementStyles;
@@ -2687,8 +2687,8 @@ export const DrawerBodyStyles: ElementStyles;
 // @public (undocumented)
 export const DrawerBodyTemplate: ElementViewTemplate<DrawerBody>;
 
-// @public (undocumented)
-export const DrawerDefinition: FASTElementDefinition<typeof Drawer>;
+// @public
+export const DrawerDefinition: PartialFASTElementDefinition;
 
 // Warning: (ae-missing-release-tag) "DrawerPosition" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -2755,7 +2755,7 @@ export type DropdownAppearance = ValuesOf<typeof DropdownAppearance>;
 export const dropdownButtonTemplate: ViewTemplate<BaseDropdown, any>;
 
 // @public
-export const DropdownDefinition: FASTElementDefinition<typeof Dropdown>;
+export const DropdownDefinition: PartialFASTElementDefinition;
 
 // @public
 export const dropdownInputTemplate: ViewTemplate<BaseDropdown, any>;
@@ -2818,7 +2818,7 @@ export class DropdownOption extends FASTElement implements Start {
 }
 
 // @public
-export const DropdownOptionDefinition: FASTElementDefinition<typeof DropdownOption>;
+export const DropdownOptionDefinition: PartialFASTElementDefinition;
 
 // @public
 export type DropdownOptionOptions = StartOptions<DropdownOption> & {
@@ -2900,7 +2900,7 @@ export class Field extends BaseField {
 }
 
 // @public
-export const FieldDefinition: FASTElementDefinition<typeof Field>;
+export const FieldDefinition: PartialFASTElementDefinition;
 
 // @public
 export const FieldLabelPosition: {
@@ -2992,7 +2992,7 @@ class Image_2 extends FASTElement {
 export { Image_2 as Image }
 
 // @public
-export const ImageDefinition: FASTElementDefinition<typeof Image_2>;
+export const ImageDefinition: PartialFASTElementDefinition;
 
 // @public
 export const ImageFit: {
@@ -3050,7 +3050,7 @@ export class Label extends FASTElement {
 }
 
 // @public
-export const LabelDefinition: FASTElementDefinition<typeof Label>;
+export const LabelDefinition: PartialFASTElementDefinition;
 
 // Warning: (ae-missing-release-tag) "LabelSize" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -3127,8 +3127,8 @@ export const LinkAppearance: {
 // @public
 export type LinkAppearance = ValuesOf<typeof LinkAppearance>;
 
-// @public (undocumented)
-export const LinkDefinition: FASTElementDefinition<typeof Link>;
+// @public
+export const LinkDefinition: PartialFASTElementDefinition;
 
 // Warning: (ae-missing-release-tag) "styles" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -3182,7 +3182,7 @@ export class Listbox extends FASTElement {
 }
 
 // @public
-export const ListboxDefinition: FASTElementDefinition<typeof Listbox>;
+export const ListboxDefinition: PartialFASTElementDefinition;
 
 // @public
 export const ListboxStyles: ElementStyles;
@@ -3256,8 +3256,8 @@ export const MenuButtonAppearance: {
 // @public
 export type MenuButtonAppearance = ValuesOf<typeof MenuButtonAppearance>;
 
-// @public (undocumented)
-export const MenuButtonDefinition: FASTElementDefinition<typeof MenuButton>;
+// @public
+export const MenuButtonDefinition: PartialFASTElementDefinition;
 
 // @public
 export const MenuButtonShape: {
@@ -3283,7 +3283,7 @@ export type MenuButtonSize = ValuesOf<typeof MenuButtonSize>;
 export const MenuButtonTemplate: ElementViewTemplate<MenuButton>;
 
 // @public
-export const MenuDefinition: FASTElementDefinition<typeof Menu>;
+export const MenuDefinition: PartialFASTElementDefinition;
 
 // Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
 // Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "MenuItem" because one of its declarations is marked as @internal
@@ -3332,8 +3332,8 @@ export interface MenuItem extends StartEnd {
 // @public (undocumented)
 export type MenuItemColumnCount = 0 | 1 | 2;
 
-// @public (undocumented)
-export const MenuItemDefinition: FASTElementDefinition<typeof MenuItem>;
+// @public
+export const MenuItemDefinition: PartialFASTElementDefinition;
 
 // @public
 export type MenuItemOptions = StartEndOptions<MenuItem> & {
@@ -3367,8 +3367,8 @@ export class MenuList extends BaseMenuList {
     setItems(): void;
 }
 
-// @public (undocumented)
-export const MenuListDefinition: FASTElementDefinition<typeof MenuList>;
+// @public
+export const MenuListDefinition: PartialFASTElementDefinition;
 
 // @public
 export const MenuListStyles: ElementStyles;
@@ -3398,7 +3398,7 @@ export class MessageBar extends FASTElement {
 }
 
 // @public
-export const MessageBarDefinition: FASTElementDefinition<typeof MessageBar>;
+export const MessageBarDefinition: PartialFASTElementDefinition;
 
 // Warning: (ae-missing-release-tag) "MessageBarIntent" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -3459,7 +3459,7 @@ export class ProgressBar extends BaseProgressBar {
 }
 
 // @public
-export const ProgressBarDefinition: FASTElementDefinition<typeof ProgressBar>;
+export const ProgressBarDefinition: PartialFASTElementDefinition;
 
 // @public
 export const ProgressBarShape: {
@@ -3516,7 +3516,7 @@ export class Radio extends BaseCheckbox {
 export type RadioControl = Pick<HTMLInputElement, 'checked' | 'disabled' | 'focus' | 'setAttribute' | 'getAttribute'>;
 
 // @public
-export const RadioDefinition: FASTElementDefinition<typeof Radio>;
+export const RadioDefinition: PartialFASTElementDefinition;
 
 // @public
 export class RadioGroup extends BaseRadioGroup {
@@ -3527,7 +3527,7 @@ export class RadioGroup extends BaseRadioGroup {
 }
 
 // @public
-export const RadioGroupDefinition: FASTElementDefinition<typeof RadioGroup>;
+export const RadioGroupDefinition: PartialFASTElementDefinition;
 
 // @public
 export const RadioGroupOrientation: {
@@ -3575,7 +3575,7 @@ export const RatingDisplayColor: {
 export type RatingDisplayColor = ValuesOf<typeof RatingDisplayColor>;
 
 // @public
-export const RatingDisplayDefinition: FASTElementDefinition<typeof RatingDisplay>;
+export const RatingDisplayDefinition: PartialFASTElementDefinition;
 
 // @public
 export const RatingDisplaySize: {
@@ -3745,7 +3745,7 @@ export interface SliderConfiguration {
 }
 
 // @public
-export const SliderDefinition: FASTElementDefinition<typeof Slider>;
+export const SliderDefinition: PartialFASTElementDefinition;
 
 // @public (undocumented)
 export const SliderMode: {
@@ -3877,8 +3877,8 @@ export const SpinnerAppearance: {
 // @public
 export type SpinnerAppearance = ValuesOf<typeof SpinnerAppearance>;
 
-// @public (undocumented)
-export const SpinnerDefinition: FASTElementDefinition<typeof Spinner>;
+// @public
+export const SpinnerDefinition: PartialFASTElementDefinition;
 
 // @public
 export const SpinnerSize: {
@@ -3950,7 +3950,7 @@ export class Switch extends BaseCheckbox {
 }
 
 // @public
-export const SwitchDefinition: FASTElementDefinition<typeof Switch>;
+export const SwitchDefinition: PartialFASTElementDefinition;
 
 // @public
 export const SwitchLabelPosition: {
@@ -3998,10 +3998,8 @@ export class Tab extends FASTElement {
 export interface Tab extends StartEnd {
 }
 
-// Warning: (ae-missing-release-tag) "definition" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
-export const TabDefinition: FASTElementDefinition<typeof Tab>;
+// @public
+export const TabDefinition: PartialFASTElementDefinition;
 
 // @public
 export class Tablist extends BaseTablist {
@@ -4022,8 +4020,8 @@ export const TablistAppearance: {
 // @public
 export type TablistAppearance = ValuesOf<typeof TablistAppearance>;
 
-// @public (undocumented)
-export const TablistDefinition: FASTElementDefinition<typeof Tablist>;
+// @public
+export const TablistDefinition: PartialFASTElementDefinition;
 
 // @public
 export const TablistOrientation: {
@@ -4135,7 +4133,7 @@ export const TextAreaAutocomplete: {
 export type TextAreaAutocomplete = ValuesOf<typeof TextAreaAutocomplete>;
 
 // @public
-export const TextAreaDefinition: FASTElementDefinition<typeof TextArea>;
+export const TextAreaDefinition: PartialFASTElementDefinition;
 
 // Warning: (ae-missing-release-tag) "TextAreaResize" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 // Warning: (ae-missing-release-tag) "TextAreaResize" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -4172,7 +4170,7 @@ export const TextAreaStyles: ElementStyles;
 export const TextAreaTemplate: ElementViewTemplate<TextArea>;
 
 // @public
-export const TextDefinition: FASTElementDefinition<typeof Text_2>;
+export const TextDefinition: PartialFASTElementDefinition;
 
 // @public
 export const TextFont: {
@@ -4223,7 +4221,7 @@ export const TextInputControlSize: {
 export type TextInputControlSize = ValuesOf<typeof TextInputControlSize>;
 
 // @public
-export const TextInputDefinition: FASTElementDefinition<typeof TextInput>;
+export const TextInputDefinition: PartialFASTElementDefinition;
 
 // @public
 export type TextInputOptions = StartEndOptions<TextInput>;
@@ -4314,8 +4312,8 @@ export const ToggleButtonAppearance: {
 // @public
 export type ToggleButtonAppearance = ValuesOf<typeof ToggleButtonAppearance>;
 
-// @public (undocumented)
-export const ToggleButtonDefinition: FASTElementDefinition<typeof ToggleButton>;
+// @public
+export const ToggleButtonDefinition: PartialFASTElementDefinition;
 
 // @public
 export const ToggleButtonShape: {
@@ -4370,7 +4368,7 @@ export class Tooltip extends FASTElement {
 }
 
 // @public
-export const TooltipDefinition: FASTElementDefinition<typeof Tooltip>;
+export const TooltipDefinition: PartialFASTElementDefinition;
 
 // @public
 export const TooltipPositioningOption: {
@@ -4416,8 +4414,8 @@ export class Tree extends BaseTree {
     updateSizeAndAppearance(): void;
 }
 
-// @public (undocumented)
-export const TreeDefinition: FASTElementDefinition<typeof Tree>;
+// @public
+export const TreeDefinition: PartialFASTElementDefinition;
 
 // Warning: (ae-missing-release-tag) "TreeItem" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -4447,8 +4445,8 @@ export const TreeItemAppearance: {
 // @public (undocumented)
 export type TreeItemAppearance = ValuesOf<typeof TreeItemAppearance>;
 
-// @public (undocumented)
-export const TreeItemDefinition: FASTElementDefinition<typeof TreeItem>;
+// @public
+export const TreeItemDefinition: PartialFASTElementDefinition;
 
 // Warning: (ae-missing-release-tag) "TreeItemSize" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 // Warning: (ae-missing-release-tag) "TreeItemSize" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/packages/web-components/src/accordion-item/accordion-item.bench.ts
+++ b/packages/web-components/src/accordion-item/accordion-item.bench.ts
@@ -1,7 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
-import { definition } from './accordion-item.definition.js';
-
-definition.define(FluentDesignSystem.registry);
+import './define.js';
 
 const itemRenderer = () => {
   const item = document.createElement('fluent-accordion-item');

--- a/packages/web-components/src/accordion-item/accordion-item.definition.ts
+++ b/packages/web-components/src/accordion-item/accordion-item.definition.ts
@@ -1,16 +1,17 @@
+import type { PartialFASTElementDefinition } from '@microsoft/fast-element';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import { tagName } from './accordion-item.options.js';
-import { AccordionItem } from './accordion-item.js';
 import { styles } from './accordion-item.styles.js';
 import { template } from './accordion-item.template.js';
 
 /**
+ * The definition configuration for the `<fluent-accordion-item>` element.
  *
  * @public
- * @remarks
- * HTML Element: \<fluent-accordion-item\>
  */
-export const definition = AccordionItem.compose({
+export const definition: PartialFASTElementDefinition = {
   name: tagName,
-  template,
+  registry: FluentDesignSystem.registry,
   styles,
-});
+  template,
+};

--- a/packages/web-components/src/accordion-item/define.ts
+++ b/packages/web-components/src/accordion-item/define.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
 import { definition } from './accordion-item.definition.js';
+import { AccordionItem } from './accordion-item.js';
 
-definition.define(FluentDesignSystem.registry);
+AccordionItem.define(definition);

--- a/packages/web-components/src/accordion/accordion.bench.ts
+++ b/packages/web-components/src/accordion/accordion.bench.ts
@@ -1,9 +1,5 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
-import { definition as accordionItemDefinition } from '../accordion-item/accordion-item.definition.js';
-import { definition as accordiongDefinition } from './accordion.definition.js';
-
-accordiongDefinition.define(FluentDesignSystem.registry);
-accordionItemDefinition.define(FluentDesignSystem.registry);
+import '../accordion-item/define.js';
+import './define.js';
 
 const itemRenderer = () => {
   const accordion = document.createElement('fluent-accordion');

--- a/packages/web-components/src/accordion/accordion.definition.ts
+++ b/packages/web-components/src/accordion/accordion.definition.ts
@@ -1,15 +1,17 @@
+import type { PartialFASTElementDefinition } from '@microsoft/fast-element';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import { tagName } from './accordion.options.js';
-import { Accordion } from './accordion.js';
 import { styles } from './accordion.styles.js';
 import { template } from './accordion.template.js';
 
 /**
+ * The definition configuration for the `<fluent-accordion>` element.
+ *
  * @public
- * @remarks
- * HTML Element: \<fluent-accordion\>
  */
-export const definition = Accordion.compose({
+export const definition: PartialFASTElementDefinition = {
   name: tagName,
-  template,
+  registry: FluentDesignSystem.registry,
   styles,
-});
+  template,
+};

--- a/packages/web-components/src/accordion/define.ts
+++ b/packages/web-components/src/accordion/define.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
 import { definition } from './accordion.definition.js';
+import { Accordion } from './accordion.js';
 
-definition.define(FluentDesignSystem.registry);
+Accordion.define(definition);

--- a/packages/web-components/src/anchor-button/anchor-button.bench.ts
+++ b/packages/web-components/src/anchor-button/anchor-button.bench.ts
@@ -1,7 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
-import { definition } from './anchor-button.definition.js';
-
-definition.define(FluentDesignSystem.registry);
+import './define.js';
 
 const itemRenderer = () => {
   const btn = document.createElement('fluent-anchor-button');

--- a/packages/web-components/src/anchor-button/anchor-button.definition.ts
+++ b/packages/web-components/src/anchor-button/anchor-button.definition.ts
@@ -1,15 +1,17 @@
+import type { PartialFASTElementDefinition } from '@microsoft/fast-element';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import { tagName } from './anchor-button.options.js';
-import { AnchorButton } from './anchor-button.js';
 import { styles } from './anchor-button.styles.js';
 import { template } from './anchor-button.template.js';
 
 /**
+ * The definition for the `<fluent-anchor-button>` element.
+ *
  * @public
- * @remarks
- * HTML Element: \<fluent-anchor-button\>
  */
-export const definition = AnchorButton.compose({
+export const definition: PartialFASTElementDefinition = {
   name: tagName,
-  template,
+  registry: FluentDesignSystem.registry,
   styles,
-});
+  template,
+};

--- a/packages/web-components/src/anchor-button/define.ts
+++ b/packages/web-components/src/anchor-button/define.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
 import { definition } from './anchor-button.definition.js';
+import { AnchorButton } from './anchor-button.js';
 
-definition.define(FluentDesignSystem.registry);
+AnchorButton.define(definition);

--- a/packages/web-components/src/avatar/avatar.bench.ts
+++ b/packages/web-components/src/avatar/avatar.bench.ts
@@ -1,7 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
-import { definition } from './avatar.definition.js';
-
-definition.define(FluentDesignSystem.registry);
+import './define.js';
 
 const itemRenderer = () => {
   const avatar = document.createElement('fluent-avatar');

--- a/packages/web-components/src/avatar/avatar.definition.ts
+++ b/packages/web-components/src/avatar/avatar.definition.ts
@@ -1,17 +1,17 @@
+import type { PartialFASTElementDefinition } from '@microsoft/fast-element';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import { tagName } from './avatar.options.js';
-import { Avatar } from './avatar.js';
 import { styles } from './avatar.styles.js';
 import { template } from './avatar.template.js';
 
 /**
- * The Fluent Avatar Element.
+ * The definition for the `<fluent-avatar>` element.
  *
  * @public
- * @remarks
- * HTML Element: \<fluent-badge\>
  */
-export const definition = Avatar.compose({
+export const definition: PartialFASTElementDefinition = {
   name: tagName,
-  template,
+  registry: FluentDesignSystem.registry,
   styles,
-});
+  template,
+};

--- a/packages/web-components/src/avatar/define.ts
+++ b/packages/web-components/src/avatar/define.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
 import { definition } from './avatar.definition.js';
+import { Avatar } from './avatar.js';
 
-definition.define(FluentDesignSystem.registry);
+Avatar.define(definition);

--- a/packages/web-components/src/badge/badge.bench.ts
+++ b/packages/web-components/src/badge/badge.bench.ts
@@ -1,7 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
-import { definition } from './badge.definition.js';
-
-definition.define(FluentDesignSystem.registry);
+import './define.js';
 
 const itemRenderer = () => {
   const badge = document.createElement('fluent-badge');

--- a/packages/web-components/src/badge/badge.definition.ts
+++ b/packages/web-components/src/badge/badge.definition.ts
@@ -1,16 +1,17 @@
+import type { PartialFASTElementDefinition } from '@microsoft/fast-element';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import { tagName } from './badge.options.js';
-import { Badge } from './badge.js';
 import { styles } from './badge.styles.js';
 import { template } from './badge.template.js';
 
 /**
+ * The definition for the `<fluent-badge>` element.
  *
  * @public
- * @remarks
- * HTML Element: \<fluent-badge\>
  */
-export const definition = Badge.compose({
+export const definition: PartialFASTElementDefinition = {
   name: tagName,
-  template,
+  registry: FluentDesignSystem.registry,
   styles,
-});
+  template,
+};

--- a/packages/web-components/src/badge/define.ts
+++ b/packages/web-components/src/badge/define.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
 import { definition } from './badge.definition.js';
+import { Badge } from './badge.js';
 
-definition.define(FluentDesignSystem.registry);
+Badge.define(definition);

--- a/packages/web-components/src/button/button.bench.ts
+++ b/packages/web-components/src/button/button.bench.ts
@@ -1,7 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
-import { definition } from './button.definition.js';
-
-definition.define(FluentDesignSystem.registry);
+import './define.js';
 
 const itemRenderer = () => {
   const button = document.createElement('fluent-button');

--- a/packages/web-components/src/button/button.definition.ts
+++ b/packages/web-components/src/button/button.definition.ts
@@ -1,17 +1,17 @@
+import type { PartialFASTElementDefinition } from '@microsoft/fast-element';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import { tagName } from './button.options.js';
-import { Button } from './button.js';
 import { styles } from './button.styles.js';
 import { template } from './button.template.js';
 
 /**
- * The definition for the Fluent Button component.
+ * The definition for the `<fluent-button>` element.
  *
  * @public
- * @remarks
- * HTML Element: `<fluent-button>`
  */
-export const definition = Button.compose({
+export const definition: PartialFASTElementDefinition = {
   name: tagName,
-  template,
+  registry: FluentDesignSystem.registry,
   styles,
-});
+  template,
+};

--- a/packages/web-components/src/button/define.ts
+++ b/packages/web-components/src/button/define.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
 import { definition } from './button.definition.js';
+import { Button } from './button.js';
 
-definition.define(FluentDesignSystem.registry);
+Button.define(definition);

--- a/packages/web-components/src/checkbox/checkbox.bench.ts
+++ b/packages/web-components/src/checkbox/checkbox.bench.ts
@@ -1,7 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
-import { definition } from './checkbox.definition.js';
-
-definition.define(FluentDesignSystem.registry);
+import './define.js';
 
 const itemRenderer = () => {
   const checkbox = document.createElement('fluent-checkbox');

--- a/packages/web-components/src/checkbox/checkbox.definition.ts
+++ b/packages/web-components/src/checkbox/checkbox.definition.ts
@@ -1,17 +1,17 @@
+import type { PartialFASTElementDefinition } from '@microsoft/fast-element';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import { tagName } from './checkbox.options.js';
-import { Checkbox } from './checkbox.js';
 import { styles } from './checkbox.styles.js';
 import { template } from './checkbox.template.js';
 
 /**
- * The Fluent Checkbox Element
+ * The definition for the `<fluent-checkbox>` element.
  *
  * @public
- * @remarks
- * HTML Element: \<fluent-checkbox\>
  */
-export const definition = Checkbox.compose({
+export const definition: PartialFASTElementDefinition = {
   name: tagName,
-  template,
+  registry: FluentDesignSystem.registry,
   styles,
-});
+  template,
+};

--- a/packages/web-components/src/checkbox/define.ts
+++ b/packages/web-components/src/checkbox/define.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
 import { definition } from './checkbox.definition.js';
+import { Checkbox } from './checkbox.js';
 
-definition.define(FluentDesignSystem.registry);
+Checkbox.define(definition);

--- a/packages/web-components/src/compound-button/compound-button.bench.ts
+++ b/packages/web-components/src/compound-button/compound-button.bench.ts
@@ -1,7 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
-import { definition } from './compound-button.definition.js';
-
-definition.define(FluentDesignSystem.registry);
+import './define.js';
 
 const itemRenderer = () => {
   const compoundButton = document.createElement('fluent-compound-button');

--- a/packages/web-components/src/compound-button/compound-button.definition.ts
+++ b/packages/web-components/src/compound-button/compound-button.definition.ts
@@ -1,15 +1,17 @@
+import type { PartialFASTElementDefinition } from '@microsoft/fast-element';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import { tagName } from './compound-button.options.js';
-import { CompoundButton } from './compound-button.js';
 import { styles } from './compound-button.styles.js';
 import { template } from './compound-button.template.js';
 
 /**
+ * The definition for the `<fluent-compound-button>` element.
+ *
  * @public
- * @remarks
- * HTML Element: \<fluent-comopund-button\>
  */
-export const definition = CompoundButton.compose({
+export const definition: PartialFASTElementDefinition = {
   name: tagName,
-  template,
+  registry: FluentDesignSystem.registry,
   styles,
-});
+  template,
+};

--- a/packages/web-components/src/compound-button/define.ts
+++ b/packages/web-components/src/compound-button/define.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
 import { definition } from './compound-button.definition.js';
+import { CompoundButton } from './compound-button.js';
 
-definition.define(FluentDesignSystem.registry);
+CompoundButton.define(definition);

--- a/packages/web-components/src/counter-badge/counter-badge.bench.ts
+++ b/packages/web-components/src/counter-badge/counter-badge.bench.ts
@@ -1,7 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
-import { definition } from './counter-badge.definition.js';
-
-definition.define(FluentDesignSystem.registry);
+import './define.js';
 
 const itemRenderer = () => {
   const counterBadge = document.createElement('fluent-counter-badge');

--- a/packages/web-components/src/counter-badge/counter-badge.definition.ts
+++ b/packages/web-components/src/counter-badge/counter-badge.definition.ts
@@ -1,15 +1,17 @@
+import type { PartialFASTElementDefinition } from '@microsoft/fast-element';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import { tagName } from './counter-badge.options.js';
-import { CounterBadge } from './counter-badge.js';
 import { styles } from './counter-badge.styles.js';
 import { template } from './counter-badge.template.js';
 
 /**
+ * The definition for the `<fluent-counter-badge>` element.
+ *
  * @public
- * @remarks
- * HTML Element: \<fluent-counter-badge\>
  */
-export const definition = CounterBadge.compose({
+export const definition: PartialFASTElementDefinition = {
   name: tagName,
-  template,
+  registry: FluentDesignSystem.registry,
   styles,
-});
+  template,
+};

--- a/packages/web-components/src/counter-badge/define.ts
+++ b/packages/web-components/src/counter-badge/define.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
 import { definition } from './counter-badge.definition.js';
+import { CounterBadge } from './counter-badge.js';
 
-definition.define(FluentDesignSystem.registry);
+CounterBadge.define(definition);

--- a/packages/web-components/src/dialog-body/define.ts
+++ b/packages/web-components/src/dialog-body/define.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
 import { definition } from './dialog-body.definition.js';
+import { DialogBody } from './dialog-body.js';
 
-definition.define(FluentDesignSystem.registry);
+DialogBody.define(definition);

--- a/packages/web-components/src/dialog-body/dialog-body.bench.ts
+++ b/packages/web-components/src/dialog-body/dialog-body.bench.ts
@@ -1,7 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
-import { definition } from './dialog-body.definition.js';
-
-definition.define(FluentDesignSystem.registry);
+import './define.js';
 
 const itemRenderer = () => {
   const dialogBody = document.createElement('fluent-dialog-body');

--- a/packages/web-components/src/dialog-body/dialog-body.definition.ts
+++ b/packages/web-components/src/dialog-body/dialog-body.definition.ts
@@ -1,17 +1,17 @@
+import type { PartialFASTElementDefinition } from '@microsoft/fast-element';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import { tagName } from './dialog-body.options.js';
-import { DialogBody } from './dialog-body.js';
-import { template } from './dialog-body.template.js';
 import { styles } from './dialog-body.styles.js';
+import { template } from './dialog-body.template.js';
 
 /**
- * The Fluent Dialog Body Element
+ * The definition for the `<fluent-dialog-body>` element.
  *
  * @public
- * @remarks
- * HTML Element: \<fluent-dialog-body\>
  */
-export const definition = DialogBody.compose({
+export const definition: PartialFASTElementDefinition = {
   name: tagName,
-  template,
+  registry: FluentDesignSystem.registry,
   styles,
-});
+  template,
+};

--- a/packages/web-components/src/dialog/define.ts
+++ b/packages/web-components/src/dialog/define.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
 import { definition } from './dialog.definition.js';
+import { Dialog } from './dialog.js';
 
-definition.define(FluentDesignSystem.registry);
+Dialog.define(definition);

--- a/packages/web-components/src/dialog/dialog.bench.ts
+++ b/packages/web-components/src/dialog/dialog.bench.ts
@@ -1,7 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
-import { definition } from './dialog.definition.js';
-
-definition.define(FluentDesignSystem.registry);
+import './define.js';
 
 const itemRenderer = () => {
   const dialog = document.createElement('fluent-dialog');

--- a/packages/web-components/src/dialog/dialog.definition.ts
+++ b/packages/web-components/src/dialog/dialog.definition.ts
@@ -1,17 +1,17 @@
+import type { PartialFASTElementDefinition } from '@microsoft/fast-element';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import { tagName } from './dialog.options.js';
-import { Dialog } from './dialog.js';
-import { template } from './dialog.template.js';
 import { styles } from './dialog.styles.js';
+import { template } from './dialog.template.js';
 
 /**
- * The Fluent Dialog Element
+ * The definition for the `<fluent-dialog>` element.
  *
  * @public
- * @remarks
- * HTML Element: \<fluent-dialog\>
  */
-export const definition = Dialog.compose({
+export const definition: PartialFASTElementDefinition = {
   name: tagName,
-  template,
+  registry: FluentDesignSystem.registry,
   styles,
-});
+  template,
+};

--- a/packages/web-components/src/divider/define.ts
+++ b/packages/web-components/src/divider/define.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
 import { definition } from './divider.definition.js';
+import { Divider } from './divider.js';
 
-definition.define(FluentDesignSystem.registry);
+Divider.define(definition);

--- a/packages/web-components/src/divider/divider.bench.ts
+++ b/packages/web-components/src/divider/divider.bench.ts
@@ -1,7 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
-import { definition } from './divider.definition.js';
-
-definition.define(FluentDesignSystem.registry);
+import './define.js';
 
 const itemRenderer = () => {
   const divider = document.createElement('fluent-divider');

--- a/packages/web-components/src/divider/divider.definition.ts
+++ b/packages/web-components/src/divider/divider.definition.ts
@@ -1,17 +1,17 @@
+import type { PartialFASTElementDefinition } from '@microsoft/fast-element';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import { tagName } from './divider.options.js';
-import { Divider } from './divider.js';
-import { template } from './divider.template.js';
 import { styles } from './divider.styles.js';
+import { template } from './divider.template.js';
 
 /**
- * The Fluent Divider Element
+ * The definition for the `<fluent-divider>` element.
  *
  * @public
- * @remarks
- * HTML Element: \<fluent-divider\>
  */
-export const definition = Divider.compose({
+export const definition: PartialFASTElementDefinition = {
   name: tagName,
-  template,
+  registry: FluentDesignSystem.registry,
   styles,
-});
+  template,
+};

--- a/packages/web-components/src/drawer-body/define.ts
+++ b/packages/web-components/src/drawer-body/define.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
 import { definition } from './drawer-body.definition.js';
+import { DrawerBody } from './drawer-body.js';
 
-definition.define(FluentDesignSystem.registry);
+DrawerBody.define(definition);

--- a/packages/web-components/src/drawer-body/drawer-body.definition.ts
+++ b/packages/web-components/src/drawer-body/drawer-body.definition.ts
@@ -1,17 +1,17 @@
+import type { PartialFASTElementDefinition } from '@microsoft/fast-element';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import { tagName } from './drawer-body.options.js';
-import { DrawerBody } from './drawer-body.js';
 import { styles } from './drawer-body.styles.js';
 import { template } from './drawer-body.template.js';
 
 /**
+ * The definition for the `<fluent-drawer-body>` element.
  *
  * @public
- * @remarks
- * HTML Element: <fluent-drawer>
  */
-
-export const definition = DrawerBody.compose({
+export const definition: PartialFASTElementDefinition = {
   name: tagName,
-  template,
+  registry: FluentDesignSystem.registry,
   styles,
-});
+  template,
+};

--- a/packages/web-components/src/drawer/define.ts
+++ b/packages/web-components/src/drawer/define.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
 import { definition } from './drawer.definition.js';
+import { Drawer } from './drawer.js';
 
-definition.define(FluentDesignSystem.registry);
+Drawer.define(definition);

--- a/packages/web-components/src/drawer/drawer.definition.ts
+++ b/packages/web-components/src/drawer/drawer.definition.ts
@@ -1,17 +1,17 @@
+import type { PartialFASTElementDefinition } from '@microsoft/fast-element';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import { tagName } from './drawer.options.js';
-import { Drawer } from './drawer.js';
 import { styles } from './drawer.styles.js';
 import { template } from './drawer.template.js';
 
 /**
+ * The definition for the `<fluent-drawer>` element.
  *
  * @public
- * @remarks
- * HTML Element: <fluent-drawer>
  */
-
-export const definition = Drawer.compose({
+export const definition: PartialFASTElementDefinition = {
   name: tagName,
-  template,
+  registry: FluentDesignSystem.registry,
   styles,
-});
+  template,
+};

--- a/packages/web-components/src/dropdown/define.ts
+++ b/packages/web-components/src/dropdown/define.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
 import { definition } from './dropdown.definition.js';
+import { Dropdown } from './dropdown.js';
 
-definition.define(FluentDesignSystem.registry);
+Dropdown.define(definition);

--- a/packages/web-components/src/dropdown/dropdown.definition.ts
+++ b/packages/web-components/src/dropdown/dropdown.definition.ts
@@ -1,17 +1,17 @@
+import type { PartialFASTElementDefinition } from '@microsoft/fast-element';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import { tagName } from './dropdown.options.js';
-import { Dropdown } from './dropdown.js';
 import { styles } from './dropdown.styles.js';
 import { template } from './dropdown.template.js';
 
 /**
- * The Fluent Dropdown Element.
+ * The definition for the `<fluent-dropdown>` element.
  *
  * @public
- * @remarks
- * HTML Element: `<fluent-dropdown>`
  */
-export const definition = Dropdown.compose({
+export const definition: PartialFASTElementDefinition = {
   name: tagName,
-  template,
+  registry: FluentDesignSystem.registry,
   styles,
-});
+  template,
+};

--- a/packages/web-components/src/field/define.ts
+++ b/packages/web-components/src/field/define.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
 import { definition } from './field.definition.js';
+import { Field } from './field.js';
 
-definition.define(FluentDesignSystem.registry);
+Field.define(definition);

--- a/packages/web-components/src/field/field.bench.ts
+++ b/packages/web-components/src/field/field.bench.ts
@@ -1,7 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
-import { definition } from './field.definition.js';
-
-definition.define(FluentDesignSystem.registry);
+import './define.js';
 
 const itemRenderer = () => {
   const field = document.createElement('fluent-field');

--- a/packages/web-components/src/field/field.definition.ts
+++ b/packages/web-components/src/field/field.definition.ts
@@ -1,20 +1,20 @@
+import type { PartialFASTElementDefinition } from '@microsoft/fast-element';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import { tagName } from './field.options.js';
-import { Field } from './field.js';
 import { styles } from './field.styles.js';
 import { template } from './field.template.js';
 
 /**
- * The Fluent Field Element
+ * The definition for the `<fluent-field>` element.
  *
  * @public
- * @remarks
- * HTML Element: `<fluent-field>`
  */
-export const definition = Field.compose({
+export const definition: PartialFASTElementDefinition = {
   name: tagName,
-  template,
-  styles,
+  registry: FluentDesignSystem.registry,
   shadowOptions: {
     delegatesFocus: true,
   },
-});
+  styles,
+  template,
+};

--- a/packages/web-components/src/image/define.ts
+++ b/packages/web-components/src/image/define.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
 import { definition } from './image.definition.js';
+import { Image } from './image.js';
 
-definition.define(FluentDesignSystem.registry);
+Image.define(definition);

--- a/packages/web-components/src/image/image.bench.ts
+++ b/packages/web-components/src/image/image.bench.ts
@@ -1,7 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
-import { definition } from './image.definition.js';
-
-definition.define(FluentDesignSystem.registry);
+import './define.js';
 
 const itemRenderer = () => {
   const image = document.createElement('fluent-image');

--- a/packages/web-components/src/image/image.definition.ts
+++ b/packages/web-components/src/image/image.definition.ts
@@ -1,17 +1,17 @@
+import type { PartialFASTElementDefinition } from '@microsoft/fast-element';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import { tagName } from './image.options.js';
-import { Image } from './image.js';
-import { template } from './image.template.js';
 import { styles } from './image.styles.js';
+import { template } from './image.template.js';
 
 /**
- * The Fluent Image Element
+ * The definition for the `<fluent-image>` element.
  *
  * @public
- * @remarks
- * HTML Element: \<fluent-image\>
  */
-export const definition = Image.compose({
+export const definition: PartialFASTElementDefinition = {
   name: tagName,
-  template,
+  registry: FluentDesignSystem.registry,
   styles,
-});
+  template,
+};

--- a/packages/web-components/src/label/define.ts
+++ b/packages/web-components/src/label/define.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
 import { definition } from './label.definition.js';
+import { Label } from './label.js';
 
-definition.define(FluentDesignSystem.registry);
+Label.define(definition);

--- a/packages/web-components/src/label/label.bench.ts
+++ b/packages/web-components/src/label/label.bench.ts
@@ -1,7 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
-import { definition } from './label.definition.js';
-
-definition.define(FluentDesignSystem.registry);
+import './define.js';
 
 const itemRenderer = () => {
   const label = document.createElement('fluent-label');

--- a/packages/web-components/src/label/label.definition.ts
+++ b/packages/web-components/src/label/label.definition.ts
@@ -1,18 +1,17 @@
+import type { PartialFASTElementDefinition } from '@microsoft/fast-element';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import { tagName } from './label.options.js';
-import { Label } from './label.js';
 import { styles } from './label.styles.js';
 import { template } from './label.template.js';
 
 /**
- * The Fluent Label Element.
- *
+ * The definition for the `<fluent-label>` element.
  *
  * @public
- * @remarks
- * HTML Element: \<fluent-label\>
  */
-export const definition = Label.compose({
+export const definition: PartialFASTElementDefinition = {
   name: tagName,
-  template,
+  registry: FluentDesignSystem.registry,
   styles,
-});
+  template,
+};

--- a/packages/web-components/src/link/define.ts
+++ b/packages/web-components/src/link/define.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
 import { definition } from './link.definition.js';
+import { Link } from './link.js';
 
-definition.define(FluentDesignSystem.registry);
+Link.define(definition);

--- a/packages/web-components/src/link/link.bench.ts
+++ b/packages/web-components/src/link/link.bench.ts
@@ -1,7 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
-import { definition } from './link.definition.js';
-
-definition.define(FluentDesignSystem.registry);
+import './define.js';
 
 const itemRenderer = () => {
   const btn = document.createElement('fluent-link');

--- a/packages/web-components/src/link/link.definition.ts
+++ b/packages/web-components/src/link/link.definition.ts
@@ -1,15 +1,17 @@
+import type { PartialFASTElementDefinition } from '@microsoft/fast-element';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import { tagName } from './link.options.js';
-import { Link } from './link.js';
 import { styles } from './link.styles.js';
 import { template } from './link.template.js';
 
 /**
+ * The definition for the `<fluent-link>` element.
+ *
  * @public
- * @remarks
- * HTML Element: \<fluent-link\>
  */
-export const definition = Link.compose({
+export const definition: PartialFASTElementDefinition = {
   name: tagName,
-  template,
+  registry: FluentDesignSystem.registry,
   styles,
-});
+  template,
+};

--- a/packages/web-components/src/listbox/define.ts
+++ b/packages/web-components/src/listbox/define.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
 import { definition } from './listbox.definition.js';
+import { Listbox } from './listbox.js';
 
-definition.define(FluentDesignSystem.registry);
+Listbox.define(definition);

--- a/packages/web-components/src/listbox/listbox.definition.ts
+++ b/packages/web-components/src/listbox/listbox.definition.ts
@@ -1,17 +1,17 @@
+import type { PartialFASTElementDefinition } from '@microsoft/fast-element';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import { tagName } from './listbox.options.js';
-import { Listbox } from './listbox.js';
 import { styles } from './listbox.styles.js';
 import { template } from './listbox.template.js';
 
 /**
- * The Fluent Listbox Element
+ * The definition for the `<fluent-listbox>` element.
  *
  * @public
- * @remarks
- * HTML Element: `<fluent-listbox>`
  */
-export const definition = Listbox.compose({
+export const definition: PartialFASTElementDefinition = {
   name: tagName,
-  template,
+  registry: FluentDesignSystem.registry,
   styles,
-});
+  template,
+};

--- a/packages/web-components/src/menu-button/define.ts
+++ b/packages/web-components/src/menu-button/define.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
 import { definition } from './menu-button.definition.js';
+import { MenuButton } from './menu-button.js';
 
-definition.define(FluentDesignSystem.registry);
+MenuButton.define(definition);

--- a/packages/web-components/src/menu-button/menu-button.bench.ts
+++ b/packages/web-components/src/menu-button/menu-button.bench.ts
@@ -1,7 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
-import { definition } from './menu-button.definition.js';
-
-definition.define(FluentDesignSystem.registry);
+import './define.js';
 
 const itemRenderer = () => {
   const btn = document.createElement('fluent-menu-button');

--- a/packages/web-components/src/menu-button/menu-button.definition.ts
+++ b/packages/web-components/src/menu-button/menu-button.definition.ts
@@ -1,15 +1,17 @@
-import { styles } from './menu-button.styles.js';
+import type { PartialFASTElementDefinition } from '@microsoft/fast-element';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import { tagName } from './menu-button.options.js';
-import { MenuButton } from './menu-button.js';
+import { styles } from './menu-button.styles.js';
 import { template } from './menu-button.template.js';
 
 /**
+ * The definition for the `<fluent-menu-button>` element.
+ *
  * @public
- * @remarks
- * HTML Element: \<fluent-button\>
  */
-export const definition = MenuButton.compose({
+export const definition: PartialFASTElementDefinition = {
   name: tagName,
-  template,
+  registry: FluentDesignSystem.registry,
   styles,
-});
+  template,
+};

--- a/packages/web-components/src/menu-item/define.ts
+++ b/packages/web-components/src/menu-item/define.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
 import { definition } from './menu-item.definition.js';
+import { MenuItem } from './menu-item.js';
 
-definition.define(FluentDesignSystem.registry);
+MenuItem.define(definition);

--- a/packages/web-components/src/menu-item/menu-item.bench.ts
+++ b/packages/web-components/src/menu-item/menu-item.bench.ts
@@ -1,7 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
-import { definition } from './menu-item.definition.js';
-
-definition.define(FluentDesignSystem.registry);
+import './define.js';
 
 const itemRenderer = () => {
   const menuItem = document.createElement('fluent-menu-item');

--- a/packages/web-components/src/menu-item/menu-item.definition.ts
+++ b/packages/web-components/src/menu-item/menu-item.definition.ts
@@ -1,15 +1,17 @@
+import type { PartialFASTElementDefinition } from '@microsoft/fast-element';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import { tagName } from './menu-item.options.js';
-import { MenuItem } from './menu-item.js';
 import { styles } from './menu-item.styles.js';
 import { template } from './menu-item.template.js';
 
 /**
+ * The definition for the `<fluent-menu-item>` element.
+ *
  * @public
- * @remarks
- * HTML Element: <fluent-menu-item>
  */
-export const definition = MenuItem.compose({
+export const definition: PartialFASTElementDefinition = {
   name: tagName,
-  template,
+  registry: FluentDesignSystem.registry,
   styles,
-});
+  template,
+};

--- a/packages/web-components/src/menu-list/define.ts
+++ b/packages/web-components/src/menu-list/define.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
 import { definition } from './menu-list.definition.js';
+import { MenuList } from './menu-list.js';
 
-definition.define(FluentDesignSystem.registry);
+MenuList.define(definition);

--- a/packages/web-components/src/menu-list/menu-list.bench.ts
+++ b/packages/web-components/src/menu-list/menu-list.bench.ts
@@ -1,9 +1,5 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
-import { definition as menuItemDefinition } from '../menu-item/menu-item.definition.js';
-import { definition as menuListDefinition } from './menu-list.definition.js';
-
-menuListDefinition.define(FluentDesignSystem.registry);
-menuItemDefinition.define(FluentDesignSystem.registry);
+import '../menu-item/define.js';
+import './define.js';
 
 const itemRenderer = () => {
   const menuList = document.createElement('fluent-menu-list');

--- a/packages/web-components/src/menu-list/menu-list.definition.ts
+++ b/packages/web-components/src/menu-list/menu-list.definition.ts
@@ -1,15 +1,17 @@
+import type { PartialFASTElementDefinition } from '@microsoft/fast-element';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import { tagName } from './menu-list.options.js';
-import { MenuList } from './menu-list.js';
 import { styles } from './menu-list.styles.js';
 import { template } from './menu-list.template.js';
 
 /**
+ * The definition for the `<fluent-menu-list>` element.
+ *
  * @public
- * @remarks
- * HTML Element: <fluent-menu-list>
  */
-export const definition = MenuList.compose({
+export const definition: PartialFASTElementDefinition = {
   name: tagName,
-  template,
+  registry: FluentDesignSystem.registry,
   styles,
-});
+  template,
+};

--- a/packages/web-components/src/menu/define.ts
+++ b/packages/web-components/src/menu/define.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
 import { definition } from './menu.definition.js';
+import { Menu } from './menu.js';
 
-definition.define(FluentDesignSystem.registry);
+Menu.define(definition);

--- a/packages/web-components/src/menu/menu.bench.ts
+++ b/packages/web-components/src/menu/menu.bench.ts
@@ -1,13 +1,7 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
-import { definition as menuButtonDefinition } from '../menu-button/menu-button.definition.js';
-import { definition as menuItemDefinition } from '../menu-item/menu-item.definition.js';
-import { definition as menuListDefinition } from '../menu-list/menu-list.definition.js';
-import { definition as menuDefinition } from './menu.definition.js';
-
-menuDefinition.define(FluentDesignSystem.registry);
-menuButtonDefinition.define(FluentDesignSystem.registry);
-menuListDefinition.define(FluentDesignSystem.registry);
-menuItemDefinition.define(FluentDesignSystem.registry);
+import '../menu-button/define.js';
+import '../menu-item/define.js';
+import '../menu-list/define.js';
+import './define.js';
 
 const itemRenderer = () => {
   const menu = document.createElement('fluent-menu');

--- a/packages/web-components/src/menu/menu.definition.ts
+++ b/packages/web-components/src/menu/menu.definition.ts
@@ -1,17 +1,17 @@
+import type { PartialFASTElementDefinition } from '@microsoft/fast-element';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import { tagName } from './menu.options.js';
-import { Menu } from './menu.js';
 import { styles } from './menu.styles.js';
 import { template } from './menu.template.js';
 
 /**
- * The Fluent Menu Element.
+ * The definition for the `<fluent-menu>` element.
  *
  * @public
- * @remarks
- * HTML Element: <fluent-menu>
  */
-export const definition = Menu.compose({
+export const definition: PartialFASTElementDefinition = {
   name: tagName,
-  template,
+  registry: FluentDesignSystem.registry,
   styles,
-});
+  template,
+};

--- a/packages/web-components/src/message-bar/define.ts
+++ b/packages/web-components/src/message-bar/define.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
 import { definition } from './message-bar.definition.js';
+import { MessageBar } from './message-bar.js';
 
-definition.define(FluentDesignSystem.registry);
+MessageBar.define(definition);

--- a/packages/web-components/src/message-bar/message-bar.bench.ts
+++ b/packages/web-components/src/message-bar/message-bar.bench.ts
@@ -1,9 +1,5 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
-import { definition as buttonDefinition } from '../button/button.definition.js';
-import { definition } from './message-bar.definition.js';
-
-definition.define(FluentDesignSystem.registry);
-buttonDefinition.define(FluentDesignSystem.registry);
+import '../button/define.js';
+import './define.js';
 
 const dismissed20Regular = `
   <svg

--- a/packages/web-components/src/message-bar/message-bar.definition.ts
+++ b/packages/web-components/src/message-bar/message-bar.definition.ts
@@ -1,21 +1,17 @@
+import type { PartialFASTElementDefinition } from '@microsoft/fast-element';
 import { FluentDesignSystem } from '../fluent-design-system.js';
 import { tagName } from './message-bar.options.js';
-import { MessageBar } from './message-bar.js';
 import { styles } from './message-bar.styles.js';
 import { template } from './message-bar.template.js';
 
 /**
- * The Fluent MessageBar Element definition.
+ * The definition for the `<fluent-message-bar>` element.
  *
  * @public
- * @remarks
- * HTML Element: `<fluent-message-bar>`
  */
-export const definition = MessageBar.compose({
+export const definition: PartialFASTElementDefinition = {
   name: tagName,
-  template,
+  registry: FluentDesignSystem.registry,
   styles,
-  shadowOptions: {
-    mode: FluentDesignSystem.shadowRootMode,
-  },
-});
+  template,
+};

--- a/packages/web-components/src/option/define.ts
+++ b/packages/web-components/src/option/define.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
 import { definition } from './option.definition.js';
+import { DropdownOption } from './option.js';
 
-definition.define(FluentDesignSystem.registry);
+DropdownOption.define(definition);

--- a/packages/web-components/src/option/option.definition.ts
+++ b/packages/web-components/src/option/option.definition.ts
@@ -1,17 +1,17 @@
+import type { PartialFASTElementDefinition } from '@microsoft/fast-element';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import { tagName } from './option.options.js';
-import { DropdownOption } from './option.js';
 import { styles } from './option.styles.js';
 import { template } from './option.template.js';
 
 /**
- * The Fluent Option Element.
+ * The definition for the `<fluent-option>` element.
  *
  * @public
- * @remarks
- * HTML Element: `<fluent-option>`
  */
-export const definition = DropdownOption.compose({
+export const definition: PartialFASTElementDefinition = {
   name: tagName,
-  template,
+  registry: FluentDesignSystem.registry,
   styles,
-});
+  template,
+};

--- a/packages/web-components/src/progress-bar/define.ts
+++ b/packages/web-components/src/progress-bar/define.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
 import { definition } from './progress-bar.definition.js';
+import { ProgressBar } from './progress-bar.js';
 
-definition.define(FluentDesignSystem.registry);
+ProgressBar.define(definition);

--- a/packages/web-components/src/progress-bar/progress-bar.bench.ts
+++ b/packages/web-components/src/progress-bar/progress-bar.bench.ts
@@ -1,7 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
-import { definition } from './progress-bar.definition.js';
-
-definition.define(FluentDesignSystem.registry);
+import './define.js';
 
 const itemRenderer = () => {
   const progressBar = document.createElement('fluent-progress-bar');

--- a/packages/web-components/src/progress-bar/progress-bar.definition.ts
+++ b/packages/web-components/src/progress-bar/progress-bar.definition.ts
@@ -1,18 +1,17 @@
+import type { PartialFASTElementDefinition } from '@microsoft/fast-element';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import { tagName } from './progress-bar.options.js';
-import { ProgressBar } from './progress-bar.js';
 import { styles } from './progress-bar.styles.js';
 import { template } from './progress-bar.template.js';
 
 /**
- * The Fluent ProgressBar Element.
- *
+ * The definition for the `<fluent-progress-bar>` element.
  *
  * @public
- * @remarks
- * HTML Element: \<fluent-progress-bar\>
  */
-export const definition = ProgressBar.compose({
+export const definition: PartialFASTElementDefinition = {
   name: tagName,
-  template,
+  registry: FluentDesignSystem.registry,
   styles,
-});
+  template,
+};

--- a/packages/web-components/src/radio-group/define.ts
+++ b/packages/web-components/src/radio-group/define.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
 import { definition } from './radio-group.definition.js';
+import { RadioGroup } from './radio-group.js';
 
-definition.define(FluentDesignSystem.registry);
+RadioGroup.define(definition);

--- a/packages/web-components/src/radio-group/radio-group.bench.ts
+++ b/packages/web-components/src/radio-group/radio-group.bench.ts
@@ -1,9 +1,5 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
-import { definition as radioDefinition } from '../radio/radio.definition.js';
-import { definition as radioGroupDefinition } from './radio-group.definition.js';
-
-radioGroupDefinition.define(FluentDesignSystem.registry);
-radioDefinition.define(FluentDesignSystem.registry);
+import '../radio/define.js';
+import './define.js';
 
 const itemRenderer = () => {
   const radioGroup = document.createElement('fluent-radio-group');

--- a/packages/web-components/src/radio-group/radio-group.definition.ts
+++ b/packages/web-components/src/radio-group/radio-group.definition.ts
@@ -1,18 +1,17 @@
+import type { PartialFASTElementDefinition } from '@microsoft/fast-element';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import { tagName } from './radio-group.options.js';
-import { RadioGroup } from './radio-group.js';
 import { styles } from './radio-group.styles.js';
 import { template } from './radio-group.template.js';
 
 /**
- * The Fluent RadioGroup Element.
- *
+ * The definition for the `<fluent-radio-group>` element.
  *
  * @public
- * @remarks
- * HTML Element: \<fluent-radio-group\>
  */
-export const definition = RadioGroup.compose({
+export const definition: PartialFASTElementDefinition = {
   name: tagName,
-  template,
+  registry: FluentDesignSystem.registry,
   styles,
-});
+  template,
+};

--- a/packages/web-components/src/radio/define.ts
+++ b/packages/web-components/src/radio/define.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
 import { definition } from './radio.definition.js';
+import { Radio } from './radio.js';
 
-definition.define(FluentDesignSystem.registry);
+Radio.define(definition);

--- a/packages/web-components/src/radio/radio.bench.ts
+++ b/packages/web-components/src/radio/radio.bench.ts
@@ -1,7 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
-import { definition } from './radio.definition.js';
-
-definition.define(FluentDesignSystem.registry);
+import './define.js';
 
 const itemRenderer = () => {
   const radio = document.createElement('fluent-radio');

--- a/packages/web-components/src/radio/radio.definition.ts
+++ b/packages/web-components/src/radio/radio.definition.ts
@@ -1,18 +1,17 @@
+import type { PartialFASTElementDefinition } from '@microsoft/fast-element';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import { tagName } from './radio.options.js';
-import { Radio } from './radio.js';
 import { styles } from './radio.styles.js';
 import { template } from './radio.template.js';
 
 /**
- * The Fluent Radio Element.
- *
+ * The definition for the `<fluent-radio>` element.
  *
  * @public
- * @remarks
- * HTML Element: \<fluent-radio\>
  */
-export const definition = Radio.compose({
+export const definition: PartialFASTElementDefinition = {
   name: tagName,
-  template,
+  registry: FluentDesignSystem.registry,
   styles,
-});
+  template,
+};

--- a/packages/web-components/src/rating-display/define.ts
+++ b/packages/web-components/src/rating-display/define.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
 import { definition } from './rating-display.definition.js';
+import { RatingDisplay } from './rating-display.js';
 
-definition.define(FluentDesignSystem.registry);
+RatingDisplay.define(definition);

--- a/packages/web-components/src/rating-display/rating-display.definition.ts
+++ b/packages/web-components/src/rating-display/rating-display.definition.ts
@@ -1,17 +1,17 @@
+import type { PartialFASTElementDefinition } from '@microsoft/fast-element';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import { tagName } from './rating-display.options.js';
-import { RatingDisplay } from './rating-display.js';
 import { styles } from './rating-display.styles.js';
 import { template } from './rating-display.template.js';
 
 /**
- * The definition for the Fluent Rating Display component.
+ * The definition for the `<fluent-rating-display>` element.
  *
  * @public
- * @remarks
- * HTML Element: `<fluent-rating-display>`
  */
-export const definition = RatingDisplay.compose({
+export const definition: PartialFASTElementDefinition = {
   name: tagName,
-  template,
+  registry: FluentDesignSystem.registry,
   styles,
-});
+  template,
+};

--- a/packages/web-components/src/slider/define.ts
+++ b/packages/web-components/src/slider/define.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
 import { definition } from './slider.definition.js';
+import { Slider } from './slider.js';
 
-definition.define(FluentDesignSystem.registry);
+Slider.define(definition);

--- a/packages/web-components/src/slider/slider.bench.ts
+++ b/packages/web-components/src/slider/slider.bench.ts
@@ -1,7 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
-import { definition } from './slider.definition.js';
-
-definition.define(FluentDesignSystem.registry);
+import './define.js';
 
 const itemRenderer = () => {
   const slider = document.createElement('fluent-slider');

--- a/packages/web-components/src/slider/slider.definition.ts
+++ b/packages/web-components/src/slider/slider.definition.ts
@@ -1,18 +1,17 @@
+import type { PartialFASTElementDefinition } from '@microsoft/fast-element';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import { tagName } from './slider.options.js';
-import { Slider } from './slider.js';
 import { styles } from './slider.styles.js';
 import { template } from './slider.template.js';
 
 /**
- * The Fluent Slider Element.
- *
+ * The definition for the `<fluent-slider>` element.
  *
  * @public
- * @remarks
- * HTML Element: \<fluent-slider\>
  */
-export const definition = Slider.compose({
+export const definition: PartialFASTElementDefinition = {
   name: tagName,
-  template,
+  registry: FluentDesignSystem.registry,
   styles,
-});
+  template,
+};

--- a/packages/web-components/src/spinner/define.ts
+++ b/packages/web-components/src/spinner/define.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
 import { definition } from './spinner.definition.js';
+import { Spinner } from './spinner.js';
 
-definition.define(FluentDesignSystem.registry);
+Spinner.define(definition);

--- a/packages/web-components/src/spinner/spinner.bench.ts
+++ b/packages/web-components/src/spinner/spinner.bench.ts
@@ -1,7 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
-import { definition } from './spinner.definition.js';
-
-definition.define(FluentDesignSystem.registry);
+import './define.js';
 
 const itemRenderer = () => {
   const spinner = document.createElement('fluent-spinner');

--- a/packages/web-components/src/spinner/spinner.definition.ts
+++ b/packages/web-components/src/spinner/spinner.definition.ts
@@ -1,15 +1,17 @@
+import type { PartialFASTElementDefinition } from '@microsoft/fast-element';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import { tagName } from './spinner.options.js';
-import { Spinner } from './spinner.js';
 import { styles } from './spinner.styles.js';
 import { template } from './spinner.template.js';
 
 /**
+ * The definition for the `<fluent-spinner>` element.
+ *
  * @public
- * @remarks
- * HTML Element: \<fluent-spinner\>
  */
-export const definition = Spinner.compose({
+export const definition: PartialFASTElementDefinition = {
   name: tagName,
-  template,
+  registry: FluentDesignSystem.registry,
   styles,
-});
+  template,
+};

--- a/packages/web-components/src/switch/define.ts
+++ b/packages/web-components/src/switch/define.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
 import { definition } from './switch.definition.js';
+import { Switch } from './switch.js';
 
-definition.define(FluentDesignSystem.registry);
+Switch.define(definition);

--- a/packages/web-components/src/switch/switch.bench.ts
+++ b/packages/web-components/src/switch/switch.bench.ts
@@ -1,7 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
-import { definition } from './switch.definition.js';
-
-definition.define(FluentDesignSystem.registry);
+import './define.js';
 
 const itemRenderer = () => {
   const switchEl = document.createElement('fluent-switch');

--- a/packages/web-components/src/switch/switch.definition.ts
+++ b/packages/web-components/src/switch/switch.definition.ts
@@ -1,17 +1,17 @@
+import type { PartialFASTElementDefinition } from '@microsoft/fast-element';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import { tagName } from './switch.options.js';
-import { Switch } from './switch.js';
-import { template } from './switch.template.js';
 import { styles } from './switch.styles.js';
+import { template } from './switch.template.js';
 
 /**
- * The Fluent Switch Element.
+ * The definition for the `<fluent-switch>` element.
  *
  * @public
- * @remarks
- * HTML Element: \<fluent-switch\>
  */
-export const definition = Switch.compose({
+export const definition: PartialFASTElementDefinition = {
   name: tagName,
-  template,
+  registry: FluentDesignSystem.registry,
   styles,
-});
+  template,
+};

--- a/packages/web-components/src/tab/define.ts
+++ b/packages/web-components/src/tab/define.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
 import { definition } from './tab.definition.js';
+import { Tab } from './tab.js';
 
-definition.define(FluentDesignSystem.registry);
+Tab.define(definition);

--- a/packages/web-components/src/tab/tab.bench.ts
+++ b/packages/web-components/src/tab/tab.bench.ts
@@ -1,7 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
-import { definition } from './tab.definition.js';
-
-definition.define(FluentDesignSystem.registry);
+import './define.js';
 
 const itemRenderer = () => {
   const tab = document.createElement('fluent-tab');

--- a/packages/web-components/src/tab/tab.definition.ts
+++ b/packages/web-components/src/tab/tab.definition.ts
@@ -1,10 +1,17 @@
+import type { PartialFASTElementDefinition } from '@microsoft/fast-element';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import { tagName } from './tab.options.js';
-import { Tab } from './tab.js';
-import { template } from './tab.template.js';
 import { styles } from './tab.styles.js';
+import { template } from './tab.template.js';
 
-export const definition = Tab.compose({
+/**
+ * The definition for the `<fluent-tab>` element.
+ *
+ * @public
+ */
+export const definition: PartialFASTElementDefinition = {
   name: tagName,
-  template,
+  registry: FluentDesignSystem.registry,
   styles,
-});
+  template,
+};

--- a/packages/web-components/src/tablist/define.ts
+++ b/packages/web-components/src/tablist/define.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
 import { definition } from './tablist.definition.js';
+import { Tablist } from './tablist.js';
 
-definition.define(FluentDesignSystem.registry);
+Tablist.define(definition);

--- a/packages/web-components/src/tablist/tablist.bench.ts
+++ b/packages/web-components/src/tablist/tablist.bench.ts
@@ -1,9 +1,5 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
-import { definition as tabDefinition } from '../tab/tab.definition.js';
-import { definition as tablistDefinition } from './tablist.definition.js';
-
-tabDefinition.define(FluentDesignSystem.registry);
-tablistDefinition.define(FluentDesignSystem.registry);
+import '../tab/define.js';
+import './define.js';
 
 const itemRenderer = () => {
   const tablist = document.createElement('fluent-tablist');

--- a/packages/web-components/src/tablist/tablist.definition.ts
+++ b/packages/web-components/src/tablist/tablist.definition.ts
@@ -1,15 +1,17 @@
+import type { PartialFASTElementDefinition } from '@microsoft/fast-element';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import { tagName } from './tablist.options.js';
-import { Tablist } from './tablist.js';
-import { template } from './tablist.template.js';
 import { styles } from './tablist.styles.js';
+import { template } from './tablist.template.js';
 
 /**
+ * The definition for the `<fluent-tablist>` element.
+ *
  * @public
- * @remarks
- * HTML Element: \<fluent-tablist\>
  */
-export const definition = Tablist.compose({
+export const definition: PartialFASTElementDefinition = {
   name: tagName,
-  template,
+  registry: FluentDesignSystem.registry,
   styles,
-});
+  template,
+};

--- a/packages/web-components/src/text-input/define.ts
+++ b/packages/web-components/src/text-input/define.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
 import { definition } from './text-input.definition.js';
+import { TextInput } from './text-input.js';
 
-definition.define(FluentDesignSystem.registry);
+TextInput.define(definition);

--- a/packages/web-components/src/text-input/text-input.bench.ts
+++ b/packages/web-components/src/text-input/text-input.bench.ts
@@ -1,7 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
-import { definition } from './text-input.definition.js';
-
-definition.define(FluentDesignSystem.registry);
+import './define.js';
 
 const itemRenderer = () => {
   const textInput = document.createElement('fluent-text-input');

--- a/packages/web-components/src/text-input/text-input.definition.ts
+++ b/packages/web-components/src/text-input/text-input.definition.ts
@@ -1,20 +1,20 @@
+import type { PartialFASTElementDefinition } from '@microsoft/fast-element';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import { tagName } from './text-input.options.js';
-import { TextInput } from './text-input.js';
 import { styles } from './text-input.styles.js';
 import { template } from './text-input.template.js';
 
 /**
- * The Fluent TextInput Element definition.
+ * The definition for the `<fluent-text-input>` element.
  *
  * @public
- * @remarks
- * HTML Element: `<fluent-text-input>`
  */
-export const definition = TextInput.compose({
+export const definition: PartialFASTElementDefinition = {
   name: tagName,
-  template,
-  styles,
+  registry: FluentDesignSystem.registry,
   shadowOptions: {
     delegatesFocus: true,
   },
-});
+  styles,
+  template,
+};

--- a/packages/web-components/src/text/define.ts
+++ b/packages/web-components/src/text/define.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
 import { definition } from './text.definition.js';
+import { Text } from './text.js';
 
-definition.define(FluentDesignSystem.registry);
+Text.define(definition);

--- a/packages/web-components/src/text/text.bench.ts
+++ b/packages/web-components/src/text/text.bench.ts
@@ -1,7 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
-import { definition } from './text.definition.js';
-
-definition.define(FluentDesignSystem.registry);
+import './define.js';
 
 const itemRenderer = () => {
   const text = document.createElement('fluent-text');

--- a/packages/web-components/src/text/text.definition.ts
+++ b/packages/web-components/src/text/text.definition.ts
@@ -1,18 +1,17 @@
+import type { PartialFASTElementDefinition } from '@microsoft/fast-element';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import { tagName } from './text.options.js';
-import { Text } from './text.js';
 import { styles } from './text.styles.js';
 import { template } from './text.template.js';
 
 /**
- * The Fluent Text Element.
- *
+ * The definition for the `<fluent-text>` element.
  *
  * @public
- * @remarks
- * HTML Element: \<fluent-text\>
  */
-export const definition = Text.compose({
+export const definition: PartialFASTElementDefinition = {
   name: tagName,
-  template,
+  registry: FluentDesignSystem.registry,
   styles,
-});
+  template,
+};

--- a/packages/web-components/src/textarea/define.ts
+++ b/packages/web-components/src/textarea/define.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
 import { definition } from './textarea.definition.js';
+import { TextArea } from './textarea.js';
 
-definition.define(FluentDesignSystem.registry);
+TextArea.define(definition);

--- a/packages/web-components/src/textarea/textarea.bench.ts
+++ b/packages/web-components/src/textarea/textarea.bench.ts
@@ -1,7 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
-import { definition } from './textarea.definition.js';
-
-definition.define(FluentDesignSystem.registry);
+import './define.js';
 
 const itemRenderer = () => {
   const textarea = document.createElement('fluent-textarea');

--- a/packages/web-components/src/textarea/textarea.definition.ts
+++ b/packages/web-components/src/textarea/textarea.definition.ts
@@ -1,20 +1,20 @@
+import type { PartialFASTElementDefinition } from '@microsoft/fast-element';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import { tagName } from './textarea.options.js';
-import { TextArea } from './textarea.js';
 import { styles } from './textarea.styles.js';
 import { template } from './textarea.template.js';
 
 /**
- * The Fluent Textarea Element definition.
+ * The definition for the `<fluent-textarea>` element.
  *
  * @public
- * @remarks
- * HTML Element: `<fluent-textarea>`
  */
-export const definition = TextArea.compose({
+export const definition: PartialFASTElementDefinition = {
   name: tagName,
-  template,
-  styles,
+  registry: FluentDesignSystem.registry,
   shadowOptions: {
     delegatesFocus: true,
   },
-});
+  styles,
+  template,
+};

--- a/packages/web-components/src/toggle-button/define.ts
+++ b/packages/web-components/src/toggle-button/define.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
 import { definition } from './toggle-button.definition.js';
+import { ToggleButton } from './toggle-button.js';
 
-definition.define(FluentDesignSystem.registry);
+ToggleButton.define(definition);

--- a/packages/web-components/src/toggle-button/toggle-button.bench.ts
+++ b/packages/web-components/src/toggle-button/toggle-button.bench.ts
@@ -1,7 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
-import { definition } from './toggle-button.definition.js';
-
-definition.define(FluentDesignSystem.registry);
+import './define.js';
 
 const itemRenderer = () => {
   const btn = document.createElement('fluent-toggle-button');

--- a/packages/web-components/src/toggle-button/toggle-button.definition.ts
+++ b/packages/web-components/src/toggle-button/toggle-button.definition.ts
@@ -1,16 +1,17 @@
+import type { PartialFASTElementDefinition } from '@microsoft/fast-element';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import { tagName } from './toggle-button.options.js';
-import { ToggleButton } from './toggle-button.js';
 import { styles } from './toggle-button.styles.js';
 import { template } from './toggle-button.template.js';
 
 /**
+ * The definition for the `<fluent-toggle-button>` element.
  *
  * @public
- * @remarks
- * HTML Element: \<fluent-toggle-button\>
  */
-export const definition = ToggleButton.compose({
+export const definition: PartialFASTElementDefinition = {
   name: tagName,
-  template,
+  registry: FluentDesignSystem.registry,
   styles,
-});
+  template,
+};

--- a/packages/web-components/src/tooltip/define.ts
+++ b/packages/web-components/src/tooltip/define.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
 import { definition } from './tooltip.definition.js';
+import { Tooltip } from './tooltip.js';
 
-definition.define(FluentDesignSystem.registry);
+Tooltip.define(definition);

--- a/packages/web-components/src/tooltip/tooltip.definition.ts
+++ b/packages/web-components/src/tooltip/tooltip.definition.ts
@@ -1,17 +1,17 @@
+import type { PartialFASTElementDefinition } from '@microsoft/fast-element';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import { tagName } from './tooltip.options.js';
-import { Tooltip } from './tooltip.js';
 import { styles } from './tooltip.styles.js';
 import { template } from './tooltip.template.js';
 
 /**
- * The {@link Tooltip } custom element definition.
+ * The definition for the `<fluent-tooltip>` element.
  *
  * @public
- * @remarks
- * HTML Element: `<fluent-tooltip>`
  */
-export const definition = Tooltip.compose({
+export const definition: PartialFASTElementDefinition = {
   name: tagName,
-  template,
+  registry: FluentDesignSystem.registry,
   styles,
-});
+  template,
+};

--- a/packages/web-components/src/tree-item/define.ts
+++ b/packages/web-components/src/tree-item/define.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
 import { definition } from './tree-item.definition.js';
+import { TreeItem } from './tree-item.js';
 
-definition.define(FluentDesignSystem.registry);
+TreeItem.define(definition);

--- a/packages/web-components/src/tree-item/tree-item.bench.ts
+++ b/packages/web-components/src/tree-item/tree-item.bench.ts
@@ -1,7 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
-import { definition } from './tree-item.definition.js';
-
-definition.define(FluentDesignSystem.registry);
+import './define.js';
 
 const itemRenderer = () => {
   const treeItem = document.createElement('fluent-tree-item');

--- a/packages/web-components/src/tree-item/tree-item.definition.ts
+++ b/packages/web-components/src/tree-item/tree-item.definition.ts
@@ -1,16 +1,17 @@
+import type { PartialFASTElementDefinition } from '@microsoft/fast-element';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import { tagName } from './tree-item.options.js';
-import { TreeItem } from './tree-item.js';
-import { styles as treeItemStyle } from './tree-item.styles.js';
-import { template as treeItemTemplate } from './tree-item.template.js';
+import { styles } from './tree-item.styles.js';
+import { template } from './tree-item.template.js';
 
 /**
+ * The definition for the `<fluent-tree-item>` element.
  *
  * @public
- * @remarks
- * HTML Element: \<fluent-tree-item\>
  */
-export const definition = TreeItem.compose({
+export const definition: PartialFASTElementDefinition = {
   name: tagName,
-  template: treeItemTemplate,
-  styles: treeItemStyle,
-});
+  registry: FluentDesignSystem.registry,
+  styles,
+  template,
+};

--- a/packages/web-components/src/tree/define.ts
+++ b/packages/web-components/src/tree/define.ts
@@ -1,4 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
 import { definition } from './tree.definition.js';
+import { Tree } from './tree.js';
 
-definition.define(FluentDesignSystem.registry);
+Tree.define(definition);

--- a/packages/web-components/src/tree/tree.bench.ts
+++ b/packages/web-components/src/tree/tree.bench.ts
@@ -1,7 +1,4 @@
-import { FluentDesignSystem } from '../fluent-design-system.js';
-import { definition } from './tree.definition.js';
-
-definition.define(FluentDesignSystem.registry);
+import './define.js';
 
 const itemRenderer = () => {
   const tree = document.createElement('fluent-tree');

--- a/packages/web-components/src/tree/tree.definition.ts
+++ b/packages/web-components/src/tree/tree.definition.ts
@@ -1,16 +1,17 @@
+import type { PartialFASTElementDefinition } from '@microsoft/fast-element';
+import { FluentDesignSystem } from '../fluent-design-system.js';
 import { tagName } from './tree.options.js';
-import { Tree } from './tree.js';
-import { styles as treeStyle } from './tree.styles.js';
-import { template as treeTemplate } from './tree.template.js';
+import { styles } from './tree.styles.js';
+import { template } from './tree.template.js';
 
 /**
+ * The definition for the `<fluent-tree>` element.
  *
  * @public
- * @remarks
- * HTML Element: \<fluent-tree\>
  */
-export const definition = Tree.compose({
+export const definition: PartialFASTElementDefinition = {
   name: tagName,
-  template: treeTemplate,
-  styles: treeStyle,
-});
+  registry: FluentDesignSystem.registry,
+  styles,
+  template,
+};

--- a/packages/web-components/tensile.config.js
+++ b/packages/web-components/tensile.config.js
@@ -5,6 +5,9 @@ const config = {
   // Importmaps for your test.
   // See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap
   imports: {
+    '@microsoft/focusgroup-polyfill': '/node_modules/@microsoft/focusgroup-polyfill/build/index.mjs',
+    '@microsoft/focusgroup-polyfill/shadowless':
+      '/node_modules/@microsoft/focusgroup-polyfill/build/index-shadowless.mjs',
     '@tensile-perf/web-components': '/node_modules/@tensile-perf/web-components/lib/index.js',
     '@microsoft/fast-element': '/node_modules/@microsoft/fast-element/dist/fast-element.min.js',
     '@microsoft/fast-element/utilities.js': '/node_modules/@microsoft/fast-element/dist/esm/utilities.js',


### PR DESCRIPTION
## Previous Behavior

Component definitions across `@fluentui/web-components` and `@fluentui/chart-web-components` were created with the `Element.compose()` API. Each `define.ts` then registered the element by calling `definition.define(FluentDesignSystem.registry)`, and benchmarks imported the composed `definition` directly to register elements.

## New Behavior

Each component definition is now a plain `PartialFASTElementDefinition` object that includes `name`, `registry`, `styles`, and `template`. Registration happens by calling `Element.define(definition)` in each `define.ts`, and benchmarks import the component's `define.js` side-effect module instead of composing the definition themselves. The generated API report and `tensile.config.js` are updated to match. Behavior is functionally equivalent; this is an internal refactor that removes the `compose()` pattern.