### PR TITLE
docs(web-components): fix sticker sheet quirks

### DIFF
--- a/change/@fluentui-web-components-d031bfa2-7b89-4756-9ee7-b46a29db0c5b.json
+++ b/change/@fluentui-web-components-d031bfa2-7b89-4756-9ee7-b46a29db0c5b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "fix minor sticker sheet quirks",
+  "packageName": "@fluentui/web-components",
+  "email": "863023+radium-v@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/src/_docs/developer/sticker-sheet.mdx
+++ b/packages/web-components/src/_docs/developer/sticker-sheet.mdx
@@ -62,8 +62,8 @@ export const stickerSheetHTML = /* html */`
     <h3>Accordion</h3>
   </fluent-text>
   <div class="sticker-row">
-    <fluent-accordion>
-      <fluent-accordion-item>
+    <fluent-accordion expand-mode="single">
+      <fluent-accordion-item expanded>
         <span slot="heading">Accordion header 1</span>
         Accordion panel 1
       </fluent-accordion-item>
@@ -146,7 +146,7 @@ export const stickerSheetHTML = /* html */`
     </fluent-field>
     <fluent-field label-position="after">
       <label slot="label">Mixed</label>
-      <fluent-checkbox slot="input" indeterminate></fluent-checkbox>
+      <fluent-checkbox slot="input" id="sticker-indeterminate-checkbox"></fluent-checkbox>
     </fluent-field>
   </div>
 </section>
@@ -543,6 +543,10 @@ export const stickerThemes = {
 export const StickerSheet = () => {
   const containerRef = React.useRef(null);
   React.useEffect(() => {
+    const indeterminateCheckbox = containerRef.current?.querySelector('#sticker-indeterminate-checkbox');
+    if (indeterminateCheckbox) {
+      indeterminateCheckbox.indeterminate = true;
+    }
     const applyGlobals = globals => {
       const themeKey = globals?.theme || 'web-light';
       const dir = globals?.dir || 'ltr';


### PR DESCRIPTION
## Previous Behavior

* The indeterminate `<fluent-checkbox>` example wasn't wired up correctly.
* The `<fluent-accordion>` example felt a bit separated.

## New Behavior

* The `indeterminate` flag is set when the page is loaded.
* The accordion example uses single expand mode.