### PR TITLE
ci: add experimental headless release pipeline

### DIFF
--- a/azure-pipelines.release-headless-experimental.yml
+++ b/azure-pipelines.release-headless-experimental.yml
@@ -7,17 +7,15 @@ parameters:
     type: boolean
     default: true
 
-# Customize build number to include major version
-# Example: v9_20201022.1
-name: 'v9_experimental_$(Date:yyyyMMdd)$(Rev:.r)'
+# Customize build number to include package prefix
+# Example: headless_experimental_20201022.1
+name: 'headless_experimental_$(Date:yyyyMMdd)$(Rev:.r)'
 
 variables:
   - group: 'Github and NPM secrets'
   - template: .devops/templates/variables.yml
     parameters:
       skipComponentGovernanceDetection: false
-  - name: release.vnext # Used to scope beachball to release only vnext packages
-    value: true
   - name: tags
     value: production,externalfacing
 
@@ -82,42 +80,47 @@ extends:
                   yarn install --frozen-lockfile
                 displayName: Install dependencies
 
-                # Deletes all existing changefiles so that only bump that happens is for nightly
+                # Deletes all existing changefiles so that only the experimental bump happens
               - script: |
                   rm -f change/*
                 displayName: 'Delete existing changefiles'
 
-                # Bumps all v9 packages to a x.x.x-experimental.<feature>.<date>-<hash> version and checks in change files
-                # x.x.x is derived from the current version @fluentui/react-components package.json
+                # Bumps headless packages to a x.x.x-experimental.<feature>.<date>-<hash> version and checks in change files.
+                # x.x.x is derived from @fluentui/react-headless-components-preview so it stays on its own 0.x line.
               - script: |
                   FEATURE_NAME=$(validation.featureName)
-                  BASE_VERSION=$(node -p "require('./packages/react-components/react-components/package.json').version")
                   DATE=$(date +"%Y%m%d")
                   HASH=$(git rev-parse --short HEAD)
+                  BASE_VERSION=$(node -p "require('./packages/react-components/react-headless-components-preview/library/package.json').version")
                   NEW_VERSION="${BASE_VERSION}-experimental.${FEATURE_NAME}.${DATE}-${HASH}"
 
                   echo "Target version: ${NEW_VERSION}"
 
-                  yarn nx g @fluentui/workspace-plugin:version-bump --all --explicitVersion "${NEW_VERSION}"
+                  yarn nx g @fluentui/workspace-plugin:version-bump --name react-headless-components-preview --explicitVersion "${NEW_VERSION}"
                   git add .
-                  git commit -m "bump experimental versions to ${NEW_VERSION}"
+                  git commit -m "bump experimental headless versions to ${NEW_VERSION}"
                   yarn change --type prerelease --message "Release ${NEW_VERSION}" --dependent-change-type "prerelease"
-                displayName: 'Bump and commit experimental versions'
+                displayName: 'Bump and commit experimental headless versions'
 
               - script: |
-                  FLUENT_PROD_BUILD=true yarn nx run-many -t build -p "tag:vNext"  --exclude "tag:npm:private,tag:tools,tag:charting,tag:react-headless" --nxBail
+                  echo "Following packages will be published (if they contain changes):"
+                  yarn nx show projects -p 'tag:react-headless,!tag:npm:private' --exclude 'apps/**'
+                displayName: Show packages
+
+              - script: |
+                  FLUENT_PROD_BUILD=true yarn nx run-many -t build -p 'tag:react-headless,!tag:npm:private,!tag:type:stories' --exclude 'apps/**' --nxBail
                 displayName: build
 
               - script: |
-                  FLUENT_PROD_BUILD=true yarn nx run-many -t lint -p "tag:vNext"  --exclude "tag:npm:private,tag:tools,tag:charting,tag:react-headless" --nxBail
+                  FLUENT_PROD_BUILD=true yarn nx run-many -t lint -p 'tag:react-headless,!tag:npm:private,!tag:type:stories' --exclude 'apps/**' --nxBail
                 displayName: lint
 
               - script: |
-                  FLUENT_PROD_BUILD=true yarn nx run-many -t test -p "tag:vNext"  --exclude "tag:npm:private,tag:tools,tag:charting,tag:react-headless" --nxBail
+                  FLUENT_PROD_BUILD=true yarn nx run-many -t test -p 'tag:react-headless,!tag:npm:private,!tag:type:stories' --exclude 'apps/**' --nxBail
                 displayName: test
 
               - script: |
-                  yarn beachball publish -b origin/$(validation.branchPath) --access public -y -n $(npmToken) --no-push --tag experimental --config scripts/beachball/src/release-vNext.config.js
+                  yarn beachball publish -b origin/$(validation.branchPath) --access public -y -n $(npmToken) --no-push --tag experimental --config scripts/beachball/src/release-headless.config.js
                   git reset --hard origin/$(validation.branchPath)
                 displayName: Publish changes and bump versions
                 condition: and(succeeded(), not(${{ parameters.dryRun }}))


### PR DESCRIPTION
## What

Adds a dedicated **experimental headless release** pipeline and removes headless from the vNext experimental build.

### Why
`react-headless-components-preview` is a **`0.x` preview package**, so it can't share the **`9.x`** experimental version line of the vNext experimental release (`version-bump --all --explicitVersion 9.x…` would drag headless to `9.x`). Rather than adding brittle per-version-line branching to the shared vNext pipeline, headless gets its own pipeline.

### Changes
- **New:** `azure-pipelines.release-headless-experimental.yml` — manual pipeline (`dryRun` default `true`) that:
  - validates an `experimental/*` branch and derives the version from `react-headless-components-preview`'s own base → `0.x.x-experimental.<feature>.<date>-<hash>`
  - `version-bump --name react-headless-components-preview --explicitVersion …`
  - builds/lint/tests the `tag:react-headless,!tag:npm:private,!tag:type:stories` graph
  - publishes via `release-headless.config.js` under the `experimental` dist-tag (`--no-push`, `git reset --hard` after)
- **Modified:** `azure-pipelines.release-vnext-experimental.yml` — add `tag:react-headless` to the build/lint/test `--exclude`. Headless carried `tag:vNext`, so it was a *direct* build target, but the vNext beachball scope never publishes it and nothing depends on it → wasted work now that it has its own pipeline.

## Notes
- Scope/config reuse: the new pipeline mirrors the existing standalone `azure-pipelines.release.headless.yml` scoping and the experimental flow from the vNext experimental pipeline.
- Verified: both YAML files parse; no package depends on `react-headless-components-preview` (safe to exclude from the vNext graph).
- The standalone (stable) headless release pipeline is untouched.

Draft for review.