### PR TITLE
docs(web-components): Update v2 to v3 migration doc

### DIFF
--- a/change/@fluentui-web-components-02af706e-1d6f-43fe-9ced-181466a6aeed.json
+++ b/change/@fluentui-web-components-02af706e-1d6f-43fe-9ced-181466a6aeed.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "update V2 to V3 migration guide",
+  "packageName": "@fluentui/web-components",
+  "email": "863023+radium-v@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/src/_docs/developer/migration.mdx
+++ b/packages/web-components/src/_docs/developer/migration.mdx
@@ -1,582 +1,675 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 
-<Meta title="Concepts/Developer/V2 → V3 Migration Guide" />
+<Meta title="Concepts/Developer/V2 to V3 Migration Guide" />
 
-# V2 → V3 Migration Guide
+# Migration Guide
 
-We're happy to announce Fluent Web Components v3 is now available. This document provides a high-level overview of the differences and API changes between previous versions. Please reach out if you have any questions.
+Fluent Web Components v3 is a ground-up rewrite of the library. If you are coming from v2 (the last v2 release was `2.6.1`), expect breaking changes across imports, component registration, theming, and the markup for most form controls. This guide covers what changed and how to update your code.
 
-Here's a snapshot of what's new and improved in v3.
+## Major Changes
 
-- Smaller bundle size (-26% compressed!)
-- Reduced DOM size and overhead by nearly 50%
-- Improved Storybook docs
-- Updated to FASTElement v2.0
-- Individual component exports
-- Leveraging ElementInternals for better form support
-- Removed hard dependency on @microsoft/fast-foundation
-- Continued alignment with Fluent React v9
-- Improved setTheme() to set/unset at the page or element level
+- **New foundation.** Fluent Web Components v3 is built directly on [FAST Element](https://fast.design) v3. The hard dependency on `@microsoft/fast-foundation` has been removed.
+- **Individual component exports.** Every component ships its own class, template, styles, and definition, so you can register only what you use.
+- **New registration model.** The `provideFluentDesignSystem().register(...)` pattern is gone. Register components with side-effect `define` imports instead.
+- **Token-based theming.** `setTheme()` replaces the design-token and `DesignSystemProvider` model, so you can apply your own theme to the whole page or a single element.
+- **`ElementInternals` everywhere.** Form-associated components use `ElementInternals` for better native form participation.
+- **Smaller and lighter.** The full-library bundle is about 20% smaller over the wire.
 
-## Component Comparison v2 → v3
+## Bundle Size Comparison
 
-A high-level look at the differences between components in v2 and v3
-
-- 🆕 14 new components
-- ⚠️ 5 renamed components
-- ⛔️ 4 removed components
-- 🛣️ 13 components on our current roadmap
-
-### Renamed Components
-
-- `anchor` = use `link` or `anchor-button`
-- `progress` = use `progress-bar`
-- `select` = use `dropdown`
-- `text-area` = `textarea`
-- `text-field` = `text-input`
-
-### Removed Components
-
-- `anchored-region`
-- `slider-label` = `use field, label`
-- `tabs` = use `tablist`
-- `tab-panel` = use `role="tabpanel"`
-
-# API Changes
-
-- Form controls now use `<fluent-field>` wrapper to handle label spacing and errors
-- Dialog = requires Dialog Body child
-- Tabs = no longer a uniform control, allows for flexibility
-- Accordion Item = attribute changes
-- RadioGroup = new API to leverage field
-
-API changes, renames, and deprecations are itemized in the table below.
+Comparing the CDN bundle that registers the entire library (`web-components.min.js`) in each version:
 
 <table>
   <thead>
     <tr>
-      <th>Component</th>
-      <th>V2</th>
-      <th>V3</th>
-      <th>Notes</th>
+      <th scope="col">Version</th>
+      <th scope="col">Bundle</th>
+      <th scope="col">Minified</th>
+      <th scope="col">Gzip</th>
+      <th scope="col">Brotli</th>
     </tr>
   </thead>
   <tbody>
     <tr>
-      <td>accordion</td>
-      <td>✅</td>
-      <td>✅</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>accordion-item</td>
-      <td>✅</td>
-      <td>✅</td>
-      <td>⚠️ API Change → Attributes changed to better match web platform</td>
-    </tr>
-    <tr>
-      <td>anchor</td>
-      <td>✅</td>
-      <td>⛔️</td>
+      <th scope="row">v2.6.1</th>
       <td>
-        Removed → Use <code>link</code> or <code>anchor-button</code>
+        <code>web-components.min.js</code>
       </td>
+      <td>366 KB</td>
+      <td>80.4 KB</td>
+      <td>67.2 KB</td>
     </tr>
     <tr>
-      <td>anchor-button</td>
-      <td></td>
-      <td>🆕</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>anchored-region</td>
-      <td>✅</td>
-      <td>⛔️</td>
-      <td>Removed</td>
-    </tr>
-    <tr>
-      <td>avatar</td>
-      <td></td>
-      <td>🆕</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>badge</td>
-      <td>✅</td>
-      <td>✅</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>breadcrumb</td>
-      <td>✅</td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>breadcrumb-item</td>
-      <td>✅</td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>button</td>
-      <td>✅</td>
-      <td>✅</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>calendar</td>
-      <td>✅</td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>card</td>
-      <td>✅</td>
-      <td></td>
-      <td>🚧 In Progress</td>
-    </tr>
-    <tr>
-      <td>checkbox</td>
-      <td>✅</td>
-      <td>✅</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>color</td>
-      <td>✅</td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>combobox</td>
-      <td>✅</td>
-      <td>✅</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>compound-button</td>
-      <td></td>
-      <td>✅</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>data-grid</td>
-      <td>✅</td>
-      <td></td>
-      <td>🚧 In Progress</td>
-    </tr>
-    <tr>
-      <td>dialog</td>
-      <td>✅</td>
-      <td>✅</td>
+      <th scope="row">v3.0.0</th>
       <td>
-        ⚠️ API Change → Use with <code>dialog-body</code>.
+        <code>web-components.min.js</code>
       </td>
+      <td>267 KB</td>
+      <td>64.5 KB</td>
+      <td>54.1 KB</td>
     </tr>
     <tr>
-      <td>dialog-body</td>
+      <th scope="row">Reduction</th>
       <td></td>
-      <td>🆕</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>divider</td>
-      <td>✅</td>
-      <td>✅</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>drawer</td>
-      <td></td>
-      <td>🆕</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>drawer-body</td>
-      <td></td>
-      <td>🆕</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>dropdown</td>
-      <td></td>
-      <td>✅</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>field</td>
-      <td></td>
-      <td>🆕</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>flipper</td>
-      <td>✅</td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>horizontal-scroll</td>
-      <td>✅</td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>image</td>
-      <td></td>
-      <td>🆕</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>listbox</td>
-      <td>✅</td>
-      <td>✅</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>listbox-option</td>
-      <td>✅</td>
-      <td>✅</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>label</td>
-      <td></td>
-      <td>🆕</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>link</td>
-      <td></td>
-      <td>✅</td>
-      <td>(Renamed)</td>
-    </tr>
-    <tr>
-      <td>menu</td>
-      <td>✅</td>
-      <td>✅</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>menu-button</td>
-      <td></td>
-      <td>🆕</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>menu-item</td>
-      <td>✅</td>
-      <td>✅</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>menu-list</td>
-      <td></td>
-      <td>🆕</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>message-bar</td>
-      <td></td>
-      <td>🆕</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>number-field</td>
-      <td>✅</td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>popover</td>
-      <td></td>
-      <td>✅</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>progress</td>
-      <td>✅</td>
-      <td>🔀</td>
       <td>
-        Renamed → See <code>progress-bar</code>
+        <strong>&minus;27%</strong>
       </td>
-    </tr>
-    <tr>
-      <td>progress-bar</td>
-      <td></td>
-      <td>🔀</td>
       <td>
-        Previously named <code>progress</code>
+        <strong>&minus;20%</strong>
       </td>
-    </tr>
-    <tr>
-      <td>progress-ring</td>
-      <td>✅</td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>radio</td>
-      <td>✅</td>
-      <td>✅</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>radio-group</td>
-      <td>✅</td>
-      <td>✅</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>search</td>
-      <td>✅</td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>select</td>
-      <td>✅</td>
-      <td>🔀</td>
       <td>
-        Renamed → Use <code>dropdown</code> with <code>type="select"</code>
+        <strong>&minus;19%</strong>
       </td>
-    </tr>
-    <tr>
-      <td>skeleton</td>
-      <td>✅</td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>slider</td>
-      <td>✅</td>
-      <td>✅</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>slider-label</td>
-      <td>✅</td>
-      <td>⛔️</td>
-      <td>
-        Removed → Use <code>label</code> with <code>field</code>
-      </td>
-    </tr>
-    <tr>
-      <td>spinner</td>
-      <td></td>
-      <td>🆕</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>switch</td>
-      <td>✅</td>
-      <td>✅</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>tab</td>
-      <td>✅</td>
-      <td>✅</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>tabs</td>
-      <td>✅</td>
-      <td>⛔️</td>
-      <td>
-        Removed → Use <code>tablist</code>
-      </td>
-    </tr>
-    <tr>
-      <td>tab-panel</td>
-      <td>✅</td>
-      <td>⛔️</td>
-      <td>
-        Removed → Use <code>role="tabpanel"</code> with <code>tablist</code>
-      </td>
-    </tr>
-    <tr>
-      <td>tablist</td>
-      <td></td>
-      <td>🆕</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>text</td>
-      <td></td>
-      <td>🆕</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>text-area</td>
-      <td>✅</td>
-      <td>🔀</td>
-      <td>
-        Renamed → See <code>textarea</code>
-      </td>
-    </tr>
-    <tr>
-      <td>textarea</td>
-      <td></td>
-      <td>🔀</td>
-      <td>
-        Previously named <code>text-area</code>
-      </td>
-    </tr>
-    <tr>
-      <td>text-field</td>
-      <td>✅</td>
-      <td>🔀</td>
-      <td>
-        Renamed→ See <code>text-input</code>
-      </td>
-    </tr>
-    <tr>
-      <td>text-input</td>
-      <td></td>
-      <td>🔀</td>
-      <td>
-        Previously named <code>text-field</code>
-      </td>
-    </tr>
-    <tr>
-      <td>toolbar</td>
-      <td>✅</td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>tooltip</td>
-      <td>✅</td>
-      <td>✅</td>
-      <td>⚠️ API differs from React implementation</td>
-    </tr>
-    <tr>
-      <td>tree-item</td>
-      <td>✅</td>
-      <td>✅</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>tree-view</td>
-      <td>✅</td>
-      <td>✅</td>
-      <td></td>
     </tr>
   </tbody>
 </table>
 
-### Notable API Changes
+The v3 `web-components-all.min.js` bundle (all components plus every named export) is 301 KB minified / 71.3 KB gzip.
 
-Here's an overview of the more significant changes in the project. Other smaller changes (like attribute renaming) will be reflected in the improved Storybook docs.
+The v2 and v3 component sets are not identical. Because every v3 component is individually importable, most applications ship far less than the full bundle by registering only the components they use.
+
+## Usage
+
+### Installation and Dependencies
+
+Fluent Web Components v3 can be installed for direct use in your project with common package managers:
+
+```bash
+# npm
+npm install @fluentui/web-components
+```
+
+`@fluentui/web-components` expects `@microsoft/fast-element@^3.0.0` to be installed as a peer dependency. If you are using a package manager that does not automatically install peer dependencies, you will need to install it manually:
+
+```bash
+# npm
+npm install @microsoft/fast-element
+```
+
+### Registering components
+
+Each component provides a side-effect import that registers the component with the browser. For example, to register the `Button` and `TextInput` components:
+
+```ts
+// V3 — register individual components
+import '@fluentui/web-components/button/define.js';
+import '@fluentui/web-components/text-input/define.js';
+```
+
+You can also register all components at once with a single import:
+
+```ts
+// V3 — register all components
+import '@fluentui/web-components/define-all.js';
+```
+
+Individual export paths allow you to import the component class, template, styles, and definition for use in your own custom elements:
+
+```ts
+import { Button } from '@fluentui/web-components/button/class.js';
+import { template as ButtonTemplate } from '@fluentui/web-components/button/template.js';
+import { styles as ButtonStyles } from '@fluentui/web-components/button/styles.js';
+import { definition as ButtonDefinition } from '@fluentui/web-components/button/definition.js';
+
+Button.define(ButtonDefinition);
+```
+
+## Theming
+
+v2 configured appearance through design tokens (for example `baseLayerLuminance`) and the `DesignSystemProvider`. v3 replaces this with `setTheme()`, which writes a flat object of theme tokens as CSS custom properties.
+
+```ts
+import { setTheme } from '@fluentui/web-components';
+import { webLightTheme, webDarkTheme } from '@fluentui/tokens';
+
+// Theme the whole document (default target)
+setTheme(webLightTheme);
+
+// Theme a single element and its subtree
+setTheme(webDarkTheme, document.querySelector('#panel'));
+
+// Unset a theme globally or on an element
+setTheme(null);
+setTheme(null, document.querySelector('#panel'));
+```
+
+`setTheme()` accepts any flat token object where each value is a string or number — it is not limited to the shipped `@fluentui/tokens` themes.
+
+When you load the CDN bundle via a script tag, `setTheme` is available on `globalThis` under the `Fluent` namespace:
+
+```html
+<script type="module" src="https://unpkg.com/@fluentui/web-components/web-components.min.js"></script>
+<script type="module">
+  Fluent.setTheme(/* your theme */);
+</script>
+```
+
+### New Components in v3
+
+These components are new in v3. Some are entirely new to the library, while others replace or rename a v2 component, as noted.
+
+<table>
+  <thead>
+    <tr>
+      <th>Component Class</th>
+      <th>v3 tag name</th>
+      <th>Note</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>AnchorButton</td>
+      <td>
+        <code>&lt;fluent-anchor-button&gt;</code>
+      </td>
+      <td>
+        Replaces <code>&lt;fluent-anchor&gt;</code>
+      </td>
+    </tr>
+    <tr>
+      <td>Avatar</td>
+      <td>
+        <code>&lt;fluent-avatar&gt;</code>
+      </td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>CounterBadge</td>
+      <td>
+        <code>&lt;fluent-counter-badge&gt;</code>
+      </td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>CompoundButton</td>
+      <td>
+        <code>&lt;fluent-compound-button&gt;</code>
+      </td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>DialogBody</td>
+      <td>
+        <code>&lt;fluent-dialog-body&gt;</code>
+      </td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Drawer</td>
+      <td>
+        <code>&lt;fluent-drawer&gt;</code>
+      </td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>DrawerBody</td>
+      <td>
+        <code>&lt;fluent-drawer-body&gt;</code>
+      </td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Dropdown</td>
+      <td>
+        <code>&lt;fluent-dropdown&gt;</code>
+      </td>
+      <td>
+        Replaces <code>&lt;fluent-combobox&gt;</code> and <code>&lt;fluent-select&gt;</code>
+      </td>
+    </tr>
+    <tr>
+      <td>Field</td>
+      <td>
+        <code>&lt;fluent-field&gt;</code>
+      </td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Image</td>
+      <td>
+        <code>&lt;fluent-image&gt;</code>
+      </td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Label</td>
+      <td>
+        <code>&lt;fluent-label&gt;</code>
+      </td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Link</td>
+      <td>
+        <code>&lt;fluent-link&gt;</code>
+      </td>
+      <td>
+        Replaces <code>&lt;fluent-anchor appearance="hypertext"&gt;</code>
+      </td>
+    </tr>
+    <tr>
+      <td>MenuButton</td>
+      <td>
+        <code>&lt;fluent-menu-button&gt;</code>
+      </td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>MenuList</td>
+      <td>
+        <code>&lt;fluent-menu-list&gt;</code>
+      </td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>MessageBar</td>
+      <td>
+        <code>&lt;fluent-message-bar&gt;</code>
+      </td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>ProgressBar</td>
+      <td>
+        <code>&lt;fluent-progress-bar&gt;</code>
+      </td>
+      <td>
+        Renamed from <code>&lt;fluent-progress&gt;</code>
+      </td>
+    </tr>
+    <tr>
+      <td>RatingDisplay</td>
+      <td>
+        <code>&lt;fluent-rating-display&gt;</code>
+      </td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Spinner</td>
+      <td>
+        <code>&lt;fluent-spinner&gt;</code>
+      </td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Tablist</td>
+      <td>
+        <code>&lt;fluent-tablist&gt;</code>
+      </td>
+      <td>
+        Renamed from <code>&lt;fluent-tabs&gt;</code>
+      </td>
+    </tr>
+    <tr>
+      <td>Text</td>
+      <td>
+        <code>&lt;fluent-text&gt;</code>
+      </td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>TextInput</td>
+      <td>
+        <code>&lt;fluent-text-input&gt;</code>
+      </td>
+      <td>
+        Renamed from <code>&lt;fluent-text-field&gt;</code>
+      </td>
+    </tr>
+    <tr>
+      <td>TextArea</td>
+      <td>
+        <code>&lt;fluent-textarea&gt;</code>
+      </td>
+      <td>
+        Renamed from <code>&lt;fluent-text-area&gt;</code>
+      </td>
+    </tr>
+    <tr>
+      <td>ToggleButton</td>
+      <td>
+        <code>&lt;fluent-toggle-button&gt;</code>
+      </td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Tree</td>
+      <td>
+        <code>&lt;fluent-tree&gt;</code>
+      </td>
+      <td>
+        Renamed from <code>&lt;fluent-tree-view&gt;</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+### Removed Components
+
+Aside from the renamed and replaced components above, the following components have been removed in v3:
+
+- Breadcrumb
+- BreadcrumbItem
+- Calendar
+- Card
+- DataGrid
+- DataGridCell
+- DataGridRow
+- DesignSystemProvider (see [Theming](#theming))
+- Flipper
+- HorizontalScroll
+- NumberField
+- Search
+- Skeleton
+- Toolbar
+
+## Major Component API Changes
 
 ### Anchor
 
-Anchor is deprecated in favor of `<fluent-link>` (for text links) and `<fluent-anchor-button>` (for links that look like buttons).
+Button-style anchors are now represented by the `AnchorButton` class and `<fluent-anchor-button>` tag. Hypertext-style anchors are now represented by the `Link` class and `<fluent-link>` tag.
 
-### Dialog
+<table>
+  <thead>
+    <tr>
+      <th>v2 Component Class</th>
+      <th>v3 Class Name</th>
+      <th>v2 tag name</th>
+      <th>v3 Equivalent</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td rowspan="2">Anchor</td>
+      <td>AnchorButton</td>
+      <td>
+        <code>&lt;fluent-anchor&gt;</code>
+      </td>
+      <td>
+        <code>&lt;fluent-anchor-button&gt;</code>
+      </td>
+    </tr>
+    <tr>
+      <td>Link</td>
+      <td>
+        <code>&lt;fluent-anchor appearance="hypertext"&gt;</code>
+      </td>
+      <td>
+        <code>&lt;fluent-link&gt;</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
 
-The previous dialog didn't allow for expressive dialogs without the default padding and presentation (like full-width imagery). This introduction of the `<fluent-dialog-body>` element allows for more custom compositions.
+### AnchoredRegion
 
-#### BEFORE:
+The `AnchoredRegion` class and `<fluent-anchored-region>` tag have been removed in v3. Use CSS anchor positioning instead.
 
-```html
-<!-- V2 -->
-<fluent-dialog>
-  <h1 slot="title">Title goes here</h1>
-  <img src="full-width.jpg" alt="" />
-  Contents go here
-</fluent-dialog>
-```
+### Combobox and Select
 
-#### AFTER:
+The `Combobox` and `Select` classes in v2 have been replaced with the `Dropdown` class in v3. The `Dropdown` class can be configured to behave like a combobox by setting the `type` attribute to `"combobox"`.
 
-```html
-<!-- V3 -->
-<fluent-dialog>
-  <img src="full-width.jpg" alt="optional image" />
-  <fluent-dialog-body>
-    <h1 slot="title">Title goes here</h1>
-    Contents go here
-  </fluent-dialog-body>
-</fluent-dialog>
-```
+<table>
+  <thead>
+    <tr>
+      <th>v2 Component Class</th>
+      <th>v3 Class Name</th>
+      <th>v2 tag name</th>
+      <th>v3 Equivalent</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Combobox</td>
+      <td rowspan="2">Dropdown</td>
+      <td>
+        <code>&lt;fluent-combobox&gt;</code>
+      </td>
+      <td>
+        <code>&lt;fluent-dropdown type="combobox"&gt;</code>
+      </td>
+    </tr>
+    <tr>
+      <td>Select</td>
+      <td>
+        <code>&lt;fluent-select&gt;</code>
+      </td>
+      <td>
+        <code>&lt;fluent-dropdown&gt;</code>
+      </td>
+    </tr>
+    <tr>
+      <td>ListboxOption</td>
+      <td>DropdownOption</td>
+      <td>
+        <code>&lt;fluent-option&gt;</code>
+      </td>
+      <td>
+        <code>&lt;fluent-option&gt;</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
 
-### Field
+### Dialog, DialogBody, Drawer, and DrawerBody
 
-We have a new form Field component to control label placement and validation errors for form controls.
+The `Dialog` component in v2 didn't allow for expressive dialogs without the default padding and presentation (like full-width imagery). The introduction of the `<fluent-dialog-body>` element allows for more custom compositions. Additionally, the `Drawer` component and `<fluent-drawer-body>` element have been added in v3 to support a new type of modal presentation.
 
-```html
-<fluent-field label-position="after">
-  <fluent-checkbox slot="input"></fluent-checkbox>
+<table>
+  <thead>
+    <tr>
+      <th>v2 Component Class</th>
+      <th>v3 Class Name</th>
+      <th>v2 tag name</th>
+      <th>v3 Equivalent</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td rowspan="2">Dialog</td>
+      <td>Dialog</td>
+      <td>
+        <code>&lt;fluent-dialog&gt;</code>
+      </td>
+      <td>
+        <code>&lt;fluent-dialog&gt;</code>
+      </td>
+    </tr>
+    <tr>
+      <td>DialogBody</td>
+      <td></td>
+      <td>
+        <code>&lt;fluent-dialog-body&gt;</code>
+      </td>
+    </tr>
+    <tr>
+      <td rowspan="2"></td>
+      <td>Drawer</td>
+      <td>
+        <code>&lt;fluent-drawer&gt;</code>
+      </td>
+      <td>
+        <code>&lt;fluent-drawer&gt;</code>
+      </td>
+    </tr>
+    <tr>
+      <td>DrawerBody</td>
+      <td></td>
+      <td>
+        <code>&lt;fluent-drawer-body&gt;</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
 
-  <label slot="label" for="checkbox">Label goes here</label>
-</fluent-field>
-```
+### Progress and ProgressRing
 
-This is also used by `<fluent-radio-group>` (see below).
+The `Progress` class in v2 has been replaced with the `ProgressBar` class in v3, and the `ProgressRing` class has been removed in favor of the `Spinner` class.
 
-Due to web platform labelling constraints of the ShadowDOM, the labelling API for `<fluent-text-input>` and `<fluent-textarea>` is slightly different. Note that `<fluent-text-input>` uses the default slot for label, while `<fluent-textarea>` uses the label slot due to its default slot is reserved for the content inside the text area.
+<table>
+  <thead>
+    <tr>
+      <th>v2 Component Class</th>
+      <th>v3 Component Class</th>
+      <th>v2 tag name</th>
+      <th>v3 Equivalent</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Progress</td>
+      <td>ProgressBar</td>
+      <td>
+        <code>&lt;fluent-progress&gt;</code>
+      </td>
+      <td>
+        <code>&lt;fluent-progress-bar&gt;</code>
+      </td>
+    </tr>
+    <tr>
+      <td>ProgressRing</td>
+      <td>Spinner</td>
+      <td>
+        <code>&lt;fluent-progress-ring&gt;</code>
+      </td>
+      <td>
+        <code>&lt;fluent-spinner&gt;</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
 
-```html
-<fluent-text-input>
-  <fluent-label>Label goes here</fluent-label>
-</fluent-text-input>
+### SliderLabel
 
-<fluent-textarea>
-  <fluent-label slot="label">Label goes here</fluent-label>
-</fluent-textarea>
-```
+The `SliderLabel` class and `<fluent-slider-label>` tag have been removed in v3. Use the `Field` or `Label` classes and `<fluent-field>` or `<fluent-label>` tags instead.
 
-### RadioGroup
+<table>
+  <thead>
+    <tr>
+      <th>v2 Component Class</th>
+      <th>v2 tag name</th>
+      <th>v3 Class Name</th>
+      <th>v3 Equivalent</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td rowspan="2">SliderLabel</td>
+      <td rowspan="2">
+        <code>&lt;fluent-slider-label&gt;</code>
+      </td>
+      <td>Field</td>
+      <td>
+        <code>&lt;fluent-field&gt;</code>
+      </td>
+    </tr>
+    <tr>
+      <td>Label</td>
+      <td>
+        <code>&lt;fluent-label&gt;</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
 
-#### BEFORE:
+### Tabs and TabPanel
 
-```html
-<fluent-radio-group id="radio-group">
-  <fluent-radio value="apple">Apple</fluent-radio>
-  <fluent-radio value="banana">Banana</fluent-radio>
-</fluent-radio-group>
-```
+The `Tabs` class in v2 has been replaced with the `Tablist` class in v3. The `TabPanel` class and `<fluent-tab-panel>` tag have been removed: supply your own panel element and associate it with a `Tab` through the tab's `aria-controls` attribute, referencing the panel's `id`. The `Tablist` applies `role="tabpanel"` to that element and shows or hides it based on the active tab.
 
-#### AFTER:
+<table>
+  <thead>
+    <tr>
+      <th>Component Class</th>
+      <th>v3 Class Name</th>
+      <th>v2 tag name</th>
+      <th>v3 Equivalent</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Tabs</td>
+      <td>Tablist</td>
+      <td>
+        <code>&lt;fluent-tabs&gt;</code>
+      </td>
+      <td>
+        <code>&lt;fluent-tablist&gt;</code>
+      </td>
+    </tr>
+    <tr>
+      <td>TabPanel</td>
+      <td>_(Removed)_</td>
+      <td>
+        <code>&lt;fluent-tab-panel&gt;</code>
+      </td>
+      <td>
+        Use your own panel element and associate it with a <code>Tab</code> through the tab's <code>aria-controls</code>{' '}
+        attribute
+      </td>
+    </tr>
+  </tbody>
+</table>
 
-```html
-<fluent-field>
-  <label slot="label" for="radio-group">Favorite Fruit</label>
-  <fluent-radio-group
-    slot="input"
-    id="radio-group"
-    aria-labelledby="radio-group--label"
-    orientation="vertical"
-    name="favorite-fruit"
-  >
-    <fluent-field label-position="after">
-      <label slot="label" for="radio-group--apple">Apple</label>
-      <fluent-radio slot="input" id="radio-group--apple" name="favorite-fruit" value="apple"></fluent-radio>
-    </fluent-field>
+### TextField and TextArea
 
-    <fluent-field label-position="after">
-      <label slot="label" for="radio-group--banana">Banana</label>
-      <fluent-radio slot="input" id="radio-group--banana" name="favorite-fruit" value="banana"></fluent-radio>
-    </fluent-field>
-  </fluent-radio-group>
-</fluent-field>
-```
+The `TextField` class in v2 has been replaced with the `TextInput` class in v3. Additionally, the `<fluent-text-area>` tag has been renamed to `<fluent-textarea>` in v3.
 
-### Bundles
+<table>
+  <thead>
+    <tr>
+      <th>v2 Component Class</th>
+      <th>v3 Component Class</th>
+      <th>v2 tag name</th>
+      <th>v3 Equivalent</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>TextField</td>
+      <td>TextInput</td>
+      <td>
+        <code>&lt;fluent-text-field&gt;</code>
+      </td>
+      <td>
+        <code>&lt;fluent-text-input&gt;</code>
+      </td>
+    </tr>
+    <tr>
+      <td>TextArea</td>
+      <td>TextArea</td>
+      <td>
+        <code>&lt;fluent-text-area&gt;</code>
+      </td>
+      <td>
+        <code>&lt;fluent-textarea&gt;</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
 
-The package ships two CDN-ready bundles, each available in minified and non-minified versions:
+### TreeView
 
-- **`web-components.js`** / **`web-components.min.js`** — Registers all components and exposes `Fluent.setTheme` on `globalThis`. This is the recommended bundle for most CDN and script-tag consumers.
-- **`web-components-all.js`** / **`web-components-all.min.js`** — Everything in the standard bundle, plus all named exports from the package (base classes, templates, styles, design tokens, and utilities). Use this if you need programmatic access to the full API surface from a CDN context.
+The `TreeView` class in v2 has been replaced with the `Tree` class in v3. `TreeItem` remains unchanged.
 
-### setTheme
-
-- `setTheme()` can set themes such as `setTheme(webLightTheme)` (defaults to document) or `setTheme(webDarkTheme, element)` to theme an element and its children
-- `setTheme()` can unset themes with `setTheme(null)` or `setTheme( null, element )`
-
-### Case studies
-
-- [Edge is seeing impressive results](https://blogs.windows.com/msedgedev/2024/05/28/an-even-faster-microsoft-edge/) when switching WebView UI to Fluent Web Components v3.
+<table>
+  <thead>
+    <tr>
+      <th>v2 Component Class</th>
+      <th>v3 Component Class</th>
+      <th>v2 tag name</th>
+      <th>v3 Equivalent</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>TreeView</td>
+      <td>Tree</td>
+      <td>
+        <code>&lt;fluent-tree-view&gt;</code>
+      </td>
+      <td>
+        <code>&lt;fluent-tree&gt;</code>
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/packages/web-components/src/_docs/developer/migration.mdx
+++ b/packages/web-components/src/_docs/developer/migration.mdx
@@ -100,18 +100,80 @@ You can also register all components at once with a single import:
 
 ```ts
 // V3 — register all components
-import '@fluentui/web-components/define-all.js';
+import '@fluentui/web-components/web-components.js';
 ```
 
 Individual export paths allow you to import the component class, template, styles, and definition for use in your own custom elements:
 
 ```ts
+// The Fluent component class, which extends the BaseButton class with Fluent-specific behavior and properties
 import { Button } from '@fluentui/web-components/button/class.js';
-import { template as ButtonTemplate } from '@fluentui/web-components/button/template.js';
-import { styles as ButtonStyles } from '@fluentui/web-components/button/styles.js';
+
+// Most components provide a base class, which can be extended to create a custom component
+import { BaseButton } from '@fluentui/web-components/button/base.js';
+
+// The raw component definition which
 import { definition as ButtonDefinition } from '@fluentui/web-components/button/definition.js';
 
-Button.define(ButtonDefinition);
+// Fluent-specific component template
+import { template as ButtonTemplate } from '@fluentui/web-components/button/template.js';
+
+// Fluent-specific composed styles
+import { styles as ButtonStyles } from '@fluentui/web-components/button/styles.js';
+
+// Attribute and property configuration options, as well as the component tag name
+import {
+  ButtonAppearance,
+  ButtonSize,
+  ButtonShape,
+  tagName as ButtonTagName,
+} from '@fluentui/web-components/button/options.js';
+```
+
+All public exports are provided in the `@fluentui/web-components` package root, so you can also import them from there:
+
+```ts
+import {
+  Button,
+  BaseButton,
+  ButtonDefinition,
+  ButtonTemplate,
+  ButtonStyles,
+  ButtonAppearance,
+  ButtonSize,
+  ButtonShape,
+  ButtonTagName,
+} from '@fluentui/web-components';
+```
+
+If you only need to define all components, you can import from the `web-components.js` entry point. The `setTheme()` function is also provided as a property on the `Fluent` global object, so you can use it without importing anything else:
+
+```ts
+// All components are defined as a side effect of this import, but no public exports are available
+import '@fluentui/web-components/web-components.js';
+
+// the global `Fluent.setTheme()` function is available on the `Fluent` global object
+Fluent.setTheme(/* your theme */);
+```
+
+If you need to define all components _and_ use public exports, you can import from the `web-components-all.js` entry point:
+
+```ts
+// All components are defined as a side effect of this import, and all public exports are available from the same entry point
+import {
+  Button,
+  BaseButton,
+  ButtonDefinition,
+  ButtonTemplate,
+  ButtonStyles,
+  ButtonAppearance,
+  ButtonSize,
+  ButtonShape,
+  ButtonTagName,
+} from '@fluentui/web-components/web-components-all.js';
+
+// the global `Fluent.setTheme()` function is also available from this entry point
+Fluent.setTheme(/* your theme */);
 ```
 
 ## Theming
@@ -133,7 +195,7 @@ setTheme(null);
 setTheme(null, document.querySelector('#panel'));
 ```
 
-`setTheme()` accepts any flat token object where each value is a string or number — it is not limited to the shipped `@fluentui/tokens` themes.
+`setTheme()` accepts any flat token object where each value is a string or number; it is not limited to the shipped `@fluentui/tokens` themes.
 
 When you load the CDN bundle via a script tag, `setTheme` is available on `globalThis` under the `Fluent` namespace:
 
@@ -144,10 +206,13 @@ When you load the CDN bundle via a script tag, `setTheme` is available on `globa
 </script>
 ```
 
+See the [Theming](?path=/docs/concepts-developer-theming--docs) page for more information.
+
 ### New Components in v3
 
 These components are new in v3. Some are entirely new to the library, while others replace or rename a v2 component, as noted.
 
+{/* prettier-ignore */}
 <table>
   <thead>
     <tr>
@@ -159,187 +224,123 @@ These components are new in v3. Some are entirely new to the library, while othe
   <tbody>
     <tr>
       <td>AnchorButton</td>
-      <td>
-        <code>&lt;fluent-anchor-button&gt;</code>
-      </td>
-      <td>
-        Replaces <code>&lt;fluent-anchor&gt;</code>
-      </td>
+      <td><code>&lt;fluent-anchor-button&gt;</code></td>
+      <td>Replaces <code>&lt;fluent-anchor&gt;</code></td>
     </tr>
     <tr>
       <td>Avatar</td>
-      <td>
-        <code>&lt;fluent-avatar&gt;</code>
-      </td>
+      <td><code>&lt;fluent-avatar&gt;</code></td>
       <td></td>
     </tr>
     <tr>
       <td>CounterBadge</td>
-      <td>
-        <code>&lt;fluent-counter-badge&gt;</code>
-      </td>
+      <td><code>&lt;fluent-counter-badge&gt;</code></td>
       <td></td>
     </tr>
     <tr>
       <td>CompoundButton</td>
-      <td>
-        <code>&lt;fluent-compound-button&gt;</code>
-      </td>
+      <td><code>&lt;fluent-compound-button&gt;</code></td>
       <td></td>
     </tr>
     <tr>
       <td>DialogBody</td>
-      <td>
-        <code>&lt;fluent-dialog-body&gt;</code>
-      </td>
+      <td><code>&lt;fluent-dialog-body&gt;</code></td>
       <td></td>
     </tr>
     <tr>
       <td>Drawer</td>
-      <td>
-        <code>&lt;fluent-drawer&gt;</code>
-      </td>
+      <td><code>&lt;fluent-drawer&gt;</code></td>
       <td></td>
     </tr>
     <tr>
       <td>DrawerBody</td>
-      <td>
-        <code>&lt;fluent-drawer-body&gt;</code>
-      </td>
+      <td><code>&lt;fluent-drawer-body&gt;</code></td>
       <td></td>
     </tr>
     <tr>
       <td>Dropdown</td>
-      <td>
-        <code>&lt;fluent-dropdown&gt;</code>
-      </td>
-      <td>
-        Replaces <code>&lt;fluent-combobox&gt;</code> and <code>&lt;fluent-select&gt;</code>
-      </td>
+      <td><code>&lt;fluent-dropdown&gt;</code></td>
+      <td>Replaces <code>&lt;fluent-combobox&gt;</code> and <code>&lt;fluent-select&gt;</code></td>
     </tr>
     <tr>
       <td>Field</td>
-      <td>
-        <code>&lt;fluent-field&gt;</code>
-      </td>
+      <td><code>&lt;fluent-field&gt;</code></td>
       <td></td>
     </tr>
     <tr>
       <td>Image</td>
-      <td>
-        <code>&lt;fluent-image&gt;</code>
-      </td>
+      <td><code>&lt;fluent-image&gt;</code></td>
       <td></td>
     </tr>
     <tr>
       <td>Label</td>
-      <td>
-        <code>&lt;fluent-label&gt;</code>
-      </td>
+      <td><code>&lt;fluent-label&gt;</code></td>
       <td></td>
     </tr>
     <tr>
       <td>Link</td>
-      <td>
-        <code>&lt;fluent-link&gt;</code>
-      </td>
-      <td>
-        Replaces <code>&lt;fluent-anchor appearance="hypertext"&gt;</code>
-      </td>
+      <td><code>&lt;fluent-link&gt;</code></td>
+      <td>Replaces <code>&lt;fluent-anchor appearance="hypertext"&gt;</code></td>
     </tr>
     <tr>
       <td>MenuButton</td>
-      <td>
-        <code>&lt;fluent-menu-button&gt;</code>
-      </td>
+      <td><code>&lt;fluent-menu-button&gt;</code></td>
       <td></td>
     </tr>
     <tr>
       <td>MenuList</td>
-      <td>
-        <code>&lt;fluent-menu-list&gt;</code>
-      </td>
+      <td><code>&lt;fluent-menu-list&gt;</code></td>
       <td></td>
     </tr>
     <tr>
       <td>MessageBar</td>
-      <td>
-        <code>&lt;fluent-message-bar&gt;</code>
-      </td>
+      <td><code>&lt;fluent-message-bar&gt;</code></td>
       <td></td>
     </tr>
     <tr>
       <td>ProgressBar</td>
-      <td>
-        <code>&lt;fluent-progress-bar&gt;</code>
-      </td>
-      <td>
-        Renamed from <code>&lt;fluent-progress&gt;</code>
-      </td>
+      <td><code>&lt;fluent-progress-bar&gt;</code></td>
+      <td>Renamed from <code>&lt;fluent-progress&gt;</code></td>
     </tr>
     <tr>
       <td>RatingDisplay</td>
-      <td>
-        <code>&lt;fluent-rating-display&gt;</code>
-      </td>
+      <td><code>&lt;fluent-rating-display&gt;</code></td>
       <td></td>
     </tr>
     <tr>
       <td>Spinner</td>
-      <td>
-        <code>&lt;fluent-spinner&gt;</code>
-      </td>
-      <td></td>
+      <td><code>&lt;fluent-spinner&gt;</code></td>
+      <td>Handles the indeterminate loading case previously covered by <code>&lt;fluent-progress-ring&gt;</code></td>
     </tr>
     <tr>
       <td>Tablist</td>
-      <td>
-        <code>&lt;fluent-tablist&gt;</code>
-      </td>
-      <td>
-        Renamed from <code>&lt;fluent-tabs&gt;</code>
-      </td>
+      <td><code>&lt;fluent-tablist&gt;</code></td>
+      <td>Renamed from <code>&lt;fluent-tabs&gt;</code></td>
     </tr>
     <tr>
       <td>Text</td>
-      <td>
-        <code>&lt;fluent-text&gt;</code>
-      </td>
+      <td><code>&lt;fluent-text&gt;</code></td>
       <td></td>
     </tr>
     <tr>
       <td>TextInput</td>
-      <td>
-        <code>&lt;fluent-text-input&gt;</code>
-      </td>
-      <td>
-        Renamed from <code>&lt;fluent-text-field&gt;</code>
-      </td>
+      <td><code>&lt;fluent-text-input&gt;</code></td>
+      <td>Renamed from <code>&lt;fluent-text-field&gt;</code></td>
     </tr>
     <tr>
       <td>TextArea</td>
-      <td>
-        <code>&lt;fluent-textarea&gt;</code>
-      </td>
-      <td>
-        Renamed from <code>&lt;fluent-text-area&gt;</code>
-      </td>
+      <td><code>&lt;fluent-textarea&gt;</code></td>
+      <td>Renamed from <code>&lt;fluent-text-area&gt;</code></td>
     </tr>
     <tr>
       <td>ToggleButton</td>
-      <td>
-        <code>&lt;fluent-toggle-button&gt;</code>
-      </td>
+      <td><code>&lt;fluent-toggle-button&gt;</code></td>
       <td></td>
     </tr>
     <tr>
       <td>Tree</td>
-      <td>
-        <code>&lt;fluent-tree&gt;</code>
-      </td>
-      <td>
-        Renamed from <code>&lt;fluent-tree-view&gt;</code>
-      </td>
+      <td><code>&lt;fluent-tree&gt;</code></td>
+      <td>Renamed from <code>&lt;fluent-tree-view&gt;</code></td>
     </tr>
   </tbody>
 </table>
@@ -348,20 +349,21 @@ These components are new in v3. Some are entirely new to the library, while othe
 
 Aside from the renamed and replaced components above, the following components have been removed in v3:
 
-- Breadcrumb
-- BreadcrumbItem
-- Calendar
-- Card
-- DataGrid
-- DataGridCell
-- DataGridRow
-- DesignSystemProvider (see [Theming](#theming))
-- Flipper
-- HorizontalScroll
-- NumberField
-- Search
-- Skeleton
-- Toolbar
+- Breadcrumb (`<fluent-breadcrumb>`)
+- BreadcrumbItem (`<fluent-breadcrumb-item>`)
+- Calendar (`<fluent-calendar>`)
+- Card (`<fluent-card>`)
+- DataGrid (`<fluent-data-grid>`)
+- DataGridCell (`<fluent-data-grid-cell>`)
+- DataGridRow (`<fluent-data-grid-row>`)
+- DesignSystemProvider (`<fluent-design-system-provider>`)
+- Flipper (`<fluent-flipper>`)
+- HorizontalScroll (`<fluent-horizontal-scroll>`)
+- NumberField (`<fluent-number-field>`)
+- ProgressRing (`<fluent-progress-ring>`)
+- Search (`<fluent-search>`)
+- Skeleton (`<fluent-skeleton>`)
+- Toolbar (`<fluent-toolbar>`)
 
 ## Major Component API Changes
 
@@ -502,9 +504,9 @@ The `Dialog` component in v2 didn't allow for expressive dialogs without the def
   </tbody>
 </table>
 
-### Progress and ProgressRing
+### Progress
 
-The `Progress` class in v2 has been replaced with the `ProgressBar` class in v3, and the `ProgressRing` class has been removed in favor of the `Spinner` class.
+The `Progress` class in v2 has been renamed to the `ProgressBar` class in v3. It remains a determinate, linear progress indicator.
 
 <table>
   <thead>
@@ -524,16 +526,6 @@ The `Progress` class in v2 has been replaced with the `ProgressBar` class in v3,
       </td>
       <td>
         <code>&lt;fluent-progress-bar&gt;</code>
-      </td>
-    </tr>
-    <tr>
-      <td>ProgressRing</td>
-      <td>Spinner</td>
-      <td>
-        <code>&lt;fluent-progress-ring&gt;</code>
-      </td>
-      <td>
-        <code>&lt;fluent-spinner&gt;</code>
       </td>
     </tr>
   </tbody>
@@ -576,6 +568,7 @@ The `SliderLabel` class and `<fluent-slider-label>` tag have been removed in v3.
 
 The `Tabs` class in v2 has been replaced with the `Tablist` class in v3. The `TabPanel` class and `<fluent-tab-panel>` tag have been removed: supply your own panel element and associate it with a `Tab` through the tab's `aria-controls` attribute, referencing the panel's `id`. The `Tablist` applies `role="tabpanel"` to that element and shows or hides it based on the active tab.
 
+{/* prettier-ignore */}
 <table>
   <thead>
     <tr>
@@ -598,14 +591,11 @@ The `Tabs` class in v2 has been replaced with the `Tablist` class in v3. The `Ta
     </tr>
     <tr>
       <td>TabPanel</td>
-      <td>_(Removed)_</td>
+      <td></td>
       <td>
         <code>&lt;fluent-tab-panel&gt;</code>
       </td>
-      <td>
-        Use your own panel element and associate it with a <code>Tab</code> through the tab's <code>aria-controls</code>{' '}
-        attribute
-      </td>
+      <td>Use your own panel element and associate it with a <code>Tab</code> through the tab's <code>aria-controls</code> attribute</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
## Previous Behavior

The V2 → V3 migration guide (`packages/web-components/src/_docs/developer/migration.mdx`) was a high-level, snapshot-style document. It listed what was new in v3 as bullet points and relied heavily on large comparison tables, but gave little concrete guidance on how to actually update code — installation, component registration, theming, and per-component markup changes were sparse or missing.

## New Behavior

The migration guide is rewritten to be a practical, task-oriented reference for moving from v2 (`2.6.1`) to v3:

- Reframes the intro around v3 being a ground-up rewrite and calls out the concrete breaking areas: imports, component registration, theming, and form-control markup.
- Adds a **Major Changes** overview (FAST Element v3 foundation, individual component exports, new registration model, token-based theming, `ElementInternals`, smaller bundle).
- Adds a real **Bundle Size Comparison** table (v2.6.1 vs v3.0.0, with minified/gzip/brotli sizes and percentage reductions).
- Adds **Usage** guidance covering installation, the `@microsoft/fast-element` peer dependency, side-effect `define` imports for individual components, `web-components.js`, and importing a component's class/template/styles/definition.
- Documents the new **Theming** model, replacing design tokens and `DesignSystemProvider` with `setTheme()` (page-level and element-level, plus unsetting).
- Updates the Storybook `Meta` title from "V2 → V3 Migration Guide" to "V2 to V3 Migration Guide" and the page heading to "Migration Guide".
