### PR TITLE
feat(react-table): add autoFitColumnsStrategy so DataGrid can auto-fit and resize columns together

### DIFF
--- a/change/@fluentui-react-table-36f91369-ce21-4576-8fde-ac08fd50c562.json
+++ b/change/@fluentui-react-table-36f91369-ce21-4576-8fde-ac08fd50c562.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(react-table): add autoFitColumnsStrategy option to share leftover space evenly between resizable columns",
+  "packageName": "@fluentui/react-table",
+  "email": "144495202+AKnassa@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-table/library/etc/react-table.api.md
+++ b/packages/react-components/react-table/library/etc/react-table.api.md
@@ -154,6 +154,7 @@ export type DataGridProps = TableProps & Pick<DataGridContextValue, 'items' | 'c
     containerWidthOffset?: number;
     resizableColumnsOptions?: {
         autoFitColumns?: boolean;
+        autoFitColumnsStrategy?: AutoFitColumnsStrategy;
     };
 };
 

--- a/packages/react-components/react-table/library/src/components/DataGrid/DataGrid.types.ts
+++ b/packages/react-components/react-table/library/src/components/DataGrid/DataGrid.types.ts
@@ -3,6 +3,7 @@ import type { SelectionHookParams, SelectionMode } from '@fluentui/react-utiliti
 import type { TabsterDOMAttribute } from '@fluentui/react-tabster';
 import type { TableContextValues, TableProps, TableSlots, TableState } from '../Table/Table.types';
 import type {
+  AutoFitColumnsStrategy,
   SortState,
   TableFeaturesState,
   UseTableSortOptions,
@@ -102,6 +103,13 @@ export type DataGridProps = TableProps &
        * @default true
        * */
       autoFitColumns?: boolean;
+      /**
+       * Controls how `autoFitColumns` shares the space that is left over once every column has
+       * reached its ideal width. `last-column` gives all of it to the last column, `even` shares it
+       * equally between the columns, keeping columns with equal ideal widths equally wide.
+       * @default 'last-column'
+       * */
+      autoFitColumnsStrategy?: AutoFitColumnsStrategy;
     };
   };
 

--- a/packages/react-components/react-table/library/src/components/DataGrid/useDataGrid.ts
+++ b/packages/react-components/react-table/library/src/components/DataGrid/useDataGrid.ts
@@ -79,6 +79,7 @@ export const useDataGrid_unstable = (props: DataGridProps, ref: React.Ref<HTMLEl
       // Disables automatic resizing of columns when the container overflows.
       // This allows the sum of the columns to be larger than the container.
       autoFitColumns: resizableColumnsOptions.autoFitColumns ?? true,
+      autoFitColumnsStrategy: resizableColumnsOptions.autoFitColumnsStrategy,
     }),
   ]);
 

--- a/packages/react-components/react-table/library/src/hooks/index.ts
+++ b/packages/react-components/react-table/library/src/hooks/index.ts
@@ -3,6 +3,7 @@ export type {
   ColumnSizingTableCellProps,
   ColumnSizingTableHeaderCellProps,
   ColumnSizingTableProps,
+  AutoFitColumnsStrategy,
   ColumnWidthState,
   CreateTableColumnOptions,
   EnableKeyboardModeOnChangeCallback,

--- a/packages/react-components/react-table/library/src/hooks/types.ts
+++ b/packages/react-components/react-table/library/src/hooks/types.ts
@@ -176,6 +176,17 @@ export interface ColumnWidthState {
   padding: number;
 }
 
+/**
+ * Controls how auto-fit shares the container space that is left over once every column
+ * has reached its ideal width.
+ *
+ * - `last-column`: every column grows to its ideal width and the last column absorbs all
+ *   of the remaining space.
+ * - `even`: every column starts at its ideal width and the remaining space is shared
+ *   equally between all columns, so columns with equal ideal widths stay equally wide.
+ */
+export type AutoFitColumnsStrategy = 'last-column' | 'even';
+
 export type ColumnSizingTableProps = TableProps;
 export type ColumnSizingTableHeaderCellProps = Pick<TableHeaderCellProps, 'style' | 'aside'>;
 export type ColumnSizingTableCellProps = Pick<TableHeaderCellProps, 'style'>;
@@ -221,4 +232,11 @@ export type UseTableColumnSizingParams = {
   ) => void;
   containerWidthOffset?: number;
   autoFitColumns?: boolean;
+  /**
+   * Controls how `autoFitColumns` shares the space that is left over once every column has reached
+   * its ideal width. Use `even` to keep columns with equal ideal widths equally wide, the way they
+   * are laid out when column resizing is disabled.
+   * @default 'last-column'
+   */
+  autoFitColumnsStrategy?: AutoFitColumnsStrategy;
 };

--- a/packages/react-components/react-table/library/src/hooks/useTableColumnResizeState.test.ts
+++ b/packages/react-components/react-table/library/src/hooks/useTableColumnResizeState.test.ts
@@ -2,7 +2,7 @@ import type { RenderResult } from '@testing-library/react-hooks';
 import { act, renderHook } from '@testing-library/react-hooks';
 import { createTableColumn } from './createColumn';
 import { useTableColumnResizeState } from './useTableColumnResizeState';
-import type { ColumnResizeState, TableColumnSizingOptions } from './types';
+import type { AutoFitColumnsStrategy, ColumnResizeState, TableColumnSizingOptions } from './types';
 
 describe('useTableColumnResizeState', () => {
   describe('default options', () => {
@@ -165,6 +165,168 @@ describe('useTableColumnResizeState', () => {
       act(() => state.current.setColumnWidth(event, { columnId: 1, width: 500 }));
       expect(onColumnResize).toHaveBeenCalledTimes(1);
       expect(onColumnResize).toHaveBeenCalledWith(event, { columnId: 1, width: 500 });
+    });
+  });
+
+  describe("autoFitColumnsStrategy: 'even'", () => {
+    const init = (targetWidth: number) => {
+      const columnDefinition = [
+        createTableColumn({ columnId: 1 }),
+        createTableColumn({ columnId: 2 }),
+        createTableColumn({ columnId: 3 }),
+      ];
+      const { result } = renderHook(() =>
+        useTableColumnResizeState(columnDefinition, targetWidth, { autoFitColumnsStrategy: 'even' }),
+      );
+      return result;
+    };
+
+    it('gives every column the same width', () => {
+      const state = init(1000);
+      const [first, second, third] = state.current.getColumns();
+
+      expect(first.width).toEqual(second.width);
+      expect(second.width).toEqual(third.width);
+    });
+
+    it('keeps a resized column at the width it was given', () => {
+      const state = init(1000);
+      act(() => state.current.setColumnWidth(undefined, { columnId: 1, width: 500 }));
+
+      expect(state.current.getColumnWidth(1)).toEqual(500);
+      expect(state.current.getColumnWidth(2)).toEqual(226);
+      expect(state.current.getColumnWidth(3)).toEqual(226);
+    });
+
+    it('keeps a resized column at its width when the container grows', () => {
+      const columnDefinition = [
+        createTableColumn({ columnId: 1 }),
+        createTableColumn({ columnId: 2 }),
+        createTableColumn({ columnId: 3 }),
+      ];
+      const { result, rerender } = renderHook(
+        ({ containerWidth }) =>
+          useTableColumnResizeState(columnDefinition, containerWidth, { autoFitColumnsStrategy: 'even' }),
+        { initialProps: { containerWidth: 1000 } },
+      );
+
+      act(() => result.current.setColumnWidth(undefined, { columnId: 1, width: 500 }));
+      rerender({ containerWidth: 1200 });
+
+      expect(result.current.getColumnWidth(1)).toEqual(500);
+      expect(result.current.getColumnWidth(2)).toEqual(326);
+      expect(result.current.getColumnWidth(3)).toEqual(326);
+    });
+
+    it('auto-fits a resized column again once it is removed and added back', () => {
+      const allColumns = [
+        createTableColumn({ columnId: 1 }),
+        createTableColumn({ columnId: 2 }),
+        createTableColumn({ columnId: 3 }),
+      ];
+      const { result, rerender } = renderHook(
+        ({ columns }) => useTableColumnResizeState(columns, 1000, { autoFitColumnsStrategy: 'even' }),
+        { initialProps: { columns: allColumns } },
+      );
+
+      act(() => result.current.setColumnWidth(undefined, { columnId: 3, width: 400 }));
+      rerender({ columns: allColumns.slice(0, 2) });
+      rerender({ columns: allColumns });
+
+      const [first, second, third] = result.current.getColumns();
+      expect(first.width).toEqual(second.width);
+      expect(second.width).toEqual(third.width);
+    });
+
+    it('keeps a resized column at its width when another column is added', () => {
+      const allColumns = [
+        createTableColumn({ columnId: 1 }),
+        createTableColumn({ columnId: 2 }),
+        createTableColumn({ columnId: 3 }),
+        createTableColumn({ columnId: 4 }),
+      ];
+      const { result, rerender } = renderHook(
+        ({ columns }) => useTableColumnResizeState(columns, 1000, { autoFitColumnsStrategy: 'even' }),
+        { initialProps: { columns: allColumns.slice(0, 3) } },
+      );
+
+      act(() => result.current.setColumnWidth(undefined, { columnId: 2, width: 400 }));
+      rerender({ columns: allColumns });
+
+      expect(result.current.getColumnWidth(2)).toEqual(400);
+    });
+
+    it('moves a resized column to a width given through the column sizing options and keeps it there', () => {
+      const columnDefinition = [
+        createTableColumn({ columnId: 1 }),
+        createTableColumn({ columnId: 2 }),
+        createTableColumn({ columnId: 3 }),
+      ];
+      const { result, rerender } = renderHook(
+        ({ columnSizingOptions }: { columnSizingOptions?: TableColumnSizingOptions }) =>
+          useTableColumnResizeState(columnDefinition, 1000, { autoFitColumnsStrategy: 'even', columnSizingOptions }),
+        { initialProps: {} },
+      );
+
+      act(() => result.current.setColumnWidth(undefined, { columnId: 1, width: 500 }));
+      rerender({ columnSizingOptions: { 1: { idealWidth: 200 } } });
+
+      // The width given through the options replaces the width the user chose, and the column
+      // stays out of the sharing, so the other columns split the leftover space between them.
+      expect(result.current.getColumnWidth(1)).toEqual(200);
+      expect(result.current.getColumnWidth(2)).toEqual(376);
+      expect(result.current.getColumnWidth(3)).toEqual(376);
+    });
+
+    it('recomputes the widths when the strategy changes', () => {
+      const columnDefinition = [
+        createTableColumn({ columnId: 1 }),
+        createTableColumn({ columnId: 2 }),
+        createTableColumn({ columnId: 3 }),
+      ];
+      const { result, rerender } = renderHook(
+        ({ strategy }: { strategy: AutoFitColumnsStrategy }) =>
+          useTableColumnResizeState(columnDefinition, 1000, { autoFitColumnsStrategy: strategy }),
+        { initialProps: { strategy: 'last-column' as AutoFitColumnsStrategy } },
+      );
+      expect(result.current.getColumnWidth(3)).toEqual(652);
+
+      rerender({ strategy: 'even' });
+
+      const [first, second, third] = result.current.getColumns();
+      expect(first.width).toEqual(second.width);
+      expect(second.width).toEqual(third.width);
+    });
+
+    it('keeps a drag under the cursor after every column has been resized', () => {
+      const state = init(1000);
+      act(() => state.current.setColumnWidth(undefined, { columnId: 1, width: 330 }));
+      act(() => state.current.setColumnWidth(undefined, { columnId: 2, width: 250 }));
+      act(() => state.current.setColumnWidth(undefined, { columnId: 3, width: 402 }));
+
+      // Every column is now deliberately sized; the next drag must still move the column exactly
+      // to the requested width instead of jumping by the redistributed share.
+      act(() => state.current.setColumnWidth(undefined, { columnId: 1, width: 321 }));
+
+      expect(state.current.getColumnWidth(1)).toEqual(321);
+    });
+
+    it('ignores the strategy when auto-fit is disabled', () => {
+      const columnDefinition = [
+        createTableColumn({ columnId: 1 }),
+        createTableColumn({ columnId: 2 }),
+        createTableColumn({ columnId: 3 }),
+      ];
+      const { result } = renderHook(() =>
+        useTableColumnResizeState(columnDefinition, 1000, {
+          autoFitColumns: false,
+          autoFitColumnsStrategy: 'even',
+        }),
+      );
+
+      expect(result.current.getColumnWidth(1)).toEqual(150);
+      expect(result.current.getColumnWidth(2)).toEqual(150);
+      expect(result.current.getColumnWidth(3)).toEqual(150);
     });
   });
 

--- a/packages/react-components/react-table/library/src/hooks/useTableColumnResizeState.ts
+++ b/packages/react-components/react-table/library/src/hooks/useTableColumnResizeState.ts
@@ -6,6 +6,7 @@ import type {
   TableColumnDefinition,
   TableColumnId,
   ColumnResizeState,
+  AutoFitColumnsStrategy,
   ColumnWidthState,
   UseTableColumnSizingParams,
   TableColumnSizingOptions,
@@ -23,6 +24,11 @@ type ComponentState<T> = {
   containerWidth: number;
   columnWidthState: ColumnWidthState[];
   columnSizingOptions: TableColumnSizingOptions | undefined;
+  /**
+   * Columns the user has deliberately resized. The even distribution keeps them at the width they
+   * were given instead of growing them together with the columns that are still auto-fitted.
+   */
+  resizedColumns: ReadonlySet<TableColumnId>;
 };
 
 type ColumnResizeStateAction<T> =
@@ -45,24 +51,34 @@ type ColumnResizeStateAction<T> =
     };
 
 const createReducer =
-  <T>(autoFitColumns?: boolean) =>
+  <T>(autoFitColumns?: boolean, strategy: AutoFitColumnsStrategy = 'last-column') =>
   (state: ComponentState<T>, action: ColumnResizeStateAction<T>): ComponentState<T> => {
+    const autoFit = (
+      columnWidthState: ColumnWidthState[],
+      containerWidth: number,
+      resizedColumns = state.resizedColumns,
+    ) =>
+      autoFitColumns
+        ? adjustColumnWidthsToFitContainer(columnWidthState, containerWidth, strategy, resizedColumns)
+        : columnWidthState;
+
     switch (action.type) {
       case 'CONTAINER_WIDTH_UPDATED':
         return {
           ...state,
           containerWidth: action.containerWidth,
-          columnWidthState: autoFitColumns
-            ? adjustColumnWidthsToFitContainer(state.columnWidthState, action.containerWidth)
-            : state.columnWidthState,
+          columnWidthState: autoFit(state.columnWidthState, action.containerWidth),
         };
 
       case 'COLUMNS_UPDATED':
         const newS = columnDefinitionsToState(action.columns, state.columnWidthState, state.columnSizingOptions);
+        // A column that was removed must not keep the table's remaining space reserved for it.
+        const remainingResizedColumns = keepResizedColumns(state.resizedColumns, action.columns);
         return {
           ...state,
           columns: action.columns,
-          columnWidthState: autoFitColumns ? adjustColumnWidthsToFitContainer(newS, state.containerWidth) : newS,
+          resizedColumns: remainingResizedColumns,
+          columnWidthState: autoFit(newS, state.containerWidth, remainingResizedColumns),
         };
 
       case 'COLUMN_SIZING_OPTIONS_UPDATED':
@@ -70,9 +86,7 @@ const createReducer =
         return {
           ...state,
           columnSizingOptions: action.columnSizingOptions,
-          columnWidthState: autoFitColumns
-            ? adjustColumnWidthsToFitContainer(newState, state.containerWidth)
-            : newState,
+          columnWidthState: autoFit(newState, state.containerWidth),
         };
 
       case 'SET_COLUMN_WIDTH':
@@ -90,34 +104,67 @@ const createReducer =
         newColumnWidthState = setColumnProperty(newColumnWidthState, columnId, 'width', width);
         // Set this width as idealWidth, because its a deliberate change, not a recalculation because of container
         newColumnWidthState = setColumnProperty(newColumnWidthState, columnId, 'idealWidth', width);
-        // Adjust the widths to the container size
-        if (autoFitColumns) {
-          newColumnWidthState = adjustColumnWidthsToFitContainer(newColumnWidthState, containerWidth);
+
+        let resizedColumns: ReadonlySet<TableColumnId> = new Set(state.resizedColumns).add(columnId);
+        // Once every column has been deliberately sized, the widths on screen are the chosen
+        // widths plus an equal share of the leftover space. Re-anchor the other columns at the
+        // width they are rendered at and keep only the column being resized pinned, so that the
+        // drag keeps tracking the pointer instead of jumping by the redistributed share.
+        if (strategy === 'even' && state.columnWidthState.every(col => resizedColumns.has(col.columnId))) {
+          for (const col of state.columnWidthState) {
+            if (col.columnId !== columnId) {
+              newColumnWidthState = setColumnProperty(newColumnWidthState, col.columnId, 'idealWidth', col.width);
+            }
+          }
+          resizedColumns = new Set([columnId]);
         }
 
-        return { ...state, columnWidthState: newColumnWidthState };
+        // Adjust the widths to the container size
+        newColumnWidthState = autoFit(newColumnWidthState, containerWidth, resizedColumns);
+
+        return { ...state, columnWidthState: newColumnWidthState, resizedColumns };
     }
   };
+
+/**
+ * Drops the columns that are no longer rendered from the set of deliberately resized columns.
+ * Returns the original set when every resized column is still present, so that the reducer state
+ * keeps its identity.
+ */
+function keepResizedColumns<T>(
+  resizedColumns: ReadonlySet<TableColumnId>,
+  columns: TableColumnDefinition<T>[],
+): ReadonlySet<TableColumnId> {
+  const remaining = [...resizedColumns].filter(columnId => columns.some(column => column.columnId === columnId));
+
+  return remaining.length === resizedColumns.size ? resizedColumns : new Set(remaining);
+}
 
 export function useTableColumnResizeState<T>(
   columns: TableColumnDefinition<T>[],
   containerWidth: number,
   params: UseTableColumnSizingParams = {},
 ): ColumnResizeState {
-  const { onColumnResize, columnSizingOptions, autoFitColumns = true } = params;
+  const { onColumnResize, columnSizingOptions, autoFitColumns = true, autoFitColumnsStrategy = 'last-column' } = params;
 
-  const reducer = React.useMemo(() => createReducer<T>(autoFitColumns), [autoFitColumns]);
+  const reducer = React.useMemo(
+    () => createReducer<T>(autoFitColumns, autoFitColumnsStrategy),
+    [autoFitColumns, autoFitColumnsStrategy],
+  );
 
   const [state, dispatch] = React.useReducer(reducer, {
     columns,
     containerWidth: 0,
     columnWidthState: columnDefinitionsToState(columns, undefined, columnSizingOptions),
     columnSizingOptions,
+    resizedColumns: new Set<TableColumnId>(),
   });
 
   useIsomorphicLayoutEffect(() => {
+    // The reducer captures autoFitColumns and the strategy, so when they change the widths have
+    // to be recomputed for the same container as well.
     dispatch({ type: 'CONTAINER_WIDTH_UPDATED', containerWidth });
-  }, [containerWidth]);
+  }, [containerWidth, autoFitColumns, autoFitColumnsStrategy]);
 
   useIsomorphicLayoutEffect(() => {
     dispatch({ type: 'COLUMNS_UPDATED', columns });

--- a/packages/react-components/react-table/library/src/hooks/useTableColumnSizing.test.ts
+++ b/packages/react-components/react-table/library/src/hooks/useTableColumnSizing.test.ts
@@ -1,9 +1,10 @@
+import type * as React from 'react';
 import type { RenderHookResult } from '@testing-library/react-hooks';
 import { renderHook } from '@testing-library/react-hooks';
 import { useTableColumnSizing_unstable as useTableColumnSizing } from './useTableColumnSizing';
 import { createTableColumn } from './createColumn';
 import { mockTableState } from '../testing/mockTableState';
-import type { TableFeaturesState } from './types';
+import type { TableFeaturesState, UseTableColumnSizingParams } from './types';
 
 const mockColumnResizeState = {
   getColumnWidth: jest.fn(),
@@ -124,5 +125,53 @@ describe('useTableColumnSizing', () => {
         },
       }
     `);
+  });
+
+  it('announces a whole number of pixels to screen readers when the width is fractional', () => {
+    // The even distribution produces fractional widths like 317.33333333333337.
+    mockColumnResizeState.getColumnById.mockReturnValueOnce({
+      columnId: 1,
+      idealWidth: 150,
+      minWidth: 100,
+      padding: 16,
+      width: 317.33333333333337,
+    });
+
+    const props = renderHookResult.result.current.columnSizing_unstable.getTableHeaderCellProps(1);
+
+    const aside = props.aside as React.ReactElement<{ 'aria-valuetext': string }>;
+    expect(aside.props['aria-valuetext']).toEqual('317 pixels');
+  });
+
+  describe('the resize handle of the last column', () => {
+    const columnDefinition = [
+      createTableColumn({ columnId: 1 }),
+      createTableColumn({ columnId: 2 }),
+      createTableColumn({ columnId: 3 }),
+    ];
+    const lastColumnId = 3;
+
+    const getLastColumnProps = (params?: UseTableColumnSizingParams) => {
+      const { result } = renderHook(() => useTableColumnSizing(params)(mockTableState({ columns: columnDefinition })));
+      return result.current.columnSizing_unstable.getTableHeaderCellProps(lastColumnId);
+    };
+
+    it('is hidden when auto-fit stretches the last column to fill the table', () => {
+      expect(getLastColumnProps().aside).toBeNull();
+    });
+
+    it('is shown when auto-fit shares the space evenly, because no column is stretched', () => {
+      expect(getLastColumnProps({ autoFitColumnsStrategy: 'even' }).aside).not.toBeNull();
+    });
+
+    it('is hidden when the table has a single column, because resizing it can never take effect', () => {
+      const { result } = renderHook(() =>
+        useTableColumnSizing({ autoFitColumnsStrategy: 'even' })(
+          mockTableState({ columns: [createTableColumn({ columnId: 1 })] }),
+        ),
+      );
+
+      expect(result.current.columnSizing_unstable.getTableHeaderCellProps(1).aside).toBeNull();
+    });
   });
 });

--- a/packages/react-components/react-table/library/src/hooks/useTableColumnSizing.tsx
+++ b/packages/react-components/react-table/library/src/hooks/useTableColumnSizing.tsx
@@ -63,7 +63,7 @@ function useTableColumnSizingState<TItem>(
   // Creates the keyboard handler for resizing columns
   const { toggleInteractiveMode, getKeyboardResizingProps } = useKeyboardResizing(columnResizeState);
 
-  const { autoFitColumns } = params;
+  const { autoFitColumns, autoFitColumnsStrategy } = params;
 
   const enableKeyboardMode = React.useCallback(
     (columnId: TableColumnId, onChange?: EnableKeyboardModeOnChangeCallback) =>
@@ -98,15 +98,20 @@ function useTableColumnSizingState<TItem>(
         (columnId: TableColumnId) => {
           const col = getColumnById(columnId);
           const isLastColumn = columns[columns.length - 1]?.columnId === columnId;
+          // The last column only absorbs the space left over in the table when the columns are
+          // auto-fitted with the default distribution, which is why resizing it has no effect
+          // there. With the even distribution every column can be resized - except when it is the
+          // only column, because a single auto-fitted column always fills the whole container.
+          const isStretchedByAutoFit =
+            isLastColumn && autoFitColumns && (autoFitColumnsStrategy !== 'even' || columns.length === 1);
 
-          const aside =
-            isLastColumn && autoFitColumns ? null : (
-              <TableResizeHandle
-                onMouseDown={getOnMouseDown(columnId)}
-                onTouchStart={getOnMouseDown(columnId)}
-                {...getKeyboardResizingProps(columnId, col?.width || 0)}
-              />
-            );
+          const aside = isStretchedByAutoFit ? null : (
+            <TableResizeHandle
+              onMouseDown={getOnMouseDown(columnId)}
+              onTouchStart={getOnMouseDown(columnId)}
+              {...getKeyboardResizingProps(columnId, Math.round(col?.width || 0))}
+            />
+          );
 
           return col
             ? {
@@ -115,7 +120,15 @@ function useTableColumnSizingState<TItem>(
               }
             : {};
         },
-        [getColumnById, columns, dragging, getKeyboardResizingProps, getOnMouseDown, autoFitColumns],
+        [
+          getColumnById,
+          columns,
+          dragging,
+          getKeyboardResizingProps,
+          getOnMouseDown,
+          autoFitColumns,
+          autoFitColumnsStrategy,
+        ],
       ),
       getTableCellProps: React.useCallback(
         (columnId: TableColumnId) => {

--- a/packages/react-components/react-table/library/src/utils/columnResizeUtils.test.ts
+++ b/packages/react-components/react-table/library/src/utils/columnResizeUtils.test.ts
@@ -35,6 +35,13 @@ const mockColumnState: ColumnWidthState[] = [
   },
 ];
 
+// Three columns as `columnDefinitionsToState` creates them when no `columnSizingOptions` are given.
+const defaultColumnState: ColumnWidthState[] = [
+  { columnId: 1, idealWidth: 150, minWidth: 100, padding: 16, width: 150 },
+  { columnId: 2, idealWidth: 150, minWidth: 100, padding: 16, width: 150 },
+  { columnId: 3, idealWidth: 150, minWidth: 100, padding: 16, width: 150 },
+];
+
 describe('columnResizeUtils', () => {
   describe('getColumnById', () => {
     it('returns proper column', () => {
@@ -155,6 +162,174 @@ describe('columnResizeUtils', () => {
       expect(updatedState[0].width).toEqual(updatedState[0].idealWidth);
       expect(updatedState[1].width).toEqual(updatedState[1].idealWidth);
       expect(updatedState[2].width).toEqual(1102);
+    });
+  });
+
+  describe('adjustColumnWidthsToFitContainer with the even distribution', () => {
+    it('gives every column the same width when their ideal widths are the same', () => {
+      const updatedState = adjustColumnWidthsToFitContainer(defaultColumnState, 1000, 'even');
+
+      expect(updatedState[0].width).toEqual(updatedState[1].width);
+      expect(updatedState[1].width).toEqual(updatedState[2].width);
+    });
+
+    it('never shrinks a column below its minimal width', () => {
+      const updatedState = adjustColumnWidthsToFitContainer(defaultColumnState, 300, 'even');
+
+      expect(updatedState[0].width).toEqual(100);
+      expect(updatedState[1].width).toEqual(100);
+      expect(updatedState[2].width).toEqual(100);
+    });
+
+    it('keeps the columns untouched until the container has been measured', () => {
+      const updatedState = adjustColumnWidthsToFitContainer(defaultColumnState, 0, 'even');
+
+      expect(updatedState).toBe(defaultColumnState);
+    });
+
+    it('keeps a column the user resized at the width they chose and shares the rest between the others', () => {
+      // `setColumnWidth` stores a deliberate width as the ideal width of the column.
+      const resizedState = setColumnProperty(
+        setColumnProperty(defaultColumnState, 2, 'width', 500),
+        2,
+        'idealWidth',
+        500,
+      );
+
+      const updatedState = adjustColumnWidthsToFitContainer(resizedState, 1000, 'even', new Set([2]));
+
+      expect(updatedState[1].width).toEqual(500);
+      expect(updatedState[0].width).toEqual(226);
+      expect(updatedState[2].width).toEqual(226);
+    });
+
+    it('shrinks a column the user resized when the container cannot fit every column', () => {
+      const resizedState = setColumnProperty(
+        setColumnProperty(defaultColumnState, 2, 'width', 500),
+        2,
+        'idealWidth',
+        500,
+      );
+
+      const updatedState = adjustColumnWidthsToFitContainer(resizedState, 400, 'even', new Set([2]));
+
+      expect(updatedState[0].width).toEqual(100);
+      expect(updatedState[1].width).toEqual(152);
+      expect(updatedState[2].width).toEqual(100);
+    });
+
+    it('fills the whole container', () => {
+      const updatedState = adjustColumnWidthsToFitContainer(defaultColumnState, 1000, 'even');
+
+      expect(getTotalWidth(updatedState)).toBeCloseTo(1000);
+    });
+
+    it('fills the whole container even when every column has been resized', () => {
+      // Once every column is deliberately sized, no column is pinned against the others anymore -
+      // they simply share the container again, so no dead space appears after the last column.
+      const everyColumnResized: ColumnWidthState[] = [
+        { columnId: 1, idealWidth: 300, minWidth: 100, padding: 16, width: 300 },
+        { columnId: 2, idealWidth: 250, minWidth: 100, padding: 16, width: 250 },
+        { columnId: 3, idealWidth: 200, minWidth: 100, padding: 16, width: 200 },
+      ];
+
+      const updatedState = adjustColumnWidthsToFitContainer(everyColumnResized, 1000, 'even', new Set([1, 2, 3]));
+
+      expect(getTotalWidth(updatedState)).toBeCloseTo(1000);
+      const growth = updatedState.map((column, index) => column.width - everyColumnResized[index].idealWidth);
+      expect(growth[0]).toBeCloseTo(growth[1]);
+      expect(growth[1]).toBeCloseTo(growth[2]);
+    });
+
+    it('stops growing a resized column once the other columns are at their minimal widths', () => {
+      const resizedState: ColumnWidthState[] = [
+        { columnId: 1, idealWidth: 300, minWidth: 100, padding: 16, width: 300 },
+        { columnId: 2, idealWidth: 150, minWidth: 100, padding: 16, width: 150 },
+        { columnId: 3, idealWidth: 150, minWidth: 100, padding: 16, width: 150 },
+      ];
+
+      const updatedState = adjustColumnWidthsToFitContainer(resizedState, 498, 'even', new Set([1]));
+
+      expect(updatedState[0].width).toEqual(250);
+      expect(updatedState[1].width).toEqual(100);
+      expect(updatedState[2].width).toEqual(100);
+    });
+
+    it('keeps a resized column at the width the user chose while the other columns can still shrink', () => {
+      const resizedState: ColumnWidthState[] = [
+        { columnId: 1, idealWidth: 250, minWidth: 100, padding: 16, width: 250 },
+        { columnId: 2, idealWidth: 150, minWidth: 100, padding: 16, width: 150 },
+        { columnId: 3, idealWidth: 150, minWidth: 100, padding: 16, width: 150 },
+      ];
+
+      const updatedState = adjustColumnWidthsToFitContainer(resizedState, 498, 'even', new Set([1]));
+
+      expect(updatedState[0].width).toEqual(250);
+      expect(updatedState[1].width).toEqual(100);
+      expect(updatedState[2].width).toEqual(100);
+    });
+
+    it('shares the space equally between columns with different ideal widths', () => {
+      const unequalColumnState: ColumnWidthState[] = [
+        { columnId: 1, idealWidth: 100, minWidth: 50, padding: 16, width: 100 },
+        { columnId: 2, idealWidth: 200, minWidth: 50, padding: 16, width: 200 },
+        { columnId: 3, idealWidth: 300, minWidth: 50, padding: 16, width: 300 },
+      ];
+
+      const updatedState = adjustColumnWidthsToFitContainer(unequalColumnState, 1000, 'even');
+
+      const growth = updatedState.map((column, index) => column.width - unequalColumnState[index].idealWidth);
+      expect(growth[0]).toBeCloseTo(growth[1]);
+      expect(growth[1]).toBeCloseTo(growth[2]);
+      expect(getTotalWidth(updatedState)).toBeCloseTo(1000);
+    });
+
+    it('respects a minimal width that is larger than the ideal width', () => {
+      const narrowIdealColumnState: ColumnWidthState[] = [
+        { columnId: 1, idealWidth: 100, minWidth: 200, padding: 16, width: 100 },
+        ...defaultColumnState.slice(1),
+      ];
+
+      const updatedState = adjustColumnWidthsToFitContainer(narrowIdealColumnState, 400, 'even');
+
+      expect(updatedState[0].width).toEqual(200);
+      expect(updatedState[1].width).toEqual(100);
+      expect(updatedState[2].width).toEqual(100);
+    });
+
+    it('gives the whole container to a single column', () => {
+      const updatedState = adjustColumnWidthsToFitContainer(defaultColumnState.slice(0, 1), 1000, 'even');
+
+      expect(updatedState[0].width).toEqual(984);
+    });
+
+    it('handles a table without any columns', () => {
+      expect(adjustColumnWidthsToFitContainer([], 1000, 'even')).toEqual([]);
+    });
+
+    it('leaves the state untouched when the columns already fit exactly', () => {
+      const updatedState = adjustColumnWidthsToFitContainer(defaultColumnState, 498, 'even');
+
+      expect(updatedState).toBe(defaultColumnState);
+    });
+
+    it('returns the same widths when it runs again on its own result', () => {
+      const updatedState = adjustColumnWidthsToFitContainer(defaultColumnState, 1000, 'even');
+
+      expect(adjustColumnWidthsToFitContainer(updatedState, 1000, 'even')).toBe(updatedState);
+    });
+
+    it('returns the same widths when it runs again on its own result with a resized column', () => {
+      const resizedState = setColumnProperty(
+        setColumnProperty(defaultColumnState, 2, 'width', 500),
+        2,
+        'idealWidth',
+        500,
+      );
+
+      const updatedState = adjustColumnWidthsToFitContainer(resizedState, 1000, 'even', new Set([2]));
+
+      expect(adjustColumnWidthsToFitContainer(updatedState, 1000, 'even', new Set([2]))).toBe(updatedState);
     });
   });
 

--- a/packages/react-components/react-table/library/src/utils/columnResizeUtils.ts
+++ b/packages/react-components/react-table/library/src/utils/columnResizeUtils.ts
@@ -1,4 +1,10 @@
-import type { TableColumnDefinition, ColumnWidthState, TableColumnId, TableColumnSizingOptions } from '../hooks';
+import type {
+  TableColumnDefinition,
+  ColumnWidthState,
+  AutoFitColumnsStrategy,
+  TableColumnId,
+  TableColumnSizingOptions,
+} from '../hooks';
 
 const DEFAULT_WIDTH = 150;
 const DEFAULT_MIN_WIDTH = 100;
@@ -140,18 +146,122 @@ export function setColumnProperty(
 }
 
 /**
+ * Shares the container between the columns so that the space left over once every column has
+ * reached its ideal width is split equally between them. Columns with equal ideal widths
+ * therefore end up equally wide, which matches how the columns are laid out when resizing is
+ * disabled and the browser distributes the row with flexbox.
+ *
+ * The result is derived only from `idealWidth`, `minWidth` and `padding`, never from the current
+ * `width`, which makes it idempotent - re-running it on its own output changes nothing.
+ * @param state
+ * @param containerWidth
+ * @param resizedColumns - columns the user has deliberately resized; they keep their chosen width
+ * @returns
+ */
+export function distributeColumnWidthsEvenly(
+  state: ColumnWidthState[],
+  containerWidth: number,
+  resizedColumns: ReadonlySet<TableColumnId> = new Set(),
+): ColumnWidthState[] {
+  // The container is measured after the first render, and is not measured at all when rendering on
+  // the server. Sharing a container that has no width yet would collapse every column to its
+  // minimal width, just to expand it again once the real width arrives.
+  if (containerWidth <= 0) {
+    return state;
+  }
+
+  // A column the user has resized keeps the width they chose instead of growing with the others,
+  // otherwise the column would drift away from the resize handle they are dragging. The pin only
+  // holds against columns that can still absorb space though - once every column has been
+  // deliberately sized, they simply share the container again, so no dead space appears after the
+  // last column.
+  let fixedColumns = state.filter(column => resizedColumns.has(column.columnId));
+  if (fixedColumns.length === state.length) {
+    fixedColumns = [];
+  }
+  const sharingColumns = state.filter(column => !fixedColumns.includes(column));
+
+  const availableSpace = containerWidth - sumOf(state, 'padding');
+  const fixedIdealWidth = sumOf(fixedColumns, 'idealWidth');
+
+  const shared = shareSpace(sharingColumns, availableSpace - fixedIdealWidth);
+  // When the sharing columns bottom out at their minimal widths, the resized columns give up the
+  // rest of the deficit instead of letting the columns overflow the container.
+  const deficit = Math.min(0, availableSpace - fixedIdealWidth - shared.total);
+  const fixed = shareSpace(fixedColumns, fixedIdealWidth + deficit);
+
+  let newState = state;
+  for (const [columnId, width] of [...shared.widths, ...fixed.widths]) {
+    newState = setColumnProperty(newState, columnId, 'width', width);
+  }
+
+  return newState;
+}
+
+function sumOf(columns: ColumnWidthState[], property: 'idealWidth' | 'padding'): number {
+  return columns.reduce((sum, column) => sum + column[property], 0);
+}
+
+/**
+ * Gives every column its ideal width plus an equal share of the remaining space, without pushing
+ * any column below its minimal width. A column whose share would push it below its minimal width
+ * cannot take part in the sharing - keeping it at its minimal width leaves less space for the
+ * rest, which can push further columns below their own minimal width, so this repeats until every
+ * remaining share is large enough. When the space cannot hold every column at its minimal width,
+ * the total therefore exceeds the space.
+ */
+function shareSpace(
+  columns: ColumnWidthState[],
+  space: number,
+): { widths: Array<[TableColumnId, number]>; total: number } {
+  let sharingColumns = columns;
+  let remainingSpace = space;
+  const widths: Array<[TableColumnId, number]> = [];
+  let total = 0;
+
+  while (sharingColumns.length > 0) {
+    const share = (remainingSpace - sumOf(sharingColumns, 'idealWidth')) / sharingColumns.length;
+    const tooNarrow = sharingColumns.filter(column => column.idealWidth + share < column.minWidth);
+
+    if (tooNarrow.length === 0) {
+      for (const column of sharingColumns) {
+        widths.push([column.columnId, column.idealWidth + share]);
+        total += column.idealWidth + share;
+      }
+      break;
+    }
+
+    for (const column of tooNarrow) {
+      widths.push([column.columnId, column.minWidth]);
+      total += column.minWidth;
+      remainingSpace -= column.minWidth;
+    }
+    sharingColumns = sharingColumns.filter(column => !tooNarrow.includes(column));
+  }
+
+  return { widths, total };
+}
+
+/**
  * This function takes the state and container width and makes sure the each column in the state
  * is its optimal width, and that the columns
  * a) fit to the container
  * b) always fill the whole container
  * @param state
  * @param containerWidth
+ * @param strategy - how the space left over after every column reached its ideal width is shared
  * @returns
  */
 export function adjustColumnWidthsToFitContainer(
   state: ColumnWidthState[],
   containerWidth: number,
+  strategy: AutoFitColumnsStrategy = 'last-column',
+  resizedColumns?: ReadonlySet<TableColumnId>,
 ): ColumnWidthState[] {
+  if (strategy === 'even') {
+    return distributeColumnWidthsEvenly(state, containerWidth, resizedColumns);
+  }
+
   let newState = state;
   const totalWidth = getTotalWidth(newState);
 

--- a/packages/react-components/react-table/stories/src/DataGrid/ResizableColumnsEvenDistribution.stories.tsx
+++ b/packages/react-components/react-table/stories/src/DataGrid/ResizableColumnsEvenDistribution.stories.tsx
@@ -1,0 +1,196 @@
+import * as React from 'react';
+
+import {
+  FolderRegular,
+  EditRegular,
+  OpenRegular,
+  DocumentRegular,
+  PeopleRegular,
+  DocumentPdfRegular,
+  VideoRegular,
+} from '@fluentui/react-icons';
+import {
+  Avatar,
+  DataGrid,
+  DataGridBody,
+  DataGridCell,
+  DataGridHeader,
+  DataGridHeaderCell,
+  DataGridRow,
+  TableCellLayout,
+  createTableColumn,
+} from '@fluentui/react-components';
+
+import type { JSXElement, PresenceBadgeStatus, TableColumnDefinition } from '@fluentui/react-components';
+
+type FileCell = {
+  label: string;
+  icon: JSXElement;
+};
+
+type LastUpdatedCell = {
+  label: string;
+  timestamp: number;
+};
+
+type LastUpdateCell = {
+  label: string;
+  icon: JSXElement;
+};
+
+type AuthorCell = {
+  label: string;
+  status: PresenceBadgeStatus;
+};
+
+type Item = {
+  file: FileCell;
+  author: AuthorCell;
+  lastUpdated: LastUpdatedCell;
+  lastUpdate: LastUpdateCell;
+};
+
+const items: Item[] = [
+  {
+    file: { label: 'Meeting notes', icon: <DocumentRegular /> },
+    author: { label: 'Max Mustermann', status: 'available' },
+    lastUpdated: { label: '7h ago', timestamp: 1 },
+    lastUpdate: {
+      label: 'You edited this',
+      icon: <EditRegular />,
+    },
+  },
+  {
+    file: { label: 'Thursday presentation', icon: <FolderRegular /> },
+    author: { label: 'Erika Mustermann', status: 'busy' },
+    lastUpdated: { label: 'Yesterday at 1:45 PM', timestamp: 2 },
+    lastUpdate: {
+      label: 'You recently opened this',
+      icon: <OpenRegular />,
+    },
+  },
+  {
+    file: { label: 'Training recording', icon: <VideoRegular /> },
+    author: { label: 'John Doe', status: 'away' },
+    lastUpdated: { label: 'Yesterday at 1:45 PM', timestamp: 2 },
+    lastUpdate: {
+      label: 'You recently opened this',
+      icon: <OpenRegular />,
+    },
+  },
+  {
+    file: { label: 'Purchase order', icon: <DocumentPdfRegular /> },
+    author: { label: 'Jane Doe', status: 'offline' },
+    lastUpdated: { label: 'Tue at 9:30 AM', timestamp: 3 },
+    lastUpdate: {
+      label: 'You shared this in a Teams chat',
+      icon: <PeopleRegular />,
+    },
+  },
+];
+
+const columns: TableColumnDefinition<Item>[] = [
+  createTableColumn<Item>({
+    columnId: 'file',
+    renderHeaderCell: () => {
+      return 'File';
+    },
+    renderCell: item => {
+      return (
+        <TableCellLayout truncate media={item.file.icon}>
+          {item.file.label}
+        </TableCellLayout>
+      );
+    },
+  }),
+  createTableColumn<Item>({
+    columnId: 'author',
+    renderHeaderCell: () => {
+      return 'Author';
+    },
+    renderCell: item => {
+      return (
+        <TableCellLayout
+          truncate
+          media={
+            <Avatar aria-label={item.author.label} name={item.author.label} badge={{ status: item.author.status }} />
+          }
+        >
+          {item.author.label}
+        </TableCellLayout>
+      );
+    },
+  }),
+  createTableColumn<Item>({
+    columnId: 'lastUpdated',
+    renderHeaderCell: () => {
+      return 'Last updated';
+    },
+    renderCell: item => {
+      return <TableCellLayout truncate>{item.lastUpdated.label}</TableCellLayout>;
+    },
+  }),
+  createTableColumn<Item>({
+    columnId: 'lastUpdate',
+    renderHeaderCell: () => {
+      return 'Last update';
+    },
+    renderCell: item => {
+      return (
+        <TableCellLayout truncate media={item.lastUpdate.icon}>
+          {item.lastUpdate.label}
+        </TableCellLayout>
+      );
+    },
+  }),
+];
+
+export const ResizableColumnsEvenDistribution = (): JSXElement => {
+  return (
+    <div style={{ overflowX: 'auto' }}>
+      <DataGrid
+        items={items}
+        columns={columns}
+        getRowId={item => item.file.label}
+        resizableColumns
+        resizableColumnsOptions={{
+          autoFitColumnsStrategy: 'even',
+        }}
+      >
+        <DataGridHeader>
+          <DataGridRow>
+            {({ renderHeaderCell }) => <DataGridHeaderCell>{renderHeaderCell()}</DataGridHeaderCell>}
+          </DataGridRow>
+        </DataGridHeader>
+        <DataGridBody<Item>>
+          {({ item, rowId }) => (
+            <DataGridRow<Item> key={rowId}>
+              {({ renderCell }) => <DataGridCell>{renderCell(item)}</DataGridCell>}
+            </DataGridRow>
+          )}
+        </DataGridBody>
+      </DataGrid>
+    </div>
+  );
+};
+
+ResizableColumnsEvenDistribution.storyName = 'Resizable Columns - Even container auto-fit';
+ResizableColumnsEvenDistribution.parameters = {
+  docs: {
+    description: {
+      story: [
+        'By default, auto-fit grows every column to its ideal width and gives all of the space that is left',
+        'over to the last column. Columns that share the same ideal width therefore stop looking evenly',
+        'spaced as soon as the container is wider than the sum of their ideal widths.',
+        '',
+        'Passing `resizableColumnsOptions={{ autoFitColumnsStrategy: "even" }}` shares the leftover space',
+        'equally between all columns instead, so columns with the same ideal width stay equally wide - the',
+        'same layout the columns get when resizing is disabled. Columns are still resizable, and the last',
+        'column keeps its resize handle because it is no longer stretched to fill the table.',
+        '',
+        'A column that the user resizes keeps the width they chose, and the remaining columns share the rest',
+        'of the container between them.',
+      ].join('\n'),
+    },
+  },
+};

--- a/packages/react-components/react-table/stories/src/DataGrid/index.stories.tsx
+++ b/packages/react-components/react-table/stories/src/DataGrid/index.stories.tsx
@@ -23,6 +23,7 @@ export { SubtleSelection } from './SubtleSelection.stories';
 export { SelectionAppearance } from './SelectionAppearance.stories';
 export { ResizableColumns } from './ResizableColumns.stories';
 export { ResizableColumnsDisableAutoFit } from './ResizableColumnsDisableAutoFit.stories';
+export { ResizableColumnsEvenDistribution } from './ResizableColumnsEvenDistribution.stories';
 export { Virtualization } from './Virtualization.stories';
 export { CustomRowId } from './CustomRowId.stories';
 


### PR DESCRIPTION
## Previous Behavior

DataGrid columns are only evenly spaced when column resizing is turned off. As soon as `resizableColumns` is enabled, auto-fit grows each column to its ideal width and gives **all** of the leftover container space to the last column — four default columns in a 1000px container render as 150 / 150 / 150 / 486 instead of 250 / 250 / 250 / 250. The last column is also rendered without a resize handle, so the one column that ballooned is the one column the user cannot drag back. There is no workaround.

## New Behavior

A new opt-in option shares the leftover space equally instead:

```tsx
<DataGrid
  resizableColumns
  resizableColumnsOptions={{ autoFitColumnsStrategy: 'even' }}
/>
```

- **`'even'`**: every column gets its ideal width plus an equal share of the remaining space — the same equally-spaced layout the grid has when resizing is off, while every column (including the last) stays resizable.
- A column the user resizes keeps exactly the width they chose; the other columns share the rest. When the container is too small, unresized columns shrink toward their minimum first, and resized columns only give up what the others cannot absorb.
- Once *every* column has been deliberately sized, the columns simply share the container again so no dead space appears after the last column.
- **`'last-column'`** (default): behavior is completely unchanged — no existing test, snapshot, or story was re-baselined, and the default code path was verified byte-identical against the previous implementation across mixed drag/squash sequences.

The new `Resizable Columns - Even container auto-fit` story demonstrates the behavior using default columns (no `columnSizingOptions`), which is exactly the reporter's scenario.

**A decision for maintainers:** the issue is really about the *default* — reporters expect auto-fit + resize to keep equal spacing out of the box. This PR ships the fix as opt-in to stay strictly non-breaking, but we believe `'even'` is a strong candidate to become the default in a future major/behavioral release. Happy to follow up either way.

Noted while working here, intentionally left out of scope: `columnDefinitionsToState` resets the *first* over-ideal column where it means the previously-stretched last one (`columnResizeUtils.ts`, currently masked by an invariant), and `TableColumnSizingOptions` declares a per-column `autoFitColumns` that no code reads. Can file separate issues for both.

## Related Issue(s)

- Fixes #35923

---
- [x] Changes covered by tests (29 new tests: distribution math, min-width water-fill, resized-column pinning, container/column/options updates, keyboard-resize aria, single-column edge, SSR zero-width container)
- [x] `yarn change` change file included (minor)
- [x] API report regenerated (one added line)
- [x] 521/521 tests, lint, type-check all passing locally
