### PR TITLE
fix(web-components): selected indicator position in vertical tablist

### DIFF
--- a/change/@fluentui-web-components-8703b661-0019-4ee5-8fb9-bf2a52fa6454.json
+++ b/change/@fluentui-web-components-8703b661-0019-4ee5-8fb9-bf2a52fa6454.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: selected indocator position in vertical tablist",
+  "packageName": "@fluentui/web-components",
+  "email": "machi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/tablist/tablist.styles.ts
+++ b/packages/web-components/src/tablist/tablist.styles.ts
@@ -188,7 +188,7 @@ export const styles = css`
    * TODO: Remove '(text-size-adjust: auto)' after this bug is fixed:
    * https://bugs.webkit.org/show_bug.cgi?id=298646
    * Also remove the same trick from tab.styles.ts.
-   * Using '@supports (text-size-adjust: auto)' here to exclude Safari 26 from
+   * Using '@supports (text-size-adjust: auto)' here to exclude Safari 26.0 from
    * using CSS Anchor Positioning here because it crashes.
    */
   @supports (anchor-name: --a) and (text-size-adjust: auto) {
@@ -200,7 +200,8 @@ export const styles = css`
       background-color: ${colorCompoundBrandStroke};
       content: '';
       inline-size: 100%;
-      inset: auto auto anchor(end) anchor(center);
+      inset-block: auto anchor(end);
+      inset-inline: anchor(center) auto;
       position: fixed;
       position-anchor: --tab;
       transform: translateX(-50%);
@@ -215,18 +216,19 @@ export const styles = css`
       height: ${strokeWidthThicker};
     }
 
+    :host(:dir(rtl))::after {
+      transform: translateX(50%);
+    }
+
     :host([orientation='vertical'])::after {
-      inset: anchor(center) anchor(end) auto 0;
+      inset-block: anchor(center) auto;
+      inset-inline: anchor(start) auto;
       transform: translateY(-50%);
       transition-property: inset-block, height;
 
       /* These styles should be in sync with #vertical-tab-highlight above */
       width: ${strokeWidthThicker};
       height: calc(anchor-size() - var(--tabIndicatorInsetBlock) * 2);
-    }
-
-    :host(:dir(rtl)[orientation='vertical'])::after {
-      inset: anchor(center) anchor(start) auto 0;
     }
 
     :host([disabled])::after {


### PR DESCRIPTION
## Previous Behavior

The selected tab indicator is incorrectly  position in `<tablist orientation="vertical">`.

<img width="401" height="282" alt="image" src="https://github.com/user-attachments/assets/946fe87b-f0fc-47fd-81b6-08a647229764" />

## New Behavior

Fixed the position, and made the CSS more logical value friendly:

<img width="388" height="232" alt="image" src="https://github.com/user-attachments/assets/e42cf251-ecb3-446c-aa0c-7f092e0147f0" />

RTL:

<img width="378" height="242" alt="image" src="https://github.com/user-attachments/assets/57bf55bf-896f-4c6e-bc80-c2143485b612" />
