### PR TITLE
fix(web-components): fix focusgroup in tree when focusgroup is natively supported

### DIFF
--- a/change/@fluentui-web-components-9c7dc48c-180c-4d64-aeb6-b7e3f1415e45.json
+++ b/change/@fluentui-web-components-9c7dc48c-180c-4d64-aeb6-b7e3f1415e45.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix focusgroup in tree when focusgroup is natively supported",
+  "packageName": "@fluentui/web-components",
+  "email": "machi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/tree/tree.template.html
+++ b/packages/web-components/src/tree/tree.template.html
@@ -1,6 +1,5 @@
 <f-template name="fluent-tree" shadowrootmode="open">
   <template
-    tabindex="0"
     focusgroup="menu inline block nowrap nomemory"
     @click="{clickHandler($e)}"
     @keydown="{keydownHandler($e)}"

--- a/packages/web-components/src/tree/tree.template.ts
+++ b/packages/web-components/src/tree/tree.template.ts
@@ -3,12 +3,11 @@ import type { Tree } from './tree.js';
 
 export const template = html<Tree>`
   <template
-    tabindex="0"
     focusgroup="menu inline block nowrap nomemory"
     @click="${(x, c) => x.clickHandler(c.event)}"
     @keydown="${(x, c) => x.keydownHandler(c.event as KeyboardEvent)}"
     @change="${(x, c) => x.changeHandler(c.event)}"
-    @toggle="${(x, c) => x.itemToggleHandler()}"
+    @toggle="${x => x.itemToggleHandler()}"
   >
     <slot ${ref('defaultSlot')} @slotchange="${x => x.handleDefaultSlotChange()}"></slot>
   </template>


### PR DESCRIPTION
## Previous Behavior

Currently when the browser focus is on the previous focusable element of a `<fluent-tree>`, in a browser that supports focusgroup, hitting Tab key moves the focus onto the tree host element itself instead of a `<fluent-tree-item>`. This is because the host element has `tabindex=0`, and because focusgroup is natively supported, the focusgroup polyfill becomes dormant hence won’t forward the focus onto a tree item.

## New Behavior

Removed the `tabindex=0` on tree host element because it’s unnecessary, when focusgroup isn’t natively supported, the polyfill already adds `tabindex=0` to the host. And when focusgroup is natively supported, the browser will take care of moving the focus.