### PR TITLE
fix(react-popover): omit role='group' from PopoverSurface when no accessible name is provided

### DIFF
--- a/change/@fluentui-react-popover-bd6da173-2885-437a-98d5-f1c9a6e312c1.json
+++ b/change/@fluentui-react-popover-bd6da173-2885-437a-98d5-f1c9a6e312c1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "omit role=group from PopoverSurface when no accessible name is provided, fixing Narrator announcing contains style group on non-modal popovers",
+  "packageName": "@fluentui/react-popover",
+  "email": "paulmardling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charts/react-charts/library/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
+++ b/packages/charts/react-charts/library/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
@@ -420,7 +420,6 @@ Object {
           <div
             class="fui-PopoverSurface"
             data-tabster="{\\"restorer\\":{\\"type\\":0}}"
-            role="group"
             style="position: fixed; left: 0px; top: 0px; margin: 0px;"
           >
             <div
@@ -640,7 +639,6 @@ Object {
         <div
           class="fui-PopoverSurface"
           data-tabster="{\\"restorer\\":{\\"type\\":0}}"
-          role="group"
           style="position: fixed; left: 0px; top: 0px; margin: 0px;"
         >
           <div
@@ -900,7 +898,6 @@ Object {
           <div
             class="fui-PopoverSurface"
             data-tabster="{\\"restorer\\":{\\"type\\":0}}"
-            role="group"
             style="position: fixed; left: 0px; top: 0px; margin: 0px;"
           >
             <div
@@ -1120,7 +1117,6 @@ Object {
         <div
           class="fui-PopoverSurface"
           data-tabster="{\\"restorer\\":{\\"type\\":0}}"
-          role="group"
           style="position: fixed; left: 0px; top: 0px; margin: 0px;"
         >
           <div

--- a/packages/charts/react-charts/library/src/components/GanttChart/__snapshots__/GanttChart.test.tsx.snap
+++ b/packages/charts/react-charts/library/src/components/GanttChart/__snapshots__/GanttChart.test.tsx.snap
@@ -427,7 +427,6 @@ exports[`GanttChart interaction and accessibility tests should render custom cal
         data-popper-placement="top"
         data-popper-reference-hidden=""
         data-tabster="{\\"restorer\\":{\\"type\\":0}}"
-        role="group"
         style="position: absolute; left: 0px; top: 0px; margin: 0px; box-sizing: border-box; max-width: 0px; max-height: -20px; overflow-y: auto; transform: translate(-10px, -40px); --fui-positioning-slide-direction-x: 0px; --fui-positioning-slide-direction-y: 1px;"
       >
         <div
@@ -4762,7 +4761,6 @@ exports[`GanttChart rendering and behavior tests should render callout correctly
         data-popper-placement="top"
         data-popper-reference-hidden=""
         data-tabster="{\\"restorer\\":{\\"type\\":0}}"
-        role="group"
         style="position: absolute; left: 0px; top: 0px; margin: 0px; box-sizing: border-box; max-width: 0px; max-height: -20px; overflow-y: auto; transform: translate(-10px, -40px); --fui-positioning-slide-direction-x: 0px; --fui-positioning-slide-direction-y: 1px;"
       >
         <div

--- a/packages/charts/react-charts/library/src/components/GaugeChart/__snapshots__/GaugeChart.test.tsx.snap
+++ b/packages/charts/react-charts/library/src/components/GaugeChart/__snapshots__/GaugeChart.test.tsx.snap
@@ -873,7 +873,6 @@ exports[`Gauge chart interactions Should hide callout on mouse leave 1`] = `
       <div
         class="fui-PopoverSurface"
         data-tabster="{\\"restorer\\":{\\"type\\":0}}"
-        role="group"
         style="position: fixed; left: 0px; top: 0px; margin: 0px;"
       >
         <div
@@ -1559,7 +1558,6 @@ exports[`Gauge chart interactions Should show callout on focus 1`] = `
       <div
         class="fui-PopoverSurface"
         data-tabster="{\\"restorer\\":{\\"type\\":0}}"
-        role="group"
         style="position: fixed; left: 0px; top: 0px; margin: 0px;"
       >
         <div
@@ -1859,7 +1857,6 @@ exports[`Gauge chart interactions Should show callout on mouse over 1`] = `
       <div
         class="fui-PopoverSurface"
         data-tabster="{\\"restorer\\":{\\"type\\":0}}"
-        role="group"
         style="position: fixed; left: 0px; top: 0px; margin: 0px;"
       >
         <div

--- a/packages/charts/react-charts/library/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
+++ b/packages/charts/react-charts/library/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
@@ -1309,7 +1309,6 @@ exports[`GroupedVerticalBarChart - mouse events Should render callout correctly 
       <div
         class="fui-PopoverSurface"
         data-tabster="{\\"restorer\\":{\\"type\\":0}}"
-        role="group"
         style="position: fixed; left: 0px; top: 0px; margin: 0px;"
       >
         <div

--- a/packages/charts/react-charts/library/src/components/LineChart/__snapshots__/LineChart.test.tsx.snap
+++ b/packages/charts/react-charts/library/src/components/LineChart/__snapshots__/LineChart.test.tsx.snap
@@ -1878,7 +1878,6 @@ exports[`LineChart - mouse events Should render callout correctly on mouseover 1
       <div
         class="fui-PopoverSurface"
         data-tabster="{\\"restorer\\":{\\"type\\":0}}"
-        role="group"
         style="position: fixed; left: 0px; top: 0px; margin: 0px;"
       >
         <div
@@ -2553,7 +2552,6 @@ exports[`LineChart - mouse events Should render customized callout per stack on 
       <div
         class="fui-PopoverSurface"
         data-tabster="{\\"restorer\\":{\\"type\\":0}}"
-        role="group"
         style="position: fixed; left: 0px; top: 0px; margin: 0px;"
       >
         <div>

--- a/packages/charts/react-charts/library/src/components/SankeyChart/__snapshots__/SankeyChart.test.tsx.snap
+++ b/packages/charts/react-charts/library/src/components/SankeyChart/__snapshots__/SankeyChart.test.tsx.snap
@@ -11596,7 +11596,6 @@ exports[`SankeyChart - mouse events Should render callout correctly on mouseover
       <div
         class="fui-PopoverSurface"
         data-tabster="{\\"restorer\\":{\\"type\\":0}}"
-        role="group"
         style="position: fixed; left: 0px; top: 0px; margin: 0px;"
       >
         <div

--- a/packages/charts/react-charts/library/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
+++ b/packages/charts/react-charts/library/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
@@ -4983,7 +4983,6 @@ exports[`VerticalBarChart - mouse events Should render callout correctly on mous
       <div
         class="fui-PopoverSurface"
         data-tabster="{\\"restorer\\":{\\"type\\":0}}"
-        role="group"
         style="position: fixed; left: 0px; top: 0px; margin: 0px;"
       >
         <div
@@ -5609,7 +5608,6 @@ exports[`VerticalBarChart - mouse events Should render customized callout on mou
       <div
         class="fui-PopoverSurface"
         data-tabster="{\\"restorer\\":{\\"type\\":0}}"
-        role="group"
         style="position: fixed; left: 0px; top: 0px; margin: 0px;"
       >
         <div>

--- a/packages/charts/react-charts/library/src/components/VerticalStackedBarChart/__snapshots__/VerticalStackedBarChart.test.tsx.snap
+++ b/packages/charts/react-charts/library/src/components/VerticalStackedBarChart/__snapshots__/VerticalStackedBarChart.test.tsx.snap
@@ -2152,7 +2152,6 @@ exports[`VerticalStackedBarChart - mouse events Should render callout correctly 
       <div
         class="fui-PopoverSurface"
         data-tabster="{\\"restorer\\":{\\"type\\":0}}"
-        role="group"
         style="position: fixed; left: 0px; top: 0px; margin: 0px;"
       >
         <div
@@ -2724,7 +2723,6 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
       <div
         class="fui-PopoverSurface"
         data-tabster="{\\"restorer\\":{\\"type\\":0}}"
-        role="group"
         style="position: fixed; left: 0px; top: 0px; margin: 0px;"
       >
         <div>
@@ -3338,7 +3336,6 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
       <div
         class="fui-PopoverSurface"
         data-tabster="{\\"restorer\\":{\\"type\\":0}}"
-        role="group"
         style="position: fixed; left: 0px; top: 0px; margin: 0px;"
       >
         <div

--- a/packages/react-components/react-popover/library/src/components/Popover/Popover.cy.tsx
+++ b/packages/react-components/react-popover/library/src/components/Popover/Popover.cy.tsx
@@ -13,7 +13,7 @@ const mount = (element: JSXElement) => {
 };
 
 const popoverTriggerSelector = '[aria-expanded]';
-const popoverContentSelector = '[role="group"]';
+const popoverContentSelector = '.fui-PopoverSurface';
 const popoverInteractiveContentSelector = '[role="dialog"]';
 
 describe('Popover', () => {

--- a/packages/react-components/react-popover/library/src/components/PopoverSurface/PopoverSurface.test.tsx
+++ b/packages/react-components/react-popover/library/src/components/PopoverSurface/PopoverSurface.test.tsx
@@ -1,6 +1,7 @@
 import { resetIdsForTests } from '@fluentui/react-utilities';
 import * as React from 'react';
 import { PopoverSurface } from './PopoverSurface';
+import { getPopoverSurfaceAriaAttributes } from './usePopoverSurface';
 import { render, fireEvent } from '@testing-library/react';
 import { isConformant } from '../../testing/isConformant';
 import { mockPopoverContext } from '../../testing/mockUsePopoverContext';
@@ -72,12 +73,47 @@ describe('PopoverSurface', () => {
     expect(queryByRole('dialog')).not.toBeNull();
   });
 
-  it('should set role group if focus trap is not active', () => {
+  it('should set role group if focus trap is not active and an accessible name is provided', () => {
     // Arrange
     mockPopoverContext({ trapFocus: false });
+    // props includes aria-label='test', so role='group' should be applied
     const { getByTestId } = render(<PopoverSurface {...props}>Content</PopoverSurface>);
 
     // Assert
-    expect(getByTestId(testid)).not.toBeNull();
+    expect(getByTestId(testid).getAttribute('role')).toEqual('group');
+  });
+});
+
+describe('getPopoverSurfaceAriaAttributes', () => {
+  it('returns dialog attributes when focus is trapped', () => {
+    expect(
+      getPopoverSurfaceAriaAttributes({
+        hasAccessibleName: false,
+        trapFocus: true,
+      }),
+    ).toEqual({
+      role: 'dialog',
+      'aria-modal': true,
+    });
+  });
+
+  it('returns group when the surface has an accessible name', () => {
+    expect(
+      getPopoverSurfaceAriaAttributes({
+        hasAccessibleName: true,
+        trapFocus: false,
+      }),
+    ).toEqual({
+      role: 'group',
+    });
+  });
+
+  it('returns no role when the surface is unlabelled', () => {
+    expect(
+      getPopoverSurfaceAriaAttributes({
+        hasAccessibleName: false,
+        trapFocus: false,
+      }),
+    ).toEqual({});
   });
 });

--- a/packages/react-components/react-popover/library/src/components/PopoverSurface/usePopoverSurface.ts
+++ b/packages/react-components/react-popover/library/src/components/PopoverSurface/usePopoverSurface.ts
@@ -7,6 +7,35 @@ import { usePopoverContext_unstable } from '../../popoverContext';
 import type { PopoverSurfaceProps, PopoverSurfaceState } from './PopoverSurface.types';
 import { useMotionForwardedRef } from '@fluentui/react-motion';
 
+type PopoverSurfaceAriaAttributes = Pick<React.HTMLAttributes<HTMLDivElement>, 'role' | 'aria-modal'>;
+
+/**
+ * Returns the ARIA role and modal attributes for a PopoverSurface.
+ *
+ * Extracted as a pure function to allow isolated unit testing of the attribute logic.
+ * - `trapFocus=true` → `role="dialog"` + `aria-modal=true`
+ * - `trapFocus=false` + accessible name present → `role="group"`
+ * - `trapFocus=false` + no accessible name → no role (plain div avoids screen reader
+ *   announcing "contains style group" for unlabelled popovers)
+ */
+export const getPopoverSurfaceAriaAttributes = ({
+  hasAccessibleName,
+  trapFocus,
+}: {
+  hasAccessibleName: boolean;
+  trapFocus: boolean;
+}): PopoverSurfaceAriaAttributes => {
+  if (trapFocus) {
+    return { role: 'dialog', 'aria-modal': true };
+  }
+
+  if (hasAccessibleName) {
+    return { role: 'group' };
+  }
+
+  return {};
+};
+
 /**
  * Create the state required to render PopoverSurface.
  *
@@ -54,8 +83,10 @@ export const usePopoverSurface_unstable = (
         // `contentRef` is wrongly assigned to be `HTMLElement` instead of `HTMLDivElement`
         // but since it would be a breaking change to fix it, we are casting ref to it's proper type
         ref: useMergedRefs(ref, contentRef, motionForwardedRef) as React.Ref<HTMLDivElement>,
-        role: trapFocus ? 'dialog' : 'group',
-        'aria-modal': trapFocus ? true : undefined,
+        ...getPopoverSurfaceAriaAttributes({
+          hasAccessibleName: Boolean(props['aria-label'] || props['aria-labelledby']),
+          trapFocus,
+        }),
         ...modalAttributes,
         ...props,
       }),

--- a/packages/react-components/react-popover/library/src/components/PopoverSurface/usePopoverSurface.ts
+++ b/packages/react-components/react-popover/library/src/components/PopoverSurface/usePopoverSurface.ts
@@ -57,7 +57,7 @@ export const usePopoverSurface_unstable = (
   const size = usePopoverContext_unstable(context => context.size);
   const withArrow = usePopoverContext_unstable(context => context.withArrow);
   const appearance = usePopoverContext_unstable(context => context.appearance);
-  const trapFocus = usePopoverContext_unstable(context => context.trapFocus);
+  const trapFocus = !!usePopoverContext_unstable(context => context.trapFocus);
   const inertTrapFocus = usePopoverContext_unstable(context => context.inertTrapFocus);
   const inline = usePopoverContext_unstable(context => context.inline);
   const motionForwardedRef = useMotionForwardedRef();

--- a/packages/react-components/react-popover/stories/src/Popover/PopoverDefault.stories.tsx
+++ b/packages/react-components/react-popover/stories/src/Popover/PopoverDefault.stories.tsx
@@ -26,7 +26,7 @@ export const Default = (props: PopoverProps): JSXElement => (
       <Button>Popover trigger</Button>
     </PopoverTrigger>
 
-    <PopoverSurface tabIndex={-1}>
+    <PopoverSurface tabIndex={-1} aria-label="Popover content">
       <ExampleContent />
     </PopoverSurface>
   </Popover>


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->
# Decision needed
The bug's full expected result is that Narrator announces the popover contents on activation, not just stops saying the wrong thing. 

The Popover component already has auto-focus logic — it focuses the surface if tabIndex is set, or the first interactive element inside it. 

The gap is when a consumer passes non-interactive content with no tabIndex={-1} on the surface: focus never leaves the trigger and Narrator never reads the content so the user is left lost without feedback

The component cannot know what content is passed in, so this cannot be solved at the component level without risking regressions in other scenarios. 

**The decision needed is:** 
Do we push consumers to handle this via guidance and documentation, or do we make a component-level change? 

This needs input from the code owners before the ticket can be closed.

## Previous Behavior

On activating a popover with no interactive elements, Narrator announces, 'contains style group'.

## New Behavior

PopoverSurface no longer applies role='group' unconditionally when is false. 
The role is now only set when the consumer provides an accessible name via aria-label or aria-labelledby — matching the WAI-ARIA 1.2 requirement that group must have an accessible name. Without one, the surface renders as a plain div, so Narrator no longer announces "contains style group" when activating a non-modal popover.

## Implementation Details

The aria attribute logic has been extracted into a pure function **getPopoverSurfaceAriaAttributes** to allow isolated unit testing independent of the hook.

The default Popover story has been updated to include aria-label as the recommended usage pattern.

## Note for discussion: 

This fix stops the incorrect announcement. The broader expected result — Narrator automatically reading the popover text content on open — requires a follow-up decision on focus management vs aria-live. 
UX input is needed before that work proceeds.

## Fixes
https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/18661
