### PR TITLE
feat(workspace-plugin): opt-in ESM-first emit gated on package type:module for migrate-converged-pkg generator

### DIFF
--- a/tools/workspace-plugin/src/generators/migrate-converged-pkg/index.spec.ts
+++ b/tools/workspace-plugin/src/generators/migrate-converged-pkg/index.spec.ts
@@ -495,6 +495,25 @@ describe('migrate-converged-pkg generator', () => {
         "
       `);
     });
+
+    it(`emits the CommonJS jest config + setup as .cjs when the package opts into "type": "module"`, async () => {
+      const projectConfig = readProjectConfiguration(tree, options.name);
+      updateJson(tree, `${projectConfig.root}/package.json`, (json: PackageJson) => {
+        json.type = 'module';
+        return json;
+      });
+
+      await generator(tree, options);
+
+      // legacy `.js` variants are replaced by `.cjs` so Node parses them as CommonJS under type:module
+      expect(tree.exists(`${projectConfig.root}/jest.config.js`)).toBeFalsy();
+      expect(tree.exists(`${projectConfig.root}/jest.config.cjs`)).toBeTruthy();
+      expect(tree.exists(`${projectConfig.root}/config/tests.js`)).toBeFalsy();
+      expect(tree.exists(`${projectConfig.root}/config/tests.cjs`)).toBeTruthy();
+      expect(tree.read(`${projectConfig.root}/jest.config.cjs`, 'utf-8')).toContain(
+        `setupFilesAfterEnv: ['./config/tests.cjs']`,
+      );
+    });
   });
 
   describe(`storybook updates`, () => {
@@ -950,6 +969,58 @@ describe('migrate-converged-pkg generator', () => {
 
         const pkgJson = getPackageJson();
         expect((pkgJson.exports?.['.'] as { import?: string }).import).toBe(undefined);
+      });
+
+      it(`opts a package into the ESM-first shape when it declares "type": "module"`, async () => {
+        const { getPackageJson } = updatePackageJson(tree, {
+          projectName: options.name,
+          jsonUpdates: {
+            type: 'module',
+            main: './lib-commonjs/index.js',
+            module: './lib/index.js',
+            style: './css/index.css',
+          },
+        });
+
+        await generator(tree, options);
+
+        const pkgJson = getPackageJson();
+        expect(pkgJson.type).toBe('module');
+        // CommonJS entry switches to `.cjs` so Node parses it correctly under `type: module`
+        expect(pkgJson.main).toBe('./lib-commonjs/index.cjs');
+        // no `node` condition; `import`/`require` carry their own per-condition `types`
+        expect((pkgJson.exports?.['.'] as { node?: unknown }).node).toBeUndefined();
+        expect(pkgJson.exports).toMatchInlineSnapshot(`
+          Object {
+            ".": Object {
+              "import": Object {
+                "default": "./lib/index.js",
+                "types": "./dist/index.d.ts",
+              },
+              "require": Object {
+                "default": "./lib-commonjs/index.cjs",
+                "types": "./dist/index.d.cts",
+              },
+              "style": "./css/index.css",
+            },
+            "./package.json": "./package.json",
+          }
+        `);
+      });
+
+      it(`keeps CommonJS packages on the legacy shape (no opt-in)`, async () => {
+        const { getPackageJson } = updatePackageJson(tree, {
+          projectName: options.name,
+          jsonUpdates: { module: './lib/index.js' },
+        });
+
+        await generator(tree, options);
+
+        const pkgJson = getPackageJson();
+        expect(pkgJson.type).toBeUndefined();
+        // CommonJS entry is not rewritten to `.cjs`
+        expect(pkgJson.main).not.toMatch(/\.cjs$/);
+        expect((pkgJson.exports?.['.'] as { node?: unknown }).node).toBe('./lib-commonjs/index.js');
       });
     });
 

--- a/tools/workspace-plugin/src/generators/migrate-converged-pkg/index.ts
+++ b/tools/workspace-plugin/src/generators/migrate-converged-pkg/index.ts
@@ -685,6 +685,33 @@ function updatePackageJson(tree: Tree, options: NormalizedSchemaWithTsConfigs) {
   }
 
   function setupExportMaps(json: PackageJson) {
+    // Opt-in: a package becomes ESM-first by declaring `"type": "module"` in its package.json. Such
+    // packages get the ESM/CJS conditional export shape (no `node` condition); every other package
+    // keeps the existing CommonJS-first shape below unchanged (this stays a no-op for them).
+    if (json.type === 'module') {
+      const esm = json.module ? normalizePackageEntryPointPaths(json.module) : null;
+      const commonjs = json.main ? normalizePackageEntryPointPaths(json.main) : null;
+      // bare Node `import` resolves to valid ESM (`lib/`), `require` resolves to CommonJS
+      // (`lib-commonjs/*.cjs`). Per-condition `types` point `require` at a `.d.cts` so `node16`/
+      // `nodenext` CJS consumers get a CommonJS-flavoured declaration (keeps `@arethetypeswrong/cli` green).
+      const commonjsCjs = commonjs ? commonjs.replace(/\.js$/, '.cjs') : null;
+      if (commonjsCjs) {
+        json.main = commonjsCjs;
+      }
+      const esmTypes = json.typings;
+      const cjsTypes = json.typings ? json.typings.replace(/\.d\.ts$/, '.d.cts') : undefined;
+      json.exports = {
+        '.': {
+          ...(json.style ? { style: normalizePackageEntryPointPaths(json.style) } : null),
+          ...(esm && esmTypes ? { import: { types: esmTypes, default: esm } } : null),
+          ...(commonjsCjs && cjsTypes ? { require: { types: cjsTypes, default: commonjsCjs } } : null),
+        },
+        './package.json': './package.json',
+      };
+
+      return json;
+    }
+
     json.exports = {
       '.': {
         types: json.typings,
@@ -719,6 +746,8 @@ function updatePackageJson(tree: Tree, options: NormalizedSchemaWithTsConfigs) {
     const typesPath = getTypes(json);
     const storybookPath = getStorybookPath(json);
     const amdPath = options.projectConfig.tags?.includes('ships-amd') ? 'lib-amd' : null;
+    // `type: module` packages also ship `.d.cts` declarations for the `require` types condition
+    const cjsTypesPath = json.type === 'module' && typesPath ? typesPath.replace(/\.d\.ts$/, '.d.cts') : null;
     const filesDefinition = [
       rootMarkdownPath,
       mainPath,
@@ -726,6 +755,7 @@ function updatePackageJson(tree: Tree, options: NormalizedSchemaWithTsConfigs) {
       ...(binPath ?? []),
       stylesPath,
       typesPath,
+      cjsTypesPath,
       storybookPath,
       amdPath,
     ]
@@ -970,20 +1000,39 @@ function updateLocalJestConfig(tree: Tree, options: NormalizedSchema) {
   const packageJson = readJson<PackageJson>(tree, options.paths.packageJson);
   packageJson.dependencies = packageJson.dependencies ?? {};
 
+  // ESM-first packages opt in via `"type": "module"`, so their CommonJS jest config + setup must use
+  // the `.cjs` extension. CommonJS (default) packages keep `.js` unchanged.
+  const isEsmFirst = packageJson.type === 'module';
+  const testSetupExtension = isEsmFirst ? 'cjs' : 'js';
+  const jestConfigPath = isEsmFirst ? options.paths.jestConfig.replace(/\.js$/, '.cjs') : options.paths.jestConfig;
+  const resolvedJestSetupFilePath = isEsmFirst ? jestSetupFilePath.replace(/\.js$/, '.cjs') : jestSetupFilePath;
+
   const config = {
     pkgName: options.normalizedPkgName,
     addSnapshotSerializers:
       packageType === 'web' &&
       Object.keys(packageJson.dependencies).some(pkgDepName => packagesThatTriggerAddingSnapshots.includes(pkgDepName)),
-    testSetupFilePath: `./${path.basename(options.paths.configRoot)}/tests.js`,
+    testSetupFilePath: `./${path.basename(options.paths.configRoot)}/tests.${testSetupExtension}`,
     platform: packageType,
     projectConfig: options.projectConfig,
   } as const;
 
-  tree.write(options.paths.jestConfig, templates.jest(config));
+  // drop the legacy `.js` variants when emitting `.cjs` (type:module packages)
+  if (isEsmFirst) {
+    if (tree.exists(options.paths.jestConfig)) {
+      tree.delete(options.paths.jestConfig);
+    }
+    if (tree.exists(jestSetupFilePath) && !tree.exists(resolvedJestSetupFilePath)) {
+      const existingSetup = tree.read(jestSetupFilePath, 'utf-8') as string;
+      tree.write(resolvedJestSetupFilePath, existingSetup);
+      tree.delete(jestSetupFilePath);
+    }
+  }
 
-  if (!tree.exists(jestSetupFilePath)) {
-    tree.write(jestSetupFilePath, templates.jestSetup);
+  tree.write(jestConfigPath, templates.jest(config));
+
+  if (!tree.exists(resolvedJestSetupFilePath)) {
+    tree.write(resolvedJestSetupFilePath, templates.jestSetup);
   }
 
   return tree;
@@ -1075,8 +1124,12 @@ function createTsSolutionConfig(tree: Tree, options: NormalizedSchema) {
 function updateTsGlobalTypes(tree: Tree, options: NormalizedSchema) {
   // update test TS config
   updateJson(tree, options.paths.tsconfig.test, (json: TsConfig) => {
-    if (tree.exists(options.paths.jestSetupFile)) {
-      const jestSetupFile = tree.read(options.paths.jestSetupFile, 'utf8')!;
+    // ESM-first (type:module) packages emit the jest setup as `.cjs`; fall back to the legacy `.js` path
+    const jestSetupFilePath = [options.paths.jestSetupFile.replace(/\.js$/, '.cjs'), options.paths.jestSetupFile].find(
+      candidate => tree.exists(candidate),
+    );
+    if (jestSetupFilePath) {
+      const jestSetupFile = tree.read(jestSetupFilePath, 'utf8')!;
 
       if (jestSetupFile.includes(`require('@testing-library/jest-dom')`)) {
         json.compilerOptions.types = json.compilerOptions.types ?? [];

--- a/tools/workspace-plugin/src/types.ts
+++ b/tools/workspace-plugin/src/types.ts
@@ -21,6 +21,7 @@ export interface TsConfig {
 
 export interface PackageJson {
   bin?: string | Record<string, string>;
+  type?: 'module' | 'commonjs';
   types?: string;
   typings?: string;
   private?: boolean;
@@ -47,7 +48,17 @@ export interface PackageJson {
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
   peerDependencies?: Record<string, string>;
-  exports?: Record<string, string | Partial<{ types: string; node: string; import: string; require: string }>>;
+  exports?: Record<
+    string,
+    | string
+    | Partial<{
+        types: string;
+        style: string;
+        node: string | { module: string; default: string };
+        import: string | { types: string; default: string };
+        require: string | { types: string; default: string };
+      }>
+  >;
 }
 
 export interface PackageJsonWithBeachball extends PackageJson {


### PR DESCRIPTION
> ## NOTE
> This is not actively used, we used it during migration of existing v9 packages to native ESM

## Context

Part 3 of the ESM-first tooling extraction (see #36359, #36360). Makes the `migrate-converged-pkg` generator **opt-in** so the infra is ready for flipping v9 packages to `type: module`, without changing any current package.

> Stacked plan: PR1 (#36359) → PR2 (#36360) → PR4 (#36361) → **PR3 (this)**. This branch is self-contained (off `master`) and inert for current packages.

## The problem this solves

On the source branch the generator emitted the ESM-first shape for **every** `platform:web` package — so running `migrate-converged-pkg --all` (the bulk normalize) would have flipped all ~70 v9 packages to `type: module` at once.

## What

Re-gates the ESM-first output on the package's **own `"type": "module"` field** instead of the `platform:web` tag. A package opts in by declaring `type: module` + a `module` field; the generator then fills in the rest:

- `setupExportMaps`: emit the ESM/CJS conditional exports (no `node` condition; per-condition `types` with a `.d.cts` for `require`) and switch `main` → `.cjs`. **CommonJS packages keep the existing flat `node`/`import`/`require` shape, byte-for-byte unchanged.**
- `setupNpmPublishFiles`: ship `dist/*.d.cts` (only for `type: module`).
- `updateLocalJestConfig` / `updateTsGlobalTypes`: emit + resolve the CommonJS jest config/setup as `.cjs` (only for `type: module`).

Deliberately **excludes** two unrelated, ungated changes that were on the source branch (the `module` export condition for *all* packages, and the `.swcrc baseUrl`) to keep this strictly opt-in / inert.

`types.ts`: widen `PackageJson` `exports`/`type` to model the nested ESM condition shape.

> `react-library` (greenfield) generator is intentionally left on CommonJS in this PR — a follow-up can add an ESM scaffolding option once this opt-in lands.

## Safety / why this is inert

- The CJS export-map branch is identical to base; all 53 pre-existing migrate specs pass with **no snapshot changes**.
- Every ESM branch is reached only when `package.json` already has `"type": "module"`.

## Validation

- `nx run workspace-plugin:test` ✅ — 240→ all pass; **+3 new opt-in specs** (ESM export map snapshot, `.cjs` jest config emit, CommonJS-unchanged)
- `nx run workspace-plugin:type-check` ✅
- `nx run workspace-plugin:lint` ✅

Draft until the rest of the stack lands.