### PR TITLE
fix(Calendar): year prev/next buttons don't lose focus when they become disabled

### DIFF
--- a/change/@fluentui-react-calendar-compat-0d9c3499-7ea6-4f4f-b600-420607d2c351.json
+++ b/change/@fluentui-react-calendar-compat-0d9c3499-7ea6-4f4f-b600-420607d2c351.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(Calendar): year prev/next buttons don't lose focus when they become disabled",
+  "packageName": "@fluentui/react-calendar-compat",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-calendar-compat/library/src/components/CalendarYear/CalendarYear.tsx
+++ b/packages/react-components/react-calendar-compat/library/src/components/CalendarYear/CalendarYear.tsx
@@ -245,11 +245,12 @@ const CalendarYearNavArrow: React.FunctionComponent<CalendarYearNavArrowProps> =
   return (
     <button
       className={mergeClasses(classNames.navigationButton, disabled && classNames.disabled)}
+      aria-disabled={disabled}
+      tabIndex={disabled ? -1 : undefined}
       onClick={!disabled ? onNavigate : undefined}
       onKeyDown={!disabled ? onKeyDown : undefined}
       type="button"
       title={ariaLabelString}
-      disabled={disabled}
     >
       {direction === CalendarYearNavDirection.Previous ? navigationIcons.upNavigation : navigationIcons.downNavigation}
     </button>


### PR DESCRIPTION
## Previous Behavior

The year grid's previous/next buttons used the HTML `disabled` prop, which means focus was lost when they became disabled. Since they can become disabled as a result of a click event, the better practice is to use `aria-disabled` + `tabindex="-1"` (similar to our Button's `disabledFocusable` state). This is the pattern already used in the CalendarMonth prev/next buttons, so I think the year grid buttons just got forgotten.

## New Behavior

They use the `disabledFocusable`-style disabling, which allows focus to stay on them when they become disabled, but they stay out of the tab order.

## Related Issue(s)

- Fixes [ADO issue](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/38152)
