### PR TITLE
fix(ComboBox): ignore Enter used to commit an IME composition

### DIFF
--- a/change/@fluentui-react-96ccd495-6dc2-4431-8f86-bd8fcb6e8497.json
+++ b/change/@fluentui-react-96ccd495-6dc2-4431-8f86-bd8fcb6e8497.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(ComboBox): ignore the Enter key used to commit an IME composition so it no longer submits the pending value",
+  "packageName": "@fluentui/react",
+  "email": "246701683+greymoth-jp@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/ComboBox/ComboBox.test.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.test.tsx
@@ -6,7 +6,7 @@ import userEvent from '@testing-library/user-event';
 import { isConformant } from '../../common/isConformant';
 import { useKeytipRef } from '../../Keytips';
 import { SelectableOptionMenuItemType } from '../../SelectableOption';
-import { resetIds } from '../../Utilities';
+import { KeyCodes, resetIds } from '../../Utilities';
 import { ComboBox } from './ComboBox';
 import type { IComboBox, IComboBoxOption } from './ComboBox.types';
 
@@ -239,6 +239,26 @@ describe('ComboBox', () => {
 
     const options = getAllByRole('option');
     expect(options[options.length - 1].textContent).toEqual('f');
+  });
+
+  it('Does not submit the pending value on Enter while an IME composition is active', () => {
+    const onChange = jest.fn();
+    const { getByRole } = render(<ComboBox options={DEFAULT_OPTIONS} allowFreeform onChange={onChange} />);
+
+    const combobox = getByRole('combobox');
+    userEvent.type(combobox, 'f');
+    onChange.mockClear();
+
+    // An IME dispatches Enter to commit the in-progress composition with
+    // `isComposing` set. ComboBox must ignore it instead of treating it as a
+    // selection, otherwise confirming the composition would also submit the
+    // pending value.
+    fireEvent.keyDown(combobox, { which: KeyCodes.enter, keyCode: KeyCodes.enter, isComposing: true });
+    expect(onChange).not.toHaveBeenCalled();
+
+    // A regular Enter (no composition) still submits the pending value.
+    fireEvent.keyDown(combobox, { which: KeyCodes.enter, keyCode: KeyCodes.enter });
+    expect(onChange).toHaveBeenCalled();
   });
 
   it('Renders a default value with options', () => {

--- a/packages/react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/react/src/components/ComboBox/ComboBox.tsx
@@ -2120,6 +2120,14 @@ class ComboBoxInternal extends React.Component<IComboBoxInternalProps, IComboBox
       return;
     }
 
+    // While an IME composition is in progress, keys such as Enter are used to
+    // commit/convert the composition and should not trigger ComboBox keyboard
+    // behaviors (for example submitting the pending value). Autofill guards its
+    // own key handling the same way.
+    if ((ev.nativeEvent as any).isComposing) {
+      return;
+    }
+
     let index = this._getPendingSelectedIndex(false /* includeCurrentPendingValue */);
 
     // eslint-disable-next-line @typescript-eslint/no-deprecated


### PR DESCRIPTION
## Previous Behavior

In the v8 `ComboBox`, `_onInputKeyDown` handles the Enter key by submitting the pending value (`_submitPendingValue`). It does not check whether an IME composition is in progress.

When typing with an IME (Japanese, Chinese, Korean), Enter is used to commit the in-progress composition. Because that Enter reaches `_onInputKeyDown` without a guard, committing the composition also submits the pending option, so a keystroke meant only for the IME ends up selecting a value. This is most observable in WebKit/Safari, where the composition-commit Enter is reported with `which === 13` and `isComposing === true`.

The sibling `Autofill` component (the input that `ComboBox` renders) already guards against this in its own `_onKeyDown`, where it skips key handling while `ev.nativeEvent.isComposing` is true. `ComboBox`'s key handler was missing the same guard.

## New Behavior

`_onInputKeyDown` returns early when `ev.nativeEvent.isComposing` is true, so the Enter used to commit a composition no longer submits the pending value. A regular Enter (no composition) still submits as before. The guard mirrors the existing one in `Autofill`.

Added a unit test that covers both cases (Enter while composing does not call `onChange`; a regular Enter still does).

## Related Issue(s)

N/A
