### PR TITLE
fix(fluent2-theme): high contrast focus styles for PrimaryButton

### DIFF
--- a/change/@fluentui-fluent2-theme-cfb7027f-13e7-4821-9077-f0c785c57017.json
+++ b/change/@fluentui-fluent2-theme-cfb7027f-13e7-4821-9077-f0c785c57017.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: fluent2-theme PrimaryButton high contrast focus style",
+  "packageName": "@fluentui/fluent2-theme",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/fluent2-theme/src/componentStyles/Button.styles.ts
+++ b/packages/fluent2-theme/src/componentStyles/Button.styles.ts
@@ -69,6 +69,12 @@ export function getPrimaryButtonStyles(theme: ITheme): Partial<IButtonStyles> {
       borderColor: semanticColors.primaryButtonBorder,
       color: semanticColors.primaryButtonText,
       ...getFocusStyle(palette.white, effects.roundedCorner2, semanticColors.focusBorder),
+      '@media (forced-colors: active)': {
+        '.ms-Fabric--isFocusVisible &:focus::after': {
+          outline: `1px solid ButtonFace`,
+          inset: '2px',
+        },
+      },
     },
     rootHovered: {
       backgroundColor: semanticColors.primaryButtonBackgroundHovered,


### PR DESCRIPTION
## Previous Behavior

The fluent2-theme styles for Button added a focus style that did not account for PrimaryButton's `forced-color-adjust: none` style. This means that the fluent2-theme focus style overrode the working v8 primary focus style with a general button focus style that didn't show in HCM:

<img width="298" height="59" alt="Screenshot of a primary and default button in dark high contrast mode. The primary button has a light background but no visible focus outline" src="https://github.com/user-attachments/assets/cdf214c1-c96c-43a4-bb9d-7630bc136be9" />

(the primary button is focused in the screenshot)

## New Behavior

This re-applies the specific primary button focus style that was getting overridden.

<img width="290" height="50" alt="Screenshot of the same two buttons, but this time the primary button as a thin dark inner stroke" src="https://github.com/user-attachments/assets/7628a0e2-2277-4a1a-948e-02d5974e7190" />

## Related Issue(s)

- Fixes #
- [ADO issue](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/38200)
