### PR TITLE
ci: scope headless experimental yarn change to release-headless config

### DIFF
--- a/azure-pipelines.release-headless-experimental.yml
+++ b/azure-pipelines.release-headless-experimental.yml
@@ -99,7 +99,11 @@ extends:
                   yarn nx g @fluentui/workspace-plugin:version-bump --name react-headless-components-preview --explicitVersion "${NEW_VERSION}"
                   git add .
                   git commit -m "bump experimental headless versions to ${NEW_VERSION}"
-                  yarn change --type prerelease --message "Release ${NEW_VERSION}" --dependent-change-type "prerelease"
+                  # Scope change-file generation to the headless beachball config. Without --config,
+                  # `yarn change` tries to create change files for EVERY package changed vs master
+                  # (the whole feature branch), and aborts on packages that disallow `prerelease` -
+                  # producing zero change files and a "Nothing to bump, skipping publish!".
+                  yarn change --config scripts/beachball/src/release-headless.config.js --type prerelease --message "Release ${NEW_VERSION}" --dependent-change-type "prerelease"
                 displayName: 'Bump and commit experimental headless versions'
 
               - script: |


### PR DESCRIPTION
## Problem

Running the **experimental headless release** pipeline (`azure-pipelines.release-headless-experimental.yml`) ends with:

```
Nothing to bump, skipping publish!
```

so nothing is published.

## Root cause

The pipeline bumps only headless (`version-bump --name react-headless-components-preview`), which clears **headless's** `disallowedChangeTypes`. But the subsequent `yarn change` is **unscoped**, so beachball tries to create a `prerelease` change file for **every** package changed vs `master` (the whole feature branch, ~85 packages). It hits a package that disallows `prerelease` — e.g. `@fluentui/react-charts` (`disallowedChangeTypes: ["major","prerelease"]`) — and aborts:

```
prerelease type is not allowed, aborting
```

Result: **zero** change files are written, so `beachball publish` has nothing to do → "Nothing to bump".

## Fix

Scope change‑file generation to the headless beachball config so it only considers the headless package:

```diff
- yarn change --type prerelease …
+ yarn change --config scripts/beachball/src/release-headless.config.js --type prerelease …
```

Verified locally: with the scoped config, `yarn change` writes exactly one change file (`@fluentui/react-headless-components-preview`, type `prerelease`) and skips `react-charts`/everything else.

## Notes

- The **vNext** experimental pipeline is **not** affected: its `version-bump --all` clears `disallowedChangeTypes` on all converged packages (including `react-charts`), and none of the other changed packages disallow `prerelease`.
- Same fix is already deployed on the `experimental/esm` branch for validation.

Draft for review.