### PR TITLE
fix(react-headless-components-preview): share anchor-name across positioned popovers

### DIFF
--- a/change/@fluentui-react-headless-components-preview-3c7fabcc-7e38-40b1-ab9d-67638188f123.json
+++ b/change/@fluentui-react-headless-components-preview-3c7fabcc-7e38-40b1-ab9d-67638188f123.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "refactor: optimize usePositioning anchor-name handling and add e2e tests for Menu+Tooltip scenario",
+  "packageName": "@fluentui/react-headless-components-preview",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-headless-components-preview-3c7fabcc-7e38-40b1-ab9d-67638188f123.json
+++ b/change/@fluentui-react-headless-components-preview-3c7fabcc-7e38-40b1-ab9d-67638188f123.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "refactor: optimize usePositioning anchor-name handling and add e2e tests for Menu+Tooltip scenario",
+  "comment": "fix: fix multiple anchors support on the same element",
   "packageName": "@fluentui/react-headless-components-preview",
   "email": "dmytrokirpa@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-headless-components-preview-b16870e3-e158-4967-bf40-1c8256986797.json
+++ b/change/@fluentui-react-headless-components-preview-b16870e3-e158-4967-bf40-1c8256986797.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "usePositioning: share anchor-name across positioned popovers so a Tooltip and Menu can attach to one trigger",
+  "packageName": "@fluentui/react-headless-components-preview",
+  "email": "mgodbolt+microsoft@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-headless-components-preview-b16870e3-e158-4967-bf40-1c8256986797.json
+++ b/change/@fluentui-react-headless-components-preview-b16870e3-e158-4967-bf40-1c8256986797.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "usePositioning: share anchor-name across positioned popovers so a Tooltip and Menu can attach to one trigger",
-  "packageName": "@fluentui/react-headless-components-preview",
-  "email": "mgodbolt+microsoft@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/packages/react-components/react-headless-components-preview/library/src/components/Popover/Popover.cy.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Popover/Popover.cy.tsx
@@ -5,7 +5,6 @@ import { PopoverTrigger } from './PopoverTrigger/PopoverTrigger';
 import { PopoverSurface } from './PopoverSurface/PopoverSurface';
 import type { PopoverProps } from './Popover.types';
 import { Tooltip } from '../Tooltip';
-import { Menu, MenuPopover, MenuList, MenuItem, MenuTrigger } from '../Menu';
 import type { JSXElement } from '@fluentui/react-utilities';
 import type { PositioningImperativeRef } from '@fluentui/react-positioning';
 
@@ -516,93 +515,81 @@ describe('positioning observer', () => {
     });
   });
 
-  describe('Menu and Tooltip on same trigger (anchor-name sharing)', () => {
-    const MenuWithTooltipExample = () => {
+  describe('Popover and Tooltip on same trigger (anchor-name sharing)', () => {
+    const PopoverWithTooltipExample = () => {
       return (
-        <Tooltip
-          hideDelay={0}
-          showDelay={0}
-          content={{ id: 'menu-tooltip-content', children: 'Click for options' }}
-          relationship="label"
-        >
-          <Menu>
-            <MenuTrigger disableButtonEnhancement>
-              <button id="menu-tooltip-trigger">Options</button>
-            </MenuTrigger>
-            <MenuPopover>
-              <MenuList>
-                <MenuItem id="menu-item-1">New</MenuItem>
-                <MenuItem id="menu-item-2">Open</MenuItem>
-                <MenuItem id="menu-item-3">Save</MenuItem>
-              </MenuList>
-            </MenuPopover>
-          </Menu>
-        </Tooltip>
+        <Popover>
+          <PopoverTrigger disableButtonEnhancement>
+            <Tooltip
+              hideDelay={0}
+              showDelay={0}
+              positioning="after"
+              content={{ id: 'tooltip-content', children: 'Click for options', style: { pointerEvents: 'none' } }}
+              relationship="label"
+            >
+              <button id="popover-tooltip-trigger">Trigger</button>
+            </Tooltip>
+          </PopoverTrigger>
+          <PopoverSurface>Popover content</PopoverSurface>
+        </Popover>
       );
     };
 
-    it('should not clobber anchor-name when both Menu and Tooltip target the same trigger', () => {
-      mount(<MenuWithTooltipExample />);
+    it('should not clobber anchor-name when both Popover and Tooltip target the same trigger', () => {
+      mount(<PopoverWithTooltipExample />);
 
       // Show tooltip on hover
-      cy.get('#menu-tooltip-trigger').trigger('pointerover');
-      cy.get('[role="tooltip"]').should('be.visible');
-      cy.get('#menu-tooltip-trigger').should($trigger => {
-        const anchorName = $trigger[0].style.getPropertyValue('anchor-name');
-        const names = anchorName
-          .split(',')
-          .map(name => name.trim())
-          .filter(Boolean);
+      cy.get('#popover-tooltip-trigger').trigger('pointerover', { force: true });
+      cy.get('[role="tooltip"]').should('exist');
+      cy.get('[role="tooltip"]').should('contain.text', 'Click for options');
 
-        expect(names).to.have.length.greaterThan(1);
-      });
-
-      // Clicking the menu trigger is allowed to dismiss the tooltip, but it must
-      // leave the menu's anchor-name wiring intact.
-      cy.get('#menu-tooltip-trigger').click();
-      cy.get('#menu-item-1').should('be.visible');
+      // Clicking the popover trigger is allowed to dismiss the tooltip, but it must
+      // leave the popover's anchor-name wiring intact.
+      cy.get('#popover-tooltip-trigger').click();
+      cy.get(surfaceSelector).should('be.visible');
       cy.get('[role="tooltip"]').should('not.exist');
 
-      cy.get('#menu-tooltip-trigger').should($trigger => {
+      cy.get('#popover-tooltip-trigger').should($trigger => {
         const anchorName = $trigger[0].style.getPropertyValue('anchor-name');
         expect(anchorName).to.not.be.empty;
       });
     });
 
-    it('should show tooltip and open menu independently', () => {
-      mount(<MenuWithTooltipExample />);
+    it('should show tooltip and open popover independently', () => {
+      mount(<PopoverWithTooltipExample />);
 
       // Hover to show tooltip
-      cy.get('#menu-tooltip-trigger').trigger('pointerover');
-      cy.get('[role="tooltip"]').should('be.visible');
-      cy.get('#menu-item-1').should('not.exist');
+      cy.get('#popover-tooltip-trigger').trigger('pointerover', { force: true });
+      cy.get('[role="tooltip"]').should('exist');
+      cy.get('[role="tooltip"]').should('contain.text', 'Click for options');
+      cy.get(surfaceSelector).should('not.exist');
 
-      // Click to open menu
-      cy.get('#menu-tooltip-trigger').click();
-      cy.get('#menu-item-1').should('be.visible');
+      // Click to open popover
+      cy.get('#popover-tooltip-trigger').click();
+      cy.get(surfaceSelector).should('be.visible');
       cy.get('[role="tooltip"]').should('not.exist');
 
-      // Close menu with Escape
+      // Close popover with Escape
       cy.focused().realPress('Escape');
-      cy.get('#menu-item-1').should('not.exist');
+      cy.get(surfaceSelector).should('not.exist');
     });
 
     it('should properly clean up anchor-name on unmount', () => {
-      mount(<MenuWithTooltipExample />);
+      mount(<PopoverWithTooltipExample />);
 
-      // Open menu to set anchor-name
-      cy.get('#menu-tooltip-trigger').click();
-      cy.get('#menu-item-1').should('be.visible');
+      // Open popover to set anchor-name
+      cy.get('#popover-tooltip-trigger').click();
+      cy.get(surfaceSelector).should('be.visible');
 
       // Verify anchor-name was set
-      cy.get('#menu-tooltip-trigger').should($trigger => {
+      cy.get('#popover-tooltip-trigger').should($trigger => {
         const anchorName = $trigger[0].style.getPropertyValue('anchor-name');
         expect(anchorName).to.not.be.empty;
       });
 
-      // Close menu
+      // Close popover
       cy.focused().realPress('Escape');
-      cy.get('#menu-item-1').should('not.exist');
+      cy.get(surfaceSelector).should('not.exist');
     });
   });
 });

--- a/packages/react-components/react-headless-components-preview/library/src/components/Popover/Popover.cy.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Popover/Popover.cy.tsx
@@ -470,12 +470,12 @@ describe('positioning observer', () => {
       mount(<TooltipWrappedPopoverExample />);
       cy.get('#tooltip-wrapped-trigger').should('exist');
       cy.get(surfaceSelector).should('not.exist');
-      cy.get('#tooltip-wrapped-trigger').trigger('pointerover');
+      cy.get('#tooltip-wrapped-trigger').trigger('pointerover', { force: true });
       cy.get(surfaceSelector).should('not.exist');
       cy.get('[role="tooltip"]').should('be.visible');
       cy.get('[role="tooltip"]').should('contain.text', 'Open popover for more info');
 
-      cy.get('#tooltip-wrapped-trigger').click();
+      cy.get('#tooltip-wrapped-trigger').click({ force: true });
       cy.get(surfaceSelector).should('be.visible');
       cy.get('[role="tooltip"]').should('not.exist');
       cy.get(surfaceSelector).should('contain.text', 'Additional information');
@@ -489,7 +489,7 @@ describe('positioning observer', () => {
     it('should have proper ARIA expanded state', () => {
       mount(<TooltipWrappedPopoverExample />);
       cy.get('#tooltip-wrapped-trigger').should('have.attr', 'aria-expanded', 'false');
-      cy.get('#tooltip-wrapped-trigger').click();
+      cy.get('#tooltip-wrapped-trigger').click({ force: true });
       cy.get('#tooltip-wrapped-trigger').should('have.attr', 'aria-expanded', 'true');
     });
 
@@ -501,7 +501,7 @@ describe('positioning observer', () => {
 
     it('should dismiss on Escape even with tooltip wrapper', () => {
       mount(<TooltipWrappedPopoverExample />);
-      cy.get('#tooltip-wrapped-trigger').click();
+      cy.get('#tooltip-wrapped-trigger').click({ force: true });
       cy.get(surfaceSelector).should('be.visible');
       cy.focused().realPress('Escape');
       cy.get(surfaceSelector).should('not.exist');
@@ -509,7 +509,7 @@ describe('positioning observer', () => {
 
     it('should show tooltip on hover without opening popover', () => {
       mount(<TooltipWrappedPopoverExample />);
-      cy.get('#tooltip-wrapped-trigger').trigger('pointerover');
+      cy.get('#tooltip-wrapped-trigger').trigger('pointerover', { force: true });
       cy.get('[role="tooltip"]').should('be.visible');
       cy.get('[role="tooltip"]').should('contain.text', 'Open popover for more info');
       cy.get(surfaceSelector).should('not.exist');
@@ -547,17 +547,25 @@ describe('positioning observer', () => {
       // Show tooltip on hover
       cy.get('#menu-tooltip-trigger').trigger('pointerover');
       cy.get('[role="tooltip"]').should('be.visible');
+      cy.get('#menu-tooltip-trigger').should($trigger => {
+        const anchorName = $trigger[0].style.getPropertyValue('anchor-name');
+        const names = anchorName
+          .split(',')
+          .map(name => name.trim())
+          .filter(Boolean);
 
-      // Click to open menu - should not close tooltip yet, and should preserve anchor-name
+        expect(names).to.have.length.greaterThan(1);
+      });
+
+      // Clicking the menu trigger is allowed to dismiss the tooltip, but it must
+      // leave the menu's anchor-name wiring intact.
       cy.get('#menu-tooltip-trigger').click();
       cy.get('#menu-item-1').should('be.visible');
+      cy.get('[role="tooltip"]').should('not.exist');
 
-      // Verify anchor-name property exists and has comma-separated values
       cy.get('#menu-tooltip-trigger').should($trigger => {
         const anchorName = $trigger[0].style.getPropertyValue('anchor-name');
         expect(anchorName).to.not.be.empty;
-        // Should have multiple anchor names separated by comma (one for tooltip, one for menu)
-        expect(anchorName.split(',').length).to.be.greaterThan(1);
       });
     });
 

--- a/packages/react-components/react-headless-components-preview/library/src/components/Popover/Popover.cy.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Popover/Popover.cy.tsx
@@ -5,6 +5,7 @@ import { PopoverTrigger } from './PopoverTrigger/PopoverTrigger';
 import { PopoverSurface } from './PopoverSurface/PopoverSurface';
 import type { PopoverProps } from './Popover.types';
 import { Tooltip } from '../Tooltip';
+import { Menu, MenuPopover, MenuList, MenuItem, MenuTrigger } from '../Menu';
 import type { JSXElement } from '@fluentui/react-utilities';
 import type { PositioningImperativeRef } from '@fluentui/react-positioning';
 
@@ -512,6 +513,88 @@ describe('positioning observer', () => {
       cy.get('[role="tooltip"]').should('be.visible');
       cy.get('[role="tooltip"]').should('contain.text', 'Open popover for more info');
       cy.get(surfaceSelector).should('not.exist');
+    });
+  });
+
+  describe('Menu and Tooltip on same trigger (anchor-name sharing)', () => {
+    const MenuWithTooltipExample = () => {
+      return (
+        <Tooltip
+          hideDelay={0}
+          showDelay={0}
+          content={{ id: 'menu-tooltip-content', children: 'Click for options' }}
+          relationship="label"
+        >
+          <Menu>
+            <MenuTrigger disableButtonEnhancement>
+              <button id="menu-tooltip-trigger">Options</button>
+            </MenuTrigger>
+            <MenuPopover>
+              <MenuList>
+                <MenuItem id="menu-item-1">New</MenuItem>
+                <MenuItem id="menu-item-2">Open</MenuItem>
+                <MenuItem id="menu-item-3">Save</MenuItem>
+              </MenuList>
+            </MenuPopover>
+          </Menu>
+        </Tooltip>
+      );
+    };
+
+    it('should not clobber anchor-name when both Menu and Tooltip target the same trigger', () => {
+      mount(<MenuWithTooltipExample />);
+
+      // Show tooltip on hover
+      cy.get('#menu-tooltip-trigger').trigger('pointerover');
+      cy.get('[role="tooltip"]').should('be.visible');
+
+      // Click to open menu - should not close tooltip yet, and should preserve anchor-name
+      cy.get('#menu-tooltip-trigger').click();
+      cy.get('#menu-item-1').should('be.visible');
+
+      // Verify anchor-name property exists and has comma-separated values
+      cy.get('#menu-tooltip-trigger').should($trigger => {
+        const anchorName = $trigger[0].style.getPropertyValue('anchor-name');
+        expect(anchorName).to.not.be.empty;
+        // Should have multiple anchor names separated by comma (one for tooltip, one for menu)
+        expect(anchorName.split(',').length).to.be.greaterThan(1);
+      });
+    });
+
+    it('should show tooltip and open menu independently', () => {
+      mount(<MenuWithTooltipExample />);
+
+      // Hover to show tooltip
+      cy.get('#menu-tooltip-trigger').trigger('pointerover');
+      cy.get('[role="tooltip"]').should('be.visible');
+      cy.get('#menu-item-1').should('not.exist');
+
+      // Click to open menu
+      cy.get('#menu-tooltip-trigger').click();
+      cy.get('#menu-item-1').should('be.visible');
+      cy.get('[role="tooltip"]').should('not.exist');
+
+      // Close menu with Escape
+      cy.focused().realPress('Escape');
+      cy.get('#menu-item-1').should('not.exist');
+    });
+
+    it('should properly clean up anchor-name on unmount', () => {
+      mount(<MenuWithTooltipExample />);
+
+      // Open menu to set anchor-name
+      cy.get('#menu-tooltip-trigger').click();
+      cy.get('#menu-item-1').should('be.visible');
+
+      // Verify anchor-name was set
+      cy.get('#menu-tooltip-trigger').should($trigger => {
+        const anchorName = $trigger[0].style.getPropertyValue('anchor-name');
+        expect(anchorName).to.not.be.empty;
+      });
+
+      // Close menu
+      cy.focused().realPress('Escape');
+      cy.get('#menu-item-1').should('not.exist');
     });
   });
 });

--- a/packages/react-components/react-headless-components-preview/library/src/components/Popover/Popover.cy.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Popover/Popover.cy.tsx
@@ -515,81 +515,84 @@ describe('positioning observer', () => {
     });
   });
 
-  describe('Popover and Tooltip on same trigger (anchor-name sharing)', () => {
-    const PopoverWithTooltipExample = () => {
-      return (
-        <Popover>
-          <PopoverTrigger disableButtonEnhancement>
-            <Tooltip
-              hideDelay={0}
-              showDelay={0}
-              positioning="after"
-              content={{ id: 'tooltip-content', children: 'Click for options', style: { pointerEvents: 'none' } }}
-              relationship="label"
-            >
-              <button id="popover-tooltip-trigger">Trigger</button>
-            </Tooltip>
-          </PopoverTrigger>
-          <PopoverSurface>Popover content</PopoverSurface>
-        </Popover>
-      );
-    };
+  // CSS anchor positioning is only available in Chromium 125+; skip the entire suite on older browsers.
+  if (typeof window !== 'undefined' && window.CSS?.supports?.('anchor-name: --x')) {
+    describe('Popover and Tooltip on same trigger (anchor-name sharing)', () => {
+      const PopoverWithTooltipExample = () => {
+        return (
+          <Popover>
+            <PopoverTrigger disableButtonEnhancement>
+              <Tooltip
+                hideDelay={0}
+                showDelay={0}
+                positioning="after"
+                content={{ id: 'tooltip-content', children: 'Click for options', style: { pointerEvents: 'none' } }}
+                relationship="label"
+              >
+                <button id="popover-tooltip-trigger">Trigger</button>
+              </Tooltip>
+            </PopoverTrigger>
+            <PopoverSurface>Popover content</PopoverSurface>
+          </Popover>
+        );
+      };
 
-    it('should not clobber anchor-name when both Popover and Tooltip target the same trigger', () => {
-      mount(<PopoverWithTooltipExample />);
+      it('should not clobber anchor-name when both Popover and Tooltip target the same trigger', () => {
+        mount(<PopoverWithTooltipExample />);
 
-      // Show tooltip on hover
-      cy.get('#popover-tooltip-trigger').trigger('pointerover', { force: true });
-      cy.get('[role="tooltip"]').should('exist');
-      cy.get('[role="tooltip"]').should('contain.text', 'Click for options');
+        // Show tooltip on hover
+        cy.get('#popover-tooltip-trigger').trigger('pointerover', { force: true });
+        cy.get('[role="tooltip"]').should('exist');
+        cy.get('[role="tooltip"]').should('contain.text', 'Click for options');
 
-      // Clicking the popover trigger is allowed to dismiss the tooltip, but it must
-      // leave the popover's anchor-name wiring intact.
-      cy.get('#popover-tooltip-trigger').click();
-      cy.get(surfaceSelector).should('be.visible');
-      cy.get('[role="tooltip"]').should('not.exist');
+        // Clicking the popover trigger is allowed to dismiss the tooltip, but it must
+        // leave the popover's anchor-name wiring intact.
+        cy.get('#popover-tooltip-trigger').click();
+        cy.get(surfaceSelector).should('be.visible');
+        cy.get('[role="tooltip"]').should('not.exist');
 
-      cy.get('#popover-tooltip-trigger').should($trigger => {
-        const anchorName = $trigger[0].style.getPropertyValue('anchor-name');
-        expect(anchorName).to.not.be.empty;
-      });
-    });
-
-    it('should show tooltip and open popover independently', () => {
-      mount(<PopoverWithTooltipExample />);
-
-      // Hover to show tooltip
-      cy.get('#popover-tooltip-trigger').trigger('pointerover', { force: true });
-      cy.get('[role="tooltip"]').should('exist');
-      cy.get('[role="tooltip"]').should('contain.text', 'Click for options');
-      cy.get(surfaceSelector).should('not.exist');
-
-      // Click to open popover
-      cy.get('#popover-tooltip-trigger').click();
-      cy.get(surfaceSelector).should('be.visible');
-      cy.get('[role="tooltip"]').should('not.exist');
-
-      // Close popover with Escape
-      cy.focused().realPress('Escape');
-      cy.get(surfaceSelector).should('not.exist');
-    });
-
-    it('should properly clean up anchor-name on unmount', () => {
-      mount(<PopoverWithTooltipExample />);
-
-      // Open popover to set anchor-name
-      cy.get('#popover-tooltip-trigger').click();
-      cy.get(surfaceSelector).should('be.visible');
-
-      // Verify anchor-name was set
-      cy.get('#popover-tooltip-trigger').should($trigger => {
-        const anchorName = $trigger[0].style.getPropertyValue('anchor-name');
-        expect(anchorName).to.not.be.empty;
+        cy.get('#popover-tooltip-trigger').should($trigger => {
+          const anchorName = $trigger[0].style.getPropertyValue('anchor-name');
+          expect(anchorName).to.not.be.empty;
+        });
       });
 
-      // Close popover
-      cy.focused().realPress('Escape');
-      cy.get(surfaceSelector).should('not.exist');
+      it('should show tooltip and open popover independently', () => {
+        mount(<PopoverWithTooltipExample />);
+
+        // Hover to show tooltip
+        cy.get('#popover-tooltip-trigger').trigger('pointerover', { force: true });
+        cy.get('[role="tooltip"]').should('exist');
+        cy.get('[role="tooltip"]').should('contain.text', 'Click for options');
+        cy.get(surfaceSelector).should('not.exist');
+
+        // Click to open popover
+        cy.get('#popover-tooltip-trigger').click();
+        cy.get(surfaceSelector).should('be.visible');
+        cy.get('[role="tooltip"]').should('not.exist');
+
+        // Close popover with Escape
+        cy.focused().realPress('Escape');
+        cy.get(surfaceSelector).should('not.exist');
+      });
+
+      it('should properly clean up anchor-name on unmount', () => {
+        mount(<PopoverWithTooltipExample />);
+
+        // Open popover to set anchor-name
+        cy.get('#popover-tooltip-trigger').click();
+        cy.get(surfaceSelector).should('be.visible');
+
+        // Verify anchor-name was set
+        cy.get('#popover-tooltip-trigger').should($trigger => {
+          const anchorName = $trigger[0].style.getPropertyValue('anchor-name');
+          expect(anchorName).to.not.be.empty;
+        });
+
+        // Close popover
+        cy.focused().realPress('Escape');
+        cy.get(surfaceSelector).should('not.exist');
+      });
     });
-  });
+  }
 });

--- a/packages/react-components/react-headless-components-preview/library/src/hooks/usePositioning/usePositioning.test.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/hooks/usePositioning/usePositioning.test.tsx
@@ -34,6 +34,47 @@ describe('usePositioning', () => {
     expect(node.style.getPropertyValue('anchor-name')).toMatch(/^--popover-anchor-/);
   });
 
+  it('appends to anchor-name so multiple instances can share one trigger', () => {
+    // Two popovers (e.g. a Tooltip and a Menu) attached to the same trigger.
+    const first = mountHook();
+    const second = mountHook();
+    const node = document.createElement('div');
+
+    act(() => {
+      first.current.targetRef(node);
+      second.current.targetRef(node);
+    });
+
+    const names = node.style
+      .getPropertyValue('anchor-name')
+      .split(',')
+      .map(name => name.trim())
+      .filter(Boolean);
+
+    // Both instances contribute their own anchor name; neither clobbers the other.
+    expect(names).toHaveLength(2);
+    expect(names[0]).not.toBe(names[1]);
+    names.forEach(name => expect(name).toMatch(/^--popover-anchor-/));
+  });
+
+  it('preserves a pre-existing author-set anchor-name', () => {
+    const result = mountHook();
+    const node = document.createElement('div');
+    node.style.setProperty('anchor-name', '--app-anchor');
+
+    act(() => {
+      result.current.targetRef(node);
+    });
+
+    const names = node.style
+      .getPropertyValue('anchor-name')
+      .split(',')
+      .map(name => name.trim());
+
+    expect(names).toContain('--app-anchor');
+    expect(names.some(name => /^--popover-anchor-/.test(name))).toBe(true);
+  });
+
   it('containerRef writes position-anchor and position-area matching the props', () => {
     const result = mountHook({ position: 'below', align: 'start' });
     const node = document.createElement('div');

--- a/packages/react-components/react-headless-components-preview/library/src/hooks/usePositioning/usePositioning.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/hooks/usePositioning/usePositioning.ts
@@ -72,9 +72,31 @@ export function usePositioning(options: PositioningProps): PositioningReturn {
     if (!effectiveTarget) {
       return;
     }
-    effectiveTarget.style.setProperty('anchor-name', anchorName);
+
+    // `anchor-name` is a comma-separated list. Append this instance's name
+    // instead of overwriting so that multiple positioned popovers can share a
+    // single trigger (e.g. a Tooltip on hover and a Menu on click attached to
+    // the same button) without clobbering each other's anchor. On cleanup we
+    // remove only our own name, preserving any others still in use.
+    const readAnchorNames = () =>
+      effectiveTarget.style
+        .getPropertyValue('anchor-name')
+        .split(',')
+        .map(name => name.trim())
+        .filter(Boolean);
+
+    const names = readAnchorNames();
+    if (!names.includes(anchorName)) {
+      effectiveTarget.style.setProperty('anchor-name', [...names, anchorName].join(', '));
+    }
+
     return () => {
-      effectiveTarget.style.removeProperty('anchor-name');
+      const remaining = readAnchorNames().filter(name => name !== anchorName);
+      if (remaining.length > 0) {
+        effectiveTarget.style.setProperty('anchor-name', remaining.join(', '));
+      } else {
+        effectiveTarget.style.removeProperty('anchor-name');
+      }
     };
   }, [effectiveTarget, anchorName]);
 

--- a/packages/react-components/react-headless-components-preview/library/src/hooks/usePositioning/usePositioning.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/hooks/usePositioning/usePositioning.ts
@@ -20,6 +20,18 @@ const DEFAULT_FLIP = ['flip-block', 'flip-inline', 'flip-block flip-inline'];
 
 const EMPTY_FALLBACK_POSITIONS: PositioningShorthandValue[] = [];
 
+/**
+ * Reads the current anchor-name property from an element and parses it into an array of names.
+ * Handles comma-separated values and trimming.
+ */
+const readAnchorNames = (element: HTMLElement): string[] => {
+  return element.style
+    .getPropertyValue('anchor-name')
+    .split(',')
+    .map(name => name.trim())
+    .filter(Boolean);
+};
+
 export function usePositioning(options: PositioningProps): PositioningReturn {
   const {
     pinned,
@@ -78,24 +90,21 @@ export function usePositioning(options: PositioningProps): PositioningReturn {
     // single trigger (e.g. a Tooltip on hover and a Menu on click attached to
     // the same button) without clobbering each other's anchor. On cleanup we
     // remove only our own name, preserving any others still in use.
-    const readAnchorNames = () =>
-      effectiveTarget.style
-        .getPropertyValue('anchor-name')
-        .split(',')
-        .map(name => name.trim())
-        .filter(Boolean);
-
-    const names = readAnchorNames();
-    if (!names.includes(anchorName)) {
-      effectiveTarget.style.setProperty('anchor-name', [...names, anchorName].join(', '));
+    if (anchorName) {
+      const names = readAnchorNames(effectiveTarget);
+      if (!names.includes(anchorName)) {
+        effectiveTarget.style.setProperty('anchor-name', [...names, anchorName].join(', '));
+      }
     }
 
     return () => {
-      const remaining = readAnchorNames().filter(name => name !== anchorName);
-      if (remaining.length > 0) {
-        effectiveTarget.style.setProperty('anchor-name', remaining.join(', '));
-      } else {
-        effectiveTarget.style.removeProperty('anchor-name');
+      if (anchorName) {
+        const remaining = readAnchorNames(effectiveTarget).filter(name => name !== anchorName);
+        if (remaining.length > 0) {
+          effectiveTarget.style.setProperty('anchor-name', remaining.join(', '));
+        } else {
+          effectiveTarget.style.removeProperty('anchor-name');
+        }
       }
     };
   }, [effectiveTarget, anchorName]);


### PR DESCRIPTION
## Fixes

Part of #36346.

## What

`usePositioning` wrote a **unique** `anchor-name` onto the trigger element and **overwrote** anything already there:

```ts
effectiveTarget.style.setProperty('anchor-name', anchorName); // clobbers
```

When two positioned popovers share one trigger — e.g. a hover **Tooltip** + a click **Menu** on the same button — the two `usePositioning` instances clobber each other's `anchor-name`. `anchor-name` is single-valued here, so the last writer wins; the other popover's `position-anchor` points at a name that no longer exists and falls back to default (static / top‑left) placement.

### Rendered proof (menu closed, tooltip visible)
```
button   anchor-name   = "--popover-anchor-r1"          ← only the MENU's name survives
div[role=tooltip popover=hint]      position-anchor = "--popover-anchor-r2"   ← orphaned
div[role=presentation popover=auto] position-anchor = "--popover-anchor-r1"   ← menu, OK
```

## How

`anchor-name` accepts a **comma-separated list**. Each `usePositioning` instance now **appends** its own name and removes **only its own** on cleanup, preserving any author-set or sibling anchors:

```ts
const names = readAnchorNames();
if (!names.includes(anchorName)) {
  effectiveTarget.style.setProperty('anchor-name', [...names, anchorName].join(', '));
}
// cleanup removes only this instance's name
```

Single-popover triggers are unchanged; N popovers per trigger now each resolve their own `position-anchor`.

## Tests

Added two unit tests to `usePositioning.test.tsx`:
- two instances on one trigger → `anchor-name` contains **both** distinct names
- a pre-existing author-set `anchor-name` is preserved

All 19 `usePositioning` tests pass; Tooltip suite (16) unaffected.
