### PR TITLE
fix(web-components): set focus on autofocus element when a dialog is open

### DIFF
--- a/change/@fluentui-web-components-98d56e17-6a5c-42cf-95b7-a060bc0f7b70.json
+++ b/change/@fluentui-web-components-98d56e17-6a5c-42cf-95b7-a060bc0f7b70.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: set focus on autofocus element when a dialog is open",
+  "packageName": "@fluentui/web-components",
+  "email": "machi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/dialog/dialog.spec.ts
+++ b/packages/web-components/src/dialog/dialog.spec.ts
@@ -387,7 +387,7 @@ test.describe('Dialog', () => {
     await expect(content).toBeHidden();
   });
 
-  test.describe('opening focus', () => {
+  test.describe('sets focus when show() is called', () => {
     test.use({
       tagName,
       waitFor: [DialogBodyTagName, TablistTagName, TabTagName, TextInputTagName],
@@ -425,7 +425,7 @@ test.describe('Dialog', () => {
       await expect(tablist).toHaveAttribute('activeid', 'tab2');
     });
 
-    test('should focus on itself', async ({ fastPage }) => {
+    test('should focus on itself if no slotted content has `autofocus` attribute', async ({ fastPage }) => {
       const { element } = fastPage;
       const content = element.locator('#content');
 
@@ -447,7 +447,7 @@ test.describe('Dialog', () => {
       await expect(element).toBeFocused();
     });
 
-    test('should focus on the element with `autofocus` attribute', async ({ fastPage }) => {
+    test('should focus on the first element with `autofocus` attribute', async ({ fastPage }) => {
       const { element } = fastPage;
       const content = element.locator('#content');
       const input = element.getByTestId('input');
@@ -457,6 +457,7 @@ test.describe('Dialog', () => {
           <${DialogBodyTagName} id="content">
             <button>before</button>
             <${TextInputTagName} autofocus data-testid="input"></${TextInputTagName}>
+            <${TextInputTagName} autofocus></${TextInputTagName}>
             <button>after</button>
           </${DialogBodyTagName}>
         `,

--- a/packages/web-components/src/dialog/dialog.spec.ts
+++ b/packages/web-components/src/dialog/dialog.spec.ts
@@ -3,6 +3,7 @@ import { expect, test } from '../../test/playwright/index.js';
 import { tagName as DialogBodyTagName } from '../dialog-body/dialog-body.options.js';
 import { tagName as TabTagName } from '../tab/tab.options.js';
 import { tagName as TablistTagName } from '../tablist/tablist.options.js';
+import { tagName as TextInputTagName } from '../text-input/text-input.options.js';
 import type { Dialog } from './dialog.js';
 import { tagName } from './dialog.options.js';
 
@@ -389,7 +390,7 @@ test.describe('Dialog', () => {
   test.describe('opening focus', () => {
     test.use({
       tagName,
-      waitFor: [DialogBodyTagName, TablistTagName, TabTagName],
+      waitFor: [DialogBodyTagName, TablistTagName, TabTagName, TextInputTagName],
     });
 
     test('should not change tablist’s `activeid` attribute', async ({ fastPage }) => {
@@ -422,6 +423,51 @@ test.describe('Dialog', () => {
 
       await expect(content).toBeVisible();
       await expect(tablist).toHaveAttribute('activeid', 'tab2');
+    });
+
+    test('should focus on itself', async ({ fastPage }) => {
+      const { element } = fastPage;
+      const content = element.locator('#content');
+
+      await fastPage.setTemplate({
+        innerHTML: /* html */ `
+          <${DialogBodyTagName} id="content">
+            <button>before</button>
+            <${TextInputTagName}></${TextInputTagName}>
+            <button>after</button>
+          </${DialogBodyTagName}>
+        `,
+      });
+
+      await element.evaluate((node: Dialog) => {
+        node.show();
+      });
+
+      await expect(content).toBeVisible();
+      await expect(element).toBeFocused();
+    });
+
+    test('should focus on the element with `autofocus` attribute', async ({ fastPage }) => {
+      const { element } = fastPage;
+      const content = element.locator('#content');
+      const input = element.getByTestId('input');
+
+      await fastPage.setTemplate({
+        innerHTML: /* html */ `
+          <${DialogBodyTagName} id="content">
+            <button>before</button>
+            <${TextInputTagName} autofocus data-testid="input"></${TextInputTagName}>
+            <button>after</button>
+          </${DialogBodyTagName}>
+        `,
+      });
+
+      await element.evaluate((node: Dialog) => {
+        node.show();
+      });
+
+      await expect(content).toBeVisible();
+      await expect(input).toBeFocused();
     });
   });
 });

--- a/packages/web-components/src/dialog/dialog.ts
+++ b/packages/web-components/src/dialog/dialog.ts
@@ -168,7 +168,7 @@ export class Dialog extends FASTElement {
       // Using `autofocus` inside a `<dialog>` is implemented inconsistently
       // across browsers, so artificially focusing here. See details:
       // https://codepen.io/marchbox/pen/PwbRmXE
-      (this.querySelector('[autofocus]') as HTMLElement)?.focus();
+      (this.querySelector('[autofocus]') as HTMLElement)?.focus?.();
       this.emitToggle();
     });
   }

--- a/packages/web-components/src/dialog/dialog.ts
+++ b/packages/web-components/src/dialog/dialog.ts
@@ -165,6 +165,7 @@ export class Dialog extends FASTElement {
       } else if (this.type === DialogType.nonModal) {
         this.dialog.show();
       }
+      (this.querySelector('[autofocus]') as HTMLElement)?.focus();
       this.emitToggle();
     });
   }

--- a/packages/web-components/src/dialog/dialog.ts
+++ b/packages/web-components/src/dialog/dialog.ts
@@ -165,6 +165,9 @@ export class Dialog extends FASTElement {
       } else if (this.type === DialogType.nonModal) {
         this.dialog.show();
       }
+      // Using `autofocus` inside a `<dialog>` is implemented inconsistently
+      // across browsers, so artificially focusing here. See details:
+      // https://codepen.io/marchbox/pen/PwbRmXE
       (this.querySelector('[autofocus]') as HTMLElement)?.focus();
       this.emitToggle();
     });

--- a/packages/web-components/src/drawer/drawer.spec.ts
+++ b/packages/web-components/src/drawer/drawer.spec.ts
@@ -202,13 +202,13 @@ test.describe('Drawer', () => {
     await expect(content).toBeHidden();
   });
 
-  test.describe('opening focus', () => {
+  test.describe('sets focus when show() is called', () => {
     test.use({
       tagName,
       waitFor: [DrawerBodyTagName, TextInputTagName],
     });
 
-    test('should focus on the element with `autofocus` attribute', async ({ fastPage }) => {
+    test('should focus on the first element with `autofocus` attribute', async ({ fastPage }) => {
       const { element } = fastPage;
       const content = element.locator('#content');
       const input = element.getByTestId('input');
@@ -218,6 +218,7 @@ test.describe('Drawer', () => {
           <${DrawerBodyTagName} id="content">
             <button>before</button>
             <${TextInputTagName} autofocus data-testid="input"></${TextInputTagName}>
+            <${TextInputTagName} autofocus></${TextInputTagName}>
             <button>after</button>
           </${DrawerBodyTagName}>
         `,

--- a/packages/web-components/src/drawer/drawer.spec.ts
+++ b/packages/web-components/src/drawer/drawer.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '../../test/playwright/index.js';
 import { tagName as DrawerBodyTagName } from '../drawer-body/drawer-body.options.js';
-import { Drawer } from './drawer.js';
+import { tagName as TextInputTagName } from '../text-input/text-input.options.js';
+import type { Drawer } from './drawer.js';
 import { DrawerPosition, DrawerSize, DrawerType, tagName } from './drawer.options.js';
 
 test.describe('Drawer', () => {
@@ -199,5 +200,35 @@ test.describe('Drawer', () => {
     await closeButton.click();
 
     await expect(content).toBeHidden();
+  });
+
+  test.describe('opening focus', () => {
+    test.use({
+      tagName,
+      waitFor: [DrawerBodyTagName, TextInputTagName],
+    });
+
+    test('should focus on the element with `autofocus` attribute', async ({ fastPage }) => {
+      const { element } = fastPage;
+      const content = element.locator('#content');
+      const input = element.getByTestId('input');
+
+      await fastPage.setTemplate({
+        innerHTML: /* html */ `
+          <${DrawerBodyTagName} id="content">
+            <button>before</button>
+            <${TextInputTagName} autofocus data-testid="input"></${TextInputTagName}>
+            <button>after</button>
+          </${DrawerBodyTagName}>
+        `,
+      });
+
+      await element.evaluate((node: Drawer) => {
+        node.show();
+      });
+
+      await expect(content).toBeVisible();
+      await expect(input).toBeFocused();
+    });
   });
 });

--- a/packages/web-components/src/drawer/drawer.ts
+++ b/packages/web-components/src/drawer/drawer.ts
@@ -199,6 +199,7 @@ export class Drawer extends FASTElement {
       } else {
         this.dialog.showModal();
       }
+      (this.querySelector('[autofocus]') as HTMLElement)?.focus();
       this.emitToggle();
     });
   }

--- a/packages/web-components/src/drawer/drawer.ts
+++ b/packages/web-components/src/drawer/drawer.ts
@@ -202,7 +202,7 @@ export class Drawer extends FASTElement {
       // Using `autofocus` inside a `<dialog>` is implemented inconsistently
       // across browsers, so artificially focusing here. See details:
       // https://codepen.io/marchbox/pen/PwbRmXE
-      (this.querySelector('[autofocus]') as HTMLElement)?.focus();
+      (this.querySelector('[autofocus]') as HTMLElement)?.focus?.();
       this.emitToggle();
     });
   }

--- a/packages/web-components/src/drawer/drawer.ts
+++ b/packages/web-components/src/drawer/drawer.ts
@@ -199,6 +199,9 @@ export class Drawer extends FASTElement {
       } else {
         this.dialog.showModal();
       }
+      // Using `autofocus` inside a `<dialog>` is implemented inconsistently
+      // across browsers, so artificially focusing here. See details:
+      // https://codepen.io/marchbox/pen/PwbRmXE
       (this.querySelector('[autofocus]') as HTMLElement)?.focus();
       this.emitToggle();
     });

--- a/packages/web-components/src/text-input/text-input.stories.ts
+++ b/packages/web-components/src/text-input/text-input.stories.ts
@@ -26,6 +26,7 @@ const Person20Regular = html.partial(/* html */ `
 
 const storyTemplate = html<StoryArgs<FluentTextInput>>`
   <fluent-text-input
+    ?autofocus="${story => story.autofocus}"
     appearance="${story => story.appearance}"
     autocomplete="${story => story.autocomplete}"
     control-size="${story => story.controlSize}"
@@ -149,5 +150,18 @@ export const Inline: Story = {
       <fluent-text-input style="display: inline-flex" placeholder="adjective"></fluent-text-input>
       dog.
     </p>
+  `),
+};
+
+export const InDialog: Story = {
+  args: {
+    slottedContent: () => 'Input in dialog',
+    autofocus: true,
+  },
+  render: renderComponent(html<StoryArgs<FluentTextInput>>`
+    <fluent-button @click="${story => story.dialog.show()}">Open dialog</fluent-button>
+    <fluent-dialog ${ref('dialog')}>
+      <fluent-dialog-body> ${storyTemplate} </fluent-dialog-body>
+    </fluent-dialog>
   `),
 };


### PR DESCRIPTION
## Previous Behavior

Due to browser implementation issues (https://codepen.io/marchbox/pen/PwbRmXE), currently if a focusable element (e.g. a `<fluent-text-input>`) with `autofocus` attribute used inside a `<fluent-dialog>` or `<fluent-drawer>`, when the dialog is open, the element doesn’t get automatically focused.

## New Behavior

On open, the dialog/drawer component finds the first element with `autofocus` attribute and call its `focus()` method (if it has it).

## Related Issue(s)

- Fixes #36326
