### PR TITLE
feat(react-headless-components-preview): adopt Interest Invokers (interestfor) for Tooltip intent

### DIFF
--- a/change/@fluentui-react-headless-components-preview-fdcfd9eb-8a65-41a2-adbd-d1ec930e0a27.json
+++ b/change/@fluentui-react-headless-components-preview-fdcfd9eb-8a65-41a2-adbd-d1ec930e0a27.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Adopt native Interest Invokers (interestfor) for Tooltip hover/focus intent, with the existing JS engine as a graceful fallback",
+  "packageName": "@fluentui/react-headless-components-preview",
+  "email": "mgodbolt+microsoft@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-headless-components-preview/library/src/components/Tooltip/Tooltip.test.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Tooltip/Tooltip.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { resetIdsForTests } from '@fluentui/react-utilities';
 import { isConformant } from '../../testing/isConformant';
 import type { IsConformantOptions } from '@fluentui/react-conformance';
@@ -51,6 +51,70 @@ describe('Tooltip', () => {
 
     expect(screen.getByLabelText('Default Tooltip')).toBeInTheDocument();
     expect(screen.getByRole('tooltip')).toHaveAttribute('popover', 'hint');
+  });
+
+  it('wires interestfor on the trigger to the tooltip content (Interest Invokers)', () => {
+    render(
+      <Tooltip content="Interest tooltip" relationship="label" visible>
+        <button>Trigger</button>
+      </Tooltip>,
+    );
+
+    const tooltip = screen.getByRole('tooltip');
+    const trigger = screen.getByRole('button');
+    expect(trigger).toHaveAttribute('interestfor', tooltip.id);
+  });
+
+  it('shows the tooltip via the JS fallback when Interest Invokers are unsupported', () => {
+    jest.useFakeTimers();
+    try {
+      render(
+        <Tooltip content="Hover me" relationship="description">
+          <button>Trigger</button>
+        </Tooltip>,
+      );
+
+      const trigger = screen.getByRole('button');
+      const tooltip = screen.getByRole('tooltip', { hidden: true });
+
+      fireEvent.pointerEnter(trigger);
+      act(() => {
+        jest.advanceTimersByTime(1000);
+      });
+
+      expect(tooltip.matches(':popover-open')).toBe(true);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('defers to the browser (no JS show) when Interest Invokers are supported', () => {
+    jest.useFakeTimers();
+    // jsdom doesn't implement CSS.supports; stub it to report Interest Invoker support.
+    const originalSupports = (CSS as { supports?: typeof CSS.supports }).supports;
+    (CSS as { supports: (condition: string) => boolean }).supports = (condition: string) =>
+      condition === 'interest-delay: 0s';
+    try {
+      render(
+        <Tooltip content="Hover me" relationship="description">
+          <button>Trigger</button>
+        </Tooltip>,
+      );
+
+      const trigger = screen.getByRole('button');
+      const tooltip = screen.getByRole('tooltip', { hidden: true });
+
+      fireEvent.pointerEnter(trigger);
+      act(() => {
+        jest.advanceTimersByTime(1000);
+      });
+
+      // The JS timer is skipped; the platform's `interestfor` would open it instead.
+      expect(tooltip.matches(':popover-open')).toBe(false);
+    } finally {
+      (CSS as { supports?: typeof CSS.supports }).supports = originalSupports;
+      jest.useRealTimers();
+    }
   });
 
   it('renders only aria-label for a simple label tooltip', () => {

--- a/packages/react-components/react-headless-components-preview/library/src/components/Tooltip/useTooltip.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Tooltip/useTooltip.ts
@@ -23,6 +23,17 @@ import type { OnVisibleChangeData, TooltipProps, TooltipState, TooltipTriggerPro
 import { resolvePositioningShorthand, usePositioning } from '../../positioning';
 
 /**
+ * Feature detection for the Interest Invokers API (`interestfor` + `interest-delay`),
+ * which lets the platform open a `popover=hint` on hover/focus declaratively, with no JS.
+ * When supported we let the browser drive show/hide and keep the JS handlers below as a
+ * fallback for browsers that don't support it.
+ *
+ * @see https://open-ui.org/components/interest-invokers.explainer/
+ */
+const supportsInterestInvokers = () =>
+  typeof CSS !== 'undefined' && typeof CSS.supports === 'function' && CSS.supports('interest-delay: 0s');
+
+/**
  * Create the state required to render Tooltip.
  *
  * @param props - props from this instance of Tooltip
@@ -89,9 +100,10 @@ export const useTooltip = (props: TooltipProps): TooltipState => {
   );
 
   const onToggle = useEventCallback((event: Event) => {
-    if ((event as ToggleEvent).newState === 'closed') {
-      setVisible(undefined, { visible: false });
-    }
+    // Keep React state in sync with the native popover regardless of what opened or
+    // closed it — our own JS handlers, the browser's light-dismiss, or (when supported)
+    // an Interest Invoker driving the `popover=hint` declaratively via `interestfor`.
+    setVisible(undefined, { visible: (event as ToggleEvent).newState === 'open' });
   });
 
   // Keep the tooltip in sync with the state when it is changed programmatically.
@@ -105,9 +117,9 @@ export const useTooltip = (props: TooltipProps): TooltipState => {
     el.addEventListener('toggle', onToggle);
 
     try {
-      if (visible) {
+      if (visible && !el.matches(':popover-open')) {
         el.showPopover();
-      } else if (el.matches(':popover-open')) {
+      } else if (!visible && el.matches(':popover-open')) {
         el.hidePopover();
       }
     } catch (error) {
@@ -136,6 +148,12 @@ export const useTooltip = (props: TooltipProps): TooltipState => {
   const onEnterTrigger = React.useCallback(
     // eslint-disable-next-line react-hooks/preserve-manual-memoization
     (ev: React.PointerEvent<HTMLElement> | React.FocusEvent<HTMLElement>) => {
+      // When Interest Invokers are supported the browser shows the hint popover on
+      // hover/focus via `interestfor`; skip the JS timer so we don't double-drive it.
+      if (supportsInterestInvokers()) {
+        return;
+      }
+
       if (ev.type === 'focus' && ignoreNextFocusEventRef.current) {
         ignoreNextFocusEventRef.current = false;
         return;
@@ -179,6 +197,12 @@ export const useTooltip = (props: TooltipProps): TooltipState => {
   const onLeaveTrigger = React.useCallback(
     // eslint-disable-next-line react-hooks/preserve-manual-memoization
     (ev: React.PointerEvent<HTMLElement> | React.FocusEvent<HTMLElement>) => {
+      // When Interest Invokers are supported the browser hides the hint popover when
+      // interest is lost; skip the JS timer so we don't double-drive it.
+      if (supportsInterestInvokers()) {
+        return;
+      }
+
       let delay = state.hideDelay;
 
       if (ev.type === 'blur') {
@@ -248,6 +272,10 @@ export const useTooltip = (props: TooltipProps): TooltipState => {
   // eslint-disable-next-line react-hooks/immutability
   state.children = applyTriggerPropsToChildren(children, {
     ...triggerAriaProps,
+    // Declarative hover/focus intent via the Interest Invokers API. The attribute is
+    // harmlessly ignored where unsupported, and the JS handlers below act as the fallback.
+    // Placed before the child's own props so an author can still override it.
+    interestfor: state.content.id,
     ...child?.props,
     ref: useMergedRefs(
       getReactElementRef<HTMLButtonElement>(child),


### PR DESCRIPTION
## Summary

Stretch proposal from #36346. Adopts the native **[Interest Invokers API](https://open-ui.org/components/interest-invokers.explainer/)** (`interestfor` + `interest-delay`) so the headless Tooltip's `popover="hint"` opens on hover/focus **declaratively, with no JS** in supporting browsers — while keeping the existing JS timer engine as a graceful fallback everywhere else.

This complements (and is independent of) the minimal anchor-name fix in #36347.

## What changed

`packages/react-components/react-headless-components-preview/library/src/components/Tooltip/useTooltip.ts`:

- **Wire `interestfor` on the trigger** → the tooltip content id. The attribute is harmlessly ignored where unsupported, and is placed before the child's own props so an author can override it.
- **Feature-gate the JS timers**: `onEnterTrigger` / `onLeaveTrigger` early-return when `CSS.supports('interest-delay: 0s')`, so we don't double-drive show/hide when the platform is already handling intent.
- **Sync state on native opens**: `onToggle` now mirrors React state for both `open` and `closed` `newState`, so a browser-driven interest open keeps `visible` in sync (previously only `closed` was handled).
- **Idempotent show/hide effect**: only `showPopover()` when not already `:popover-open`, and only `hidePopover()` when it is — so the effect never fights the platform (and never throws `InvalidStateError` on a redundant `showPopover()`).

Detection is **client-only** (inside the handlers); the `interestfor` attribute is rendered deterministically, so there's no SSR/hydration mismatch.

## Why progressive enhancement

- **Supported browsers**: zero JS for tooltip intent — the platform handles hover/focus, delay, and light-dismiss. Forward-compatible with the standard.
- **Unsupported browsers**: identical behavior to today via the existing timer engine.

## Tests

`Tooltip.test.tsx`:
- `interestfor` on the trigger equals the tooltip content id.
- JS fallback still opens the tooltip on hover when Interest Invokers are unsupported (jsdom default).
- When `CSS.supports('interest-delay: 0s')` is stubbed true, the JS timer is skipped (the platform would open it instead).

All 19 Tooltip tests pass.

## Notes / follow-ups

- **`interest-delay` matching**: I prototyped setting `interest-delay: <showDelay> <hideDelay>` to match the configured JS cadence, but the positioning engine rewrites the content element's inline `style`, so the value was clobbered. Matching the delay cleanly belongs in the positioning style writer — happy to follow up if maintainers want it. Browsers fall back to the spec default delay in the meantime.
- TypeScript doesn't yet ship `interestfor` in its DOM/React types; the attribute is plain lowercase so React passes it through to the DOM as-is.

Related: #36346 (root cause + proposals), #36347 (minimal anchor-name fix).
