### PR TITLE
fix: remove floating-ui from headless components bundle

### DIFF
--- a/change/@fluentui-react-headless-components-preview-414b4eae-d302-4622-bb3a-a2b90a0ec94c.json
+++ b/change/@fluentui-react-headless-components-preview-414b4eae-d302-4622-bb3a-a2b90a0ec94c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove floating-ui from bundle by vendoring resolvePositioningShorthand",
+  "packageName": "@fluentui/react-headless-components-preview",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-headless-components-preview/library/etc/positioning.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/positioning.api.md
@@ -11,7 +11,6 @@ import type { PositioningProps as PositioningProps_2 } from '@fluentui/react-pos
 import { PositioningShorthand } from '@fluentui/react-positioning';
 import { PositioningShorthandValue } from '@fluentui/react-positioning';
 import type * as React_2 from 'react';
-import { resolvePositioningShorthand } from '@fluentui/react-positioning';
 
 export { Alignment }
 
@@ -50,7 +49,8 @@ export const POSITIONS: {
     readonly after: "after";
 };
 
-export { resolvePositioningShorthand }
+// @public (undocumented)
+export function resolvePositioningShorthand(shorthand: PositioningShorthand | undefined | null): Readonly<PositioningProps_2>;
 
 // @public (undocumented)
 export function usePositioning(options: PositioningProps): PositioningReturn;

--- a/packages/react-components/react-headless-components-preview/library/src/hooks/usePositioning/index.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/hooks/usePositioning/index.ts
@@ -1,4 +1,4 @@
-export { resolvePositioningShorthand } from '@fluentui/react-positioning';
+export { resolvePositioningShorthand } from './utils';
 export { usePositioning } from './usePositioning';
 export { getPlacementString } from './utils';
 export { POSITIONS, ALIGNMENTS } from './constants';

--- a/packages/react-components/react-headless-components-preview/library/src/hooks/usePositioning/utils/index.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/hooks/usePositioning/utils/index.ts
@@ -4,3 +4,4 @@ export { debounce } from './debounce';
 export { applyOffset, resolveOffset } from './offset';
 export { getCoverSelfAlignment, getPlacementString, shorthandToPositionArea } from './placement';
 export { resolveElementRef } from './resolveElementRef';
+export { resolvePositioningShorthand } from './resolvePositioningShorthand';

--- a/packages/react-components/react-headless-components-preview/library/src/hooks/usePositioning/utils/placement.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/hooks/usePositioning/utils/placement.ts
@@ -1,7 +1,7 @@
-import { resolvePositioningShorthand } from '@fluentui/react-positioning';
 import type { Alignment, Position, PositioningShorthandValue } from '@fluentui/react-positioning';
 import type { LogicalAlignment } from '../types';
 import { ALIGNMENTS, POSITIONS, POSITION_AREA_MAP } from '../constants';
+import { resolvePositioningShorthand } from './resolvePositioningShorthand';
 
 const ALIGN_ALIASES: Record<string, LogicalAlignment> = {
   top: ALIGNMENTS.start,

--- a/packages/react-components/react-headless-components-preview/library/src/hooks/usePositioning/utils/resolvePositioningShorthand.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/hooks/usePositioning/utils/resolvePositioningShorthand.ts
@@ -1,0 +1,30 @@
+import type { PositioningProps, PositioningShorthand, PositioningShorthandValue } from '@fluentui/react-positioning';
+
+const shorthandLookup: Record<PositioningShorthandValue, Pick<PositioningProps, 'position' | 'align'>> = {
+  above: { position: 'above', align: 'center' },
+  'above-start': { position: 'above', align: 'start' },
+  'above-end': { position: 'above', align: 'end' },
+  below: { position: 'below', align: 'center' },
+  'below-start': { position: 'below', align: 'start' },
+  'below-end': { position: 'below', align: 'end' },
+  before: { position: 'before', align: 'center' },
+  'before-top': { position: 'before', align: 'top' },
+  'before-bottom': { position: 'before', align: 'bottom' },
+  after: { position: 'after', align: 'center' },
+  'after-top': { position: 'after', align: 'top' },
+  'after-bottom': { position: 'after', align: 'bottom' },
+};
+
+export function resolvePositioningShorthand(
+  shorthand: PositioningShorthand | undefined | null,
+): Readonly<PositioningProps> {
+  if (shorthand === undefined || shorthand === null) {
+    return {};
+  }
+
+  if (typeof shorthand === 'string') {
+    return shorthandLookup[shorthand];
+  }
+
+  return shorthand as Readonly<PositioningProps>;
+}


### PR DESCRIPTION
`@fluentui/react-headless-components-preview` positions via native CSS anchor positioning and should not bundle `@floating-ui/dom`. It still pulled it in transitively through a single runtime import of `resolvePositioningShorthand` from `@fluentui/react-positioning`, whose barrel eagerly loads `usePositioning` → `@floating-ui/dom`.